### PR TITLE
fix(index): index the vault when its root is reached through a symlink

### DIFF
--- a/benchmarks/lme/runner.py
+++ b/benchmarks/lme/runner.py
@@ -58,6 +58,22 @@ from .normalize import ingest_field_groups, neutralize, render_neutral_session
 from equivalence.selection import CANONICAL_LME_S_SOURCE, load_frozen_lme_selection, select_lme_s_25
 
 
+def _dataset_case_count(dataset: LmeDataset) -> int:
+    """Rows in the pinned source, including any this parse deferred.
+
+    `DatasetIdentity` pairs this count with a sha256 taken over the whole file,
+    so it has to describe the file rather than our yield from it. Scoped
+    deferral makes those two numbers diverge: `len(questions)` silently became
+    "rows we could parse" the moment a bad row could be carried instead of
+    raised, which would label a 500-row digest as 493 cases.
+
+    The census covers every source row. It is empty only for datasets built
+    directly rather than loaded — pilot slices, fixtures — where the questions
+    are all the rows there are.
+    """
+    return len(dataset.census) or len(dataset.questions)
+
+
 class LmeRunInvalid(RuntimeError):
     """The run was invalidated by an environment fault and has no score."""
 
@@ -607,7 +623,7 @@ def execute_run(
         source="xiaowu0162/longmemeval-cleaned",
         revision=(CANONICAL_LME_S_SOURCE["revision"] if config.canonical_selection else config.dataset_revision or "fixture-local"),
         sha256=dataset_checksum,
-        case_count=len(parent_dataset.questions),
+        case_count=_dataset_case_count(parent_dataset),
     )
     pilot = (
         {

--- a/src/exomem/corpus_aware.py
+++ b/src/exomem/corpus_aware.py
@@ -270,10 +270,13 @@ def _best_cosine_per_file(
             return {}
         vecs = embeddings.embed_texts(chunks, is_query=False)
         idx = embeddings.get_embedding_index(vault_root)
-        root = vault_root.resolve()
         allowed_paths = {
-            path.relative_to(root).as_posix()
-            for path in index_paths.iter_index_markdown(vault_root)
+            rel
+            for rel in (
+                index_paths.rel_to_vault(vault_root, path)
+                for path in index_paths.iter_index_markdown(vault_root)
+            )
+            if rel is not None
         }
         best_per_file: dict[str, float] = {}
         for v in vecs:

--- a/src/exomem/embedding_index.py
+++ b/src/exomem/embedding_index.py
@@ -907,11 +907,13 @@ class EmbeddingIndex:
         """
         from . import freshness, recall_policy
 
-        root = self.vault_root.resolve()
         rows: list[tuple[str, tuple[int, int, int]]] = []
         for path in index_paths.iter_index_markdown(self.vault_root):
+            rel = index_paths.rel_to_vault(self.vault_root, path)
+            if rel is None:
+                continue
             try:
-                rows.append((path.relative_to(root).as_posix(), freshness.stat_signature(path)))
+                rows.append((rel, freshness.stat_signature(path)))
             except (OSError, ValueError):
                 continue
         return recall_policy.recall_policy_identity(self.vault_root), tuple(sorted(rows))

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -1061,15 +1061,13 @@ def upsert_after_write_status(
 ) -> EmbeddingSyncStatus:
     """Re-embed eligible files and return an observable bounded outcome."""
     global _IMPORT_FAILED
-    root = vault_root.resolve()
     md_paths: list[Path] = []
     rejected_paths: list[str] = []
     for path in written_paths:
         if not index_paths.is_embeddable_path(path):
             continue
-        try:
-            rel = path.relative_to(root).as_posix()
-        except ValueError:
+        rel = index_paths.rel_to_vault(vault_root, path)
+        if rel is None:
             continue
         # Admission is intentionally before defer/model/page-cache/content work.
         # A raw Record stays structured-only even when the vector backend is off.
@@ -1106,12 +1104,10 @@ def upsert_after_write_status(
 
         if readiness.should_defer("embeddings"):
             rels: list[str] = []
-            root = vault_root.resolve()
             for path in md_paths:
-                try:
-                    rels.append(path.resolve().relative_to(root).as_posix())
-                except (OSError, ValueError):
-                    continue
+                rel = index_paths.rel_to_vault(vault_root, path)
+                if rel is not None:
+                    rels.append(rel)
             try:
                 race_receipts = deferred_index.add_receipts(vault_root, rels)
             except (OSError, sqlite3.Error):

--- a/src/exomem/index_paths.py
+++ b/src/exomem/index_paths.py
@@ -62,6 +62,37 @@ def iter_index_markdown(vault_root: Path):
         yield from iter_recall_markdown(vault_root, find_module._walk_md(kb))
 
 
+def rel_to_vault(vault_root: Path, path: Path) -> str | None:
+    """Vault-relative POSIX path, or `None` when `path` is not in the vault.
+
+    The single place derived indexes decide vault membership. `relative_to` is
+    purely lexical, so mixing spellings of one directory — a resolved root
+    against an unresolved path, or the reverse — declares every file in the
+    vault to be outside it. Each caller reacts by skipping the file, so the
+    result is a silently empty index rather than an error. Symlinked roots are
+    ordinary: macOS `/tmp` is a link to `/private/tmp`, and synced or mounted
+    vaults sit behind one routinely.
+
+    Callers build their paths from the same root they pass here, so the lexical
+    comparison answers first and costs what it always did; resolving is the
+    fallback for the mixed-spelling case that started this. Membership is a
+    question about location, not about link structure: an in-vault name whose
+    target lives elsewhere stays a member, because symlinking an external file
+    into a vault is a way of putting it in the vault. Paths that do not exist
+    still answer, because deletion sync asks about files that are already gone.
+    """
+    path = Path(path)
+    root = Path(vault_root)
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        pass
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except (OSError, ValueError):
+        return None
+
+
 def is_embeddable_path(path: Path) -> bool:
     """True when a path is markdown content that derived indexes should consider."""
     if path.suffix.lower() != ".md":

--- a/tests/test_dataset_identity_case_count.py
+++ b/tests/test_dataset_identity_case_count.py
@@ -1,0 +1,113 @@
+"""`case_count` describes the pinned dataset, not what our parser accepted.
+
+`DatasetIdentity` binds a `sha256` computed over the whole source file to a
+`case_count`. Deriving that count from the rows we successfully loaded makes the
+pair self-contradictory the moment any row is deferred: a digest of 500 rows
+labelled as 493 cases.
+
+This is fallout from scoped deferral. Before it, an unparseable row raised, so
+"rows loaded" and "rows in the file" were necessarily equal and either could
+stand in for the other. Once a row could be carried instead of raised, the two
+diverged silently — and the census exists precisely because the frozen source,
+not our parse of it, is the thing being identified.
+
+The guest lane found this: MemoryBench validates the plan's `case_count` against
+the real file and refused, correctly. Had we matched the plan to the run instead,
+`dataset_identity` would have differed across the two lanes under an equivalence
+comparison, for a reason that has nothing to do with retrieval.
+
+Deferral only survives the canonical-selection path, which requires the real
+frozen digest, so the divergence cannot be reached from a fixture end-to-end.
+These tests pin the derivation itself and guard the run that must not change.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+from lme.dataset import LmeDataset, load_dataset_bytes
+from lme.reader import StubReader
+from lme.runner import RunConfig, _dataset_case_count, execute_run
+
+
+def _row(question_id: str, **overrides):
+    row = {
+        "question_id": question_id,
+        "question_type": "single-session-user",
+        "question": "which lantern?",
+        "answer": "the violet one",
+        "question_date": "2026-01-01",
+        "haystack_session_ids": ["s1"],
+        "haystack_sessions": [[{"role": "user", "content": "a turn"}]],
+        "haystack_dates": ["2026-01-01"],
+        "answer_session_ids": ["s1"],
+    }
+    row.update(overrides)
+    return row
+
+
+def test_a_deferred_row_still_counts_toward_the_dataset_identity() -> None:
+    """The number must match the file the sha256 was taken over."""
+    rows = [_row("keep"), _row("broken", question_type="not-a-real-type")]
+    dataset = load_dataset_bytes(json.dumps(rows).encode("utf-8"))
+
+    assert len(dataset.questions) == 1
+    assert _dataset_case_count(dataset) == 2
+
+
+def test_the_count_is_unchanged_when_nothing_is_deferred() -> None:
+    rows = [_row("keep-1"), _row("keep-2")]
+    dataset = load_dataset_bytes(json.dumps(rows).encode("utf-8"))
+
+    assert _dataset_case_count(dataset) == len(dataset.questions) == 2
+
+
+def test_a_dataset_built_without_a_census_falls_back_to_its_questions() -> None:
+    """Pilot slices and fixtures are constructed directly, not loaded.
+
+    They carry no census, and for them the questions *are* every row there is,
+    so the fallback must not report zero.
+    """
+    rows = [_row("keep-1"), _row("keep-2")]
+    loaded = load_dataset_bytes(json.dumps(rows).encode("utf-8"))
+    detached = LmeDataset(loaded.questions)
+
+    assert detached.census == ()
+    assert _dataset_case_count(detached) == 2
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("sentence_transformers") is None,
+    reason="requires the embeddings extra and a warm Hugging Face cache",
+)
+def test_a_normal_run_records_the_source_row_count(tmp_path: Path) -> None:
+    """End-to-end guard: the healthy path keeps the value it always had.
+
+    Scoring a case needs the real semantic capability, so this is the one test
+    here that cannot run in the lean matrix. The three derivation tests above
+    carry the actual contract and run everywhere.
+    """
+    rows = [_row("keep-1"), _row("keep-2")]
+    dataset_path = tmp_path / "dataset.json"
+    dataset_path.write_text(json.dumps(rows), encoding="utf-8")
+
+    execute_run(
+        RunConfig(
+            dataset=dataset_path,
+            out=tmp_path / "out",
+            run_id="run",
+            dataset_sha256=hashlib.sha256(dataset_path.read_bytes()).hexdigest(),
+            dataset_revision="test-pin",
+            pilot=1,
+        ),
+        reader=StubReader(),
+    )
+
+    run_dir = next((tmp_path / "out").iterdir())
+    manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    # A pilot scores one case, but identity still describes the whole source.
+    assert manifest["dataset"]["case_count"] == 2

--- a/tests/test_symlinked_vault_root.py
+++ b/tests/test_symlinked_vault_root.py
@@ -1,0 +1,171 @@
+"""A vault reached through a symlink must still index its own files.
+
+`Path.relative_to` is purely lexical — it never consults the filesystem. Code
+that resolves the vault root but compares it against unresolved file paths
+therefore decides that every file in the vault is *outside* the vault, and the
+sites below all react by silently skipping the file rather than raising.
+
+The visible symptom is total, quiet semantic loss: nothing is ever embedded, the
+vector lane finds nothing, every search falls back to keyword ranking, and the
+write path reports the benign `no_eligible_paths` while doing so. Symlinked
+vault roots are ordinary — macOS `/tmp` is a symlink to `/private/tmp`, and
+synced or NAS-mounted vaults routinely sit behind one.
+
+What must NOT change is which files are eligible. Location and eligibility are
+separate questions — `recall_policy` already declines symlinked files on their
+own merits — and the fix must not quietly answer the second one while repairing
+the first, so that boundary is pinned here too.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from exomem import embedding_index, embeddings, index_paths, recall_policy
+from exomem.kbdir import kb_dirname
+
+
+@pytest.fixture
+def symlinked_vault(tmp_path: Path) -> tuple[Path, Path]:
+    """A real vault plus an equivalent path that traverses a symlink.
+
+    Returns `(real_root, linked_root)`. Both name the same directory; only the
+    spelling differs, which is exactly what a lexical comparison gets wrong.
+    """
+    real = tmp_path / "real" / "vault"
+    (real / kb_dirname() / "Notes").mkdir(parents=True)
+    link_parent = tmp_path / "link"
+    link_parent.mkdir()
+    (link_parent / "alias").symlink_to(tmp_path / "real")
+    linked = link_parent / "alias" / "vault"
+    assert linked.resolve() == real.resolve()
+    assert str(linked) != str(real)
+    return real, linked
+
+
+def _write_note(root: Path, name: str = "note.md") -> Path:
+    path = root / kb_dirname() / "Notes" / name
+    path.write_text("---\ntype: note\n---\n\nA sentence worth embedding.\n", encoding="utf-8")
+    return path
+
+
+def test_a_written_file_is_eligible_through_a_symlinked_root(
+    symlinked_vault: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The bug in one assertion: admission counted zero files that exist.
+
+    `eligible_count` is the observable that survives `EXOMEM_DISABLE_EMBEDDINGS`,
+    so this pins the path-admission defect without loading a model.
+    """
+    _real, linked = symlinked_vault
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    written = _write_note(linked)
+
+    status = embeddings.upsert_after_write_status(linked, [written])
+
+    assert status.eligible_count == 1
+
+
+def test_admission_is_identical_through_either_spelling(
+    symlinked_vault: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two names for one directory must not produce two different verdicts."""
+    real, linked = symlinked_vault
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    _write_note(linked)
+
+    through_real = embeddings.upsert_after_write_status(
+        real, [real / kb_dirname() / "Notes" / "note.md"]
+    )
+    through_link = embeddings.upsert_after_write_status(
+        linked, [linked / kb_dirname() / "Notes" / "note.md"]
+    )
+
+    assert through_link.eligible_count == through_real.eligible_count == 1
+
+
+def test_a_path_genuinely_outside_the_vault_is_still_rejected(
+    symlinked_vault: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Resolving both sides must not turn containment into a rubber stamp."""
+    _real, linked = symlinked_vault
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    outsider = tmp_path / "elsewhere.md"
+    outsider.write_text("not in the vault\n", encoding="utf-8")
+
+    status = embeddings.upsert_after_write_status(linked, [outsider])
+
+    assert status.eligible_count == 0
+
+
+def test_a_symlinked_file_is_still_refused_by_recall_policy_not_by_geometry(
+    symlinked_vault: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two different questions that a lexical bug had been conflating.
+
+    `rel_to_vault` answers *where* a file is; `recall_policy` answers *whether*
+    it may be indexed, and it already declines symlinked files on their own
+    merits. Keeping those separate is the point: the fix must not start
+    admitting files policy rejects, nor keep rejecting files only because the
+    root was spelled through a link.
+    """
+    _real, linked = symlinked_vault
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    outsider = tmp_path / "outside.md"
+    outsider.write_text("shared notes\n", encoding="utf-8")
+    linked_in = linked / kb_dirname() / "Notes" / "shared.md"
+    linked_in.symlink_to(outsider)
+
+    # Located inside the vault ...
+    assert index_paths.rel_to_vault(linked, linked_in) == f"{kb_dirname()}/Notes/shared.md"
+    # ... and declined anyway, by the gate that owns that decision.
+    assert recall_policy.is_recall_candidate(linked, linked_in) is False
+    assert embeddings.upsert_after_write_status(linked, [linked_in]).eligible_count == 0
+
+
+def test_the_corpus_signature_sees_the_corpus_through_a_symlinked_root(
+    symlinked_vault: tuple[Path, Path],
+) -> None:
+    """An empty signature would let a stale sidecar look current."""
+    _real, linked = symlinked_vault
+    _write_note(linked)
+
+    _identity, rows = embedding_index.EmbeddingIndex(linked)._projected_source_snapshot()
+
+    assert [rel for rel, _signature in rows] == [f"{kb_dirname()}/Notes/note.md"]
+
+
+def test_rel_to_vault_agrees_across_spellings(symlinked_vault: tuple[Path, Path]) -> None:
+    """The shared helper is the single place this comparison is made."""
+    real, linked = symlinked_vault
+    _write_note(linked)
+    expected = f"{kb_dirname()}/Notes/note.md"
+
+    assert index_paths.rel_to_vault(linked, linked / expected) == expected
+    assert index_paths.rel_to_vault(linked, real / expected) == expected
+    assert index_paths.rel_to_vault(real, linked / expected) == expected
+
+
+def test_rel_to_vault_reports_absence_rather_than_raising(
+    symlinked_vault: tuple[Path, Path], tmp_path: Path
+) -> None:
+    """Callers skip non-members; a raised error would abort the whole batch."""
+    _real, linked = symlinked_vault
+    outsider = tmp_path / "elsewhere.md"
+    outsider.write_text("x\n", encoding="utf-8")
+
+    assert index_paths.rel_to_vault(linked, outsider) is None
+    assert index_paths.rel_to_vault(linked, Path(os.devnull)) is None
+
+
+def test_rel_to_vault_tolerates_a_path_that_does_not_exist(
+    symlinked_vault: tuple[Path, Path],
+) -> None:
+    """Deletion sync asks about paths that are already gone."""
+    _real, linked = symlinked_vault
+    expected = f"{kb_dirname()}/Notes/deleted.md"
+
+    assert index_paths.rel_to_vault(linked, linked / expected) == expected


### PR DESCRIPTION
**A vault whose root path traverses a symlink indexed nothing, and said so nowhere.**

Every search on such a vault silently returned keyword-ranked results with a
`degraded: ["keyword"]` marker. The vector lane was permanently empty because
nothing had ever been embedded.

## The defect

`upsert_after_write_status` resolved the vault root, then compared it against
written paths that were *not* resolved:

```python
root = vault_root.resolve()          # /real/vault
for path in written_paths:           # /link/alias/vault/Knowledge Base/…
    try:
        rel = path.relative_to(root).as_posix()
    except ValueError:
        continue                     # ← every file, every time
```

`Path.relative_to` is purely lexical — it never consults the filesystem — so
two spellings of one directory do not match. Every file in the vault was judged
to be outside the vault, and each caller's reaction to "outside" is to skip it.

The failure then laundered itself through three layers that each looked
reasonable in isolation:

| Layer | What it saw | What it concluded |
|---|---|---|
| admission loop | no path matched | `md_paths` empty |
| `upsert_after_write_status` | empty `md_paths` | `no_eligible_paths` |
| `full_upsert_succeeded` | `accepted / no_eligible_paths` | upsert succeeded |

Nothing raised. The write path reported success while the semantic index stayed
empty forever.

Symlinked roots are ordinary — macOS `/tmp` is a link to `/private/tmp`, and
synced or NAS-mounted vaults routinely sit behind one.

## Scope

Three sites shared the pattern:

- `embeddings.upsert_after_write_status` — nothing is embedded (the visible bug)
- `EmbeddingIndex._projected_source_snapshot` — the corpus signature comes back
  empty, so a stale sidecar can look current
- `corpus_aware._best_cosine_per_file` — raises on the first path, disabling
  duplicate **and** contradiction detection on every write

The same file already contained the correct `path.resolve().relative_to(root)`
form forty lines away, in the deferred-warm branch. This was an internal
inconsistency, not a missing idea, so the fix is one decision in one place:
`index_paths.rel_to_vault`.

A sweep for the same shape found no others. (`context_pack` resolves both sides;
`public_artifact_privacy` passes its already-resolved root into the file lister,
so spellings agree.)

## Two things deliberately *not* changed

**Cost.** The helper compares lexically first. Callers build their paths from
the same root they pass in, so that answers in the common case — including the
symlinked one — at exactly the cost the comparison had before. Resolving is the
fallback for the mixed-spelling case that caused this. Measured on a 2000-file
corpus, resolving unconditionally cost **+45% over the whole walk** (171 ms →
247 ms), on a path that runs inline on every add, note, edit, and pack assembly.

**Eligibility.** An earlier draft resolved both sides unconditionally, which
also silently changed *which files count*. `recall_policy.is_recall_candidate`
already declines symlinked files on their own merits — location and eligibility
are separate questions with separate owners. The helper answers only where a
file is, and a test pins that boundary so a future change can't quietly move it.

## Verification

Red-first. Six of eight tests fail on `main`; the other two are the
boundary guards described above and are green both ways by design.

Mutation-tested in both halves:

| Mutation | Result |
|---|---|
| restore `path.relative_to(vault_root.resolve())` at the call site | 2 scenario tests fail |
| delete the resolving fallback from the helper | helper test fails |

End-to-end, driving real ingest + retrieval through a `ln -s` vault root: three
known-answer probes go from `FAILED: degraded marker: ['keyword']` to passing,
matching the non-symlinked control exactly.

Found while setting up the 25-case direct-vs-MemoryBench equivalence gate,
where the harness hands providers a `/proc/<pid>/fd/<n>` custody path. A plain
`ln -s` reproduces it with no harness involved, which is why this is filed as a
product fix rather than a harness workaround.
