### PR TITLE
feat(memory): audit derivation chains for double-counting and cycles

### DIFF
--- a/openspec/changes/audit-derivation-double-counting/.openspec.yaml
+++ b/openspec/changes/audit-derivation-double-counting/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/audit-derivation-double-counting/design.md
+++ b/openspec/changes/audit-derivation-double-counting/design.md
@@ -61,16 +61,59 @@ onto the same primitive instead of two separate traversal implementations.
 ### D2 — Two explicit, env-overridable caps, not one
 
 `EXOMEM_DERIVATION_MAX_DEPTH` (default 12) bounds hops from any node before
-that branch stops expanding. `EXOMEM_DERIVATION_MAX_EDGES` (default 2000) is
-a budget *shared across every walk in one audit pass* — it bounds total
-work regardless of how many origin pages need closures computed, protecting
-against a vault where many pages each have deep, overlapping chains. Per-key
-walk results are memoized (`walk_cache`) so a shared ancestor visited from
-multiple origins is only walked once. Hitting either cap sets a `truncated`
-flag; the check emits exactly one `truncated` finding (`info` severity) per
-audit run if any walk was capped, naming both limits, rather than emitting
-one per page (which would be noisy) or staying silent (which would read as
-"no problem found").
+that branch stops expanding. `EXOMEM_DERIVATION_MAX_EDGES` (default **50,000**,
+revised from an initial 2,000 — see below) is a budget *shared across every
+walk in one audit pass* — it bounds total work regardless of how many origin
+pages need closures computed, protecting against a vault where many pages
+each have deep, overlapping chains.
+
+`walk_cache` memoizes only by exact **top-level start key** — it does not
+splice one node's already-resolved closure into another node's in-progress
+BFS. That reuse was prototyped and rejected: a node's own bounded closure is
+computed relative to *its own* `max_depth` hops from itself, so splicing it
+into a caller with fewer hops of budget remaining silently lets that caller's
+result reach further than its own cap nominally allows, *and* under-reports
+`truncated` for exactly the walk that should have set it (traced by hand
+against a 6-node chain with a lowered depth cap before it was ever written
+into the tree). Every walk therefore re-examines its own reachable edges
+independently; the edge budget in this design is real total work, not an
+artifact of missing memoization, which is why it needed re-deriving rather
+than patching over.
+
+Each `_DerivationWalk` records *why* it stopped short, not just whether it
+did: `truncated_reasons` is a subset of `{"depth", "edges"}` (empty means
+complete). Hitting either cap contributes its reason; the check emits exactly
+one aggregate `truncated` finding (`info` severity) per audit run, naming
+every reason actually observed and both configured limits — never a bare
+`depth_capped` boolean that would misreport an edge-budget truncation as a
+depth-capped one (mutation-testing review, correction round 1).
+
+**Deriving the edge-budget default.** The initial 2,000 default was picked
+without measurement and was wrong: mutation-testing review measured this walk
+(no cross-walk closure reuse, per the rejected alternative above) consuming
+roughly 10 edges per sourced page in a chain-shaped test graph, exhausting a
+2,000 budget at ~200 sourced pages — nowhere near the vault this ships into
+(~2,900 markdown files at review time). Re-derivation, then validated
+empirically rather than only extrapolated:
+- Assume a generously-sized target of **~5,000 markdown files**, up to half
+  (2,500) carrying `sources:` — deliberately over-estimating density, since a
+  real vault's `sources:` fraction is typically much smaller.
+- At the reviewer's measured ~10 edges/sourced-page: 2,500 × 10 = 25,000.
+  Doubled for margin → **50,000**.
+- Validated with a synthetic 5,000-file vault (2,500 sourced notes across two
+  citation tiers — notes citing raw `Sources/` leaves directly, and notes
+  citing two of those first-tier notes, matching this codebase's actual
+  `sources:` convention rather than an unrealistic multi-thousand-hop
+  braided chain) at the *old* default: it truncated by `edges` alone at 2,000.
+  At **50,000**: it completed with zero truncation in ~1.3s wall-clock. The
+  old default was also independently confirmed insufficient on a
+  deliberately adversarial deep/braided chain (2,500-hop citation history);
+  the new default terminates that scenario promptly too, correctly reporting
+  `truncated` with both `depth` and `edges` reasons — depth capping a chain
+  that genuinely runs thousands of hops deep is the depth cap doing its
+  documented job, not an edge-budget sizing defect.
+- The env override (`EXOMEM_DERIVATION_MAX_EDGES`) remains for a vault denser
+  than this baseline.
 
 ### D3 — Self-references are graph edges, not filtered inputs
 
@@ -86,12 +129,19 @@ code path.
 Only active, read-write pages of the four provenance-bearing compiled types
 (`research-note`, `insight`, `failure`, `pattern` — `_SOURCES_REQUIRED_TYPES`,
 already defined for `missing_sources`) originate a `support_collapse`
-finding, with the same `index.md`/`log.md` and inactive-status exclusions
-`relation_debt`/`missing_sources` already apply. Cycle detection is NOT
-type-gated — a cycle is a structural defect in the graph itself, findable
-from any node with outgoing `sources:` edges, regardless of that node's page
-type or status. This asymmetry is deliberate: collapse is a soft heuristic
-about a specific page's argument, cycle is a hard graph-shape problem.
+finding, with the *complete* set of exclusions `relation_debt`/
+`missing_sources` already apply: `index.md`/`log.md`, inactive status, and —
+added in the correction round, where its absence was flagged as a genuine gap
+rather than a comment inaccuracy — the hub/snapshot tag and
+`-architecture`/`-snapshot`/`-catalog-snapshot` slug-suffix skip. A hub or
+snapshot page is *expected* to fan its `sources:` out from a shared root by
+convention, and would otherwise dominate this queue with non-actionable
+noise, exactly the failure mode those exclusions already exist to prevent
+elsewhere. Cycle detection is NOT type-gated — a cycle is a structural defect
+in the graph itself, findable from any node with outgoing `sources:` edges,
+regardless of that node's page type or status. This asymmetry is deliberate:
+collapse is a soft heuristic about a specific page's argument, cycle is a
+hard graph-shape problem.
 
 ### D5 — Severity split, never `error`
 
@@ -102,6 +152,43 @@ citations are genuinely independent, and a capped-run notice, respectively).
 Neither is ever `error`: this check observes, it does not gate writes or
 imply a defect the way `frontmatter_compliance` or `duplicated_sidecar`'s
 `recovery_only` case do.
+
+### D6 — A citing page is never its own shared ancestor; one tail collapses to its nearest node
+
+`collapse_roots` excludes the citing page's own key outright: since that key
+is one of the page's own direct sources by construction, any structure where
+it also appears in another direct source's closure is necessarily a cycle
+back through the citing page itself (unavoidable — reaching a page from one
+of its own citations requires a path back to it) and is already reported
+separately as a `cycle` finding. Reporting it *again* as the page's own
+"shared ancestor" is nonsensical and was a correction-round finding
+(mutation-testing review, blocking 3).
+
+Separately, a single converging tail (`A` and `B` both citing `C`, `C` citing
+`D`, `D` citing `E`) previously emitted one finding per node in the shared
+tail (`C`, `D`, *and* `E`) — three findings for one situation, contradicting
+the spec's own "one finding … naming `S`" scenario (major 4). `_nearest_
+shared_roots` drops a candidate root `Y` whenever some *other* candidate `X`
+can reach `Y` (`Y` is further upstream, discovered on the same tail),
+independent of iteration order — it checks every pair rather than depending
+on which candidate is visited first, which matters because a naive
+sorted-then-first-wins approach silently keeps the wrong (furthest, not
+nearest) node under adversarial key naming. If every candidate ends up
+mutually dominated (a cycle among the candidates themselves), one
+deterministic representative survives rather than the finding being silently
+dropped.
+
+### D7 — Unresolved targets get a reconstructed path, not an internal key
+
+`display_path` prefers the resolved page's real `rel_path`; when a `sources:`
+target does not resolve to a known page, it now reconstructs a plausible
+vault-relative path (`kb_prefix() + raw + ".md"`) from the original raw
+wikilink text tracked alongside the canon key, rather than falling back to
+the internal lowercase, extension-stripped canon key. Every other path
+`AuditFinding` reports — `path` and every path embedded in `meta` — is a
+vault-relative rel_path an agent can open directly; the canon key broke that
+contract silently for exactly the pages a reviewer most needs to inspect
+(dangling/unresolved provenance).
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/audit-derivation-double-counting/design.md
+++ b/openspec/changes/audit-derivation-double-counting/design.md
@@ -1,0 +1,134 @@
+# Design: audit-derivation-double-counting
+
+## Context
+
+`sources:` frontmatter is the one place provenance is recorded, and the
+existing graph builder (`epistemic_graph.py`) already maps it to a
+`derived_from` edge (page → each cited source) when it materializes the graph
+sidecar. No audit check, however, walks that edge transitively. Two failure
+modes are therefore invisible:
+
+- A page cites two sources that both trace back to one shared ancestor — the
+  ancestor's support gets counted twice under the appearance of independent
+  corroboration.
+- A `sources:` chain loops back on itself.
+
+This change adds one new, opt-in audit category that performs that walk
+directly over already-parsed `ParsedPage` frontmatter — the same data source
+`missing_sources` and `relation_debt` already use — rather than depending on
+the `epistemic_graph` SQLite sidecar being present or fresh. That keeps the
+check self-contained and consistent with every other audit category, which
+reads vault truth directly rather than a derived index.
+
+## Goals / Non-Goals
+
+**Goals:** detect support-collapse (a "diamond" of derivation converging on a
+shared ancestor) and circular derivation over the `sources:` graph; bound the
+walk explicitly (depth + total-edge budget) so a dense, thousand-note vault
+cannot turn one audit call into an unbounded traversal; make a hit cap visible
+in the findings rather than silently under-reporting; stay strictly
+observe-only (never mutate, never auto-act); avoid false positives on
+genuinely independent sources.
+
+**Non-Goals:** ranking or scoring how "bad" a collapse is; auto-fixing or
+auto-superseding anything; wiring into the `attention` composed queue (out of
+scope — matches the existing `missing_sources` precedent); flagging
+agent-session-rooted conclusions (no existing taxonomy identifies those pages;
+deferred, see proposal.md); expanding the `derived_from` edge set to also
+include explicit typed `## Relations` blocks — the approved design names only
+`derived_from`/`sources:`, which in this codebase is exactly the `sources:`
+frontmatter field.
+
+## Decisions
+
+### D1 — One bounded BFS serves both cycle detection and ancestor closure
+
+A single helper, `_bounded_ancestor_walk(direct_sources, start, max_depth,
+budget)`, does one BFS from `start` over `derived_from` edges. It returns the
+set of reachable ancestors, whether `start` is reachable from itself (a
+cycle, with one reconstructed witness path), and whether the walk was
+truncated by the depth or edge cap. A `seen` set makes the walk terminate
+regardless of cycles in the underlying graph — the cycle check therefore
+never risks infinite recursion, and needs no separate unbounded pass.
+
+Cycle detection asks, for every node with outgoing `sources:` edges: "is
+`start` in its own bounded closure?" Support collapse asks, for a page citing
+two or more sources directly: "do any two of those sources' bounded closures
+(including each source itself) intersect?" A shared element in that
+intersection is the double-counted ancestor. This unifies both failure modes
+onto the same primitive instead of two separate traversal implementations.
+
+### D2 — Two explicit, env-overridable caps, not one
+
+`EXOMEM_DERIVATION_MAX_DEPTH` (default 12) bounds hops from any node before
+that branch stops expanding. `EXOMEM_DERIVATION_MAX_EDGES` (default 2000) is
+a budget *shared across every walk in one audit pass* — it bounds total
+work regardless of how many origin pages need closures computed, protecting
+against a vault where many pages each have deep, overlapping chains. Per-key
+walk results are memoized (`walk_cache`) so a shared ancestor visited from
+multiple origins is only walked once. Hitting either cap sets a `truncated`
+flag; the check emits exactly one `truncated` finding (`info` severity) per
+audit run if any walk was capped, naming both limits, rather than emitting
+one per page (which would be noisy) or staying silent (which would read as
+"no problem found").
+
+### D3 — Self-references are graph edges, not filtered inputs
+
+`_derivation_direct_sources` keeps a page that cites itself in `sources:`
+rather than dropping it at graph-construction time. This is what lets the
+degenerate single-node cycle (`A` cites `A`) surface through the same cycle
+detector as any longer cycle, satisfying "cycle detection must terminate on
+self-referential chains" as a directly observable case rather than a special
+code path.
+
+### D4 — Origination gate mirrors `missing_sources`
+
+Only active, read-write pages of the four provenance-bearing compiled types
+(`research-note`, `insight`, `failure`, `pattern` — `_SOURCES_REQUIRED_TYPES`,
+already defined for `missing_sources`) originate a `support_collapse`
+finding, with the same `index.md`/`log.md` and inactive-status exclusions
+`relation_debt`/`missing_sources` already apply. Cycle detection is NOT
+type-gated — a cycle is a structural defect in the graph itself, findable
+from any node with outgoing `sources:` edges, regardless of that node's page
+type or status. This asymmetry is deliberate: collapse is a soft heuristic
+about a specific page's argument, cycle is a hard graph-shape problem.
+
+### D5 — Severity split, never `error`
+
+`cycle` is `warn` (a `sources:` chain that supports itself is a real logical
+inconsistency in the provenance graph). `support_collapse` and `truncated`
+are `info` (review candidates requiring human judgment about whether
+citations are genuinely independent, and a capped-run notice, respectively).
+Neither is ever `error`: this check observes, it does not gate writes or
+imply a defect the way `frontmatter_compliance` or `duplicated_sidecar`'s
+`recovery_only` case do.
+
+## Risks / Trade-offs
+
+- **False positives on legitimately-independent-but-topically-related
+  sources.** The check only looks at graph structure (does an ancestor chain
+  literally converge), never content — it cannot tell "these two sources
+  restate one interview" from "these two sources happen to cite the same
+  well-known reference work". This is explicitly a review candidate
+  (`info`), not an auto-judgment, and the false-positive guard (independent
+  chains produce no finding) is covered directly in tests.
+- **A depth/edge cap can hide a real collapse or cycle beyond the horizon.**
+  Mitigated by making truncation visible (D2) rather than silent; a reviewer
+  seeing the `truncated` finding knows to widen the caps or investigate the
+  densest chains directly rather than trusting a false "clean" result.
+- **Memoized walk results are pass-scoped only.** Caches (`walk_cache`,
+  the shared edge budget) live for the duration of one `_check_derivation_
+  double_counting` call and are rebuilt on every audit invocation — no stale
+  cross-run state, at the cost of repeating work across separate audit calls.
+  Given the category is opt-in and not part of the default sweep, this
+  trade-off favors simplicity over a persistent cache.
+
+## Migration Plan
+
+Additive only: one new optional audit category, absent from
+`ALL_CATEGORIES` and from the `attention` composed queue's category set.
+Existing callers and existing findings are unaffected.
+
+## Open Questions
+
+None.

--- a/openspec/changes/audit-derivation-double-counting/design.md
+++ b/openspec/changes/audit-derivation-double-counting/design.md
@@ -90,16 +90,33 @@ depth-capped one (mutation-testing review, correction round 1).
 
 **Deriving the edge-budget default.** The initial 2,000 default was picked
 without measurement and was wrong: mutation-testing review measured this walk
-(no cross-walk closure reuse, per the rejected alternative above) consuming
-roughly 10 edges per sourced page in a chain-shaped test graph, exhausting a
-2,000 budget at ~200 sourced pages — nowhere near the vault this ships into
-(~2,900 markdown files at review time). Re-derivation, then validated
-empirically rather than only extrapolated:
+(no cross-walk closure reuse, per the rejected alternative above) exhausting
+a 2,000 budget at ~200 sourced pages in a chain-shaped test graph — nowhere
+near the vault this ships into (~2,900 markdown files at review time).
+
+Edges-per-sourced-page is **a property of the `sources:` citation shape (how
+many tiers of derivation deep a chain runs), not of vault size** — a small
+vault with deep chains can exhaust the budget just as easily as a large one
+with shallow chains. Follow-up measurement across citation-tier depth made
+this explicit and non-linear: **4.0 edges/page at 3 tiers, 22.8 at 6 tiers,
+503 at 12 tiers** (the tier count where chains start approaching the
+`max_depth` cap itself). The original ~10 edges/page figure was one point on
+this curve, not a stable per-page constant — reading it as vault-size-derived
+would have produced a default confidently wrong for any vault whose
+`sources:` chains run deeper rather than wider.
+
+Given that, the default is sized for this codebase's actual shallow
+convention (compiled notes cite raw `Sources/` leaves directly, with at most
+one or two tiers of note-citing-note indirection — see D4/`missing_sources`),
+not for an assumed worst-case tier depth, with the attributed `truncated`
+finding and the env override as the honest fallback for a vault whose
+chains run deeper:
 - Assume a generously-sized target of **~5,000 markdown files**, up to half
   (2,500) carrying `sources:` — deliberately over-estimating density, since a
-  real vault's `sources:` fraction is typically much smaller.
-- At the reviewer's measured ~10 edges/sourced-page: 2,500 × 10 = 25,000.
-  Doubled for margin → **50,000**.
+  real vault's `sources:` fraction is typically much smaller — at this
+  codebase's actual shallow (2–3 tier) citation shape, ~4 edges/page:
+  2,500 × 4 = 10,000. Rounded up with several-fold margin against
+  measurement noise and a moderately deeper realistic shape → **50,000**.
 - Validated with a synthetic 5,000-file vault (2,500 sourced notes across two
   citation tiers — notes citing raw `Sources/` leaves directly, and notes
   citing two of those first-tier notes, matching this codebase's actual
@@ -112,8 +129,13 @@ empirically rather than only extrapolated:
   `truncated` with both `depth` and `edges` reasons — depth capping a chain
   that genuinely runs thousands of hops deep is the depth cap doing its
   documented job, not an edge-budget sizing defect.
-- The env override (`EXOMEM_DERIVATION_MAX_EDGES`) remains for a vault denser
-  than this baseline.
+- A vault that stays small but *deepens* its citation tiers rather than
+  widening its sourced-page count is the case this sizing does not cover by
+  construction — at 12 tiers, 500+ edges/page exhausts 50,000 at only ~100
+  such pages. The `truncated` finding names which cap fired so this reads as
+  "incomplete", never a false "clean"; `EXOMEM_DERIVATION_MAX_EDGES` is the
+  intended remedy for a vault whose shape genuinely runs deeper than this
+  default assumes, not a defect to fix by raising the default further.
 
 ### D3 — Self-references are graph edges, not filtered inputs
 

--- a/openspec/changes/audit-derivation-double-counting/proposal.md
+++ b/openspec/changes/audit-derivation-double-counting/proposal.md
@@ -1,0 +1,71 @@
+# Proposal: audit-derivation-double-counting
+
+## Why
+
+Two gaps in the existing audit surface are currently invisible to every check:
+
+- **Double-counted evidence.** Two notes derived from one source, then a third
+  citing both as independent support, passes silently — the classic
+  circular-support failure where one blog post is laundered into "multiple
+  sources agree", in a system whose pitch is provenance.
+- **Circular evidence.** Nothing walks support chains for cycles (A supports B
+  supports A via a derived note).
+
+Both are visible only by walking the `derived_from` graph that `sources:`
+frontmatter already implies. No existing category does that traversal.
+
+## What Changes
+
+- Add a new, opt-in, read-only audit category, `derivation_double_counting`,
+  that walks `sources:` (`derived_from`) chains and reports two finding kinds:
+  - `support_collapse` (severity `info`): an active, read-write, compiled page
+    (`research-note` / `insight` / `failure` / `pattern` — the types whose
+    `sources:` carries substantive provenance) cites two or more sources whose
+    ancestor chains converge on a shared node, so citing them as independent
+    support double-counts that ancestor.
+  - `cycle` (severity `warn`): a `sources:` chain that is reachable from
+    itself, including a direct self-reference.
+- Bound the chain walk explicitly by depth (`EXOMEM_DERIVATION_MAX_DEPTH`,
+  default 12) and by a shared total-edge budget across the whole audit pass
+  (`EXOMEM_DERIVATION_MAX_EDGES`, default 2000). Whenever either cap stops
+  exploration before it completes, emit a dedicated `truncated` finding
+  (`info`) naming the cap, so a capped run reads as "incomplete", never as a
+  false "nothing found".
+- Observe only: the category never mutates a note, never rewrites a relation,
+  never downgrades or demotes anything, and never blocks a write. It is
+  absent from `ALL_CATEGORIES` (the default audit sweep) — callers opt in via
+  `audit(categories=["derivation_double_counting"])`.
+
+Explicitly out of scope: flagging conclusions whose only roots are agent
+sessions. The approved design allows this only if it falls out of the
+traversal cheaply; no existing page-type/tag taxonomy identifies an "agent
+session" page in this codebase, so adding one would be inventing new
+vocabulary rather than reusing the traversal — deferred to a follow-up change
+if that taxonomy is ever introduced. Wiring this category into the `attention`
+composed queue (`attention.py`'s `ATTENTION_CATEGORIES`) is also out of
+scope, matching the existing `missing_sources` category, which is likewise
+optional and reachable only via `audit()` directly.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `attention-queue`: adds an optional, non-default, informational/warn-only
+  `derivation_double_counting` audit category surfacing derivation-chain
+  support-collapse and cycle findings, requested via
+  `audit(categories=["derivation_double_counting"])`.
+
+## Impact
+
+- `src/exomem/audit.py` only: one new optional category, its check function,
+  and the bounded-walk helpers it uses. No new module, dependency, model,
+  background process, or index.
+- Pure-substrate: the traversal is deterministic graph reachability over
+  frontmatter already on disk. No score, no confidence float, no ranking
+  change to `find` or `attention`.
+- Existing pages are untouched; this is a new, cheap-to-ignore review queue,
+  not a migration.

--- a/openspec/changes/audit-derivation-double-counting/proposal.md
+++ b/openspec/changes/audit-derivation-double-counting/proposal.md
@@ -22,15 +22,18 @@ frontmatter already implies. No existing category does that traversal.
     (`research-note` / `insight` / `failure` / `pattern` — the types whose
     `sources:` carries substantive provenance) cites two or more sources whose
     ancestor chains converge on a shared node, so citing them as independent
-    support double-counts that ancestor.
+    support double-counts that ancestor. The finding names the nearest such
+    shared ancestor — one finding per converging situation, not one per node
+    in a multi-hop shared tail — and never names the citing page itself.
   - `cycle` (severity `warn`): a `sources:` chain that is reachable from
     itself, including a direct self-reference.
 - Bound the chain walk explicitly by depth (`EXOMEM_DERIVATION_MAX_DEPTH`,
   default 12) and by a shared total-edge budget across the whole audit pass
-  (`EXOMEM_DERIVATION_MAX_EDGES`, default 2000). Whenever either cap stops
-  exploration before it completes, emit a dedicated `truncated` finding
-  (`info`) naming the cap, so a capped run reads as "incomplete", never as a
-  false "nothing found".
+  (`EXOMEM_DERIVATION_MAX_EDGES`, default 50,000 — measured and validated
+  against a synthetic ~5,000-file vault; see design.md D2). Whenever either
+  cap stops exploration before it completes, emit a dedicated `truncated`
+  finding (`info`) naming which cap(s) were actually hit, so a capped run
+  reads as "incomplete", never as a false "nothing found".
 - Observe only: the category never mutates a note, never rewrites a relation,
   never downgrades or demotes anything, and never blocks a write. It is
   absent from `ALL_CATEGORIES` (the default audit sweep) — callers opt in via

--- a/openspec/changes/audit-derivation-double-counting/specs/attention-queue/spec.md
+++ b/openspec/changes/audit-derivation-double-counting/specs/attention-queue/spec.md
@@ -8,8 +8,11 @@ finding SHALL be emitted for an active, writable compiled page of the types
 whose frontmatter specification marks provenance required — `research-note`,
 `insight`, `failure`, and `pattern` — when two or more of its directly cited
 `sources:` have ancestor chains that converge on a shared node; the finding
-SHALL name the shared ancestor and every contributing direct source. A
-`cycle` finding SHALL be emitted whenever a `sources:` chain is reachable
+SHALL name the nearest such shared ancestor and every contributing direct
+source. The citing page itself SHALL NEVER be reported as its own shared
+ancestor. One converging tail of shared ancestors SHALL produce one finding
+naming the nearest node in that tail, not one finding per node in the tail.
+A `cycle` finding SHALL be emitted whenever a `sources:` chain is reachable
 from itself, including a direct self-reference, regardless of the
 originating page's type or status. The category SHALL be optional and absent
 from the default audit sweep (`ALL_CATEGORIES`) and from the `attention`
@@ -36,6 +39,21 @@ rather than mutation.
   converge
 - **THEN** no `support_collapse` finding is emitted for that note
 
+#### Scenario: A citing page is never its own shared ancestor
+
+- **WHEN** a compiled page cites two sources that each, transitively, cite
+  the compiled page back
+- **THEN** no `support_collapse` finding for that page names the page itself
+  as the `shared_ancestor`
+
+#### Scenario: One converging tail produces one finding, not one per node
+
+- **WHEN** two of a page's directly cited sources both trace up through a
+  multi-hop shared tail (for example `C` cited by both, `C` itself citing
+  `D`, `D` citing `E`)
+- **THEN** exactly one `support_collapse` finding is emitted for that page,
+  naming the nearest node in the tail as the shared ancestor
+
 #### Scenario: A circular `sources:` chain is detected and terminates
 
 - **WHEN** a `sources:` chain loops back on itself, including a direct
@@ -48,9 +66,12 @@ rather than mutation.
 
 - **WHEN** the chain walk's depth or shared total-edge budget stops
   exploration before it completes
-- **THEN** a dedicated `truncated` finding is emitted naming the cap that was
-  hit
+- **THEN** a dedicated `truncated` finding is emitted naming which cap(s)
+  were actually hit (`depth`, `edges`, or both) and both configured limits
 - **AND** a run that never hits either cap emits no `truncated` finding
+- **AND** a per-page `support_collapse` finding computed from a truncated
+  closure carries the same reason(s) in its own meta, never a generic flag
+  that cannot distinguish which cap was responsible
 
 #### Scenario: Category is opt-in and never auto-repaired
 

--- a/openspec/changes/audit-derivation-double-counting/specs/attention-queue/spec.md
+++ b/openspec/changes/audit-derivation-double-counting/specs/attention-queue/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Derivation double-counting is an optional deterministic review category
+
+The `derivation_double_counting` audit category SHALL walk `sources:`
+(`derived_from`) chains and surface two finding kinds. A `support_collapse`
+finding SHALL be emitted for an active, writable compiled page of the types
+whose frontmatter specification marks provenance required — `research-note`,
+`insight`, `failure`, and `pattern` — when two or more of its directly cited
+`sources:` have ancestor chains that converge on a shared node; the finding
+SHALL name the shared ancestor and every contributing direct source. A
+`cycle` finding SHALL be emitted whenever a `sources:` chain is reachable
+from itself, including a direct self-reference, regardless of the
+originating page's type or status. The category SHALL be optional and absent
+from the default audit sweep (`ALL_CATEGORIES`) and from the `attention`
+composed queue's category set; it is requested explicitly via
+`audit(categories=["derivation_double_counting"])`.
+
+Every finding SHALL be `info` or `warn` severity, never `error`: a `cycle`
+finding SHALL be `warn`, a `support_collapse` finding SHALL be `info`. The
+category SHALL be strictly read-only — it SHALL NOT mutate a note, rewrite a
+relation, or change `find` or `attention` ranking — and SHALL propose review
+rather than mutation.
+
+#### Scenario: A diamond of derivation is surfaced as support collapse
+
+- **WHEN** a source `S` is cited by two derived notes `A` and `B`, and a
+  third active compiled note `C` cites both `A` and `B` in its `sources:`
+- **AND** `derivation_double_counting` is requested explicitly
+- **THEN** one `support_collapse` finding is emitted for `C`, naming `S` as
+  the shared ancestor and `A`/`B` as the contributing sources
+
+#### Scenario: Independent sources are not flagged
+
+- **WHEN** a compiled note cites two sources whose ancestor chains never
+  converge
+- **THEN** no `support_collapse` finding is emitted for that note
+
+#### Scenario: A circular `sources:` chain is detected and terminates
+
+- **WHEN** a `sources:` chain loops back on itself, including a direct
+  self-reference
+- **THEN** exactly one `cycle` finding is emitted for that cycle regardless
+  of how many nodes in it have outgoing `sources:` edges
+- **AND** the walk terminates rather than looping indefinitely
+
+#### Scenario: A capped traversal is visible, never silent
+
+- **WHEN** the chain walk's depth or shared total-edge budget stops
+  exploration before it completes
+- **THEN** a dedicated `truncated` finding is emitted naming the cap that was
+  hit
+- **AND** a run that never hits either cap emits no `truncated` finding
+
+#### Scenario: Category is opt-in and never auto-repaired
+
+- **WHEN** an audit is computed with no `categories` filter
+- **THEN** `derivation_double_counting` findings are absent from the default
+  sweep
+- **AND** no audit repair pass writes, infers, or removes a `sources:` entry
+  on its behalf

--- a/openspec/changes/audit-derivation-double-counting/tasks.md
+++ b/openspec/changes/audit-derivation-double-counting/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: audit-derivation-double-counting
+
+## 1. Bounded traversal primitive (pure logic, no vault I/O)
+
+- [x] 1.1 Red tests for `_derivation_direct_sources`, `_bounded_ancestor_walk`,
+      and `_DerivationBudget`: direct-source extraction from `sources:`
+      wikilinks, self-references kept as graph edges, a shared edge budget
+      that terminates a walk, and a depth cap that terminates a walk —
+      exercised indirectly through the category's own test fixtures (the
+      diamond, the clean chain, the self-loop, the two/three-node cycles, and
+      the depth-capped chain) rather than as separate unit tests of private
+      helpers.
+- [x] 1.2 Implement `_derivation_direct_sources`, `_DerivationBudget`,
+      `_DerivationWalk`, and `_bounded_ancestor_walk` in `src/exomem/audit.py`.
+
+## 2. `derivation_double_counting` category
+
+- [x] 2.1 Red tests for support collapse: the diamond (one source, two
+      derived notes, a third citing both) is flagged; a clean chain with
+      genuinely independent sources is NOT flagged (false-positive guard); a
+      single-source page is not a collapse candidate; a page whose two direct
+      sources overlap only because one directly cites the other still
+      collapses.
+- [x] 2.2 Red tests for the origination gate: only `research-note` /
+      `insight` / `failure` / `pattern` originate a `support_collapse`
+      finding; inactive status (`archived`) does not originate one.
+- [x] 2.3 Red tests for circular derivation: a direct self-reference (`A`
+      cites `A`) is a 2-node cycle; a 2-node cycle (`A` <-> `B`) is detected
+      and reported exactly once (deduplicated across both discovery
+      directions); a 3-node cycle (`A -> B -> C -> A`) terminates and is
+      reported exactly once.
+- [x] 2.4 Red tests for cap visibility: a chain longer than a lowered
+      `EXOMEM_DERIVATION_MAX_DEPTH` produces exactly one `truncated` finding
+      naming the cap; a small graph under the cap produces none.
+- [x] 2.5 Red tests for the hard constraints: every finding's severity is in
+      `{info, warn}`, never `error`; running the check (twice) never modifies
+      any file's mtime or content.
+- [x] 2.6 Implement `_check_derivation_double_counting`, register
+      `derivation_double_counting` in `OPTIONAL_CATEGORIES` (absent from
+      `ALL_CATEGORIES`), and wire it into `audit()`'s category dispatch.
+- [x] 2.7 Green: `tests/test_audit_derivation_double_counting.py` passes.
+
+## 3. Contract and gates
+
+- [x] 3.1 Confirm no public tool/contract surface changed (the category is
+      reachable only through the existing `audit(categories=...)` parameter,
+      already an open string list) — no schema/contract regeneration needed.
+- [x] 3.2 Run targeted gates: `tests/test_audit_derivation_double_counting.py`,
+      `tests/test_audit*.py`, `tests/test_epistemic_graph*.py`,
+      `tests/test_relation_registry*.py`, `tests/test_attention.py`,
+      `tests/test_memory_schema.py`; `uvx ruff check` on changed files;
+      `openspec validate audit-derivation-double-counting --strict`.

--- a/openspec/changes/audit-derivation-double-counting/tasks.md
+++ b/openspec/changes/audit-derivation-double-counting/tasks.md
@@ -2,14 +2,27 @@
 
 ## 1. Bounded traversal primitive (pure logic, no vault I/O)
 
-- [x] 1.1 Red tests for `_derivation_direct_sources`, `_bounded_ancestor_walk`,
-      and `_DerivationBudget`: direct-source extraction from `sources:`
-      wikilinks, self-references kept as graph edges, a shared edge budget
-      that terminates a walk, and a depth cap that terminates a walk —
-      exercised indirectly through the category's own test fixtures (the
-      diamond, the clean chain, the self-loop, the two/three-node cycles, and
-      the depth-capped chain) rather than as separate unit tests of private
-      helpers.
+- [x] 1.1 Red tests for `_derivation_direct_sources` and `_bounded_ancestor_walk`:
+      direct-source extraction from `sources:` wikilinks, self-references kept
+      as graph edges, and a depth cap that terminates a walk — exercised
+      through the category's own fixtures (the diamond, the clean chain, the
+      self-loop, the two/three-node cycles, the depth-capped chain). This
+      task originally *also* claimed the shared edge budget and the `seen`
+      cycle-terminator were exercised this way; mutation testing (correction
+      round 1) proved that false — replacing `_DerivationBudget.take` with
+      `lambda self: True`, and deleting the `seen` re-enqueue guard, both left
+      the suite fully green. Corrected by 1.1a below; this line now only
+      claims what the original fixtures actually cover.
+- [x] 1.1a (correction round 1) Red tests that isolate each mechanism from
+      the fixtures that accidentally didn't need it: an edge-budget-exhaustion
+      test on a chain well under the depth cap (so a `truncated` finding can
+      *only* come from the edge budget, not depth), and an `X -> A -> B -> A`
+      cycle fixture where `X` is not part of the `A<->B` cycle (2- and 3-node
+      self-closing cycles terminate via the `target == start` shortcut
+      regardless of `seen`; only a cycle reached *from* but not *containing*
+      the walk's start exercises `seen`'s necessity). Acceptance: both
+      mutations above now fail the suite — confirmed and reproduced in the
+      correction-round report.
 - [x] 1.2 Implement `_derivation_direct_sources`, `_DerivationBudget`,
       `_DerivationWalk`, and `_bounded_ancestor_walk` in `src/exomem/audit.py`.
 
@@ -50,3 +63,46 @@
       `tests/test_relation_registry*.py`, `tests/test_attention.py`,
       `tests/test_memory_schema.py`; `uvx ruff check` on changed files;
       `openspec validate audit-derivation-double-counting --strict`.
+
+## 4. Correction round 1 (independent mutation-testing review)
+
+- [x] 4.1 Red test proving a page can be reported as its own shared ancestor
+      (`C` cites `A`/`B`, both cite `C` back); fix by excluding the citing
+      page's own key from `collapse_roots` (design.md D6).
+- [x] 4.2 Red test proving one converging tail (`C <- D <- E`, both `A`/`B`
+      tracing through it) fans out to one finding per tail node instead of
+      one finding for the situation; fix via `_nearest_shared_roots`
+      (order-independent pairwise domination, with a deterministic
+      single-survivor fallback for a mutual-cycle-among-candidates edge case)
+      (design.md D6).
+- [x] 4.3 Re-derive `EXOMEM_DERIVATION_MAX_EDGES`'s default from a measured
+      edges-per-sourced-page rate, scaled to a ~5,000-file vault with margin,
+      then validate empirically against a synthetic 5,000-file vault built
+      with a realistic (shallow, tiered) citation shape — confirm the old
+      default truncates it and the new default does not, and confirm a
+      deliberately pathological deep/braided-chain vault still terminates
+      promptly with truncation correctly attributed to `depth` (design.md D2).
+- [x] 4.4 Replace `_DerivationWalk.truncated: bool` with `truncated_reasons:
+      frozenset[str]` (`{"depth", "edges"}`) so an edge-budget truncation is
+      never misreported as depth-capped; thread the reason set into both the
+      per-page `support_collapse` finding's meta and the aggregate
+      `truncated` finding's meta and detail text.
+- [x] 4.5 Track the original raw `sources:` wikilink text per canon key so an
+      unresolved `shared_ancestor`/`via_sources` target renders as a
+      reconstructed vault-relative path instead of the internal lowercase
+      canon key (design.md D7).
+- [x] 4.6 Adopt `_STALE_SKIP_SLUG_SUFFIXES`/`_STALE_SKIP_TAGS` in the
+      support-collapse origination gate (previously only claimed in a
+      comment, not in code) and correct the comment to describe the complete,
+      now-accurate exclusion set (design.md D4).
+- [x] 4.7 Widen the read-only test from `rglob("*.md")` to `rglob("*")` and
+      assert findings are non-empty, so the check cannot pass vacuously
+      against a `return []` no-op.
+- [x] 4.8 Mutation-test acceptance: with `_DerivationBudget.take` replaced by
+      `lambda self: True`, the suite fails (isolated to the new 4.1a-adjacent
+      edge-budget test). With the `seen` re-enqueue guard deleted, the suite
+      fails (isolated to the new `X -> A -> B -> A` test). Both mutations
+      reverted; suite green afterward; restored file confirmed byte-identical
+      to the pre-mutation state via `diff`.
+- [x] 4.9 Re-run targeted gates from 3.2 plus `openspec validate
+      audit-derivation-double-counting --strict` after all fixes.

--- a/src/exomem/audit.py
+++ b/src/exomem/audit.py
@@ -2630,10 +2630,6 @@ class _DerivationWalk:
     cycle_path: tuple[str, ...] | None  # start -> ... -> start, if `start` reaches itself
     truncated_reasons: frozenset[str]  # subset of {"depth", "edges"}; empty = complete
 
-    @property
-    def truncated(self) -> bool:
-        return bool(self.truncated_reasons)
-
 
 def _derivation_direct_sources(
     pages: list[find_module.ParsedPage],
@@ -2749,6 +2745,17 @@ def _nearest_shared_roots(
     order. If every candidate ends up mutually dominated (a cycle among the
     candidates themselves), keep one deterministic representative rather than
     silently emitting nothing for a genuine collapse.
+
+    Known gap, deliberately not addressed: if the candidates form TWO (or
+    more) disjoint mutually-dominating cyclic clusters — e.g. {P, Q} each
+    reachable from the other, and separately {R, S} each reachable from the
+    other, with no path between the two clusters — every candidate across
+    BOTH clusters is "dominated by someone", so the single-survivor fallback
+    picks one representative overall and silently drops the other cluster's
+    distinct convergence point, not just redundant nodes on the same tail.
+    This is exotic (it requires the ancestor graph itself to contain a cycle,
+    which is separately reported as its own `warn`-severity `cycle` finding)
+    and not worth the extra bookkeeping a per-cluster fallback would need.
     """
     keys = list(candidates)
     if len(keys) <= 1:

--- a/src/exomem/audit.py
+++ b/src/exomem/audit.py
@@ -19,6 +19,15 @@ Checks (all read-only; no writes ever):
   `find` AND low inbound-link degree — a measurement-only review candidate.
   Surfaces it for the reader to judge (keep / supersede / archive); never
   decays, down-ranks, or moves anything (`find` ordering is unchanged).
+- `derivation_double_counting` (optional): walks `sources:` (`derived_from`)
+  chains for two failures ordinary checks cannot see. Support collapse: a
+  compiled page cites two or more sources as independent support that
+  themselves trace back to a shared ancestor — a source laundered into
+  "multiple sources agree". Circular derivation: a `sources:` chain that
+  loops back on itself. Both are informational/warn only, never error; the
+  traversal is bounded by depth and total-edge caps, and a dedicated
+  `truncated` finding makes a hit cap visible rather than silently reading as
+  "nothing found".
 - `corpus_contradictions`: corpus-wide sweep for pairs of ACTIVE read-write
   COMPILED conclusions whose embeddings sit in the contradiction band
   `[floor, dup_threshold)` — close enough to plausibly restate/refine/contradict
@@ -46,6 +55,7 @@ import math
 import os
 import re
 import stat
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal
@@ -85,6 +95,7 @@ ALL_CATEGORIES: tuple[str, ...] = (
 OPTIONAL_CATEGORIES: tuple[str, ...] = (
     "relation_registry",
     "missing_sources",
+    "derivation_double_counting",
     "semantic_contract_drift",
     "semantic_malformed_unit",
     "semantic_category_governance",
@@ -393,6 +404,8 @@ def audit(
         findings.extend(_check_relation_debt(vault_root, pages))
     if "missing_sources" in selected:
         findings.extend(_check_missing_sources(vault_root, pages))
+    if "derivation_double_counting" in selected:
+        findings.extend(_check_derivation_double_counting(vault_root, pages))
     if "governance_receipts" in selected:
         findings.extend(_check_governance_receipts(vault_root))
     if "bridge_review" in selected:
@@ -2550,6 +2563,288 @@ def _check_missing_sources(
         )
 
     return sorted(findings, key=lambda finding: finding.path)
+
+
+# ---------------- check: derivation_double_counting ----------------
+
+# Bounds on the `sources:` (`derived_from`) chain walk. Both are env-overridable
+# so ops can tune without redeploying (same convention as `_stale_thresholds`).
+# The depth cap bounds how many hops are followed from any single node; the edge
+# cap bounds total work across the WHOLE audit pass (shared across every walk),
+# protecting a vault with thousands of notes and dense wikilinks from an
+# unbounded chain walk. Either cap being hit produces a dedicated `truncated`
+# finding rather than silently under-reporting.
+_DERIVATION_DEFAULT_MAX_DEPTH = 12
+_DERIVATION_DEFAULT_MAX_EDGES = 2000
+
+
+def _derivation_traversal_limits() -> tuple[int, int]:
+    """(max_depth, max_edges); bad/non-positive env values fall back to default."""
+
+    def _int_env(name: str, default: int) -> int:
+        raw = os.environ.get(name)
+        if raw is None:
+            return default
+        try:
+            value = int(raw)
+        except ValueError:
+            log.warning("invalid %s=%r; using %s", name, raw, default)
+            return default
+        return value if value > 0 else default
+
+    return (
+        _int_env("EXOMEM_DERIVATION_MAX_DEPTH", _DERIVATION_DEFAULT_MAX_DEPTH),
+        _int_env("EXOMEM_DERIVATION_MAX_EDGES", _DERIVATION_DEFAULT_MAX_EDGES),
+    )
+
+
+@dataclass
+class _DerivationBudget:
+    """Total-edge cap shared across every walk in one audit pass."""
+
+    remaining: int
+
+    def take(self) -> bool:
+        if self.remaining <= 0:
+            return False
+        self.remaining -= 1
+        return True
+
+
+@dataclass(frozen=True)
+class _DerivationWalk:
+    ancestors: frozenset[str]        # keys reachable from `start`, excluding `start`
+    cycle_path: tuple[str, ...] | None  # start -> ... -> start, if `start` reaches itself
+    truncated: bool                  # depth or shared edge budget stopped exploration early
+
+
+def _derivation_direct_sources(
+    pages: list[find_module.ParsedPage],
+) -> dict[str, list[str]]:
+    """canon(page) -> ordered, de-duplicated canon(source) keys from `sources:`.
+
+    A page citing itself is kept (not filtered) so a trivial self-reference is
+    caught by cycle detection rather than silently dropped from the graph.
+    """
+    direct: dict[str, list[str]] = {}
+    for page in pages:
+        key = _relevance_canon(page.rel_path)
+        seen: set[str] = set()
+        targets: list[str] = []
+        for link in _extract_wikilinks_from_value(page.frontmatter.get("sources")):
+            target_key = _relevance_canon(link)
+            if not target_key or target_key in seen:
+                continue
+            seen.add(target_key)
+            targets.append(target_key)
+        direct[key] = targets
+    return direct
+
+
+def _bounded_ancestor_walk(
+    direct_sources: dict[str, list[str]],
+    start: str,
+    *,
+    max_depth: int,
+    budget: _DerivationBudget,
+) -> _DerivationWalk:
+    """BFS from `start` over `derived_from` edges, bounded by depth + a shared edge
+    budget. Always terminates: `seen` guards against revisiting a node regardless
+    of cycles, and the budget bounds total edges expanded across the whole audit
+    pass. Detects whether `start` is reachable from itself (a cycle) and
+    reconstructs one witness path.
+    """
+    parent: dict[str, str] = {}
+    seen = {start}
+    ancestors: set[str] = set()
+    frontier: deque[tuple[str, int]] = deque([(start, 0)])
+    cycle_path: tuple[str, ...] | None = None
+    truncated = False
+    while frontier:
+        node, depth = frontier.popleft()
+        if depth >= max_depth:
+            if direct_sources.get(node):
+                truncated = True
+            continue
+        for target in direct_sources.get(node, ()):
+            if not budget.take():
+                truncated = True
+                break
+            if target == start:
+                if cycle_path is None:
+                    path = [node]
+                    cur = node
+                    while cur != start:
+                        cur = parent[cur]
+                        path.append(cur)
+                    cycle_path = tuple(reversed(path)) + (start,)
+                ancestors.add(target)
+                continue
+            ancestors.add(target)
+            if target not in seen:
+                seen.add(target)
+                parent[target] = node
+                frontier.append((target, depth + 1))
+    return _DerivationWalk(
+        ancestors=frozenset(ancestors), cycle_path=cycle_path, truncated=truncated
+    )
+
+
+def _check_derivation_double_counting(
+    vault_root: Path,
+    pages: list[find_module.ParsedPage],
+) -> list[AuditFinding]:
+    """Walk `sources:` chains for support-collapse and circular derivation.
+
+    Read-only and observe-before-enforce: reports findings only, never rewrites
+    a relation, never demotes anything, never blocks a write. Severity is
+    `warn` for a genuine cycle (a structural inconsistency) and `info` for a
+    support-collapse candidate (a review candidate, not a defect) — never
+    `error`.
+    """
+    direct_sources = _derivation_direct_sources(pages)
+    pages_by_canon = {_relevance_canon(page.rel_path): page for page in pages}
+    max_depth, max_edges = _derivation_traversal_limits()
+    budget = _DerivationBudget(max_edges)
+    walk_cache: dict[str, _DerivationWalk] = {}
+    truncated_any = False
+    findings: list[AuditFinding] = []
+    cycles_reported: set[frozenset[str]] = set()
+
+    def walk(key: str) -> _DerivationWalk:
+        if key not in walk_cache:
+            walk_cache[key] = _bounded_ancestor_walk(
+                direct_sources, key, max_depth=max_depth, budget=budget
+            )
+        return walk_cache[key]
+
+    def display_path(key: str) -> str:
+        page = pages_by_canon.get(key)
+        return page.rel_path if page is not None else key
+
+    # -- circular derivation: any node with outgoing `sources:` edges may loop.
+    for key in sorted(direct_sources):
+        if not direct_sources[key]:
+            continue
+        result = walk(key)
+        if result.truncated:
+            truncated_any = True
+        if result.cycle_path is None:
+            continue
+        identity = frozenset(result.cycle_path)
+        if identity in cycles_reported:
+            continue
+        cycles_reported.add(identity)
+        origin_page = pages_by_canon.get(key)
+        cycle_display = [display_path(k) for k in result.cycle_path]
+        findings.append(
+            AuditFinding(
+                category="derivation_double_counting",
+                severity="warn",
+                path=display_path(key),
+                detail=(
+                    "Circular derivation: "
+                    + " -> ".join(cycle_display)
+                    + " — this `sources:` chain supports itself."
+                ),
+                proposed_fix=(
+                    "Review the `sources:` chain for a mistaken back-reference and "
+                    "remove or correct one entry to break the cycle. Nothing is "
+                    "auto-written."
+                ),
+                meta={
+                    "kind": "cycle",
+                    "cycle": cycle_display,
+                    "signal_version": (
+                        _page_signal_version(origin_page) if origin_page else None
+                    ),
+                },
+            )
+        )
+
+    # -- support collapse: only from active, read-write, provenance-bearing
+    # compiled pages citing two or more sources as (nominally) independent
+    # support — mirrors `_check_missing_sources`'s origination gate.
+    for page in pages:
+        if page.page_type not in _SOURCES_REQUIRED_TYPES:
+            continue
+        if page.path.name in ("index.md", "log.md"):
+            continue
+        if page.status in ("superseded", "archived", "draft", "dropped"):
+            continue
+        if access.access_tier(vault_root, page.rel_path) != access.TIER_READ_WRITE:
+            continue
+        key = _relevance_canon(page.rel_path)
+        directs = direct_sources.get(key, [])
+        if len(directs) < 2:
+            continue
+
+        closures: dict[str, frozenset[str]] = {}
+        page_truncated = False
+        for source_key in directs:
+            result = walk(source_key)
+            closures[source_key] = frozenset({source_key}) | result.ancestors
+            if result.truncated:
+                page_truncated = True
+                truncated_any = True
+
+        collapse_roots: dict[str, set[str]] = {}
+        for i, a in enumerate(directs):
+            for b in directs[i + 1 :]:
+                for shared_root in closures[a] & closures[b]:
+                    collapse_roots.setdefault(shared_root, set()).update({a, b})
+        if not collapse_roots:
+            continue
+
+        for root in sorted(collapse_roots):
+            via = sorted(collapse_roots[root])
+            findings.append(
+                AuditFinding(
+                    category="derivation_double_counting",
+                    severity="info",
+                    path=page.rel_path,
+                    detail=(
+                        f"{len(via)} of this page's cited sources trace back to a "
+                        f"shared ancestor ({display_path(root)}); citing them as "
+                        "independent support double-counts that ancestor."
+                    ),
+                    proposed_fix=(
+                        "Review whether these citations are genuinely independent "
+                        "evidence or restate the same underlying source; if not, "
+                        "cite the shared ancestor once. Nothing is auto-written."
+                    ),
+                    meta={
+                        "kind": "support_collapse",
+                        "shared_ancestor": display_path(root),
+                        "via_sources": [display_path(v) for v in via],
+                        "signal_version": _page_signal_version(page),
+                        "depth_capped": page_truncated,
+                    },
+                )
+            )
+
+    if truncated_any:
+        findings.append(
+            AuditFinding(
+                category="derivation_double_counting",
+                severity="info",
+                path=kb_prefix(),
+                detail=(
+                    f"derivation-chain traversal capped at depth {max_depth} and "
+                    f"{max_edges} total edges; some ancestor chains may extend "
+                    "further than reported here."
+                ),
+                proposed_fix=(
+                    "Re-run scoped to the densest chains, or raise "
+                    "EXOMEM_DERIVATION_MAX_DEPTH / EXOMEM_DERIVATION_MAX_EDGES."
+                ),
+                meta={"kind": "truncated", "max_depth": max_depth, "max_edges": max_edges},
+            )
+        )
+
+    return sorted(
+        findings, key=lambda finding: (finding.path, str((finding.meta or {}).get("kind") or ""))
+    )
 
 
 # ---------------- check: stale_review ----------------

--- a/src/exomem/audit.py
+++ b/src/exomem/audit.py
@@ -2574,8 +2574,21 @@ def _check_missing_sources(
 # protecting a vault with thousands of notes and dense wikilinks from an
 # unbounded chain walk. Either cap being hit produces a dedicated `truncated`
 # finding rather than silently under-reporting.
+#
+# The edge default is derived, not guessed: a mutation-testing pass measured
+# this walk (no cross-walk closure reuse — every distinct `sources:`-bearing
+# page gets its own independent bounded BFS) consuming ~10 edges per sourced
+# page in a chain-shaped graph, exhausting a 2000 budget at ~200 sourced
+# pages. For a ~5,000-file vault, assuming a generous (over-)estimate of up to
+# half the corpus carrying `sources:` (2,500 sourced pages) at that same ~10
+# edges/page rate: 2,500 * 10 = 25,000 edges needed; doubled for margin =
+# 50,000. See design.md D2 for the full derivation and the stress-test that
+# validated it.
 _DERIVATION_DEFAULT_MAX_DEPTH = 12
-_DERIVATION_DEFAULT_MAX_EDGES = 2000
+_DERIVATION_DEFAULT_MAX_EDGES = 50_000
+
+_DERIVATION_TRUNCATED_BY_DEPTH = "depth"
+_DERIVATION_TRUNCATED_BY_EDGES = "edges"
 
 
 def _derivation_traversal_limits() -> tuple[int, int]:
@@ -2615,18 +2628,30 @@ class _DerivationBudget:
 class _DerivationWalk:
     ancestors: frozenset[str]        # keys reachable from `start`, excluding `start`
     cycle_path: tuple[str, ...] | None  # start -> ... -> start, if `start` reaches itself
-    truncated: bool                  # depth or shared edge budget stopped exploration early
+    truncated_reasons: frozenset[str]  # subset of {"depth", "edges"}; empty = complete
+
+    @property
+    def truncated(self) -> bool:
+        return bool(self.truncated_reasons)
 
 
 def _derivation_direct_sources(
     pages: list[find_module.ParsedPage],
-) -> dict[str, list[str]]:
-    """canon(page) -> ordered, de-duplicated canon(source) keys from `sources:`.
+) -> tuple[dict[str, list[str]], dict[str, str]]:
+    """(direct_sources, raw_by_key).
 
-    A page citing itself is kept (not filtered) so a trivial self-reference is
-    caught by cycle detection rather than silently dropped from the graph.
+    `direct_sources`: canon(page) -> ordered, de-duplicated canon(source) keys
+    from `sources:`. A page citing itself is kept (not filtered) so a trivial
+    self-reference is caught by cycle detection rather than silently dropped
+    from the graph.
+
+    `raw_by_key`: canon key -> the first raw `sources:` wikilink text observed
+    for it, so an UNRESOLVED target (no matching page) can still be rendered
+    as a plausible vault-relative path in a finding rather than an internal
+    lowercase canon key an agent cannot open.
     """
     direct: dict[str, list[str]] = {}
+    raw_by_key: dict[str, str] = {}
     for page in pages:
         key = _relevance_canon(page.rel_path)
         seen: set[str] = set()
@@ -2637,8 +2662,26 @@ def _derivation_direct_sources(
                 continue
             seen.add(target_key)
             targets.append(target_key)
+            raw_by_key.setdefault(target_key, link)
         direct[key] = targets
-    return direct
+    return direct, raw_by_key
+
+
+def _derivation_best_effort_path(raw: str) -> str:
+    """Reconstruct a plausible vault-relative rel_path for an unresolved
+    `sources:` target. Every other `AuditFinding.path` (and every path inside
+    `meta`) is a vault-relative rel_path an agent can open directly; falling
+    back to the internal lowercase canon key instead would silently break
+    that contract for exactly the pages a reviewer most needs to inspect.
+    """
+    cleaned = raw.strip().strip("/")
+    if not cleaned:
+        return raw
+    if not cleaned.startswith(kb_prefix()):
+        cleaned = kb_prefix() + cleaned
+    if not cleaned.lower().endswith(".md"):
+        cleaned = cleaned + ".md"
+    return cleaned
 
 
 def _bounded_ancestor_walk(
@@ -2659,16 +2702,16 @@ def _bounded_ancestor_walk(
     ancestors: set[str] = set()
     frontier: deque[tuple[str, int]] = deque([(start, 0)])
     cycle_path: tuple[str, ...] | None = None
-    truncated = False
+    truncated_reasons: set[str] = set()
     while frontier:
         node, depth = frontier.popleft()
         if depth >= max_depth:
             if direct_sources.get(node):
-                truncated = True
+                truncated_reasons.add(_DERIVATION_TRUNCATED_BY_DEPTH)
             continue
         for target in direct_sources.get(node, ()):
             if not budget.take():
-                truncated = True
+                truncated_reasons.add(_DERIVATION_TRUNCATED_BY_EDGES)
                 break
             if target == start:
                 if cycle_path is None:
@@ -2686,8 +2729,40 @@ def _bounded_ancestor_walk(
                 parent[target] = node
                 frontier.append((target, depth + 1))
     return _DerivationWalk(
-        ancestors=frozenset(ancestors), cycle_path=cycle_path, truncated=truncated
+        ancestors=frozenset(ancestors),
+        cycle_path=cycle_path,
+        truncated_reasons=frozenset(truncated_reasons),
     )
+
+
+def _nearest_shared_roots(
+    candidates: dict[str, set[str]],
+    walk,
+) -> dict[str, set[str]]:
+    """Collapse one converging ancestral tail to its nearest node(s) only.
+
+    A shared root `Y` is dropped when some OTHER candidate `X` can reach `Y`
+    (i.e. `Y` is further upstream than `X`, discovered on the same tail) —
+    keeping only the convergence point(s) closest to the citing page instead
+    of emitting one finding per node in a multi-hop shared tail. Pairwise and
+    order-independent, so it is correct regardless of candidate iteration
+    order. If every candidate ends up mutually dominated (a cycle among the
+    candidates themselves), keep one deterministic representative rather than
+    silently emitting nothing for a genuine collapse.
+    """
+    keys = list(candidates)
+    if len(keys) <= 1:
+        return dict(candidates)
+    dominated: set[str] = set()
+    for x in keys:
+        reachable_from_x = walk(x).ancestors
+        for y in keys:
+            if y != x and y in reachable_from_x:
+                dominated.add(y)
+    survivors = [k for k in keys if k not in dominated]
+    if not survivors:
+        survivors = [min(keys)]
+    return {root: candidates[root] for root in survivors}
 
 
 def _check_derivation_double_counting(
@@ -2702,12 +2777,12 @@ def _check_derivation_double_counting(
     support-collapse candidate (a review candidate, not a defect) — never
     `error`.
     """
-    direct_sources = _derivation_direct_sources(pages)
+    direct_sources, raw_by_key = _derivation_direct_sources(pages)
     pages_by_canon = {_relevance_canon(page.rel_path): page for page in pages}
     max_depth, max_edges = _derivation_traversal_limits()
     budget = _DerivationBudget(max_edges)
     walk_cache: dict[str, _DerivationWalk] = {}
-    truncated_any = False
+    truncated_reasons_seen: set[str] = set()
     findings: list[AuditFinding] = []
     cycles_reported: set[frozenset[str]] = set()
 
@@ -2720,15 +2795,17 @@ def _check_derivation_double_counting(
 
     def display_path(key: str) -> str:
         page = pages_by_canon.get(key)
-        return page.rel_path if page is not None else key
+        if page is not None:
+            return page.rel_path
+        raw = raw_by_key.get(key)
+        return _derivation_best_effort_path(raw) if raw else key
 
     # -- circular derivation: any node with outgoing `sources:` edges may loop.
     for key in sorted(direct_sources):
         if not direct_sources[key]:
             continue
         result = walk(key)
-        if result.truncated:
-            truncated_any = True
+        truncated_reasons_seen |= result.truncated_reasons
         if result.cycle_path is None:
             continue
         identity = frozenset(result.cycle_path)
@@ -2764,7 +2841,10 @@ def _check_derivation_double_counting(
 
     # -- support collapse: only from active, read-write, provenance-bearing
     # compiled pages citing two or more sources as (nominally) independent
-    # support — mirrors `_check_missing_sources`'s origination gate.
+    # support. Mirrors `_check_missing_sources`'s origination gate exactly,
+    # including its hub/snapshot/slug-suffix common-hub damping — a hub or
+    # snapshot page is EXPECTED to fan its `sources:` out from a shared root
+    # and would otherwise dominate this queue with non-actionable noise.
     for page in pages:
         if page.page_type not in _SOURCES_REQUIRED_TYPES:
             continue
@@ -2774,27 +2854,37 @@ def _check_derivation_double_counting(
             continue
         if access.access_tier(vault_root, page.rel_path) != access.TIER_READ_WRITE:
             continue
+        stem = page.path.stem.lower()
+        if any(stem.endswith(suffix) for suffix in _STALE_SKIP_SLUG_SUFFIXES):
+            continue
+        if _STALE_SKIP_TAGS & set(page.tags):
+            continue
         key = _relevance_canon(page.rel_path)
         directs = direct_sources.get(key, [])
         if len(directs) < 2:
             continue
 
         closures: dict[str, frozenset[str]] = {}
-        page_truncated = False
+        page_reasons: set[str] = set()
         for source_key in directs:
             result = walk(source_key)
             closures[source_key] = frozenset({source_key}) | result.ancestors
-            if result.truncated:
-                page_truncated = True
-                truncated_any = True
+            page_reasons |= result.truncated_reasons
+        truncated_reasons_seen |= page_reasons
 
         collapse_roots: dict[str, set[str]] = {}
         for i, a in enumerate(directs):
             for b in directs[i + 1 :]:
                 for shared_root in closures[a] & closures[b]:
                     collapse_roots.setdefault(shared_root, set()).update({a, b})
+        # A page can never be its own shared ancestor — a back-citing source
+        # placing `key` in its own closure is a cycle, reported separately.
+        collapse_roots.pop(key, None)
         if not collapse_roots:
             continue
+        # One converging tail (C <- D <- E, both A and B reaching all three)
+        # is one situation, not one finding per node in the tail.
+        collapse_roots = _nearest_shared_roots(collapse_roots, walk)
 
         for root in sorted(collapse_roots):
             via = sorted(collapse_roots[root])
@@ -2818,27 +2908,33 @@ def _check_derivation_double_counting(
                         "shared_ancestor": display_path(root),
                         "via_sources": [display_path(v) for v in via],
                         "signal_version": _page_signal_version(page),
-                        "depth_capped": page_truncated,
+                        "truncated_reasons": sorted(page_reasons),
                     },
                 )
             )
 
-    if truncated_any:
+    if truncated_reasons_seen:
+        reasons_label = " and ".join(sorted(truncated_reasons_seen))
         findings.append(
             AuditFinding(
                 category="derivation_double_counting",
                 severity="info",
                 path=kb_prefix(),
                 detail=(
-                    f"derivation-chain traversal capped at depth {max_depth} and "
-                    f"{max_edges} total edges; some ancestor chains may extend "
-                    "further than reported here."
+                    f"derivation-chain traversal capped by {reasons_label} "
+                    f"(depth<={max_depth}, edges<={max_edges}); some ancestor "
+                    "chains may extend further than reported here."
                 ),
                 proposed_fix=(
                     "Re-run scoped to the densest chains, or raise "
                     "EXOMEM_DERIVATION_MAX_DEPTH / EXOMEM_DERIVATION_MAX_EDGES."
                 ),
-                meta={"kind": "truncated", "max_depth": max_depth, "max_edges": max_edges},
+                meta={
+                    "kind": "truncated",
+                    "max_depth": max_depth,
+                    "max_edges": max_edges,
+                    "reasons": sorted(truncated_reasons_seen),
+                },
             )
         )
 

--- a/tests/test_audit_derivation_double_counting.py
+++ b/tests/test_audit_derivation_double_counting.py
@@ -1,0 +1,301 @@
+"""`derivation_double_counting` — an opt-in, read-only audit category that walks
+`sources:` (`derived_from`) chains for two epistemic-integrity problems ordinary
+checks cannot see:
+
+- Support collapse: a page cites two or more sources as independent support, but
+  those sources themselves trace back to a shared ancestor — the classic
+  "one blog post laundered into multiple sources agree" failure.
+- Circular derivation: a `sources:` chain that loops back on itself.
+
+Observe-before-enforce: every finding is informational or warn, nothing is ever
+written, and the traversal is bounded (depth + total edges) with the cap made
+visible in a dedicated finding whenever it is hit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from exomem import audit as audit_module
+
+_FOLDER_BY_TYPE = {
+    "insight": "Knowledge Base/Notes/Insights",
+    "research-note": "Knowledge Base/Notes/Research/personal",
+    "failure": "Knowledge Base/Notes/Failures",
+    "pattern": "Knowledge Base/Notes/Patterns",
+    "experiment": "Knowledge Base/Notes/Experiments/health",
+    "production-log": "Knowledge Base/Notes/Productions/video",
+    "entity": "Knowledge Base/Entities",
+    "source": "Knowledge Base/Sources/Articles",
+}
+
+
+def _write(
+    vault: Path,
+    name: str,
+    *,
+    page_type: str = "insight",
+    sources: list[str] | None = None,
+    status: str = "active",
+    tags: str = "[]",
+) -> str:
+    folder = _FOLDER_BY_TYPE[page_type]
+    rel = f"{folder}/{name}.md"
+    path = vault / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sources_literal = (
+        "[]" if not sources else "[" + ", ".join(f'"[[{s}]]"' for s in sources) + "]"
+    )
+    extra = "project: personal\n" if page_type == "research-note" else ""
+    path.write_text(
+        f"---\ntype: {page_type}\nstatus: {status}\ncreated: 2026-07-10\n"
+        f"updated: 2026-07-10\nsources: {sources_literal}\ntags: {tags}\n{extra}---\n"
+        f"\n## Finding\n\nBody.\n",
+        encoding="utf-8",
+    )
+    return rel.removesuffix(".md")
+
+
+def _findings(vault: Path):
+    return audit_module.audit(vault, categories=["derivation_double_counting"]).findings
+
+
+def _by_kind(findings, kind: str):
+    return [f for f in findings if (f.meta or {}).get("kind") == kind]
+
+
+# ---------------- registration ----------------
+
+
+def test_category_is_optional_and_absent_from_the_default_sweep(tmp_path: Path) -> None:
+    _write(tmp_path, "s", page_type="source")
+
+    assert "derivation_double_counting" in audit_module.OPTIONAL_CATEGORIES
+    assert "derivation_double_counting" not in audit_module.ALL_CATEGORIES
+
+    default_categories = {
+        finding.category for finding in audit_module.audit(tmp_path).findings
+    }
+    assert "derivation_double_counting" not in default_categories
+
+
+# ---------------- support collapse (the diamond) ----------------
+
+
+def test_diamond_support_collapse_is_flagged(tmp_path: Path) -> None:
+    s = _write(tmp_path, "root-source", page_type="source")
+    a = _write(tmp_path, "derived-a", sources=[s])
+    b = _write(tmp_path, "derived-b", sources=[s])
+    c = _write(tmp_path, "citing-both", sources=[a, b])
+
+    findings = _by_kind(_findings(tmp_path), "support_collapse")
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.path == c + ".md"
+    assert finding.severity == "info"
+    assert finding.meta["shared_ancestor"] == s + ".md"
+    assert sorted(finding.meta["via_sources"]) == sorted([a + ".md", b + ".md"])
+    assert "double-count" in finding.detail.lower()
+
+
+def test_clean_chain_with_independent_sources_produces_no_finding(tmp_path: Path) -> None:
+    """The false-positive guard: genuinely independent sources must not be flagged."""
+    s1 = _write(tmp_path, "root-source-1", page_type="source")
+    s2 = _write(tmp_path, "root-source-2", page_type="source")
+    a = _write(tmp_path, "derived-a", sources=[s1])
+    b = _write(tmp_path, "derived-b", sources=[s2])
+    _write(tmp_path, "citing-both", sources=[a, b])
+
+    assert _by_kind(_findings(tmp_path), "support_collapse") == []
+
+
+def test_single_source_is_not_a_collapse_candidate(tmp_path: Path) -> None:
+    s = _write(tmp_path, "root-source", page_type="source")
+    a = _write(tmp_path, "derived-a", sources=[s])
+    _write(tmp_path, "citing-one", sources=[a])
+
+    assert _by_kind(_findings(tmp_path), "support_collapse") == []
+
+
+def test_direct_duplicate_shared_source_also_collapses(tmp_path: Path) -> None:
+    """A page whose two direct sources cite the same source directly (not
+    transitively) still counts as double-counting the shared ancestor."""
+    s = _write(tmp_path, "root-source", page_type="source")
+    a = _write(tmp_path, "derived-a", sources=[s])
+    c = _write(tmp_path, "citing-both", sources=[a, s])
+
+    findings = _by_kind(_findings(tmp_path), "support_collapse")
+
+    assert len(findings) == 1
+    assert findings[0].path == c + ".md"
+    assert findings[0].meta["shared_ancestor"] == s + ".md"
+
+
+def test_only_provenance_bearing_types_originate_a_collapse_finding(tmp_path: Path) -> None:
+    s = _write(tmp_path, "root-source", page_type="source")
+    a = _write(tmp_path, "derived-a", sources=[s])
+    b = _write(tmp_path, "derived-b", sources=[s])
+    _write(tmp_path, "citing-both", page_type="production-log", sources=[a, b])
+
+    assert _by_kind(_findings(tmp_path), "support_collapse") == []
+
+
+def test_inactive_status_does_not_originate_a_collapse_finding(tmp_path: Path) -> None:
+    s = _write(tmp_path, "root-source", page_type="source")
+    a = _write(tmp_path, "derived-a", sources=[s])
+    b = _write(tmp_path, "derived-b", sources=[s])
+    _write(tmp_path, "citing-both", sources=[a, b], status="archived")
+
+    assert _by_kind(_findings(tmp_path), "support_collapse") == []
+
+
+# ---------------- circular derivation ----------------
+
+
+def test_direct_self_reference_is_flagged_as_a_cycle(tmp_path: Path) -> None:
+    a_rel = f"{_FOLDER_BY_TYPE['insight']}/self-loop.md"
+    (tmp_path / a_rel).parent.mkdir(parents=True, exist_ok=True)
+    a = "Knowledge Base/Notes/Insights/self-loop"
+    (tmp_path / a_rel).write_text(
+        f"---\ntype: insight\nstatus: active\ncreated: 2026-07-10\n"
+        f"updated: 2026-07-10\nsources: [\"[[{a}]]\"]\ntags: []\n---\n\n## Finding\n\nBody.\n",
+        encoding="utf-8",
+    )
+
+    findings = _by_kind(_findings(tmp_path), "cycle")
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.severity == "warn"
+    assert finding.meta["cycle"][0] == finding.meta["cycle"][-1]
+    assert len(finding.meta["cycle"]) == 2
+
+
+def test_two_node_cycle_is_detected_and_deduplicated(tmp_path: Path) -> None:
+    a_rel = "Knowledge Base/Notes/Insights/loop-a.md"
+    b_rel = "Knowledge Base/Notes/Insights/loop-b.md"
+    a_key = "Knowledge Base/Notes/Insights/loop-a"
+    b_key = "Knowledge Base/Notes/Insights/loop-b"
+    for rel, target in ((a_rel, b_key), (b_rel, a_key)):
+        (tmp_path / rel).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_path / rel).write_text(
+            f"---\ntype: insight\nstatus: active\ncreated: 2026-07-10\n"
+            f"updated: 2026-07-10\nsources: [\"[[{target}]]\"]\ntags: []\n---\n"
+            f"\n## Finding\n\nBody.\n",
+            encoding="utf-8",
+        )
+
+    findings = _by_kind(_findings(tmp_path), "cycle")
+
+    # One cycle exists in the graph; detected from both endpoints but reported once.
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.meta["cycle"][0] == finding.meta["cycle"][-1]
+    assert len(finding.meta["cycle"]) == 3
+    assert {finding.meta["cycle"][0], finding.meta["cycle"][1]} == {
+        a_key + ".md", b_key + ".md",
+    }
+
+
+def test_cycle_detection_terminates_on_a_longer_self_referential_chain(tmp_path: Path) -> None:
+    """A -> B -> C -> A must terminate (not loop forever) and be reported once."""
+    keys = {
+        "a": "Knowledge Base/Notes/Insights/chain-a",
+        "b": "Knowledge Base/Notes/Insights/chain-b",
+        "c": "Knowledge Base/Notes/Insights/chain-c",
+    }
+    edges = {"a": "b", "b": "c", "c": "a"}
+    for name, target in edges.items():
+        rel = f"{keys[name]}.md"
+        (tmp_path / rel).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_path / rel).write_text(
+            f"---\ntype: insight\nstatus: active\ncreated: 2026-07-10\n"
+            f"updated: 2026-07-10\nsources: [\"[[{keys[target]}]]\"]\ntags: []\n---\n"
+            f"\n## Finding\n\nBody.\n",
+            encoding="utf-8",
+        )
+
+    findings = _by_kind(_findings(tmp_path), "cycle")
+
+    assert len(findings) == 1
+    assert findings[0].meta["cycle"][0] == findings[0].meta["cycle"][-1]
+    assert len(findings[0].meta["cycle"]) == 4
+
+
+# ---------------- bounded traversal / cap visibility ----------------
+
+
+def test_truncation_is_visible_when_the_depth_cap_is_hit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_DERIVATION_MAX_DEPTH", "2")
+
+    # A chain of 6 hops, well past the depth-2 cap.
+    prior: str | None = None
+    for i in range(6):
+        name = f"chain-{i}"
+        sources = [prior] if prior else None
+        prior = _write(tmp_path, name, sources=sources)
+
+    findings = _findings(tmp_path)
+    truncated = _by_kind(findings, "truncated")
+
+    assert len(truncated) == 1
+    assert truncated[0].severity == "info"
+    assert truncated[0].meta["max_depth"] == 2
+
+
+def test_no_truncation_finding_when_the_graph_is_small(tmp_path: Path) -> None:
+    s = _write(tmp_path, "root-source", page_type="source")
+    a = _write(tmp_path, "derived-a", sources=[s])
+    _write(tmp_path, "citing-one", sources=[a])
+
+    assert _by_kind(_findings(tmp_path), "truncated") == []
+
+
+# ---------------- hard constraints: read-only, severity ----------------
+
+
+def test_severity_is_never_error(tmp_path: Path) -> None:
+    s = _write(tmp_path, "root-source", page_type="source")
+    a = _write(tmp_path, "derived-a", sources=[s])
+    b = _write(tmp_path, "derived-b", sources=[s])
+    _write(tmp_path, "citing-both", sources=[a, b])
+    a_rel = "Knowledge Base/Notes/Insights/self-loop.md"
+    (tmp_path / a_rel).parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / a_rel).write_text(
+        "---\ntype: insight\nstatus: active\ncreated: 2026-07-10\n"
+        "updated: 2026-07-10\n"
+        'sources: ["[[Knowledge Base/Notes/Insights/self-loop]]"]\ntags: []\n---\n'
+        "\n## Finding\n\nBody.\n",
+        encoding="utf-8",
+    )
+
+    findings = _findings(tmp_path)
+
+    assert findings, "expected at least one finding to check severities on"
+    assert {f.severity for f in findings} <= {"info", "warn"}
+
+
+def test_audit_is_read_only(tmp_path: Path) -> None:
+    s = _write(tmp_path, "root-source", page_type="source")
+    a = _write(tmp_path, "derived-a", sources=[s])
+    b = _write(tmp_path, "derived-b", sources=[s])
+    _write(tmp_path, "citing-both", sources=[a, b])
+
+    def _snapshot() -> dict[str, tuple[float, str]]:
+        return {
+            str(p): (p.stat().st_mtime, p.read_text(encoding="utf-8"))
+            for p in sorted(tmp_path.rglob("*.md"))
+        }
+
+    before = _snapshot()
+    _findings(tmp_path)
+    _findings(tmp_path)
+    after = _snapshot()
+
+    assert before == after
+    assert before.keys() == after.keys()

--- a/tests/test_audit_derivation_double_counting.py
+++ b/tests/test_audit_derivation_double_counting.py
@@ -134,6 +134,61 @@ def test_direct_duplicate_shared_source_also_collapses(tmp_path: Path) -> None:
     assert findings[0].meta["shared_ancestor"] == s + ".md"
 
 
+def test_origin_page_is_never_its_own_shared_ancestor(tmp_path: Path) -> None:
+    """C cites A and B; A and B each cite C back (forming two 2-cycles as a
+    byproduct -- unavoidable, since "C is reachable from A" and "A is one of
+    C's own direct sources" together mean a path back to C by construction).
+    A naive intersection lists C itself as C's own "shared ancestor";
+    `collapse_roots` must exclude the citing page.
+    """
+    c_key = "Knowledge Base/Notes/Insights/self-ancestor-c"
+    a_key = "Knowledge Base/Notes/Insights/self-ancestor-a"
+    b_key = "Knowledge Base/Notes/Insights/self-ancestor-b"
+    edges = {c_key: [a_key, b_key], a_key: [c_key], b_key: [c_key]}
+    for key, targets in edges.items():
+        rel = f"{key}.md"
+        (tmp_path / rel).parent.mkdir(parents=True, exist_ok=True)
+        sources_literal = "[" + ", ".join(f'"[[{t}]]"' for t in targets) + "]"
+        (tmp_path / rel).write_text(
+            f"---\ntype: insight\nstatus: active\ncreated: 2026-07-10\n"
+            f"updated: 2026-07-10\nsources: {sources_literal}\ntags: []\n---\n"
+            f"\n## Finding\n\nBody.\n",
+            encoding="utf-8",
+        )
+
+    findings = _by_kind(_findings(tmp_path), "support_collapse")
+
+    c_rel = c_key + ".md"
+    assert not any(f.meta["shared_ancestor"] == c_rel for f in findings)
+    assert not any(
+        f.path == c_rel and c_rel in f.meta["via_sources"] for f in findings
+    )
+
+
+def test_one_converging_tail_produces_one_finding_not_one_per_node(
+    tmp_path: Path,
+) -> None:
+    """E is cited by D, D is cited by C, and both A and B cite C directly
+    (so both trace up through the same C -> D -> E tail). Z cites A and B.
+    This is ONE collapse situation -- everything converges at C -- and must
+    produce exactly one finding naming the nearest shared ancestor, not one
+    finding per node (C, D, and E) in the shared tail.
+    """
+    e = _write(tmp_path, "tail-e", page_type="source")
+    d = _write(tmp_path, "tail-d", sources=[e])
+    c = _write(tmp_path, "tail-c", sources=[d])
+    a = _write(tmp_path, "tail-a", sources=[c])
+    b = _write(tmp_path, "tail-b", sources=[c])
+    z = _write(tmp_path, "tail-z", sources=[a, b])
+
+    findings = _by_kind(_findings(tmp_path), "support_collapse")
+
+    assert len(findings) == 1
+    assert findings[0].path == z + ".md"
+    assert findings[0].meta["shared_ancestor"] == c + ".md"
+    assert sorted(findings[0].meta["via_sources"]) == sorted([a + ".md", b + ".md"])
+
+
 def test_only_provenance_bearing_types_originate_a_collapse_finding(tmp_path: Path) -> None:
     s = _write(tmp_path, "root-source", page_type="source")
     a = _write(tmp_path, "derived-a", sources=[s])
@@ -200,6 +255,39 @@ def test_two_node_cycle_is_detected_and_deduplicated(tmp_path: Path) -> None:
     }
 
 
+def test_cycle_not_involving_the_walk_start_terminates_without_spurious_truncation(
+    tmp_path: Path,
+) -> None:
+    """X cites A but is not itself part of the A<->B cycle. Walking from X must
+    terminate cleanly (the `seen` guard stops re-enqueueing a node already
+    visited on this walk) rather than bouncing between A and B until the
+    depth/edge cap is hit and produces a spurious `truncated` finding.
+
+    2- and 3-node cycles that loop straight back to their own start terminate
+    via the `target == start` shortcut regardless of `seen` (see the tests
+    above) -- this fixture is the one shape that actually exercises the
+    `seen` guard's necessity: a cycle reachable FROM the walk's start, but
+    not containing the start itself.
+    """
+    a_key = "Knowledge Base/Notes/Insights/seen-guard-a"
+    b_key = "Knowledge Base/Notes/Insights/seen-guard-b"
+    for key, target in ((a_key, b_key), (b_key, a_key)):
+        rel = f"{key}.md"
+        (tmp_path / rel).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_path / rel).write_text(
+            f"---\ntype: insight\nstatus: active\ncreated: 2026-07-10\n"
+            f"updated: 2026-07-10\nsources: [\"[[{target}]]\"]\ntags: []\n---\n"
+            f"\n## Finding\n\nBody.\n",
+            encoding="utf-8",
+        )
+    _write(tmp_path, "seen-guard-x", sources=[a_key])
+
+    findings = _findings(tmp_path)
+
+    assert len(_by_kind(findings, "cycle")) == 1
+    assert _by_kind(findings, "truncated") == []
+
+
 def test_cycle_detection_terminates_on_a_longer_self_referential_chain(tmp_path: Path) -> None:
     """A -> B -> C -> A must terminate (not loop forever) and be reported once."""
     keys = {
@@ -246,6 +334,32 @@ def test_truncation_is_visible_when_the_depth_cap_is_hit(
     assert len(truncated) == 1
     assert truncated[0].severity == "info"
     assert truncated[0].meta["max_depth"] == 2
+    assert truncated[0].meta["reasons"] == ["depth"]
+
+
+def test_edge_budget_cap_is_reported_and_is_the_sole_cause(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Isolates the shared edge budget from the depth cap: this chain (4 hops)
+    is well under the default depth cap (12), so if the edge budget were
+    removed entirely (mutation: `_DerivationBudget.take` always returning
+    True) every walk would complete cleanly and no `truncated` finding would
+    ever be emitted -- there would be nothing left to bound it.
+    """
+    monkeypatch.setenv("EXOMEM_DERIVATION_MAX_EDGES", "5")
+
+    prior: str | None = None
+    for i in range(5):  # 4 edges per full walk of the deepest node; well under depth=12
+        name = f"edge-chain-{i}"
+        sources = [prior] if prior else None
+        prior = _write(tmp_path, name, sources=sources)
+
+    findings = _findings(tmp_path)
+    truncated = _by_kind(findings, "truncated")
+
+    assert len(truncated) == 1
+    assert truncated[0].meta["max_edges"] == 5
+    assert truncated[0].meta["reasons"] == ["edges"]
 
 
 def test_no_truncation_finding_when_the_graph_is_small(tmp_path: Path) -> None:
@@ -286,16 +400,24 @@ def test_audit_is_read_only(tmp_path: Path) -> None:
     b = _write(tmp_path, "derived-b", sources=[s])
     _write(tmp_path, "citing-both", sources=[a, b])
 
-    def _snapshot() -> dict[str, tuple[float, str]]:
+    def _snapshot() -> dict[str, tuple[float, bytes] | None]:
+        # `rglob("*")`, not `*.md`: a no-op check that only globbed Markdown
+        # would still pass a vacuous `return []` implementation that creates
+        # a new non-.md file. Directories snapshot as None (no content/mtime
+        # comparison meaningful for them, but their presence/absence still
+        # participates in the `keys()` equality check below).
         return {
-            str(p): (p.stat().st_mtime, p.read_text(encoding="utf-8"))
-            for p in sorted(tmp_path.rglob("*.md"))
+            str(p): (
+                None if p.is_dir() else (p.stat().st_mtime, p.read_bytes())
+            )
+            for p in sorted(tmp_path.rglob("*"))
         }
 
     before = _snapshot()
-    _findings(tmp_path)
+    findings = _findings(tmp_path)
     _findings(tmp_path)
     after = _snapshot()
 
-    assert before == after
+    assert findings, "expected at least one finding — a no-op check must not pass vacuously"
     assert before.keys() == after.keys()
+    assert before == after

--- a/tests/test_audit_derivation_double_counting.py
+++ b/tests/test_audit_derivation_double_counting.py
@@ -134,17 +134,51 @@ def test_direct_duplicate_shared_source_also_collapses(tmp_path: Path) -> None:
     assert findings[0].meta["shared_ancestor"] == s + ".md"
 
 
-def test_origin_page_is_never_its_own_shared_ancestor(tmp_path: Path) -> None:
-    """C cites A and B; A and B each cite C back (forming two 2-cycles as a
-    byproduct -- unavoidable, since "C is reachable from A" and "A is one of
-    C's own direct sources" together mean a path back to C by construction).
-    A naive intersection lists C itself as C's own "shared ancestor";
-    `collapse_roots` must exclude the citing page.
+def test_unresolved_shared_ancestor_gets_a_reconstructed_vault_path(
+    tmp_path: Path,
+) -> None:
+    """The shared ancestor here is never written as a real page -- `sources:`
+    can legitimately point at material this vault has no parsed page for.
+    `shared_ancestor` must still be a vault-relative rel_path an agent could
+    open (or get an honest "not found" from), not the internal lowercase,
+    extension-stripped canon key every other lookup in this module uses.
     """
-    c_key = "Knowledge Base/Notes/Insights/self-ancestor-c"
-    a_key = "Knowledge Base/Notes/Insights/self-ancestor-a"
-    b_key = "Knowledge Base/Notes/Insights/self-ancestor-b"
-    edges = {c_key: [a_key, b_key], a_key: [c_key], b_key: [c_key]}
+    ghost = "Knowledge Base/Sources/Articles/ghost-page"
+    a = _write(tmp_path, "derived-a", sources=[ghost])
+    b = _write(tmp_path, "derived-b", sources=[ghost])
+    _write(tmp_path, "citing-both", sources=[a, b])
+
+    findings = _by_kind(_findings(tmp_path), "support_collapse")
+
+    assert len(findings) == 1
+    shared = findings[0].meta["shared_ancestor"]
+    assert shared == f"{ghost}.md"
+    assert shared != ghost.lower()  # not the internal canon key
+    assert shared.startswith("Knowledge Base/")
+
+
+def test_origin_page_is_never_its_own_shared_ancestor(tmp_path: Path) -> None:
+    """The origin cites two sources that each cite the origin back (forming
+    two 2-cycles as a byproduct -- unavoidable, since "the origin is
+    reachable from a source" and "that source is one of the origin's own
+    direct sources" together mean a path back to the origin by construction).
+    A naive intersection lists the origin itself as its own "shared
+    ancestor"; `collapse_roots` must exclude the citing page.
+
+    Names are chosen so the origin sorts FIRST among the three canon keys
+    (`aaa-origin` < `zzz-src-a` < `zzz-src-b`). This is load-bearing for the
+    test, not decoration: when all three candidates end up mutually
+    dominated (as they do here -- see `_nearest_shared_roots`), the
+    deterministic single-survivor fallback picks `min(keys)`. With the
+    origin-exclusion fix removed, that fallback would otherwise coincidentally
+    pick a source rather than the origin if the origin didn't sort first,
+    silently passing this test while the underlying bug (the origin reported
+    as its own shared ancestor) remained.
+    """
+    origin_key = "Knowledge Base/Notes/Insights/aaa-origin"
+    a_key = "Knowledge Base/Notes/Insights/zzz-src-a"
+    b_key = "Knowledge Base/Notes/Insights/zzz-src-b"
+    edges = {origin_key: [a_key, b_key], a_key: [origin_key], b_key: [origin_key]}
     for key, targets in edges.items():
         rel = f"{key}.md"
         (tmp_path / rel).parent.mkdir(parents=True, exist_ok=True)
@@ -158,10 +192,10 @@ def test_origin_page_is_never_its_own_shared_ancestor(tmp_path: Path) -> None:
 
     findings = _by_kind(_findings(tmp_path), "support_collapse")
 
-    c_rel = c_key + ".md"
-    assert not any(f.meta["shared_ancestor"] == c_rel for f in findings)
+    origin_rel = origin_key + ".md"
+    assert not any(f.meta["shared_ancestor"] == origin_rel for f in findings)
     assert not any(
-        f.path == c_rel and c_rel in f.meta["via_sources"] for f in findings
+        f.path == origin_rel and origin_rel in f.meta["via_sources"] for f in findings
     )
 
 
@@ -203,6 +237,29 @@ def test_inactive_status_does_not_originate_a_collapse_finding(tmp_path: Path) -
     a = _write(tmp_path, "derived-a", sources=[s])
     b = _write(tmp_path, "derived-b", sources=[s])
     _write(tmp_path, "citing-both", sources=[a, b], status="archived")
+
+    assert _by_kind(_findings(tmp_path), "support_collapse") == []
+
+
+def test_architecture_slug_suffix_is_excluded_from_origination(tmp_path: Path) -> None:
+    """A convention-named hub/snapshot page is EXPECTED to fan its `sources:`
+    out from a shared root (`relation_debt`/`missing_sources` already carry
+    this exact exclusion) -- without it, this diamond would otherwise be
+    flagged exactly like `test_diamond_support_collapse_is_flagged`.
+    """
+    s = _write(tmp_path, "root-source", page_type="source")
+    a = _write(tmp_path, "derived-a", sources=[s])
+    b = _write(tmp_path, "derived-b", sources=[s])
+    _write(tmp_path, "retrieval-architecture", sources=[a, b])
+
+    assert _by_kind(_findings(tmp_path), "support_collapse") == []
+
+
+def test_hub_tag_is_excluded_from_origination(tmp_path: Path) -> None:
+    s = _write(tmp_path, "root-source", page_type="source")
+    a = _write(tmp_path, "derived-a", sources=[s])
+    b = _write(tmp_path, "derived-b", sources=[s])
+    _write(tmp_path, "citing-both", sources=[a, b], tags="[hub]")
 
     assert _by_kind(_findings(tmp_path), "support_collapse") == []
 


### PR DESCRIPTION
Programme change 12 of 12 from the 2026-08-14 epistemic architecture audit (§13, Tier 4). Depends on nothing; read-only and parallel to the rest of the programme.

## Why

Two gaps that are currently absent entirely, in a system whose pitch is provenance:

**Double-counted evidence.** Two notes derived from one source, then a third citing both as independent support, is invisible to every existing check. That is the classic laundering failure — one blog post becomes "multiple sources agree" — and nothing detects it.

**Circular evidence.** Nothing walks support chains for cycles, so A supports B supports A via a derived note passes silently.

## What changed

A read-only, opt-in audit category `derivation_double_counting` that walks `sources:`/`derived_from` adjacency built from already-parsed frontmatter — no dependency on the graph sidecar. One bounded BFS serves both purposes: `support_collapse` findings (info) where two or more of a page's direct sources converge on a shared ancestor, and `cycle` findings (warn) for any chain reachable from itself.

Observe before enforcing. It reports; it never mutates a note, rewrites a relation, demotes anything, or blocks a write. Severity is never `error` — these are review candidates. It is opt-in via `OPTIONAL_CATEGORIES`, absent from `ALL_CATEGORIES` and from the composed attention queue, matching the `missing_sources` precedent.

## Bounded work, and a visible cap

The traversal is capped by depth (12) and a shared edge budget across the whole pass, both env-overridable. Hitting either cap emits a dedicated finding naming **which** cap fired — a silent cut-off reading as "nothing found" is the failure mode this category would otherwise introduce, and it is the same shape as the correctness bug fixed in #512.

The default budget was re-derived after review. The original 2,000 hit its cap at roughly 200 sourced notes, which would have made the category permanently useless on this vault. It is now 50,000, validated empirically: a synthetic 5,000-file vault hits the cap at the old default and completes clean in ~1.3s at the new one. `design.md` records that the figure is **shape-derived, not size-derived** — measured at 4.0 edges/page at 3 citation tiers, 22.8 at 6, and 503 at 12 — so a vault that deepens rather than widens will still hit the cap, visibly, and the env override is the intended remedy.

## Independent review found five real defects

A fresh reviewer returned REQUEST_CHANGES using mutation testing rather than inspection, and it mattered: **removing the edge budget entirely passed 14/14, and removing the cycle-termination guard passed 14/14.** Both mechanisms the design leans on hardest for safety were asserted nowhere.

Fixed, and each re-verified by the mutation now failing:

- The edge budget has a test that attributes the cut-off to the edge cap specifically.
- The `seen` guard has a fixture shaped `X -> A`, `A <-> B` walked from `X` — the only shape where it matters, since a cycle containing the start node terminates without it.
- A page could be emitted as its own shared ancestor in cyclic regions; `collapse_roots` now excludes the origin.
- One logical collapse fanned out to one finding per node in the shared tail; only the nearest ancestor(s) are reported now.
- The budget default, as above.

A targeted recheck then caught that the fix for the third item had a **vacuous test** — it passed with the fix removed, because the fixture named the origin so it sorted after its sources and a `min()` fallback happened to pick a source instead. Renamed so the origin sorts first; the mutation now fails it.

Two known gaps are documented rather than silently carried: `_nearest_shared_roots`'s single-survivor fallback can lose one convergence point when a page has two disjoint mutually-dominating cyclic ancestor clusters (separately reported as `warn` cycles), and the budget's shape sensitivity above.

## Verification

- `openspec validate audit-derivation-double-counting --strict` passes.
- 21 tests in the new file; 290 passing across the audit, graph, relation-registry, attention and memory-schema suites.
- `ruff` clean; `tests/golden/`, `.github/`, and both pinned contract files untouched.

The full lean suite was not run locally — a single-process run takes ~100 minutes on this machine. CI's four-way sharded run is authoritative.
