### PR TITLE
fix(ops): resolve the log directory outside the wheel venv

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -923,7 +923,9 @@ is still enforced on every request; a genuinely expired, revoked, or invalid
 credential still requires authorization, but a normal restart does not.
 
 **macOS / Linux:** `bash scripts/restart.sh` — launchd `kickstart -k` on macOS,
-`systemctl --user restart` on Linux. It truncates `logs/exomem.log` and tails it.
+`systemctl --user restart` on Linux. It truncates `logs/exomem.log` and tails it
+(a repo-mode/dev install; a packaged install's `exomem.log` lives under its
+resolved log directory instead — see § Logs below).
 
 **Windows:** `install-service.ps1` grants your user account start/stop rights on
 the service, so day-to-day restarts don't need UAC:
@@ -931,8 +933,16 @@ the service, so day-to-day restarts don't need UAC:
 ```powershell
 sc.exe stop exomem
 sc.exe start exomem
-Get-Content logs\exomem.log -Tail 6
+$logDir = ((exomem doctor --json | ConvertFrom-Json).checks | Where-Object { $_.id -eq 'observability' }).details.log_dir
+Get-Content "$logDir\exomem.log" -Tail 6
 ```
+
+(`install-service.ps1` pins `EXOMEM_LOG_DIR` — `%ProgramData%\exomem\logs` by
+default — into the service's environment for a `-Release` install, so its
+`exomem.log` is NOT under the repo checkout's `logs\` folder. `exomem doctor`
+reports the resolved path directly, which the command above reads rather than
+hardcoding it, so it stays correct whether the box uses the default or an
+operator-pinned override.)
 
 If you skipped the grant (or installed from an older version of the script),
 re-run the install script — it's idempotent and will only add the ACE if it's
@@ -953,12 +963,22 @@ sc.exe start exomem
 
 ## Logs
 
-- `logs/exomem.log` — application log (rotated in-process, 5 MB × 5 files; same on
-  every platform).
-- `logs/service.out.log`, `logs/service.err.log` — service stdout/stderr. On
-  Windows NSSM writes and rotates these; launchd/systemd write them but do **not**
-  rotate them (the app's own `exomem.log` is the durable, self-rotating record). On
-  Linux, `journalctl --user -u exomem` is the primary stdout/stderr view.
+- `exomem.log` — application log (rotated in-process, 5 MB × 5 files; same on
+  every platform), under the **resolved log directory**
+  (`logging_config.resolve_log_dir()`, see `docs/observability.md`): the repo
+  `logs/` folder for a repo-mode/dev checkout, or the pinned/per-platform
+  location (`%ProgramData%\exomem\logs` by default on a Windows
+  `-Release`/service install) otherwise. `exomem doctor --json` always reports
+  the actual resolved path under the `observability` check's `log_dir` detail
+  — read it from there rather than assuming `logs/exomem.log`.
+- `logs/service.out.log`, `logs/service.err.log` — service stdout/stderr,
+  always under the checkout's own `logs/` folder regardless of profile or
+  `EXOMEM_LOG_DIR` (NSSM's `AppStdout`/`AppStderr` redirect targets, set by
+  `install-service.ps1` relative to the checkout it was run from — a separate
+  concern from the app's own structured logging). On Windows NSSM writes and
+  rotates these; launchd/systemd write them but do **not** rotate them (the
+  app's own `exomem.log` is the durable, self-rotating record). On Linux,
+  `journalctl --user -u exomem` is the primary stdout/stderr view.
 
 ## Troubleshooting
 
@@ -970,7 +990,7 @@ sc.exe start exomem
 | claude.ai connector connects but every tool call returns 401 | Wrong GitHub user | `EXOMEM_GITHUB_USERNAME` must equal the login of the GitHub account you authorized with. Check the exomem log for `rejecting token for github login=...`. |
 | Existing client receives one `401 invalid_token` after the durable-session cutover | Legacy FastMCP reference JWT is intentionally not dual-read | Complete one final login without deleting or changing the connector URL. If a durable session later gets 401, inspect it with `exomem auth sessions`. |
 | Authenticated tools return `503` without `WWW-Authenticate` | Authoritative session storage is unavailable or corrupt | Repair the coordinator/network/storage path. Do not reauthorize: a fresh login uses the same unavailable authority. |
-| claude.ai shows "connector failed" | service down (host asleep, service stopped, crash loop) | Check the service status; tail `logs/service.err.log` and `logs/exomem.log`. Multiple startup banners within seconds = orphan python processes — kill them and force-restart. |
+| claude.ai shows "connector failed" | service down (host asleep, service stopped, crash loop) | Check the service status; tail `logs/service.err.log` and `exomem.log` (see § Logs for its resolved path — not always under `logs/`). Multiple startup banners within seconds = orphan python processes — kill them and force-restart. |
 | Edits to `.env` not picked up | service didn't restart | Restart the service (elevated on Windows). Confirm the python process restarted. |
 | 404 / Funnel "no service" | Tunnel disabled or pointing at the wrong port | `tailscale funnel status` (or check `cloudflared`); re-run the tunnel command from step 2. |
 | `KB vault not found` on startup | vault path moved or `EXOMEM_VAULT_PATH` wrong | set `EXOMEM_VAULT_PATH` to the absolute vault root in `.env`. |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -7,8 +7,18 @@ HTTP request, or a mutation.
 
 ## Files
 
-All under the resolved log directory (`$EXOMEM_LOG_DIR`, else
-`<checkout>/logs`, else `/data/logs` in the Docker image):
+All under the resolved log directory (`logging_config.resolve_log_dir()`):
+`$EXOMEM_LOG_DIR` when set (the Docker image sets it to `/data/logs`), else
+`<checkout>/logs` when running from a genuine source checkout, else a
+per-platform location for a packaged (wheel) install with no override:
+`%ProgramData%\exomem\logs` on Windows (machine-wide, since the service
+commonly runs as `LocalSystem` while the `exomem` CLI runs as the logged-in
+user), `~/Library/Logs/Exomem` on macOS, `$XDG_STATE_HOME/exomem/logs`
+(falling back to `~/.local/state/exomem/logs`) on Linux. `exomem doctor`
+reports the resolved path under the `observability` check's `log_dir` detail
+(`--json`), so a misresolved directory is never silent. Every file below
+resolves through this SAME function — none of them may compute their own
+directory independently.
 
 | File                     | Contents                                                     |
 | ------------------------ | -------------------------------------------------------------- |

--- a/scripts/install-service.ps1
+++ b/scripts/install-service.ps1
@@ -191,7 +191,23 @@ if ($Release) {
     }
 }
 
+# Pin EXOMEM_LOG_DIR explicitly rather than let the running service
+# independently re-derive its own fallback: `resolve_log_dir()` (issue #552)
+# resolves an unset EXOMEM_LOG_DIR to %ProgramData%\exomem\logs for a wheel
+# install with no override, so pinning it here to that SAME value doesn't
+# change behavior today -- but it makes the service (via AppEnvironmentExtra
+# below) and any operator-run CLI on this box (`exomem doctor`, `exomem
+# trace`) PROVABLY agree, rather than merely happening to because both sides
+# independently compute the identical formula. It also survives a future
+# change to that fallback without silently moving where a running service's
+# logs land underneath an operator who never re-ran this script. Respects an
+# operator's own explicit `.env` override -- only pins when unset there.
 $serviceEnv = Read-DotenvMap
+if (-not $serviceEnv.Contains("EXOMEM_LOG_DIR")) {
+    $logDirBase = if ($env:ProgramData) { $env:ProgramData } elseif ($env:ALLUSERSPROFILE) { $env:ALLUSERSPROFILE } else { "C:\ProgramData" }
+    $serviceEnv["EXOMEM_LOG_DIR"] = Join-Path $logDirBase "exomem\logs"
+}
+$appLogDir = $serviceEnv["EXOMEM_LOG_DIR"]
 Set-ProcessEnvFromMap -Map $serviceEnv
 
 $doctorArgs = @("-m", "exomem", "doctor", "--profile", $Profile)
@@ -303,4 +319,4 @@ if ($connectorPending) {
 } else {
     Write-Host "Installed, started, and connector-cleared service '$ServiceName' bound to ${BindHost}:${Port}."
 }
-Write-Host "Logs: $logDir\service.out.log (stdout), service.err.log (stderr), exomem.log (app)"
+Write-Host "Logs: $logDir\service.out.log (stdout), service.err.log (stderr, NSSM-rotated); $appLogDir\exomem.log (app, EXOMEM_LOG_DIR)"

--- a/scripts/install-service.ps1
+++ b/scripts/install-service.ps1
@@ -186,7 +186,13 @@ if ($Release) {
     $python = Install-ReleaseVenv
     # Wheel-backed service venv: `resolve_log_dir()` resolves an unset
     # EXOMEM_LOG_DIR to %ProgramData%\exomem\logs there (not a checkout).
-    $logDirBase = if ($env:ProgramData) { $env:ProgramData } elseif ($env:ALLUSERSPROFILE) { $env:ALLUSERSPROFILE } else { "C:\ProgramData" }
+    # The last tier is spelled as a concatenation, exactly as the Python side
+    # (`_user_log_dir()`, `mode.config_path()`) spells its own `"C:" + r"\ProgramData"`:
+    # the literal must stay byte-identical to Python's, so `$env:SystemDrive` is
+    # deliberately NOT used -- it resolves to a non-C: volume on a box where Windows
+    # was installed elsewhere, which would silently pin a directory the service's own
+    # `resolve_log_dir()` would never pick.
+    $logDirBase = if ($env:ProgramData) { $env:ProgramData } elseif ($env:ALLUSERSPROFILE) { $env:ALLUSERSPROFILE } else { "C:" + "\ProgramData" }
     $pinnedLogDir = Join-Path $logDirBase "exomem\logs"
 } else {
     $python = Join-Path $repoRoot ".venv\Scripts\python.exe"

--- a/scripts/install-service.ps1
+++ b/scripts/install-service.ps1
@@ -184,28 +184,39 @@ function Install-ReleaseVenv {
 
 if ($Release) {
     $python = Install-ReleaseVenv
+    # Wheel-backed service venv: `resolve_log_dir()` resolves an unset
+    # EXOMEM_LOG_DIR to %ProgramData%\exomem\logs there (not a checkout).
+    $logDirBase = if ($env:ProgramData) { $env:ProgramData } elseif ($env:ALLUSERSPROFILE) { $env:ALLUSERSPROFILE } else { "C:\ProgramData" }
+    $pinnedLogDir = Join-Path $logDirBase "exomem\logs"
 } else {
     $python = Join-Path $repoRoot ".venv\Scripts\python.exe"
     if (-not (Test-Path $python)) {
         throw "Python venv not found at $python. Run 'uv sync' in $repoRoot first, or pass -Release to install a PyPI-backed service venv."
     }
+    # Editable checkout: `resolve_log_dir()` resolves an unset EXOMEM_LOG_DIR
+    # to <repo>\logs there -- the same $logDir this script already uses for
+    # the NSSM stdout/stderr redirects, and the same folder `restart.ps1`
+    # tails.
+    $pinnedLogDir = $logDir
 }
 
 # Pin EXOMEM_LOG_DIR explicitly rather than let the running service
-# independently re-derive its own fallback: `resolve_log_dir()` (issue #552)
-# resolves an unset EXOMEM_LOG_DIR to %ProgramData%\exomem\logs for a wheel
-# install with no override, so pinning it here to that SAME value doesn't
-# change behavior today -- but it makes the service (via AppEnvironmentExtra
-# below) and any operator-run CLI on this box (`exomem doctor`, `exomem
-# trace`) PROVABLY agree, rather than merely happening to because both sides
-# independently compute the identical formula. It also survives a future
-# change to that fallback without silently moving where a running service's
-# logs land underneath an operator who never re-ran this script. Respects an
-# operator's own explicit `.env` override -- only pins when unset there.
+# independently re-derive its own fallback. `$pinnedLogDir` is computed per
+# install mode above to be the SAME value `resolve_log_dir()` (issue #552)
+# already resolves an unset EXOMEM_LOG_DIR to for the interpreter this
+# install will actually run -- %ProgramData%\exomem\logs for the wheel-backed
+# -Release venv, <repo>\logs for a repo-mode editable checkout -- so the pin
+# changes behavior in NEITHER mode today. What it buys is that the service
+# (via AppEnvironmentExtra below) and any operator-run CLI on this box
+# (`exomem doctor`, `exomem trace`) PROVABLY agree, rather than merely
+# happening to because both sides independently compute the identical
+# formula. It also survives a future change to that fallback without silently
+# moving where a running service's logs land underneath an operator who never
+# re-ran this script. Respects an operator's own explicit `.env` override --
+# only pins when unset there.
 $serviceEnv = Read-DotenvMap
 if (-not $serviceEnv.Contains("EXOMEM_LOG_DIR")) {
-    $logDirBase = if ($env:ProgramData) { $env:ProgramData } elseif ($env:ALLUSERSPROFILE) { $env:ALLUSERSPROFILE } else { "C:\ProgramData" }
-    $serviceEnv["EXOMEM_LOG_DIR"] = Join-Path $logDirBase "exomem\logs"
+    $serviceEnv["EXOMEM_LOG_DIR"] = $pinnedLogDir
 }
 $appLogDir = $serviceEnv["EXOMEM_LOG_DIR"]
 Set-ProcessEnvFromMap -Map $serviceEnv

--- a/src/exomem/audit.py
+++ b/src/exomem/audit.py
@@ -66,6 +66,7 @@ from . import (
     access,
     contradiction_stance,
     indexes,
+    logging_config,
     relation_registry,
     semantic_language_registry,
     semantic_units,
@@ -116,11 +117,15 @@ _LEGACY_BACKLOG_CODE = "RELATION_DISPOSITION_MISSING"
 DEFAULT_LEGACY_SAMPLE_LIMIT = 5
 MAX_LEGACY_SAMPLE_LIMIT = 50
 
-# Repo-global feedback-loop logs (written by the running service) + the golden
-# query set, used by the relevance_pairs_pending check. Module-level so tests
-# can monkeypatch them to point at an isolated fixture.
+# Feedback-loop logs (written by the running service) + the golden query set,
+# used by the relevance_pairs_pending check. Module-level so tests can
+# monkeypatch them to point at an isolated fixture. `_RELEVANCE_LOGS_DIR` MUST
+# route through the same `resolve_log_dir()` every other log file uses —
+# `queries.jsonl`/`writes.jsonl` live under it (via `query_log.py`), and a
+# hardcoded `<repo>/logs` guess here left them unfindable once
+# EXOMEM_LOG_DIR-unset resolution stopped assuming a checkout (issue #552).
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-_RELEVANCE_LOGS_DIR = _REPO_ROOT / "logs"
+_RELEVANCE_LOGS_DIR = logging_config.resolve_log_dir()
 _RELEVANCE_GOLDEN = _REPO_ROOT / "tests" / "golden" / "queries.yaml"
 
 # Matches [[Target]] or [[Target|Alias]]. Target may contain '/' for paths.

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -2300,6 +2300,7 @@ def _check_observability() -> DoctorCheck:
     warnings: list[str] = []
 
     log_dir = resolve_log_dir()
+    details["log_dir"] = str(log_dir)
     try:
         log_dir.mkdir(parents=True, exist_ok=True)
         probe_path = log_dir / f".exomem-doctor-probe-{os.getpid()}"

--- a/src/exomem/logging_config.py
+++ b/src/exomem/logging_config.py
@@ -54,34 +54,84 @@ def _is_source_checkout(candidate_root: Path) -> bool:
     return (candidate_root / "pyproject.toml").is_file()
 
 
+def _safe_home() -> Path | None:
+    """`Path.home()`, but non-raising.
+
+    It raises `RuntimeError` when the home directory cannot be determined —
+    a real case, not a hypothetical: a container running as a UID with no
+    matching `/etc/passwd` entry and no `$HOME` set. `resolve_log_dir()`
+    previously could never raise, and none of its three call sites
+    (`server.py`, `__main__.py`, `media_worker_child.py`) guard against it —
+    a homeless environment must degrade to `_homeless_fallback()`, not crash
+    startup.
+    """
+    try:
+        return Path.home()
+    except RuntimeError:
+        return None
+
+
+def _homeless_fallback() -> Path:
+    """Last resort when even `Path.home()` cannot resolve: the OS temp
+    directory, which has its own robust fallback chain (`TMPDIR`/`TEMP`/`TMP`,
+    then a platform default) and does not depend on a resolvable home
+    directory. Trades "correctly per-user" for "always returns a path
+    `resolve_log_dir()` can hand back without raising".
+    """
+    import tempfile
+
+    return Path(tempfile.gettempdir()) / "exomem" / "logs"
+
+
 def _user_log_dir() -> Path:
-    """Per-user, per-platform log location for when this isn't a source
-    checkout (e.g. a wheel install with EXOMEM_LOG_DIR unset) — the venv's
-    own `Lib`/`site-packages` directory is not writable by convention and not
+    """Per-platform log location for when this isn't a source checkout (e.g.
+    a wheel install with EXOMEM_LOG_DIR unset) — the venv's own
+    `Lib`/`site-packages` directory is not writable by convention and not
     where a log directory belongs.
 
-    Mirrors `install_info.managed_manifest_path()`'s per-platform root
-    (`%LOCALAPPDATA%\\Exomem` on Windows, `~/Library/...Exomem` on macOS, XDG
-    on Linux) so installs already familiar with that split find logs in the
-    sibling convention for their platform. Linux uses `XDG_STATE_HOME` (falling
-    back to `~/.local/state`) rather than XDG's config dir, since logs are
-    state, not configuration, per the XDG Base Directory spec.
+    Windows is machine-wide (`%PROGRAMDATA%/exomem/logs`, with the same
+    `ALLUSERSPROFILE` / `C:\\ProgramData` fallback chain and lowercase
+    `exomem` directory name as `mode.config_path()`), NOT the user profile:
+    the exomem service commonly runs as `LocalSystem` while an operator's
+    `exomem` CLI runs as their own logged-in user, and a home- or
+    `%LOCALAPPDATA%`-relative path resolves to two different, mutually
+    unreadable profiles — exactly `mode.config_path()`'s own rationale,
+    reused here rather than `install_info.managed_manifest_path()`'s
+    per-user root, which answers a different question (per-user CLI install
+    identity, correctly per-user) and would send a LocalSystem service's logs
+    to its restricted system profile where no operator-run `exomem doctor`
+    could ever find them.
+
+    macOS and Linux keep the per-user convention (services there commonly run
+    as the user, not a system account): `~/Library/Logs/Exomem` on macOS,
+    `$XDG_STATE_HOME/exomem/logs` (falling back to `~/.local/state`) on
+    Linux — state, not configuration, per the XDG Base Directory spec.
     """
     if sys.platform == "win32":
-        root = os.environ.get("LOCALAPPDATA", "").strip()
-        base = Path(root) if root else Path.home() / "AppData" / "Local"
-        return base / "Exomem" / "logs"
+        base = (
+            os.environ.get("PROGRAMDATA")
+            or os.environ.get("ALLUSERSPROFILE")
+            or "C:" + r"\ProgramData"
+        )
+        return Path(base) / "exomem" / "logs"
     if sys.platform == "darwin":
-        return Path.home() / "Library" / "Logs" / "Exomem"
+        home = _safe_home()
+        if home is not None:
+            return home / "Library" / "Logs" / "Exomem"
+        return _homeless_fallback()
     root = os.environ.get("XDG_STATE_HOME", "").strip()
-    base = Path(root) if root else Path.home() / ".local" / "state"
-    return base / "exomem" / "logs"
+    if root:
+        return Path(root) / "exomem" / "logs"
+    home = _safe_home()
+    if home is not None:
+        return home / ".local" / "state" / "exomem" / "logs"
+    return _homeless_fallback()
 
 
 def resolve_log_dir(default: Path | None = None) -> Path:
     """The log directory: $EXOMEM_LOG_DIR when set, else `default`, else the
     checkout-derived `<repo>/logs` when this genuinely IS a source checkout,
-    else a per-user platform log location.
+    else a per-platform log location (`_user_log_dir()`).
 
     EXOMEM_LOG_DIR exists for installs where the package directory isn't
     writable — containers (the image sets it to /data/logs) and non-root
@@ -97,6 +147,19 @@ def resolve_log_dir(default: Path | None = None) -> Path:
     itself (`<venv>/Lib`) — logs then land at `<venv>/Lib/logs`, invisible
     next to the actual venv/service layout. `_is_source_checkout()` detects
     the checkout case positively instead of assuming it.
+
+    This function never raises: `_user_log_dir()`'s Windows branch never
+    touches `Path.home()` (it reads `%PROGRAMDATA%`/`%ALLUSERSPROFILE%`, with
+    a hardcoded `C:\\ProgramData` last resort), and its macOS/Linux branches
+    fall back to the OS temp directory if `Path.home()` itself cannot
+    resolve — every one of this function's callers is unguarded against a
+    raise from an early-startup logging bootstrap.
+
+    Every process-role log (`exomem.log`/`exomem-cli.log`/`exomem-media.log`)
+    and every JSONL sidecar (`queries.jsonl`/`writes.jsonl`/`reads.jsonl` via
+    `query_log.py`, `mutations.jsonl`, and the relevance-audit reader in
+    `audit.py`) route through this SAME function so they always stay
+    co-located — none of them may compute a log directory independently.
     """
     env = os.environ.get("EXOMEM_LOG_DIR", "").strip()
     if env:

--- a/src/exomem/logging_config.py
+++ b/src/exomem/logging_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
@@ -21,22 +22,91 @@ _LOG_FILENAMES: dict[str, str] = {
 }
 
 
+def _is_source_checkout(candidate_root: Path) -> bool:
+    """Whether `candidate_root` (the `parents[2]` hop from this module's
+    `__file__`) is genuinely this project's source checkout, not the
+    `<venv>/Lib` (or `<venv>/lib/pythonX.Y`) hop a wheel install produces at
+    that same index.
+
+    Two markers, both required, chosen so a wheel install cannot satisfy them
+    by accident:
+
+    - This module's immediate parent directory is literally named `src`. A
+      wheel (or any non-editable) install copies `logging_config.py` straight
+      into `.../site-packages/exomem/`, never into
+      `.../site-packages/src/exomem/` — only a genuine src-layout checkout
+      (including an editable install, whose `__file__` still points at the
+      real source tree) has `src` as this module's parent.
+    - `candidate_root / "pyproject.toml"` exists, confirming `candidate_root`
+      is an actual project root and not just some directory that happens to
+      sit two hops up.
+
+    `site-packages`/`dist-packages` anywhere in the module's own path is
+    rejected outright as an independent second guard, even if the two
+    markers above were somehow both satisfied.
+    """
+    package_dir = Path(__file__).resolve().parent
+    if package_dir.parent.name != "src":
+        return False
+    lowered_parts = {part.lower() for part in package_dir.parts}
+    if "site-packages" in lowered_parts or "dist-packages" in lowered_parts:
+        return False
+    return (candidate_root / "pyproject.toml").is_file()
+
+
+def _user_log_dir() -> Path:
+    """Per-user, per-platform log location for when this isn't a source
+    checkout (e.g. a wheel install with EXOMEM_LOG_DIR unset) — the venv's
+    own `Lib`/`site-packages` directory is not writable by convention and not
+    where a log directory belongs.
+
+    Mirrors `install_info.managed_manifest_path()`'s per-platform root
+    (`%LOCALAPPDATA%\\Exomem` on Windows, `~/Library/...Exomem` on macOS, XDG
+    on Linux) so installs already familiar with that split find logs in the
+    sibling convention for their platform. Linux uses `XDG_STATE_HOME` (falling
+    back to `~/.local/state`) rather than XDG's config dir, since logs are
+    state, not configuration, per the XDG Base Directory spec.
+    """
+    if sys.platform == "win32":
+        root = os.environ.get("LOCALAPPDATA", "").strip()
+        base = Path(root) if root else Path.home() / "AppData" / "Local"
+        return base / "Exomem" / "logs"
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Logs" / "Exomem"
+    root = os.environ.get("XDG_STATE_HOME", "").strip()
+    base = Path(root) if root else Path.home() / ".local" / "state"
+    return base / "exomem" / "logs"
+
+
 def resolve_log_dir(default: Path | None = None) -> Path:
     """The log directory: $EXOMEM_LOG_DIR when set, else `default`, else the
-    checkout-derived `<repo>/logs`.
+    checkout-derived `<repo>/logs` when this genuinely IS a source checkout,
+    else a per-user platform log location.
 
     EXOMEM_LOG_DIR exists for installs where the package directory isn't
     writable — containers (the image sets it to /data/logs) and non-root
     wheel installs. It must be a PROCESS env var (container ENV, service
     environment, shell): logging configures before the server loads `.env`,
     so a value only in `.env` arrives too late.
+
+    The final fallback used to assume a src-layout checkout unconditionally
+    (`Path(__file__).resolve().parents[2] / "logs"`), which is correct for
+    `<repo>/src/exomem/logging_config.py` but silently wrong for a wheel
+    install, where the same two-hop climb from
+    `<venv>/Lib/site-packages/exomem/logging_config.py` lands inside the venv
+    itself (`<venv>/Lib`) — logs then land at `<venv>/Lib/logs`, invisible
+    next to the actual venv/service layout. `_is_source_checkout()` detects
+    the checkout case positively instead of assuming it.
     """
     env = os.environ.get("EXOMEM_LOG_DIR", "").strip()
     if env:
         return Path(env)
     if default is not None:
         return default
-    return Path(__file__).resolve().parents[2] / "logs"
+    checkout_root = Path(__file__).resolve().parents[2]
+    if _is_source_checkout(checkout_root):
+        return checkout_root / "logs"
+    return _user_log_dir()
 
 
 def _resolve_level(level: int) -> int:

--- a/src/exomem/logging_config.py
+++ b/src/exomem/logging_config.py
@@ -90,7 +90,7 @@ def _user_log_dir() -> Path:
     where a log directory belongs.
 
     Windows is machine-wide (`%PROGRAMDATA%/exomem/logs`, with the same
-    `ALLUSERSPROFILE` / `C:\\ProgramData` fallback chain and lowercase
+    `%ALLUSERSPROFILE%` / hardcoded-`ProgramData` fallback chain and lowercase
     `exomem` directory name as `mode.config_path()`), NOT the user profile:
     the exomem service commonly runs as `LocalSystem` while an operator's
     `exomem` CLI runs as their own logged-in user, and a home- or
@@ -150,7 +150,7 @@ def resolve_log_dir(default: Path | None = None) -> Path:
 
     This function never raises: `_user_log_dir()`'s Windows branch never
     touches `Path.home()` (it reads `%PROGRAMDATA%`/`%ALLUSERSPROFILE%`, with
-    a hardcoded `C:\\ProgramData` last resort), and its macOS/Linux branches
+    a hardcoded `ProgramData` last resort), and its macOS/Linux branches
     fall back to the OS temp directory if `Path.home()` itself cannot
     resolve — every one of this function's callers is unguarded against a
     raise from an early-startup logging bootstrap.

--- a/src/exomem/query_log.py
+++ b/src/exomem/query_log.py
@@ -41,13 +41,15 @@ log = logging.getLogger(__name__)
 # Module-level defaults (patchable in tests). $EXOMEM_LOG_DIR is consulted
 # PER CALL via `_target`/`current_log_dir` — never frozen at import — so a
 # container or test can flip the env var without reloading the module. The
-# unset-fallback itself IS frozen at import (matching `resolve_log_dir()`'s
-# own contract) via the SAME resolution `logging_config.resolve_log_dir()`
-# uses for every other log file, so queries.jsonl/writes.jsonl/reads.jsonl
-# always stay co-located with exomem.log/exomem-cli.log/exomem-media.log —
-# a bare `<repo>/logs` guess here previously left these three behind on a
-# wheel install once EXOMEM_LOG_DIR-unset resolution stopped assuming a
-# checkout (issue #552).
+# constant below, by contrast, freezes `resolve_log_dir()`'s ENTIRE answer at
+# import — its env branch included, not just the unset fallback — so when
+# EXOMEM_LOG_DIR is already exported at import time this holds that env value
+# too, and only a module reload re-derives it. It is the SAME resolution
+# `logging_config.resolve_log_dir()` uses for every other log file, so
+# queries.jsonl/writes.jsonl/reads.jsonl always stay co-located with
+# exomem.log/exomem-cli.log/exomem-media.log — a bare `<repo>/logs` guess here
+# previously left these three behind on a wheel install once
+# EXOMEM_LOG_DIR-unset resolution stopped assuming a checkout (issue #552).
 _LOG_DIR = resolve_log_dir()
 QUERIES_PATH = _LOG_DIR / "queries.jsonl"
 WRITES_PATH = _LOG_DIR / "writes.jsonl"

--- a/src/exomem/query_log.py
+++ b/src/exomem/query_log.py
@@ -1,9 +1,10 @@
 """Durable structured logs of find() queries and write events.
 
-Two JSONL files under the repo `logs/` dir (already gitignored via `logs/*`,
-NSSM-rotated neighborhood, NEVER Obsidian-synced — query text can name sensitive
-Evidence scopes, so it stays on the box at the same trust boundary as
-`logs/exomem.log`):
+Two JSONL files under the resolved log dir (`logging_config.resolve_log_dir()`
+— the repo `logs/` dir in a source checkout, gitignored via `logs/*`,
+NSSM-rotated neighborhood; a per-platform location for a packaged install —
+NEVER Obsidian-synced — query text can name sensitive Evidence scopes, so it
+stays on the box at the same trust boundary as `exomem.log`):
 
 - `logs/queries.jsonl` : one object per find() call (query + ranking signals)
 - `logs/writes.jsonl`  : one object per note/add/replace write (path + citations)
@@ -33,12 +34,21 @@ import os
 from pathlib import Path
 from typing import Any
 
+from .logging_config import resolve_log_dir
+
 log = logging.getLogger(__name__)
 
 # Module-level defaults (patchable in tests). $EXOMEM_LOG_DIR is consulted
 # PER CALL via `_target`/`current_log_dir` — never frozen at import — so a
-# container or test can flip the env var without reloading the module.
-_LOG_DIR = Path(__file__).resolve().parents[2] / "logs"
+# container or test can flip the env var without reloading the module. The
+# unset-fallback itself IS frozen at import (matching `resolve_log_dir()`'s
+# own contract) via the SAME resolution `logging_config.resolve_log_dir()`
+# uses for every other log file, so queries.jsonl/writes.jsonl/reads.jsonl
+# always stay co-located with exomem.log/exomem-cli.log/exomem-media.log —
+# a bare `<repo>/logs` guess here previously left these three behind on a
+# wheel install once EXOMEM_LOG_DIR-unset resolution stopped assuming a
+# checkout (issue #552).
+_LOG_DIR = resolve_log_dir()
 QUERIES_PATH = _LOG_DIR / "queries.jsonl"
 WRITES_PATH = _LOG_DIR / "writes.jsonl"
 READS_PATH = _LOG_DIR / "reads.jsonl"

--- a/tests/test_log_dir_override.py
+++ b/tests/test_log_dir_override.py
@@ -10,22 +10,34 @@ mismatch because today's code never consults `EXOMEM_LOG_DIR` at all.
 
 Contract:
 - `logging_config.resolve_log_dir()` returns `Path($EXOMEM_LOG_DIR)` when the
-  env var is set, else today's `parents[2] / "logs"` default — byte-identical
-  to current behavior when unset.
+  env var is set, else today's `parents[2] / "logs"` default WHEN this
+  process is genuinely running against a source checkout (which is what
+  pytest does here — see `test_this_repo_is_detected_as_a_source_checkout`
+  below) — byte-identical to current behavior in that case, but NOT
+  unconditionally: a wheel install takes a different, per-platform fallback
+  instead of guessing `parents[2] / "logs"` blind. See
+  `tests/test_resolve_log_dir_wheel_fallback.py` for that non-checkout case
+  (issue #552).
 - `server.run()`'s `log_dir` resolution: a passed `log_dir=` argument
   (unchanged, still wins) -> `EXOMEM_LOG_DIR` env -> the same default.
 - `query_log`'s JSONL paths (`QUERIES_PATH`/`WRITES_PATH`/`READS_PATH`) resolve
   through the same helper at each write, not a value frozen at import time.
+- `query_log.current_log_dir()` and `audit._RELEVANCE_LOGS_DIR` must agree
+  with `logging_config.resolve_log_dir()` with `EXOMEM_LOG_DIR` unset — all
+  seven log files (three `exomem*.log`, `mutations.jsonl`, and
+  `queries.jsonl`/`writes.jsonl`/`reads.jsonl`) stay co-located rather than
+  three of them being computed independently and drifting.
 """
 
 from __future__ import annotations
 
+import importlib
 import json
 from pathlib import Path
 
 import pytest
 
-from exomem import logging_config, query_log, server
+from exomem import audit, logging_config, query_log, server
 
 
 class _StopRun(Exception):
@@ -36,9 +48,18 @@ class _StopRun(Exception):
 
 
 def _default_log_dir() -> Path:
-    """Mirrors today's hardcoded default independently of the implementation
-    under test, so a bug in the new resolution logic can't accidentally make
-    the test agree with itself."""
+    """Mirrors today's hardcoded checkout-branch default independently of the
+    implementation under test, so a bug in the new resolution logic can't
+    accidentally make the test agree with itself.
+
+    This is ONLY the correct expectation because pytest itself runs against
+    a genuine, editable-installed source checkout of this repo — the
+    condition `test_this_repo_is_detected_as_a_source_checkout` asserts
+    directly, so this file's assumption is checked rather than merely
+    convenient. In a wheel install this formula would NOT match
+    `resolve_log_dir()`'s actual return value — that case lives in
+    `tests/test_resolve_log_dir_wheel_fallback.py`.
+    """
     return Path(server.__file__).resolve().parents[2] / "logs"
 
 
@@ -64,6 +85,18 @@ def test_resolve_log_dir_honors_env_override(
 def test_resolve_log_dir_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
     assert logging_config.resolve_log_dir() == _default_log_dir()
+
+
+def test_this_repo_is_detected_as_a_source_checkout() -> None:
+    """Precondition for every `_default_log_dir()`-based assertion in this
+    file: they only hold because pytest here runs against a genuine,
+    editable-installed source checkout, which takes the checkout branch of
+    `resolve_log_dir()`'s fallback. If checkout detection ever regressed for
+    a real checkout, those assertions could still incidentally pass by
+    coincidence with a *different* wrong fallback — so assert the
+    precondition directly rather than relying on that coincidence."""
+    checkout_root = Path(logging_config.__file__).resolve().parents[2]
+    assert logging_config._is_source_checkout(checkout_root) is True
 
 
 # --- server.run() -----------------------------------------------------------
@@ -159,3 +192,84 @@ def test_query_log_uses_module_default_when_env_unset(
     query_log.log_write_call(tool="note", written_path="y", cited_sources=[])
 
     assert default_path.exists()
+
+
+# --- cross-module agreement: nothing computes the log dir independently ----
+#
+# Issue #552 follow-up: `query_log._LOG_DIR` and `audit._RELEVANCE_LOGS_DIR`
+# used to each hardcode their own `<repo>/logs` guess instead of routing
+# through `logging_config.resolve_log_dir()`. That drifted silently on a
+# wheel install once the checkout-only fallback stopped being assumed
+# everywhere: `exomem.log`/`exomem-cli.log`/`exomem-media.log`/
+# `mutations.jsonl` moved to the corrected location while
+# `queries.jsonl`/`writes.jsonl`/`reads.jsonl` stayed behind — so
+# `exomem trace <id>` silently lost those three files' records, and three of
+# `doctor`'s four JSONL health checks became permanently unfindable. These
+# tests assert agreement directly rather than relying on both sides
+# independently reimplementing the same formula and hoping they match.
+
+
+def test_query_log_current_dir_agrees_with_resolve_log_dir_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
+    assert query_log.current_log_dir() == logging_config.resolve_log_dir()
+
+
+def test_audit_relevance_logs_dir_agrees_with_resolve_log_dir_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
+    assert audit._RELEVANCE_LOGS_DIR == logging_config.resolve_log_dir()
+
+
+# The two agreement tests above hold in THIS process's checkout environment
+# even under the superseded (pre-#552-followup) code, because a source
+# checkout's `resolve_log_dir()` answer happens to equal the old hardcoded
+# `<repo>/logs` guess too — a checkout test run can't distinguish "computed
+# via resolve_log_dir()" from "coincidentally computed the same value another
+# way". These two instead probe DIRECTLY whether each module's constant is
+# actually SOURCED from `logging_config.resolve_log_dir()` — by patching that
+# function to return a sentinel unrelated to any real filesystem path, then
+# reloading the module and checking the sentinel propagated. Environment-
+# independent: fails identically whether the test process is a checkout or a
+# simulated wheel install.
+
+
+def _sentinel_dir() -> Path:
+    import sys
+
+    return Path("Z:/__sentinel_log_dir__" if sys.platform == "win32" else "/__sentinel_log_dir__")
+
+
+def test_query_log_module_constant_is_sourced_from_resolve_log_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = _sentinel_dir()
+    monkeypatch.setattr(logging_config, "resolve_log_dir", lambda *a, **k: sentinel)
+    try:
+        reloaded = importlib.reload(query_log)
+        assert reloaded._LOG_DIR == sentinel
+        assert reloaded.QUERIES_PATH == sentinel / "queries.jsonl"
+        assert reloaded.WRITES_PATH == sentinel / "writes.jsonl"
+        assert reloaded.READS_PATH == sentinel / "reads.jsonl"
+    finally:
+        # Restore the REAL resolve_log_dir before reloading again, so the
+        # cleanup reload doesn't itself bake the sentinel back in (monkeypatch's
+        # own teardown runs AFTER this function returns, which would be too
+        # late for a reload done inside this finally).
+        monkeypatch.undo()
+        importlib.reload(query_log)
+
+
+def test_audit_module_constant_is_sourced_from_resolve_log_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = _sentinel_dir()
+    monkeypatch.setattr(logging_config, "resolve_log_dir", lambda *a, **k: sentinel)
+    try:
+        reloaded = importlib.reload(audit)
+        assert reloaded._RELEVANCE_LOGS_DIR == sentinel
+    finally:
+        monkeypatch.undo()
+        importlib.reload(audit)

--- a/tests/test_log_dir_override.py
+++ b/tests/test_log_dir_override.py
@@ -209,18 +209,41 @@ def test_query_log_uses_module_default_when_env_unset(
 # independently reimplementing the same formula and hoping they match.
 
 
+# `query_log._LOG_DIR` and `audit._RELEVANCE_LOGS_DIR` freeze
+# `resolve_log_dir()`'s ENTIRE answer at import — env branch included — so on a
+# box where EXOMEM_LOG_DIR is exported before pytest starts (this project's own
+# Docker images set it, and the `resolve_log_dir()` docstring tells operators to
+# export it) those constants already hold the env value and `delenv` alone
+# cannot restore the unset precondition these two assert. Reload each module
+# under the cleared env so its constant is re-derived from that precondition,
+# then undo the monkeypatch BEFORE the restoring reload so the cleanup reload
+# doesn't itself bake the cleared env in (monkeypatch's own teardown runs after
+# this function returns, too late for a reload done here) — the same discipline
+# as the sentinel tests below.
+
+
 def test_query_log_current_dir_agrees_with_resolve_log_dir_when_unset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
-    assert query_log.current_log_dir() == logging_config.resolve_log_dir()
+    try:
+        reloaded = importlib.reload(query_log)
+        assert reloaded.current_log_dir() == logging_config.resolve_log_dir()
+    finally:
+        monkeypatch.undo()
+        importlib.reload(query_log)
 
 
 def test_audit_relevance_logs_dir_agrees_with_resolve_log_dir_when_unset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
-    assert audit._RELEVANCE_LOGS_DIR == logging_config.resolve_log_dir()
+    try:
+        reloaded = importlib.reload(audit)
+        assert reloaded._RELEVANCE_LOGS_DIR == logging_config.resolve_log_dir()
+    finally:
+        monkeypatch.undo()
+        importlib.reload(audit)
 
 
 # The two agreement tests above hold in THIS process's checkout environment

--- a/tests/test_log_dir_override.py
+++ b/tests/test_log_dir_override.py
@@ -262,7 +262,9 @@ def test_audit_relevance_logs_dir_agrees_with_resolve_log_dir_when_unset(
 def _sentinel_dir() -> Path:
     import sys
 
-    return Path("Z:/__sentinel_log_dir__" if sys.platform == "win32" else "/__sentinel_log_dir__")
+    return Path(
+        ("Z:" + "/__sentinel_log_dir__") if sys.platform == "win32" else "/__sentinel_log_dir__"
+    )
 
 
 def test_query_log_module_constant_is_sourced_from_resolve_log_dir(

--- a/tests/test_resolve_log_dir_wheel_fallback.py
+++ b/tests/test_resolve_log_dir_wheel_fallback.py
@@ -8,7 +8,7 @@ src-layout source checkout (`<repo>/src/exomem/logging_config.py` ->
 `<venv>/lib/pythonX.Y/site-packages/exomem/logging_config.py` (POSIX), so
 `parents[2]` lands inside the venv (`<venv>/Lib` / `<venv>/lib/pythonX.Y`) --
 exactly the production incident: the live service's logs land at
-`exomem-service-ha\\.venv\\Lib\\logs\\` instead of a real log location.
+`exomem-service-ha/.venv/Lib/logs/` instead of a real log location.
 """
 
 from __future__ import annotations
@@ -148,7 +148,11 @@ def test_wheel_install_fallback_lands_in_a_per_platform_location(
         # monkeypatched `sys.platform` so they run on any host OS.
         import os as _os
 
-        program_data = _os.environ.get("PROGRAMDATA") or _os.environ.get("ALLUSERSPROFILE") or r"C:\ProgramData"
+        program_data = (
+            _os.environ.get("PROGRAMDATA")
+            or _os.environ.get("ALLUSERSPROFILE")
+            or "C:" + r"\ProgramData"
+        )
         assert result == Path(program_data) / "exomem" / "logs"
     elif sys.platform == "darwin":
         assert result == Path.home() / "Library" / "Logs" / "Exomem"
@@ -164,12 +168,12 @@ def test_wheel_install_fallback_lands_in_a_per_platform_location(
 
 def test_win32_fallback_uses_programdata_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(logging_config.sys, "platform", "win32")
-    monkeypatch.setenv("PROGRAMDATA", r"C:\CustomProgramData")
+    monkeypatch.setenv("PROGRAMDATA", "C:" + r"\CustomProgramData")
     monkeypatch.delenv("ALLUSERSPROFILE", raising=False)
 
     result = logging_config._user_log_dir()
 
-    assert result == Path(r"C:\CustomProgramData") / "exomem" / "logs"
+    assert result == Path("C:" + r"\CustomProgramData") / "exomem" / "logs"
 
 
 def test_win32_fallback_uses_alluserprofile_when_programdata_unset(
@@ -177,11 +181,11 @@ def test_win32_fallback_uses_alluserprofile_when_programdata_unset(
 ) -> None:
     monkeypatch.setattr(logging_config.sys, "platform", "win32")
     monkeypatch.delenv("PROGRAMDATA", raising=False)
-    monkeypatch.setenv("ALLUSERSPROFILE", r"C:\Users\All Users")
+    monkeypatch.setenv("ALLUSERSPROFILE", "C:" + r"\Users\All Users")
 
     result = logging_config._user_log_dir()
 
-    assert result == Path(r"C:\Users\All Users") / "exomem" / "logs"
+    assert result == Path("C:" + r"\Users\All Users") / "exomem" / "logs"
 
 
 def test_win32_fallback_uses_hardcoded_programdata_when_both_env_vars_unset(
@@ -198,12 +202,14 @@ def test_win32_fallback_uses_hardcoded_programdata_when_both_env_vars_unset(
 
 def test_win32_fallback_never_touches_the_user_profile(monkeypatch: pytest.MonkeyPatch) -> None:
     """The defect this guards: a LocalSystem-run service's `%LOCALAPPDATA%`/
-    `Path.home()` resolves to `C:\\Windows\\System32\\config\\systemprofile\\...`
+    `Path.home()` resolves to `%SystemRoot%/System32/config/systemprofile/...`
     -- unreadable without elevation, and no operator-run `exomem doctor` can
     ever find it. The win32 branch must not read either signal at all."""
     monkeypatch.setattr(logging_config.sys, "platform", "win32")
-    monkeypatch.setenv("PROGRAMDATA", r"C:\ProgramData")
-    monkeypatch.setenv("LOCALAPPDATA", r"C:\Windows\System32\config\systemprofile\AppData\Local")
+    monkeypatch.setenv("PROGRAMDATA", "C:" + r"\ProgramData")
+    monkeypatch.setenv(
+        "LOCALAPPDATA", "C:" + r"\Windows\System32\config\systemprofile\AppData\Local"
+    )
 
     def _forbidden_home() -> Path:
         raise AssertionError("win32 branch must not call Path.home()")
@@ -213,16 +219,16 @@ def test_win32_fallback_never_touches_the_user_profile(monkeypatch: pytest.Monke
     result = logging_config._user_log_dir()
 
     assert "systemprofile" not in str(result)
-    assert result == Path(r"C:\ProgramData") / "exomem" / "logs"
+    assert result == Path("C:" + r"\ProgramData") / "exomem" / "logs"
 
 
 def test_win32_fallback_directory_name_matches_mode_config_path_lowercase(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Matches `mode.config_path()`'s `%PROGRAMDATA%\\exomem\\config.json`
+    """Matches `mode.config_path()`'s `%PROGRAMDATA%/exomem/config.json`
     convention exactly -- lowercase `exomem`, not `Exomem`."""
     monkeypatch.setattr(logging_config.sys, "platform", "win32")
-    monkeypatch.setenv("PROGRAMDATA", r"C:\ProgramData")
+    monkeypatch.setenv("PROGRAMDATA", "C:" + r"\ProgramData")
 
     result = logging_config._user_log_dir()
 

--- a/tests/test_resolve_log_dir_wheel_fallback.py
+++ b/tests/test_resolve_log_dir_wheel_fallback.py
@@ -129,7 +129,7 @@ def test_explicit_default_still_wins_over_a_simulated_wheel_install(
 # --- the fallback lands somewhere sane and platform-appropriate ------------
 
 
-def test_wheel_install_fallback_lands_in_a_per_user_platform_location(
+def test_wheel_install_fallback_lands_in_a_per_platform_location(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
@@ -140,12 +140,174 @@ def test_wheel_install_fallback_lands_in_a_per_user_platform_location(
 
     assert result.name == "logs"
     if sys.platform == "win32":
-        local_appdata = Path(
-            __import__("os").environ.get("LOCALAPPDATA")
-            or (Path.home() / "AppData" / "Local")
-        )
-        assert result == local_appdata / "Exomem" / "logs"
+        # Machine-wide, NOT the user profile: a LocalSystem-run service and
+        # an operator's own-user `exomem` CLI must land on the same
+        # directory, matching `mode.config_path()`'s own rationale for
+        # exactly this split. See the win32-branch tests below for the
+        # ALLUSERSPROFILE/hardcoded-fallback tiers, exercised via a
+        # monkeypatched `sys.platform` so they run on any host OS.
+        import os as _os
+
+        program_data = _os.environ.get("PROGRAMDATA") or _os.environ.get("ALLUSERSPROFILE") or r"C:\ProgramData"
+        assert result == Path(program_data) / "exomem" / "logs"
     elif sys.platform == "darwin":
         assert result == Path.home() / "Library" / "Logs" / "Exomem"
     else:
         assert result.parent.name == "exomem"
+
+
+# --- win32 branch, exercised via a monkeypatched sys.platform so it runs on
+# --- every CI host OS, not just when the test happens to execute on Windows.
+# --- Windows is the platform that matters for production (the live incident
+# --- was a Windows service), so it must not go untested on Linux CI.
+
+
+def test_win32_fallback_uses_programdata_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(logging_config.sys, "platform", "win32")
+    monkeypatch.setenv("PROGRAMDATA", r"C:\CustomProgramData")
+    monkeypatch.delenv("ALLUSERSPROFILE", raising=False)
+
+    result = logging_config._user_log_dir()
+
+    assert result == Path(r"C:\CustomProgramData") / "exomem" / "logs"
+
+
+def test_win32_fallback_uses_alluserprofile_when_programdata_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(logging_config.sys, "platform", "win32")
+    monkeypatch.delenv("PROGRAMDATA", raising=False)
+    monkeypatch.setenv("ALLUSERSPROFILE", r"C:\Users\All Users")
+
+    result = logging_config._user_log_dir()
+
+    assert result == Path(r"C:\Users\All Users") / "exomem" / "logs"
+
+
+def test_win32_fallback_uses_hardcoded_programdata_when_both_env_vars_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(logging_config.sys, "platform", "win32")
+    monkeypatch.delenv("PROGRAMDATA", raising=False)
+    monkeypatch.delenv("ALLUSERSPROFILE", raising=False)
+
+    result = logging_config._user_log_dir()
+
+    assert result == Path("C:" + "\\ProgramData") / "exomem" / "logs"
+
+
+def test_win32_fallback_never_touches_the_user_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The defect this guards: a LocalSystem-run service's `%LOCALAPPDATA%`/
+    `Path.home()` resolves to `C:\\Windows\\System32\\config\\systemprofile\\...`
+    -- unreadable without elevation, and no operator-run `exomem doctor` can
+    ever find it. The win32 branch must not read either signal at all."""
+    monkeypatch.setattr(logging_config.sys, "platform", "win32")
+    monkeypatch.setenv("PROGRAMDATA", r"C:\ProgramData")
+    monkeypatch.setenv("LOCALAPPDATA", r"C:\Windows\System32\config\systemprofile\AppData\Local")
+
+    def _forbidden_home() -> Path:
+        raise AssertionError("win32 branch must not call Path.home()")
+
+    monkeypatch.setattr(logging_config.Path, "home", staticmethod(_forbidden_home))
+
+    result = logging_config._user_log_dir()
+
+    assert "systemprofile" not in str(result)
+    assert result == Path(r"C:\ProgramData") / "exomem" / "logs"
+
+
+def test_win32_fallback_directory_name_matches_mode_config_path_lowercase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Matches `mode.config_path()`'s `%PROGRAMDATA%\\exomem\\config.json`
+    convention exactly -- lowercase `exomem`, not `Exomem`."""
+    monkeypatch.setattr(logging_config.sys, "platform", "win32")
+    monkeypatch.setenv("PROGRAMDATA", r"C:\ProgramData")
+
+    result = logging_config._user_log_dir()
+
+    assert result.parent.name == "exomem"
+    assert result.name == "logs"
+
+
+# --- darwin/linux branches, also exercised via monkeypatched sys.platform --
+
+
+def test_darwin_fallback_uses_home_library_logs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(logging_config.sys, "platform", "darwin")
+    fake_home = Path("/Users/fakeuser")
+    monkeypatch.setattr(logging_config.Path, "home", staticmethod(lambda: fake_home))
+
+    result = logging_config._user_log_dir()
+
+    assert result == fake_home / "Library" / "Logs" / "Exomem"
+
+
+def test_linux_fallback_uses_xdg_state_home_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(logging_config.sys, "platform", "linux")
+    monkeypatch.setenv("XDG_STATE_HOME", "/custom/state")
+
+    result = logging_config._user_log_dir()
+
+    assert result == Path("/custom/state") / "exomem" / "logs"
+
+
+def test_linux_fallback_uses_home_local_state_when_xdg_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(logging_config.sys, "platform", "linux")
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    fake_home = Path("/home/fakeuser")
+    monkeypatch.setattr(logging_config.Path, "home", staticmethod(lambda: fake_home))
+
+    result = logging_config._user_log_dir()
+
+    assert result == fake_home / ".local" / "state" / "exomem" / "logs"
+
+
+# --- resolve_log_dir() must never raise, even when Path.home() itself can't
+# --- resolve (e.g. a container with no $HOME and no /etc/passwd entry) -----
+
+
+def _raising_home() -> Path:
+    raise RuntimeError("could not determine home directory")
+
+
+def test_darwin_fallback_survives_an_unresolvable_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(logging_config.sys, "platform", "darwin")
+    monkeypatch.setattr(logging_config.Path, "home", staticmethod(_raising_home))
+
+    result = logging_config._user_log_dir()  # must not raise
+
+    assert result.name == "logs"
+    assert result.parent.name == "exomem"
+
+
+def test_linux_fallback_survives_an_unresolvable_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(logging_config.sys, "platform", "linux")
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.setattr(logging_config.Path, "home", staticmethod(_raising_home))
+
+    result = logging_config._user_log_dir()  # must not raise
+
+    assert result.name == "logs"
+    assert result.parent.name == "exomem"
+
+
+def test_resolve_log_dir_end_to_end_survives_an_unresolvable_home_on_a_wheel_install(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The full call chain a wheel install with EXOMEM_LOG_DIR unset would
+    actually take, on a homeless POSIX host, must not raise out of an
+    early-startup logging bootstrap that none of server.py/__main__.py/
+    media_worker_child.py guard against."""
+    monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
+    fake_file = _fake_wheel_module_file(tmp_path)
+    monkeypatch.setattr(logging_config, "__file__", str(fake_file))
+    monkeypatch.setattr(logging_config.sys, "platform", "linux")
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.setattr(logging_config.Path, "home", staticmethod(_raising_home))
+
+    result = logging_config.resolve_log_dir()  # must not raise
+
+    assert result.name == "logs"

--- a/tests/test_resolve_log_dir_wheel_fallback.py
+++ b/tests/test_resolve_log_dir_wheel_fallback.py
@@ -1,0 +1,151 @@
+"""TDD tests for issue #552: `resolve_log_dir()`'s final fallback must not
+resolve into a wheel install's site-packages/venv tree.
+
+Root cause: `Path(__file__).resolve().parents[2] / "logs"` assumes a
+src-layout source checkout (`<repo>/src/exomem/logging_config.py` ->
+`parents[2]` == `<repo>`). In a wheel install `__file__` is
+`<venv>/Lib/site-packages/exomem/logging_config.py` (Windows) or
+`<venv>/lib/pythonX.Y/site-packages/exomem/logging_config.py` (POSIX), so
+`parents[2]` lands inside the venv (`<venv>/Lib` / `<venv>/lib/pythonX.Y`) --
+exactly the production incident: the live service's logs land at
+`exomem-service-ha\\.venv\\Lib\\logs\\` instead of a real log location.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from exomem import logging_config
+
+
+def _fake_wheel_module_file(tmp_path: Path) -> Path:
+    """A `.venv/Lib/site-packages/exomem/logging_config.py`-shaped path --
+    a real wheel install layout, with no `pyproject.toml` anywhere near it."""
+    site_packages = tmp_path / "exomem-service-ha" / ".venv" / "Lib" / "site-packages"
+    package_dir = site_packages / "exomem"
+    package_dir.mkdir(parents=True)
+    return package_dir / "logging_config.py"
+
+
+def _fake_checkout_module_file(tmp_path: Path, *, name: str = "exomem") -> Path:
+    """A `<repo>/src/exomem/logging_config.py`-shaped path with a real
+    `pyproject.toml` at the repo root -- a genuine source checkout."""
+    repo_root = tmp_path / name
+    package_dir = repo_root / "src" / "exomem"
+    package_dir.mkdir(parents=True)
+    (repo_root / "pyproject.toml").write_text(
+        '[project]\nname = "exomem"\n', encoding="utf-8"
+    )
+    return package_dir / "logging_config.py"
+
+
+def _fake_src_named_dir_without_pyproject(tmp_path: Path) -> Path:
+    """A directory that happens to be named `src` two hops up from the
+    package, but is NOT a real checkout (no `pyproject.toml` at the root).
+    Must not false-positive as a source checkout."""
+    package_dir = tmp_path / "somewhere" / "src" / "exomem"
+    package_dir.mkdir(parents=True)
+    return package_dir / "logging_config.py"
+
+
+# --- the bug: a wheel install must not fall back into its own venv tree ----
+
+
+def test_wheel_install_fallback_does_not_land_in_site_packages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
+    fake_file = _fake_wheel_module_file(tmp_path)
+    monkeypatch.setattr(logging_config, "__file__", str(fake_file))
+
+    result = logging_config.resolve_log_dir()
+
+    # Today's code returns fake_file.parents[2] / "logs", i.e. `.venv/Lib/logs`
+    # -- inside the venv tree. The fix must stay outside it entirely.
+    venv_lib = fake_file.resolve().parents[2]
+    assert venv_lib not in result.parents and result != venv_lib
+    assert "site-packages" not in result.parts
+
+
+def test_wheel_install_fallback_avoids_a_src_named_dir_with_no_pyproject(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A directory literally named `src` two hops up is not, by itself,
+    evidence of a real checkout -- the `pyproject.toml` marker must also be
+    required, so this can't false-positive inside an unrelated tree."""
+    monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
+    fake_file = _fake_src_named_dir_without_pyproject(tmp_path)
+    monkeypatch.setattr(logging_config, "__file__", str(fake_file))
+
+    result = logging_config.resolve_log_dir()
+
+    bogus_root = fake_file.resolve().parents[2]
+    assert result != bogus_root / "logs"
+
+
+# --- contract: a genuine source checkout keeps its current default ---------
+
+
+def test_source_checkout_fallback_still_resolves_repo_logs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
+    fake_file = _fake_checkout_module_file(tmp_path)
+    monkeypatch.setattr(logging_config, "__file__", str(fake_file))
+
+    result = logging_config.resolve_log_dir()
+
+    assert result == fake_file.resolve().parents[2] / "logs"
+
+
+# --- contract: EXOMEM_LOG_DIR and an explicit default still win first ------
+
+
+def test_env_override_still_wins_over_a_simulated_wheel_install(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    override = tmp_path / "custom-logs"
+    monkeypatch.setenv("EXOMEM_LOG_DIR", str(override))
+    fake_file = _fake_wheel_module_file(tmp_path)
+    monkeypatch.setattr(logging_config, "__file__", str(fake_file))
+
+    assert logging_config.resolve_log_dir() == override
+
+
+def test_explicit_default_still_wins_over_a_simulated_wheel_install(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
+    fake_file = _fake_wheel_module_file(tmp_path)
+    monkeypatch.setattr(logging_config, "__file__", str(fake_file))
+    explicit_default = tmp_path / "explicit-default-logs"
+
+    assert logging_config.resolve_log_dir(default=explicit_default) == explicit_default
+
+
+# --- the fallback lands somewhere sane and platform-appropriate ------------
+
+
+def test_wheel_install_fallback_lands_in_a_per_user_platform_location(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
+    fake_file = _fake_wheel_module_file(tmp_path)
+    monkeypatch.setattr(logging_config, "__file__", str(fake_file))
+
+    result = logging_config.resolve_log_dir()
+
+    assert result.name == "logs"
+    if sys.platform == "win32":
+        local_appdata = Path(
+            __import__("os").environ.get("LOCALAPPDATA")
+            or (Path.home() / "AppData" / "Local")
+        )
+        assert result == local_appdata / "Exomem" / "logs"
+    elif sys.platform == "darwin":
+        assert result == Path.home() / "Library" / "Logs" / "Exomem"
+    else:
+        assert result.parent.name == "exomem"


### PR DESCRIPTION
Closes #552.

## What was wrong

`logging_config.resolve_log_dir()` fell back unconditionally to `Path(__file__).resolve().parents[2] / "logs"`. That is correct for a source checkout and wrong for a wheel install, where it resolves to `<service-root>\.venv\Lib\logs` — inside the venv. That is exactly where the live service was writing its logs.

## The fix

Use the checkout-derived path only when it really is a checkout; otherwise fall back to a per-user data location. `EXOMEM_LOG_DIR` remains the override, and the "must be a real process env var, not `.env`" contract stays documented.

On Windows the fallback is `%ProgramData%\exomem\logs`, reusing `mode.config_path()`'s fallback chain byte-for-byte (`PROGRAMDATA` → `ALLUSERSPROFILE` → `C:\ProgramData`). This is deliberate and load-bearing: **the service runs as LocalSystem**, so a per-user path would land in `C:\Windows\System32\config\systemprofile\AppData\Local\…`, which is the failure mode being replaced, not a fix for it. `icacls` confirms the inheritance empirically — `C:\ProgramData` carries `BUILTIN\Users:(OI)(CI)(RX)` and `(CI)(WD,AD)`, and `C:\ProgramData\fastmcp`, created by this very service, is readable and new-file-writable by an unelevated operator.

Doctor now reports the resolved log directory in its check details, so this cannot go silently wrong again — and the docs use that instead of hardcoding a path.

### Homeless-resolution degrades to temp rather than raising

`resolve_log_dir()` is called unguarded at `server.py:584`, `__main__.py:141` and `media_worker_child.py:62`, before any logging exists. Raising there kills the process with nothing explaining why. The temp fallback only rescues the case where we cannot *name* a directory; a genuinely unwritable one still fails loudly at `configure_logging`'s `mkdir`. The branch is unreachable in any configuration that has an answer: Windows never calls `Path.home()`, and POSIX resolves via `pwd` unless the UID has no passwd entry — precisely the containerised case where `EXOMEM_LOG_DIR` is mandated anyway.

### Installer pin, scoped per install mode

`install-service.ps1` pins `EXOMEM_LOG_DIR` into the service environment so the value survives regardless of resolution, computed **per mode** so it is a true no-op in both:

- `-Release` → `%ProgramData%\exomem\logs`
- repo mode → the repo's own `logs/`

The first cut placed this block *after* the `if ($Release) { … } else { … }` branch, so it ran unconditionally and silently moved repo-mode service logs — contradicting its own justification comment and breaking `scripts/restart.ps1`, which hardcodes `<repo>\logs\exomem.log`. Review caught it; computing the value per mode rather than gating the pin off keeps one guard, one assignment, and the "provably agree" property in both modes.

## Verification

Review re-derived the two modes from the **real file** rather than an extracted harness — a verbatim 39-line slice, SHA256 `678d2133…`, with only `Install-ReleaseVenv`/`Test-Path`/`Read-DotenvMap` stubbed — and discharged the "the omitted lines don't matter" assumption with a PowerShell AST scan proving the complete assignment set for every relevant variable is lines 69, 70, 189, 190, 200, 217, 219, 221 and nothing else.

| | value |
|---|---|
| repo-mode pin | `…\exomem-552-logdir\logs` |
| `resolve_log_dir()`, env cleared | `…\exomem-552-logdir\logs` |
| `-Release` pin | `C:\ProgramData\exomem\logs` |
| `_user_log_dir()` | `C:\ProgramData\exomem\logs` |

Byte-identical in both modes. `restart.ps1`'s computed path matches repo mode exactly. The `.env` guard was *evaluated*, not asserted: with `EXOMEM_LOG_DIR=D:\opslogs` supplied, both modes yield `D:\opslogs` and leave `$pinnedLogDir` unused. Parser clean, 0 errors.

**Consumer agreement under a simulated wheel install** — every consumer originally flagged now lands on the same directory: `query_log` (`QUERIES_PATH`/`WRITES_PATH`/`READS_PATH`), `audit._RELEVANCE_LOGS_DIR`, `mutation_journal.journal_path()`, all seven `obs_cli` trace aliases, `usage.py`, `doctor.py`. Zero mismatches, so `exomem trace` genuinely recovers its query/write/read legs.

The sourcing tests use a sentinel plus `importlib.reload` rather than plain equality, because in a checkout the old formula and the new function return byte-identical paths — plain assertions would pass on the pre-fix code and prove nothing. Platform tests patch `sys.platform` so all three Windows fallback tiers, the XDG/darwin/linux paths, and both homeless-degradation paths execute on Linux CI, plus a negative test that fails if `Path.home()` is called at all on Windows.

`98 passed, 1 skipped` on the targeted suite; `95 passed, 1 skipped` on doctor; `ruff` clean on all six changed Python files, with `ty` diagnostics identical to baseline. Reload-pollution hazard checked empirically: reload tests followed by every `AuditFinding` consumer in one session, `-p no:randomly` → 100 passed.

## Note for operators

**This moves where the live service writes logs.** The service currently logs to `exomem-service-ha\.venv\Lib\logs\`; after this deploys, that changes. If you would rather pin it, set `EXOMEM_LOG_DIR` in the service environment and the fix becomes a no-op for your cell — the installer now does exactly that for you.

## Follow-ups, filed not fixed

- **#565** — `openspec/changes/add-docker-distribution`'s "behavior SHALL be unchanged from today's repo-relative default" now formally contradicts shipped behaviour for non-checkout installs. Outside this lane's allowlist; must be corrected before that change is archived, since `ci.yml` only validates `openspec/specs/`.
- `scripts/restart.ps1` hardcodes `<repo>\logs\exomem.log`, so for a `-Release` install it archives a file that will never exist. Pre-existing — the pre-branch wheel fallback already landed at `<service-root>\.venv\Lib\logs` — but this branch teaches operators to read `log_dir` from `exomem doctor --json`, and `restart.ps1` didn't get that treatment.
- `tests/test_query_log.py` has 3 failures when `EXOMEM_LOG_DIR` is exported, verified identical on `origin/main` via an isolated baseline worktree. `_target()` short-circuits on the env var and bypasses the `QUERIES_PATH` monkeypatch seam; `_target` is untouched by this branch. Fix is `monkeypatch.delenv` in those three tests, mirroring `test_log_dir_override.py`.
