### PR TITLE
fix(graph): publish without depending on the reader, and stop failures poisoning vault freshness

### DIFF
--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -235,8 +235,8 @@ _PUBLICATION_FAILURE_TYPES: tuple[type[BaseException], ...] = (
 _PUBLICATION_FAILURE_OP_CODES = frozenset(
     {
         "MUTATION_BUSY",
+        "MUTATION_WARMING",
         "MUTATION_LOCK_UNAVAILABLE",
-        "GRAPH_MUTATION_BUSY",
     }
 )
 
@@ -311,8 +311,9 @@ def _publication_identity(vault_root: Path) -> str:
     """Name the exact publication a refusal applies to.
 
     A refusal memo must expire the moment the vault asks for a *different*
-    publication, so it is keyed by the required checkpoint (or, with no
-    checkpoint, the sidecar's own mtime lineage) rather than by time alone.
+    publication, so it carries the durable checkpoint digest rather than
+    trusting time alone. A vault with no checkpoint yet has one unnamed
+    publication, and the time bound is the only thing scoping it.
     """
     try:
         checkpoint = graph_sync.read_checkpoint(vault_root)

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -984,16 +984,26 @@ class EpistemicGraphIndex:
         advance it to the already-published event checkpoint.
 
         The `freshness.external_pending` guard here and at the tail of this
-        method is an **optimization, not a correctness fence** (issue #508,
-        joint freshness-liveness contract, section 2.1, deliverable D7). What
-        actually stops a stale sidecar being served as current is graph-owned
-        state proved against canonical disk: the publication ticket/epoch gate,
-        the persisted read barrier, the availability-marker re-proof against the
-        *current* recall projection identity (with a direct source-bytes and
-        resolver-topology proof outside the exact live-checkpoint lineage), and
-        the graph_sync checkpoint acknowledgement. Every one of those still
-        holds with vault freshness fully live. The guard survives only as a
-        cheap short-circuit, and only because `external_pending` is now set
+        method is an **optimization for public readers, not a correctness
+        fence** (issue #508, joint freshness-liveness contract, section 2.1,
+        deliverable D7). What actually stops a stale sidecar being served as
+        current is graph-owned state proved against canonical disk: the
+        publication ticket/epoch gate, the persisted read barrier, the
+        availability-marker re-proof against the *current* recall projection
+        identity (with a direct source-bytes and resolver-topology proof
+        outside the exact live-checkpoint lineage), and the graph_sync
+        checkpoint acknowledgement. Every one of those still holds with vault
+        freshness fully live.
+
+        Note where those four live, though: all of them are inside the
+        `require_current_projection` branch below. The three maintenance
+        readers that pass `require_current_projection=False` — the graph_sync
+        predecessor probe, the incremental refresh, and its topology re-read —
+        deliberately skip them, so for those callers this guard is the *only*
+        `freshness`-side check in this method that an unobserved external event
+        has landed. That is a second reason it stays, beyond cheapness.
+
+        It stays admissible only because `external_pending` is now set
         exclusively by Class A (registry loss) and Class C (proven-stale)
         signals — never by a publication failure. If a future change lets a
         Class B failure mark again, this guard becomes a liveness bug wearing a
@@ -1604,8 +1614,14 @@ class EpistemicGraphIndex:
         interval for the open ones to close, and collects any left by a thread
         that has since died. Readers that outlast the drain are not forced
         shut: closing a connection its borrower still holds would surface
-        `sqlite3.ProgrammingError` inside an unrelated read. They are published
-        around instead, by `graph_sync.replace_sidecar`'s in-place path.
+        `sqlite3.ProgrammingError` inside an unrelated read.
+
+        This drain is the only thing that clears an open read *transaction*.
+        `replace_sidecar`'s in-place path publishes around an open *handle*, but
+        the sidecar is a rollback-journal database, so a reader inside
+        `BEGIN` — which is exactly what `_open_read_snapshot` returns — holds a
+        SHARED lock that blocks the backup's EXCLUSIVE one. Draining first and
+        publishing in place second are complementary, not redundant.
 
         Returns the hold to release once the replacement has been attempted.
         """

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -207,6 +207,387 @@ def sidecar_path(vault_root: Path) -> Path:
     return vault_root / kb_dirname() / ".graph.sqlite"
 
 
+# --------------------------------------------------------------------------
+# Publication failure classification (issue #508, "Joint freshness-liveness
+# contract", section 1).
+#
+# `freshness.*` describes what the event registry knows about the vault's
+# files.  It must never describe whether this projection managed to publish.
+# Only Class A (registry loss, owned by the watcher) and Class C (proven-stale
+# data, distinguished inside `_rebuild_all_locked`) may touch vault freshness.
+# Class B — a projection publication failure — records recovery state in the
+# graph's own store and owns its own bounded retry instead.
+# --------------------------------------------------------------------------
+
+_PUBLICATION_FAILURE_TYPES: tuple[type[BaseException], ...] = (
+    # Every member of this hierarchy is graph-projection-local: a refused
+    # `os.replace` (GraphSidecarReplaceUnavailable), rebuild-owner loss
+    # (GraphRebuildLockUnavailable), a stopped or capacity-exhausted registered
+    # builder, an incoherent epoch lineage, a refused lineage reset.  None of
+    # them is evidence that the event registry stopped naming the file set.
+    graph_sync.GraphRebuildRegistrationError,
+)
+
+# `OpError` codes raised by the shared vault mutation boundary.  A publication
+# that could not take the boundary is Class B for the same reason a refused
+# replacement is: the registry is intact, only this projection failed to
+# publish.  Any other `OpError` stays unclassified and keeps today's behaviour.
+_PUBLICATION_FAILURE_OP_CODES = frozenset(
+    {
+        "MUTATION_BUSY",
+        "MUTATION_LOCK_UNAVAILABLE",
+        "GRAPH_MUTATION_BUSY",
+    }
+)
+
+
+class GraphPublicationUnavailable(graph_sync.GraphRebuildRegistrationError):
+    """A rebuild proved nothing stale but still could not publish (Class B)."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(
+            "GRAPH_SYNC_PUBLICATION_UNAVAILABLE",
+            "Retry the mutation, or run reconcile to recover the derived graph.",
+        )
+        self.args = (f"{message}: {self.args[0]}",)
+
+
+class GraphProjectionMoved(RuntimeError):
+    """Class C: the vault bytes or recall projection moved under an in-flight proof.
+
+    Raised only for the two conditions the contract admits as proven-stale, so
+    a caller can tell them apart from a generic non-stabilization.  The proof
+    that produced it has already marked the registry externally pending; no
+    caller may mark again (contract R1).
+    """
+
+
+def is_publication_failure(error: BaseException) -> bool:
+    """Whether `error` is a Class B projection-publication failure.
+
+    True means: the event registry observed and recorded everything, and only
+    this projection failed to publish its derived copy.  Such a failure MUST
+    NOT call `freshness.invalidate` or `freshness.mark_external_pending`.
+
+    An unrecognised exception is deliberately *not* classified, so genuine
+    registry-loss signals keep the pre-contract behaviour rather than being
+    silently downgraded.
+    """
+    if isinstance(error, _PUBLICATION_FAILURE_TYPES):
+        return True
+    if isinstance(error, OpError):
+        return getattr(error, "code", None) in _PUBLICATION_FAILURE_OP_CODES
+    return False
+
+
+def may_mark_external_pending(error: BaseException) -> bool:
+    """Whether a graph dispatch failure may cool the vault-global registry.
+
+    False for Class B — the registry observed everything and only this
+    projection failed to publish — and false for Class C, because the proof
+    that detected it has already marked exactly once and R1 forbids a second
+    epoch: each extra epoch defeats the compare-and-ack the watcher's recovery
+    depends on.
+
+    True only for an exception this module cannot classify, so a genuine
+    registry-loss signal keeps its pre-contract behaviour instead of being
+    silently downgraded.
+    """
+    return not (isinstance(error, GraphProjectionMoved) or is_publication_failure(error))
+
+
+# --- Class B recovery state and its bounded, single-flight retry (R2) ------
+
+_PUBLICATION_MEMO_LOCK = threading.Lock()
+_PUBLICATION_REFUSALS: dict[str, tuple[str, float]] = {}
+PUBLICATION_RETRY_BACKOFF_SECONDS = 60.0
+
+
+def _publication_memo_key(vault_root: Path) -> str:
+    return os.path.normcase(str(Path(vault_root).resolve(strict=False)))
+
+
+def _publication_identity(vault_root: Path) -> str:
+    """Name the exact publication a refusal applies to.
+
+    A refusal memo must expire the moment the vault asks for a *different*
+    publication, so it is keyed by the required checkpoint (or, with no
+    checkpoint, the sidecar's own mtime lineage) rather than by time alone.
+    """
+    try:
+        checkpoint = graph_sync.read_checkpoint(vault_root)
+    except Exception:  # noqa: BLE001 - an unreadable checkpoint memoizes nothing
+        return ""
+    return "" if checkpoint is None else checkpoint.checkpoint_sha256
+
+
+def note_publication_refusal(vault_root: Path) -> None:
+    """Memoize one refused publication so the next cycle does not re-pay it.
+
+    Contract R2: a failure mode known to be non-self-healing within the process
+    — the resident-service reader on Windows — must not be re-attempted at full
+    rebuild cost on every cycle. This is `lexstore._REPAIRS_IN_FLIGHT`'s shape:
+    projection-local, bounded, and invisible to `freshness.*`.
+    """
+    identity = _publication_identity(vault_root)
+    deadline = time.monotonic() + PUBLICATION_RETRY_BACKOFF_SECONDS
+    with _PUBLICATION_MEMO_LOCK:
+        _PUBLICATION_REFUSALS[_publication_memo_key(vault_root)] = (identity, deadline)
+
+
+def clear_publication_refusal(vault_root: Path) -> None:
+    """Drop the memo after a publication succeeds (or a caller forces a retry)."""
+    with _PUBLICATION_MEMO_LOCK:
+        _PUBLICATION_REFUSALS.pop(_publication_memo_key(vault_root), None)
+
+
+def publication_refusal_active(vault_root: Path) -> bool:
+    """Whether the same publication was refused recently enough to skip a retry."""
+    key = _publication_memo_key(vault_root)
+    with _PUBLICATION_MEMO_LOCK:
+        memo = _PUBLICATION_REFUSALS.get(key)
+        if memo is None:
+            return False
+        identity, deadline = memo
+        if time.monotonic() >= deadline:
+            _PUBLICATION_REFUSALS.pop(key, None)
+            return False
+    if identity != _publication_identity(vault_root):
+        # A different publication is being asked for; it has not been proven
+        # doomed and must be attempted.
+        clear_publication_refusal(vault_root)
+        return False
+    return True
+
+
+def clear_publication_memos() -> None:
+    """Test seam: drop every per-process publication refusal memo."""
+    with _PUBLICATION_MEMO_LOCK:
+        _PUBLICATION_REFUSALS.clear()
+
+
+def record_publication_recovery_state(
+    vault_root: Path,
+    *,
+    mutation_coordinator: mutation_lock.VaultMutationCoordinator | None = None,
+) -> None:
+    """Persist the graph's own Class B recovery marker instead of cooling freshness.
+
+    The graph already owns a fence that is idempotent under retry (contract
+    R1): the persisted read barrier. Re-asserting it rewrites the same value,
+    so a doomed publication that repeats every cycle cannot defeat the
+    watcher's compare-and-ack the way a fresh `mark_external_pending` epoch
+    would. `file_watcher._recover_suspended_graph` is its clearer.
+    """
+    try:
+        if not graph_enabled() or not sidecar_path(vault_root).exists():
+            return
+        index = EpistemicGraphIndex(vault_root, mutation_coordinator=mutation_coordinator)
+        index.suspend_reads()
+    except Exception:  # noqa: BLE001 - the unacknowledged checkpoint still fails closed
+        log.warning("graph publication recovery state could not be persisted", exc_info=True)
+    finally:
+        note_publication_refusal(vault_root)
+
+
+# --- In-process live-sidecar reader registry (publication hold) ------------
+
+_SIDECAR_READERS_LOCK = threading.Lock()
+_SIDECAR_READERS_CHANGED = threading.Condition(_SIDECAR_READERS_LOCK)
+_SIDECAR_READERS: dict[str, dict[int, tuple[sqlite3.Connection, threading.Thread]]] = {}
+_SIDECAR_PUBLICATION_HOLDS: set[str] = set()
+
+PUBLICATION_READER_DRAIN_SECONDS = 1.0
+PUBLICATION_READER_OPEN_WAIT_SECONDS = 2.0
+
+
+def _reader_cycling_enabled() -> bool:
+    """Whether a publication must cycle this process's readers before replacing.
+
+    Linux keeps the plain `os.replace` fast path: the rename succeeds with
+    readers attached, so the hold would be pure overhead. Windows refuses it,
+    which is what makes the hold worth its cost there. Tests drive the Windows
+    branch on any platform through this seam.
+    """
+    return os.name == "nt"
+
+
+def _sidecar_registry_key(live: Path) -> str:
+    return os.path.normcase(str(Path(live).absolute()))
+
+
+class _TrackedSidecarConnection(sqlite3.Connection):
+    """A live-sidecar reader that leaves the publication registry when closed."""
+
+    def close(self) -> None:
+        key = self.__dict__.get("_exomem_registry_key")
+        try:
+            super().close()
+        finally:
+            if key is not None:
+                self.__dict__["_exomem_registry_key"] = None
+                _release_sidecar_reader(key, self)
+
+
+def _await_publication_hold(key: str) -> None:
+    """Block a new reader for the bounded replacement window, then proceed.
+
+    Failing open after the wait is deliberate: the hold exists to make the
+    replacement likely, never to make reads unavailable. A reader that outlasts
+    the window is handled by the in-place publication path instead.
+    """
+    deadline = time.monotonic() + PUBLICATION_READER_OPEN_WAIT_SECONDS
+    with _SIDECAR_READERS_CHANGED:
+        while key in _SIDECAR_PUBLICATION_HOLDS:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            _SIDECAR_READERS_CHANGED.wait(remaining)
+
+
+def _register_sidecar_reader(key: str, conn: sqlite3.Connection) -> None:
+    with _SIDECAR_READERS_CHANGED:
+        _SIDECAR_READERS.setdefault(key, {})[id(conn)] = (conn, threading.current_thread())
+
+
+def _release_sidecar_reader(key: str, conn: sqlite3.Connection) -> None:
+    with _SIDECAR_READERS_CHANGED:
+        readers = _SIDECAR_READERS.get(key)
+        if readers is not None:
+            readers.pop(id(conn), None)
+            if not readers:
+                _SIDECAR_READERS.pop(key, None)
+        _SIDECAR_READERS_CHANGED.notify_all()
+
+
+def _acquire_publication_hold(live: Path) -> str | None:
+    """Block new live-sidecar readers, drain the open ones, and return the hold."""
+    key = _sidecar_registry_key(live)
+    with _SIDECAR_READERS_CHANGED:
+        if key in _SIDECAR_PUBLICATION_HOLDS:
+            return None
+        _SIDECAR_PUBLICATION_HOLDS.add(key)
+    deadline = time.monotonic() + PUBLICATION_READER_DRAIN_SECONDS
+    with _SIDECAR_READERS_CHANGED:
+        while _SIDECAR_READERS.get(key):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            _SIDECAR_READERS_CHANGED.wait(remaining)
+        # A reader whose owning thread is gone can never close itself, so it is
+        # the only connection safe to close from here: closing one a live
+        # caller still holds would surface `sqlite3.ProgrammingError` inside an
+        # unrelated read. Readers that outlast the drain are published around
+        # by `graph_sync.replace_sidecar`'s in-place path.
+        abandoned = [
+            conn
+            for conn, owner in _SIDECAR_READERS.get(key, {}).values()
+            if not owner.is_alive()
+        ]
+    # Outside the registry lock: closing re-enters it to deregister.
+    for conn in abandoned:
+        try:
+            conn.close()
+        except sqlite3.Error:  # pragma: no cover - defensive
+            _release_sidecar_reader(key, conn)
+    return key
+
+
+def _release_publication_hold(key: str | None) -> None:
+    if key is None:
+        return
+    with _SIDECAR_READERS_CHANGED:
+        _SIDECAR_PUBLICATION_HOLDS.discard(key)
+        _SIDECAR_READERS_CHANGED.notify_all()
+
+
+def reset_publication_holds() -> None:
+    """Test seam: forget every reader registration and publication hold."""
+    with _SIDECAR_READERS_CHANGED:
+        _SIDECAR_READERS.clear()
+        _SIDECAR_PUBLICATION_HOLDS.clear()
+        _SIDECAR_READERS_CHANGED.notify_all()
+
+
+# --- Preserved-temporary reaping (contract R3) -----------------------------
+
+PRESERVED_TEMPORARY_LIMIT = 1
+_TEMPORARY_COMPANION_SUFFIXES = ("-journal", "-wal", "-shm")
+
+
+def _temporary_base_name(name: str) -> str:
+    for suffix in _TEMPORARY_COMPANION_SUFFIXES:
+        if name.endswith(suffix):
+            return name.removesuffix(suffix)
+    return name
+
+
+def _reap_preserved_temporaries(
+    live: Path, *, keep: int = PRESERVED_TEMPORARY_LIMIT
+) -> list[Path]:
+    """Bound the `.graph-rebuild-*` artifacts a refused publication leaves behind.
+
+    A refused replacement deliberately preserves its complete private sidecar,
+    because that build is recoverable the moment the live file's reader lets
+    go. Exactly one of them is recoverable, though — the newest — so every
+    older one is dead weight, and on the reported vault it grew to 527 MB.
+
+    Anything still registered as an in-flight rebuild target is left alone. Of
+    the remainder the newest `keep` survive; the rest go with their SQLite
+    companions. A Windows reader may still refuse an unlink, in which case that
+    file is simply collected on a later pass rather than failing the rebuild.
+    """
+    directory = live.parent
+    try:
+        if not directory.is_dir():
+            return []
+        entries = list(directory.iterdir())
+    except OSError:
+        return []
+    active = graph_sync.live_temporary_paths()
+    groups: dict[str, list[Path]] = {}
+    for candidate in entries:
+        name = candidate.name
+        if not vault_module.is_graph_rebuild_runtime_file_name(name):
+            continue
+        base = _temporary_base_name(name)
+        base_path = directory / base
+        try:
+            registered = base_path.resolve(strict=False) in active
+        except OSError:  # pragma: no cover - defensive
+            registered = True
+        if registered or base_path.absolute() in active:
+            continue
+        groups.setdefault(base, []).append(candidate)
+    if len(groups) <= max(0, keep):
+        return []
+
+    def _recency(base: str) -> float:
+        newest = 0.0
+        for path in groups[base]:
+            try:
+                newest = max(newest, path.stat().st_mtime)
+            except OSError:
+                continue
+        return newest
+
+    ordered = sorted(groups, key=_recency, reverse=True)
+    removed: list[Path] = []
+    for base in ordered[max(0, keep) :]:
+        for path in groups[base]:
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                # A reader still holds delete-sharing authority on Windows.
+                continue
+            removed.append(path)
+    if removed:
+        log.info(
+            "reaped %d orphaned graph rebuild artifact(s) from %s", len(removed), directory
+        )
+    return removed
+
+
 def _disk_vault_freshness(vault_root: Path) -> tuple[int, int, str]:
     """Direct-disk freshness of the ordinary-recall projection only.
 
@@ -505,6 +886,22 @@ class EpistemicGraphIndex:
         event-maintained (or cold-walk) projection. Incremental maintenance may
         open a structurally current but freshness-stale sidecar specifically to
         advance it to the already-published event checkpoint.
+
+        The `freshness.external_pending` guard here and at the tail of this
+        method is an **optimization, not a correctness fence** (issue #508,
+        joint freshness-liveness contract, section 2.1, deliverable D7). What
+        actually stops a stale sidecar being served as current is graph-owned
+        state proved against canonical disk: the publication ticket/epoch gate,
+        the persisted read barrier, the availability-marker re-proof against the
+        *current* recall projection identity (with a direct source-bytes and
+        resolver-topology proof outside the exact live-checkpoint lineage), and
+        the graph_sync checkpoint acknowledgement. Every one of those still
+        holds with vault freshness fully live. The guard survives only as a
+        cheap short-circuit, and only because `external_pending` is now set
+        exclusively by Class A (registry loss) and Class C (proven-stale)
+        signals — never by a publication failure. If a future change lets a
+        Class B failure mark again, this guard becomes a liveness bug wearing a
+        safety costume and must be removed rather than relied on.
         """
         if (
             not graph_enabled()
@@ -513,9 +910,13 @@ class EpistemicGraphIndex:
         ):
             return None
         conn: sqlite3.Connection | None = None
+        registry_key = _sidecar_registry_key(self.path)
+        _await_publication_hold(registry_key)
         try:
             uri = f"{self.path.resolve().as_uri()}?mode=ro"
-            conn = sqlite3.connect(uri, uri=True)
+            conn = sqlite3.connect(uri, uri=True, factory=_TrackedSidecarConnection)
+            conn.__dict__["_exomem_registry_key"] = registry_key
+            _register_sidecar_reader(registry_key, conn)
             graph_sync.limit_graph_metadata_read(conn)
             conn.execute("BEGIN")
             # This marker validation MUST remain the first read in the transaction.
@@ -604,6 +1005,9 @@ class EpistemicGraphIndex:
                     conn,
                     resolver_fingerprint=values.get(_RESOLVER_TOPOLOGY_KEY),
                 )
+        # The `external_pending` term is the same cheap short-circuit described
+        # in this method's docstring (contract D7), re-read after the proof so a
+        # Class A/C signal that landed mid-proof still fails closed.
         if not current or freshness.external_pending(self.vault_root):
             conn.close()
             return None
@@ -709,6 +1113,10 @@ class EpistemicGraphIndex:
         live = self.path
         attempts = 0
         epoch_error: graph_sync.GraphEpochIncoherent | None = None
+        # Artifacts of an earlier failed publication belong to this projection
+        # (contract R3). Collect them before adding another one, so repeated
+        # refusal cannot grow the directory without bound.
+        _reap_preserved_temporaries(live)
         while attempts < REBUILD_PUBLICATION_ATTEMPTS:
             attempts += 1
             prepared_recall = freshness.prepare_recall_publication(self.vault_root, "vault")
@@ -769,7 +1177,10 @@ class EpistemicGraphIndex:
                         self.vault_root, required, availability=self.available
                     ):
                         return {"indexed_files": 0, "nodes": 0, "edges": 0, "joined": 1}
-                    raise RuntimeError(
+                    # Losing the rebuild owner is Class B by name in the
+                    # contract: the registry is intact, this projection simply
+                    # could not publish. Type it so callers can classify.
+                    raise GraphPublicationUnavailable(
                         "another graph rebuild owner did not publish a current sidecar"
                     )
                 temporary_index = EpistemicGraphIndex(
@@ -816,19 +1227,27 @@ class EpistemicGraphIndex:
                     if not self._publication_ticket_matches(ticket):
                         continue
                     try:
-                        self._before_publish_replacement(temporary, live)
+                        publication_hold = self._before_publish_replacement(temporary, live)
                     except Exception:  # noqa: BLE001 - discard this ticket and retry boundedly
                         continue
-                    if not self._publication_ticket_matches(ticket):
-                        continue
                     try:
-                        graph_sync.replace_sidecar(temporary, live)
-                    except graph_sync.GraphSidecarReplaceUnavailable:
-                        # The complete private sidecar is recoverable after a
-                        # Windows reader releases the live file.
-                        preserve_temporary = True
-                        raise
-                    return report
+                        if not self._publication_ticket_matches(ticket):
+                            continue
+                        try:
+                            graph_sync.replace_sidecar(temporary, live)
+                        except graph_sync.GraphSidecarReplaceUnavailable:
+                            # Neither the atomic replacement nor the in-place
+                            # publication could land. The complete private
+                            # sidecar stays recoverable, and the refusal is
+                            # memoized so the next cycle does not re-pay a full
+                            # rebuild for the same doomed publication (R2).
+                            preserve_temporary = True
+                            note_publication_refusal(self.vault_root)
+                            raise
+                        clear_publication_refusal(self.vault_root)
+                        return report
+                    finally:
+                        _release_publication_hold(publication_hold)
             finally:
                 if owner_claimed:
                     graph_sync.release_rebuild_owner(
@@ -841,8 +1260,17 @@ class EpistemicGraphIndex:
                     graph_sync.unregister_temporary(registered_temporary)
                 if not preserve_temporary:
                     temporary.unlink(missing_ok=True)
+                # Owner release is the other moment the retained set can be
+                # bounded safely: no attempt of ours is registered any more.
+                _reap_preserved_temporaries(live)
         if epoch_error is not None:
             raise epoch_error
+        # Exhausting the publication attempts for any reason other than a proven
+        # stale projection is a Class B publication failure, not evidence that
+        # the event registry fell behind the disk (contract section 1). The
+        # exception type already carries that classification; only the memo is
+        # new, so the next cycle does not re-pay the same doomed rebuild.
+        note_publication_refusal(self.vault_root)
         raise graph_sync.GraphRebuildRegistrationError(
             "GRAPH_SYNC_STABILIZATION_EXHAUSTED",
             "graph publication did not stabilize after "
@@ -1062,9 +1490,25 @@ class EpistemicGraphIndex:
         except (OSError, graph_sync.GraphEpochIncoherent):
             return False
 
-    def _before_publish_replacement(self, temporary: Path, live: Path) -> None:
-        """Original-index publication seam, intentionally after temp handles close."""
-        del temporary, live
+    def _before_publish_replacement(self, temporary: Path, live: Path) -> str | None:
+        """Clear this process's live-sidecar readers for the replacement window.
+
+        Original-index publication seam, intentionally after temp handles
+        close. On Windows `os.replace` is refused while any handle is open on
+        the destination, and a resident service holds one routinely — so the
+        publisher blocks new readers of the live sidecar, waits a bounded
+        interval for the open ones to close, and collects any left by a thread
+        that has since died. Readers that outlast the drain are not forced
+        shut: closing a connection its borrower still holds would surface
+        `sqlite3.ProgrammingError` inside an unrelated read. They are published
+        around instead, by `graph_sync.replace_sidecar`'s in-place path.
+
+        Returns the hold to release once the replacement has been attempted.
+        """
+        del temporary
+        if not _reader_cycling_enabled():
+            return None
+        return _acquire_publication_hold(live)
 
     def _wait_for_legacy_rebuild(self) -> bool:
         """Wait for a competing legacy builder without requiring an epoch."""
@@ -1078,7 +1522,14 @@ class EpistemicGraphIndex:
     def _rebuild_all_locked(self) -> dict[str, int]:
         pass_started = False
         stable = False
-        proof_invalidated = False
+        # Contract section 1 / deliverable D2. `projection_moved` may be set
+        # only for the two conditions that are positive evidence the *registry*
+        # is behind the disk: the supplied freshness identity failing to name
+        # the resolver bytes, and the recall projection moving across the pass.
+        # Every other non-stabilization — a marker that would not publish, a
+        # refused replacement, any OS or ownership error — is Class B and must
+        # leave vault freshness untouched.
+        projection_moved = False
         try:
             for _attempt in range(REBUILD_STABILIZATION_ATTEMPTS):
                 before_disk = _disk_vault_freshness(self.vault_root)
@@ -1096,8 +1547,9 @@ class EpistemicGraphIndex:
                     # The supplied freshness identity did not actually name the
                     # resolver bytes (for example after a coarse-metadata edit).
                     # Clear both the resolver and page cache before retrying.
+                    # Class C, first admitted cause.
                     self._mark_unavailable()
-                    proof_invalidated = True
+                    projection_moved = True
                     find_module.unload_ram_caches()
                     continue
                 pass_started = True
@@ -1132,23 +1584,37 @@ class EpistemicGraphIndex:
                     # it.  Publishing without an event checkpoint makes public
                     # reads re-prove disk identity and makes the next live
                     # incremental refresh rebuild rather than bridge a gap.
-                    if (
-                        self._mark_available(before, checkpoint=checkpoint)
-                        and self._recall_membership() == resolver_membership
-                        and self._source_versions_current(resolver_versions)
-                    ):
-                        stable = True
-                        return report
+                    if self._mark_available(before, checkpoint=checkpoint):
+                        if self._recall_membership() == resolver_membership and (
+                            self._source_versions_current(resolver_versions)
+                        ):
+                            stable = True
+                            return report
+                        # The projection moved between writing the availability
+                        # marker and confirming it: Class C, second cause.
+                        projection_moved = True
+                    # A marker that would not publish is a publication failure,
+                    # not proof that the registry is behind the disk.
                     self._mark_unavailable()
-                proof_invalidated = True
-            raise RuntimeError("epistemic graph rebuild did not stabilize after 2 attempts")
+                else:
+                    # `_recall_projection_identity`, `_recall_membership` or the
+                    # resolver source versions changed across the pass: Class C,
+                    # second admitted cause.
+                    projection_moved = True
+            message = "epistemic graph rebuild did not stabilize after 2 attempts"
+            if projection_moved:
+                raise GraphProjectionMoved(message)
+            raise RuntimeError(message)
         finally:
             if pass_started and not stable:
                 self._mark_unavailable()
-            if not stable and proof_invalidated:
-                # The private pass proved the live exact-checkpoint fast path
-                # stale, but publication never replaced it. Withdraw admission
-                # out of band without modifying the old live sidecar bytes.
+            if not stable and projection_moved:
+                # Class C, and the only place in this module that may cool the
+                # vault registry: the private pass proved the live
+                # exact-checkpoint fast path stale, but publication never
+                # replaced it. Withdraw admission out of band without modifying
+                # the old live sidecar bytes. Marked exactly once per proof, so
+                # a repeating Class B refusal can never allocate an epoch here.
                 freshness.mark_external_pending(self.vault_root)
 
     def _rebuild_all_pass(
@@ -3257,6 +3723,29 @@ def _join_registered_standalone(
     return GraphDispatchResult("completed", "graph_rebuild_completed", result.checkpoint)
 
 
+def _handle_graph_dispatch_failure(
+    vault_root: Path,
+    error: BaseException,
+    *,
+    mutation_coordinator: mutation_lock.VaultMutationCoordinator | None = None,
+) -> None:
+    """Classify one graph dispatch failure before deciding what it may cool.
+
+    This is the decision the joint freshness-liveness contract moves off the
+    write path (deliverable D3). A publication failure — a refused
+    `os.replace`, rebuild-owner loss, a busy mutation boundary, an exhausted
+    publication attempt — says nothing about what the event registry knows, so
+    it records the graph's own recovery state and its retry memo instead of
+    cooling a vault-global signal that every later write then pays for. Class C
+    has already been marked exactly once by the proof that detected it. Only an
+    exception this module cannot classify keeps the pre-contract marking.
+    """
+    if may_mark_external_pending(error):
+        freshness.mark_external_pending(vault_root)
+        return
+    record_publication_recovery_state(vault_root, mutation_coordinator=mutation_coordinator)
+
+
 def schedule_background_rebuild(
     vault_root: Path,
     *,
@@ -3269,8 +3758,14 @@ def schedule_background_rebuild(
     converges without blocking the request. At most one rebuild per vault runs at
     a time (a second call while one is in flight is a no-op); the daemon thread
     swallows its own errors so a failed rebuild never surfaces on the request.
+
+    A publication already refused for this exact checkpoint is not re-attempted
+    until its bounded memo expires (contract R2): re-paying a full rebuild on
+    every stale query is precisely the loop that filled the reported vault.
     """
     if not graph_scheduling_enabled():
+        return False
+    if publication_refusal_active(vault_root):
         return False
     if mutation_coordinator is None:
         from .writer_lease import active_manager
@@ -3287,8 +3782,10 @@ def schedule_background_rebuild(
             EpistemicGraphIndex(
                 vault_root, mutation_coordinator=mutation_coordinator
             ).rebuild_all()
-        except Exception:  # noqa: BLE001 - request path remains non-blocking
-            freshness.mark_external_pending(vault_root)
+        except Exception as error:  # noqa: BLE001 - request path remains non-blocking
+            _handle_graph_dispatch_failure(
+                vault_root, error, mutation_coordinator=mutation_coordinator
+            )
             log.warning("background graph rebuild failed; graph remains unavailable", exc_info=True)
         finally:
             with _REBUILD_LOCK:
@@ -3385,8 +3882,10 @@ def upsert_after_write(
                 mutation_coordinator,
             )
         return GraphDispatchResult("completed", "incremental_completed", required)
-    except OpError:
-        freshness.mark_external_pending(vault_root)
+    except OpError as error:
+        _handle_graph_dispatch_failure(
+            vault_root, error, mutation_coordinator=mutation_coordinator
+        )
         if required is not None:
             assert mutation_coordinator is not None
             return _join_registered_standalone(
@@ -3395,8 +3894,10 @@ def upsert_after_write(
                 mutation_coordinator,
             )
         raise
-    except Exception:  # noqa: BLE001 - canonical bytes must still report graph failure exactly
-        freshness.mark_external_pending(vault_root)
+    except Exception as error:  # noqa: BLE001 - canonical bytes must still report graph failure
+        _handle_graph_dispatch_failure(
+            vault_root, error, mutation_coordinator=mutation_coordinator
+        )
         log.warning("graph post-commit dispatch failed", exc_info=True)
         if required is not None:
             assert mutation_coordinator is not None
@@ -3436,8 +3937,10 @@ def delete_after_remove(vault_root: Path, removed_rel_paths: list[str]) -> Graph
             return GraphDispatchResult("deferred", "graph_index_disabled", required)
         index.delete_paths(removed_rel_paths)
         return GraphDispatchResult("completed", "delete_completed", required)
-    except OpError:
-        freshness.mark_external_pending(vault_root)
+    except OpError as error:
+        _handle_graph_dispatch_failure(
+            vault_root, error, mutation_coordinator=mutation_coordinator
+        )
         if required is not None:
             assert mutation_coordinator is not None
             return _join_registered_standalone(
@@ -3446,8 +3949,10 @@ def delete_after_remove(vault_root: Path, removed_rel_paths: list[str]) -> Graph
                 mutation_coordinator,
             )
         raise
-    except Exception:  # noqa: BLE001 - canonical bytes must still report graph failure exactly
-        freshness.mark_external_pending(vault_root)
+    except Exception as error:  # noqa: BLE001 - canonical bytes must still report graph failure
+        _handle_graph_dispatch_failure(
+            vault_root, error, mutation_coordinator=mutation_coordinator
+        )
         log.warning("graph post-remove dispatch failed", exc_info=True)
         if required is not None:
             assert mutation_coordinator is not None

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -436,6 +436,11 @@ def _await_publication_hold(key: str) -> None:
     replacement likely, never to make reads unavailable. A reader that outlasts
     the window is handled by the in-place publication path instead.
     """
+    if not _SIDECAR_PUBLICATION_HOLDS:
+        # The overwhelmingly common case, and this is the hot graph read path:
+        # no publication is holding anything, so do not even take the lock.
+        # Linux never takes a hold at all (`_reader_cycling_enabled`).
+        return
     deadline = time.monotonic() + PUBLICATION_READER_OPEN_WAIT_SECONDS
     with _SIDECAR_READERS_CHANGED:
         while key in _SIDECAR_PUBLICATION_HOLDS:

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -541,7 +541,9 @@ def _reap_preserved_temporaries(
     try:
         if not directory.is_dir():
             return []
-        entries = list(directory.iterdir())
+        # Prefix-filtered, like `graph_sync.sweep_abandoned_temporaries`: the KB
+        # directory of a large vault must not be enumerated in full for this.
+        entries = list(directory.glob(".graph-rebuild-*"))
     except OSError:
         return []
     active = graph_sync.live_temporary_paths()

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -573,30 +573,23 @@ def _temporary_base_name(name: str) -> str:
     return name
 
 
-def _reap_preserved_temporaries(
-    live: Path, *, keep: int = PRESERVED_TEMPORARY_LIMIT
-) -> list[Path]:
-    """Bound the `.graph-rebuild-*` artifacts a refused publication leaves behind.
+def _unregistered_temporary_groups(live: Path) -> dict[str, list[Path]]:
+    """Group `.graph-rebuild-*` artifacts this process has not registered.
 
-    A refused replacement deliberately preserves its complete private sidecar,
-    because that build is recoverable the moment the live file's reader lets
-    go. Exactly one of them is recoverable, though — the newest — so every
-    older one is dead weight, and on the reported vault it grew to 527 MB.
-
-    Anything still registered as an in-flight rebuild target is left alone. Of
-    the remainder the newest `keep` survive; the rest go with their SQLite
-    companions. A Windows reader may still refuse an unlink, in which case that
-    file is simply collected on a later pass rather than failing the rebuild.
+    Process-local registration (`graph_sync.live_temporary_paths`) protects our
+    own in-flight builds. It says nothing about another process's, which is why
+    every caller must hold the cross-process rebuild-owner claim before acting
+    on what this returns.
     """
     directory = live.parent
     try:
         if not directory.is_dir():
-            return []
+            return {}
         # Prefix-filtered, like `graph_sync.sweep_abandoned_temporaries`: the KB
         # directory of a large vault must not be enumerated in full for this.
         entries = list(directory.glob(".graph-rebuild-*"))
     except OSError:
-        return []
+        return {}
     active = graph_sync.live_temporary_paths()
     groups: dict[str, list[Path]] = {}
     for candidate in entries:
@@ -612,6 +605,56 @@ def _reap_preserved_temporaries(
         if registered or base_path.absolute() in active:
             continue
         groups.setdefault(base, []).append(candidate)
+    return groups
+
+
+def _reap_preserved_temporaries(
+    live: Path,
+    vault_root: Path,
+    *,
+    state_root: Path | None = None,
+    keep: int = PRESERVED_TEMPORARY_LIMIT,
+) -> list[Path]:
+    """Bound the `.graph-rebuild-*` artifacts a refused publication leaves behind.
+
+    A refused replacement deliberately preserves its complete private sidecar,
+    because that build is recoverable the moment the live file's reader lets
+    go. Exactly one of them is recoverable, though — the newest — so every
+    older one is dead weight, and on the reported vault it grew to 527 MB.
+
+    Ownership is cross-process, exactly as `graph_sync.sweep_abandoned_temporaries`
+    treats it: this holds the rebuild-owner claim for the whole decision, because
+    process-local registration cannot see an *out-of-process* repair's in-flight
+    build. Reaping one would be worse than the orphans — on Linux the unlink
+    succeeds, that builder's `os.replace` then raises `FileNotFoundError`, and an
+    unclassified error is exactly what still cools the registry. Failing to claim
+    means someone else is building; leave everything alone and reap next time.
+
+    Under the claim, the newest `keep` groups survive and the rest go with their
+    SQLite companions. A Windows reader may still refuse an unlink, in which case
+    that file is collected on a later pass rather than failing the rebuild.
+    """
+    # Cheap pre-check without the claim: nothing to bound, nothing to lock.
+    if len(_unregistered_temporary_groups(live)) <= max(0, keep):
+        return []
+    probe = live.with_name(f".graph-rebuild-reap-{secrets.token_hex(12)}.sqlite")
+    try:
+        claimed = graph_sync.claim_rebuild_owner(vault_root, probe, state_root=state_root)
+    except graph_sync.GraphRebuildRegistrationError:
+        return []
+    if not claimed:
+        return []
+    try:
+        return _reap_unowned_temporaries(live, keep=keep)
+    finally:
+        graph_sync.release_rebuild_owner(vault_root, probe, state_root=state_root)
+
+
+def _reap_unowned_temporaries(live: Path, *, keep: int) -> list[Path]:
+    """Do the reaping. Caller MUST already hold the rebuild-owner claim."""
+    directory = live.parent
+    # Re-scan under the claim: the pre-check ran without it.
+    groups = _unregistered_temporary_groups(live)
     if len(groups) <= max(0, keep):
         return []
 
@@ -1170,8 +1213,11 @@ class EpistemicGraphIndex:
         epoch_error: graph_sync.GraphEpochIncoherent | None = None
         # Artifacts of an earlier failed publication belong to this projection
         # (contract R3). Collect them before adding another one, so repeated
-        # refusal cannot grow the directory without bound.
-        _reap_preserved_temporaries(live)
+        # refusal cannot grow the directory without bound. The reaper takes the
+        # cross-process rebuild-owner claim itself, so this runs before ours.
+        _reap_preserved_temporaries(
+            live, self.vault_root, state_root=self._mutation_coordinator.state_root
+        )
         while attempts < REBUILD_PUBLICATION_ATTEMPTS:
             attempts += 1
             prepared_recall = freshness.prepare_recall_publication(self.vault_root, "vault")
@@ -1316,8 +1362,11 @@ class EpistemicGraphIndex:
                 if not preserve_temporary:
                     temporary.unlink(missing_ok=True)
                 # Owner release is the other moment the retained set can be
-                # bounded safely: no attempt of ours is registered any more.
-                _reap_preserved_temporaries(live)
+                # bounded safely: no attempt of ours is registered any more, and
+                # the reaper can take the claim it needs.
+                _reap_preserved_temporaries(
+                    live, self.vault_root, state_root=self._mutation_coordinator.state_root
+                )
         if epoch_error is not None:
             raise epoch_error
         # Exhausting the publication attempts for any reason other than a proven

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -424,7 +424,14 @@ def _sidecar_registry_key(live: Path) -> str:
 
 
 class _TrackedSidecarConnection(sqlite3.Connection):
-    """A live-sidecar reader that leaves the publication registry when closed."""
+    """A live-sidecar reader that leaves the publication registry when closed.
+
+    Opened with `check_same_thread=False` so a publication hold can actually
+    close a reader whose owning thread has died. SQLite itself is serialized,
+    and every caller in this module still uses its snapshot on the thread that
+    opened it; the guard is dropped only to make the abandoned-reader collection
+    real rather than raising `ProgrammingError` and leaving the handle open.
+    """
 
     def close(self) -> None:
         key = self.__dict__.get("_exomem_registry_key")
@@ -960,7 +967,9 @@ class EpistemicGraphIndex:
         _await_publication_hold(registry_key)
         try:
             uri = f"{self.path.resolve().as_uri()}?mode=ro"
-            conn = sqlite3.connect(uri, uri=True, factory=_TrackedSidecarConnection)
+            conn = sqlite3.connect(
+                uri, uri=True, factory=_TrackedSidecarConnection, check_same_thread=False
+            )
             conn.__dict__["_exomem_registry_key"] = registry_key
             _register_sidecar_reader(registry_key, conn)
             graph_sync.limit_graph_metadata_read(conn)

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -474,22 +474,28 @@ def _acquire_publication_hold(live: Path) -> str | None:
             return None
         _SIDECAR_PUBLICATION_HOLDS.add(key)
     deadline = time.monotonic() + PUBLICATION_READER_DRAIN_SECONDS
-    with _SIDECAR_READERS_CHANGED:
-        while _SIDECAR_READERS.get(key):
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                break
-            _SIDECAR_READERS_CHANGED.wait(remaining)
-        # A reader whose owning thread is gone can never close itself, so it is
-        # the only connection safe to close from here: closing one a live
-        # caller still holds would surface `sqlite3.ProgrammingError` inside an
-        # unrelated read. Readers that outlast the drain are published around
-        # by `graph_sync.replace_sidecar`'s in-place path.
-        abandoned = [
-            conn
-            for conn, owner in _SIDECAR_READERS.get(key, {}).values()
-            if not owner.is_alive()
-        ]
+    try:
+        with _SIDECAR_READERS_CHANGED:
+            while _SIDECAR_READERS.get(key):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                _SIDECAR_READERS_CHANGED.wait(remaining)
+            # A reader whose owning thread is gone can never close itself, so
+            # it is the only connection safe to close from here: closing one a
+            # live caller still holds would surface `sqlite3.ProgrammingError`
+            # inside an unrelated read. Readers that outlast the drain are
+            # published around by `graph_sync.replace_sidecar`'s in-place path.
+            abandoned = [
+                conn
+                for conn, owner in _SIDECAR_READERS.get(key, {}).values()
+                if not owner.is_alive()
+            ]
+    except BaseException:
+        # Never leak a hold: an unreleased one would make every reader of this
+        # sidecar pay the full open-wait for the life of the process.
+        _release_publication_hold(key)
+        raise
     # Outside the registry lock: closing re-enters it to deregister.
     for conn in abandoned:
         try:

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -16,6 +16,7 @@ import secrets
 import sqlite3
 import threading
 import time
+import weakref
 from collections.abc import Iterable
 from contextlib import nullcontext
 from dataclasses import dataclass
@@ -395,7 +396,12 @@ def record_publication_recovery_state(
 
 _SIDECAR_READERS_LOCK = threading.Lock()
 _SIDECAR_READERS_CHANGED = threading.Condition(_SIDECAR_READERS_LOCK)
-_SIDECAR_READERS: dict[str, dict[int, tuple[sqlite3.Connection, threading.Thread]]] = {}
+# Weak references only: a registry that pinned its connections would keep the
+# very file handles alive that make a Windows replacement impossible, and a
+# reader leaked on an exception path would never be collected.
+_SIDECAR_READERS: dict[
+    str, dict[int, tuple["weakref.ref[sqlite3.Connection]", int]]
+] = {}
 _SIDECAR_PUBLICATION_HOLDS: set[str] = set()
 
 PUBLICATION_READER_DRAIN_SECONDS = 1.0
@@ -453,7 +459,10 @@ def _await_publication_hold(key: str) -> None:
 
 def _register_sidecar_reader(key: str, conn: sqlite3.Connection) -> None:
     with _SIDECAR_READERS_CHANGED:
-        _SIDECAR_READERS.setdefault(key, {})[id(conn)] = (conn, threading.current_thread())
+        _SIDECAR_READERS.setdefault(key, {})[id(conn)] = (
+            weakref.ref(conn),
+            threading.get_ident(),
+        )
 
 
 def _release_sidecar_reader(key: str, conn: sqlite3.Connection) -> None:
@@ -466,6 +475,28 @@ def _release_sidecar_reader(key: str, conn: sqlite3.Connection) -> None:
         _SIDECAR_READERS_CHANGED.notify_all()
 
 
+def _live_sidecar_readers(key: str) -> list[tuple[sqlite3.Connection, int]]:
+    """Prune collected readers and return the ones still holding the file.
+
+    Caller must hold `_SIDECAR_READERS_CHANGED`. A connection dropped without
+    `close()` is finalized by CPython without running the Python-level override,
+    so its registry entry is pruned here rather than lingering forever.
+    """
+    readers = _SIDECAR_READERS.get(key)
+    if not readers:
+        return []
+    live: list[tuple[sqlite3.Connection, int]] = []
+    for token, (reference, owner_ident) in list(readers.items()):
+        conn = reference()
+        if conn is None:
+            readers.pop(token, None)
+            continue
+        live.append((conn, owner_ident))
+    if not readers:
+        _SIDECAR_READERS.pop(key, None)
+    return live
+
+
 def _acquire_publication_hold(live: Path) -> str | None:
     """Block new live-sidecar readers, drain the open ones, and return the hold."""
     key = _sidecar_registry_key(live)
@@ -476,7 +507,7 @@ def _acquire_publication_hold(live: Path) -> str | None:
     deadline = time.monotonic() + PUBLICATION_READER_DRAIN_SECONDS
     try:
         with _SIDECAR_READERS_CHANGED:
-            while _SIDECAR_READERS.get(key):
+            while _live_sidecar_readers(key):
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     break
@@ -486,10 +517,11 @@ def _acquire_publication_hold(live: Path) -> str | None:
             # live caller still holds would surface `sqlite3.ProgrammingError`
             # inside an unrelated read. Readers that outlast the drain are
             # published around by `graph_sync.replace_sidecar`'s in-place path.
+            running = {thread.ident for thread in threading.enumerate()}
             abandoned = [
                 conn
-                for conn, owner in _SIDECAR_READERS.get(key, {}).values()
-                if not owner.is_alive()
+                for conn, owner_ident in _live_sidecar_readers(key)
+                if owner_ident not in running
             ]
     except BaseException:
         # Never leak a hold: an unreleased one would make every reader of this

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -984,10 +984,26 @@ class FileWatcher:
             except Exception:  # noqa: BLE001 - availability is the required outcome
                 graph_current = False
             if not graph_current:
-                freshness.mark_external_pending(self._vault_root)
-                log.warning(
-                    "file watcher: graph fan-out incomplete; periodic recovery re-armed"
-                )
+                # The third door onto `external_pending`, and the one that made
+                # the loop self-sustaining: this drain withdrew the marker at
+                # the top, compare-and-acked the epoch, and now finds the graph
+                # still not current. If the fan-out's publication was *refused*
+                # that is Class B -- the registry recorded every event and only
+                # this projection failed to publish -- so re-assert the barrier
+                # the graph owns instead of allocating a fresh epoch on every
+                # drain cycle (contract R1). Any other incompleteness keeps the
+                # previous behaviour.
+                if epistemic_graph.publication_refusal_active(self._vault_root):
+                    epistemic_graph.record_publication_recovery_state(self._vault_root)
+                    log.warning(
+                        "file watcher: graph publication refused during fan-out; "
+                        "graph barrier re-asserted, vault freshness untouched"
+                    )
+                else:
+                    freshness.mark_external_pending(self._vault_root)
+                    log.warning(
+                        "file watcher: graph fan-out incomplete; periodic recovery re-armed"
+                    )
         return admitted_semantic
 
     def _run_reconcile(self) -> None:

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -594,13 +594,28 @@ class FileWatcher:
         freshness.clear_external_pending(self._vault_root, through=pending_epoch)
         if freshness.external_pending(self._vault_root) or not rebuild_graph:
             return
+        if epistemic_graph.publication_refusal_active(self._vault_root):
+            # The same publication was refused recently; re-paying a full
+            # rebuild every 300 s is exactly what the contract's R2 forbids.
+            # The persisted barrier keeps the graph fenced meanwhile.
+            return
         try:
             graph.rebuild_all()
             if not graph.available():
-                raise RuntimeError("rebuilt graph did not publish an available marker")
-        except Exception:  # noqa: BLE001 - retain a retry signal and fail closed
-            if not freshness.external_pending(self._vault_root):
-                freshness.mark_external_pending(self._vault_root)
+                raise epistemic_graph.GraphPublicationUnavailable(
+                    "rebuilt graph did not publish an available marker"
+                )
+        except Exception as error:  # noqa: BLE001 - retain a retry signal and fail closed
+            # A refused publication is Class B: the registry observed and
+            # recorded every event, and only this projection failed to publish.
+            # Re-marking here would allocate a fresh external-pending epoch on
+            # every cycle and defeat the compare-and-ack above (contract R1),
+            # which is why this loop kept the vault permanently pending.
+            if epistemic_graph.may_mark_external_pending(error):
+                if not freshness.external_pending(self._vault_root):
+                    freshness.mark_external_pending(self._vault_root)
+            else:
+                epistemic_graph.record_publication_recovery_state(self._vault_root)
             log.exception("file watcher: pending epoch graph recovery failed")
 
     def _recover_suspended_graph(self) -> None:
@@ -618,6 +633,12 @@ class FileWatcher:
         graph = epistemic_graph.EpistemicGraphIndex(self._vault_root)
         if not graph.reads_suspended():
             return
+        if epistemic_graph.publication_refusal_active(self._vault_root):
+            # Contract R2: a publication already proven doomed for this exact
+            # checkpoint must not be re-attempted at full rebuild cost on every
+            # 300 s cycle. The barrier this method repairs is itself the fence,
+            # so deferring costs nothing but the delay.
+            return
         try:
             find_module.evict_resolver_caches(self._vault_root)
             vault_module.evict_inbound_index(self._vault_root)
@@ -626,7 +647,9 @@ class FileWatcher:
                 return
             graph.rebuild_all()
             if not graph.available():
-                raise RuntimeError("recovered graph did not publish an available marker")
+                raise epistemic_graph.GraphPublicationUnavailable(
+                    "recovered graph did not publish an available marker"
+                )
         except Exception:  # noqa: BLE001 - persisted barrier remains a retry signal
             try:
                 graph.suspend_reads()

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -999,6 +999,18 @@ class FileWatcher:
                         "file watcher: graph publication refused during fan-out; "
                         "graph barrier re-asserted, vault freshness untouched"
                     )
+                elif not epistemic_graph.graph_scheduling_enabled():
+                    # The graph is deliberately not being maintained, so "not
+                    # current" is the configured outcome rather than a failure
+                    # to classify. The barrier withdrawn at the top of this
+                    # drain still fences every reader; marking on top of it
+                    # would cool the registry on every cycle for as long as the
+                    # mitigation is deployed, which is exactly the cost this
+                    # contract exists to remove.
+                    log.info(
+                        "file watcher: graph scheduling disabled; graph stays fenced "
+                        "by its barrier and vault freshness is untouched"
+                    )
                 else:
                     freshness.mark_external_pending(self._vault_root)
                     log.warning(

--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -2495,6 +2495,7 @@ def temporary_sidecar_path(live: Path, checkpoint: GraphSyncCheckpoint) -> Path:
 
 PUBLISH_IN_PLACE_ATTEMPTS = 3
 PUBLISH_IN_PLACE_BUSY_TIMEOUT_SECONDS = 5.0
+PUBLISH_IN_PLACE_RETRY_SECONDS = 0.25
 
 
 def replace_sidecar(temporary: Path, live: Path) -> None:
@@ -2506,8 +2507,14 @@ def replace_sidecar(temporary: Path, live: Path) -> None:
     open, and a resident service makes that a routine condition rather than a
     rare one, so a refusal must not be the end of the road: fall back to
     publishing the same proven bytes *into* the existing file with SQLite's
-    backup API, which needs only a write transaction on the destination and
-    therefore leaves the directory entry (and every open handle) untouched.
+    backup API, which leaves the directory entry untouched and so does not care
+    how many handles are open on it.
+
+    That fallback covers open *handles*, not open read *transactions*. This
+    sidecar runs in rollback-journal mode, where a reader inside `BEGIN` holds a
+    SHARED lock that blocks the backup's EXCLUSIVE one — so a reader that holds
+    a transaction across the whole window still defeats both paths. Bounded
+    retries absorb the ordinary case where the reader commits and lets go.
 
     Only when both fail is the publication genuinely unavailable. Leaving the
     complete old sidecar in place is fail-closed; the checkpoint remains
@@ -2532,14 +2539,21 @@ def _publish_sidecar_in_place(temporary: Path, live: Path) -> bool:
 
     `sqlite3.Connection.backup` copies the whole source database inside one
     destination transaction, so a concurrent reader either sees the complete
-    old content or the complete new content — never a half-written file. A
-    reader holding a *read* transaction blocks the write briefly, which the
-    busy timeout absorbs; a reader that never yields exhausts the bounded
-    attempts and leaves the live sidecar exactly as it was.
+    old content or the complete new content — never a half-written file.
+
+    The sidecar is a rollback-journal database (nothing sets `journal_mode`), so
+    a reader inside `BEGIN` holds a SHARED lock and the backup's EXCLUSIVE lock
+    waits on it. The busy timeout absorbs that once the connection is open; a
+    failure raised at *open* time returns immediately, so the attempts are also
+    spaced, or all three would burn in microseconds and prove nothing. A reader
+    that never yields exhausts them and leaves the live sidecar exactly as it
+    was.
     """
     if not live.exists():
         return False
     for attempt in range(PUBLISH_IN_PLACE_ATTEMPTS):
+        if attempt:
+            time.sleep(PUBLISH_IN_PLACE_RETRY_SECONDS)
         try:
             source = sqlite3.connect(temporary)
             try:
@@ -2548,7 +2562,6 @@ def _publish_sidecar_in_place(temporary: Path, live: Path) -> bool:
                 )
                 try:
                     source.backup(destination)
-                    destination.execute("PRAGMA wal_checkpoint(TRUNCATE)")
                 finally:
                     destination.close()
             finally:

--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -2493,15 +2493,78 @@ def temporary_sidecar_path(live: Path, checkpoint: GraphSyncCheckpoint) -> Path:
     )
 
 
+PUBLISH_IN_PLACE_ATTEMPTS = 3
+PUBLISH_IN_PLACE_BUSY_TIMEOUT_SECONDS = 5.0
+
+
 def replace_sidecar(temporary: Path, live: Path) -> None:
-    """Use the platform's atomic replacement primitive after all handles close."""
+    """Publish the proven temporary as the live sidecar.
+
+    The fast path is the platform's atomic replacement primitive, which Linux
+    always grants and which Windows grants once no handle is open on the
+    destination. Windows refuses it while any reader keeps the live SQLite file
+    open, and a resident service makes that a routine condition rather than a
+    rare one, so a refusal must not be the end of the road: fall back to
+    publishing the same proven bytes *into* the existing file with SQLite's
+    backup API, which needs only a write transaction on the destination and
+    therefore leaves the directory entry (and every open handle) untouched.
+
+    Only when both fail is the publication genuinely unavailable. Leaving the
+    complete old sidecar in place is fail-closed; the checkpoint remains
+    unacknowledged and the graph's own recovery path retries later.
+    """
     try:
         os.replace(temporary, live)
     except PermissionError as error:
-        # Windows refuses replacement while a reader keeps the SQLite file
-        # open. Leaving the complete old sidecar in place is fail-closed; the
-        # checkpoint remains unacknowledged and reconcile can retry later.
+        if _publish_sidecar_in_place(temporary, live):
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                # A retained temp is inert once the live file already carries
+                # the published bytes; the reaper collects it on a later pass.
+                pass
+            return
         raise GraphSidecarReplaceUnavailable("live graph sidecar has an open reader") from error
+
+
+def _publish_sidecar_in_place(temporary: Path, live: Path) -> bool:
+    """Copy a proven temp sidecar over the live file without moving the entry.
+
+    `sqlite3.Connection.backup` copies the whole source database inside one
+    destination transaction, so a concurrent reader either sees the complete
+    old content or the complete new content — never a half-written file. A
+    reader holding a *read* transaction blocks the write briefly, which the
+    busy timeout absorbs; a reader that never yields exhausts the bounded
+    attempts and leaves the live sidecar exactly as it was.
+    """
+    if not live.exists():
+        return False
+    for attempt in range(PUBLISH_IN_PLACE_ATTEMPTS):
+        try:
+            source = sqlite3.connect(temporary)
+            try:
+                destination = sqlite3.connect(
+                    live, timeout=PUBLISH_IN_PLACE_BUSY_TIMEOUT_SECONDS
+                )
+                try:
+                    source.backup(destination)
+                    destination.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                finally:
+                    destination.close()
+            finally:
+                source.close()
+        except sqlite3.Error:
+            logger.debug(
+                "graph sidecar in-place publication attempt %d/%d did not complete",
+                attempt + 1,
+                PUBLISH_IN_PLACE_ATTEMPTS,
+                exc_info=True,
+            )
+            continue
+        except OSError:
+            return False
+        return True
+    return False
 
 
 def _rebuild_runtime_root(state_root: Path | None) -> Path:

--- a/tests/test_freshness_liveness_contract.py
+++ b/tests/test_freshness_liveness_contract.py
@@ -861,7 +861,7 @@ def test_repeated_refusal_keeps_at_most_one_preserved_temporary(
 def test_reaper_never_collects_an_in_flight_registered_temporary(
     contract_vault: Path,
 ) -> None:
-    """D6: a build another owner still holds is not an orphan."""
+    """D6: a build this process still holds is not an orphan."""
     root = contract_vault
     live = epistemic_graph.sidecar_path(root)
     in_flight = graph_sync.temporary_sidecar_path(live, _contract_checkpoint(1))
@@ -872,7 +872,7 @@ def test_reaper_never_collects_an_in_flight_registered_temporary(
         time.sleep(0.02)
     graph_sync.register_temporary(in_flight)
     try:
-        removed = epistemic_graph._reap_preserved_temporaries(live)
+        removed = epistemic_graph._reap_preserved_temporaries(live, root)
     finally:
         graph_sync.unregister_temporary(in_flight.resolve())
 
@@ -880,3 +880,65 @@ def test_reaper_never_collects_an_in_flight_registered_temporary(
     assert orphan_newer.exists()
     assert not orphan_older.exists()
     assert removed == [orphan_older]
+
+
+def test_reaper_leaves_everything_alone_while_another_owner_is_building(
+    contract_vault: Path,
+) -> None:
+    """D6: process-local registration cannot see an out-of-process build.
+
+    A foreign repair's temporary is fresh and complete but unregistered here.
+    Reaping it would be worse than the orphans it collects -- on Linux the
+    unlink succeeds, that builder's `os.replace` then raises FileNotFoundError,
+    and an unclassified error is exactly what still cools the registry. The
+    cross-process rebuild-owner claim is the only thing that can tell the two
+    apart, so failing to take it must mean reaping nothing.
+    """
+    root = contract_vault
+    live = epistemic_graph.sidecar_path(root)
+    # Deliberately the OLDEST, so recency cannot accidentally save it: only the
+    # ownership claim can.
+    foreign_in_flight = graph_sync.temporary_sidecar_path(live, _contract_checkpoint(1))
+    orphan_older = graph_sync.temporary_sidecar_path(live, _contract_checkpoint(2))
+    orphan_newer = graph_sync.temporary_sidecar_path(live, _contract_checkpoint(3))
+    for path in (foreign_in_flight, orphan_older, orphan_newer):
+        path.write_bytes(b"sqlite artifact")
+        time.sleep(0.02)
+
+    # Stand in for the other process: hold the same cross-process claim it would.
+    owner_probe = live.with_name(".graph-rebuild-foreign-owner.sqlite")
+    assert graph_sync.claim_rebuild_owner(root, owner_probe) is True
+    try:
+        removed = epistemic_graph._reap_preserved_temporaries(live, root)
+    finally:
+        graph_sync.release_rebuild_owner(root, owner_probe)
+
+    assert removed == []
+    assert foreign_in_flight.exists(), "a foreign in-flight build must survive"
+    assert orphan_older.exists()
+    assert orphan_newer.exists()
+
+    # Once that owner releases, nothing is in flight anywhere and the same call
+    # bounds the retained set to the newest complete build.
+    removed = epistemic_graph._reap_preserved_temporaries(live, root)
+    assert set(removed) == {foreign_in_flight, orphan_older}
+    assert orphan_newer.exists()
+
+
+def test_publication_hold_is_platform_gated(contract_vault: Path) -> None:
+    """Linux keeps the plain `os.replace` fast path: no hold, no drain."""
+    root = contract_vault
+    index = epistemic_graph.EpistemicGraphIndex(root)
+    epistemic_graph.reset_publication_holds()
+
+    hold = index._before_publish_replacement(index.path, index.path)
+    try:
+        if epistemic_graph._reader_cycling_enabled():
+            assert hold == epistemic_graph._sidecar_registry_key(index.path)
+            assert epistemic_graph._SIDECAR_PUBLICATION_HOLDS == {hold}
+        else:
+            assert hold is None
+            assert epistemic_graph._SIDECAR_PUBLICATION_HOLDS == set()
+    finally:
+        epistemic_graph._release_publication_hold(hold)
+    assert epistemic_graph._SIDECAR_PUBLICATION_HOLDS == set()

--- a/tests/test_freshness_liveness_contract.py
+++ b/tests/test_freshness_liveness_contract.py
@@ -1,33 +1,51 @@
-"""The joint freshness-liveness contract, corpus half (#510 slices A/B).
+"""The joint freshness-liveness contract — both halves.
 
-`freshness.*` describes what the event registry knows about the vault's
-files. It must never be used to describe whether a downstream projection
-managed to publish its own derived copy. These tests pin the corpus-side
-consequences of that separation:
+Source of truth: GitHub issue #508, comment "Joint freshness-liveness
+contract". Two lanes implement it from opposite ends and both keep this file
+green:
 
-* a Class B failure -- the registry advanced, only the corpus PATCH failed --
-  must leave vault freshness live and not externally pending, and must leave
-  the corpus projection able to warm itself again on the next publish;
-* a Class A failure -- the registry-advance half itself failed -- must still
-  take the full withdraw, because the event suffix really is unknowable;
-* a publish that finds no warm corpus entry must POPULATE one (D8) instead of
-  silently returning, so the next reader is an event-hit rather than a full
-  stat census of the vault;
-* that populate must never stamp an event token onto a context whose walk an
-  event leapfrogged (contract SS5, clauses L1-L5).
+* the **corpus half** (#510 slices A/B), in `TestCorpusHalf` below — a Class B
+  corpus-patch failure must leave vault freshness live, a Class A
+  registry-advance failure must still withdraw, and populate-on-miss must never
+  stamp a token onto a context an event leapfrogged (section 5, clauses L1-L5);
+* the **graph half** (#508), at module level after it — the shared defending
+  test of section 4 plus the deliverables it decomposes into: a refused graph
+  publication is Class B, so it MUST NOT call `freshness.invalidate` or
+  `freshness.mark_external_pending`, MUST record recovery state in its own
+  store, and MUST own a bounded retry.
 
-The graph-side halves of the shared defending test (contract SS4 assertions 3
-and 4) belong to the parallel `lane/graph-publish-hygiene` lane and are not
-asserted here.
+For the shared defending test (section 4), #510 owns assertion 2, #508 owns
+assertions 3 and 4, and assertion 1 is jointly owned. **Neither lane may weaken
+assertions 1 or 3 to make its own change pass.**
+
+The rule both halves follow from: `freshness.*` describes what the event
+registry knows about the vault's files. It must never be used to describe
+whether a downstream projection managed to publish its own derived copy.
+
+The two halves build deliberately different pages — `_corpus_page` carries no
+headings, `_page` carries the `## Claim` block the graph lane's relation
+assertions read — so both builders are kept and named for what they produce
+rather than collapsed into one whose content would silently change the other
+half's fixtures.
 """
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
 
-from exomem import freshness, index_sync, relation_registry, semantic_contract
+from exomem import (
+    epistemic_graph,
+    freshness,
+    graph_sync,
+    index_sync,
+    relation_registry,
+    semantic_contract,
+)
+from exomem import find as find_module
+from exomem import vault as vault_module
 
 _PAGE_REL = "Knowledge Base/Notes/Insights/one.md"
 _OTHER_REL = "Knowledge Base/Notes/Insights/two.md"
@@ -38,28 +56,16 @@ _EXTENDED_REGISTRY = (
 )
 
 
-def _page(*, title: str = "Page", body: str = "Body.\n") -> str:
+def _corpus_page(*, title: str = "Page", body: str = "Body.\n") -> str:
     return f"---\ntitle: {title}\ntype: insight\nstatus: active\nproject: atlas\n---\n\n{body}"
-
-
-@pytest.fixture(autouse=True)
-def _corpus_cache_on(monkeypatch: pytest.MonkeyPatch):
-    # The suite-wide conftest defaults the corpus cache OFF; this contract is
-    # entirely about that cache's lifecycle, so opt back in and start cold.
-    monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
-    semantic_contract.reset_corpus_context_cache()
-    freshness.clear()
-    yield
-    semantic_contract.reset_corpus_context_cache()
-    freshness.clear()
 
 
 @pytest.fixture()
 def vault(tmp_path: Path) -> Path:
     notes = tmp_path / "Knowledge Base" / "Notes" / "Insights"
     notes.mkdir(parents=True)
-    (notes / "one.md").write_text(_page(title="One"), encoding="utf-8")
-    (notes / "two.md").write_text(_page(title="Two"), encoding="utf-8")
+    (notes / "one.md").write_text(_corpus_page(title="One"), encoding="utf-8")
+    (notes / "two.md").write_text(_corpus_page(title="Two"), encoding="utf-8")
     freshness.rebaseline(tmp_path)
     return tmp_path
 
@@ -108,251 +114,507 @@ def _poison_corpus_patch(monkeypatch: pytest.MonkeyPatch):
     return real_patch
 
 
-def test_refused_corpus_patch_does_not_cool_vault_freshness(
-    vault: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Contract C1.1: a Class B corpus-patch failure is not registry loss.
+# --- corpus half (#510 slices A/B) -----------------------------------------
 
-    Red on `main` for the contract's stated reason: `publish_corpus_delta`'s
-    `_withdraw_unbridgeable_corpus_consumers` calls `freshness.invalidate`
-    (index_sync.py:63) and `freshness.mark_external_pending` (:64) for ANY
-    publish failure, so `triple()` returns None, the corpus event-hit gate is
-    structurally unreachable, and every later caller pays a full stat census.
+
+class TestCorpusHalf:
+    """The corpus-cache lifecycle half of the contract.
+
+    The cache-on fixture below is autouse **at class scope on purpose**: it
+    forces the corpus cache on and clears the freshness registry around every
+    test, which is right for these and wrong for the graph half, whose tests
+    seed and inspect that registry themselves. Module-level autouse would have
+    applied it to both halves silently.
     """
-    semantic_contract.build_corpus_context(vault)
-    assert freshness.triple(vault, "vault") is not None
 
-    page = vault / _PAGE_REL
-    page.write_text(_page(title="One changed"), encoding="utf-8")
-    real_patch = _poison_corpus_patch(monkeypatch)
+    @pytest.fixture(autouse=True)
+    def _corpus_cache_on(self, monkeypatch: pytest.MonkeyPatch):
+        # The suite-wide conftest defaults the corpus cache OFF; this contract is
+        # entirely about that cache's lifecycle, so opt back in and start cold.
+        monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
+        semantic_contract.reset_corpus_context_cache()
+        freshness.clear()
+        yield
+        semantic_contract.reset_corpus_context_cache()
+        freshness.clear()
 
-    assert index_sync.publish_corpus_delta(vault, changed=(page,)) is False
+    def test_refused_corpus_patch_does_not_cool_vault_freshness(
+        self,
+        vault: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Contract C1.1: a Class B corpus-patch failure is not registry loss.
 
-    # 1. Liveness preserved: the registry saw the event, only the projection
-    #    could not publish its derived copy.
-    assert freshness.triple(vault, "vault") is not None
-    assert freshness.is_live(vault, "vault") is True
-    assert freshness.external_pending(vault) is False
+        Red on `main` for the contract's stated reason: `publish_corpus_delta`'s
+        `_withdraw_unbridgeable_corpus_consumers` calls `freshness.invalidate`
+        (index_sync.py:63) and `freshness.mark_external_pending` (:64) for ANY
+        publish failure, so `triple()` returns None, the corpus event-hit gate is
+        structurally unreachable, and every later caller pays a full stat census.
+        """
+        semantic_contract.build_corpus_context(vault)
+        assert freshness.triple(vault, "vault") is not None
 
-    # 2. The corpus projection can warm itself again with no operator action:
-    #    the next publish repopulates on miss, and the read after it is an
-    #    event-hit paying zero full censuses.
-    monkeypatch.setattr(semantic_contract, "_patch_corpus_files_changed_locked", real_patch)
-    other = vault / _OTHER_REL
-    other.write_text(_page(title="Two changed"), encoding="utf-8")
-    assert index_sync.publish_corpus_delta(vault, changed=(other,)) is True
+        page = vault / _PAGE_REL
+        page.write_text(_corpus_page(title="One changed"), encoding="utf-8")
+        real_patch = _poison_corpus_patch(monkeypatch)
 
-    cache_key = semantic_contract._corpus_cache_key(vault)
-    assert semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS.get(cache_key) == freshness.triple(
-        vault, "vault"
+        assert index_sync.publish_corpus_delta(vault, changed=(page,)) is False
+
+        # 1. Liveness preserved: the registry saw the event, only the projection
+        #    could not publish its derived copy.
+        assert freshness.triple(vault, "vault") is not None
+        assert freshness.is_live(vault, "vault") is True
+        assert freshness.external_pending(vault) is False
+
+        # 2. The corpus projection can warm itself again with no operator action:
+        #    the next publish repopulates on miss, and the read after it is an
+        #    event-hit paying zero full censuses.
+        monkeypatch.setattr(semantic_contract, "_patch_corpus_files_changed_locked", real_patch)
+        other = vault / _OTHER_REL
+        other.write_text(_corpus_page(title="Two changed"), encoding="utf-8")
+        assert index_sync.publish_corpus_delta(vault, changed=(other,)) is True
+
+        cache_key = semantic_contract._corpus_cache_key(vault)
+        assert semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS.get(cache_key) == freshness.triple(
+            vault, "vault"
+        )
+
+        censuses, builds = _spy_corpus_work(monkeypatch)
+        context = semantic_contract.build_corpus_context(vault)
+        assert (censuses, builds) == ([], [])
+        assert context.pages[_OTHER_REL].title == "Two changed"
+        assert context.pages[_PAGE_REL].title == "One changed"
+
+
+    def test_registry_advance_failure_still_withdraws_vault_freshness(
+        self,
+        vault: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Contract Class A: the registry-advance half failing IS registry loss.
+
+        Green before and after -- this is the guard that the narrowing in C1.1
+        stays narrow. `freshness.on_files_changed` raising means the event suffix
+        really is unknowable, so the full withdraw (invalidate + external pending)
+        remains correct and must survive the split seam.
+        """
+        semantic_contract.build_corpus_context(vault)
+        assert freshness.triple(vault, "vault") is not None
+
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("registry advance failed")
+
+        monkeypatch.setattr(semantic_contract.freshness, "on_files_changed", boom)
+        page = vault / _PAGE_REL
+        page.write_text(_corpus_page(title="One changed"), encoding="utf-8")
+
+        assert index_sync.publish_corpus_delta(vault, changed=(page,)) is False
+
+        assert freshness.triple(vault, "vault") is None
+        assert freshness.is_live(vault, "vault") is False
+        assert freshness.external_pending(vault) is True
+        cache_key = semantic_contract._corpus_cache_key(vault)
+        assert cache_key not in semantic_contract._CORPUS_CONTEXT_CACHE
+
+
+    def test_publish_populates_a_cold_corpus_cache_for_the_next_reader(
+        self,
+        vault: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Deliverable 8: the `entry is None` no-op must populate, not return.
+
+        Red on `main` for the contract's stated reason: `semantic_contract.py`'s
+        `_patch_corpus_files_changed_locked` returns silently when the cache holds
+        no entry (sc:1745-1746), so a write onto a cold cache leaves it cold and
+        the very next preflight pays a full stat census of the vault.
+        """
+        page = vault / _PAGE_REL
+        page.write_text(_corpus_page(title="One changed"), encoding="utf-8")
+
+        semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
+
+        cache_key = semantic_contract._corpus_cache_key(vault)
+        entry = semantic_contract._CORPUS_CONTEXT_CACHE.get(cache_key)
+        assert entry is not None
+        assert entry[1].pages[_PAGE_REL].title == "One changed"
+        assert semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS.get(cache_key) == freshness.triple(
+            vault, "vault"
+        )
+
+        censuses, builds = _spy_corpus_work(monkeypatch)
+        context = semantic_contract.build_corpus_context(vault)
+        assert (censuses, builds) == ([], [])
+        assert context is entry[1]
+
+
+    def test_populate_on_miss_never_stamps_a_context_an_event_leapfrogged(
+        self,
+        vault: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Contract L2/L3: the populate's admission gate is the consumer checkpoint.
+
+        The populate cannot hold `_CORPUS_CONTEXT_UPDATE_LOCK` across its own walk
+        (the publisher advances freshness under that lock), so it takes L2's shape:
+        capture `freshness.consumer_checkpoint` BEFORE the walk, then admit the
+        built context only if the checkpoint is unchanged and the cache slot is
+        still the empty one it observed. Here an external event lands mid-walk, so
+        the built context provably misses a delta the current token covers and must
+        be discarded rather than stamped.
+        """
+        page = vault / _PAGE_REL
+        page.write_text(_corpus_page(title="One changed"), encoding="utf-8")
+
+        other = vault / _OTHER_REL
+        builds: list[str] = []
+        real_build = semantic_contract._build_corpus_context_uncached
+
+        def build_with_racing_event(root: Path, **kwargs):
+            builds.append("build")
+            context = real_build(root, **kwargs)
+            # An external editor lands a change the registry sees, while this
+            # populate's walk is already behind it.
+            other.write_text(_corpus_page(title="Two leapfrogged"), encoding="utf-8")
+            freshness.on_files_changed(root, changed=(other,))
+            return context
+
+        monkeypatch.setattr(
+            semantic_contract, "_build_corpus_context_uncached", build_with_racing_event
+        )
+        confirms: list[Path] = []
+        real_confirm = semantic_contract._deferred_corpus_census
+
+        def counted_confirm(root: Path, sink, outcome: str):
+            confirms.append(root)
+            return real_confirm(root, sink, outcome)
+
+        monkeypatch.setattr(semantic_contract, "_deferred_corpus_census", counted_confirm)
+
+        semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
+
+        assert builds, "the populate must have attempted a build to be a real discard"
+        # Attribution: the checkpoint decided this, not the census re-confirm that
+        # follows it. That is the point of L3 -- the generation-bearing checkpoint
+        # is the admission gate, and it is cheap enough to be consulted first.
+        assert confirms == []
+        cache_key = semantic_contract._corpus_cache_key(vault)
+        # Never stamp: the leapfrogged context must reach neither the cache nor
+        # the event-token map (contract L2 "on any mismatch discard ... never
+        # stamp", L5 "entry, token and language hash move together").
+        assert cache_key not in semantic_contract._CORPUS_CONTEXT_CACHE
+        assert cache_key not in semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS
+        assert cache_key not in semantic_contract._CORPUS_CONTEXT_LANGUAGE_HASHES
+
+        # And the next honest build sees BOTH deltas, so nothing was lost.
+        context = semantic_contract.build_corpus_context(vault)
+        assert context.pages[_PAGE_REL].title == "One changed"
+        assert context.pages[_OTHER_REL].title == "Two leapfrogged"
+
+
+    def test_populate_on_miss_never_stamps_a_context_built_with_a_superseded_registry(
+        self,
+        vault: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The populate loads its registries BEFORE its walk, so it must re-prove
+        them against disk before installing.
+
+        `_corpus_census` stats the two `_Schema` registry files at the END of its
+        walk. A registry rewritten between the load and that stat therefore yields
+        a census that records the NEW file captioning a context built with the OLD
+        registry. The event-hit gate would refuse such an entry -- it re-checks the
+        registry identity -- but the census-reuse path admits on census equality
+        alone, and would hand that context back as current.
+
+        Every other install site guards with `_registries_match_disk`; this pins
+        that the populate does too.
+        """
+        page = vault / _PAGE_REL
+        page.write_text(_corpus_page(title="One changed"), encoding="utf-8")
+        registry_path = vault / _REGISTRY_REL
+        superseded = relation_registry.load_registry(vault)
+
+        real_census = semantic_contract._corpus_census
+        walks: list[str] = []
+
+        def census_with_a_registry_rewrite(root: Path):
+            walks.append(str(root))
+            if len(walks) == 1:
+                # Interleaved into the populate's own walk window: the registry
+                # this census is about to stat is no longer the one in hand.
+                registry_path.parent.mkdir(parents=True, exist_ok=True)
+                registry_path.write_text(_EXTENDED_REGISTRY, encoding="utf-8")
+            return real_census(root)
+
+        monkeypatch.setattr(semantic_contract, "_corpus_census", census_with_a_registry_rewrite)
+
+        semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
+
+        assert walks, "the populate must have walked for this to be a real discard"
+        assert relation_registry.load_registry(vault).extension_hash != superseded.extension_hash
+        cache_key = semantic_contract._corpus_cache_key(vault)
+        assert cache_key not in semantic_contract._CORPUS_CONTEXT_CACHE
+        assert cache_key not in semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS
+        assert cache_key not in semantic_contract._CORPUS_CONTEXT_LANGUAGE_HASHES
+
+
+    def test_populate_on_miss_never_overwrites_a_slot_a_competitor_filled(
+        self,
+        vault: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """L2's other admission half: the slot must still be the one observed.
+
+        A concurrent cold build can install its own entry while this populate is
+        still walking. The populate observed an EMPTY slot; a slot that is no
+        longer empty means it lost the race, and losing means discarding, not
+        overwriting -- the analogue of the
+        `_CORPUS_CONTEXT_CACHE.get(cache_key) is entry` identity check every other
+        stamp site makes.
+        """
+        page = vault / _PAGE_REL
+        page.write_text(_corpus_page(title="One changed"), encoding="utf-8")
+        cache_key = semantic_contract._corpus_cache_key(vault)
+        competitor = (("competitor-census",), object())
+
+        real_build = semantic_contract._build_corpus_context_uncached
+        builds: list[str] = []
+
+        def build_then_lose_the_slot(root: Path, **kwargs):
+            builds.append("build")
+            context = real_build(root, **kwargs)
+            with semantic_contract._CORPUS_CONTEXT_CACHE_LOCK:
+                semantic_contract._CORPUS_CONTEXT_CACHE[cache_key] = competitor
+            return context
+
+        monkeypatch.setattr(
+            semantic_contract, "_build_corpus_context_uncached", build_then_lose_the_slot
+        )
+
+        semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
+
+        assert builds, "the populate must have built for this to be a real discard"
+        assert semantic_contract._CORPUS_CONTEXT_CACHE[cache_key] is competitor
+        assert cache_key not in semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS
+        assert cache_key not in semantic_contract._CORPUS_CONTEXT_LANGUAGE_HASHES
+
+
+# --- graph half (#508) ------------------------------------------------------
+
+INSIGHT_A = "Knowledge Base/Notes/Insights/contract-a.md"
+INSIGHT_B = "Knowledge Base/Notes/Insights/contract-b.md"
+INSIGHT_C = "Knowledge Base/Notes/Insights/contract-c.md"
+
+
+def _page(title: str, body: str) -> str:
+    return f"""---
+type: insight
+status: active
+---
+# {title}
+
+## Claim
+
+{body}
+"""
+
+
+def _seed_live_freshness(root: Path) -> None:
+    freshness.seed(
+        root,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault_module.walk_vault_md(root)),
+    )
+    kb = root / "Knowledge Base"
+    freshness.seed(
+        root,
+        "kb",
+        ((str(path), freshness.stat_signature(path)) for path in find_module._walk_md(kb)),
     )
 
-    censuses, builds = _spy_corpus_work(monkeypatch)
-    context = semantic_contract.build_corpus_context(vault)
-    assert (censuses, builds) == ([], [])
-    assert context.pages[_OTHER_REL].title == "Two changed"
-    assert context.pages[_PAGE_REL].title == "One changed"
+
+def _governed_write(root: Path, rel: str, content: str) -> Path:
+    """One governed write through the normal batch path, with post-commit fan-out."""
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(path, content)],
+        vault_root=root,
+    )
+    return path
 
 
-def test_registry_advance_failure_still_withdraws_vault_freshness(
-    vault: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Contract Class A: the registry-advance half failing IS registry loss.
-
-    Green before and after -- this is the guard that the narrowing in C1.1
-    stays narrow. `freshness.on_files_changed` raising means the event suffix
-    really is unknowable, so the full withdraw (invalidate + external pending)
-    remains correct and must survive the split seam.
-    """
-    semantic_contract.build_corpus_context(vault)
-    assert freshness.triple(vault, "vault") is not None
-
-    def boom(*_args, **_kwargs):
-        raise RuntimeError("registry advance failed")
-
-    monkeypatch.setattr(semantic_contract.freshness, "on_files_changed", boom)
-    page = vault / _PAGE_REL
-    page.write_text(_page(title="One changed"), encoding="utf-8")
-
-    assert index_sync.publish_corpus_delta(vault, changed=(page,)) is False
-
-    assert freshness.triple(vault, "vault") is None
-    assert freshness.is_live(vault, "vault") is False
-    assert freshness.external_pending(vault) is True
-    cache_key = semantic_contract._corpus_cache_key(vault)
-    assert cache_key not in semantic_contract._CORPUS_CONTEXT_CACHE
+def _drain_background_rebuilds(timeout: float = 20.0) -> None:
+    deadline = time.monotonic() + timeout
+    while epistemic_graph._REBUILDING and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert not epistemic_graph._REBUILDING, "a background graph rebuild did not finish"
 
 
-def test_publish_populates_a_cold_corpus_cache_for_the_next_reader(
-    vault: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Deliverable 8: the `entry is None` no-op must populate, not return.
-
-    Red on `main` for the contract's stated reason: `semantic_contract.py`'s
-    `_patch_corpus_files_changed_locked` returns silently when the cache holds
-    no entry (sc:1745-1746), so a write onto a cold cache leaves it cold and
-    the very next preflight pays a full stat census of the vault.
-    """
-    page = vault / _PAGE_REL
-    page.write_text(_page(title="One changed"), encoding="utf-8")
-
-    semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
-
-    cache_key = semantic_contract._corpus_cache_key(vault)
-    entry = semantic_contract._CORPUS_CONTEXT_CACHE.get(cache_key)
-    assert entry is not None
-    assert entry[1].pages[_PAGE_REL].title == "One changed"
-    assert semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS.get(cache_key) == freshness.triple(
-        vault, "vault"
+def preserved_temporaries(root: Path) -> list[Path]:
+    """Every retained `.graph-rebuild-*` artifact of a failed publication."""
+    kb = root / "Knowledge Base"
+    if not kb.is_dir():
+        return []
+    return sorted(
+        candidate
+        for candidate in kb.iterdir()
+        if vault_module.is_graph_rebuild_runtime_file_name(candidate.name)
     )
 
-    censuses, builds = _spy_corpus_work(monkeypatch)
-    context = semantic_contract.build_corpus_context(vault)
-    assert (censuses, builds) == ([], [])
-    assert context is entry[1]
 
+def refuse_graph_publication(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    """The existing injected-refusal idiom (tests/test_graph_rebuild_availability.py).
 
-def test_populate_on_miss_never_stamps_a_context_an_event_leapfrogged(
-    vault: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Contract L2/L3: the populate's admission gate is the consumer checkpoint.
-
-    The populate cannot hold `_CORPUS_CONTEXT_UPDATE_LOCK` across its own walk
-    (the publisher advances freshness under that lock), so it takes L2's shape:
-    capture `freshness.consumer_checkpoint` BEFORE the walk, then admit the
-    built context only if the checkpoint is unchanged and the cache slot is
-    still the empty one it observed. Here an external event lands mid-walk, so
-    the built context provably misses a delta the current token covers and must
-    be discarded rather than stamped.
+    Covers the Windows sharing-refusal branch on any platform.
     """
-    page = vault / _PAGE_REL
-    page.write_text(_page(title="One changed"), encoding="utf-8")
+    refused: list[Path] = []
 
-    other = vault / _OTHER_REL
-    builds: list[str] = []
-    real_build = semantic_contract._build_corpus_context_uncached
+    def refuse_replacement(temporary: Path, _live: Path) -> None:
+        refused.append(temporary)
+        raise graph_sync.GraphSidecarReplaceUnavailable("live graph sidecar has an open reader")
 
-    def build_with_racing_event(root: Path, **kwargs):
-        builds.append("build")
-        context = real_build(root, **kwargs)
-        # An external editor lands a change the registry sees, while this
-        # populate's walk is already behind it.
-        other.write_text(_page(title="Two leapfrogged"), encoding="utf-8")
-        freshness.on_files_changed(root, changed=(other,))
-        return context
+    monkeypatch.setattr(graph_sync, "replace_sidecar", refuse_replacement)
+    return refused
 
-    monkeypatch.setattr(
-        semantic_contract, "_build_corpus_context_uncached", build_with_racing_event
+
+def publication_cycle(root: Path, paths: list[Path], *, governed: tuple[str, str]) -> None:
+    """One production cycle in which the graph sidecar must be republished.
+
+    Every surface here is real and is named by the contract:
+
+    * the post-write graph fan-out (`index_sync.upsert_after_write`, the
+      watcher / deferred-drain shape that runs outside a writer-lease direct
+      mutation boundary).  A dispatched path outside the graph's retained event
+      suffix cannot be bridged incrementally, so the fan-out rebuilds and
+      publishes -- reaching `epistemic_graph.py`'s blanket `except Exception:
+      freshness.mark_external_pending(...)` on that write path;
+    * one governed write through the normal batch path, whose post-commit
+      fan-out must now rebuild (the sidecar is no longer current) and whose
+      refused publication leaves its graph checkpoint unacknowledged; and
+    * the read-side warming rebuild the same stale sidecar schedules
+      (`schedule_background_rebuild`), whose thread carries its own
+      `mark_external_pending` on any failure.
+    """
+    index_sync.upsert_after_write(root, paths, publish_corpus_change=False)
+    _governed_write(root, governed[0], governed[1])
+    epistemic_graph.schedule_background_rebuild(root)
+    _drain_background_rebuilds()
+
+
+@pytest.fixture
+def contract_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
+    root = tmp_path / "vault"
+    (root / "Knowledge Base/Notes/Insights").mkdir(parents=True)
+    (root / INSIGHT_A).write_text(
+        _page("Contract A", "A claims against [[contract-b]]."), encoding="utf-8"
     )
-    confirms: list[Path] = []
-    real_confirm = semantic_contract._deferred_corpus_census
-
-    def counted_confirm(root: Path, sink, outcome: str):
-        confirms.append(root)
-        return real_confirm(root, sink, outcome)
-
-    monkeypatch.setattr(semantic_contract, "_deferred_corpus_census", counted_confirm)
-
-    semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
-
-    assert builds, "the populate must have attempted a build to be a real discard"
-    # Attribution: the checkpoint decided this, not the census re-confirm that
-    # follows it. That is the point of L3 -- the generation-bearing checkpoint
-    # is the admission gate, and it is cheap enough to be consulted first.
-    assert confirms == []
-    cache_key = semantic_contract._corpus_cache_key(vault)
-    # Never stamp: the leapfrogged context must reach neither the cache nor
-    # the event-token map (contract L2 "on any mismatch discard ... never
-    # stamp", L5 "entry, token and language hash move together").
-    assert cache_key not in semantic_contract._CORPUS_CONTEXT_CACHE
-    assert cache_key not in semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS
-    assert cache_key not in semantic_contract._CORPUS_CONTEXT_LANGUAGE_HASHES
-
-    # And the next honest build sees BOTH deltas, so nothing was lost.
-    context = semantic_contract.build_corpus_context(vault)
-    assert context.pages[_PAGE_REL].title == "One changed"
-    assert context.pages[_OTHER_REL].title == "Two leapfrogged"
+    (root / INSIGHT_B).write_text(_page("Contract B", "B is a plain claim."), encoding="utf-8")
+    _seed_live_freshness(root)
+    epistemic_graph.EpistemicGraphIndex(root).rebuild_all()
+    semantic_contract.build_corpus_context(root)
+    return root
 
 
-def test_populate_on_miss_never_stamps_a_context_built_with_a_superseded_registry(
-    vault: Path, monkeypatch: pytest.MonkeyPatch
+def test_refused_graph_publication_does_not_cool_vault_freshness(
+    contract_vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The populate loads its registries BEFORE its walk, so it must re-prove
-    them against disk before installing.
+    root = contract_vault
 
-    `_corpus_census` stats the two `_Schema` registry files at the END of its
-    walk. A registry rewritten between the load and that stat therefore yields
-    a census that records the NEW file captioning a context built with the OLD
-    registry. The event-hit gate would refuse such an entry -- it re-checks the
-    registry identity -- but the census-reuse path admits on census equality
-    alone, and would hand that context back as current.
+    # --- Setup (contract 4): live freshness + a warm corpus entry through the
+    # normal governed path.
+    _governed_write(
+        root, INSIGHT_B, _page("Contract B", "B is a plain claim, now with a body edit.")
+    )
+    semantic_contract.build_corpus_context(root)
+    cache_key = semantic_contract._corpus_cache_key(root)
+    assert freshness.triple(root, "vault") is not None
+    assert semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS.get(cache_key) is not None
 
-    Every other install site guards with `_registries_match_disk`; this pins
-    that the populate does too.
-    """
-    page = vault / _PAGE_REL
-    page.write_text(_page(title="One changed"), encoding="utf-8")
-    registry_path = vault / _REGISTRY_REL
-    superseded = relation_registry.load_registry(vault)
+    pre_failure_edges = epistemic_graph.EpistemicGraphIndex(root).edges()
+    pre_failure_relations = {
+        (edge["source_path"], edge["relation_type"]) for edge in pre_failure_edges
+    }
+    assert pre_failure_relations, "the pre-failure sidecar must carry at least one relation"
 
+    # `mark_external_pending` allocates from one process-global, strictly
+    # increasing clock (freshness.py `_external_pending_clock`).  Sampling it on
+    # an unrelated root is how R1 -- "a Class B retry may never allocate a new
+    # external-pending epoch" -- becomes observable without patching production.
+    epoch_probe = tmp_path / "epoch-probe-root"
+    clock_before = freshness.mark_external_pending(epoch_probe)
+
+    # --- Act (contract 4): every graph publication is refused from here on.
+    refused = refuse_graph_publication(monkeypatch)
+
+    # A new page and its new relation arrive out of band (an external editor),
+    # observed by the registry exactly as the watcher observes it.  The graph
+    # fan-out also carries a sibling path outside the retained event suffix, so
+    # the graph must rebuild and publish rather than bridge.
+    new_page = root / INSIGHT_C
+    new_page.write_text(
+        _page("Contract C", "C claims against [[contract-a]]."), encoding="utf-8"
+    )
+    assert index_sync.publish_corpus_delta(root, changed=(new_page,)) is True
+    publication_cycle(
+        root,
+        [new_page, root / INSIGHT_A],
+        governed=(INSIGHT_B, _page("Contract B", "B gains a first governed body revision.")),
+    )
+    assert refused, "the fan-out must have attempted a graph publication"
+
+    # --- Assertion 1 (jointly owned): liveness preserved. -------------------
+    assert freshness.triple(root, "vault") is not None
+    assert freshness.is_live(root, "vault") is True
+    assert freshness.external_pending(root) is False
+
+    first_cycle_temporaries = preserved_temporaries(root)
+    refused_after_first_cycle = len(refused)
+
+    # --- A second cycle, so the retry bound is observable. -------------------
+    censuses: list[object] = []
     real_census = semantic_contract._corpus_census
-    walks: list[str] = []
 
-    def census_with_a_registry_rewrite(root: Path):
-        walks.append(str(root))
-        if len(walks) == 1:
-            # Interleaved into the populate's own walk window: the registry
-            # this census is about to stat is no longer the one in hand.
-            registry_path.parent.mkdir(parents=True, exist_ok=True)
-            registry_path.write_text(_EXTENDED_REGISTRY, encoding="utf-8")
-        return real_census(root)
+    def counting_census(*args: object, **kwargs: object) -> object:
+        censuses.append(args)
+        return real_census(*args, **kwargs)
 
-    monkeypatch.setattr(semantic_contract, "_corpus_census", census_with_a_registry_rewrite)
-
-    semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
-
-    assert walks, "the populate must have walked for this to be a real discard"
-    assert relation_registry.load_registry(vault).extension_hash != superseded.extension_hash
-    cache_key = semantic_contract._corpus_cache_key(vault)
-    assert cache_key not in semantic_contract._CORPUS_CONTEXT_CACHE
-    assert cache_key not in semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS
-    assert cache_key not in semantic_contract._CORPUS_CONTEXT_LANGUAGE_HASHES
-
-
-def test_populate_on_miss_never_overwrites_a_slot_a_competitor_filled(
-    vault: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """L2's other admission half: the slot must still be the one observed.
-
-    A concurrent cold build can install its own entry while this populate is
-    still walking. The populate observed an EMPTY slot; a slot that is no
-    longer empty means it lost the race, and losing means discarding, not
-    overwriting -- the analogue of the
-    `_CORPUS_CONTEXT_CACHE.get(cache_key) is entry` identity check every other
-    stamp site makes.
-    """
-    page = vault / _PAGE_REL
-    page.write_text(_page(title="One changed"), encoding="utf-8")
-    cache_key = semantic_contract._corpus_cache_key(vault)
-    competitor = (("competitor-census",), object())
-
-    real_build = semantic_contract._build_corpus_context_uncached
-    builds: list[str] = []
-
-    def build_then_lose_the_slot(root: Path, **kwargs):
-        builds.append("build")
-        context = real_build(root, **kwargs)
-        with semantic_contract._CORPUS_CONTEXT_CACHE_LOCK:
-            semantic_contract._CORPUS_CONTEXT_CACHE[cache_key] = competitor
-        return context
-
-    monkeypatch.setattr(
-        semantic_contract, "_build_corpus_context_uncached", build_then_lose_the_slot
+    monkeypatch.setattr(semantic_contract, "_corpus_census", counting_census)
+    publication_cycle(
+        root,
+        [new_page, root / INSIGHT_A],
+        governed=(INSIGHT_B, _page("Contract B", "B gains a second governed body revision.")),
     )
+    semantic_contract.build_corpus_context(root)
+    monkeypatch.setattr(semantic_contract, "_corpus_census", real_census)
 
-    semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
+    assert freshness.triple(root, "vault") is not None
+    assert freshness.is_live(root, "vault") is True
+    assert freshness.external_pending(root) is False
 
-    assert builds, "the populate must have built for this to be a real discard"
-    assert semantic_contract._CORPUS_CONTEXT_CACHE[cache_key] is competitor
-    assert cache_key not in semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS
-    assert cache_key not in semantic_contract._CORPUS_CONTEXT_LANGUAGE_HASHES
+    # --- Assertion 2 (#510): the corpus cache stays warm. -------------------
+    assert semantic_contract._CORPUS_CONTEXT_EVENT_TOKENS.get(cache_key) == freshness.triple(
+        root, "vault"
+    )
+    assert semantic_contract.cached_corpus_census(root) is not None
+    assert censuses == [], "a refused graph publication must not cost a full-vault census"
+
+    # --- Assertion 3 (#508): graph fails closed, serves nothing as current. --
+    index = epistemic_graph.EpistemicGraphIndex(root)
+    assert index.available() is False
+    assert graph_sync.status(root)["state"] in {"recovery_required", "unavailable"}
+    served = {(edge["source_path"], edge["relation_type"]) for edge in index.edges()}
+    assert served == set(), "a refused publication must serve no sidecar rows as current"
+    assert not (served & pre_failure_relations)
+    assert INSIGHT_C not in {str(node.get("path")) for node in index.nodes()}
+    assert index.relation_participants(["supports"]).status != "available"
+
+    # --- Assertion 4 (#508): bounded, not looping. --------------------------
+    assert len(first_cycle_temporaries) <= 1, (
+        "a refused publication may leave at most one preserved temporary per checkpoint"
+    )
+    assert len(preserved_temporaries(root)) <= 1
+    assert freshness.external_pending_epoch(root) is None
+    clock_after = freshness.mark_external_pending(epoch_probe)
+    assert clock_after == clock_before + 1, (
+        "a Class B retry must allocate no new external-pending epoch (contract R1)"
+    )
+    assert len(refused) > refused_after_first_cycle, (
+        "the second cycle must still have retried the publication"
+    )

--- a/tests/test_freshness_liveness_contract.py
+++ b/tests/test_freshness_liveness_contract.py
@@ -759,8 +759,12 @@ def test_watcher_recovery_allocates_no_new_epoch_for_a_refused_publication(
     )
 
 
+@pytest.mark.parametrize("graph_scheduling", [True, False], ids=["scheduled", "disabled"])
 def test_watcher_drain_allocates_no_epoch_when_the_fan_out_publication_is_refused(
-    contract_vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    contract_vault: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    graph_scheduling: bool,
 ) -> None:
     """D4: the drain's own completeness check is a third door onto the registry.
 
@@ -771,12 +775,20 @@ def test_watcher_drain_allocates_no_epoch_when_the_fan_out_publication_is_refuse
     a fresh epoch on *every* drain cycle. That is the self-sustaining loop the
     contract exists to end, and it falsifies the D7 precondition that
     `external_pending` is set only by Class A and Class C.
+
+    The `disabled` case is the same site reached the other way: with
+    `EXOMEM_DISABLE_GRAPH_SCHEDULING=1` — the mitigation deployed today — no
+    publication is even attempted, so the graph is *configured* not to be
+    current. That is not a failure to classify either, and it must not cool the
+    registry for as long as the mitigation is on.
     """
     from exomem.file_watcher import FileWatcher
 
     root = contract_vault
     _governed_write(root, INSIGHT_B, _page("Contract B", "B revised once."))
     refuse_graph_publication(monkeypatch)
+    if not graph_scheduling:
+        monkeypatch.setenv("EXOMEM_DISABLE_GRAPH_SCHEDULING", "1")
     watcher = FileWatcher(root)
 
     epoch_probe = tmp_path / "epoch-probe-root"

--- a/tests/test_freshness_liveness_contract.py
+++ b/tests/test_freshness_liveness_contract.py
@@ -824,6 +824,61 @@ def test_watcher_drain_allocates_no_epoch_when_the_fan_out_publication_is_refuse
     )
 
 
+def test_watcher_drain_still_marks_unclassified_graph_incompleteness(
+    contract_vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D3/D4: the fail-closed default the two carve-outs are carved out of.
+
+    The drain site has exactly two reasons not to mark -- a refused publication
+    (Class B, memoized by the projection) and scheduling deliberately off -- and
+    both are pinned above. This pins the branch they are exceptions to: a graph
+    that is simply not current, with no refusal recorded and scheduling on, is
+    an incompleteness this module cannot classify, so it must keep cooling the
+    registry exactly as it did before the contract landed.
+
+    Without this test a future widening of either carve-out could swallow a
+    genuine Class A signal with the whole suite still green.
+    """
+    from exomem.file_watcher import FileWatcher
+
+    root = contract_vault
+    _governed_write(root, INSIGHT_B, _page("Contract B", "B revised once."))
+    epistemic_graph.clear_publication_memos()
+
+    # A graph dispatch that fails without ever attempting -- let alone being
+    # refused -- a publication: nothing writes a refusal memo, so neither
+    # carve-out can apply.
+    def deferred_without_publishing(*_args: object, **_kwargs: object):
+        return epistemic_graph.GraphDispatchResult("failed", "graph_dispatch_failed")
+
+    monkeypatch.setattr(epistemic_graph, "upsert_after_write", deferred_without_publishing)
+
+    watcher = FileWatcher(root)
+    epoch_probe = tmp_path / "epoch-probe-root"
+    clock_before = freshness.mark_external_pending(epoch_probe)
+
+    edited = root / INSIGHT_A
+    edited.write_text(
+        _page("Contract A", "A claims against [[contract-b]] -- unclassified."),
+        encoding="utf-8",
+    )
+    pending_epoch = freshness.mark_external_pending(root)
+    watcher._dispatch_batch(
+        [edited], [INSIGHT_A], [], cap=False, pending_epoch=pending_epoch
+    )
+
+    # Neither carve-out was available, so the default had to fire.
+    assert epistemic_graph.publication_refusal_active(root) is False
+    assert epistemic_graph.graph_scheduling_enabled() is True
+    assert epistemic_graph.EpistemicGraphIndex(root).available() is False
+    assert freshness.external_pending(root) is True, (
+        "an unclassified graph incompleteness must still fail closed"
+    )
+    clock_after = freshness.mark_external_pending(epoch_probe)
+    # One watchdog observation, one mark from the drain site, one probe.
+    assert clock_after == clock_before + 3
+
+
 def test_refused_publication_is_memoized_instead_of_retried_at_full_cost(
     contract_vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_freshness_liveness_contract.py
+++ b/tests/test_freshness_liveness_contract.py
@@ -31,7 +31,9 @@ half's fixtures.
 
 from __future__ import annotations
 
+import sqlite3
 import time
+from contextlib import closing
 from pathlib import Path
 
 import pytest
@@ -46,6 +48,7 @@ from exomem import (
 )
 from exomem import find as find_module
 from exomem import vault as vault_module
+from exomem.cli_ops import OpError
 
 _PAGE_REL = "Knowledge Base/Notes/Insights/one.md"
 _OTHER_REL = "Knowledge Base/Notes/Insights/two.md"
@@ -401,6 +404,15 @@ INSIGHT_B = "Knowledge Base/Notes/Insights/contract-b.md"
 INSIGHT_C = "Knowledge Base/Notes/Insights/contract-c.md"
 
 
+def _contract_checkpoint(generation: int) -> graph_sync.GraphSyncCheckpoint:
+    return graph_sync.GraphSyncCheckpoint.create(
+        generation=generation,
+        mutation_id=f"{generation:024x}",
+        paths=((INSIGHT_A, "d" * 64),),
+        created_paths=(INSIGHT_A,),
+    )
+
+
 def _page(title: str, body: str) -> str:
     return f"""---
 type: insight
@@ -618,3 +630,200 @@ def test_refused_graph_publication_does_not_cool_vault_freshness(
     assert len(refused) > refused_after_first_cycle, (
         "the second cycle must still have retried the publication"
     )
+
+
+# ---------------------------------------------------------------------------
+# Deliverables owned by the #508 lane. The shared test above pins the joint
+# outcome; these pin each clause the contract assigns to graph publish hygiene.
+# ---------------------------------------------------------------------------
+
+
+def test_class_c_marking_is_narrowed_to_a_moved_projection(
+    contract_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D2: only a proven-stale projection may mark, not any non-stabilization."""
+    root = contract_vault
+    index = epistemic_graph.EpistemicGraphIndex(root)
+
+    # A projection that provably moved under the in-flight proof: the supplied
+    # freshness identity does not name the resolver bytes.
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex,
+        "_resolver_source_versions",
+        lambda *_args, **_kwargs: None,
+    )
+    with pytest.raises(epistemic_graph.GraphProjectionMoved, match="did not stabilize"):
+        index._rebuild_all_locked()
+    assert freshness.external_pending(root) is True
+    moved_epoch = freshness.external_pending_epoch(root)
+    assert moved_epoch is not None
+    monkeypatch.undo()
+
+    freshness.clear_external_pending(root, through=moved_epoch)
+    assert freshness.external_pending(root) is False
+
+    # A marker that would not publish is a publication failure. It is *not*
+    # evidence that the registry fell behind the disk, so it may not mark.
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex,
+        "_mark_available",
+        lambda *_args, **_kwargs: False,
+    )
+    with pytest.raises(RuntimeError, match="did not stabilize") as raised:
+        epistemic_graph.EpistemicGraphIndex(root)._rebuild_all_locked()
+    assert not isinstance(raised.value, epistemic_graph.GraphProjectionMoved)
+    assert freshness.external_pending(root) is False
+
+
+def test_publication_failure_records_graph_recovery_state_not_vault_freshness(
+    contract_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D3: a Class B write-path failure fences the graph and leaves freshness alone."""
+    root = contract_vault
+    _governed_write(root, INSIGHT_B, _page("Contract B", "B revised once."))
+    refuse_graph_publication(monkeypatch)
+
+    index_sync.upsert_after_write(root, [root / INSIGHT_A], publish_corpus_change=False)
+
+    assert freshness.external_pending(root) is False
+    assert freshness.is_live(root, "vault") is True
+    index = epistemic_graph.EpistemicGraphIndex(root)
+    # The graph's own fence: idempotent under retry, and cleared by
+    # `file_watcher._recover_suspended_graph`.
+    assert index.reads_suspended() is True
+    assert index.available() is False
+    assert epistemic_graph.publication_refusal_active(root) is True
+
+
+def test_unclassifiable_dispatch_failure_still_marks_the_registry(
+    contract_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D3: only *classified* failures are downgraded; the rest keep marking."""
+    root = contract_vault
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex,
+        "refresh_paths",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("unclassified")),
+    )
+
+    epistemic_graph.upsert_after_write(root, [root / INSIGHT_A])
+
+    assert freshness.external_pending(root) is True
+
+
+def test_classification_covers_the_contract_named_class_b_members() -> None:
+    """D3: the classifier, stated directly against contract section 1."""
+    assert epistemic_graph.is_publication_failure(graph_sync.GraphSidecarReplaceUnavailable())
+    assert epistemic_graph.is_publication_failure(
+        graph_sync.GraphRebuildLockUnavailable("secure graph rebuild lock unavailable")
+    )
+    assert epistemic_graph.is_publication_failure(
+        epistemic_graph.GraphPublicationUnavailable("owner lost")
+    )
+    assert epistemic_graph.is_publication_failure(OpError("MUTATION_BUSY", "busy"))
+    assert not epistemic_graph.is_publication_failure(OpError("VAULT_UNREADABLE", "gone"))
+    assert not epistemic_graph.is_publication_failure(ValueError("unclassified"))
+    # Class C already marked exactly once; a caller may not mark again (R1).
+    assert not epistemic_graph.may_mark_external_pending(
+        epistemic_graph.GraphProjectionMoved("moved")
+    )
+    assert epistemic_graph.may_mark_external_pending(ValueError("unclassified"))
+
+
+def test_watcher_recovery_allocates_no_new_epoch_for_a_refused_publication(
+    contract_vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D4: the 300 s recovery loop must not re-contaminate the registry (R1/R2)."""
+    from exomem.file_watcher import FileWatcher
+
+    root = contract_vault
+    _governed_write(root, INSIGHT_B, _page("Contract B", "B revised once."))
+    refuse_graph_publication(monkeypatch)
+
+    watcher = FileWatcher(root)
+    pending_epoch = freshness.mark_external_pending(root)
+    epoch_probe = tmp_path / "epoch-probe-root"
+    clock_before = freshness.mark_external_pending(epoch_probe)
+
+    watcher._recover_external_pending(pending_epoch)
+    first_epoch = freshness.external_pending_epoch(root)
+
+    # A second cycle over the same doomed publication.
+    watcher._recover_external_pending(pending_epoch)
+    watcher._recover_suspended_graph()
+
+    assert freshness.external_pending_epoch(root) == first_epoch
+    clock_after = freshness.mark_external_pending(epoch_probe)
+    assert clock_after == clock_before + 1, (
+        "each recovery cycle must not allocate a fresh external-pending epoch"
+    )
+
+
+def test_refused_publication_is_memoized_instead_of_retried_at_full_cost(
+    contract_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D5: the lexstore `_REPAIRS_IN_FLIGHT` shape, applied to graph publication."""
+    root = contract_vault
+    _governed_write(root, INSIGHT_B, _page("Contract B", "B revised once."))
+    refuse_graph_publication(monkeypatch)
+    epistemic_graph.clear_publication_memos()
+
+    assert epistemic_graph.schedule_background_rebuild(root) is True
+    _drain_background_rebuilds()
+
+    assert epistemic_graph.publication_refusal_active(root) is True
+    assert epistemic_graph.schedule_background_rebuild(root) is False, (
+        "the same doomed publication must not be re-attempted at full rebuild cost"
+    )
+
+    # The memo is projection-local and bounded: clearing it restores the retry.
+    epistemic_graph.clear_publication_memos()
+    assert epistemic_graph.schedule_background_rebuild(root) is True
+    _drain_background_rebuilds()
+
+
+def test_repeated_refusal_keeps_at_most_one_preserved_temporary(
+    contract_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D6: `preserve_temporary` is bounded; the 527 MB orphan field cannot recur."""
+    root = contract_vault
+    _governed_write(root, INSIGHT_B, _page("Contract B", "B revised once."))
+    refused = refuse_graph_publication(monkeypatch)
+    index = epistemic_graph.EpistemicGraphIndex(root)
+
+    for cycle in range(4):
+        with pytest.raises(graph_sync.GraphRebuildRegistrationError):
+            index.rebuild_all()
+        retained = preserved_temporaries(root)
+        assert len(retained) <= 1, f"cycle {cycle} retained {len(retained)}: {retained}"
+
+    assert len(refused) >= 4
+    retained = preserved_temporaries(root)
+    assert len(retained) == 1
+    # The survivor is the newest complete build, still recoverable.
+    with closing(sqlite3.connect(retained[0])) as conn:
+        assert conn.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+
+
+def test_reaper_never_collects_an_in_flight_registered_temporary(
+    contract_vault: Path,
+) -> None:
+    """D6: a build another owner still holds is not an orphan."""
+    root = contract_vault
+    live = epistemic_graph.sidecar_path(root)
+    in_flight = graph_sync.temporary_sidecar_path(live, _contract_checkpoint(1))
+    orphan_older = graph_sync.temporary_sidecar_path(live, _contract_checkpoint(2))
+    orphan_newer = graph_sync.temporary_sidecar_path(live, _contract_checkpoint(3))
+    for path in (in_flight, orphan_older, orphan_newer):
+        path.write_bytes(b"sqlite artifact")
+        time.sleep(0.02)
+    graph_sync.register_temporary(in_flight)
+    try:
+        removed = epistemic_graph._reap_preserved_temporaries(live)
+    finally:
+        graph_sync.unregister_temporary(in_flight.resolve())
+
+    assert in_flight.exists()
+    assert orphan_newer.exists()
+    assert not orphan_older.exists()
+    assert removed == [orphan_older]

--- a/tests/test_freshness_liveness_contract.py
+++ b/tests/test_freshness_liveness_contract.py
@@ -759,6 +759,59 @@ def test_watcher_recovery_allocates_no_new_epoch_for_a_refused_publication(
     )
 
 
+def test_watcher_drain_allocates_no_epoch_when_the_fan_out_publication_is_refused(
+    contract_vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D4: the drain's own completeness check is a third door onto the registry.
+
+    `_dispatch_batch` withdraws the graph marker, compare-and-acks the drained
+    epoch, fans out, and then asserts the graph came back current. When the
+    fan-out's publication is refused (Class B) the barrier is still set, so that
+    assertion fails and the drain marks the vault externally pending again --
+    a fresh epoch on *every* drain cycle. That is the self-sustaining loop the
+    contract exists to end, and it falsifies the D7 precondition that
+    `external_pending` is set only by Class A and Class C.
+    """
+    from exomem.file_watcher import FileWatcher
+
+    root = contract_vault
+    _governed_write(root, INSIGHT_B, _page("Contract B", "B revised once."))
+    refuse_graph_publication(monkeypatch)
+    watcher = FileWatcher(root)
+
+    epoch_probe = tmp_path / "epoch-probe-root"
+    clock_before = freshness.mark_external_pending(epoch_probe)
+
+    for cycle, body in enumerate(("first external edit", "second external edit")):
+        edited = root / INSIGHT_A
+        edited.write_text(
+            _page("Contract A", f"A claims against [[contract-b]] -- {body}."),
+            encoding="utf-8",
+        )
+        # Exactly what `_record` does when watchdog observes an out-of-band edit.
+        pending_epoch = freshness.mark_external_pending(root)
+        watcher._dispatch_batch(
+            [edited],
+            [INSIGHT_A],
+            [],
+            cap=False,
+            pending_epoch=pending_epoch,
+        )
+        assert freshness.external_pending(root) is False, (
+            f"drain {cycle} re-armed the vault for a refused publication"
+        )
+        assert freshness.is_live(root, "vault") is True
+        # The graph is fenced by the barrier it owns, which is idempotent under
+        # retry -- that is what replaces the epoch.
+        assert epistemic_graph.EpistemicGraphIndex(root).reads_suspended() is True
+
+    clock_after = freshness.mark_external_pending(epoch_probe)
+    # Two legitimate Class A observations plus this probe: nothing else.
+    assert clock_after == clock_before + 3, (
+        "a refused fan-out publication must allocate no external-pending epoch"
+    )
+
+
 def test_refused_publication_is_memoized_instead_of_retried_at_full_cost(
     contract_vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_graph_rebuild_availability.py
+++ b/tests/test_graph_rebuild_availability.py
@@ -2839,7 +2839,9 @@ def test_live_sidecar_readers_are_registered_and_drained_for_a_publication_hold(
 
     # A reader whose owning thread is gone can never close itself; the hold is
     # the only place it is safe to collect one.
-    leaked: list[object] = []
+    import sqlite3
+
+    leaked: list = []
 
     def leak_a_reader() -> None:
         leaked.append(index._open_read_snapshot())
@@ -2854,6 +2856,10 @@ def test_live_sidecar_readers_are_registered_and_drained_for_a_publication_hold(
     try:
         assert held == key
         assert not epistemic_graph._SIDECAR_READERS.get(key)
+        # Really closed, not merely deregistered: a handle that stays open is
+        # still blocking the replacement the hold exists to enable.
+        with pytest.raises(sqlite3.ProgrammingError):
+            leaked[0].execute("SELECT 1")
         # Single flight: a second publisher does not get the same hold.
         assert epistemic_graph._acquire_publication_hold(index.path) is None
     finally:

--- a/tests/test_graph_rebuild_availability.py
+++ b/tests/test_graph_rebuild_availability.py
@@ -2702,3 +2702,164 @@ def test_temp_sweep_removes_abandoned_sqlite_companions_but_keeps_active_set(
     assert set(removed) == set(abandoned_set)
     assert all(not path.exists() for path in abandoned_set)
     assert all(path.exists() for path in active_set)
+
+
+# --- Publication robustness: the replace must not depend on a reader leaving --
+
+
+def _refuse_replacement_onto(monkeypatch: pytest.MonkeyPatch, live: Path) -> None:
+    """Model Windows refusing `os.replace` onto one open destination only.
+
+    Patching `os.replace` wholesale would also break the vault mutation lock,
+    which uses it for unrelated runtime state.
+    """
+    real_replace = os.replace
+
+    def refuse_for_live(source, destination, *args, **kwargs):
+        try:
+            refused = Path(destination) == live
+        except TypeError:  # pragma: no cover - descriptor-based call
+            refused = False
+        if refused:
+            raise PermissionError("live graph sidecar has an open reader")
+        return real_replace(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(graph_sync.os, "replace", refuse_for_live)
+
+
+def test_refused_replacement_publishes_in_place_without_moving_the_live_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A reader that never lets go no longer costs the vault its publication.
+
+    Windows refuses `os.replace` while any handle is open on the destination.
+    Publishing the same proven bytes *into* the existing file leaves the
+    directory entry — and therefore every open handle — intact, which is what
+    lets a resident service's reader see the new content instead of pinning the
+    old sidecar forever.
+    """
+    import sqlite3
+
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/in-place-publish.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, "# Before\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    index = EpistemicGraphIndex(tmp_path)
+    index.rebuild_all()
+    live = index.path
+    identity_before = live.stat()
+    note.write_text("# After the refused replacement\n", encoding="utf-8")
+
+    _refuse_replacement_onto(monkeypatch, live)
+    # A reader that stays open across the whole publication, exactly the
+    # resident-service condition the issue reports.
+    with closing(sqlite3.connect(f"{live.resolve().as_uri()}?mode=ro", uri=True)) as reader:
+        reader.execute("SELECT COUNT(*) FROM graph_meta").fetchone()
+
+        index.rebuild_all()
+
+        published = dict(
+            reader.execute(
+                "SELECT key, value FROM graph_meta WHERE key IN "
+                "('schema_version', 'recall_projection_identity')"
+            ).fetchall()
+        )
+
+    identity_after = live.stat()
+    assert (identity_after.st_dev, identity_after.st_ino) == (
+        identity_before.st_dev,
+        identity_before.st_ino,
+    ), "an in-place publication must not move the live directory entry"
+    assert published.get("schema_version") is not None
+    assert published.get("recall_projection_identity") is not None
+    assert index.available() is True
+    assert not list(
+        live.parent.glob(".graph-rebuild-*.sqlite")
+    ), "a landed publication leaves no preserved temporary"
+
+
+def test_publication_refused_by_both_paths_still_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When neither publication path can land, the old sidecar survives intact."""
+    from exomem import epistemic_graph
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/both-paths-refused.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, "# Before\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    index = EpistemicGraphIndex(tmp_path)
+    index.rebuild_all()
+    old_live = index.path.read_bytes()
+    note.write_text("# After\n", encoding="utf-8")
+    epistemic_graph.clear_publication_memos()
+
+    _refuse_replacement_onto(monkeypatch, index.path)
+    monkeypatch.setattr(graph_sync, "_publish_sidecar_in_place", lambda *_args: False)
+
+    with pytest.raises(graph_sync.GraphSidecarReplaceUnavailable):
+        index.rebuild_all()
+
+    assert index.path.read_bytes() == old_live
+    retained = list(index.path.parent.glob(".graph-rebuild-*.sqlite"))
+    assert len(retained) == 1, "exactly one complete build stays recoverable"
+    assert epistemic_graph.publication_refusal_active(tmp_path) is True
+
+
+def test_live_sidecar_readers_are_registered_and_drained_for_a_publication_hold(
+    tmp_path: Path,
+) -> None:
+    """The publisher owns an in-process registry of live-sidecar readers."""
+    from exomem import epistemic_graph
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/reader-registry.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, "# Registry\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    index = EpistemicGraphIndex(tmp_path)
+    index.rebuild_all()
+    key = epistemic_graph._sidecar_registry_key(index.path)
+    epistemic_graph.reset_publication_holds()
+
+    snapshot = index._open_read_snapshot()
+    assert snapshot is not None
+    assert len(epistemic_graph._SIDECAR_READERS.get(key, {})) == 1
+    snapshot.close()
+    assert key not in epistemic_graph._SIDECAR_READERS
+
+    # A reader whose owning thread is gone can never close itself; the hold is
+    # the only place it is safe to collect one.
+    leaked: list[object] = []
+
+    def leak_a_reader() -> None:
+        leaked.append(index._open_read_snapshot())
+
+    worker = threading.Thread(target=leak_a_reader)
+    worker.start()
+    worker.join(10)
+    assert leaked and leaked[0] is not None
+    assert len(epistemic_graph._SIDECAR_READERS.get(key, {})) == 1
+
+    held = epistemic_graph._acquire_publication_hold(index.path)
+    try:
+        assert held == key
+        assert not epistemic_graph._SIDECAR_READERS.get(key)
+        # Single flight: a second publisher does not get the same hold.
+        assert epistemic_graph._acquire_publication_hold(index.path) is None
+    finally:
+        epistemic_graph._release_publication_hold(held)
+    assert key not in epistemic_graph._SIDECAR_PUBLICATION_HOLDS
+    # A released hold lets readers back in immediately.
+    reopened = index._open_read_snapshot()
+    assert reopened is not None
+    reopened.close()


### PR DESCRIPTION
## What

#508 under the freshness-liveness contract (posted on the issue): the graph
sidecar publish no longer depends on a reader disappearing, and a publication
failure no longer poisons vault freshness.

- **Classification before marking (contract D2-D4)**: `proof_invalidated` is
  narrowed to the two genuine proven-stale causes; the five write-path sites
  and BOTH watcher recovery functions route through a classifier — a
  publication failure (Class B) records the graph's own read barrier plus a
  refusal memo and never touches vault freshness; anything unclassifiable
  still marks (fail-closed, pinned by a mutation-tested test). Review found —
  and the lane then found a second route to — a **third door** in the
  watcher's main drain (`_dispatch_batch`): a refused publication, and equally
  the deployed `EXOMEM_DISABLE_GRAPH_SCHEDULING=1` mitigation (no publication
  → no memo), each caused a fresh external-pending epoch EVERY 300 s cycle.
  Both routes are classified now and pinned by a parametrized drain test —
  meaning the mitigation flag itself had been feeding the freshness
  contamination it was deployed to avoid.
- **Single-flight refusal memo (D5)**: keyed to the exact checkpoint, cleared
  on successful publish / checkpoint change / 60 s / restart — a known-doomed
  publish is not re-attempted at full rebuild cost every cycle, and retries
  allocate no epochs (contract R1).
- **Orphan reaping (D6)**: unowned `.graph-rebuild-*` temporaries are reaped
  under the same cross-process `claim_rebuild_owner` discipline as the
  existing sweeper (review-hardened: an out-of-process repair's in-flight
  build — deliberately made the OLDEST in the adversarial test — survives
  because of the claim, not recency), keeping at most the newest recoverable
  one. Repeated refusal is test-pinned to ≤1 preserved temporary.
- **Publish robustness**: `_before_publish_replacement` takes a real
  (Windows-gated) reader hold — abandoned readers are closed, live ones are
  published around via a SQLite backup-API in-place fallback inside
  `replace_sidecar` (readers see complete-old or complete-new, never a torn
  db; byte-identity pinned on double-failure). Linux keeps the plain
  `os.replace` fast path; the Windows branches are covered on any OS via
  injected PermissionError fakes.
- **D7**: the `external_pending` read gate is KEPT as a documented
  optimization, contingent on the classification (the real fences — identity
  re-proof, read barrier, acknowledgement — are §2.1's, verified present),
  with the docstring naming the three maintenance readers the gate also
  serves.
- The shared defending test (contract §4) ships with all four assertions; the
  file now unions both lanes' halves (20 tests) with the corpus fixture scoped
  to its class.

## Deployment caveat (deliberate, recorded)

The write-latency loop closes **conditionally on the in-place publish working
against the live resident-service reader**, which has not yet been exercised in
production. Keep `EXOMEM_DISABLE_GRAPH_SCHEDULING=1` until the observation
signal appears after deploy: a rebuild completing with **no**
`GRAPH_SYNC_PLATFORM_SHARING_REFUSED` and **no** new `.graph-rebuild-*`
artifact while the service is live and serving reads. (Post-this-PR, the flag
no longer costs freshness epochs while set.) A deliberate WAL adoption for the
sidecar is noted as a possible follow-up; the in-place path's docstrings
describe rollback-journal reality (open handles vs open read transactions).

## Verification

- The shared defending test was committed RED first at the fork point with the
  contract's exact predicted failures (epoch allocation per cycle, unbounded
  temporaries); every subsequent finding carries its own verbatim red/green in
  the lane record, including the drain test red on both routes and the
  adversarial reaper red.
- Independent review (REQUEST_CHANGES) → correction rounds → targeted recheck:
  **all findings FIXED, independently verified** (the recheck re-ran the
  drain, reaper, and platform tests itself and comm-diffed the 16-file
  graph/watcher/freshness suite against a fork-point baseline: **zero
  lane-only failures**; one baseline-only failure the lane fixes).
- At the pushed tip: contract file 20 passed; publish-robustness subset 3
  passed; schema gates 19 passed (no digest movement); `uvx ruff check
  --select F` clean repo-wide; the post-rebase run on top of #540's
  semantic_contract/index_sync changes shows zero new failures.

Closes #508
