### PR TITLE
fix(write): fail loud with a distinct code when a reviewed transition token has expired

### DIFF
--- a/src/exomem/create_file.py
+++ b/src/exomem/create_file.py
@@ -211,7 +211,10 @@ def create_file(
         date_iso = token_value.render_date
         stamp_iso = token_value.stamp()
     elif draft_token is not None and is_markdown and existing_file and overwrite:
-        stamp_iso = semantic_writes.reviewed_transition_stamp(draft_token, now) or stamp_iso
+        try:
+            stamp_iso = semantic_writes.resolve_reviewed_date_iso(draft_token, now)
+        except semantic_writes.SemanticWriteError as error:
+            raise CreateFileError(error.code, error.reason) from error
 
     # For markdown files, normalize wikilinks in the body to canonical form.
     # Skip non-md files (skill manifests, JSON, scratch) — their `[[...]]`

--- a/src/exomem/edit.py
+++ b/src/exomem/edit.py
@@ -110,6 +110,52 @@ class EditError(Exception):
         return {"code": self.code, "missing": self.missing, "reason": self.reason}
 
 
+def _resolve_date_iso(
+    semantic_transition_token: str | None, now: dt.date | dt.datetime
+) -> str:
+    """The `updated:` stamp to write, honouring a reviewed token when given.
+
+    No token supplied: mint a fresh stamp — that's the legacy path and is
+    unchanged, correct behaviour, not a fallback.
+
+    Token supplied and still within the reviewed-stamp window: reuse its
+    exact reviewed instant, so the committed bytes match what was validated.
+
+    Token supplied but refused for age (>24h) or clock skew (>5min): this
+    used to silently mint a fresh stamp too, which changes `after_hash` and
+    fails downstream with the unrelated-looking `LIFECYCLE_TRANSITION_MISMATCH`.
+    Raise a distinct, honest error instead. A token that carries no reviewable
+    instant at all (no `stamp` field — pre-dates that field) is a different,
+    unrelated refusal; keep minting a fresh stamp for it as before.
+    """
+    if semantic_transition_token is None:
+        return temporal.stamp(now)
+    reviewed = semantic_writes.reviewed_transition_stamp(semantic_transition_token, now)
+    if reviewed is not None:
+        return reviewed
+    refusal = semantic_writes.reviewed_transition_refusal_reason(
+        semantic_transition_token, now
+    )
+    if refusal is None:
+        return temporal.stamp(now)
+    if refusal == "expired":
+        message = (
+            "reviewed transition token is more than 24h old — its reviewed "
+            "state is stale; re-run validate_only to mint a fresh token "
+            "before committing"
+        )
+    else:
+        message = (
+            "reviewed transition token's reviewed instant is more than 5 "
+            "minutes in the future (clock skew); re-run validate_only to "
+            "mint a fresh token before committing"
+        )
+    refusal_error = semantic_writes.SemanticWriteError(
+        "LIFECYCLE_TRANSITION_TOKEN_EXPIRED", message
+    )
+    raise EditError(refusal_error.code, [], refusal_error.reason) from refusal_error
+
+
 def edit(
     vault_root: Path,
     *,
@@ -209,10 +255,7 @@ def edit(
         )
 
     now = today or temporal.now()
-    date_iso = (
-        semantic_writes.reviewed_transition_stamp(semantic_transition_token, now)
-        or temporal.stamp(now)
-    )
+    date_iso = _resolve_date_iso(semantic_transition_token, now)
 
     editable = load_editable(
         vault_root,

--- a/src/exomem/edit.py
+++ b/src/exomem/edit.py
@@ -115,45 +115,17 @@ def _resolve_date_iso(
 ) -> str:
     """The `updated:` stamp to write, honouring a reviewed token when given.
 
-    No token supplied: mint a fresh stamp — that's the legacy path and is
-    unchanged, correct behaviour, not a fallback.
-
-    Token supplied and still within the reviewed-stamp window: reuse its
-    exact reviewed instant, so the committed bytes match what was validated.
-
-    Token supplied but refused for age (>24h) or clock skew (>5min): this
-    used to silently mint a fresh stamp too, which changes `after_hash` and
-    fails downstream with the unrelated-looking `LIFECYCLE_TRANSITION_MISMATCH`.
-    Raise a distinct, honest error instead. A token that carries no reviewable
-    instant at all (no `stamp` field — pre-dates that field) is a different,
-    unrelated refusal; keep minting a fresh stamp for it as before.
+    Thin `EditError`-flavored wrapper around the shared
+    `semantic_writes.resolve_reviewed_date_iso` — every existing-page writer
+    (`edit`, `multi_edit`, `set_frontmatter_field`, `create_file`'s
+    overwrite-by-token path) shares that decision and only differs in which
+    domain error it converts a refusal into. See its docstring for the full
+    no-token/reviewed/expired/skewed/unreviewable breakdown.
     """
-    if semantic_transition_token is None:
-        return temporal.stamp(now)
-    reviewed = semantic_writes.reviewed_transition_stamp(semantic_transition_token, now)
-    if reviewed is not None:
-        return reviewed
-    refusal = semantic_writes.reviewed_transition_refusal_reason(
-        semantic_transition_token, now
-    )
-    if refusal is None:
-        return temporal.stamp(now)
-    if refusal == "expired":
-        message = (
-            "reviewed transition token is more than 24h old — its reviewed "
-            "state is stale; re-run validate_only to mint a fresh token "
-            "before committing"
-        )
-    else:
-        message = (
-            "reviewed transition token's reviewed instant is more than 5 "
-            "minutes in the future (clock skew); re-run validate_only to "
-            "mint a fresh token before committing"
-        )
-    refusal_error = semantic_writes.SemanticWriteError(
-        "LIFECYCLE_TRANSITION_TOKEN_EXPIRED", message
-    )
-    raise EditError(refusal_error.code, [], refusal_error.reason) from refusal_error
+    try:
+        return semantic_writes.resolve_reviewed_date_iso(semantic_transition_token, now)
+    except semantic_writes.SemanticWriteError as error:
+        raise EditError(error.code, [], error.reason) from error
 
 
 def edit(

--- a/src/exomem/multi_edit.py
+++ b/src/exomem/multi_edit.py
@@ -27,6 +27,7 @@ from pydantic import BeforeValidator
 from . import guards, semantic_writes, temporal
 from .edit import (
     EditError,
+    _resolve_date_iso,
     _set_or_append,
     apply_surgical_replace,
     commit_edit,
@@ -155,10 +156,7 @@ def multi_edit(
     edits = normalized_edits
 
     now = today or temporal.now()
-    date_iso = (
-        semantic_writes.reviewed_transition_stamp(semantic_transition_token, now)
-        or temporal.stamp(now)
-    )
+    date_iso = _resolve_date_iso(semantic_transition_token, now)
 
     editable = load_editable(
         vault_root, path, expected_hash=expected_hash, allow_frontmatterless=True

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -1304,17 +1304,19 @@ def transition_token_stamp(token: str | None) -> str | None:
     return stamp if type(stamp) is str and stamp else None
 
 
-def reviewed_transition_stamp(
+def _reviewed_transition_delta(
     transition_token: str | None,
     now: dt.date | dt.datetime,
-) -> str | None:
-    """Reuse the bounded instant already reviewed by an existing transition.
+) -> tuple[str, dt.timedelta] | None:
+    """The reviewed stamp a token carries and its age relative to `now`.
 
-    Existing-page writers render their proposed bytes before semantic preflight,
-    so this is the shared seam that keeps every leaf's server-owned `updated:`
-    value identical between validation and commit.
+    `None` when the token carries no reviewable instant at all (no token,
+    a token minted before the `stamp` field existed, or a bare-day stamp
+    with no precise instant) — this is shared math for
+    `reviewed_transition_stamp` and `reviewed_transition_refusal_reason`;
+    neither the age/skew accept-or-refuse decision nor the reason label for
+    a refusal lives here.
     """
-
     stamp = transition_token_stamp(transition_token)
     if stamp is None:
         return None
@@ -1326,10 +1328,52 @@ def reviewed_transition_stamp(
         reference = reference.astimezone(dt.UTC)
     else:
         reference = dt.datetime.combine(now, dt.time.max, tzinfo=dt.UTC)
-    delta = reference - moment.instant
+    return stamp, reference - moment.instant
+
+
+def reviewed_transition_stamp(
+    transition_token: str | None,
+    now: dt.date | dt.datetime,
+) -> str | None:
+    """Reuse the bounded instant already reviewed by an existing transition.
+
+    Existing-page writers render their proposed bytes before semantic preflight,
+    so this is the shared seam that keeps every leaf's server-owned `updated:`
+    value identical between validation and commit.
+    """
+
+    found = _reviewed_transition_delta(transition_token, now)
+    if found is None:
+        return None
+    stamp, delta = found
     if delta > _MAX_REVIEWED_STAMP_AGE or -delta > _MAX_REVIEWED_STAMP_SKEW:
         return None
     return stamp
+
+
+def reviewed_transition_refusal_reason(
+    transition_token: str | None,
+    now: dt.date | dt.datetime,
+) -> Literal["expired", "skewed"] | None:
+    """Why a SUPPLIED token's reviewed stamp was refused, for a distinct error.
+
+    Callers reach for this only once `reviewed_transition_stamp` has already
+    returned `None` for a token that was actually supplied — it draws on the
+    exact same delta and never loosens or duplicates that accept/reject
+    decision, only labels it. Returns `None` when the token carries no
+    reviewable instant at all (no token, pre-`stamp`, or bare-day) — that
+    refusal is unrelated to age/skew, and callers should keep their
+    pre-existing fallback behaviour for it, unchanged.
+    """
+    found = _reviewed_transition_delta(transition_token, now)
+    if found is None:
+        return None
+    _, delta = found
+    if delta > _MAX_REVIEWED_STAMP_AGE:
+        return "expired"
+    if -delta > _MAX_REVIEWED_STAMP_SKEW:
+        return "skewed"
+    return None
 
 
 def _existing_transition_id(token: str) -> str:

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -1376,6 +1376,56 @@ def reviewed_transition_refusal_reason(
     return None
 
 
+_REVIEWED_TOKEN_REFUSAL_MESSAGES: dict[Literal["expired", "skewed"], str] = {
+    "expired": (
+        "reviewed transition token is more than 24h old — its reviewed "
+        "state is stale; re-run validate_only to mint a fresh token before "
+        "committing"
+    ),
+    "skewed": (
+        "reviewed transition token's reviewed instant is more than 5 "
+        "minutes in the future (clock skew); re-run validate_only to mint "
+        "a fresh token before committing"
+    ),
+}
+
+
+def resolve_reviewed_date_iso(
+    transition_token: str | None,
+    now: dt.date | dt.datetime,
+) -> str:
+    """The `updated:` stamp to write, honouring a reviewed token when given.
+
+    Shared by every existing-page writer (`edit`, `multi_edit`,
+    `set_frontmatter_field`, and `create_file`'s overwrite-by-token path) so
+    the accept/refuse/message decision lives in exactly one place.
+
+    - No token supplied: mint a fresh stamp — the legacy path, unchanged,
+      correct behaviour, not a fallback.
+    - Token supplied and still within the reviewed-stamp window: reuse its
+      exact reviewed instant, so committed bytes match what was validated.
+    - Token supplied but refused for age (>24h) or clock skew (>5min): raise
+      `SemanticWriteError("LIFECYCLE_TRANSITION_TOKEN_EXPIRED", ...)` naming
+      the actual cause, instead of silently minting a fresh stamp — which
+      changes `after_hash` and fails downstream with the unrelated-looking
+      `LIFECYCLE_TRANSITION_MISMATCH`.
+    - Token supplied but carries no reviewable instant at all (no `stamp`
+      field — pre-dates that field): unrelated to age/skew; keep minting a
+      fresh stamp, as before.
+    """
+    if transition_token is None:
+        return temporal.stamp(now)
+    reviewed = reviewed_transition_stamp(transition_token, now)
+    if reviewed is not None:
+        return reviewed
+    refusal = reviewed_transition_refusal_reason(transition_token, now)
+    if refusal is None:
+        return temporal.stamp(now)
+    raise SemanticWriteError(
+        "LIFECYCLE_TRANSITION_TOKEN_EXPIRED", _REVIEWED_TOKEN_REFUSAL_MESSAGES[refusal]
+    )
+
+
 def _existing_transition_id(token: str) -> str:
     return str(_decode_existing_transition_token(token)["transition_id"])
 

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -1376,16 +1376,29 @@ def reviewed_transition_refusal_reason(
     return None
 
 
+def _format_hours(value: dt.timedelta) -> str:
+    hours = value.total_seconds() / 3600
+    return f"{hours:g}h"
+
+
+def _format_minutes(value: dt.timedelta) -> str:
+    minutes = value.total_seconds() / 60
+    unit = "minute" if minutes == 1 else "minutes"
+    return f"{minutes:g} {unit}"
+
+
+# Derived from the bound constants (not hard-coded) so retuning either one
+# can't leave the refusal message quoting a stale figure.
 _REVIEWED_TOKEN_REFUSAL_MESSAGES: dict[Literal["expired", "skewed"], str] = {
     "expired": (
-        "reviewed transition token is more than 24h old — its reviewed "
-        "state is stale; re-run validate_only to mint a fresh token before "
-        "committing"
+        f"reviewed transition token is more than {_format_hours(_MAX_REVIEWED_STAMP_AGE)} "
+        "old — its reviewed state is stale; re-run validate_only to mint a "
+        "fresh token before committing"
     ),
     "skewed": (
-        "reviewed transition token's reviewed instant is more than 5 "
-        "minutes in the future (clock skew); re-run validate_only to mint "
-        "a fresh token before committing"
+        "reviewed transition token's reviewed instant is more than "
+        f"{_format_minutes(_MAX_REVIEWED_STAMP_SKEW)} in the future (clock "
+        "skew); re-run validate_only to mint a fresh token before committing"
     ),
 }
 

--- a/src/exomem/set_frontmatter_field.py
+++ b/src/exomem/set_frontmatter_field.py
@@ -178,10 +178,12 @@ def set_frontmatter_field(
     body = m.group(2)
 
     now = today or temporal.now()
-    date_iso = (
-        semantic_writes.reviewed_transition_stamp(semantic_transition_token, now)
-        or temporal.stamp(now)
-    )
+    try:
+        date_iso = semantic_writes.resolve_reviewed_date_iso(
+            semantic_transition_token, now
+        )
+    except semantic_writes.SemanticWriteError as error:
+        raise SetFrontmatterError(error.code, error.reason) from error
 
     value = _governed_enum_value(
         field, value, page_type=_read_yaml_field(fm_text, "type")

--- a/tests/test_edit_transition_token_expiry.py
+++ b/tests/test_edit_transition_token_expiry.py
@@ -1,0 +1,147 @@
+"""Issue #506: an expired/skewed reviewed transition token fails loud with its
+own code, instead of the `edit.py` `or`-fallback silently minting a fresh
+stamp and later tripping the unrelated ``LIFECYCLE_TRANSITION_MISMATCH``
+guard on ``after_hash``.
+
+On current `main` (pre-fix), the age/skew scenarios below fail with the
+misleading ``LIFECYCLE_TRANSITION_MISMATCH`` code. After the fix they fail
+with the distinct ``LIFECYCLE_TRANSITION_TOKEN_EXPIRED`` code and a message
+that names the actual cause. The fresh-token and no-token paths are
+regression-pinned to keep committing exactly as before.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+from exomem import edit as edit_module
+
+_PAGE = "Knowledge Base/Notes/Insights/lifecycle-token-expiry.md"
+_ID = "00000000-0000-4000-8000-0000000000f1"
+
+
+def _source(body: str) -> str:
+    return (
+        "---\n"
+        "title: Lifecycle Token Expiry\n"
+        "type: insight\n"
+        "status: active\n"
+        f"exomem_id: {_ID}\n"
+        "---\n\n"
+        f"{body}\n\n"
+        "## Relations\n"
+    )
+
+
+def _write(root: Path, rel: str, source: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8", newline="\n")
+    return path
+
+
+def _preview_token(tmp_path: Path, *, today: dt.datetime) -> str:
+    _write(tmp_path, _PAGE, _source("A"))
+    result = edit_module.edit(
+        tmp_path,
+        path=_PAGE,
+        why="preview for token-expiry coverage",
+        old_string="A",
+        new_string="B",
+        validate_only=True,
+        today=today,
+    )
+    assert result.semantic is not None
+    token = result.semantic["transition_token"]
+    assert isinstance(token, str)
+    return token
+
+
+def test_expired_reviewed_token_fails_with_its_own_code(tmp_path: Path) -> None:
+    reviewed_at = dt.datetime(2026, 7, 14, 12, 0, 0, tzinfo=dt.UTC)
+    token = _preview_token(tmp_path, today=reviewed_at)
+
+    committed_at = reviewed_at + dt.timedelta(hours=24, minutes=1)
+    with pytest.raises(edit_module.EditError) as exc:
+        edit_module.edit(
+            tmp_path,
+            path=_PAGE,
+            why="commit after the reviewed stamp expired",
+            old_string="A",
+            new_string="B",
+            semantic_transition_token=token,
+            today=committed_at,
+        )
+
+    assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
+    assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
+    assert "24" in exc.value.reason
+    assert "validate_only" in exc.value.reason
+
+
+def test_skewed_reviewed_token_fails_with_its_own_code(tmp_path: Path) -> None:
+    reviewed_at = dt.datetime(2026, 7, 14, 12, 10, 0, tzinfo=dt.UTC)
+    token = _preview_token(tmp_path, today=reviewed_at)
+
+    committed_at = reviewed_at - dt.timedelta(minutes=6)
+    with pytest.raises(edit_module.EditError) as exc:
+        edit_module.edit(
+            tmp_path,
+            path=_PAGE,
+            why="commit before the reviewed stamp's skew window",
+            old_string="A",
+            new_string="B",
+            semantic_transition_token=token,
+            today=committed_at,
+        )
+
+    assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
+    assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
+    assert "skew" in exc.value.reason.lower()
+    assert "5" in exc.value.reason
+
+
+def test_fresh_reviewed_token_still_commits(tmp_path: Path) -> None:
+    reviewed_at = dt.datetime(2026, 7, 14, 12, 0, 0, tzinfo=dt.UTC)
+    token = _preview_token(tmp_path, today=reviewed_at)
+    page = tmp_path / _PAGE
+
+    committed_at = reviewed_at + dt.timedelta(minutes=5)
+    result = edit_module.edit(
+        tmp_path,
+        path=_PAGE,
+        why="commit within the reviewed window",
+        old_string="A",
+        new_string="B",
+        semantic_transition_token=token,
+        today=committed_at,
+    )
+
+    assert result.semantic is not None
+    assert result.semantic["mutated"] is True
+    # The committed `updated:` reuses the reviewed instant, not the (later)
+    # commit-time clock — that's the whole point of the reviewed-stamp seam.
+    assert "updated: 2026-07-14T12:00:00Z" in page.read_text(encoding="utf-8")
+
+
+def test_no_token_legacy_path_still_commits_with_a_fresh_stamp(
+    tmp_path: Path,
+) -> None:
+    page = _write(tmp_path, _PAGE, _source("A"))
+    now = dt.datetime(2026, 7, 14, 12, 0, 0, tzinfo=dt.UTC)
+
+    result = edit_module.edit(
+        tmp_path,
+        path=_PAGE,
+        why="legacy commit without a reviewed token",
+        old_string="A",
+        new_string="B",
+        today=now,
+    )
+
+    assert result.semantic is not None
+    assert result.semantic["mutated"] is True
+    assert "updated: 2026-07-14T12:00:00Z" in page.read_text(encoding="utf-8")

--- a/tests/test_edit_transition_token_expiry.py
+++ b/tests/test_edit_transition_token_expiry.py
@@ -1,13 +1,17 @@
 """Issue #506: an expired/skewed reviewed transition token fails loud with its
-own code, instead of the `edit.py` `or`-fallback silently minting a fresh
-stamp and later tripping the unrelated ``LIFECYCLE_TRANSITION_MISMATCH``
-guard on ``after_hash``.
+own code, instead of the `... or temporal.stamp(now)` fallback silently
+minting a fresh stamp and later tripping the unrelated
+``LIFECYCLE_TRANSITION_MISMATCH`` guard on ``after_hash``.
 
 On current `main` (pre-fix), the age/skew scenarios below fail with the
 misleading ``LIFECYCLE_TRANSITION_MISMATCH`` code. After the fix they fail
 with the distinct ``LIFECYCLE_TRANSITION_TOKEN_EXPIRED`` code and a message
 that names the actual cause. The fresh-token and no-token paths are
 regression-pinned to keep committing exactly as before.
+
+Covers all four writers that shared the identical bug shape:
+`edit`, `multi_edit`, `set_frontmatter_field`, and `create_file`'s
+overwrite-by-token path.
 """
 
 from __future__ import annotations
@@ -17,7 +21,10 @@ from pathlib import Path
 
 import pytest
 
+from exomem import create_file as create_file_module
 from exomem import edit as edit_module
+from exomem import multi_edit as multi_edit_module
+from exomem import set_frontmatter_field as set_frontmatter_module
 
 _PAGE = "Knowledge Base/Notes/Insights/lifecycle-token-expiry.md"
 _ID = "00000000-0000-4000-8000-0000000000f1"
@@ -145,3 +152,406 @@ def test_no_token_legacy_path_still_commits_with_a_fresh_stamp(
     assert result.semantic is not None
     assert result.semantic["mutated"] is True
     assert "updated: 2026-07-14T12:00:00Z" in page.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# multi_edit — same bug shape, reuses edit._resolve_date_iso directly.
+# ---------------------------------------------------------------------------
+
+_ME_PAGE = "Knowledge Base/Notes/Insights/lifecycle-token-expiry-multi.md"
+_ME_ID = "00000000-0000-4000-8000-0000000000f2"
+
+
+def _me_source(body: str) -> str:
+    return (
+        "---\n"
+        "title: Lifecycle Token Expiry (multi_edit)\n"
+        "type: insight\n"
+        "status: active\n"
+        f"exomem_id: {_ME_ID}\n"
+        "---\n\n"
+        f"{body}\n\n"
+        "## Relations\n"
+    )
+
+
+def _me_preview_token(tmp_path: Path, *, today: dt.datetime) -> str:
+    _write(tmp_path, _ME_PAGE, _me_source("A"))
+    result = multi_edit_module.multi_edit(
+        tmp_path,
+        path=_ME_PAGE,
+        why="preview for multi_edit token-expiry coverage",
+        edits=[{"old_string": "A", "new_string": "B"}],
+        validate_only=True,
+        today=today,
+    )
+    assert result.semantic is not None
+    token = result.semantic["transition_token"]
+    assert isinstance(token, str)
+    return token
+
+
+def test_multi_edit_expired_reviewed_token_fails_with_its_own_code(
+    tmp_path: Path,
+) -> None:
+    reviewed_at = dt.datetime(2026, 7, 14, 12, 0, 0, tzinfo=dt.UTC)
+    token = _me_preview_token(tmp_path, today=reviewed_at)
+
+    committed_at = reviewed_at + dt.timedelta(hours=24, minutes=1)
+    with pytest.raises(edit_module.EditError) as exc:
+        multi_edit_module.multi_edit(
+            tmp_path,
+            path=_ME_PAGE,
+            why="commit after the reviewed stamp expired",
+            edits=[{"old_string": "A", "new_string": "B"}],
+            semantic_transition_token=token,
+            today=committed_at,
+        )
+
+    assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
+    assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
+    assert "24" in exc.value.reason
+    assert "validate_only" in exc.value.reason
+
+
+def test_multi_edit_skewed_reviewed_token_fails_with_its_own_code(
+    tmp_path: Path,
+) -> None:
+    reviewed_at = dt.datetime(2026, 7, 14, 12, 10, 0, tzinfo=dt.UTC)
+    token = _me_preview_token(tmp_path, today=reviewed_at)
+
+    committed_at = reviewed_at - dt.timedelta(minutes=6)
+    with pytest.raises(edit_module.EditError) as exc:
+        multi_edit_module.multi_edit(
+            tmp_path,
+            path=_ME_PAGE,
+            why="commit before the reviewed stamp's skew window",
+            edits=[{"old_string": "A", "new_string": "B"}],
+            semantic_transition_token=token,
+            today=committed_at,
+        )
+
+    assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
+    assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
+    assert "skew" in exc.value.reason.lower()
+    assert "5" in exc.value.reason
+
+
+def test_multi_edit_fresh_reviewed_token_still_commits(tmp_path: Path) -> None:
+    reviewed_at = dt.datetime(2026, 7, 14, 12, 0, 0, tzinfo=dt.UTC)
+    token = _me_preview_token(tmp_path, today=reviewed_at)
+    page = tmp_path / _ME_PAGE
+
+    committed_at = reviewed_at + dt.timedelta(minutes=5)
+    result = multi_edit_module.multi_edit(
+        tmp_path,
+        path=_ME_PAGE,
+        why="commit within the reviewed window",
+        edits=[{"old_string": "A", "new_string": "B"}],
+        semantic_transition_token=token,
+        today=committed_at,
+    )
+
+    assert result.semantic is not None
+    assert result.semantic["mutated"] is True
+    assert "updated: 2026-07-14T12:00:00Z" in page.read_text(encoding="utf-8")
+
+
+def test_multi_edit_no_token_legacy_path_still_commits_with_a_fresh_stamp(
+    tmp_path: Path,
+) -> None:
+    page = _write(tmp_path, _ME_PAGE, _me_source("A"))
+    now = dt.datetime(2026, 7, 14, 12, 0, 0, tzinfo=dt.UTC)
+
+    result = multi_edit_module.multi_edit(
+        tmp_path,
+        path=_ME_PAGE,
+        why="legacy commit without a reviewed token",
+        edits=[{"old_string": "A", "new_string": "B"}],
+        today=now,
+    )
+
+    assert result.semantic is not None
+    assert result.semantic["mutated"] is True
+    assert "updated: 2026-07-14T12:00:00Z" in page.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# set_frontmatter_field — same bug shape, raises SetFrontmatterError.
+# ---------------------------------------------------------------------------
+
+_SF_PAGE = "Knowledge Base/Notes/Insights/lifecycle-token-expiry-setfm.md"
+_SF_ID = "00000000-0000-4000-8000-0000000000f3"
+
+
+def _sf_source(body: str) -> str:
+    return (
+        "---\n"
+        "title: Lifecycle Token Expiry (set_frontmatter_field)\n"
+        "type: insight\n"
+        "status: active\n"
+        f"exomem_id: {_SF_ID}\n"
+        "---\n\n"
+        f"{body}\n\n"
+        "## Relations\n"
+    )
+
+
+def _sf_preview_token(tmp_path: Path, *, today: dt.datetime) -> str:
+    _write(tmp_path, _SF_PAGE, _sf_source("Prose."))
+    result = set_frontmatter_module.set_frontmatter_field(
+        tmp_path,
+        path=_SF_PAGE,
+        field="title",
+        value="Renamed title",
+        why="preview for set_frontmatter_field token-expiry coverage",
+        validate_only=True,
+        today=today,
+    )
+    assert result.semantic is not None
+    token = result.semantic["transition_token"]
+    assert isinstance(token, str)
+    return token
+
+
+def test_set_frontmatter_field_expired_reviewed_token_fails_with_its_own_code(
+    tmp_path: Path,
+) -> None:
+    reviewed_at = dt.datetime(2026, 7, 14, 12, 0, 0, tzinfo=dt.UTC)
+    token = _sf_preview_token(tmp_path, today=reviewed_at)
+
+    committed_at = reviewed_at + dt.timedelta(hours=24, minutes=1)
+    with pytest.raises(set_frontmatter_module.SetFrontmatterError) as exc:
+        set_frontmatter_module.set_frontmatter_field(
+            tmp_path,
+            path=_SF_PAGE,
+            field="title",
+            value="Renamed title",
+            why="commit after the reviewed stamp expired",
+            semantic_transition_token=token,
+            today=committed_at,
+        )
+
+    assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
+    assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
+    assert "24" in exc.value.reason
+    assert "validate_only" in exc.value.reason
+
+
+def test_set_frontmatter_field_skewed_reviewed_token_fails_with_its_own_code(
+    tmp_path: Path,
+) -> None:
+    reviewed_at = dt.datetime(2026, 7, 14, 12, 10, 0, tzinfo=dt.UTC)
+    token = _sf_preview_token(tmp_path, today=reviewed_at)
+
+    committed_at = reviewed_at - dt.timedelta(minutes=6)
+    with pytest.raises(set_frontmatter_module.SetFrontmatterError) as exc:
+        set_frontmatter_module.set_frontmatter_field(
+            tmp_path,
+            path=_SF_PAGE,
+            field="title",
+            value="Renamed title",
+            why="commit before the reviewed stamp's skew window",
+            semantic_transition_token=token,
+            today=committed_at,
+        )
+
+    assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
+    assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
+    assert "skew" in exc.value.reason.lower()
+    assert "5" in exc.value.reason
+
+
+def test_set_frontmatter_field_fresh_reviewed_token_still_commits(
+    tmp_path: Path,
+) -> None:
+    reviewed_at = dt.datetime(2026, 7, 14, 12, 0, 0, tzinfo=dt.UTC)
+    token = _sf_preview_token(tmp_path, today=reviewed_at)
+    page = tmp_path / _SF_PAGE
+
+    committed_at = reviewed_at + dt.timedelta(minutes=5)
+    result = set_frontmatter_module.set_frontmatter_field(
+        tmp_path,
+        path=_SF_PAGE,
+        field="title",
+        value="Renamed title",
+        why="commit within the reviewed window",
+        semantic_transition_token=token,
+        today=committed_at,
+    )
+
+    assert result.semantic is not None
+    assert result.semantic["mutated"] is True
+    assert "updated: 2026-07-14T12:00:00Z" in page.read_text(encoding="utf-8")
+
+
+def test_set_frontmatter_field_no_token_legacy_path_still_commits_with_a_fresh_stamp(
+    tmp_path: Path,
+) -> None:
+    page = _write(tmp_path, _SF_PAGE, _sf_source("Prose."))
+    now = dt.datetime(2026, 7, 14, 12, 0, 0, tzinfo=dt.UTC)
+
+    result = set_frontmatter_module.set_frontmatter_field(
+        tmp_path,
+        path=_SF_PAGE,
+        field="title",
+        value="Renamed title",
+        why="legacy commit without a reviewed token",
+        today=now,
+    )
+
+    assert result.semantic is not None
+    assert result.semantic["mutated"] is True
+    assert "updated: 2026-07-14T12:00:00Z" in page.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# create_file — overwrite-by-token path, raises CreateFileError.
+# ---------------------------------------------------------------------------
+
+_CF_PAGE = "Knowledge Base/Notes/Insights/lifecycle-token-expiry-createfile.md"
+_CF_ID = "00000000-0000-4000-8000-0000000000f4"
+
+
+def _cf_initial_source(body: str) -> str:
+    return (
+        "---\n"
+        "title: Lifecycle Token Expiry (create_file)\n"
+        "type: insight\n"
+        "status: active\n"
+        f"exomem_id: {_CF_ID}\n"
+        "---\n\n"
+        f"{body}\n\n"
+        "## Relations\n"
+    )
+
+
+_CF_FRONTMATTER = {
+    "title": "Lifecycle Token Expiry (create_file)",
+    "type": "insight",
+    "status": "active",
+    "exomem_id": _CF_ID,
+}
+
+
+def _cf_body(body: str) -> str:
+    return f"{body}\n\n## Relations\n"
+
+
+def _cf_preview_token(tmp_path: Path, *, today: dt.datetime) -> str:
+    # Overwrite via a `frontmatter=` dict (not raw `content=`) so `created`/
+    # `updated` are stamp-filled into the actual page bytes, exactly like
+    # edit/multi_edit/set_frontmatter_field — that's what makes a silently
+    # re-minted stamp change `after_hash` and reach the mismatch guard.
+    _write(tmp_path, _CF_PAGE, _cf_initial_source("A"))
+    preview = create_file_module.create_file(
+        tmp_path,
+        path=_CF_PAGE,
+        content=_cf_body("B"),
+        frontmatter=dict(_CF_FRONTMATTER),
+        overwrite=True,
+        validate_only=True,
+        today=today,
+    )
+    token = preview.transition_token
+    assert isinstance(token, str)
+    return token
+
+
+def test_create_file_overwrite_expired_reviewed_token_fails_with_its_own_code(
+    tmp_path: Path,
+) -> None:
+    reviewed_at = dt.datetime(2026, 7, 14, 12, 0, 0, tzinfo=dt.UTC)
+    token = _cf_preview_token(tmp_path, today=reviewed_at)
+
+    committed_at = reviewed_at + dt.timedelta(hours=24, minutes=1)
+    with pytest.raises(create_file_module.CreateFileError) as exc:
+        create_file_module.create_file(
+            tmp_path,
+            path=_CF_PAGE,
+            content=_cf_body("B"),
+            frontmatter=dict(_CF_FRONTMATTER),
+            overwrite=True,
+            draft_token=token,
+            today=committed_at,
+        )
+
+    assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
+    assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
+    assert "24" in exc.value.reason
+    assert "validate_only" in exc.value.reason
+
+
+def test_create_file_overwrite_skewed_reviewed_token_fails_with_its_own_code(
+    tmp_path: Path,
+) -> None:
+    reviewed_at = dt.datetime(2026, 7, 14, 12, 10, 0, tzinfo=dt.UTC)
+    token = _cf_preview_token(tmp_path, today=reviewed_at)
+
+    committed_at = reviewed_at - dt.timedelta(minutes=6)
+    with pytest.raises(create_file_module.CreateFileError) as exc:
+        create_file_module.create_file(
+            tmp_path,
+            path=_CF_PAGE,
+            content=_cf_body("B"),
+            frontmatter=dict(_CF_FRONTMATTER),
+            overwrite=True,
+            draft_token=token,
+            today=committed_at,
+        )
+
+    assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
+    assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
+    assert "skew" in exc.value.reason.lower()
+    assert "5" in exc.value.reason
+
+
+def test_create_file_overwrite_fresh_reviewed_token_still_commits(
+    tmp_path: Path,
+) -> None:
+    reviewed_at = dt.datetime(2026, 7, 14, 12, 0, 0, tzinfo=dt.UTC)
+    token = _cf_preview_token(tmp_path, today=reviewed_at)
+    page = tmp_path / _CF_PAGE
+
+    committed_at = reviewed_at + dt.timedelta(minutes=5)
+    result = create_file_module.create_file(
+        tmp_path,
+        path=_CF_PAGE,
+        content=_cf_body("B"),
+        frontmatter=dict(_CF_FRONTMATTER),
+        overwrite=True,
+        draft_token=token,
+        today=committed_at,
+    )
+
+    assert result.semantic is not None
+    assert result.semantic["mutated"] is True
+    text = page.read_text(encoding="utf-8")
+    # The committed `updated:`/`created:` reuse the reviewed instant, not the
+    # (later) commit-time clock — same reviewed-stamp seam as the siblings.
+    # `serialize_frontmatter` quotes ISO-instant scalars.
+    assert 'updated: "2026-07-14T12:00:00Z"' in text
+    assert 'created: "2026-07-14T12:00:00Z"' in text
+    assert "B\n\n## Relations" in text
+
+
+def test_create_file_overwrite_no_token_legacy_path_still_commits_with_a_fresh_stamp(
+    tmp_path: Path,
+) -> None:
+    page = _write(tmp_path, _CF_PAGE, _cf_initial_source("A"))
+    now = dt.datetime(2026, 7, 14, 12, 0, 0, tzinfo=dt.UTC)
+
+    result = create_file_module.create_file(
+        tmp_path,
+        path=_CF_PAGE,
+        content=_cf_body("B"),
+        frontmatter=dict(_CF_FRONTMATTER),
+        overwrite=True,
+        today=now,
+    )
+
+    assert result.semantic is not None
+    assert result.semantic["mutated"] is True
+    text = page.read_text(encoding="utf-8")
+    assert 'updated: "2026-07-14T12:00:00Z"' in text
+    assert "B\n\n## Relations" in text

--- a/tests/test_edit_transition_token_expiry.py
+++ b/tests/test_edit_transition_token_expiry.py
@@ -24,10 +24,20 @@ import pytest
 from exomem import create_file as create_file_module
 from exomem import edit as edit_module
 from exomem import multi_edit as multi_edit_module
+from exomem import semantic_writes
 from exomem import set_frontmatter_field as set_frontmatter_module
+from exomem import temporal
 
 _PAGE = "Knowledge Base/Notes/Insights/lifecycle-token-expiry.md"
 _ID = "00000000-0000-4000-8000-0000000000f1"
+
+# Derived from the same bound constants the production message is built
+# from (`semantic_writes._format_hours`/`_format_minutes` applied to
+# `_MAX_REVIEWED_STAMP_AGE`/`_MAX_REVIEWED_STAMP_SKEW`) rather than hard-coded
+# "24"/"5" literals, so retuning either bound can't silently desync the
+# message assertions below from the constant that actually governs behavior.
+_EXPECTED_AGE_BOUND = semantic_writes._format_hours(semantic_writes._MAX_REVIEWED_STAMP_AGE)
+_EXPECTED_SKEW_BOUND = semantic_writes._format_minutes(semantic_writes._MAX_REVIEWED_STAMP_SKEW)
 
 
 def _source(body: str) -> str:
@@ -85,7 +95,7 @@ def test_expired_reviewed_token_fails_with_its_own_code(tmp_path: Path) -> None:
 
     assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
     assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
-    assert "24" in exc.value.reason
+    assert _EXPECTED_AGE_BOUND in exc.value.reason
     assert "validate_only" in exc.value.reason
 
 
@@ -108,7 +118,7 @@ def test_skewed_reviewed_token_fails_with_its_own_code(tmp_path: Path) -> None:
     assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
     assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
     assert "skew" in exc.value.reason.lower()
-    assert "5" in exc.value.reason
+    assert _EXPECTED_SKEW_BOUND in exc.value.reason
 
 
 def test_fresh_reviewed_token_still_commits(tmp_path: Path) -> None:
@@ -210,7 +220,7 @@ def test_multi_edit_expired_reviewed_token_fails_with_its_own_code(
 
     assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
     assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
-    assert "24" in exc.value.reason
+    assert _EXPECTED_AGE_BOUND in exc.value.reason
     assert "validate_only" in exc.value.reason
 
 
@@ -234,7 +244,7 @@ def test_multi_edit_skewed_reviewed_token_fails_with_its_own_code(
     assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
     assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
     assert "skew" in exc.value.reason.lower()
-    assert "5" in exc.value.reason
+    assert _EXPECTED_SKEW_BOUND in exc.value.reason
 
 
 def test_multi_edit_fresh_reviewed_token_still_commits(tmp_path: Path) -> None:
@@ -334,7 +344,7 @@ def test_set_frontmatter_field_expired_reviewed_token_fails_with_its_own_code(
 
     assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
     assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
-    assert "24" in exc.value.reason
+    assert _EXPECTED_AGE_BOUND in exc.value.reason
     assert "validate_only" in exc.value.reason
 
 
@@ -359,7 +369,7 @@ def test_set_frontmatter_field_skewed_reviewed_token_fails_with_its_own_code(
     assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
     assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
     assert "skew" in exc.value.reason.lower()
-    assert "5" in exc.value.reason
+    assert _EXPECTED_SKEW_BOUND in exc.value.reason
 
 
 def test_set_frontmatter_field_fresh_reviewed_token_still_commits(
@@ -478,7 +488,7 @@ def test_create_file_overwrite_expired_reviewed_token_fails_with_its_own_code(
 
     assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
     assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
-    assert "24" in exc.value.reason
+    assert _EXPECTED_AGE_BOUND in exc.value.reason
     assert "validate_only" in exc.value.reason
 
 
@@ -503,7 +513,7 @@ def test_create_file_overwrite_skewed_reviewed_token_fails_with_its_own_code(
     assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
     assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
     assert "skew" in exc.value.reason.lower()
-    assert "5" in exc.value.reason
+    assert _EXPECTED_SKEW_BOUND in exc.value.reason
 
 
 def test_create_file_overwrite_fresh_reviewed_token_still_commits(
@@ -555,3 +565,105 @@ def test_create_file_overwrite_no_token_legacy_path_still_commits_with_a_fresh_s
     text = page.read_text(encoding="utf-8")
     assert 'updated: "2026-07-14T12:00:00Z"' in text
     assert "B\n\n## Relations" in text
+
+
+def test_create_file_overwrite_raw_content_expired_token_raises_and_writes_nothing(
+    tmp_path: Path,
+) -> None:
+    """Reviewer finding 1: raw `content=` overwrite (no `frontmatter=` dict)
+    never embeds `stamp_iso` into the page bytes, so on unfixed `main` an
+    expired token was silently accepted there — the commit still succeeded,
+    just with a wrong log-entry date, since the `after_hash` never diverged.
+    That's a real, previously-succeeding path with zero prior coverage.
+    After the fix it now correctly raises `LIFECYCLE_TRANSITION_TOKEN_EXPIRED`
+    too, because the refusal happens at stamp resolution — before create_file
+    ever looks at whether a `frontmatter=` dict was supplied — and nothing is
+    written.
+    """
+    raw_overwrite = _cf_initial_source("B")
+    page = _write(tmp_path, _CF_PAGE, _cf_initial_source("A"))
+
+    reviewed_at = dt.datetime(2026, 7, 14, 12, 0, 0, tzinfo=dt.UTC)
+    preview = create_file_module.create_file(
+        tmp_path,
+        path=_CF_PAGE,
+        content=raw_overwrite,
+        overwrite=True,
+        validate_only=True,
+        today=reviewed_at,
+    )
+    token = preview.transition_token
+    assert isinstance(token, str)
+
+    before_bytes = page.read_bytes()
+    committed_at = reviewed_at + dt.timedelta(hours=24, minutes=1)
+    with pytest.raises(create_file_module.CreateFileError) as exc:
+        create_file_module.create_file(
+            tmp_path,
+            path=_CF_PAGE,
+            content=raw_overwrite,
+            overwrite=True,
+            draft_token=token,
+            today=committed_at,
+        )
+
+    assert exc.value.code == "LIFECYCLE_TRANSITION_TOKEN_EXPIRED"
+    assert exc.value.code != "LIFECYCLE_TRANSITION_MISMATCH"
+    assert _EXPECTED_AGE_BOUND in exc.value.reason
+    assert page.read_bytes() == before_bytes
+
+
+# ---------------------------------------------------------------------------
+# semantic_writes.reviewed_transition_stamp — direct shape pin.
+#
+# Reviewer finding 4: no writer in this file calls it directly anymore (they
+# all go through resolve_reviewed_date_iso), but it's still public API in
+# semantic_writes.py whose backward-compatible shape the spec locked this
+# task to preserving for other callers. Pin its own behavior directly rather
+# than only exercising it indirectly through a writer round-trip.
+# ---------------------------------------------------------------------------
+
+
+def test_reviewed_transition_stamp_direct_shape() -> None:
+    reviewed_at = dt.datetime(2026, 7, 14, 12, 0, 0, tzinfo=dt.UTC)
+    reviewed_stamp = temporal.stamp(reviewed_at)
+    token = semantic_writes._existing_transition_token(
+        operation="edit",
+        path="Knowledge Base/Notes/Insights/shape-pin.md",
+        before_hash="a" * 64,
+        after_hash="b" * 64,
+        stamp=reviewed_stamp,
+    )
+
+    # No token: None.
+    assert semantic_writes.reviewed_transition_stamp(None, reviewed_at) is None
+
+    # Malformed token: None (decode failure, not a raise).
+    assert (
+        semantic_writes.reviewed_transition_stamp("not-a-real-token", reviewed_at)
+        is None
+    )
+
+    # In-window: returns the exact reviewed stamp string.
+    assert (
+        semantic_writes.reviewed_transition_stamp(
+            token, reviewed_at + dt.timedelta(minutes=5)
+        )
+        == reviewed_stamp
+    )
+
+    # Aged past the bound: None.
+    assert (
+        semantic_writes.reviewed_transition_stamp(
+            token,
+            reviewed_at + semantic_writes._MAX_REVIEWED_STAMP_AGE + dt.timedelta(minutes=1),
+        )
+        is None
+    )
+
+    # A bare `dt.date` reference is accepted (treated as end-of-day UTC), not
+    # just `dt.datetime`.
+    assert (
+        semantic_writes.reviewed_transition_stamp(token, reviewed_at.date())
+        == reviewed_stamp
+    )


### PR DESCRIPTION
## What

#506: a reviewed transition token older than 24 h (or clock-skewed >5 min) was
silently replaced by a fresh stamp, which changed `after_hash` and failed with
the misleading `LIFECYCLE_TRANSITION_MISMATCH`. Decision (locked): fail loud
with a distinct code, never silently re-stamp, never widen the window.

- New shared resolver `semantic_writes.resolve_reviewed_date_iso()`: no token →
  fresh stamp (unchanged legacy behavior); valid in-window token → reused stamp;
  supplied-but-refused token → **`LIFECYCLE_TRANSITION_TOKEN_EXPIRED`** with a
  message distinguishing age from skew (bounds formatted from
  `_MAX_REVIEWED_STAMP_AGE`/`_MAX_REVIEWED_STAMP_SKEW`, so retuning a constant
  cannot produce a lying message) and a re-run-validate remediation.
- Applied across **all four writers that used the fallback** — `edit_memory`
  plus the identical bug found by in-lane audit in `create_file`, `multi_edit`,
  `set_frontmatter_field` — each converting through its own established error
  idiom. `append_to_file` never had the bug (verified).
- Malformed/foreign tokens keep their existing classification
  (`LIFECYCLE_TRANSITION_INVALID_TOKEN` / downstream MISMATCH) — reviewer-probed,
  not swept into the new code.
- `reviewed_transition_stamp` stays public and byte-compatible (now
  direct-unit-tested since it has no production caller left).

Known accepted trade (reviewer finding, deliberate): the token-age check runs
before path resolution, so an expired token plus a nonexistent/foreign path
reports EXPIRED rather than the more specific NOT_FOUND/MISMATCH; re-running
validate surfaces the underlying error. A pre-existing (unchanged) create_file
quirk — log date vs reviewed `updated:` split on the accept path — is noted in
the lane record.

## Verification

- Red-first per writer, verbatim in the lane record: expired/skewed tokens
  failed with the misleading MISMATCH code on main, the new code after; the
  independent reviewer additionally monkeypatched main's semantics back in and
  confirmed all 8 red tests fail for exactly the right reason.
- `tests/test_edit_transition_token_expiry.py` (new): **18 passed**
  (expired/skewed/fresh/no-token × 4 writers + the raw-content overwrite pin —
  a previously-silently-succeeding path that now correctly refuses and writes
  nothing — + the resolver shape pin).
- `test_edit_operations.py` + `test_consolidated_tools.py`: 60 passed;
  lifecycle-writers suite: 274 passed; `test_mcp_schema_fidelity.py`: 8 passed
  (no tool-surface digest movement). `uvx ruff check --select F` clean.
- Independent review verdict: **APPROVE — no blockers** (error-surface parity
  verified against `commands.py` formatting and the hosted allowlist; per-writer
  rewrap idioms verified byte-consistent with each file's existing patterns).

Closes #506
