### PR TITLE
fix(benchmarks): derive the LME CLI provider choices from the registry

### DIFF
--- a/benchmarks/lme/cli.py
+++ b/benchmarks/lme/cli.py
@@ -38,7 +38,11 @@ def _parser() -> argparse.ArgumentParser:
     run.add_argument("--openai-api-key-env", default="OPENAI_API_KEY")
     run.add_argument("--claude-binary", default="claude")
     run.add_argument("--top-k", type=int, default=10)
-    run.add_argument("--provider", choices=("exomem-source-only", "hybrid-rag-control", "no-memory"))
+    # The registry is the closed source of truth; a hand-copied list here would
+    # silently strand any newly registered row.
+    from .providers.registry import registered_provider_names
+
+    run.add_argument("--provider", choices=registered_provider_names())
     run.add_argument(
         "--budget-cap-usd", type=float, default=float(os.environ.get("PROTOCOL_BUDGET_CAP_USD", "0") or 0),
         help="cap written into the run's immutable budget ledger (env: PROTOCOL_BUDGET_CAP_USD)",

--- a/tests/test_lme_cli_provider_choices.py
+++ b/tests/test_lme_cli_provider_choices.py
@@ -1,0 +1,52 @@
+"""The CLI's --provider choices must be the registry, not a copy of it.
+
+A registered row the CLI cannot select is unreachable in practice, and a
+hand-maintained duplicate of the closed registry drifts silently the moment a
+row is added.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _provider_action():
+    from lme.cli import _parser
+
+    for action in _parser()._subparsers._group_actions[0].choices["run"]._actions:
+        if action.dest == "provider":
+            return action
+    raise AssertionError("the run subcommand has no --provider argument")
+
+
+def test_cli_provider_choices_are_exactly_the_closed_registry() -> None:
+    from lme.providers.registry import registered_provider_names
+
+    assert tuple(sorted(_provider_action().choices)) == registered_provider_names()
+
+
+def test_every_registered_row_is_selectable_from_the_cli() -> None:
+    """Including rows whose execution model is not in-process."""
+
+    from lme.providers.registry import provider_spec, registered_provider_names
+
+    choices = set(_provider_action().choices)
+    for name in registered_provider_names():
+        assert name in choices, f"{name} is registered but unreachable from the CLI"
+    subprocess_rows = [
+        name for name in registered_provider_names()
+        if provider_spec(name).descriptor.execution_model
+        == "owned-subprocess-terminated-at-cleanup"
+    ]
+    assert subprocess_rows, "expected at least one out-of-process row to be selectable"
+    assert set(subprocess_rows) <= choices
+
+
+def test_the_cli_still_refuses_an_unregistered_provider() -> None:
+    from lme.cli import _parser
+
+    with pytest.raises(SystemExit):
+        _parser().parse_args([
+            "run", "--dataset", "x", "--reader", "stub", "--out", "y",
+            "--provider", "supermemory-cloud",
+        ])


### PR DESCRIPTION
Follow-up to #504, found while setting up the §4.6 equivalence run.

`benchmarks/lme/cli.py` carried a hand-copied tuple of provider names on the `run` subcommand, so the `basic-memory-direct` row landed **registered but unreachable** — `registered_provider_names()` admitted it and the CLI refused it. It was the only duplicate of the registry list in the tree.

The registry is already the closed source of truth and raises `unknown direct provider` on a bad name, so the CLI now derives its choices from it rather than keeping a second list that drifts the moment a row is added.

## Red first

```
AssertionError: basic-memory-direct is registered but unreachable from the CLI
assert 'basic-memory-direct' in {'exomem-source-only', 'hybrid-rag-control', 'no-memory'}
2 failed, 1 passed
```

Three tests pin it: choices equal the registry exactly, every registered row is selectable (including out-of-process ones), and an unregistered name still exits non-zero.

## Verification

```
lme + protocol + equivalence   428 passed, 1 skipped
ruff check . --select F        All checks passed
```