### PR TITLE
fix(governance): classify governed refusals in the mutation journal

### DIFF
--- a/src/exomem/cli_ops.py
+++ b/src/exomem/cli_ops.py
@@ -274,31 +274,60 @@ def error_dict(exc: Exception) -> dict:
 def leaf_contract_code(exc: BaseException) -> str | None:
     """Return the stable refusal code an exception carries, or `None`.
 
-    Mirrors `error_dict`'s classification precedence — a duck-typed
-    `as_public_dict()` payload (e.g. `OpError`, `vault.BatchWriteError`),
-    then `OpError.code` directly, then the "CODE: message" leaf-contract
-    convention on a plain `ValueError`/`TypeError`/`RuntimeError` — but
-    returns `None` instead of a fallback sentinel (`error_dict` uses
-    "OP_ERROR"/"INTERNAL") when nothing structured is found. Callers that
-    need a code for *every* exception (like `error_dict`, which must always
-    answer a client) keep their own fallback; callers that must not invent a
-    plausible-looking code for a genuinely unexpected exception (like the
-    mutation journal) use `None` to fall back to the exception's class name
-    instead — so real bugs stay visible as bugs.
+    Mirrors `error_dict`'s FULL classification precedence, in the same
+    order:
+
+    1. The semantic chain walk (`semantic_validation_error_dict`), which can
+       surface a code from `exc.__cause__`/`__context__` rather than `exc`
+       itself. This matters because ~25 sites in `commands.py` re-wrap a
+       `SemanticWriteError` as `raise ValueError(f"{e.code}: {e.reason}")
+       from e` — the re-wrap's own `str()` carries the *raw* `e.code` (e.g.
+       "SEMANTIC_CONTRACT_VIOLATION"), but `as_semantic_validation_error()`
+       on the chained cause projects the *canonical* semantic code (e.g.
+       "missing_semantic_unit") that the client actually receives via
+       `error_dict`. Skipping this step would journal a code no client ever
+       saw for a whole refusal class — exactly the join-breaking gap this
+       lane exists to close.
+    2. A duck-typed `as_public_dict()` payload (e.g. `OpError`,
+       `vault.BatchWriteError`).
+    3. `OpError.code` directly.
+    4. The "CODE: message" leaf-contract convention on a plain
+       `ValueError`/`TypeError`/`RuntimeError`.
+
+    Unlike `error_dict` (which must always answer a client and so falls back
+    to "OP_ERROR"/"INTERNAL"), this returns `None` — never a fallback
+    sentinel — when nothing structured is found. That includes a structured
+    source whose "code" is present but empty (`{"code": ""}`): no current
+    caller produces this, but an empty string is not a real refusal code, so
+    it is treated the same as "nothing found" rather than returned in place
+    of `None`. Callers use `None` to fall back to the exception's own class
+    name instead of inventing a plausible-looking code for a genuinely
+    unexpected error — so real bugs stay visible as bugs.
     """
+
+    def _code_of(payload: object) -> str | None:
+        if not isinstance(payload, dict):
+            return None
+        code = payload.get("code")
+        return code if isinstance(code, str) and code else None
+
+    semantic_code = _code_of(semantic_validation_error_dict(exc))
+    if semantic_code is not None:
+        return semantic_code
     public_dict = getattr(exc, "as_public_dict", None)
     if callable(public_dict):
         try:
             payload = public_dict()
         except Exception:  # noqa: BLE001 - fall through to the narrower checks
             payload = None
-        if isinstance(payload, dict) and isinstance(payload.get("code"), str):
-            return payload["code"]
-    if isinstance(exc, OpError):
+        public_code = _code_of(payload)
+        if public_code is not None:
+            return public_code
+    if isinstance(exc, OpError) and exc.code:
         return exc.code
     if isinstance(exc, (ValueError, TypeError, RuntimeError)):
         m = _CODE_PREFIX.match(str(exc))
-        if m:
+        if m and m.group(1):
             return m.group(1)
     return None
 

--- a/src/exomem/cli_ops.py
+++ b/src/exomem/cli_ops.py
@@ -271,6 +271,38 @@ def error_dict(exc: Exception) -> dict:
     return {"code": "INTERNAL", "message": text, "remediation": None}
 
 
+def leaf_contract_code(exc: BaseException) -> str | None:
+    """Return the stable refusal code an exception carries, or `None`.
+
+    Mirrors `error_dict`'s classification precedence — a duck-typed
+    `as_public_dict()` payload (e.g. `OpError`, `vault.BatchWriteError`),
+    then `OpError.code` directly, then the "CODE: message" leaf-contract
+    convention on a plain `ValueError`/`TypeError`/`RuntimeError` — but
+    returns `None` instead of a fallback sentinel (`error_dict` uses
+    "OP_ERROR"/"INTERNAL") when nothing structured is found. Callers that
+    need a code for *every* exception (like `error_dict`, which must always
+    answer a client) keep their own fallback; callers that must not invent a
+    plausible-looking code for a genuinely unexpected exception (like the
+    mutation journal) use `None` to fall back to the exception's class name
+    instead — so real bugs stay visible as bugs.
+    """
+    public_dict = getattr(exc, "as_public_dict", None)
+    if callable(public_dict):
+        try:
+            payload = public_dict()
+        except Exception:  # noqa: BLE001 - fall through to the narrower checks
+            payload = None
+        if isinstance(payload, dict) and isinstance(payload.get("code"), str):
+            return payload["code"]
+    if isinstance(exc, OpError):
+        return exc.code
+    if isinstance(exc, (ValueError, TypeError, RuntimeError)):
+        m = _CODE_PREFIX.match(str(exc))
+        if m:
+            return m.group(1)
+    return None
+
+
 def http_status_for(code: str) -> int:
     """HTTP status for an error code (REST). Defaults to 400."""
     if code in _NOT_FOUND_CODES or code.endswith("_NOT_FOUND"):

--- a/src/exomem/cli_ops.py
+++ b/src/exomem/cli_ops.py
@@ -242,6 +242,41 @@ def semantic_validation_error_dict(exc: Exception) -> dict[str, Any] | None:
     return None
 
 
+def _semantic_validation_error_dict_cause_only(exc: BaseException) -> dict[str, Any] | None:
+    """Like `semantic_validation_error_dict`, but follows `__cause__` only.
+
+    `semantic_validation_error_dict` also follows `__context__` — the chain
+    Python sets IMPLICITLY whenever one exception is raised while another is
+    already being handled, with no `from` required. That is correct for
+    `error_dict`, which must always answer a client with *some* code and
+    accepts the (rare) risk of an implicit chain. It is NOT safe for a
+    caller that must tell a genuine bug apart from a refusal: a teardown bug
+    (a `finally`/`__exit__`/lease-release/graph-sync failure) that fires
+    while a semantic refusal is unwinding gets `__context__` set to that
+    refusal automatically, with no `from` anywhere in the bug's own code.
+    Following `__context__` there would misattribute the bug's own class
+    name to the refusal code it happened to interrupt. This variant follows
+    only the EXPLICIT `raise ... from e` idiom (`__cause__`) — the one
+    `commands.py`'s `raise ValueError(f"{e.code}: {e.reason}") from e`
+    re-wraps actually use — so an implicit, incidental `__context__` chain
+    never contributes a code.
+    """
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        projector = getattr(current, "as_semantic_validation_error", None)
+        if callable(projector):
+            try:
+                payload = projector()
+            except Exception:  # noqa: BLE001 - keep the original error path intact
+                payload = None
+            if isinstance(payload, dict):
+                return payload
+        current = current.__cause__
+    return None
+
+
 def error_dict(exc: Exception) -> dict:
     """Convert any raised error into the envelope's `error` block.
 
@@ -274,35 +309,60 @@ def error_dict(exc: Exception) -> dict:
 def leaf_contract_code(exc: BaseException) -> str | None:
     """Return the stable refusal code an exception carries, or `None`.
 
-    Mirrors `error_dict`'s FULL classification precedence, in the same
-    order:
+    This is DELIBERATELY STRICTER than `error_dict`'s classification, not a
+    mirror of it. `error_dict` answers a client, who has already lost the
+    ability to see anything other than a code — every exception must map to
+    *some* code, so `error_dict` accepts a small amount of misattribution
+    risk (see below) in exchange for never leaving a request unanswered.
+    This function feeds the mutation journal instead, whose entire job is
+    separating genuine refusals from genuine bugs — a code that looks
+    like a refusal but was actually produced by a bug is worse here than a
+    class name that's merely uninformative, because it hides the bug inside
+    what reads as normal traffic. So where the two intentionally diverge,
+    this function is the more conservative one:
 
-    1. The semantic chain walk (`semantic_validation_error_dict`), which can
-       surface a code from `exc.__cause__`/`__context__` rather than `exc`
-       itself. This matters because ~25 sites in `commands.py` re-wrap a
-       `SemanticWriteError` as `raise ValueError(f"{e.code}: {e.reason}")
-       from e` — the re-wrap's own `str()` carries the *raw* `e.code` (e.g.
-       "SEMANTIC_CONTRACT_VIOLATION"), but `as_semantic_validation_error()`
-       on the chained cause projects the *canonical* semantic code (e.g.
-       "missing_semantic_unit") that the client actually receives via
-       `error_dict`. Skipping this step would journal a code no client ever
-       saw for a whole refusal class — exactly the join-breaking gap this
-       lane exists to close.
+    1. The semantic chain walk uses `_semantic_validation_error_dict_cause_only`
+       (walks `exc.__cause__` only), NOT `error_dict`'s
+       `semantic_validation_error_dict` (which also walks `__context__`).
+       `__context__` is set IMPLICITLY by Python whenever an exception is
+       raised while another is already being handled — no `from` required —
+       so it can carry an unrelated `SemanticWriteError` merely because a
+       teardown bug happened to fire while that refusal was unwinding
+       (`finally`/`__exit__`/lease-release/graph-sync code in `writer_lease`
+       runs inside every one of the ~21 `except SemanticWriteError:`
+       handlers across `create_file.py`/`edit.py`/`append_to_file.py`/
+       `link.py`). `error_dict` accepts that risk; the journal must not, or
+       a live bug in that teardown path would be invisible in the refusal
+       distribution — recorded as a benign content refusal instead of a
+       bug. `__cause__` only picks up the EXPLICIT
+       `raise ValueError(f"{e.code}: {e.reason}") from e` re-wrap idiom
+       `commands.py` uses at ~25 sites, which is the case this step exists
+       to fix: the re-wrap's own `str()` carries the *raw* `e.code` (e.g.
+       "SEMANTIC_CONTRACT_VIOLATION"), while `as_semantic_validation_error()`
+       on the explicitly-chained cause projects the *canonical* semantic
+       code (e.g. "missing_semantic_unit") that the client actually receives
+       via `error_dict`.
     2. A duck-typed `as_public_dict()` payload (e.g. `OpError`,
        `vault.BatchWriteError`).
     3. `OpError.code` directly.
     4. The "CODE: message" leaf-contract convention on a plain
        `ValueError`/`TypeError`/`RuntimeError`.
 
-    Unlike `error_dict` (which must always answer a client and so falls back
-    to "OP_ERROR"/"INTERNAL"), this returns `None` — never a fallback
-    sentinel — when nothing structured is found. That includes a structured
-    source whose "code" is present but empty (`{"code": ""}`): no current
-    caller produces this, but an empty string is not a real refusal code, so
-    it is treated the same as "nothing found" rather than returned in place
-    of `None`. Callers use `None` to fall back to the exception's own class
-    name instead of inventing a plausible-looking code for a genuinely
-    unexpected error — so real bugs stay visible as bugs.
+    Two more inert divergences from `error_dict`, for accuracy: if the
+    semantic payload has no `"code"` key, or `code == ""`, `error_dict`
+    returns that payload verbatim (so a client could see a codeless error
+    block). This function instead falls through to steps 2-4 on `exc`
+    itself. Nothing exercises this today — `as_semantic_validation_error()`
+    always sets a non-empty canonical finding code — but if it ever
+    happened, falling through is the safer direction for a journal: it
+    still prefers a real code over `None` when one is available lower in
+    the precedence, rather than silently accepting an empty one.
+
+    Unlike `error_dict`, this returns `None` — never a fallback sentinel —
+    when nothing structured is found. Callers use `None` to fall back to
+    the exception's own class name instead of inventing a plausible-looking
+    code for a genuinely unexpected error — so real bugs stay visible as
+    bugs.
     """
 
     def _code_of(payload: object) -> str | None:
@@ -311,7 +371,7 @@ def leaf_contract_code(exc: BaseException) -> str | None:
         code = payload.get("code")
         return code if isinstance(code, str) and code else None
 
-    semantic_code = _code_of(semantic_validation_error_dict(exc))
+    semantic_code = _code_of(_semantic_validation_error_dict_cause_only(exc))
     if semantic_code is not None:
         return semantic_code
     public_dict = getattr(exc, "as_public_dict", None)
@@ -326,8 +386,11 @@ def leaf_contract_code(exc: BaseException) -> str | None:
     if isinstance(exc, OpError) and exc.code:
         return exc.code
     if isinstance(exc, (ValueError, TypeError, RuntimeError)):
+        # `_CODE_PREFIX`'s first group is `[A-Z][A-Z0-9_]+` (one-or-more
+        # after the first char), so a match can never capture an empty
+        # string — no `and m.group(1)` truthiness check needed here.
         m = _CODE_PREFIX.match(str(exc))
-        if m and m.group(1):
+        if m:
             return m.group(1)
     return None
 

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
-from .cli_ops import OpError
+from .cli_ops import OpError, leaf_contract_code
 from .mutation_lock import (
     VaultMutationCoordinator,
     canonical_mutation_identity,
@@ -2933,7 +2933,15 @@ class LeaseManager:
                 command=command.name,
                 receipt=receipt,
                 outcome="failed",
-                error_code=error.code if isinstance(error, OpError) else type(error).__name__,
+                # `OpError` carries a real code directly; a leaf-contract
+                # `ValueError` ("CODE: message") encodes one in its string
+                # form (issue #553 — the journal was recording the Python
+                # exception class name for these, losing the refusal
+                # classification entirely). Anything that doesn't match
+                # either structured shape keeps its class name so a
+                # genuinely unexpected exception stays visible as a bug
+                # rather than being laundered into a plausible-looking code.
+                error_code=leaf_contract_code(error) or type(error).__name__,
                 duration_ms=round((time.perf_counter() - t_start) * 1000, 2),
                 scope=implicit_idempotency_scope or idempotency_principal_scope,
                 targets=[str(mutation_subject)],

--- a/tests/test_cli_ops.py
+++ b/tests/test_cli_ops.py
@@ -93,6 +93,48 @@ def test_mutation_lock_errors_have_actionable_remediation(code: str) -> None:
     assert error["remediation"]
 
 
+# ---------------- leaf_contract_code (issue #553: journal classification) ----------------
+
+
+def test_leaf_contract_code_from_op_error() -> None:
+    assert cli_ops.leaf_contract_code(cli_ops.OpError("BAD_BOOL", "nope")) == "BAD_BOOL"
+
+
+def test_leaf_contract_code_parses_leaf_contract_valueerror() -> None:
+    err = ValueError("NOT_FOUND: no such file")
+    assert cli_ops.leaf_contract_code(err) == "NOT_FOUND"
+
+
+def test_leaf_contract_code_from_as_public_dict_exception() -> None:
+    # BatchWriteError (vault.py) carries `.code`/`as_public_dict()` like OpError
+    # but isn't an OpError subclass — the duck-typed public-dict path must
+    # still surface its real code.
+    from exomem import vault as vault_module
+
+    error = vault_module.BatchWriteError(
+        "BATCH_ROLLBACK_INCOMPLETE",
+        vault_module.BatchTargetSummary(1, ("a.md",), 0),
+        committed=False,
+    )
+    assert cli_ops.leaf_contract_code(error) == "BATCH_ROLLBACK_INCOMPLETE"
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ValueError("just a message, no code prefix"),
+        TypeError("bad type somewhere"),
+        RuntimeError("something broke"),
+        KeyError("missing"),
+    ],
+)
+def test_leaf_contract_code_is_none_for_unexpected_exceptions(exc: BaseException) -> None:
+    # Case 3's safety property: an exception that is NOT the leaf-contract
+    # "CODE: message" shape must yield None, not a laundered/plausible code —
+    # callers fall back to the exception's own class name.
+    assert cli_ops.leaf_contract_code(exc) is None
+
+
 # ---------------- coercion ----------------
 
 _PARAMS = (

--- a/tests/test_cli_ops.py
+++ b/tests/test_cli_ops.py
@@ -2,11 +2,49 @@
 
 from __future__ import annotations
 
+import datetime
+import json
+
 import pytest
 
 from exomem import cli_ops
 from exomem import vault as vault_module
 from exomem.commands import Param
+
+
+# Real stdlib exceptions used as leaf_contract_code boundary cases (see
+# test_leaf_contract_code_is_none_for_unexpected_exceptions): built once at
+# module scope so pytest.param can carry live exception instances.
+def _fromisoformat_error(value: str) -> ValueError:
+    try:
+        datetime.date.fromisoformat(value)
+    except ValueError as e:
+        return e
+    raise AssertionError("expected fromisoformat to raise")  # pragma: no cover
+
+
+def _json_decode_error() -> json.JSONDecodeError:
+    try:
+        json.loads("{}x")
+    except json.JSONDecodeError as e:
+        return e
+    raise AssertionError("expected json.loads to raise")  # pragma: no cover
+
+
+def _int_base10_error() -> ValueError:
+    try:
+        int("x", 10)
+    except ValueError as e:
+        return e
+    raise AssertionError("expected int() to raise")  # pragma: no cover
+
+
+def _unicode_decode_error() -> UnicodeDecodeError:
+    try:
+        b"\xff".decode("utf-8")
+    except UnicodeDecodeError as e:
+        return e
+    raise AssertionError("expected bytes.decode to raise")  # pragma: no cover
 
 
 def test_envelope_success_shape() -> None:
@@ -119,6 +157,72 @@ def test_leaf_contract_code_from_as_public_dict_exception() -> None:
     assert cli_ops.leaf_contract_code(error) == "BATCH_ROLLBACK_INCOMPLETE"
 
 
+def test_leaf_contract_code_prefers_semantic_chain_over_leaf_prefix() -> None:
+    # ~25 sites in commands.py re-wrap a SemanticWriteError as
+    # `raise ValueError(f"{e.code}: {e.reason}") from e`. The re-wrap's own
+    # str() carries the *raw* SemanticWriteError.code
+    # ("SEMANTIC_CONTRACT_VIOLATION"), but `as_semantic_validation_error()`
+    # on the chained `__cause__` projects the *canonical* semantic code
+    # ("missing_semantic_unit") that `error_dict` — and therefore the
+    # client — actually surfaces. The journal must agree with what the
+    # client saw, not with the discarded raw prefix.
+    from exomem import semantic_contract, semantic_writes
+
+    finding = semantic_contract.ContractFinding(
+        code="missing_semantic_unit",
+        severity="error",
+        path="Knowledge Base/Notes/x.md",
+        span=None,
+        detail="page has no semantic unit",
+        remediation="add one",
+        governed_element_identity=(),
+        resolved_rule=("r", "r", "r"),
+    )
+    cause = semantic_writes.SemanticWriteError(
+        "SEMANTIC_CONTRACT_VIOLATION",
+        "page has no semantic unit",
+        validation_findings=(finding,),
+    )
+    try:
+        raise ValueError(f"{cause.code}: {cause.reason}") from cause
+    except ValueError as rewrapped:
+        assert str(rewrapped) == "SEMANTIC_CONTRACT_VIOLATION: page has no semantic unit"
+        assert cli_ops.leaf_contract_code(rewrapped) == "missing_semantic_unit"
+        # Parity with the client-facing envelope: the journal must not
+        # diverge from what error_dict actually answers for the same error.
+        assert cli_ops.error_dict(rewrapped)["code"] == "missing_semantic_unit"
+
+
+def test_leaf_contract_code_semantic_chain_outranks_public_dict_and_own_code() -> None:
+    # Precedence check in isolation from the real semantic-authoring
+    # machinery: a chained cause exposing `as_semantic_validation_error()`
+    # must win even over an exception that ALSO carries its own
+    # `as_public_dict()`/`.code` (which would otherwise win via the
+    # duck-typed or OpError branches).
+    class _Cause(Exception):
+        def as_semantic_validation_error(self):
+            return {"code": "missing_semantic_unit"}
+
+    rewrap = cli_ops.OpError("SEMANTIC_CONTRACT_VIOLATION", "page has no semantic unit")
+    rewrap.__cause__ = _Cause("synthetic cause")
+    assert cli_ops.leaf_contract_code(rewrap) == "missing_semantic_unit"
+
+
+def test_leaf_contract_code_empty_string_code_is_treated_as_absent() -> None:
+    # Nothing in the codebase produces an empty "code" today, but the
+    # contract is pinned explicitly: an empty string is not a real refusal
+    # code, so `leaf_contract_code` must not return it in place of `None`.
+    # The mutation journal's `leaf_contract_code(error) or
+    # type(error).__name__` then still falls back to the class name.
+    class _EmptyCode(Exception):
+        def as_public_dict(self):
+            return {"code": ""}
+
+    error = _EmptyCode("does not matter")
+    assert cli_ops.leaf_contract_code(error) is None
+    assert (cli_ops.leaf_contract_code(error) or type(error).__name__) == "_EmptyCode"
+
+
 @pytest.mark.parametrize(
     "exc",
     [
@@ -126,6 +230,17 @@ def test_leaf_contract_code_from_as_public_dict_exception() -> None:
         TypeError("bad type somewhere"),
         RuntimeError("something broke"),
         KeyError("missing"),
+        # Boundary cases: real stdlib exceptions whose messages sit close to
+        # the "CODE: message" shape (a leading capital, an embedded colon)
+        # without actually matching `_CODE_PREFIX` — must still yield None,
+        # not a code sniffed out of an unrelated message.
+        pytest.param(
+            _fromisoformat_error("2026"),
+            id="date-fromisoformat",
+        ),
+        pytest.param(_json_decode_error(), id="json-decode-error"),
+        pytest.param(_int_base10_error(), id="int-base10"),
+        pytest.param(_unicode_decode_error(), id="unicode-decode-error"),
     ],
 )
 def test_leaf_contract_code_is_none_for_unexpected_exceptions(exc: BaseException) -> None:

--- a/tests/test_mutation_journal.py
+++ b/tests/test_mutation_journal.py
@@ -162,3 +162,76 @@ def test_rotates_at_size_cap(tmp_path: Path, _journal_log_dir: Path, monkeypatch
         )
     rotated = _journal_log_dir / "mutations.jsonl.1"
     assert rotated.exists()
+
+
+# --------------------------------------------------------------------------- #
+# Issue #553: the journal must classify a leaf-contract `ValueError` by its
+# real refusal code, not by the Python exception class name — while a
+# genuinely unexpected exception (not the "CODE: message" leaf-contract
+# shape) must keep its class name so real bugs stay visible as bugs instead
+# of being laundered into a plausible-looking refusal code.
+# --------------------------------------------------------------------------- #
+def test_leaf_contract_valueerror_is_journaled_with_its_real_code(
+    tmp_path: Path, _journal_log_dir: Path
+) -> None:
+    def boom():
+        raise ValueError("NOT_FOUND: no such vault path: Knowledge Base/missing.md")
+
+    command = _command(writes=True, leaf=boom)
+    with pytest.raises(ValueError):
+        _standalone_manager(tmp_path / "state").invoke(
+            command, (), {}, mutation_request_id="req-leaf-contract"
+        )
+
+    records = _read_journal(_journal_log_dir)
+    assert len(records) == 1
+    assert records[0]["outcome"] == "failed"
+    assert records[0]["error_code"] == "NOT_FOUND"
+
+
+def test_op_error_keeps_its_own_code_in_the_journal(
+    tmp_path: Path, _journal_log_dir: Path
+) -> None:
+    def boom():
+        raise OpError("STALE_CONTRACT", "the parent hash moved under you")
+
+    command = _command(writes=True, leaf=boom)
+    with pytest.raises(OpError):
+        _standalone_manager(tmp_path / "state").invoke(
+            command, (), {}, mutation_request_id="req-op-error"
+        )
+
+    records = _read_journal(_journal_log_dir)
+    assert len(records) == 1
+    assert records[0]["outcome"] == "failed"
+    assert records[0]["error_code"] == "STALE_CONTRACT"
+
+
+@pytest.mark.parametrize(
+    ("exc_factory", "expected_class_name"),
+    [
+        (lambda: ValueError("something went wrong"), "ValueError"),
+        (lambda: KeyError("missing"), "KeyError"),
+    ],
+)
+def test_unexpected_exception_keeps_its_class_name_in_the_journal(
+    tmp_path: Path,
+    _journal_log_dir: Path,
+    exc_factory,  # noqa: ANN001
+    expected_class_name: str,
+) -> None:
+    def boom():
+        raise exc_factory()
+
+    command = _command(writes=True, leaf=boom)
+    with pytest.raises((ValueError, KeyError)):
+        _standalone_manager(tmp_path / "state").invoke(
+            command, (), {}, mutation_request_id="req-unexpected"
+        )
+
+    records = _read_journal(_journal_log_dir)
+    assert len(records) == 1
+    assert records[0]["outcome"] == "failed"
+    # Not a real refusal code and not laundered into one — the class name
+    # stays visible so this reads as a bug, not a governed refusal.
+    assert records[0]["error_code"] == expected_class_name

--- a/tests/test_mutation_journal.py
+++ b/tests/test_mutation_journal.py
@@ -5,13 +5,14 @@ timing, content-classified targets, and best-effort (never-raises) writes.
 
 from __future__ import annotations
 
+import contextlib
 import json
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
-from exomem import metrics, mutation_journal
+from exomem import metrics, mutation_journal, semantic_contract, semantic_writes
 from exomem.cli_ops import OpError
 from exomem.writer_lease import LeaseConfig, LeaseManager
 
@@ -212,6 +213,12 @@ def test_op_error_keeps_its_own_code_in_the_journal(
     [
         (lambda: ValueError("something went wrong"), "ValueError"),
         (lambda: KeyError("missing"), "KeyError"),
+        # Control for test_bug_raised_inside_except_semanticwriteerror_handler_
+        # is_not_laundered_into_its_refusal_code below: the SAME exception
+        # type, with no semantic context in flight, already journals its own
+        # class name — proves it is specifically the (implicit) chain that
+        # is at risk of being misattributed, not something about TypeError.
+        (lambda: TypeError("bad type somewhere"), "TypeError"),
     ],
 )
 def test_unexpected_exception_keeps_its_class_name_in_the_journal(
@@ -224,7 +231,7 @@ def test_unexpected_exception_keeps_its_class_name_in_the_journal(
         raise exc_factory()
 
     command = _command(writes=True, leaf=boom)
-    with pytest.raises((ValueError, KeyError)):
+    with pytest.raises((ValueError, KeyError, TypeError)):
         _standalone_manager(tmp_path / "state").invoke(
             command, (), {}, mutation_request_id="req-unexpected"
         )
@@ -235,3 +242,89 @@ def test_unexpected_exception_keeps_its_class_name_in_the_journal(
     # Not a real refusal code and not laundered into one — the class name
     # stays visible so this reads as a bug, not a governed refusal.
     assert records[0]["error_code"] == expected_class_name
+
+
+def _semantic_write_error() -> semantic_writes.SemanticWriteError:
+    finding = semantic_contract.ContractFinding(
+        code="missing_semantic_unit",
+        severity="error",
+        path="Knowledge Base/Notes/x.md",
+        span=None,
+        detail="page has no semantic unit",
+        remediation="add one",
+        governed_element_identity=(),
+        resolved_rule=("r", "r", "r"),
+    )
+    return semantic_writes.SemanticWriteError(
+        "SEMANTIC_CONTRACT_VIOLATION", "no unit", validation_findings=(finding,)
+    )
+
+
+def test_teardown_bug_during_semantic_unwind_is_not_laundered_into_its_refusal_code(
+    tmp_path: Path, _journal_log_dir: Path
+) -> None:
+    """Realistic shape of the laundering bug the semantic-chain step must NOT
+    reintroduce: writer_lease's mutation boundary runs teardown code
+    (lease-release/graph-sync/`finally`) around every leaf invocation,
+    including the ~21 `except SemanticWriteError:` handlers across
+    create_file.py/edit.py/append_to_file.py/link.py that re-raise the
+    refusal `from error`. If that teardown itself has a bug — here,
+    `{}["lease_handle"]` — the resulting KeyError's `__context__` is set to
+    the in-flight SemanticWriteError IMPLICITLY (no `from` in the bug's own
+    code). The journal must record the real bug's class name, not the
+    refusal it happened to interrupt.
+    """
+
+    @contextlib.contextmanager
+    def mutation_boundary():
+        try:
+            yield
+        finally:
+            {}["lease_handle"]  # a genuine teardown bug, not a semantic refusal
+
+    def boom():
+        with mutation_boundary():
+            raise _semantic_write_error()
+
+    command = _command(writes=True, leaf=boom)
+    with pytest.raises(KeyError):
+        _standalone_manager(tmp_path / "state").invoke(
+            command, (), {}, mutation_request_id="req-teardown-bug"
+        )
+
+    records = _read_journal(_journal_log_dir)
+    assert len(records) == 1
+    assert records[0]["outcome"] == "failed"
+    assert records[0]["error_code"] == "KeyError"
+
+
+def test_bug_raised_inside_except_semanticwriteerror_handler_is_not_laundered_into_its_refusal_code(
+    tmp_path: Path, _journal_log_dir: Path
+) -> None:
+    """Second reachable shape: a genuine bug raised directly inside an
+    `except SemanticWriteError:` handler, without `from` — its `__context__`
+    is still set implicitly to the SemanticWriteError being handled. Pairs
+    with the `TypeError` control case in
+    test_unexpected_exception_keeps_its_class_name_in_the_journal (same
+    exception type, no semantic context in flight, already journals its own
+    class name) to prove it is specifically the chain that matters. The
+    journal must record the bug's own class name here too, not the semantic
+    refusal it interrupted.
+    """
+
+    def boom():
+        try:
+            raise _semantic_write_error()
+        except semantic_writes.SemanticWriteError:
+            raise TypeError("bad type somewhere")  # noqa: B904 - deliberately no `from`
+
+    command = _command(writes=True, leaf=boom)
+    with pytest.raises(TypeError):
+        _standalone_manager(tmp_path / "state").invoke(
+            command, (), {}, mutation_request_id="req-handler-bug"
+        )
+
+    records = _read_journal(_journal_log_dir)
+    assert len(records) == 1
+    assert records[0]["outcome"] == "failed"
+    assert records[0]["error_code"] == "TypeError"


### PR DESCRIPTION
Closes #553.

Instrumentation only. **No remediation prose changes** — the distribution that would direct them does not exist yet, and this PR is what creates it.

## Why the issue's stated method could not work

The plan was "pull the refusal-code distribution from the mutation journal, then improve the top offenders". The journal cannot yield that distribution. Of 2300 mutations, 525 failed (22.8%, matching the issue title), and **449 of those 525 — 85.5% — are recorded as `ValueError`**: the Python class name, not a governed refusal code. They concentrate in the two main agent-facing write tools, `remember` (222) and `edit_memory` (144).

The cause is `writer_lease.py:2936`:

```python
error_code=error.code if isinstance(error, OpError) else type(error).__name__,
```

Per `OpError`'s own docstring (`cli_ops.py:172-177`), this codebase deliberately raises **leaf-contract `ValueError`s** whose `str()` is already `"CODE: message"`. So callers are very likely getting decent refusals; the *journal* is what is blind. Any prose work before this lands is guesswork.

## The fix

`leaf_contract_code` derives the journal's code from the leaf-contract `"CODE: message"` shape as well as from `OpError`, so a governed refusal records its real code, an `OpError` keeps its existing one, and a genuinely unexpected exception still records its class name — real bugs stay visible as bugs.

**`error_dict()` and `semantic_validation_error_dict()` are untouched.** `git diff --numstat origin/main -- src/exomem/cli_ops.py` is `124 0` — 124 insertions, **zero deletions** across all three commits. Nothing pre-existing in the client-facing path was modified.

### The `__cause__`-only decision

The journal's semantic-code walker follows `__cause__` only, deliberately **not** mirroring `semantic_validation_error_dict`'s `__cause__ or __context__` precedence. Python sets `__context__` *implicitly* for any exception raised during another's handling, so following it launders unrelated bugs into governed codes:

| case | context-following | `__cause__`-only |
|---|---|---|
| `KeyError` teardown bug during semantic unwind | `missing_semantic_unit` | `KeyError` |
| `TypeError` inside `except SemanticWriteError:` | `missing_semantic_unit` | `TypeError` |
| `RuntimeError` two links down the `__context__` chain | `missing_semantic_unit` | `RuntimeError` |
| `KeyboardInterrupt` during semantic unwind | `missing_semantic_unit` | `KeyboardInterrupt` |
| legitimate `raise ... from e` re-wrap | `missing_semantic_unit` | `missing_semantic_unit` |

A crash inside a semantic handler would have been journalled as a governed refusal — exactly inverting what this lane exists to fix. The stricter walk keeps genuine re-wraps classified while refusing to claim the implicit ones.

`__cause__`-only is sufficient, not over-narrow: review enumerated **all 21** `except SemanticWriteError` sites and confirmed every one re-raises with an explicit `from` — `append_to_file.py`, `create_file.py`, `edit.py`, `link.py`, `move_file.py`, `note.py`, `observe_memory.py`, `set_frontmatter_field.py`, `recover_from_trash.py` — as do the nine outer `commands.py` handlers. The one `from None` in these leaves (`edit.py:407`) sits on a path-resolution error carrying its own governed code. No classification is lost. Two real multi-hop chains were run end to end (`SemanticWriteError` → `CreateFileError` → `ValueError`, and the `EditError` equivalent); both journal `missing_semantic_unit` and match `error_dict`'s client-facing code exactly.

The divergence from `error_dict` is documented in the docstring as deliberate, with its reason — the client must always get *some* code, while the journal's job is separating refusals from bugs — including two residual divergences that nothing exercises today.

## Verification

New tests are red against the prior commit for the right reason: rebinding the walker to the context-following variant produces `assert 'missing_semantic_unit' == 'KeyError'` and `== 'TypeError'`, failing on the laundered value rather than on incidental shape. A same-type-no-semantic-context control row isolates the chain as the variable.

51/51 in the two changed test files; 73/73 across `test_catalog_error_surfaces`, `test_cli_core_ops`, `test_mutation_state_machine`. Allowlist holds at four files.

## Follow-ups

- Once a few days of classified telemetry exist, re-pull the distribution and open a scoped ergonomics lane against the real top offenders. Expect `ValueError` to collapse from 85% of failures to near zero, replaced by real codes — that distribution is the input.
- Review flagged that the new walker is a 14-line near-copy of `semantic_validation_error_dict`, differing only in the traversal step, and is now the third copy of related precedence logic. The copy is defensible here precisely because the zero-deletions property is what makes the untouched-client-path claim verifiable, but unifying both behind a private `_semantic_walk(exc, *, follow_context)` is worth doing separately.
