### PR TITLE
fix(embeddings): refuse catch-up unless the change log covers the whole delta

### DIFF
--- a/src/exomem/embedding_index.py
+++ b/src/exomem/embedding_index.py
@@ -26,11 +26,15 @@ VECTOR_DIM = 768
 SEMANTIC_UNIT_SCHEMA_VERSION = 3
 
 # Per-path change log for the read-side bounded catch-up (see sidecar_store's
-# "bounded catch-up" note). CHUNK_PATH_LOG_TABLE records the generation at which
-# each `chunks.file_path` was last mutated; CHUNK_PATH_LOG_MARKER is the meta key
-# holding the generation from which that log is authoritative.
-CHUNK_PATH_LOG_TABLE = "chunk_path_log"
-CHUNK_PATH_LOG_MARKER = "chunk_path_log_from"
+# "bounded catch-up" note). The table records the generation at which each
+# `chunks.file_path` was last mutated; the two meta keys bound the contiguous run
+# of generations that log fully covers, so a bump from any writer that does not
+# maintain it — an older generation-AWARE binary sharing this vault, a manual
+# repair, a future in-tree writer — forces the full reload instead of reading as
+# "this write changed nothing".
+CHUNK_PATH_LOG = sidecar_store.PathChangeLog(
+    "chunk_path_log", "chunk_path_log_from", "chunk_path_log_upto"
+)
 
 # Catch-up bounds. PATHS is the real cost knob, not generations: one bump can
 # retire a whole batch of paths (a purge) and many bumps can rewrite one path
@@ -97,11 +101,13 @@ def _splice_path_blocks(
 
     `metadata` is sorted by file_path (both producers keep it that way), so
     `sidecar_store.file_block` locates each path's block — or, for a path with no
-    rows yet, its insertion point. Processing the replacements in sorted order
-    therefore walks the input once, left to right; blocks that go backwards mean
-    the caller handed in unsorted metadata and raise rather than silently
-    scrambling the matrix. An empty replacement (`new_vecs` None or zero rows)
-    deletes the block.
+    rows yet, its insertion point. It scans from index 0 every time, so this is
+    O(paths x rows), not a single pass; that is affordable only because the
+    caller bounds the path count (CATCHUP_MAX_PATHS). The replacements are
+    processed in sorted order and `cursor` only ever moves forward, so blocks
+    that go backwards mean the caller handed in unsorted metadata and raise
+    rather than silently scrambling the matrix. An empty replacement (`new_vecs`
+    None or zero rows) deletes the block.
 
     Copy-on-write: builds fresh containers and never mutates the arrays a
     concurrent reader may be holding. Raises ValueError on any inconsistency;
@@ -233,7 +239,7 @@ class EmbeddingIndex:
         # Before any write on this connection: every writer must have the log, so
         # that every generation past its floor is recorded (see sidecar_store).
         sidecar_store.ensure_path_change_log(
-            conn, CHUNK_PATH_LOG_TABLE, CHUNK_PATH_LOG_MARKER
+            conn, CHUNK_PATH_LOG
         )
         stored_unit_schema = conn.execute(
             "SELECT value FROM meta WHERE key = 'semantic_unit_schema_version'"
@@ -287,7 +293,7 @@ class EmbeddingIndex:
                 # (epoch, generation, instance) token, stable under the write
                 # lock. The cache keys on it, not the mtime.
                 sidecar_store.bump_generation_for_paths(
-                    conn, CHUNK_PATH_LOG_TABLE, [rel_path]
+                    conn, CHUNK_PATH_LOG, [rel_path]
                 )
                 own_epoch, own_gen, own_instance = sidecar_store.read_meta_token(conn)
         finally:
@@ -347,7 +353,7 @@ class EmbeddingIndex:
                     # the generation delta alone could never say how many, or
                     # which, paths this retired.
                     sidecar_store.bump_generation_for_paths(
-                        conn, CHUNK_PATH_LOG_TABLE, removed_paths
+                        conn, CHUNK_PATH_LOG, removed_paths
                     )
                     sidecar_store.bump_meta(conn, "semantic_unit_generation")
                     own_epoch, own_gen, own_instance = sidecar_store.read_meta_token(conn)
@@ -657,28 +663,29 @@ class EmbeddingIndex:
         snapshot, so a split read could pair one write's generation with another
         write's rows and then label the result as current.
 
-        The final `COUNT(*)` is the cheap cross-check that the log told the whole
-        truth: if some write ever bumped the generation without declaring its
-        paths, the spliced matrix would disagree with the sidecar's row count and
-        this refuses rather than serving it.
+        What keeps an unlogged generation bump from being read as "this write
+        changed nothing" is `catchup_is_eligible`'s run check, NOT the `COUNT(*)`
+        below: a count cannot see an in-place re-embed of an existing chunk,
+        which preserves the row count exactly. The count is a cheap secondary
+        cross-check for insert/delete-shaped divergence only.
         """
         conn = self._connect()
         try:
             conn.execute("BEGIN")
             try:
                 epoch, gen, instance = sidecar_store.read_meta_token(conn)
-                floor = sidecar_store.path_change_log_floor(conn, CHUNK_PATH_LOG_MARKER)
+                run = sidecar_store.read_logged_run(conn, CHUNK_PATH_LOG)
                 if not sidecar_store.catchup_is_eligible(
                     c,
                     epoch,
                     gen,
                     instance,
-                    floor=floor,
+                    run=run,
                     max_generations=CATCHUP_MAX_GENERATIONS,
                 ):
                     return None
                 changed = sidecar_store.changed_paths_since(
-                    conn, CHUNK_PATH_LOG_TABLE, c.generation, limit=CATCHUP_MAX_PATHS
+                    conn, CHUNK_PATH_LOG, c.generation, limit=CATCHUP_MAX_PATHS
                 )
                 if len(changed) > CATCHUP_MAX_PATHS:
                     return None  # wider than the bound — one clean reload is cheaper
@@ -1240,7 +1247,7 @@ class EmbeddingIndex:
                 # whole-table rewrite, so it resets and its authority floor moves
                 # here — no cache may be caught up across this write.
                 sidecar_store.bump_generation_for_reset(
-                    conn, CHUNK_PATH_LOG_TABLE, CHUNK_PATH_LOG_MARKER
+                    conn, CHUNK_PATH_LOG
                 )
                 sidecar_store.bump_meta(conn, "epoch")
                 sidecar_store.bump_meta(conn, "semantic_unit_generation")

--- a/src/exomem/embedding_index.py
+++ b/src/exomem/embedding_index.py
@@ -237,10 +237,9 @@ class EmbeddingIndex:
         )
         sidecar_store.ensure_meta_table(conn, "chunks", self.path.name)
         # Before any write on this connection: every writer must have the log, so
-        # that every generation past its floor is recorded (see sidecar_store).
-        sidecar_store.ensure_path_change_log(
-            conn, CHUNK_PATH_LOG
-        )
+        # that a writer which bumps the generation without logging its paths is
+        # DETECTED rather than silently caught up (see sidecar_store).
+        sidecar_store.ensure_path_change_log(conn, CHUNK_PATH_LOG)
         stored_unit_schema = conn.execute(
             "SELECT value FROM meta WHERE key = 'semantic_unit_schema_version'"
         ).fetchone()
@@ -1244,11 +1243,9 @@ class EmbeddingIndex:
                 # exposure a full reload always had racing a wipe/rebuild window,
                 # unchanged by this PR. epoch catches re-embeds that changed no
                 # file mtimes. The per-path change log cannot describe a
-                # whole-table rewrite, so it resets and its authority floor moves
+                # whole-table rewrite, so it resets and a fresh logged run starts
                 # here — no cache may be caught up across this write.
-                sidecar_store.bump_generation_for_reset(
-                    conn, CHUNK_PATH_LOG
-                )
+                sidecar_store.bump_generation_for_reset(conn, CHUNK_PATH_LOG)
                 sidecar_store.bump_meta(conn, "epoch")
                 sidecar_store.bump_meta(conn, "semantic_unit_generation")
         finally:

--- a/src/exomem/embedding_index.py
+++ b/src/exomem/embedding_index.py
@@ -25,6 +25,30 @@ log = logging.getLogger(__name__)
 VECTOR_DIM = 768
 SEMANTIC_UNIT_SCHEMA_VERSION = 3
 
+# Per-path change log for the read-side bounded catch-up (see sidecar_store's
+# "bounded catch-up" note). CHUNK_PATH_LOG_TABLE records the generation at which
+# each `chunks.file_path` was last mutated; CHUNK_PATH_LOG_MARKER is the meta key
+# holding the generation from which that log is authoritative.
+CHUNK_PATH_LOG_TABLE = "chunk_path_log"
+CHUNK_PATH_LOG_MARKER = "chunk_path_log_from"
+
+# Catch-up bounds. PATHS is the real cost knob, not generations: one bump can
+# retire a whole batch of paths (a purge) and many bumps can rewrite one path
+# (repeated upserts), so the changed-path count — not the generation delta — is
+# what the splice actually pays for. Per path it costs one `file_block` walk over
+# the key list plus that path's rows; the whole delta then costs ONE concatenate.
+# A full reload instead fetches and re-materializes every vector blob (a ~3 KB
+# BLOB per row against a bare string compare per key), so the per-path unit is
+# more than an order of magnitude cheaper than the per-row unit it replaces. 32
+# is set an order of magnitude below where those two could plausibly meet, and
+# comfortably above the 1-11 path deltas seen in production; it is a safety bound
+# on a fallback, not a tuned break-even, and the fallback is always correct.
+# GENERATIONS is only a cheap pre-filter: a cache that far behind belongs to an
+# idle process rejoining a busy vault, where one clean reload is the simpler
+# answer.
+CATCHUP_MAX_PATHS = 32
+CATCHUP_MAX_GENERATIONS = 64
+
 # --------------------------------------------------------------- generation meta
 #
 # The matrix caches key on an in-band WRITE GENERATION, not the sidecar file's
@@ -57,6 +81,64 @@ class _EmbCache(NamedTuple):
     recall_policy_identity: tuple[str, str]
     metadata: list[tuple[str, int]]
     matrix: np.ndarray
+
+
+def _splice_path_blocks(
+    metadata: list[tuple[str, int]],
+    matrix: np.ndarray,
+    replacements: dict[str, tuple[list[tuple[str, int]], np.ndarray | None]],
+) -> tuple[list[tuple[str, int]], np.ndarray]:
+    """Replace whole per-path row blocks in a `(metadata, matrix)` pair.
+
+    THE splice: the write-side single-path patch and the read-side bounded
+    catch-up both go through here, so there is exactly one implementation of
+    "swap a file's contiguous block for its current rows, keeping the pair sorted
+    by file_path and the two halves the same length".
+
+    `metadata` is sorted by file_path (both producers keep it that way), so
+    `sidecar_store.file_block` locates each path's block — or, for a path with no
+    rows yet, its insertion point. Processing the replacements in sorted order
+    therefore walks the input once, left to right; blocks that go backwards mean
+    the caller handed in unsorted metadata and raise rather than silently
+    scrambling the matrix. An empty replacement (`new_vecs` None or zero rows)
+    deletes the block.
+
+    Copy-on-write: builds fresh containers and never mutates the arrays a
+    concurrent reader may be holding. Raises ValueError on any inconsistency;
+    both callers treat that as "drop the cache and take the full reload".
+    """
+    keys = [m[0] for m in metadata]
+    out_meta: list[tuple[str, int]] = []
+    parts: list[np.ndarray] = []
+    cursor = 0
+    for path in sorted(replacements):
+        lo, hi = sidecar_store.file_block(keys, path)
+        if lo < cursor:
+            raise ValueError(
+                f"unsorted matrix metadata at {path}: block starts at {lo}, "
+                f"behind cursor {cursor}"
+            )
+        out_meta.extend(metadata[cursor:lo])
+        parts.append(matrix[cursor:lo])
+        new_meta, new_vecs = replacements[path]
+        out_meta.extend(new_meta)
+        if new_vecs is not None and new_vecs.shape[0]:
+            parts.append(new_vecs)
+        cursor = hi
+    out_meta.extend(metadata[cursor:])
+    parts.append(matrix[cursor:])
+    parts = [p for p in parts if p.shape[0]]
+    new_matrix = (
+        np.concatenate(parts, axis=0)
+        if parts
+        else np.zeros((0, VECTOR_DIM), dtype=np.float32)
+    )
+    if len(out_meta) != new_matrix.shape[0]:
+        raise ValueError(
+            f"splice invariant broken for {sorted(replacements)}: "
+            f"{len(out_meta)} meta rows vs {new_matrix.shape[0]} vectors"
+        )
+    return out_meta, new_matrix
 
 
 class SemanticUnitVectorHit(NamedTuple):
@@ -148,6 +230,11 @@ class EmbeddingIndex:
             "ON semantic_unit_vectors(parent_path, parent_generation)"
         )
         sidecar_store.ensure_meta_table(conn, "chunks", self.path.name)
+        # Before any write on this connection: every writer must have the log, so
+        # that every generation past its floor is recorded (see sidecar_store).
+        sidecar_store.ensure_path_change_log(
+            conn, CHUNK_PATH_LOG_TABLE, CHUNK_PATH_LOG_MARKER
+        )
         stored_unit_schema = conn.execute(
             "SELECT value FROM meta WHERE key = 'semantic_unit_schema_version'"
         ).fetchone()
@@ -194,10 +281,14 @@ class EmbeddingIndex:
                     )
                     if vec_on:
                         self._vec.dual_insert(conn, "file_path = ?", (rel_path,))
-                # Bump the write generation INSIDE this txn, then read back the
-                # FULL (epoch, generation, instance) token — stable under the
-                # write lock. The cache keys on it, not the mtime.
-                sidecar_store.bump_meta(conn, "generation")
+                # Bump the write generation INSIDE this txn — declaring the path
+                # it changed, so a reader one generation behind can catch up from
+                # the log instead of full-loading — then read back the FULL
+                # (epoch, generation, instance) token, stable under the write
+                # lock. The cache keys on it, not the mtime.
+                sidecar_store.bump_generation_for_paths(
+                    conn, CHUNK_PATH_LOG_TABLE, [rel_path]
+                )
                 own_epoch, own_gen, own_instance = sidecar_store.read_meta_token(conn)
         finally:
             conn.close()
@@ -231,6 +322,7 @@ class EmbeddingIndex:
             vec_on = vec_gate(self, conn)
             with conn:
                 removed = 0
+                removed_paths: list[str] = []
                 for rel_path in paths:
                     chunk_count = conn.execute(
                         "SELECT COUNT(*) FROM chunks WHERE file_path = ?", (rel_path,)
@@ -249,8 +341,14 @@ class EmbeddingIndex:
                         (rel_path,),
                     )
                     removed += 1
+                    removed_paths.append(rel_path)
                 if removed:
-                    sidecar_store.bump_meta(conn, "generation")
+                    # ONE bump for the whole batch — hence the explicit path list:
+                    # the generation delta alone could never say how many, or
+                    # which, paths this retired.
+                    sidecar_store.bump_generation_for_paths(
+                        conn, CHUNK_PATH_LOG_TABLE, removed_paths
+                    )
                     sidecar_store.bump_meta(conn, "semantic_unit_generation")
                     own_epoch, own_gen, own_instance = sidecar_store.read_meta_token(conn)
         finally:
@@ -445,23 +543,9 @@ class EmbeddingIndex:
                 )
                 return  # not contiguous with what THIS cache holds -> never splice
             try:
-                lo, hi = sidecar_store.file_block([m[0] for m in c.metadata], rel_path)
-                new_metadata = c.metadata[:lo] + list(new_meta) + c.metadata[hi:]
-                parts = [c.matrix[:lo]]
-                if new_vecs is not None and new_vecs.shape[0]:
-                    parts.append(new_vecs)
-                parts.append(c.matrix[hi:])
-                parts = [p for p in parts if p.shape[0]]
-                new_matrix = (
-                    np.concatenate(parts, axis=0)
-                    if parts
-                    else np.zeros((0, VECTOR_DIM), dtype=np.float32)
+                new_metadata, new_matrix = _splice_path_blocks(
+                    c.metadata, c.matrix, {rel_path: (list(new_meta), new_vecs)}
                 )
-                if len(new_metadata) != new_matrix.shape[0]:
-                    raise ValueError(
-                        f"splice invariant broken for {rel_path}: "
-                        f"{len(new_metadata)} meta rows vs {new_matrix.shape[0]} vectors"
-                    )
                 self._cache = _EmbCache(
                     c.epoch,
                     own_gen,
@@ -509,6 +593,21 @@ class EmbeddingIndex:
             )
             if served is not None:
                 return served.metadata, served.matrix
+            # Bounded catch-up BEFORE the full reload: a cache a couple of
+            # generations behind (the common case — another instance wrote, or a
+            # patch was refused as non-contiguous) is patched from the changed
+            # paths' rows alone, instead of paying the O(vault) SELECT + stack.
+            if c is not None and c.recall_policy_identity == policy_identity:
+                try:
+                    patched = self._catch_up_cache(c)
+                except Exception as e:  # noqa: BLE001 — always fall back, never raise
+                    log.warning(
+                        "embedding matrix catch-up failed (%s); taking the full load", e
+                    )
+                    patched = None
+                if patched is not None:
+                    self._cache = patched
+                    return patched.metadata, patched.matrix
             # Keep this call zero-argument: cache tests and production probes
             # deliberately wrap the named full-reload seam.
             loaded = self._load_all_rows()
@@ -542,6 +641,91 @@ class EmbeddingIndex:
             "epoch": c.epoch,
             "generation": c.generation,
         }
+
+    def _catch_up_cache(self, c: _EmbCache) -> _EmbCache | None:
+        """Patch a slightly-stale warm cache forward from the changed paths only.
+
+        Returns the patched cache, or None when this delta is not eligible (the
+        caller then takes the full reload). Call under `self._lock` with `c` the
+        cache that was just found stale and already known to match the current
+        recall-policy identity.
+
+        Everything the decision rests on — the meta token, the change log, the
+        replacement rows, and the row count that cross-checks them — is read
+        inside ONE explicit `BEGIN`, for exactly the reason `_load_all_rows`
+        does it: python sqlite3 in autocommit gives every bare SELECT its own
+        snapshot, so a split read could pair one write's generation with another
+        write's rows and then label the result as current.
+
+        The final `COUNT(*)` is the cheap cross-check that the log told the whole
+        truth: if some write ever bumped the generation without declaring its
+        paths, the spliced matrix would disagree with the sidecar's row count and
+        this refuses rather than serving it.
+        """
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN")
+            try:
+                epoch, gen, instance = sidecar_store.read_meta_token(conn)
+                floor = sidecar_store.path_change_log_floor(conn, CHUNK_PATH_LOG_MARKER)
+                if not sidecar_store.catchup_is_eligible(
+                    c,
+                    epoch,
+                    gen,
+                    instance,
+                    floor=floor,
+                    max_generations=CATCHUP_MAX_GENERATIONS,
+                ):
+                    return None
+                changed = sidecar_store.changed_paths_since(
+                    conn, CHUNK_PATH_LOG_TABLE, c.generation, limit=CATCHUP_MAX_PATHS
+                )
+                if len(changed) > CATCHUP_MAX_PATHS:
+                    return None  # wider than the bound — one clean reload is cheaper
+                replacements: dict[
+                    str, tuple[list[tuple[str, int]], np.ndarray | None]
+                ] = {}
+                for path in changed:
+                    rows = conn.execute(
+                        "SELECT chunk_idx, vector FROM chunks "
+                        "WHERE file_path = ? ORDER BY chunk_idx",
+                        (path,),
+                    ).fetchall()
+                    key = sys.intern(path)
+                    replacements[key] = (
+                        [(key, idx) for idx, _blob in rows],
+                        np.stack(
+                            [np.frombuffer(blob, dtype=np.float32) for _idx, blob in rows],
+                            axis=0,
+                        )
+                        if rows
+                        else None,
+                    )
+                total_rows = int(conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0])
+            finally:
+                conn.rollback()  # read-only txn — release the snapshot
+        finally:
+            conn.close()
+        metadata, matrix = _splice_path_blocks(c.metadata, c.matrix, replacements)
+        if len(metadata) != total_rows:
+            raise ValueError(
+                f"catch-up row count disagrees with the sidecar: {len(metadata)} "
+                f"spliced vs {total_rows} stored (gen {c.generation} -> {gen})"
+            )
+        log.info(
+            "embedding matrix catch-up: reason=%s paths=%d rows=%d gen=%d epoch=%d "
+            "cached_gen=%d delta=%d",
+            sidecar_store.CATCHUP_REASON,
+            len(replacements),
+            len(metadata),
+            gen,
+            epoch,
+            c.generation,
+            gen - c.generation,
+        )
+        return _EmbCache(
+            epoch, gen, instance, c.mtime, c.recall_policy_identity, metadata, matrix
+        )
 
     def _load_all_rows(self, policy_identity: tuple[str, str] | None = None) -> _EmbCache:
         """Full reload from the sidecar → an `_EmbCache`.
@@ -1052,8 +1236,12 @@ class EmbeddingIndex:
                 # serving empty until this commit moves the token — the same
                 # exposure a full reload always had racing a wipe/rebuild window,
                 # unchanged by this PR. epoch catches re-embeds that changed no
-                # file mtimes.
-                sidecar_store.bump_meta(conn, "generation")
+                # file mtimes. The per-path change log cannot describe a
+                # whole-table rewrite, so it resets and its authority floor moves
+                # here — no cache may be caught up across this write.
+                sidecar_store.bump_generation_for_reset(
+                    conn, CHUNK_PATH_LOG_TABLE, CHUNK_PATH_LOG_MARKER
+                )
                 sidecar_store.bump_meta(conn, "epoch")
                 sidecar_store.bump_meta(conn, "semantic_unit_generation")
         finally:

--- a/src/exomem/sidecar_store.py
+++ b/src/exomem/sidecar_store.py
@@ -6,6 +6,7 @@ import logging
 import random
 import sqlite3
 from pathlib import Path
+from typing import NamedTuple
 
 log = logging.getLogger(__name__)
 
@@ -163,56 +164,102 @@ def reload_reason(old_cache, new_epoch: int, new_gen: int) -> str:
 # can rewrite one path (repeated upserts). So the delta alone cannot drive an
 # incremental read — the sidecar has to record what each generation changed.
 #
-# `<log_table>(file_path, generation)` is that record: one row per path, holding
-# the generation at which it was LAST mutated (inserted, updated, or deleted —
-# a delete leaves its log row behind precisely so the reader can see it). It is
+# `<table>(file_path, generation)` is that record: one row per path, holding the
+# generation at which it was LAST mutated (inserted, updated, or deleted — a
+# delete leaves its log row behind precisely so the reader can see it). It is
 # written inside the same transaction as the generation bump, so a path appears
 # in the delta iff its rows changed in that window.
 #
-# `<marker_key>` in `meta` is the log's authority floor: the generation in force
-# when the log started recording. Writes at or before it predate the log and are
-# invisible to it, so only a cache at or past the floor may be caught up. Below
-# the floor — and for gen 0, an epoch change, or an instance change — the full
-# reload remains the only correct answer.
+# THE DANGEROUS CASE is a generation bump that wrote NO log row: the reader would
+# read it as "this write changed nothing" and let a stale cache advance its label
+# without the rows. That is not hypothetical — a generation-AWARE binary that
+# predates this log (0.52.2) bumps the generation and writes no log row, and
+# `scripts/upgrade.ps1` can leave exactly that CLI pointed at a vault a newer
+# service also writes. On the pre-catch-up code such a writer was safe, because
+# ANY bump invalidated the matrix; the catch-up must not regress that.
+#
+# A row count cannot detect it (an in-place re-embed of one chunk preserves the
+# count) and neither can "the newest generation was logged" (a gap earlier in the
+# window still passes). So the two markers in `meta` bound a CONTIGUOUS RUN of
+# logged generations: `<upto_key>` is the newest logged generation and
+# `<from_key>` the oldest generation of the unbroken run ending there. Each
+# logged bump extends the run, or — finding itself not adjacent to the previous
+# logged generation — restarts it, permanently excluding the window containing
+# the gap. Catch-up then requires `upto == gen` (the newest generation is logged)
+# AND `cache.generation >= from` (every generation since is too). Anything else,
+# plus gen 0, an epoch change, or an instance change, takes the full reload.
 
 CATCHUP_REASON = "catchup"
 
 
-def _check_log_table(log_table: str) -> None:
-    """Reject a non-identifier table name (these are interpolated into SQL)."""
-    if not log_table.isidentifier():
-        raise ValueError(f"unsupported change-log table name: {log_table!r}")
+class PathChangeLog(NamedTuple):
+    """Names of one sidecar's change-log table and its two `meta` run markers."""
+
+    table: str
+    from_key: str
+    upto_key: str
+
+    def validate(self) -> None:
+        """Reject a non-identifier table name (it is interpolated into SQL)."""
+        if not self.table.isidentifier():
+            raise ValueError(f"unsupported change-log table name: {self.table!r}")
 
 
-def ensure_path_change_log(conn: sqlite3.Connection, log_table: str, marker_key: str) -> None:
-    """Create the per-path change log and stamp its authority floor once.
+def ensure_path_change_log(conn: sqlite3.Connection, log: PathChangeLog) -> None:
+    """Create the per-path change log if absent, in the sidecar's connect path.
 
-    Call this from the sidecar's connect path, BEFORE any write: every writer
-    then has the table, so every generation after the floor is recorded. The
-    floor is read outside a write lock on purpose — landing one generation
-    either side of a concurrent commit is safe, because both a slightly low and
-    a slightly high floor only ever make catch-up MORE conservative.
+    Call this BEFORE any write on the connection, so every writer that goes
+    through it records what it changed.
+
+    Creating the table also CLEARS the run markers: a table that had to be
+    created while markers survived means the log was dropped out from under them
+    (a repair, a partial restore), and an empty log must never read as "nothing
+    changed". Catch-up then stays refused until a fresh run is established.
     """
-    _check_log_table(log_table)
+    log.validate()
+    existed = (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (log.table,)
+        ).fetchone()
+        is not None
+    )
     conn.execute(
-        f"CREATE TABLE IF NOT EXISTS {log_table} ("
+        f"CREATE TABLE IF NOT EXISTS {log.table} ("
         "file_path TEXT PRIMARY KEY, generation INTEGER NOT NULL)"
     )
     conn.execute(
-        f"CREATE INDEX IF NOT EXISTS {log_table}_generation ON {log_table}(generation)"
+        f"CREATE INDEX IF NOT EXISTS {log.table}_generation ON {log.table}(generation)"
     )
-    if conn.execute("SELECT 1 FROM meta WHERE key = ?", (marker_key,)).fetchone():
-        return
-    _epoch, generation, _instance = read_meta_token(conn)
+    if not existed:
+        conn.execute(
+            "DELETE FROM meta WHERE key IN (?, ?)", (log.from_key, log.upto_key)
+        )
+        conn.commit()
+
+
+def _extend_logged_run(conn: sqlite3.Connection, log: PathChangeLog, generation: int) -> None:
+    """Advance the contiguous logged run to `generation`, in the caller's txn.
+
+    When the previous logged generation is not `generation - 1`, some bump in
+    between bypassed these helpers and its rows are unrecorded, so the run
+    RESTARTS here instead of extending — that is what keeps a gap from being
+    waved through once a later write is logged normally.
+    """
+    previous = _read_meta_int(conn, log.upto_key)
+    if previous != generation - 1:
+        conn.execute(
+            "INSERT INTO meta (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (log.from_key, generation - 1),
+        )
     conn.execute(
-        "INSERT OR IGNORE INTO meta (key, value) VALUES (?, ?)", (marker_key, generation)
+        "INSERT INTO meta (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (log.upto_key, generation),
     )
-    conn.commit()
 
 
-def bump_generation_for_paths(
-    conn: sqlite3.Connection, log_table: str, paths, /
-) -> int:
+def bump_generation_for_paths(conn: sqlite3.Connection, log: PathChangeLog, paths) -> int:
     """Bump `generation` AND record the paths it changed, in the caller's txn.
 
     Bumping and recording are ONE call by design. The reader treats an unlogged
@@ -220,51 +267,58 @@ def bump_generation_for_paths(
     its paths would let a stale cache advance its label without ever receiving
     the rows — the same corruption the write-side contiguity gate exists to
     prevent, arriving through the read side instead.
+
+    Safe against concurrent writers: SQLite serializes write transactions, so the
+    read-modify-write of the run markers happens under the write lock this
+    transaction already holds.
     """
-    _check_log_table(log_table)
+    log.validate()
     generation = bump_meta(conn, "generation")
     rows = [(path, generation) for path in dict.fromkeys(paths)]
     if rows:
         conn.executemany(
-            f"INSERT INTO {log_table} (file_path, generation) VALUES (?, ?) "
+            f"INSERT INTO {log.table} (file_path, generation) VALUES (?, ?) "
             "ON CONFLICT(file_path) DO UPDATE SET generation = excluded.generation",
             rows,
         )
+    _extend_logged_run(conn, log, generation)
     return generation
 
 
-def bump_generation_for_reset(
-    conn: sqlite3.Connection, log_table: str, marker_key: str
-) -> int:
+def bump_generation_for_reset(conn: sqlite3.Connection, log: PathChangeLog) -> int:
     """Bump `generation` for a whole-table rewrite, in the caller's txn.
 
     A wipe-and-rebuild changes every path at once; enumerating them would make
     the log as big as the corpus and buy nothing, since such a write also bumps
     the epoch and no cache may be caught up across that. So the log is emptied
-    and its authority floor moves to the new generation — catch-up resumes from
-    the next ordinary write.
+    and a fresh run starts at the new generation — catch-up resumes from the next
+    ordinary write.
     """
-    _check_log_table(log_table)
+    log.validate()
     generation = bump_meta(conn, "generation")
-    conn.execute(f"DELETE FROM {log_table}")
-    conn.execute(
+    conn.execute(f"DELETE FROM {log.table}")
+    conn.executemany(
         "INSERT INTO meta (key, value) VALUES (?, ?) "
         "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-        (marker_key, generation),
+        ((log.from_key, generation), (log.upto_key, generation)),
     )
     return generation
 
 
-def path_change_log_floor(conn: sqlite3.Connection, marker_key: str) -> int | None:
-    """The generation the change log became authoritative at, or None."""
-    row = conn.execute("SELECT value FROM meta WHERE key = ?", (marker_key,)).fetchone()
+def _read_meta_int(conn: sqlite3.Connection, key: str) -> int | None:
+    row = conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
     if row is None or row[0] is None:
         return None
     return int(row[0])
 
 
+def read_logged_run(conn: sqlite3.Connection, log: PathChangeLog) -> tuple[int | None, int | None]:
+    """`(from, upto)` — the contiguous run of generations the log fully covers."""
+    return _read_meta_int(conn, log.from_key), _read_meta_int(conn, log.upto_key)
+
+
 def changed_paths_since(
-    conn: sqlite3.Connection, log_table: str, generation: int, *, limit: int
+    conn: sqlite3.Connection, log: PathChangeLog, generation: int, *, limit: int
 ) -> list[str]:
     """Paths mutated strictly after `generation`, per the change log.
 
@@ -275,11 +329,11 @@ def changed_paths_since(
     selects — python sqlite3 in autocommit gives every bare SELECT its own
     snapshot, so a split read could pair a generation with another write's log.
     """
-    _check_log_table(log_table)
+    log.validate()
     return [
         str(row[0])
         for row in conn.execute(
-            f"SELECT file_path FROM {log_table} WHERE generation > ? LIMIT ?",
+            f"SELECT file_path FROM {log.table} WHERE generation > ? LIMIT ?",
             (generation, max(limit, 0) + 1),
         )
     ]
@@ -291,26 +345,36 @@ def catchup_is_eligible(
     gen: int,
     instance: int,
     *,
-    floor: int | None,
+    run: tuple[int | None, int | None],
     max_generations: int,
 ) -> bool:
     """Whether a warm cache may be patched forward instead of fully reloaded.
 
-    ONLY a forward generation delta on the same physical sidecar qualifies. An
-    epoch change (a re-embed replaced vectors the log never names) or an instance
-    change (the ABA case: the sidecar was deleted and recreated, so its counters
-    restarted and its rows are unrelated) must still force the full reload, as
-    must a generation-0 legacy sidecar, whose freshness is mtime-keyed and which
-    has no log history behind it.
+    ONLY a forward generation delta on the same physical sidecar, entirely
+    covered by the log's contiguous run, qualifies:
+
+    * `upto == gen` — the sidecar's CURRENT generation was logged. Any bump that
+      bypassed the logging helpers (an older generation-aware binary, a future
+      in-tree writer, a manual repair) leaves `upto < gen` and is refused here.
+    * `c.generation >= run_from` — and so was every generation since the cache
+      was labelled, because the run is unbroken by construction.
+
+    An epoch change (a re-embed replaced vectors the log never names), an
+    instance change (the ABA case: the sidecar was deleted and recreated, so its
+    counters restarted and its rows are unrelated), and a generation-0 legacy
+    sidecar (mtime-keyed, no log history) all still force the full reload.
     """
+    run_from, run_upto = run
     if c is None or gen < 1 or c.generation < 1:
         return False
     if c.epoch != epoch or c.instance != instance:
         return False
     if gen <= c.generation:  # already fresh, or a sidecar that moved backwards
         return False
-    if floor is None or c.generation < floor:
-        return False  # the window reaches back before the log recorded anything
+    if run_upto != gen:
+        return False  # the newest generation was not recorded by the log
+    if run_from is None or c.generation < run_from:
+        return False  # the window reaches back past a gap in the log
     return (gen - c.generation) <= max_generations
 
 

--- a/src/exomem/sidecar_store.py
+++ b/src/exomem/sidecar_store.py
@@ -182,7 +182,9 @@ def reload_reason(old_cache, new_epoch: int, new_gen: int) -> str:
 # count) and neither can "the newest generation was logged" (a gap earlier in the
 # window still passes). So the two markers in `meta` bound a CONTIGUOUS RUN of
 # logged generations: `<upto_key>` is the newest logged generation and
-# `<from_key>` the oldest generation of the unbroken run ending there. Each
+# `<from_key>` sits one BELOW the run's oldest logged generation — i.e. it is the
+# oldest *cache* generation the run can carry forward, which is what the
+# `cache.generation >= from` check below compares against. Each
 # logged bump extends the run, or — finding itself not adjacent to the previous
 # logged generation — restarts it, permanently excluding the window containing
 # the gap. Catch-up then requires `upto == gen` (the newest generation is logged)

--- a/src/exomem/sidecar_store.py
+++ b/src/exomem/sidecar_store.py
@@ -156,6 +156,164 @@ def reload_reason(old_cache, new_epoch: int, new_gen: int) -> str:
     return "genuine"
 
 
+# ------------------------------------------------------------ bounded catch-up
+#
+# A generation delta says HOW MANY writes happened, never WHICH rows they
+# touched: one bump can retire a whole batch of paths (a purge) and many bumps
+# can rewrite one path (repeated upserts). So the delta alone cannot drive an
+# incremental read — the sidecar has to record what each generation changed.
+#
+# `<log_table>(file_path, generation)` is that record: one row per path, holding
+# the generation at which it was LAST mutated (inserted, updated, or deleted —
+# a delete leaves its log row behind precisely so the reader can see it). It is
+# written inside the same transaction as the generation bump, so a path appears
+# in the delta iff its rows changed in that window.
+#
+# `<marker_key>` in `meta` is the log's authority floor: the generation in force
+# when the log started recording. Writes at or before it predate the log and are
+# invisible to it, so only a cache at or past the floor may be caught up. Below
+# the floor — and for gen 0, an epoch change, or an instance change — the full
+# reload remains the only correct answer.
+
+CATCHUP_REASON = "catchup"
+
+
+def _check_log_table(log_table: str) -> None:
+    """Reject a non-identifier table name (these are interpolated into SQL)."""
+    if not log_table.isidentifier():
+        raise ValueError(f"unsupported change-log table name: {log_table!r}")
+
+
+def ensure_path_change_log(conn: sqlite3.Connection, log_table: str, marker_key: str) -> None:
+    """Create the per-path change log and stamp its authority floor once.
+
+    Call this from the sidecar's connect path, BEFORE any write: every writer
+    then has the table, so every generation after the floor is recorded. The
+    floor is read outside a write lock on purpose — landing one generation
+    either side of a concurrent commit is safe, because both a slightly low and
+    a slightly high floor only ever make catch-up MORE conservative.
+    """
+    _check_log_table(log_table)
+    conn.execute(
+        f"CREATE TABLE IF NOT EXISTS {log_table} ("
+        "file_path TEXT PRIMARY KEY, generation INTEGER NOT NULL)"
+    )
+    conn.execute(
+        f"CREATE INDEX IF NOT EXISTS {log_table}_generation ON {log_table}(generation)"
+    )
+    if conn.execute("SELECT 1 FROM meta WHERE key = ?", (marker_key,)).fetchone():
+        return
+    _epoch, generation, _instance = read_meta_token(conn)
+    conn.execute(
+        "INSERT OR IGNORE INTO meta (key, value) VALUES (?, ?)", (marker_key, generation)
+    )
+    conn.commit()
+
+
+def bump_generation_for_paths(
+    conn: sqlite3.Connection, log_table: str, paths, /
+) -> int:
+    """Bump `generation` AND record the paths it changed, in the caller's txn.
+
+    Bumping and recording are ONE call by design. The reader treats an unlogged
+    generation as "this write changed no rows", so a bump that forgot to declare
+    its paths would let a stale cache advance its label without ever receiving
+    the rows — the same corruption the write-side contiguity gate exists to
+    prevent, arriving through the read side instead.
+    """
+    _check_log_table(log_table)
+    generation = bump_meta(conn, "generation")
+    rows = [(path, generation) for path in dict.fromkeys(paths)]
+    if rows:
+        conn.executemany(
+            f"INSERT INTO {log_table} (file_path, generation) VALUES (?, ?) "
+            "ON CONFLICT(file_path) DO UPDATE SET generation = excluded.generation",
+            rows,
+        )
+    return generation
+
+
+def bump_generation_for_reset(
+    conn: sqlite3.Connection, log_table: str, marker_key: str
+) -> int:
+    """Bump `generation` for a whole-table rewrite, in the caller's txn.
+
+    A wipe-and-rebuild changes every path at once; enumerating them would make
+    the log as big as the corpus and buy nothing, since such a write also bumps
+    the epoch and no cache may be caught up across that. So the log is emptied
+    and its authority floor moves to the new generation — catch-up resumes from
+    the next ordinary write.
+    """
+    _check_log_table(log_table)
+    generation = bump_meta(conn, "generation")
+    conn.execute(f"DELETE FROM {log_table}")
+    conn.execute(
+        "INSERT INTO meta (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (marker_key, generation),
+    )
+    return generation
+
+
+def path_change_log_floor(conn: sqlite3.Connection, marker_key: str) -> int | None:
+    """The generation the change log became authoritative at, or None."""
+    row = conn.execute("SELECT value FROM meta WHERE key = ?", (marker_key,)).fetchone()
+    if row is None or row[0] is None:
+        return None
+    return int(row[0])
+
+
+def changed_paths_since(
+    conn: sqlite3.Connection, log_table: str, generation: int, *, limit: int
+) -> list[str]:
+    """Paths mutated strictly after `generation`, per the change log.
+
+    Reads `limit + 1` rows so the caller can detect "too many to be worth
+    patching" without materializing a delta it is going to throw away.
+
+    Read this in the SAME explicit transaction as the meta token and the rows it
+    selects — python sqlite3 in autocommit gives every bare SELECT its own
+    snapshot, so a split read could pair a generation with another write's log.
+    """
+    _check_log_table(log_table)
+    return [
+        str(row[0])
+        for row in conn.execute(
+            f"SELECT file_path FROM {log_table} WHERE generation > ? LIMIT ?",
+            (generation, max(limit, 0) + 1),
+        )
+    ]
+
+
+def catchup_is_eligible(
+    c,
+    epoch: int,
+    gen: int,
+    instance: int,
+    *,
+    floor: int | None,
+    max_generations: int,
+) -> bool:
+    """Whether a warm cache may be patched forward instead of fully reloaded.
+
+    ONLY a forward generation delta on the same physical sidecar qualifies. An
+    epoch change (a re-embed replaced vectors the log never names) or an instance
+    change (the ABA case: the sidecar was deleted and recreated, so its counters
+    restarted and its rows are unrelated) must still force the full reload, as
+    must a generation-0 legacy sidecar, whose freshness is mtime-keyed and which
+    has no log history behind it.
+    """
+    if c is None or gen < 1 or c.generation < 1:
+        return False
+    if c.epoch != epoch or c.instance != instance:
+        return False
+    if gen <= c.generation:  # already fresh, or a sidecar that moved backwards
+        return False
+    if floor is None or c.generation < floor:
+        return False  # the window reaches back before the log recorded anything
+    return (gen - c.generation) <= max_generations
+
+
 def peek_sidecar_token(path: Path) -> tuple[int, int, int] | None:
     """Read `(epoch, generation, instance)` without creating or migrating a sidecar."""
     if not path.exists():

--- a/tests/test_embedding_bounded_catchup.py
+++ b/tests/test_embedding_bounded_catchup.py
@@ -76,6 +76,37 @@ def _seed(idx, count: int = 4) -> None:
         idx.upsert_file(f"f{i:02d}.md", ["c"], _mat([float(i), 0.0]), float(i))
 
 
+def _skew_write(path: Path, rel_path: str, vectors: np.ndarray) -> int:
+    """Write one path exactly as a generation-AWARE 0.52.2 binary does on the wire.
+
+    Replaces the path's rows and bumps `meta.generation` in one transaction, and
+    writes NO change-log row -- that binary has never heard of one. This is not
+    hypothetical: `scripts/upgrade.ps1` restarts the service BEFORE calling
+    `Sync-ExomemUvCli` (upgrade.ps1:144), and `-SkipRestart` / `-CliSync never`
+    skip that sync outright, so "new service, old CLI, one vault" is a supported
+    reachable state; `docs/deployment.md:377-379` documents direct CLI
+    maintenance against that same vault.
+
+    On origin/main such a write ALWAYS invalidated the warm matrix, because any
+    generation bump did. The catch-up must not regress that.
+    """
+    conn = sqlite3.connect(path)
+    try:
+        with conn:
+            conn.execute("DELETE FROM chunks WHERE file_path = ?", (rel_path,))
+            conn.executemany(
+                "INSERT INTO chunks (file_path, chunk_idx, chunk_text, vector, file_mtime) "
+                "VALUES (?, ?, ?, ?, ?)",
+                [
+                    (rel_path, i, "t", vectors[i].astype(np.float32).tobytes(), 9.0)
+                    for i in range(vectors.shape[0])
+                ],
+            )
+            return sidecar_store.bump_meta(conn, "generation")
+    finally:
+        conn.close()
+
+
 # --------------------------------------------------------------------------- #
 # The fire: a 2-generation drift must NOT cost a full O(vault) reload
 # --------------------------------------------------------------------------- #
@@ -346,16 +377,137 @@ def test_legacy_generation_zero_sidecar_is_never_caught_up(tmp_path, monkeypatch
 
 
 # --------------------------------------------------------------------------- #
+# The regression guard: an UNLOGGED generation bump must never be absorbed
+# --------------------------------------------------------------------------- #
+
+
+def test_unlogged_bump_with_unchanged_row_count_forces_a_full_reload(
+    tmp_path, monkeypatch
+):
+    """The case no row-count cross-check can see.
+
+    A generation-aware older binary replaces one chunk's vector in place: same
+    path, same chunk count, different bytes, `meta.generation` bumped, no change
+    -log row. `COUNT(*)` is identical before and after, so the count check is
+    blind to it. Only a per-generation assertion that the log actually covers
+    the whole delta window can refuse this -- and refuse it it must, because on
+    origin/main this write invalidated the matrix and served the new vector.
+    """
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    idx.upsert_file("b.md", ["b"], _mat([0, 1]), 2.0)
+    idx.all_vectors()  # warm
+    warm_rows = len(idx._cache.metadata)
+
+    count = _count_loads(monkeypatch, idx)
+    _skew_write(idx.path, "a.md", _mat([7, 7]))  # same row count, new vector
+
+    metadata, matrix = idx.all_vectors()
+
+    assert len(metadata) == warm_rows  # the row count genuinely did not move
+    assert count["n"] == 1, "an unlogged generation bump was absorbed as a catch-up"
+    row = matrix[[m[0] for m in metadata].index("a.md")]
+    assert np.array_equal(row[:2], [7, 7]), "served the stale pre-skew vector"
+    truth_meta, truth_matrix = _ground_truth(vault)
+    assert metadata == truth_meta
+    assert np.array_equal(matrix, truth_matrix)
+
+
+def test_unlogged_bump_is_not_papered_over_by_later_logged_writes(tmp_path, monkeypatch):
+    """The permanence case, and the one a "last bump was logged" check misses.
+
+    The skew write is followed by five ordinary logged writes with NO read in
+    between, so by the time the reader looks, the most recent generation IS
+    logged. Asserting only that would wave the whole window through and leave
+    the stale block resident indefinitely -- its log row sits behind the cache
+    generation, so no later delta ever revisits it. The log must be trusted only
+    across an unbroken run of logged generations.
+    """
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    idx.upsert_file("b.md", ["b"], _mat([0, 1]), 2.0)
+    idx.all_vectors()  # warm
+
+    count = _count_loads(monkeypatch, idx)
+    _skew_write(idx.path, "a.md", _mat([7, 7]))
+
+    external = embeddings.EmbeddingIndex(vault)
+    for i in range(5):
+        external.upsert_file(f"later{i}.md", ["x"], _mat([0, 0, float(i)]), float(20 + i))
+
+    metadata, matrix = idx.all_vectors()
+
+    assert count["n"] == 1
+    row = matrix[[m[0] for m in metadata].index("a.md")]
+    assert np.array_equal(row[:2], [7, 7]), "stale block survived behind later writes"
+    truth_meta, truth_matrix = _ground_truth(vault)
+    assert metadata == truth_meta
+    assert np.array_equal(matrix, truth_matrix)
+
+
+def test_catchup_resumes_after_an_unlogged_bump_heals(tmp_path, monkeypatch):
+    """The refusal is scoped, not permanent: once the reader has full-loaded past
+    the gap, a fresh contiguous run of logged writes is catch-up-eligible again."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    idx.all_vectors()  # warm
+
+    count = _count_loads(monkeypatch, idx)
+    _skew_write(idx.path, "a.md", _mat([7, 7]))
+    idx.all_vectors()  # heals via one full reload
+    assert count["n"] == 1
+
+    embeddings.EmbeddingIndex(vault).upsert_file("c.md", ["c"], _mat([0, 1]), 3.0)
+    metadata, matrix = idx.all_vectors()
+
+    assert count["n"] == 1  # back to patching
+    truth_meta, truth_matrix = _ground_truth(vault)
+    assert metadata == truth_meta
+    assert np.array_equal(matrix, truth_matrix)
+
+
+def test_dropped_change_log_table_is_not_trusted_from_its_surviving_markers(
+    tmp_path, monkeypatch
+):
+    """Recovery gap: a repair that drops the log table while `meta` survives must
+    not let an empty log read as "nothing changed"."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    idx.upsert_file("b.md", ["b"], _mat([0, 1]), 2.0)
+    idx.all_vectors()  # warm
+
+    count = _count_loads(monkeypatch, idx)
+    conn = sqlite3.connect(idx.path)
+    try:
+        with conn:
+            conn.execute("DROP TABLE chunk_path_log")
+            conn.execute("DELETE FROM chunks WHERE file_path = 'b.md'")
+            sidecar_store.bump_meta(conn, "generation")
+    finally:
+        conn.close()
+
+    metadata, _ = idx.all_vectors()
+    assert count["n"] == 1
+    assert [m[0] for m in metadata] == ["a.md"]
+
+
+# --------------------------------------------------------------------------- #
 # Structural guard: a generation bump must always declare what it changed
 # --------------------------------------------------------------------------- #
 
 
 def test_no_bare_generation_bump_in_the_embedding_sidecar() -> None:
-    """The catch-up reads an unlogged generation as "this write changed no chunk
-    rows". A bare `bump_meta(conn, "generation")` would therefore let a stale
-    cache advance its label without ever receiving the rows -- exactly the
-    corruption `_patch_cache`'s contiguity gate exists to prevent. Every bump
-    must go through a helper that records the affected paths (or resets the log).
+    """Keep in-tree bumps on the logging helpers, so this module's own writes stay
+    catch-up-eligible instead of silently degrading every reader to a full reload.
+
+    This is a lint, not the safety guarantee: correctness rests on the runtime
+    invariant (`catchup_is_eligible` refuses unless the log's contiguous run
+    covers the whole delta window), which is what protects against writers this
+    grep cannot see -- other modules, wrapped calls, older binaries.
     """
     source = (
         Path(__file__).resolve().parent.parent / "src" / "exomem" / "embedding_index.py"

--- a/tests/test_embedding_bounded_catchup.py
+++ b/tests/test_embedding_bounded_catchup.py
@@ -1,0 +1,372 @@
+"""Bounded read-side catch-up for the embedding matrix cache (GitHub #531, H4).
+
+Before this change, a warm matrix cache that fell even ONE generation behind the
+sidecar was thrown away wholesale: `sidecar_store.cache_is_fresh` demands exact
+generation equality, `try_serve_cached` then returns None, and
+`EmbeddingIndex.all_vectors()` falls through to `_load_all_rows()` -- the
+O(vault) `SELECT` + `np.stack`. Production telemetry (0.52.2) showed that firing
+on deltas of 2 and 11 generations over 60k rows, ~21 s per reload, every ~26-44
+minutes.
+
+These tests lock the bounded catch-up: a SMALL delta patches only the rows whose
+paths actually changed, while epoch/instance changes, wide deltas, and legacy
+(generation 0) sidecars still take the full reload. Every assertion counts
+`_load_all_rows` calls (the named full-reload seam) and compares the served
+matrix against a genuinely-reloaded one -- never wall-clock.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from exomem import embedding_index, embeddings, sidecar_store
+
+
+@pytest.fixture(autouse=True)
+def _clean_memo() -> None:
+    """Each test starts with an empty shared-index memo."""
+    embeddings.clear_embedding_indexes()
+    yield
+    embeddings.clear_embedding_indexes()
+
+
+def _fresh_vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    (vault / "Knowledge Base").mkdir(parents=True)
+    return vault
+
+
+def _pad(vals: list[float]) -> np.ndarray:
+    out = np.zeros(embeddings.VECTOR_DIM, dtype=np.float32)
+    out[: len(vals)] = vals
+    return out
+
+
+def _mat(*rows: list[float]) -> np.ndarray:
+    return np.stack([_pad(r) for r in rows], axis=0)
+
+
+def _count_loads(monkeypatch: pytest.MonkeyPatch, idx) -> dict[str, int]:
+    """Wrap idx._load_all_rows to count genuine full reloads."""
+    calls = {"n": 0}
+    orig = idx._load_all_rows
+
+    def wrapped():
+        calls["n"] += 1
+        return orig()
+
+    monkeypatch.setattr(idx, "_load_all_rows", wrapped)
+    return calls
+
+
+def _ground_truth(vault: Path) -> tuple[list[tuple[str, int]], np.ndarray]:
+    """What a cold instance loads straight from the sidecar right now."""
+    cold = embeddings.EmbeddingIndex(vault)
+    return cold.all_vectors()
+
+
+def _seed(idx, count: int = 4) -> None:
+    for i in range(count):
+        idx.upsert_file(f"f{i:02d}.md", ["c"], _mat([float(i), 0.0]), float(i))
+
+
+# --------------------------------------------------------------------------- #
+# The fire: a 2-generation drift must NOT cost a full O(vault) reload
+# --------------------------------------------------------------------------- #
+
+
+def test_small_generation_delta_patches_instead_of_full_reloading(tmp_path, monkeypatch):
+    """RED before the fix: a cache 2 generations stale full-reloads everything.
+
+    Reproduces the production shape exactly -- writes land through an instance
+    that is NOT the one holding the warm matrix, so the warm cache drifts a
+    couple of generations behind the sidecar without any epoch or instance
+    change. The catch-up must serve the correct, current matrix having read only
+    the changed paths' rows.
+    """
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    _seed(idx)
+    idx.all_vectors()  # warm
+    warm_gen = idx._cache.generation
+
+    count = _count_loads(monkeypatch, idx)
+
+    external = embeddings.EmbeddingIndex(vault)
+    external.upsert_file("f01.md", ["c"], _mat([9.0, 9.0]), 10.0)  # update
+    external.upsert_file("z.md", ["z1", "z2"], _mat([0.0, 1.0], [1.0, 1.0]), 11.0)  # insert
+
+    metadata, matrix = idx.all_vectors()
+
+    assert idx._cache.generation == warm_gen + 2  # exactly the observed drift
+    assert count["n"] == 0, "a 2-generation delta still paid a full O(vault) reload"
+
+    truth_meta, truth_matrix = _ground_truth(vault)
+    assert metadata == truth_meta
+    assert np.array_equal(matrix, truth_matrix)
+
+
+def test_catchup_matrix_is_identical_to_a_full_reload_across_edit_kinds(
+    tmp_path, monkeypatch
+):
+    """Insert, grow, shrink, and delete inside one delta window: the patched
+    matrix must be byte-identical to what a from-scratch reload produces."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    _seed(idx)
+    idx.all_vectors()  # warm
+
+    count = _count_loads(monkeypatch, idx)
+
+    external = embeddings.EmbeddingIndex(vault)
+    external.upsert_file("aaa.md", ["a1", "a2", "a3"], _mat([1, 0], [2, 0], [3, 0]), 5.0)
+    external.upsert_file("f00.md", ["only"], _mat([7, 7]), 6.0)  # shrink f00 to 1 row
+    external.upsert_file("f02.md", ["g1", "g2"], _mat([4, 4], [5, 5]), 7.0)  # grow
+    external.delete_file("f03.md")
+
+    metadata, matrix = idx.all_vectors()
+    assert count["n"] == 0
+
+    truth_meta, truth_matrix = _ground_truth(vault)
+    assert metadata == truth_meta
+    assert np.array_equal(matrix, truth_matrix)
+    assert [m[0] for m in metadata] == [
+        "aaa.md",
+        "aaa.md",
+        "aaa.md",
+        "f00.md",
+        "f01.md",
+        "f02.md",
+        "f02.md",
+    ]  # inserted block sorts first, f00 shrank, f02 grew, f03 is gone
+
+
+def test_delete_only_delta_is_caught_up(tmp_path, monkeypatch):
+    """A pure removal leaves no row to read -- the tombstone must come from the
+    per-path change log, not from the surviving rows."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    _seed(idx)
+    idx.all_vectors()  # warm
+
+    count = _count_loads(monkeypatch, idx)
+    embeddings.EmbeddingIndex(vault).delete_file("f01.md")
+
+    metadata, matrix = idx.all_vectors()
+    assert count["n"] == 0
+    assert [m[0] for m in metadata] == ["f00.md", "f02.md", "f03.md"]
+    truth_meta, truth_matrix = _ground_truth(vault)
+    assert metadata == truth_meta
+    assert np.array_equal(matrix, truth_matrix)
+
+
+def test_catchup_emits_a_distinct_reason_tag(tmp_path, caplog):
+    """Production verification greps for `reason=genuine`; a patched catch-up
+    must therefore log under its OWN reason so the two never blur."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    _seed(idx)
+    idx.all_vectors()  # warm
+    warm_gen = idx._cache.generation
+
+    caplog.set_level(logging.INFO, logger="exomem.embedding_index")
+    embeddings.EmbeddingIndex(vault).upsert_file("z.md", ["z"], _mat([0, 1]), 9.0)
+    idx.all_vectors()
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert not [m for m in messages if "reason=genuine" in m], messages
+    catchups = [m for m in messages if "reason=catchup" in m]
+    assert len(catchups) == 1, messages
+    line = catchups[0]
+    assert re.search(r"\bpaths=1\b", line), line
+    assert re.search(r"\bdelta=1\b", line), line
+    assert re.search(rf"\bcached_gen={warm_gen}\b", line), line
+    assert re.search(rf"\bgen={warm_gen + 1}\b", line), line
+
+
+# --------------------------------------------------------------------------- #
+# The bounds: everything the catch-up must still refuse
+# --------------------------------------------------------------------------- #
+
+
+def test_wide_delta_falls_back_to_a_full_reload(tmp_path, monkeypatch, caplog):
+    """Past the bound, a full reload is the cheaper and simpler answer -- and it
+    must still be tagged `reason=genuine`."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    _seed(idx)
+    idx.all_vectors()  # warm
+
+    monkeypatch.setattr(embedding_index, "CATCHUP_MAX_PATHS", 1)
+    count = _count_loads(monkeypatch, idx)
+
+    external = embeddings.EmbeddingIndex(vault)
+    external.upsert_file("y.md", ["y"], _mat([1, 1]), 8.0)
+    external.upsert_file("z.md", ["z"], _mat([0, 1]), 9.0)
+
+    caplog.set_level(logging.INFO, logger="exomem.embedding_index")
+    metadata, matrix = idx.all_vectors()
+
+    assert count["n"] == 1
+    assert [m[0] for m in metadata][-2:] == ["y.md", "z.md"]
+    assert [m for m in (r.getMessage() for r in caplog.records) if "reason=genuine" in m]
+
+
+def test_generation_delta_bound_forces_a_full_reload(tmp_path, monkeypatch):
+    """A cache left behind for many generations is not a catch-up candidate."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    _seed(idx)
+    idx.all_vectors()  # warm
+
+    monkeypatch.setattr(embedding_index, "CATCHUP_MAX_GENERATIONS", 1)
+    count = _count_loads(monkeypatch, idx)
+
+    external = embeddings.EmbeddingIndex(vault)
+    external.upsert_file("z.md", ["z"], _mat([0, 1]), 9.0)
+    external.upsert_file("z.md", ["z", "z2"], _mat([0, 1], [1, 1]), 10.0)
+
+    metadata, _ = idx.all_vectors()
+    assert count["n"] == 1
+    assert [m[0] for m in metadata][-2:] == ["z.md", "z.md"]
+
+
+def test_epoch_bump_still_forces_a_full_reload(tmp_path, monkeypatch):
+    """A re-embed (rebuild_all) replaces every vector; only the epoch says so,
+    and the per-path log cannot describe it. Catch-up must refuse."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    _seed(idx)
+    idx.all_vectors()  # warm
+
+    count = _count_loads(monkeypatch, idx)
+    conn = sqlite3.connect(idx.path)
+    try:
+        with conn:
+            sidecar_store.bump_meta(conn, "epoch")
+    finally:
+        conn.close()
+
+    idx.all_vectors()
+    assert count["n"] == 1
+
+
+def test_recreated_sidecar_instance_change_still_forces_a_full_reload(
+    tmp_path, monkeypatch
+):
+    """F3's ABA guard survives the catch-up: a deleted-and-recreated sidecar
+    carries a new instance nonce, so no delta may be applied to the old rows."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("old.md", ["old"], _mat([1, 0]), 1.0)
+    idx.all_vectors()  # warm at generation 1
+    old_gen = idx._cache.generation
+
+    count = _count_loads(monkeypatch, idx)
+    for suffix in ("", "-wal", "-shm"):
+        p = idx.path.with_name(idx.path.name + suffix)
+        if p.exists():
+            p.unlink()
+    embeddings.EmbeddingIndex(vault).upsert_file("new.md", ["new"], _mat([0, 1]), 5.0)
+
+    _epoch, new_gen, _instance = sidecar_store.peek_sidecar_token(idx.path)
+    assert new_gen == old_gen  # (epoch, gen) alone would look catch-up-eligible
+
+    metadata, _ = idx.all_vectors()
+    assert count["n"] == 1
+    assert [m[0] for m in metadata] == ["new.md"]
+
+
+def test_rebuild_all_is_never_caught_up(tmp_path, monkeypatch):
+    """An external rebuild wipes and re-embeds everything; the next read must be
+    a genuine full reload serving the NEW vectors, never a patched old matrix."""
+    vault = _fresh_vault(tmp_path)
+    kb = vault / "Knowledge Base"
+    (kb / "one.md").write_text("---\ntype: note\n---\n# One\nalpha beta\n", encoding="utf-8")
+
+    seq = {"n": 0}
+
+    def fake_embed(texts, *, is_query=False):
+        seq["n"] += 1
+        return np.stack([_pad([float(seq["n"]), 0.0]) for _ in texts], axis=0)
+
+    monkeypatch.setattr(embeddings, "embed_texts", fake_embed)
+
+    idx = embeddings.get_embedding_index(vault)
+    idx.rebuild_all()
+    first = idx.all_vectors()[1][0].copy()
+
+    count = _count_loads(monkeypatch, idx)
+    embeddings.EmbeddingIndex(vault).rebuild_all()
+
+    second = idx.all_vectors()[1][0]
+    assert count["n"] == 1
+    assert not np.array_equal(second, first)
+
+
+def test_legacy_generation_zero_sidecar_is_never_caught_up(tmp_path, monkeypatch):
+    """Generation 0 means the mtime fallback is in force; there is no per-path
+    log history to catch up from."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    path = idx.path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            "CREATE TABLE chunks (file_path TEXT NOT NULL, chunk_idx INTEGER NOT NULL, "
+            "chunk_text TEXT NOT NULL, vector BLOB NOT NULL, file_mtime REAL NOT NULL, "
+            "PRIMARY KEY (file_path, chunk_idx))"
+        )
+        conn.execute(
+            "INSERT INTO chunks VALUES (?, ?, ?, ?, ?)",
+            ("a.md", 0, "t", _pad([1, 0]).tobytes(), 1.0),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    count = _count_loads(monkeypatch, idx)
+    assert [m[0] for m in idx.all_vectors()[0]] == ["a.md"]
+    assert idx._cache.generation == 0
+    assert count["n"] == 1
+
+    st = path.stat()
+    import os
+
+    os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 2_000_000_000))
+    idx.all_vectors()
+    assert count["n"] == 2  # mtime fallback, not a catch-up
+
+
+# --------------------------------------------------------------------------- #
+# Structural guard: a generation bump must always declare what it changed
+# --------------------------------------------------------------------------- #
+
+
+def test_no_bare_generation_bump_in_the_embedding_sidecar() -> None:
+    """The catch-up reads an unlogged generation as "this write changed no chunk
+    rows". A bare `bump_meta(conn, "generation")` would therefore let a stale
+    cache advance its label without ever receiving the rows -- exactly the
+    corruption `_patch_cache`'s contiguity gate exists to prevent. Every bump
+    must go through a helper that records the affected paths (or resets the log).
+    """
+    source = (
+        Path(__file__).resolve().parent.parent / "src" / "exomem" / "embedding_index.py"
+    ).read_text(encoding="utf-8")
+    offenders = [
+        line.strip()
+        for line in source.splitlines()
+        if re.search(r"bump_meta\(\s*conn\s*,\s*[\"']generation[\"']", line)
+    ]
+    assert offenders == [], (
+        "bump the embedding sidecar's generation through "
+        "sidecar_store.bump_generation_for_paths / bump_generation_for_reset "
+        f"so the per-path change log stays authoritative: {offenders}"
+    )

--- a/tests/test_embedding_cache_contract.py
+++ b/tests/test_embedding_cache_contract.py
@@ -274,11 +274,17 @@ def test_purge_refusal_on_non_contiguous_write_is_logged(
 
 
 def test_full_load_log_names_the_stale_cache_generation(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The full-load log line (embedding_index.py:489-495) now carries
     `cached_gen=<old cache generation or -1>` so a production
-    `reason=genuine` entry names the exact gap that forced the reload."""
+    `reason=genuine` entry names the exact gap that forced the reload.
+
+    The warm-but-stale half pins `CATCHUP_MAX_PATHS` to 0: since #531 H4 a small
+    external delta is absorbed by the bounded catch-up (logged under
+    `reason=catchup`), so a GENUINE full reload has to be provoked by putting the
+    delta out of catch-up range — which is exactly what `reason=genuine` is
+    supposed to mean now."""
     vault = _fresh_vault(tmp_path)
     idx = embeddings.get_embedding_index(vault)
     idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
@@ -300,6 +306,7 @@ def test_full_load_log_names_the_stale_cache_generation(
     external = embedding_index.EmbeddingIndex(vault)
     external.upsert_file("c.md", ["c"], _mat([0, 0, 1]), 3.0)
 
+    monkeypatch.setattr(embedding_index, "CATCHUP_MAX_PATHS", 0)  # out of catch-up range
     idx.all_vectors()
     warm_loads = [r for r in caplog.records if "embedding matrix full load" in r.getMessage()]
     assert warm_loads

--- a/tests/test_embedding_matrix_cache.py
+++ b/tests/test_embedding_matrix_cache.py
@@ -240,6 +240,8 @@ def test_external_writer_is_served_without_a_full_reload(tmp_path, monkeypatch):
     assert count["n"] == 0
     assert [m[0] for m in metadata] == ["a.md", "b.md"]
     assert matrix.shape[0] == 2
+    assert np.array_equal(matrix[0][:2], [1, 0])  # a.md untouched by the splice
+    assert np.array_equal(matrix[1][:2], [0, 1])  # b.md carries the writer's vector
     # A second read reuses; still no reload.
     idx.all_vectors()
     assert count["n"] == 0

--- a/tests/test_embedding_matrix_cache.py
+++ b/tests/test_embedding_matrix_cache.py
@@ -215,9 +215,15 @@ def test_incremental_matches_full_reload(tmp_path, monkeypatch):
     assert np.array_equal(spliced_matrix, reload_matrix)
 
 
-def test_external_writer_triggers_exactly_one_reload(tmp_path, monkeypatch):
+def test_external_writer_is_served_without_a_full_reload(tmp_path, monkeypatch):
     """An out-of-band sidecar change (a writer that bypassed the shared instance)
-    is caught by the mtime gate: exactly one reload, reflecting the new content."""
+    is caught and served with the new content.
+
+    Was `test_external_writer_triggers_exactly_one_reload`: until the bounded
+    catch-up (#531 H4) the only way to absorb an external write was to throw the
+    whole matrix away and re-`SELECT` the vault. A one-generation delta now
+    patches just the changed path's block, so the assertion moved from "exactly
+    one full reload" to "zero, and the content is still right"."""
     vault = _fresh_vault(tmp_path)
     idx = embeddings.get_embedding_index(vault)
     idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
@@ -231,11 +237,12 @@ def test_external_writer_triggers_exactly_one_reload(tmp_path, monkeypatch):
     _bump_mtime(idx.path)  # guarantee a distinct mtime for the gate
 
     metadata, matrix = idx.all_vectors()
-    assert count["n"] == 1
+    assert count["n"] == 0
     assert [m[0] for m in metadata] == ["a.md", "b.md"]
-    # A second read reuses; no further reload.
+    assert matrix.shape[0] == 2
+    # A second read reuses; still no reload.
     idx.all_vectors()
-    assert count["n"] == 1
+    assert count["n"] == 0
 
 
 def test_utime_bump_alone_does_not_reload(tmp_path, monkeypatch):
@@ -475,7 +482,11 @@ def test_writer_under_held_reader_txn_no_reload(tmp_path, monkeypatch):
 
 def test_external_writer_detected_via_generation(tmp_path, monkeypatch):
     """A second instance writing the sidecar bumps the on-disk generation; the
-    shared index detects it and serves the new rows — with NO mtime bump needed."""
+    shared index detects it and serves the new rows — with NO mtime bump needed.
+
+    Since #531 H4 the detection is absorbed by the bounded catch-up rather than a
+    full reload: one generation behind, one changed path, so the block is patched
+    in and no O(vault) `SELECT` runs."""
     vault = _fresh_vault(tmp_path)
     idx = embeddings.get_embedding_index(vault)
     idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
@@ -486,14 +497,19 @@ def test_external_writer_detected_via_generation(tmp_path, monkeypatch):
     external.upsert_file("b.md", ["b"], _mat([0, 1]), 2.0)  # bumps DB generation
 
     metadata, matrix = idx.all_vectors()
-    assert count["n"] == 1
+    assert count["n"] == 0
     assert [m[0] for m in metadata] == ["a.md", "b.md"]
+    assert np.array_equal(matrix[1][:2], [0, 1])  # the external writer's vector
     idx.all_vectors()
-    assert count["n"] == 1  # second read reuses the reloaded cache
+    assert count["n"] == 0  # second read reuses the patched cache
 
 
 def test_external_delete_detected_via_generation(tmp_path, monkeypatch):
-    """An external delete bumps the generation; the block is dropped on next read."""
+    """An external delete bumps the generation; the block is dropped on next read.
+
+    Since #531 H4 that drop is a catch-up splice, not a full reload: the deleted
+    path leaves a row in the per-path change log, which is how the reader learns
+    a block vanished when no surviving row could tell it."""
     vault = _fresh_vault(tmp_path)
     idx = embeddings.get_embedding_index(vault)
     idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
@@ -505,7 +521,7 @@ def test_external_delete_detected_via_generation(tmp_path, monkeypatch):
     external.delete_file("a.md")  # bumps DB generation
 
     metadata, matrix = idx.all_vectors()
-    assert count["n"] == 1
+    assert count["n"] == 0
     assert [m[0] for m in metadata] == ["b.md"]
     assert matrix.shape[0] == 1
 


### PR DESCRIPTION
Closes #531.

## The evidence

The live service log shows repeated full matrix reloads tagged `reason=genuine`:

| time (UTC) | rows | gen | cached_gen | delta |
|---|---|---|---|---|
| 00:19:27 | 60218 | 74589 | -1 (cold) | — |
| 01:03:49 | 60269 | 74619 | 74608 | **11** |
| 01:30:14 | 60291 | 74662 | 74660 | **2** |

A cache **2 generations** stale triggered a full `SELECT` of 60,291 rows plus `np.stack` — roughly 21 s. The intervals (44 min, 26 min) match the reported "every ~40 min". `sidecar_store.cache_is_fresh` required `c.generation == gen`: exact equality, no bounded catch-up. This is hypothesis H4 from the issue, now evidence-backed rather than assumed.

## The fix

When the delta window is small, patch the cached matrix from the changed rows instead of full-loading, reusing the existing splice machinery from the write path rather than writing a second one. `reload_reason` gains a `patched` outcome so the log still distinguishes a genuine full reload.

**The interesting part is the gate, not the patch.** Catch-up is only sound if the change log covers the *entire* delta window, and two cheaper gates that look sufficient are not:

- **`COUNT(*)` cannot detect it.** An in-place re-embed of an existing chunk preserves the row count exactly.
- **"the newest generation was logged" (`upto == gen`) cannot detect it either.** A gap *earlier* in the window still passes.

The second point was established the hard way. The first reviewer prescribed exactly that gate; the implementer pushed back saying it was insufficient; I asked the reviewer to adjudicate its own prescription directly. It reproduced the counterexample and conceded:

```
cache_gen=2  sidecar gen=4  run_from=3  run_upto=4
  'upto == gen' alone would PASS : True
  run check (cache_gen >= from)  : False  -> REFUSE
```

An unlogged write at gen 3 followed by an ordinary logged write at gen 4 leaves `upto == gen == 4`, so the `upto`-only gate waves the whole `(2, 4]` window through and gen 3's rows are never applied — the *permanent* half of the original reproduction, where five later logged writes leave the stale block resident indefinitely.

So the two markers bound a **contiguous run of logged generations**: `upto` is the newest logged generation, `from` sits one below the run's oldest. Each logged bump extends the run, or — finding itself not adjacent to the previous logged generation — restarts it, permanently excluding the window containing the gap. Catch-up requires `upto == gen` **and** `cache.generation >= from`. Everything else, plus gen 0, an epoch change, or an instance change, takes the full reload.

## Verification

**Exhaustive, not argued.** Every pattern in {logged, unlogged}^k crossed with every intermediate read point, with unlogged writes made count-preserving in-place re-embeds so `COUNT(*)` is blind, serving `(metadata, matrix)` compared against a cold full load each time:

```
k=4: 80 pattern x readpoint combos  -> final read: catchup=31 reload=49  ALL served == truth
k=5: 192 pattern x readpoint combos -> final read: catchup=63 reload=129 ALL served == truth
```

Catch-ups still fire in ~33% of cases, so the gate is real rather than degenerate refuse-everything. Marker evolution was traced step by step through two separate unlogged bumps, an unlogged bump immediately after a restart, and interleaved runs; no ordering absorbs a gap. Both original blocking reproductions now match `origin/main` exactly.

**Concurrency and crash-atomicity.** `_extend_logged_run`'s read-modify-write runs after `bump_meta`'s `UPDATE meta` has taken the SQLite write lock on every call path, with markers and log rows inside the caller's transaction. Forcing an exception before commit left the markers bit-identical — the run can never claim a generation it never logged. Stress with 2 logged writers + 1 unlogged writer + a hot reader over 3 seeds: 0 errors, served matrix identical to truth every time, and markers showing genuine gap-driven restarts under contention rather than races through.

**Recovery.** `ensure_path_change_log` detects table creation, so after a `DROP TABLE` the markers clear rather than letting an empty log read as "nothing changed" from markers that outlived it. Upgrade from the pre-existing marker layout self-heals: `upto is None != gen` refuses, full reload, and the first logged bump re-establishes the run.

50/50 across the three cache test files; the three new regression tests are genuinely red on the pre-fix commit. Diffstat is 5 files, all inside the lane allowlist — `clip_index.py` and `claims.py` are untouched.

## Scope

`clip_index.py` and `claims.py` have the same shape and are deliberately **not** included; they are a follow-up.

After deploy, the check is: grep the service log for `embedding matrix full load: reason=genuine` over a day. Small-delta reloads should be gone, replaced by patch events, with genuine full loads rare.

#283 should also be re-measured after this lands — it may substantially close itself.
