### PR TITLE
feat(memory): advise when a page outgrows its own declared scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,7 @@ jobs:
           src/exomem/memory_context.py
           src/exomem/memory_schema.py
           src/exomem/relation_registry.py
+          src/exomem/structure_promotion.py
           src/exomem/traversal_profiles.py
           src/exomem/epistemic_graph.py
           scripts/e2e_product_loop.py
@@ -291,6 +292,7 @@ jobs:
           tests/test_observe_memory.py
           tests/test_memory_schema.py
           tests/test_relation_registry.py
+          tests/test_structure_promotion.py
           tests/test_traversal_profiles.py
           --select E,F,I,B,UP,BLE
       - name: Targeted contract type check
@@ -301,6 +303,7 @@ jobs:
           src/exomem/memory_context.py
           src/exomem/memory_schema.py
           src/exomem/relation_registry.py
+          src/exomem/structure_promotion.py
           src/exomem/traversal_profiles.py
           src/exomem/epistemic_graph.py
 

--- a/docs/ai-assistant-guide.md
+++ b/docs/ai-assistant-guide.md
@@ -208,6 +208,19 @@ come back as `warnings` — at most 8 entries of at most 300 characters each.
 rest were trimmed. Two cases return a count with no `warnings`: an upload
 receipt, whose warnings are already per-file rows under `files`, and a mutation
 recovered from a portable receipt, which deliberately retains no leaf content.
+
+A compiled-note write may also return `structure_suggestion`. It is advisory
+feedback that recurring durable material on the written page now sits outside
+its own declared scope, carrying `kind`, a `strength` of `strong` or `moderate`,
+deterministic `reasons`, the number of durable units in the group, and at most
+six `cluster_terms`. Every value comes from the page named in the same response,
+so it discloses nothing about any other page. It never changes `status`,
+`mutated`, `warnings_count`, mutation identity, or replay, and a detection
+failure omits the field rather than affecting the write. The runtime detects
+only; it never reorganises the vault. Agents should normally raise a `strong`
+suggestion with the user in ordinary domain language, prefer an existing
+suitable destination, and ask before restructuring.
+
 Use `response_detail="full"` when an agent
 needs the previous leaf diagnostics nested under `diagnostics`.
 `response_detail="legacy"` returns the old raw result for temporary

--- a/openspec/changes/add-structural-promotion-suggestions/.openspec.yaml
+++ b/openspec/changes/add-structural-promotion-suggestions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/add-structural-promotion-suggestions/design.md
+++ b/openspec/changes/add-structural-promotion-suggestions/design.md
@@ -1,0 +1,86 @@
+## Context
+
+Four product tools mutate compiled notes: `remember`, `edit_memory`, `observe_memory`, and `replace_memory`. They fan into exactly two commit functions in one module — `semantic_writes.commit_creation` and `semantic_writes.commit_existing` — whose results already reach the caller as `leaf_result["creation"]` and `leaf_result["semantic"]`.
+
+Three facts from the current source shape this design.
+
+First, `write_feedback` is not a viable carrier. It is built only in `note._build_write_feedback`, so it exists for `remember` alone, and `mutation_terminal.project_terminal` is a strict allowlist over `_ENVELOPE_KEYS` that never merges `leaf_result` into a compact response. Every writer defaults to `response_detail="compact"`, so `write_feedback` reaches no caller unless one explicitly asks for `full` or `legacy`. Attaching structural advice there would cover one of four writers and would be invisible in the default response of that one.
+
+Second, the evidence is already in memory. `semantic_contract.SemanticCorpusContext` is built and process-cached on every write and retained on the preflight as `before_corpus` and `after_corpus`. Its `SemanticPageState` carries `page_type`, `projects`, `status`, `title`, `frontmatter`, `body_wikilinks`, and the fully parsed `SemanticUnitDocument`, whose source-ordered units each expose `category`, `kind`, `tags`, `content`, and `anchor`. No read, query, or index is required to inspect the page that was just written.
+
+Third, there is no per-page mutation history recording which units a given write added. `log.md` records an operation, a date, and a rationale per page, but costs a whole-file read and retains only the newest entries vault-wide; the `mutations` table is idempotency state. A detector that wants "the same off-scope topic recurring" therefore cannot count write events cheaply.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detect that a just-written compiled page has accumulated recurring durable material outside its own declared scope.
+- Reach all four compiled writers from one place, without editing the writer leaves or the writer-lease safety core.
+- Make the signal visible in the default response, since an advisory nobody receives is not a feature.
+- Keep the payload explainable: named reason codes and counts a human can check against the page.
+- Fail silent and stay advisory under every error, refusal, or missing optional state.
+
+**Non-Goals:**
+
+- Proposing, naming, or creating a destination page, hub, or project.
+- Moving, splitting, retitling, or rescoping any file.
+- Emitting a numeric confidence, score, or probability.
+- Persisting suggestion state, acceptance, dismissal, or cooldown.
+- Any whole-corpus scan, background job, embedding, or model call.
+
+## Decisions
+
+### Carry the suggestion on the two commit results, not on `write_feedback`
+
+`CreationCommit` and `ExistingCommit` gain one optional field, emitted from `as_dict()` only when a suggestion exists. `remember` and `replace_memory` surface it at `creation.structure_suggestion`; `edit_memory` and `observe_memory` surface it at `semantic.structure_suggestion`. Both already flow to the terminal, so no writer leaf changes.
+
+`project_terminal` then lifts the suggestion from either location into the compact envelope, following the existing precedent that projected bounded `warnings` texts and the `graph_sync` outcome fields out of the leaf. `_ENVELOPE_KEYS` is not extended: those keys are the closed set a client may branch on for the outcome of the mutation, and a structural advisory is not part of that machine. The live Records acceptance allowlist gains the key as an optional compact field.
+
+The alternative — hooking `writer_lease.invoke_leaf`, the single highest common layer — was rejected. It sees `leaf_result` and the vault root but not the parsed page, so it would have to re-read and re-parse the file it just wrote; and it is the module holding receipts, fencing, commit evidence, and idempotency, where a post-commit exception converts a committed write into an uncertain outcome.
+
+### Compute after the guarded section, from state already held
+
+The detector runs inside the commit function but after the locked write completes, over the page state the preflight already produced. It performs no file read, no database access, and no network or model call, so the mutation critical section is unchanged and the pure-substrate constraint is satisfied by construction: the server measures the page it just wrote, and the agent reasons about it.
+
+The whole call is wrapped in a bare exception guard that logs and returns nothing, matching the established idiom for optional post-write work. A detector fault cannot change `status`, `mutated`, `warnings_count`, or any existing key.
+
+### Judge units against declared identity, never against length
+
+The page's declared identity is the union of its frontmatter tags, the significant tokens of its title, and its project keys. A durable unit is off-scope when its own tag vocabulary is dominated by terms outside that identity — strictly more out-of-scope terms than in-scope ones, and at least two out-of-scope terms, so a thinly tagged unit cannot qualify on one stray word.
+
+Unit tags alone carry the topic signal in v1. Categories are deliberately excluded: the vocabulary is open, and many categories name an epistemic role such as decision or constraint rather than a subject, so admitting them would mix two different axes for no gain on the motivating case. A page whose units carry no tags therefore produces no signal, which is the correct default for an advisory.
+
+Off-scope units are then grouped by shared vocabulary, and a term only seeds a group when it appears in at least two off-scope units. That recurrence requirement is what separates a genuine emerging topic from an incidental tangent, and it is why one or two off-topic observations cannot trigger.
+
+Four reason codes are emitted, all deterministic and independently checkable:
+
+- `off_scope_cluster_recurs` — the group's seeding vocabulary appears across multiple off-scope units.
+- `declared_scope_mismatch` — that vocabulary is absent from the page's declared identity.
+- `cluster_reaches_child_note_mass` — the group has enough units and enough distinct recurring terms to justify its own note.
+- `page_retains_original_scope` — enough units still match the declared identity, so the page is genuinely mixed rather than simply misnamed.
+
+At least two codes are required to emit anything; all four are required for `strong`. A single signal never produces a suggestion.
+
+### Recurrence is measured over units, not over write events
+
+This is the design's known approximation and it is deliberate. Units are what writes deposit, so counting recurrence across durable units tracks the same underlying accumulation, and it costs nothing. It does mean a single write depositing many units is treated like several writes depositing one each. The reason codes and the specification therefore speak of units, never of writes, so the contract does not claim history it does not read.
+
+### Exclude by declared identity rather than by heuristic
+
+Only compiled note types are eligible; sources, evidence, media, records, planning, and structured collections never enter the path. Navigational pages are excluded. A page tagged as a deliberate hub or snapshot is excluded, reusing the existing convention that already exempts those tags from staleness and activation pressure.
+
+A correctly built hub is additionally quiet on principle rather than by exemption: it declares its breadth in its own tags and title, so its units are in scope and no divergence exists. The same property produces the post-restructuring behaviour — once material is routed into a destination whose declared identity matches it, neither the new page nor the cleaned original diverges, and the advice stops without any dismissal state.
+
+### Report only what the caller just wrote
+
+Every value in the payload — the reason codes, the off-scope unit count, and the bounded list of recurring terms — is derived from the page named in the same response. No other page's path, title, project, or count is read or reported. The governance requirement is met structurally: there is nothing in the payload that a caller who performed this write could not already see, so no disclosure decision is needed on the write path.
+
+## Risks / Trade-offs
+
+- [Unit-recurrence stands in for write-recurrence] -> Name units in the contract and reason codes so nothing overclaims; revisit only if a cheap per-page write history appears.
+- [Untagged units carry no vocabulary] -> Such pages simply produce no signal. The failure mode is silence, which is the correct default for an advisory.
+- [Synonym drift could read as topic drift] -> A page whose units consistently tag the declared subject with different words than the frontmatter does could look divergent. Partly mitigated: if most units drift that way, `page_retains_original_scope` fails and nothing is emitted; if only a few do, the group cannot reach mass. It remains the most plausible false positive, and the honest first calibration target.
+- [A page whose title and tags are stale could look divergent] -> Require `page_retains_original_scope`, so a page that has wholly moved on reads as misnamed and stays quiet rather than being told to split.
+- [Per-write cost is added to the commit path] -> The detector is a bounded pass over units already parsed and held in memory, with no I/O; the existing write-latency ceilings and the superlinear-scaling bound remain the gate.
+- [A new compact key could be read as part of the outcome machine] -> Leave `_ENVELOPE_KEYS` unchanged and document the field as advisory, exactly as `warnings` and the graph outcome fields are.
+- [Advice could become nagging across a conversation] -> The runtime reports the condition; the agent contract carries in-conversation suppression, and durable dismissal state is deferred rather than invented here.

--- a/openspec/changes/add-structural-promotion-suggestions/proposal.md
+++ b/openspec/changes/add-structural-promotion-suggestions/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Durable knowledge silently outgrows the page it is written into. A compiled note can begin as one coherent subject and, through a sequence of individually defensible writes, accumulate several unrelated durable topics until it is no longer the right canonical home for any of them. Nothing in the write path notices. Today only a user who understands note types, project scope and hub structure can catch it, which contradicts the product thesis that governed structure should feel effortless.
+
+The runtime already parses every semantic unit and holds the page's declared identity in memory at commit time, so the condition is observable without new infrastructure. What is missing is a bounded, advisory signal that says the current destination has stopped being coherent, so the agent can raise it in ordinary language and offer to organise it.
+
+## What Changes
+
+- Add a deterministic, local, read-only detector that decides whether a just-written compiled page shows recurring durable material outside its own declared scope.
+- Return at most one advisory `structure_suggestion` on successful compiled-note mutations from `remember`, `edit_memory`, `observe_memory`, and `replace_memory`, carried on the existing commit results and projected into the default compact terminal.
+- Report `strength` as `strong` or `moderate` with sorted deterministic reason codes, and never a numeric confidence.
+- Require convergent evidence: a single weak signal never produces a suggestion, and raw page length is never an input.
+- Restrict every reported fact to the page the caller just wrote, so no other page's path, title, or count can be inferred from the suggestion.
+- Exclude non-compiled material, navigational pages, and pages whose declared identity already announces breadth.
+- Keep the analysis advisory: any detector failure, refusal, or absent optional state leaves the committed mutation and its terminal unchanged.
+- Teach bootstrap and the canonical workflow skill how to inspect and present a suggestion, and correct the existing post-write instruction that names response fields the default response does not carry.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `command-surface`: successful compiled-note mutations may carry one bounded advisory structural suggestion in the default compact terminal, without changing mutation identity, status, or existing keys.
+- `agent-bootstrap-contract`: bootstrap and the canonical write loop teach agents to inspect a structural suggestion, surface a strong one in domain language, ask before restructuring, and stay quiet on a moderate one.
+
+## Impact
+
+The compiled-write commit results, the compact terminal projection, the live Records acceptance allowlist, the bootstrap post-write guidance, and the scaffold skill and operations reference change, plus a new pure detector module and its focused tests. Regenerated Claude plugin skill copies follow their existing packaging path.
+
+No MCP tool is added. No tool description, parameter, or input schema changes, so the packaged tool-surface fingerprint and the external connector attestation are untouched. No new table, index, background worker, embedding call, persistent review object, graph schema change, or automatic file or project migration is introduced. Existing write-latency, governance, and mutation-safety gates continue to apply unchanged.
+
+Deliberately out of scope: proposing a destination page or project, naming an existing target, persisting accept or dismiss state, cross-session cooldown, whole-corpus structural audits, and any migration preview or execution.

--- a/openspec/changes/add-structural-promotion-suggestions/specs/agent-bootstrap-contract/spec.md
+++ b/openspec/changes/add-structural-promotion-suggestions/specs/agent-bootstrap-contract/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: The agent contract teaches structural-promotion presentation
+
+Bootstrap and the canonical write loop SHALL teach agents that a compiled write may return one advisory `structure_suggestion`, and SHALL state how to act on it.
+
+The guidance SHALL direct agents to normally surface a `strong` suggestion, to describe it in the user's own domain language rather than in Exomem's internal terms, to ask before reorganising unless the user has explicitly delegated curation, to prefer an existing suitable destination over creating a new one, to avoid repeating the same recommendation within one interaction, and to exercise judgement on a `moderate` suggestion where mentioning it would be bureaucracy rather than help.
+
+The guidance SHALL state that the suggestion is advisory and that the runtime never reorganises knowledge on its own.
+
+#### Scenario: Bootstrap names the signal and the expected behaviour
+
+- **WHEN** a generic client reads the bootstrap post-write guidance
+- **THEN** it learns that a durable write may return a structural suggestion and where to find it
+- **AND** it learns to surface a strong suggestion, to ask before restructuring, and to prefer an existing destination
+
+#### Scenario: Guidance is presentational, not executable
+
+- **WHEN** bootstrap describes structural suggestions
+- **THEN** reading bootstrap creates, moves, or reorganises nothing
+- **AND** no new tool or parameter is required to receive the suggestion
+
+### Requirement: Post-write guidance names only fields the response carries
+
+The write-loop guidance SHALL describe the fields a successful mutation actually returns at its default response detail, and SHALL identify the response detail required for any field it names that is not returned by default.
+
+#### Scenario: The write loop does not direct agents to absent fields
+
+- **WHEN** the canonical write loop tells an agent to inspect the result of a durable write
+- **THEN** every field it names is either present in the default committed response
+- **AND** or is explicitly marked as requiring a higher response detail

--- a/openspec/changes/add-structural-promotion-suggestions/specs/command-surface/spec.md
+++ b/openspec/changes/add-structural-promotion-suggestions/specs/command-surface/spec.md
@@ -1,0 +1,109 @@
+## ADDED Requirements
+
+### Requirement: Compiled writes may return one advisory structural-promotion suggestion
+
+When a compiled-note mutation commits, the system SHALL evaluate whether the written page now carries recurring durable material outside its own declared scope. When it does, the successful result SHALL include at most one `structure_suggestion`, carried on the existing commit result and projected into the default compact terminal, for every compiled writer: `remember`, `edit_memory`, `observe_memory`, and `replace_memory`.
+
+The suggestion SHALL report `kind`, a `strength` of exactly `strong` or `moderate`, a deterministically ordered list of reason codes, the count of off-scope durable units, and a bounded list of the recurring terms that formed the group. It SHALL NOT report a numeric confidence, score, probability, or any other continuous quantity.
+
+The suggestion is advisory. It SHALL NOT add a value to the closed set of keys a client branches on for mutation outcome, and it SHALL NOT alter `status`, `mutated`, `path`, `warnings_count`, mutation identity, or replay behaviour. When no condition is detected the key SHALL be absent rather than null or empty.
+
+#### Scenario: A diverged compiled page returns a suggestion in the default response
+
+- **WHEN** a compiled page whose declared identity describes one subject accumulates recurring durable units describing a materially different subject, and a further compiled write commits
+- **THEN** the write succeeds with its existing committed terminal unchanged
+- **AND** the default compact response carries one `structure_suggestion` with `strength` of `strong` or `moderate`
+- **AND** the suggestion names at least two reason codes in deterministic order
+- **AND** the response reports no numeric confidence for the suggestion
+
+#### Scenario: Every compiled writer can carry the suggestion
+
+- **WHEN** the same diverged page is mutated through `remember`, `edit_memory`, `observe_memory`, or `replace_memory`
+- **THEN** each committed result can carry the suggestion
+- **AND** the suggestion has the same shape regardless of which writer produced it
+
+#### Scenario: A coherent page returns no suggestion
+
+- **WHEN** a compiled write commits to a page whose durable units remain within its declared scope
+- **THEN** the response contains no `structure_suggestion` key
+
+### Requirement: Structural detection is conservative and never triggered by size
+
+The system SHALL require convergent evidence before emitting a suggestion. It SHALL emit nothing on a single signal, and it SHALL reserve `strong` for the case where every reason code holds.
+
+Recurrence SHALL be established over durable semantic units rather than over write events, and the reported reason codes SHALL describe units accordingly. A term SHALL contribute to a group only when it recurs across more than one off-scope unit.
+
+Raw page length, byte size, unit count alone, section count, and category variety SHALL NOT be sufficient to emit a suggestion. A long page whose durable units remain within its declared scope SHALL produce no suggestion regardless of its size.
+
+#### Scenario: A long coherent research note stays quiet
+
+- **WHEN** a compiled write commits to a large note containing many durable units, many categories, and many sections that all remain within one declared subject
+- **THEN** no suggestion is emitted
+- **AND** the outcome does not depend on the page's length
+
+#### Scenario: One or two tangents do not trigger promotion
+
+- **WHEN** an otherwise coherent page contains one or two durable units outside its declared scope
+- **THEN** no suggestion is emitted, because no term recurs across enough off-scope units to form a group
+
+#### Scenario: A single signal is insufficient
+
+- **WHEN** fewer than two reason codes hold for a page
+- **THEN** no suggestion is emitted
+
+### Requirement: Structural detection is scoped to compiled knowledge
+
+The system SHALL evaluate only compiled note pages. Sources, evidence, media artifacts, structured collections, planning items, navigational pages, and any page ineligible for recall SHALL NOT be analysed and SHALL NOT produce a suggestion.
+
+A page whose declared identity announces deliberate breadth SHALL NOT be nagged toward further division. A page carrying the established hub or snapshot convention SHALL be excluded from analysis.
+
+#### Scenario: Source and evidence artifacts never enter the advisory path
+
+- **WHEN** a write commits to a source, evidence, or other non-compiled artifact, however large or heterogeneous
+- **THEN** no structural analysis runs and no suggestion is emitted
+
+#### Scenario: A deliberate hub is not told to split
+
+- **WHEN** a compiled write commits to a page that declares itself a hub by the established convention
+- **THEN** no suggestion is emitted
+
+#### Scenario: Advice stops once the material is correctly routed
+
+- **WHEN** the diverged material has been moved into a destination whose declared identity matches it, and further writes are directed there
+- **THEN** neither that destination nor the original page emits a suggestion
+- **AND** the silence follows from scope agreement rather than from any recorded dismissal
+
+### Requirement: Structural suggestions never weaken a committed write
+
+Structural analysis SHALL be failure-isolated. An exception, an unavailable optional signal, or an undecidable result SHALL cause the suggestion to be omitted, and SHALL NOT fail, delay, retry, roll back, or alter the committed mutation or its terminal.
+
+The system SHALL NOT move, rename, split, retitle, rescope, create, or delete any page, project, or folder as a consequence of structural detection.
+
+Existing write-latency requirements SHALL continue to hold unchanged, including the absolute commit ceilings and the bound on how commit cost may scale with page size.
+
+#### Scenario: A detector failure leaves the write committed
+
+- **WHEN** structural analysis raises during an otherwise successful compiled write
+- **THEN** the mutation remains committed with its existing terminal
+- **AND** no `structure_suggestion` is present
+- **AND** no warning, error code, or retry is produced for the caller
+
+#### Scenario: Detection never restructures the vault
+
+- **WHEN** a suggestion is emitted at any strength
+- **THEN** no page, project, or folder has been created, moved, renamed, or deleted by the system
+
+### Requirement: Structural evidence is confined to the written page
+
+Every fact reported in a suggestion SHALL be derived from the page named in the same response. The suggestion SHALL NOT include or allow inference of any other page's path, title, project, tags, or count, whether or not the caller is permitted to see that page.
+
+#### Scenario: The payload discloses nothing about other pages
+
+- **WHEN** a suggestion is emitted for a page in a vault containing pages the caller may not see
+- **THEN** the payload contains no path, title, project, or count belonging to any page other than the one written
+
+#### Scenario: The payload is bounded and deterministic
+
+- **WHEN** the same page state is evaluated twice
+- **THEN** the reason codes, counts, and recurring terms are identical and identically ordered
+- **AND** at most one suggestion is returned, with its recurring-term list bounded to a small fixed maximum

--- a/openspec/changes/add-structural-promotion-suggestions/tasks.md
+++ b/openspec/changes/add-structural-promotion-suggestions/tasks.md
@@ -1,0 +1,47 @@
+## 1. Contract and red-first behavioural acceptance
+
+- [x] 1.1 Add the `command-surface` delta covering the advisory suggestion, conservative triggering, scope exclusions, failure isolation, and intra-page evidence.
+- [x] 1.2 Add the `agent-bootstrap-contract` delta covering presentation invariants and truthful post-write field naming.
+- [x] 1.3 Build the accumulating dogfood fixture: a coherent travel note that gains durable clusters over successive mutations across relocation/property, financing/land, agricultural infrastructure, grants/qualification, livestock/husbandry, and hospitality. Bind assertions to structural behaviour and reason codes, never to fixture prose.
+- [x] 1.4 Assert the journey is quiet at its early stages and reaches a `strong` suggestion before the accumulation becomes absurd.
+- [x] 1.5 Add the long coherent research-note negative control, made larger than the positive fixture at its trigger point so length cannot be the discriminator.
+- [x] 1.6 Add the one-and-two-tangent negative control.
+- [x] 1.7 Add the source/evidence and non-compiled exclusion controls.
+- [x] 1.8 Add the deliberate-hub control.
+- [x] 1.9 Add the post-restructuring control proving both the new destination and the cleaned original stay quiet.
+- [x] 1.10 Add failure-isolation, intra-page-evidence, boundedness, and determinism regressions.
+- [x] 1.11 Add public compiled-write regressions proving the suggestion reaches the default compact response from all four writers.
+
+## 2. Detector
+
+- [x] 2.1 Add the pure detector module with no file, database, network, or model access.
+- [x] 2.2 Implement the eligibility gate for compiled types, navigational pages, recall eligibility, declared-hub convention, and the minimum unit floor.
+- [x] 2.3 Derive declared identity from frontmatter tags, significant title tokens, and project keys.
+- [x] 2.4 Classify off-scope units and group them by vocabulary recurring across more than one unit.
+- [x] 2.5 Emit deterministic reason codes, require at least two to suggest and all four for `strong`, and bound the payload.
+
+## 3. Write path and terminal
+
+- [x] 3.1 Carry the optional suggestion on both compiled commit results, emitted from their dictionaries only when present.
+- [x] 3.2 Compute it after the guarded write completes, from state the preflight already holds, inside a failure-isolating guard.
+- [x] 3.3 Project the suggestion into the default compact terminal without extending the closed outcome-key set.
+- [x] 3.4 Extend the live acceptance allowlist for the new optional compact field.
+
+## 4. Agent contract and generated surfaces
+
+- [x] 4.1 Add bootstrap post-write guidance within the existing compact budget.
+- [x] 4.2 Update the scaffold skill write loop and mutation-terminal reference, and correct the existing instruction that names fields the default response omits.
+- [x] 4.3 Regenerate the packaged Claude plugin skill copies from the scaffold rather than editing them.
+- [x] 4.4 Audit both hosted client packages and the assistant guide for the same current contract. Outcome: `plugins/hosted/**` is a frozen v1 release identity byte-pinned by `tests/fixtures/hosted/v1-release-identities.json`, so it is deliberately left untouched and the hosted agent contract lands with the next hosted release identity.
+- [x] 4.5 Confirm the packaged tool-surface fingerprint and schema fixture are unchanged.
+- [x] 4.6 Add the new module and its test to the strict lint and targeted type-check lists.
+
+## 5. Verification
+
+- [x] 5.1 Prove the tests bind the mechanism: disable detection, confirm the positive journey fails while every negative control still passes, and record the failure output.
+- [x] 5.2 Run focused detector, mutation-terminal, note, observe, creation, lifecycle, and transactional-write tests.
+- [x] 5.3 Run governance egress and postfilter tests.
+- [x] 5.4 Run the semantic write-latency gate before and after, on the same quiesced machine, and report the delta against the absolute ceilings and the size-scaling bound.
+- [x] 5.5 Run the retrieval latency gate, scaffold leak, plugin sync, bootstrap budget, and schema fidelity tests.
+- [x] 5.6 Validate the change in strict mode and run the repository lint and lean suite.
+- [x] 5.7 Drive a real installed compiled-write sequence and confirm the suggestion appears in the default response.

--- a/plugins/claude-code/skills/exomem/SKILL.md
+++ b/plugins/claude-code/skills/exomem/SKILL.md
@@ -128,12 +128,30 @@ Use this loop whenever a durable conclusion should enter Exomem:
    that genuinely clarify provenance or context, and write accepted note-level
    edges under `## Relations` as `- relation_type [[Target]]`. Carry accepted
    links into the *first* write; do not defer them to a follow-up `edit_memory`.
-6. Write, then inspect the returned `warnings`, optional `suggestions`, and
-   `write_feedback` — which reports `sources.cited`, `links.body_wikilinks`, and
-   `relations.relation_debt`. If all three are zero and that is not honest, fix it
-   before reporting.
+6. Write, then inspect the result. The default committed response carries
+   `warnings` (when the write warned) and an optional `structure_suggestion`.
+   The fuller structural checklist — `write_feedback` with `sources.cited`,
+   `links.body_wikilinks`, and `relations.relation_debt`, plus corpus-aware
+   `suggestions` — lives under `diagnostics` and needs `response_detail="full"`.
+   Ask for it when provenance or connectivity is in doubt; if all three counts
+   are zero and that is not honest, fix it before reporting.
 7. If a near-duplicate warning fires, prefer `edit_memory` or `replace_memory` over a parallel page. If suggestions are useful, add them with a follow-up `edit_memory`.
-8. Report one line: `Saved -> <path>`.
+8. If the write returned a `structure_suggestion`, handle it as below.
+9. Report one line: `Saved -> <path>`.
+
+**When a write says the page has outgrown its scope.** A compiled write may return
+`structure_suggestion` — the runtime's observation that recurring durable material
+on that page now sits outside what the page says it is about. It is advice, not an
+instruction, and nothing has been moved.
+
+Normally surface a `strong` one, in the user's own words: name the threads that have
+grown up, say it looks like its own project or note now, and offer to organise it.
+Never recite the reason codes or say "scope divergence" — that is internal
+vocabulary. Prefer routing into an existing suitable destination over inventing a
+new one, so search before proposing. Ask before restructuring anything unless the
+user has already delegated curation. Do not raise the same recommendation twice in
+one conversation. On a `moderate` one, use judgement: if mentioning it would be
+bureaucracy rather than help, stay quiet.
 
 **Comprehensive coverage, minimal expression.** Capturing at the landing is about
 *timing*, not *volume* — it never means keep less. Minimality is a property of
@@ -366,6 +384,13 @@ than the count means the rest were trimmed; ask for `response_detail="full"` to
 see them all. An upload receipt reports its warnings as per-file rows under
 `files` instead, and a mutation recovered from a portable receipt reports the
 count alone because it retains no leaf content.
+A compiled-note write may also carry `structure_suggestion`: an advisory
+`kind`, a `strength` of `strong` or `moderate`, deterministic `reasons`, the
+number of durable units in the group, and up to six recurring `cluster_terms`.
+It is present only when the written page shows recurring durable material
+outside its own declared scope, it reports nothing about any other page, and it
+never affects `status`, `mutated`, or replay. Nothing is reorganised by the
+runtime; acting on it is the agent's decision with the user.
 Use `response_detail="full"` when existing leaf diagnostics are needed under
 `diagnostics`. Use `response_detail="legacy"` only for temporary compatibility
 with the former raw result. Response detail is presentation-only: changing it

--- a/plugins/claude-code/skills/exomem/references/operations.md
+++ b/plugins/claude-code/skills/exomem/references/operations.md
@@ -143,6 +143,19 @@ entries of 300 characters each; `warnings_count` stays authoritative, so a
 shorter list means the remainder was trimmed. Upload receipts carry their
 warnings as per-file rows under `files`, and a terminal rebuilt from a portable
 receipt reports only the count, since that receipt retains no leaf content.
+
+A compiled-note write may additionally return `structure_suggestion`, an
+advisory signal that recurring durable material on the written page now sits
+outside its own declared scope. It carries `kind`, a `strength` of either
+`strong` or `moderate`, a deterministically ordered `reasons` list, the count of
+durable units in the group, and at most six `cluster_terms`. Every
+value is derived from the page named in the same response; it never reports a
+path, title, or count belonging to another page. It is advisory only: it is
+absent when nothing is detected, it never changes `status`, `mutated`,
+`warnings_count`, mutation identity, or replay, and detection failure omits the
+field rather than affecting the write. The runtime never creates, moves,
+renames, or deletes anything as a result.
+
 `response_detail="full"` adds the existing leaf result under
 `diagnostics`. `response_detail="legacy"` returns that old raw leaf result and
 is retained for at least one compatibility release. The response-detail choice

--- a/scripts/records_live_acceptance.py
+++ b/scripts/records_live_acceptance.py
@@ -53,6 +53,10 @@ _COMPACT_MUTATION_OPTIONAL = frozenset(
         # Present only when the leaf actually warned; absent on receipt recovery,
         # which reports a count with no retained texts.
         "warnings",
+        # Advisory structural feedback on a compiled-note write. Absent unless the
+        # written page shows recurring durable material outside its declared scope,
+        # and never carried by a Records mutation.
+        "structure_suggestion",
     }
 )
 _COMPACT_V1_RECEIPT = frozenset(

--- a/src/exomem/_scaffold/_Schema/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/SKILL.md
@@ -128,12 +128,30 @@ Use this loop whenever a durable conclusion should enter Exomem:
    that genuinely clarify provenance or context, and write accepted note-level
    edges under `## Relations` as `- relation_type [[Target]]`. Carry accepted
    links into the *first* write; do not defer them to a follow-up `edit_memory`.
-6. Write, then inspect the returned `warnings`, optional `suggestions`, and
-   `write_feedback` — which reports `sources.cited`, `links.body_wikilinks`, and
-   `relations.relation_debt`. If all three are zero and that is not honest, fix it
-   before reporting.
+6. Write, then inspect the result. The default committed response carries
+   `warnings` (when the write warned) and an optional `structure_suggestion`.
+   The fuller structural checklist — `write_feedback` with `sources.cited`,
+   `links.body_wikilinks`, and `relations.relation_debt`, plus corpus-aware
+   `suggestions` — lives under `diagnostics` and needs `response_detail="full"`.
+   Ask for it when provenance or connectivity is in doubt; if all three counts
+   are zero and that is not honest, fix it before reporting.
 7. If a near-duplicate warning fires, prefer `edit_memory` or `replace_memory` over a parallel page. If suggestions are useful, add them with a follow-up `edit_memory`.
-8. Report one line: `Saved -> <path>`.
+8. If the write returned a `structure_suggestion`, handle it as below.
+9. Report one line: `Saved -> <path>`.
+
+**When a write says the page has outgrown its scope.** A compiled write may return
+`structure_suggestion` — the runtime's observation that recurring durable material
+on that page now sits outside what the page says it is about. It is advice, not an
+instruction, and nothing has been moved.
+
+Normally surface a `strong` one, in the user's own words: name the threads that have
+grown up, say it looks like its own project or note now, and offer to organise it.
+Never recite the reason codes or say "scope divergence" — that is internal
+vocabulary. Prefer routing into an existing suitable destination over inventing a
+new one, so search before proposing. Ask before restructuring anything unless the
+user has already delegated curation. Do not raise the same recommendation twice in
+one conversation. On a `moderate` one, use judgement: if mentioning it would be
+bureaucracy rather than help, stay quiet.
 
 **Comprehensive coverage, minimal expression.** Capturing at the landing is about
 *timing*, not *volume* — it never means keep less. Minimality is a property of
@@ -366,6 +384,13 @@ than the count means the rest were trimmed; ask for `response_detail="full"` to
 see them all. An upload receipt reports its warnings as per-file rows under
 `files` instead, and a mutation recovered from a portable receipt reports the
 count alone because it retains no leaf content.
+A compiled-note write may also carry `structure_suggestion`: an advisory
+`kind`, a `strength` of `strong` or `moderate`, deterministic `reasons`, the
+number of durable units in the group, and up to six recurring `cluster_terms`.
+It is present only when the written page shows recurring durable material
+outside its own declared scope, it reports nothing about any other page, and it
+never affects `status`, `mutated`, or replay. Nothing is reorganised by the
+runtime; acting on it is the agent's decision with the user.
 Use `response_detail="full"` when existing leaf diagnostics are needed under
 `diagnostics`. Use `response_detail="legacy"` only for temporary compatibility
 with the former raw result. Response detail is presentation-only: changing it

--- a/src/exomem/_scaffold/_Schema/references/operations.md
+++ b/src/exomem/_scaffold/_Schema/references/operations.md
@@ -143,6 +143,19 @@ entries of 300 characters each; `warnings_count` stays authoritative, so a
 shorter list means the remainder was trimmed. Upload receipts carry their
 warnings as per-file rows under `files`, and a terminal rebuilt from a portable
 receipt reports only the count, since that receipt retains no leaf content.
+
+A compiled-note write may additionally return `structure_suggestion`, an
+advisory signal that recurring durable material on the written page now sits
+outside its own declared scope. It carries `kind`, a `strength` of either
+`strong` or `moderate`, a deterministically ordered `reasons` list, the count of
+durable units in the group, and at most six `cluster_terms`. Every
+value is derived from the page named in the same response; it never reports a
+path, title, or count belonging to another page. It is advisory only: it is
+absent when nothing is detected, it never changes `status`, `mutated`,
+`warnings_count`, mutation identity, or replay, and detection failure omits the
+field rather than affecting the write. The runtime never creates, moves,
+renames, or deletes anything as a result.
+
 `response_detail="full"` adds the existing leaf result under
 `diagnostics`. `response_detail="legacy"` returns that old raw leaf result and
 is retained for at least one compatibility release. The response-detail choice

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -601,8 +601,11 @@ def op_bootstrap(
                 "near_duplicate_warnings": "if they fire, consider edit or replace instead of a parallel page",
             },
             "post_write": {
-                "remember_suggestions": "non-binding related pages returned by remember(suggestions=true)",
-                "write_feedback": "structural feedback returned by remember(): semantic blocks, typed note/block relations, generic/source links, relation debt, unresolved wikilinks, and next actions",
+                "remember_suggestions": "non-binding related pages returned by remember(suggestions=true); reachable via response_detail='full'",
+                "write_feedback": "structural feedback from remember(): semantic blocks, typed note/block relations, generic/source links, relation debt, unresolved wikilinks, and next actions; reachable via response_detail='full' under diagnostics",
+                "structure_suggestion": "advisory signal on a compiled write that recurring durable material on that page now sits outside its declared scope; present in the default committed response with kind, strength (strong|moderate), reasons, off_scope_units, and cluster_terms",
+                "structure_suggestion_handling": "normally surface a strong one in the user's domain language, never in Exomem terms; prefer routing into an existing suitable destination, so search first; ask before restructuring unless curation was delegated; do not repeat it in one interaction; use judgement on a moderate one and prefer silence over bureaucracy",
+                "structure_suggestion_authority": "advisory only; the runtime detects and never creates, moves, renames, or deletes anything",
                 "accepted_links": "persist only through edit_memory/remember/replace_memory; never auto-write suggestions",
             },
             "note_type_recipes": {

--- a/src/exomem/mutation_terminal.py
+++ b/src/exomem/mutation_terminal.py
@@ -314,6 +314,67 @@ def _artifact_receipt_projection(result: Any) -> dict[str, Any]:
     return {"files": projected, "summary": {"stored": stored, "failed": failed}}
 
 
+#: Bounds on the advisory structural suggestion compact may carry. Same posture as
+#: `warnings`: advisory, projected from the leaf, and never something a client
+#: branches on for the outcome of the mutation (see `_ENVELOPE_KEYS`).
+_STRUCTURE_STRENGTHS = frozenset({"strong", "moderate"})
+_MAX_STRUCTURE_REASONS = 8
+_MAX_STRUCTURE_TERMS = 6
+_MAX_STRUCTURE_TOKEN_CHARS = 64
+
+
+def _structure_suggestion_projection(leaf: Any) -> dict[str, Any] | None:
+    """Lift one advisory structural suggestion out of a compiled-write leaf.
+
+    Compiled creations carry it under `creation`, compiled edits under `semantic`.
+    The shape is re-validated here rather than trusted, so a malformed or oversized
+    advisory is dropped instead of widening the wire contract.
+    """
+    if not isinstance(leaf, Mapping):
+        return None
+    for container_key in ("creation", "semantic"):
+        container = leaf.get(container_key)
+        if not isinstance(container, Mapping):
+            continue
+        value = container.get("structure_suggestion")
+        if not isinstance(value, Mapping):
+            continue
+        kind = value.get("kind")
+        strength = value.get("strength")
+        reasons = value.get("reasons")
+        terms = value.get("cluster_terms")
+        units = value.get("off_scope_units")
+        if not isinstance(kind, str) or not kind or len(kind) > _MAX_STRUCTURE_TOKEN_CHARS:
+            continue
+        if strength not in _STRUCTURE_STRENGTHS:
+            continue
+        if type(units) is not int or units < 0:
+            continue
+        if not _bounded_tokens(reasons, _MAX_STRUCTURE_REASONS):
+            continue
+        if not _bounded_tokens(terms, _MAX_STRUCTURE_TERMS):
+            continue
+        return {
+            "kind": kind,
+            "strength": strength,
+            "reasons": list(reasons),
+            "off_scope_units": units,
+            "cluster_terms": list(terms),
+        }
+    return None
+
+
+def _bounded_tokens(value: Any, limit: int) -> bool:
+    return (
+        isinstance(value, (list, tuple))
+        and 0 < len(value) <= limit
+        and all(
+            isinstance(item, str) and 0 < len(item) <= _MAX_STRUCTURE_TOKEN_CHARS
+            for item in value
+        )
+    )
+
+
 def receipt_leaf_projection(leaf_result: Any) -> dict[str, Any]:
     """Portable graph receipts never retain collection paths or content metadata."""
     # Collection receipts are public API results, not portable graph protocol
@@ -533,6 +594,9 @@ def project_terminal(result: Any, detail: ResponseDetail = "compact") -> Any:
         warning = leaf.get("graph_rebuild_warning")
         if isinstance(warning, str) and 0 < len(warning) <= 128:
             compact["graph_rebuild_warning"] = warning
+    structure_suggestion = _structure_suggestion_projection(leaf)
+    if structure_suggestion is not None:
+        compact["structure_suggestion"] = structure_suggestion
     compact["warnings_count"] = result["warnings_count"]
     # Projected from the leaf, never from the receipt. Receipt recovery replaces
     # `leaf_result` with `{}` on purpose (the portable receipt must not retain

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -9,13 +9,14 @@ import contextvars
 import datetime as dt
 import hashlib
 import json
+import logging
 import os
 import re
 import time
 import uuid
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Literal
 
@@ -38,6 +39,8 @@ from . import (
 )
 from .kbdir import kb_prefix
 from .mutation_timings import MutationTimings, mutation_timing_span
+
+log = logging.getLogger(__name__)
 
 # v2 froze the authored *instant* alongside the authored day. v1 tokens are
 # rejected: a token minted before the bump carries no knowledge-time stamp,
@@ -883,9 +886,12 @@ class CreationCommit:
     written_paths: tuple[str, ...]
     contract_result: semantic_contract.SemanticContractResult | None
     creation_commit: relation_review.CreationDraftCommit | None
+    # Advisory only. Absent unless the written page shows recurring durable
+    # material outside its own declared scope; never affects the commit.
+    structure_suggestion: dict[str, Any] | None = None
 
     def as_dict(self) -> dict[str, Any]:
-        return {
+        value = {
             "applicability": self.applicability,
             "mutated": self.mutated,
             "written_paths": list(self.written_paths),
@@ -896,6 +902,9 @@ class CreationCommit:
                 self.creation_commit.as_dict() if self.creation_commit is not None else None
             ),
         }
+        if self.structure_suggestion is not None:
+            value["structure_suggestion"] = self.structure_suggestion
+        return value
 
 
 @dataclass(frozen=True, slots=True)
@@ -959,6 +968,9 @@ class ExistingCommit:
     index_report: Any | None
     lifecycle_state: str | None
     transition_token: str
+    # Advisory only. Absent unless the written page shows recurring durable
+    # material outside its own declared scope; never affects the commit.
+    structure_suggestion: dict[str, Any] | None = None
 
     def as_dict(self) -> dict[str, Any]:
         value = {
@@ -973,6 +985,8 @@ class ExistingCommit:
         }
         if self.index_report is not None:
             value["index"] = self.index_report.as_dict()
+        if self.structure_suggestion is not None:
+            value["structure_suggestion"] = self.structure_suggestion
         return value
 
 
@@ -2086,6 +2100,22 @@ def _revalidate_existing_preflight(
         )
 
 
+def _structure_suggestion(state: Any) -> dict[str, Any] | None:
+    """Measure structural divergence for a committed page. Advisory; never raises.
+
+    Runs only after the guarded write has returned, over the page state the
+    preflight already built, so it adds no I/O and holds no lock. A fault here
+    costs the caller a suggestion, never the write.
+    """
+    try:
+        from . import structure_promotion
+
+        return structure_promotion.suggest_for_state(state)
+    except Exception:  # noqa: BLE001 — structural advice never breaks a commit
+        log.debug("structural promotion analysis failed (non-fatal)", exc_info=True)
+        return None
+
+
 def commit_existing(
     vault_root: Path,
     *,
@@ -2100,12 +2130,16 @@ def commit_existing(
     returned payload changes.
     """
     with _write_metric("exomem_write_commit_ms", str(preflight.operation)):
-        return _commit_existing(
+        committed = _commit_existing(
             vault_root,
             preflight=preflight,
             auxiliary_writes=auxiliary_writes,
             timings=timings,
         )
+    suggestion = _structure_suggestion(preflight.after)
+    if suggestion is None:
+        return committed
+    return replace(committed, structure_suggestion=suggestion)
 
 
 def _commit_existing(
@@ -3398,6 +3432,36 @@ def _prewarm_embeddings() -> None:
 
 
 def commit_creation(
+    vault_root: Path,
+    *,
+    preflight: CreationPreflight,
+    auxiliary_writes: tuple[vault.PlannedWrite, ...] | list[vault.PlannedWrite] = (),
+    relation_disposition: str | None = None,
+    relation_review_hash: str | None = None,
+    relation_review_reason: str | None = None,
+    operation: str,
+    predecessor_path: str | None = None,
+    predecessor_content_hash: str | None = None,
+) -> CreationCommit:
+    """Commit a page creation, then attach advisory structural feedback."""
+    committed = _commit_creation(
+        vault_root,
+        preflight=preflight,
+        auxiliary_writes=auxiliary_writes,
+        relation_disposition=relation_disposition,
+        relation_review_hash=relation_review_hash,
+        relation_review_reason=relation_review_reason,
+        operation=operation,
+        predecessor_path=predecessor_path,
+        predecessor_content_hash=predecessor_content_hash,
+    )
+    suggestion = _structure_suggestion(preflight.semantic_state)
+    if suggestion is None:
+        return committed
+    return replace(committed, structure_suggestion=suggestion)
+
+
+def _commit_creation(
     vault_root: Path,
     *,
     preflight: CreationPreflight,

--- a/src/exomem/structure_promotion.py
+++ b/src/exomem/structure_promotion.py
@@ -1,0 +1,275 @@
+"""Advisory detection that a compiled page has outgrown its own declared scope.
+
+The runtime measures; the agent reasons. This module answers exactly one question
+about the page a caller just wrote: has recurring durable material accumulated that
+sits outside what the page says it is about? It never proposes a destination, never
+names another page, and never moves anything.
+
+Everything it reads is already parsed and in memory at commit time — the page's
+frontmatter, title, project keys, and semantic units. There is no file read, no
+database access, no embedding, and no model call, so the result is deterministic and
+the cost is a bounded pass over units the write already produced.
+
+The signal is convergent by construction. A single tangent cannot trigger it: a term
+only groups material when it recurs across more than one off-scope unit, the group
+must reach enough mass to justify its own note, and the page must still hold its
+original subject. Raw length is never an input, because a long note about one thing
+is not structural debt.
+
+Known approximation: recurrence is counted over durable units, not over write events.
+There is no cheap per-page record of which units a given mutation added, and units are
+what writes deposit, so the reason codes speak of units and claim nothing more.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+KIND = "scope_divergence"
+
+#: A page must carry at least this many durable units before its shape means anything.
+MIN_UNITS = 6
+#: A page that declares almost nothing about itself cannot be judged against itself.
+MIN_IDENTITY_TERMS = 2
+#: A unit needs this many out-of-scope terms before one stray word can push it out.
+MIN_OFF_SCOPE_TERMS = 2
+#: A term groups material only when it recurs — this is the recurrence requirement.
+TERM_RECURRENCE_MIN = 2
+#: How much material must gather before a focused child note would actually help.
+CLUSTER_MIN_UNITS = 5
+CLUSTER_MIN_TERMS = 4
+#: Enough of the original subject must remain for "separate" to beat "rename".
+MIN_RETAINED_UNITS = 3
+#: Above this overlap the group is a sub-topic of the declared subject, not a rival.
+MISMATCH_MAX_OVERLAP = 0.34
+#: Bound on the evidence returned to the caller.
+MAX_CLUSTER_TERMS = 6
+
+REASON_RECURS = "off_scope_cluster_recurs"
+REASON_MASS = "cluster_reaches_child_note_mass"
+REASON_RETAINED = "page_retains_original_scope"
+REASON_MISMATCH = "declared_scope_mismatch"
+
+#: Pages that deliberately announce breadth. Same convention that already exempts
+#: these tags from staleness pressure and semantic-unit requirements elsewhere.
+BREADTH_TAGS = frozenset({"hub", "snapshot"})
+
+#: Filenames the corpus already treats as navigation rather than knowledge.
+NAVIGATION_BASENAMES = frozenset({"index.md", "log.md"})
+
+_TOKEN_SPLIT = re.compile(r"[^a-z0-9]+")
+
+# Title words that carry no subject. Deliberately small: this is a stop list for
+# glue, not an attempt to model English.
+_STOPWORDS = frozenset(
+    {
+        "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "how", "in",
+        "into", "is", "it", "its", "of", "on", "or", "our", "over", "the", "their",
+        "this", "to", "via", "was", "were", "what", "when", "which", "why", "with",
+        "note", "notes", "plan", "plans", "draft", "overview", "summary",
+    }
+)
+
+
+def _terms(values: Iterable[str]) -> frozenset[str]:
+    """Normalise tags, title words, and project keys into one comparable vocabulary."""
+    out: set[str] = set()
+    for value in values:
+        for token in _TOKEN_SPLIT.split(str(value).casefold()):
+            if len(token) > 2 and token not in _STOPWORDS and not token.isdigit():
+                out.add(token)
+    return frozenset(out)
+
+
+def _frontmatter_tags(frontmatter: Mapping[Any, Any]) -> list[str]:
+    raw = frontmatter.get("tags")
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, (list, tuple)):
+        return [str(item) for item in raw]
+    return []
+
+
+@dataclass(frozen=True, slots=True)
+class PageShape:
+    """The minimum a page must expose to be judged. Deliberately not a vault type."""
+
+    page_type: str | None
+    title: str
+    tags: tuple[str, ...]
+    projects: tuple[str, ...]
+    basename: str
+    unit_tags: tuple[tuple[str, ...], ...]
+
+
+def _cluster(off_scope: Sequence[frozenset[str]]) -> tuple[list[int], frozenset[str]]:
+    """Group off-scope units by vocabulary that recurs across more than one of them.
+
+    Returns the largest group's unit indices and the recurring terms that formed it.
+    A term appearing in only one unit joins nothing — that is what keeps an
+    incidental aside from ever looking like an emerging project.
+    """
+    counts: dict[str, int] = {}
+    for terms in off_scope:
+        for term in terms:
+            counts[term] = counts.get(term, 0) + 1
+    recurring = {term for term, count in counts.items() if count >= TERM_RECURRENCE_MIN}
+    if not recurring:
+        return [], frozenset()
+
+    # Union-find over units that share at least one recurring term.
+    parent = list(range(len(off_scope)))
+
+    def find(node: int) -> int:
+        while parent[node] != node:
+            parent[node] = parent[parent[node]]
+            node = parent[node]
+        return node
+
+    def union(left: int, right: int) -> None:
+        left_root, right_root = find(left), find(right)
+        if left_root != right_root:
+            parent[max(left_root, right_root)] = min(left_root, right_root)
+
+    first_seen: dict[str, int] = {}
+    for index, terms in enumerate(off_scope):
+        for term in terms & recurring:
+            if term in first_seen:
+                union(first_seen[term], index)
+            else:
+                first_seen[term] = index
+
+    groups: dict[int, list[int]] = {}
+    for index, terms in enumerate(off_scope):
+        if terms & recurring:
+            groups.setdefault(find(index), []).append(index)
+    if not groups:
+        return [], frozenset()
+
+    # Largest group wins; ties break on the earliest unit so the result is stable.
+    best_root = min(groups, key=lambda root: (-len(groups[root]), groups[root][0]))
+    members = groups[best_root]
+    seeds = frozenset(
+        term for index in members for term in off_scope[index] & recurring
+    )
+    return members, seeds
+
+
+def detect(shape: PageShape) -> dict[str, Any] | None:
+    """Decide whether `shape` has outgrown its declared scope. Pure; no I/O."""
+    if shape.page_type not in _compiled_types():
+        return None
+    if shape.basename.casefold() in NAVIGATION_BASENAMES:
+        return None
+    if len(shape.unit_tags) < MIN_UNITS:
+        return None
+
+    tag_terms = _terms(shape.tags)
+    if tag_terms & BREADTH_TAGS:
+        return None
+
+    identity = tag_terms | _terms([shape.title]) | _terms(shape.projects)
+    if len(identity) < MIN_IDENTITY_TERMS:
+        return None
+
+    off_scope: list[frozenset[str]] = []
+    off_scope_all_terms: list[frozenset[str]] = []
+    retained = 0
+    for tags in shape.unit_tags:
+        terms = _terms(tags)
+        if not terms:
+            continue
+        outside = terms - identity
+        inside = terms & identity
+        if len(outside) > len(inside) and len(outside) >= MIN_OFF_SCOPE_TERMS:
+            off_scope.append(outside)
+            off_scope_all_terms.append(terms)
+        else:
+            retained += 1
+
+    if not off_scope:
+        return None
+
+    members, seeds = _cluster(off_scope)
+    if not members:
+        return None
+
+    reasons = [REASON_RECURS]
+    if len(members) >= CLUSTER_MIN_UNITS and len(seeds) >= CLUSTER_MIN_TERMS:
+        reasons.append(REASON_MASS)
+    if retained >= MIN_RETAINED_UNITS:
+        reasons.append(REASON_RETAINED)
+
+    # All three gates must hold. Mass alone is noise; without retained scope the page
+    # has simply moved on, which is a naming problem rather than a splitting one.
+    if REASON_MASS not in reasons or REASON_RETAINED not in reasons:
+        return None
+
+    group_vocabulary = frozenset().union(*(off_scope_all_terms[i] for i in members))
+    overlap = len(group_vocabulary & identity) / len(group_vocabulary)
+    if overlap < MISMATCH_MAX_OVERLAP:
+        reasons.append(REASON_MISMATCH)
+
+    # Most-recurrent terms first for selection, alphabetical for the payload, so the
+    # evidence is both the strongest available and byte-stable across runs.
+    seed_counts = {
+        term: sum(1 for index in members if term in off_scope[index]) for term in seeds
+    }
+    top = sorted(seed_counts, key=lambda term: (-seed_counts[term], term))
+    return {
+        "kind": KIND,
+        "strength": "strong" if REASON_MISMATCH in reasons else "moderate",
+        "reasons": sorted(reasons),
+        "off_scope_units": len(members),
+        "cluster_terms": sorted(top[:MAX_CLUSTER_TERMS]),
+    }
+
+
+def _compiled_types() -> frozenset[str]:
+    from . import semantic_contract
+
+    return semantic_contract.COMPILED_TYPES
+
+
+def shape_from_state(state: Any) -> PageShape:
+    """Adapt a `SemanticPageState` the write path already built."""
+    frontmatter = state.frontmatter or {}
+    return PageShape(
+        page_type=state.page_type,
+        title=state.title or "",
+        tags=tuple(_frontmatter_tags(frontmatter)),
+        projects=tuple(state.projects or ()),
+        basename=state.path.rsplit("/", 1)[-1],
+        unit_tags=tuple(tuple(unit.tags) for unit in state.document.units),
+    )
+
+
+def suggest_for_state(state: Any) -> dict[str, Any] | None:
+    """Detect over a page state the caller already holds."""
+    return detect(shape_from_state(state))
+
+
+def suggest_for_page(vault_root: Path, rel_path: str) -> dict[str, Any] | None:
+    """Detect over a page on disk. For out-of-band callers; the write path uses state."""
+    from . import semantic_units, vault
+
+    source = (vault_root / rel_path).read_text(encoding="utf-8")
+    frontmatter, body, _ = vault.parse_frontmatter(source)
+    document = semantic_units.parse_semantic_units(body, path=rel_path, validate=False)
+    projects = frontmatter.get("projects") or frontmatter.get("project") or ()
+    if isinstance(projects, str):
+        projects = (projects,)
+    return detect(
+        PageShape(
+            page_type=frontmatter.get("type"),
+            title=str(frontmatter.get("title") or ""),
+            tags=tuple(_frontmatter_tags(frontmatter)),
+            projects=tuple(str(item) for item in projects),
+            basename=rel_path.rsplit("/", 1)[-1],
+            unit_tags=tuple(tuple(unit.tags) for unit in document.units),
+        )
+    )

--- a/tests/test_structure_promotion.py
+++ b/tests/test_structure_promotion.py
@@ -1,0 +1,573 @@
+"""Behavioural acceptance for advisory structural-promotion suggestions.
+
+These tests bind the *mechanism*, not a fixture's prose. The positive case is a
+reconstruction of a real dogfood failure: a coherent travel note that accumulated
+property finance, farmland, agricultural grants, livestock husbandry and hospitality
+across a sequence of individually defensible `observe_memory` writes until it was no
+longer the right canonical home for any of them.
+
+Nothing here asserts on the words that made that case memorable. Every assertion is
+about structure: whether recurring durable material sits outside the page's own
+declared scope, how much of it there is, and whether the page still holds its
+original subject. Swap the domain and the tests still hold.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from exomem import commands, structure_promotion, writer_lease
+
+TRAVEL_PAGE = "Knowledge Base/Notes/Research/Travel/seasonal-fare-and-relocation-scouting.md"
+TRAVEL_ID = "00000000-0000-4000-8000-0000000005a1"
+
+
+def _command(name: str):
+    return next(command for command in commands.PRODUCT_COMMANDS if command.name == name)
+
+
+def _page(
+    *,
+    page_id: str,
+    title: str,
+    tags: list[str],
+    body: str,
+    page_type: str = "research-note",
+    project: str = "travel",
+) -> str:
+    """Render a compiled page with a declared identity and durable units."""
+    return (
+        "---\n"
+        f"title: {title}\n"
+        f"type: {page_type}\n"
+        f"project: {project}\n"
+        "status: active\n"
+        f"exomem_id: {page_id}\n"
+        "updated: 2026-08-15\n"
+        f"tags: [{', '.join(tags)}]\n"
+        "---\n\n"
+        f"# {title}\n\n"
+        f"{body.rstrip()}\n"
+    )
+
+
+def _unit(category: str, content: str, tags: list[str], anchor: str) -> str:
+    return f"- [{category}] {content} {' '.join('#' + tag for tag in tags)} ^{anchor}"
+
+
+# --- the coherent starting point -------------------------------------------------
+# Declared identity: airline fares, seasonality, island destinations, family travel.
+
+_TRAVEL_TITLE = "Seasonal fare portfolio and relocation scouting plan"
+_TRAVEL_TAGS = ["carrier-sale", "fares", "relocation", "travel", "islands", "family"]
+
+_COHERENT_UNITS = [
+    _unit(
+        "decision",
+        "Wait for the annual late-summer fare campaign and buy on the first day a "
+        "matching itinerary appears rather than committing the budget earlier.",
+        ["travel", "carrier-sale", "booking"],
+        "wait-for-campaign",
+    ),
+    _unit(
+        "priority",
+        "Prioritise one southern-coast journey, one island trip, and one city break "
+        "across the sale year rather than compressing them into a single destination.",
+        ["travel", "carrier-sale", "islands"],
+        "trip-priority",
+    ),
+    _unit(
+        "constraint",
+        "Protect midsummer for home and schedule the coastal and island trips in "
+        "spring or autumn by default.",
+        ["travel", "fares", "islands"],
+        "season-constraint",
+    ),
+    _unit(
+        "benchmark",
+        "The prior campaign ran for two weeks and offered return benchmarks well "
+        "below the ordinary published fares for the same routes.",
+        ["carrier-sale", "fares", "travel"],
+        "fare-benchmarks",
+    ),
+    _unit(
+        "logistics",
+        "Price both three-person and four-person bookings and buy checked baggage "
+        "with the tickets, because later addition is normally dearer.",
+        ["travel", "family", "carrier-sale"],
+        "party-logistics",
+    ),
+    _unit(
+        "decision",
+        "Keep the journey a genuine family holiday with scouting embedded lightly "
+        "into ordinary neighbourhood stays.",
+        ["travel", "relocation", "family"],
+        "scout-structure",
+    ),
+]
+
+
+def _travel_page(extra_units: list[str] | None = None) -> str:
+    units = list(_COHERENT_UNITS) + list(extra_units or [])
+    body = "## Observations\n\n" + "\n".join(units) + "\n"
+    return _page(
+        page_id=TRAVEL_ID,
+        title=_TRAVEL_TITLE,
+        tags=_TRAVEL_TAGS,
+        body=body,
+    )
+
+
+# --- the accumulation, one durable cluster at a time -----------------------------
+# Each stage is what a further defensible write would have deposited.
+
+STAGE_PROPERTY = [
+    _unit(
+        "property_target",
+        "The working target is a large rural principal residence of roughly ten "
+        "hectares with outbuildings and fenced ground.",
+        ["property", "smallholding", "land", "countryside"],
+        "property-target",
+    ),
+]
+
+STAGE_FINANCING = [
+    _unit(
+        "financing",
+        "Do not wait for the full cash target before testing mortgage eligibility; "
+        "the practical bottleneck is which income a lender accepts as stable.",
+        ["mortgage", "financing", "lending", "deposit"],
+        "mortgage-timing",
+    ),
+    _unit(
+        "financing",
+        "Treat the deposit, acquisition costs and initial renovation buffer as "
+        "short-horizon capital and keep that core liquid.",
+        ["financing", "liquidity", "savings", "deposit"],
+        "treasury-policy",
+    ),
+]
+
+STAGE_LAND = [
+    _unit(
+        "property_candidate",
+        "A rural agency listing of an old mill with pasture, wooded meadow and water "
+        "plus substantial former farm buildings is a strong fit candidate.",
+        ["land", "smallholding", "pasture", "property", "countryside"],
+        "land-candidate",
+    ),
+    _unit(
+        "infrastructure",
+        "Barn, hangar and stable capacity determines what the holding can carry "
+        "before any new building is considered.",
+        ["smallholding", "buildings", "pasture", "land"],
+        "holding-capacity",
+    ),
+]
+
+STAGE_GRANTS = [
+    _unit(
+        "funding_strategy",
+        "Treat public support as separate eligible buckets rather than one blanket "
+        "renovation grant, because residential and agricultural schemes differ.",
+        ["grants", "funding", "agriculture", "subsidy"],
+        "funding-stack",
+    ),
+    _unit(
+        "qualification_strategy",
+        "Target the minimum recognised qualification that is both practically useful "
+        "and accepted for installation aid rather than a full degree.",
+        ["qualification", "agriculture", "training", "grants"],
+        "qualification-path",
+    ),
+]
+
+STAGE_LIVESTOCK = [
+    _unit(
+        "husbandry",
+        "The planned operation should optimise for animal welfare rather than "
+        "intensive throughput, maximising pasture access and natural behaviours.",
+        ["livestock", "husbandry", "pasture", "animal-welfare"],
+        "husbandry-principle",
+    ),
+    _unit(
+        "husbandry",
+        "Dual-purpose dairy animals can enter the meat system at older ages instead "
+        "of being culled early for maximum yield.",
+        ["livestock", "dairy", "husbandry", "animal-welfare"],
+        "dual-purpose",
+    ),
+]
+
+STAGE_HOSPITALITY = [
+    _unit(
+        "business_option",
+        "Part of the holding could carry accommodation and experience revenue, "
+        "monetising excess buildings without forcing throughput on the livestock.",
+        ["hospitality", "accommodation", "business", "smallholding"],
+        "hospitality-line",
+    ),
+]
+
+JOURNEY = [
+    ("baseline", []),
+    ("property", STAGE_PROPERTY),
+    ("financing", STAGE_FINANCING),
+    ("land", STAGE_LAND),
+    ("grants", STAGE_GRANTS),
+    ("livestock", STAGE_LIVESTOCK),
+    ("hospitality", STAGE_HOSPITALITY),
+]
+
+
+def _journey_states() -> list[tuple[str, str]]:
+    """Cumulative page source after each stage of the accumulation."""
+    states: list[tuple[str, str]] = []
+    accumulated: list[str] = []
+    for name, stage in JOURNEY:
+        accumulated.extend(stage)
+        states.append((name, _travel_page(accumulated)))
+    return states
+
+
+def _suggest(tmp_path: Path, rel: str, source: str) -> dict | None:
+    """Detect over a page exactly as the write path does, via the public helper."""
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+    return structure_promotion.suggest_for_page(tmp_path, rel)
+
+
+# --------------------------------------------------------------------------------
+# Positive journey
+# --------------------------------------------------------------------------------
+
+
+def test_early_accumulation_stays_quiet(tmp_path: Path) -> None:
+    """One emerging thread is not yet a separate project."""
+    for name, source in _journey_states()[:3]:  # baseline, property, financing
+        suggestion = _suggest(tmp_path, TRAVEL_PAGE, source)
+        assert suggestion is None, f"stage {name!r} suggested too early: {suggestion}"
+
+
+def test_sustained_accumulation_reaches_a_strong_suggestion(tmp_path: Path) -> None:
+    """By the time several durable threads recur, the page has outgrown its scope."""
+    states = dict(_journey_states())
+    suggestion = _suggest(tmp_path, TRAVEL_PAGE, states["hospitality"])
+
+    assert suggestion is not None, "the fully accumulated page produced no suggestion"
+    assert suggestion["kind"] == "scope_divergence"
+    assert suggestion["strength"] == "strong"
+    assert set(suggestion["reasons"]) == {
+        "cluster_reaches_child_note_mass",
+        "declared_scope_mismatch",
+        "off_scope_cluster_recurs",
+        "page_retains_original_scope",
+    }
+    assert suggestion["off_scope_units"] >= 5
+
+
+def test_the_suggestion_arrives_before_the_page_becomes_absurd(tmp_path: Path) -> None:
+    """It must fire while a knowledgeable user would still be deciding, not after."""
+    fired_at = [
+        name
+        for name, source in _journey_states()
+        if _suggest(tmp_path, TRAVEL_PAGE, source) is not None
+    ]
+
+    assert fired_at, "the journey never produced a suggestion"
+    # Not before the third cluster recurs, and not later than the sixth.
+    assert fired_at[0] in {"land", "grants", "livestock"}, fired_at
+
+
+# --------------------------------------------------------------------------------
+# Negative controls
+# --------------------------------------------------------------------------------
+
+
+def _long_coherent_source() -> str:
+    """A deliberately large single-subject note: more units than the positive case."""
+    units = []
+    for index in range(40):
+        units.append(
+            _unit(
+                ["decision", "finding", "risk", "constraint"][index % 4],
+                f"Retrieval behaviour observation number {index} covering ranking, "
+                "fusion, and recall of the indexing subsystem under load.",
+                ["retrieval", "indexing", ["ranking", "fusion", "recall"][index % 3]],
+                f"retrieval-{index}",
+            )
+        )
+    body = (
+        "## Question\n\nHow should the retrieval stack rank and fuse candidates?\n\n"
+        + "\n\n".join(f"### Section {i}\n\nExtended prose block {i}." for i in range(12))
+        + "\n\n## Observations\n\n"
+        + "\n".join(units)
+        + "\n"
+    )
+    return _page(
+        page_id="00000000-0000-4000-8000-0000000005a2",
+        title="Retrieval ranking and fusion research",
+        tags=["retrieval", "indexing", "ranking", "fusion", "recall"],
+        body=body,
+        project="search",
+    )
+
+
+def test_a_long_coherent_research_note_stays_quiet(tmp_path: Path) -> None:
+    """Length is not structural debt. This note is larger than the positive case."""
+    rel = "Knowledge Base/Notes/Research/Search/retrieval-ranking.md"
+    source = _long_coherent_source()
+    positive = dict(_journey_states())["hospitality"]
+
+    assert len(source) > len(positive), "the control must be larger to prove the point"
+    assert _suggest(tmp_path, rel, source) is None
+
+
+def test_one_or_two_tangents_do_not_trigger(tmp_path: Path) -> None:
+    """An incidental aside is not an emerging project."""
+    tangents = [
+        _unit(
+            "aside",
+            "A lender's published rate table was easier to read than expected.",
+            ["mortgage", "lending", "rates"],
+            "rate-aside",
+        ),
+        _unit(
+            "aside",
+            "Rural building conversions appear on regional agency listings.",
+            ["property", "buildings", "countryside"],
+            "conversion-aside",
+        ),
+    ]
+    assert _suggest(tmp_path, TRAVEL_PAGE, _travel_page(tangents)) is None
+
+
+def test_source_and_evidence_artifacts_never_enter_the_path(tmp_path: Path) -> None:
+    """Non-compiled material is excluded regardless of how heterogeneous it is."""
+    accumulated = [unit for _, stage in JOURNEY for unit in stage]
+    body = "## Observations\n\n" + "\n".join(_COHERENT_UNITS + accumulated) + "\n"
+    for page_type, rel in (
+        ("source", "Knowledge Base/Sources/Other/2026-08-15-mixed-capture.md"),
+        ("evidence", "Knowledge Base/Evidence/case/mixed-artifact.md"),
+    ):
+        source = _page(
+            page_id="00000000-0000-4000-8000-0000000005a3",
+            title="Mixed capture",
+            tags=_TRAVEL_TAGS,
+            body=body,
+            page_type=page_type,
+        )
+        assert _suggest(tmp_path, rel, source) is None, page_type
+
+
+def test_a_deliberate_hub_is_not_nagged_into_splitting(tmp_path: Path) -> None:
+    """A hub declares its breadth on purpose; breadth is its job."""
+    accumulated = [unit for _, stage in JOURNEY for unit in stage]
+    body = "## Observations\n\n" + "\n".join(accumulated) + "\n"
+    source = _page(
+        page_id="00000000-0000-4000-8000-0000000005a4",
+        title="Rural holding hub",
+        tags=["hub", "smallholding", "land", "livestock", "grants", "hospitality"],
+        body=body,
+        project="holding",
+    )
+    rel = "Knowledge Base/Notes/Research/Holding/rural-holding-hub.md"
+    assert _suggest(tmp_path, rel, source) is None
+
+
+def test_advice_stops_once_the_material_is_routed_into_matching_scope(
+    tmp_path: Path,
+) -> None:
+    """The end state of acting on the advice must itself be quiet, with no dismissal."""
+    accumulated = [unit for _, stage in JOURNEY for unit in stage]
+
+    # The new destination declares the scope the material actually has.
+    destination = _page(
+        page_id="00000000-0000-4000-8000-0000000005a5",
+        title="Rural holding property, funding and livestock",
+        tags=[
+            "smallholding",
+            "property",
+            "land",
+            "financing",
+            "grants",
+            "livestock",
+            "husbandry",
+            "hospitality",
+        ],
+        body="## Observations\n\n" + "\n".join(accumulated) + "\n",
+        project="holding",
+    )
+    assert (
+        _suggest(
+            tmp_path,
+            "Knowledge Base/Notes/Research/Holding/property-funding-livestock.md",
+            destination,
+        )
+        is None
+    )
+
+    # And the original page, with the material removed, is quiet again.
+    assert _suggest(tmp_path, TRAVEL_PAGE, _travel_page()) is None
+
+
+# --------------------------------------------------------------------------------
+# Contract guarantees
+# --------------------------------------------------------------------------------
+
+
+def test_payload_is_bounded_and_deterministic(tmp_path: Path) -> None:
+    source = dict(_journey_states())["hospitality"]
+    first = _suggest(tmp_path, TRAVEL_PAGE, source)
+    second = _suggest(tmp_path, TRAVEL_PAGE, source)
+
+    assert first == second
+    assert first is not None
+    assert first["reasons"] == sorted(first["reasons"])
+    assert len(first["cluster_terms"]) <= structure_promotion.MAX_CLUSTER_TERMS
+    assert first["cluster_terms"] == sorted(first["cluster_terms"])
+    assert set(first) == {
+        "kind",
+        "strength",
+        "reasons",
+        "off_scope_units",
+        "cluster_terms",
+    }
+    assert not isinstance(first["strength"], (int, float))
+    assert first["strength"] in {"strong", "moderate"}
+
+
+def test_evidence_never_names_another_page(tmp_path: Path) -> None:
+    """Every reported fact comes from the page the caller just wrote."""
+    source = dict(_journey_states())["hospitality"]
+    # A neighbour the caller may not be entitled to see.
+    (tmp_path / "Knowledge Base/Notes/Research/Secret").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "Knowledge Base/Notes/Research/Secret/classified-holding.md").write_text(
+        _page(
+            page_id="00000000-0000-4000-8000-0000000005a6",
+            title="Classified holding programme",
+            tags=["smallholding", "livestock", "grants"],
+            body="## Observations\n\n"
+            + "\n".join(unit for _, stage in JOURNEY for unit in stage)
+            + "\n",
+            project="holding",
+        ),
+        encoding="utf-8",
+    )
+
+    suggestion = _suggest(tmp_path, TRAVEL_PAGE, source)
+
+    assert suggestion is not None
+    blob = repr(suggestion)
+    for leaked in ("Secret", "classified", "Classified", ".md", "Knowledge Base"):
+        assert leaked not in blob, f"{leaked!r} leaked into {blob}"
+    assert all(isinstance(term, str) and "/" not in term for term in suggestion["cluster_terms"])
+
+
+def test_detector_failure_leaves_the_write_committed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An advisory that raises must not touch the mutation."""
+    path = tmp_path / TRAVEL_PAGE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dict(_journey_states())["livestock"], encoding="utf-8")
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("structural analysis exploded")
+
+    monkeypatch.setattr(structure_promotion, "suggest_for_state", _boom)
+
+    result = writer_lease.invoke_command(
+        _command("observe_memory"),
+        tmp_path,
+        path=TRAVEL_PAGE,
+        operation="add",
+        category="business_option",
+        content="Events and seasonal lettings could use the larger barn.",
+        tags=["hospitality", "accommodation", "business"],
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "committed"
+    assert result["mutated"] is True
+    assert "structure_suggestion" not in result
+
+
+# --------------------------------------------------------------------------------
+# The public surface: every compiled writer, in the default response
+# --------------------------------------------------------------------------------
+
+
+def test_observe_memory_surfaces_the_suggestion_in_the_default_response(
+    tmp_path: Path,
+) -> None:
+    """The motivating dogfood path. Compact is the default; it must be visible there."""
+    path = tmp_path / TRAVEL_PAGE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dict(_journey_states())["livestock"], encoding="utf-8")
+
+    result = writer_lease.invoke_command(
+        _command("observe_memory"),
+        tmp_path,
+        path=TRAVEL_PAGE,
+        operation="add",
+        category="business_option",
+        content="Part of the holding could carry accommodation and experience revenue.",
+        tags=["hospitality", "accommodation", "business", "smallholding"],
+    )
+
+    assert result["status"] == "committed"
+    suggestion = result["structure_suggestion"]
+    assert suggestion["kind"] == "scope_divergence"
+    assert suggestion["strength"] == "strong"
+
+
+def test_edit_memory_surfaces_the_suggestion_in_the_default_response(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / TRAVEL_PAGE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dict(_journey_states())["livestock"], encoding="utf-8")
+
+    result = writer_lease.invoke_command(
+        _command("edit_memory"),
+        tmp_path,
+        path=TRAVEL_PAGE,
+        operation={
+            "kind": "edit_section",
+            "heading": "## Observations",
+            "section_position": "append",
+            "new_string": _unit(
+                "business_option",
+                "Guest accommodation could monetise the excess buildings.",
+                ["hospitality", "accommodation", "business", "smallholding"],
+                "hospitality-append",
+            ),
+        },
+        why="record the emerging hospitality thread",
+    )
+
+    assert result["status"] == "committed"
+    assert result["structure_suggestion"]["strength"] == "strong"
+
+
+def test_a_coherent_write_carries_no_suggestion_key(tmp_path: Path) -> None:
+    path = tmp_path / TRAVEL_PAGE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_travel_page(), encoding="utf-8")
+
+    result = writer_lease.invoke_command(
+        _command("observe_memory"),
+        tmp_path,
+        path=TRAVEL_PAGE,
+        operation="add",
+        category="logistics",
+        content="Confirm the baggage allowance shown for each passenger before payment.",
+        tags=["travel", "family", "carrier-sale"],
+    )
+
+    assert result["status"] == "committed"
+    assert "structure_suggestion" not in result


### PR DESCRIPTION
## Why

A compiled note can start coherent and, through a sequence of individually defensible writes, accumulate several unrelated durable topics until it is no longer the right home for any of them. Nothing in the write path noticed. Only a user who already understands note types and project scope could catch it — which is exactly the internal model Exomem is supposed to hide.

The motivating case is real: a travel note accumulated property finance, farmland, agricultural grants, qualification paths, livestock husbandry and hospitality across **12 successive `observe_memory` writes** before a human intervened.

## What this does

Compiled writes now carry an optional `structure_suggestion` — the runtime's observation that recurring durable material on the written page sits outside what the page declares itself to be about. It is advice. Nothing is moved.

```json
"structure_suggestion": {
  "kind": "scope_divergence",
  "strength": "strong",
  "reasons": ["cluster_reaches_child_note_mass", "declared_scope_mismatch",
              "off_scope_cluster_recurs", "page_retains_original_scope"],
  "off_scope_units": 6,
  "cluster_terms": ["animal", "countryside", "husbandry", "land", "pasture", "smallholding"]
}
```

That payload is real output from driving the live MCP handler across the accumulating fixture — quiet at the financing stage, `strong` by the livestock stage.

## Two audit findings that shaped the design

**`write_feedback` was the wrong carrier.** It never survives the default response: `project_terminal` is a strict allowlist over `_ENVELOPE_KEYS` and every compiled writer defaults to `compact`. It is also built only in `note._build_write_feedback`, so it exists for `remember` alone — and the motivating drift happened entirely through `observe_memory`. Attaching the advisory there would have shipped a feature no agent receives, on one writer in four. This PR also corrects the shipped scaffold instruction that told agents to inspect `suggestions` and `write_feedback`, neither of which the default response carries.

**The evidence was already in memory.** `SemanticCorpusContext` is built and process-cached on every write and retained on the preflight, carrying each page's type, projects, title, frontmatter and fully parsed units. No index, table, query, embedding or model call was needed.

## Architecture

Detection is a pure pass over preflight state, run after the guarded commit returns, inside an exception guard — a fault costs a suggestion, never the write. It rides the two commit results in `semantic_writes`, which already reach the terminal, so all four compiled writers get it from two call sites with **no change to a writer leaf or to `writer_lease`**. It is projected into the compact envelope without extending `_ENVELOPE_KEYS`, which stays the closed set clients branch on for mutation outcome.

The signal is convergent by construction: a term groups material only when it recurs across more than one off-scope unit, the group must reach mass, and the page must still hold its original subject. Raw length is never an input. Strength is `strong`/`moderate` with sorted reason codes — never a numeric confidence, per the pure-substrate rule.

Evidence is confined to the page just written, so the payload cannot disclose another page's path, title or count. The governance requirement is met structurally rather than by filtering, and no disclosure decision is needed on the write path. The cost is that v1 names no destination — the agent's job anyway, and the agent can search.

## Scope gate

Passes on every clause: no new index, table, background worker, synchronous embedding, full-vault scan, persistent review object, graph-schema change, automatic restructure, or new MCP tool. Tool descriptions and input schemas are byte-identical, so the packaged tool-surface fingerprint is unchanged and no external connector attestation becomes release-blocking.

`plugins/hosted/**` is deliberately untouched. It is a frozen v1 release identity byte-pinned by `tests/fixtures/hosted/v1-release-identities.json` down to its skill source, so the hosted agent contract for this feature belongs with the next hosted release identity rather than in a feature PR.

## Verification

**The tests bind the mechanism.** With `detect()` stubbed to return `None`, 6 tests fail — the full positive journey and both public-surface tests — while all six negative controls still pass, which is correct since they assert silence:

```
FAILED test_sustained_accumulation_reaches_a_strong_suggestion
FAILED test_the_suggestion_arrives_before_the_page_becomes_absurd
FAILED test_payload_is_bounded_and_deterministic
FAILED test_evidence_never_names_another_page
FAILED test_observe_memory_surfaces_the_suggestion_in_the_default_response
FAILED test_edit_memory_surfaces_the_suggestion_in_the_default_response
6 failed, 8 passed
```

Negative controls are substantive. The long coherent research note is asserted to be **larger than the positive fixture at its trigger point**, so length cannot be the discriminator. The others cover one/two tangents, Sources/Evidence, a deliberate hub, and the post-restructuring end state — where both the new destination and the cleaned original go quiet through scope agreement, with no dismissal state.

**Gates.** 548 focused tests green (detector, mutation terminal, note, observe, creation, lifecycle, transactional writes, hosted rendering, marketplace release, package skills, plugin sync, scaffold leak, bootstrap budget, schema fidelity, mutation timings). Governance egress + postfilter 374 green. Retrieval latency gate green. Installed-wheel product E2E `PASS`. OpenSpec strict valid, 36/36 specs. Ruff `F` clean repo-wide; new module clean under `E,F,I,B,UP,BLE` and mypy.

**Latency.** Detector-off vs detector-on on the same build: 8k commit median 167.9 ms → 137.2 ms, 2k 63.7 ms → 56.4 ms. The enabled build measured *faster* on both medians, so the cost sits inside run-to-run variance. Ceilings are 750 ms median / 1500 ms p95; the size-scaling bound has ample headroom. `semantic_write_latency.py --check` exits 0.

Local full-suite failures are environmental and reproduce identically on clean `origin/main`: 91 memorybench tests need `bun`, which CI installs pinned and this machine lacks.

## Known risks

- Recurrence is counted over durable **units**, not write events — no cheap per-page record of per-mutation units exists. The contract and reason codes say units and claim nothing more.
- Pages whose units carry no tags produce no signal: a deliberate false-negative bias.
- Most plausible false positive is synonym drift — a page tagging its own subject with different words than its frontmatter. Partly mitigated by the retained-scope and mass gates, and named as the first calibration target.
- Thresholds come from one reconstructed dogfood case and should be calibrated on real alpha behaviour rather than tuned further in the dark.
