### PR TITLE
chore(graph): unbreak main's ruff gate on the sidecar reader registry

### DIFF
--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -399,9 +399,7 @@ _SIDECAR_READERS_CHANGED = threading.Condition(_SIDECAR_READERS_LOCK)
 # Weak references only: a registry that pinned its connections would keep the
 # very file handles alive that make a Windows replacement impossible, and a
 # reader leaked on an exception path would never be collected.
-_SIDECAR_READERS: dict[
-    str, dict[int, tuple["weakref.ref[sqlite3.Connection]", int]]
-] = {}
+_SIDECAR_READERS: dict[str, dict[int, tuple[weakref.ref[sqlite3.Connection], int]]] = {}
 _SIDECAR_PUBLICATION_HOLDS: set[str] = set()
 
 PUBLICATION_READER_DRAIN_SECONDS = 1.0

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -245,6 +245,12 @@ _PUBLICATION_FAILURE_OP_CODES = frozenset(
 class GraphPublicationUnavailable(graph_sync.GraphRebuildRegistrationError):
     """A rebuild proved nothing stale but still could not publish (Class B)."""
 
+    # The targeted type gate runs with `--follow-imports skip`, so the base class
+    # resolves to `Any` and `BaseException.args` is invisible.  Without this
+    # declaration the rewrite below reads `self.args` to compute the value it
+    # assigns to `self.args`, and mypy reports a circular `has-type` error.
+    args: tuple[Any, ...]
+
     def __init__(self, message: str) -> None:
         super().__init__(
             "GRAPH_SYNC_PUBLICATION_UNAVAILABLE",


### PR DESCRIPTION
PR #541 was merged while its own `lint + targeted types` check was already failing, so `main` is currently red on a single ruff error:

```
UP037 [*] Remove quotes from type annotation
   --> src/exomem/epistemic_graph.py:403:26
Found 1 error.
```

`epistemic_graph.py` is in the targeted Ruff gate's explicit file list, and `weakref` is a plain top-level import in that module, so the quotes around `weakref.ref[sqlite3.Connection]` are genuinely unnecessary. Every branch updated from main inherits the failure — it is what turned PR #532 red after `update-branch` — which blocks the follow-up release.

Lint-only, no behaviour change: the annotation still evaluates at runtime (`weakref.ref` has been generic since 3.9, and the module carries `from __future__ import annotations` regardless).

Verification:
- `uvx ruff check src/exomem/epistemic_graph.py --select E,F,I,B,UP,BLE` → `All checks passed!`
- `python -c "import weakref, sqlite3; dict[str, dict[int, tuple[weakref.ref[sqlite3.Connection], int]]]"` → OK