### PR TITLE
fix(memory): thread the validating census into the preflight validity token

### DIFF
--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -1966,9 +1966,12 @@ def build_corpus_context_with_census(
     reuse the census this call already walked instead of paying for another
     one. The census is ``None`` whenever no single walk unambiguously matches
     the returned context: candidate-bearing builds, a disabled cache, a
-    registry that does not match disk, or a cold build whose post-publish
-    reconciliation never stabilized. A caller that gets ``None`` here has no
-    cheaper option than its own fresh walk — same as before this existed.
+    registry that does not match disk, a cold build whose post-publish
+    reconciliation never stabilized, or an in-flight-dedup waiter (it only
+    confirmed its own pre-wait walk matched the flight it is chasing, not
+    whatever the owning build's stabilization loop settles on or gives up on
+    afterward). A caller that gets ``None`` here has no cheaper option than
+    its own fresh walk — same as before this existed.
     """
     root = Path(vault_root)
     relation_definitions = registry or relation_registry.load_registry(root)
@@ -2116,7 +2119,13 @@ def build_corpus_context_with_census(
             if flight.error is not None:
                 raise flight.error
             assert flight.result is not None
-            return flight.result, census
+            # Not `census`: that is this WAITER's own pre-wait walk, pinned
+            # only to confirm it is chasing the same flight (`same_inputs`
+            # above). The owner's stabilization loop can still reconcile
+            # `flight.result` to a different final census after that check,
+            # or give up entirely -- either way this waiter has no census
+            # that is honestly known to match the context it is returning.
+            return flight.result, None
 
     try:
         started = time.perf_counter()

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -1942,6 +1942,34 @@ def build_corpus_context(
     Candidate-bearing builds always take the uncached path.
     ``EXOMEM_DISABLE_CORPUS_CACHE=1`` restores the always-rebuild behavior.
     """
+    context, _census = build_corpus_context_with_census(
+        vault_root,
+        candidate=candidate,
+        registry=registry,
+        language_registry=language_registry,
+    )
+    return context
+
+
+def build_corpus_context_with_census(
+    vault_root: Path,
+    *,
+    candidate: SemanticPageState | None = None,
+    registry: relation_registry.RelationRegistry | None = None,
+    language_registry: semantic_language_registry.SemanticLanguageRegistry | None = None,
+) -> tuple[SemanticCorpusContext, tuple | None]:
+    """``build_corpus_context`` plus the exact census that validated it.
+
+    Identical corpus/cache mechanics to ``build_corpus_context`` (that
+    function is a thin wrapper over this one) — the only difference is a
+    second return so a caller about to compute ``corpus_validity_token`` can
+    reuse the census this call already walked instead of paying for another
+    one. The census is ``None`` whenever no single walk unambiguously matches
+    the returned context: candidate-bearing builds, a disabled cache, a
+    registry that does not match disk, or a cold build whose post-publish
+    reconciliation never stabilized. A caller that gets ``None`` here has no
+    cheaper option than its own fresh walk — same as before this existed.
+    """
     root = Path(vault_root)
     relation_definitions = registry or relation_registry.load_registry(root)
     language = language_registry or semantic_language_registry.load_registry(root)
@@ -1974,7 +2002,7 @@ def build_corpus_context(
                     "semantic corpus context event-hit pages=%d",
                     len(event_entry[1].pages),
                 )
-                return event_entry[1]
+                return event_entry[1], event_entry[0]
         # This walk's meaning is only settled by the branch it lands in, and
         # every one of those branches decides while a cache lock is held. So
         # the disposition is recorded in place and emitted by `_census_walk_log`
@@ -2007,12 +2035,12 @@ def build_corpus_context(
                                 census_ms,
                             )
                             walk[1] = "hit"
-                            return entry[1]
+                            return entry[1], entry[0]
                     if entry is not None and entry[0] == census:
                         with _CORPUS_CONTEXT_CACHE_LOCK:
                             if _CORPUS_CONTEXT_CACHE.get(cache_key) is entry:
                                 walk[1] = "hit"
-                                return entry[1]
+                                return entry[1], entry[0]
                 if entry is not None:
                     changed_paths = _markdown_census_delta(entry[0], census)
                     if changed_paths is not None:
@@ -2045,10 +2073,10 @@ def build_corpus_context(
                                         census_ms,
                                     )
                                     walk[1] = "patch"
-                                    return context
+                                    return context, census
                                 if current is not None and current is not entry:
                                     walk[1] = "hit"
-                                    return current[1]
+                                    return current[1], current[0]
             else:
                 census = None
 
@@ -2079,7 +2107,7 @@ def build_corpus_context(
             )
             flight.done.wait()
             if not same_inputs:
-                return build_corpus_context(
+                return build_corpus_context_with_census(
                     root,
                     candidate=candidate,
                     registry=registry,
@@ -2088,7 +2116,7 @@ def build_corpus_context(
             if flight.error is not None:
                 raise flight.error
             assert flight.result is not None
-            return flight.result
+            return flight.result, census
 
     try:
         started = time.perf_counter()
@@ -2177,7 +2205,7 @@ def build_corpus_context(
             if _CORPUS_CONTEXT_FLIGHTS.get(cache_key) is flight:
                 del _CORPUS_CONTEXT_FLIGHTS[cache_key]
         flight.done.set()
-    return context
+    return context, (census if stored else None)
 
 
 def _build_corpus_context_uncached(

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -1680,7 +1680,7 @@ def _preflight_existing(
         _write_metric("exomem_write_corpus_context_ms", str(operation)),
         mutation_timing_span(timings, "preflight.corpus_context"),
     ):
-        before_corpus = semantic_contract.build_corpus_context(
+        before_corpus, before_corpus_census = semantic_contract.build_corpus_context_with_census(
             root, registry=registry, language_registry=language
         )
     resolver_freshness_after = freshness.triple(root, "vault")
@@ -1826,7 +1826,9 @@ def _preflight_existing(
             language_registry=language,
         )
     with mutation_timing_span(timings, "preflight.validity_token"):
-        census_token = _capture_validity_stamp(root, entry_generation)
+        census_token = _capture_validity_stamp(
+            root, entry_generation, corpus_census=before_corpus_census
+        )
     return ExistingPreflight(
         applicability,
         operation,
@@ -3205,11 +3207,19 @@ def _evaluate_structural(
 ) -> tuple[
     semantic_contract.SemanticContractResult,
     semantic_contract.SemanticPageState,
+    tuple | None,
 ]:
+    """Returns ``(result, state, corpus_census)``.
+
+    ``corpus_census`` is the exact census that validated the ``before`` corpus
+    context this evaluation just built, for a preflight caller to thread
+    straight into ``_capture_validity_stamp`` without paying for a second
+    walk; see ``semantic_contract.build_corpus_context_with_census``.
+    """
     registry = relation_registry.load_registry(root)
     language = semantic_language_registry.load_registry(root)
     contracts = memory_schema.load_saved_contracts(root)
-    before = semantic_contract.build_corpus_context(
+    before, before_census = semantic_contract.build_corpus_context_with_census(
         root, registry=registry, language_registry=language
     )
     candidate = semantic_contract.build_page_state(
@@ -3239,6 +3249,7 @@ def _evaluate_structural(
             language_registry=language,
         ),
         candidate,
+        before_census,
     )
 
 
@@ -3276,7 +3287,9 @@ def preflight_creation(
     except vault.FrontmatterError as error:
         raise SemanticWriteError(error.code, "draft frontmatter is invalid") from error
     entry_generation = _entry_commit_generation(root)
-    result, state = _evaluate_structural(root, destination=path, source=source, operation=operation)
+    result, state, corpus_census = _evaluate_structural(
+        root, destination=path, source=source, operation=operation
+    )
     if semantic_contract.requires_semantic_unit(state):
         if draft_id is None:
             raise SemanticWriteError("DRAFT_IDENTITY_MISMATCH", "active draft requires identity")
@@ -3291,7 +3304,9 @@ def preflight_creation(
             predecessor_path=predecessor_path,
             predecessor_content_hash=predecessor_content_hash,
         )
-        census_token = _capture_validity_stamp(root, entry_generation)
+        census_token = _capture_validity_stamp(
+            root, entry_generation, corpus_census=corpus_census
+        )
         return CreationPreflight(
             "full",
             path,
@@ -3309,7 +3324,7 @@ def preflight_creation(
         if state.page_type is not None or semantic_contract.compiled_intent(state)
         else "not_semantic"
     )
-    census_token = _capture_validity_stamp(root, entry_generation)
+    census_token = _capture_validity_stamp(root, entry_generation, corpus_census=corpus_census)
     return CreationPreflight(
         applicability, path, source, draft_id, draft_token, False, result, None, state, census_token
     )
@@ -3324,19 +3339,35 @@ def _entry_commit_generation(root: Path):  # noqa: ANN201 - int | None
     return read_commit_generation(root)
 
 
-def _capture_validity_stamp(root: Path, entry_generation) -> tuple | None:  # noqa: ANN001
+def _capture_validity_stamp(
+    root: Path,
+    entry_generation,  # noqa: ANN001
+    *,
+    corpus_census: tuple | None = None,
+) -> tuple | None:
     """Assemble the preflight validity stamp WITHOUT a second corpus walk.
 
-    The corpus census is reused from the cache entry the validation's own
-    ``build_corpus_context`` call just walked/validated; only the cheap
-    review-artifact census is computed here. The stamp pairs that with the
-    entry commit-generation; the in-boundary admission check is then
+    Pass ``corpus_census`` when the caller's own ``build_corpus_context_with_census``
+    call already walked/validated one — this is the direct plumbing from the
+    corpus context the preflight just built, and it never depends on the
+    global process cache still holding that entry (a cold build that could not
+    cache, a candidate build, or a concurrent eviction between the build and
+    this capture would otherwise all fall through to a second walk). Omitting
+    it falls back to ``cached_corpus_census`` for a caller that has no corpus
+    context in hand. Either way, only the cheap review-artifact census is
+    computed here. The stamp pairs the result with the entry commit-generation;
+    the in-boundary admission check is then
     ``semantic_contract.validity_stamp_current`` — O(sidecars), no walk.
     """
     if entry_generation is None:
         return None
     sc_token = semantic_contract.corpus_validity_token(
-        root, corpus_census=semantic_contract.cached_corpus_census(root)
+        root,
+        corpus_census=(
+            corpus_census
+            if corpus_census is not None
+            else semantic_contract.cached_corpus_census(root)
+        ),
     )
     if sc_token is None:
         return None

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -3482,7 +3482,7 @@ def commit_creation(
             commit_generation=read_commit_generation(root),
         ):
             relation_review._record_prevalidated_commit_outcome("revalidated")
-            contract_result, _fresh_state = _evaluate_structural(
+            contract_result, _fresh_state, _fresh_census = _evaluate_structural(
                 root,
                 destination=preflight.destination,
                 source=preflight.source,

--- a/tests/test_mutation_timings.py
+++ b/tests/test_mutation_timings.py
@@ -520,6 +520,61 @@ def test_preflight_creation_structural_shares_the_same_one_walk_seam(
     assert preflight.census_token is not None
 
 
+def _direct_creation_write(
+    root: Path,
+    *,
+    bump: bool,
+    path: str = "Knowledge Base/Notes/plain-creation-commit.md",
+) -> semantic_writes.CreationCommit:
+    """One structural creation preflight+commit pair, optionally with a stale
+    commit generation bumped in between -- mirrors `_direct_write`'s `bump`
+    shape for the creation seam (`preflight_creation` / `commit_creation`).
+    """
+    source = (
+        "---\n"
+        "status: active\n"
+        "---\n\n"
+        "# Plain commit creation\n\n"
+        "Ordinary prose, no compiled type.\n"
+    )
+    token = semantic_writes.DraftToken(
+        "test_writer", "tier2_create", path, TODAY.isoformat()
+    ).encode()
+    preflight = semantic_writes.preflight_creation(
+        root,
+        path=path,
+        source=source,
+        operation="tier2_create",
+        writer="test_writer",
+        draft_id=None,
+        draft_token=token,
+    )
+    assert preflight.applicability == "not_semantic"
+    if bump:
+        writer_lease._bump_commit_generation(
+            writer_lease.active_manager().config.state_dir, root
+        )
+    return semantic_writes.commit_creation(root, preflight=preflight, operation="tier2_create")
+
+
+def test_creation_commit_survives_a_stale_validity_stamp_at_boundary_entry(
+    tmp_path: Path,
+) -> None:
+    """`commit_creation`'s structural/non-semantic revalidation branch (taken
+    whenever `validity_stamp_current` is False at boundary entry) calls
+    `_evaluate_structural` too, and must unpack its 3-tuple return the same
+    way every other caller does. A commit-generation bump landing between
+    preflight and commit -- exactly the boundary-entry staleness
+    `_direct_write(bump=True)` already covers for
+    `preflight_existing`/`commit_existing` -- forces this exact branch.
+    """
+    committed = _direct_creation_write(tmp_path, bump=True)
+
+    assert committed.mutated is True
+    assert committed.applicability == "not_semantic"
+    assert committed.written_paths
+
+
 def test_corpus_metrics_carry_caller_and_outcome(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
     # Force the census-based reuse path: the event-token fast path returns

--- a/tests/test_mutation_timings.py
+++ b/tests/test_mutation_timings.py
@@ -347,6 +347,179 @@ def test_a_broken_metrics_registry_cannot_mask_the_boundary_error(
     assert isinstance(timings.as_dict()["boundary"]["waited_ms"], float)
 
 
+def _spy_corpus_census(monkeypatch) -> list[Path]:
+    """Monkeypatch `_corpus_census` to record every real call it still makes."""
+    calls: list[Path] = []
+    real_census = semantic_contract._corpus_census
+
+    def spy(root: Path):
+        calls.append(root)
+        return real_census(root)
+
+    monkeypatch.setattr(semantic_contract, "_corpus_census", spy)
+    return calls
+
+
+def _force_walk_confirmed_cache_path(monkeypatch) -> None:
+    """Disable the event-token fast path so a cache hit still walks once.
+
+    The event-hit branch in `build_corpus_context` returns before any stat
+    walk at all, which would make a "warm cache costs one walk" assertion
+    vacuous (it would cost zero). Forcing `freshness.triple` to miss routes
+    every call through the census-confirmed reuse path instead, which walks
+    exactly once whether it reuses, patches, or rebuilds.
+    """
+    monkeypatch.setattr("exomem.freshness.triple", lambda *args, **kwargs: None)
+
+
+def test_preflight_existing_warm_cache_costs_one_census_walk(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Warm reuse must stay at exactly one walk after threading the census."""
+    monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
+    _force_walk_confirmed_cache_path(monkeypatch)
+    semantic_contract.reset_corpus_context_cache()
+    path = _seed(tmp_path)
+    after_source = path.read_text(encoding="utf-8").replace(BEFORE_LINE, AFTER_LINE)
+    semantic_contract.build_corpus_context(tmp_path)  # warm the process cache
+
+    calls = _spy_corpus_census(monkeypatch)
+    preflight = semantic_writes.preflight_existing(
+        tmp_path,
+        path=PAGE,
+        after_source=after_source,
+        operation="edit",
+    )
+
+    assert len(calls) == 1, f"expected exactly one census walk, got {len(calls)}"
+    assert preflight.census_token is not None
+
+
+def _evict_between_build_and_capture(monkeypatch, root: Path) -> None:
+    """Simulate a concurrent eviction landing between corpus build and capture.
+
+    `semantic_contract.evaluate` is the last thing `_preflight_existing` (and
+    `_evaluate_structural`) run between `build_corpus_context_with_census` and
+    `_capture_validity_stamp` — evicting from inside it lands exactly in the
+    window where the old `cached_corpus_census(root)` global-cache read would
+    come back empty and force a second walk.
+    """
+    real_evaluate = semantic_contract.evaluate
+
+    def evicting_evaluate(*args, **kwargs):
+        semantic_contract.evict_corpus_context(root)
+        return real_evaluate(*args, **kwargs)
+
+    monkeypatch.setattr(semantic_contract, "evaluate", evicting_evaluate)
+
+
+def test_preflight_existing_evicted_cache_costs_one_census_walk(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The fix under test: a preflight must never pay a second walk for its
+    own validity token, even when the global corpus-context cache entry it
+    just built is evicted before the token is captured.
+
+    Against unpatched `main` this is red: `cached_corpus_census(root)` comes
+    back `None` after the eviction, so `corpus_validity_token`'s own fallback
+    walks the corpus a second time — TWO walks for one preflight. Threading
+    the census straight from the corpus context the preflight already built
+    means the eviction never matters: still exactly ONE walk.
+
+    The cache is warmed before the spy/eviction hook attach so the one walk
+    being counted is the preflight's own confirm-and-reuse walk, not the
+    unrelated multi-walk stabilization a genuinely cold, from-scratch build
+    already pays before this fix's seam is ever reached.
+    """
+    monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
+    _force_walk_confirmed_cache_path(monkeypatch)
+    semantic_contract.reset_corpus_context_cache()
+    path = _seed(tmp_path)
+    after_source = path.read_text(encoding="utf-8").replace(BEFORE_LINE, AFTER_LINE)
+    semantic_contract.build_corpus_context(tmp_path)  # warm the process cache
+
+    _evict_between_build_and_capture(monkeypatch, tmp_path)
+    calls = _spy_corpus_census(monkeypatch)
+
+    preflight = semantic_writes.preflight_existing(
+        tmp_path,
+        path=PAGE,
+        after_source=after_source,
+        operation="edit",
+    )
+
+    assert len(calls) == 1, f"expected exactly one census walk, got {len(calls)}"
+    assert preflight.census_token is not None
+
+
+def test_preflight_existing_census_token_matches_the_old_uncached_path(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Threading the census must not change what the validity token contains.
+
+    Reconstructs the corpus-census half of the stamp exactly the way the old,
+    un-threaded `_capture_validity_stamp` produced it — `cached_corpus_census`
+    missing, falling back to `corpus_validity_token`'s own walk — on the same
+    unchanged corpus, right after the real preflight ran. Both walks see
+    identical on-disk state, so the two tokens must be byte-for-byte equal.
+    """
+    monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
+    _force_walk_confirmed_cache_path(monkeypatch)
+    semantic_contract.reset_corpus_context_cache()
+    path = _seed(tmp_path)
+    after_source = path.read_text(encoding="utf-8").replace(BEFORE_LINE, AFTER_LINE)
+    semantic_contract.build_corpus_context(tmp_path)  # warm the process cache
+    _evict_between_build_and_capture(monkeypatch, tmp_path)
+
+    preflight = semantic_writes.preflight_existing(
+        tmp_path,
+        path=PAGE,
+        after_source=after_source,
+        operation="edit",
+    )
+
+    assert preflight.census_token is not None
+    sc_token, _generation = preflight.census_token
+    # The eviction is still in effect (nothing repopulated the cache since),
+    # so this reproduces the old fallback path on the identical corpus state.
+    old_style_sc_token = semantic_contract.corpus_validity_token(
+        tmp_path, corpus_census=semantic_contract.cached_corpus_census(tmp_path)
+    )
+    assert old_style_sc_token == sc_token
+
+
+def test_preflight_creation_structural_shares_the_same_one_walk_seam(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """`preflight_creation`'s structural/not_semantic path shares
+    `_capture_validity_stamp` with `preflight_existing` through
+    `_evaluate_structural`, and must show the same one-walk behaviour under
+    the same evicted-cache condition.
+    """
+    from exomem import create_file
+
+    monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
+    _force_walk_confirmed_cache_path(monkeypatch)
+    semantic_contract.reset_corpus_context_cache()
+    semantic_contract.build_corpus_context(tmp_path)  # warm the process cache
+
+    _evict_between_build_and_capture(monkeypatch, tmp_path)
+    calls = _spy_corpus_census(monkeypatch)
+
+    preflight = create_file.create_file(
+        tmp_path,
+        path="Knowledge Base/Notes/plain-creation.md",
+        content="# Plain creation\n\nOrdinary prose, no compiled type.\n",
+        frontmatter={"status": "active"},
+        today=TODAY,
+        validate_only=True,
+    )
+
+    assert preflight.applicability == "not_semantic"
+    assert len(calls) == 1, f"expected exactly one census walk, got {len(calls)}"
+    assert preflight.census_token is not None
+
+
 def test_corpus_metrics_carry_caller_and_outcome(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
     # Force the census-based reuse path: the event-token fast path returns


### PR DESCRIPTION
## What

#510 slice C: preflight paid a **second** full corpus-census stat-walk for its
validity token whenever the global cache entry was absent at capture time
(cold build that couldn't cache, candidate builds, stabilization give-up,
cache disabled, or a concurrent eviction between build and capture) — real
seconds inside every affected preflight at vault scale.

- `build_corpus_context` is now a thin public wrapper over
  `build_corpus_context_with_census(...) -> (context, census | None)`: every
  cache-lifecycle branch returns the exact census that validated the context
  it returns (`None` where no single walk unambiguously describes it —
  candidate builds, stabilization give-up, the in-flight-dedup waiter). Branch
  logic untouched — returns and signatures only.
- `_capture_validity_stamp` takes the threaded census; the
  `cached_corpus_census` fallback (and its metered fallback walk) remains for
  callers with no context in hand.
- Threaded through `preflight_existing` and `preflight_creation` (via
  `_evaluate_structural`); `preflight_move`/`preflight_recovery` verified to
  not share the seam (no `census_token`).
- Residual same-shape seam recorded on #510 for the A/B lane:
  `relation_review.py:3720-3723`.

## Verification

- Red-first on a disposable main worktree: the evicted-cache preflight paid
  **2** census walks before, **1** after; token equality asserted against the
  old fallback path. Walk-counting spies sit on the module-level
  `_corpus_census` seam both timed and deferred paths resolve.
- Independent review (REQUEST_CHANGES → fixed → recheck all FIXED) caught an
  execution-proven blocker before delivery: the second `_evaluate_structural`
  call site still unpacked two values, crashing structural creations whose
  stamp went stale at boundary entry — exactly the concurrency branch the
  stamp protects. Fixed; now pinned by a test that genuinely commits through
  `commit_creation` with the generation bumped between preflight and commit.
  The in-flight-dedup waiter now honestly returns `None` rather than pairing
  the owner's context with its own pre-wait census.
- `tests/test_mutation_timings.py`: 16 passed. Creation-writers + regression
  sweep: 429 passed. Schema fidelity: 8 passed (no digest movement).
  `uvx ruff check --select F` clean. Local write-gate comparison vs main
  showed statistically indistinguishable pre-existing contention overshoots
  (Linux CI adjudicates).

Part of #510 (slices A/B — populate-on-miss and the withdraw narrowing under
the freshness-liveness contract — follow in their own lane).
