### PR TITLE
fix(benchmarks): give the guest lane the manifest lineage rule

### DIFF
--- a/benchmarks/memorybench/export.py
+++ b/benchmarks/memorybench/export.py
@@ -25,6 +25,7 @@ from protocol.models import (
     MemoryBenchExport,
     MemoryBenchPrivateGold,
     MemoryBenchRunPlan,
+    PreregistrationLineage,
     RunManifest,
 )
 from equivalence.selection import CANONICAL_LME_S_SOURCE, load_frozen_lme_selection, select_lme_s_25
@@ -1468,6 +1469,9 @@ def _started_manifest(
         "provider_variant": plan.provider_variant,
         "control_config_sha256": None,
         "preregistration_identity": preregistration_identity,
+        "preregistration_lineage": PreregistrationLineage.for_manifest(
+            preregistration_identity
+        ),
     }).model_dump(mode="json")
 
 

--- a/benchmarks/protocol/manifest.py
+++ b/benchmarks/protocol/manifest.py
@@ -89,10 +89,8 @@ def start_manifest(
         leakage=leakage or LeakageSummary(scanned_cases=0, invalidated_cases=0),
         contamination=contamination, budget=budget,
         preregistration_identity=preregistration_identity,
-        preregistration_lineage=(
-            PreregistrationLineage.from_identity(preregistration_identity)
-            if preregistration_identity.amendments
-            else None
+        preregistration_lineage=PreregistrationLineage.for_manifest(
+            preregistration_identity
         ),
         provider_variant=provider_variant, control_config_sha256=control_config_sha256,
     )

--- a/benchmarks/protocol/models.py
+++ b/benchmarks/protocol/models.py
@@ -220,6 +220,19 @@ class PreregistrationLineage(StrictModel):
             effective_sha256=identity.effective.sha256,
         )
 
+    @classmethod
+    def for_manifest(cls, identity: PreregistrationIdentity) -> PreregistrationLineage | None:
+        """The lineage a manifest must carry for `identity`, if any.
+
+        `RunManifest` requires lineage exactly when the identity is amended, and
+        refuses it as base-only otherwise. Every manifest author therefore has
+        to re-derive the same condition, and a lane that gets it wrong does not
+        write a wrong manifest — it writes none, mid-run. Owning the condition
+        here means a new construction site inherits the rule instead of being
+        told it separately.
+        """
+        return cls.from_identity(identity) if identity.amendments else None
+
 
 class RunManifest(StrictModel):
     protocol_version: Literal[PROTOCOL_VERSION] = PROTOCOL_VERSION

--- a/tests/test_memorybench_export.py
+++ b/tests/test_memorybench_export.py
@@ -2368,3 +2368,102 @@ def test_feedback5_private_gold_parent_symlink_never_writes_or_chmods_outside_ou
     assert (tmp_path / "output/guest-cleanup.v1.json").is_file()
     manifest = json.loads((tmp_path / "output/manifest.json").read_text())
     assert manifest["status"] == "INVALID" and manifest["finalized_at"] is not None
+
+
+def _amended_identity(*, amended: bool):
+    """A pre-registration identity with, or without, one acknowledged amendment.
+
+    Built by hand rather than derived from the repository so the test states
+    which case it is exercising instead of depending on whether the real
+    contract happens to carry an amendment today.
+    """
+    from protocol.contracts import (
+        AmendmentIdentity,
+        ContractArtifactIdentity,
+        PreregistrationIdentity,
+        ReceiptIdentity,
+    )
+
+    original = ContractArtifactIdentity(
+        path="benchmarks/epistemic/PREREGISTRATION.md",
+        sha256="a" * 64,
+        repository_revision="1" * 40,
+    )
+    ratification = ReceiptIdentity(
+        receipt_path="benchmarks/epistemic/contracts/ratification.v1.json",
+        receipt_sha256="b" * 64,
+        introduction_revision="2" * 40,
+    )
+    if not amended:
+        return PreregistrationIdentity(
+            contract_revision="2" * 40,
+            original=original,
+            ratification=ratification,
+            amendments=(),
+            effective=original,
+        )
+    effective = ContractArtifactIdentity(
+        path=original.path, sha256="c" * 64, repository_revision="3" * 40
+    )
+    amendment = AmendmentIdentity(
+        sequence=1,
+        receipt=ReceiptIdentity(
+            receipt_path="benchmarks/epistemic/contracts/amendment-0001.v1.json",
+            receipt_sha256="d" * 64,
+            introduction_revision="4" * 40,
+        ),
+        parent_contract_sha256=original.sha256,
+        contract=effective,
+        affected_sections=("§7",),
+        rationale="reason",
+        effective_policy="after acknowledgment",
+        acknowledgment_status="acknowledged",
+        introduced_family_ids=(),
+    )
+    return PreregistrationIdentity(
+        contract_revision="4" * 40,
+        original=original,
+        ratification=ratification,
+        amendments=(amendment,),
+        effective=effective,
+    )
+
+
+def test_started_manifest_carries_lineage_for_an_amended_preregistration(
+    tmp_path: Path,
+) -> None:
+    """An amended pre-registration must reach the manifest as lineage.
+
+    `RunManifest` refuses an amended identity that arrives without lineage, so
+    omitting it here does not mislabel the run — it stops the guest lane from
+    producing a manifest at all, before the first case is ingested. The direct
+    lane derives lineage in `protocol.manifest`; this construction site is the
+    second author of the same manifest and had to be told separately.
+    """
+    import memorybench.export as export
+    from protocol.models import MemoryBenchRunPlan, PreregistrationLineage
+
+    plan = MemoryBenchRunPlan.model_validate(_plan_payload(tmp_path))
+    identity = _amended_identity(amended=True)
+
+    manifest = export._started_manifest(plan, "2026-08-16T00:00:00Z", identity, {})
+
+    assert manifest["preregistration_lineage"] == (
+        PreregistrationLineage.from_identity(identity).model_dump(mode="json")
+    )
+
+
+def test_started_manifest_omits_lineage_for_an_unamended_preregistration(
+    tmp_path: Path,
+) -> None:
+    """Lineage records amendments; a base-only run has none to record."""
+    import memorybench.export as export
+    from protocol.models import MemoryBenchRunPlan
+
+    plan = MemoryBenchRunPlan.model_validate(_plan_payload(tmp_path))
+
+    manifest = export._started_manifest(
+        plan, "2026-08-16T00:00:00Z", _amended_identity(amended=False), {}
+    )
+
+    assert manifest["preregistration_lineage"] is None


### PR DESCRIPTION
**The guest lane could not write a started manifest at all.**

`RunManifest` requires `preregistration_lineage` exactly when the pre-registration
identity carries amendments. `protocol.manifest` derived it. `memorybench.export._started_manifest`
— the second author of the same manifest — did not.

The pre-registration has been amended once. So the guest lane created its output
root, failed model validation on the first write, and returned `INVALID` with an
empty directory and no diagnostic. The direct lane, which goes through the
canonical writer, was unaffected and has been writing correct lineage all along.

## What this is and isn't

Nothing was mislabelled. The validator refused rather than admitted — the run
produced no manifest instead of a wrong one. The defect is that a second
construction site had to be told a rule the model already enforces, and wasn't.

## The fix

`PreregistrationLineage.for_manifest` now owns the condition ("lineage iff
amended") and both construction sites call it. `protocol.manifest` loses its
inline conditional; `memorybench.export` gains the field it was missing. A third
manifest author inherits the rule instead of rediscovering it the way this one
did.

## Testing

| Test | Pins |
|---|---|
| amended identity reaches the manifest as lineage | the defect itself |
| base-only identity carries no lineage | the other half of the condition |

Mutation-tested: making `for_manifest` unconditional fails the base-only test;
removing the export call site fails the amended test. Both are load-bearing.

Full `tests/test_memorybench_export.py`, `tests/test_epistemic_amendment_governance.py`
and `tests/test_protocol_schema_conformance.py` green (234 passed). Ruff `--select F`
clean; no new findings on the touched files against baseline.

## How it was found

Running the real 25-case guest lane for the §4.6c equivalence gate. With this
fix the lane gets past the manifest and both MemoryBench stages execute.

Stacked on #557.
