### PR TITLE
feat(benchmarks): give the export somewhere to put what the guest observed

### DIFF
--- a/benchmarks/memorybench/equivalence_projection.py
+++ b/benchmarks/memorybench/equivalence_projection.py
@@ -1,0 +1,169 @@
+"""Project a MemoryBench export into the differ's right-hand side.
+
+`lme/runner.py` writes `equivalence.json` for the direct lane; nothing wrote
+one for the guest lane, so the differ had only a left side. This mirrors that
+emitter's twelve keys from the public export plus the private gold mapping.
+
+A key the export could not source stays `None`. That is deliberate: the differ
+treats null as never equal to anything, including another null, so an unsourced
+key becomes a difference demanding an explanation rather than a silent pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "equivalence-input.v1"
+
+#: The subset of readiness the direct emitter compares; `evidence` is prose.
+_READINESS_FIELDS = ("lane", "requested", "verified", "method", "fallback_detected")
+
+
+def _prompt_digest(question_text: str) -> str:
+    return hashlib.sha256(question_text.encode("utf-8")).hexdigest()
+
+
+def _project_case(
+    case: dict[str, Any],
+    *,
+    question_id: str,
+    case_set: list[str],
+    container_tag: str | None,
+    dataset: dict[str, Any],
+    session_normalization: str | None,
+    readiness: list[dict[str, Any]] | None,
+    judge_config: dict[str, Any],
+) -> dict[str, Any]:
+    from lme.reader import CONTEXT_SEPARATOR
+
+    search = case.get("search")
+    ingest = case.get("ingest")
+    retrieved_text = [hit["content"] for hit in case.get("hits") or []]
+    question_text = (case.get("question") or {}).get("text") or ""
+
+    return {
+        "case_id": question_id,
+        "dataset_identity": dataset,
+        "case_set": case_set,
+        "session_normalization": session_normalization,
+        # The guest derives its namespace from the container tag, so the
+        # pattern is what can be compared across runs, not the literal.
+        "namespace": f"memorybench.container-tag/{container_tag}" if container_tag else None,
+        "ingestion_payloads": (ingest or {}).get("transmitted_payload_sha256"),
+        "readiness": (
+            [{field: lane[field] for field in _READINESS_FIELDS} for lane in readiness]
+            if readiness is not None
+            else None
+        ),
+        "exact_query": (search or {}).get("transmitted_query"),
+        "top_k": ((search or {}).get("options") or {}).get("limit"),
+        "retrieved_ids": (search or {}).get("normalized_hit_ids"),
+        "retrieved_text": retrieved_text,
+        "packed_context": CONTEXT_SEPARATOR.join(retrieved_text),
+        "answer_judge_prompt_model_config": {
+            **judge_config,
+            "prompt_sha256": _prompt_digest(question_text),
+        },
+    }
+
+
+def project_export(
+    export: dict[str, Any],
+    private_golds: dict[str, dict[str, Any]],
+    *,
+    judge_config: dict[str, Any],
+) -> dict[str, Any]:
+    """Build one `equivalence-input.v1` envelope from an export and its gold.
+
+    `private_golds` is keyed by `case_id_hmac_sha256`; the public artifact
+    carries only pseudonyms, and the comparison needs the real question ids.
+    """
+
+    cases = export.get("cases") or []
+    resolved: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    for case in cases:
+        digest = case.get("case_id_hmac_sha256")
+        gold = private_golds.get(digest)
+        if gold is None or not isinstance(gold.get("question_id"), str):
+            raise ValueError(f"no private gold mapping for case digest {digest}")
+        resolved.append((case, gold))
+
+    case_set = sorted(gold["question_id"] for _case, gold in resolved)
+    return {
+        "schema": SCHEMA,
+        "run_id": export.get("run_id"),
+        "provider_variant": export.get("provider_variant"),
+        "cases": [
+            _project_case(
+                case,
+                question_id=gold["question_id"],
+                case_set=case_set,
+                container_tag=gold.get("container_tag"),
+                dataset=export.get("dataset"),
+                session_normalization=export.get("session_normalization"),
+                readiness=export.get("readiness"),
+                judge_config=judge_config,
+            )
+            for case, gold in resolved
+        ],
+    }
+
+
+def _load_private_golds(directory: Path) -> dict[str, dict[str, Any]]:
+    """Read the mode-0700 private-gold directory beside an export."""
+
+    golds: dict[str, dict[str, Any]] = {}
+    if not directory.is_dir():
+        return golds
+    for child in sorted(directory.iterdir()):
+        if child.suffix != ".json" or stat.S_ISLNK(child.lstat().st_mode):
+            continue
+        gold = json.loads(child.read_text(encoding="utf-8"))
+        digest = gold.get("case_id_hmac_sha256")
+        if isinstance(digest, str):
+            golds[digest] = gold
+    return golds
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--export", required=True, type=Path)
+    parser.add_argument(
+        "--private-gold", type=Path,
+        help="private-gold directory; defaults to `private-gold/` beside the export",
+    )
+    parser.add_argument("--out", required=True, type=Path, help="run directory to write into")
+    parser.add_argument("--reader", default="stub")
+    parser.add_argument("--reader-model", default="gpt-4o")
+    parser.add_argument("--judge-model", default="gpt-4o")
+    args = parser.parse_args(argv)
+
+    export = json.loads(args.export.read_text(encoding="utf-8"))
+    gold_dir = args.private_gold or (args.export.parent / "private-gold")
+    payload = project_export(
+        export,
+        _load_private_golds(gold_dir),
+        judge_config={
+            "reader": args.reader,
+            "reader_model": args.reader_model,
+            "judge_model": args.judge_model,
+        },
+    )
+    args.out.mkdir(parents=True, exist_ok=True)
+    destination = args.out / "equivalence.json"
+    descriptor = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o644)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+        handle.write("\n")
+    print(destination)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/memorybench/export.py
+++ b/benchmarks/memorybench/export.py
@@ -28,6 +28,7 @@ from protocol.models import (
     RunManifest,
 )
 from equivalence.selection import CANONICAL_LME_S_SOURCE, load_frozen_lme_selection, select_lme_s_25
+from memorybench.guest_observations import project_guest_evidence
 
 try:
     from .setup import verify_checkout
@@ -965,8 +966,12 @@ def _build_export(
     result_set_rejected = bool(result_failures) or result_set_mismatch
 
     cases: list[dict[str, Any]] = []
+    # Run-level facts the guest observes once, not per case.
+    run_readiness: list[dict[str, Any]] | None = None
+    run_session_normalization: str | None = None
     cleanup_targets = _cleanup_target_union(plan, checkpoint_by_id, failures)
     for ordinal, dataset_case in enumerate(dataset_raw, start=1):
+        container_tag: str | None = None
         question_id = dataset_case["question_id"]
         case_digest = privacy_hmac_sha256(plan.privacy_hmac_key_hex, "case-id", question_id)
         case_failures: set[str] = set()
@@ -1119,6 +1124,26 @@ def _build_export(
             result_ref = None
             private_ref = None
             hits = []
+
+        # The Exomem guest already logs a request/response pair per call, so
+        # publishing those facts reads its own evidence rather than adding
+        # instrumentation. Absence keeps its missing_fields label; the export
+        # model refuses any disagreement between the two.
+        search_observation: dict[str, Any] | None = None
+        ingest_observation: dict[str, Any] | None = None
+        if plan.provider == "exomem" and isinstance(container_tag, str) and container_tag:
+            observed = project_guest_evidence(
+                Path(plan.guest_evidence_root) / "exomem" / _sha256_text(container_tag)[:24]
+            )
+            case_failures.update(observed.problems)
+            search_observation = observed.search
+            ingest_observation = observed.ingest
+            missing -= observed.resolved_labels()
+            if observed.readiness is not None and run_readiness is None:
+                run_readiness = observed.readiness
+            if observed.session_normalization is not None:
+                run_session_normalization = observed.session_normalization
+
         failures.update(case_failures)
         cases.append({
             "case_ordinal": ordinal,
@@ -1136,6 +1161,8 @@ def _build_export(
             "hits": hits,
             "failure_codes": sorted(case_failures),
             "missing_fields": sorted(missing),
+            "search": search_observation,
+            "ingest": ingest_observation,
         })
 
     try:
@@ -1175,6 +1202,8 @@ def _build_export(
         "latency": {"publishable": False, "reason": "host_unvalidated"},
         "failure_codes": sorted(failures),
         "cases": cases,
+        "session_normalization": run_session_normalization,
+        "readiness": run_readiness,
     }
     if _secure_read(Path(plan.dataset_path), private=False) != original_dataset_bytes:
         raise ValueError("dataset bytes changed during the run")

--- a/benchmarks/memorybench/guest_observations.py
+++ b/benchmarks/memorybench/guest_observations.py
@@ -1,0 +1,250 @@
+"""Project the Exomem guest's own call log into export observations.
+
+The guest already records a request/response pair for every call it makes, so
+nothing here instruments anything new. It reads what was written and publishes
+only what those entries prove: a half-recorded call, a response that breaks the
+guest's own limit contract, or an empty directory all yield absence, never a
+value. Absence keeps its `missing_fields` label; that coupling is enforced by
+`MemoryBenchExportCase`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SEARCH_PATH = "/api/ask_memory"
+INGEST_PATH = "/api/capture_source"
+READ_PATH = "/api/read_memory"
+DOCTOR_RESPONSE = "doctor-response"
+
+SEARCH_LABELS = frozenset({
+    "search.transmitted_query",
+    "search.options.limit",
+    "search.normalized_hit_ids",
+})
+INGEST_LABELS = frozenset({"ingest.transmitted_payloads"})
+
+#: The renderer identity is a property of the pinned harness, not of a run.
+SESSION_NORMALIZATION = "memorybench.longmemeval_to_corpus/v1"
+
+_ENTRY_NAME = re.compile(r"^operation-(\d{6})-[0-9a-f]{12}\.json$")
+_MAX_ENTRY_BYTES = 8 * 1024 * 1024
+_MAX_ENTRIES = 100_000
+
+_EVIDENCE_INVALID = "guest_evidence_invalid"
+_EVIDENCE_INCOMPLETE = "guest_evidence_incomplete"
+
+
+@dataclass(frozen=True)
+class GuestObservations:
+    """What the guest's log proves, plus any reason it proved less than expected."""
+
+    search: dict[str, Any] | None = None
+    ingest: dict[str, Any] | None = None
+    readiness: list[dict[str, Any]] | None = None
+    session_normalization: str | None = None
+    problems: frozenset[str] = frozenset()
+
+    def resolved_labels(self) -> frozenset[str]:
+        """Missing-field labels this projection is entitled to clear."""
+
+        labels: set[str] = set()
+        if self.search is not None:
+            labels |= SEARCH_LABELS
+        if self.ingest is not None:
+            labels |= INGEST_LABELS
+        return frozenset(labels)
+
+
+def _canonical_digest(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+
+
+def read_guest_evidence(evidence_dir: Path) -> tuple[list[dict[str, Any]], set[str]]:
+    """Read one guest evidence directory in transmission order.
+
+    Ordering comes from the sequence field in the filename, never from
+    directory order: sequence 10 must not sort before sequence 2.
+    """
+
+    problems: set[str] = set()
+    try:
+        metadata = evidence_dir.lstat()
+    except (FileNotFoundError, NotADirectoryError):
+        return [], problems
+    except OSError:
+        return [], {_EVIDENCE_INVALID}
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        return [], {_EVIDENCE_INVALID}
+
+    numbered: list[tuple[int, Path]] = []
+    for child in evidence_dir.iterdir():
+        match = _ENTRY_NAME.match(child.name)
+        if match is None:
+            # Lock reservations and unrelated names are not evidence.
+            if not child.name.startswith("."):
+                problems.add(_EVIDENCE_INVALID)
+            continue
+        numbered.append((int(match.group(1)), child))
+    if len(numbered) > _MAX_ENTRIES:
+        return [], {_EVIDENCE_INVALID}
+
+    entries: list[dict[str, Any]] = []
+    for _sequence, path in sorted(numbered, key=lambda item: item[0]):
+        try:
+            if path.lstat().st_size > _MAX_ENTRY_BYTES:
+                problems.add(_EVIDENCE_INVALID)
+                continue
+            entry = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            problems.add(_EVIDENCE_INVALID)
+            continue
+        if not isinstance(entry, dict) or entry.get("protocol_version") != 1:
+            problems.add(_EVIDENCE_INVALID)
+            continue
+        if not isinstance(entry.get("event"), str) or not isinstance(entry.get("data"), dict):
+            problems.add(_EVIDENCE_INVALID)
+            continue
+        entries.append(entry)
+    return entries, problems
+
+
+def _call_path(entry: dict[str, Any]) -> str | None:
+    value = entry["data"].get("path")
+    return value if isinstance(value, str) else None
+
+
+def _project_search(entries: Sequence[dict[str, Any]], problems: set[str]) -> dict[str, Any] | None:
+    request: dict[str, Any] | None = None
+    response: Any = None
+    for entry in entries:
+        if _call_path(entry) != SEARCH_PATH:
+            continue
+        if entry["event"] == "request":
+            if request is not None:
+                # More than one search per case is outside this contract.
+                problems.add(_EVIDENCE_INVALID)
+                return None
+            body = entry["data"].get("body")
+            request = body if isinstance(body, dict) else None
+            if request is None:
+                problems.add(_EVIDENCE_INVALID)
+                return None
+        elif entry["event"] == "response":
+            response = entry["data"].get("response")
+    if request is None:
+        return None
+
+    query = request.get("query")
+    limit = request.get("limit")
+    if not isinstance(query, str) or not query:
+        return None
+    if not isinstance(limit, bool) and isinstance(limit, int) and limit > 0:
+        pass
+    else:
+        return None
+    if response is None:
+        problems.add(_EVIDENCE_INCOMPLETE)
+        return None
+    if not isinstance(response, list):
+        problems.add(_EVIDENCE_INVALID)
+        return None
+
+    hit_ids: list[str] = []
+    for selected in response:
+        if not isinstance(selected, dict):
+            problems.add(_EVIDENCE_INVALID)
+            return None
+        path = selected.get("path")
+        if not isinstance(path, str) or not path:
+            problems.add(_EVIDENCE_INVALID)
+            return None
+        hit_ids.append(path)
+    if len(hit_ids) > limit:
+        # The guest refuses an over-limit response before returning, so
+        # evidence showing one is not a value to publish.
+        problems.add(_EVIDENCE_INVALID)
+        return None
+    return {
+        "transmitted_query": query,
+        "options": {"limit": limit},
+        "normalized_hit_ids": hit_ids,
+    }
+
+
+def _project_ingest(entries: Sequence[dict[str, Any]], problems: set[str]) -> dict[str, Any] | None:
+    digests: list[str] = []
+    for entry in entries:
+        if entry["event"] != "request" or _call_path(entry) != INGEST_PATH:
+            continue
+        body = entry["data"].get("body")
+        if not isinstance(body, dict):
+            problems.add(_EVIDENCE_INVALID)
+            return None
+        digests.append(_canonical_digest(body))
+    if not digests:
+        return None
+    return {"transmitted_payload_sha256": digests}
+
+
+def _project_readiness(
+    entries: Sequence[dict[str, Any]], problems: set[str]
+) -> list[dict[str, Any]] | None:
+    checks: dict[str, Any] | None = None
+    for entry in entries:
+        if entry["event"] != DOCTOR_RESPONSE:
+            continue
+        response = entry["data"].get("response")
+        if not isinstance(response, dict):
+            problems.add(_EVIDENCE_INVALID)
+            return None
+        candidate = response.get("checks")
+        if not isinstance(candidate, dict):
+            problems.add(_EVIDENCE_INVALID)
+            return None
+        checks = candidate
+    if checks is None:
+        return None
+
+    failed = sorted(name for name, outcome in checks.items() if outcome != "pass")
+    verified = not failed
+    evidence = (
+        "hybrid doctor checks pass: " + ", ".join(sorted(checks))
+        if verified
+        else "hybrid doctor checks failed: " + ", ".join(failed)
+    )
+    return [{
+        "lane": "semantic",
+        "requested": True,
+        "verified": verified,
+        "method": "doctor-check" if verified else "readiness-unverifiable",
+        "evidence": evidence,
+        # A failed semantic check on this path means the guest served a
+        # degraded lane, which is precisely a fallback.
+        "fallback_detected": bool(failed),
+    }]
+
+
+def project_guest_evidence(evidence_dir: Path) -> GuestObservations:
+    """Read one guest evidence directory and publish only what it proves."""
+
+    entries, problems = read_guest_evidence(Path(evidence_dir))
+    search = _project_search(entries, problems)
+    ingest = _project_ingest(entries, problems)
+    readiness = _project_readiness(entries, problems)
+    return GuestObservations(
+        search=search,
+        ingest=ingest,
+        readiness=readiness,
+        session_normalization=SESSION_NORMALIZATION if entries else None,
+        problems=frozenset(problems),
+    )

--- a/benchmarks/protocol/models.py
+++ b/benchmarks/protocol/models.py
@@ -703,6 +703,47 @@ class MemoryBenchHit(StrictModel):
         return value
 
 
+class MemoryBenchSearchOptions(StrictModel):
+    limit: int = Field(ge=1)
+
+
+class MemoryBenchSearchObservation(StrictModel):
+    """What the guest actually transmitted and got back, not what we assume."""
+
+    transmitted_query: str = Field(min_length=1)
+    options: MemoryBenchSearchOptions
+    normalized_hit_ids: list[str]
+
+    @model_validator(mode="after")
+    def _hits_respect_the_transmitted_limit(self) -> "MemoryBenchSearchObservation":
+        if len(self.normalized_hit_ids) > self.options.limit:
+            raise ValueError("normalized hit ids exceed the transmitted search limit")
+        return self
+
+
+class MemoryBenchIngestObservation(StrictModel):
+    transmitted_payload_sha256: list[str]
+
+    @field_validator("transmitted_payload_sha256")
+    @classmethod
+    def _digests_are_sha256(cls, value: list[str]) -> list[str]:
+        if any(not re.fullmatch(_SHA256_PATTERN, item) for item in value):
+            raise ValueError("transmitted payload digests must be sha256 hex")
+        return value
+
+
+#: Each optional observation owns the missing-field labels it answers for, so a
+#: value can never be both published and declared absent.
+_OBSERVATION_LABELS: dict[str, tuple[str, ...]] = {
+    "search": (
+        "search.normalized_hit_ids",
+        "search.options.limit",
+        "search.transmitted_query",
+    ),
+    "ingest": ("ingest.transmitted_payloads",),
+}
+
+
 class MemoryBenchExportCase(StrictModel):
     case_ordinal: int = Field(ge=1)
     case_id_hmac_sha256: str = Field(pattern=_SHA256_PATTERN)
@@ -715,11 +756,29 @@ class MemoryBenchExportCase(StrictModel):
     hits: list[MemoryBenchHit]
     failure_codes: list[ExportFailureCode]
     missing_fields: list[MissingField]
+    search: MemoryBenchSearchObservation | None = None
+    ingest: MemoryBenchIngestObservation | None = None
 
     @field_validator("failure_codes", "missing_fields")
     @classmethod
     def _canonical_arrays(cls, value: list[str], info):
         return _require_sorted_unique(value, info.field_name)
+
+    @model_validator(mode="after")
+    def _observations_agree_with_missing_fields(self) -> "MemoryBenchExportCase":
+        declared = set(self.missing_fields)
+        for name, labels in _OBSERVATION_LABELS.items():
+            present = getattr(self, name) is not None
+            overlap = declared & set(labels)
+            if present and overlap:
+                raise ValueError(
+                    f"{name} is published but missing_fields still declares {sorted(overlap)}"
+                )
+            if not present and overlap != set(labels):
+                raise ValueError(
+                    f"{name} is absent, so missing_fields must declare {sorted(labels)}"
+                )
+        return self
 
     def is_complete(self) -> bool:
         return (
@@ -763,6 +822,9 @@ class MemoryBenchExport(StrictModel):
     latency: MemoryBenchLatency
     failure_codes: list[ExportFailureCode]
     cases: list[MemoryBenchExportCase] = Field(min_length=1)
+    # Run-level facts the guest observes once, not per case.
+    session_normalization: str | None = None
+    readiness: list[LaneReadiness] | None = None
 
     @field_validator("failure_codes")
     @classmethod

--- a/benchmarks/protocol/schema/memorybench-export.v1.schema.json
+++ b/benchmarks/protocol/schema/memorybench-export.v1.schema.json
@@ -129,6 +129,53 @@
       "title": "DatasetIdentity",
       "type": "object"
     },
+    "LaneReadiness": {
+      "additionalProperties": false,
+      "properties": {
+        "evidence": {
+          "title": "Evidence",
+          "type": "string"
+        },
+        "fallback_detected": {
+          "default": false,
+          "title": "Fallback Detected",
+          "type": "boolean"
+        },
+        "lane": {
+          "title": "Lane",
+          "type": "string"
+        },
+        "method": {
+          "enum": [
+            "index-count",
+            "config-state",
+            "semantic-probe",
+            "memories-canary",
+            "doctor-check",
+            "readiness-unverifiable"
+          ],
+          "title": "Method",
+          "type": "string"
+        },
+        "requested": {
+          "title": "Requested",
+          "type": "boolean"
+        },
+        "verified": {
+          "title": "Verified",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "lane",
+        "requested",
+        "verified",
+        "method",
+        "evidence"
+      ],
+      "title": "LaneReadiness",
+      "type": "object"
+    },
     "MemoryBenchExportCase": {
       "additionalProperties": false,
       "properties": {
@@ -211,6 +258,17 @@
           "title": "Hits",
           "type": "array"
         },
+        "ingest": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MemoryBenchIngestObservation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "missing_fields": {
           "items": {
             "enum": [
@@ -247,6 +305,17 @@
         },
         "question": {
           "$ref": "#/$defs/MemoryBenchQuestion"
+        },
+        "search": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MemoryBenchSearchObservation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
@@ -316,6 +385,23 @@
         "score"
       ],
       "title": "MemoryBenchHit",
+      "type": "object"
+    },
+    "MemoryBenchIngestObservation": {
+      "additionalProperties": false,
+      "properties": {
+        "transmitted_payload_sha256": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Transmitted Payload Sha256",
+          "type": "array"
+        }
+      },
+      "required": [
+        "transmitted_payload_sha256"
+      ],
+      "title": "MemoryBenchIngestObservation",
       "type": "object"
     },
     "MemoryBenchLatency": {
@@ -501,6 +587,49 @@
         "date"
       ],
       "title": "MemoryBenchQuestion",
+      "type": "object"
+    },
+    "MemoryBenchSearchObservation": {
+      "additionalProperties": false,
+      "description": "What the guest actually transmitted and got back, not what we assume.",
+      "properties": {
+        "normalized_hit_ids": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Normalized Hit Ids",
+          "type": "array"
+        },
+        "options": {
+          "$ref": "#/$defs/MemoryBenchSearchOptions"
+        },
+        "transmitted_query": {
+          "minLength": 1,
+          "title": "Transmitted Query",
+          "type": "string"
+        }
+      },
+      "required": [
+        "transmitted_query",
+        "options",
+        "normalized_hit_ids"
+      ],
+      "title": "MemoryBenchSearchObservation",
+      "type": "object"
+    },
+    "MemoryBenchSearchOptions": {
+      "additionalProperties": false,
+      "properties": {
+        "limit": {
+          "minimum": 1,
+          "title": "Limit",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "limit"
+      ],
+      "title": "MemoryBenchSearchOptions",
       "type": "object"
     }
   },
@@ -833,6 +962,21 @@
       "title": "Provider Variant",
       "type": "string"
     },
+    "readiness": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/LaneReadiness"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Readiness"
+    },
     "run_id": {
       "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$",
       "title": "Run Id",
@@ -842,6 +986,18 @@
       "const": 1,
       "title": "Schema Version",
       "type": "integer"
+    },
+    "session_normalization": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Session Normalization"
     },
     "status": {
       "enum": [

--- a/docs/benchmarks/equivalence-gate-runbook.md
+++ b/docs/benchmarks/equivalence-gate-runbook.md
@@ -1,0 +1,134 @@
+# §4.6c runbook — the 25-case Exomem direct-vs-MemoryBench equivalence gate
+
+The prerequisite for every comparative run. Both lanes retrieve; neither reads
+or judges, so this tier is **unmetered** — the ⛳ founder gate at §7.4 covers the
+metered reader/judge tier, not this. No `OPENAI_API_KEY` is needed.
+
+## Before you start
+
+**Run only on a quiesced machine.** This ingests 25 LongMemEval-S cases twice —
+once in-process, once through MemoryBench's Bun harness against an ephemeral
+Exomem REST service. Check first; the programme forbids benchmark runs on a busy
+host, and **no latency claim may ever come from this machine**.
+
+```
+uptime; free -g | sed -n 2p; ps -eo comm --no-headers | grep -c '^claude$'
+```
+
+Preconditions, all currently satisfied:
+
+| Thing | Where | Check |
+|---|---|---|
+| LongMemEval-S | `<data-dir>/longmemeval-cleaned-98d7416c…/longmemeval_s_cleaned.json` | `python -m benchmarks.lme.fetch verify <path> --sha256 d6f21ea9…` |
+| 25-case cohort | `benchmarks/equivalence/subsets/lme-s-25.json` | 25 `target_question_ids`, frozen against the same pin |
+| MemoryBench | `<projects-dir>/memorybench` @ `118209a` | pinned in `benchmarks/memorybench/LOCKFILE.json` |
+| Bun | on `PATH` | must report `1.3.14` |
+
+## 1. Materialize the pinned overlay
+
+`setup.py` reads the checkout locations from the environment named in the
+LOCKFILE, and refuses on any drift.
+
+```
+export MEMORYBENCH_HOME="$PROJECTS_DIR/memorybench"
+export BASIC_MEMORY_HOME="$PROJECTS_DIR/basic-memory"
+python -m benchmarks.memorybench.setup --verify
+python -m benchmarks.memorybench.setup --materialize
+```
+
+`--restore` puts the checkout back pristine and must be run when you are done,
+whether or not the gate passed.
+
+## 2. Left side — the direct lane
+
+`--canonical-selection` binds the run to the frozen 25-case cohort; do not
+substitute `--pilot 25`, which is a different, non-comparative selection.
+
+```
+EXOMEM_DISABLE_EMBEDDINGS=0 PYTHONPATH=src python -m benchmarks.lme.cli run --dataset "$LME_S" --reader stub --provider exomem-source-only --canonical-selection --top-k 10 --out "$RUNS/direct"
+```
+
+Then confirm the run is publishable before comparing anything to it:
+
+```
+python -m benchmarks.protocol.cli validate --run-dir "$RUNS/direct/<run-id>" --strict
+```
+
+It writes `equivalence.json` itself. A run that is not `VALID` is an
+environment fault, never a contender result.
+
+## 3. Right side — the guest lane
+
+Author a `memorybench-run-plan.v1` as an **absolute, owned, mode-0600** file.
+Required fields: `run_id`, `upstream_run_id`, `provider` (`exomem`),
+`provider_variant`, `benchmark`, `selection`, `harness`, `dataset`,
+`dataset_path`, `provider_checkout`, `memorybench_home`, `output_root`,
+`guest_work_root`, `guest_evidence_root`, `contract_revision`,
+`preregistration_sha256`, `privacy_hmac_key_hex`.
+
+Set `selection` to the explicit ordered ids — the ingest entrypoint passes them
+through MemoryBench's own `questionIds` seam:
+
+```
+"selection": {"mode": "explicit", "target_question_ids": [ …the 25 ids… ]}
+```
+
+Never use `--limit` or sampling: the cohort is the artifact, not a sample size.
+
+```
+chmod 600 "$PLAN"
+python -m benchmarks.memorybench.export --plan "$PLAN"
+```
+
+Exit codes are independent of status: `0` VALID, `1` INVALID, `2` BLOCKED
+(pre-provider only), `3` unproved cleanup, `130`/`143` on a caught signal.
+
+## 4. Project the guest export
+
+```
+python -m benchmarks.memorybench.equivalence_projection --export "$OUT/memorybench-export.v1.json" --out "$RUNS/guest" --reader stub --reader-model gpt-4o --judge-model gpt-4o
+```
+
+The reader/model triple must match what the left run recorded, or
+`answer_judge_prompt_model_config` differs for a reason that has nothing to do
+with retrieval.
+
+## 5. The gate
+
+```
+python -m benchmarks.equivalence.cli gate --left "$RUNS/direct/<run-id>" --right "$RUNS/guest" --mode blocking
+```
+
+Exit `1` means a blocking difference. **Expect that on the first run.**
+
+## Reading the first result honestly
+
+Several BLOCKING keys will differ because the two paths *genuinely* differ, not
+because either is wrong:
+
+- `session_normalization` — `lme.normalize.render_neutral_session/v1` vs
+  `memorybench.longmemeval_to_corpus/v1`
+- `namespace` — different derivations
+- `ingestion_payloads` — digest of a rendered neutral session vs of a
+  `capture_source` body
+
+`retrieved_ids` will differ too (positional `exomem-N` ids vs vault paths), but
+that key is REPORTED, not blocking.
+
+Run `--mode report` first to read the full picture without the exit code, then
+decide per key whether it is a genuine incomparability — which belongs in the
+exceptions register as an **expiring weaker predicate with a written reason** —
+or a real disagreement between the two paths, which is a finding.
+
+Do not author exception entries before seeing the measured diff. The register
+exists to record known incomparabilities, not to make a red gate green.
+
+## Afterwards
+
+```
+python -m benchmarks.memorybench.setup --restore
+python -m benchmarks.memorybench.setup --verify
+```
+
+Record the outcome against ledger §4.6c in
+`openspec/changes/add-competitive-benchmark-programme/tasks.md`.

--- a/openspec/changes/add-competitive-benchmark-programme/tasks.md
+++ b/openspec/changes/add-competitive-benchmark-programme/tasks.md
@@ -268,7 +268,35 @@ them. Mission acceptance criteria (§14) close only from this ledger.
       all lock hashes recompute. Final independent FEEDBACK6 recheck: `CLEAR`.
       No competitor/provider/network/model/dataset benchmark, credential,
       metered call, commit, push, or §4.6 work occurred.
-- [ ] 4.6 25-case Exomem direct-vs-MemoryBench equivalence gate GREEN
+- [ ] 4.6a Publish the already-observed guest facts in `memorybench-export.v1`.
+      Blocked discovery (2026-08-15): five of the nine BLOCKING equivalence keys
+      had no source in the export — `session_normalization`,
+      `ingestion_payloads`, `readiness`, `top_k`, and
+      `answer_judge_prompt_model_config`. The names `search.transmitted_query`,
+      `search.options.limit`, and `search.normalized_hit_ids` appear in the
+      schema ONLY as labels inside the `missing_fields` enum; there is no
+      search `$def`, and `readiness`/`session_normalization`/`payload_sha`
+      appear nowhere. Under the differ's null-never-equals rule those five
+      mismatch by construction, so the blocking gate could never go green — not
+      because the paths disagree, but because one side was never asked.
+      This is NOT a §4.5 defect: its export was deliberately scoped to executed
+      ingest/indexing/search with a closed no-fabrication vocabulary.
+      The facts are already captured and validated: the Exomem guest records
+      `request`/`response` evidence for every call
+      (`providers/exomem/index.ts`), builds the search body from the exact
+      `{query, limit}`, refuses an over-limit response, and requires a selected
+      path per hit; `export.py` already reads and validates guest evidence.
+      So this is a PROJECTION extension — additive export fields sourced from
+      existing evidence, no TS provider change, no `registration.patch` churn,
+      no lock-hash recomputation. The no-fabrication rule holds: a field appears
+      only when its evidence proves it, otherwise it stays in `missing_fields`.
+      `answer_judge_prompt_model_config` is sourced from the run plan (an
+      operator declaration both sides share), never from the harness, which
+      excludes answer/evaluate/report by design.
+- [ ] 4.6b `memorybench-export.v1` → `equivalence-input.v1` projector, so the
+      differ has a right-hand side (only `lme/runner.py` writes
+      `equivalence.json` today)
+- [ ] 4.6c 25-case Exomem direct-vs-MemoryBench equivalence gate GREEN
       (mode=blocking) — prerequisite for every comparative run
 - [ ] 4.7 Ratify and implement the native Supermemory vendor-hit projection
       (distinct from 4.5's flat guest-hit wire), then run the Supermemory

--- a/openspec/changes/add-competitive-benchmark-programme/tasks.md
+++ b/openspec/changes/add-competitive-benchmark-programme/tasks.md
@@ -323,9 +323,33 @@ them. Mission acceptance criteria (§14) close only from this ledger.
             Evidence: 14 focused checks red-first, then 503 passed across
             memorybench + protocol with the export's recompute-and-compare
             invariant intact.
-- [ ] 4.6b `memorybench-export.v1` → `equivalence-input.v1` projector, so the
-      differ has a right-hand side (only `lme/runner.py` writes
-      `equivalence.json` today)
+- [x] 4.6b `memorybench-export.v1` → `equivalence-input.v1` projector.
+      `benchmarks/memorybench/equivalence_projection.py` mirrors the twelve
+      keys `lme/runner.py::_equivalence_case` emits, sourced from the public
+      export plus the private-gold mapping (the public artifact carries only
+      HMAC pseudonyms; the comparison needs the real question ids). Readiness
+      is narrowed to the same five fields the direct emitter compares, dropping
+      `evidence` because prose would never match. A key the export could not
+      source stays NULL rather than being invented — the differ treats null as
+      never equal to anything, so an unsourced key becomes a difference
+      demanding an explanation instead of a silent pass. A case with no private
+      gold mapping is refused, never guessed. CLI writes `equivalence.json`
+      into a run directory (`--export`, `--private-gold`, `--out`).
+      Evidence: 13 checks, red-first. The decisive two run the REAL emitter
+      rather than a hand-copy — one asserts both sides carry identical key sets
+      so the differ compares like with like, and a round trip through
+      `compare_runs` shows identical projections produce no blocking difference
+      while a widened `top_k` (10 vs 30) is caught as blocking.
+      EXPECTED at 4.6c: several BLOCKING keys will legitimately differ because
+      the two paths genuinely differ, not because either is wrong —
+      `session_normalization` (`lme.normalize.render_neutral_session/v1` vs
+      `memorybench.longmemeval_to_corpus/v1`), `namespace` (different
+      derivations), and `ingestion_payloads` (digest of a rendered neutral
+      session vs of a `capture_source` body). `retrieved_ids` will differ too
+      (the direct row emits positional `exomem-N` ids, the guest emits vault
+      paths) but that key is REPORTED, not blocking. These are the measured
+      findings 4.6c exists to surface and the exceptions register exists to
+      carry, with expiry — they are not to be papered over before the gate runs.
 - [ ] 4.6c 25-case Exomem direct-vs-MemoryBench equivalence gate GREEN
       (mode=blocking) — prerequisite for every comparative run
 - [ ] 4.7 Ratify and implement the native Supermemory vendor-hit projection

--- a/openspec/changes/add-competitive-benchmark-programme/tasks.md
+++ b/openspec/changes/add-competitive-benchmark-programme/tasks.md
@@ -306,12 +306,23 @@ them. Mission acceptance criteria (§14) close only from this ledger.
             Schema regenerated; drift and conformance gates green. Evidence:
             958 passed / 32 skipped across membench + protocol + memorybench +
             privacy, `ruff --select F` clean, OpenSpec strict valid.
-      - [ ] 4.6a-2 POPULATE: project the fields from the existing guest
-            evidence in `export.py` (the Exomem guest already logs
-            `request`/`response` per call, and `_basic_evidence_targets` is the
-            precedent for reading it). No-fabrication holds: absent evidence
-            keeps the `missing_fields` label. `normalized_scores` stays absent
+      - [x] 4.6a-2 POPULATE: `benchmarks/memorybench/guest_observations.py`
+            reads one guest evidence directory in TRANSMISSION order (the
+            sequence in the filename, never directory order — sequence 10 must
+            not sort before 2) and publishes only what those entries prove.
+            Wired into the single case-assembly site in `export.py`, which
+            starts from "everything missing" and subtracts only the labels the
+            evidence resolves. Scoped to the `exomem` guest; the Basic sidecar
+            records a different evidence shape and keeps its labels declared.
+            Absence is never a value: a request with no paired response records
+            `guest_evidence_incomplete`, and a response breaking the guest's own
+            limit contract (refused at `index.ts:205` before returning) records
+            `guest_evidence_invalid` rather than publishing it. An empty
+            directory is absence, not a fault. `normalized_scores` stays absent
             — the guest search path hard-codes `score: 0.0`.
+            Evidence: 14 focused checks red-first, then 503 passed across
+            memorybench + protocol with the export's recompute-and-compare
+            invariant intact.
 - [ ] 4.6b `memorybench-export.v1` → `equivalence-input.v1` projector, so the
       differ has a right-hand side (only `lme/runner.py` writes
       `equivalence.json` today)

--- a/openspec/changes/add-competitive-benchmark-programme/tasks.md
+++ b/openspec/changes/add-competitive-benchmark-programme/tasks.md
@@ -293,6 +293,25 @@ them. Mission acceptance criteria (§14) close only from this ledger.
       `answer_judge_prompt_model_config` is sourced from the run plan (an
       operator declaration both sides share), never from the harness, which
       excludes answer/evaluate/report by design.
+      - [x] 4.6a-1 SCHEMA: additive `MemoryBenchSearchObservation`
+            (`transmitted_query`, `options.limit`, `normalized_hit_ids`),
+            `MemoryBenchIngestObservation` (`transmitted_payload_sha256`), and
+            run-level `session_normalization` + `readiness`. The honesty
+            coupling is enforced, not documented: `_OBSERVATION_LABELS` binds
+            each optional block to the `missing_fields` labels it answers for,
+            and a model validator refuses BOTH a published value whose label is
+            still declared missing AND an absent value whose labels are not all
+            declared. Hit ids may not outnumber the transmitted limit — the
+            same contract the guest already enforces at `index.ts:205`.
+            Schema regenerated; drift and conformance gates green. Evidence:
+            958 passed / 32 skipped across membench + protocol + memorybench +
+            privacy, `ruff --select F` clean, OpenSpec strict valid.
+      - [ ] 4.6a-2 POPULATE: project the fields from the existing guest
+            evidence in `export.py` (the Exomem guest already logs
+            `request`/`response` per call, and `_basic_evidence_targets` is the
+            precedent for reading it). No-fabrication holds: absent evidence
+            keeps the `missing_fields` label. `normalized_scores` stays absent
+            — the guest search path hard-codes `score: 0.0`.
 - [ ] 4.6b `memorybench-export.v1` → `equivalence-input.v1` projector, so the
       differ has a right-hand side (only `lme/runner.py` writes
       `equivalence.json` today)

--- a/tests/test_memorybench_equivalence_projection.py
+++ b/tests/test_memorybench_equivalence_projection.py
@@ -1,0 +1,229 @@
+"""4.6b: project a MemoryBench export into the differ's right-hand side.
+
+Only `lme/runner.py` wrote `equivalence.json` before this, so the differ had
+nothing to compare against. The projection mirrors that emitter's twelve keys
+exactly, and leaves a key null when the export could not source it — null never
+equals anything, so an unsourced key becomes a difference demanding an
+explanation rather than a silent pass.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_SHA = "c" * 64
+JUDGE = {
+    "reader": "stub",
+    "reader_model": "gpt-4o",
+    "judge_model": "gpt-4o",
+}
+
+
+def _export(**overrides):
+    case = {
+        "case_ordinal": 1,
+        "case_id_hmac_sha256": "d" * 64,
+        "question": {"text": "which lantern?", "type": "knowledge-update", "date": None},
+        "container_tag_hmac_sha256": "e" * 64,
+        "checkpoint": None,
+        "canonical_result": None,
+        "private_gold": None,
+        "phases": {
+            name: {"status": "completed", "failure_code": None}
+            for name in ("ingest", "indexing", "search")
+        },
+        "hits": [{"content": "first session", "score": 0.0}, {"content": "second", "score": 0.0}],
+        "failure_codes": [],
+        "missing_fields": [],
+        "search": {
+            "transmitted_query": "which lantern?",
+            "options": {"limit": 10},
+            "normalized_hit_ids": ["Notes/a.md", "Notes/b.md"],
+        },
+        "ingest": {"transmitted_payload_sha256": [_SHA]},
+    }
+    export = {
+        "run_id": "mb-20260815T000000Z",
+        "provider_variant": "exomem-source-only",
+        "dataset": {
+            "id": "longmemeval", "variant": "s", "source": "local",
+            "revision": "pin", "sha256": "f" * 64, "case_count": 25,
+        },
+        "session_normalization": "memorybench.longmemeval_to_corpus/v1",
+        "readiness": [{
+            "lane": "semantic", "requested": True, "verified": True,
+            "method": "doctor-check", "evidence": "hybrid doctor checks pass",
+            "fallback_detected": False,
+        }],
+        "cases": [case],
+    }
+    export.update(overrides)
+    return export
+
+
+def _golds():
+    return {"d" * 64: {"question_id": "q-01", "container_tag": "mb-container-01"}}
+
+
+_UNSET = object()
+
+
+def _project(export=None, golds=_UNSET, **kwargs):
+    """`golds={}` means "no mapping", which is not the same as "use the default"."""
+
+    from memorybench.equivalence_projection import project_export
+
+    resolved = _golds() if golds is _UNSET else golds
+    return project_export(export or _export(), resolved, judge_config=JUDGE, **kwargs)
+
+
+def test_the_envelope_matches_what_the_differ_loads() -> None:
+    payload = _project()
+
+    assert payload["schema"] == "equivalence-input.v1"
+    assert payload["run_id"] == "mb-20260815T000000Z"
+    assert payload["provider_variant"] == "exomem-source-only"
+    assert [case["case_id"] for case in payload["cases"]] == ["q-01"]
+
+
+def test_every_one_of_the_twelve_keys_is_present_on_each_case() -> None:
+    from equivalence.differ import EQUIVALENCE_KEYS
+
+    case = _project()["cases"][0]
+    assert set(EQUIVALENCE_KEYS) <= set(case)
+
+
+def test_the_observed_search_facts_become_query_limit_and_hit_ids() -> None:
+    case = _project()["cases"][0]
+
+    assert case["exact_query"] == "which lantern?"
+    assert case["top_k"] == 10
+    assert case["retrieved_ids"] == ["Notes/a.md", "Notes/b.md"]
+
+
+def test_retrieved_text_and_packed_context_use_the_readers_own_separator() -> None:
+    from lme.reader import CONTEXT_SEPARATOR
+
+    case = _project()["cases"][0]
+    assert case["retrieved_text"] == ["first session", "second"]
+    assert case["packed_context"] == CONTEXT_SEPARATOR.join(["first session", "second"])
+
+
+def test_case_set_comes_from_private_gold_not_the_public_pseudonyms() -> None:
+    """The public artifact carries HMACs; the comparison needs the real ids."""
+
+    case = _project()["cases"][0]
+    assert case["case_set"] == ["q-01"]
+    assert "d" * 64 not in json.dumps(case["case_set"])
+
+
+def test_an_unsourced_key_is_null_rather_than_invented() -> None:
+    export = _export()
+    export["cases"][0]["search"] = None
+    export["cases"][0]["missing_fields"] = sorted([
+        "search.transmitted_query", "search.options.limit", "search.normalized_hit_ids",
+    ])
+    case = _project(export)["cases"][0]
+
+    assert case["exact_query"] is None
+    assert case["top_k"] is None
+    assert case["retrieved_ids"] is None
+
+
+def test_absent_run_level_facts_are_null_on_every_case() -> None:
+    export = _export(session_normalization=None, readiness=None)
+    case = _project(export)["cases"][0]
+
+    assert case["session_normalization"] is None
+    assert case["readiness"] is None
+
+
+def test_readiness_is_narrowed_to_the_fields_the_left_side_compares() -> None:
+    """The emitter drops `evidence`, which is prose and would never match."""
+
+    case = _project()["cases"][0]
+    assert case["readiness"] == [{
+        "lane": "semantic", "requested": True, "verified": True,
+        "method": "doctor-check", "fallback_detected": False,
+    }]
+
+
+def test_the_judge_config_is_an_operator_declaration_with_a_per_case_prompt_digest() -> None:
+    import hashlib
+
+    case = _project()["cases"][0]
+    assert case["answer_judge_prompt_model_config"] == {
+        "reader": "stub", "reader_model": "gpt-4o", "judge_model": "gpt-4o",
+        "prompt_sha256": hashlib.sha256("which lantern?".encode()).hexdigest(),
+    }
+
+
+def test_a_case_with_no_private_gold_mapping_is_refused_not_guessed() -> None:
+    with pytest.raises(ValueError, match="private gold"):
+        _project(golds={})
+
+
+def test_the_projection_round_trips_through_the_differ_against_itself(tmp_path: Path) -> None:
+    """Two identical projections must produce no blocking difference."""
+
+    from equivalence.differ import compare_runs
+
+    for name in ("left", "right"):
+        directory = tmp_path / name
+        directory.mkdir()
+        (directory / "equivalence.json").write_text(json.dumps(_project()), encoding="utf-8")
+
+    result = compare_runs(tmp_path / "left", tmp_path / "right", mode="blocking", out=tmp_path / "left")
+    assert result.blocking is False
+
+
+def test_both_sides_carry_the_same_keys_so_the_differ_compares_like_with_like() -> None:
+    """The real left-side emitter, not a hand-copy of it."""
+
+    from types import SimpleNamespace
+
+    from lme.runner import _equivalence_case
+    from protocol.models import DatasetIdentity, LaneReadiness
+
+    identity = DatasetIdentity(
+        id="longmemeval", variant="s", source="local", revision="pin",
+        sha256="f" * 64, case_count=25,
+    )
+    left = _equivalence_case(
+        question=SimpleNamespace(question_id="q-01", question="which lantern?"),
+        case_ids=["q-01"],
+        namespace_pattern="exomem/{run}/{session}",
+        payload_shas=[_SHA],
+        readiness=[LaneReadiness(
+            lane="semantic", requested=True, verified=False,
+            method="readiness-unverifiable", evidence="probes pending",
+        )],
+        retrieved_ids=["exomem-0"], retrieved_text=["first session"], top_k=10,
+        dataset_identity=identity, reader_name="stub", reader_model="gpt-4o",
+    )
+    right = _project()["cases"][0]
+
+    assert set(left) == set(right)
+    # And the readiness rows are narrowed identically on both sides.
+    assert set(left["readiness"][0]) == set(right["readiness"][0])
+
+
+def test_a_changed_blocking_key_is_caught_by_the_differ(tmp_path: Path) -> None:
+    from equivalence.differ import compare_runs
+
+    (tmp_path / "left").mkdir()
+    (tmp_path / "left" / "equivalence.json").write_text(json.dumps(_project()), encoding="utf-8")
+
+    widened = _export()
+    widened["cases"][0]["search"]["options"]["limit"] = 30
+    (tmp_path / "right").mkdir()
+    (tmp_path / "right" / "equivalence.json").write_text(
+        json.dumps(_project(widened)), encoding="utf-8"
+    )
+
+    result = compare_runs(tmp_path / "left", tmp_path / "right", mode="blocking", out=tmp_path / "left")
+    assert result.blocking is True
+    assert any(diff.field == "top_k" for diff in result.diffs)

--- a/tests/test_memorybench_export_observations.py
+++ b/tests/test_memorybench_export_observations.py
@@ -1,0 +1,202 @@
+"""4.6a: the export publishes what the guest already observed, or says it didn't.
+
+The honesty coupling is the whole point. A closed `missing_fields` vocabulary
+that names a value the schema cannot carry lets a consumer read "sometimes
+absent" where the truth is "never available". Every observation added here is
+bound to its own missing-field label so the two can never disagree.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+_SHA = "a" * 64
+
+
+def _dataset():
+    from protocol.models import DatasetIdentity
+
+    return DatasetIdentity(
+        id="longmemeval", variant="s", source="local", revision="pin",
+        sha256=_SHA, case_count=25,
+    )
+
+
+def _harness():
+    """The pinned identity is frozen in the models; mirror it rather than invent one."""
+
+    from protocol import models
+
+    return {
+        "repository": models.MEMORYBENCH_REPOSITORY,
+        "commit": models.MEMORYBENCH_COMMIT,
+        "tree": models.MEMORYBENCH_TREE,
+        "bun_lock_sha256": models.MEMORYBENCH_BUN_LOCK_SHA256,
+    }
+
+
+def _phases(status: str = "completed"):
+    return {
+        "ingest": {"status": status, "failure_code": None},
+        "indexing": {"status": status, "failure_code": None},
+        "search": {"status": status, "failure_code": None},
+    }
+
+
+def _case(**overrides):
+    """A self-consistent case: both observations published, nothing declared missing.
+
+    Tests vary one observation at a time, so the other stays present and never
+    becomes an accidental second cause of a validation error.
+    """
+
+    base = {
+        "case_ordinal": 1,
+        "case_id_hmac_sha256": _SHA,
+        "question": {"text": "which lantern?", "type": "knowledge-update", "date": None},
+        "container_tag_hmac_sha256": _SHA,
+        "checkpoint": None,
+        "canonical_result": None,
+        "private_gold": None,
+        "phases": _phases(),
+        "hits": [{"content": "a hit", "score": 0.0}],
+        "failure_codes": [],
+        "missing_fields": [],
+        "search": {
+            "transmitted_query": "which lantern?",
+            "options": {"limit": 10},
+            "normalized_hit_ids": ["Knowledge Base/Notes/a.md"],
+        },
+        "ingest": {"transmitted_payload_sha256": [_SHA]},
+    }
+    base.update(overrides)
+    return base
+
+
+SEARCH_LABELS = ["search.normalized_hit_ids", "search.options.limit", "search.transmitted_query"]
+
+
+def test_a_search_observation_can_be_carried_at_all() -> None:
+    """The gap that blocked 4.6: there was nowhere to put these."""
+
+    from protocol.models import MemoryBenchExportCase
+
+    case = MemoryBenchExportCase.model_validate(_case(search={
+        "transmitted_query": "which lantern?",
+        "options": {"limit": 10},
+        "normalized_hit_ids": ["Knowledge Base/Notes/a.md"],
+    }))
+    assert case.search is not None
+    assert case.search.options.limit == 10
+    assert case.search.transmitted_query == "which lantern?"
+    assert case.search.normalized_hit_ids == ["Knowledge Base/Notes/a.md"]
+
+
+def test_an_absent_search_observation_must_declare_every_one_of_its_labels() -> None:
+    from protocol.models import MemoryBenchExportCase
+
+    with pytest.raises(ValueError, match="missing_fields"):
+        MemoryBenchExportCase.model_validate(_case(search=None, missing_fields=[]))
+
+    # Declaring only some of them is the dishonest middle ground.
+    with pytest.raises(ValueError, match="missing_fields"):
+        MemoryBenchExportCase.model_validate(
+            _case(search=None, missing_fields=["search.transmitted_query"])
+        )
+
+    case = MemoryBenchExportCase.model_validate(
+        _case(search=None, missing_fields=sorted(SEARCH_LABELS))
+    )
+    assert case.search is None
+
+
+def test_a_present_search_observation_may_not_also_be_declared_missing() -> None:
+    """Presence and its absence-label are mutually exclusive, both ways."""
+
+    from protocol.models import MemoryBenchExportCase
+
+    with pytest.raises(ValueError, match="missing_fields"):
+        MemoryBenchExportCase.model_validate(_case(
+            search={
+                "transmitted_query": "q", "options": {"limit": 3},
+                "normalized_hit_ids": ["p"],
+            },
+            missing_fields=sorted(SEARCH_LABELS),
+        ))
+
+
+def test_ingest_payload_digests_are_carried_or_declared() -> None:
+    from protocol.models import MemoryBenchExportCase
+
+    case = MemoryBenchExportCase.model_validate(_case())
+    assert case.ingest is not None
+    assert case.ingest.transmitted_payload_sha256 == [_SHA]
+
+    # Absent, but its label not declared.
+    with pytest.raises(ValueError, match="missing_fields"):
+        MemoryBenchExportCase.model_validate(_case(ingest=None))
+
+    declared = MemoryBenchExportCase.model_validate(
+        _case(ingest=None, missing_fields=["ingest.transmitted_payloads"])
+    )
+    assert declared.ingest is None
+
+
+def test_the_search_limit_must_be_a_real_positive_integer() -> None:
+    from protocol.models import MemoryBenchExportCase
+
+    for bad in (0, -1):
+        with pytest.raises(ValueError):
+            MemoryBenchExportCase.model_validate(_case(search={
+                "transmitted_query": "q", "options": {"limit": bad},
+                "normalized_hit_ids": [],
+            }))
+
+
+def test_hit_ids_may_not_outnumber_the_limit_that_was_sent() -> None:
+    """An over-limit response is a contract breach the guest already refuses."""
+
+    from protocol.models import MemoryBenchExportCase
+
+    with pytest.raises(ValueError, match="limit"):
+        MemoryBenchExportCase.model_validate(_case(search={
+            "transmitted_query": "q", "options": {"limit": 1},
+            "normalized_hit_ids": ["a", "b"],
+        }))
+
+
+def test_run_level_readiness_and_normalization_are_carried() -> None:
+    from protocol.models import MemoryBenchExport
+
+    export = MemoryBenchExport.model_validate({
+        "protocol_version": "1.0.0", "schema_version": 1,
+        # The fixture case carries no source references, so "partial" is the
+        # only status its evidence supports.
+        "artifact_type": "memorybench-export.v1", "status": "partial",
+        "run_id": "mb-20260815T000000Z", "provider": "exomem",
+        "provider_variant": "exomem-source-only", "benchmark": "longmemeval",
+        "harness": _harness(),
+        "dataset": _dataset().model_dump(),
+        "executed_stages": ["ingest", "indexing", "search"],
+        "excluded_stages": ["answer", "evaluate", "report"],
+        "privacy": {
+            "classification": "provider_safe_reader_input",
+            "contains_ground_truth": False,
+            "source_results_contain_ground_truth": True,
+        },
+        "latency": {"publishable": False, "reason": "host_unvalidated"},
+        "failure_codes": [],
+        "session_normalization": "memorybench.longmemeval_to_corpus/v1",
+        "readiness": [{
+            "lane": "semantic", "requested": True, "verified": True,
+            "method": "doctor-check", "evidence": "hybrid doctor checks pass",
+            "fallback_detected": False,
+        }],
+        "cases": [_case(
+            search={"transmitted_query": "q", "options": {"limit": 10}, "normalized_hit_ids": ["p"]},
+            ingest={"transmitted_payload_sha256": [_SHA]},
+        )],
+    })
+    assert export.session_normalization == "memorybench.longmemeval_to_corpus/v1"
+    assert export.readiness is not None
+    assert export.readiness[0].method == "doctor-check"

--- a/tests/test_memorybench_guest_observations.py
+++ b/tests/test_memorybench_guest_observations.py
@@ -1,0 +1,194 @@
+"""4.6a-2: project what the Exomem guest already recorded, and nothing else.
+
+The guest logs a request/response pair for every call it makes. These checks
+pin that the projection reports only what those entries prove: a half-recorded
+call, a response that breaks the guest's own limit contract, or an empty
+evidence directory must never become a published value.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+SEARCH_LABELS = {
+    "search.transmitted_query",
+    "search.options.limit",
+    "search.normalized_hit_ids",
+}
+INGEST_LABELS = {"ingest.transmitted_payloads"}
+
+
+def _write(directory: Path, sequence: int, event: str, data: dict) -> None:
+    entry = {
+        "protocol_version": 1,
+        "event": event,
+        "recorded_at_utc": "2026-08-15T00:00:00.000Z",
+        "data": data,
+    }
+    payload = json.dumps(entry, sort_keys=True) + "\n"
+    digest = hashlib.sha256(payload.encode()).hexdigest()[:12]
+    (directory / f"operation-{sequence:06d}-{digest}.json").write_text(payload, encoding="utf-8")
+
+
+def _search_pair(directory: Path, *, query: str, limit: int, paths: list[str], start: int = 1) -> None:
+    _write(directory, start, "request", {
+        "path": "/api/ask_memory",
+        "body": {"query": query, "limit": limit, "scope": "kb", "mode": "hybrid", "detail": "full"},
+    })
+    _write(directory, start + 1, "response", {
+        "path": "/api/ask_memory",
+        "response": [{"path": item} for item in paths],
+    })
+
+
+def _project(directory: Path):
+    from memorybench.guest_observations import project_guest_evidence
+
+    return project_guest_evidence(directory)
+
+
+def test_a_recorded_search_yields_the_transmitted_query_limit_and_hit_order(tmp_path: Path) -> None:
+    _search_pair(tmp_path, query="which lantern?", limit=10, paths=["b.md", "a.md"])
+    observed = _project(tmp_path)
+
+    assert observed.search == {
+        "transmitted_query": "which lantern?",
+        "options": {"limit": 10},
+        # Returned order is the retrieval result; sorting it would destroy the
+        # only ranking signal this path carries.
+        "normalized_hit_ids": ["b.md", "a.md"],
+    }
+    assert SEARCH_LABELS <= observed.resolved_labels()
+    assert not observed.problems
+
+
+def test_a_request_with_no_paired_response_publishes_nothing(tmp_path: Path) -> None:
+    _write(tmp_path, 1, "request", {
+        "path": "/api/ask_memory",
+        "body": {"query": "q", "limit": 3, "scope": "kb", "mode": "hybrid", "detail": "full"},
+    })
+    observed = _project(tmp_path)
+
+    assert observed.search is None
+    assert not (SEARCH_LABELS & observed.resolved_labels())
+    assert "guest_evidence_incomplete" in observed.problems
+
+
+def test_an_over_limit_response_is_a_problem_not_a_published_value(tmp_path: Path) -> None:
+    """The guest refuses this before returning, so evidence showing it is suspect."""
+
+    _search_pair(tmp_path, query="q", limit=1, paths=["a.md", "b.md"])
+    observed = _project(tmp_path)
+
+    assert observed.search is None
+    assert "guest_evidence_invalid" in observed.problems
+
+
+def test_ingest_payload_digests_follow_transmission_order(tmp_path: Path) -> None:
+    bodies = [{"title": "s1", "body": "one"}, {"title": "s2", "body": "two"}]
+    for index, body in enumerate(bodies):
+        _write(tmp_path, index + 1, "request", {"path": "/api/capture_source", "body": body})
+        _write(tmp_path, index + 10, "response", {"path": "/api/capture_source", "response": {"ok": True}})
+    observed = _project(tmp_path)
+
+    expected = [
+        hashlib.sha256(json.dumps(body, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+        for body in bodies
+    ]
+    assert observed.ingest == {"transmitted_payload_sha256": expected}
+    assert INGEST_LABELS <= observed.resolved_labels()
+
+
+def test_doctor_evidence_becomes_verified_semantic_readiness(tmp_path: Path) -> None:
+    _write(tmp_path, 1, "doctor-request", {"profile": "hybrid"})
+    _write(tmp_path, 2, "doctor-response", {
+        "response": {"checks": {"models.cache": "pass", "embeddings.sidecar": "pass"}}
+    })
+    observed = _project(tmp_path)
+
+    assert observed.readiness is not None
+    lane = observed.readiness[0]
+    assert lane["lane"] == "semantic"
+    assert lane["verified"] is True
+    assert lane["method"] == "doctor-check"
+    assert lane["fallback_detected"] is False
+
+
+def test_a_failing_doctor_check_is_reported_unverified_not_omitted(tmp_path: Path) -> None:
+    _write(tmp_path, 1, "doctor-request", {"profile": "hybrid"})
+    _write(tmp_path, 2, "doctor-response", {
+        "response": {"checks": {"models.cache": "pass", "embeddings.sidecar": "fail"}}
+    })
+    observed = _project(tmp_path)
+
+    lane = observed.readiness[0]
+    assert lane["verified"] is False
+    assert lane["fallback_detected"] is True
+    assert "embeddings.sidecar" in lane["evidence"]
+
+
+def test_an_empty_evidence_directory_is_absence_not_a_fault(tmp_path: Path) -> None:
+    observed = _project(tmp_path)
+
+    assert observed.search is None and observed.ingest is None and observed.readiness is None
+    assert observed.resolved_labels() == frozenset()
+    assert not observed.problems
+
+
+def test_projection_never_emits_a_bearer_token_or_absolute_path(tmp_path: Path) -> None:
+    _search_pair(tmp_path, query="q", limit=2, paths=["a.md"])
+    _write(tmp_path, 5, "request", {
+        "path": "/api/capture_source",
+        "body": {"title": "s", "body": "x", "authorization": "Bearer super-secret-token"},
+    })
+    _write(tmp_path, 6, "response", {"path": "/api/capture_source", "response": {"ok": True}})
+    observed = _project(tmp_path)
+
+    rendered = json.dumps({
+        "search": observed.search, "ingest": observed.ingest, "readiness": observed.readiness,
+    })
+    assert "super-secret-token" not in rendered
+    assert str(tmp_path) not in rendered
+
+
+def test_entries_are_read_in_sequence_order_not_directory_order(tmp_path: Path) -> None:
+    """Sequence 10 must not sort before sequence 2."""
+
+    for index, body in enumerate([{"n": i} for i in range(12)]):
+        _write(tmp_path, index + 1, "request", {"path": "/api/capture_source", "body": body})
+    observed = _project(tmp_path)
+
+    expected = [
+        hashlib.sha256(json.dumps({"n": i}, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+        for i in range(12)
+    ]
+    assert observed.ingest["transmitted_payload_sha256"] == expected
+
+
+def test_a_malformed_entry_is_a_problem_and_stops_publication(tmp_path: Path) -> None:
+    (tmp_path / "operation-000001-deadbeefcafe.json").write_text("{not json", encoding="utf-8")
+    observed = _project(tmp_path)
+
+    assert observed.search is None
+    assert "guest_evidence_invalid" in observed.problems
+
+
+@pytest.mark.parametrize("body", [
+    {"query": "", "limit": 3},
+    {"query": "q", "limit": 0},
+    {"query": "q", "limit": "3"},
+    {"query": "q"},
+])
+def test_a_search_body_that_does_not_prove_query_and_limit_publishes_nothing(
+    tmp_path: Path, body: dict
+) -> None:
+    _write(tmp_path, 1, "request", {"path": "/api/ask_memory", "body": body})
+    _write(tmp_path, 2, "response", {"path": "/api/ask_memory", "response": [{"path": "a.md"}]})
+    observed = _project(tmp_path)
+
+    assert observed.search is None
+    assert not (SEARCH_LABELS & observed.resolved_labels())

--- a/tests/test_protocol_schema_conformance.py
+++ b/tests/test_protocol_schema_conformance.py
@@ -264,8 +264,14 @@ def _memorybench_payloads() -> dict[str, dict]:
                 "hits": [{"content": "first", "score": 0.9}],
                 "failure_codes": [],
                 "missing_fields": missing,
+                # This fixture declares every observation missing, so both
+                # optional blocks stay null and their labels stay in `missing`.
+                "search": None,
+                "ingest": None,
             }
         ],
+        "session_normalization": None,
+        "readiness": None,
     }
     private_gold = {
         "protocol_version": "1.0.0",


### PR DESCRIPTION
Unblocks §4.6. Records why the equivalence gate could not have gone green, and adds the schema slots that fix it.

## The gate could not have gone green

Five of the nine **BLOCKING** equivalence keys had no source in `memorybench-export.v1`: `session_normalization`, `ingestion_payloads`, `readiness`, `top_k`, and `answer_judge_prompt_model_config`.

The names `search.transmitted_query`, `search.options.limit`, and `search.normalized_hit_ids` appeared in the schema **only as labels inside the `missing_fields` enum**. There was no search `$def`, and `readiness`, `session_normalization`, and `payload_sha` appeared nowhere at all. The artifact could say "I did not observe the transmitted query"; it had no field in which to say what the query *was*.

`differ.py:145` is explicit — *"Null never equals anything, including null; absence demands an explanation."* So those five mismatch by construction. The gate would fail every run, not because the two paths disagree, but because one side was never asked.

**This is not a §4.5 defect.** Its export was deliberately scoped to executed ingest/indexing/search under a closed no-fabrication vocabulary; it refuses to invent what it did not observe. The gap is that §4.6 asks it a question it was never built to answer.

## What this adds

- `MemoryBenchSearchObservation` — `transmitted_query`, `options.limit`, `normalized_hit_ids`
- `MemoryBenchIngestObservation` — `transmitted_payload_sha256`
- run-level `session_normalization` and `readiness`

**The honesty coupling is enforced, not documented.** `_OBSERVATION_LABELS` binds each optional block to the `missing_fields` labels it answers for, and a model validator refuses **both** directions:

- a published value whose label is still declared missing
- an absent value whose labels are not *all* declared (the partial-declaration middle ground is the dishonest one)

Hit ids may not outnumber the transmitted limit — the same contract the guest already enforces at `providers/exomem/index.ts:205` before returning.

## Why the remedy is small

The facts are already captured and validated. The Exomem guest records `request`/`response` evidence for every call (`index.ts:117-119`), builds its search body from the exact `{query, limit}` (188-194), refuses an over-limit response (205), and requires a selected path per hit (209); doctor readiness is logged too (156-158). `export.py` already reads and validates guest evidence — `_basic_evidence_targets` does exactly this for Basic's ingest receipts today.

So this is an **additive projection**, not new instrumentation: no TS provider change, no `registration.patch` churn, no lock-hash recomputation.

## Scope

This is the **schema half** (4.6a-1). Populating the fields from guest evidence is 4.6a-2, then the projector (4.6b), then the run (4.6c). Two constraints carried forward: `normalized_scores` stays honestly absent because the guest search path hard-codes `score: 0.0`, and `answer_judge_prompt_model_config` comes from the run plan — an operator declaration both sides share — never from a harness that excludes answer stages by design.

## Verification

```
membench + protocol + memorybench + privacy   958 passed, 32 skipped
export-schemas --check                        EXIT=0  (one additive schema)
ruff check . --select F                       All checks passed
openspec validate --strict                    valid
```
