### PR TITLE
feat(doctor): add write-path observability checks

### DIFF
--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -98,6 +98,20 @@ _DEFERRED_BACKLOG_FAIL_TOTAL = 300
 _REBUILD_TEMP_ORPHAN_FAIL_COUNT = 5
 _REBUILD_TEMP_ORPHAN_FAIL_BYTES = 50 * 1024 * 1024
 
+#: Age (by mtime) above which a matching rebuild-temp file is treated as an
+#: orphan candidate rather than a legitimate in-flight rebuild. A single
+#: `rebuild_atomic()` pass (corpus scan + delta replay + WAL fold, or the
+#: graph-rebuild equivalent) writes to its temp file throughout the build, so
+#: an active one has a continuously fresh mtime; only a killed process leaves
+#: one whose mtime stops advancing. 60 minutes is comfortably above any
+#: plausible single-build write gap (the incident's abandoned files sat
+#: unmodified for days-to-weeks — 30 rebuilds spanning July 25-Aug 15 — not
+#: minutes) while still catching a truly abandoned temp promptly. Below this
+#: age, size is NOT evidence of a leak: the incident's own abandoned files
+#: averaged ~79 MB, well above the 50 MB fail-by-bytes threshold, but a
+#: same-sized in-flight rebuild is routine and must not fail.
+_REBUILD_TEMP_STALE_AGE_SECONDS = 60 * 60
+
 #: lexstore.rebuild_atomic() (lexstore.py:2469) names its detached build sibling
 #: `<lexical sidecar name>.rebuild-<uuid4().hex>.tmp`, optionally with a
 #: `-wal`/`-shm`/`-journal` companion suffix, and reaps it in its own `finally`
@@ -727,6 +741,13 @@ def _check_graph_sync_state(vault_root: Path | None) -> DoctorCheck:
     committed_graph_failure() when a real checkpoint is available, falling back
     to an honest message when it is not; unavailable fails with an honest
     message. Never claims to fix this itself — recovery is reconcile's job.
+
+    committed_graph_failure()'s own default remediation ("Run reconcile to
+    recover the derived graph.") names an internal op, not a runnable command
+    (see `_REBUILD_VECTORS_CMD`'s own comment for that history) — so this
+    always ensures the printed remediation includes the actual runnable
+    command, augmenting the canned text rather than discarding it when it is
+    more specific than the default.
     """
     if vault_root is None:
         return _check(
@@ -767,6 +788,13 @@ def _check_graph_sync_state(vault_root: Path | None) -> DoctorCheck:
             remediation = graph_sync.committed_graph_failure(checkpoint)[
                 "graph_sync_remediation"
             ]
+            if _REBUILD_VECTORS_CMD not in remediation:
+                # The canned text (its own default: "Run reconcile to recover
+                # the derived graph.") names an internal op, not a runnable
+                # shell command. Augment rather than replace so a more
+                # specific canned message (e.g. a threaded
+                # GraphRebuildRegistrationError remediation) is preserved.
+                remediation = f"{remediation} Run `{_REBUILD_VECTORS_CMD}`."
         else:
             remediation = f"Run `{_REBUILD_VECTORS_CMD}` to recover the derived graph."
         return _check(
@@ -803,17 +831,32 @@ def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
       matched via `_LEXICAL_REBUILD_TEMP_RE` (see its module-level comment for
       why this is hand-derived rather than imported).
 
-    Reports count + total bytes per family (`details["graph_rebuild"]`,
-    `details["lexical_rebuild"]`) plus a combined `count`/`total_bytes`.
-    Reclaiming either family requires the service stopped and no rebuild in
-    flight, so remediation names `exomem maintain` run out-of-process
-    (it reads the vault from EXOMEM_VAULT_PATH, not `--vault`).
+    A matching name alone is NOT evidence of an orphan: a legitimate in-flight
+    rebuild has a matching name too, and can legitimately be large (the
+    incident's own abandoned files averaged ~79 MB). Only a file whose mtime is
+    older than `_REBUILD_TEMP_STALE_AGE_SECONDS` is treated as a stale orphan
+    candidate; WARN/FAIL thresholds evaluate STALE counts/bytes exclusively, so
+    a fresh in-flight temporary of any size or count never trips them — its
+    remediation ("stop the service...") would itself create a real orphan if
+    followed against a rebuild that is still running.
+
+    `details` reports, per family (`details["graph_rebuild"]`,
+    `details["lexical_rebuild"]`) and combined: total `count`/`total_bytes`
+    (every matching name, regardless of age) and `stale_count`/`stale_bytes`
+    (age-gated, the population thresholds actually act on), plus
+    `stale_age_seconds`. Reclaiming a stale file requires the service stopped
+    and no rebuild in flight, so remediation names `exomem maintain` run
+    out-of-process (it reads the vault from EXOMEM_VAULT_PATH, not `--vault`).
     """
+    empty_family = {"count": 0, "total_bytes": 0, "stale_count": 0, "stale_bytes": 0}
     details: dict[str, object] = {
         "count": 0,
         "total_bytes": 0,
-        "graph_rebuild": {"count": 0, "total_bytes": 0},
-        "lexical_rebuild": {"count": 0, "total_bytes": 0},
+        "stale_count": 0,
+        "stale_bytes": 0,
+        "stale_age_seconds": _REBUILD_TEMP_STALE_AGE_SECONDS,
+        "graph_rebuild": dict(empty_family),
+        "lexical_rebuild": dict(empty_family),
     }
     if vault_root is None:
         return _check(
@@ -840,14 +883,27 @@ def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
             elif _LEXICAL_REBUILD_TEMP_RE.fullmatch(name) is not None:
                 lexical_orphans.append(entry)
 
+    now = time.time()
+
     def _family_stats(paths: list[Path]) -> dict[str, int]:
         total = 0
+        stale_count = 0
+        stale_total = 0
         for entry in paths:
             try:
-                total += entry.stat().st_size
+                st = entry.stat()
             except OSError:
                 continue
-        return {"count": len(paths), "total_bytes": total}
+            total += st.st_size
+            if now - st.st_mtime > _REBUILD_TEMP_STALE_AGE_SECONDS:
+                stale_count += 1
+                stale_total += st.st_size
+        return {
+            "count": len(paths),
+            "total_bytes": total,
+            "stale_count": stale_count,
+            "stale_bytes": stale_total,
+        }
 
     graph_stats = _family_stats(graph_orphans)
     lexical_stats = _family_stats(lexical_orphans)
@@ -855,9 +911,15 @@ def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
     details["lexical_rebuild"] = lexical_stats
     count = graph_stats["count"] + lexical_stats["count"]
     total_bytes = graph_stats["total_bytes"] + lexical_stats["total_bytes"]
+    stale_count = graph_stats["stale_count"] + lexical_stats["stale_count"]
+    stale_bytes = graph_stats["stale_bytes"] + lexical_stats["stale_bytes"]
     details["count"] = count
     details["total_bytes"] = total_bytes
+    details["stale_count"] = stale_count
+    details["stale_bytes"] = stale_bytes
     mb = total_bytes / (1024 * 1024)
+    stale_mb = stale_bytes / (1024 * 1024)
+    age_minutes = _REBUILD_TEMP_STALE_AGE_SECONDS // 60
 
     if count == 0:
         return _check(
@@ -866,39 +928,53 @@ def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
             "No orphaned rebuild temporaries found.",
             details=details,
         )
+    if stale_count == 0:
+        return _check(
+            "rebuild_temp.orphans",
+            "pass",
+            f"{count} rebuild temporary file(s) totaling {mb:.1f} MB present, none "
+            f"older than {age_minutes} minutes — likely an in-flight rebuild, not "
+            "an orphan.",
+            details=details,
+        )
     remediation = (
         "Stop the exomem service, then run `exomem maintain` out-of-process "
         "(it reads the vault from EXOMEM_VAULT_PATH, not --vault) to reclaim "
         "orphaned rebuild temporaries — reclaim is only safe once no rebuild is "
         "in flight."
     )
-    summary = f"graph={graph_stats['count']}, lexical={lexical_stats['count']}"
+    summary = (
+        f"graph={graph_stats['stale_count']}/{graph_stats['count']}, "
+        f"lexical={lexical_stats['stale_count']}/{lexical_stats['count']} "
+        "(stale/total)"
+    )
     if (
-        count > _REBUILD_TEMP_ORPHAN_FAIL_COUNT
-        or total_bytes > _REBUILD_TEMP_ORPHAN_FAIL_BYTES
+        stale_count > _REBUILD_TEMP_ORPHAN_FAIL_COUNT
+        or stale_bytes > _REBUILD_TEMP_ORPHAN_FAIL_BYTES
     ):
         return _check(
             "rebuild_temp.orphans",
             "fail",
-            f"{count} orphaned rebuild temporary file(s) totaling {mb:.1f} MB are "
-            f"leaking disk space from interrupted rebuilds ({summary}).",
+            f"{stale_count} rebuild temporary file(s) older than {age_minutes} "
+            f"minutes, totaling {stale_mb:.1f} MB, are leaking disk space from "
+            f"interrupted rebuilds ({summary}).",
             remediation,
             details=details,
         )
-    if count > 1:
+    if stale_count > 1:
         return _check(
             "rebuild_temp.orphans",
             "warn",
-            f"{count} orphaned rebuild temporary file(s) totaling {mb:.1f} MB "
-            f"({summary}).",
+            f"{stale_count} rebuild temporary file(s) older than {age_minutes} "
+            f"minutes, totaling {stale_mb:.1f} MB ({summary}).",
             remediation,
             details=details,
         )
     return _check(
         "rebuild_temp.orphans",
         "pass",
-        f"{count} orphaned rebuild temporary file(s) totaling {mb:.1f} MB "
-        "(below the warn threshold).",
+        f"{stale_count} rebuild temporary file older than {age_minutes} minutes, "
+        f"totaling {stale_mb:.1f} MB (below the warn threshold).",
         details=details,
     )
 

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -24,6 +24,7 @@ import importlib
 import importlib.util
 import json
 import os
+import re
 import shutil
 import sqlite3
 import subprocess
@@ -72,6 +73,44 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 #: reconcile` (or the `maintain` alias). Remediation strings named the internal
 #: ops, so every one of them fell through to the server argument parser.
 _REBUILD_VECTORS_CMD = "exomem maintain --reconcile"
+
+#: Absolute deferred-queue FAIL threshold (total semantic_upserts + full_upserts
+#: items), independent of vault size. The existing WARN tier is a 10% fraction
+#: of indexed pages — fine for scaling with a vault, but it never fires an
+#: absolute ceiling: a large vault can carry thousands of queued items and stay
+#: under 10%, and by then every operation on that vault is durably slow. The
+#: incident this guards: 3,724 items (2,116 semantic + 1,608 full) queued on a
+#: 2,872-page vault took per-operation latency from ~300ms to ~60s. 300 sits
+#: comfortably below that (12x headroom) and comfortably above a healthy
+#: transient of "a few dozen" items (7-12x headroom), so neither end flips the
+#: other's verdict.
+_DEFERRED_BACKLOG_FAIL_TOTAL = 300
+
+#: Orphaned rebuild-temporary files left by an interrupted background rebuild
+#: (either the `.graph-rebuild-*.sqlite[-journal|-wal|-shm]` or the
+#: `.lexical.sqlite.rebuild-*.tmp[-wal|-shm|-journal]` family — see
+#: `_check_rebuild_temp_orphans`). WARN above a small count (a single
+#: interrupted rebuild can leave a handful of sibling files for one attempt);
+#: FAIL once either count or size indicates an unbounded leak rather than one
+#: incomplete attempt. Incidents this guards: 18 graph-rebuild orphans totaling
+#: 527 MB; separately, 74 lexical-rebuild orphans totaling 5.84 GiB across 30
+#: abandoned rebuilds with nothing reaping them.
+_REBUILD_TEMP_ORPHAN_FAIL_COUNT = 5
+_REBUILD_TEMP_ORPHAN_FAIL_BYTES = 50 * 1024 * 1024
+
+#: lexstore.rebuild_atomic() (lexstore.py:2469) names its detached build sibling
+#: `<lexical sidecar name>.rebuild-<uuid4().hex>.tmp`, optionally with a
+#: `-wal`/`-shm`/`-journal` companion suffix, and reaps it in its own `finally`
+#: on any graceful return — so a surviving one means the process was killed
+#: mid-build. No PUBLIC matcher for this name exists to import: lexstore.py
+#: itself has none, and governance/tool.py carries an identical PRIVATE regex
+#: (`_LEXICAL_REBUILD_TEMP_RE`) for its own unrelated fail-closed
+#: non-Markdown-membership purpose — private, and governance/tool.py is out of
+#: this task's scope to touch. This is a hand-derived duplicate of that same
+#: pattern, sourced from lexstore's construction call rather than guessed.
+_LEXICAL_REBUILD_TEMP_RE = re.compile(
+    r"^\.lexical\.sqlite\.rebuild-[0-9a-f]{32}\.tmp(?:-(?:wal|shm|journal))?$"
+)
 
 
 @dataclass
@@ -600,10 +639,19 @@ def _check_lexical(vault_root: Path | None) -> DoctorCheck:
 
 
 def _check_deferred_index_backlog(vault_root: Path | None) -> DoctorCheck:
-    """Warn when durable index work is a material share of indexed pages."""
+    """FAIL/WARN when durable index work threatens or already degrades every op.
+
+    Two independent tiers: an absolute FAIL ceiling
+    (`_DEFERRED_BACKLOG_FAIL_TOTAL`) that fires regardless of vault size, and
+    the pre-existing relative WARN tier (10% of indexed pages) below it.
+    Reconcile only re-embeds paths it itself changes — it never drains this
+    queue — so remediation always names the one command that does:
+    `exomem index --vault <root> --scope vault`.
+    """
     details: dict[str, object] = {
         "indexed_pages": 0,
         "warn_fraction": 0.10,
+        "fail_total": _DEFERRED_BACKLOG_FAIL_TOTAL,
         "semantic_upserts": 0,
         "full_upserts": 0,
     }
@@ -627,6 +675,23 @@ def _check_deferred_index_backlog(vault_root: Path | None) -> DoctorCheck:
     for queue in ("semantic_upserts", "full_upserts"):
         details[queue] = int(status.get(queue, {}).get("count", 0))
     indexed_pages = int(details["indexed_pages"])
+    semantic = int(details["semantic_upserts"])
+    full = int(details["full_upserts"])
+    total = semantic + full
+    command = f'exomem index --vault "{vault_root}" --scope vault'
+
+    if total >= _DEFERRED_BACKLOG_FAIL_TOTAL:
+        return _check(
+            "deferred_index_backlog",
+            "fail",
+            f"Deferred index backlog is {total} item(s) (semantic_upserts={semantic}, "
+            f"full_upserts={full}) — at this depth every vault operation degrades. "
+            "Reconcile only re-embeds paths it itself changes; it does not drain "
+            "this backlog.",
+            f"Run `{command}` to drain the backlog now.",
+            details=details,
+        )
+
     warn_above = indexed_pages * float(details["warn_fraction"])
     offenders = [
         f"{queue}={details[queue]}"
@@ -634,19 +699,279 @@ def _check_deferred_index_backlog(vault_root: Path | None) -> DoctorCheck:
         if int(details[queue]) > warn_above
     ]
     if offenders:
-        command = f'exomem index --vault "{vault_root}" --scope vault'
         return _check(
             "deferred_index_backlog",
             "warn",
             f"Deferred index backlog exceeds 10% of {indexed_pages} indexed page(s): "
             + ", ".join(offenders),
-            f"Reconciliation drains it automatically; run `{command}` to drain now.",
+            f"Run `{command}` to drain it — reconcile does not drain this queue on "
+            "its own.",
             details=details,
         )
     return _check(
         "deferred_index_backlog",
         "pass",
         f"Deferred index backlog is below 10% of {indexed_pages} indexed page(s).",
+        details=details,
+    )
+
+
+def _check_graph_sync_state(vault_root: Path | None) -> DoctorCheck:
+    """graph_sync epoch health: whether the derived graph is servable.
+
+    Reads graph_sync.status() (current/recovery_required/unavailable) plus
+    checkpoint_state() (whose "malformed" outcome status() alone cannot
+    distinguish). current -> pass; a malformed checkpoint always fails, even if
+    status() otherwise reports current; recovery_required fails using the same
+    canned remediation graph_sync itself hands to callers via
+    committed_graph_failure() when a real checkpoint is available, falling back
+    to an honest message when it is not; unavailable fails with an honest
+    message. Never claims to fix this itself — recovery is reconcile's job.
+    """
+    if vault_root is None:
+        return _check(
+            "graph_sync.state",
+            "pass",
+            "No vault configured; graph_sync state was not inspected.",
+        )
+    from . import graph_sync
+
+    status = graph_sync.status(vault_root)
+    state = status.get("state")
+    generation = status.get("generation")
+    checkpoint_status, checkpoint = graph_sync.checkpoint_state(vault_root)
+    details: dict[str, object] = {
+        "state": state,
+        "generation": generation,
+        "checkpoint_state": checkpoint_status,
+    }
+
+    if checkpoint_status == "malformed":
+        return _check(
+            "graph_sync.state",
+            "fail",
+            f"graph_sync checkpoint is malformed (generation {generation}); the "
+            "derived graph cannot be trusted until it is recovered.",
+            f"Run `{_REBUILD_VECTORS_CMD}` to recover the derived graph.",
+            details=details,
+        )
+    if state == "current":
+        return _check(
+            "graph_sync.state",
+            "pass",
+            f"graph_sync is current at generation {generation}.",
+            details=details,
+        )
+    if state == "recovery_required":
+        if checkpoint is not None:
+            remediation = graph_sync.committed_graph_failure(checkpoint)[
+                "graph_sync_remediation"
+            ]
+        else:
+            remediation = f"Run `{_REBUILD_VECTORS_CMD}` to recover the derived graph."
+        return _check(
+            "graph_sync.state",
+            "fail",
+            f"graph_sync requires recovery at generation {generation}; the derived "
+            "graph is not current.",
+            remediation,
+            details=details,
+        )
+    # state == "unavailable" (or any value outside the documented set).
+    return _check(
+        "graph_sync.state",
+        "fail",
+        f"graph_sync is unavailable at generation {generation}; graph-backed reads "
+        "cannot be trusted.",
+        f"Run `{_REBUILD_VECTORS_CMD}` to recover the derived graph.",
+        details=details,
+    )
+
+
+def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
+    """Leaked rebuild-temporary files from interrupted background rebuilds.
+
+    Two independent families, both normally self-cleaned on a graceful exit and
+    both leakable only by a hard process kill mid-rebuild:
+
+    - `.graph-rebuild-*.sqlite[-journal|-wal|-shm]` — graph_sync's rebuild path.
+      Matched via `vault.is_graph_rebuild_runtime_file_name`, a strict regex
+      that deliberately excludes `.graph-rebuild-user-copy.sqlite`, a real
+      (tested) user file.
+    - `.lexical.sqlite.rebuild-<32-hex>.tmp[-wal|-shm|-journal]` —
+      lexstore.rebuild_atomic()'s detached build sibling (lexstore.py:2469),
+      matched via `_LEXICAL_REBUILD_TEMP_RE` (see its module-level comment for
+      why this is hand-derived rather than imported).
+
+    Reports count + total bytes per family (`details["graph_rebuild"]`,
+    `details["lexical_rebuild"]`) plus a combined `count`/`total_bytes`.
+    Reclaiming either family requires the service stopped and no rebuild in
+    flight, so remediation names `exomem maintain` run out-of-process
+    (it reads the vault from EXOMEM_VAULT_PATH, not `--vault`).
+    """
+    details: dict[str, object] = {
+        "count": 0,
+        "total_bytes": 0,
+        "graph_rebuild": {"count": 0, "total_bytes": 0},
+        "lexical_rebuild": {"count": 0, "total_bytes": 0},
+    }
+    if vault_root is None:
+        return _check(
+            "rebuild_temp.orphans",
+            "pass",
+            "No vault configured; rebuild temporaries were not inspected.",
+            details=details,
+        )
+    from . import vault as vault_module
+
+    kb = Path(vault_root) / kb_dirname()
+    graph_orphans: list[Path] = []
+    lexical_orphans: list[Path] = []
+    if kb.is_dir():
+        for entry in kb.iterdir():
+            try:
+                if not entry.is_file():
+                    continue
+            except OSError:
+                continue
+            name = entry.name
+            if vault_module.is_graph_rebuild_runtime_file_name(name):
+                graph_orphans.append(entry)
+            elif _LEXICAL_REBUILD_TEMP_RE.fullmatch(name) is not None:
+                lexical_orphans.append(entry)
+
+    def _family_stats(paths: list[Path]) -> dict[str, int]:
+        total = 0
+        for entry in paths:
+            try:
+                total += entry.stat().st_size
+            except OSError:
+                continue
+        return {"count": len(paths), "total_bytes": total}
+
+    graph_stats = _family_stats(graph_orphans)
+    lexical_stats = _family_stats(lexical_orphans)
+    details["graph_rebuild"] = graph_stats
+    details["lexical_rebuild"] = lexical_stats
+    count = graph_stats["count"] + lexical_stats["count"]
+    total_bytes = graph_stats["total_bytes"] + lexical_stats["total_bytes"]
+    details["count"] = count
+    details["total_bytes"] = total_bytes
+    mb = total_bytes / (1024 * 1024)
+
+    if count == 0:
+        return _check(
+            "rebuild_temp.orphans",
+            "pass",
+            "No orphaned rebuild temporaries found.",
+            details=details,
+        )
+    remediation = (
+        "Stop the exomem service, then run `exomem maintain` out-of-process "
+        "(it reads the vault from EXOMEM_VAULT_PATH, not --vault) to reclaim "
+        "orphaned rebuild temporaries — reclaim is only safe once no rebuild is "
+        "in flight."
+    )
+    summary = f"graph={graph_stats['count']}, lexical={lexical_stats['count']}"
+    if (
+        count > _REBUILD_TEMP_ORPHAN_FAIL_COUNT
+        or total_bytes > _REBUILD_TEMP_ORPHAN_FAIL_BYTES
+    ):
+        return _check(
+            "rebuild_temp.orphans",
+            "fail",
+            f"{count} orphaned rebuild temporary file(s) totaling {mb:.1f} MB are "
+            f"leaking disk space from interrupted rebuilds ({summary}).",
+            remediation,
+            details=details,
+        )
+    if count > 1:
+        return _check(
+            "rebuild_temp.orphans",
+            "warn",
+            f"{count} orphaned rebuild temporary file(s) totaling {mb:.1f} MB "
+            f"({summary}).",
+            remediation,
+            details=details,
+        )
+    return _check(
+        "rebuild_temp.orphans",
+        "pass",
+        f"{count} orphaned rebuild temporary file(s) totaling {mb:.1f} MB "
+        "(below the warn threshold).",
+        details=details,
+    )
+
+
+def _check_write_path_env_flags(vault_root: Path | None) -> DoctorCheck:
+    """Env kill-switches that change or disable write-path background work.
+
+    Doctor is out-of-process and read-only: it can only see environment
+    configuration, never the running service's in-memory state. It
+    deliberately does NOT invent an accessor for the in-process corpus-context
+    cache dict (semantic_contract.py) — that structure is process-private and
+    meaningless from here. What it can honestly report: whether the cache is
+    switched on at all (EXOMEM_DISABLE_CORPUS_CACHE), whether the service runs
+    any periodic drain (EXOMEM_DISABLE_EVENT_INDEXES — when set, file_watcher
+    starts no reconcile thread at all), and whether new graph work is being
+    scheduled (EXOMEM_DISABLE_GRAPH_SCHEDULING). A disabled periodic drain
+    combined with an already non-empty deferred queue is the sharpest signal:
+    that backlog will not shrink on its own.
+    """
+    from . import epistemic_graph, freshness, semantic_contract
+
+    corpus_cache = semantic_contract.corpus_context_cache_enabled()
+    event_indexes = freshness.event_indexes_enabled()
+    graph_scheduling = epistemic_graph.graph_scheduling_enabled()
+    details: dict[str, object] = {
+        "corpus_context_cache_enabled": corpus_cache,
+        "event_indexes_enabled": event_indexes,
+        "graph_scheduling_enabled": graph_scheduling,
+    }
+
+    if not event_indexes and vault_root is not None:
+        from . import index_sync
+
+        status = index_sync.deferred_work_status(vault_root)
+        semantic = int(status.get("semantic_upserts", {}).get("count", 0))
+        full = int(status.get("full_upserts", {}).get("count", 0))
+        total = semantic + full
+        details["semantic_upserts"] = semantic
+        details["full_upserts"] = full
+        if total > 0:
+            command = f'exomem index --vault "{vault_root}" --scope vault'
+            level: Status = "fail" if total >= _DEFERRED_BACKLOG_FAIL_TOTAL else "warn"
+            return _check(
+                "write_path.env_flags",
+                level,
+                "EXOMEM_DISABLE_EVENT_INDEXES is set: the service runs no periodic "
+                f"drain, and {total} item(s) are already queued (semantic_upserts="
+                f"{semantic}, full_upserts={full}). This backlog will not shrink on "
+                "its own.",
+                f"Unset EXOMEM_DISABLE_EVENT_INDEXES, or run `{command}` manually.",
+                details=details,
+            )
+
+    notes = []
+    if not corpus_cache:
+        notes.append("EXOMEM_DISABLE_CORPUS_CACHE is set (corpus-context cache off).")
+    if not event_indexes:
+        notes.append("EXOMEM_DISABLE_EVENT_INDEXES is set (no periodic drain).")
+    if not graph_scheduling:
+        notes.append("EXOMEM_DISABLE_GRAPH_SCHEDULING is set (no new graph work).")
+    if notes:
+        return _check(
+            "write_path.env_flags",
+            "warn",
+            " ".join(notes),
+            "These are deliberate kill switches; unset the variable(s) to restore "
+            "default write-path behavior.",
+            details=details,
+        )
+    return _check(
+        "write_path.env_flags",
+        "pass",
+        "No write-path kill switches are set.",
         details=details,
     )
 
@@ -2083,6 +2408,9 @@ def doctor(
         _check_resource_posture(profile),
         _check_lexical(vault_root),
         _check_deferred_index_backlog(vault_root),
+        _check_graph_sync_state(vault_root),
+        _check_rebuild_temp_orphans(vault_root),
+        _check_write_path_env_flags(vault_root),
     ]
     runtime_processes = _check_runtime_processes()
     if runtime_processes is not None:

--- a/tests/test_doctor_write_path.py
+++ b/tests/test_doctor_write_path.py
@@ -1,0 +1,426 @@
+"""Doctor write-path observability: deferred-queue FAIL tier, graph_sync state,
+orphaned graph-rebuild temporaries, and write-path env kill-switch facts.
+
+Incident context: the deferred-index queue reached 3,724 items (2,116 semantic
++ 1,608 full) on a 2,872-page vault and doctor only WARNed, with remediation
+text claiming reconciliation drains it automatically — which is false
+(reconcile.reconcile() never calls index_sync.drain_deferred_work). At that
+depth the vault degrades from ~300 ms to ~60 s per operation.
+
+This file adds the new write-path checks. The pre-existing WARN-tier
+regression test lives in tests/test_deferred_work_drain.py
+(test_doctor_warns_on_deferred_queue_fraction) and is intentionally NOT
+touched here (out of scope) — it is re-verified by the acceptance run instead.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from exomem import deferred_index
+from exomem import doctor as doctor_module
+from exomem import graph_sync
+from exomem.kbdir import kb_dirname
+
+
+def _seed_lexical_pages(vault: Path, count: int) -> None:
+    from exomem import lexstore
+
+    sidecar = lexstore.lexical_path(vault)
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(sidecar) as connection:
+        connection.execute("CREATE TABLE pages (id INTEGER PRIMARY KEY)")
+        connection.executemany(
+            "INSERT INTO pages DEFAULT VALUES", [() for _ in range(count)]
+        )
+
+
+# --- 1. Deferred-queue FAIL tier --------------------------------------------
+
+
+def test_deep_queue_fails_names_index_command_and_never_claims_automatic_drain(
+    vault: Path,
+) -> None:
+    """The incident scenario: 2,116 semantic + 1,608 full queued on 2,872 pages."""
+    _seed_lexical_pages(vault, 2872)
+    deferred_index.add_full(
+        vault, [f"Knowledge Base/deferred/full-{i}.md" for i in range(1608)]
+    )
+    deferred_index.add(
+        vault, [f"Knowledge Base/deferred/sem-{i}.md" for i in range(2116)]
+    )
+
+    check = doctor_module._check_deferred_index_backlog(vault)
+
+    assert check.status == "fail"
+    assert check.remediation is not None
+    assert f'exomem index --vault "{vault}" --scope vault' in check.remediation
+    haystack = f"{check.message} {check.remediation}".lower()
+    assert "automatic" not in haystack
+    assert check.details["semantic_upserts"] == 2116
+    assert check.details["full_upserts"] == 1608
+
+
+def test_small_healthy_queue_still_warns_not_fails(vault: Path) -> None:
+    """No regression for the existing check id: 11/100 pages (11%) stays WARN."""
+    _seed_lexical_pages(vault, 100)
+    deferred_index.add_full(
+        vault, [f"Knowledge Base/deferred/{i}.md" for i in range(11)]
+    )
+
+    check = doctor_module._check_deferred_index_backlog(vault)
+
+    assert check.status == "warn"
+    assert "automatic" not in check.message.lower()
+    assert "automatic" not in (check.remediation or "").lower()
+
+
+def test_a_few_dozen_backlog_on_a_small_vault_does_not_fail(vault: Path) -> None:
+    """A healthy transient of a few dozen items must never hit the FAIL tier,
+    even on a small vault where it blows the 10% relative WARN fraction."""
+    _seed_lexical_pages(vault, 300)
+    deferred_index.add_full(
+        vault, [f"Knowledge Base/deferred/{i}.md" for i in range(40)]
+    )
+
+    check = doctor_module._check_deferred_index_backlog(vault)
+
+    assert check.status == "warn"  # 40/300 = 13.3% > 10% warn fraction, but not FAIL
+
+
+def test_tiny_backlog_passes(vault: Path) -> None:
+    _seed_lexical_pages(vault, 500)
+    deferred_index.add_full(vault, ["Knowledge Base/deferred/one.md"])
+
+    check = doctor_module._check_deferred_index_backlog(vault)
+
+    assert check.status == "pass"
+
+
+def test_no_vault_configured_passes(vault: Path) -> None:
+    check = doctor_module._check_deferred_index_backlog(None)
+
+    assert check.status == "pass"
+
+
+# --- 2. graph_sync state -----------------------------------------------------
+
+
+def test_graph_sync_current_passes(vault: Path) -> None:
+    check = doctor_module._check_graph_sync_state(vault)
+
+    assert check.status == "pass"
+    assert check.details["generation"] == 0
+
+
+def test_graph_sync_recovery_required_fails_with_canned_remediation(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=4,
+        mutation_id="0123456789abcdef01234567",
+        paths=(),
+        created_paths=(),
+        scope="full",
+    )
+    monkeypatch.setattr(
+        graph_sync, "status", lambda _root: {"state": "recovery_required", "generation": 4}
+    )
+    monkeypatch.setattr(
+        graph_sync, "checkpoint_state", lambda _root: ("valid", checkpoint)
+    )
+
+    check = doctor_module._check_graph_sync_state(vault)
+
+    assert check.status == "fail"
+    expected = graph_sync.committed_graph_failure(checkpoint)["graph_sync_remediation"]
+    assert check.remediation == expected
+    assert check.details["generation"] == 4
+
+
+def test_graph_sync_unavailable_fails_with_honest_message(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        graph_sync, "status", lambda _root: {"state": "unavailable", "generation": 2}
+    )
+    monkeypatch.setattr(graph_sync, "checkpoint_state", lambda _root: ("absent", None))
+
+    check = doctor_module._check_graph_sync_state(vault)
+
+    assert check.status == "fail"
+    assert "unavailable" in check.message.lower()
+
+
+def test_graph_sync_malformed_checkpoint_fails_even_if_state_looks_current(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        graph_sync, "status", lambda _root: {"state": "current", "generation": 1}
+    )
+    monkeypatch.setattr(graph_sync, "checkpoint_state", lambda _root: ("malformed", None))
+
+    check = doctor_module._check_graph_sync_state(vault)
+
+    assert check.status == "fail"
+    assert "malformed" in check.message.lower()
+
+
+def test_graph_sync_no_vault_configured_passes() -> None:
+    check = doctor_module._check_graph_sync_state(None)
+
+    assert check.status == "pass"
+
+
+# --- 3. Orphaned rebuild temporaries (graph + lexical families) -------------
+#
+# Live diagnosis (brief amendment): `.graph-rebuild-*` behaved correctly in
+# production (transient, always cleaned; final count 0). The actual unbounded
+# leak is the OTHER rebuild-temp family lexstore.rebuild_atomic() creates
+# (lexstore.py:2469): `.lexical.sqlite.rebuild-<32-hex>.tmp[-wal|-shm|-journal]`.
+# Live state: 74 files / 5.84 GiB across 30 abandoned rebuilds — nothing reaps
+# them. This check covers both families and reports each separately.
+
+
+def _rebuild_name(seed: int, suffix: str = "") -> str:
+    return f".graph-rebuild-{seed:064x}-{seed:024x}.sqlite{suffix}"
+
+
+def _lexical_rebuild_name(digest: str, suffix: str = "") -> str:
+    return f".lexical.sqlite.rebuild-{digest}.tmp{suffix}"
+
+
+def test_orphan_count_excludes_user_copy_and_sums_bytes(vault: Path) -> None:
+    kb = vault / kb_dirname()
+    (kb / _rebuild_name(1)).write_bytes(b"x" * 1000)
+    (kb / _rebuild_name(2, "-wal")).write_bytes(b"y" * 2000)
+    (kb / ".graph-rebuild-user-copy.sqlite").write_bytes(b"z" * 5000)
+
+    check = doctor_module._check_rebuild_temp_orphans(vault)
+
+    assert check.details["count"] == 2
+    assert check.details["total_bytes"] == 3000
+    assert check.details["graph_rebuild"] == {"count": 2, "total_bytes": 3000}
+    assert check.details["lexical_rebuild"] == {"count": 0, "total_bytes": 0}
+
+
+def test_single_small_orphan_passes(vault: Path) -> None:
+    kb = vault / kb_dirname()
+    (kb / _rebuild_name(3)).write_bytes(b"x" * 10)
+
+    check = doctor_module._check_rebuild_temp_orphans(vault)
+
+    assert check.status == "pass"
+    assert check.details["count"] == 1
+
+
+def test_a_couple_of_orphans_warns(vault: Path) -> None:
+    kb = vault / kb_dirname()
+    (kb / _rebuild_name(4)).write_bytes(b"x" * 10)
+    (kb / _rebuild_name(5, "-journal")).write_bytes(b"y" * 10)
+
+    check = doctor_module._check_rebuild_temp_orphans(vault)
+
+    assert check.status == "warn"
+
+
+def test_many_orphans_fail_by_count(vault: Path) -> None:
+    """The incident: 18 orphans (well below the byte threshold each) must FAIL."""
+    kb = vault / kb_dirname()
+    for i in range(18):
+        (kb / _rebuild_name(100 + i)).write_bytes(b"\0" * 16)
+
+    check = doctor_module._check_rebuild_temp_orphans(vault)
+
+    assert check.status == "fail"
+    assert check.details["count"] == 18
+
+
+def test_one_large_orphan_fails_by_bytes(vault: Path) -> None:
+    kb = vault / kb_dirname()
+    path = kb / _rebuild_name(200)
+    size = 60 * 1024 * 1024  # 60 MB, above the 50 MB fail threshold
+    with path.open("wb") as fh:
+        fh.seek(size - 1)
+        fh.write(b"\0")
+
+    check = doctor_module._check_rebuild_temp_orphans(vault)
+
+    assert check.status == "fail"
+    assert check.details["total_bytes"] == size
+
+
+def test_no_orphans_passes(vault: Path) -> None:
+    check = doctor_module._check_rebuild_temp_orphans(vault)
+
+    assert check.status == "pass"
+    assert check.details["count"] == 0
+    assert check.details["graph_rebuild"] == {"count": 0, "total_bytes": 0}
+    assert check.details["lexical_rebuild"] == {"count": 0, "total_bytes": 0}
+
+
+def test_orphans_no_vault_configured_passes() -> None:
+    check = doctor_module._check_rebuild_temp_orphans(None)
+
+    assert check.status == "pass"
+
+
+def test_single_fresh_lexical_rebuild_temp_passes(vault: Path) -> None:
+    """A single in-flight lexical rebuild temporary must not FAIL."""
+    kb = vault / kb_dirname()
+    (kb / _lexical_rebuild_name("a" * 32)).write_bytes(b"x" * 10)
+
+    check = doctor_module._check_rebuild_temp_orphans(vault)
+
+    assert check.status == "pass"
+    assert check.details["lexical_rebuild"] == {"count": 1, "total_bytes": 10}
+    assert check.details["graph_rebuild"] == {"count": 0, "total_bytes": 0}
+
+
+def test_lexical_rebuild_orphans_counted_separately_and_summed(vault: Path) -> None:
+    kb = vault / kb_dirname()
+    (kb / _lexical_rebuild_name("b" * 32)).write_bytes(b"x" * 1000)
+    (kb / _lexical_rebuild_name("c" * 32, "-wal")).write_bytes(b"y" * 2000)
+
+    check = doctor_module._check_rebuild_temp_orphans(vault)
+
+    assert check.details["lexical_rebuild"] == {"count": 2, "total_bytes": 3000}
+    assert check.details["graph_rebuild"] == {"count": 0, "total_bytes": 0}
+    assert check.details["count"] == 2
+    assert check.details["total_bytes"] == 3000
+    assert check.status == "warn"
+
+
+def test_lexical_rebuild_many_stale_files_fail(vault: Path) -> None:
+    """The live-diagnosis state: 74 abandoned lexical-rebuild temporaries."""
+    kb = vault / kb_dirname()
+    for i in range(74):
+        (kb / _lexical_rebuild_name(f"{i:032x}")).write_bytes(b"\0" * 16)
+
+    check = doctor_module._check_rebuild_temp_orphans(vault)
+
+    assert check.status == "fail"
+    assert check.details["lexical_rebuild"]["count"] == 74
+    assert check.details["graph_rebuild"] == {"count": 0, "total_bytes": 0}
+
+
+def test_mixed_graph_and_lexical_orphans_report_both_families(vault: Path) -> None:
+    kb = vault / kb_dirname()
+    (kb / _rebuild_name(6)).write_bytes(b"x" * 500)
+    (kb / _lexical_rebuild_name("d" * 32)).write_bytes(b"y" * 700)
+
+    check = doctor_module._check_rebuild_temp_orphans(vault)
+
+    assert check.details["graph_rebuild"] == {"count": 1, "total_bytes": 500}
+    assert check.details["lexical_rebuild"] == {"count": 1, "total_bytes": 700}
+    assert check.details["count"] == 2
+    assert check.details["total_bytes"] == 1200
+
+
+# --- 4. Write-path env kill-switch facts -------------------------------------
+
+
+def test_write_path_flags_all_enabled_passes(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_EVENT_INDEXES", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_GRAPH_SCHEDULING", raising=False)
+
+    check = doctor_module._check_write_path_env_flags(vault)
+
+    assert check.status == "pass"
+    assert check.details["corpus_context_cache_enabled"] is True
+    assert check.details["event_indexes_enabled"] is True
+    assert check.details["graph_scheduling_enabled"] is True
+
+
+def test_corpus_cache_disabled_alone_warns(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_DISABLE_CORPUS_CACHE", "1")
+    monkeypatch.delenv("EXOMEM_DISABLE_EVENT_INDEXES", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_GRAPH_SCHEDULING", raising=False)
+
+    check = doctor_module._check_write_path_env_flags(vault)
+
+    assert check.status == "warn"
+    assert "EXOMEM_DISABLE_CORPUS_CACHE" in check.message
+
+
+def test_graph_scheduling_disabled_alone_warns(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_EVENT_INDEXES", raising=False)
+    monkeypatch.setenv("EXOMEM_DISABLE_GRAPH_SCHEDULING", "1")
+
+    check = doctor_module._check_write_path_env_flags(vault)
+
+    assert check.status == "warn"
+    assert "EXOMEM_DISABLE_GRAPH_SCHEDULING" in check.message
+
+
+def test_event_indexes_disabled_with_nonempty_queue_surfaces(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_DISABLE_EVENT_INDEXES", "1")
+    deferred_index.add_full(vault, ["Knowledge Base/deferred/x.md"])
+
+    check = doctor_module._check_write_path_env_flags(vault)
+
+    assert check.status in {"warn", "fail"}
+    assert "EXOMEM_DISABLE_EVENT_INDEXES" in check.message
+    assert check.details["full_upserts"] == 1
+
+
+def test_event_indexes_disabled_with_deep_queue_fails(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_DISABLE_EVENT_INDEXES", "1")
+    deferred_index.add_full(
+        vault, [f"Knowledge Base/deferred/{i}.md" for i in range(400)]
+    )
+
+    check = doctor_module._check_write_path_env_flags(vault)
+
+    assert check.status == "fail"
+
+
+def test_write_path_flags_without_vault_reports_env_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_EVENT_INDEXES", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_GRAPH_SCHEDULING", raising=False)
+
+    check = doctor_module._check_write_path_env_flags(None)
+
+    assert check.status == "pass"
+
+
+# --- Wiring into the ordered report ------------------------------------------
+
+
+def test_new_checks_are_wired_into_the_ordered_report(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_EVENT_INDEXES", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_GRAPH_SCHEDULING", raising=False)
+
+    report = doctor_module.doctor(vault=str(vault))
+
+    ids = [c.id for c in report.checks]
+    assert "graph_sync.state" in ids
+    assert "rebuild_temp.orphans" in ids
+    assert "write_path.env_flags" in ids
+    i = ids.index("deferred_index_backlog")
+    assert ids[i + 1 : i + 4] == [
+        "graph_sync.state",
+        "rebuild_temp.orphans",
+        "write_path.env_flags",
+    ]
+    assert report.success is True

--- a/tests/test_doctor_write_path.py
+++ b/tests/test_doctor_write_path.py
@@ -15,7 +15,9 @@ touched here (out of scope) — it is re-verified by the acceptance run instead.
 
 from __future__ import annotations
 
+import os
 import sqlite3
+import time
 from pathlib import Path
 
 import pytest
@@ -116,9 +118,13 @@ def test_graph_sync_current_passes(vault: Path) -> None:
     assert check.details["generation"] == 0
 
 
-def test_graph_sync_recovery_required_fails_with_canned_remediation(
+def test_graph_sync_recovery_required_fails_with_augmented_canned_remediation(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Correction round (MINOR): committed_graph_failure()'s own default text
+    ("Run reconcile to recover the derived graph.") names an internal op, not
+    a runnable command. The printed remediation must always include the
+    actual runnable command too, without discarding the canned text."""
     checkpoint = graph_sync.GraphSyncCheckpoint.create(
         generation=4,
         mutation_id="0123456789abcdef01234567",
@@ -136,9 +142,43 @@ def test_graph_sync_recovery_required_fails_with_canned_remediation(
     check = doctor_module._check_graph_sync_state(vault)
 
     assert check.status == "fail"
-    expected = graph_sync.committed_graph_failure(checkpoint)["graph_sync_remediation"]
-    assert check.remediation == expected
+    canned = graph_sync.committed_graph_failure(checkpoint)["graph_sync_remediation"]
+    assert check.remediation is not None
+    assert canned in check.remediation
+    assert "exomem maintain --reconcile" in check.remediation
     assert check.details["generation"] == 4
+
+
+def test_graph_sync_recovery_required_keeps_an_already_specific_remediation(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the canned remediation already names the runnable command (e.g. a
+    threaded GraphRebuildRegistrationError.remediation), it is used as-is
+    rather than duplicated."""
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=7,
+        mutation_id="0123456789abcdef01234567",
+        paths=(),
+        created_paths=(),
+        scope="full",
+    )
+    specific = "Run `exomem maintain --reconcile` after clearing the stuck lease."
+    monkeypatch.setattr(
+        graph_sync, "status", lambda _root: {"state": "recovery_required", "generation": 7}
+    )
+    monkeypatch.setattr(
+        graph_sync, "checkpoint_state", lambda _root: ("valid", checkpoint)
+    )
+    monkeypatch.setattr(
+        graph_sync,
+        "committed_graph_failure",
+        lambda _checkpoint: {"graph_sync_remediation": specific},
+    )
+
+    check = doctor_module._check_graph_sync_state(vault)
+
+    assert check.status == "fail"
+    assert check.remediation == specific
 
 
 def test_graph_sync_unavailable_fails_with_honest_message(
@@ -181,8 +221,16 @@ def test_graph_sync_no_vault_configured_passes() -> None:
 # production (transient, always cleaned; final count 0). The actual unbounded
 # leak is the OTHER rebuild-temp family lexstore.rebuild_atomic() creates
 # (lexstore.py:2469): `.lexical.sqlite.rebuild-<32-hex>.tmp[-wal|-shm|-journal]`.
-# Live state: 74 files / 5.84 GiB across 30 abandoned rebuilds — nothing reaps
-# them. This check covers both families and reports each separately.
+# Live state: 74 files / 5.84 GiB across 30 abandoned rebuilds spanning
+# July 25-Aug 15 — nothing reaps them. This check covers both families and
+# reports each separately.
+#
+# Correction round (MAJOR): a matching name alone is not evidence of an
+# orphan — a legitimate in-flight rebuild matches the same name pattern and
+# can legitimately be large (the incident's own abandoned files averaged
+# ~79 MB). Every test below is explicit about mtime: `_age_file` back-dates a
+# file past `_REBUILD_TEMP_STALE_AGE_SECONDS` to simulate an abandoned
+# rebuild; a file left un-aged simulates one still in flight.
 
 
 def _rebuild_name(seed: int, suffix: str = "") -> str:
@@ -193,64 +241,122 @@ def _lexical_rebuild_name(digest: str, suffix: str = "") -> str:
     return f".lexical.sqlite.rebuild-{digest}.tmp{suffix}"
 
 
+def _age_file(path: Path, *, minutes_ago: float) -> None:
+    """Back-date a file's mtime (and atime) by `minutes_ago` minutes."""
+    ts = time.time() - minutes_ago * 60
+    os.utime(path, (ts, ts))
+
+
+# A comfortable margin past doctor_module._REBUILD_TEMP_STALE_AGE_SECONDS
+# (60 minutes), used throughout to mark a file as an abandoned orphan.
+_STALE_MINUTES = 120
+
+
 def test_orphan_count_excludes_user_copy_and_sums_bytes(vault: Path) -> None:
     kb = vault / kb_dirname()
-    (kb / _rebuild_name(1)).write_bytes(b"x" * 1000)
-    (kb / _rebuild_name(2, "-wal")).write_bytes(b"y" * 2000)
+    a = kb / _rebuild_name(1)
+    b = kb / _rebuild_name(2, "-wal")
+    a.write_bytes(b"x" * 1000)
+    b.write_bytes(b"y" * 2000)
     (kb / ".graph-rebuild-user-copy.sqlite").write_bytes(b"z" * 5000)
+    _age_file(a, minutes_ago=_STALE_MINUTES)
+    _age_file(b, minutes_ago=_STALE_MINUTES)
 
     check = doctor_module._check_rebuild_temp_orphans(vault)
 
     assert check.details["count"] == 2
     assert check.details["total_bytes"] == 3000
-    assert check.details["graph_rebuild"] == {"count": 2, "total_bytes": 3000}
-    assert check.details["lexical_rebuild"] == {"count": 0, "total_bytes": 0}
+    assert check.details["stale_count"] == 2
+    assert check.details["stale_bytes"] == 3000
+    assert check.details["graph_rebuild"] == {
+        "count": 2,
+        "total_bytes": 3000,
+        "stale_count": 2,
+        "stale_bytes": 3000,
+    }
+    assert check.details["lexical_rebuild"]["count"] == 0
 
 
-def test_single_small_orphan_passes(vault: Path) -> None:
+def test_single_stale_small_orphan_passes(vault: Path) -> None:
     kb = vault / kb_dirname()
-    (kb / _rebuild_name(3)).write_bytes(b"x" * 10)
+    path = kb / _rebuild_name(3)
+    path.write_bytes(b"x" * 10)
+    _age_file(path, minutes_ago=_STALE_MINUTES)
 
     check = doctor_module._check_rebuild_temp_orphans(vault)
 
     assert check.status == "pass"
     assert check.details["count"] == 1
+    assert check.details["stale_count"] == 1
 
 
-def test_a_couple_of_orphans_warns(vault: Path) -> None:
+def test_a_couple_of_stale_orphans_warn(vault: Path) -> None:
     kb = vault / kb_dirname()
-    (kb / _rebuild_name(4)).write_bytes(b"x" * 10)
-    (kb / _rebuild_name(5, "-journal")).write_bytes(b"y" * 10)
+    a = kb / _rebuild_name(4)
+    b = kb / _rebuild_name(5, "-journal")
+    a.write_bytes(b"x" * 10)
+    b.write_bytes(b"y" * 10)
+    _age_file(a, minutes_ago=_STALE_MINUTES)
+    _age_file(b, minutes_ago=_STALE_MINUTES)
 
     check = doctor_module._check_rebuild_temp_orphans(vault)
 
     assert check.status == "warn"
+    assert check.details["stale_count"] == 2
 
 
-def test_many_orphans_fail_by_count(vault: Path) -> None:
-    """The incident: 18 orphans (well below the byte threshold each) must FAIL."""
+def test_many_stale_orphans_fail_by_count(vault: Path) -> None:
+    """The incident: 18 stale orphans (well below the byte threshold each) fail."""
     kb = vault / kb_dirname()
     for i in range(18):
-        (kb / _rebuild_name(100 + i)).write_bytes(b"\0" * 16)
+        path = kb / _rebuild_name(100 + i)
+        path.write_bytes(b"\0" * 16)
+        _age_file(path, minutes_ago=_STALE_MINUTES)
 
     check = doctor_module._check_rebuild_temp_orphans(vault)
 
     assert check.status == "fail"
     assert check.details["count"] == 18
+    assert check.details["stale_count"] == 18
 
 
-def test_one_large_orphan_fails_by_bytes(vault: Path) -> None:
+def test_one_large_stale_orphan_fails_by_bytes(vault: Path) -> None:
     kb = vault / kb_dirname()
     path = kb / _rebuild_name(200)
     size = 60 * 1024 * 1024  # 60 MB, above the 50 MB fail threshold
     with path.open("wb") as fh:
         fh.seek(size - 1)
         fh.write(b"\0")
+    _age_file(path, minutes_ago=_STALE_MINUTES)
 
     check = doctor_module._check_rebuild_temp_orphans(vault)
 
     assert check.status == "fail"
     assert check.details["total_bytes"] == size
+    assert check.details["stale_bytes"] == size
+
+
+def test_large_fresh_rebuild_temp_passes(vault: Path) -> None:
+    """MAJOR fix, red-first: a large temp with a FRESH mtime is routine for an
+    in-flight rebuild (the incident's abandoned files averaged ~79 MB), not an
+    orphan. Size alone must never fail a temp that is still being written.
+    (Pre-fix this failed identically to test_one_large_stale_orphan_fails_by_bytes
+    above, since size was the only signal — see .task/RESULT.md for the
+    verbatim red run.)"""
+    kb = vault / kb_dirname()
+    path = kb / _rebuild_name(201)
+    size = 60 * 1024 * 1024  # 60 MB — above the 50 MB fail-by-bytes threshold
+    with path.open("wb") as fh:
+        fh.seek(size - 1)
+        fh.write(b"\0")
+    # Freshly written: mtime is "now" (no aging applied).
+
+    check = doctor_module._check_rebuild_temp_orphans(vault)
+
+    assert check.status == "pass"
+    assert check.details["total_bytes"] == size
+    assert check.details["stale_bytes"] == 0
+    assert check.details["stale_count"] == 0
 
 
 def test_no_orphans_passes(vault: Path) -> None:
@@ -258,8 +364,9 @@ def test_no_orphans_passes(vault: Path) -> None:
 
     assert check.status == "pass"
     assert check.details["count"] == 0
-    assert check.details["graph_rebuild"] == {"count": 0, "total_bytes": 0}
-    assert check.details["lexical_rebuild"] == {"count": 0, "total_bytes": 0}
+    assert check.details["stale_count"] == 0
+    assert check.details["graph_rebuild"]["count"] == 0
+    assert check.details["lexical_rebuild"]["count"] == 0
 
 
 def test_orphans_no_vault_configured_passes() -> None:
@@ -276,48 +383,119 @@ def test_single_fresh_lexical_rebuild_temp_passes(vault: Path) -> None:
     check = doctor_module._check_rebuild_temp_orphans(vault)
 
     assert check.status == "pass"
-    assert check.details["lexical_rebuild"] == {"count": 1, "total_bytes": 10}
-    assert check.details["graph_rebuild"] == {"count": 0, "total_bytes": 0}
+    assert check.details["lexical_rebuild"]["count"] == 1
+    assert check.details["lexical_rebuild"]["total_bytes"] == 10
+    assert check.details["lexical_rebuild"]["stale_count"] == 0
+    assert check.details["graph_rebuild"]["count"] == 0
 
 
-def test_lexical_rebuild_orphans_counted_separately_and_summed(vault: Path) -> None:
+def test_fresh_lexical_rebuild_temps_of_any_count_or_size_do_not_warn_or_fail(
+    vault: Path,
+) -> None:
+    """A fresh in-flight temporary must pass regardless of count or size —
+    neither alone is evidence of an orphan without staleness."""
     kb = vault / kb_dirname()
-    (kb / _lexical_rebuild_name("b" * 32)).write_bytes(b"x" * 1000)
-    (kb / _lexical_rebuild_name("c" * 32, "-wal")).write_bytes(b"y" * 2000)
+    for i, size in enumerate((1_000, 2_000, 70 * 1024 * 1024)):
+        path = kb / _lexical_rebuild_name(f"{i:032x}")
+        with path.open("wb") as fh:
+            if size > 1_000_000:
+                fh.seek(size - 1)
+                fh.write(b"\0")
+            else:
+                fh.write(b"x" * size)
+        # No aging: every file keeps a fresh "just written" mtime.
 
     check = doctor_module._check_rebuild_temp_orphans(vault)
 
-    assert check.details["lexical_rebuild"] == {"count": 2, "total_bytes": 3000}
-    assert check.details["graph_rebuild"] == {"count": 0, "total_bytes": 0}
+    assert check.status == "pass"
+    assert check.details["lexical_rebuild"]["count"] == 3
+    assert check.details["stale_count"] == 0
+
+
+def test_stale_lexical_rebuild_orphans_counted_separately_and_summed(
+    vault: Path,
+) -> None:
+    kb = vault / kb_dirname()
+    a = kb / _lexical_rebuild_name("b" * 32)
+    b = kb / _lexical_rebuild_name("c" * 32, "-wal")
+    a.write_bytes(b"x" * 1000)
+    b.write_bytes(b"y" * 2000)
+    _age_file(a, minutes_ago=_STALE_MINUTES)
+    _age_file(b, minutes_ago=_STALE_MINUTES)
+
+    check = doctor_module._check_rebuild_temp_orphans(vault)
+
+    assert check.details["lexical_rebuild"]["count"] == 2
+    assert check.details["lexical_rebuild"]["total_bytes"] == 3000
+    assert check.details["lexical_rebuild"]["stale_count"] == 2
+    assert check.details["graph_rebuild"]["count"] == 0
     assert check.details["count"] == 2
-    assert check.details["total_bytes"] == 3000
+    assert check.details["stale_count"] == 2
     assert check.status == "warn"
 
 
+def test_mixed_fresh_and_stale_files_count_only_the_stale(vault: Path) -> None:
+    """Extend tests per the correction: a mix of fresh and stale temporaries in
+    the same family must count only the stale ones toward WARN/FAIL."""
+    kb = vault / kb_dirname()
+    stale_a = kb / _lexical_rebuild_name("1" * 32)
+    stale_b = kb / _lexical_rebuild_name("2" * 32, "-wal")
+    fresh = kb / _lexical_rebuild_name("3" * 32, "-shm")
+    stale_a.write_bytes(b"x" * 100)
+    stale_b.write_bytes(b"y" * 200)
+    fresh.write_bytes(b"z" * 300)
+    _age_file(stale_a, minutes_ago=_STALE_MINUTES)
+    _age_file(stale_b, minutes_ago=_STALE_MINUTES)
+    # `fresh` is left un-aged.
+
+    check = doctor_module._check_rebuild_temp_orphans(vault)
+
+    assert check.details["lexical_rebuild"]["count"] == 3
+    assert check.details["lexical_rebuild"]["total_bytes"] == 600
+    assert check.details["lexical_rebuild"]["stale_count"] == 2
+    assert check.details["lexical_rebuild"]["stale_bytes"] == 300
+    assert check.details["count"] == 3
+    assert check.details["stale_count"] == 2
+    assert check.details["stale_bytes"] == 300
+    assert check.status == "warn"  # 2 stale -> warn, the fresh one is invisible to it
+
+
 def test_lexical_rebuild_many_stale_files_fail(vault: Path) -> None:
-    """The live-diagnosis state: 74 abandoned lexical-rebuild temporaries."""
+    """The live-diagnosis state: 74 abandoned lexical-rebuild temporaries
+    (production incident spanned July 25-Aug 15 — days to weeks old, comfortably
+    past the 60-minute staleness threshold; 2 hours is used here for speed)."""
     kb = vault / kb_dirname()
     for i in range(74):
-        (kb / _lexical_rebuild_name(f"{i:032x}")).write_bytes(b"\0" * 16)
+        path = kb / _lexical_rebuild_name(f"{i:032x}")
+        path.write_bytes(b"\0" * 16)
+        _age_file(path, minutes_ago=_STALE_MINUTES)
 
     check = doctor_module._check_rebuild_temp_orphans(vault)
 
     assert check.status == "fail"
     assert check.details["lexical_rebuild"]["count"] == 74
-    assert check.details["graph_rebuild"] == {"count": 0, "total_bytes": 0}
+    assert check.details["lexical_rebuild"]["stale_count"] == 74
+    assert check.details["graph_rebuild"]["count"] == 0
 
 
 def test_mixed_graph_and_lexical_orphans_report_both_families(vault: Path) -> None:
     kb = vault / kb_dirname()
-    (kb / _rebuild_name(6)).write_bytes(b"x" * 500)
-    (kb / _lexical_rebuild_name("d" * 32)).write_bytes(b"y" * 700)
+    a = kb / _rebuild_name(6)
+    b = kb / _lexical_rebuild_name("d" * 32)
+    a.write_bytes(b"x" * 500)
+    b.write_bytes(b"y" * 700)
+    _age_file(a, minutes_ago=_STALE_MINUTES)
+    _age_file(b, minutes_ago=_STALE_MINUTES)
 
     check = doctor_module._check_rebuild_temp_orphans(vault)
 
-    assert check.details["graph_rebuild"] == {"count": 1, "total_bytes": 500}
-    assert check.details["lexical_rebuild"] == {"count": 1, "total_bytes": 700}
+    assert check.details["graph_rebuild"]["count"] == 1
+    assert check.details["graph_rebuild"]["total_bytes"] == 500
+    assert check.details["lexical_rebuild"]["count"] == 1
+    assert check.details["lexical_rebuild"]["total_bytes"] == 700
     assert check.details["count"] == 2
     assert check.details["total_bytes"] == 1200
+    assert check.details["stale_count"] == 2
 
 
 # --- 4. Write-path env kill-switch facts -------------------------------------


### PR DESCRIPTION
## What

Doctor gains the write-path observability that the recent latency incident
proved missing (context: #510, #508 — a 3,724-item deferred-index backlog and a
multi-GiB temp leak, both invisible or mis-described by doctor):

1. **`deferred_index_backlog`** — new absolute **FAIL** tier (≥300 combined
   queued items) alongside the retained relative 10% WARN, with semantic/full
   counts reported separately. The remediation no longer claims
   "Reconciliation drains it automatically" — that claim is false
   (`reconcile.reconcile()` never calls `index_sync.drain_deferred_work`; it
   only clears receipts for paths it re-embedded itself). It now names the
   command that actually drains: `exomem index --vault "<root>" --scope vault`.
2. **`graph_sync.state`** (new) — fails on `recovery_required` / `unavailable` /
   malformed checkpoint, always printing a runnable remediation
   (`exomem maintain --reconcile`), passing through a more specific canned
   remediation when graph_sync provides one. Generation included in details.
3. **`rebuild_temp.orphans`** (new) — counts orphaned rebuild temporaries in
   **both** families: `.graph-rebuild-*.sqlite*` (via the existing
   `vault.is_graph_rebuild_runtime_file_name` matcher; the tested
   `.graph-rebuild-user-copy.sqlite` user file is excluded) and
   `.lexical.sqlite.rebuild-*` (pattern derived from `lexstore`'s actual
   temp-name construction — live production currently holds **74 files /
   5.84 GiB** of abandoned lexical rebuilds that nothing reaps).
   Orphan-hood is **age-gated on mtime (60 min)**: an active rebuild keeps
   advancing its temp's mtime, so only stale files drive WARN/FAIL — a single
   legitimately in-flight large rebuild can no longer false-FAIL and trigger
   remediation advice that would corrupt it. Details report total and stale
   count/bytes per family plus the threshold.
4. **`write_path.env_flags`** (new) — reports the write-path kill-switches
   (`EXOMEM_DISABLE_CORPUS_CACHE`, `EXOMEM_DISABLE_EVENT_INDEXES`,
   `EXOMEM_DISABLE_GRAPH_SCHEDULING`) as facts; disabled event indexes with a
   non-empty queue surfaces (with event indexes off, the service runs **no**
   periodic drain at all). Deliberately no in-process cache accessor — doctor
   runs out-of-process, where that state is unobservable.

## Verification

- Red-first evidence recorded for every check (including
  `'fail' == 'pass'` on the large-fresh-temp case before the staleness gate).
- `tests/test_doctor_write_path.py` (new): 32 passed. `tests/test_doctor.py`:
  63 passed, 1 pre-existing skip. `tests/test_deferred_work_drain.py`
  regression: 26 passed. `uvx ruff check . --select F` clean. Manual
  `exomem doctor` CLI run confirmed rendering.
- Independent review verdict: **APPROVE** (the reviewer independently verified
  the lexical pattern against `lexstore.py`'s construction and the incident
  thresholds); its one Major (in-flight false positive) was fixed in the
  staleness-gate commit and re-verified **FIXED** by a targeted recheck.
- `tests/test_latency_gate.py` fails on this loaded native-Windows box in code
  paths this diff does not touch; Linux CI is the authoritative gate.
