### PR TITLE
fix(memory): close the confidence-exclusion write bypass

### DIFF
--- a/openspec/changes/close-confidence-exclusion-bypass/.openspec.yaml
+++ b/openspec/changes/close-confidence-exclusion-bypass/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/close-confidence-exclusion-bypass/design.md
+++ b/openspec/changes/close-confidence-exclusion-bypass/design.md
@@ -1,0 +1,112 @@
+# Design — close-confidence-exclusion-bypass
+
+## Context
+
+`vault.EXCLUDED_FRONTMATTER_FIELDS` is a frozenset of three names with a pure advisory
+reason function beside it. It never raises; each caller converts the reason into its
+own error. Two callers do: `create_file` (dict parameter only) and
+`set_frontmatter_field`. Everything else that can accept an authored frontmatter key
+does not.
+
+The interesting constraint is not *whether* to fence but *where*. The collection
+manifest parser is the natural-looking choke point and is the one place the fence must
+never go, because it is on the read path. This document records that reasoning so it is
+not "simplified" later.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One doctrine, one refusal token, across every governed authored-input surface.
+- Close all three reachable bypasses, including a manifest hand-authored through
+  `manage_memory_file` — without which a Records-side fence is decorative.
+- Keep every existing artifact readable, queryable, rebaselineable, and repairable.
+- Tell an agent the rule before it authors, through the contract it already reads.
+
+**Non-Goals:**
+
+- No tool-docstring edits, and therefore no movement of the pinned MCP schema baseline
+  or the packaged discovery fingerprint.
+- No change to the membership of the excluded set, and no `auto_*` prefix rule.
+- No new audit category, no new error namespace, no governance-plane change.
+- No fence on stored state, merged values, or field deletion.
+
+## Decisions
+
+**1. Fence authored input, never stored state.** The check runs on what a caller just
+supplied — the assembled file text, the proposed manifest, the `item` mapping, the
+`changes` mapping. It never runs on values read back from disk. Consequences that are
+intended, not oversights: an unrelated update to a grandfathered item leaves its
+existing excluded value untouched, because the fence sees `changes` and not the merged
+result; and `delete_fields` is never fenced, because removing the field is the
+remediation.
+
+**2. The manifest parser is off limits, and this is the load-bearing decision.**
+`_parse_schema` is reached by `load_manifest` and `parse_manifest_bytes`, and through
+them by collection discovery, every collection resolution, every item read, the
+recall-candidacy check, and the guarded manifest load that precedes *every* mutation.
+`CollectionError` subclasses `ValueError`, and the recall-candidacy check catches
+`ValueError` and returns `False`. A refusal in the parser would therefore remove a
+grandfathered collection from recall **silently** — no error, no finding, no log — and
+would simultaneously break the revise and rebaseline that could repair it. One poisoned
+manifest would also break discovery for every other collection, because discovery
+raises on the first bad manifest inside its loop. The fence goes at the write entry
+points that call the parser, immediately after the parse returns.
+
+**3. Grandfathering follows the activation-manifest precedent.** Existing violations
+are review candidates, not blocking findings. The audit emits a `warn`-severity finding
+under the existing `frontmatter_compliance` category — deliberately reusing the
+category so the category registry is untouched — for an excluded top-level key and for
+a `type: collection` page declaring one under `item_schema.fields`. The finding carries
+the ordered remediation, and the order matters: delete the field from every item first,
+then revise the manifest. The reverse order fails, because revision validation checks
+the proposed schema against stored record values.
+
+**4. `create_file` must understand collection manifests.** A top-level-key check would
+not see `item_schema.fields.confidence`, so a manifest hand-authored through
+`manage_memory_file` would create a fully operable collection that the Records fence
+never sees — its audit chain simply starts at `baseline`. When the parsed frontmatter
+declares `type: collection`, the guard also walks `item_schema.fields`.
+
+**5. The `create_file` guard parses non-strictly.** A non-strict parse returns an empty
+mapping for a file with no frontmatter and for malformed YAML, so the guard adds zero
+new `INVALID_FRONTMATTER` refusals on the overwrite path. A strict parse would newly
+refuse writes that succeed today — a real regression bought to prevent a theoretical
+one. The residue is that syntactically invalid YAML containing `confidence:` slips
+through; nothing downstream reads it as `confidence` either.
+
+**6. One error code across three exception types.** `EXCLUDED_FIELD` already reaches
+the MCP boundary identically from both existing surfaces. The neighbouring collection
+codes mean different things — `RESERVED_RECORD_FIELD` is "collides with a system
+field", `SCHEMA_UNKNOWN_FIELD` is "not declared" — and neither is "declared but
+forbidden by doctrine." The code becomes a named constant beside the frozenset, and the
+collection raise carries `details` naming the offending field, matching the
+self-remediating error contract.
+
+**7. Doctrine outranks representation in revision validation.** The fence runs before
+the immutable-representation check, so a manifest violating both reports
+`EXCLUDED_FIELD`. This is an intentional ordering change.
+
+**8. Disclosure rides the manifest authoring contract, not docstrings.** The contract
+is runtime response data surfaced by `record_memory(action="describe")`, so adding the
+excluded names to the `item_schema.fields` node satisfies the requirement that a client
+with no repository or fixture access can author a valid manifest from `describe` alone
+"without any guessed field name" — while leaving the pinned tool schemas byte-identical.
+
+## Risks / Trade-offs
+
+- [A future reader "simplifies" the fence into `_parse_schema`] -> Decision 2 above,
+  plus an anti-regression test asserting a grandfathered collection remains a recall
+  candidate. That test is the guardrail; it must not be removed as unrelated.
+- [The `type: collection` branch looks like scope creep and gets cut] -> Without it the
+  Records fence is decorative. If scope must be cut, cut the contract disclosure first.
+- [Error-ordering change breaks a test asserting the immutability code on an input that
+  violates both] -> Run the record lifecycle and mutation-matrix suites deliberately.
+- [Revising a grandfathered collection's unrelated fields is blocked until cleanup] ->
+  Accepted. Rebaseline stays open so nothing is stuck, and the audit finding states the
+  ordered remedy. The alternative — fencing only the delta of fields added versus the
+  current schema — is more code and more state, and it lets a grandfathered field
+  survive an explicit re-authoring of the contract.
+- [Grandfathering tests must plant a manifest on disk directly, because a governed
+  create refuses it after this change] -> Unavoidable and correct. The test docstrings
+  say so, so nobody converts them into governed calls and silently guts the coverage.

--- a/openspec/changes/close-confidence-exclusion-bypass/proposal.md
+++ b/openspec/changes/close-confidence-exclusion-bypass/proposal.md
@@ -1,0 +1,97 @@
+# Close the confidence-exclusion bypass
+
+## Why
+
+Exomem's substrate constraint is stated flatly in `openspec/config.yaml`: "No
+confidence/authority floats on notes." The enforcement primitive exists —
+`vault.EXCLUDED_FRONTMATTER_FIELDS` (`confidence`, `decay_at`, `expires_at`) plus
+`excluded_frontmatter_reason()` — but only two call sites consult it: `create_file`'s
+`frontmatter` dict parameter and `set_frontmatter_field`. The documented stance is
+therefore enforced at two of N governed write surfaces.
+
+Three authored-input paths accept an excluded field today:
+
+1. `manage_memory_file` with `frontmatter` omitted writes `content` verbatim, embedded
+   YAML included. `create_file`'s docstring advertises this ("the caller is responsible
+   for any frontmatter already in it") and never mentions excluded fields.
+2. The same path with `overwrite=true` on an existing Markdown file, which skips even
+   the compiled-type frontmatter parse.
+3. A collection manifest — Records or Planning — may declare `confidence` in
+   `item_schema.fields` or as the Markdown-log note field. Manifest text is written
+   byte-for-byte and unknown keys are silently preserved. Worse, a manifest can be
+   hand-authored straight through `manage_memory_file`, so a Records-side fence alone
+   would be decorative.
+
+Item writes are already fenced by `SCHEMA_UNKNOWN_FIELD`, so an item cannot introduce
+an excluded key unless a manifest declared it first. Manifest authoring is the root
+cause; the renderers are not.
+
+The audit that surfaced this graded it minor because "agents follow the docstrings."
+That premise does not hold: the pinned MCP tool surface contains zero occurrences of
+`confidence`, `decay`, or `EXCLUDED_FIELD`. The rule lives only in scaffold files an
+agent reads if it loads the skill. The fence should close before the epistemic
+primitives arrive and third-party agents start writing confidence numbers into
+hypothesis and prediction units.
+
+## What Changes
+
+- Add a shared `EXCLUDED_FIELD_CODE` constant and a pure `first_excluded_field(names)`
+  helper beside the existing frozenset, and replace the two bare `"EXCLUDED_FIELD"`
+  literals with the constant.
+- Refuse an excluded field on every **authored-input** surface: `create_file`'s
+  assembled text for any Markdown write (covering the raw-`content` and `overwrite`
+  paths, and `item_schema.fields` when the frontmatter declares `type: collection`),
+  Records and Planning manifest create and revise, and the caller-supplied `item` and
+  `changes` mappings on record append and update.
+- Disclose the excluded names through the manifest authoring contract so
+  `record_memory(action="describe")` tells a client before it authors an invalid
+  manifest.
+- Surface pre-existing violations as `warn`-severity `frontmatter_compliance` audit
+  findings carrying the ordered remediation, never as blocking findings.
+
+**Explicitly not changed** — each is a read path, and refusing there would make a
+grandfathered collection silently vanish from recall (`CollectionError` subclasses
+`ValueError`, which the recall-candidacy check swallows into `False`) and would break
+the very revise that repairs it: `_parse_schema`, `_manifest_from_frontmatter`,
+`load_manifest`, `parse_manifest_bytes`, `validate_storage_contract`,
+`_validate_values`. `delete_fields` is never fenced, and `rebaseline_collection`
+reaches neither manifest fence, so the repair path stays open.
+
+**Non-goals.** No tool-docstring edits: they would move the pinned MCP schema baseline
+and the packaged discovery fingerprint, whose ChatGPT Personal Plugin attestation is
+release-blocking until that external consumer is refreshed. That is a separate change.
+The `auto_*` prefix rule documented in the scaffold is also out of scope: a prefix
+predicate is a different rule shape with different blast radius on foreign vault
+frontmatter. No change to the excluded set's membership.
+
+## Capabilities
+
+### New Capabilities
+
+- `schema-field-exclusion`: Governed writes refuse schema-excluded frontmatter field
+  names on authored input, while existing artifacts stay readable and repairable and
+  their violations surface for review.
+
+### Modified Capabilities
+
+- `structured-collections`: Item schemas are open-vocabulary except for the
+  schema-excluded set, and uncertainty may not be expressed as a numeric confidence
+  field.
+
+## Impact
+
+Additive refusal on authored input only; no data migration exists and none is needed.
+Verified: zero collections in the repository declare an excluded field, and the four
+`_collection.md` fixtures are clean. A grandfathered collection in a user vault stays
+loadable, queryable, rebaselineable, and repairable — its items can still be cleaned
+with `delete_fields`, after which the manifest can be revised. The one accepted cost
+is that revising such a collection's other fields is blocked until the excluded field
+is removed; rebaseline remains open, so nothing is stuck.
+
+Pure-substrate justification: no model runs on any path this change touches. The check
+is a casefolded membership test against a frozen set of three names, and the audit
+finding it feeds is a deterministic string comparison over already-parsed frontmatter.
+
+The pinned MCP tool surface does not move. `tests/fixtures/mcp_tool_schemas.json` and
+`src/exomem/tool_surface_contract.json` must both be byte-identical after this change;
+the manifest authoring contract is runtime response data, not pinned schema.

--- a/openspec/changes/close-confidence-exclusion-bypass/specs/schema-field-exclusion/spec.md
+++ b/openspec/changes/close-confidence-exclusion-bypass/specs/schema-field-exclusion/spec.md
@@ -1,0 +1,91 @@
+# schema-field-exclusion — delta
+
+## ADDED Requirements
+
+### Requirement: Governed writes refuse schema-excluded frontmatter fields
+
+Exomem SHALL maintain one registry of schema-excluded frontmatter field names and one
+refusal code for them. Every governed write path that accepts caller-authored
+frontmatter — a frontmatter mapping, a whole file body, a collection manifest, or a
+structured item payload — SHALL consult that registry and refuse before any bytes are
+published. The comparison SHALL normalize case and surrounding whitespace. The refusal
+SHALL name the offending field and state why the schema excludes it.
+
+#### Scenario: A file body carrying an excluded field refuses
+
+- **WHEN** a caller writes a Markdown file through the file-management surface with the
+  frontmatter embedded in the body rather than supplied as a mapping
+- **THEN** the write refuses with the shared excluded-field code and no bytes are
+  published, whether the target is a new file or an overwrite of an existing one
+
+#### Scenario: A collection manifest declaring an excluded field refuses
+
+- **WHEN** a Records or Planning manifest declares a schema-excluded name in its item
+  schema fields or as its Markdown-log note field, whether authored through the
+  collection surface or hand-authored through the file-management surface
+- **THEN** collection create and revise refuse with the shared excluded-field code, the
+  refusal carries the offending field name, and the on-disk manifest is unchanged
+
+#### Scenario: A structured item payload carrying an excluded field refuses
+
+- **WHEN** a caller appends or updates a collection item whose supplied values carry a
+  schema-excluded key
+- **THEN** the write refuses before the writer lease is taken, and Planning add, update,
+  and triage inherit the same refusal because they share the substrate
+
+#### Scenario: The refusal is discoverable before authoring
+
+- **WHEN** a client with no repository, skill, or fixture access requests the manifest
+  authoring contract
+- **THEN** the contract discloses the excluded field names, so the client never has to
+  guess one to learn it is forbidden
+
+### Requirement: Existing artifacts stay readable and repairable
+
+The exclusion SHALL apply to caller-authored input only, never to stored state. Reading,
+resolving, discovering, querying, and recall-candidacy evaluation SHALL be unaffected by
+the presence of an excluded field in an artifact written before this contract. The
+substrate SHALL retain a path to remove such a field.
+
+#### Scenario: A pre-existing collection stays available
+
+- **WHEN** a collection whose manifest declares an excluded field is loaded, resolved,
+  discovered, queried, or evaluated for recall candidacy
+- **THEN** every one of those operations behaves exactly as it did before this contract,
+  and the collection is never silently dropped from recall candidacy
+
+#### Scenario: Removing an excluded field is always permitted
+
+- **WHEN** a caller removes an excluded field from an item through field deletion, or
+  rebaselines a collection carrying one
+- **THEN** the operation is permitted, because deletion and rebaseline are the
+  remediation and refusing them would strand the artifact
+
+#### Scenario: An unrelated edit does not refuse on stored values
+
+- **WHEN** a caller updates an unrelated field of an item that already stores an
+  excluded value
+- **THEN** the update is evaluated against the supplied changes only, so it succeeds and
+  leaves the stored excluded value untouched
+
+### Requirement: Pre-existing violations surface for review, never block
+
+Artifacts carrying an excluded field written before this contract SHALL surface as
+review candidates through the existing frontmatter-compliance audit category at
+non-blocking severity, carrying the ordered remediation. They SHALL NOT produce blocking
+findings and SHALL NOT require a new audit category.
+
+#### Scenario: A grandfathered violation is reported as a review candidate
+
+- **WHEN** the audit runs over a vault containing a page with an excluded top-level
+  frontmatter key, or a collection manifest declaring one in its item schema fields
+- **THEN** each is reported under the existing frontmatter-compliance category at
+  warning severity, no finding for them carries error severity, and the audit category
+  registry is unchanged
+
+#### Scenario: The remediation order is stated
+
+- **WHEN** such a finding is reported for a collection
+- **THEN** its proposed fix states that the field must be deleted from every item before
+  the manifest is revised, because revision validation checks the proposed schema
+  against stored record values

--- a/openspec/changes/close-confidence-exclusion-bypass/specs/structured-collections/spec.md
+++ b/openspec/changes/close-confidence-exclusion-bypass/specs/structured-collections/spec.md
@@ -1,0 +1,22 @@
+# structured-collections — delta
+
+## MODIFIED Requirements
+
+### Requirement: Minimal typed item schemas
+Collection schemas SHALL support required and optional open-vocabulary fields with bounded primitive types, enums, arrays, objects, date or datetime values, units metadata, and link fields, except that a schema SHALL NOT declare a schema-excluded frontmatter field name. The substrate SHALL impose only identity and schema-version mechanics universally; occurred time, status, units, provenance, relations, uncertainty, reconstruction, and lifecycle SHALL be present only when the collection schema makes them meaningful, and uncertainty SHALL NOT be expressed as a numeric confidence field because the schema-excluded set forbids that name.
+
+#### Scenario: Domain fields validate before publication
+- **WHEN** an item violates a required field, type, enum, identifier, or declared unit constraint
+- **THEN** append or update refuses before any canonical file or history entry is published
+
+#### Scenario: Optional schema inference is advisory
+- **WHEN** Exomem infers a candidate schema from existing human-authored items
+- **THEN** it returns a bounded proposal with provenance and does not make that proposal binding or rewrite historical items without explicit adoption
+
+#### Scenario: A schema-excluded field name cannot be declared
+- **WHEN** a manifest declares a schema-excluded name among its item schema fields or as its Markdown-log note field
+- **THEN** collection create and revise refuse before any bytes are published, and the projected manifest authoring contract discloses the excluded names so a client authoring from the contract alone never has to guess one
+
+#### Scenario: A schema declaring one before this contract stays parseable
+- **WHEN** a manifest written before this contract declares a schema-excluded name
+- **THEN** parsing, loading, discovery, resolution, and query continue to behave exactly as before, because the refusal lives at the write entry points and never in the parser

--- a/openspec/changes/close-confidence-exclusion-bypass/tasks.md
+++ b/openspec/changes/close-confidence-exclusion-bypass/tasks.md
@@ -2,126 +2,133 @@
 
 ## 1. Pure-Logic Unit Tests First
 
-- [ ] 1.1 Add `tests/test_schema_field_exclusion.py` covering a new
+- [x] 1.1 Add `tests/test_schema_field_exclusion.py` covering a new
       `vault.first_excluded_field(names)`: it reports the offending name and its
       reason, returns `None` for clean input and for an empty iterable, skips
       non-string names without raising, and honors the existing casefold/strip
       normalization (`Confidence`, `DECAY_AT`, `" expires_at "`). Run RED and record
       the verbatim failures.
-- [ ] 1.2 Assert `vault.EXCLUDED_FIELD_CODE == "EXCLUDED_FIELD"` and that it is the
+- [x] 1.2 Assert `vault.EXCLUDED_FIELD_CODE == "EXCLUDED_FIELD"` and that it is the
       code both `create_file` and `set_frontmatter_field` raise, so a later rename
       cannot silently split the namespace.
-- [ ] 1.3 Add the grandfathering anti-regression tests, which MUST pass both before
+- [x] 1.3 Add the grandfathering anti-regression tests, which MUST pass both before
       and after the fence: a manifest planted on disk declaring `confidence` stays
       loadable and queryable, its items stay readable, and
       `recall_policy.is_recall_candidate` returns True for it. State in the docstring
       that the manifest is planted directly because a governed create refuses it after
       this change. Run GREEN and record the baseline.
-- [ ] 1.4 Add anti-regression tests that the repair path stays open: an item's
+- [x] 1.4 Add anti-regression tests that the repair path stays open: an item's
       excluded field can be removed with `update_record(delete_fields=...)`, the
       manifest can then be revised without it, and `rebaseline_collection` is never
       refused with `EXCLUDED_FIELD`. Run GREEN and record the baseline.
 
 ## 2. Bypass Regression Tests
 
-- [ ] 2.1 `manage_memory_file` raw-content bypass: `create_file` with
+- [x] 2.1 `manage_memory_file` raw-content bypass: `create_file` with
       `frontmatter=None` and an embedded `confidence:` refuses with `EXCLUDED_FIELD`
       and writes no bytes. Run RED.
-- [ ] 2.2 `overwrite=true` bypass: overwriting an existing Markdown note with raw
+- [x] 2.2 `overwrite=true` bypass: overwriting an existing Markdown note with raw
       content carrying `decay_at:` refuses and leaves the prior bytes intact. Run RED.
-- [ ] 2.3 Hand-authored manifest through `manage_memory_file`: a
+- [x] 2.3 Hand-authored manifest through `manage_memory_file`: a
       `Knowledge Base/Records/<name>/_collection.md` declaring `confidence` under
       `item_schema.fields` refuses. Run RED. This is the test that proves the Records
       fence is not decorative.
-- [ ] 2.4 Records manifest authoring: `create_collection`, `validate_collection_create`,
+- [x] 2.4 Records manifest authoring: `create_collection`, `validate_collection_create`,
       `revise_collection`, and `validate_collection_revision` each refuse a manifest
       declaring an excluded name in `item_schema.fields`, and the on-disk manifest is
       unchanged. Run RED.
-- [ ] 2.5 The second declaration surface: a manifest declaring the excluded name as the
+- [x] 2.5 The second declaration surface: a manifest declaring the excluded name as the
       Markdown-log note field refuses on create. Run RED.
-- [ ] 2.6 Planning manifest authoring: `planning.create_collection` refuses the same
+- [x] 2.6 Planning manifest authoring: `planning.create_collection` refuses the same
       manifest, proving both profiles ride one fence. Run RED.
-- [ ] 2.7 Item authoring against a grandfathered collection:
+- [x] 2.7 Item authoring against a grandfathered collection:
       `append_record(item=...)` and `update_record(changes=...)` refuse an excluded
       key, while `update_record(delete_fields=...)` still succeeds. Run RED.
-- [ ] 2.8 `expires_at` coverage across `set_frontmatter_field`,
+- [x] 2.8 `expires_at` coverage across `set_frontmatter_field`,
       `create_file(frontmatter=...)`, `create_file` raw content, and
       `records.create_collection`. Confirm `tests/test_tier2.py` still passes untouched.
 
 ## 3. Shared Exclusion Primitive
 
-- [ ] 3.1 Add `EXCLUDED_FIELD_CODE` and a pure, non-raising
+- [x] 3.1 Add `EXCLUDED_FIELD_CODE` and a pure, non-raising
       `first_excluded_field(names) -> tuple[str, str] | None` to `src/exomem/vault.py`
       beside `EXCLUDED_FRONTMATTER_FIELDS`. Add one comment naming the deferred
       `auto_*` gap and citing the scaffold reference that documents it.
-- [ ] 3.2 Replace the bare `"EXCLUDED_FIELD"` literals in `create_file.py` and
+- [x] 3.2 Replace the bare `"EXCLUDED_FIELD"` literals in `create_file.py` and
       `set_frontmatter_field.py` with the constant; behavior unchanged.
 
 ## 4. Close The Raw-Content And Overwrite Paths
 
-- [ ] 4.1 Guard the assembled file text for every Markdown write in `create_file`,
+- [x] 4.1 Guard the assembled file text for every Markdown write in `create_file`,
       after the text is assembled and before the stable-identity guard, using a
       NON-strict frontmatter parse so no file that writes today begins failing with
       `INVALID_FRONTMATTER`.
-- [ ] 4.2 Extend that guard so that when the parsed frontmatter declares
+- [x] 4.2 Extend that guard so that when the parsed frontmatter declares
       `type: collection`, an excluded name declared under `item_schema.fields` also
-      refuses.
-- [ ] 4.3 Keep the existing `frontmatter` dict guard in place; it refuses before path
+      refuses — and, per independent review, an excluded name declared as the
+      Markdown-log `storage.item_heading.note.field` too. Both surfaces route through
+      one shared `vault.excluded_field_in_collection_frontmatter` helper, so
+      `create_file`, `records`, and the audit cannot drift apart on what counts as a
+      declaration.
+- [x] 4.3 Keep the existing `frontmatter` dict guard in place; it refuses before path
       resolution and an existing test asserts that ordering.
 
 ## 5. Close The Manifest-Authoring Path
 
-- [ ] 5.1 Add a private helper in `records.py` that refuses a parsed manifest
+- [x] 5.1 Add a private helper in `records.py` that refuses a parsed manifest
       declaring an excluded name in `item_schema.fields` or as the Markdown-log note
       field, raising `CollectionError` with the shared code and `details` naming the
       field.
-- [ ] 5.2 Call it from the collection-create preflight immediately after the manifest
+- [x] 5.2 Call it from the collection-create preflight immediately after the manifest
       parse, and from revision validation immediately after its parse and BEFORE the
       immutable-representation check so doctrine outranks representation.
-- [ ] 5.3 Do NOT call it from `_parse_schema`, `_manifest_from_frontmatter`,
+- [x] 5.3 Do NOT call it from `_parse_schema`, `_manifest_from_frontmatter`,
       `load_manifest`, `parse_manifest_bytes`, `validate_storage_contract`, or
       `_validate_values`. Confirm by test that `rebaseline_collection` reaches neither
       fence, so a grandfathered collection keeps its repair path.
 
 ## 6. Close The Item-Authoring Path
 
-- [ ] 6.1 Fence the caller-supplied `item` in `append_record` before collection
+- [x] 6.1 Fence the caller-supplied `item` in `append_record` before collection
       resolution, and the caller-supplied `changes` in `update_record` before the
       writer lease is taken. Never fence `delete_fields`, merged values, or stored
       values.
-- [ ] 6.2 Confirm by test that Planning `add`, `update`, and `triage` inherit the fence
+- [x] 6.2 Confirm by test that Planning `add`, `update`, and `triage` inherit the fence
       with no Planning-side code change.
 
 ## 7. Surface, Do Not Block, Existing Violations
 
-- [ ] 7.1 Extend the audit's frontmatter-compliance check to emit a `warn`-severity
+- [x] 7.1 Extend the audit's frontmatter-compliance check to emit a `warn`-severity
       finding for any page carrying an excluded top-level key, and for any
       `type: collection` page declaring one under `item_schema.fields`. Reuse the
       existing category so the category registry is untouched.
-- [ ] 7.2 Give each finding a proposed fix naming the ordered remediation: delete the
+- [x] 7.2 Give each finding a proposed fix naming the ordered remediation: delete the
       field from every item first, then revise the manifest.
-- [ ] 7.3 Assert no such finding carries `error` severity — review candidate, never
+- [x] 7.3 Assert no such finding carries `error` severity — review candidate, never
       blocking.
 
 ## 8. Agent-Facing Contract
 
-- [ ] 8.1 Disclose the excluded names on the `item_schema.fields` node of the manifest
+- [x] 8.1 Disclose the excluded names on the `item_schema.fields` node of the manifest
       authoring contract so `record_memory(action="describe")` tells a client before it
       authors an invalid manifest, satisfying the describe-alone authoring requirement.
 
 ## 9. Verification
 
-- [ ] 9.1 `openspec validate close-confidence-exclusion-bypass --strict` and
+- [x] 9.1 `openspec validate close-confidence-exclusion-bypass --strict` and
       `openspec validate --specs --strict`.
-- [ ] 9.2 Run the new file plus `tests/test_tier2.py`, `tests/test_record_lifecycle.py`,
+- [x] 9.2 Run the new file plus `tests/test_tier2.py`, `tests/test_record_lifecycle.py`,
       `tests/test_record_mutation.py`, `tests/test_structured_collections.py`,
       `tests/test_planning_mutation.py`, `tests/test_records_recall_policy.py`,
       `tests/test_audit.py`, and `tests/test_record_presentation_contract.py`.
-- [ ] 9.3 Lean suite `uv run python -m pytest -q` and the latency gate
-      `uv run python -m pytest tests/test_latency_gate.py -q` both green;
-      `uvx ruff check .` clean on changed files.
-- [ ] 9.4 `git diff --exit-code tests/fixtures/mcp_tool_schemas.json` and
+- [x] 9.3 Latency gate `uv run python -m pytest tests/test_latency_gate.py -q` green
+      and `uvx ruff check` clean on changed files. The complete lean suite was NOT
+      run to completion locally: a single-process full run takes roughly 100 minutes
+      on this machine and produced an order-dependent failure cluster that also
+      reproduces on pristine `origin/main`, so it is not attributable here. CI runs
+      the lean suite sharded four ways, which is the authoritative result.
+- [x] 9.4 `git diff --exit-code tests/fixtures/mcp_tool_schemas.json` and
       `git diff --exit-code src/exomem/tool_surface_contract.json` both clean — the
       proof no docstring drifted into this change.
-- [ ] 9.5 Independent reviewer pass over the actual diff, focused on read-path
+- [x] 9.5 Independent reviewer pass over the actual diff, focused on read-path
       regressions, grandfathered-collection availability, and the error-ordering change.

--- a/openspec/changes/close-confidence-exclusion-bypass/tasks.md
+++ b/openspec/changes/close-confidence-exclusion-bypass/tasks.md
@@ -1,0 +1,127 @@
+# Tasks — close-confidence-exclusion-bypass
+
+## 1. Pure-Logic Unit Tests First
+
+- [ ] 1.1 Add `tests/test_schema_field_exclusion.py` covering a new
+      `vault.first_excluded_field(names)`: it reports the offending name and its
+      reason, returns `None` for clean input and for an empty iterable, skips
+      non-string names without raising, and honors the existing casefold/strip
+      normalization (`Confidence`, `DECAY_AT`, `" expires_at "`). Run RED and record
+      the verbatim failures.
+- [ ] 1.2 Assert `vault.EXCLUDED_FIELD_CODE == "EXCLUDED_FIELD"` and that it is the
+      code both `create_file` and `set_frontmatter_field` raise, so a later rename
+      cannot silently split the namespace.
+- [ ] 1.3 Add the grandfathering anti-regression tests, which MUST pass both before
+      and after the fence: a manifest planted on disk declaring `confidence` stays
+      loadable and queryable, its items stay readable, and
+      `recall_policy.is_recall_candidate` returns True for it. State in the docstring
+      that the manifest is planted directly because a governed create refuses it after
+      this change. Run GREEN and record the baseline.
+- [ ] 1.4 Add anti-regression tests that the repair path stays open: an item's
+      excluded field can be removed with `update_record(delete_fields=...)`, the
+      manifest can then be revised without it, and `rebaseline_collection` is never
+      refused with `EXCLUDED_FIELD`. Run GREEN and record the baseline.
+
+## 2. Bypass Regression Tests
+
+- [ ] 2.1 `manage_memory_file` raw-content bypass: `create_file` with
+      `frontmatter=None` and an embedded `confidence:` refuses with `EXCLUDED_FIELD`
+      and writes no bytes. Run RED.
+- [ ] 2.2 `overwrite=true` bypass: overwriting an existing Markdown note with raw
+      content carrying `decay_at:` refuses and leaves the prior bytes intact. Run RED.
+- [ ] 2.3 Hand-authored manifest through `manage_memory_file`: a
+      `Knowledge Base/Records/<name>/_collection.md` declaring `confidence` under
+      `item_schema.fields` refuses. Run RED. This is the test that proves the Records
+      fence is not decorative.
+- [ ] 2.4 Records manifest authoring: `create_collection`, `validate_collection_create`,
+      `revise_collection`, and `validate_collection_revision` each refuse a manifest
+      declaring an excluded name in `item_schema.fields`, and the on-disk manifest is
+      unchanged. Run RED.
+- [ ] 2.5 The second declaration surface: a manifest declaring the excluded name as the
+      Markdown-log note field refuses on create. Run RED.
+- [ ] 2.6 Planning manifest authoring: `planning.create_collection` refuses the same
+      manifest, proving both profiles ride one fence. Run RED.
+- [ ] 2.7 Item authoring against a grandfathered collection:
+      `append_record(item=...)` and `update_record(changes=...)` refuse an excluded
+      key, while `update_record(delete_fields=...)` still succeeds. Run RED.
+- [ ] 2.8 `expires_at` coverage across `set_frontmatter_field`,
+      `create_file(frontmatter=...)`, `create_file` raw content, and
+      `records.create_collection`. Confirm `tests/test_tier2.py` still passes untouched.
+
+## 3. Shared Exclusion Primitive
+
+- [ ] 3.1 Add `EXCLUDED_FIELD_CODE` and a pure, non-raising
+      `first_excluded_field(names) -> tuple[str, str] | None` to `src/exomem/vault.py`
+      beside `EXCLUDED_FRONTMATTER_FIELDS`. Add one comment naming the deferred
+      `auto_*` gap and citing the scaffold reference that documents it.
+- [ ] 3.2 Replace the bare `"EXCLUDED_FIELD"` literals in `create_file.py` and
+      `set_frontmatter_field.py` with the constant; behavior unchanged.
+
+## 4. Close The Raw-Content And Overwrite Paths
+
+- [ ] 4.1 Guard the assembled file text for every Markdown write in `create_file`,
+      after the text is assembled and before the stable-identity guard, using a
+      NON-strict frontmatter parse so no file that writes today begins failing with
+      `INVALID_FRONTMATTER`.
+- [ ] 4.2 Extend that guard so that when the parsed frontmatter declares
+      `type: collection`, an excluded name declared under `item_schema.fields` also
+      refuses.
+- [ ] 4.3 Keep the existing `frontmatter` dict guard in place; it refuses before path
+      resolution and an existing test asserts that ordering.
+
+## 5. Close The Manifest-Authoring Path
+
+- [ ] 5.1 Add a private helper in `records.py` that refuses a parsed manifest
+      declaring an excluded name in `item_schema.fields` or as the Markdown-log note
+      field, raising `CollectionError` with the shared code and `details` naming the
+      field.
+- [ ] 5.2 Call it from the collection-create preflight immediately after the manifest
+      parse, and from revision validation immediately after its parse and BEFORE the
+      immutable-representation check so doctrine outranks representation.
+- [ ] 5.3 Do NOT call it from `_parse_schema`, `_manifest_from_frontmatter`,
+      `load_manifest`, `parse_manifest_bytes`, `validate_storage_contract`, or
+      `_validate_values`. Confirm by test that `rebaseline_collection` reaches neither
+      fence, so a grandfathered collection keeps its repair path.
+
+## 6. Close The Item-Authoring Path
+
+- [ ] 6.1 Fence the caller-supplied `item` in `append_record` before collection
+      resolution, and the caller-supplied `changes` in `update_record` before the
+      writer lease is taken. Never fence `delete_fields`, merged values, or stored
+      values.
+- [ ] 6.2 Confirm by test that Planning `add`, `update`, and `triage` inherit the fence
+      with no Planning-side code change.
+
+## 7. Surface, Do Not Block, Existing Violations
+
+- [ ] 7.1 Extend the audit's frontmatter-compliance check to emit a `warn`-severity
+      finding for any page carrying an excluded top-level key, and for any
+      `type: collection` page declaring one under `item_schema.fields`. Reuse the
+      existing category so the category registry is untouched.
+- [ ] 7.2 Give each finding a proposed fix naming the ordered remediation: delete the
+      field from every item first, then revise the manifest.
+- [ ] 7.3 Assert no such finding carries `error` severity — review candidate, never
+      blocking.
+
+## 8. Agent-Facing Contract
+
+- [ ] 8.1 Disclose the excluded names on the `item_schema.fields` node of the manifest
+      authoring contract so `record_memory(action="describe")` tells a client before it
+      authors an invalid manifest, satisfying the describe-alone authoring requirement.
+
+## 9. Verification
+
+- [ ] 9.1 `openspec validate close-confidence-exclusion-bypass --strict` and
+      `openspec validate --specs --strict`.
+- [ ] 9.2 Run the new file plus `tests/test_tier2.py`, `tests/test_record_lifecycle.py`,
+      `tests/test_record_mutation.py`, `tests/test_structured_collections.py`,
+      `tests/test_planning_mutation.py`, `tests/test_records_recall_policy.py`,
+      `tests/test_audit.py`, and `tests/test_record_presentation_contract.py`.
+- [ ] 9.3 Lean suite `uv run python -m pytest -q` and the latency gate
+      `uv run python -m pytest tests/test_latency_gate.py -q` both green;
+      `uvx ruff check .` clean on changed files.
+- [ ] 9.4 `git diff --exit-code tests/fixtures/mcp_tool_schemas.json` and
+      `git diff --exit-code src/exomem/tool_surface_contract.json` both clean — the
+      proof no docstring drifted into this change.
+- [ ] 9.5 Independent reviewer pass over the actual diff, focused on read-path
+      regressions, grandfathered-collection availability, and the error-ordering change.

--- a/src/exomem/audit.py
+++ b/src/exomem/audit.py
@@ -61,6 +61,7 @@ from . import (
     temporal,
 )
 from . import find as find_module
+from . import vault as vault_module
 from .kbdir import kb_dirname, kb_prefix
 from .vault import (
     _mask_code_spans,
@@ -1947,9 +1948,57 @@ def _check_frontmatter_compliance(
     findings: list[AuditFinding] = []
     for page in pages:
         fm = page.frontmatter
+        excluded = vault_module.first_excluded_field(fm)
+        if excluded is not None:
+            field, _reason = excluded
+            findings.append(AuditFinding(
+                category="frontmatter_compliance",
+                severity="warn",
+                path=page.rel_path,
+                detail=f"{field!r} is a schema-excluded frontmatter field.",
+                proposed_fix=f"Remove the {field!r} frontmatter field.",
+            ))
         page_type = fm.get("type")
         if not isinstance(page_type, str):
             continue
+        if page_type == "collection":
+            nested_excluded = vault_module.excluded_field_in_collection_frontmatter(fm)
+            if nested_excluded is not None:
+                field, _reason = nested_excluded
+                item_schema = fm.get("item_schema")
+                schema_fields = (
+                    item_schema.get("fields") if isinstance(item_schema, dict) else None
+                )
+                in_schema = isinstance(schema_fields, dict) and field in schema_fields
+                if in_schema:
+                    detail = (
+                        f"Collection item_schema.fields declares schema-excluded "
+                        f"field {field!r}."
+                    )
+                    proposed_fix = (
+                        f"Delete {field!r} from every item first, then revise the "
+                        "collection manifest to remove the field declaration."
+                    )
+                else:
+                    # The note field lives in the immutable storage descriptor, so
+                    # revise refuses with IMMUTABLE_COLLECTION_REPRESENTATION. The
+                    # only route out is a new collection plus migration.
+                    detail = (
+                        f"Collection Markdown-log note field declares schema-excluded "
+                        f"field {field!r}."
+                    )
+                    proposed_fix = (
+                        f"Delete {field!r} from every item, then migrate to a new "
+                        "collection whose note field uses a permitted name — the "
+                        "storage descriptor is immutable, so revise cannot remove it."
+                    )
+                findings.append(AuditFinding(
+                    category="frontmatter_compliance",
+                    severity="warn",
+                    path=page.rel_path,
+                    detail=detail,
+                    proposed_fix=proposed_fix,
+                ))
         required = _REQUIRED_FIELDS_BY_TYPE.get(page_type)
         if required:
             missing = [k for k in required if not fm.get(k)]

--- a/src/exomem/create_file.py
+++ b/src/exomem/create_file.py
@@ -35,10 +35,11 @@ from . import (
 )
 from . import vault as vault_module
 from .vault import (
+    EXCLUDED_FIELD_CODE,
     PlannedWrite,
     VaultPathError,
     batch_atomic_write,
-    excluded_frontmatter_reason,
+    first_excluded_field,
     in_append_only_tree,
     in_curated_tree,
     kb_root,
@@ -99,10 +100,10 @@ def create_file(
     | semantic_writes.ExistingPreflight
 ):
     if frontmatter:
-        for key in frontmatter:
-            reason = excluded_frontmatter_reason(str(key))
-            if reason is not None:
-                raise CreateFileError(code="EXCLUDED_FIELD", reason=reason)
+        excluded = first_excluded_field(frontmatter)
+        if excluded is not None:
+            _field, reason = excluded
+            raise CreateFileError(code=EXCLUDED_FIELD_CODE, reason=reason)
 
     try:
         abs_path, rel_path = resolve_under_vault(
@@ -227,6 +228,17 @@ def create_file(
         full_text = f"---\n{fm_block}\n---\n{body}"
     else:
         full_text = content
+
+    if is_markdown:
+        parsed_frontmatter, _, _ = vault_module.parse_frontmatter(full_text)
+        excluded = first_excluded_field(parsed_frontmatter)
+        if excluded is None and parsed_frontmatter.get("type") == "collection":
+            excluded = vault_module.excluded_field_in_collection_frontmatter(
+                parsed_frontmatter
+            )
+        if excluded is not None:
+            _field, reason = excluded
+            raise CreateFileError(code=EXCLUDED_FIELD_CODE, reason=reason)
 
     if existing_file and overwrite and is_markdown and existing_text is not None:
         _guard_tier2_stable_identity(existing_text, full_text)

--- a/src/exomem/records.py
+++ b/src/exomem/records.py
@@ -146,6 +146,7 @@ def append_record(
     """Append one structured item, or return a content-identical replay."""
     root = Path(vault_root)
     _validate_why(why)
+    _refuse_excluded_authored_names(item)
     supplied_manifest = record_governance.resolve_collection_for_mutation(root, collection)
     if supplied_manifest.storage.strategy == "dataset":
         record_formats.load_adapter(root, supplied_manifest).refuse_mutation("append")
@@ -349,6 +350,7 @@ def update_record(
         raise collections.CollectionError(
             "INVALID_RECORD_CHANGES", "changes must be a non-empty object"
         )
+    _refuse_excluded_authored_names(changes)
     with writer_lease.active_manager().mutation_guard(root, operation="record_update"):
         manifest, manifest_text, manifest_guard = _load_guarded_manifest(root, collection)
         if refresh_presentation and manifest.record_presentation is None:
@@ -923,6 +925,7 @@ def _validate_revision_manifest(
     if not isinstance(manifest_text, str) or not manifest_text:
         raise collections.CollectionError("INVALID_COLLECTION_MANIFEST", "manifest text is required")
     proposed = collections.parse_manifest_bytes(root, root / current.path, manifest_text.encode("utf-8"))
+    _refuse_excluded_manifest_fields(proposed)
     if proposed.view_diagnostics:
         diagnostic = proposed.view_diagnostics[0]
         raise collections.CollectionError(diagnostic.code, diagnostic.reason)
@@ -1089,6 +1092,7 @@ def _preflight_collection_create(
             "CREATE_ONLY_CONFLICT", "collection manifest already exists"
         )
     manifest = collections.parse_manifest_bytes(root, path, manifest_text.encode("utf-8"))
+    _refuse_excluded_manifest_fields(manifest)
     if manifest.view_diagnostics:
         diagnostic = manifest.view_diagnostics[0]
         raise collections.CollectionError(diagnostic.code, diagnostic.reason)
@@ -2015,6 +2019,33 @@ def _log_note_field(manifest: collections.CollectionManifest) -> str | None:
     note = heading.get("note") if isinstance(heading, Mapping) else None
     field = note.get("field") if isinstance(note, Mapping) else None
     return field if isinstance(field, str) else None
+
+
+def _refuse_excluded_authored_names(names: object) -> None:
+    if not isinstance(names, Mapping):
+        return
+    excluded = vault.first_excluded_field(names)
+    if excluded is None:
+        return
+    field, reason = excluded
+    raise collections.CollectionError(
+        vault.EXCLUDED_FIELD_CODE, reason, details={"field": field}
+    )
+
+
+def _refuse_excluded_manifest_fields(
+    manifest: collections.CollectionManifest,
+) -> None:
+    excluded = vault.first_excluded_field(manifest.schema.fields)
+    note_field = _log_note_field(manifest)
+    if excluded is None and note_field is not None:
+        excluded = vault.first_excluded_field((note_field,))
+    if excluded is None:
+        return
+    field, reason = excluded
+    raise collections.CollectionError(
+        vault.EXCLUDED_FIELD_CODE, reason, details={"field": field}
+    )
 
 
 def _validate_representable(value: Any) -> None:

--- a/src/exomem/set_frontmatter_field.py
+++ b/src/exomem/set_frontmatter_field.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from . import project_keys, semantic_writes, temporal
 from .vault import (
+    EXCLUDED_FIELD_CODE,
     PlannedWrite,
     VaultPathError,
     _format_yaml_line,
@@ -124,7 +125,7 @@ def set_frontmatter_field(
         )
     excluded_reason = excluded_frontmatter_reason(field)
     if excluded_reason is not None:
-        raise SetFrontmatterError(code="EXCLUDED_FIELD", reason=excluded_reason)
+        raise SetFrontmatterError(code=EXCLUDED_FIELD_CODE, reason=excluded_reason)
 
     try:
         abs_path, rel_path = resolve_under_vault(

--- a/src/exomem/structured_collections.py
+++ b/src/exomem/structured_collections.py
@@ -187,6 +187,17 @@ def manifest_authoring_contract() -> dict[str, Any]:
                         "type": "object",
                         "minProperties": 1,
                         "maxProperties": _MAX_SCHEMA_FIELDS,
+                        "propertyNames": {
+                            "not": {"enum": sorted(vault.EXCLUDED_FRONTMATTER_FIELDS)},
+                            "description": (
+                                "Schema-excluded field names are refused on every "
+                                "governed write. Matching ignores case and "
+                                "surrounding whitespace, so 'Confidence' and "
+                                "' expires_at ' are refused too, and the same names "
+                                "are refused as a Markdown-log "
+                                "storage.item_heading.note.field."
+                            ),
+                        },
                         "additionalProperties": {"$ref": "#/$defs/field"},
                     },
                 },

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -88,6 +88,51 @@ APPEND_ONLY_KB_SUBPATHS: tuple[str, ...] = (
 # Governed write paths refuse them so the documented "no confidence floats / no
 # retention decay" stance is actually enforced, not just described.
 EXCLUDED_FRONTMATTER_FIELDS: frozenset[str] = frozenset({"confidence", "decay_at", "expires_at"})
+EXCLUDED_FIELD_CODE = "EXCLUDED_FIELD"
+
+# The broader `auto_*` exclusion documented in
+# `_scaffold/_Schema/references/frontmatter.md` is deliberately deferred: it is
+# a prefix rule with a different compatibility surface from this exact-name set.
+
+
+def first_excluded_field(names: Iterable[object]) -> tuple[str, str] | None:
+    """Return the first excluded string name and its reason, without raising."""
+    for name in names:
+        if not isinstance(name, str):
+            continue
+        reason = excluded_frontmatter_reason(name)
+        if reason is not None:
+            return name, reason
+    return None
+
+
+def excluded_field_in_collection_frontmatter(
+    frontmatter: Mapping[str, Any],
+) -> tuple[str, str] | None:
+    """First excluded name a collection manifest's frontmatter declares, else None.
+
+    A collection declares item field names on two surfaces, and both must be
+    fenced. `item_schema.fields` is the obvious one. The Markdown-log note field
+    under `storage.item_heading.note.field` is the other: `_validate_values`
+    admits that name as a legal item key *outside* the schema, so an excluded
+    name declared there is fully operable. It is also the more dangerous of the
+    two, because it lives in the immutable storage descriptor — revising it away
+    refuses with IMMUTABLE_COLLECTION_REPRESENTATION, so a manifest that slips
+    past this check can never be repaired.
+    """
+    item_schema = frontmatter.get("item_schema")
+    fields = item_schema.get("fields") if isinstance(item_schema, Mapping) else None
+    if isinstance(fields, Mapping):
+        excluded = first_excluded_field(fields)
+        if excluded is not None:
+            return excluded
+    storage = frontmatter.get("storage")
+    if not isinstance(storage, Mapping) or storage.get("strategy") != "markdown-log":
+        return None
+    heading = storage.get("item_heading")
+    note = heading.get("note") if isinstance(heading, Mapping) else None
+    field = note.get("field") if isinstance(note, Mapping) else None
+    return first_excluded_field((field,)) if isinstance(field, str) else None
 
 
 def excluded_frontmatter_reason(field: str) -> str | None:

--- a/tests/test_schema_field_exclusion.py
+++ b/tests/test_schema_field_exclusion.py
@@ -1,0 +1,722 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from exomem import audit as audit_module
+from exomem import create_file as create_file_module
+from exomem import (
+    planning,
+    recall_policy,
+    record_formats,
+    record_governance,
+    records,
+    vault,
+)
+from exomem import set_frontmatter_field as set_frontmatter_field_module
+from exomem import structured_collections as collections
+
+COLLECTION_ID = "12345678-1234-4abc-8def-123456789abc"
+RECORD_ID = "11111111-1111-4111-8111-111111111111"
+SECOND_RECORD_ID = "22222222-2222-4222-8222-222222222222"
+
+
+def _seed_vault(root: Path) -> None:
+    kb = root / "Knowledge Base"
+    kb.mkdir(parents=True, exist_ok=True)
+    (kb / "log.md").write_text("# Activity\n", encoding="utf-8")
+
+
+def _field_block(name: str, *, required: bool = False) -> str:
+    return (
+        f"    {name}:\n"
+        "      type: string\n"
+        + ("      required: true\n" if required else "")
+    )
+
+
+def _records_manifest(
+    *, excluded_field: str | None = None, note_field: str | None = None
+) -> str:
+    storage = (
+        "storage:\n"
+        "  strategy: markdown-log\n"
+        "  source: Records.md\n"
+        "  format_version: 1\n"
+        "  section:\n"
+        "    level: 2\n"
+        "    title: Records\n"
+        "  item_heading:\n"
+        "    level: 3\n"
+        "    fields:\n"
+        "      - name: title\n"
+        "        type: string\n"
+        "    separator: ' · '\n"
+        f"    note:\n      field: {note_field}\n      open: ' ('\n      close: ')'\n"
+        "  insertion: newest-first\n"
+        "  child_rows:\n"
+        "    prefix: '- '\n"
+        "    delimiter: '|'\n"
+        "    fields: [value]\n"
+        "    container_field: entries\n"
+        if note_field is not None
+        else "storage:\n  strategy: markdown-items\n  source: Items\n  format_version: 1\n"
+    )
+    fields = _field_block("title", required=True)
+    if note_field is not None:
+        fields += "    entries:\n      type: array\n      items:\n        type: object\n"
+    if excluded_field is not None:
+        fields += _field_block(excluded_field)
+    return (
+        "---\n"
+        "type: collection\n"
+        f"exomem_id: {COLLECTION_ID}\n"
+        "title: Test records\n"
+        "semantic_profile: records\n"
+        "collection_version: 1\n"
+        "schema_version: 1\n"
+        "lifecycle: active\n"
+        f"{storage}"
+        "item_schema:\n"
+        "  natural_key: [title]\n"
+        "  fields:\n"
+        f"{fields}"
+        "---\n"
+    )
+
+
+def _planning_manifest(*, excluded_field: str | None = None) -> str:
+    fields = "".join(
+        _field_block(name, required=name == "title")
+        for name in (
+            "title",
+            "kind",
+            "status",
+            "lifecycle",
+            "priority",
+            "commitment",
+            "horizon",
+            "health",
+            "area",
+            "parent",
+        )
+    )
+    if excluded_field is not None:
+        fields += _field_block(excluded_field)
+    return (
+        "---\n"
+        "type: collection\n"
+        f"exomem_id: {COLLECTION_ID}\n"
+        "title: Planning work\n"
+        "semantic_profile: planning\n"
+        "collection_version: 1\n"
+        "schema_version: 1\n"
+        "lifecycle: active\n"
+        "storage:\n"
+        "  strategy: markdown-items\n"
+        "  source: Items\n"
+        "  format_version: 1\n"
+        "item_schema:\n"
+        "  natural_key: [title]\n"
+        "  fields:\n"
+        f"{fields}"
+        "---\n"
+    )
+
+
+def _plant_grandfathered_records(root: Path, field: str = "confidence") -> Path:
+    """Plant directly because governed collection creation refuses this after the fence."""
+    _seed_vault(root)
+    directory = root / "Knowledge Base" / "Records" / "Grandfathered"
+    items = directory / "Items"
+    items.mkdir(parents=True)
+    manifest = directory / "_collection.md"
+    manifest.write_text(_records_manifest(excluded_field=field), encoding="utf-8")
+    (items / f"{RECORD_ID}.md").write_text(
+        "---\n"
+        "type: record\n"
+        f"collection_id: {COLLECTION_ID}\n"
+        f"record_id: {RECORD_ID}\n"
+        "schema_version: 1\n"
+        "title: Existing\n"
+        f"{field}: '0.75'\n"
+        "---\n\nGrandfathered item.\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def _plant_grandfathered_planning(root: Path, field: str = "confidence") -> Path:
+    """Plant directly because governed Planning creation refuses this after the fence."""
+    _seed_vault(root)
+    directory = root / "Knowledge Base" / "Planning" / "Grandfathered"
+    items = directory / "Items"
+    items.mkdir(parents=True)
+    manifest = directory / "_collection.md"
+    manifest.write_text(_planning_manifest(excluded_field=field), encoding="utf-8")
+    (items / f"{RECORD_ID}.md").write_text(
+        "---\n"
+        "type: plan\n"
+        f"collection_id: {COLLECTION_ID}\n"
+        f"plan_id: {RECORD_ID}\n"
+        "schema_version: 1\n"
+        "title: Existing\n"
+        "kind: work-item\n"
+        "status: candidate\n"
+        "lifecycle: active\n"
+        "priority: none\n"
+        "commitment: uncommitted\n"
+        "horizon: inbox\n"
+        "health: unknown\n"
+        f"{field}: '0.75'\n"
+        "---\n\nGrandfathered plan.\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def _assert_excluded(
+    error: (
+        create_file_module.CreateFileError
+        | set_frontmatter_field_module.SetFrontmatterError
+        | collections.CollectionError
+    ),
+    field: str,
+) -> None:
+    assert error.code == "EXCLUDED_FIELD"
+    assert field.strip().casefold() in error.reason.casefold()
+
+
+@pytest.mark.parametrize(
+    ("names", "expected"),
+    [
+        (("title", "Confidence", "decay_at"), "Confidence"),
+        ((None, 42, "DECAY_AT"), "DECAY_AT"),
+        (("title", " expires_at "), " expires_at "),
+    ],
+)
+def test_first_excluded_field_returns_original_name_and_reason(
+    names: tuple[object, ...], expected: str
+) -> None:
+    result = vault.first_excluded_field(names)
+
+    assert result is not None
+    assert result == (expected, vault.excluded_frontmatter_reason(expected))
+
+
+@pytest.mark.parametrize("names", [(), (None, 42, object()), ("title", "status")])
+def test_first_excluded_field_returns_none_for_clean_input(names: tuple[object, ...]) -> None:
+    assert vault.first_excluded_field(names) is None
+
+
+def test_shared_error_code_is_used_by_existing_file_surfaces(tmp_path: Path) -> None:
+    assert vault.EXCLUDED_FIELD_CODE == "EXCLUDED_FIELD"
+
+    with pytest.raises(create_file_module.CreateFileError) as create_error:
+        create_file_module.create_file(
+            tmp_path,
+            path="outside-any-valid-root.md",
+            content="body",
+            frontmatter={"Expires_At": "2026-09-01"},
+        )
+    assert create_error.value.code == vault.EXCLUDED_FIELD_CODE
+
+    path = tmp_path / "Knowledge Base" / "Notes" / "note.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("---\ntype: note\n---\nbody\n", encoding="utf-8")
+    with pytest.raises(set_frontmatter_field_module.SetFrontmatterError) as set_error:
+        set_frontmatter_field_module.set_frontmatter_field(
+            tmp_path,
+            path="Knowledge Base/Notes/note.md",
+            field=" expires_at ",
+            value="2026-09-01",
+            why="exercise exclusion",
+        )
+    assert set_error.value.code == vault.EXCLUDED_FIELD_CODE
+
+
+def test_grandfathered_collection_stays_loadable_queryable_and_recallable(tmp_path: Path) -> None:
+    """Plant directly because governed collection creation refuses this after the fence."""
+    path = _plant_grandfathered_records(tmp_path)
+
+    loaded = collections.load_manifest(tmp_path, path)
+    resolved = collections.resolve_collection(tmp_path, path)
+    discovered = collections.discover_collections(tmp_path)
+    queried = record_governance.query_collection(tmp_path, path)
+
+    assert loaded.path == resolved.path
+    assert [manifest.path for manifest in discovered] == [loaded.path]
+    assert queried.rows[0]["confidence"] == "0.75"
+    assert record_formats.load_adapter(tmp_path, loaded).read().records[0].values["confidence"] == "0.75"
+    assert recall_policy.is_recall_candidate(tmp_path, path)
+
+
+def test_delete_then_revise_repairs_a_grandfathered_collection(tmp_path: Path) -> None:
+    path = _plant_grandfathered_records(tmp_path)
+    manifest = collections.load_manifest(tmp_path, path)
+    snapshot = record_formats.load_adapter(tmp_path, manifest).read()
+    record = snapshot.records[0]
+
+    records.update_record(
+        tmp_path,
+        manifest,
+        item_key=record.identity.key,
+        changes={},
+        delete_fields=("confidence",),
+        expected_container_hash=snapshot.snapshot,
+        expected_item_version=record.source.hash,
+        why="remove excluded field",
+    )
+    current = collections.load_manifest(tmp_path, path)
+    current_snapshot = record_formats.load_adapter(tmp_path, current).read()
+    before = path.read_bytes()
+    proposed = path.read_text(encoding="utf-8").replace(
+        "    confidence:\n      type: string\n", ""
+    )
+
+    result = records.revise_collection(
+        tmp_path,
+        current,
+        manifest_text=proposed,
+        expected_manifest_hash=current.manifest_version.hash,
+        expected_container_hash=records.lifecycle_guards(current, current_snapshot)[
+            "expected_container_hash"
+        ],
+        why="remove excluded schema field",
+    )
+
+    assert result["operation"] == "revise"
+    assert path.read_bytes() != before
+    assert "confidence" not in collections.load_manifest(tmp_path, path).schema.fields
+
+
+def test_rebaseline_never_refuses_a_grandfathered_collection_as_excluded(tmp_path: Path) -> None:
+    path = _plant_grandfathered_records(tmp_path)
+    manifest = collections.load_manifest(tmp_path, path)
+    snapshot = record_formats.load_adapter(tmp_path, manifest).read()
+    record = snapshot.records[0]
+    records.update_record(
+        tmp_path,
+        manifest,
+        item_key=record.identity.key,
+        changes={"title": "Still grandfathered"},
+        expected_container_hash=snapshot.snapshot,
+        expected_item_version=record.source.hash,
+        why="make a governed transition",
+    )
+    path.write_text(
+        path.read_text(encoding="utf-8").replace("title: Test records", "title: Direct edit"),
+        encoding="utf-8",
+    )
+    current = collections.load_manifest(tmp_path, path)
+    current_snapshot = record_formats.load_adapter(tmp_path, current).read()
+    gap = records.inspect_audit_gap(tmp_path, current)
+
+    try:
+        result = records.rebaseline_collection(
+            tmp_path,
+            current,
+            expected_manifest_hash=current.manifest_version.hash,
+            expected_container_hash=records.lifecycle_guards(current, current_snapshot)[
+                "expected_container_hash"
+            ],
+            acknowledged_gap_codes=tuple(gap["gaps"]),
+            why="acknowledge direct edit",
+        )
+    except collections.CollectionError as error:
+        assert error.code != "EXCLUDED_FIELD"
+        raise
+
+    assert result["operation"] == "rebaseline"
+
+
+def test_unrelated_update_ignores_stored_excluded_value(tmp_path: Path) -> None:
+    path = _plant_grandfathered_records(tmp_path)
+    manifest = collections.load_manifest(tmp_path, path)
+    snapshot = record_formats.load_adapter(tmp_path, manifest).read()
+    record = snapshot.records[0]
+
+    result = records.update_record(
+        tmp_path,
+        manifest,
+        item_key=record.identity.key,
+        changes={"title": "Unrelated change"},
+        expected_container_hash=snapshot.snapshot,
+        expected_item_version=record.source.hash,
+        why="change an unrelated field",
+    )
+
+    assert result["operation"] == "update"
+    current = record_formats.load_adapter(
+        tmp_path, collections.load_manifest(tmp_path, path)
+    ).read().records[0]
+    assert current.values["confidence"] == "0.75"
+
+
+@pytest.mark.parametrize("field", ["confidence", "DECAY_AT", "Expires_At"])
+def test_create_file_raw_markdown_refuses_excluded_frontmatter(
+    tmp_path: Path, field: str
+) -> None:
+    _seed_vault(tmp_path)
+    target = tmp_path / "Knowledge Base" / "Notes" / "raw.md"
+    with pytest.raises(create_file_module.CreateFileError) as raised:
+        create_file_module.create_file(
+            tmp_path,
+            path="Knowledge Base/Notes/raw.md",
+            content=f"---\ntype: note\n{field}: value\n---\nbody\n",
+        )
+
+    _assert_excluded(raised.value, field)
+    assert not target.exists()
+
+
+def test_create_file_overwrite_refuses_excluded_frontmatter_without_changing_bytes(
+    tmp_path: Path,
+) -> None:
+    _seed_vault(tmp_path)
+    target = tmp_path / "Knowledge Base" / "Notes" / "existing.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("---\ntype: note\n---\noriginal\n", encoding="utf-8")
+    before = target.read_bytes()
+
+    with pytest.raises(create_file_module.CreateFileError) as raised:
+        create_file_module.create_file(
+            tmp_path,
+            path="Knowledge Base/Notes/existing.md",
+            content="---\ntype: note\ndecay_at: 2026-09-01\n---\nreplacement\n",
+            overwrite=True,
+        )
+
+    _assert_excluded(raised.value, "decay_at")
+    assert target.read_bytes() == before
+
+
+def test_create_file_refuses_hand_authored_collection_schema(tmp_path: Path) -> None:
+    _seed_vault(tmp_path)
+    relative = "Knowledge Base/Records/Hand Authored/_collection.md"
+
+    with pytest.raises(create_file_module.CreateFileError) as raised:
+        create_file_module.create_file(
+            tmp_path,
+            path=relative,
+            content=_records_manifest(excluded_field="Confidence"),
+        )
+
+    _assert_excluded(raised.value, "Confidence")
+    assert not (tmp_path / relative).exists()
+
+
+@pytest.mark.parametrize("operation", ["create", "validate_create"])
+@pytest.mark.parametrize("field", ["confidence", "DECAY_AT", "Expires_At"])
+def test_records_collection_create_surfaces_refuse_excluded_schema_field(
+    tmp_path: Path, operation: str, field: str
+) -> None:
+    _seed_vault(tmp_path)
+    relative = "Knowledge Base/Records/New/_collection.md"
+    manifest = _records_manifest(excluded_field=field)
+
+    with pytest.raises(collections.CollectionError) as raised:
+        if operation == "create":
+            records.create_collection(tmp_path, relative, manifest, why="create records")
+        else:
+            records.validate_collection_create(tmp_path, relative, manifest)
+
+    _assert_excluded(raised.value, field)
+    assert raised.value.details["field"] == field
+    assert not (tmp_path / relative).exists()
+
+
+@pytest.mark.parametrize("operation", ["revise", "validate_revision"])
+def test_records_collection_revision_surfaces_refuse_before_representation_check(
+    tmp_path: Path, operation: str
+) -> None:
+    _seed_vault(tmp_path)
+    relative = "Knowledge Base/Records/New/_collection.md"
+    records.create_collection(
+        tmp_path, relative, _records_manifest(), why="create clean records"
+    )
+    current = collections.load_manifest(tmp_path, relative)
+    snapshot = record_formats.load_adapter(tmp_path, current).read()
+    before = (tmp_path / relative).read_bytes()
+    proposed = _records_manifest(excluded_field="confidence").replace(
+        "source: Items", "source: OtherItems"
+    )
+
+    with pytest.raises(collections.CollectionError) as raised:
+        if operation == "revise":
+            records.revise_collection(
+                tmp_path,
+                current,
+                manifest_text=proposed,
+                expected_manifest_hash=current.manifest_version.hash,
+                expected_container_hash=records.lifecycle_guards(current, snapshot)[
+                    "expected_container_hash"
+                ],
+                why="try excluded revision",
+            )
+        else:
+            records.validate_collection_revision(tmp_path, current, proposed)
+
+    _assert_excluded(raised.value, "confidence")
+    assert raised.value.details["field"] == "confidence"
+    assert (tmp_path / relative).read_bytes() == before
+
+
+def test_markdown_log_note_field_cannot_use_an_excluded_name(tmp_path: Path) -> None:
+    _seed_vault(tmp_path)
+    relative = "Knowledge Base/Records/Log/_collection.md"
+
+    with pytest.raises(collections.CollectionError) as raised:
+        records.create_collection(
+            tmp_path,
+            relative,
+            _records_manifest(note_field="Expires_At"),
+            why="create log collection",
+        )
+
+    _assert_excluded(raised.value, "Expires_At")
+    assert raised.value.details["field"] == "Expires_At"
+    assert not (tmp_path / relative).exists()
+
+
+def test_planning_collection_create_refuses_excluded_schema_field(tmp_path: Path) -> None:
+    _seed_vault(tmp_path)
+    relative = "Knowledge Base/Planning/Work/_collection.md"
+
+    with pytest.raises(collections.CollectionError) as raised:
+        planning.create_collection(
+            tmp_path,
+            relative,
+            _planning_manifest(excluded_field="Expires_At"),
+            why="create planning collection",
+        )
+
+    _assert_excluded(raised.value, "Expires_At")
+    assert not (tmp_path / relative).exists()
+
+
+@pytest.mark.parametrize("operation", ["append", "update"])
+def test_record_item_authored_values_refuse_against_grandfathered_schema(
+    tmp_path: Path, operation: str
+) -> None:
+    path = _plant_grandfathered_records(tmp_path, "Expires_At")
+    manifest = collections.load_manifest(tmp_path, path)
+    snapshot = record_formats.load_adapter(tmp_path, manifest).read()
+
+    with pytest.raises(collections.CollectionError) as raised:
+        if operation == "append":
+            records.append_record(
+                tmp_path,
+                manifest,
+                item={"title": "New", "Expires_At": "2026-09-01"},
+                item_key=SECOND_RECORD_ID,
+                expected_container_hash=snapshot.snapshot,
+                why="append excluded value",
+            )
+        else:
+            existing = snapshot.records[0]
+            records.update_record(
+                tmp_path,
+                manifest,
+                item_key=existing.identity.key,
+                changes={"Expires_At": "2026-09-01"},
+                expected_container_hash=snapshot.snapshot,
+                expected_item_version=existing.source.hash,
+                why="update excluded value",
+            )
+
+    _assert_excluded(raised.value, "Expires_At")
+    assert raised.value.details["field"] == "Expires_At"
+
+
+def test_append_refuses_excluded_item_before_collection_resolution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_resolution(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("collection resolution ran before the exclusion fence")
+
+    monkeypatch.setattr(
+        records.record_governance, "resolve_collection_for_mutation", fail_resolution
+    )
+
+    with pytest.raises(collections.CollectionError) as raised:
+        records.append_record(
+            tmp_path,
+            "missing",
+            item={"confidence": 0.5},
+            why="exercise ordering",
+        )
+
+    _assert_excluded(raised.value, "confidence")
+
+
+def test_update_refuses_excluded_changes_before_writer_lease(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_manager() -> object:
+        raise AssertionError("writer lease was requested before the exclusion fence")
+
+    monkeypatch.setattr(records.writer_lease, "active_manager", fail_manager)
+
+    with pytest.raises(collections.CollectionError) as raised:
+        records.update_record(
+            tmp_path,
+            "missing",
+            item_key=RECORD_ID,
+            changes={"DECAY_AT": "2026-09-01"},
+            expected_container_hash="0" * 64,
+            expected_item_version="0" * 64,
+            why="exercise ordering",
+        )
+
+    _assert_excluded(raised.value, "DECAY_AT")
+
+
+@pytest.mark.parametrize("operation", ["add", "update"])
+def test_planning_authored_values_inherit_the_shared_exclusion_fence(
+    tmp_path: Path, operation: str
+) -> None:
+    path = _plant_grandfathered_planning(tmp_path)
+    manifest = collections.load_manifest(tmp_path, path)
+    snapshot = record_formats.load_adapter(tmp_path, manifest).read()
+
+    with pytest.raises(collections.CollectionError) as raised:
+        if operation == "add":
+            planning.add(
+                tmp_path,
+                manifest,
+                item={"title": "New", "confidence": "0.5"},
+                plan_id=SECOND_RECORD_ID,
+                expected_container_hash=snapshot.snapshot,
+                why="add excluded planning value",
+            )
+        else:
+            record = snapshot.records[0]
+            planning.update(
+                tmp_path,
+                manifest,
+                plan_id=record.identity.key,
+                changes={"confidence": "0.5"},
+                expected_container_hash=snapshot.snapshot,
+                expected_item_version=record.source.hash,
+                why="update excluded planning value",
+            )
+
+    _assert_excluded(raised.value, "confidence")
+
+
+def test_planning_triage_ignores_a_grandfathered_stored_excluded_value(
+    tmp_path: Path,
+) -> None:
+    path = _plant_grandfathered_planning(tmp_path)
+    manifest = collections.load_manifest(tmp_path, path)
+    snapshot = record_formats.load_adapter(tmp_path, manifest).read()
+    record = snapshot.records[0]
+
+    result = planning.triage(
+        tmp_path,
+        manifest,
+        plan_id=record.identity.key,
+        transition={
+            "status": "planned",
+            "commitment": "considering",
+            "horizon": "quarter",
+        },
+        expected_container_hash=snapshot.snapshot,
+        expected_item_version=record.source.hash,
+        why="triage grandfathered plan",
+    )
+
+    assert result["operation"] == "triage"
+
+
+def test_audit_warns_for_top_level_and_collection_schema_violations(tmp_path: Path) -> None:
+    _seed_vault(tmp_path)
+    note = tmp_path / "Knowledge Base" / "Notes" / "Insights" / "old.md"
+    note.parent.mkdir(parents=True)
+    note.write_text(
+        "---\ntype: insight\nstatus: active\ncreated: 2026-01-01\n"
+        "updated: 2026-01-01\nconfidence: 0.5\n---\nbody\n",
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "Knowledge Base" / "Records" / "Old" / "_collection.md"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(_records_manifest(excluded_field="Expires_At"), encoding="utf-8")
+
+    report = audit_module.audit(tmp_path, categories=["frontmatter_compliance"])
+    matches = [
+        finding
+        for finding in report.findings
+        if finding.path in {
+            note.relative_to(tmp_path).as_posix(),
+            manifest.relative_to(tmp_path).as_posix(),
+        }
+        and "schema-excluded" in finding.detail
+    ]
+
+    assert len(matches) == 2, [finding.as_dict() for finding in report.findings]
+    assert {finding.severity for finding in matches} == {"warn"}
+    collection_finding = next(finding for finding in matches if finding.path == manifest.relative_to(tmp_path).as_posix())
+    assert "delete" in collection_finding.proposed_fix.lower()
+    assert "every item" in collection_finding.proposed_fix.lower()
+    assert collection_finding.proposed_fix.lower().index("delete") < collection_finding.proposed_fix.lower().index("revise")
+
+
+def test_manifest_authoring_contract_discloses_excluded_field_names() -> None:
+    fields = collections.manifest_authoring_contract()["json_schema"]["properties"][
+        "item_schema"
+    ]["properties"]["fields"]
+
+    property_names = fields["propertyNames"]
+    assert property_names["not"]["enum"] == sorted(vault.EXCLUDED_FRONTMATTER_FIELDS)
+
+    # The enum matches literally, but enforcement casefolds and strips. A client
+    # authoring from `describe` alone must learn that from the contract rather
+    # than by being refused at runtime, so the description carries it.
+    description = property_names["description"].casefold()
+    assert "case" in description
+    assert "whitespace" in description
+    # The second declaration surface is enforced but not modelled in the storage
+    # node, so the contract must name it here or it stays undiscoverable.
+    assert "note" in description
+
+
+def test_create_file_refuses_hand_authored_markdown_log_note_field(tmp_path: Path) -> None:
+    """The note field is a second declaration surface, and an immutable one.
+
+    A name declared under `storage.item_heading.note.field` becomes a legal item
+    key outside `item_schema.fields`. Because it lives in the storage descriptor,
+    revising it away refuses with IMMUTABLE_COLLECTION_REPRESENTATION, so a write
+    that slips past this fence can never be repaired.
+    """
+    _seed_vault(tmp_path)
+    relative = "Knowledge Base/Records/Hand Authored Log/_collection.md"
+
+    with pytest.raises(create_file_module.CreateFileError) as raised:
+        create_file_module.create_file(
+            tmp_path,
+            path=relative,
+            content=_records_manifest(note_field="confidence"),
+        )
+
+    _assert_excluded(raised.value, "confidence")
+    assert not (tmp_path / relative).exists()
+
+
+def test_audit_warns_for_markdown_log_note_field_violation(tmp_path: Path) -> None:
+    _seed_vault(tmp_path)
+    manifest = tmp_path / "Knowledge Base" / "Records" / "OldLog" / "_collection.md"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(_records_manifest(note_field="confidence"), encoding="utf-8")
+
+    report = audit_module.audit(tmp_path, categories=["frontmatter_compliance"])
+    matches = [
+        finding
+        for finding in report.findings
+        if finding.path == manifest.relative_to(tmp_path).as_posix()
+        and "schema-excluded" in finding.detail
+    ]
+
+    assert len(matches) == 1, [finding.as_dict() for finding in report.findings]
+    assert matches[0].severity == "warn"


### PR DESCRIPTION
Programme change 2 of 12 from the 2026-08-14 whole-system epistemic architecture audit (§13, Tier 1). Depends on nothing; `add-epistemic-loop-primitives` remains blocked on the acknowledgment for #501.

## Why

`openspec/config.yaml` states the constraint flatly: "No confidence/authority floats on notes." The primitive to enforce it exists — `vault.EXCLUDED_FRONTMATTER_FIELDS` plus `excluded_frontmatter_reason` — but only two call sites consulted it, so the documented stance was enforced at two of N governed write surfaces.

The audit graded this minor because "agents follow the docstrings." That premise does not hold: the pinned MCP tool surface contains zero occurrences of `confidence`, `decay`, or `EXCLUDED_FIELD`, and `op_create_file`'s docstring advertises the hole it now closes without naming the rule.

## What changed

Refuse an excluded field on every **authored-input** surface:

- `create_file`'s assembled text for any Markdown write — closing the raw-`content` path and the `overwrite=true` path, plus collection manifests hand-authored through `manage_memory_file`.
- Records and Planning manifest create and revise, covering both declaration surfaces: `item_schema.fields` and the Markdown-log `storage.item_heading.note.field`.
- The caller-supplied `item` on append and `changes` on update.
- `manifest_authoring_contract()` now discloses the excluded names, so `record_memory(action="describe")` tells a client before it authors an invalid manifest.
- Pre-existing violations surface as `warn` findings under the existing `frontmatter_compliance` category, carrying a remediation that differs per surface.

## The load-bearing design decision

**The fence is write-time only.** The manifest parser looks like the ideal choke point and is the one place it must never go: `_parse_schema` is reached by `load_manifest`, `parse_manifest_bytes`, discovery, every mutation preflight, and `recall_policy.is_recall_candidate`. `CollectionError` subclasses `ValueError`, and that recall check catches `ValueError` and returns `False` — so a refusal there would drop a grandfathered collection out of recall **silently**, with no error, no finding and no log, while simultaneously breaking the `revise` that would repair it.

Consequently: `delete_fields` is never fenced, `update_record` fences `changes` and never merged or stored values, and `rebaseline_collection` reaches neither manifest fence. Every existing artifact stays readable, queryable, rebaselineable and repairable.

Four anti-regression tests pass **before and after** and exist to catch anyone later "simplifying" the fence into the parser — most importantly one asserting a grandfathered collection remains a recall candidate.

## Independent review

A fresh zero-context reviewer over the actual diff returned **APPROVE, 0 blocking**, verifying every invariant against the files. It raised one major finding, now fixed in this branch: `create_file` originally checked only `item_schema.fields`, leaving the Markdown-log note field unfenced on the `manage_memory_file` path — invisible to audit and **unrepairable**, since that field lives in the immutable storage descriptor and revising it away refuses with `IMMUTABLE_COLLECTION_REPRESENTATION`. Both surfaces now route through one shared helper so the three call sites cannot drift.

## Non-goals

No tool-docstring edits. Those would move `tests/fixtures/mcp_tool_schemas.json` and `src/exomem/tool_surface_contract.json`, and `scripts/dump-tool-schemas.py` makes a changed ChatGPT Personal Plugin attestation release-blocking until that external consumer is refreshed. Both files are verified byte-identical here; the documentation half is filed as a follow-up. The `auto_*` prefix rule is likewise deferred — a prefix predicate has a different blast radius on foreign vault frontmatter.

## Verification

- `openspec validate close-confidence-exclusion-bypass --strict` and `openspec validate --specs --strict` pass.
- 37 tests in the new `tests/test_schema_field_exclusion.py`; 219 passing across the mutation, records, planning, structured-collections, audit and tier-2 suites after rebase onto `c708d66b`.
- 232 passing across the adjacent contract gates, including `test_mcp_schema_fidelity.py` and `test_tool_surface_contract.py`.
- Latency gate green. `ruff` clean on changed files.
- `tests/golden/`, `.github/`, `tests/test_latency_gate.py`, `tests/test_retrieval_golden.py` untouched.

The complete lean suite was not run to completion locally — a single-process run takes ~100 minutes on this machine and produces an order-dependent failure cluster that **also reproduces on pristine `origin/main`**, so it is not attributable to this change. CI's four-way sharded run is the authoritative result.
