### PR TITLE
test(media): make the _TransientChild stub set returncode like Popen

### DIFF
--- a/tests/test_media_worker.py
+++ b/tests/test_media_worker.py
@@ -2120,10 +2120,14 @@ def test_supervisor_backs_off_after_transient_child_exit(
 
     class _TransientChild:
         pid = 2_147_483_645
+        returncode = None
 
-        @staticmethod
-        def poll():
-            return returncode
+        def poll(self):
+            # Mirrors real subprocess.Popen.poll(), which sets the `returncode`
+            # ATTRIBUTE as a side effect — the consumer reads `child.returncode`
+            # separately from the poll() return value.
+            self.returncode = returncode
+            return self.returncode
 
     worker._child = _TransientChild()
     monkeypatch.setattr(
@@ -2136,6 +2140,9 @@ def test_supervisor_backs_off_after_transient_child_exit(
     thread.start()
     try:
         time.sleep(0.1)
+        assert thread.is_alive(), (
+            "supervisor thread died — the transient-exit backoff branch was never reached"
+        )
         assert worker._child is None
     finally:
         worker._stop_event.set()


### PR DESCRIPTION
## What

Test-only fix for #505: the `_TransientChild` stub defined `poll()` as a
`@staticmethod` returning a closed-over exit code but never set a `returncode`
attribute. The production supervisor (`media_worker._supervise`) calls
`child.poll()` and then reads `child.returncode` separately, so the stub raised
`AttributeError` inside the supervisor thread's `try` (which has no `except`) —
the thread died silently, its `finally` cleared `worker._child`, and the test's
only assertion (`worker._child is None`) passed without ever reaching the
transient-relaunch backoff branch it claims to test.

- `poll()` is now an instance method that sets `self.returncode` before
  returning it, mirroring real `Popen` semantics.
- Added `assert thread.is_alive()` before the existing assertion, so the test
  can never again pass via a dead supervisor thread.

Production code untouched.

## Verification

- Red first: with only the strengthened assertion applied to the old stub, both
  parametrized cases failed — the supervisor thread died with
  `AttributeError: '_TransientChild' object has no attribute 'returncode'`
  (surfaced via `PytestUnhandledThreadExceptionWarning`), then the new
  `thread.is_alive()` assertion failed as designed.
- Green: `2 passed` for the node; full file `uv run --frozen python -m pytest
  tests/test_media_worker.py -q` → **76 passed** on native Windows.
- `uvx ruff check tests/test_media_worker.py --select F` clean.
- Independent review verdict: **APPROVE, zero findings** — reviewer re-ran the
  tests, verified the failure mechanism against `media_worker.py:782-790`, and
  confirmed the backoff delays (5 s/30 s) leave no flake window around the
  0.1 s check (the risk direction under load is toward *passing*, not flaking).

Closes #505
