### PR TITLE
feat(planning): link plans to their motivating knowledge

### DIFF
--- a/openspec/changes/link-planning-motivation/.openspec.yaml
+++ b/openspec/changes/link-planning-motivation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/link-planning-motivation/design.md
+++ b/openspec/changes/link-planning-motivation/design.md
@@ -1,0 +1,120 @@
+## Context
+
+Exomem's epistemic architecture audit (2026-08-14, §13, Tier 2 item 6) named
+Planning as epistemically orphaned: `src/exomem/planning.py` already models
+areas, outcomes, initiatives, and work items with rich lifecycle/hierarchy
+semantics and two existing reference-bearing optional fields —
+`progress_evidence` (bounded list of `{collection, role, view}` descriptors
+pointing at Records) and `execution` (bounded list of `{kind, ref, label?}`
+pointers to external systems) — but nothing connects a plan to the *belief*
+that justifies its existence. When a Note is superseded, nothing in the
+system can answer "which plans were premised on this."
+
+`memory_refs.py` already defines the stable `exomem://memory/<uuid>` reference
+namespace used throughout the rest of the product (Records' `progress_evidence`
+validates its `collection` field the same way: `memory_refs.parse_memory_ref(...)
+is None` refuses malformed values). `motivation` reuses that exact primitive
+rather than inventing a new reference shape.
+
+Planning items are already structurally outside recall and the graph — not by
+per-field convention but by path: `recall_policy.is_structured_only_path`
+excludes every raw Planning item, and `index_sync` only ever pushes the
+collection *manifest* into the lexical/vector/graph indexers, never a raw
+item file (`tests/test_planning_recall.py` locks this down at 1,000-item
+scale). `motivation` lives inside a raw item's frontmatter, so it inherits
+that exclusion for free — no new enforcement point is required to keep plans
+out of recall.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let a Planning item declare which memory (Notes, Entities, Evidence — any
+  `exomem://memory/...`-addressable page) motivated it, with the same shape
+  discipline as `progress_evidence`: bounded list, validated ref format,
+  refused when malformed, optional and defaultless.
+- Let a `plan_memory query` caller select the plans premised on a given piece
+  of knowledge, so a superseded belief's dependent plans become discoverable.
+- Keep the change purely additive: no existing Planning item, manifest, or
+  caller is invalidated by this field's absence.
+
+**Non-Goals:**
+
+- Planning items do not enter recall or the relation graph through this
+  field. `motivation` is a reference from plan to knowledge, never the
+  reverse — it must not create a graph edge and must not make a plan appear
+  as a memory hit anywhere recall is evaluated.
+- No resolution, existence-checking, or dereferencing of the referenced
+  memory. Exactly like `progress_evidence`'s `collection` ref, `motivation`
+  entries are validated for shape only; a ref to a memory page that does not
+  exist (yet, or ever) is not an error here.
+- No automatic supersession propagation. This change adds the pointer that
+  makes "which plans cite this belief" answerable by query; it does not add
+  the reasoning that walks from a superseded Note to its dependent plans.
+  That consumption is a separate, later concern.
+- No new top-level `plan_memory`/`planning.query()` parameter. See Decision 2.
+
+## Decisions
+
+### 1. Model `motivation` on `progress_evidence`, not as a new pattern
+
+`progress_evidence` is already the precedent for "a bounded list of validated
+references living on a Planning item, refused-not-resolved." `motivation` is
+simpler than `progress_evidence` (a flat list of ref strings, not
+`{collection, role, view}` descriptors) because it needs no role or view —
+just "this belief motivates this plan." Reusing
+`memory_refs.parse_memory_ref` for the per-entry check and the same 16-entry
+bound keeps the validation vocabulary the caller already knows for
+`progress_evidence` and `execution`.
+
+Alternative rejected: a single optional string `motivation_ref` instead of a
+list. A plan is often premised on more than one belief (e.g. a market
+observation Note and a technical feasibility Note together); a bounded list
+matches how `progress_evidence` already handles "more than one, but not
+unbounded."
+
+### 2. The `motivation_ref=` filter is the existing generic `filters` mechanism, not a new parameter
+
+The approved outline names the query filter `motivation_ref=`. Read literally
+as a new top-level keyword argument on `plan_memory`/`planning.query()` (the
+way `lifecycle=` is today), it would add a property to `plan_memory`'s
+introspected input schema — which is what `tests/fixtures/mcp_tool_schemas.json`
+and `src/exomem/tool_surface_contract.json` pin byte-for-byte. Task
+instructions are explicit that moving that pinned surface means stopping and
+reporting rather than regenerating it.
+
+`planning.query()`'s existing generic `filters` list already supports this
+without any signature change: once a collection's manifest declares
+`motivation` as a schema field (exactly as it must already declare
+`progress_evidence` or `execution` to use them), `filters=[{"column":
+"motivation", "op": "contains", "value": "exomem://memory/<uuid>"}]` selects
+every item whose `motivation` list contains that reference, through the same
+`query_data.evaluate_rows` path every other array-valued Planning field
+already uses. This satisfies "the query filter selects the right items"
+without moving the pinned tool surface. See the deviation note in the final
+report.
+
+### 3. No manifest-schema hardcoding in `planning.py`
+
+Like `progress_evidence`, `execution`, and `tags`, `motivation` is validated
+by Planning's own semantic layer (`_validate_optional`) independent of
+whether any given collection's manifest declares it as a schema field. A
+vault author opts a collection into `motivation` by declaring it in that
+collection's `item_schema.fields`, the same way they already opt into
+`progress_evidence`. `require_planning_profile`'s fixed core-field check is
+untouched.
+
+## Risks / Trade-offs
+
+- **[`motivation_ref=` reads as a missing parameter]** → Documented as
+  Decision 2 and called out explicitly as a deviation in the implementation
+  report; the generic-filter path delivers the same selection capability
+  without moving the pinned MCP surface.
+- **[A plan reference smuggled into `motivation` could look like a graph
+  edge]** → `_validate_motivation` only accepts `exomem://memory/...` refs
+  (via `memory_refs.parse_memory_ref`); an `exomem://plan/...` reference is
+  refused the same as any other malformed value, so `motivation` cannot be
+  repurposed as an undeclared `parent`/`area` relation.
+- **[Future consumers assume `motivation` targets are resolved/valid]** →
+  Documented as a non-goal here and mirrors the existing, already-understood
+  `progress_evidence` contract; no new expectation is introduced.

--- a/openspec/changes/link-planning-motivation/proposal.md
+++ b/openspec/changes/link-planning-motivation/proposal.md
@@ -24,10 +24,11 @@ stale beliefs are prevented from doing.
 
 ### New Capabilities
 
-- `planning`: no `openspec/specs/planning/` capability exists yet even though
-  Planning already ships in `src/exomem/planning.py`; this change is the first
-  to formalize any part of that surface as an OpenSpec capability, scoped to
-  the `motivation` field and its query filter.
+- `planning`: no `openspec/specs/planning/` capability exists under
+  `openspec/specs/` yet, so this delta declares a new capability. Note that
+  `add-multi-horizon-planning` also declares `planning` and is complete but
+  unarchived; the two deltas share no requirement names, so archive order is
+  safe. This delta is scoped to the `motivation` field and its query filter.
 
 ### Modified Capabilities
 
@@ -45,4 +46,7 @@ None.
 - New focused tests in `tests/test_planning_motivation.py` covering shape
   validation, round-trip, the query filter, and the relation-graph non-goal.
 - Additive and optional: absence of `motivation` behaves exactly as before
-  this change; no existing Planning item is invalidated.
+  this change. The governed ref-list shape is enforced only where the manifest
+  declares `motivation` as an array, so a vault that had already declared its
+  own `motivation` field of another type keeps reading, querying and mutating
+  exactly as before rather than being refused on every normalized record.

--- a/openspec/changes/link-planning-motivation/proposal.md
+++ b/openspec/changes/link-planning-motivation/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Planning is epistemically orphaned. No field connects a plan to the knowledge
+that motivates it, so "why does this initiative exist" is unanswerable from
+the system, and when a motivating belief is superseded nothing can surface the
+plans premised on it — stale plans survive contrary evidence exactly the way
+stale beliefs are prevented from doing.
+
+## What Changes
+
+- Add an optional `motivation` field to Planning items: a bounded list (≤16)
+  of `exomem://memory/` references, validated the same way `progress_evidence`
+  is validated — shape-checked, ref-format-checked, and refused when
+  malformed, without resolving the target or inferring anything from it.
+- Support filtering Planning queries by a motivating reference through the
+  existing generic `filters` mechanism (`column: motivation`), so `plan_memory`
+  callers can select the plans premised on a given piece of knowledge.
+- Explicit non-goal: Planning items remain outside recall and the graph.
+  `motivation` is a reference from a plan to knowledge, never the reverse; it
+  creates no relation-graph edge and never makes a plan appear as a memory
+  hit. Plans cite knowledge, never the reverse.
+
+## Capabilities
+
+### New Capabilities
+
+- `planning`: no `openspec/specs/planning/` capability exists yet even though
+  Planning already ships in `src/exomem/planning.py`; this change is the first
+  to formalize any part of that surface as an OpenSpec capability, scoped to
+  the `motivation` field and its query filter.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `src/exomem/planning.py`: new `_validate_motivation` shape validator, wired
+  into `_validate_optional`; `motivation` added to `_OPTIONAL` so it can be
+  deleted through `update()` like every other optional field.
+- No change to `src/exomem/plan_memory.py`, `tests/fixtures/mcp_tool_schemas.json`,
+  or `src/exomem/tool_surface_contract.json` — the field rides the existing
+  `item`/`changes` dicts and the existing generic `filters` list, so the
+  pinned MCP tool surface does not move.
+- New focused tests in `tests/test_planning_motivation.py` covering shape
+  validation, round-trip, the query filter, and the relation-graph non-goal.
+- Additive and optional: absence of `motivation` behaves exactly as before
+  this change; no existing Planning item is invalidated.

--- a/openspec/changes/link-planning-motivation/specs/planning/spec.md
+++ b/openspec/changes/link-planning-motivation/specs/planning/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: Planning items may declare motivating knowledge
+
+A Planning item MAY declare an optional `motivation` property: a list of at
+most 16 `exomem://memory/<uuid>` references to the knowledge that motivates
+the item. Each entry SHALL be validated the same way a `progress_evidence`
+collection reference is validated — parsed and refused if malformed — without
+resolving the referenced page or checking that it exists. A non-list value, a
+list of more than 16 entries, or any entry that is not a well-formed
+`exomem://memory/` reference SHALL be refused. Absence of `motivation` SHALL
+behave exactly as before this field existed: no default is applied, and no
+existing Planning item's validity changes because it omits the field. A
+collection MAY accept `motivation` only after declaring it in its manifest
+`item_schema.fields`, the same precondition `progress_evidence` and
+`execution` already require.
+
+#### Scenario: Valid motivation list is accepted and round-trips
+- **WHEN** `add` receives an item with a `motivation` list of one or more
+  well-formed `exomem://memory/` references, on a collection whose manifest
+  declares `motivation`
+- **THEN** the item is captured, the references serialize unchanged into the
+  item's frontmatter, and a subsequent query returns the same list
+
+#### Scenario: More than sixteen motivations is refused
+- **WHEN** an `add` or `update` request supplies a `motivation` list with
+  more than 16 entries
+- **THEN** validation refuses before canonical publication
+
+#### Scenario: Malformed motivation reference is refused
+- **WHEN** a `motivation` entry is not a well-formed `exomem://memory/<uuid>`
+  reference — including an `exomem://plan/...` reference to another Planning
+  item
+- **THEN** validation refuses the same way an invalid `progress_evidence`
+  collection reference is refused
+
+#### Scenario: Non-list motivation is refused
+- **WHEN** `motivation` is supplied as a value other than a list
+- **THEN** validation refuses before it reaches generic schema type-checking
+
+#### Scenario: Absence of motivation behaves exactly as before
+- **WHEN** an item omits `motivation` entirely
+- **THEN** capture, update, triage, and query behave exactly as they did
+  before this field existed, with no key defaulted in
+
+### Requirement: Motivation is queryable and never becomes a relation or recall edge
+
+Planning queries SHALL support selecting items by a motivating reference
+through the existing generic filter mechanism: a filter on the `motivation`
+column selects every item whose `motivation` list contains the given
+reference, on any collection whose manifest declares `motivation`. This
+capability SHALL NOT require a new top-level query parameter, since the
+existing `filters` argument already expresses it. `motivation` SHALL NOT
+participate in Planning's parent/area relation graph — it SHALL NOT satisfy a
+required `parent` or `area` relation, and it SHALL NOT be read when computing
+hierarchy edges. Because raw Planning items never enter ordinary semantic
+recall or the relation graph regardless of field content, a plan carrying
+`motivation` SHALL NOT appear as a memory hit and SHALL NOT create a graph
+edge toward the memory it cites. Plans cite knowledge; knowledge never cites
+plans back through this field.
+
+#### Scenario: Motivation query filter selects the referencing items
+- **WHEN** a query supplies a filter selecting Planning items whose
+  `motivation` contains a given `exomem://memory/` reference
+- **THEN** only items whose `motivation` list contains that reference are
+  returned
+
+#### Scenario: Motivation does not satisfy a required relation
+- **WHEN** a committed initiative or work item supplies `motivation` but
+  omits the `parent` its commitment requires
+- **THEN** validation refuses the missing relation exactly as it would
+  without `motivation` present
+
+#### Scenario: Motivated plans remain outside recall and the graph
+- **WHEN** a Planning item declares one or more `motivation` references
+- **THEN** the item remains excluded from ordinary semantic recall and from
+  the relation graph exactly as every other raw Planning item is, and no new
+  graph edge is created toward the referenced memory

--- a/openspec/changes/link-planning-motivation/tasks.md
+++ b/openspec/changes/link-planning-motivation/tasks.md
@@ -1,0 +1,60 @@
+## 1. Red Contracts For Motivation Shape
+
+- [x] 1.1 Write failing `normalize_item` unit tests: a valid `motivation` list
+      is accepted, a list of more than 16 refs is refused, a malformed ref
+      string is refused, a non-list value is refused, and an
+      `exomem://plan/...` reference is refused (motivation cites knowledge,
+      never another plan).
+- [x] 1.2 Write a failing regression test proving absence of `motivation`
+      produces exactly today's defaulted item shape (no key added).
+- [x] 1.3 Run `uv run --frozen python -m pytest -q tests/test_planning_motivation.py`
+      and capture the failing output before writing implementation.
+
+## 2. Motivation Shape Validation
+
+- [x] 2.1 Add `_validate_motivation` to `src/exomem/planning.py`, mirroring
+      `_validate_evidence`: bounded list (≤16), each entry checked through
+      `memory_refs.parse_memory_ref`, refused (`INVALID_PLAN`) otherwise.
+- [x] 2.2 Wire `_validate_motivation` into `_validate_optional` alongside the
+      existing `progress_evidence`/`execution` calls.
+- [x] 2.3 Add `motivation` to `_OPTIONAL` so `update()` can delete it like any
+      other optional field.
+- [x] 2.4 Run `uv run --frozen python -m pytest -q tests/test_planning_motivation.py`
+      and confirm green.
+
+## 3. Round Trip And Query Filter
+
+- [x] 3.1 Write/confirm a serialization round-trip test through
+      `record_formats.render_markdown_item` + `vault.parse_frontmatter`.
+- [x] 3.2 Write/confirm an `add()`/`query()` integration round trip, including
+      that a collection must declare `motivation` in its manifest schema to
+      accept it (same precondition as `progress_evidence`).
+- [x] 3.3 Write/confirm a query-filter test selecting only the item whose
+      `motivation` contains a given ref via the existing generic
+      `filters=[{"column": "motivation", "op": "contains", "value": ref}]`
+      path (no new `plan_memory` parameter — see `design.md` Decision 2).
+
+## 4. Non-Goal Enforcement
+
+- [x] 4.1 Write/confirm a test proving `motivation` does not satisfy a
+      committed initiative's required `parent` relation — the relation graph
+      only reads `parent`/`area`, never `motivation`.
+- [x] 4.2 Confirm (by inspection, documented in the report) that raw Planning
+      items — where `motivation` lives — never reach the lexical/vector/graph
+      indexers; only the collection manifest does
+      (`tests/test_planning_recall.py` already locks this at scale). No new
+      recall-exclusion test is needed because the guarantee is path-based,
+      not field-based.
+
+## 5. Spec And Gates
+
+- [x] 5.1 Author `specs/planning/spec.md` as `## ADDED Requirements` (no
+      `openspec/specs/planning/` capability exists yet).
+- [x] 5.2 Run `openspec validate link-planning-motivation --strict`.
+- [x] 5.3 Run `uvx ruff check` on changed files.
+- [x] 5.4 Run the targeted gate: new tests, `tests/test_planning_*.py`, and
+      the record mutation suites (`test_record_audit_protocol.py`,
+      `test_record_formats.py`, `test_record_formats_rereview.py`,
+      `test_record_formats_review.py`, `test_record_governance.py`,
+      `test_record_mutation.py`, `test_record_mutation_matrix.py`). Do not
+      run the full suite.

--- a/src/exomem/planning.py
+++ b/src/exomem/planning.py
@@ -33,6 +33,7 @@ _OPTIONAL = frozenset(
         "progress_evidence",
         "execution",
         "tags",
+        "motivation",
     }
 )
 
@@ -1215,6 +1216,26 @@ def _validate_optional(values: Mapping[str, Any]) -> None:
             _bounded_string(tag, "tag", 128)
     _validate_evidence(values.get("progress_evidence"))
     _validate_execution(values.get("execution"))
+    _validate_motivation(values.get("motivation"))
+
+
+def _validate_motivation(value: Any) -> None:
+    """Refuse anything but a bounded list of `exomem://memory/` refs.
+
+    Motivation is a reference from a plan to the knowledge that motivates it,
+    never the reverse: only `exomem://memory/` refs are accepted, so a
+    `exomem://plan/...` reference (or any other malformed value) is refused
+    the same way an invalid `progress_evidence` collection ref is refused.
+    Planning items stay outside recall and the graph regardless — this field
+    never becomes a relation-graph edge, it is validated shape only.
+    """
+    if value is None:
+        return
+    if not isinstance(value, list) or len(value) > 16:
+        _invalid("motivation must be a bounded list")
+    for ref in value:
+        if memory_refs.parse_memory_ref(ref) is None:
+            _invalid("motivation reference is invalid")
 
 
 def _validate_evidence(value: Any) -> None:

--- a/src/exomem/planning.py
+++ b/src/exomem/planning.py
@@ -46,7 +46,26 @@ class _PlanningEnvelope:
         return dict(self.payload)
 
 
-def normalize_item(item: Mapping[str, Any], *, apply_defaults: bool = True) -> dict[str, Any]:
+def motivation_is_governed(manifest: collections.CollectionManifest) -> bool:
+    """True when this collection declares `motivation` as the governed ref list.
+
+    A vault authored before this contract may legally have declared `motivation`
+    as its own free-text field. Imposing ref semantics on that value would refuse
+    it on every path that normalizes stored records — including the snapshot read
+    inside `query` — which would make one legacy item render the whole collection
+    unqueryable and unrepairable. So the governed shape is enforced only where the
+    manifest actually declares the array form.
+    """
+    field = manifest.schema.fields.get("motivation")
+    return field is not None and field.type == "array"
+
+
+def normalize_item(
+    item: Mapping[str, Any],
+    *,
+    apply_defaults: bool = True,
+    validate_motivation: bool = True,
+) -> dict[str, Any]:
     """Validate one authored Planning item without inferring from prose."""
     if not isinstance(item, Mapping):
         _invalid("item must be an object")
@@ -68,7 +87,7 @@ def normalize_item(item: Mapping[str, Any], *, apply_defaults: bool = True) -> d
     if values["kind"] == "area":
         if _AREA_FORBIDDEN & values.keys():
             _invalid("areas cannot carry delivery state or hierarchy")
-        _validate_optional(values)
+        _validate_optional(values, validate_motivation=validate_motivation)
         return values
     for name, allowed in (
         ("status", _STATUSES),
@@ -78,7 +97,7 @@ def normalize_item(item: Mapping[str, Any], *, apply_defaults: bool = True) -> d
     ):
         _enum(values.get(name), allowed, name)
     _validate_lifecycle(values)
-    _validate_optional(values)
+    _validate_optional(values, validate_motivation=validate_motivation)
     return values
 
 
@@ -170,7 +189,7 @@ def add(
     record_governance.require_mutation_visibility(vault_root, manifest)
     _validate_public_text(why, "why")
     _validate_public_text(body, "body")
-    values = normalize_item(item)
+    values = normalize_item(item, validate_motivation=motivation_is_governed(manifest))
     _validate_declared_text(manifest, values)
     snapshot = record_formats.load_adapter(
         vault_root,
@@ -564,7 +583,10 @@ def _valid_hierarchy_node(value: Any, manifest: collections.CollectionManifest) 
     if memory_refs.normalize_id(value.get("plan_id")) != value.get("plan_id"):
         return False
     try:
-        normalize_item(value, apply_defaults=False)
+        normalize_item(
+            value, apply_defaults=False,
+            validate_motivation=motivation_is_governed(manifest),
+        )
         for name, field_value in value.items():
             if name in manifest.schema.fields:
                 collections._validate_field_value(name, field_value, manifest.schema.fields[name])
@@ -733,8 +755,9 @@ def _validate_authorized_snapshot(
     snapshot = record_formats.load_adapter(
         vault_root, manifest, authorize_path=authorize_path
     ).read()
+    governed = motivation_is_governed(manifest)
     for record in snapshot.records:
-        normalize_item(record.values, apply_defaults=False)
+        normalize_item(record.values, apply_defaults=False, validate_motivation=governed)
     if validate_relationships:
         _validate_relationships(manifest, snapshot.records, None, None)
 
@@ -922,7 +945,10 @@ def update(
     if final == dict(matches[0].values) and (body is None or body == matches[0].body):
         raise CollectionError("INVALID_PLAN", "Planning update does not change authored state")
     _require_same_area_side(matches[0].values, final)
-    normalize_item(final, apply_defaults=False)
+    normalize_item(
+        final, apply_defaults=False,
+        validate_motivation=motivation_is_governed(manifest),
+    )
     _validate_declared_text(manifest, final)
     _validate_relationships(manifest, snapshot.records, plan_id, final)
     return records.update_record(
@@ -980,7 +1006,10 @@ def triage(
     if final == dict(matches[0].values):
         raise CollectionError("INVALID_PLAN", "Planning triage does not change authored state")
     _require_same_area_side(matches[0].values, final)
-    normalize_item(final, apply_defaults=False)
+    normalize_item(
+        final, apply_defaults=False,
+        validate_motivation=motivation_is_governed(manifest),
+    )
     _validate_declared_text(manifest, final)
     _validate_relationships(manifest, snapshot.records, plan_id, final)
     return records.update_record(
@@ -1063,7 +1092,10 @@ def _validate_relationships(
         if record.ambiguous or record.identity.key in plans:
             _relation_error()
         values = dict(record.values)
-        normalize_item(values, apply_defaults=False)
+        normalize_item(
+            values, apply_defaults=False,
+            validate_motivation=motivation_is_governed(manifest),
+        )
         plans[record.identity.key] = values
     if plan_id is not None and candidate is not None:
         plans[plan_id] = dict(candidate)
@@ -1144,7 +1176,10 @@ def _validate_final_relationships(
         (record.values for record in snapshot.records if record.identity.key == plan_id), values
     )
     _require_same_area_side(before, values)
-    normalize_item(values, apply_defaults=False)
+    normalize_item(
+        values, apply_defaults=False,
+        validate_motivation=motivation_is_governed(manifest),
+    )
     _validate_declared_text(manifest, values)
     _validate_relationships(manifest, snapshot.records, plan_id, values)
 
@@ -1190,7 +1225,9 @@ def _relation_error() -> Never:
     raise CollectionError("INVALID_PLAN_RELATION", "Planning relationship is not available")
 
 
-def _validate_optional(values: Mapping[str, Any]) -> None:
+def _validate_optional(
+    values: Mapping[str, Any], *, validate_motivation: bool = True
+) -> None:
     for name in ("health",):
         if name in values:
             _enum(values[name], _HEALTH, name)
@@ -1216,7 +1253,8 @@ def _validate_optional(values: Mapping[str, Any]) -> None:
             _bounded_string(tag, "tag", 128)
     _validate_evidence(values.get("progress_evidence"))
     _validate_execution(values.get("execution"))
-    _validate_motivation(values.get("motivation"))
+    if validate_motivation:
+        _validate_motivation(values.get("motivation"))
 
 
 def _validate_motivation(value: Any) -> None:

--- a/tests/test_planning_motivation.py
+++ b/tests/test_planning_motivation.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 from test_planning_mutation import _manifest
 
+from exomem import planning
 from exomem.structured_collections import CollectionError
 
 REF_A = "exomem://memory/5c252e6f-2639-4ee4-819a-fc9099200e1a"
@@ -26,6 +27,16 @@ def _manifest_with_motivation() -> str:
         "    health:\n      type: string\n"
         "    motivation:\n      type: array\n      items: {type: string}\n",
     )
+
+
+def _seed_collection_with(tmp_path: Path, manifest_text: str) -> str:
+    (tmp_path / "Knowledge Base").mkdir()
+    (tmp_path / "Knowledge Base" / "log.md").write_text("# Log\n", encoding="utf-8")
+    manifest_path = "Knowledge Base/Planning/Work/_collection.md"
+    from exomem.planning import create_collection
+
+    create_collection(tmp_path, manifest_path, manifest_text, why="create planning collection")
+    return manifest_path
 
 
 def _seed_collection(tmp_path: Path) -> str:
@@ -281,3 +292,65 @@ def test_motivation_update_can_be_deleted_like_other_optional_fields(tmp_path: P
         / f"{added['plan_id']}.md"
     )
     assert "motivation" not in item_path.read_text(encoding="utf-8")
+
+
+def test_legacy_untyped_motivation_field_does_not_brick_the_collection(tmp_path: Path) -> None:
+    """A vault that declared its own `motivation` field keeps working.
+
+    The governed ref-list shape is enforced only where the manifest declares
+    `motivation` as an array. Without that gate, `query` — which normalizes every
+    stored record — would refuse the whole collection because of one legacy item,
+    leaving it unqueryable and unrepairable.
+    """
+    manifest = _manifest().replace(
+        "    health:\n      type: string\n",
+        "    health:\n      type: string\n    motivation:\n      type: string\n",
+    )
+    collection = _seed_collection_with(tmp_path, manifest)
+
+    planning.add(
+        tmp_path,
+        collection,
+        item={"title": "Legacy", "motivation": "because the customer asked"},
+        why="legacy free-text motivation predating the governed contract",
+    )
+
+    rows = planning.query(tmp_path, collection)["rows"]
+    assert any(row.get("motivation") == "because the customer asked" for row in rows)
+
+
+def test_motivation_deletion_relies_on_optional_membership(tmp_path: Path) -> None:
+    """Pin `_OPTIONAL` membership as load-bearing, not incidental.
+
+    With `motivation` declared required, deletion is refused either way — but by
+    a different layer, and the code says which. In `_OPTIONAL` the Planning check
+    passes and the schema layer refuses with SCHEMA_REQUIRED_FIELD; drop it from
+    `_OPTIONAL` and Planning refuses first with INVALID_PLAN. Asserting the code
+    makes membership observable rather than decorative.
+    """
+    manifest = _manifest().replace(
+        "    health:\n      type: string\n",
+        "    health:\n      type: string\n"
+        "    motivation:\n      type: array\n      required: true\n"
+        "      items: {type: string}\n",
+    )
+    collection = _seed_collection_with(tmp_path, manifest)
+    added = planning.add(
+        tmp_path,
+        collection,
+        item={"title": "Required motivation", "motivation": [REF_A]},
+        why="seed an item whose motivation is declared required",
+    )
+
+    with pytest.raises(CollectionError) as raised:
+        planning.update(
+            tmp_path,
+            collection,
+            plan_id=added["plan_id"],
+            changes={"motivation": None},
+            expected_container_hash=added["after_container_hash"],
+            expected_item_version=added["after_item_hash"],
+            why="deleting a required field must be refused by the schema layer",
+        )
+
+    assert raised.value.code == "SCHEMA_REQUIRED_FIELD"

--- a/tests/test_planning_motivation.py
+++ b/tests/test_planning_motivation.py
@@ -1,0 +1,283 @@
+"""Planning `motivation`: a bounded list of `exomem://memory/` refs.
+
+Planning items remain outside recall and the graph (see
+`tests/test_planning_recall.py`); `motivation` is a reference from a plan to
+the knowledge that motivates it, never the reverse, and never a relation-graph
+edge. These tests cover the field's shape, its query filter, and that its
+absence behaves exactly as before this change.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from test_planning_mutation import _manifest
+
+from exomem.structured_collections import CollectionError
+
+REF_A = "exomem://memory/5c252e6f-2639-4ee4-819a-fc9099200e1a"
+REF_B = "exomem://memory/7a6d9f2e-2b3d-4a6b-8a3e-9a1e2f3b4c5d"
+
+
+def _manifest_with_motivation() -> str:
+    return _manifest().replace(
+        "    health:\n      type: string\n",
+        "    health:\n      type: string\n"
+        "    motivation:\n      type: array\n      items: {type: string}\n",
+    )
+
+
+def _seed_collection(tmp_path: Path) -> str:
+    (tmp_path / "Knowledge Base").mkdir()
+    (tmp_path / "Knowledge Base" / "log.md").write_text("# Log\n", encoding="utf-8")
+    manifest_path = "Knowledge Base/Planning/Work/_collection.md"
+    from exomem.planning import create_collection
+
+    create_collection(
+        tmp_path, manifest_path, _manifest_with_motivation(), why="create planning collection"
+    )
+    return manifest_path
+
+
+# -- Pure shape validation (normalize_item), no vault I/O -------------------
+
+
+def test_normalize_item_accepts_a_valid_motivation_list() -> None:
+    from exomem.planning import normalize_item
+
+    values = normalize_item({"title": "Ship the migration", "motivation": [REF_A, REF_B]})
+
+    assert values["motivation"] == [REF_A, REF_B]
+
+
+def test_normalize_item_refuses_more_than_sixteen_motivation_entries() -> None:
+    from exomem.planning import normalize_item
+
+    refs = [f"exomem://memory/00000000-0000-4000-8000-{index:012d}" for index in range(17)]
+
+    with pytest.raises(CollectionError, match="^INVALID_PLAN:"):
+        normalize_item({"title": "Too many motivations", "motivation": refs})
+
+
+def test_normalize_item_accepts_exactly_sixteen_motivation_entries() -> None:
+    from exomem.planning import normalize_item
+
+    refs = [f"exomem://memory/00000000-0000-4000-8000-{index:012d}" for index in range(16)]
+
+    values = normalize_item({"title": "At the bound", "motivation": refs})
+
+    assert values["motivation"] == refs
+
+
+def test_normalize_item_refuses_a_malformed_motivation_reference() -> None:
+    from exomem.planning import normalize_item
+
+    with pytest.raises(CollectionError, match="^INVALID_PLAN:"):
+        normalize_item({"title": "Bad ref", "motivation": ["not-a-memory-ref"]})
+
+
+def test_normalize_item_refuses_a_non_list_motivation() -> None:
+    from exomem.planning import normalize_item
+
+    with pytest.raises(CollectionError, match="^INVALID_PLAN:"):
+        normalize_item({"title": "Not a list", "motivation": REF_A})
+
+
+def test_normalize_item_refuses_a_plan_reference_as_motivation() -> None:
+    """Non-goal: motivation cites knowledge, never another plan."""
+    from exomem.planning import normalize_item
+
+    plan_ref = "exomem://plan/2db90f18-70df-4e41-986e-2d7d7db1caca/991acdd4-16b9-4396-8220-2cb37b7e8516"
+
+    with pytest.raises(CollectionError, match="^INVALID_PLAN:"):
+        normalize_item({"title": "Wrong namespace", "motivation": [plan_ref]})
+
+
+def test_normalize_item_omits_motivation_when_absent() -> None:
+    """Absence must behave exactly as today: no key is defaulted in."""
+    from exomem.planning import normalize_item
+
+    values = normalize_item({"title": "Keep this for later"})
+
+    assert "motivation" not in values
+    assert values == {
+        "title": "Keep this for later",
+        "kind": "work-item",
+        "status": "candidate",
+        "lifecycle": "active",
+        "priority": "none",
+        "commitment": "uncommitted",
+        "horizon": "inbox",
+        "health": "unknown",
+    }
+
+
+# -- Serialization round trip -------------------------------------------
+
+
+def test_markdown_item_renderer_round_trips_motivation_refs(tmp_path: Path) -> None:
+    from exomem import record_formats, vault
+    from exomem.structured_collections import load_manifest
+
+    directory = tmp_path / "Knowledge Base" / "Planning" / "Work"
+    directory.mkdir(parents=True)
+    (directory / "_collection.md").write_text(_manifest_with_motivation(), encoding="utf-8")
+    manifest = load_manifest(tmp_path, directory / "_collection.md")
+
+    rendered = record_formats.render_markdown_item(
+        manifest,
+        {"title": "Ship the migration", "motivation": [REF_A, REF_B]},
+        "991acdd4-16b9-4396-8220-2cb37b7e8516",
+    )
+
+    frontmatter, _body, _marker = vault.parse_frontmatter(rendered, strict=True)
+    assert frontmatter["motivation"] == [REF_A, REF_B]
+
+
+# -- add()/query() integration -------------------------------------------
+
+
+def test_planning_add_and_query_round_trip_motivation(tmp_path: Path) -> None:
+    from exomem.planning import add, query
+
+    manifest_path = _seed_collection(tmp_path)
+
+    added = add(
+        tmp_path,
+        manifest_path,
+        item={"title": "Ship the migration", "motivation": [REF_A, REF_B]},
+        why="capture motivated work",
+    )
+
+    result = query(tmp_path, manifest_path)
+
+    assert result["rows"][0]["plan_id"] == added["plan_id"]
+    assert result["rows"][0]["motivation"] == [REF_A, REF_B]
+
+
+def test_planning_add_refuses_more_than_sixteen_motivation_entries(tmp_path: Path) -> None:
+    from exomem.planning import add
+
+    manifest_path = _seed_collection(tmp_path)
+    refs = [f"exomem://memory/00000000-0000-4000-8000-{index:012d}" for index in range(17)]
+
+    with pytest.raises(CollectionError, match="^INVALID_PLAN:"):
+        add(tmp_path, manifest_path, item={"title": "Too many", "motivation": refs}, why="capture")
+
+
+def test_planning_add_refuses_a_malformed_motivation_reference(tmp_path: Path) -> None:
+    from exomem.planning import add
+
+    manifest_path = _seed_collection(tmp_path)
+
+    with pytest.raises(CollectionError, match="^INVALID_PLAN:"):
+        add(
+            tmp_path,
+            manifest_path,
+            item={"title": "Bad ref", "motivation": ["not-a-ref"]},
+            why="capture",
+        )
+
+
+def test_planning_add_refuses_a_non_list_motivation(tmp_path: Path) -> None:
+    from exomem.planning import add
+
+    manifest_path = _seed_collection(tmp_path)
+
+    with pytest.raises(CollectionError, match="^INVALID_PLAN:"):
+        add(tmp_path, manifest_path, item={"title": "Not a list", "motivation": REF_A}, why="capture")
+
+
+def test_planning_add_without_motivation_behaves_exactly_as_today(tmp_path: Path) -> None:
+    from exomem.planning import add, query
+
+    manifest_path = _seed_collection(tmp_path)
+
+    add(tmp_path, manifest_path, item={"title": "Keep this for later"}, why="capture future work")
+    result = query(tmp_path, manifest_path)
+
+    assert "motivation" not in result["rows"][0]
+
+
+def test_motivation_query_filter_selects_the_referencing_item(tmp_path: Path) -> None:
+    from exomem.planning import add, query
+
+    manifest_path = _seed_collection(tmp_path)
+    motivated = add(
+        tmp_path,
+        manifest_path,
+        item={"title": "Motivated by a belief", "motivation": [REF_A]},
+        why="capture motivated work",
+    )
+    add(
+        tmp_path,
+        manifest_path,
+        item={"title": "Motivated by something else", "motivation": [REF_B]},
+        why="capture other work",
+    )
+    add(tmp_path, manifest_path, item={"title": "Unmotivated work"}, why="capture plain work")
+
+    result = query(
+        tmp_path,
+        manifest_path,
+        filters=[{"column": "motivation", "op": "contains", "value": REF_A}],
+    )
+
+    assert [row["plan_id"] for row in result["rows"]] == [motivated["plan_id"]]
+    assert result["total_matched"] == 1
+
+
+def test_motivation_does_not_satisfy_the_required_parent_relation(tmp_path: Path) -> None:
+    """Non-goal: motivation never stands in for the plan graph."""
+    from exomem.planning import add
+
+    manifest_path = _seed_collection(tmp_path)
+
+    with pytest.raises(CollectionError, match="INVALID_PLAN_RELATION"):
+        add(
+            tmp_path,
+            manifest_path,
+            item={
+                "title": "Committed without a parent",
+                "kind": "initiative",
+                "status": "active",
+                "commitment": "committed",
+                "horizon": "quarter",
+                "motivation": [REF_A],
+            },
+            why="capture committed initiative",
+        )
+
+
+def test_motivation_update_can_be_deleted_like_other_optional_fields(tmp_path: Path) -> None:
+    from exomem.planning import add, update
+
+    manifest_path = _seed_collection(tmp_path)
+    added = add(
+        tmp_path,
+        manifest_path,
+        item={"title": "Ship the migration", "motivation": [REF_A]},
+        why="capture motivated work",
+    )
+
+    receipt = update(
+        tmp_path,
+        manifest_path,
+        plan_id=added["plan_id"],
+        changes={"motivation": None},
+        expected_container_hash=added["after_container_hash"],
+        expected_item_version=added["after_item_hash"],
+        why="drop motivation",
+    )
+
+    assert receipt["operation"] == "update"
+    item_path = (
+        tmp_path
+        / "Knowledge Base"
+        / "Planning"
+        / "Work"
+        / "Items"
+        / f"{added['plan_id']}.md"
+    )
+    assert "motivation" not in item_path.read_text(encoding="utf-8")


### PR DESCRIPTION
Programme change 6 of 12 from the 2026-08-14 epistemic architecture audit (§13, Tier 2). Depends on nothing.

## Why

Planning is epistemically orphaned. No field, relation, or graph edge connects a plan to the knowledge that motivates it, so "why does this initiative exist" is unanswerable from the system — and when a motivating belief is superseded, nothing can even in principle surface the plans premised on it. Stale plans survive contrary evidence exactly the way stale beliefs are prevented from doing.

## What changed

An optional `motivation` field on Planning items: a bounded list of at most 16 `exomem://memory/` refs, validated the same way `progress_evidence` is. Querying by it rides the existing generic `filters` argument.

**Non-goal, enforced and tested:** Planning items stay outside recall and the graph. `motivation` points from plan to knowledge and never the reverse — an `exomem://plan/...` ref is refused, so it cannot masquerade as a `parent` or `area` relation. Plans cite knowledge; knowledge never cites plans.

## Two review findings, both fixed

An independent reviewer returned APPROVE with two majors. Both are worth reading, because the first is a compatibility break that the first implementation would have shipped.

**A vault that had already declared its own `motivation` field was bricked.** `query` normalizes every stored record, so imposing ref semantics on a legacy free-text value made one item render the entire collection unqueryable *and* unrepairable, with no diagnostic pointing at the cause. This is the same shape as the parse-path hazard fixed in #512: new validation reaching stored state. The governed ref-list shape is now enforced only where the manifest actually declares `motivation` as an array, threaded through every `normalize_item` call site rather than the read path alone. A regression test covers the legacy vault.

**A test that looked load-bearing was not.** The reviewer proposed declaring the field required so `_OPTIONAL` membership would be exercised — but the schema layer refuses required-field deletion *before* Planning's `_OPTIONAL` check runs, so that test would have passed for the wrong reason. The two paths do differ observably by error code (`SCHEMA_REQUIRED_FIELD` from the schema layer, `INVALID_PLAN` from Planning), so the test now pins that. Drop `motivation` from `_OPTIONAL` and it fails.

Also corrected two claims in `proposal.md` that did not survive review: that no `planning` capability delta exists (`add-multi-horizon-planning` has one, complete but unarchived — no requirement-name collision, so archive order is safe), and the flat "no existing Planning item is invalidated", now scoped to what is actually true.

## Deviation from the audit outline

The outline named a `motivation_ref=` query filter. Adding that keyword would add a property to the introspected input schema pinned in `tests/fixtures/mcp_tool_schemas.json` and `src/exomem/tool_surface_contract.json` — a release-blocking fan-out via the ChatGPT Personal Plugin attestation. Filtering instead uses the existing generic `filters` path, which already works for any manifest-declared array field. Same capability, and both pinned files are verified byte-identical.

## Verification

- `openspec validate link-planning-motivation --strict` passes.
- 18 tests in `tests/test_planning_motivation.py`, including the legacy-vault regression.
- 114 passing across the planning, plan-memory-command, and record-mutation suites.
- `ruff` clean on changed files; `tests/golden/`, `.github/`, and both pinned contract files untouched.

The full lean suite was not run locally — a single-process run takes ~100 minutes on this machine. CI's four-way sharded run is the authoritative result.
