### PR TITLE
fix(graph): classify the Class B stabilization exhaustion so the publication-refusal memo arms

### DIFF
--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -1654,6 +1654,12 @@ class EpistemicGraphIndex:
         # refused replacement, any OS or ownership error — is Class B and must
         # leave vault freshness untouched.
         projection_moved = False
+        # Which non-stabilization actually fired.  Both raises below share one
+        # sentence, so without this the class survives only in the exception
+        # type and the specific cause is discarded entirely — which is why a
+        # cell that logged this failure 34 times could not be diagnosed from
+        # its log at all.
+        cause = "no stabilization attempt completed"
         try:
             for _attempt in range(REBUILD_STABILIZATION_ATTEMPTS):
                 before_disk = _disk_vault_freshness(self.vault_root)
@@ -1674,15 +1680,23 @@ class EpistemicGraphIndex:
                     # Class C, first admitted cause.
                     self._mark_unavailable()
                     projection_moved = True
+                    cause = "the supplied freshness identity did not name the resolver bytes"
                     find_module.unload_ram_caches()
                     continue
                 pass_started = True
                 report = self._rebuild_all_pass(resolver)
                 after_disk = _disk_vault_freshness(self.vault_root)
+                # Bound to names so the `else` below can say *which* of the three
+                # conditions moved without re-running either O(vault) proof.  The
+                # walrus keeps the short-circuit exactly as it was: membership is
+                # still not captured when the identity already differs.
+                after_identity = _recall_projection_identity(
+                    self.vault_root, disk_freshness=after_disk
+                )
+                after_membership: frozenset[str] | None = None
                 if (
-                    _recall_projection_identity(self.vault_root, disk_freshness=after_disk)
-                    == before
-                    and self._recall_membership() == resolver_membership
+                    after_identity == before
+                    and (after_membership := self._recall_membership()) == resolver_membership
                     and self._source_versions_current(resolver_versions)
                 ):
                     live_checkpoint = (
@@ -1717,6 +1731,12 @@ class EpistemicGraphIndex:
                         # The projection moved between writing the availability
                         # marker and confirming it: Class C, second cause.
                         projection_moved = True
+                        cause = (
+                            "the recall projection moved after the availability "
+                            "marker was written"
+                        )
+                    else:
+                        cause = "the availability marker would not publish"
                     # A marker that would not publish is a publication failure,
                     # not proof that the registry is behind the disk.
                     self._mark_unavailable()
@@ -1725,10 +1745,31 @@ class EpistemicGraphIndex:
                     # resolver source versions changed across the pass: Class C,
                     # second admitted cause.
                     projection_moved = True
-            message = "epistemic graph rebuild did not stabilize after 2 attempts"
+                    if after_identity != before:
+                        cause = "the recall projection identity moved across the pass"
+                    elif after_membership != resolver_membership:
+                        cause = "the recall membership moved across the pass"
+                    else:
+                        cause = "the resolver source versions moved across the pass"
+            attempts = (
+                "epistemic graph rebuild did not stabilize after "
+                f"{REBUILD_STABILIZATION_ATTEMPTS} attempts"
+            )
             if projection_moved:
-                raise GraphProjectionMoved(message)
-            raise RuntimeError(message)
+                raise GraphProjectionMoved(f"{attempts} (Class C, projection moved): {cause}")
+            # Class B by elimination: this pass proved nothing stale and still
+            # could not publish, which is precisely what
+            # `GraphPublicationUnavailable` names.  A bare `RuntimeError` here
+            # was unclassified, so `may_mark_external_pending` answered True and
+            # `file_watcher._recover_external_pending` cooled vault freshness
+            # instead of arming the bounded refusal memo.  That allocated a
+            # fresh external-pending epoch on every recovery cycle, which is
+            # what re-armed the same lane for the next one: the loop fed itself
+            # a full doomed rebuild indefinitely, and left the registry
+            # permanently cool for every later write to pay.
+            raise GraphPublicationUnavailable(
+                f"{attempts} (Class B, publication failure): {cause}"
+            )
         finally:
             if pass_started and not stable:
                 self._mark_unavailable()

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -254,7 +254,13 @@ class GraphPublicationUnavailable(graph_sync.GraphRebuildRegistrationError):
     def __init__(self, message: str) -> None:
         super().__init__(
             "GRAPH_SYNC_PUBLICATION_UNAVAILABLE",
-            "Retry the mutation, or run reconcile to recover the derived graph.",
+            # `graph_sync._run` wraps only an *unclassified* builder failure, so
+            # this type reaches `graph_sync_remediation` in the mutation
+            # terminal payload verbatim rather than as `GraphRebuildStopped`.
+            # It therefore has to carry the runnable command itself: "run
+            # reconcile" is an internal registry name that matches neither the
+            # MCP tool nor the CLI, which is the #479 defect.
+            f"Retry the mutation, or {graph_sync._RECONCILE_HINT}",
         )
         self.args = (f"{message}: {self.args[0]}",)
 
@@ -1657,9 +1663,18 @@ class EpistemicGraphIndex:
         # Which non-stabilization actually fired.  Both raises below share one
         # sentence, so without this the class survives only in the exception
         # type and the specific cause is discarded entirely — which is why a
-        # cell that logged this failure 34 times could not be diagnosed from
+        # cell that logged this failure 143 times could not be diagnosed from
         # its log at all.
-        cause = "no stabilization attempt completed"
+        #
+        # Tracked per class rather than as one string, because `projection_moved`
+        # is sticky across attempts and a run may fire both: a Class C condition
+        # on one attempt and the Class B one on another.  One shared string lets
+        # the later attempt overwrite the earlier, so the raise announces one
+        # class and quotes the other class's cause — in precisely the mixed
+        # failure this message exists to explain.  Each raise reads only the
+        # cause belonging to the branch it takes.
+        moved_cause = "no stabilization attempt completed"
+        publication_cause = "no stabilization attempt completed"
         try:
             for _attempt in range(REBUILD_STABILIZATION_ATTEMPTS):
                 before_disk = _disk_vault_freshness(self.vault_root)
@@ -1680,7 +1695,7 @@ class EpistemicGraphIndex:
                     # Class C, first admitted cause.
                     self._mark_unavailable()
                     projection_moved = True
-                    cause = "the supplied freshness identity did not name the resolver bytes"
+                    moved_cause = "the supplied freshness identity did not name the resolver bytes"
                     find_module.unload_ram_caches()
                     continue
                 pass_started = True
@@ -1731,12 +1746,12 @@ class EpistemicGraphIndex:
                         # The projection moved between writing the availability
                         # marker and confirming it: Class C, second cause.
                         projection_moved = True
-                        cause = (
+                        moved_cause = (
                             "the recall projection moved after the availability "
                             "marker was written"
                         )
                     else:
-                        cause = "the availability marker would not publish"
+                        publication_cause = "the availability marker would not publish"
                     # A marker that would not publish is a publication failure,
                     # not proof that the registry is behind the disk.
                     self._mark_unavailable()
@@ -1746,17 +1761,19 @@ class EpistemicGraphIndex:
                     # second admitted cause.
                     projection_moved = True
                     if after_identity != before:
-                        cause = "the recall projection identity moved across the pass"
+                        moved_cause = "the recall projection identity moved across the pass"
                     elif after_membership != resolver_membership:
-                        cause = "the recall membership moved across the pass"
+                        moved_cause = "the recall membership moved across the pass"
                     else:
-                        cause = "the resolver source versions moved across the pass"
+                        moved_cause = "the resolver source versions moved across the pass"
             attempts = (
                 "epistemic graph rebuild did not stabilize after "
                 f"{REBUILD_STABILIZATION_ATTEMPTS} attempts"
             )
             if projection_moved:
-                raise GraphProjectionMoved(f"{attempts} (Class C, projection moved): {cause}")
+                raise GraphProjectionMoved(
+                    f"{attempts} (Class C, projection moved): {moved_cause}"
+                )
             # Class B by elimination: this pass proved nothing stale and still
             # could not publish, which is precisely what
             # `GraphPublicationUnavailable` names.  A bare `RuntimeError` here
@@ -1768,7 +1785,7 @@ class EpistemicGraphIndex:
             # a full doomed rebuild indefinitely, and left the registry
             # permanently cool for every later write to pay.
             raise GraphPublicationUnavailable(
-                f"{attempts} (Class B, publication failure): {cause}"
+                f"{attempts} (Class B, publication failure): {publication_cause}"
             )
         finally:
             if pass_started and not stable:

--- a/tests/test_graph_stabilization_exhaustion.py
+++ b/tests/test_graph_stabilization_exhaustion.py
@@ -15,8 +15,9 @@ The unclassified Class B raise is the reported defect. `may_mark_external_pendin
 answered True for it, so `file_watcher._recover_external_pending` took the
 `mark_external_pending` branch, never armed the Class B refusal memo, and
 `publication_refusal_active` never tripped -- so a doomed full rebuild was
-re-paid on every recovery cycle. The reported cell logged 34 such cycles at
-~62 min intervals and burned ~41 h of CPU on rebuilds that were all discarded.
+re-paid on every recovery cycle. The reported cell logged 143 such cycles over
+days, at ~62 min intervals, holding ~4.5 cores continuously on rebuilds that
+were all discarded.
 
 Class B exhaustion is exactly what `GraphPublicationUnavailable` already
 documents: "A rebuild proved nothing stale but still could not publish".
@@ -92,6 +93,27 @@ def _move_the_resolver_identity(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         EpistemicGraphIndex, "_resolver_source_versions", lambda *_args, **_kwargs: None
     )
+
+
+def _move_the_resolver_identity_on_the_first_attempt_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Class C on attempt 1; every later attempt resolves its source versions."""
+    real = EpistemicGraphIndex._resolver_source_versions
+    attempts = 0
+
+    def first_attempt_moves(
+        self: EpistemicGraphIndex,
+        resolver: vault_module.WikilinkResolver,
+        expected_membership: frozenset[str],
+    ) -> dict[str, epistemic_graph.GraphSourceSignature] | None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return None
+        return real(self, resolver, expected_membership)
+
+    monkeypatch.setattr(EpistemicGraphIndex, "_resolver_source_versions", first_attempt_moves)
 
 
 # --- F1: the exhaustion is a classified Class B publication failure ---------
@@ -259,3 +281,50 @@ def test_the_message_distinguishes_a_moved_source_version_from_the_others(
     message = str(raised.value)
     assert "Class C" in message
     assert "resolver source versions" in message
+
+
+def test_a_mixed_run_reports_the_cause_of_the_class_it_actually_raises(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Attempt 1 fires Class C, attempt 2 fires Class B; only two attempts exist.
+
+    `projection_moved` is sticky by design -- the conservative choice, and the
+    raised type must stay `GraphProjectionMoved`. A single sticky `cause`
+    string is not: the last writer wins, so the Class B cause overwrote the
+    Class C one and the message announced "Class C, projection moved" while
+    quoting the reason the *marker* would not publish. That contradiction lands
+    in exactly the mixed failure this message exists to explain.
+    """
+    _move_the_resolver_identity_on_the_first_attempt_only(monkeypatch)
+    _refuse_the_availability_marker(monkeypatch)
+
+    with pytest.raises(epistemic_graph.GraphProjectionMoved) as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    message = str(raised.value)
+    assert "Class C" in message
+    assert "resolver bytes" in message, "the Class C label must quote the Class C cause"
+    assert "availability marker" not in message, (
+        "the Class C label quoted the Class B cause: " + message
+    )
+
+
+# --- The classified type must not cost the write path its runnable command ---
+
+
+def test_the_class_b_remediation_keeps_the_runnable_reconcile_command() -> None:
+    """`graph_sync._run` no longer wraps this raise, so it carries its own hint.
+
+    A bare `RuntimeError` fell through to `_run`'s `else` and became
+    `GraphRebuildStopped`, whose remediation is built from `_RECONCILE_HINT`.
+    `GraphPublicationUnavailable` subclasses `GraphRebuildRegistrationError`,
+    so it now passes through unwrapped and its own remediation reaches
+    `graph_sync_remediation` in the mutation terminal payload verbatim. It has
+    to name the same runnable surfaces -- "run reconcile" is an internal
+    registry name that matches neither the MCP tool nor the CLI (#479).
+    """
+    remediation = epistemic_graph.GraphPublicationUnavailable("exhausted").remediation
+
+    assert graph_sync._RECONCILE_HINT in remediation
+    assert 'maintain_memory(mode="reconcile")' in remediation
+    assert "exomem maintain --reconcile" in remediation

--- a/tests/test_graph_stabilization_exhaustion.py
+++ b/tests/test_graph_stabilization_exhaustion.py
@@ -1,0 +1,261 @@
+"""Issue #566: a Class B stabilization exhaustion must be a classified failure.
+
+`EpistemicGraphIndex._rebuild_all_locked` can exhaust
+`REBUILD_STABILIZATION_ATTEMPTS` for two different reasons:
+
+* **Class C** -- the vault bytes or the recall projection provably moved under
+  the in-flight proof. It raises `GraphProjectionMoved`, and the proof that
+  detected it has already marked the registry externally pending exactly once.
+* **Class B** -- the pass proved nothing stale and still could not publish. It
+  used to raise a bare `RuntimeError`, which `is_publication_failure`
+  deliberately leaves *unclassified* so genuine registry-loss signals keep the
+  pre-contract behaviour.
+
+The unclassified Class B raise is the reported defect. `may_mark_external_pending`
+answered True for it, so `file_watcher._recover_external_pending` took the
+`mark_external_pending` branch, never armed the Class B refusal memo, and
+`publication_refusal_active` never tripped -- so a doomed full rebuild was
+re-paid on every recovery cycle. The reported cell logged 34 such cycles at
+~62 min intervals and burned ~41 h of CPU on rebuilds that were all discarded.
+
+Class B exhaustion is exactly what `GraphPublicationUnavailable` already
+documents: "A rebuild proved nothing stale but still could not publish".
+
+Scope note. Classifying the exhaustion stops the loop from *self-sustaining*
+through the registry: the recovery handler no longer allocates a fresh
+external-pending epoch, so `_reconcile_once`'s `pending_epoch is not None`
+gate stops re-arming this lane. It does not by itself lower the rebuild
+cadence, because the sibling `_recover_suspended_graph` lane -- unblocked once
+the vault is no longer externally pending -- retries the same doomed
+publication once per reconcile interval, and `PUBLICATION_RETRY_BACKOFF_SECONDS`
+(60 s) is far below that interval (>= 300 s), so the memo has always expired by
+then. Lowering the cadence of a persistently doomed publication is a separate
+decision about the backoff, not about this classification.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from exomem import epistemic_graph, freshness, graph_sync
+from exomem import find as find_module
+from exomem import vault as vault_module
+from exomem.epistemic_graph import EpistemicGraphIndex
+from exomem.file_watcher import FileWatcher
+
+PAGE_A = "Knowledge Base/Notes/Insights/exhaustion-a.md"
+PAGE_B = "Knowledge Base/Notes/Insights/exhaustion-b.md"
+
+
+def _page(title: str, body: str) -> str:
+    return f"---\ntype: insight\nstatus: active\n---\n# {title}\n\n## Claim\n\n{body}\n"
+
+
+def _seed_live_freshness(root: Path) -> None:
+    freshness.seed(
+        root,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault_module.walk_vault_md(root)),
+    )
+    kb = root / "Knowledge Base"
+    freshness.seed(
+        root,
+        "kb",
+        ((str(path), freshness.stat_signature(path)) for path in find_module._walk_md(kb)),
+    )
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    root = tmp_path / "vault"
+    (root / "Knowledge Base/Notes/Insights").mkdir(parents=True)
+    (root / PAGE_A).write_text(_page("A", "A claims against [[exhaustion-b]]."), encoding="utf-8")
+    (root / PAGE_B).write_text(_page("B", "B is a plain claim."), encoding="utf-8")
+    _seed_live_freshness(root)
+    EpistemicGraphIndex(root).rebuild_all()
+    epistemic_graph.clear_publication_memos()
+    yield root
+    epistemic_graph.clear_publication_memos()
+
+
+def _refuse_the_availability_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Class B: every pass is internally stable, but the marker will not publish."""
+    monkeypatch.setattr(
+        EpistemicGraphIndex, "_mark_available", lambda *_args, **_kwargs: False
+    )
+
+
+def _move_the_resolver_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Class C: the supplied freshness identity does not name the resolver bytes."""
+    monkeypatch.setattr(
+        EpistemicGraphIndex, "_resolver_source_versions", lambda *_args, **_kwargs: None
+    )
+
+
+# --- F1: the exhaustion is a classified Class B publication failure ---------
+
+
+def test_class_b_exhaustion_raises_a_classified_publication_failure(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The mechanism: the raised type must be one `is_publication_failure` knows."""
+    _refuse_the_availability_marker(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="did not stabilize") as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    error = raised.value
+    assert not isinstance(error, epistemic_graph.GraphProjectionMoved)
+    assert isinstance(error, epistemic_graph.GraphPublicationUnavailable)
+    assert epistemic_graph.is_publication_failure(error) is True
+    assert epistemic_graph.may_mark_external_pending(error) is False
+    # Class B may never cool the vault-global registry (contract section 1).
+    assert freshness.external_pending(vault) is False
+
+
+def test_watcher_recovery_arms_the_memo_for_a_class_b_exhaustion(
+    vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The classification has to reach the watcher's own branch, not just the type."""
+    _refuse_the_availability_marker(monkeypatch)
+    watcher = FileWatcher(vault)
+    epoch_probe = tmp_path / "epoch-probe-root"
+    clock_before = freshness.mark_external_pending(epoch_probe)
+
+    pending_epoch = freshness.mark_external_pending(vault)
+    watcher._recover_external_pending(pending_epoch)
+
+    assert epistemic_graph.publication_refusal_active(vault) is True
+    assert EpistemicGraphIndex(vault).available() is False
+    # R1: a Class B retry allocates no fresh external-pending epoch. One mark
+    # above (ours) plus the probe below is the whole budget.
+    clock_after = freshness.mark_external_pending(epoch_probe)
+    assert clock_after == clock_before + 2
+
+
+def test_second_recovery_cycle_does_not_repay_the_doomed_rebuild(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reported symptom: ~62 min apart, forever, at full rebuild cost."""
+    rebuilds: list[str] = []
+    real_rebuild = EpistemicGraphIndex._rebuild_all_locked
+
+    def counting_rebuild(self: EpistemicGraphIndex) -> dict[str, int]:
+        rebuilds.append("rebuild")
+        return real_rebuild(self)
+
+    monkeypatch.setattr(EpistemicGraphIndex, "_rebuild_all_locked", counting_rebuild)
+    _refuse_the_availability_marker(monkeypatch)
+    watcher = FileWatcher(vault)
+
+    watcher._recover_external_pending(freshness.mark_external_pending(vault))
+    after_first_cycle = len(rebuilds)
+    assert after_first_cycle >= 1, "the first cycle must actually have attempted a rebuild"
+
+    watcher._recover_external_pending(freshness.mark_external_pending(vault))
+
+    assert len(rebuilds) == after_first_cycle, (
+        "the same doomed publication was re-paid at full rebuild cost"
+    )
+
+
+# --- The memo is a bounded backoff, never a permanent fence -----------------
+
+
+def test_the_memo_expires_on_its_deadline(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(epistemic_graph, "PUBLICATION_RETRY_BACKOFF_SECONDS", 0.0)
+    epistemic_graph.note_publication_refusal(vault)
+
+    assert epistemic_graph.publication_refusal_active(vault) is False
+
+
+def test_the_memo_expires_when_a_different_publication_is_asked_for(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _checkpoint(generation: int) -> graph_sync.GraphSyncCheckpoint:
+        return graph_sync.GraphSyncCheckpoint.create(
+            generation=generation,
+            mutation_id=f"{generation:024x}",
+            paths=((PAGE_A, "d" * 64),),
+            created_paths=(PAGE_A,),
+        )
+
+    monkeypatch.setattr(graph_sync, "read_checkpoint", lambda *_a, **_k: _checkpoint(1))
+    epistemic_graph.note_publication_refusal(vault)
+    assert epistemic_graph.publication_refusal_active(vault) is True
+
+    monkeypatch.setattr(graph_sync, "read_checkpoint", lambda *_a, **_k: _checkpoint(2))
+
+    assert epistemic_graph.publication_refusal_active(vault) is False
+
+
+# --- Class C is untouched ---------------------------------------------------
+
+
+def test_class_c_exhaustion_keeps_its_type_and_its_single_mark(
+    vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: the fix must not widen Class C into the publication classifier."""
+    _move_the_resolver_identity(monkeypatch)
+    epoch_probe = tmp_path / "epoch-probe-root"
+    clock_before = freshness.mark_external_pending(epoch_probe)
+
+    with pytest.raises(epistemic_graph.GraphProjectionMoved, match="did not stabilize") as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    error = raised.value
+    assert type(error) is epistemic_graph.GraphProjectionMoved
+    assert epistemic_graph.is_publication_failure(error) is False
+    assert epistemic_graph.may_mark_external_pending(error) is False
+    # The proof marks exactly once and arms no Class B memo.
+    assert freshness.external_pending(vault) is True
+    assert epistemic_graph.publication_refusal_active(vault) is False
+    clock_after = freshness.mark_external_pending(epoch_probe)
+    assert clock_after == clock_before + 2
+
+
+# --- F2: the failure is diagnosable ----------------------------------------
+
+
+def test_the_message_names_the_class_and_the_marker_refusal_cause(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _refuse_the_availability_marker(monkeypatch)
+
+    with pytest.raises(RuntimeError) as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    message = str(raised.value)
+    assert "Class B" in message
+    assert "availability marker" in message
+
+
+def test_the_message_names_the_class_and_the_resolver_identity_cause(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _move_the_resolver_identity(monkeypatch)
+
+    with pytest.raises(epistemic_graph.GraphProjectionMoved) as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    message = str(raised.value)
+    assert "Class C" in message
+    assert "resolver bytes" in message
+
+
+def test_the_message_distinguishes_a_moved_source_version_from_the_others(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A third cause, so the message is not merely a per-class constant."""
+    monkeypatch.setattr(
+        EpistemicGraphIndex, "_source_versions_current", lambda *_args, **_kwargs: False
+    )
+
+    with pytest.raises(epistemic_graph.GraphProjectionMoved) as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    message = str(raised.value)
+    assert "Class C" in message
+    assert "resolver source versions" in message


### PR DESCRIPTION
Closes #566.

## What was wrong

An exomem cell re-paid a doomed full epistemic-graph rebuild every ~62 minutes: **143 occurrences** across log rotations, surviving restarts and a version upgrade.

`_rebuild_all_locked` raised a bare `RuntimeError` for its Class B (non-`projection_moved`) exhaustion. That propagated through `_rebuild_all_off_boundary` *around* its `note_publication_refusal()`, which sits on the fall-through path rather than the exception path. `file_watcher._recover_external_pending` then branched on `may_mark_external_pending(error)`, and:

```python
def may_mark_external_pending(error):
    return not (isinstance(error, GraphProjectionMoved) or is_publication_failure(error))
```

`is_publication_failure` deliberately leaves unrecognised exceptions unclassified so *"genuine registry-loss signals keep the pre-contract behaviour"* — a sound default for foreign exceptions, and exactly wrong for one the module raised about itself. So the watcher marked external-pending instead of calling `record_publication_recovery_state`, the backoff memo was never armed, and `publication_refusal_active` at `file_watcher.py:597` never tripped.

**The module already defined the right type.** `GraphPublicationUnavailable` subclasses `graph_sync.GraphRebuildRegistrationError` — hence is in `_PUBLICATION_FAILURE_TYPES` — and is documented as *"A rebuild proved nothing stale but still could not publish (Class B)"*, a verbatim description of this failure.

## Scope correction, disclosed

The blast radius is **narrower** than #566 states. The write path was *already* correctly Class B on `origin/main`: `graph_sync._run` wraps an unclassified exception into `GraphRebuildStopped`, itself a `GraphRebuildRegistrationError`. Only the two paths that see the raw exception — `file_watcher._recover_external_pending` and `_handle_graph_dispatch_failure` — were misclassified.

A consequence of the pass-through is that the write path's terminal code changes `GRAPH_SYNC_REBUILD_STOPPED` → `GRAPH_SYNC_PUBLICATION_UNAVAILABLE`. Disclosed rather than silent.

## What this does and does not fix

**It does not reduce per-cycle CPU.** Measured independently by implementer and reviewer:

```
origin/main:  rebuilds per cycle: [1, 1, 1, 1, 1]   external_pending at end: True
branch:       rebuilds per cycle: [1, 1, 1, 1, 1]   external_pending at end: False
```

`file_watcher._recover_suspended_graph` was previously suppressed by the very `external_pending` flag the bug set; once that stops, it becomes eligible and retries the same doomed publication once per reconcile interval. `PUBLICATION_RETRY_BACKOFF_SECONDS = 60.0` cannot bite against a ≥300 s interval — the measured crossover is a 30 s interval, which is not production.

What this **does** remove is the self-sustaining loop and the permanent freshness contamination every later write was paying for. The wasted rebuild is #571.

## Diagnosability

```
before: RuntimeError: epistemic graph rebuild did not stabilize after 2 attempts
after:  GraphPublicationUnavailable: epistemic graph rebuild did not stabilize after 2 attempts
        (Class B, publication failure): the availability marker would not publish:
        GRAPH_SYNC_PUBLICATION_UNAVAILABLE: Retry the mutation, or run
        maintain_memory(mode="reconcile") — `exomem maintain --reconcile` from a shell
        to recover the derived graph.
```

Five causes are separated: resolver-bytes identity, projection identity, recall membership, resolver source versions, and marker refusal. This is what made #571's diagnosis possible.

## Two defects caught in review and fixed

**A contradictory message on a mixed run.** A single sticky `cause` alongside the already-sticky `projection_moved` could pair one class's label with the other's cause — `(Class C, projection moved): the availability marker would not publish` — precisely in the mixed failure the message exists to serve. Split into `moved_cause` / `publication_cause`, each raise reading only its own. Verified across all four orderings, with both homogeneous cases byte-identical to the prior commit.

**A reintroduced #479 defect.** The pass-through surfaced `GraphPublicationUnavailable`'s own remediation, whose literal said "run reconcile" — an internal registry name matching neither `maintain_memory(mode="reconcile")` nor `exomem maintain --reconcile`, so an operator had nothing runnable to type. Now sourced from `graph_sync._RECONCILE_HINT` and pinned by a test.

## Verification

Nine tests red on `origin/main`, plus two more red on the first commit, all green here. The production log line is reproduced verbatim in the red run. Classification reproduced end to end by the reviewer on a real vault with a real sidecar:

| | origin/main | branch |
|---|---|---|
| raised type | `RuntimeError` | `GraphPublicationUnavailable` |
| `is_publication_failure` | False | True |
| `may_mark_external_pending` | True | False |
| after watcher cycle | `ext_pending=True, memo=False` | `ext_pending=False, memo=True` |

**The memo cannot strand the graph** — the one way this could be worse than the bug. 60 s deadline expiry measured (`+59s → True`, `+61s → False`), publication-identity clearing verified, clear-on-success at `epistemic_graph.py:1362`, and at the real cadence a permanently-doomed publication is retried **every** cycle: `[1,1,1,1,1]`.

**Class C untouched** — `finally` block byte-identical between trees, type still `GraphProjectionMoved`, exactly one `mark_external_pending`, no memo armed.

**Regression:** sorted failure-ID **set** comparison, not counts, since at least one pre-existing failure is flaky. Implementer over 17 modules and reviewer independently over a different 19: both empty set diffs, with the pass delta exactly the new tests.

`ruff` clean under project config and both CI gates; targeted mypy clean. Full suite, latency and golden gates deferred to Linux CI — four modules cannot import on native Windows (`fcntl`, `os.O_DIRECTORY`), each confirmed to behave identically on `origin/main` rather than assumed.

## Follow-ups filed

- **#571** — the upstream root cause: `external_pending` set mid-rebuild is misread as instability, burning a second doomed pass and escaping the one loop that could reconcile it. This is the fix that removes the wasted rebuild.
- **#573** — the lineage-unavailable advice escalation is reached by only one classified rebuild failure, so others recommend a recovery that cannot fix the condition. This branch joins existing behaviour rather than creating the anomaly.
