### PR TITLE
fix(benchmarks): count the dataset, not our parse of it

### DIFF
--- a/benchmarks/lme/runner.py
+++ b/benchmarks/lme/runner.py
@@ -58,6 +58,22 @@ from .normalize import ingest_field_groups, neutralize, render_neutral_session
 from equivalence.selection import CANONICAL_LME_S_SOURCE, load_frozen_lme_selection, select_lme_s_25
 
 
+def _dataset_case_count(dataset: LmeDataset) -> int:
+    """Rows in the pinned source, including any this parse deferred.
+
+    `DatasetIdentity` pairs this count with a sha256 taken over the whole file,
+    so it has to describe the file rather than our yield from it. Scoped
+    deferral makes those two numbers diverge: `len(questions)` silently became
+    "rows we could parse" the moment a bad row could be carried instead of
+    raised, which would label a 500-row digest as 493 cases.
+
+    The census covers every source row. It is empty only for datasets built
+    directly rather than loaded — pilot slices, fixtures — where the questions
+    are all the rows there are.
+    """
+    return len(dataset.census) or len(dataset.questions)
+
+
 class LmeRunInvalid(RuntimeError):
     """The run was invalidated by an environment fault and has no score."""
 
@@ -607,7 +623,7 @@ def execute_run(
         source="xiaowu0162/longmemeval-cleaned",
         revision=(CANONICAL_LME_S_SOURCE["revision"] if config.canonical_selection else config.dataset_revision or "fixture-local"),
         sha256=dataset_checksum,
-        case_count=len(parent_dataset.questions),
+        case_count=_dataset_case_count(parent_dataset),
     )
     pilot = (
         {

--- a/tests/test_dataset_identity_case_count.py
+++ b/tests/test_dataset_identity_case_count.py
@@ -1,0 +1,102 @@
+"""`case_count` describes the pinned dataset, not what our parser accepted.
+
+`DatasetIdentity` binds a `sha256` computed over the whole source file to a
+`case_count`. Deriving that count from the rows we successfully loaded makes the
+pair self-contradictory the moment any row is deferred: a digest of 500 rows
+labelled as 493 cases.
+
+This is fallout from scoped deferral. Before it, an unparseable row raised, so
+"rows loaded" and "rows in the file" were necessarily equal and either could
+stand in for the other. Once a row could be carried instead of raised, the two
+diverged silently — and the census exists precisely because the frozen source,
+not our parse of it, is the thing being identified.
+
+The guest lane found this: MemoryBench validates the plan's `case_count` against
+the real file and refused, correctly. Had we matched the plan to the run instead,
+`dataset_identity` would have differed across the two lanes under an equivalence
+comparison, for a reason that has nothing to do with retrieval.
+
+Deferral only survives the canonical-selection path, which requires the real
+frozen digest, so the divergence cannot be reached from a fixture end-to-end.
+These tests pin the derivation itself and guard the run that must not change.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from lme.dataset import LmeDataset, load_dataset_bytes
+from lme.reader import StubReader
+from lme.runner import RunConfig, _dataset_case_count, execute_run
+
+
+def _row(question_id: str, **overrides):
+    row = {
+        "question_id": question_id,
+        "question_type": "single-session-user",
+        "question": "which lantern?",
+        "answer": "the violet one",
+        "question_date": "2026-01-01",
+        "haystack_session_ids": ["s1"],
+        "haystack_sessions": [[{"role": "user", "content": "a turn"}]],
+        "haystack_dates": ["2026-01-01"],
+        "answer_session_ids": ["s1"],
+    }
+    row.update(overrides)
+    return row
+
+
+def test_a_deferred_row_still_counts_toward_the_dataset_identity() -> None:
+    """The number must match the file the sha256 was taken over."""
+    rows = [_row("keep"), _row("broken", question_type="not-a-real-type")]
+    dataset = load_dataset_bytes(json.dumps(rows).encode("utf-8"))
+
+    assert len(dataset.questions) == 1
+    assert _dataset_case_count(dataset) == 2
+
+
+def test_the_count_is_unchanged_when_nothing_is_deferred() -> None:
+    rows = [_row("keep-1"), _row("keep-2")]
+    dataset = load_dataset_bytes(json.dumps(rows).encode("utf-8"))
+
+    assert _dataset_case_count(dataset) == len(dataset.questions) == 2
+
+
+def test_a_dataset_built_without_a_census_falls_back_to_its_questions() -> None:
+    """Pilot slices and fixtures are constructed directly, not loaded.
+
+    They carry no census, and for them the questions *are* every row there is,
+    so the fallback must not report zero.
+    """
+    rows = [_row("keep-1"), _row("keep-2")]
+    loaded = load_dataset_bytes(json.dumps(rows).encode("utf-8"))
+    detached = LmeDataset(loaded.questions)
+
+    assert detached.census == ()
+    assert _dataset_case_count(detached) == 2
+
+
+def test_a_normal_run_records_the_source_row_count(tmp_path: Path) -> None:
+    """End-to-end guard: the healthy path keeps the value it always had."""
+    rows = [_row("keep-1"), _row("keep-2")]
+    dataset_path = tmp_path / "dataset.json"
+    dataset_path.write_text(json.dumps(rows), encoding="utf-8")
+
+    execute_run(
+        RunConfig(
+            dataset=dataset_path,
+            out=tmp_path / "out",
+            run_id="run",
+            dataset_sha256=hashlib.sha256(dataset_path.read_bytes()).hexdigest(),
+            dataset_revision="test-pin",
+            pilot=1,
+        ),
+        reader=StubReader(),
+    )
+
+    run_dir = next((tmp_path / "out").iterdir())
+    manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    # A pilot scores one case, but identity still describes the whole source.
+    assert manifest["dataset"]["case_count"] == 2

--- a/tests/test_dataset_identity_case_count.py
+++ b/tests/test_dataset_identity_case_count.py
@@ -24,9 +24,11 @@ These tests pin the derivation itself and guard the run that must not change.
 from __future__ import annotations
 
 import hashlib
+import importlib.util
 import json
 from pathlib import Path
 
+import pytest
 from lme.dataset import LmeDataset, load_dataset_bytes
 from lme.reader import StubReader
 from lme.runner import RunConfig, _dataset_case_count, execute_run
@@ -78,8 +80,17 @@ def test_a_dataset_built_without_a_census_falls_back_to_its_questions() -> None:
     assert _dataset_case_count(detached) == 2
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("sentence_transformers") is None,
+    reason="requires the embeddings extra and a warm Hugging Face cache",
+)
 def test_a_normal_run_records_the_source_row_count(tmp_path: Path) -> None:
-    """End-to-end guard: the healthy path keeps the value it always had."""
+    """End-to-end guard: the healthy path keeps the value it always had.
+
+    Scoring a case needs the real semantic capability, so this is the one test
+    here that cannot run in the lean matrix. The three derivation tests above
+    carry the actual contract and run everywhere.
+    """
     rows = [_row("keep-1"), _row("keep-2")]
     dataset_path = tmp_path / "dataset.json"
     dataset_path.write_text(json.dumps(rows), encoding="utf-8")


### PR DESCRIPTION
**A run published a 500-row digest labelled as 493 cases.**

`DatasetIdentity` pairs a `sha256` taken over the whole source file with a
`case_count`. That count came from `len(parent_dataset.questions)` — the rows
*this parse* accepted — so the pair became self-contradictory the moment scoped
deferral let a row be carried instead of raised. The pinned LongMemEval-S
release has 500 rows and we defer 7.

## Why it went unnoticed

Before deferral, an unparseable row raised. A dataset could not load with fewer
rows than its file had, so "rows loaded" and "rows in the file" were necessarily
equal and either could stand in for the other.

Deferral changed what `len(questions)` *means* — from "rows in the dataset" to
"rows we could parse" — without changing its type or any call site. Every caller
reading it as the former kept compiling.

## Why the census is the right source

This is the same distinction #532 already drew. Cohort selection regenerates
against `dataset.census` rather than `dataset.questions` because **the cohort is
a property of the frozen source, not of what our parser accepted**. Identity is
the same kind of claim about the same frozen source, and it kept reading the
loaded rows.

So this PR applies an existing decision one layer further out rather than
introducing a new one.

## How it was found

The MemoryBench guest lane validates a run plan's `case_count` against the real
file (`export.py::_native_dataset`) and refused the plan.

That refusal was correct, and the tempting fix was wrong: matching the plan to
the run would have made `dataset_identity` differ across the two lanes — 493 on
the left, 500 on the right — under an equivalence comparison whose whole purpose
is detecting exactly that kind of divergence. The gate would have blocked on our
own bookkeeping while presenting as a genuine retrieval-path difference.

Worth stating plainly: a competitor's harness caught a defect in ours, on a
number it had no stake in.

## Testing

Deferral only survives the canonical-selection path, which requires the real
frozen digest, so the divergence is unreachable from a fixture end-to-end. The
derivation is therefore a named helper that can be tested directly:

| Test | Pins |
|---|---|
| a deferred row still counts | the defect itself |
| unchanged when nothing is deferred | no regression on the healthy path |
| a dataset without a census falls back to its questions | pilot slices and fixtures, built directly rather than loaded |
| a normal run records the source row count | end-to-end guard |

Mutation-tested: restoring `len(dataset.questions)` fails the deferred-row test
and leaves the rest green — which is the point, since a future change that
reintroduces it would otherwise pass whenever nothing happens to be deferred.

Stacked on #556.
