### PR TITLE
feat(memory): surface authored contradictions and a competing-alternatives stance

### DIFF
--- a/benchmarks/membench/trackd/journeys.py
+++ b/benchmarks/membench/trackd/journeys.py
@@ -679,11 +679,19 @@ class PlantedItem:
 
 @dataclass(frozen=True)
 class QueueObservation:
-    """What one ``review_memory`` mode actually surfaced."""
+    """What one ``review_memory`` mode actually surfaced.
+
+    ``unsupported_lanes`` names sub-lanes of a SUPPORTED queue that this profile
+    still cannot exercise. A queue is not always all-or-nothing: the contradiction
+    queue has a deterministic authored-edge lane and an embeddings-gated proximity
+    lane, and collapsing that to one boolean would either deny the product credit
+    it earned or claim a measurement that never ran.
+    """
 
     mode: str
     paths: tuple[str, ...]
     supported: bool = True
+    unsupported_lanes: tuple[str, ...] = ()
 
 
 def score_review_queue(
@@ -694,11 +702,14 @@ def score_review_queue(
 ) -> dict:
     """Deterministic planted-id recall/precision + false-surface rate.
 
-    An unsupported queue (e.g. the contradiction sweep under the lexical
-    profile, which is embeddings-gated) reports every metric as ``None`` —
-    unsupported is NEVER converted to a zero. ``precision`` and
-    ``false_surface_rate`` are ``None`` when nothing surfaced (no claim can
-    be made about an empty list's composition).
+    An unsupported queue reports every metric as ``None`` — unsupported is NEVER
+    converted to a zero. ``precision`` and ``false_surface_rate`` are ``None``
+    when nothing surfaced (no claim can be made about an empty list's
+    composition).
+
+    ``unsupported_lanes`` rides along on a supported queue's score so a reader
+    cannot mistake a partial measurement for a whole one: the metrics below
+    describe only the lanes this profile actually exercised.
     """
 
     expected = sorted({p.path for p in planted if p.kind in expected_kinds})
@@ -706,6 +717,7 @@ def score_review_queue(
     base = {
         "mode": observation.mode,
         "supported": observation.supported,
+        "unsupported_lanes": list(observation.unsupported_lanes),
         "expected": expected,
         "surfaced": list(observation.paths),
     }
@@ -845,6 +857,28 @@ def _queue_paths(payload: dict | None) -> tuple[str, ...]:
     )
 
 
+def _queue_related_paths(payload: dict | None) -> tuple[str, ...]:
+    """Every counterpart path named by a surfaced item's reasons.
+
+    A pair-shaped finding surfaces as ONE row anchored on the lower path, so the
+    anchor alone cannot show the pair was captured whole — the counterpart lives
+    in the reason's ``related_paths``.
+    """
+    data = _data(payload)
+    items = data.get("items", []) if isinstance(data, dict) else []
+    out: list[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        for reason in item.get("reasons", []) or []:
+            if not isinstance(reason, dict):
+                continue
+            for path in reason.get("related_paths", []) or []:
+                if path and str(path) not in out:
+                    out.append(str(path))
+    return tuple(out)
+
+
 def run_j3_weekly_review(workdir: Path, *, instant: dt.datetime | None = None) -> J3Result:
     """J3: weekly review over planted stale/contradiction/unprocessed/open-loop
     items, scored by planted-id recall+precision, false-surface rate, and
@@ -860,10 +894,20 @@ def run_j3_weekly_review(workdir: Path, *, instant: dt.datetime | None = None) -
       knob ``EXOMEM_STALE_AGE_DAYS=0`` (recorded in the journey env), so the
       stale queue measures the DORMANCY conjunct: an unlinked conclusion is
       flagged, well-linked decoys (>= 2 inbound wikilinks) are not.
-    - The corpus-contradiction sweep is embeddings-gated and no-ops under
-      ``EXOMEM_DISABLE_EMBEDDINGS`` (the deterministic lexical profile), so
-      the planted contradiction pair is recorded and the queue is scored
-      UNSUPPORTED — never zero.
+    - The contradiction queue has TWO lanes and this profile exercises exactly
+      one of them. The ASSERTED lane reads authored ``contradicts`` graph edges
+      and is deterministic — it needs no embeddings, so the planted authored
+      pair surfaces under ``EXOMEM_DISABLE_EMBEDDINGS`` and IS scored. The
+      PROXIMITY lane (the embedding-band sweep that finds UNSTATED tension) is
+      still embeddings-gated, no-ops in this profile, and is declared an
+      unsupported lane — never zero, and never folded into the asserted lane's
+      recall. The journey plants no proximity item, because none could be
+      measured here; claiming otherwise is the one thing this benchmark must
+      not do.
+    - A contradiction pair surfaces as ONE row anchored on the lower of its two
+      paths (the product's documented one-row-per-pair contract), so the pair is
+      planted as a single expected item at that anchor and the counterpart is
+      verified through the surfaced row's related paths.
     - Compiled pages after the first need a qualifying typed relation
       (``## Relations`` bullets; ``sources=`` frontmatter maps to the excluded
       ``derivation`` family and does NOT qualify). The first note commits under
@@ -978,8 +1022,12 @@ def run_j3_weekly_review(workdir: Path, *, instant: dt.datetime | None = None) -
         f"sources={s3}",
     )
     n3_ref = n3.removesuffix(".md")
-    planted.append(PlantedItem("p-contradiction-a", "contradiction", n2))
-    planted.append(PlantedItem("p-contradiction-b", "contradiction", n3))
+    # ONE planted item at the pair anchor: a contradiction pair surfaces as a
+    # single row anchored on the lower of its two paths, so planting both
+    # endpoints would make a correct one-row answer score 0.5 recall.
+    contradiction_anchor = min(n2, n3)
+    contradiction_other = max(n2, n3)
+    planted.append(PlantedItem("p-contradiction", "contradiction", contradiction_anchor))
 
     # N4 - the planted DORMANT conclusion: no inbound links (its outbound
     # links give N2/N3 inbound degree instead).
@@ -1015,6 +1063,7 @@ def run_j3_weekly_review(workdir: Path, *, instant: dt.datetime | None = None) -
 
     # ---- the weekly review itself: four queues -------------------------
     observations: dict[str, QueueObservation] = {}
+    contradiction_related: tuple[str, ...] = ()
     for mode in ("stale", "contradiction", "unprocessed-sources", "attention"):
         run, payload = runner.run("review_memory", "--mode", mode, "--json")
         checks.append(
@@ -1024,12 +1073,16 @@ def run_j3_weekly_review(workdir: Path, *, instant: dt.datetime | None = None) -
                 f"exit={run.returncode}",
             )
         )
+        if mode == "contradiction":
+            contradiction_related = _queue_related_paths(payload)
         observations[mode] = QueueObservation(
             mode=mode,
             paths=_queue_paths(payload),
-            # The contradiction sweep is embeddings-gated: honestly
-            # unsupported under the lexical profile, never scored zero.
-            supported=(mode != "contradiction"),
+            # The asserted (authored-edge) lane is deterministic and DOES run
+            # here; the proximity lane is embeddings-gated and does not. Naming
+            # the unmeasured lane keeps `supported=True` from overclaiming.
+            supported=True,
+            unsupported_lanes=(("proximity",) if mode == "contradiction" else ()),
         )
 
     stale_score = score_review_queue(
@@ -1042,11 +1095,13 @@ def run_j3_weekly_review(workdir: Path, *, instant: dt.datetime | None = None) -
         planted, observations["unprocessed-sources"], expected_kinds=("unprocessed",)
     )
     # Attention = the open-loop union view of everything surfaceable in this
-    # profile (contradictions cannot surface here; see docstring).
+    # profile. The authored contradiction DOES surface here now, so it belongs in
+    # the expected set: omitting it would score a correct union as a false
+    # surface and penalise the product for being right.
     attention_score = score_review_queue(
         planted,
         observations["attention"],
-        expected_kinds=("stale", "unprocessed", "open_loop"),
+        expected_kinds=("stale", "unprocessed", "open_loop", "contradiction"),
     )
     queue_scores = [stale_score, contradiction_score, unprocessed_score, attention_score]
 
@@ -1067,11 +1122,28 @@ def run_j3_weekly_review(workdir: Path, *, instant: dt.datetime | None = None) -
     )
     checks.append(
         JourneyCheck(
-            "contradiction queue honestly unsupported in the lexical profile",
-            contradiction_score["supported"] is False
-            and contradiction_score["recall"] is None
-            and not observations["contradiction"].paths,
-            "embeddings-gated sweep; planted pair recorded, metrics None (never zero)",
+            "contradiction queue surfaces exactly the planted authored pair",
+            contradiction_score["recall"] == 1.0
+            and contradiction_score["false_surface_rate"] == 0.0,
+            f"recall={contradiction_score['recall']} "
+            f"false={contradiction_score['false_surfaces']}",
+        )
+    )
+    checks.append(
+        JourneyCheck(
+            "contradiction row names both endpoints of the planted pair",
+            contradiction_other in contradiction_related,
+            f"related={len(contradiction_related)} path(s); counterpart present="
+            f"{contradiction_other in contradiction_related}",
+        )
+    )
+    checks.append(
+        JourneyCheck(
+            "contradiction proximity lane declared unsupported, not scored zero",
+            contradiction_score["unsupported_lanes"] == ["proximity"]
+            and not [p for p in planted if p.kind == "proximity"],
+            "embeddings-gated lane; no proximity item planted, so nothing is "
+            "claimed for a lane this profile never ran",
         )
     )
     checks.append(
@@ -1102,8 +1174,13 @@ def run_j3_weekly_review(workdir: Path, *, instant: dt.datetime | None = None) -
         f"{len(unprocessed_score['matched'])} of {len(unprocessed_score['expected'])} "
         f"planted items (false-surface rate "
         f"{_fmt_rate(unprocessed_score['false_surface_rate'])}); "
-        "the contradiction sweep is unsupported in this deterministic profile "
-        "and is reported unsupported rather than zero; the combined attention "
+        "the contradiction queue surfaced "
+        f"{len(contradiction_score['matched'])} of "
+        f"{len(contradiction_score['expected'])} planted authored conflicts "
+        f"(false-surface rate {_fmt_rate(contradiction_score['false_surface_rate'])}) "
+        "from its deterministic authored-edge lane, while its proximity lane - "
+        "which finds unstated tension - is embeddings-gated, did not run in this "
+        "profile, and is reported unsupported rather than zero; the combined attention "
         f"view covered {len(attention_score['matched'])} of "
         f"{len(attention_score['expected'])} open loops; triage burden was "
         f"{burden} scripted operations with 0 manual interventions."

--- a/openspec/changes/surface-authored-contradictions/.openspec.yaml
+++ b/openspec/changes/surface-authored-contradictions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/surface-authored-contradictions/design.md
+++ b/openspec/changes/surface-authored-contradictions/design.md
@@ -149,10 +149,21 @@ re-affirm the stance.
 
 `attention._apply_review_state` checks the item-level record first; if that yields a
 non-open state, it wins, because it is the more specific decision about this exact
-signal composite. Otherwise, for an item carrying exactly one contradiction pair, the
-pair stance is consulted and can make the item `competing`. Since every queue filters
-by `item.state == state` and `competing` is not `open`, "honored by all queues" falls
-out of the existing filter rather than needing per-queue code.
+signal composite. Otherwise the pair stances for every contradiction the item carries
+are consulted, and the item becomes `competing` only when ALL of them are stanced.
+Since every queue filters by `item.state == state` and `competing` is not `open`,
+"honored by all queues" falls out of the existing filter rather than needing
+per-queue code.
+
+An item can carry more than one pair, and that is the ordinary shape, not an edge
+case: both lanes anchor a pair on `min(a, b)`, so a note that is the
+alphabetically-first endpoint of two conflicts is one item with two reasons. Treating
+that as "no pair" would make such an item unstanceable, and — worse — would strand an
+existing stance the moment a second pair drifted onto the same anchor: the record
+would stay live and keep muting the write-time warning while being impossible to
+re-affirm or clear. So `pairs_from_reasons` returns every pair, `record_stance`
+records each, and `clear_stance` clears each. `reopen` clears by review id rather
+than by fingerprint, so it also releases a stance recorded against older content.
 
 `competing` joins `VALID_ACTIONS` and `VALID_VIEWS` so the store, the state summary,
 and the `state=` view parameter all accept it. `reopen` on a contradiction-pair item
@@ -211,10 +222,22 @@ proximity pass ran — so an embeddings-off pack now reports
   reader's own explicit stance or their own authored edge, it is fingerprint-bound,
   and the pair still appears in the contradiction queue and in deep packs.
 - [The asserted lane adds a graph read to an audit category that previously touched
-  only the vector sidecar] -> It is one `relation_participants` lookup for the
-  participant set plus one anchored lookup per participating page, all indexed, and
-  the whole lane soft-fails to empty when the graph is disabled or warming rather
-  than fabricating or blocking.
+  only the vector sidecar] -> It is ONE indexed `relation_edges` query for the whole
+  vault, and the lane soft-fails to empty when the graph is disabled or warming
+  rather than fabricating or blocking. The obvious implementation — a participant
+  lookup plus an anchored lookup per participating page — is a trap:
+  `relation_participants` narrows by anchor in Python AFTER running the same
+  unnarrowed `relation_type IN (...)` query, so that shape costs O(pages x edges)
+  with one read snapshot per page (measured ~1 s at 250 authored edges) and it
+  reaches the retrieve/inject path through `find(pack=true)` and
+  `memory_context.assemble_context`. `relation_edges` exists because
+  `RelationFilterResult.provenance` keeps only one counterpart per page and so
+  cannot answer "which page is joined to which" in a single pass.
+- [The write-time exemption scales with vault edge count, not candidate count] ->
+  `DeclaredPairFilter` builds one `DeclaredEdges` snapshot (two indexed queries) and
+  one review-state read LAZILY on the first candidate and reuses both, so the cost is
+  flat in the number of candidates and is paid only on a write that would have warned
+  at all.
 - [A warming graph silently yields no asserted entries] -> Documented in the spec as
   an explicit absence contract rather than a fabricated result; the proximity lane is
   unaffected, and the next audit after the rebuild surfaces them.

--- a/openspec/changes/surface-authored-contradictions/design.md
+++ b/openspec/changes/surface-authored-contradictions/design.md
@@ -1,0 +1,220 @@
+## Context
+
+Three mechanisms touch contradiction today and none of them reads an authored
+`contradicts` edge.
+
+`audit._check_corpus_contradictions` sweeps every active read-write compiled
+conclusion against the embedding sidecar, keeps pairs whose max chunk cosine lands
+in `[CONTRADICTION_FLOOR, DUP_THRESHOLD)`, orders them by
+`cosine + w * pair_dormancy`, demotes same-family pairs, caps at
+`EXOMEM_CONTRADICTION_TOP_N`, and returns `AuditFinding` rows. It short-circuits to
+`[]` whenever `EXOMEM_DISABLE_EMBEDDINGS` is set, which is the whole fast test
+suite.
+
+`attention._rank` fuses each queue's emission order through weighted RRF and dedups
+by anchor path, then `attention._apply_review_state` binds each item to a stable
+`review_id` plus a `signal_fingerprint` and folds in a `dismiss` / `snooze` decision
+from `.review-state.json`. Emission order is rank, so whatever the contradiction
+check emits first ranks first.
+
+`corpus_aware.detect_duplicates` and `corpus_aware.detect_contradictions` run at
+write time against a draft. They are the only near-duplicate mechanism in the
+product; there is no standing duplicate queue. `edit.commit` calls
+`detect_contradictions` after the write lands; `add` calls both before the page
+exists.
+
+The typed graph already stores authored relations. `contradicts` is a core,
+symmetric relation, and `EpistemicGraphIndex.relation_participants` answers "which
+pages participate in a typed edge" with an explicit availability status that never
+false-empties. Nothing consumes it for review.
+
+`context_pack._tension_pairs` measures the same cosine band among the packed notes
+and labels every pair "proximity, not polarity — reader decides".
+
+The MCP tool surface is frozen byte-for-byte by `tests/test_mcp_schema_fidelity.py`
+against `tests/fixtures/mcp_tool_schemas.json` and
+`src/exomem/tool_surface_contract.json`, both of which are guarded files. Tool
+docstrings become tool descriptions, so no operation docstring may change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Feed authored `contradicts` edges into the contradiction queue as first-class,
+  triageable entries that outrank every proximity pair.
+- Make asserted entries independent of the embedding sidecar, so the strongest
+  signal survives a torch-less deploy and is testable in the fast suite.
+- Make provenance explicit on every contradiction entry and every deep-pack tension
+  pair, so a reader never confuses "you said these conflict" with "these sit close
+  in vector space".
+- Give a reader one durable way to say "these are rivals; keep both" that silences
+  the write-time nag while resurfacing honestly the moment either note is edited.
+- Exempt pairs whose authored structure already declares them as rivals from the
+  redundant write-time proximity warning.
+
+**Non-Goals:**
+
+- Judging which rival is right, ranking rivals against each other, auto-merging,
+  auto-superseding, or auto-dismissing anything.
+- Adding a relation type. `contradicts` and `answers` already exist;
+  `tests/golden/relation_compatibility.yaml` stays untouched.
+- Building a standing duplicate queue. The write-time warning remains the only
+  duplicate mechanism.
+- Changing any MCP tool signature, docstring, parameter, or description.
+- Inferring polarity from text. The claim-level polarity lane is unchanged.
+
+## Decisions
+
+### Asserted entries live inside `corpus_contradictions`, emitted first
+
+An authored `contradicts` edge produces an `AuditFinding` in the existing
+`corpus_contradictions` category rather than a new category. A new category would
+have to be registered in `ALL_CATEGORIES`, `ATTENTION_CATEGORIES`, the attention
+tiebreak order, and `review_memory`'s mode list, and every existing consumer that
+asks for "the contradiction queue" would silently miss the strongest half of it.
+Keeping one category also means the deduplication and multi-signal additivity rules
+in `attention-queue` apply unchanged.
+
+Ordering falls out of the existing contract: `attention._rank` treats emission order
+as intra-queue rank, so emitting every asserted finding before the first proximity
+pair is exactly "ranked above proximity". No ranking code changes.
+
+The asserted lane runs before the `EXOMEM_DISABLE_EMBEDDINGS` short-circuit, because
+an authored edge is read from the graph sidecar and needs no vectors. The proximity
+sweep keeps its short-circuit verbatim.
+
+### Endpoint eligibility mirrors the proximity lane
+
+An asserted pair surfaces only when both endpoints pass `_is_active_compiled_rw`:
+an active, read-write, compiled conclusion that is not an index or log hub. That is
+the same gate the proximity sweep uses, and for the same reason — those are the only
+pages a contradiction can actually be reconciled against through
+edit / replace / supersede. An authored edge into a raw source, an archived note, or
+a read-only tree is left alone rather than surfaced as unactionable work.
+
+### Asserted pairs are not capped by `EXOMEM_CONTRADICTION_TOP_N`
+
+That cap exists because the proximity sweep is combinatorial: every eligible page
+against every other, bounded only by the band. Authored edges are finite, deliberate,
+and written one at a time by a human. Capping them would mean silently hiding
+something the user typed. The cap, the summary finding, and its `meta.truncated` /
+`meta.shown` / `meta.total` counts therefore keep describing the proximity lane
+exactly as before, which also keeps existing cap regressions byte-stable.
+
+### An asserted pair suppresses its own proximity duplicate
+
+Two notes can be both authored-as-contradicting and close in vector space; the
+polarity case ("X works" / "X fails") is precisely where cosine is highest. Surfacing
+the same pair twice under the same anchor would double its RRF vote in attention and
+present the reader with two rows for one decision. The asserted entry is strictly
+stronger, so the proximity duplicate is dropped before scoring — it is not counted
+toward the cap and does not appear in the omitted count.
+
+### Provenance is `meta`, not `detail`
+
+`review_state.fingerprint` reads `meta.signal_version` verbatim and ignores every
+other `meta` key, so adding `meta.provenance` cannot churn a stored dismissal.
+`attention._reason` copies `finding.meta` wholesale into each reason, so provenance
+reaches the ranked surface with no attention-side change. Existing proximity
+findings gain `provenance: "proximity"` and keep their `signal_version` byte-for-byte
+so no stored decision resurfaces spuriously.
+
+Asserted findings compute their `signal_version` from the same two page signal
+versions but through a distinct `asserted` discriminator, so an asserted entry and a
+proximity entry over the same pair can never collide in the review-state store.
+
+### The competing-alternatives stance is keyed on the pair, not the queue item
+
+The obvious implementation — reuse the attention item's `review_id` — is wrong. An
+attention item's identity and fingerprint fold in every category that flagged its
+anchor, so the same pair has a different item fingerprint depending on whether the
+anchor also happens to be stale or relation-poor that day, and the write-time check
+in `corpus_aware` has no way to reconstruct it from two paths.
+
+The stance is therefore recorded under a pair-derived `review_id`:
+`item_id("competing:" + "|".join(sorted([ref_a, ref_b])))`, with a pair fingerprint
+built from the two endpoints' `refs_for_paths` refs and their on-disk page signal
+versions. It is written into the same `.review-state.json` with the same
+`review_id:fingerprint` record key and the same atomic writer as dismiss and snooze —
+"recorded like dismiss/snooze in review state" is literal.
+
+Because the fingerprint folds in both endpoints' content, editing either rival
+changes the fingerprint, the stored record no longer matches, and the pair resurfaces
+as open. That is the required honest-resurfacing property, and it is the same
+mechanism dismiss already relies on. `edit.commit` runs the write-time check after
+the write lands, so an edit to a rival correctly re-warns once, and the reader can
+re-affirm the stance.
+
+### Queues honor the stance by consulting the pair record
+
+`attention._apply_review_state` checks the item-level record first; if that yields a
+non-open state, it wins, because it is the more specific decision about this exact
+signal composite. Otherwise, for an item carrying exactly one contradiction pair, the
+pair stance is consulted and can make the item `competing`. Since every queue filters
+by `item.state == state` and `competing` is not `open`, "honored by all queues" falls
+out of the existing filter rather than needing per-queue code.
+
+`competing` joins `VALID_ACTIONS` and `VALID_VIEWS` so the store, the state summary,
+and the `state=` view parameter all accept it. `reopen` on a contradiction-pair item
+clears both the item record and the pair record, so the inverse is complete.
+
+### Discoverability without touching a tool docstring
+
+`triage_memory`'s description is frozen by the schema-fidelity gate, so the new
+action cannot be documented in its `Args`. Three response-side channels carry it
+instead: the `INVALID_REVIEW_ACTION` error already renders `sorted(VALID_ACTIONS)`
+and so names `competing` automatically; each asserted finding's `proposed_fix` names
+the stance explicitly; and the CLI gains `exomem review competing <ref>` plus a
+`--state competing` view, neither of which is part of the MCP schema. This is a real
+limitation of the frozen surface, recorded below as a trade-off.
+
+### The structural-pair exemption is graph-derived, not stance-derived
+
+If the author already wrote `- contradicts [[B]]` on A, or both A and B `answers` the
+same question page, they have declared the relationship structurally. The write-time
+proximity warning then tells them nothing they did not type themselves. Both the
+duplicate band and the overlap band consult the same predicate, because a genuine
+rival pair often sits above the duplicate threshold, not below it.
+
+The exemption applies only to the write-time warnings. The asserted queue entry is
+deliberately not exempt: surfacing it is the entire point of this change, and the
+reader dismisses or marks it competing through triage like any other item.
+
+### Deep packs label, they do not suppress
+
+`context_pack._tension_pairs` gains asserted pairs (from authored `contradicts` edges
+among the packed notes, emitted first and needing no sidecar) and a `provenance` field
+on every pair. It does not consult review state. A pack is reasoning context, not a
+work queue: knowing two packed notes are declared rivals is useful signal, and reading
+`.review-state.json` during assembly would add coupling and cost to a read path that
+deliberately touches only content, frontmatter, wikilinks, and precomputed vectors.
+
+`embeddings_available` keeps meaning exactly what it means today — whether the
+proximity pass ran — so an embeddings-off pack now reports
+`embeddings_available: false` while still carrying asserted tension pairs.
+
+## Risks / Trade-offs
+
+- [`competing` is invisible to an MCP client because the frozen tool description
+  cannot list it] -> Accept and route discovery through the `INVALID_REVIEW_ACTION`
+  error, asserted findings' `proposed_fix`, and the CLI; revisit whenever the tool
+  contract is next intentionally revised.
+- [A pair-keyed stance is a second identity scheme in one state file] -> Reuse
+  `review_state.item_id` and `review_state.fingerprint` verbatim under a `competing:`
+  discriminator so the record shape, the record key, and the atomic writer stay
+  single-sourced, and namespace it so it can never collide with an attention,
+  activation, relation, or adoption id.
+- [Editing either rival silences nothing and re-nags] -> That is the specified
+  behaviour, not a defect: a stance that survived arbitrary edits would be a standing
+  mute rather than a fingerprint-bound decision. Re-affirming is one triage call.
+- [Suppressing a warning is a form of hiding] -> The suppression is only ever the
+  reader's own explicit stance or their own authored edge, it is fingerprint-bound,
+  and the pair still appears in the contradiction queue and in deep packs.
+- [The asserted lane adds a graph read to an audit category that previously touched
+  only the vector sidecar] -> It is one `relation_participants` lookup for the
+  participant set plus one anchored lookup per participating page, all indexed, and
+  the whole lane soft-fails to empty when the graph is disabled or warming rather
+  than fabricating or blocking.
+- [A warming graph silently yields no asserted entries] -> Documented in the spec as
+  an explicit absence contract rather than a fabricated result; the proximity lane is
+  unaffected, and the next audit after the rebuild surfaces them.

--- a/openspec/changes/surface-authored-contradictions/design.md
+++ b/openspec/changes/surface-authored-contradictions/design.md
@@ -191,6 +191,41 @@ The exemption applies only to the write-time warnings. The asserted queue entry 
 deliberately not exempt: surfacing it is the entire point of this change, and the
 reader dismisses or marks it competing through triage like any other item.
 
+### An orphaned stance stays addressable by its own pair ref
+
+A stance survives its pair leaving every queue — the proximity pair drifts out of
+band, or the authored edge is deleted. The record is then on no item's `reasons`,
+so the item-walking `clear_stance` cannot see it, while `DeclaredPairFilter` still
+consults it and suppresses the write-time warning. `dismiss` orphans identically,
+but a dismissal has no write-time side effect, so this one is the one that bites.
+
+Rather than leave it un-clearable, `triage_memory(ref=<pair_ref>, action="reopen")`
+now clears a stance addressed directly by its own pair ref — the ref the stance
+write returns under `pairs[].ref`, and which every annotated contradiction reason
+carries. That needs no new tool parameter, which matters because the tool schema is
+frozen. An unknown ref still raises `REVIEW_ITEM_NOT_FOUND`; only a ref that
+actually carries a stance record is treated this way.
+
+Two bounded residuals remain, deliberately. Discovery still depends on holding the
+pair ref: there is no "list every orphaned stance" surface, because the record
+stores refs and hashes rather than paths and adding paths would change the persisted
+record shape. And the orphan self-heals on the next edit to either endpoint, since
+the write-time check reads both pages' current content — an edit changes the pair
+signal version, the record stops matching, and the warning returns. The exposure is
+therefore at most one suppressed warning on one write, on a pair the reader
+themselves declared, and only while neither note changes.
+
+### A stanced pair is annotated on the item, not hidden
+
+An item that is only partially stanced — the drift case, where one of two pairs
+carries a stance — would otherwise serialize as an ordinary open item with two
+reasons and no hint that one of them is dispositioned and muting a warning. Each
+contradiction reason therefore carries `pair_ref`, and a stanced one also carries
+`stance`. The annotation is applied AFTER the item fingerprint is computed:
+`review_state.fingerprint` reads only `category`, `meta.signal_version`, `detail`,
+and `related_paths`, so these keys cannot feed back into review identity, but
+ordering the write after the hash keeps that true independently of that field list.
+
 ### Deep packs label, they do not suppress
 
 `context_pack._tension_pairs` gains asserted pairs (from authored `contradicts` edges
@@ -237,7 +272,13 @@ proximity pass ran — so an embeddings-off pack now reports
   `DeclaredPairFilter` builds one `DeclaredEdges` snapshot (two indexed queries) and
   one review-state read LAZILY on the first candidate and reuses both, so the cost is
   flat in the number of candidates and is paid only on a write that would have warned
-  at all.
+  at all. The residual is real and worth stating plainly: that snapshot is
+  proportional to the vault's TOTAL `contradicts` + `answers` edge count, not to the
+  handful of candidates being checked, so a vault with an order of magnitude more
+  such edges pays proportionally more on every warned write (measured 7.3 ms at 5
+  edges, 69.6 ms at 250, with six candidates). Narrowing it would mean an
+  anchor-narrowed query, which the graph layer does not currently support without
+  the O(P x E) fan-out this change removed.
 - [A warming graph silently yields no asserted entries] -> Documented in the spec as
   an explicit absence contract rather than a fabricated result; the proximity lane is
   unaffected, and the next audit after the rebuild surfaces them.

--- a/openspec/changes/surface-authored-contradictions/proposal.md
+++ b/openspec/changes/surface-authored-contradictions/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+The strongest contradiction signal in the vault is the only one review ignores. A
+user who writes `- contradicts [[Other Note]]` under `## Relations` has asserted a
+conflict in their own words, yet that authored edge feeds no review queue at all.
+The `corpus_contradictions` queue is stance-blind by construction: it measures
+embedding proximity, and cosine cannot separate "X works" from "X fails". Near
+duplicate detection exists only as a write-time draft warning with no standing
+queue behind it.
+
+The result is backwards. Assert the contradiction explicitly, or write both rivals
+as proper notes, and review support disappears; leave the tension implicit and only
+then does a proximity band notice it. Two notes that are genuine competing
+alternatives ("we keep both on purpose") have no way to say so, so the write-time
+overlap warning nags on every edit to either one.
+
+## What Changes
+
+- Surface authored `contradicts` graph edges as asserted entries in the
+  `corpus_contradictions` queue, ranked above every proximity pair and carrying the
+  same fingerprint-bound triage contract as existing entries.
+- Emit asserted entries without embeddings: the proximity sweep still short-circuits
+  under `EXOMEM_DISABLE_EMBEDDINGS`, but an authored edge needs no sidecar.
+- Label every contradiction entry with an explicit `provenance` of `asserted` or
+  `proximity`, and suppress the proximity duplicate of a pair already surfaced as
+  asserted.
+- Add a competing-alternatives stance: a fingerprint-bound triage disposition on a
+  contradiction pair ("rivals; keep both"), recorded in the existing review-state
+  store exactly like dismiss and snooze, and honored by every queue.
+- Honor that stance, plus a structural-pair exemption for pairs that already carry
+  an authored `contradicts` edge or `answers` edges into the same question, in the
+  write-time near-duplicate and overlap draft warnings.
+- Annotate deep-pack tension pairs with the same `asserted` / `proximity`
+  provenance, and include asserted pairs among packed notes even when the sidecar
+  is unavailable.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `contradiction-queue`: authored `contradicts` edges become asserted queue entries
+  ranked above proximity, every entry carries a provenance label, and a
+  competing-alternatives pair stance plus a structural-pair exemption govern the
+  write-time proximity warnings.
+- `attention-queue`: the ranked review surface preserves asserted-before-proximity
+  order, exposes entry provenance in each reason, and treats `competing` as a
+  first-class review state honored by every queue.
+- `context-packs`: deep-pack tension pairs carry provenance, and authored
+  `contradicts` pairs among the packed notes surface without embeddings.
+
+## Impact
+
+The `corpus_contradictions` audit check, the review-state disposition vocabulary,
+the attention review-state application, the write-time corpus-aware duplicate and
+overlap checks, deep-pack tension assembly, the triage command leaf, and their
+focused tests change. A new pure-logic module holds the pair-stance identity and
+graph-lookup helpers. No MCP tool docstring, tool parameter set, or relation
+registry entry changes, so `tests/fixtures/mcp_tool_schemas.json`,
+`src/exomem/tool_surface_contract.json`, and `tests/golden/` stay untouched. No new
+external dependency.

--- a/openspec/changes/surface-authored-contradictions/proposal.md
+++ b/openspec/changes/surface-authored-contradictions/proposal.md
@@ -57,7 +57,17 @@ None.
 The `corpus_contradictions` audit check, the review-state disposition vocabulary,
 the attention review-state application, the write-time corpus-aware duplicate and
 overlap checks, deep-pack tension assembly, the triage command leaf, and their
-focused tests change. A new pure-logic module holds the pair-stance identity and
+focused tests change.
+
+The competitive benchmark's J3 weekly-review journey
+(`benchmarks/membench/trackd/journeys.py`) changes too, and deliberately: it
+scored the contradiction queue as wholly UNSUPPORTED because the sweep was
+entirely embeddings-gated. That is no longer true — the asserted lane is
+deterministic — so the journey now scores the authored-edge lane and declares the
+still-gated proximity lane as an explicitly unsupported sub-lane rather than
+collapsing both into one boolean. The planted pair also becomes a single expected
+item at the pair anchor, matching the one-row-per-pair contract. This is a change
+to what a scored journey measures, not a test fix. A new pure-logic module holds the pair-stance identity and
 graph-lookup helpers. No MCP tool docstring, tool parameter set, or relation
 registry entry changes, so `tests/fixtures/mcp_tool_schemas.json`,
 `src/exomem/tool_surface_contract.json`, and `tests/golden/` stay untouched. No new

--- a/openspec/changes/surface-authored-contradictions/specs/attention-queue/spec.md
+++ b/openspec/changes/surface-authored-contradictions/specs/attention-queue/spec.md
@@ -44,8 +44,10 @@ alongside the existing states.
 
 For a contradiction item, an item-level review decision SHALL take precedence over
 the pair stance; the pair stance SHALL be consulted only when no item-level decision
-applies. `reopen` on such an item SHALL clear both the item-level record and the pair
-stance.
+applies. An item carrying several contradiction pairs SHALL resolve to `competing`
+only when EVERY one of its pairs is stanced, because one un-stanced rival is still
+open review work. `reopen` on such an item SHALL clear both the item-level record and
+the stance on every pair it carries.
 
 #### Scenario: A competing item leaves the open view
 
@@ -59,6 +61,11 @@ stance.
 - **WHEN** a contradiction item carries both a matching item-level dismissal and a
   matching pair stance
 - **THEN** its effective state is `dismissed`
+
+#### Scenario: One un-stanced pair keeps the item open
+
+- **WHEN** an item carries two contradiction pairs and only one of them is stanced
+- **THEN** the item remains in the default open view
 
 #### Scenario: Reopen restores the item to the open view
 

--- a/openspec/changes/surface-authored-contradictions/specs/attention-queue/spec.md
+++ b/openspec/changes/surface-authored-contradictions/specs/attention-queue/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Asserted Contradictions Rank Above Proximity In Attention
+
+The ranked review surface SHALL preserve the `corpus_contradictions` queue's
+asserted-before-proximity emission order as intra-queue rank, so an authored
+`contradicts` pair receives a better rank — and therefore a larger Reciprocal Rank
+Fusion vote — than any proximity pair from the same queue. The composition SHALL
+require no separate ranking rule for asserted entries: emission order remains rank,
+exactly as it is for every other queue.
+
+Each surfaced item's reasons SHALL carry the contributing finding's
+`meta.provenance` unchanged, so a reader can tell an asserted conflict from a
+measured adjacency without leaving the review surface. Asserted entries SHALL carry
+the same stable review reference, fingerprint, and triage contract as every other
+attention item, and SHALL be dismissable, snoozable, and reopenable through the same
+path.
+
+An asserted entry SHALL NOT be mistaken for the contradiction queue's trailing
+upstream-cap summary finding: only a finding carrying an upstream truncation count is
+folded into `upstream_truncated`.
+
+#### Scenario: Asserted contradiction outranks a proximity contradiction
+
+- **WHEN** the contradiction queue contributes one asserted pair and one proximity
+  pair over otherwise unflagged anchors
+- **THEN** the asserted pair's item scores above the proximity pair's item
+- **AND** its contradiction reason carries `meta.provenance: "asserted"`
+
+#### Scenario: Asserted entries are triageable like any item
+
+- **WHEN** an asserted contradiction item is dismissed through the normal triage path
+- **THEN** it leaves the default open view and resurfaces only when either endpoint's
+  content changes
+
+### Requirement: Competing Is A Review State Honored By Every Queue
+
+`competing` SHALL be a valid review action and a valid review view alongside `open`,
+`all`, `snoozed`, and `dismissed`. An item whose effective state is `competing` SHALL
+be excluded from the default open view by the same state filter that excludes
+dismissed and snoozed items, so every queue built on the review-state store honors it
+without queue-specific code. The reported state summary SHALL count `competing`
+alongside the existing states.
+
+For a contradiction item, an item-level review decision SHALL take precedence over
+the pair stance; the pair stance SHALL be consulted only when no item-level decision
+applies. `reopen` on such an item SHALL clear both the item-level record and the pair
+stance.
+
+#### Scenario: A competing item leaves the open view
+
+- **WHEN** a contradiction pair carries a `competing` stance
+- **THEN** the default open attention view omits it and the state summary counts it
+  under `competing`
+- **AND** requesting the `competing` view returns it
+
+#### Scenario: Item-level dismissal takes precedence
+
+- **WHEN** a contradiction item carries both a matching item-level dismissal and a
+  matching pair stance
+- **THEN** its effective state is `dismissed`
+
+#### Scenario: Reopen restores the item to the open view
+
+- **WHEN** `reopen` is applied to a contradiction item that carries a pair stance
+- **THEN** the item returns to the default open view

--- a/openspec/changes/surface-authored-contradictions/specs/attention-queue/spec.md
+++ b/openspec/changes/surface-authored-contradictions/specs/attention-queue/spec.md
@@ -49,6 +49,12 @@ only when EVERY one of its pairs is stanced, because one un-stanced rival is sti
 open review work. `reopen` on such an item SHALL clear both the item-level record and
 the stance on every pair it carries.
 
+Each contradiction reason SHALL carry a reference addressing its own pair's stance,
+and a reason whose pair carries a stance SHALL be marked as such, so a partially
+stanced item cannot present as an ordinary open item while one of its conflicts is
+already dispositioned and suppressing a write-time warning. These annotations MUST
+NOT alter the item's review identity or signal fingerprint.
+
 #### Scenario: A competing item leaves the open view
 
 - **WHEN** a contradiction pair carries a `competing` stance
@@ -66,6 +72,8 @@ the stance on every pair it carries.
 
 - **WHEN** an item carries two contradiction pairs and only one of them is stanced
 - **THEN** the item remains in the default open view
+- **AND** the stanced reason is marked as stanced while the other is not
+- **AND** every contradiction reason carries a reference to its own pair's stance
 
 #### Scenario: Reopen restores the item to the open view
 

--- a/openspec/changes/surface-authored-contradictions/specs/context-packs/spec.md
+++ b/openspec/changes/surface-authored-contradictions/specs/context-packs/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: Contradictions And Supersession Among The Packed Set
+
+The system SHALL surface, within the pack's `contradictions`, two measured relations
+among the notes in the set: recorded `superseded` edges read from `status` /
+`superseded_by` frontmatter, and `tension` pairs among the packed notes. Tension pairs
+SHALL come from two distinct sources, each labelled with an explicit `provenance`
+field: `asserted` pairs, read from authored `contradicts` graph edges between two
+packed notes, and `proximity` pairs, whose pairwise cosine sits in the existing
+contradiction band `[CONTRADICTION_FLOOR, DUP_THRESHOLD)`. A pair that is both
+authored and in band SHALL be surfaced once, as `asserted`.
+
+Asserted pairs SHALL be ordered before proximity pairs and SHALL NOT depend on the
+embedding sidecar. A proximity pair SHALL be labelled as proximity, not polarity,
+deferring the judgment to the reader, and SHALL be computed only among the packed
+notes. When the embedding sidecar is unavailable (embeddings disabled or
+unimportable), `embeddings_available` SHALL be `false` and no proximity pair SHALL be
+surfaced, while asserted pairs and `superseded` edges (which need no embeddings) SHALL
+still be surfaced.
+
+Pack assembly SHALL NOT consult review state: an authored or stanced pair is
+reasoning context here, not a work item, and labelling it MUST NOT suppress it.
+
+#### Scenario: A recorded supersession edge is surfaced
+
+- **WHEN** a packed note's `superseded_by` points at another note in the set
+- **THEN** `contradictions.superseded` carries that `{from, to}` edge, read from
+  frontmatter without embeddings
+
+#### Scenario: Embeddings-off still yields a useful pack
+
+- **WHEN** `find(pack=true)` runs with embeddings disabled
+- **THEN** `embeddings_available` is `false`, no proximity tension pair is surfaced,
+  and `claims`, `neighborhood`, and `contradictions.superseded` are still populated
+
+#### Scenario: An authored contradicts pair is surfaced without embeddings
+
+- **WHEN** two packed notes carry an authored `contradicts` edge and embeddings are
+  disabled
+- **THEN** `contradictions.tension` carries that pair with `provenance: "asserted"`
+- **AND** `embeddings_available` remains `false`
+
+#### Scenario: Proximity pairs are labelled and ordered after asserted pairs
+
+- **WHEN** a pack contains both an authored `contradicts` pair and an in-band
+  proximity pair
+- **THEN** the asserted pair appears first with `provenance: "asserted"` and the
+  proximity pair follows with `provenance: "proximity"`

--- a/openspec/changes/surface-authored-contradictions/specs/contradiction-queue/spec.md
+++ b/openspec/changes/surface-authored-contradictions/specs/contradiction-queue/spec.md
@@ -101,6 +101,10 @@ the item carries. Clearing SHALL release a stance recorded against an earlier co
 version as well as one matching the current fingerprint, so a stance can never become
 un-clearable while still suppressing a warning.
 
+A stance whose pair no longer surfaces on any review item SHALL remain clearable
+through a reference that addresses the pair directly, so a recorded stance can never
+reach a state where it suppresses a write-time warning with no way to release it.
+
 The stance SHALL be refused only for a review item that carries no counterpart at
 all, because "rivals; keep both" is meaningless for a single-note signal. Recording a
 stance MUST NOT mutate any note, MUST NOT supersede, merge, or rank either rival
@@ -144,6 +148,13 @@ against the other, and MUST NOT change `find` ordering.
 
 - **WHEN** `reopen` is applied to a pair that carries a `competing` stance
 - **THEN** the pair stance is cleared and the pair returns to the open view
+
+#### Scenario: An orphaned stance is still clearable
+
+- **WHEN** a stanced pair stops surfacing on any review item and `reopen` is applied
+  to the reference addressing that pair
+- **THEN** the stance is cleared and no longer suppresses the write-time warning
+- **AND** a reference carrying no stance record still reports the item as not found
 
 ### Requirement: Structural-Pair Exemption For Write-Time Proximity Warnings
 

--- a/openspec/changes/surface-authored-contradictions/specs/contradiction-queue/spec.md
+++ b/openspec/changes/surface-authored-contradictions/specs/contradiction-queue/spec.md
@@ -1,0 +1,238 @@
+## ADDED Requirements
+
+### Requirement: Asserted Contradiction Entries From Authored Edges
+
+The `corpus_contradictions` queue SHALL surface every authored `contradicts` graph
+edge as an asserted entry, sourced from typed graph edges whose `relation_type` is
+`contradicts` rather than from embedding proximity. Both endpoints of an asserted
+entry SHALL satisfy the same eligibility the proximity sweep applies — an active,
+read-write, compiled conclusion that is not an index or log hub — so that only pairs
+a reader can actually reconcile are surfaced. A symmetric authored edge SHALL yield
+exactly one deduped, unordered pair anchored on the smaller path, carrying the other
+endpoint in the finding's `paths`, exactly like a proximity pair.
+
+Asserted entries SHALL NOT depend on the embedding sidecar: they SHALL be emitted
+even when `EXOMEM_DISABLE_EMBEDDINGS` is set, when no sidecar exists, or when the
+contradiction band is inverted. Asserted entries SHALL NOT be subject to the
+`EXOMEM_CONTRADICTION_TOP_N` cap, and the cap's summary finding and omitted counts
+SHALL continue to describe only the proximity lane.
+
+Asserted entries SHALL carry the same fingerprint-bound triage contract as every
+other entry: a stable review identity and a `meta.signal_version` derived from both
+endpoints' current content, so a dismissal resurfaces when either note changes. Their
+`meta.signal_version` SHALL be distinct from the proximity entry's for the same pair.
+
+When the typed graph index is disabled, missing, or warming, asserted entries SHALL be
+absent rather than fabricated, and the proximity lane SHALL be unaffected.
+
+#### Scenario: An authored contradicts edge surfaces without embeddings
+
+- **WHEN** an active compiled note authors `contradicts` against another active
+  compiled note and `EXOMEM_DISABLE_EMBEDDINGS` is set
+- **THEN** the `corpus_contradictions` category emits exactly one finding for that
+  pair, anchored on the smaller path with both paths in `paths`
+- **AND** no embedding model is loaded and no sidecar is read
+
+#### Scenario: Asserted entries are emitted before every proximity pair
+
+- **WHEN** the queue contains both authored `contradicts` pairs and in-band proximity
+  pairs
+- **THEN** every asserted finding is emitted before the first proximity finding
+- **AND** the proximity findings keep their existing priority, same-family, and cap
+  ordering among themselves
+
+#### Scenario: Ineligible endpoint is not surfaced
+
+- **WHEN** an authored `contradicts` edge points at a superseded, archived, draft,
+  raw-source, or read-only page
+- **THEN** no asserted finding is emitted for that pair
+
+#### Scenario: Unavailable graph yields no asserted entries
+
+- **WHEN** the typed graph index is disabled or has not been built
+- **THEN** the category emits no asserted findings and reports no fabricated pair
+- **AND** the proximity sweep behaves exactly as it does today
+
+### Requirement: Entry Provenance Labelling
+
+Every `corpus_contradictions` pair finding SHALL carry an explicit
+`meta.provenance` of `asserted` or `proximity`, so a reader can distinguish a
+conflict the author asserted from a conflict the embedding band merely measured. A
+pair surfaced as asserted MUST NOT also surface as a proximity pair, MUST NOT be
+counted toward the `EXOMEM_CONTRADICTION_TOP_N` cap, and MUST NOT appear in the
+summary finding's omitted count.
+
+Adding the provenance label MUST NOT change any existing entry's
+`meta.signal_version`, so no already-recorded triage decision resurfaces because of
+this labelling alone.
+
+#### Scenario: Both lanes are labelled
+
+- **WHEN** the queue emits an asserted pair and an in-band proximity pair
+- **THEN** the asserted finding carries `meta.provenance: "asserted"` and the
+  proximity finding carries `meta.provenance: "proximity"`
+
+#### Scenario: An asserted pair suppresses its proximity duplicate
+
+- **WHEN** a pair is both authored as `contradicts` and in the proximity band
+- **THEN** exactly one finding is emitted for that pair, with
+  `meta.provenance: "asserted"`
+- **AND** the pair is not counted in the cap's total or omitted count
+
+### Requirement: Competing-Alternatives Pair Stance
+
+The system SHALL provide a `competing` triage disposition recording that two notes
+are competing alternatives the reader intends to keep ("rivals; keep both"). The
+stance SHALL be recorded in the existing review-state store with the same record
+shape, record key, and atomic write path as `dismiss` and `snooze`, keyed on a
+review identity derived from the pair rather than from a single queue item, so that
+the same stance is addressable both from the review queue and from a write-time
+check that knows only the two paths.
+
+The stance SHALL be fingerprint-bound to both endpoints' current content. Editing
+either note SHALL change the pair fingerprint so that the stored stance no longer
+matches and the pair resurfaces as open, exactly as a fingerprint-bound dismissal
+does. `reopen` on a stanced pair SHALL clear the pair stance.
+
+The stance SHALL be refused for a review item that carries no counterpart, because
+"rivals; keep both" is meaningless for a single-note signal. Recording a stance MUST
+NOT mutate any note, MUST NOT supersede, merge, or rank either rival against the
+other, and MUST NOT change `find` ordering.
+
+#### Scenario: A stance removes the pair from the open queue
+
+- **WHEN** a reader records the `competing` stance on a surfaced contradiction pair
+- **THEN** the pair's effective review state becomes `competing` and it no longer
+  appears in the default open view
+- **AND** no file under the vault other than the review-state store is created,
+  modified, moved, or deleted
+
+#### Scenario: Editing a rival resurfaces the stance
+
+- **WHEN** either note of a `competing` pair is edited
+- **THEN** the pair fingerprint changes, the stored stance no longer applies, and the
+  pair returns to the open view
+
+#### Scenario: A stance is refused for a pairless item
+
+- **WHEN** `competing` is requested for a review item with no counterpart reference
+- **THEN** the request is refused with an explicit error and nothing is recorded
+
+#### Scenario: Reopen clears the stance
+
+- **WHEN** `reopen` is applied to a pair that carries a `competing` stance
+- **THEN** the pair stance is cleared and the pair returns to the open view
+
+### Requirement: Structural-Pair Exemption For Write-Time Proximity Warnings
+
+The write-time near-duplicate and overlap draft warnings — the only duplicate
+mechanism in the product — SHALL suppress a candidate when the draft's own page and
+that candidate are a declared pair. A pair SHALL count as declared when the reader has
+recorded a matching `competing` stance, or structurally when the two pages already
+carry an authored `contradicts` edge between them, or when both carry an authored
+`answers` edge into the same target. Suppression SHALL apply to both the
+near-duplicate band and the overlap band, because genuine rivals frequently sit above
+the duplicate threshold rather than below it.
+
+Suppression SHALL apply only when the draft has an existing page identity; a draft
+with no page of its own SHALL warn exactly as it does today. Suppression MUST NOT
+apply to the contradiction queue or to deep packs: an authored or stanced pair still
+surfaces there for review.
+
+#### Scenario: A stanced pair stops warning at write time
+
+- **WHEN** a page carrying a `competing` stance with a candidate is edited
+- **THEN** no near-duplicate or overlap warning is emitted for that candidate
+- **AND** the pair still appears in the contradiction queue
+
+#### Scenario: An authored contradicts edge exempts the pair
+
+- **WHEN** a page that already authors `contradicts` against a candidate is edited
+- **THEN** no near-duplicate or overlap warning is emitted for that candidate, with
+  no stance recorded
+
+#### Scenario: Two answers to one question exempt the pair
+
+- **WHEN** the edited page and the candidate both author an `answers` edge into the
+  same question page
+- **THEN** no near-duplicate or overlap warning is emitted for that candidate
+
+#### Scenario: An undeclared pair still warns
+
+- **WHEN** the edited page and the candidate carry no stance and no declaring edge
+- **THEN** the near-duplicate and overlap warnings are emitted exactly as today
+
+## MODIFIED Requirements
+
+### Requirement: Review-Priority Ordering by Cosine and Dormancy
+
+The system SHALL order the surfaced proximity `corpus_contradictions` pairs by a
+per-pair review priority computed from the pair's embedding cosine (closer pairs
+ranked higher) and the ACT-R base-level dormancy of the pair's two notes (a more
+dormant note raises the pair's priority), so that the most-worth-reviewing pairs
+surface first. The priority SHALL reuse the existing `stale_review` activation
+machinery and SHALL be sort-only — it MUST NOT change which pairs are eligible, the
+band edges, or `find` ranking.
+
+Asserted entries SHALL be ordered ahead of every proximity pair regardless of that
+priority, because an authored conflict is a stated stance rather than a measured
+adjacency. The priority, dormancy, and same-family computations SHALL NOT be applied
+to asserted entries, and asserted entries SHALL be ordered among themselves
+deterministically by anchor path and then counterpart path.
+
+#### Scenario: Closer pair ranks above a more distant pair at equal dormancy
+
+- **WHEN** two cross-family in-band pairs have equal note dormancy but different
+  cosines
+- **THEN** the pair with the higher cosine appears earlier in the findings list
+- **AND** each finding carries `meta.cosine` and `meta.priority`
+
+#### Scenario: Dormant note lifts an equally-close pair
+
+- **WHEN** two cross-family pairs have the same cosine but one pair contains a
+  note that is dormant (never surfaced/read/cited) while the other pair's notes
+  are recently and frequently accessed
+- **THEN** the pair containing the dormant note appears earlier in the findings
+  list
+- **AND** the access signal being gated or absent is treated as maximally dormant,
+  never as a fabricated "active" note
+
+#### Scenario: An asserted pair outranks the closest proximity pair
+
+- **WHEN** an authored `contradicts` pair and a maximum-priority proximity pair are
+  both eligible
+- **THEN** the asserted finding appears earlier in the findings list
+- **AND** the asserted finding carries no `meta.priority`, `meta.dormancy`, or
+  `meta.same_family`
+
+### Requirement: Measurement-Only Ordering
+
+The ordering, demotion, and capping SHALL be measurement-only. The system MUST
+NOT mutate any note, MUST NOT auto-supersede, and MUST NOT affect `find` ranking.
+When embeddings are disabled (`EXOMEM_DISABLE_EMBEDDINGS`), the proximity sweep
+SHALL continue to short-circuit to an empty result without loading any model, while
+asserted entries — which are read from authored graph edges and need no vectors —
+SHALL still be surfaced.
+
+Surfacing an asserted conflict SHALL remain proposal-only. The system MUST NOT rank
+the two rivals against each other, MUST NOT infer which is correct, and MUST NOT
+auto-merge, auto-supersede, or auto-dismiss either of them.
+
+#### Scenario: Audit run leaves notes untouched
+
+- **WHEN** an audit with the `corpus_contradictions` category runs over a vault
+- **THEN** no file under the vault is created, modified, moved, or deleted
+- **AND** `find` ranking is unchanged
+
+#### Scenario: Embeddings disabled keeps the proximity lane a no-op
+
+- **WHEN** `EXOMEM_DISABLE_EMBEDDINGS` is set and no page authors a `contradicts`
+  edge
+- **THEN** the category returns no findings and loads no embedding model
+
+#### Scenario: Embeddings disabled still surfaces authored conflicts
+
+- **WHEN** `EXOMEM_DISABLE_EMBEDDINGS` is set and a page authors a `contradicts`
+  edge against another eligible page
+- **THEN** the category returns that asserted finding and still loads no embedding
+  model

--- a/openspec/changes/surface-authored-contradictions/specs/contradiction-queue/spec.md
+++ b/openspec/changes/surface-authored-contradictions/specs/contradiction-queue/spec.md
@@ -90,14 +90,21 @@ the same stance is addressable both from the review queue and from a write-time
 check that knows only the two paths.
 
 The stance SHALL be fingerprint-bound to both endpoints' current content. Editing
-either note SHALL change the pair fingerprint so that the stored stance no longer
+EITHER note SHALL change the pair fingerprint so that the stored stance no longer
 matches and the pair resurfaces as open, exactly as a fingerprint-bound dismissal
-does. `reopen` on a stanced pair SHALL clear the pair stance.
+does; a change to only one endpoint SHALL be sufficient.
 
-The stance SHALL be refused for a review item that carries no counterpart, because
-"rivals; keep both" is meaningless for a single-note signal. Recording a stance MUST
-NOT mutate any note, MUST NOT supersede, merge, or rank either rival against the
-other, and MUST NOT change `find` ordering.
+A review item MAY carry more than one contradiction pair, because both lanes anchor a
+pair on the lower of its two paths. Recording the stance on such an item SHALL record
+it on every pair the item carries, and `reopen` SHALL clear the stance on every pair
+the item carries. Clearing SHALL release a stance recorded against an earlier content
+version as well as one matching the current fingerprint, so a stance can never become
+un-clearable while still suppressing a warning.
+
+The stance SHALL be refused only for a review item that carries no counterpart at
+all, because "rivals; keep both" is meaningless for a single-note signal. Recording a
+stance MUST NOT mutate any note, MUST NOT supersede, merge, or rank either rival
+against the other, and MUST NOT change `find` ordering.
 
 #### Scenario: A stance removes the pair from the open queue
 
@@ -107,9 +114,10 @@ other, and MUST NOT change `find` ordering.
 - **AND** no file under the vault other than the review-state store is created,
   modified, moved, or deleted
 
-#### Scenario: Editing a rival resurfaces the stance
+#### Scenario: Editing either rival resurfaces the stance
 
-- **WHEN** either note of a `competing` pair is edited
+- **WHEN** exactly one note of a `competing` pair is edited, whichever of the two it
+  is
 - **THEN** the pair fingerprint changes, the stored stance no longer applies, and the
   pair returns to the open view
 
@@ -117,6 +125,20 @@ other, and MUST NOT change `find` ordering.
 
 - **WHEN** `competing` is requested for a review item with no counterpart reference
 - **THEN** the request is refused with an explicit error and nothing is recorded
+
+#### Scenario: An anchor carrying two conflicts is stanceable
+
+- **WHEN** one note is the anchor of two contradiction pairs and `competing` is
+  recorded on that item
+- **THEN** both pairs are stanced and the item leaves the open view
+- **AND** `reopen` on that item clears both pair stances
+
+#### Scenario: A newly drifted pair reopens the item without stranding the stance
+
+- **WHEN** a stanced anchor later acquires a second, un-stanced contradiction pair
+- **THEN** the item returns to the open view
+- **AND** the original stance can still be re-affirmed or cleared through the same
+  item
 
 #### Scenario: Reopen clears the stance
 

--- a/openspec/changes/surface-authored-contradictions/tasks.md
+++ b/openspec/changes/surface-authored-contradictions/tasks.md
@@ -58,3 +58,14 @@
 - [x] 8.7 Filter declared rivals inside each detect loop so an exempt pair cannot consume a `top_n` slot.
 - [x] 8.8 Pin the proximity `signal_version` formula, the inverted-band asserted path, and the warming-graph proximity path.
 - [x] 8.9 Correct the design.md cost claim and re-validate the change in strict mode.
+
+## 9. Mutation-survivor closure
+
+- [x] 9.1 Pin the recall filter on `relation_edges` AND `relation_participants` with a withheld endpoint that was indexed while ordinary, so the disclosure mutation is reachable.
+- [x] 9.2 Assert the read-snapshot count at the `asserted_pairs` level so the fan-out cannot be reintroduced one call site above `relation_edges`.
+- [x] 9.3 Mirror the slot-consumption test for the contradiction lane.
+- [x] 9.4 Pin `top_n` explicitly in both slot tests instead of leaning on the default.
+- [x] 9.5 Make an orphaned stance clearable by its own pair ref, and document the bounded residual.
+- [x] 9.6 Annotate each contradiction reason with its pair ref and stance, after the fingerprint is computed.
+- [x] 9.7 State `declared_pairs`' residual cost in design.md.
+

--- a/openspec/changes/surface-authored-contradictions/tasks.md
+++ b/openspec/changes/surface-authored-contradictions/tasks.md
@@ -69,3 +69,13 @@
 - [x] 9.6 Annotate each contradiction reason with its pair ref and stance, after the fingerprint is computed.
 - [x] 9.7 State `declared_pairs`' residual cost in design.md.
 
+## 10. Competitive benchmark journey
+
+- [x] 10.1 Re-plant the J3 contradiction pair as ONE expected item at the pair anchor, matching the one-row-per-pair contract.
+- [x] 10.2 Score the asserted (authored-edge) lane, which is deterministic without embeddings, instead of scoring the whole queue unsupported.
+- [x] 10.3 Declare the still-gated proximity lane as an explicit unsupported sub-lane so `supported=True` cannot overclaim a measurement that never ran.
+- [x] 10.4 Assert the surfaced row names both endpoints, so the pair is verified captured whole rather than merely present.
+- [x] 10.5 Add the authored contradiction to the attention union's expected set so a correct union is not scored as a false surface.
+- [x] 10.6 Update the J3 docstring and judge-facing summary text, both of which asserted now-false "unsupported" prose.
+- [x] 10.7 Mirror in `tests/test_membench_trackd.py` and run shard 4/4.
+

--- a/openspec/changes/surface-authored-contradictions/tasks.md
+++ b/openspec/changes/surface-authored-contradictions/tasks.md
@@ -1,0 +1,48 @@
+## 1. Delta specifications
+
+- [x] 1.1 Add the `contradiction-queue` delta: asserted entries, provenance labelling, the competing-alternatives pair stance, the structural-pair exemption, and the two modified ordering/measurement requirements.
+- [x] 1.2 Add the `attention-queue` delta: asserted-before-proximity preservation, provenance on reasons, and `competing` as a review state honored by every queue.
+- [x] 1.3 Add the `context-packs` delta: tension-pair provenance and asserted pairs without embeddings.
+
+## 2. Pure-logic units (red first)
+
+- [x] 2.1 Test the pair-stance identity helpers: order-independent pair key, namespaced pair id, and a pair fingerprint that changes when either endpoint's signal version changes.
+- [x] 2.2 Test that `review_state` accepts `competing` as an action and a view, resolves it to a `competing` effective state, refuses `until`, and clears on `reopen`.
+- [x] 2.3 Test the asserted-pair graph reader: both endpoints resolved, symmetric edges deduped to one unordered pair, and an unavailable or warming graph yielding an explicit empty result.
+- [x] 2.4 Test the structural-pair predicate: an authored `contradicts` edge and two `answers` edges into one question both qualify; an unrelated pair does not.
+
+## 3. Asserted contradiction entries
+
+- [x] 3.1 Test that an authored `contradicts` edge surfaces a `corpus_contradictions` finding with `meta.provenance == "asserted"` while embeddings are disabled.
+- [x] 3.2 Test that asserted findings are emitted before every proximity finding and that proximity findings carry `meta.provenance == "proximity"`.
+- [x] 3.3 Test that a pair surfaced as asserted does not also surface as a proximity pair and is not counted in the cap's omitted total.
+- [x] 3.4 Test endpoint eligibility: an authored edge whose other endpoint is archived, a raw source, or read-only does not surface.
+- [x] 3.5 Implement the asserted lane in `_check_corpus_contradictions` ahead of the embeddings short-circuit, tag both lanes with `provenance`, and suppress the proximity duplicate.
+
+## 4. Competing-alternatives stance
+
+- [x] 4.1 Test that `triage_memory(action="competing")` on a contradiction item records a pair-keyed decision and removes the item from the open attention view.
+- [x] 4.2 Test that editing either rival resurfaces the pair as open.
+- [x] 4.3 Test that `competing` is refused for a review item that carries no pair.
+- [x] 4.4 Test that `reopen` on a stanced pair clears both the item record and the pair record.
+- [x] 4.5 Implement `competing` in `review_state`, the pair-stance consultation in `attention._apply_review_state`, the `state_summary` key, and the triage leaf routing.
+
+## 5. Write-time warnings
+
+- [x] 5.1 Test that a competing-stanced pair is suppressed from both `detect_duplicates` and `detect_contradictions` candidates.
+- [x] 5.2 Test that a structurally paired pair is suppressed from both, with no stance recorded.
+- [x] 5.3 Test that an unrelated, unstanced pair still warns exactly as today.
+- [x] 5.4 Implement the shared suppression filter in `corpus_aware`, keyed on `self_path` and each candidate path, no-op when `self_path` is absent.
+
+## 6. Deep-pack tension provenance
+
+- [x] 6.1 Test that every tension pair carries `provenance`, that authored pairs are labelled `asserted` and emitted first, and that proximity pairs stay `proximity`.
+- [x] 6.2 Test that an embeddings-off pack still carries asserted tension pairs while `embeddings_available` stays `false`.
+- [x] 6.3 Implement asserted pairs and provenance labelling in `context_pack._tension_pairs`.
+
+## 7. Verification
+
+- [x] 7.1 Run the new test module plus the attention, contradiction-queue, corpus-aware, context-pack, relation-queue, review-context, and graph relation-filter suites.
+- [x] 7.2 Run `uvx ruff check` on every changed file.
+- [x] 7.3 Confirm the guarded goldens and the MCP schema fixture are untouched by the diff.
+- [x] 7.4 Validate the OpenSpec change in strict mode.

--- a/openspec/changes/surface-authored-contradictions/tasks.md
+++ b/openspec/changes/surface-authored-contradictions/tasks.md
@@ -46,3 +46,15 @@
 - [x] 7.2 Run `uvx ruff check` on every changed file.
 - [x] 7.3 Confirm the guarded goldens and the MCP schema fixture are untouched by the diff.
 - [x] 7.4 Validate the OpenSpec change in strict mode.
+
+## 8. Correction round
+
+- [x] 8.1 Return every contradiction pair from `pairs_from_reasons`; record and clear the stance on each, and resolve an item to `competing` only when all its pairs are stanced.
+- [x] 8.2 Cover an anchor carrying two conflicts: record, honour, reopen-clears-all, and the drift-reopen transition that previously stranded a stance.
+- [x] 8.3 Parametrize the resurfacing test over both endpoints so the both-sides fingerprint binding is pinned.
+- [x] 8.4 Replace the per-anchor asserted-pair fan-out with one indexed `EpistemicGraphIndex.relation_edges` query, and cover the new method directly.
+- [x] 8.5 Build the write-time declared-pair snapshot once per call instead of per candidate.
+- [x] 8.6 Report the item's own identity from a `competing` triage, with pair identities under `pairs`.
+- [x] 8.7 Filter declared rivals inside each detect loop so an exempt pair cannot consume a `top_n` slot.
+- [x] 8.8 Pin the proximity `signal_version` formula, the inverted-band asserted path, and the warming-graph proximity path.
+- [x] 8.9 Correct the design.md cost claim and re-validate the change in strict mode.

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -1911,7 +1911,7 @@ def _simple_capture_main(argv: list[str]) -> int:
 
 
 def _simple_review_main(argv: list[str]) -> int:
-    triage_actions = {"dismiss", "snooze", "reopen"}
+    triage_actions = {"dismiss", "snooze", "reopen", "competing"}
     if argv and argv[0] in triage_actions:
         action = argv[0]
         parser = argparse.ArgumentParser(
@@ -1950,7 +1950,7 @@ def _simple_review_main(argv: list[str]) -> int:
     parser.add_argument("--limit", type=int, default=25, help="attention item cap")
     parser.add_argument(
         "--state",
-        choices=("open", "all", "snoozed", "dismissed"),
+        choices=("open", "all", "snoozed", "dismissed", "competing"),
         default="open",
         help="review state view",
     )
@@ -2404,7 +2404,7 @@ def _print_review_human(result: dict) -> None:
         f"{all_total} total"
     )
     hidden = []
-    for name in ("snoozed", "dismissed"):
+    for name in ("snoozed", "dismissed", "competing"):
         if states.get(name):
             hidden.append(f"{states[name]} {name}")
     if hidden:

--- a/src/exomem/attention.py
+++ b/src/exomem/attention.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 from . import activation as activation_module
 from . import audit as audit_module
+from . import contradiction_stance as contradiction_stance_module
 from . import fusion
 from . import review_state as review_state_module
 from .audit import AuditFinding
@@ -388,7 +389,7 @@ def _apply_review_state(
     refs = review_state_module.refs_for_paths(vault_root, all_paths)
     store = review_state_module.ReviewStateStore(vault_root)
     state_payload = store.load()
-    state_summary = {"open": 0, "snoozed": 0, "dismissed": 0}
+    state_summary = {state: 0 for state in review_state_module.VALID_STATES}
 
     for item in report.items:
         target_ref = refs[item.path]
@@ -426,6 +427,23 @@ def _apply_review_state(
             today=today,
             payload=state_payload,
         )
+        if effective == "open":
+            # No item-level decision APPLIES (none recorded, or a snooze that has
+            # since lapsed), so a competing-alternatives stance recorded on the
+            # contradiction pair itself still governs. The item-level record is
+            # checked first because it is the more specific decision about this
+            # exact signal composite.
+            pair = contradiction_stance_module.pair_from_reasons(item.reasons)
+            if pair is not None:
+                stance = contradiction_stance_module.pair_decision(
+                    vault_root,
+                    *pair,
+                    store=store,
+                    payload=state_payload,
+                    refs=refs,
+                )
+                if stance is not None:
+                    effective, decision = "competing", stance
         item.item_id = review_id
         item.ref = review_state_module.review_ref(review_id)
         item.target_ref = target_ref

--- a/src/exomem/attention.py
+++ b/src/exomem/attention.py
@@ -433,17 +433,23 @@ def _apply_review_state(
             # contradiction pair itself still governs. The item-level record is
             # checked first because it is the more specific decision about this
             # exact signal composite.
-            pair = contradiction_stance_module.pair_from_reasons(item.reasons)
-            if pair is not None:
-                stance = contradiction_stance_module.pair_decision(
-                    vault_root,
-                    *pair,
-                    store=store,
-                    payload=state_payload,
-                    refs=refs,
-                )
-                if stance is not None:
-                    effective, decision = "competing", stance
+            pairs = contradiction_stance_module.pairs_from_reasons(item.reasons)
+            if pairs:
+                stances = [
+                    contradiction_stance_module.pair_decision(
+                        vault_root,
+                        *pair,
+                        store=store,
+                        payload=state_payload,
+                        refs=refs,
+                    )
+                    for pair in pairs
+                ]
+                # EVERY conflict on the anchor must be dispositioned before the item
+                # is: one un-stanced rival — a newly drifted pair, say — is still
+                # open review work, so the item honestly reopens.
+                if all(stance is not None for stance in stances):
+                    effective, decision = "competing", stances[0]
         item.item_id = review_id
         item.ref = review_state_module.review_ref(review_id)
         item.target_ref = target_ref

--- a/src/exomem/attention.py
+++ b/src/exomem/attention.py
@@ -433,23 +433,22 @@ def _apply_review_state(
             # contradiction pair itself still governs. The item-level record is
             # checked first because it is the more specific decision about this
             # exact signal composite.
-            pairs = contradiction_stance_module.pairs_from_reasons(item.reasons)
-            if pairs:
-                stances = [
-                    contradiction_stance_module.pair_decision(
-                        vault_root,
-                        *pair,
-                        store=store,
-                        payload=state_payload,
-                        refs=refs,
-                    )
-                    for pair in pairs
-                ]
-                # EVERY conflict on the anchor must be dispositioned before the item
-                # is: one un-stanced rival — a newly drifted pair, say — is still
-                # open review work, so the item honestly reopens.
-                if all(stance is not None for stance in stances):
-                    effective, decision = "competing", stances[0]
+            # Annotating here also makes a partially-stanced item legible: a reader
+            # sees which reason is already dispositioned, and the `pair_ref` that
+            # addresses it, instead of an ordinary-looking open item.
+            stances = contradiction_stance_module.annotate_reasons(
+                vault_root,
+                item.reasons,
+                store=store,
+                payload=state_payload,
+                refs=refs,
+            )
+            # EVERY conflict on the anchor must be dispositioned before the item is:
+            # one un-stanced rival — a newly drifted pair, say — is still open
+            # review work, so the item honestly reopens.
+            if stances and all(stance is not None for stance in stances.values()):
+                effective = "competing"
+                decision = stances[min(stances)]
         item.item_id = review_id
         item.ref = review_state_module.review_ref(review_id)
         item.target_ref = target_ref

--- a/src/exomem/audit.py
+++ b/src/exomem/audit.py
@@ -54,6 +54,7 @@ import yaml
 
 from . import (
     access,
+    contradiction_stance,
     indexes,
     relation_registry,
     semantic_language_registry,
@@ -2959,11 +2960,106 @@ def _pair_polarity(vault_root: Path, a: str, b: str) -> dict | None:
         return None
 
 
+_ASSERTED_FIX = (
+    "Surfaced for REVIEW only — this is YOUR authored `contradicts` edge, not a "
+    "server judgment about which side is right. Read both: `replace` (supersede) "
+    "the stale one, `reconcile` them, or — if they are genuine rivals you intend "
+    "to keep — record the competing-alternatives stance with `triage_memory` "
+    "using `action='competing'`. Never auto-acted."
+)
+
+
+def _asserted_contradictions(
+    eligible: dict[str, find_module.ParsedPage],
+    pairs: list[tuple[str, str]],
+) -> tuple[list[AuditFinding], set[tuple[str, str]]]:
+    """Authored `contradicts` edges as contradiction findings, plus their pair keys.
+
+    The strongest contradiction signal a vault carries is the one the author wrote
+    down, and until this lane existed nothing consumed it. Unlike the proximity
+    sweep this needs NO embeddings — it reads typed graph edges — so it survives a
+    torch-less deploy and an `EXOMEM_DISABLE_EMBEDDINGS` run. Both endpoints must
+    clear the same `_is_active_compiled_rw` bar the proximity sweep uses, because
+    those are the only pages a contradiction can actually be reconciled against.
+
+    Deliberately NOT capped by `EXOMEM_CONTRADICTION_TOP_N`: that cap exists for the
+    combinatorial proximity sweep, and silently hiding an edge the user typed by hand
+    would be a different thing entirely.
+    """
+    findings: list[AuditFinding] = []
+    keys: set[tuple[str, str]] = set()
+    for a, b in pairs:
+        if a not in eligible or b not in eligible:
+            continue
+        keys.add((a, b))
+        findings.append(AuditFinding(
+            category="corpus_contradictions",
+            severity="info",
+            path=a,
+            detail=(
+                f"Authored `contradicts` edge with {b!r} — you asserted these "
+                "conflict. Is the conflict still live, or has one side become the "
+                "stale view?"
+            ),
+            proposed_fix=_ASSERTED_FIX,
+            paths=[a, b],
+            meta={
+                # Distinct from the proximity signal version for the same pair, so
+                # an asserted decision and a proximity decision can never collide.
+                "signal_version": content_hash(
+                    "asserted\n"
+                    + _page_signal_version(eligible[a])
+                    + "\n"
+                    + _page_signal_version(eligible[b])
+                )[:16],
+                "provenance": "asserted",
+                "relation_type": "contradicts",
+            },
+        ))
+    return findings, keys
+
+
 def _check_corpus_contradictions(
     vault_root: Path,
     pages: list[find_module.ParsedPage],
     *,
     today: dt.date | None = None,
+) -> list[AuditFinding]:
+    """The contradiction queue: authored conflicts first, then measured proximity.
+
+    Two lanes, one category. Asserted entries come from authored `contradicts`
+    graph edges and are emitted FIRST — `attention` treats emission order as
+    intra-queue rank, so "ranked above proximity" needs no ranking code. Proximity
+    entries come from the embedding-band sweep below and keep their existing
+    priority, same-family demotion, and cap behaviour among themselves.
+
+    A pair that is both authored and in band surfaces once, as asserted: the
+    authored edge is strictly the stronger signal, and two rows for one decision
+    would double the pair's RRF vote in `attention`.
+    """
+    pairs = contradiction_stance.asserted_pairs(vault_root)
+    if not pairs and os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
+        # Nothing authored and no sidecar lane to run: keep the pre-existing
+        # torch-less fast path — one indexed graph query and out, without paying
+        # the eligibility walk this category used to skip entirely.
+        return []
+    eligible: dict[str, find_module.ParsedPage] = {
+        page.rel_path: page
+        for page in pages
+        if _is_active_compiled_rw(vault_root, page)
+    }
+    asserted, asserted_keys = _asserted_contradictions(eligible, pairs)
+    return asserted + _proximity_contradictions(
+        vault_root, eligible, today=today, exclude=asserted_keys
+    )
+
+
+def _proximity_contradictions(
+    vault_root: Path,
+    eligible: dict[str, find_module.ParsedPage],
+    *,
+    today: dt.date | None = None,
+    exclude: set[tuple[str, str]] | None = None,
 ) -> list[AuditFinding]:
     """Corpus-wide contradiction sweep: surface PAIRS of active read-write compiled
     conclusions whose embeddings sit in the band `[floor, dup_threshold)`.
@@ -3024,14 +3120,11 @@ def _check_corpus_contradictions(
     if not metadata or matrix.shape[0] == 0:
         return []
 
-    # Both endpoints of a flagged pair must be active read-write compiled.
-    eligible: dict[str, find_module.ParsedPage] = {
-        page.rel_path: page
-        for page in pages
-        if _is_active_compiled_rw(vault_root, page)
-    }
+    # Both endpoints of a flagged pair must be active read-write compiled — the
+    # caller already applied that gate when building `eligible`.
     if len(eligible) < 2:
         return []
+    excluded = exclude or set()
 
     rows_by_file: dict[str, list[int]] = {}
     for i, (fp, _cidx) in enumerate(metadata):
@@ -3053,6 +3146,10 @@ def _check_corpus_contradictions(
             score = float(col_max[int(j)])
             a, b = sorted((fp, other_fp))
             key = (a, b)
+            # Already surfaced as an authored contradiction: the stronger signal
+            # owns the pair, so it is not re-measured, re-counted, or re-capped.
+            if key in excluded:
+                continue
             if key not in pair_cos or score > pair_cos[key]:
                 pair_cos[key] = score
 
@@ -3108,6 +3205,7 @@ def _check_corpus_contradictions(
             "priority": round(priority, 4),
             "dormancy": round(dormancy, 4),
             "same_family": same_family,
+            "provenance": "proximity",
         }
         if polarity:
             meta["polarity"] = polarity["label"]

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -5138,19 +5138,24 @@ def op_triage_memory(
     if normalized == contradiction_stance_module.STANCE_ACTION:
         # "rivals; keep both" is a statement about a PAIR, so it is recorded on the
         # pair identity rather than on this item's composite signal — that is the
-        # only key the write-time draft check can reconstruct from two paths.
-        result = contradiction_stance_module.record_stance(
+        # only key the write-time draft check can reconstruct from two paths. The
+        # RESPONSE still reports the item's own identity, so a client that
+        # round-trips the returned fingerprint into `expected_fingerprint` is
+        # comparing like with like; the pair identities ride along under `pairs`.
+        recorded = contradiction_stance_module.record_stance(
             vault_root, reasons=item.reasons, until=until, why=why
         )
-        result["ref"] = ref
-        result.update(
-            {
-                "path": item.path,
-                "target_ref": item.target_ref,
-                "categories": item.categories,
-            }
-        )
-        return result
+        return {
+            "item_id": item.item_id,
+            "ref": item.ref or ref,
+            "fingerprint": item.fingerprint,
+            "state": "competing",
+            "decision": recorded[0]["decision"],
+            "pairs": recorded,
+            "path": item.path,
+            "target_ref": item.target_ref,
+            "categories": item.categories,
+        }
     result = review_state_module.ReviewStateStore(vault_root).apply(
         item.item_id or review_state_module.parse_review_ref(ref),
         item.fingerprint or "",

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -48,6 +48,7 @@ from . import audit_fix as audit_fix_module
 from . import capabilities as capabilities_module
 from . import compile_proposal as compile_proposal_module
 from . import context_pack as context_pack_module
+from . import contradiction_stance as contradiction_stance_module
 from . import corpus_aware as corpus_aware_module
 from . import create_directory as create_directory_module
 from . import create_file as create_file_module
@@ -5066,6 +5067,21 @@ def op_review_item_context(
     return egress_module.filter_withheld_entries(vault_root, assembled)
 
 
+def _refuse_pairless_stance(ref: str, action: str) -> None:
+    """Guard the namespaced queues, which never carry a contradiction pair.
+
+    "rivals; keep both" is a statement about two competing notes. An Adoption
+    Studio proposal and a relation-queue candidate are single-sided, so the stance
+    is meaningless there and must not be silently recorded as a standing mute.
+    """
+    if str(action or "").strip().lower() != contradiction_stance_module.STANCE_ACTION:
+        return
+    raise ValueError(
+        "INVALID_REVIEW_ACTION: `competing` records that two notes are rivals worth "
+        f"keeping, so it does not apply to {ref}"
+    )
+
+
 def op_triage_memory(
     vault_root: Path,
     ref: str,
@@ -5091,6 +5107,7 @@ def op_triage_memory(
             the write and asks the caller to refresh.
     """
     if adoption_proposals_module.is_adoption_ref(ref):
+        _refuse_pairless_stance(ref, action)
         return adoption_proposals_module.triage(
             vault_root,
             ref=ref,
@@ -5100,6 +5117,7 @@ def op_triage_memory(
             expected_fingerprint=expected_fingerprint,
         )
     if relation_queue_module.is_relation_ref(ref):
+        _refuse_pairless_stance(ref, action)
         return relation_queue_module.triage(
             vault_root,
             ref=ref,
@@ -5116,6 +5134,23 @@ def op_triage_memory(
             "REVIEW_ITEM_CHANGED: the review signal changed; refresh the worklist "
             f"and inspect {item.ref} again"
         )
+    normalized = str(action or "").strip().lower()
+    if normalized == contradiction_stance_module.STANCE_ACTION:
+        # "rivals; keep both" is a statement about a PAIR, so it is recorded on the
+        # pair identity rather than on this item's composite signal — that is the
+        # only key the write-time draft check can reconstruct from two paths.
+        result = contradiction_stance_module.record_stance(
+            vault_root, reasons=item.reasons, until=until, why=why
+        )
+        result["ref"] = ref
+        result.update(
+            {
+                "path": item.path,
+                "target_ref": item.target_ref,
+                "categories": item.categories,
+            }
+        )
+        return result
     result = review_state_module.ReviewStateStore(vault_root).apply(
         item.item_id or review_state_module.parse_review_ref(ref),
         item.fingerprint or "",
@@ -5123,6 +5158,10 @@ def op_triage_memory(
         until=until,
         why=why,
     )
+    if normalized == "reopen":
+        # Reopen is the complete inverse: an item-level record alone would leave a
+        # pair stance quietly suppressing the same item.
+        contradiction_stance_module.clear_stance(vault_root, reasons=item.reasons)
     result.update(
         {
             "path": item.path,

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -5126,15 +5126,28 @@ def op_triage_memory(
             why=why,
             expected_fingerprint=expected_fingerprint,
         )
-    item = attention_module.item_by_ref(
-        vault_root, ref, expected_fingerprint=expected_fingerprint
-    )
+    normalized = str(action or "").strip().lower()
+    try:
+        item = attention_module.item_by_ref(
+            vault_root, ref, expected_fingerprint=expected_fingerprint
+        )
+    except ValueError:
+        # A competing stance whose pair has drifted off every queue item is on no
+        # item's reasons, so the item-walking clear cannot reach it — while it still
+        # suppresses the write-time warning. Its own pair ref (returned by the stance
+        # write, and echoed on every annotated reason) addresses it directly.
+        if normalized == "reopen":
+            orphan = contradiction_stance_module.clear_orphan_stance(
+                vault_root, ref=ref
+            )
+            if orphan is not None:
+                return orphan
+        raise
     if expected_fingerprint and item.fingerprint != expected_fingerprint:
         raise ValueError(
             "REVIEW_ITEM_CHANGED: the review signal changed; refresh the worklist "
             f"and inspect {item.ref} again"
         )
-    normalized = str(action or "").strip().lower()
     if normalized == contradiction_stance_module.STANCE_ACTION:
         # "rivals; keep both" is a statement about a PAIR, so it is recorded on the
         # pair identity rather than on this item's composite signal — that is the

--- a/src/exomem/context_pack.py
+++ b/src/exomem/context_pack.py
@@ -557,6 +557,8 @@ def _asserted_tension(
     """
     pairs: list[dict] = []
     keys: set[frozenset[str]] = set()
+    if len(by_canon) < 2:
+        return pairs, keys  # no pair is possible — don't touch the graph at all
     for a, b in contradiction_stance.asserted_pairs(vault_root):
         canon_a, canon_b = corpus_aware._canon(a), corpus_aware._canon(b)
         if canon_a not in by_canon or canon_b not in by_canon:

--- a/src/exomem/context_pack.py
+++ b/src/exomem/context_pack.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Any
 
 from . import (
+    contradiction_stance,
     corpus_aware,
     epistemic_graph,
     find_corpus,
@@ -544,18 +545,54 @@ def _supersession_edges(packed_pages: list[ParsedPage]) -> list[dict]:
     return edges
 
 
+def _asserted_tension(
+    vault_root: Path, by_canon: dict[str, str]
+) -> tuple[list[dict], set[frozenset[str]]]:
+    """Authored `contradicts` pairs among the packed notes, plus their canon keys.
+
+    An authored edge is the author's own stance, not a measurement, so it carries no
+    cosine and needs no sidecar — an embeddings-off pack still shows it. Labelling it
+    is the point: a reader must be able to tell "you said these conflict" from "these
+    sit close in vector space".
+    """
+    pairs: list[dict] = []
+    keys: set[frozenset[str]] = set()
+    for a, b in contradiction_stance.asserted_pairs(vault_root):
+        canon_a, canon_b = corpus_aware._canon(a), corpus_aware._canon(b)
+        if canon_a not in by_canon or canon_b not in by_canon:
+            continue
+        keys.add(frozenset((canon_a, canon_b)))
+        left, right = sorted((by_canon[canon_a], by_canon[canon_b]))
+        pairs.append(
+            {
+                "a": left,
+                "b": right,
+                "cosine": None,
+                "provenance": "asserted",
+                "note": "authored `contradicts` edge — asserted, not measured",
+            }
+        )
+    pairs.sort(key=lambda d: (d["a"], d["b"]))
+    return pairs, keys
+
+
 def _tension_pairs(
     vault_root: Path, packed_pages: list[ParsedPage], max_tension: int
 ) -> tuple[list[dict], int, bool]:
-    """Proximity-tension pairs AMONG the packed notes whose pairwise cosine lands in the
-    contradiction band. Reuses the embedding sidecar; soft-fails to empty when off.
+    """Tension pairs AMONG the packed notes: authored `contradicts` edges first, then
+    proximity pairs whose pairwise cosine lands in the contradiction band. Reuses the
+    embedding sidecar for the proximity half only; soft-fails to empty when off.
 
     `embeddings_available` is True iff a cosine pass returned scores AND the band is
     active; an inverted/disabled band (floor >= ceiling) reports it False — the band is
-    off, so no tension can be measured regardless of the sidecar."""
+    off, so no proximity tension can be measured regardless of the sidecar. Asserted
+    pairs are independent of it and are surfaced either way.
+
+    A pair that is both authored and in band appears once, as asserted."""
     floor = corpus_aware._contradiction_floor()
     ceiling = corpus_aware._dup_threshold()
     by_canon = {corpus_aware._canon(p.rel_path): p.rel_path for p in packed_pages}
+    asserted, asserted_keys = _asserted_tension(vault_root, by_canon)
     pair_best: dict[frozenset[str], float] = {}
     embeddings_available = False
 
@@ -572,21 +609,25 @@ def _tension_pairs(
                 if not (floor <= score < ceiling):
                     continue
                 key = frozenset((self_canon, canon))
+                if key in asserted_keys:
+                    continue  # the authored edge owns this pair
                 if key not in pair_best or score > pair_best[key]:
                     pair_best[key] = score
 
-    pairs: list[dict] = []
+    proximity: list[dict] = []
     for key, score in pair_best.items():
         a, b = sorted(key)
-        pairs.append(
+        proximity.append(
             {
                 "a": by_canon[a],
                 "b": by_canon[b],
                 "cosine": round(float(score), 4),
+                "provenance": "proximity",
                 "note": "proximity, not polarity — reader decides",
             }
         )
-    pairs.sort(key=lambda d: (-d["cosine"], d["a"], d["b"]))
+    proximity.sort(key=lambda d: (-d["cosine"], d["a"], d["b"]))
+    pairs = asserted + proximity
     shown = pairs[:max_tension] if max_tension > 0 else pairs
     dropped = len(pairs) - len(shown)
     return shown, dropped, embeddings_available

--- a/src/exomem/contradiction_stance.py
+++ b/src/exomem/contradiction_stance.py
@@ -31,6 +31,7 @@ auto-dismisses. The reader decides; the server only remembers what they decided.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -181,11 +182,15 @@ def is_competing(
     )
 
 
-def pair_from_reasons(reasons: list[dict] | None) -> tuple[str, str] | None:
-    """The single contradiction pair a review item carries, or None.
+def pairs_from_reasons(reasons: list[dict] | None) -> list[tuple[str, str]]:
+    """EVERY distinct contradiction pair a review item carries, in pair order.
 
-    A stance is meaningless without exactly one counterpart, so an item flagged
-    over several distinct pairs (or none) yields None and the caller refuses.
+    Both contradiction lanes anchor a pair on `min(a, b)`, so a note that is the
+    alphabetically-first endpoint of two conflicts collapses into ONE attention item
+    carrying two reasons — the ordinary "this conflicts with these two older ones"
+    shape. Returning only a lone pair would leave such an item unstanceable and,
+    worse, leave an existing stance un-clearable once a second pair drifted onto the
+    same anchor while it kept muting the write-time warning. Callers handle the list.
     """
     pairs = {
         pair_key(paths[0], paths[1])
@@ -194,9 +199,7 @@ def pair_from_reasons(reasons: list[dict] | None) -> tuple[str, str] | None:
         for paths in [sorted(set(reason.get("related_paths") or []))]
         if len(paths) == 2
     }
-    if len(pairs) != 1:
-        return None
-    return next(iter(pairs))
+    return sorted(pair for pair in pairs if pair[0] != pair[1])
 
 
 def record_stance(
@@ -205,40 +208,57 @@ def record_stance(
     reasons: list[dict] | None,
     until: str | None = None,
     why: str | None = None,
-) -> dict[str, Any]:
-    """Persist the competing-alternatives stance for a review item's pair."""
-    pair = pair_from_reasons(reasons)
-    if pair is None:
+) -> list[dict[str, Any]]:
+    """Persist the competing-alternatives stance on every pair the item carries.
+
+    The triage surface addresses an ITEM, and an item can legitimately carry more
+    than one conflict, so "these are rivals I keep" applies to each of them. Every
+    pair record stays independently fingerprint-bound, so editing one rival reopens
+    only the pairs that note participates in.
+    """
+    pairs = pairs_from_reasons(reasons)
+    if not pairs:
         raise ValueError(
             "INVALID_REVIEW_ACTION: `competing` records that two notes are rivals "
-            "worth keeping, so it applies only to a review item carrying exactly "
+            "worth keeping, so it applies only to a review item carrying at least "
             "one contradiction pair"
         )
-    identity = pair_identity(vault_root, *pair)
-    if identity is None:
-        raise ValueError(
-            "REVIEW_ITEM_CHANGED: one side of the pair is no longer readable; "
-            "refresh the worklist and inspect the item again"
+    store = review_state_module.ReviewStateStore(Path(vault_root))
+    recorded: list[dict[str, Any]] = []
+    for pair in pairs:
+        identity = pair_identity(vault_root, *pair)
+        if identity is None:
+            raise ValueError(
+                "REVIEW_ITEM_CHANGED: one side of the pair is no longer readable; "
+                "refresh the worklist and inspect the item again"
+            )
+        applied = store.apply(
+            identity[0], identity[1], action=STANCE_ACTION, until=until, why=why
         )
-    result = review_state_module.ReviewStateStore(Path(vault_root)).apply(
-        identity[0], identity[1], action=STANCE_ACTION, until=until, why=why
-    )
-    result["pair"] = list(pair)
-    result["pair_ref"] = review_state_module.review_ref(identity[0])
-    return result
+        recorded.append(
+            {
+                "paths": list(pair),
+                "ref": applied["ref"],
+                "fingerprint": identity[1],
+                "decision": applied["decision"],
+            }
+        )
+    return recorded
 
 
 def clear_stance(vault_root: Path, *, reasons: list[dict] | None) -> None:
-    """Drop any recorded stance for a review item's pair. Best-effort, never raises."""
-    pair = pair_from_reasons(reasons)
-    if pair is None:
-        return
-    identity = pair_identity(vault_root, *pair)
-    if identity is None:
-        return
-    review_state_module.ReviewStateStore(Path(vault_root)).apply(
-        identity[0], identity[1], action="reopen"
-    )
+    """Drop every recorded stance on a review item's pairs. Never raises.
+
+    `ReviewStateStore.apply(action="reopen")` clears by review id, not by
+    fingerprint, so this also releases a stance recorded against an earlier content
+    version — which is exactly the state a drifted pair would otherwise be stuck in.
+    """
+    store = review_state_module.ReviewStateStore(Path(vault_root))
+    for pair in pairs_from_reasons(reasons):
+        identity = pair_identity(vault_root, *pair)
+        if identity is None:
+            continue
+        store.apply(identity[0], identity[1], action="reopen")
 
 
 # ----------------------------- authored graph edges -----------------------------
@@ -246,6 +266,48 @@ def clear_stance(vault_root: Path, *, reasons: list[dict] | None) -> None:
 
 def _index(vault_root: Path) -> epistemic_graph_module.EpistemicGraphIndex:
     return epistemic_graph_module.EpistemicGraphIndex(Path(vault_root))
+
+
+@dataclass(frozen=True)
+class DeclaredEdges:
+    """One snapshot of the authored edges that declare two pages as rivals.
+
+    Built from exactly TWO indexed queries for the whole vault, then answered from
+    memory. The earlier per-anchor form re-ran an unnarrowed edge query per page,
+    which is O(pages x edges) and reaches the retrieve/inject path through deep
+    packs.
+    """
+
+    contradicts: frozenset[tuple[str, str]]   # `pair_key` form
+    answers: dict[str, frozenset[str]]        # page -> the targets it answers
+
+
+def declared_edges(
+    vault_root: Path,
+    *,
+    index: epistemic_graph_module.EpistemicGraphIndex | None = None,
+) -> DeclaredEdges:
+    """Read both declaring relations in two queries. Empty on any unavailability."""
+    try:
+        idx = index or _index(vault_root)
+        contra = idx.relation_edges([CONTRADICTS])
+        answered = idx.relation_edges([ANSWERS])
+        pairs = (
+            frozenset(pair_key(src, dst) for src, dst in contra.edges)
+            if contra.status == "available"
+            else frozenset()
+        )
+        answers: dict[str, set[str]] = {}
+        if answered.status == "available":
+            for src, dst in answered.edges:
+                answers.setdefault(src, set()).add(dst)
+        return DeclaredEdges(
+            contradicts=frozenset(pair for pair in pairs if pair[0] != pair[1]),
+            answers={page: frozenset(targets) for page, targets in answers.items()},
+        )
+    except Exception as error:  # noqa: BLE001 — a graph miss never breaks a write
+        log.debug("declared-edge snapshot failed: %s", error)
+        return DeclaredEdges(contradicts=frozenset(), answers={})
 
 
 def asserted_pairs(
@@ -256,23 +318,17 @@ def asserted_pairs(
     """Deduped, unordered page pairs joined by an authored `contradicts` edge.
 
     `contradicts` is symmetric, so one authored bullet yields ONE pair, ordered by
-    path exactly like a proximity pair. A disabled, missing, or warming graph index
-    yields `[]` — an explicit absence, never a fabricated result.
+    path exactly like a proximity pair. One indexed query for the whole vault. A
+    disabled, missing, or warming graph index yields `[]` — an explicit absence,
+    never a fabricated result.
     """
     try:
         idx = index or _index(vault_root)
-        participants = idx.relation_participants([CONTRADICTS])
-        if participants.status != "available" or not participants.paths:
+        result = idx.relation_edges([CONTRADICTS])
+        if result.status != "available":
             return []
-        pairs: set[tuple[str, str]] = set()
-        for path in sorted(participants.paths):
-            anchored = idx.relation_participants([CONTRADICTS], anchor=path)
-            if anchored.status != "available":
-                continue
-            for other in anchored.paths:
-                if other != path:
-                    pairs.add(pair_key(path, other))
-        return sorted(pairs)
+        pairs = {pair_key(src, dst) for src, dst in result.edges}
+        return sorted(pair for pair in pairs if pair[0] != pair[1])
     except Exception as error:  # noqa: BLE001 — a graph miss never breaks review
         log.debug("asserted contradiction lookup failed: %s", error)
         return []
@@ -283,6 +339,7 @@ def structural_pair(
     a: str,
     b: str,
     *,
+    edges: DeclaredEdges | None = None,
     index: epistemic_graph_module.EpistemicGraphIndex | None = None,
 ) -> str | None:
     """Why the author already declared this pair as rivals, or None.
@@ -290,62 +347,73 @@ def structural_pair(
     Returns `"contradicts"` for an authored contradiction edge between the two, and
     `"answers_same_question"` when both pages answer one common target. Either way
     the write-time proximity warning would only tell the author what they typed.
+    Pass a prepared `edges` snapshot to answer many candidates without re-querying.
     """
     left, right = pair_key(a, b)
     if left == right:
         return None
-    try:
-        idx = index or _index(vault_root)
-        contra = idx.relation_participants([CONTRADICTS], anchor=left)
-        if contra.status == "available" and right in contra.paths:
-            return CONTRADICTS
-        left_answers = idx.relation_participants(
-            [ANSWERS], anchor=left, direction="outbound"
-        )
-        right_answers = idx.relation_participants(
-            [ANSWERS], anchor=right, direction="outbound"
-        )
-        if (
-            left_answers.status == "available"
-            and right_answers.status == "available"
-            and (left_answers.paths & right_answers.paths)
-        ):
-            return "answers_same_question"
-    except Exception as error:  # noqa: BLE001 — a graph miss never breaks a write
-        log.debug("structural pair lookup failed for (%s, %s): %s", left, right, error)
+    snapshot = edges if edges is not None else declared_edges(vault_root, index=index)
+    if (left, right) in snapshot.contradicts:
+        return CONTRADICTS
+    if snapshot.answers.get(left, frozenset()) & snapshot.answers.get(
+        right, frozenset()
+    ):
+        return "answers_same_question"
     return None
 
 
-def declared_pairs(vault_root: Path, self_path: str, others: list[str]) -> set[str]:
-    """The subset of `others` already declared a rival pair with `self_path`.
+class DeclaredPairFilter:
+    """Memoized "has the author already declared this pair?" predicate.
 
     Declared means the reader recorded a competing stance, or the pages already
     carry an authored `contradicts` edge, or both answer one question. Used by the
     write-time near-duplicate and overlap warnings, which have nothing to add once
-    the relationship is on the page. Best-effort: any failure declares nothing, so a
-    warning is never silently lost to an infrastructure problem.
+    the relationship is on the page.
+
+    Everything is built LAZILY on the first candidate and shared for the rest of the
+    call, so a write with no candidate pays nothing and a write with several pays two
+    graph queries and one state read in total rather than per candidate. Best-effort:
+    any failure declares nothing, so a warning is never silently lost to an
+    infrastructure problem.
     """
-    if not self_path or not others:
-        return set()
-    try:
-        idx = _index(vault_root)
-        store = review_state_module.ReviewStateStore(Path(vault_root))
-        payload = store.load()
-        declared: set[str] = set()
-        for other in others:
-            if not other:
-                continue
-            left, right = pair_key(self_path, other)
-            if left == right:
-                continue  # the draft's own page is never its own rival
-            if structural_pair(vault_root, self_path, other, index=idx) is not None:
-                declared.add(other)
-                continue
-            if is_competing(
-                vault_root, self_path, other, store=store, payload=payload
-            ):
-                declared.add(other)
+
+    def __init__(self, vault_root: Path, self_path: str | None):
+        self.vault_root = Path(vault_root)
+        self.self_path = str(self_path) if self_path else None
+        self._edges: DeclaredEdges | None = None
+        self._store: review_state_module.ReviewStateStore | None = None
+        self._payload: dict[str, Any] | None = None
+        self._cache: dict[str, bool] = {}
+
+    def __call__(self, other: str) -> bool:
+        if not self.self_path or not other:
+            return False
+        cached = self._cache.get(other)
+        if cached is not None:
+            return cached
+        declared = False
+        try:
+            left, right = pair_key(self.self_path, other)
+            if left != right:  # the draft's own page is never its own rival
+                if self._edges is None:
+                    self._edges = declared_edges(self.vault_root)
+                    self._store = review_state_module.ReviewStateStore(self.vault_root)
+                    self._payload = self._store.load()
+                declared = (
+                    structural_pair(
+                        self.vault_root, self.self_path, other, edges=self._edges
+                    )
+                    is not None
+                    or is_competing(
+                        self.vault_root,
+                        self.self_path,
+                        other,
+                        store=self._store,
+                        payload=self._payload,
+                    )
+                )
+        except Exception as error:  # noqa: BLE001 — never break a write
+            log.debug("declared-pair check failed for %s: %s", other, error)
+            declared = False
+        self._cache[other] = declared
         return declared
-    except Exception as error:  # noqa: BLE001 — never break a write
-        log.debug("declared-pair filter failed for %s: %s", self_path, error)
-        return set()

--- a/src/exomem/contradiction_stance.py
+++ b/src/exomem/contradiction_stance.py
@@ -182,6 +182,92 @@ def is_competing(
     )
 
 
+def annotate_reasons(
+    vault_root: Path,
+    reasons: list[dict] | None,
+    *,
+    store: review_state_module.ReviewStateStore,
+    payload: dict[str, Any] | None = None,
+    refs: dict[str, str] | None = None,
+) -> dict[tuple[str, str], review_state_module.ReviewDecision | None]:
+    """Tag each contradiction reason with its pair's stance, and return the map.
+
+    Without this a drifted item serializes as an ordinary open item with two
+    reasons and no hint that one of them is already dispositioned and silently
+    muting a write-time warning. Each reason gains `pair_ref` — the handle that
+    addresses that pair's stance directly — and, when a stance is recorded,
+    `stance`.
+
+    MUST be called after the item's `signal_fingerprint` is computed:
+    `review_state.fingerprint` reads only `category`, `meta.signal_version`,
+    `detail`, and `related_paths`, so these keys cannot feed back into review
+    identity, but computing the fingerprint first keeps that independent of
+    ordering rather than of a field list.
+    """
+    resolved: dict[
+        tuple[str, str],
+        tuple[tuple[str, str] | None, review_state_module.ReviewDecision | None],
+    ] = {}
+    for reason in reasons or []:
+        if str(reason.get("category") or "") != "corpus_contradictions":
+            continue
+        paths = sorted(set(reason.get("related_paths") or []))
+        if len(paths) != 2:
+            continue
+        pair = pair_key(paths[0], paths[1])
+        if pair[0] == pair[1]:
+            continue
+        if pair not in resolved:
+            identity = pair_identity(vault_root, *pair, refs=refs)
+            decision = None
+            if identity is not None:
+                found = store.decision(identity[0], identity[1], payload=payload)
+                if found is not None and found.action == STANCE_ACTION:
+                    decision = found
+            resolved[pair] = (identity, decision)
+        identity, decision = resolved[pair]
+        if identity is not None:
+            reason["pair_ref"] = review_state_module.review_ref(identity[0])
+        if decision is not None:
+            reason["stance"] = STANCE_ACTION
+    return {pair: decision for pair, (_identity, decision) in resolved.items()}
+
+
+def clear_orphan_stance(
+    vault_root: Path, *, ref: str
+) -> dict[str, Any] | None:
+    """Clear a competing stance addressed directly by its own pair ref, or None.
+
+    A stance whose pair has drifted off every queue item is otherwise unreachable:
+    `clear_stance` walks the pairs an ITEM currently carries, and an orphan is on
+    none of them, while the record keeps suppressing the write-time warning. The
+    pair ref returned by the original stance write addresses it directly.
+
+    Returns None when `ref` is not a review reference or carries no stance record,
+    so the caller can fall through to its ordinary not-found error.
+    """
+    try:
+        review_id = review_state_module.parse_review_ref(ref)
+    except ValueError:
+        return None
+    store = review_state_module.ReviewStateStore(Path(vault_root))
+    payload = store.load()
+    prefix = f"{review_id}:"
+    stanced = [
+        record
+        for key, record in payload["records"].items()
+        if key.startswith(prefix)
+        and isinstance(record, dict)
+        and str(record.get("action") or "") == STANCE_ACTION
+    ]
+    if not stanced:
+        return None
+    fingerprint_value = str(stanced[0].get("fingerprint") or "")
+    result = store.apply(review_id, fingerprint_value, action="reopen")
+    result["cleared"] = STANCE_ACTION
+    return result
+
+
 def pairs_from_reasons(reasons: list[dict] | None) -> list[tuple[str, str]]:
     """EVERY distinct contradiction pair a review item carries, in pair order.
 

--- a/src/exomem/contradiction_stance.py
+++ b/src/exomem/contradiction_stance.py
@@ -1,0 +1,351 @@
+"""Authored contradictions and the competing-alternatives pair stance.
+
+Two things live here, both about a PAIR of pages rather than a single note:
+
+- `asserted_pairs()` / `structural_pair()` read the typed graph for relationships
+  the author wrote down — a `contradicts` edge between two pages, or two `answers`
+  edges into one question. An authored `contradicts` edge is the strongest
+  contradiction signal a vault can carry (the author stated the conflict in their
+  own words), and it is the source of the `corpus_contradictions` queue's asserted
+  entries.
+- the competing-alternatives stance — a durable "rivals; keep both" disposition on
+  one pair, recorded in the SAME `.review-state.json` store, with the same record
+  shape and the same `review_id:fingerprint` key, as `dismiss` and `snooze`.
+
+The stance is keyed on the pair, not on a queue item, for one concrete reason: a
+queue item's identity folds in every category that flagged its anchor, so the same
+pair would key differently depending on whether the anchor also happened to be stale
+that day — and the write-time draft check in `corpus_aware` knows only two paths, so
+it could never reconstruct such an id. A pair-derived id is reachable from both.
+
+The pair fingerprint folds in BOTH endpoints' on-disk content, so editing either
+rival changes the fingerprint, the stored record stops matching, and the pair
+resurfaces as open — the same honest-resurfacing property a fingerprint-bound
+dismissal already has.
+
+ALTITUDE: everything here is measurement and disposition recording. Nothing judges
+which rival is right, ranks them against each other, merges, supersedes, or
+auto-dismisses. The reader decides; the server only remembers what they decided.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from . import epistemic_graph as epistemic_graph_module
+from . import review_state as review_state_module
+from .vault import content_hash
+
+log = logging.getLogger(__name__)
+
+CONTRADICTS = "contradicts"
+ANSWERS = "answers"
+STANCE_ACTION = "competing"
+
+# Namespaces the pair identity so it can never collide with an attention,
+# activation, relation-queue, or adoption review id in the shared state file.
+_PAIR_NAMESPACE = "competing"
+
+
+# ----------------------------- pair identity -----------------------------
+
+
+def pair_key(a: str, b: str) -> tuple[str, str]:
+    """Order-independent, `.md`-normalized identity for an unordered page pair."""
+    left = epistemic_graph_module._with_md(str(a or ""))
+    right = epistemic_graph_module._with_md(str(b or ""))
+    return (left, right) if left <= right else (right, left)
+
+
+def pair_item_id(ref_left: str, ref_right: str) -> str:
+    """Stable review id for a pair. Refs MUST arrive in `pair_key` (path) order."""
+    return review_state_module.item_id(
+        f"{_PAIR_NAMESPACE}:{ref_left}|{ref_right}"
+    )
+
+
+def pair_signal_version(signal_left: str, signal_right: str) -> str:
+    """A version that changes whenever EITHER endpoint's content changes."""
+    return content_hash(
+        f"{_PAIR_NAMESPACE}\n{signal_left}\n{signal_right}"
+    )[:16]
+
+
+def pair_fingerprint(
+    *,
+    ref_left: str,
+    ref_right: str,
+    signal_left: str,
+    signal_right: str,
+) -> str:
+    """The pair's signal fingerprint, built through the shared review-state hasher."""
+    return review_state_module.fingerprint(
+        target_ref=ref_left,
+        categories=[_PAIR_NAMESPACE],
+        reasons=[
+            {
+                "category": _PAIR_NAMESPACE,
+                "meta": {
+                    "signal_version": pair_signal_version(signal_left, signal_right)
+                },
+            }
+        ],
+        related_refs=[ref_right],
+    )
+
+
+def page_signal_version(vault_root: Path, rel_path: str) -> str | None:
+    """The on-disk content version of one page, or None when it is not readable."""
+    from . import audit as audit_module
+    from . import find as find_module
+
+    root = Path(vault_root)
+    try:
+        page = find_module._CACHE.get(root / rel_path, root)
+    except OSError:
+        return None
+    if page is None:
+        return None
+    return audit_module._page_signal_version(page)
+
+
+def pair_identity(
+    vault_root: Path,
+    a: str,
+    b: str,
+    *,
+    refs: dict[str, str] | None = None,
+) -> tuple[str, str] | None:
+    """`(review_id, fingerprint)` for one pair, or None when either page is gone.
+
+    `refs` lets a caller that already resolved memory refs (the attention surface
+    does) hand them in rather than paying a second reference-index lookup.
+    """
+    left, right = pair_key(a, b)
+    signal_left = page_signal_version(vault_root, left)
+    signal_right = page_signal_version(vault_root, right)
+    if signal_left is None or signal_right is None:
+        return None
+    if refs is None or left not in refs or right not in refs:
+        refs = review_state_module.refs_for_paths(vault_root, [left, right])
+    ref_left = str(refs.get(left) or left)
+    ref_right = str(refs.get(right) or right)
+    return (
+        pair_item_id(ref_left, ref_right),
+        pair_fingerprint(
+            ref_left=ref_left,
+            ref_right=ref_right,
+            signal_left=signal_left,
+            signal_right=signal_right,
+        ),
+    )
+
+
+# ----------------------------- stance read / write -----------------------------
+
+
+def pair_decision(
+    vault_root: Path,
+    a: str,
+    b: str,
+    *,
+    store: review_state_module.ReviewStateStore | None = None,
+    payload: dict[str, Any] | None = None,
+    refs: dict[str, str] | None = None,
+) -> review_state_module.ReviewDecision | None:
+    """The recorded competing stance for this pair at its CURRENT signal, else None."""
+    identity = pair_identity(vault_root, a, b, refs=refs)
+    if identity is None:
+        return None
+    store = store or review_state_module.ReviewStateStore(Path(vault_root))
+    decision = store.decision(identity[0], identity[1], payload=payload)
+    if decision is None or decision.action != STANCE_ACTION:
+        return None
+    return decision
+
+
+def is_competing(
+    vault_root: Path,
+    a: str,
+    b: str,
+    *,
+    store: review_state_module.ReviewStateStore | None = None,
+    payload: dict[str, Any] | None = None,
+    refs: dict[str, str] | None = None,
+) -> bool:
+    return (
+        pair_decision(vault_root, a, b, store=store, payload=payload, refs=refs)
+        is not None
+    )
+
+
+def pair_from_reasons(reasons: list[dict] | None) -> tuple[str, str] | None:
+    """The single contradiction pair a review item carries, or None.
+
+    A stance is meaningless without exactly one counterpart, so an item flagged
+    over several distinct pairs (or none) yields None and the caller refuses.
+    """
+    pairs = {
+        pair_key(paths[0], paths[1])
+        for reason in (reasons or [])
+        if str(reason.get("category") or "") == "corpus_contradictions"
+        for paths in [sorted(set(reason.get("related_paths") or []))]
+        if len(paths) == 2
+    }
+    if len(pairs) != 1:
+        return None
+    return next(iter(pairs))
+
+
+def record_stance(
+    vault_root: Path,
+    *,
+    reasons: list[dict] | None,
+    until: str | None = None,
+    why: str | None = None,
+) -> dict[str, Any]:
+    """Persist the competing-alternatives stance for a review item's pair."""
+    pair = pair_from_reasons(reasons)
+    if pair is None:
+        raise ValueError(
+            "INVALID_REVIEW_ACTION: `competing` records that two notes are rivals "
+            "worth keeping, so it applies only to a review item carrying exactly "
+            "one contradiction pair"
+        )
+    identity = pair_identity(vault_root, *pair)
+    if identity is None:
+        raise ValueError(
+            "REVIEW_ITEM_CHANGED: one side of the pair is no longer readable; "
+            "refresh the worklist and inspect the item again"
+        )
+    result = review_state_module.ReviewStateStore(Path(vault_root)).apply(
+        identity[0], identity[1], action=STANCE_ACTION, until=until, why=why
+    )
+    result["pair"] = list(pair)
+    result["pair_ref"] = review_state_module.review_ref(identity[0])
+    return result
+
+
+def clear_stance(vault_root: Path, *, reasons: list[dict] | None) -> None:
+    """Drop any recorded stance for a review item's pair. Best-effort, never raises."""
+    pair = pair_from_reasons(reasons)
+    if pair is None:
+        return
+    identity = pair_identity(vault_root, *pair)
+    if identity is None:
+        return
+    review_state_module.ReviewStateStore(Path(vault_root)).apply(
+        identity[0], identity[1], action="reopen"
+    )
+
+
+# ----------------------------- authored graph edges -----------------------------
+
+
+def _index(vault_root: Path) -> epistemic_graph_module.EpistemicGraphIndex:
+    return epistemic_graph_module.EpistemicGraphIndex(Path(vault_root))
+
+
+def asserted_pairs(
+    vault_root: Path,
+    *,
+    index: epistemic_graph_module.EpistemicGraphIndex | None = None,
+) -> list[tuple[str, str]]:
+    """Deduped, unordered page pairs joined by an authored `contradicts` edge.
+
+    `contradicts` is symmetric, so one authored bullet yields ONE pair, ordered by
+    path exactly like a proximity pair. A disabled, missing, or warming graph index
+    yields `[]` — an explicit absence, never a fabricated result.
+    """
+    try:
+        idx = index or _index(vault_root)
+        participants = idx.relation_participants([CONTRADICTS])
+        if participants.status != "available" or not participants.paths:
+            return []
+        pairs: set[tuple[str, str]] = set()
+        for path in sorted(participants.paths):
+            anchored = idx.relation_participants([CONTRADICTS], anchor=path)
+            if anchored.status != "available":
+                continue
+            for other in anchored.paths:
+                if other != path:
+                    pairs.add(pair_key(path, other))
+        return sorted(pairs)
+    except Exception as error:  # noqa: BLE001 — a graph miss never breaks review
+        log.debug("asserted contradiction lookup failed: %s", error)
+        return []
+
+
+def structural_pair(
+    vault_root: Path,
+    a: str,
+    b: str,
+    *,
+    index: epistemic_graph_module.EpistemicGraphIndex | None = None,
+) -> str | None:
+    """Why the author already declared this pair as rivals, or None.
+
+    Returns `"contradicts"` for an authored contradiction edge between the two, and
+    `"answers_same_question"` when both pages answer one common target. Either way
+    the write-time proximity warning would only tell the author what they typed.
+    """
+    left, right = pair_key(a, b)
+    if left == right:
+        return None
+    try:
+        idx = index or _index(vault_root)
+        contra = idx.relation_participants([CONTRADICTS], anchor=left)
+        if contra.status == "available" and right in contra.paths:
+            return CONTRADICTS
+        left_answers = idx.relation_participants(
+            [ANSWERS], anchor=left, direction="outbound"
+        )
+        right_answers = idx.relation_participants(
+            [ANSWERS], anchor=right, direction="outbound"
+        )
+        if (
+            left_answers.status == "available"
+            and right_answers.status == "available"
+            and (left_answers.paths & right_answers.paths)
+        ):
+            return "answers_same_question"
+    except Exception as error:  # noqa: BLE001 — a graph miss never breaks a write
+        log.debug("structural pair lookup failed for (%s, %s): %s", left, right, error)
+    return None
+
+
+def declared_pairs(vault_root: Path, self_path: str, others: list[str]) -> set[str]:
+    """The subset of `others` already declared a rival pair with `self_path`.
+
+    Declared means the reader recorded a competing stance, or the pages already
+    carry an authored `contradicts` edge, or both answer one question. Used by the
+    write-time near-duplicate and overlap warnings, which have nothing to add once
+    the relationship is on the page. Best-effort: any failure declares nothing, so a
+    warning is never silently lost to an infrastructure problem.
+    """
+    if not self_path or not others:
+        return set()
+    try:
+        idx = _index(vault_root)
+        store = review_state_module.ReviewStateStore(Path(vault_root))
+        payload = store.load()
+        declared: set[str] = set()
+        for other in others:
+            if not other:
+                continue
+            left, right = pair_key(self_path, other)
+            if left == right:
+                continue  # the draft's own page is never its own rival
+            if structural_pair(vault_root, self_path, other, index=idx) is not None:
+                declared.add(other)
+                continue
+            if is_competing(
+                vault_root, self_path, other, store=store, payload=payload
+            ):
+                declared.add(other)
+        return declared
+    except Exception as error:  # noqa: BLE001 — never break a write
+        log.debug("declared-pair filter failed for %s: %s", self_path, error)
+        return set()

--- a/src/exomem/corpus_aware.py
+++ b/src/exomem/corpus_aware.py
@@ -291,10 +291,8 @@ def _best_cosine_per_file(
         return {}
 
 
-def _drop_declared_pairs(
-    vault_root: Path, self_path: str | None, candidates: list[DupCandidate]
-) -> list[DupCandidate]:
-    """Drop candidates the author already declared a rival pair with `self_path`.
+def _declared_pair_filter(vault_root: Path, self_path: str | None):
+    """A candidate-level "already declared a rival pair with `self_path`?" predicate.
 
     Declared means a recorded competing-alternatives stance, an authored
     `contradicts` edge between the two pages, or both answering one question. In
@@ -302,17 +300,14 @@ def _drop_declared_pairs(
     the stance is fingerprint-bound, so editing either rival brings the warning
     back. A draft with no page identity of its own (`self_path is None`) has no
     pair to declare, so it warns exactly as before.
+
+    Applied INSIDE each detect loop rather than to the finished list: filtering
+    afterwards would let an exempt rival consume a `top_n` slot, so three declared
+    rivals ranked above a genuine near-duplicate would suppress the real warning.
     """
-    if not self_path or not candidates:
-        return candidates
     from . import contradiction_stance
 
-    declared = contradiction_stance.declared_pairs(
-        vault_root, self_path, [candidate.path for candidate in candidates]
-    )
-    if not declared:
-        return candidates
-    return [candidate for candidate in candidates if candidate.path not in declared]
+    return contradiction_stance.DeclaredPairFilter(vault_root, self_path)
 
 
 def detect_duplicates(
@@ -352,6 +347,7 @@ def detect_duplicates(
     from . import recall_policy
 
     self_canon = _canon(self_path) if self_path else None
+    declared = _declared_pair_filter(vault_root, self_path)
     out: list[DupCandidate] = []
     for fp, score in sorted(best_per_file.items(), key=lambda t: -t[1]):
         if score < threshold:
@@ -365,10 +361,12 @@ def detect_duplicates(
             continue
         if types_filter and page.page_type not in types_filter:
             continue
+        if declared(fp):
+            continue  # already declared rivals — and it must not eat a `top_n` slot
         out.append(DupCandidate(path=fp, title=page.title, cosine=round(float(score), 4)))
         if len(out) >= top_n:
             break
-    return _drop_declared_pairs(vault_root, self_path, out)
+    return out
 
 
 def detect_contradictions(
@@ -419,6 +417,7 @@ def detect_contradictions(
     from . import find as find_module
 
     self_canon = _canon(self_path) if self_path else None
+    declared = _declared_pair_filter(vault_root, self_path)
     out: list[DupCandidate] = []
     for fp, score in sorted(best_per_file.items(), key=lambda t: -t[1]):
         if score >= ceiling:
@@ -440,18 +439,15 @@ def detect_contradictions(
             continue
         if access.access_tier(vault_root, page.rel_path) != access.TIER_READ_WRITE:
             continue
+        if declared(fp):
+            continue  # already declared rivals — and it must not eat a `top_n` slot
         out.append(DupCandidate(path=fp, title=page.title, cosine=round(float(score), 4)))
         if len(out) >= top_n:
             break
     # Sharpen PROXIMITY → POLARITY on the flagged pairs (opt-in; no-op when the
     # EXOMEM_CLAIM_LEVEL gate is off, so `out` and every downstream warning are
     # byte-identical to baseline).
-    return _refine_contradictions(
-        vault_root,
-        title=title,
-        body=body,
-        candidates=_drop_declared_pairs(vault_root, self_path, out),
-    )
+    return _refine_contradictions(vault_root, title=title, body=body, candidates=out)
 
 
 def dup_warning(candidate: DupCandidate) -> str:

--- a/src/exomem/corpus_aware.py
+++ b/src/exomem/corpus_aware.py
@@ -291,6 +291,30 @@ def _best_cosine_per_file(
         return {}
 
 
+def _drop_declared_pairs(
+    vault_root: Path, self_path: str | None, candidates: list[DupCandidate]
+) -> list[DupCandidate]:
+    """Drop candidates the author already declared a rival pair with `self_path`.
+
+    Declared means a recorded competing-alternatives stance, an authored
+    `contradicts` edge between the two pages, or both answering one question. In
+    every case the proximity warning would only repeat what the author typed, and
+    the stance is fingerprint-bound, so editing either rival brings the warning
+    back. A draft with no page identity of its own (`self_path is None`) has no
+    pair to declare, so it warns exactly as before.
+    """
+    if not self_path or not candidates:
+        return candidates
+    from . import contradiction_stance
+
+    declared = contradiction_stance.declared_pairs(
+        vault_root, self_path, [candidate.path for candidate in candidates]
+    )
+    if not declared:
+        return candidates
+    return [candidate for candidate in candidates if candidate.path not in declared]
+
+
 def detect_duplicates(
     vault_root: Path,
     *,
@@ -344,7 +368,7 @@ def detect_duplicates(
         out.append(DupCandidate(path=fp, title=page.title, cosine=round(float(score), 4)))
         if len(out) >= top_n:
             break
-    return out
+    return _drop_declared_pairs(vault_root, self_path, out)
 
 
 def detect_contradictions(
@@ -422,7 +446,12 @@ def detect_contradictions(
     # Sharpen PROXIMITY → POLARITY on the flagged pairs (opt-in; no-op when the
     # EXOMEM_CLAIM_LEVEL gate is off, so `out` and every downstream warning are
     # byte-identical to baseline).
-    return _refine_contradictions(vault_root, title=title, body=body, candidates=out)
+    return _refine_contradictions(
+        vault_root,
+        title=title,
+        body=body,
+        candidates=_drop_declared_pairs(vault_root, self_path, out),
+    )
 
 
 def dup_warning(candidate: DupCandidate) -> str:

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -172,6 +172,20 @@ class RelationFilterResult:
     reason: str | None = None
 
 
+@dataclass(frozen=True)
+class RelationEdgeResult:
+    """Outcome of a typed-edge endpoint lookup.
+
+    `edges` are `(source_page, destination_page)` as stored, in source order — a
+    symmetric relation is still one row, so callers normalize. `status` carries the
+    same never-false-empty contract as `RelationFilterResult`.
+    """
+
+    status: str
+    edges: tuple[tuple[str, str], ...] = ()
+    reason: str | None = None
+
+
 def graph_enabled() -> bool:
     return os.environ.get("EXOMEM_DISABLE_GRAPH_INDEX", "").strip().lower() not in {
         "1",
@@ -2567,6 +2581,81 @@ class EpistemicGraphIndex:
         return RelationFilterResult(
             status="available", paths=frozenset(paths), provenance=provenance
         )
+
+    def relation_edges(self, keys: Iterable[str]) -> RelationEdgeResult:
+        """Every typed edge whose canonical `relation_type` or `parent_relation` is
+        in `keys`, resolved to its two page endpoints, in ONE query.
+
+        `relation_participants` cannot answer "which page is joined to which": its
+        `provenance` keeps only the best counterpart per page, so a caller needing
+        every pair had to re-issue an anchored lookup per participating page — and
+        an anchored lookup runs the SAME unnarrowed `relation_type IN (...)` query
+        (narrowing happens in Python afterwards), so that fan-out costs
+        O(pages x edges) and one read snapshot per page. This is the single-query
+        form for callers that want the whole edge set.
+
+        Endpoint resolution is identical: block-level endpoints resolve to their
+        owning page through the INNER JOIN (which also drops unresolved
+        placeholders), self-edges drop out, and both endpoints must pass the recall
+        policy. Status mirrors the exact-recall reliability contract — "available"
+        is authoritative (an empty `edges` is a real "no such edges"), "warming"
+        means the sidecar is missing or stale, "temporarily_unavailable" means the
+        graph index is disabled. It never scans the corpus and never false-empties.
+        """
+        key_set = {str(k) for k in keys if k}
+        if not key_set:
+            return RelationEdgeResult(status="available")
+        if not graph_enabled():
+            return RelationEdgeResult(
+                status="temporarily_unavailable", reason="graph_index_disabled"
+            )
+        if not self.path.exists():
+            return RelationEdgeResult(status="warming")
+        conn = self._open_read_snapshot()
+        if conn is None:
+            return RelationEdgeResult(status="warming")
+        select = (
+            "SELECT s.path, d.path, e.rowid "
+            "FROM graph_edges e "
+            "JOIN graph_nodes s ON s.node_key = e.src_key "
+            "JOIN graph_nodes d ON d.node_key = e.dst_key "
+        )
+        placeholders = ",".join("?" for _ in key_set)
+        params = list(key_set)
+        try:
+            # Two indexed lookups UNIONed, exactly as `relation_participants` does —
+            # an OR across relation_type/parent_relation would defeat both indexes.
+            rows = conn.execute(
+                f"{select} WHERE e.relation_type IN ({placeholders}) "
+                f"UNION {select} WHERE e.parent_relation IN ({placeholders}) "
+                "ORDER BY 3",
+                params + params,
+            ).fetchall()
+        except sqlite3.Error:
+            return RelationEdgeResult(status="warming")
+        finally:
+            conn.close()
+
+        allowed_paths: dict[str, bool] = {}
+
+        def _path_allowed(rel_path: str) -> bool:
+            allowed = allowed_paths.get(rel_path)
+            if allowed is None:
+                allowed = _recall_path_allowed(self.vault_root, rel_path)
+                allowed_paths[rel_path] = allowed
+            return allowed
+
+        edges: list[tuple[str, str]] = []
+        seen: set[tuple[str, str]] = set()
+        for src_path, dst_path, _rowid in rows:
+            edge = (str(src_path), str(dst_path))
+            if edge[0] == edge[1] or edge in seen:
+                continue
+            if not _path_allowed(edge[0]) or not _path_allowed(edge[1]):
+                continue
+            seen.add(edge)
+            edges.append(edge)
+        return RelationEdgeResult(status="available", edges=tuple(edges))
 
 
 def graph_context(

--- a/src/exomem/review_state.py
+++ b/src/exomem/review_state.py
@@ -18,8 +18,19 @@ from .kbdir import kb_dirname
 SCHEMA_VERSION = 1
 STATE_FILENAME = ".review-state.json"
 REVIEW_PREFIX = "exomem://review/"
-VALID_ACTIONS = frozenset({"dismiss", "snooze", "reopen"})
-VALID_VIEWS = frozenset({"open", "all", "snoozed", "dismissed"})
+VALID_ACTIONS = frozenset({"dismiss", "snooze", "reopen", "competing"})
+VALID_VIEWS = frozenset({"open", "all", "snoozed", "dismissed", "competing"})
+# Every effective state a decision can resolve to, in report order. `all` is a view
+# over these, never a state an item is in.
+VALID_STATES: tuple[str, ...] = ("open", "snoozed", "dismissed", "competing")
+# Actions that leave a standing record; `reopen` clears rather than records.
+_RECORDING_ACTIONS = frozenset({"dismiss", "snooze", "competing"})
+_ACTION_STATE: dict[str, str] = {
+    "reopen": "open",
+    "dismiss": "dismissed",
+    "snooze": "snoozed",
+    "competing": "competing",
+}
 _LOCK = threading.Lock()
 
 
@@ -147,7 +158,7 @@ class ReviewStateStore:
         if not isinstance(record, dict):
             return None
         action = str(record.get("action") or "")
-        if action not in {"dismiss", "snooze"}:
+        if action not in _RECORDING_ACTIONS:
             return None
         return ReviewDecision(
             action=action,
@@ -173,6 +184,10 @@ class ReviewStateStore:
             return "open", None
         if decision.action == "dismiss":
             return "dismissed", decision
+        if decision.action == "competing":
+            # A competing-alternatives stance never expires on a clock: it is
+            # fingerprint-bound, so editing either rival is what reopens it.
+            return "competing", decision
         current = today or dt.date.today()
         until = _parse_until(decision.until)
         return ("snoozed", decision) if until >= current else ("open", decision)
@@ -229,7 +244,7 @@ class ReviewStateStore:
             "item_id": review_id,
             "ref": review_ref(review_id),
             "fingerprint": signal_fingerprint,
-            "state": "open" if action == "reopen" else "dismissed" if action == "dismiss" else "snoozed",
+            "state": _ACTION_STATE[action],
             "decision": decision,
         }
 

--- a/tests/test_authored_contradictions.py
+++ b/tests/test_authored_contradictions.py
@@ -1,0 +1,651 @@
+"""Authored contradictions: asserted queue entries, provenance, and the
+competing-alternatives pair stance.
+
+The strongest contradiction signal in a vault is an authored `contradicts` edge,
+and until this change nothing consumed it: the `corpus_contradictions` queue only
+measured embedding proximity, and cosine cannot separate "X works" from "X fails".
+This suite covers the four moving parts:
+
+- asserted entries sourced from the typed graph, emitted before every proximity
+  pair and independent of the embedding sidecar,
+- an explicit `meta.provenance` of `asserted` / `proximity` on every entry, with an
+  asserted pair suppressing its own proximity duplicate,
+- the fingerprint-bound competing-alternatives pair stance ("rivals; keep both"),
+  recorded in the same review-state store as dismiss/snooze and honored by the
+  queues and by the write-time draft warnings,
+- the structural-pair exemption for pairs whose authored edges already declare them.
+
+Torch-free throughout: the asserted lane needs no vectors, and the mixed
+asserted/proximity tests patch `EmbeddingIndex.all_vectors` with synthetic unit
+vectors exactly as `test_audit_contradiction_order.py` does.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from exomem import attention as attention_module
+from exomem import audit as audit_module
+from exomem import commands as commands_module
+from exomem import context_pack as context_pack_module
+from exomem import contradiction_stance as stance_module
+from exomem import corpus_aware as corpus_aware_module
+from exomem import embeddings as embeddings_module
+from exomem import epistemic_graph as epistemic_graph_module
+from exomem import find as find_module
+from exomem import review_state as review_state_module
+from exomem.audit import AuditFinding
+from exomem.find import Hit
+
+_TODAY = dt.date(2026, 6, 27)
+_BODY = "Zylo narwhal quokka substrate measure-not-judge authored contradiction body."
+
+
+# ----------------------------- helpers -----------------------------
+
+
+def _seed(
+    vault: Path,
+    rel: str,
+    *,
+    relations: list[str] | None = None,
+    type_: str = "insight",
+    status: str = "active",
+    body: str = _BODY,
+) -> str:
+    """Write one compiled page; return its vault-relative key (with .md)."""
+    path = vault / "Knowledge Base" / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = (
+        f"---\ntype: {type_}\nstatus: {status}\n"
+        f"created: 2026-01-01\nupdated: 2026-01-01\n---\n\n# {rel}\n\n{body}\n"
+    )
+    if relations:
+        text += "\n## Relations\n\n" + "".join(f"- {row}\n" for row in relations)
+    path.write_text(text, encoding="utf-8")
+    return f"Knowledge Base/{rel}"
+
+
+def _link(key: str) -> str:
+    return f"[[{key.removesuffix('.md')}]]"
+
+
+def _build_graph(vault: Path) -> None:
+    find_module.clear_cache()
+    epistemic_graph_module.EpistemicGraphIndex(vault).rebuild_all()
+
+
+def _cc(vault: Path, *, today: dt.date = _TODAY) -> list[AuditFinding]:
+    return audit_module.audit(
+        vault, categories=["corpus_contradictions"], today=today
+    ).findings
+
+
+def _pair_key(finding: AuditFinding) -> tuple[str, ...]:
+    return tuple(sorted(finding.paths or []))
+
+
+def _install_vectors(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pairs: list[tuple[str, str, float]],
+    *,
+    floor: float = 0.5,
+    ceiling: float = 0.95,
+) -> None:
+    """Patch `all_vectors` so each already-seeded key pair has exactly `cos`."""
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("EXOMEM_CONTRADICTION_FLOOR", str(floor))
+    monkeypatch.setenv("EXOMEM_DUP_THRESHOLD", str(ceiling))
+    dim = 2 * len(pairs)
+    vecs: dict[str, np.ndarray] = {}
+    order: list[str] = []
+    for index, (key_a, key_b, cos) in enumerate(pairs):
+        va = np.zeros(dim, dtype=np.float32)
+        vb = np.zeros(dim, dtype=np.float32)
+        va[2 * index] = 1.0
+        vb[2 * index] = cos
+        vb[2 * index + 1] = float((1.0 - cos * cos) ** 0.5)
+        for key, vec in ((key_a, va), (key_b, vb)):
+            if key not in vecs:
+                vecs[key] = vec
+                order.append(key)
+    metadata = [(key, 0) for key in order]
+    matrix = np.array([vecs[key] for key in order], dtype=np.float32)
+    monkeypatch.setattr(
+        embeddings_module.EmbeddingIndex, "all_vectors", lambda self: (metadata, matrix)
+    )
+
+
+def _hit(rel: str) -> Hit:
+    return Hit(path=rel, type=None, scope=None, title="", updated="", excerpt="")
+
+
+# ----------------------------- pure logic: pair identity -----------------------------
+
+
+def test_pair_key_is_order_independent_and_md_normalized() -> None:
+    a = "Knowledge Base/Notes/Insights/a"
+    b = "Knowledge Base/Notes/Insights/b.md"
+    assert stance_module.pair_key(a, b) == stance_module.pair_key(b, a)
+    assert stance_module.pair_key(a, b) == (
+        "Knowledge Base/Notes/Insights/a.md",
+        "Knowledge Base/Notes/Insights/b.md",
+    )
+
+
+def test_pair_identity_is_order_independent(vault: Path) -> None:
+    a = _seed(vault, "Notes/Insights/pi-a.md")
+    b = _seed(vault, "Notes/Insights/pi-b.md")
+    find_module.clear_cache()
+    assert stance_module.pair_identity(vault, a, b) == stance_module.pair_identity(
+        vault, b, a
+    )
+
+
+def test_pair_fingerprint_changes_when_an_endpoint_changes(vault: Path) -> None:
+    a = _seed(vault, "Notes/Insights/pf-a.md")
+    b = _seed(vault, "Notes/Insights/pf-b.md")
+    find_module.clear_cache()
+    before = stance_module.pair_identity(vault, a, b)
+    assert before is not None
+    (vault / "Knowledge Base" / "Notes/Insights/pf-a.md").write_text(
+        "---\ntype: insight\nstatus: active\ncreated: 2026-01-01\nupdated: 2026-01-02\n"
+        "---\n\n# pf-a\n\nA materially different claim now lives here.\n",
+        encoding="utf-8",
+    )
+    find_module.clear_cache()
+    after = stance_module.pair_identity(vault, a, b)
+    assert after is not None
+    assert after[0] == before[0], "the pair review id is stable across edits"
+    assert after[1] != before[1], "the pair fingerprint tracks endpoint content"
+
+
+def test_pair_identity_is_none_for_a_missing_page(vault: Path) -> None:
+    a = _seed(vault, "Notes/Insights/pm-a.md")
+    find_module.clear_cache()
+    assert stance_module.pair_identity(vault, a, "Knowledge Base/Notes/nope.md") is None
+
+
+# ----------------------------- pure logic: review state -----------------------------
+
+
+def test_review_state_accepts_competing_as_action_and_view() -> None:
+    assert "competing" in review_state_module.VALID_ACTIONS
+    assert "competing" in review_state_module.VALID_VIEWS
+    assert "competing" in review_state_module.VALID_STATES
+
+
+def test_competing_decision_resolves_to_a_competing_state(vault: Path) -> None:
+    store = review_state_module.ReviewStateStore(vault)
+    result = store.apply("a" * 24, "b" * 24, action="competing", why="rivals; keep both")
+    assert result["state"] == "competing"
+    effective, decision = store.effective_state("a" * 24, "b" * 24, today=_TODAY)
+    assert effective == "competing"
+    assert decision is not None and decision.action == "competing"
+
+
+def test_competing_refuses_an_until_date(vault: Path) -> None:
+    store = review_state_module.ReviewStateStore(vault)
+    with pytest.raises(ValueError, match="INVALID_REVIEW_ACTION"):
+        store.apply("a" * 24, "b" * 24, action="competing", until="2026-09-01")
+
+
+def test_reopen_clears_a_competing_record(vault: Path) -> None:
+    store = review_state_module.ReviewStateStore(vault)
+    store.apply("a" * 24, "b" * 24, action="competing", why="rivals")
+    store.apply("a" * 24, "b" * 24, action="reopen")
+    effective, decision = store.effective_state("a" * 24, "b" * 24, today=_TODAY)
+    assert effective == "open"
+    assert decision is None
+
+
+def test_a_competing_fingerprint_mismatch_does_not_apply(vault: Path) -> None:
+    store = review_state_module.ReviewStateStore(vault)
+    store.apply("a" * 24, "b" * 24, action="competing", why="rivals")
+    effective, _decision = store.effective_state("a" * 24, "c" * 24, today=_TODAY)
+    assert effective == "open"
+
+
+# ----------------------------- pure logic: graph readers -----------------------------
+
+
+def test_asserted_pairs_dedupes_a_symmetric_edge(vault: Path) -> None:
+    b = _seed(vault, "Notes/Insights/ap-b.md")
+    a = _seed(vault, "Notes/Insights/ap-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(vault)
+    assert stance_module.asserted_pairs(vault) == [tuple(sorted((a, b)))]
+
+
+def test_asserted_pairs_is_empty_without_a_built_graph(vault: Path) -> None:
+    b = _seed(vault, "Notes/Insights/ng-b.md")
+    _seed(vault, "Notes/Insights/ng-a.md", relations=[f"contradicts {_link(b)}"])
+    find_module.clear_cache()
+    assert stance_module.asserted_pairs(vault) == []
+
+
+def test_asserted_pairs_ignores_other_relations(vault: Path) -> None:
+    b = _seed(vault, "Notes/Insights/or-b.md")
+    _seed(vault, "Notes/Insights/or-a.md", relations=[f"supports {_link(b)}"])
+    _build_graph(vault)
+    assert stance_module.asserted_pairs(vault) == []
+
+
+def test_structural_pair_detects_an_authored_contradicts_edge(vault: Path) -> None:
+    b = _seed(vault, "Notes/Insights/sp-b.md")
+    a = _seed(vault, "Notes/Insights/sp-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(vault)
+    assert stance_module.structural_pair(vault, a, b) == "contradicts"
+    assert stance_module.structural_pair(vault, b, a) == "contradicts"
+
+
+def test_structural_pair_detects_two_answers_to_one_question(vault: Path) -> None:
+    q = _seed(vault, "Notes/Insights/sq-question.md")
+    a = _seed(vault, "Notes/Insights/sq-a.md", relations=[f"answers {_link(q)}"])
+    b = _seed(vault, "Notes/Insights/sq-b.md", relations=[f"answers {_link(q)}"])
+    _build_graph(vault)
+    assert stance_module.structural_pair(vault, a, b) == "answers_same_question"
+
+
+def test_structural_pair_is_none_for_an_undeclared_pair(vault: Path) -> None:
+    a = _seed(vault, "Notes/Insights/su-a.md")
+    b = _seed(vault, "Notes/Insights/su-b.md")
+    _build_graph(vault)
+    assert stance_module.structural_pair(vault, a, b) is None
+
+
+# ----------------------------- asserted queue entries -----------------------------
+
+
+def test_authored_edge_surfaces_without_embeddings(vault: Path) -> None:
+    b = _seed(vault, "Notes/Insights/ae-b.md")
+    a = _seed(vault, "Notes/Insights/ae-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(vault)
+    mine = [f for f in _cc(vault) if _pair_key(f) == tuple(sorted((a, b)))]
+    assert len(mine) == 1, [f.as_dict() for f in _cc(vault)]
+    finding = mine[0]
+    assert finding.category == "corpus_contradictions"
+    assert finding.severity == "info"
+    assert finding.path == min(a, b)
+    assert finding.meta["provenance"] == "asserted"
+    assert finding.meta["signal_version"]
+    assert "competing" in (finding.proposed_fix or "")
+
+
+def test_asserted_entries_precede_every_proximity_entry(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    near_a = _seed(vault, "Notes/Insights/pr-near-a.md")
+    near_b = _seed(vault, "Notes/Insights/pr-near-b.md")
+    asserted_b = _seed(vault, "Notes/Insights/pr-zz-b.md")
+    asserted_a = _seed(
+        vault, "Notes/Insights/pr-zz-a.md", relations=[f"contradicts {_link(asserted_b)}"]
+    )
+    _build_graph(vault)
+    _install_vectors(vault, monkeypatch, [(near_a, near_b, 0.9)])
+
+    findings = [f for f in _cc(vault) if f.paths]
+    provenance = [f.meta["provenance"] for f in findings]
+    assert provenance == ["asserted", "proximity"], [f.as_dict() for f in findings]
+    assert _pair_key(findings[0]) == tuple(sorted((asserted_a, asserted_b)))
+    assert "priority" not in findings[0].meta
+    assert "same_family" not in findings[0].meta
+    assert findings[1].meta["provenance"] == "proximity"
+    assert findings[1].meta["cosine"] == 0.9
+
+
+def test_an_asserted_pair_suppresses_its_proximity_duplicate(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    b = _seed(vault, "Notes/Insights/sd-b.md")
+    a = _seed(vault, "Notes/Insights/sd-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(vault)
+    _install_vectors(vault, monkeypatch, [(a, b, 0.9)])
+
+    mine = [f for f in _cc(vault) if _pair_key(f) == tuple(sorted((a, b)))]
+    assert len(mine) == 1
+    assert mine[0].meta["provenance"] == "asserted"
+    assert "cosine" not in mine[0].meta
+
+
+def test_asserted_signal_version_differs_from_the_proximity_one(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    b = _seed(vault, "Notes/Insights/sv-b.md")
+    a = _seed(vault, "Notes/Insights/sv-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(vault)
+    asserted = next(f for f in _cc(vault) if _pair_key(f) == tuple(sorted((a, b))))
+
+    plain_b = _seed(vault, "Notes/Insights/sv-plain-b.md")
+    plain_a = _seed(vault, "Notes/Insights/sv-plain-a.md")
+    _install_vectors(vault, monkeypatch, [(plain_a, plain_b, 0.9)])
+    proximity = next(
+        f for f in _cc(vault) if _pair_key(f) == tuple(sorted((plain_a, plain_b)))
+    )
+    assert asserted.meta["signal_version"] != proximity.meta["signal_version"]
+
+
+def test_an_ineligible_endpoint_is_not_surfaced(vault: Path) -> None:
+    b = _seed(vault, "Notes/Insights/el-b.md", status="archived")
+    a = _seed(vault, "Notes/Insights/el-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(vault)
+    assert not [f for f in _cc(vault) if _pair_key(f) == tuple(sorted((a, b)))]
+
+
+def test_asserted_entries_are_not_capped(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_CONTRADICTION_TOP_N", "1")
+    keys = []
+    for index in range(3):
+        other = _seed(vault, f"Notes/Insights/cap-b{index}.md")
+        own = _seed(
+            vault,
+            f"Notes/Insights/cap-a{index}.md",
+            relations=[f"contradicts {_link(other)}"],
+        )
+        keys.append(tuple(sorted((own, other))))
+    _build_graph(vault)
+    surfaced = {_pair_key(f) for f in _cc(vault) if f.paths}
+    assert set(keys) <= surfaced
+    assert not [f for f in _cc(vault) if f.meta and "truncated" in f.meta]
+
+
+# ----------------------------- attention composition -----------------------------
+
+
+def _finding(path: str, other: str, provenance: str, version: str) -> AuditFinding:
+    return AuditFinding(
+        category="corpus_contradictions",
+        severity="info",
+        path=path,
+        detail=f"{provenance} contradiction with {other}",
+        proposed_fix="review only",
+        paths=sorted([path, other]),
+        meta={"signal_version": version, "provenance": provenance},
+    )
+
+
+def test_asserted_reason_outranks_a_proximity_reason() -> None:
+    report = attention_module._rank(
+        [
+            _finding("a.md", "b.md", "asserted", "v1"),
+            _finding("c.md", "d.md", "proximity", "v2"),
+        ],
+        categories={"corpus_contradictions"},
+        limit=0,
+    )
+    assert [item.path for item in report.items] == ["a.md", "c.md"]
+    assert report.items[0].score > report.items[1].score
+    assert report.items[0].reasons[0]["meta"]["provenance"] == "asserted"
+
+
+def test_attention_surfaces_an_asserted_pair_with_a_stable_ref(vault: Path) -> None:
+    b = _seed(vault, "Notes/Insights/at-b.md")
+    a = _seed(vault, "Notes/Insights/at-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(vault)
+    report = attention_module.attention(
+        vault, categories=["corpus_contradictions"], limit=0, today=_TODAY
+    )
+    item = next(i for i in report.items if i.path == min(a, b))
+    assert item.ref and item.fingerprint and item.state == "open"
+    assert sorted(item.reasons[0]["related_paths"]) == sorted([a, b])
+    assert item.reasons[0]["meta"]["provenance"] == "asserted"
+
+
+def test_state_summary_counts_competing(vault: Path) -> None:
+    b = _seed(vault, "Notes/Insights/ss-b.md")
+    _seed(vault, "Notes/Insights/ss-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(vault)
+    report = attention_module.attention(
+        vault, categories=["corpus_contradictions"], limit=0, state="all", today=_TODAY
+    )
+    assert "competing" in (report.state_summary or {})
+
+
+# ----------------------------- the competing stance end to end -----------------------------
+
+
+@pytest.fixture
+def rivals(vault: Path) -> tuple[Path, str, str, str]:
+    """A surfaced asserted pair plus its review ref."""
+    b = _seed(vault, "Notes/Insights/rv-b.md")
+    a = _seed(vault, "Notes/Insights/rv-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(vault)
+    report = attention_module.attention(
+        vault, categories=["corpus_contradictions"], limit=0, today=_TODAY
+    )
+    item = next(i for i in report.items if i.path == min(a, b))
+    assert item.ref is not None
+    return vault, a, b, item.ref
+
+
+def _open_paths(vault: Path, *, state: str = "open") -> list[str]:
+    report = attention_module.attention(
+        vault, categories=["corpus_contradictions"], limit=0, state=state, today=_TODAY
+    )
+    return [item.path for item in report.items]
+
+
+def test_competing_stance_removes_the_pair_from_the_open_view(rivals) -> None:
+    vault, a, b, ref = rivals
+    result = commands_module.op_triage_memory(
+        vault, ref=ref, action="competing", why="rivals; keep both"
+    )
+    assert result["state"] == "competing"
+    assert sorted(result["pair"]) == sorted([a, b])
+    assert min(a, b) not in _open_paths(vault)
+    assert min(a, b) in _open_paths(vault, state="competing")
+
+
+def test_competing_stance_is_recorded_on_the_pair_identity(rivals) -> None:
+    vault, a, b, ref = rivals
+    commands_module.op_triage_memory(vault, ref=ref, action="competing", why="rivals")
+    assert stance_module.is_competing(vault, a, b)
+    assert stance_module.is_competing(vault, b, a)
+
+
+def test_editing_a_rival_resurfaces_the_pair(rivals) -> None:
+    vault, a, b, ref = rivals
+    commands_module.op_triage_memory(vault, ref=ref, action="competing", why="rivals")
+    assert min(a, b) not in _open_paths(vault)
+
+    target = vault / a
+    target.write_text(
+        target.read_text(encoding="utf-8") + "\nA materially revised claim.\n",
+        encoding="utf-8",
+    )
+    _build_graph(vault)
+    assert min(a, b) in _open_paths(vault)
+    assert not stance_module.is_competing(vault, a, b)
+
+
+def test_reopen_clears_the_pair_stance(rivals) -> None:
+    vault, a, b, ref = rivals
+    commands_module.op_triage_memory(vault, ref=ref, action="competing", why="rivals")
+    commands_module.op_triage_memory(vault, ref=ref, action="reopen")
+    assert min(a, b) in _open_paths(vault)
+    assert not stance_module.is_competing(vault, a, b)
+
+
+def test_item_level_dismissal_beats_the_pair_stance(rivals) -> None:
+    vault, a, b, ref = rivals
+    commands_module.op_triage_memory(vault, ref=ref, action="competing", why="rivals")
+    commands_module.op_triage_memory(vault, ref=ref, action="dismiss", why="handled")
+    report = attention_module.attention(
+        vault, categories=["corpus_contradictions"], limit=0, state="all", today=_TODAY
+    )
+    item = next(i for i in report.items if i.path == min(a, b))
+    assert item.state == "dismissed"
+
+
+def test_competing_is_refused_for_an_item_without_a_pair(vault: Path) -> None:
+    _seed(vault, "Notes/Insights/nopair.md")
+    find_module.clear_cache()
+    report = attention_module.attention(
+        vault, categories=["relation_debt"], limit=0, today=_TODAY
+    )
+    item = next(
+        i for i in report.items if i.path == "Knowledge Base/Notes/Insights/nopair.md"
+    )
+    with pytest.raises(ValueError, match="INVALID_REVIEW_ACTION"):
+        commands_module.op_triage_memory(
+            vault, ref=item.ref, action="competing", why="not a pair"
+        )
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "exomem://review/adoption/" + "a" * 24,
+        "exomem://review/relation/" + "a" * 24,
+    ],
+)
+def test_competing_is_refused_for_a_namespaced_single_sided_queue(
+    vault: Path, ref: str
+) -> None:
+    with pytest.raises(ValueError, match="INVALID_REVIEW_ACTION"):
+        commands_module.op_triage_memory(
+            vault, ref=ref, action="competing", why="not a pair"
+        )
+
+
+def test_recording_a_stance_mutates_no_note(rivals) -> None:
+    vault, a, b, ref = rivals
+    before = {
+        path: path.read_bytes() for path in (vault / "Knowledge Base").rglob("*.md")
+    }
+    commands_module.op_triage_memory(vault, ref=ref, action="competing", why="rivals")
+    after = {path: path.read_bytes() for path in (vault / "Knowledge Base").rglob("*.md")}
+    assert before == after
+
+
+# ----------------------------- write-time draft warnings -----------------------------
+
+
+def _overlap(vault: Path, self_key: str, other_key: str, cosine: float) -> list:
+    return corpus_aware_module.detect_contradictions(
+        vault,
+        title="Draft",
+        body=_BODY,
+        self_path=self_key,
+        precomputed={other_key: cosine},
+    )
+
+
+def _dups(vault: Path, self_key: str, other_key: str, cosine: float) -> list:
+    return corpus_aware_module.detect_duplicates(
+        vault,
+        title="Draft",
+        body=_BODY,
+        self_path=self_key,
+        precomputed={other_key: cosine},
+        threshold=0.9,
+    )
+
+
+@pytest.fixture
+def write_time(vault: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("EXOMEM_CONTRADICTION_FLOOR", "0.5")
+    monkeypatch.setenv("EXOMEM_DUP_THRESHOLD", "0.95")
+    return vault
+
+
+def test_an_undeclared_pair_still_warns(write_time: Path) -> None:
+    a = _seed(write_time, "Notes/Insights/wu-a.md")
+    b = _seed(write_time, "Notes/Insights/wu-b.md")
+    _build_graph(write_time)
+    assert [c.path for c in _overlap(write_time, a, b, 0.8)] == [b]
+    assert [c.path for c in _dups(write_time, a, b, 0.99)] == [b]
+
+
+def test_an_authored_contradicts_edge_exempts_the_pair(write_time: Path) -> None:
+    b = _seed(write_time, "Notes/Insights/wc-b.md")
+    a = _seed(write_time, "Notes/Insights/wc-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(write_time)
+    assert _overlap(write_time, a, b, 0.8) == []
+    assert _dups(write_time, a, b, 0.99) == []
+
+
+def test_two_answers_to_one_question_exempt_the_pair(write_time: Path) -> None:
+    q = _seed(write_time, "Notes/Insights/wq-question.md")
+    a = _seed(write_time, "Notes/Insights/wq-a.md", relations=[f"answers {_link(q)}"])
+    b = _seed(write_time, "Notes/Insights/wq-b.md", relations=[f"answers {_link(q)}"])
+    _build_graph(write_time)
+    assert _overlap(write_time, a, b, 0.8) == []
+    assert _dups(write_time, a, b, 0.99) == []
+
+
+def test_a_competing_stance_exempts_the_pair(write_time: Path) -> None:
+    a = _seed(write_time, "Notes/Insights/ws-a.md")
+    b = _seed(write_time, "Notes/Insights/ws-b.md")
+    _build_graph(write_time)
+    identity = stance_module.pair_identity(write_time, a, b)
+    assert identity is not None
+    review_state_module.ReviewStateStore(write_time).apply(
+        identity[0], identity[1], action="competing", why="rivals"
+    )
+    assert _overlap(write_time, a, b, 0.8) == []
+    assert _dups(write_time, a, b, 0.99) == []
+
+
+def test_a_draft_with_no_page_identity_still_warns(write_time: Path) -> None:
+    b = _seed(write_time, "Notes/Insights/wd-b.md")
+    _build_graph(write_time)
+    candidates = corpus_aware_module.detect_contradictions(
+        write_time, title="Draft", body=_BODY, self_path=None, precomputed={b: 0.8}
+    )
+    assert [c.path for c in candidates] == [b]
+
+
+# ----------------------------- deep-pack tension provenance -----------------------------
+
+
+def test_pack_tension_carries_asserted_provenance_without_embeddings(vault: Path) -> None:
+    b = _seed(vault, "Notes/Insights/pk-b.md")
+    a = _seed(vault, "Notes/Insights/pk-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(vault)
+    pack = context_pack_module.assemble_pack(vault, [_hit(a), _hit(b)])
+    tension = pack["contradictions"]["tension"]
+    assert len(tension) == 1, tension
+    assert {tension[0]["a"], tension[0]["b"]} == {a, b}
+    assert tension[0]["provenance"] == "asserted"
+    assert pack["embeddings_available"] is False
+
+
+def test_pack_proximity_pairs_are_labelled_and_follow_asserted(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    b = _seed(vault, "Notes/Insights/pp-b.md")
+    a = _seed(vault, "Notes/Insights/pp-a.md", relations=[f"contradicts {_link(b)}"])
+    c = _seed(vault, "Notes/Insights/pp-c.md")
+    d = _seed(vault, "Notes/Insights/pp-d.md")
+    _build_graph(vault)
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("EXOMEM_CONTRADICTION_FLOOR", "0.5")
+    monkeypatch.setenv("EXOMEM_DUP_THRESHOLD", "0.95")
+
+    cosines = {frozenset((c, d)): 0.85, frozenset((a, b)): 0.9}
+
+    def fake_bcpf(vault_root, *, title, body, k: int = 15):
+        # `_seed` writes `# {rel}`, so a packed page's title is its KB-relative path.
+        del vault_root, body, k
+        for key, score in cosines.items():
+            for member in key:
+                if title and member.endswith(title):
+                    return {other: score for other in key if other != member}
+        return {}
+
+    monkeypatch.setattr(corpus_aware_module, "_best_cosine_per_file", fake_bcpf)
+    pack = context_pack_module.assemble_pack(
+        vault, [_hit(a), _hit(b), _hit(c), _hit(d)]
+    )
+    tension = pack["contradictions"]["tension"]
+    provenance = [pair["provenance"] for pair in tension]
+    assert provenance == ["asserted", "proximity"], tension
+    assert {tension[0]["a"], tension[0]["b"]} == {a, b}
+    assert {tension[1]["a"], tension[1]["b"]} == {c, d}
+    assert tension[1]["cosine"] == 0.85

--- a/tests/test_authored_contradictions.py
+++ b/tests/test_authored_contradictions.py
@@ -37,6 +37,7 @@ from exomem import corpus_aware as corpus_aware_module
 from exomem import embeddings as embeddings_module
 from exomem import epistemic_graph as epistemic_graph_module
 from exomem import find as find_module
+from exomem import recall_policy
 from exomem import review_state as review_state_module
 from exomem.audit import AuditFinding
 from exomem.find import Hit
@@ -220,6 +221,93 @@ def test_asserted_pairs_dedupes_a_symmetric_edge(vault: Path) -> None:
     a = _seed(vault, "Notes/Insights/ap-a.md", relations=[f"contradicts {_link(b)}"])
     _build_graph(vault)
     assert stance_module.asserted_pairs(vault) == [tuple(sorted((a, b)))]
+
+
+def test_asserted_pairs_excludes_a_recall_withheld_endpoint(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A weakened recall filter here is a disclosure bug, so pin it end to end.
+
+    The filter matters precisely when a page was INDEXED while ordinary and its
+    recall status changed afterwards: the sidecar still holds the node, and the
+    query-time check is the only thing standing between a stale node and a caller.
+    Withholding at seed time instead would never index the node at all, the INNER
+    JOIN would drop the edge, and the assertion would hold with the filter removed.
+    """
+    b = _seed(vault, "Notes/Insights/rw-b.md")
+    a = _seed(vault, "Notes/Insights/rw-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(vault)
+    assert stance_module.asserted_pairs(vault) == [tuple(sorted((a, b)))]
+
+    original = recall_policy.is_recall_candidate
+
+    def _withhold(vault_root, path):
+        if str(path).replace("\\", "/").endswith(b):
+            return False
+        return original(vault_root, path)
+
+    monkeypatch.setattr(recall_policy, "is_recall_candidate", _withhold)
+    assert stance_module.asserted_pairs(vault) == []
+    assert epistemic_graph_module.EpistemicGraphIndex(vault).relation_edges(
+        ["contradicts"]
+    ).edges == ()
+    assert not [f for f in _cc(vault) if _pair_key(f) == tuple(sorted((a, b)))]
+
+
+def test_relation_participants_excludes_a_recall_withheld_endpoint(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same disclosure guarantee on the older lookup, which had no such test."""
+    b = _seed(vault, "Notes/Insights/rp-b.md")
+    a = _seed(vault, "Notes/Insights/rp-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(vault)
+    index = epistemic_graph_module.EpistemicGraphIndex(vault)
+    assert index.relation_participants(["contradicts"]).paths == frozenset({a, b})
+
+    original = recall_policy.is_recall_candidate
+
+    def _withhold(vault_root, path):
+        if str(path).replace("\\", "/").endswith(b):
+            return False
+        return original(vault_root, path)
+
+    monkeypatch.setattr(recall_policy, "is_recall_candidate", _withhold)
+    assert index.relation_participants(["contradicts"]).paths == frozenset()
+
+
+def test_asserted_pairs_uses_exactly_one_read_snapshot(vault: Path) -> None:
+    """Pin the O(P x E) fan-out fix at the CALLER, not only inside the index.
+
+    A snapshot assertion on `relation_edges` alone leaves the regression
+    reintroducible one call site up: restoring a per-page anchored loop inside
+    `asserted_pairs` keeps `relation_edges` pristine and passes.
+    """
+    expected = []
+    for index in range(6):
+        other = _seed(vault, f"Notes/Insights/snap-b{index}.md")
+        own = _seed(
+            vault,
+            f"Notes/Insights/snap-a{index}.md",
+            relations=[f"contradicts {_link(other)}"],
+        )
+        expected.append(tuple(sorted((own, other))))
+    _build_graph(vault)
+
+    opens = {"n": 0}
+    original = epistemic_graph_module.EpistemicGraphIndex._open_read_snapshot
+
+    def _counting(self, *args, **kwargs):
+        opens["n"] += 1
+        return original(self, *args, **kwargs)
+
+    epistemic_graph_module.EpistemicGraphIndex._open_read_snapshot = _counting
+    try:
+        pairs = stance_module.asserted_pairs(vault)
+    finally:
+        epistemic_graph_module.EpistemicGraphIndex._open_read_snapshot = original
+
+    assert sorted(pairs) == sorted(expected)
+    assert opens["n"] == 1, "one indexed query for the whole corpus, not one per page"
 
 
 def test_asserted_pairs_is_empty_without_a_built_graph(vault: Path) -> None:
@@ -684,6 +772,73 @@ def test_a_drifted_second_pair_never_strands_the_first_stance(vault: Path) -> No
     assert a in _open_paths(vault)
 
 
+def test_a_stanced_reason_is_visible_on_a_partially_stanced_item(
+    two_conflicts,
+) -> None:
+    """A drifted item must not look like an ordinary open item.
+
+    One reason is already dispositioned and silently muting a write-time warning;
+    the payload has to say so, and hand back the ref that addresses it.
+    """
+    vault, a, b, _c, _ref = two_conflicts
+    identity = stance_module.pair_identity(vault, a, b)
+    assert identity is not None
+    review_state_module.ReviewStateStore(vault).apply(
+        identity[0], identity[1], action="competing", why="only this one"
+    )
+    report = attention_module.attention(
+        vault, categories=["corpus_contradictions"], limit=0, today=_TODAY
+    )
+    item = next(i for i in report.items if i.path == a)
+    stanced = [r for r in item.reasons if r.get("stance") == "competing"]
+    assert len(stanced) == 1
+    assert sorted(stanced[0]["related_paths"]) == sorted([a, b])
+    assert stanced[0]["pair_ref"] == review_state_module.review_ref(identity[0])
+    # Every contradiction reason carries the handle, stanced or not.
+    assert all("pair_ref" in r for r in item.reasons)
+
+
+def test_an_orphaned_stance_is_clearable_by_its_pair_ref(vault: Path) -> None:
+    """A stance whose pair left every queue item is still reachable.
+
+    It is on no item's reasons, so the item-walking clear cannot see it, while it
+    keeps suppressing the write-time warning. The pair ref returned by the stance
+    write addresses it directly.
+    """
+    b = _seed(vault, "Notes/Insights/orph-b.md")
+    a = _seed(vault, "Notes/Insights/orph-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(vault)
+    report = attention_module.attention(
+        vault, categories=["corpus_contradictions"], limit=0, today=_TODAY
+    )
+    item_ref = next(i for i in report.items if i.path == min(a, b)).ref
+    stance = commands_module.op_triage_memory(
+        vault, ref=item_ref, action="competing", why="rivals"
+    )
+    pair_ref = stance["pairs"][0]["ref"]
+
+    # Drop the authored edge: the pair now surfaces on no queue item at all.
+    target = vault / a
+    target.write_text(
+        target.read_text(encoding="utf-8").split("## Relations")[0], encoding="utf-8"
+    )
+    _build_graph(vault)
+    assert _open_paths(vault) == []
+
+    cleared = commands_module.op_triage_memory(vault, ref=pair_ref, action="reopen")
+    assert cleared["state"] == "open"
+    assert cleared["cleared"] == "competing"
+    assert review_state_module.ReviewStateStore(vault).load()["records"] == {}
+
+
+def test_an_unknown_ref_still_reports_not_found(vault: Path) -> None:
+    """The orphan route must not swallow a genuinely bad reference."""
+    with pytest.raises(ValueError, match="REVIEW_ITEM_NOT_FOUND"):
+        commands_module.op_triage_memory(
+            vault, ref="exomem://review/" + "a" * 24, action="reopen"
+        )
+
+
 def test_reopen_clears_a_stance_recorded_against_older_content(vault: Path) -> None:
     """Clearing keys on the review id, not the fingerprint, so a drifted record goes."""
     b = _seed(vault, "Notes/Insights/oc-b.md")
@@ -798,29 +953,35 @@ def test_a_competing_stance_exempts_the_pair(write_time: Path) -> None:
     assert _dups(write_time, a, b, 0.99) == []
 
 
-def test_declared_rivals_do_not_consume_a_top_n_slot(write_time: Path) -> None:
+def _slot_fixture(vault: Path, prefix: str, rivals: int = 3) -> tuple[str, list[str], str]:
+    """A draft page, `rivals` pages declared as its rivals, and one genuine match."""
+    question = _seed(vault, f"Notes/Insights/{prefix}-question.md")
+    self_page = _seed(
+        vault, f"Notes/Insights/{prefix}-self.md", relations=[f"answers {_link(question)}"]
+    )
+    declared = [
+        _seed(
+            vault,
+            f"Notes/Insights/{prefix}-rival-{index}.md",
+            relations=[f"answers {_link(question)}"],
+        )
+        for index in range(rivals)
+    ]
+    genuine = _seed(vault, f"Notes/Insights/{prefix}-genuine.md")
+    _build_graph(vault)
+    return self_page, declared, genuine
+
+
+def test_declared_rivals_do_not_consume_a_dup_slot(write_time: Path) -> None:
     """Exempt rivals must be filtered INSIDE the accumulation loop.
 
-    With `top_n=3`, three declared rivals ranked above a genuine near-duplicate would
-    otherwise fill every slot and the real duplicate warning would never fire.
+    Three declared rivals ranked above a genuine near-duplicate would otherwise fill
+    every slot and the real duplicate warning would never fire. `top_n` is pinned to
+    the rival count rather than leaning on the default, so the test cannot start
+    passing because post-loop filtering happens to fit under a larger default.
     """
-    q = _seed(write_time, "Notes/Insights/ts-question.md")
-    self_page = _seed(
-        write_time, "Notes/Insights/ts-self.md", relations=[f"answers {_link(q)}"]
-    )
-    rivals = [
-        _seed(
-            write_time,
-            f"Notes/Insights/ts-rival-{index}.md",
-            relations=[f"answers {_link(q)}"],
-        )
-        for index in range(3)
-    ]
-    genuine = _seed(write_time, "Notes/Insights/ts-genuine.md")
-    _build_graph(write_time)
-
-    # Rivals score higher than the genuine near-duplicate, so they sort first.
-    precomputed = {rival: 0.99 for rival in rivals}
+    self_page, rivals, genuine = _slot_fixture(write_time, "ts")
+    precomputed = {rival: 0.99 for rival in rivals}  # rivals sort above the real match
     precomputed[genuine] = 0.97
     candidates = corpus_aware_module.detect_duplicates(
         write_time,
@@ -829,6 +990,23 @@ def test_declared_rivals_do_not_consume_a_top_n_slot(write_time: Path) -> None:
         self_path=self_page,
         precomputed=precomputed,
         threshold=0.9,
+        top_n=len(rivals),
+    )
+    assert [c.path for c in candidates] == [genuine]
+
+
+def test_declared_rivals_do_not_consume_an_overlap_slot(write_time: Path) -> None:
+    """The contradiction lane has the same slot-consumption hazard and the same fix."""
+    self_page, rivals, genuine = _slot_fixture(write_time, "tc")
+    precomputed = {rival: 0.9 for rival in rivals}  # in band, above the real match
+    precomputed[genuine] = 0.7
+    candidates = corpus_aware_module.detect_contradictions(
+        write_time,
+        title="Draft",
+        body=_BODY,
+        self_path=self_page,
+        precomputed=precomputed,
+        top_n=len(rivals),
     )
     assert [c.path for c in candidates] == [genuine]
 

--- a/tests/test_authored_contradictions.py
+++ b/tests/test_authored_contradictions.py
@@ -40,6 +40,7 @@ from exomem import find as find_module
 from exomem import review_state as review_state_module
 from exomem.audit import AuditFinding
 from exomem.find import Hit
+from exomem.vault import content_hash
 
 _TODAY = dt.date(2026, 6, 27)
 _BODY = "Zylo narwhal quokka substrate measure-not-judge authored contradiction body."
@@ -329,6 +330,60 @@ def test_asserted_signal_version_differs_from_the_proximity_one(
     assert asserted.meta["signal_version"] != proximity.meta["signal_version"]
 
 
+def test_proximity_signal_version_is_unchanged_by_the_provenance_label(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Adding `meta.provenance` must not churn a stored dismissal.
+
+    `review_state.fingerprint` reads `meta.signal_version` verbatim, so if the label
+    had been folded into the version instead, every dismissal in a real vault would
+    resurface on upgrade. Pin the exact pre-change formula.
+    """
+    a = _seed(vault, "Notes/Insights/sig-a.md")
+    b = _seed(vault, "Notes/Insights/sig-b.md")
+    _install_vectors(vault, monkeypatch, [(a, b, 0.9)])
+    finding = next(f for f in _cc(vault) if _pair_key(f) == tuple(sorted((a, b))))
+
+    left, right = sorted((a, b))
+    page_left = find_module._CACHE.get(vault / left, vault)
+    page_right = find_module._CACHE.get(vault / right, vault)
+    expected = content_hash(
+        audit_module._page_signal_version(page_left)
+        + "\n"
+        + audit_module._page_signal_version(page_right)
+    )[:16]
+    assert finding.meta["signal_version"] == expected
+    assert finding.meta["provenance"] == "proximity"
+
+
+def test_asserted_entries_survive_an_inverted_band(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An inverted band disables the proximity sweep; an authored edge needs no band."""
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("EXOMEM_CONTRADICTION_FLOOR", "0.99")
+    monkeypatch.setenv("EXOMEM_DUP_THRESHOLD", "0.5")
+    b = _seed(vault, "Notes/Insights/ib-b.md")
+    a = _seed(vault, "Notes/Insights/ib-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(vault)
+    mine = [f for f in _cc(vault) if _pair_key(f) == tuple(sorted((a, b)))]
+    assert len(mine) == 1
+    assert mine[0].meta["provenance"] == "asserted"
+
+
+def test_a_warming_graph_leaves_the_proximity_lane_intact(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No graph sidecar at all: asserted entries are absent, proximity is unaffected."""
+    a = _seed(vault, "Notes/Insights/wg-a.md")
+    b = _seed(vault, "Notes/Insights/wg-b.md")
+    _install_vectors(vault, monkeypatch, [(a, b, 0.9)])
+    assert stance_module.asserted_pairs(vault) == []
+    mine = [f for f in _cc(vault) if _pair_key(f) == tuple(sorted((a, b)))]
+    assert len(mine) == 1
+    assert mine[0].meta["provenance"] == "proximity"
+
+
 def test_an_ineligible_endpoint_is_not_surfaced(vault: Path) -> None:
     b = _seed(vault, "Notes/Insights/el-b.md", status="archived")
     a = _seed(vault, "Notes/Insights/el-a.md", relations=[f"contradicts {_link(b)}"])
@@ -435,9 +490,25 @@ def test_competing_stance_removes_the_pair_from_the_open_view(rivals) -> None:
         vault, ref=ref, action="competing", why="rivals; keep both"
     )
     assert result["state"] == "competing"
-    assert sorted(result["pair"]) == sorted([a, b])
+    assert [sorted(pair["paths"]) for pair in result["pairs"]] == [sorted([a, b])]
     assert min(a, b) not in _open_paths(vault)
     assert min(a, b) in _open_paths(vault, state="competing")
+
+
+def test_competing_response_reports_the_item_identity_not_the_pair(rivals) -> None:
+    """A client round-tripping the returned fingerprint must not get a false
+    REVIEW_ITEM_CHANGED, so the envelope carries the ITEM's identity and the pair's
+    rides along under `pairs`."""
+    vault, _a, _b, ref = rivals
+    item = attention_module.item_by_ref(vault, ref)
+    result = commands_module.op_triage_memory(
+        vault, ref=ref, action="competing", why="rivals"
+    )
+    assert result["item_id"] == item.item_id
+    assert result["ref"] == ref
+    assert result["fingerprint"] == item.fingerprint
+    assert result["pairs"][0]["fingerprint"] != item.fingerprint
+    assert result["pairs"][0]["ref"].startswith("exomem://review/")
 
 
 def test_competing_stance_is_recorded_on_the_pair_identity(rivals) -> None:
@@ -447,12 +518,23 @@ def test_competing_stance_is_recorded_on_the_pair_identity(rivals) -> None:
     assert stance_module.is_competing(vault, b, a)
 
 
-def test_editing_a_rival_resurfaces_the_pair(rivals) -> None:
+@pytest.mark.parametrize("endpoint", ["left", "right"])
+def test_editing_either_rival_resurfaces_the_pair(rivals, endpoint: str) -> None:
+    """The stance must bind BOTH endpoints' content.
+
+    `pair_key` sorts by path, so a test that only ever rewrites the alphabetically
+    first note exercises the left half of `pair_signal_version` and nothing else — a
+    version that hashed only the left signal would survive it, and the "keep both"
+    record would then mute the pair forever no matter what happened to the other
+    note. Parametrizing pins both halves.
+    """
     vault, a, b, ref = rivals
     commands_module.op_triage_memory(vault, ref=ref, action="competing", why="rivals")
     assert min(a, b) not in _open_paths(vault)
 
-    target = vault / a
+    left, right = stance_module.pair_key(a, b)
+    edited = left if endpoint == "left" else right
+    target = vault / edited
     target.write_text(
         target.read_text(encoding="utf-8") + "\nA materially revised claim.\n",
         encoding="utf-8",
@@ -494,6 +576,130 @@ def test_competing_is_refused_for_an_item_without_a_pair(vault: Path) -> None:
         commands_module.op_triage_memory(
             vault, ref=item.ref, action="competing", why="not a pair"
         )
+
+
+# ----------------------------- an anchor with two conflicts -----------------------------
+
+
+@pytest.fixture
+def two_conflicts(vault: Path) -> tuple[Path, str, str, str, str]:
+    """One anchor that contradicts two other notes.
+
+    Both lanes anchor a pair on `min(a, b)`, so `tc-a` — alphabetically first —
+    collapses into ONE attention item carrying two contradiction reasons. This is the
+    ordinary "this conflicts with these two older ones" shape, not an edge case.
+    """
+    b = _seed(vault, "Notes/Insights/tc-b.md")
+    c = _seed(vault, "Notes/Insights/tc-c.md")
+    a = _seed(
+        vault,
+        "Notes/Insights/tc-a.md",
+        relations=[f"contradicts {_link(b)}", f"contradicts {_link(c)}"],
+    )
+    _build_graph(vault)
+    report = attention_module.attention(
+        vault, categories=["corpus_contradictions"], limit=0, today=_TODAY
+    )
+    item = next(i for i in report.items if i.path == a)
+    assert item.ref is not None
+    return vault, a, b, c, item.ref
+
+
+def test_an_anchor_with_two_conflicts_is_one_item_with_two_pairs(two_conflicts) -> None:
+    vault, a, b, c, _ref = two_conflicts
+    report = attention_module.attention(
+        vault, categories=["corpus_contradictions"], limit=0, today=_TODAY
+    )
+    item = next(i for i in report.items if i.path == a)
+    assert stance_module.pairs_from_reasons(item.reasons) == sorted(
+        [stance_module.pair_key(a, b), stance_module.pair_key(a, c)]
+    )
+
+
+def test_a_two_conflict_anchor_can_be_stanced_and_reopened(two_conflicts) -> None:
+    vault, a, b, c, ref = two_conflicts
+    result = commands_module.op_triage_memory(
+        vault, ref=ref, action="competing", why="both are live rivals"
+    )
+    assert result["state"] == "competing"
+    assert len(result["pairs"]) == 2
+    assert stance_module.is_competing(vault, a, b)
+    assert stance_module.is_competing(vault, a, c)
+    assert a not in _open_paths(vault)
+
+    commands_module.op_triage_memory(vault, ref=ref, action="reopen")
+    assert not stance_module.is_competing(vault, a, b)
+    assert not stance_module.is_competing(vault, a, c)
+    assert a in _open_paths(vault)
+
+
+def test_one_unstanced_pair_keeps_the_anchor_open(two_conflicts) -> None:
+    vault, a, b, c, _ref = two_conflicts
+    identity = stance_module.pair_identity(vault, a, b)
+    assert identity is not None
+    review_state_module.ReviewStateStore(vault).apply(
+        identity[0], identity[1], action="competing", why="only this one"
+    )
+    assert a in _open_paths(vault), "an un-stanced rival is still open review work"
+    assert stance_module.is_competing(vault, a, b)
+    assert not stance_module.is_competing(vault, a, c)
+
+
+def test_a_drifted_second_pair_never_strands_the_first_stance(vault: Path) -> None:
+    """The transition that used to trap a stance.
+
+    Stance (a, b); a third note later drifts into the band with `a`; the item
+    reopens. The original record must remain re-affirmable and clearable through the
+    same item — otherwise it would keep muting the write-time warning with no escape
+    but editing a rival.
+    """
+    b = _seed(vault, "Notes/Insights/dr-b.md")
+    a = _seed(vault, "Notes/Insights/dr-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(vault)
+    report = attention_module.attention(
+        vault, categories=["corpus_contradictions"], limit=0, today=_TODAY
+    )
+    ref = next(i for i in report.items if i.path == a).ref
+    commands_module.op_triage_memory(vault, ref=ref, action="competing", why="rivals")
+    assert a not in _open_paths(vault)
+
+    # A third note drifts in: `a` now anchors two conflicts.
+    c = _seed(vault, "Notes/Insights/dr-c.md", relations=[f"contradicts {_link(a)}"])
+    _build_graph(vault)
+    assert a in _open_paths(vault)
+    assert stance_module.is_competing(vault, a, b), "the first record is still live"
+
+    # Re-affirmable: stancing the item now covers both pairs.
+    report = attention_module.attention(
+        vault, categories=["corpus_contradictions"], limit=0, today=_TODAY
+    )
+    ref = next(i for i in report.items if i.path == a).ref
+    commands_module.op_triage_memory(vault, ref=ref, action="competing", why="both")
+    assert a not in _open_paths(vault)
+
+    # And clearable: reopen releases every pair, so nothing keeps muting a warning.
+    commands_module.op_triage_memory(vault, ref=ref, action="reopen")
+    assert not stance_module.is_competing(vault, a, b)
+    assert not stance_module.is_competing(vault, a, c)
+    assert a in _open_paths(vault)
+
+
+def test_reopen_clears_a_stance_recorded_against_older_content(vault: Path) -> None:
+    """Clearing keys on the review id, not the fingerprint, so a drifted record goes."""
+    b = _seed(vault, "Notes/Insights/oc-b.md")
+    a = _seed(vault, "Notes/Insights/oc-a.md", relations=[f"contradicts {_link(b)}"])
+    _build_graph(vault)
+    identity = stance_module.pair_identity(vault, a, b)
+    assert identity is not None
+    store = review_state_module.ReviewStateStore(vault)
+    store.apply(identity[0], "f" * 24, action="competing", why="stale fingerprint")
+
+    report = attention_module.attention(
+        vault, categories=["corpus_contradictions"], limit=0, today=_TODAY
+    )
+    item = next(i for i in report.items if i.path == a)
+    commands_module.op_triage_memory(vault, ref=item.ref, action="reopen")
+    assert store.load()["records"] == {}
 
 
 @pytest.mark.parametrize(
@@ -590,6 +796,41 @@ def test_a_competing_stance_exempts_the_pair(write_time: Path) -> None:
     )
     assert _overlap(write_time, a, b, 0.8) == []
     assert _dups(write_time, a, b, 0.99) == []
+
+
+def test_declared_rivals_do_not_consume_a_top_n_slot(write_time: Path) -> None:
+    """Exempt rivals must be filtered INSIDE the accumulation loop.
+
+    With `top_n=3`, three declared rivals ranked above a genuine near-duplicate would
+    otherwise fill every slot and the real duplicate warning would never fire.
+    """
+    q = _seed(write_time, "Notes/Insights/ts-question.md")
+    self_page = _seed(
+        write_time, "Notes/Insights/ts-self.md", relations=[f"answers {_link(q)}"]
+    )
+    rivals = [
+        _seed(
+            write_time,
+            f"Notes/Insights/ts-rival-{index}.md",
+            relations=[f"answers {_link(q)}"],
+        )
+        for index in range(3)
+    ]
+    genuine = _seed(write_time, "Notes/Insights/ts-genuine.md")
+    _build_graph(write_time)
+
+    # Rivals score higher than the genuine near-duplicate, so they sort first.
+    precomputed = {rival: 0.99 for rival in rivals}
+    precomputed[genuine] = 0.97
+    candidates = corpus_aware_module.detect_duplicates(
+        write_time,
+        title="Draft",
+        body=_BODY,
+        self_path=self_page,
+        precomputed=precomputed,
+        threshold=0.9,
+    )
+    assert [c.path for c in candidates] == [genuine]
 
 
 def test_a_draft_with_no_page_identity_still_warns(write_time: Path) -> None:

--- a/tests/test_epistemic_graph_relation_filter.py
+++ b/tests/test_epistemic_graph_relation_filter.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 from exomem import epistemic_graph
 
 A = "Knowledge Base/Notes/Insights/a.md"
@@ -215,3 +217,73 @@ def test_participant_validation_is_bounded_by_unique_endpoints(tmp_path: Path, m
     assert idx.relation_participants(["supports"]).paths == frozenset(rels)
     assert set(calls) == set(rels)
     assert len(calls) == len(rels)
+
+
+# ---------------------------------------------------------------- relation_edges
+
+
+def test_relation_edges_returns_both_endpoints_in_one_query(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The single-query form callers need to enumerate PAIRS.
+
+    `relation_participants` keeps only one counterpart per page in `provenance`, so
+    enumerating every pair through it required an anchored lookup per page — and an
+    anchored lookup re-runs the same unnarrowed query, making that O(pages x edges).
+    """
+    vault = tmp_path / "vault"
+    idx = _built(vault)
+    opens = {"n": 0}
+    original = epistemic_graph.EpistemicGraphIndex._open_read_snapshot
+
+    def _counting(self, *args, **kwargs):
+        opens["n"] += 1
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex, "_open_read_snapshot", _counting
+    )
+    result = idx.relation_edges(["supports"])
+    assert result.status == "available"
+    assert result.edges == ((A, B),)  # directed as stored, source order
+    assert opens["n"] == 1
+
+
+def test_relation_edges_symmetric_relation_is_one_row(tmp_path: Path) -> None:
+    # `contradicts` is symmetric; the authored bullet is still a single edge, so
+    # callers normalize rather than receiving both orientations.
+    idx = _built(tmp_path / "vault")
+    assert idx.relation_edges(["contradicts"]).edges == ((A, C),)
+
+
+def test_relation_edges_drops_unresolved_placeholder_targets(tmp_path: Path) -> None:
+    # `A` links_to a page that does not exist; the INNER JOIN drops it.
+    idx = _built(tmp_path / "vault")
+    targets = {dst for _src, dst in idx.relation_edges(["links_to"]).edges}
+    assert not any("does-not-exist" in target for target in targets)
+
+
+def test_relation_edges_empty_keys_are_authoritative(tmp_path: Path) -> None:
+    idx = _built(tmp_path / "vault")
+    result = idx.relation_edges([])
+    assert result.status == "available"
+    assert result.edges == ()
+
+
+def test_relation_edges_reports_disabled_graph(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    idx = _built(tmp_path / "vault")
+    monkeypatch.setenv("EXOMEM_DISABLE_GRAPH_INDEX", "1")
+    result = idx.relation_edges(["supports"])
+    assert result.status == "temporarily_unavailable"
+    assert result.edges == ()
+
+
+def test_relation_edges_reports_a_missing_sidecar_as_warming(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _seed(vault)
+    idx = epistemic_graph.EpistemicGraphIndex(vault)  # never built
+    result = idx.relation_edges(["supports"])
+    assert result.status == "warming"
+    assert result.edges == ()

--- a/tests/test_membench_trackd.py
+++ b/tests/test_membench_trackd.py
@@ -286,7 +286,11 @@ def test_j3_weekly_review_live_green(tmp_path: Path) -> None:
     names = {c.name for c in result.checks}
     assert "stale queue surfaces exactly the planted dormant conclusion" in names
     assert "unprocessed queue surfaces exactly the planted raw sources" in names
-    assert "contradiction queue honestly unsupported in the lexical profile" in names
+    assert "contradiction queue surfaces exactly the planted authored pair" in names
+    assert "contradiction row names both endpoints of the planted pair" in names
+    assert (
+        "contradiction proximity lane declared unsupported, not scored zero" in names
+    )
     assert "attention queue covers every surfaceable open loop" in names
     assert "triage burden equals the scripted op count" in names
 
@@ -307,5 +311,11 @@ def test_j3_weekly_review_live_green(tmp_path: Path) -> None:
     contradiction = next(
         q for q in report["queue_scores"] if q["mode"] == "contradiction"
     )
-    assert contradiction["supported"] is False  # embeddings-gated sweep
-    assert contradiction["recall"] is None  # unsupported is never zero
+    # The asserted (authored-edge) lane is deterministic and runs without
+    # embeddings, so it is measured; the proximity lane is still gated and must
+    # stay declared-unsupported rather than folded into that recall.
+    assert contradiction["supported"] is True
+    assert contradiction["recall"] == 1.0
+    assert contradiction["unsupported_lanes"] == ["proximity"]
+    # One row per pair, anchored on the lower path — not one row per endpoint.
+    assert len(contradiction["expected"]) == 1


### PR DESCRIPTION
Programme change 3 of 12 from the 2026-08-14 epistemic architecture audit (§13, Tier 2). Closes gap (c). Depends on nothing.

## Why

The strongest contradiction signal a vault carries is the only one review ignores. An authored `contradicts` edge — a human deliberately saying "these two disagree" — fed no queue at all. The proximity queue is stance-blind by construction, because cosine cannot separate "X works" from "X fails". And near-duplicate detection exists only as a write-time draft warning, with no standing queue.

So a user who does everything right — authors the contradiction explicitly, or writes both rivals as proper notes — got no review support whatsoever. Only accidental near-misses inside one 0.08-wide cosine band got any.

## What changed

**An asserted lane in the contradiction queue.** Entries sourced from typed graph edges, emitted before the proximity sweep. Ranking needed no new code: `attention._rank` already treats emission order as intra-queue rank, and there is now a test that fails if the lanes are emitted in the opposite order. Asserted entries run before the embeddings short-circuit, so they surface with embeddings disabled, and they are exempt from the proximity cap — silently hiding a hand-typed edge is a different thing from bounding a combinatorial sweep.

**Provenance** — `asserted` or `proximity` on every pair finding, deliberately in `meta` rather than `signal_version` so no stored dismissal churns. A test pins the proximity `signal_version` formula so a provenance-driven churn is caught.

**A competing-alternatives stance.** A fingerprint-bound triage disposition meaning "rivals, keep both", recorded like dismiss and snooze, honoured by all queues and by the write-time near-duplicate warning. The pair fingerprint folds both endpoints' signal versions, so editing either rival resurfaces it — the mechanism that stops a stale mute outliving the notes it was about.

**Deep-pack tension provenance.** Packs label pairs and never suppress them, and never read review state.

## Independent review found two blocking defects

**A note contradicting two others could not be stanced at all** — the ordinary "this conflicts with these two older ones" shape. Worse, an existing stance could become unhonoured, un-reaffirmable *and* un-clearable while still muting the write-time warning: a mute with no escape hatch. Fixed by returning every pair, clearing each, and resolving to `competing` only when all pairs are stanced, so an un-stanced rival honestly keeps the item open. `reopen` now clears by review id rather than fingerprint, which is what makes the trapped state unreachable rather than merely less likely.

**The both-endpoints fingerprint binding had no coverage.** A one-sided mutation survived 40/40, because both tests that claimed to cover it rewrote the alphabetically-first note and `pair_key` sorts. Now parametrized over both endpoints, selected through `pair_key` so it cannot silently degenerate again.

Two performance findings were also real. `asserted_pairs` was an N+1 whose per-page lookups were not index-narrowed, reaching the retrieve/inject path via pack assembly; a new single-query `relation_edges` makes read-snapshot opens constant rather than linear in participating pages. The write-time filter now builds one snapshot lazily and memoizes per candidate instead of re-querying per candidate.

A follow-up round then closed four surviving mutations, including an untested recall filter — the mechanism enforcing "you may not see this page" was unpinned on both the new method and the pre-existing one. Both are now pinned, and the pre-existing gap is filed separately since it predates this change.

## Notable

The disclosure test needed care to be non-vacuous: a genuinely withheld page is never indexed as a graph node, so the join drops the edge and the query-time filter never runs. The test would have passed forever while pinning nothing. It instead builds the graph with the page ordinary and withholds it at the recall-policy seam, one level below the mutated function — which is the real disclosure scenario, a stale sidecar serving a node that is no longer recallable.

## Verification

- `openspec validate surface-authored-contradictions --strict` passes.
- 79 passing across the change's own suite and the graph relation-filter suite after rebase.
- 369 and 385 passing across two wider gate batches covering attention, review state, audit, context packs, corpus-aware, relation queues, schema fidelity, governance egress and connector guardrails.
- `ruff` clean; `tests/golden/`, `.github/`, and both pinned contract files untouched.
- No new relations, so the golden relation-compatibility file is unchanged.

Known and documented rather than hidden: `relation_edges` is uncapped, which is correct for the two finite hand-authored relations it serves but would need a spec'd truncation signal before a high-cardinality caller; the TUI has no binding for the new stance; and `competing` is undiscoverable from the MCP schema because the tool docstring is the frozen description — routed instead through the error payload, the finding's proposed fix, and the CLI.

The full lean suite was not run locally — a single-process run takes ~100 minutes on this machine. CI's four-way sharded run is authoritative.
