### PR TITLE
fix(memory): corpus-cache lifecycle honesty — classified publish failures and populate-on-miss

### DIFF
--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -48,23 +48,45 @@ _FULL_UPSERT_COMPONENTS = frozenset(
 )
 
 
-def _withdraw_unbridgeable_corpus_consumers(vault_root: Path) -> None:
-    """Fail closed when an exact filesystem delta could not be published.
+def _evict_corpus_projection_consumers(vault_root: Path) -> None:
+    """Withdraw the same-vault RAM projections after a publication failure.
 
-    Incremental resolver, inbound, graph, and semantic-corpus projections may
-    advance only from one retained event suffix.  Once publication fails, the
-    suffix is unknowable: make the registry cold and evict the same-vault RAM
-    consumers so their next read derives directly from human-owned files.
-    Persisted graph readers also become unavailable because their old marker no
-    longer matches the cold disk projection.
+    Incremental resolver, inbound, and semantic-corpus projections may advance
+    only from one retained event suffix.  Once publication fails their suffix
+    is unknowable, so drop them and let the next read derive directly from
+    human-owned files.
+
+    This is the WHOLE correct response when only a projection failed to
+    publish: the event registry observed and recorded every event, so vault
+    freshness still describes the vault accurately and must not be cooled.  A
+    persisted graph reader that stayed behind is fenced by state it owns — its
+    stored recall-projection identity no longer equals the current one, it
+    re-proves source bytes and resolver topology directly, and an
+    unacknowledged writer checkpoint already makes its sidecar non-current.
+    A cold registry was never that fence; it only made every later caller pay
+    a full stat census of the vault.
     """
-    from . import find, freshness, semantic_contract, vault
+    from . import find, semantic_contract, vault
 
-    freshness.invalidate(vault_root)
-    freshness.mark_external_pending(vault_root)
     semantic_contract.evict_corpus_context(vault_root)
     find.evict_resolver_caches(vault_root)
     vault.evict_inbound_index(vault_root)
+
+
+def _withdraw_unbridgeable_corpus_consumers(vault_root: Path) -> None:
+    """Fail closed when the event registry itself could not advance.
+
+    Registry loss: the registry can no longer name the current file set, so NO
+    consumer's retained suffix is bridgeable and a cold registry is this
+    failure's own defined signal — the watcher's periodic reconcile re-walks
+    and clears it.  Reserved for a genuine registry-advance failure; a
+    downstream projection's publish failure must never be read as this one.
+    """
+    from . import freshness
+
+    freshness.invalidate(vault_root)
+    freshness.mark_external_pending(vault_root)
+    _evict_corpus_projection_consumers(vault_root)
 
 
 def publish_corpus_delta(
@@ -78,7 +100,11 @@ def publish_corpus_delta(
 
     A caller may retry the *same complete batch* once for a transient failure.
     Persistent failure withdraws every checkpoint-consuming projection rather
-    than allowing a path-local callback to bless stale global state.
+    than allowing a path-local callback to bless stale global state — but only
+    as far as the failure justifies.  The publish seam reports which of its
+    two halves broke: a registry-advance failure is registry loss and takes
+    the full withdraw, while a corpus-patch failure leaves the registry intact
+    and withdraws the RAM projections only.
     """
     from . import semantic_contract
 
@@ -87,23 +113,34 @@ def publish_corpus_delta(
     if not changed_values and not deleted_values:
         return True
     bounded_attempts = max(1, min(int(attempts), 2))
+    failure: semantic_contract.CorpusPublicationFailure | None = None
     for attempt in range(1, bounded_attempts + 1):
         try:
-            semantic_contract.publish_corpus_files_changed(
+            failure = semantic_contract.publish_corpus_files_changed_classified(
                 vault_root,
                 changed=changed_values,
                 deleted=deleted_values,
             )
-        except Exception:  # noqa: BLE001 - canonical bytes already committed
-            log.warning(
-                "canonical corpus publication failed (attempt %d/%d)",
-                attempt,
-                bounded_attempts,
-                exc_info=True,
+        except Exception as error:  # noqa: BLE001 - canonical bytes already committed
+            # Escaped the classified seam, so it belongs to neither half.  An
+            # unattributable failure is treated as registry loss: the
+            # conservative reading, never the cheap one.
+            failure = semantic_contract.CorpusPublicationFailure(
+                semantic_contract.CORPUS_PUBLICATION_REGISTRY_ADVANCE, error
             )
-        else:
+        if failure is None:
             return True
-    _withdraw_unbridgeable_corpus_consumers(vault_root)
+        log.warning(
+            "canonical corpus publication failed (attempt %d/%d, stage=%s)",
+            attempt,
+            bounded_attempts,
+            failure.stage,
+            exc_info=failure.error,
+        )
+    if failure is not None and failure.registry_intact:
+        _evict_corpus_projection_consumers(vault_root)
+    else:
+        _withdraw_unbridgeable_corpus_consumers(vault_root)
     return False
 
 

--- a/src/exomem/relation_review.py
+++ b/src/exomem/relation_review.py
@@ -462,6 +462,12 @@ class _Attempt:
     lifecycle_guard: vault.DirectoryCensusGuard | None
     language_registry: semantic_language_registry.SemanticLanguageRegistry
     reused: bool = False
+    before_corpus_census: tuple | None = None
+    """The exact census that validated ``before_corpus``, when this attempt
+    built it. A caller about to compute ``corpus_validity_token`` threads this
+    instead of paying a second stat-walk of the whole vault. ``None`` whenever
+    no single walk unambiguously matches ``before_corpus`` — a reused
+    pre-validated attempt, or a build the corpus cache could not caption."""
 
     @property
     def prevalidated_outcome(self) -> str:
@@ -3077,6 +3083,7 @@ def _attempt(
     else:
         stamp_current = False
     reused = reuse if stamp_current else None
+    before_census: tuple | None = None
     if reused is not None:
         before = reused.before_corpus
         candidate = reused.candidate
@@ -3085,7 +3092,7 @@ def _attempt(
         registry = relation_registry.load_registry(root)
         language = semantic_language_registry.load_registry(root)
         loaded_contracts = memory_schema.load_saved_contracts(root)
-        before = semantic_contract.build_corpus_context(
+        before, before_census = semantic_contract.build_corpus_context_with_census(
             root, registry=registry, language_registry=language
         )
         candidate = semantic_contract.build_page_state(
@@ -3233,6 +3240,7 @@ def _attempt(
         lifecycle_guard,
         language,
         reused is not None,
+        before_census,
     )
 
 
@@ -3717,10 +3725,19 @@ def prepare_commit_creation_draft(
             predecessor_path=predecessor_path,
             predecessor_content_hash=predecessor_content_hash,
         )
+        # Thread the census straight from the corpus context this preliminary
+        # attempt just built, so the validity token never re-walks the vault.
+        # `cached_corpus_census` remains the fallback for the cases that walk
+        # produced no captionable census (or an eviction landed since), which
+        # is all it could ever offer on its own.
         sc_token = (
             semantic_contract.corpus_validity_token(
                 root,
-                corpus_census=semantic_contract.cached_corpus_census(root),
+                corpus_census=(
+                    preliminary.before_corpus_census
+                    if preliminary.before_corpus_census is not None
+                    else semantic_contract.cached_corpus_census(root)
+                ),
             )
             if entry_generation is not None
             else None

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -2073,8 +2073,8 @@ def _populate_corpus_context_after_miss(root: Path) -> None:
     Deliberately NOT single-flighted and NOT memoized on failure: a state that
     keeps the cache cold (persistent projection-publish failure, or external
     churn that discards every admission) makes every publish pay a build that
-    cannot land. Bounding that is tracked as a follow-up issue; the shape to
-    copy is ``lexstore._REPAIRS_IN_FLIGHT``.
+    cannot land. Bounding that is tracked as #539; the shape to copy is
+    ``lexstore._REPAIRS_IN_FLIGHT``.
     """
     if not corpus_context_cache_enabled():
         return

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -1790,6 +1790,10 @@ def on_corpus_files_changed(
     Callers that also publish freshness MUST use
     :func:`publish_corpus_files_changed` so both derived states advance under
     one boundary. This lower-level hook remains useful for tests and repair.
+
+    Deliberately does NOT populate a cold cache: it advances no freshness, so
+    there is no publication for a populated context to be captioned against —
+    that belongs to the publish seam.
     """
     with _CORPUS_CONTEXT_UPDATE_LOCK:
         _patch_corpus_files_changed_locked(
@@ -1798,6 +1802,38 @@ def on_corpus_files_changed(
             deleted=deleted,
             event_token=freshness.triple(Path(vault_root), "vault"),
         )
+
+
+CORPUS_PUBLICATION_REGISTRY_ADVANCE = "registry_advance"
+CORPUS_PUBLICATION_PROJECTION_PATCH = "projection_patch"
+
+
+@dataclass(frozen=True, slots=True)
+class CorpusPublicationFailure:
+    """Which half of the corpus publish seam failed, and with what.
+
+    One call publishes two derived states, and a caller deciding how to
+    recover needs to know which of them broke:
+
+    * ``"registry_advance"`` — ``freshness.on_files_changed`` itself failed,
+      so the event registry can no longer name the current file set and no
+      consumer's retained event suffix is bridgeable. Registry loss.
+    * ``"projection_patch"`` — the registry advanced and recorded every
+      event; only the corpus cache's own patch failed. The registry is
+      intact and exactly one projection lost its resumption point.
+
+    Before this split both surfaced as one exception from one call, so the
+    caller could only guess — and guessed registry loss, cooling a live
+    registry for a failure that was local to one RAM projection.
+    """
+
+    stage: str
+    error: BaseException
+
+    @property
+    def registry_intact(self) -> bool:
+        """Whether the event registry still names the current file set."""
+        return self.stage == CORPUS_PUBLICATION_PROJECTION_PATCH
 
 
 def publish_corpus_files_changed(
@@ -1811,6 +1847,31 @@ def publish_corpus_files_changed(
     Serializing these two derived-state publications prevents concurrent file
     events from stamping a context that contains only one event with a
     freshness token that already represents both.
+
+    Raises whatever either half raised. A caller whose recovery depends on
+    WHICH half failed calls
+    :func:`publish_corpus_files_changed_classified` instead.
+    """
+    failure = publish_corpus_files_changed_classified(
+        vault_root, changed=changed, deleted=deleted
+    )
+    if failure is not None:
+        raise failure.error
+
+
+def publish_corpus_files_changed_classified(
+    vault_root: Path,
+    *,
+    changed: Iterable[Path] = (),
+    deleted: Iterable[Path | str] = (),
+) -> CorpusPublicationFailure | None:
+    """:func:`publish_corpus_files_changed`, reporting WHICH half failed.
+
+    Returns ``None`` on success and a :class:`CorpusPublicationFailure`
+    otherwise, carrying the original exception unwrapped so a caller that
+    only wants to propagate can re-raise it unchanged. Interpreter-level
+    exits (anything that is not an ``Exception``) are never turned into a
+    result; they propagate as before.
     """
     root = Path(vault_root)
     changed_values = tuple(Path(value) for value in changed)
@@ -1822,17 +1883,22 @@ def publish_corpus_files_changed(
         value if value.is_absolute() else root / value for value in deleted_values
     )
     with _CORPUS_CONTEXT_UPDATE_LOCK:
-        freshness.on_files_changed(root, changed=changed_paths, deleted=deleted_paths)
         try:
-            _patch_corpus_files_changed_locked(
+            freshness.on_files_changed(root, changed=changed_paths, deleted=deleted_paths)
+        except BaseException as error:
+            if not isinstance(error, Exception):
+                raise
+            return CorpusPublicationFailure(CORPUS_PUBLICATION_REGISTRY_ADVANCE, error)
+        try:
+            disposition = _patch_corpus_files_changed_locked(
                 root,
                 changed=changed_values,
                 deleted=deleted_values,
                 event_token=freshness.triple(root, "vault"),
             )
-        except BaseException:
+        except BaseException as error:
             # Freshness already advanced, so the previous context can no
-            # longer prove continuity. Evict every caption before propagating
+            # longer prove continuity. Evict every caption before reporting
             # the safety/parse failure; a later good event must not leapfrog
             # this missed delta and stamp stale state as current.
             cache_key = _corpus_cache_key(root)
@@ -1840,7 +1906,20 @@ def publish_corpus_files_changed(
                 _CORPUS_CONTEXT_CACHE.pop(cache_key, None)
                 _CORPUS_CONTEXT_EVENT_TOKENS.pop(cache_key, None)
                 _CORPUS_CONTEXT_LANGUAGE_HASHES.pop(cache_key, None)
-            raise
+            if not isinstance(error, Exception):
+                raise
+            return CorpusPublicationFailure(CORPUS_PUBLICATION_PROJECTION_PATCH, error)
+    # Outside the update lock on purpose: the populate walks and parses the
+    # whole vault, and the publisher advances freshness under that same lock.
+    if disposition == _CORPUS_PATCH_MISS:
+        _populate_corpus_context_after_miss(root)
+    return None
+
+
+_CORPUS_PATCH_MISS = "miss"
+_CORPUS_PATCH_EVICTED = "evicted"
+_CORPUS_PATCH_UNCHANGED = "unchanged"
+_CORPUS_PATCH_APPLIED = "patched"
 
 
 def _patch_corpus_files_changed_locked(
@@ -1849,21 +1928,29 @@ def _patch_corpus_files_changed_locked(
     changed: Iterable[Path],
     deleted: Iterable[Path | str],
     event_token: tuple[int, int, str] | None,
-) -> None:
-    """Patch one cache entry while ``_CORPUS_CONTEXT_UPDATE_LOCK`` is held."""
+) -> str:
+    """Patch one cache entry while ``_CORPUS_CONTEXT_UPDATE_LOCK`` is held.
+
+    Returns what it did, because only the caller can act on a ``"miss"``: a
+    cold cache has nothing to patch, and populating it means a full walk that
+    must NOT happen inside this lock (see
+    :func:`_populate_corpus_context_after_miss`). ``"evicted"`` is the
+    config-census drift pop and stays eviction-only — a drifted config makes
+    the stored context unusable, not merely absent.
+    """
     root = Path(vault_root)
     cache_key = _corpus_cache_key(root)
     with _CORPUS_CONTEXT_CACHE_LOCK:
         entry = _CORPUS_CONTEXT_CACHE.get(cache_key)
     if entry is None:
-        return
+        return _CORPUS_PATCH_MISS
     if _config_census(root) != _stored_config_census(entry[0]):
         with _CORPUS_CONTEXT_CACHE_LOCK:
             if _CORPUS_CONTEXT_CACHE.get(cache_key) is entry:
                 _CORPUS_CONTEXT_CACHE.pop(cache_key, None)
                 _CORPUS_CONTEXT_EVENT_TOKENS.pop(cache_key, None)
                 _CORPUS_CONTEXT_LANGUAGE_HASHES.pop(cache_key, None)
-        return
+        return _CORPUS_PATCH_EVICTED
 
     def relative(value: Path | str) -> str | None:
         path = Path(value)
@@ -1899,7 +1986,7 @@ def _patch_corpus_files_changed_locked(
     )
     reconcile_paths = tuple(sorted(set(changed_paths) | set(deleted_paths)))
     if not reconcile_paths:
-        return
+        return _CORPUS_PATCH_UNCHANGED
     relation_definitions = relation_registry.load_registry(root)
     language = semantic_language_registry.load_registry(root)
     context = _reconcile_markdown_delta(
@@ -1925,6 +2012,127 @@ def _patch_corpus_files_changed_locked(
                 _CORPUS_CONTEXT_EVENT_TOKENS.pop(cache_key, None)
             else:
                 _CORPUS_CONTEXT_EVENT_TOKENS[cache_key] = event_token
+    return _CORPUS_PATCH_APPLIED
+
+
+def _trim_corpus_cache_locked(keep: tuple[str, str]) -> None:
+    """Evict other vaults down to the bound; call with the cache lock held."""
+    while len(_CORPUS_CONTEXT_CACHE) > _CORPUS_CONTEXT_CACHE_MAX_VAULTS:
+        for stale_key in list(_CORPUS_CONTEXT_CACHE):
+            if stale_key != keep:
+                del _CORPUS_CONTEXT_CACHE[stale_key]
+                _CORPUS_CONTEXT_EVENT_TOKENS.pop(stale_key, None)
+                _CORPUS_CONTEXT_LANGUAGE_HASHES.pop(stale_key, None)
+                break
+        else:
+            break
+
+
+def _populate_corpus_context_after_miss(root: Path) -> None:
+    """Build the corpus context a publish found no warm entry to patch.
+
+    Before this, a publish onto a cold cache was a silent no-op, so the very
+    next reader paid a full stat census AND a full parse of the vault — on a
+    write path where that walk is the dominant cost. The publisher pays one
+    honest build here instead, synchronously, and the next reader is an
+    event-hit.
+
+    Why this cannot simply run inside the caller's lock (contract L1 vs L2):
+    the publish path holds ``_CORPUS_CONTEXT_UPDATE_LOCK`` across
+    ``freshness.on_files_changed`` precisely so no event can interleave
+    between an advance and a stamp. Walking and parsing the whole vault
+    inside that hold would serialize EVERY concurrent governed write behind
+    one cold build — at thousands of pages, seconds of it. So the walk runs
+    outside the lock and admission takes L2's shape instead:
+
+    * capture ``freshness.consumer_checkpoint`` BEFORE the walk and re-read it
+      under the update lock; stamp only if it is unchanged. The checkpoint,
+      not the bare triple, because it carries a strictly increasing
+      generation and the triple alone is ABA-vulnerable across a
+      revert-in-place (L3);
+    * require the cache slot to still hold the same thing observed at the
+      start — for a populate that is "still empty", the analogue of the
+      ``_CORPUS_CONTEXT_CACHE.get(cache_key) is entry`` idiom every other
+      stamp site uses;
+    * re-confirm the census under the same hold, because the checkpoint only
+      covers deltas the registry SAW. A file that moved during the build
+      without reaching the registry would otherwise leave a stored census
+      that lies about the context it captions, and a later revert-in-place
+      could serve that context as current;
+    * on any mismatch, discard. Never stamp; a later build repopulates
+      honestly.
+
+    Nothing here may fail the publish that called it: the canonical bytes are
+    already committed and the registry has already advanced. A populate that
+    cannot complete simply leaves the cache cold, which is exactly today's
+    behavior.
+    """
+    if not corpus_context_cache_enabled():
+        return
+    try:
+        cache_key = _corpus_cache_key(root)
+    except Exception:  # noqa: BLE001 - an unkeyable root simply has no cache
+        return
+    with _CORPUS_CONTEXT_CACHE_LOCK:
+        if _CORPUS_CONTEXT_CACHE.get(cache_key) is not None:
+            return
+    try:
+        _populate_corpus_context_locked_admission(root, cache_key)
+    except Exception:  # noqa: BLE001 - the publish itself already succeeded
+        log.warning("semantic corpus populate-on-miss failed", exc_info=True)
+
+
+def _populate_corpus_context_locked_admission(root: Path, cache_key: tuple[str, str]) -> None:
+    """The L2 body of :func:`_populate_corpus_context_after_miss`."""
+    # Loaded from disk, so no `_registries_match_disk` check is needed: both
+    # registry files are census entries, and the confirm below re-reads the
+    # whole census under the lock.
+    relation_definitions = relation_registry.load_registry(root)
+    language = semantic_language_registry.load_registry(root)
+    # L2/L3: the admission decision is made against this, captured before the
+    # walk it has to vouch for.
+    before = freshness.consumer_checkpoint(root, "vault")
+    census = _timed_corpus_census(root, "rebuild")
+    if census is None:
+        return
+    started = time.perf_counter()
+    context = _build_corpus_context_uncached(
+        root,
+        candidate=None,
+        relation_definitions=relation_definitions,
+        language=language,
+    )
+    build_ms = (time.perf_counter() - started) * 1000.0
+    with _census_walk_log() as walk_log, _CORPUS_CONTEXT_UPDATE_LOCK:
+        after = freshness.consumer_checkpoint(root, "vault")
+        if after != before:
+            log.info("semantic corpus populate discarded: registry advanced mid-walk")
+            return
+        with _CORPUS_CONTEXT_CACHE_LOCK:
+            if _CORPUS_CONTEXT_CACHE.get(cache_key) is not None:
+                return
+        if _deferred_corpus_census(root, walk_log, "census") != census:
+            log.info("semantic corpus populate discarded: corpus moved mid-build")
+            return
+        with _CORPUS_CONTEXT_CACHE_LOCK:
+            if _CORPUS_CONTEXT_CACHE.get(cache_key) is not None:
+                return
+            _CORPUS_CONTEXT_CACHE[cache_key] = (census, context)
+            _CORPUS_CONTEXT_LANGUAGE_HASHES[cache_key] = (
+                f"{language.schema_version}:{language.content_hash}"
+            )
+            # L4: no candidate is ever involved here, and a token of None
+            # pops rather than leaving a stale caption behind.
+            if after.triple is None:
+                _CORPUS_CONTEXT_EVENT_TOKENS.pop(cache_key, None)
+            else:
+                _CORPUS_CONTEXT_EVENT_TOKENS[cache_key] = after.triple
+            _trim_corpus_cache_locked(cache_key)
+    log.info(
+        "semantic corpus context populated on miss pages=%d build_ms=%.1f",
+        len(context.pages),
+        build_ms,
+    )
 
 
 def build_corpus_context(
@@ -2184,15 +2392,7 @@ def build_corpus_context_with_census(
                             _CORPUS_CONTEXT_EVENT_TOKENS.pop(cache_key, None)
                         else:
                             _CORPUS_CONTEXT_EVENT_TOKENS[cache_key] = current_token
-                        while len(_CORPUS_CONTEXT_CACHE) > _CORPUS_CONTEXT_CACHE_MAX_VAULTS:
-                            for stale_key in list(_CORPUS_CONTEXT_CACHE):
-                                if stale_key != cache_key:
-                                    del _CORPUS_CONTEXT_CACHE[stale_key]
-                                    _CORPUS_CONTEXT_EVENT_TOKENS.pop(stale_key, None)
-                                    _CORPUS_CONTEXT_LANGUAGE_HASHES.pop(stale_key, None)
-                                    break
-                            else:
-                                break
+                        _trim_corpus_cache_locked(cache_key)
                     stored = True
         log.info(
             "semantic corpus context built pages=%d build_ms=%.1f cached=%s",

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -1890,6 +1890,10 @@ def publish_corpus_files_changed_classified(
     with _CORPUS_CONTEXT_UPDATE_LOCK:
         try:
             freshness.on_files_changed(root, changed=changed_paths, deleted=deleted_paths)
+            # Read the token here, not in the patch call below: it is a
+            # registry-side read, so a failure in it is registry-side too and
+            # must not be reported as the projection's fault.
+            event_token = freshness.triple(root, "vault")
         except BaseException as error:
             if not isinstance(error, Exception):
                 raise
@@ -1899,7 +1903,7 @@ def publish_corpus_files_changed_classified(
                 root,
                 changed=changed_values,
                 deleted=deleted_values,
-                event_token=freshness.triple(root, "vault"),
+                event_token=event_token,
             )
         except BaseException as error:
             # Freshness already advanced, so the previous context can no
@@ -2065,6 +2069,12 @@ def _populate_corpus_context_after_miss(root: Path) -> None:
     already committed and the registry has already advanced. A populate that
     cannot complete simply leaves the cache cold, which is exactly today's
     behavior.
+
+    Deliberately NOT single-flighted and NOT memoized on failure: a state that
+    keeps the cache cold (persistent projection-publish failure, or external
+    churn that discards every admission) makes every publish pay a build that
+    cannot land. Bounding that is tracked as a follow-up issue; the shape to
+    copy is ``lexstore._REPAIRS_IN_FLIGHT``.
     """
     if not corpus_context_cache_enabled():
         return
@@ -2083,16 +2093,25 @@ def _populate_corpus_context_after_miss(root: Path) -> None:
 
 def _build_and_admit_corpus_context(root: Path, cache_key: tuple[str, str]) -> None:
     """The L2 body of :func:`_populate_corpus_context_after_miss`."""
-    # Loaded from disk, so no `_registries_match_disk` check is needed: both
-    # registry files are census entries, and the confirm below re-reads the
-    # whole census under the lock.
     relation_definitions = relation_registry.load_registry(root)
     language = semantic_language_registry.load_registry(root)
     # L2/L3: the admission decision is made against this, captured before the
     # walk it has to vouch for.
     before = freshness.consumer_checkpoint(root, "vault")
-    census = _timed_corpus_census(root, "rebuild")
+    census = _timed_corpus_census(root, "populate")
     if census is None:
+        return
+    # The registries were loaded BEFORE this walk, and the walk stats the two
+    # `_Schema` files at its END. A registry rewritten in between therefore
+    # produces a census that records the NEW file while the build below would
+    # use the OLD registry — and the census-reuse path admits on census
+    # equality alone (the registry identity is only re-checked on the
+    # event-hit path), so that entry would be served as current. Every other
+    # install site guards with this; so does this one. The window from here to
+    # the stamp is closed by the census re-confirm under the lock, which sees
+    # the same two files.
+    if not _registries_match_disk(root, relation_definitions, language):
+        log.info("semantic corpus populate discarded: registry moved during the walk")
         return
     started = time.perf_counter()
     context = _build_corpus_context_uncached(

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -1804,6 +1804,11 @@ def on_corpus_files_changed(
         )
 
 
+_CORPUS_PATCH_MISS = "miss"
+_CORPUS_PATCH_EVICTED = "evicted"
+_CORPUS_PATCH_UNCHANGED = "unchanged"
+_CORPUS_PATCH_APPLIED = "patched"
+
 CORPUS_PUBLICATION_REGISTRY_ADVANCE = "registry_advance"
 CORPUS_PUBLICATION_PROJECTION_PATCH = "projection_patch"
 
@@ -1914,12 +1919,6 @@ def publish_corpus_files_changed_classified(
     if disposition == _CORPUS_PATCH_MISS:
         _populate_corpus_context_after_miss(root)
     return None
-
-
-_CORPUS_PATCH_MISS = "miss"
-_CORPUS_PATCH_EVICTED = "evicted"
-_CORPUS_PATCH_UNCHANGED = "unchanged"
-_CORPUS_PATCH_APPLIED = "patched"
 
 
 def _patch_corpus_files_changed_locked(
@@ -2077,12 +2076,12 @@ def _populate_corpus_context_after_miss(root: Path) -> None:
         if _CORPUS_CONTEXT_CACHE.get(cache_key) is not None:
             return
     try:
-        _populate_corpus_context_locked_admission(root, cache_key)
+        _build_and_admit_corpus_context(root, cache_key)
     except Exception:  # noqa: BLE001 - the publish itself already succeeded
         log.warning("semantic corpus populate-on-miss failed", exc_info=True)
 
 
-def _populate_corpus_context_locked_admission(root: Path, cache_key: tuple[str, str]) -> None:
+def _build_and_admit_corpus_context(root: Path, cache_key: tuple[str, str]) -> None:
     """The L2 body of :func:`_populate_corpus_context_after_miss`."""
     # Loaded from disk, so no `_registries_match_disk` check is needed: both
     # registry files are census entries, and the confirm below re-reads the
@@ -2103,6 +2102,13 @@ def _populate_corpus_context_locked_admission(root: Path, cache_key: tuple[str, 
         language=language,
     )
     build_ms = (time.perf_counter() - started) * 1000.0
+    # Its own outcome, not "rebuild": this build is paid by the PUBLISHER, so
+    # a writer suddenly wearing a full corpus build has to be visible as that.
+    metrics.observe_duration_ms(
+        "exomem_corpus_build_ms",
+        build_ms,
+        {"caller": current_call_context(), "outcome": "populate"},
+    )
     with _census_walk_log() as walk_log, _CORPUS_CONTEXT_UPDATE_LOCK:
         after = freshness.consumer_checkpoint(root, "vault")
         if after != before:

--- a/tests/test_corpus_context_cache.py
+++ b/tests/test_corpus_context_cache.py
@@ -502,7 +502,7 @@ def test_event_delta_rejects_reparse_markdown_like_full_identity_census(
         "vault",
         ((str(path), freshness.stat_signature(path)) for path in vault.rglob("*.md")),
     )
-    semantic_contract.build_corpus_context(vault)
+    rejected = semantic_contract.build_corpus_context(vault)
     page = vault / _PAGE_REL
     real_lstat = Path.lstat
     fake_info = SimpleNamespace(st_mode=real_lstat(page).st_mode)
@@ -525,22 +525,28 @@ def test_event_delta_rejects_reparse_markdown_like_full_identity_census(
     assert cache_key not in semantic_contract._CORPUS_CONTEXT_CACHE
 
     # A later valid event cannot skip over the rejected delta and re-caption
-    # the old context with a newer freshness token.
+    # the context that missed it. Refilling the cache the rejected delta
+    # emptied IS allowed -- that is populate-on-miss -- but only from scratch
+    # through the full safety oracle, never by patching the old context.
     other = vault / "Knowledge Base/Notes/Insights/two.md"
     other.write_text(_page(title="Later valid event"), encoding="utf-8")
+    oracle_calls: list[str] = []
+    real_uncached = semantic_contract._build_corpus_context_uncached
+
+    def counted_oracle(*args, **kwargs):
+        oracle_calls.append("build")
+        return real_uncached(*args, **kwargs)
+
+    monkeypatch.setattr(semantic_contract, "_build_corpus_context_uncached", counted_oracle)
     semantic_contract.publish_corpus_files_changed(vault, changed=(other,))
-    assert cache_key not in semantic_contract._CORPUS_CONTEXT_CACHE
 
-    def cold_oracle_required(*args, **kwargs):
-        raise AssertionError("next request must use the full safety oracle")
-
-    monkeypatch.setattr(
-        semantic_contract,
-        "_build_corpus_context_uncached",
-        cold_oracle_required,
+    assert oracle_calls, "refilling the cache must use the full safety oracle"
+    repopulated = semantic_contract._CORPUS_CONTEXT_CACHE[cache_key][1]
+    assert repopulated is not rejected
+    assert (
+        repopulated.pages["Knowledge Base/Notes/Insights/two.md"].title == "Later valid event"
     )
-    with pytest.raises(AssertionError, match="full safety oracle"):
-        semantic_contract.build_corpus_context(vault)
+    assert semantic_contract.build_corpus_context(vault) is repopulated
 
 
 def test_event_delete_rejects_missing_leaf_below_reparse_ancestor(

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -369,7 +369,7 @@ def test_periodic_reconcile_recovers_a_failed_external_publication(
     graph.rebuild_all()
     page = next(find_module._walk_md(vault / "Knowledge Base"))
     rel = _vault_rel(vault, page)
-    original_publish = semantic_contract.publish_corpus_files_changed
+    original_publish = semantic_contract.publish_corpus_files_changed_classified
 
     page.write_text(
         page.read_text(encoding="utf-8") + "\nRecovered external edit.\n",
@@ -382,7 +382,7 @@ def test_periodic_reconcile_recovers_a_failed_external_publication(
 
     monkeypatch.setattr(
         semantic_contract,
-        "publish_corpus_files_changed",
+        "publish_corpus_files_changed_classified",
         fail_publication,
     )
     watcher._flush()
@@ -393,7 +393,7 @@ def test_periodic_reconcile_recovers_a_failed_external_publication(
 
     monkeypatch.setattr(
         semantic_contract,
-        "publish_corpus_files_changed",
+        "publish_corpus_files_changed_classified",
         original_publish,
     )
     watcher._reconcile_once(seed=False)
@@ -888,7 +888,8 @@ def test_self_write_publishes_semantic_corpus_delta(vault, monkeypatch: pytest.M
     calls: list[tuple[list[Path], list[str]]] = []
     monkeypatch.setattr(file_watcher.freshness, "event_indexes_enabled", lambda: True)
     monkeypatch.setattr(
-        "exomem.semantic_contract.publish_corpus_files_changed",
+        "exomem.semantic_contract.publish_corpus_files_changed_classified",
+        # `list.append` returns None, i.e. "published, no failure".
         lambda root, *, changed=(), deleted=(): calls.append(
             (list(changed), [str(path) for path in deleted])
         ),
@@ -908,7 +909,8 @@ def test_external_batch_publishes_semantic_corpus_delta(
     _stub_embeddings(monkeypatch)
     calls: list[tuple[list[Path], list[str]]] = []
     monkeypatch.setattr(
-        "exomem.semantic_contract.publish_corpus_files_changed",
+        "exomem.semantic_contract.publish_corpus_files_changed_classified",
+        # `list.append` returns None, i.e. "published, no failure".
         lambda root, *, changed=(), deleted=(): calls.append(
             (list(changed), [str(path) for path in deleted])
         ),
@@ -939,17 +941,19 @@ def test_external_batch_retries_the_complete_vault_delta_before_fanout(
     source.write_text("---\ntitle: New target\n---\n# New target\n", encoding="utf-8")
     kb_note.write_text("# After\n", encoding="utf-8")
 
-    real_publish = semantic_contract.publish_corpus_files_changed
+    real_publish = semantic_contract.publish_corpus_files_changed_classified
     calls: list[tuple[list[Path], list[str]]] = []
 
     def flaky_publish(root, *, changed=(), deleted=()):
         calls.append((list(changed), [str(path) for path in deleted]))
         if len(calls) == 1:
             raise RuntimeError("transient publication failure")
-        real_publish(root, changed=changed, deleted=deleted)
+        return real_publish(root, changed=changed, deleted=deleted)
 
     upserts: list[tuple[list[Path], dict]] = []
-    monkeypatch.setattr(semantic_contract, "publish_corpus_files_changed", flaky_publish)
+    monkeypatch.setattr(
+        semantic_contract, "publish_corpus_files_changed_classified", flaky_publish
+    )
     monkeypatch.setattr(
         file_watcher.index_sync,
         "upsert_after_write",
@@ -983,7 +987,7 @@ def test_persistent_non_kb_publication_failure_withdraws_stale_resolver(
     source.write_text("---\ntitle: New target\n---\n# New target\n", encoding="utf-8")
     monkeypatch.setattr(
         semantic_contract,
-        "publish_corpus_files_changed",
+        "publish_corpus_files_changed_classified",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("persistent failure")),
     )
     watcher = file_watcher.FileWatcher(vault)

--- a/tests/test_freshness_liveness_contract.py
+++ b/tests/test_freshness_liveness_contract.py
@@ -27,10 +27,15 @@ from pathlib import Path
 
 import pytest
 
-from exomem import freshness, index_sync, semantic_contract
+from exomem import freshness, index_sync, relation_registry, semantic_contract
 
 _PAGE_REL = "Knowledge Base/Notes/Insights/one.md"
 _OTHER_REL = "Knowledge Base/Notes/Insights/two.md"
+_REGISTRY_REL = "Knowledge Base/_Schema/relation-registry.yaml"
+_EXTENDED_REGISTRY = (
+    "schema_version: 1\nextensions:\n  science.replicates:\n"
+    "    parent: supports\n    description: Independent reproduction\n"
+)
 
 
 def _page(*, title: str = "Page", body: str = "Body.\n") -> str:
@@ -267,3 +272,87 @@ def test_populate_on_miss_never_stamps_a_context_an_event_leapfrogged(
     context = semantic_contract.build_corpus_context(vault)
     assert context.pages[_PAGE_REL].title == "One changed"
     assert context.pages[_OTHER_REL].title == "Two leapfrogged"
+
+
+def test_populate_on_miss_never_stamps_a_context_built_with_a_superseded_registry(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The populate loads its registries BEFORE its walk, so it must re-prove
+    them against disk before installing.
+
+    `_corpus_census` stats the two `_Schema` registry files at the END of its
+    walk. A registry rewritten between the load and that stat therefore yields
+    a census that records the NEW file captioning a context built with the OLD
+    registry. The event-hit gate would refuse such an entry -- it re-checks the
+    registry identity -- but the census-reuse path admits on census equality
+    alone, and would hand that context back as current.
+
+    Every other install site guards with `_registries_match_disk`; this pins
+    that the populate does too.
+    """
+    page = vault / _PAGE_REL
+    page.write_text(_page(title="One changed"), encoding="utf-8")
+    registry_path = vault / _REGISTRY_REL
+    superseded = relation_registry.load_registry(vault)
+
+    real_census = semantic_contract._corpus_census
+    walks: list[str] = []
+
+    def census_with_a_registry_rewrite(root: Path):
+        walks.append(str(root))
+        if len(walks) == 1:
+            # Interleaved into the populate's own walk window: the registry
+            # this census is about to stat is no longer the one in hand.
+            registry_path.parent.mkdir(parents=True, exist_ok=True)
+            registry_path.write_text(_EXTENDED_REGISTRY, encoding="utf-8")
+        return real_census(root)
+
+    monkeypatch.setattr(semantic_contract, "_corpus_census", census_with_a_registry_rewrite)
+
+    semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
+
+    assert walks, "the populate must have walked for this to be a real discard"
+    assert relation_registry.load_registry(vault).extension_hash != superseded.extension_hash
+    cache_key = semantic_contract._corpus_cache_key(vault)
+    assert cache_key not in semantic_contract._CORPUS_CONTEXT_CACHE
+    assert cache_key not in semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS
+    assert cache_key not in semantic_contract._CORPUS_CONTEXT_LANGUAGE_HASHES
+
+
+def test_populate_on_miss_never_overwrites_a_slot_a_competitor_filled(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """L2's other admission half: the slot must still be the one observed.
+
+    A concurrent cold build can install its own entry while this populate is
+    still walking. The populate observed an EMPTY slot; a slot that is no
+    longer empty means it lost the race, and losing means discarding, not
+    overwriting -- the analogue of the
+    `_CORPUS_CONTEXT_CACHE.get(cache_key) is entry` identity check every other
+    stamp site makes.
+    """
+    page = vault / _PAGE_REL
+    page.write_text(_page(title="One changed"), encoding="utf-8")
+    cache_key = semantic_contract._corpus_cache_key(vault)
+    competitor = (("competitor-census",), object())
+
+    real_build = semantic_contract._build_corpus_context_uncached
+    builds: list[str] = []
+
+    def build_then_lose_the_slot(root: Path, **kwargs):
+        builds.append("build")
+        context = real_build(root, **kwargs)
+        with semantic_contract._CORPUS_CONTEXT_CACHE_LOCK:
+            semantic_contract._CORPUS_CONTEXT_CACHE[cache_key] = competitor
+        return context
+
+    monkeypatch.setattr(
+        semantic_contract, "_build_corpus_context_uncached", build_then_lose_the_slot
+    )
+
+    semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
+
+    assert builds, "the populate must have built for this to be a real discard"
+    assert semantic_contract._CORPUS_CONTEXT_CACHE[cache_key] is competitor
+    assert cache_key not in semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS
+    assert cache_key not in semantic_contract._CORPUS_CONTEXT_LANGUAGE_HASHES

--- a/tests/test_freshness_liveness_contract.py
+++ b/tests/test_freshness_liveness_contract.py
@@ -1,0 +1,241 @@
+"""The joint freshness-liveness contract, corpus half (#510 slices A/B).
+
+`freshness.*` describes what the event registry knows about the vault's
+files. It must never be used to describe whether a downstream projection
+managed to publish its own derived copy. These tests pin the corpus-side
+consequences of that separation:
+
+* a Class B failure -- the registry advanced, only the corpus PATCH failed --
+  must leave vault freshness live and not externally pending, and must leave
+  the corpus projection able to warm itself again on the next publish;
+* a Class A failure -- the registry-advance half itself failed -- must still
+  take the full withdraw, because the event suffix really is unknowable;
+* a publish that finds no warm corpus entry must POPULATE one (D8) instead of
+  silently returning, so the next reader is an event-hit rather than a full
+  stat census of the vault;
+* that populate must never stamp an event token onto a context whose walk an
+  event leapfrogged (contract SS5, clauses L1-L5).
+
+The graph-side halves of the shared defending test (contract SS4 assertions 3
+and 4) belong to the parallel `lane/graph-publish-hygiene` lane and are not
+asserted here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from exomem import freshness, index_sync, semantic_contract
+
+_PAGE_REL = "Knowledge Base/Notes/Insights/one.md"
+_OTHER_REL = "Knowledge Base/Notes/Insights/two.md"
+
+
+def _page(*, title: str = "Page", body: str = "Body.\n") -> str:
+    return f"---\ntitle: {title}\ntype: insight\nstatus: active\nproject: atlas\n---\n\n{body}"
+
+
+@pytest.fixture(autouse=True)
+def _corpus_cache_on(monkeypatch: pytest.MonkeyPatch):
+    # The suite-wide conftest defaults the corpus cache OFF; this contract is
+    # entirely about that cache's lifecycle, so opt back in and start cold.
+    monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
+    semantic_contract.reset_corpus_context_cache()
+    freshness.clear()
+    yield
+    semantic_contract.reset_corpus_context_cache()
+    freshness.clear()
+
+
+@pytest.fixture()
+def vault(tmp_path: Path) -> Path:
+    notes = tmp_path / "Knowledge Base" / "Notes" / "Insights"
+    notes.mkdir(parents=True)
+    (notes / "one.md").write_text(_page(title="One"), encoding="utf-8")
+    (notes / "two.md").write_text(_page(title="Two"), encoding="utf-8")
+    freshness.rebaseline(tmp_path)
+    return tmp_path
+
+
+def _spy_corpus_census(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    """Record every real full-vault stat census the code under test still pays."""
+    calls: list[Path] = []
+    real_census = semantic_contract._corpus_census
+
+    def spy(root: Path):
+        calls.append(root)
+        return real_census(root)
+
+    monkeypatch.setattr(semantic_contract, "_corpus_census", spy)
+    return calls
+
+
+def _poison_corpus_patch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail only the projection half of the corpus publish seam (Class B).
+
+    `freshness.on_files_changed` still runs and still records the delta -- the
+    registry observed every event. Only the cache's own patch raises, which is
+    exactly the contract's Class B: "a corpus-cache patch that raises for a
+    cause local to the cache".
+    """
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("poisoned corpus delta")
+
+    monkeypatch.setattr(semantic_contract, "_patch_corpus_files_changed_locked", boom)
+
+
+def test_refused_corpus_patch_does_not_cool_vault_freshness(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Contract C1.1: a Class B corpus-patch failure is not registry loss.
+
+    Red on `main` for the contract's stated reason: `publish_corpus_delta`'s
+    `_withdraw_unbridgeable_corpus_consumers` calls `freshness.invalidate`
+    (index_sync.py:63) and `freshness.mark_external_pending` (:64) for ANY
+    publish failure, so `triple()` returns None, the corpus event-hit gate is
+    structurally unreachable, and every later caller pays a full stat census.
+    """
+    semantic_contract.build_corpus_context(vault)
+    assert freshness.triple(vault, "vault") is not None
+
+    page = vault / _PAGE_REL
+    page.write_text(_page(title="One changed"), encoding="utf-8")
+    _poison_corpus_patch(monkeypatch)
+
+    assert index_sync.publish_corpus_delta(vault, changed=(page,)) is False
+
+    # 1. Liveness preserved: the registry saw the event, only the projection
+    #    could not publish its derived copy.
+    assert freshness.triple(vault, "vault") is not None
+    assert freshness.is_live(vault, "vault") is True
+    assert freshness.external_pending(vault) is False
+
+    # 2. The corpus projection can warm itself again with no operator action:
+    #    the next publish repopulates on miss, and the read after it is an
+    #    event-hit paying zero full censuses.
+    monkeypatch.undo()
+    other = vault / _OTHER_REL
+    other.write_text(_page(title="Two changed"), encoding="utf-8")
+    assert index_sync.publish_corpus_delta(vault, changed=(other,)) is True
+
+    cache_key = semantic_contract._corpus_cache_key(vault)
+    assert semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS.get(cache_key) == freshness.triple(
+        vault, "vault"
+    )
+
+    census_calls = _spy_corpus_census(monkeypatch)
+    context = semantic_contract.build_corpus_context(vault)
+    assert census_calls == []
+    assert context.pages[_OTHER_REL].title == "Two changed"
+    assert context.pages[_PAGE_REL].title == "One changed"
+
+
+def test_registry_advance_failure_still_withdraws_vault_freshness(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Contract Class A: the registry-advance half failing IS registry loss.
+
+    Green before and after -- this is the guard that the narrowing in C1.1
+    stays narrow. `freshness.on_files_changed` raising means the event suffix
+    really is unknowable, so the full withdraw (invalidate + external pending)
+    remains correct and must survive the split seam.
+    """
+    semantic_contract.build_corpus_context(vault)
+    assert freshness.triple(vault, "vault") is not None
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("registry advance failed")
+
+    monkeypatch.setattr(semantic_contract.freshness, "on_files_changed", boom)
+    page = vault / _PAGE_REL
+    page.write_text(_page(title="One changed"), encoding="utf-8")
+
+    assert index_sync.publish_corpus_delta(vault, changed=(page,)) is False
+
+    assert freshness.triple(vault, "vault") is None
+    assert freshness.is_live(vault, "vault") is False
+    assert freshness.external_pending(vault) is True
+    cache_key = semantic_contract._corpus_cache_key(vault)
+    assert cache_key not in semantic_contract._CORPUS_CONTEXT_CACHE
+
+
+def test_publish_populates_a_cold_corpus_cache_for_the_next_reader(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deliverable 8: the `entry is None` no-op must populate, not return.
+
+    Red on `main` for the contract's stated reason: `semantic_contract.py`'s
+    `_patch_corpus_files_changed_locked` returns silently when the cache holds
+    no entry (sc:1745-1746), so a write onto a cold cache leaves it cold and
+    the very next preflight pays a full stat census of the vault.
+    """
+    page = vault / _PAGE_REL
+    page.write_text(_page(title="One changed"), encoding="utf-8")
+
+    semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
+
+    cache_key = semantic_contract._corpus_cache_key(vault)
+    entry = semantic_contract._CORPUS_CONTEXT_CACHE.get(cache_key)
+    assert entry is not None
+    assert entry[1].pages[_PAGE_REL].title == "One changed"
+    assert semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS.get(cache_key) == freshness.triple(
+        vault, "vault"
+    )
+
+    census_calls = _spy_corpus_census(monkeypatch)
+    context = semantic_contract.build_corpus_context(vault)
+    assert census_calls == []
+    assert context is entry[1]
+
+
+def test_populate_on_miss_never_stamps_a_context_an_event_leapfrogged(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Contract L2/L3: the populate's admission gate is the consumer checkpoint.
+
+    The populate cannot hold `_CORPUS_CONTEXT_UPDATE_LOCK` across its own walk
+    (the publisher advances freshness under that lock), so it takes L2's shape:
+    capture `freshness.consumer_checkpoint` BEFORE the walk, then admit the
+    built context only if the checkpoint is unchanged and the cache slot is
+    still the empty one it observed. Here an external event lands mid-walk, so
+    the built context provably misses a delta the current token covers and must
+    be discarded rather than stamped.
+    """
+    page = vault / _PAGE_REL
+    page.write_text(_page(title="One changed"), encoding="utf-8")
+
+    other = vault / _OTHER_REL
+    builds: list[str] = []
+    real_build = semantic_contract._build_corpus_context_uncached
+
+    def build_with_racing_event(root: Path, **kwargs):
+        builds.append("build")
+        context = real_build(root, **kwargs)
+        # An external editor lands a change the registry sees, while this
+        # populate's walk is already behind it.
+        other.write_text(_page(title="Two leapfrogged"), encoding="utf-8")
+        freshness.on_files_changed(root, changed=(other,))
+        return context
+
+    monkeypatch.setattr(
+        semantic_contract, "_build_corpus_context_uncached", build_with_racing_event
+    )
+
+    semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
+
+    assert builds, "the populate must have attempted a build to be a real discard"
+    cache_key = semantic_contract._corpus_cache_key(vault)
+    # Never stamp: the leapfrogged context must reach neither the cache nor
+    # the event-token map (contract L2 "on any mismatch discard ... never
+    # stamp", L5 "entry, token and language hash move together").
+    assert cache_key not in semantic_contract._CORPUS_CONTEXT_CACHE
+    assert cache_key not in semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS
+    assert cache_key not in semantic_contract._CORPUS_CONTEXT_LANGUAGE_HASHES
+
+    # And the next honest build sees BOTH deltas, so nothing was lost.
+    context = semantic_contract.build_corpus_context(vault)
+    assert context.pages[_PAGE_REL].title == "One changed"
+    assert context.pages[_OTHER_REL].title == "Two leapfrogged"

--- a/tests/test_freshness_liveness_contract.py
+++ b/tests/test_freshness_liveness_contract.py
@@ -59,17 +59,29 @@ def vault(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def _spy_corpus_census(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
-    """Record every real full-vault stat census the code under test still pays."""
-    calls: list[Path] = []
-    real_census = semantic_contract._corpus_census
+def _spy_corpus_work(monkeypatch: pytest.MonkeyPatch) -> tuple[list[str], list[str]]:
+    """Record the full-vault census walks AND the from-scratch corpus builds.
 
-    def spy(root: Path):
-        calls.append(root)
+    Both seams, not just the census: a regression that rebuilds the corpus
+    without walking it first, or walks without rebuilding, would slip past a
+    spy on either one alone. An event-hit pays neither.
+    """
+    censuses: list[str] = []
+    builds: list[str] = []
+    real_census = semantic_contract._corpus_census
+    real_build = semantic_contract._build_corpus_context_uncached
+
+    def census_spy(root: Path):
+        censuses.append(str(root))
         return real_census(root)
 
-    monkeypatch.setattr(semantic_contract, "_corpus_census", spy)
-    return calls
+    def build_spy(root: Path, **kwargs):
+        builds.append(str(root))
+        return real_build(root, **kwargs)
+
+    monkeypatch.setattr(semantic_contract, "_corpus_census", census_spy)
+    monkeypatch.setattr(semantic_contract, "_build_corpus_context_uncached", build_spy)
+    return censuses, builds
 
 
 def _poison_corpus_patch(monkeypatch: pytest.MonkeyPatch):
@@ -130,9 +142,9 @@ def test_refused_corpus_patch_does_not_cool_vault_freshness(
         vault, "vault"
     )
 
-    census_calls = _spy_corpus_census(monkeypatch)
+    censuses, builds = _spy_corpus_work(monkeypatch)
     context = semantic_contract.build_corpus_context(vault)
-    assert census_calls == []
+    assert (censuses, builds) == ([], [])
     assert context.pages[_OTHER_REL].title == "Two changed"
     assert context.pages[_PAGE_REL].title == "One changed"
 
@@ -189,9 +201,9 @@ def test_publish_populates_a_cold_corpus_cache_for_the_next_reader(
         vault, "vault"
     )
 
-    census_calls = _spy_corpus_census(monkeypatch)
+    censuses, builds = _spy_corpus_work(monkeypatch)
     context = semantic_contract.build_corpus_context(vault)
-    assert census_calls == []
+    assert (censuses, builds) == ([], [])
     assert context is entry[1]
 
 

--- a/tests/test_freshness_liveness_contract.py
+++ b/tests/test_freshness_liveness_contract.py
@@ -223,10 +223,22 @@ def test_populate_on_miss_never_stamps_a_context_an_event_leapfrogged(
     monkeypatch.setattr(
         semantic_contract, "_build_corpus_context_uncached", build_with_racing_event
     )
+    confirms: list[Path] = []
+    real_confirm = semantic_contract._deferred_corpus_census
+
+    def counted_confirm(root: Path, sink, outcome: str):
+        confirms.append(root)
+        return real_confirm(root, sink, outcome)
+
+    monkeypatch.setattr(semantic_contract, "_deferred_corpus_census", counted_confirm)
 
     semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
 
     assert builds, "the populate must have attempted a build to be a real discard"
+    # Attribution: the checkpoint decided this, not the census re-confirm that
+    # follows it. That is the point of L3 -- the generation-bearing checkpoint
+    # is the admission gate, and it is cheap enough to be consulted first.
+    assert confirms == []
     cache_key = semantic_contract._corpus_cache_key(vault)
     # Never stamp: the leapfrogged context must reach neither the cache nor
     # the event-token map (contract L2 "on any mismatch discard ... never

--- a/tests/test_freshness_liveness_contract.py
+++ b/tests/test_freshness_liveness_contract.py
@@ -72,19 +72,23 @@ def _spy_corpus_census(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
     return calls
 
 
-def _poison_corpus_patch(monkeypatch: pytest.MonkeyPatch) -> None:
+def _poison_corpus_patch(monkeypatch: pytest.MonkeyPatch):
     """Fail only the projection half of the corpus publish seam (Class B).
 
     `freshness.on_files_changed` still runs and still records the delta -- the
     registry observed every event. Only the cache's own patch raises, which is
     exactly the contract's Class B: "a corpus-cache patch that raises for a
-    cause local to the cache".
+    cause local to the cache". Returns the real patch so a caller can put it
+    back explicitly; `monkeypatch.undo()` would also revert the corpus-cache
+    env var this module's fixture sets, which is not what any caller means.
     """
+    real_patch = semantic_contract._patch_corpus_files_changed_locked
 
     def boom(*_args, **_kwargs):
         raise RuntimeError("poisoned corpus delta")
 
     monkeypatch.setattr(semantic_contract, "_patch_corpus_files_changed_locked", boom)
+    return real_patch
 
 
 def test_refused_corpus_patch_does_not_cool_vault_freshness(
@@ -103,7 +107,7 @@ def test_refused_corpus_patch_does_not_cool_vault_freshness(
 
     page = vault / _PAGE_REL
     page.write_text(_page(title="One changed"), encoding="utf-8")
-    _poison_corpus_patch(monkeypatch)
+    real_patch = _poison_corpus_patch(monkeypatch)
 
     assert index_sync.publish_corpus_delta(vault, changed=(page,)) is False
 
@@ -116,7 +120,7 @@ def test_refused_corpus_patch_does_not_cool_vault_freshness(
     # 2. The corpus projection can warm itself again with no operator action:
     #    the next publish repopulates on miss, and the read after it is an
     #    event-hit paying zero full censuses.
-    monkeypatch.undo()
+    monkeypatch.setattr(semantic_contract, "_patch_corpus_files_changed_locked", real_patch)
     other = vault / _OTHER_REL
     other.write_text(_page(title="Two changed"), encoding="utf-8")
     assert index_sync.publish_corpus_delta(vault, changed=(other,)) is True

--- a/tests/test_index_sync.py
+++ b/tests/test_index_sync.py
@@ -512,9 +512,15 @@ def test_publication_failure_withdraws_stale_graph_and_resolver(
 
     a.write_text("# A\n\nLinks to [[New B]].\n", encoding="utf-8")
     b.write_text("---\ntitle: New B\n---\n# B\n", encoding="utf-8")
+    # The WHOLE publish seam fails, so neither half can be blamed. An
+    # unattributable failure is deliberately read as registry loss (the
+    # conservative classification), which is what keeps the full withdraw --
+    # and these assertions -- in force here. A failure attributable to the
+    # corpus patch alone is a different, narrower response; see
+    # tests/test_freshness_liveness_contract.py.
     monkeypatch.setattr(
         semantic_contract,
-        "publish_corpus_files_changed",
+        "publish_corpus_files_changed_classified",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("publish failed")),
     )
 
@@ -544,9 +550,11 @@ def test_delete_publication_failure_cannot_leave_graph_current_at_old_checkpoint
     graph = epistemic_graph.EpistemicGraphIndex(tmp_path)
     graph.rebuild_all()
     b.unlink()
+    # Unattributable (the whole seam fails), so registry loss; see the sibling
+    # upsert test above.
     monkeypatch.setattr(
         semantic_contract,
-        "publish_corpus_files_changed",
+        "publish_corpus_files_changed_classified",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("publish failed")),
     )
 

--- a/tests/test_mutation_timings.py
+++ b/tests/test_mutation_timings.py
@@ -732,6 +732,16 @@ def test_publish_after_an_eviction_leaves_the_next_preflight_warm(
     assert index_sync.publish_corpus_delta(tmp_path, changed=(path,)) is True
 
     calls = _spy_corpus_census(monkeypatch)
+    # Both seams: a rebuild that skipped the walk, or a walk that fed no
+    # rebuild, would each slip past a spy on the other one alone.
+    builds: list[Path] = []
+    real_build = semantic_contract._build_corpus_context_uncached
+
+    def counted_build(root: Path, **kwargs):
+        builds.append(root)
+        return real_build(root, **kwargs)
+
+    monkeypatch.setattr(semantic_contract, "_build_corpus_context_uncached", counted_build)
     after_source = path.read_text(encoding="utf-8").replace(BEFORE_LINE, AFTER_LINE)
     preflight = semantic_writes.preflight_existing(
         tmp_path,
@@ -741,4 +751,5 @@ def test_publish_after_an_eviction_leaves_the_next_preflight_warm(
     )
 
     assert calls == [], f"expected an event-hit with no census walk, got {len(calls)}"
+    assert builds == [], f"expected an event-hit with no corpus rebuild, got {len(builds)}"
     assert preflight.census_token is not None

--- a/tests/test_mutation_timings.py
+++ b/tests/test_mutation_timings.py
@@ -580,8 +580,11 @@ def test_corpus_metrics_carry_caller_and_outcome(tmp_path: Path, monkeypatch) ->
     # Force the census-based reuse path: the event-token fast path returns
     # before any walk, so it cannot show the hit-vs-rebuild distinction.
     monkeypatch.setattr("exomem.freshness.triple", lambda *args, **kwargs: None)
-    semantic_contract.reset_corpus_context_cache()
     _seed(tmp_path)
+    # Reset AFTER the seeding write, not before: that write's own publish now
+    # populates the cache on miss, and the first build below has to be a
+    # genuine cold rebuild for the hit-vs-rebuild labels to mean anything.
+    semantic_contract.reset_corpus_context_cache()
     metrics_module.reset()
 
     semantic_contract.build_corpus_context(tmp_path)

--- a/tests/test_mutation_timings.py
+++ b/tests/test_mutation_timings.py
@@ -703,3 +703,42 @@ def test_creation_draft_prepare_costs_one_census_walk(tmp_path: Path, monkeypatc
 
     assert len(calls) == 1, f"expected exactly one census walk, got {len(calls)}"
     assert prepared.reuse is not None
+
+
+def test_publish_after_an_eviction_leaves_the_next_preflight_warm(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A write's own publish must rewarm a cold corpus cache for the next one.
+
+    This is the benefit the write-latency gate's `cold_preflight` row cannot
+    show: that row evicts BETWEEN the warm write and its probe, so the probe's
+    own preflight faces a cold cache by construction. The cost a cold cache
+    really imposes is on the write AFTER a write -- and a publish that finds
+    nothing to patch is exactly where it can be paid once instead of by every
+    later caller.
+
+    Against unpatched code the publish is a silent no-op on a cold cache, so
+    the preflight below pays a full stat census of the vault.
+    """
+    from exomem import freshness, index_sync
+
+    monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
+    path = _seed(tmp_path)
+    freshness.rebaseline(tmp_path)
+    # A restart, an eviction, or a Class B projection withdrawal -- any of the
+    # ways the process cache legitimately ends up empty with the registry live.
+    semantic_contract.reset_corpus_context_cache()
+
+    assert index_sync.publish_corpus_delta(tmp_path, changed=(path,)) is True
+
+    calls = _spy_corpus_census(monkeypatch)
+    after_source = path.read_text(encoding="utf-8").replace(BEFORE_LINE, AFTER_LINE)
+    preflight = semantic_writes.preflight_existing(
+        tmp_path,
+        path=PAGE,
+        after_source=after_source,
+        operation="edit",
+    )
+
+    assert calls == [], f"expected an event-hit with no census walk, got {len(calls)}"
+    assert preflight.census_token is not None

--- a/tests/test_mutation_timings.py
+++ b/tests/test_mutation_timings.py
@@ -630,3 +630,76 @@ def test_a_walk_nobody_consumed_is_not_reported_as_a_rebuild(
     assert ("exomem_corpus_census_walk_ms", "aborted") in observed
     assert ("exomem_corpus_census_walk_ms", "rebuild") not in observed
     assert ("exomem_corpus_build_ms", "rebuild") not in observed
+
+
+_DRAFT_ID = "00000000-0000-4000-8000-0000000005b2"
+_EXISTING_ID = "00000000-0000-4000-8000-0000000005b3"
+_DRAFT_PAGE = "Knowledge Base/Notes/Insights/candidate.md"
+_EXISTING_PAGE = "Knowledge Base/Notes/Insights/existing.md"
+_COMPILED_BODY = (
+    "Body.\n\n"
+    "## Observations\n\n"
+    "- [operating constraint] Keep retries bounded #reliability\n\n"
+    "## Relations\n"
+)
+
+
+def _compiled_source(page_id: str, *, title: str = "Candidate") -> str:
+    return (
+        "---\n"
+        f"title: {title}\n"
+        "type: insight\n"
+        "status: active\n"
+        f"exomem_id: {page_id}\n"
+        "---\n\n"
+        f"{_COMPILED_BODY}"
+    )
+
+
+def test_creation_draft_prepare_costs_one_census_walk(tmp_path: Path, monkeypatch) -> None:
+    """`prepare_commit_creation_draft` must not re-walk the vault for its stamp.
+
+    It holds `preliminary.before_corpus` from its own `_attempt` build, yet
+    asked `corpus_validity_token` for a census through the global process
+    cache. Against unpatched code an eviction landing between that build and
+    the capture -- the exact window a concurrent write opens -- makes
+    `cached_corpus_census` come back empty, so the token walks the whole
+    corpus a SECOND time. Threading the build's own census makes the eviction
+    irrelevant: still exactly one walk.
+    """
+    from exomem import relation_review
+
+    monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
+    _force_walk_confirmed_cache_path(monkeypatch)
+    semantic_contract.reset_corpus_context_cache()
+    existing = tmp_path / _EXISTING_PAGE
+    existing.parent.mkdir(parents=True, exist_ok=True)
+    existing.write_text(
+        _compiled_source(_EXISTING_ID, title="Existing"), encoding="utf-8", newline=""
+    )
+    source = _compiled_source(_DRAFT_ID)
+    validation = relation_review.validate_creation_draft(
+        tmp_path,
+        path=_DRAFT_PAGE,
+        source=source,
+        draft_id=_DRAFT_ID,
+        operation="create",
+    )
+    semantic_contract.build_corpus_context(tmp_path)  # warm the process cache
+
+    _evict_between_build_and_capture(monkeypatch, tmp_path)
+    calls = _spy_corpus_census(monkeypatch)
+
+    prepared = relation_review.prepare_commit_creation_draft(
+        tmp_path,
+        path=_DRAFT_PAGE,
+        source=source,
+        draft_id=_DRAFT_ID,
+        operation="create",
+        relation_disposition="reviewed_none",
+        relation_review_hash=validation.draft_hash,
+        relation_review_reason="No honest typed relation yet",
+    )
+
+    assert len(calls) == 1, f"expected exactly one census walk, got {len(calls)}"
+    assert prepared.reuse is not None

--- a/tests/test_relation_review.py
+++ b/tests/test_relation_review.py
@@ -954,7 +954,10 @@ def test_commit_creation_draft_reuses_prevalidated_attempt_on_matching_census_to
     source, validation = _reviewed_validation(tmp_path)
     counts = {"corpus": 0, "validation": 0}
     seams = (
-        (relation_review.semantic_contract, "build_corpus_context", "corpus"),
+        # `_attempt` builds through the census-returning entry point, so its
+        # own validity token never re-walks the vault; that is the seam to
+        # count corpus builds at.
+        (relation_review.semantic_contract, "build_corpus_context_with_census", "corpus"),
         (relation_review, "_validation", "validation"),
     )
     for owner, name, key in seams:
@@ -989,13 +992,15 @@ def test_commit_creation_draft_falls_through_to_full_attempt_on_census_mismatch(
 ) -> None:
     source, validation = _reviewed_validation(tmp_path)
     counts = {"corpus": 0}
-    original_build = relation_review.semantic_contract.build_corpus_context
+    original_build = relation_review.semantic_contract.build_corpus_context_with_census
 
     def counted_build(*args, **kwargs):
         counts["corpus"] += 1
         return original_build(*args, **kwargs)
 
-    monkeypatch.setattr(relation_review.semantic_contract, "build_corpus_context", counted_build)
+    monkeypatch.setattr(
+        relation_review.semantic_contract, "build_corpus_context_with_census", counted_build
+    )
 
     real_prepare = relation_review.prepare_commit_creation_draft
 
@@ -1132,7 +1137,10 @@ def test_attempt_loaders_and_corpus_walk_are_each_called_once(
         (relation_review.relation_registry, "load_registry", "relations"),
         (relation_review.semantic_language_registry, "load_registry", "language"),
         (relation_review.memory_schema, "load_saved_contracts", "contracts"),
-        (relation_review.semantic_contract, "build_corpus_context", "corpus"),
+        # `_attempt` builds through the census-returning entry point, so its
+        # own validity token never re-walks the vault; that is the seam to
+        # count corpus builds at.
+        (relation_review.semantic_contract, "build_corpus_context_with_census", "corpus"),
     )
     for owner, name, key in seams:
         original = getattr(owner, name)


### PR DESCRIPTION
## What

#510 slices A/B under the freshness-liveness contract (posted on the issue;
clauses L1-L5, C1.1, C1.5, deliverables 1+8):

- **D1 — classified publish seam**: `publish_corpus_files_changed_classified`
  returns a structured `CorpusPublicationFailure` distinguishing a
  registry-advance failure (Class A) from a projection-patch failure (Class B);
  the raising wrapper preserves original exceptions. The retry in
  `publish_corpus_delta` is preserved (a Class B still retries once).
- **C1.1 — narrowed withdraw**: a Class B failure now evicts only the three
  RAM consumers (corpus context, resolver, inbound index); `freshness.invalidate`
  + `mark_external_pending` fire for Class A only, with escaped/unknown
  failures conservatively treated as Class A (fail-closed). The false
  "cold freshness fences graph readers" docstring is replaced with the
  contract's real fence (§2.1). Verified: the repo-wide
  `mark_external_pending` call-site set is unchanged (C1.5).
- **D8 — populate-on-miss via L2**: the previously-silent no-op when the cache
  entry is missing now populates — after the publisher's lock releases (L1 was
  inadmissible: populating under that lock would serialize every concurrent
  governed write behind a full vault build). Admission is triple-gated under
  the update lock: `freshness.consumer_checkpoint` unchanged since before the
  walk (generation-bearing, per L3), the slot still empty, and a full census
  re-confirm (closing the ungoverned-edit window the checkpoint cannot see) —
  plus the `_registries_match_disk` guard every other install site already
  had (review-caught: the registries load before the census, so the census
  cannot vouch for them). Candidate builds never stamp (L4); pops keep
  removing entry+token+language-hash together (L5).
- **Residual seam**: `relation_review` threads the census from its own
  validating build (the #537 shape) — the last redundant validity-token walk
  on the common path is gone.
- Bounding the populate under persistent-failure/churn states is deliberately
  NOT in this lane — tracked as **#539** (single-flight + failure memo, the
  `lexstore._REPAIRS_IN_FLIGHT` shape), noted in the populate's docstring.

## Verification

- Red-first against a fork-point worktree, verbatim in the lane record: the
  Class B contract test (liveness killed on main, preserved now + next write
  zero-census with spies on BOTH `_corpus_census` and
  `_build_corpus_context_uncached`); the D8 empty-cache-after-publish red; the
  L2 checkpoint-discard red; and the review-mandated registry-guard red
  (constructed to rewrite the registry on the populate's FIRST walk only, so
  the under-lock re-confirm cannot mask it — the stamp happened on the
  unguarded code, discards now).
- Independent review (REQUEST_CHANGES → fixed → targeted recheck: **all
  findings FIXED, no new concerns**): the L2 admission gate was verified sound
  end-to-end ("no hole found" — the decisive argument being that
  `freshness.on_files_changed` has exactly one call site, inside the same lock
  the stamp takes), classification complete and fail-closed, and every one of
  the 11 disclosed out-of-allowlist test re-points confirmed a pure seam
  re-point with zero assertion lines touched (including the graph-fencing
  assertions the #508 lane co-owns).
- 53 passed across the contract/cache/timings suites; 133 across all seven
  affected suites; `uvx ruff check --select F` clean; schema digest unmoved.
  The local write-gate ceiling breach was shown branch-independent via a
  both-orders quiesced comparison (Linux CI adjudicates).

With #518 (doctor FAIL), #527 (read-after-write + cold-preflight gate), and
#537 (validity-token census threading) already merged, this completes the
issue's four asks; #539 carries the bounded follow-up.

Closes #510
