### PR TITLE
feat(gate): bound the read-after-write and cold-preflight cost in the write-latency gate

### DIFF
--- a/scripts/semantic_write_latency.py
+++ b/scripts/semantic_write_latency.py
@@ -31,6 +31,52 @@ COMMIT_P95_MS = 1_500.0
 SCALING_RATIO = 2.0
 SCALING_SLACK_MS = 200.0
 
+# --- Read-after-write budget (warm path). A governed write normally PATCHES
+# the corpus-context cache and the live freshness registry, so the very next
+# caller's read stays cheap. These ceilings bound THAT read, not just the
+# preflight+commit that preceded it -- the gap this gate used to leave open
+# (a change moving cost from inside commit onto the next caller's read read
+# as a pure improvement).
+#
+# MEASURED BASIS (contended Windows dev box, EXOMEM_LEXICAL_BACKEND=python so
+# the read runs the reference O(N) scan every time, not just cold):
+#   read_after_write_median_ms   2k ~6193ms   8k ~30601ms   (~4.9x @ 4x pages)
+# Linux CI has neither the per-file Windows short-name resolve() this scan
+# pays (`recall_policy._safe_regular_file`) nor this box's contention, so the
+# real gate floor is expected to sit well under these numbers -- headroom is
+# wide on purpose. Re-measure (don't hand-tune) if that basis changes.
+READ_AFTER_WRITE_MEDIAN_MS = 60_000.0
+READ_AFTER_WRITE_P95_MS = 75_000.0
+# Separate (not shared with SCALING_RATIO/SCALING_SLACK_MS): this read is
+# deliberately O(N) even when warm (see EXOMEM_LEXICAL_BACKEND above), so its
+# expected growth over a 4x corpus (the DEFAULT_SIZES jump) is ~4x, not flat
+# like validate/commit's cached steady state. Ratio/slack sit above the
+# measured ~4.9x with real headroom so ordinary linear scaling never trips
+# this; a super-linear regression still would.
+READ_AFTER_WRITE_SCALING_RATIO = 8.0
+READ_AFTER_WRITE_SCALING_SLACK_MS = 2_000.0
+
+# --- Cold/evicted read-after-write (the row the upcoming #510 fix must
+# move). `reset_corpus_context_cache()` + `freshness.clear()` mirror what the
+# withdraw at index_sync.py:51-67 does to a vault's liveness: the corpus
+# cache entry goes missing (the post-write patch at semantic_contract.py
+# ~:1745 is then a no-op -- nothing to patch) and the freshness registry
+# scope stays not-live (only the file watcher re-seeds it in production; see
+# FreshnessSnapshot's O(N) stat-walk fallback in find.py). The very next
+# caller's read pays a COLD corpus/registry rebuild instead of the warm
+# patch path.
+#
+# MEASURED BASIS (same box/run as above):
+#   cold_read_after_write_ms     2k ~11153ms   8k ~51596ms   (~4.6x @ 4x pages)
+# PROVISIONAL: calibrated generously from this lane's own measured 2k/8k
+# numbers so it is a regression net against materially WORSE behavior, not a
+# tight bound on today's known-bad cost -- re-measure after #510 lands and
+# tighten (Linux CI, not this contended Windows box, is the authoritative
+# floor).
+COLD_READ_AFTER_WRITE_MS = 120_000.0
+COLD_READ_AFTER_WRITE_SCALING_RATIO = 8.0
+COLD_READ_AFTER_WRITE_SCALING_SLACK_MS = 3_000.0
+
 
 def _percentile(values: list[float], fraction: float) -> float:
     ordered = sorted(values)
@@ -59,7 +105,7 @@ def _next_source(source: str, version: int) -> str:
     return source[:start] + str(version) + source[end:]
 
 
-def _transition(vault_root: Path, rel_path: str, version: int) -> tuple[float, float]:
+def _transition(vault_root: Path, rel_path: str, version: int) -> tuple[float, float, float]:
     path = vault_root / rel_path
     before = path.read_text(encoding="utf-8")
     after = _next_source(before, version)
@@ -77,7 +123,21 @@ def _transition(vault_root: Path, rel_path: str, version: int) -> tuple[float, f
     started = time.perf_counter()
     semantic_writes.commit_existing(vault_root, preflight=preflight)
     commit_ms = (time.perf_counter() - started) * 1_000.0
-    return validate_ms, commit_ms
+
+    # Read-after-write budget: what the NEXT caller pays to see this write,
+    # not just what the writer itself paid. A fast-but-stale read must fail
+    # the gate, not pass it, so this asserts visibility as well as timing.
+    marker = f"Synthetic write latency version {version} "
+    started = time.perf_counter()
+    hits = find.find(vault_root, query=marker.strip(), scope="kb", mode="keyword", limit=5)
+    read_after_write_ms = (time.perf_counter() - started) * 1_000.0
+    if not any(marker in (hit.excerpt or "") for hit in hits):
+        excerpts = [hit.excerpt for hit in hits]
+        raise RuntimeError(
+            f"read-after-write visibility failed: version {version} marker not found "
+            f"in {len(hits)} hit(s) for {rel_path}: {excerpts!r}"
+        )
+    return validate_ms, commit_ms, read_after_write_ms
 
 
 def measure(vault_root: Path, size: int, samples: int) -> dict[str, float | int]:
@@ -110,10 +170,22 @@ def measure(vault_root: Path, size: int, samples: int) -> dict[str, float | int]
     _transition(vault_root, target_rel, 1)
     validates: list[float] = []
     commits: list[float] = []
+    reads: list[float] = []
     for version in range(2, samples + 2):
-        validate_ms, commit_ms = _transition(vault_root, target_rel, version)
+        validate_ms, commit_ms, read_ms = _transition(vault_root, target_rel, version)
         validates.append(validate_ms)
         commits.append(commit_ms)
+        reads.append(read_ms)
+
+    # Cold/evicted scenario: force the expensive path a governed write can
+    # relocate onto its NEXT caller (see the module-level constant comments),
+    # then measure exactly what that caller's read pays. One sample, kept out
+    # of the warm `reads`/`validates`/`commits` lists above so it cannot skew
+    # ceilings scoped to steady-state (cache-warm) operation.
+    semantic_contract.reset_corpus_context_cache()
+    freshness.clear()
+    _, _, cold_read_after_write_ms = _transition(vault_root, target_rel, samples + 2)
+
     return {
         "pages": size,
         "samples": samples,
@@ -122,6 +194,9 @@ def measure(vault_root: Path, size: int, samples: int) -> dict[str, float | int]
         "validate_p95_ms": round(_percentile(validates, 0.95), 1),
         "commit_median_ms": round(statistics.median(commits), 1),
         "commit_p95_ms": round(_percentile(commits, 0.95), 1),
+        "read_after_write_median_ms": round(statistics.median(reads), 1),
+        "read_after_write_p95_ms": round(_percentile(reads, 0.95), 1),
+        "cold_read_after_write_ms": round(cold_read_after_write_ms, 1),
     }
 
 
@@ -134,6 +209,9 @@ def check(results: list[dict[str, float | int]]) -> None:
             ("validate_p95_ms", VALIDATE_P95_MS),
             ("commit_median_ms", COMMIT_MEDIAN_MS),
             ("commit_p95_ms", COMMIT_P95_MS),
+            ("read_after_write_median_ms", READ_AFTER_WRITE_MEDIAN_MS),
+            ("read_after_write_p95_ms", READ_AFTER_WRITE_P95_MS),
+            ("cold_read_after_write_ms", COLD_READ_AFTER_WRITE_MS),
         ):
             value = float(result[key])
             if value >= ceiling:
@@ -149,6 +227,29 @@ def check(results: list[dict[str, float | int]]) -> None:
                     f"{operation} scaling: {large[key]}ms >= {bound:.1f}ms "
                     f"({small['pages']} -> {large['pages']} pages)"
                 )
+        read_key = "read_after_write_median_ms"
+        read_bound = (
+            float(small[read_key]) * READ_AFTER_WRITE_SCALING_RATIO
+            + READ_AFTER_WRITE_SCALING_SLACK_MS
+        )
+        if float(large[read_key]) >= read_bound:
+            failures.append(
+                f"read_after_write scaling: {large[read_key]}ms >= {read_bound:.1f}ms "
+                f"({small['pages']} -> {large['pages']} pages)"
+            )
+        # The relocated-cost trap #510 must close: the cold row growing
+        # faster than headroom allows means the "next caller" bill is
+        # scaling with corpus size, not staying flat.
+        cold_key = "cold_read_after_write_ms"
+        cold_bound = (
+            float(small[cold_key]) * COLD_READ_AFTER_WRITE_SCALING_RATIO
+            + COLD_READ_AFTER_WRITE_SCALING_SLACK_MS
+        )
+        if float(large[cold_key]) >= cold_bound:
+            failures.append(
+                f"cold_read_after_write scaling: {large[cold_key]}ms >= {cold_bound:.1f}ms "
+                f"({small['pages']} -> {large['pages']} pages)"
+            )
     if failures:
         raise SystemExit("semantic write latency gate failed: " + "; ".join(failures))
 
@@ -198,6 +299,18 @@ def main(argv: list[str] | None = None) -> int:
         "EXOMEM_DISABLE_RANKING",
     ):
         os.environ[name] = "1"
+    # The read-after-write probe (`_transition`) must measure the corpus/
+    # freshness cost this gate exists for, not the lexical sidecar's OWN
+    # independent eventual-consistency window: a commit's incremental
+    # lexstore upsert defers to a background thread when it can't nest inside
+    # the write's own vault lock (VAULT_LOCK_NESTED; "heals on next sync"),
+    # so an immediate keyword read can race a multi-second async rebuild that
+    # has nothing to do with corpus-context/freshness eviction. The `python`
+    # kill switch (same lean/model-free spirit as the DISABLE_* vars above)
+    # routes keyword search through the synchronous, always-current
+    # reference scan instead, so a stale read here can only mean OUR target
+    # mechanism regressed.
+    os.environ["EXOMEM_LEXICAL_BACKEND"] = "python"
 
     results = measure_all(args.sizes, args.samples, args.root)
     print(json.dumps({"results": results}, sort_keys=True))

--- a/scripts/semantic_write_latency.py
+++ b/scripts/semantic_write_latency.py
@@ -44,7 +44,9 @@ SCALING_SLACK_MS = 200.0
 # Linux CI has neither the per-file Windows short-name resolve() this scan
 # pays (`recall_policy._safe_regular_file`) nor this box's contention, so the
 # real gate floor is expected to sit well under these numbers -- headroom is
-# wide on purpose. Re-measure (don't hand-tune) if that basis changes.
+# wide on purpose. Re-measure (don't hand-tune) if that basis changes; retune
+# alongside the cold rows below once #510 lands and the relocated cost has a
+# real shape to calibrate against.
 READ_AFTER_WRITE_MEDIAN_MS = 60_000.0
 READ_AFTER_WRITE_P95_MS = 75_000.0
 # Separate (not shared with SCALING_RATIO/SCALING_SLACK_MS): this read is
@@ -56,26 +58,44 @@ READ_AFTER_WRITE_P95_MS = 75_000.0
 READ_AFTER_WRITE_SCALING_RATIO = 8.0
 READ_AFTER_WRITE_SCALING_SLACK_MS = 2_000.0
 
-# --- Cold/evicted read-after-write (the row the upcoming #510 fix must
-# move). `reset_corpus_context_cache()` + `freshness.clear()` mirror what the
-# withdraw at index_sync.py:51-67 does to a vault's liveness: the corpus
-# cache entry goes missing (the post-write patch at semantic_contract.py
-# ~:1745 is then a no-op -- nothing to patch) and the freshness registry
-# scope stays not-live (only the file watcher re-seeds it in production; see
-# FreshnessSnapshot's O(N) stat-walk fallback in find.py). The very next
-# caller's read pays a COLD corpus/registry rebuild instead of the warm
-# patch path.
+# --- Cold/evicted scenario (the row the upcoming #510 fix must move a cost
+# onto). `reset_corpus_context_cache()` drops the semantic-contract
+# corpus-context cache; `freshness.clear()` drops freshness liveness (only
+# the file watcher re-seeds it in production -- see FreshnessSnapshot's O(N)
+# stat-walk fallback in find.py). Eviction runs BETWEEN an ordinary warm
+# write and the two probes that follow it, not before the write: preflight
+# calls build_corpus_context() itself, so evicting before the write just lets
+# that SAME write's own preflight quietly repopulate the cache before
+# anything is timed -- the relocated cost would never land on any gated row.
+# One eviction, two rows:
+#   cold_read_after_write_ms -- the very next read's honest reader-side cold
+#     cost (freshness-liveness fallback etc.), visibility-asserted the same
+#     as the warm row.
+#   cold_preflight_ms -- the very next transition's validate_ms. Preflight is
+#     where a cold corpus-context rebuild lands BY CONSTRUCTION
+#     (build_corpus_context has no cache entry to patch), so this is the
+#     honest incident-class net: the ~70s relocated walk from the incident
+#     would breach THIS row, not the read.
 #
-# MEASURED BASIS (same box/run as above):
-#   cold_read_after_write_ms     2k ~11153ms   8k ~51596ms   (~4.6x @ 4x pages)
-# PROVISIONAL: calibrated generously from this lane's own measured 2k/8k
-# numbers so it is a regression net against materially WORSE behavior, not a
-# tight bound on today's known-bad cost -- re-measure after #510 lands and
-# tighten (Linux CI, not this contended Windows box, is the authoritative
-# floor).
-COLD_READ_AFTER_WRITE_MS = 120_000.0
+# MEASURED BASIS (contended Windows dev box, same run as the warm figures,
+# post-reorder so eviction genuinely lands after the write and before both
+# probes -- see the restructured `measure()` cold block):
+#   cold_read_after_write_ms   2k ~9861ms   8k ~36734ms   (~3.7x @ 4x pages)
+#   cold_preflight_ms          2k ~6462ms   8k ~23749ms   (~3.7x @ 4x pages)
+# PROVISIONAL for both: calibrated generously from this lane's own measured
+# 2k/8k numbers so they are a regression net against materially WORSE
+# behavior, not a tight bound on today's known-bad cost -- re-measure after
+# #510 lands and tighten (Linux CI, not this contended Windows box, is the
+# authoritative floor). Both rows are n=1 per size: a `--root` run refuses a
+# pre-existing directory so it gets exactly one attempt with no re-measure,
+# so a contended box can make either row noisy in isolation -- expected, and
+# Linux CI adjudicates a reproducible failure.
+COLD_READ_AFTER_WRITE_MS = 100_000.0
 COLD_READ_AFTER_WRITE_SCALING_RATIO = 8.0
 COLD_READ_AFTER_WRITE_SCALING_SLACK_MS = 3_000.0
+COLD_PREFLIGHT_MS = 80_000.0
+COLD_PREFLIGHT_SCALING_RATIO = 8.0
+COLD_PREFLIGHT_SCALING_SLACK_MS = 5_000.0
 
 
 def _percentile(values: list[float], fraction: float) -> float:
@@ -105,6 +125,26 @@ def _next_source(source: str, version: int) -> str:
     return source[:start] + str(version) + source[end:]
 
 
+def _read_after_write(vault_root: Path, rel_path: str, version: int) -> float:
+    """Timed, visibility-asserted keyword read for a version already committed.
+
+    What the NEXT caller pays to see a write, not just what the writer itself
+    paid. A fast-but-stale read must fail the gate, not pass it, so this
+    asserts the new content is actually visible before returning its cost.
+    """
+    marker = f"Synthetic write latency version {version} "
+    started = time.perf_counter()
+    hits = find.find(vault_root, query=marker.strip(), scope="kb", mode="keyword", limit=5)
+    read_ms = (time.perf_counter() - started) * 1_000.0
+    if not any(marker in (hit.excerpt or "") for hit in hits):
+        excerpts = [hit.excerpt for hit in hits]
+        raise RuntimeError(
+            f"read-after-write visibility failed: version {version} marker not found "
+            f"in {len(hits)} hit(s) for {rel_path}: {excerpts!r}"
+        )
+    return read_ms
+
+
 def _transition(vault_root: Path, rel_path: str, version: int) -> tuple[float, float, float]:
     path = vault_root / rel_path
     before = path.read_text(encoding="utf-8")
@@ -123,20 +163,7 @@ def _transition(vault_root: Path, rel_path: str, version: int) -> tuple[float, f
     started = time.perf_counter()
     semantic_writes.commit_existing(vault_root, preflight=preflight)
     commit_ms = (time.perf_counter() - started) * 1_000.0
-
-    # Read-after-write budget: what the NEXT caller pays to see this write,
-    # not just what the writer itself paid. A fast-but-stale read must fail
-    # the gate, not pass it, so this asserts visibility as well as timing.
-    marker = f"Synthetic write latency version {version} "
-    started = time.perf_counter()
-    hits = find.find(vault_root, query=marker.strip(), scope="kb", mode="keyword", limit=5)
-    read_after_write_ms = (time.perf_counter() - started) * 1_000.0
-    if not any(marker in (hit.excerpt or "") for hit in hits):
-        excerpts = [hit.excerpt for hit in hits]
-        raise RuntimeError(
-            f"read-after-write visibility failed: version {version} marker not found "
-            f"in {len(hits)} hit(s) for {rel_path}: {excerpts!r}"
-        )
+    read_after_write_ms = _read_after_write(vault_root, rel_path, version)
     return validate_ms, commit_ms, read_after_write_ms
 
 
@@ -177,14 +204,22 @@ def measure(vault_root: Path, size: int, samples: int) -> dict[str, float | int]
         commits.append(commit_ms)
         reads.append(read_ms)
 
-    # Cold/evicted scenario: force the expensive path a governed write can
-    # relocate onto its NEXT caller (see the module-level constant comments),
-    # then measure exactly what that caller's read pays. One sample, kept out
-    # of the warm `reads`/`validates`/`commits` lists above so it cannot skew
-    # ceilings scoped to steady-state (cache-warm) operation.
+    # Cold/evicted scenario (see the module-level constant comments for the
+    # full mechanism). Eviction must land BETWEEN a write and the probes that
+    # follow it, not before the write: preflight_existing() itself calls
+    # build_corpus_context(), so evicting first just lets that SAME write's
+    # own preflight quietly repopulate the cache before anything is timed --
+    # the relocated cost would never land on any gated row. One eviction, two
+    # samples, neither folded into the warm `reads`/`validates`/`commits`
+    # lists above so they cannot skew ceilings scoped to steady-state
+    # (cache-warm) operation:
+    cold_write_version = samples + 2
+    cold_probe_version = samples + 3
+    _transition(vault_root, target_rel, cold_write_version)  # ordinary warm write
     semantic_contract.reset_corpus_context_cache()
     freshness.clear()
-    _, _, cold_read_after_write_ms = _transition(vault_root, target_rel, samples + 2)
+    cold_read_after_write_ms = _read_after_write(vault_root, target_rel, cold_write_version)
+    cold_preflight_ms, _, _ = _transition(vault_root, target_rel, cold_probe_version)
 
     return {
         "pages": size,
@@ -197,6 +232,7 @@ def measure(vault_root: Path, size: int, samples: int) -> dict[str, float | int]
         "read_after_write_median_ms": round(statistics.median(reads), 1),
         "read_after_write_p95_ms": round(_percentile(reads, 0.95), 1),
         "cold_read_after_write_ms": round(cold_read_after_write_ms, 1),
+        "cold_preflight_ms": round(cold_preflight_ms, 1),
     }
 
 
@@ -212,6 +248,7 @@ def check(results: list[dict[str, float | int]]) -> None:
             ("read_after_write_median_ms", READ_AFTER_WRITE_MEDIAN_MS),
             ("read_after_write_p95_ms", READ_AFTER_WRITE_P95_MS),
             ("cold_read_after_write_ms", COLD_READ_AFTER_WRITE_MS),
+            ("cold_preflight_ms", COLD_PREFLIGHT_MS),
         ):
             value = float(result[key])
             if value >= ceiling:
@@ -249,6 +286,19 @@ def check(results: list[dict[str, float | int]]) -> None:
             failures.append(
                 f"cold_read_after_write scaling: {large[cold_key]}ms >= {cold_bound:.1f}ms "
                 f"({small['pages']} -> {large['pages']} pages)"
+            )
+        # The true incident-class net: a cold preflight IS where the
+        # relocated corpus rebuild lands, so this is the row that would
+        # actually catch the ~70s walk moving back in.
+        cold_preflight_key = "cold_preflight_ms"
+        cold_preflight_bound = (
+            float(small[cold_preflight_key]) * COLD_PREFLIGHT_SCALING_RATIO
+            + COLD_PREFLIGHT_SCALING_SLACK_MS
+        )
+        if float(large[cold_preflight_key]) >= cold_preflight_bound:
+            failures.append(
+                f"cold_preflight scaling: {large[cold_preflight_key]}ms >= "
+                f"{cold_preflight_bound:.1f}ms ({small['pages']} -> {large['pages']} pages)"
             )
     if failures:
         raise SystemExit("semantic write latency gate failed: " + "; ".join(failures))
@@ -309,7 +359,8 @@ def main(argv: list[str] | None = None) -> int:
     # kill switch (same lean/model-free spirit as the DISABLE_* vars above)
     # routes keyword search through the synchronous, always-current
     # reference scan instead, so a stale read here can only mean OUR target
-    # mechanism regressed.
+    # mechanism regressed. The excluded async-lexstore read-after-write
+    # window this pin steps around is tracked separately as #526.
     os.environ["EXOMEM_LEXICAL_BACKEND"] = "python"
 
     results = measure_all(args.sizes, args.samples, args.root)

--- a/tests/test_semantic_write_latency_gate.py
+++ b/tests/test_semantic_write_latency_gate.py
@@ -28,7 +28,15 @@ def load_module():
     return module
 
 
-def result(pages: int, *, commit: float, validate: float = 30.0) -> dict[str, float | int]:
+def result(
+    pages: int,
+    *,
+    commit: float,
+    validate: float = 30.0,
+    read_after_write: float = 500.0,
+    cold_read_after_write: float = 800.0,
+    cold_preflight: float = 900.0,
+) -> dict[str, float | int]:
     return {
         "pages": pages,
         "samples": 5,
@@ -37,6 +45,10 @@ def result(pages: int, *, commit: float, validate: float = 30.0) -> dict[str, fl
         "validate_p95_ms": validate * 1.4,
         "commit_median_ms": commit,
         "commit_p95_ms": commit * 1.15,
+        "read_after_write_median_ms": read_after_write,
+        "read_after_write_p95_ms": read_after_write * 1.4,
+        "cold_read_after_write_ms": cold_read_after_write,
+        "cold_preflight_ms": cold_preflight,
     }
 
 
@@ -53,6 +65,27 @@ def test_absolute_ceiling_breach_fails() -> None:
     module = load_module()
     with pytest.raises(SystemExit, match="commit_median_ms"):
         module.check([result(8_000, commit=module.COMMIT_MEDIAN_MS + 1)])
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "read_after_write_median_ms",
+        "read_after_write_p95_ms",
+        "cold_read_after_write_ms",
+        "cold_preflight_ms",
+    ],
+)
+def test_missing_new_key_fails_loudly(key: str) -> None:
+    """check() hard-indexes every gate key -- a result dict missing one must
+    fail loudly, not silently pass via a `.get()` skip (the exact
+    invisibility class this lane closes: a relocated cost that never lands
+    on any row would otherwise pass the build unnoticed)."""
+    module = load_module()
+    incomplete = result(2_000, commit=51.5)
+    del incomplete[key]
+    with pytest.raises(KeyError, match=key):
+        module.check([incomplete])
 
 
 def test_superlinear_scaling_fails() -> None:


### PR DESCRIPTION
## What

The write-latency gate measured only preflight+commit (`COMMIT_MEDIAN_MS=750`),
so cost moved past the measured boundary read as an improvement — the exact
mechanism behind the recent ~70 s incident (#510). This closes the gate's blind
side:

- **Read-after-write budget**: `_transition` now runs a timed `find.find()`
  immediately after `commit_existing` with a **visibility assertion** — the
  just-written version marker (with a trailing delimiter so `version 1` can't
  match `version 10`) must appear in the hits; a fast-but-stale read raises and
  fails the gate rather than passing. New `read_after_write_median_ms/_p95_ms`
  rows with absolute ceilings + a cross-size scaling bound.
- **Cold rows that measure the incident class**: after a governed write, the
  corpus-context cache and freshness liveness are evicted, then two things are
  gated: `cold_read_after_write_ms` (reader-side cold cost) and
  `cold_preflight_ms` — the **next preflight on the evicted cache**, which is
  where a relocated corpus rebuild lands by construction (preflight's first act
  is `build_corpus_context`; `find` never calls it). Ordering matters and was
  corrected in review: evicting *before* the write measures nothing, because
  that write's own preflight rebuilds the cache.
- Ceilings calibrated from fresh 2k/8k measurements (cold_preflight 6.5 s →
  23.7 s; cold read 9.9 s → 36.7 s on a heavily contended box), set generous
  and marked **PROVISIONAL — tighten when #510 lands** (warm block carries the
  same trigger note). Cold rows are n=1 by design; `--root` runs get one
  attempt; Linux CI is the authoritative floor.
- `check()` **hard-indexes** the new rows (a missing row is a loud `KeyError`,
  pinned by a parametrized test — a silent skip would recreate the exact
  invisibility this closes). No pre-existing ceiling changed
  (`VALIDATE_*`/`COMMIT_*`/`SCALING_*` byte-identical).
- The gate pins `EXOMEM_LEXICAL_BACKEND=python` (consistent with its existing
  model-free env block) so the visibility assertion is deterministic: on
  `auto`/fts5, a write's deferred sidecar upsert opens an orthogonal
  read-after-write window (deferral → daemon full-corpus repair → sync
  reconcile or a false-empty keyword read). That window is real and now
  tracked as **#526** rather than silently excluded.

## Verification

- Red-first: baseline output shown to contain no read-after-write key; a
  deliberately-wrong-version query raises and fails the gate; restored passes.
  The cold-row restructure was re-calibrated with fresh 2k/8k runs.
- `tests/test_semantic_write_latency_gate.py`: **12 passed** (extended with the
  new result keys + the missing-key loud-failure test).
  `uvx ruff check --select F` clean on both files.
- Full `--check` on the corrected code: **every new row and every new scaling
  bound passed with margin on both attempts**; the only breaches were the
  pre-existing, untouched `COMMIT_*` ceilings under extreme local contention
  (a 144 s mutation-lock hold from a concurrent process was logged) — the
  known contended-runner failure mode the script's own comments document;
  Linux CI adjudicates.
- Independent review: REQUEST_CHANGES (hard-index KeyError breaking the gate's
  unit tests; the cold-row ordering; the excluded lexstore window needing an
  in-repo record). All fixed; targeted recheck verdict: **all findings FIXED**,
  with the reviewer independently verifying the post-correction `--check` run.
