### PR TITLE
fix(lexstore): reap abandoned lexical rebuild temporaries

### DIFF
--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -24,7 +24,6 @@ import importlib
 import importlib.util
 import json
 import os
-import re
 import shutil
 import sqlite3
 import subprocess
@@ -99,32 +98,24 @@ _REBUILD_TEMP_ORPHAN_FAIL_COUNT = 5
 _REBUILD_TEMP_ORPHAN_FAIL_BYTES = 50 * 1024 * 1024
 
 #: Age (by mtime) above which a matching rebuild-temp file is treated as an
-#: orphan candidate rather than a legitimate in-flight rebuild. A single
-#: `rebuild_atomic()` pass (corpus scan + delta replay + WAL fold, or the
-#: graph-rebuild equivalent) writes to its temp file throughout the build, so
-#: an active one has a continuously fresh mtime; only a killed process leaves
-#: one whose mtime stops advancing. 60 minutes is comfortably above any
-#: plausible single-build write gap (the incident's abandoned files sat
-#: unmodified for days-to-weeks — 30 rebuilds spanning July 25-Aug 15 — not
-#: minutes) while still catching a truly abandoned temp promptly. Below this
-#: age, size is NOT evidence of a leak: the incident's own abandoned files
-#: averaged ~79 MB, well above the 50 MB fail-by-bytes threshold, but a
-#: same-sized in-flight rebuild is routine and must not fail.
-_REBUILD_TEMP_STALE_AGE_SECONDS = 60 * 60
-
-#: lexstore.rebuild_atomic() (lexstore.py:2469) names its detached build sibling
-#: `<lexical sidecar name>.rebuild-<uuid4().hex>.tmp`, optionally with a
-#: `-wal`/`-shm`/`-journal` companion suffix, and reaps it in its own `finally`
-#: on any graceful return — so a surviving one means the process was killed
-#: mid-build. No PUBLIC matcher for this name exists to import: lexstore.py
-#: itself has none, and governance/tool.py carries an identical PRIVATE regex
+#: orphan candidate rather than a legitimate in-flight rebuild. Below this
+#: age, size is NOT evidence of a leak either: the incident's own abandoned
+#: files averaged ~79 MB, well above the 50 MB fail-by-bytes threshold, but a
+#: same-sized in-flight rebuild is routine and must not fail. Defined once in
+#: `vault.REBUILD_TEMP_STALE_AGE_SECONDS` (see its own comment for the full
+#: rationale) and reused here rather than copied — the same threshold also
+#: gates `graph_sync.sweep_abandoned_temporaries`'s actual deletion of the
+#: lexical family, not just this read-only diagnostic.
+#:
+#: `vault.is_lexical_rebuild_runtime_file_name` is likewise the one PUBLIC
+#: matcher for lexstore.rebuild_atomic()'s (lexstore.py:2469) detached build
+#: sibling `<lexical sidecar name>.rebuild-<uuid4().hex>.tmp[-wal|-shm|
+#: -journal]`, which it reaps in its own `finally` on any graceful return —
+#: so a surviving one means the process was killed mid-build.
+#: governance/tool.py carries an independent PRIVATE regex
 #: (`_LEXICAL_REBUILD_TEMP_RE`) for its own unrelated fail-closed
-#: non-Markdown-membership purpose — private, and governance/tool.py is out of
-#: this task's scope to touch. This is a hand-derived duplicate of that same
-#: pattern, sourced from lexstore's construction call rather than guessed.
-_LEXICAL_REBUILD_TEMP_RE = re.compile(
-    r"^\.lexical\.sqlite\.rebuild-[0-9a-f]{32}\.tmp(?:-(?:wal|shm|journal))?$"
-)
+#: non-Markdown-membership purpose — private, and governance/tool.py is out
+#: of this module's scope to touch.
 
 
 @dataclass
@@ -828,17 +819,18 @@ def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
       (tested) user file.
     - `.lexical.sqlite.rebuild-<32-hex>.tmp[-wal|-shm|-journal]` —
       lexstore.rebuild_atomic()'s detached build sibling (lexstore.py:2469),
-      matched via `_LEXICAL_REBUILD_TEMP_RE` (see its module-level comment for
-      why this is hand-derived rather than imported).
+      matched via `vault.is_lexical_rebuild_runtime_file_name` (the same
+      matcher `graph_sync.sweep_abandoned_temporaries` uses to gate its
+      actual deletion of this family).
 
     A matching name alone is NOT evidence of an orphan: a legitimate in-flight
     rebuild has a matching name too, and can legitimately be large (the
     incident's own abandoned files averaged ~79 MB). Only a file whose mtime is
-    older than `_REBUILD_TEMP_STALE_AGE_SECONDS` is treated as a stale orphan
-    candidate; WARN/FAIL thresholds evaluate STALE counts/bytes exclusively, so
-    a fresh in-flight temporary of any size or count never trips them — its
-    remediation ("stop the service...") would itself create a real orphan if
-    followed against a rebuild that is still running.
+    older than `vault.REBUILD_TEMP_STALE_AGE_SECONDS` is treated as a stale
+    orphan candidate; WARN/FAIL thresholds evaluate STALE counts/bytes
+    exclusively, so a fresh in-flight temporary of any size or count never
+    trips them — its remediation ("stop the service...") would itself create a
+    real orphan if followed against a rebuild that is still running.
 
     `details` reports, per family (`details["graph_rebuild"]`,
     `details["lexical_rebuild"]`) and combined: total `count`/`total_bytes`
@@ -848,13 +840,15 @@ def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
     and no rebuild in flight, so remediation names `exomem maintain` run
     out-of-process (it reads the vault from EXOMEM_VAULT_PATH, not `--vault`).
     """
+    from . import vault as vault_module
+
     empty_family = {"count": 0, "total_bytes": 0, "stale_count": 0, "stale_bytes": 0}
     details: dict[str, object] = {
         "count": 0,
         "total_bytes": 0,
         "stale_count": 0,
         "stale_bytes": 0,
-        "stale_age_seconds": _REBUILD_TEMP_STALE_AGE_SECONDS,
+        "stale_age_seconds": vault_module.REBUILD_TEMP_STALE_AGE_SECONDS,
         "graph_rebuild": dict(empty_family),
         "lexical_rebuild": dict(empty_family),
     }
@@ -865,7 +859,6 @@ def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
             "No vault configured; rebuild temporaries were not inspected.",
             details=details,
         )
-    from . import vault as vault_module
 
     kb = Path(vault_root) / kb_dirname()
     graph_orphans: list[Path] = []
@@ -880,7 +873,7 @@ def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
             name = entry.name
             if vault_module.is_graph_rebuild_runtime_file_name(name):
                 graph_orphans.append(entry)
-            elif _LEXICAL_REBUILD_TEMP_RE.fullmatch(name) is not None:
+            elif vault_module.is_lexical_rebuild_runtime_file_name(name):
                 lexical_orphans.append(entry)
 
     now = time.time()
@@ -895,7 +888,7 @@ def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
             except OSError:
                 continue
             total += st.st_size
-            if now - st.st_mtime > _REBUILD_TEMP_STALE_AGE_SECONDS:
+            if now - st.st_mtime > vault_module.REBUILD_TEMP_STALE_AGE_SECONDS:
                 stale_count += 1
                 stale_total += st.st_size
         return {
@@ -919,7 +912,7 @@ def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
     details["stale_bytes"] = stale_bytes
     mb = total_bytes / (1024 * 1024)
     stale_mb = stale_bytes / (1024 * 1024)
-    age_minutes = _REBUILD_TEMP_STALE_AGE_SECONDS // 60
+    age_minutes = vault_module.REBUILD_TEMP_STALE_AGE_SECONDS // 60
 
     if count == 0:
         return _check(

--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -2821,6 +2821,20 @@ def readable_sidecar(path: Path) -> Path | None:
     return None if path.name.startswith(_TEMP_PREFIX) else path
 
 
+# The lexical sidecar's detached-build temp, minted at lexstore.py's
+# `LexicalStore.rebuild_atomic` as
+# `self.path.with_name(f"{self.path.name}.rebuild-{uuid.uuid4().hex}.tmp")`
+# where `self.path.name` is always `.lexical.sqlite` (`lexstore.lexical_path`,
+# issue #551). Only the glob pre-filter prefix lives here — the strict match
+# is `vault.is_lexical_rebuild_runtime_file_name`, the one PUBLIC matcher for
+# this shape (also used by `doctor.py`'s `_check_rebuild_temp_orphans`).
+# `governance/tool.py`'s `_LEXICAL_REBUILD_TEMP_RE` still independently
+# encodes the same shape for its own unrelated membership-classification
+# purpose — keep it, and `lexstore.py`'s mint site itself, in sync if this
+# shape ever changes.
+_LEXICAL_TEMP_PREFIX = ".lexical.sqlite.rebuild-"
+
+
 def sweep_abandoned_temporaries(
     vault_root: Path,
     live: Path,
@@ -2828,33 +2842,121 @@ def sweep_abandoned_temporaries(
     live_paths: set[Path],
     state_root: Path | None = None,
 ) -> list[Path]:
+    """Unlink abandoned rebuild temporaries sharing `live`'s parent directory.
+
+    Two families, one pass, deliberately asymmetric on how "abandoned" is
+    proven — a matching name is necessary but never sufficient on its own:
+
+    - Graph (`.graph-rebuild-*.sqlite[-journal|-wal|-shm]`): its mint site
+      (`temporary_sidecar_path`) is only ever written by a builder that holds
+      `claim_rebuild_owner` for the builder's ENTIRE run, including the final
+      `replace_sidecar` (`epistemic_graph.py`). This sweep must ALSO hold that
+      same claim (`probe`, below) before it may touch anything, and the claim
+      is exclusive — so a successful claim here already proves no builder
+      currently holds it, which means any name-matching graph temp found is
+      abandoned by construction. No age check is needed or applied.
+      One pre-existing, unchanged-by-this-function exception:
+      `epistemic_graph.py` deliberately sets `preserve_temporary = True` and
+      releases BOTH the claim and the registration (in the same `finally`, see
+      its `_rebuild_all_off_boundary`) when `graph_sync.replace_sidecar`
+      raises `GraphSidecarReplaceUnavailable` — the complete sidecar is kept
+      recoverable rather than discarded (contract R2). That temp then sits
+      unclaimed and unregistered exactly like an abandoned one, so THIS sweep
+      would remove it too; `epistemic_graph._reap_preserved_temporaries` is
+      the dedicated bounded reaper for that class instead. "Abandoned by
+      construction" describes every OTHER graph temp this sweep can see, not
+      a universal.
+    - Lexical (`.lexical.sqlite.rebuild-*.tmp[-wal|-shm|-journal]`):
+      `lexstore.py`'s `rebuild_atomic` has no dependency on `graph_sync`
+      (adding one would invert the module dependency) and so never
+      registers or claims its temp. A name match alone is therefore NOT
+      evidence of abandonment for this family — a live build's temp looks
+      byte-for-byte identical to an abandoned one by name and can
+      legitimately be large. Only an mtime older than
+      `vault.REBUILD_TEMP_STALE_AGE_SECONDS` counts as abandoned here
+      (mirrors doctor.py's read-only `_check_rebuild_temp_orphans`, which
+      gates its own orphan diagnostic on the same threshold for the same
+      reason).
+
+    Each family is swept inside its own `try`/`except OSError`: an unlink or
+    enumeration failure in one family (an unexpected directory matching the
+    glob, a transient sharing violation beyond plain `PermissionError`, ...)
+    must not abort the other family's pass — this is issue #551's only
+    reaper for the lexical family, so a graph-side failure silently starving
+    it would resume the exact leak this function exists to close.
+    """
+    from . import vault as vault_module
+
     probe = live.with_name(f"{_TEMP_PREFIX}sweep-{secrets.token_hex(12)}.sqlite")
     if not claim_rebuild_owner(vault_root, probe, state_root=state_root):
         return []
     removed: list[Path] = []
     try:
         active_paths = {path.resolve() for path in live_paths} | live_temporary_paths()
-        for candidate in live.parent.glob(f"{_TEMP_PREFIX}*.sqlite*"):
-            base_name = candidate.name
-            for companion_suffix in ("-journal", "-wal", "-shm"):
-                if base_name.endswith(companion_suffix):
-                    base_name = base_name.removesuffix(companion_suffix)
-                    break
-            if (
-                re.fullmatch(
-                    rf"{re.escape(_TEMP_PREFIX)}[0-9a-f]{{64}}-[0-9a-f]{{24}}\.sqlite",
-                    base_name,
+        # (glob pre-filter, strict PUBLIC matcher, requires-mtime-staleness).
+        families: tuple[tuple[str, Callable[[str], bool], bool], ...] = (
+            (
+                f"{_TEMP_PREFIX}*.sqlite*",
+                vault_module.is_graph_rebuild_runtime_file_name,
+                False,
+            ),
+            (
+                f"{_LEXICAL_TEMP_PREFIX}*.tmp*",
+                vault_module.is_lexical_rebuild_runtime_file_name,
+                True,
+            ),
+        )
+        for glob_pattern, matches_name, stale_gated in families:
+            try:
+                for candidate in live.parent.glob(glob_pattern):
+                    if not matches_name(candidate.name):
+                        continue
+                    base_name = candidate.name
+                    for companion_suffix in ("-journal", "-wal", "-shm"):
+                        if base_name.endswith(companion_suffix):
+                            base_name = base_name.removesuffix(companion_suffix)
+                            break
+                    if candidate.with_name(base_name).resolve() in active_paths:
+                        continue
+                    if stale_gated:
+                        try:
+                            # `Path.stat()` follows symlinks by default. A
+                            # broken symlink whose own name happens to match
+                            # the lexical shape therefore raises OSError here
+                            # and is silently left in place rather than
+                            # reaped — a small, self-limited leak (one dead
+                            # link, not a growing sidecar), not a safety
+                            # issue: `unlink()` below only ever removes the
+                            # link itself, never a target it points at.
+                            age_seconds = time.time() - candidate.stat().st_mtime
+                        except OSError:
+                            # Vanished between glob() and stat() (or is a
+                            # broken symlink, see above): another sweep or
+                            # the builder itself already resolved it, or
+                            # there is nothing safely stat-able to age-check.
+                            continue
+                        if age_seconds <= vault_module.REBUILD_TEMP_STALE_AGE_SECONDS:
+                            # Fresh mtime: this family carries no ownership
+                            # signal of its own, so a recent write is the
+                            # only evidence that a build is still in flight.
+                            continue
+                    try:
+                        candidate.unlink(missing_ok=True)
+                    except PermissionError:
+                        # Windows readers hold delete-sharing authority. A
+                        # retained complete temp is recoverable state, so
+                        # leave it for the next sweep after that reader
+                        # closes.
+                        continue
+                    removed.append(candidate)
+            except OSError:
+                logger.warning(
+                    "abandoned-temporary sweep failed for family glob %r; other "
+                    "families are still swept this pass",
+                    glob_pattern,
+                    exc_info=True,
                 )
-                and candidate.with_name(base_name).resolve() not in active_paths
-            ):
-                try:
-                    candidate.unlink(missing_ok=True)
-                except PermissionError:
-                    # Windows readers hold delete-sharing authority. A retained
-                    # complete temp is recoverable state, so leave it for the
-                    # next sweep after that reader closes.
-                    continue
-                removed.append(candidate)
+                continue
         return removed
     finally:
         release_rebuild_owner(vault_root, probe, state_root=state_root)

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -121,6 +121,8 @@ def _prune_identity_census_directory(kb: Path, directory: Path, name: str) -> bo
         return vault.is_graph_reset_runtime_dir_name(name)
     if name.startswith(".graph-rebuild-"):
         return vault.is_graph_rebuild_runtime_file_name(name)
+    if name.startswith(".lexical.sqlite.rebuild-"):
+        return vault.is_lexical_rebuild_runtime_file_name(name)
     return False
 
 

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -212,6 +212,55 @@ _GRAPH_REBUILD_RUNTIME_FILE_NAME = re.compile(
     r"(?:-(?:journal|wal|shm))?$",
     re.ASCII,
 )
+# The lexical sidecar's detached-build temp, minted at lexstore.py's
+# `LexicalStore.rebuild_atomic` as
+# `self.path.with_name(f"{self.path.name}.rebuild-{uuid.uuid4().hex}.tmp")`
+# where `self.path.name` is always `.lexical.sqlite` (`lexstore.lexical_path`,
+# issue #551). This is the one PUBLIC matcher for that shape — both
+# `graph_sync.sweep_abandoned_temporaries` and `doctor.py`'s
+# `_check_rebuild_temp_orphans` call `is_lexical_rebuild_runtime_file_name`
+# rather than keep their own copy. `governance/tool.py`'s
+# `_LEXICAL_REBUILD_TEMP_RE` still independently encodes this same shape for
+# its own unrelated membership-classification purpose (out of this module's
+# scope to touch) — keep it, and `lexstore.py`'s mint site itself, in sync if
+# this shape ever changes.
+_LEXICAL_REBUILD_RUNTIME_FILE_NAME = re.compile(
+    r"^\.lexical\.sqlite\.rebuild-[0-9a-f]{32}\.tmp"
+    r"(?:-(?:journal|wal|shm))?$",
+    re.ASCII,
+)
+
+#: Age (by mtime) above which a matching rebuild-temp file is treated as an
+#: orphan/abandoned candidate rather than a legitimate in-flight rebuild. This
+#: is NOT "written continuously" for the lexical family: under
+#: `PRAGMA journal_mode=WAL` (lexstore.py's `_connect_setup`) an in-flight
+#: build's writes land in the temp's `-wal` companion, and the MAIN temp
+#: file's own mtime only advances at SQLite's periodic auto-checkpoints
+#: (default: every ~1000 pages, ~4 MB) and at the final WAL fold
+#: (`_fold_to_single_file`) — not on every write. 60 minutes is comfortably
+#: above the write gap between checkpoints on any plausible corpus (issue
+#: #551's own incident: abandoned lexical-rebuild temps sat unmodified for
+#: days-to-weeks, not minutes) while still catching a truly abandoned temp
+#: promptly.
+#:
+#: One window is genuinely uncovered by mtime freshness, as a documented
+#: trade-off rather than a defect: after the fold and `conn.close()`
+#: (lexstore.py:2576) `rebuild_atomic` runs a full second `_walk_entries()`
+#: corpus re-walk plus guard checks before the publishing `os.replace`
+#: (lexstore.py:2646), touching the temp not at all. If that tail alone ever
+#: exceeded this threshold on some pathological corpus, the sweep could in
+#: principle reap a build still finishing that walk. This threshold is the
+#: same one `doctor.py` already chose for its own orphan diagnostic before
+#: this file's `sweep_abandoned_temporaries` reused it for deletion — raise
+#: it if that tail is ever observed to approach it in practice.
+#:
+#: Shared by two independent consumers rather than copied a third time:
+#: `graph_sync.sweep_abandoned_temporaries` (the LEXICAL family's only
+#: abandonment signal — that family cannot participate in
+#: `claim_rebuild_owner`/`register_temporary` the way the graph family does,
+#: so a matching name alone is never sufficient there) and `doctor.py`'s
+#: read-only `_check_rebuild_temp_orphans` diagnostic (for both families).
+REBUILD_TEMP_STALE_AGE_SECONDS = 60 * 60
 
 
 def is_graph_reset_runtime_dir_name(name: str) -> bool:
@@ -222,6 +271,11 @@ def is_graph_reset_runtime_dir_name(name: str) -> bool:
 def is_graph_rebuild_runtime_file_name(name: str) -> bool:
     """Whether ``name`` is one exact graph rebuild SQLite artifact."""
     return _GRAPH_REBUILD_RUNTIME_FILE_NAME.fullmatch(name) is not None
+
+
+def is_lexical_rebuild_runtime_file_name(name: str) -> bool:
+    """Whether ``name`` is one exact lexical rebuild SQLite artifact."""
+    return _LEXICAL_REBUILD_RUNTIME_FILE_NAME.fullmatch(name) is not None
 
 
 def in_excluded_scan_dir(rel_path: str) -> bool:

--- a/tests/test_corpus_context_cache.py
+++ b/tests/test_corpus_context_cache.py
@@ -151,6 +151,23 @@ def test_reserved_runtime_trees_do_not_enter_identity_census_or_cache_token(
     assert not semantic_contract._prune_identity_census_directory(
         kb, kb / "Notes", graph_rebuild
     )
+    lexical_rebuild = f".lexical.sqlite.rebuild-{'a' * 32}.tmp"
+    assert semantic_contract._prune_identity_census_directory(kb, kb, lexical_rebuild)
+    assert semantic_contract._prune_identity_census_directory(
+        kb, kb, f"{lexical_rebuild}-wal"
+    )
+    assert semantic_contract._prune_identity_census_directory(
+        kb, kb, f"{lexical_rebuild}-shm"
+    )
+    assert not semantic_contract._prune_identity_census_directory(
+        kb, kb, lexical_rebuild.upper()
+    )
+    assert not semantic_contract._prune_identity_census_directory(
+        kb, kb, ".lexical.sqlite.rebuild-user-copy.tmp"
+    )
+    assert not semantic_contract._prune_identity_census_directory(
+        kb, kb / "Notes", lexical_rebuild
+    )
     assert vault_module.in_excluded_scan_dir(
         f"Knowledge Base/.graph-reset-{'f' * 24}/private.md"
     )

--- a/tests/test_lexical_temp_reaping.py
+++ b/tests/test_lexical_temp_reaping.py
@@ -1,0 +1,259 @@
+"""Contract coverage for reaping abandoned lexical rebuild temporaries (#551).
+
+`LexicalStore.rebuild_atomic` (lexstore.py) mints its detached-build sibling as
+`<lexical-sidecar-name>.rebuild-<uuid4 hex>.tmp` and relies on its own
+`finally: self._cleanup_sidecar_files(temp_path)` to remove it. That cleanup
+never runs if the process is killed mid-build, so the temp (and any `-wal`/
+`-shm` SQLite companions) is abandoned on disk forever. `graph_sync.
+sweep_abandoned_temporaries` is the existing reaper for the sibling
+`.graph-rebuild-*` family; before the #551 fix it does not know the lexical
+shape at all.
+
+Correction round (MAJOR, post-review): unlike the graph family, `lexstore.py`
+has NO dependency on `graph_sync` — its mint site never calls
+`register_temporary` or `claim_rebuild_owner`. A matching name is therefore
+NOT sufficient evidence of abandonment for this family: a live in-flight
+`rebuild_atomic()` build looks byte-for-byte identical by name to an
+abandoned one. Every test below that expects removal explicitly ages the
+file's mtime past `vault.REBUILD_TEMP_STALE_AGE_SECONDS` first
+(`_age_file`, mirroring `tests/test_doctor_write_path.py`'s own helper); a
+file left un-aged simulates one still being written by a live build.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from exomem import graph_sync, lexstore, vault
+
+
+def _lexical_temp(vault_root: Path) -> Path:
+    """Mint a path matching `lexstore.py`'s `rebuild_atomic` temp shape exactly.
+
+    Mirrors the minting site directly:
+    ``temp_path = self.path.with_name(f"{self.path.name}.rebuild-{uuid.uuid4().hex}.tmp")``
+    """
+    live = lexstore.lexical_path(vault_root)
+    return live.with_name(f"{live.name}.rebuild-{uuid.uuid4().hex}.tmp")
+
+
+def _age_file(path: Path, *, minutes_ago: float) -> None:
+    """Back-date a file's mtime (and atime) by `minutes_ago` minutes."""
+    ts = time.time() - minutes_ago * 60
+    os.utime(path, (ts, ts))
+
+
+# A comfortable margin past vault.REBUILD_TEMP_STALE_AGE_SECONDS (60 minutes),
+# used throughout to mark a file as a genuinely abandoned orphan.
+_STALE_MINUTES = 120
+
+
+def test_sweep_removes_a_genuinely_stale_lexical_rebuild_temp_and_companions(
+    tmp_path: Path,
+) -> None:
+    vault_root = tmp_path
+    live = lexstore.lexical_path(vault_root)
+    live.parent.mkdir(parents=True)
+    live.write_bytes(b"live lexical catalog")
+
+    abandoned = _lexical_temp(vault_root)
+    companions = [
+        abandoned.with_name(f"{abandoned.name}{suffix}") for suffix in ("-wal", "-shm")
+    ]
+    for path in (abandoned, *companions):
+        path.write_bytes(b"abandoned lexical rebuild temp")
+        _age_file(path, minutes_ago=_STALE_MINUTES)
+
+    removed = graph_sync.sweep_abandoned_temporaries(vault_root, live, live_paths=set())
+
+    assert set(removed) == {abandoned, *companions}
+    assert not abandoned.exists()
+    assert all(not path.exists() for path in companions)
+    assert live.read_bytes() == b"live lexical catalog"
+
+
+def test_sweep_preserves_a_fresh_unclaimed_unregistered_lexical_temp(
+    tmp_path: Path,
+) -> None:
+    """The blocking defect this test guards: `lexstore.py` never registers or
+    claims its temp (no dependency on `graph_sync`), so a live in-flight
+    build has NO ownership signal at all — the ONLY thing standing between
+    the sweep and a live rebuild's temp is the mtime staleness gate. A fresh
+    (just-written) temp must survive even though nothing registered or
+    claimed it."""
+    vault_root = tmp_path
+    live = lexstore.lexical_path(vault_root)
+    live.parent.mkdir(parents=True)
+
+    in_flight = _lexical_temp(vault_root)
+    in_flight.write_bytes(b"actively being written by rebuild_atomic")
+    # No aging, no register_temporary, no claim_rebuild_owner: this is
+    # exactly what a live lexstore build looks like on disk mid-build.
+
+    removed = graph_sync.sweep_abandoned_temporaries(vault_root, live, live_paths=set())
+
+    assert in_flight not in removed
+    assert in_flight.exists()
+    assert in_flight.read_bytes() == b"actively being written by rebuild_atomic"
+
+
+def test_sweep_still_respects_live_path_exclusion_for_the_lexical_family(
+    tmp_path: Path,
+) -> None:
+    """Defense in depth: even though production never registers a lexical
+    temp today, a *stale* one that some caller DID register or claim must
+    still be preserved — the active-path exclusion applies uniformly across
+    families."""
+    vault_root = tmp_path
+    live = lexstore.lexical_path(vault_root)
+    live.parent.mkdir(parents=True)
+
+    registered = _lexical_temp(vault_root)
+    registered.write_bytes(b"registered and stale")
+    _age_file(registered, minutes_ago=_STALE_MINUTES)
+    graph_sync.register_temporary(registered)
+    try:
+        removed = graph_sync.sweep_abandoned_temporaries(vault_root, live, live_paths=set())
+        assert registered not in removed
+        assert registered.exists()
+    finally:
+        graph_sync.unregister_temporary(registered)
+
+
+def test_sweep_does_not_touch_a_similarly_named_but_non_matching_lexical_file(
+    tmp_path: Path,
+) -> None:
+    vault_root = tmp_path
+    live = lexstore.lexical_path(vault_root)
+    live.parent.mkdir(parents=True)
+
+    # Not a match: hex segment is one character short of the minted 32.
+    short_hex = live.with_name(f"{live.name}.rebuild-{'a' * 31}.tmp")
+    # Not a match: an extra path segment sits between the hex and `.tmp`.
+    extra_segment = live.with_name(f"{live.name}.rebuild-{uuid.uuid4().hex}.extra.tmp")
+    # Not a match: uppercase hex (the mint site is always lowercase `.hex`).
+    uppercase_hex = live.with_name(f"{live.name}.rebuild-{uuid.uuid4().hex.upper()}.tmp")
+    # Not a match: a user file that merely happens to share the literal prefix.
+    user_copy = live.with_name(f"{live.name}.rebuild-user-copy.tmp")
+    decoys = (short_hex, extra_segment, uppercase_hex, user_copy)
+    for path in decoys:
+        path.write_bytes(b"decoy")
+        # Aged too: even a stale decoy must never match on name alone.
+        _age_file(path, minutes_ago=_STALE_MINUTES)
+
+    removed = graph_sync.sweep_abandoned_temporaries(vault_root, live, live_paths=set())
+
+    assert removed == []
+    assert all(path.exists() for path in decoys)
+
+
+def test_sweep_still_removes_the_graph_family_alongside_a_stale_lexical_one(
+    tmp_path: Path,
+) -> None:
+    """The refactor must not regress the pre-existing `.graph-rebuild-*`
+    family. Unlike lexical, the graph family needs no aging: its mint site
+    holds `claim_rebuild_owner` for its entire build, and this sweep can only
+    ever claim ownership itself while no builder currently holds it — so any
+    name-matching graph temp found under a successful claim is abandoned by
+    construction, fresh mtime or not."""
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="1" * 24,
+        paths=(("Knowledge Base/Notes/example.md", "a" * 64),),
+        created_paths=("Knowledge Base/Notes/example.md",),
+    )
+    vault_root = tmp_path
+    live = vault_root / "Knowledge Base" / ".graph.sqlite"
+    live.parent.mkdir(parents=True)
+    graph_abandoned = graph_sync.temporary_sidecar_path(live, checkpoint)
+    graph_abandoned.write_bytes(b"abandoned graph rebuild temp")
+    # Deliberately left fresh (un-aged): the graph family's protection is the
+    # ownership claim, not mtime, and must remove this immediately.
+
+    lexical_live = lexstore.lexical_path(vault_root)
+    lexical_abandoned = _lexical_temp(vault_root)
+    lexical_abandoned.write_bytes(b"abandoned lexical rebuild temp")
+    _age_file(lexical_abandoned, minutes_ago=_STALE_MINUTES)
+
+    removed = graph_sync.sweep_abandoned_temporaries(vault_root, live, live_paths=set())
+
+    assert set(removed) == {graph_abandoned, lexical_abandoned}
+    assert not graph_abandoned.exists()
+    assert not lexical_abandoned.exists()
+    assert lexical_live.parent == live.parent
+
+
+def test_a_family_level_unlink_failure_does_not_starve_the_other_family(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Per-family error isolation: a non-`PermissionError` unlink failure
+    while sweeping the graph family (swept first) must not abort the lexical
+    family's sweep in the same pass — this call is #551's only reaper for the
+    lexical family, so letting a graph-side failure starve it would silently
+    resume the exact leak this function exists to close."""
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="3" * 24,
+        paths=(("Knowledge Base/Notes/example.md", "b" * 64),),
+        created_paths=("Knowledge Base/Notes/example.md",),
+    )
+    vault_root = tmp_path
+    live = vault_root / "Knowledge Base" / ".graph.sqlite"
+    live.parent.mkdir(parents=True)
+    graph_abandoned = graph_sync.temporary_sidecar_path(live, checkpoint)
+    graph_abandoned.write_bytes(b"abandoned graph rebuild temp")
+
+    lexical_stale = _lexical_temp(vault_root)
+    lexical_stale.write_bytes(b"stale abandoned lexical rebuild temp")
+    _age_file(lexical_stale, minutes_ago=_STALE_MINUTES)
+
+    original_unlink = Path.unlink
+
+    def _fail_like_ebusy_for_graph_candidate(
+        self: Path, *, missing_ok: bool = False
+    ) -> None:
+        if self == graph_abandoned:
+            raise OSError(16, "simulated device-or-resource-busy failure")  # EBUSY
+        original_unlink(self, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", _fail_like_ebusy_for_graph_candidate)
+
+    removed = graph_sync.sweep_abandoned_temporaries(vault_root, live, live_paths=set())
+
+    assert lexical_stale in removed
+    assert not lexical_stale.exists()
+    # The graph family's own failure is isolated to that family: it neither
+    # propagates out of the call nor removes the graph temp itself.
+    assert graph_abandoned not in removed
+    assert graph_abandoned.exists()
+
+
+def test_stale_age_threshold_is_shared_with_vault_module(tmp_path: Path) -> None:
+    """The staleness gate must reuse `vault.REBUILD_TEMP_STALE_AGE_SECONDS`
+    (also `doctor.py`'s threshold) rather than a private duplicate: a temp
+    aged to just inside the threshold survives, one aged just past it does
+    not."""
+    vault_root = tmp_path
+    live = lexstore.lexical_path(vault_root)
+    live.parent.mkdir(parents=True)
+    threshold_minutes = vault.REBUILD_TEMP_STALE_AGE_SECONDS / 60
+
+    just_fresh = _lexical_temp(vault_root)
+    just_fresh.write_bytes(b"just inside the threshold")
+    _age_file(just_fresh, minutes_ago=threshold_minutes - 1)
+
+    just_stale = _lexical_temp(vault_root)
+    just_stale.write_bytes(b"just past the threshold")
+    _age_file(just_stale, minutes_ago=threshold_minutes + 1)
+
+    removed = graph_sync.sweep_abandoned_temporaries(vault_root, live, live_paths=set())
+
+    assert just_fresh not in removed
+    assert just_fresh.exists()
+    assert just_stale in removed
+    assert not just_stale.exists()


### PR DESCRIPTION
Closes #551.

## What was wrong

`lexstore.rebuild_atomic` mints `<name>.rebuild-<uuid4hex>.tmp`, but the only reaper — `graph_sync.sweep_abandoned_temporaries` — knew about the `.graph-rebuild-` prefix alone. 78 files / 6.5 GB of abandoned lexical temporaries were observed in production.

## The fix

`sweep_abandoned_temporaries` now iterates registered temp families instead of one hardcoded prefix, and the lexical family is registered alongside the graph one. Every safety property of the original is preserved: claim-owned ownership probe, companion-suffix stripping for `-journal`/`-wal`/`-shm`, a strict `re.fullmatch` guard on the base name, live-path exclusion, and `PermissionError` tolerance for Windows readers holding delete-sharing.

**The lexical family additionally requires mtime staleness.** This is the important asymmetry, and it is not symmetric with the graph family by accident. The graph mint site holds `claim_rebuild_owner` for its entire build — including `replace_sidecar` — and calls `register_temporary`, so a sweep that successfully claims ownership has already proven any matching graph temp is abandoned. `lexstore.py` does neither, so for the lexical family both of those protections would have been **vacuous**: a name match alone would have unlinked in-flight rebuilds.

That is not hypothetical. The first iteration of this change did exactly that, demonstrated end-to-end: `reconcile.py:539` starts a background repair via `ensure_fresh` → `_schedule_repair` → `rebuild_atomic`, and `reconcile.py:615` sweeps ~75 lines later in the same pass, producing `lexical atomic publish failed ([WinError 2] ...); live sidecar preserved` and discarding a completed multi-GB rebuild. The repo had already documented and rejected the name-match-alone approach in `doctor.py`: *"A matching name alone is NOT evidence of an orphan: a legitimate in-flight rebuild has a matching name too."*

The staleness threshold is now `vault.REBUILD_TEMP_STALE_AGE_SECONDS`, shared rather than copied — `doctor.py`'s independent constant and regex are removed in favour of it and of `vault.is_lexical_rebuild_runtime_file_name`, and `graph_sync.py` uses the public matchers too. That takes four independent encodings of the temp-name shape down to one public matcher plus `governance/tool.py`'s separate private copy.

**Per-family error isolation.** Each family's glob-and-unlink loop is wrapped in its own handler, so a non-`PermissionError` failure in one family no longer aborts before the other is swept, and no longer propagates out of `reconcile.py:615`. Per-candidate `PermissionError` handling is unchanged and still matches first.

**Census prune.** `.lexical.sqlite.rebuild-*` is added to the identity-census directory prune. `strict_walk` stats every entry before the `.md` filter, so a temp vanishing between `scandir` and `stat` raises `FileNotFoundError`, is swallowed into a `None` census, and forces an uncached corpus rebuild — the same rationale already documented for `.embeddings.sqlite-shm/-wal` and `.graph-rebuild-*`.

## Verification

Seven tests, red against the pre-fix commit for the right reasons — a fresh unclaimed temp appearing in `removed`, a raw `OSError` escaping the sweep, and the shared constant not existing.

Independent review ran the original defect reproducer against the fix (sweep now returns `[]`, `rebuild_atomic()` publishes `True`), re-ran a 22-name adversarial probe with every file aged stale (zero false positives, live sidecars intact, and the regex rather than the glob confirmed as the gate), and fuzzed the removed `doctor.py` regex against the shared `vault` matcher over 8,048 generated names with zero disagreements.

`ruff check` clean on every touched file. Existing graph sweep and reap tests unaffected.

## Scope

This stops the leak going forward. It does **not** clear the existing 6.5 GB backlog, which still needs an operator maintenance window.

## Related

- #561 — `_corpus_census` stats before the `.md` filter, so vanishing sidecar `-wal`/`-shm` files can still degrade the census to `None`. The prune here closes one entrant; the general case is the #528 fix never applied to `_corpus_census`.
