### PR TITLE
fix(graph): converge a superseded publication instead of paying a doomed rebuild pass

### DIFF
--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -52,6 +52,17 @@ UNIT_PARENT_REF_MAX_CANDIDATES = 16
 EDGE_INSPECTION_MULTIPLIER = 4
 REBUILD_STABILIZATION_ATTEMPTS = 2
 REBUILD_PUBLICATION_ATTEMPTS = REBUILD_STABILIZATION_ATTEMPTS * 2
+# How many publication attempts may be spent re-running a rebuild that a newer
+# external epoch superseded (issue #571). Deliberately far below
+# `REBUILD_PUBLICATION_ATTEMPTS`: a superseded attempt can itself cost two
+# stabilization passes, so charging the whole publication budget to this one
+# condition would quadruple a rebuild's cost, and `claim_rebuild_owner` is held
+# for the duration and serializes graph rebuilds against each other. One retry
+# is what the evidence supports — every logged episode cleared on the very next
+# reconcile, and the "epoch marked before the call" control publishes in a
+# single pass — while a supersession that survives it is not transient, so
+# re-running the rebuild cannot be what fixes it.
+REBUILD_SUPERSESSION_RETRIES = 1
 _AVAILABILITY_FRESHNESS_KEY = "recall_projection_identity"
 _RECALL_CHECKPOINT_KEY = "recall_projection_checkpoint"
 _RESOLVER_TOPOLOGY_KEY = "recall_resolver_topology"
@@ -263,6 +274,22 @@ class GraphPublicationUnavailable(graph_sync.GraphRebuildRegistrationError):
             f"Retry the mutation, or {graph_sync._RECONCILE_HINT}",
         )
         self.args = (f"{message}: {self.args[0]}",)
+
+
+class GraphPublicationSuperseded(GraphPublicationUnavailable):
+    """Class B: a newer external epoch landed mid-pass and superseded this one.
+
+    A distinct type, not a distinct message, because `_rebuild_all_off_boundary`
+    has to catch *exactly* this refusal and no other. `GraphPublicationUnavailable`
+    also names a lost rebuild owner and a marker that would not publish for any
+    other reason — both genuinely doomed for this call — so the base type alone
+    cannot separate them, and widening the catch to it would silently retry a
+    publication that has already been proven hopeless.
+
+    Everything the classification contract reads comes from the base: this is
+    still a `graph_sync.GraphRebuildRegistrationError`, so `is_publication_failure`
+    answers True and `may_mark_external_pending` answers False.
+    """
 
 
 class GraphProjectionMoved(RuntimeError):
@@ -1230,6 +1257,7 @@ class EpistemicGraphIndex:
         """Build and prove a private sidecar before its bounded replacement hold."""
         live = self.path
         attempts = 0
+        superseded_retries = 0
         epoch_error: graph_sync.GraphEpochIncoherent | None = None
         # Artifacts of an earlier failed publication belong to this projection
         # (contract R3). Collect them before adding another one, so repeated
@@ -1312,7 +1340,51 @@ class EpistemicGraphIndex:
                 # while the actual SQLite target remains private.
                 if "_index_path" in self.__dict__:
                     temporary_index._index_path = self._index_path  # type: ignore[method-assign]
-                report = temporary_index._rebuild_all_locked()
+                try:
+                    report = temporary_index._rebuild_all_locked()
+                except GraphPublicationSuperseded:
+                    # A newer external epoch landed mid-pass. This loop is the
+                    # only place that can clear it — `prepare_recall_publication`
+                    # above returns `None` for exactly this condition and this
+                    # seam answers it — which is why an epoch marked *before* the
+                    # call already publishes in a single pass. Reconcile and
+                    # retry here so an interactive write converges inside the
+                    # same call instead of failing and waiting ~5 minutes for the
+                    # next reconcile tick with the graph unavailable.
+                    #
+                    # Bounded by its own budget rather than the publication one.
+                    # A superseded attempt is not always one pass: the marker can
+                    # fail on stabilization attempt 1 for an unrelated reason and
+                    # only then be superseded on attempt 2, so charging the whole
+                    # publication budget here would cost eight passes where the
+                    # unfixed code costs two. `claim_rebuild_owner` is held
+                    # across all of them and serializes graph rebuilds against
+                    # each other, so that is not free.
+                    #
+                    # Exhausting the retry re-raises this same refusal, which is
+                    # already the classification the caller needs — Class B,
+                    # `may_mark_external_pending` False — and carries the
+                    # runnable remediation its base builds. The memo is what
+                    # stops the next cycle re-paying the same doomed rebuild.
+                    #
+                    # Only this subtype is caught; a genuinely doomed
+                    # `GraphPublicationUnavailable` still propagates unchanged.
+                    if superseded_retries >= REBUILD_SUPERSESSION_RETRIES:
+                        # Still reconcile before giving up. The epoch this
+                        # publication could not overtake is otherwise left set,
+                        # which is what fences the graph for the ~5 minutes
+                        # until the next reconcile tick — the availability gap
+                        # this issue is about. Best effort: the classified
+                        # refusal is the outcome the caller must see either way.
+                        try:
+                            self._reconcile_recall_publication()
+                        except Exception:  # noqa: BLE001 - the refusal is the outcome
+                            pass
+                        note_publication_refusal(self.vault_root)
+                        raise
+                    superseded_retries += 1
+                    self._reconcile_recall_publication()
+                    continue
                 ticket = self._prepare_publication_ticket(
                     temporary,
                     epoch=graph_sync.GraphPublicationEpoch(
@@ -1397,8 +1469,13 @@ class EpistemicGraphIndex:
         note_publication_refusal(self.vault_root)
         raise graph_sync.GraphRebuildRegistrationError(
             "GRAPH_SYNC_STABILIZATION_EXHAUSTED",
+            # "run reconcile" is an internal registry name that matches neither
+            # the MCP tool nor the CLI — the #479 defect. This remediation
+            # reaches `graph_sync_remediation` in the mutation terminal verbatim,
+            # so it has to name a surface the reader can actually run, the same
+            # substitution `GraphPublicationUnavailable` already makes.
             "graph publication did not stabilize after "
-            f"{REBUILD_PUBLICATION_ATTEMPTS} attempts; run reconcile to recover the derived graph.",
+            f"{REBUILD_PUBLICATION_ATTEMPTS} attempts; {graph_sync._RECONCILE_HINT}",
         )
 
     def _reconcile_recall_publication(self) -> None:
@@ -1714,6 +1791,7 @@ class EpistemicGraphIndex:
                     and (after_membership := self._recall_membership()) == resolver_membership
                     and self._source_versions_current(resolver_versions)
                 ):
+                    superseded = False
                     live_checkpoint = (
                         freshness.recall_checkpoint(self.vault_root, "vault")
                         if freshness.recall_is_live(self.vault_root, "vault")
@@ -1750,11 +1828,40 @@ class EpistemicGraphIndex:
                             "the recall projection moved after the availability "
                             "marker was written"
                         )
+                    elif freshness.external_pending(self.vault_root):
+                        # `_mark_available`'s first false-term. The pass itself
+                        # proved nothing stale — identity, membership and source
+                        # versions all agree across it — so this is not
+                        # instability, it is a newer external epoch superseding
+                        # the publication.
+                        superseded = True
+                        publication_cause = (
+                            "a newer external epoch superseded this rebuild publication"
+                        )
                     else:
                         publication_cause = "the availability marker would not publish"
                     # A marker that would not publish is a publication failure,
                     # not proof that the registry is behind the disk.
                     self._mark_unavailable()
+                    if superseded and not projection_moved:
+                        # Nothing in this loop can clear `external_pending`:
+                        # `_mark_unavailable` does not, and `unload_ram_caches`
+                        # is only on the `resolver_versions is None` branch. Only
+                        # the caller's prepare/reconcile seam can. Attempt 2
+                        # would therefore rebuild the whole graph again and fail
+                        # at this identical guard, deterministically — 43 times
+                        # in ten hours on the reported cell. Refuse as Class B
+                        # instead of paying that second doomed pass.
+                        #
+                        # Gated on `projection_moved` being False so the mixed
+                        # run cannot mis-fire: a sticky Class C owes the registry
+                        # exactly one `mark_external_pending` from the `finally`
+                        # block below, and raising Class B here would both
+                        # misname the class and still allocate that epoch.
+                        raise GraphPublicationSuperseded(
+                            "epistemic graph rebuild refused a superseded publication "
+                            f"(Class B, publication failure): {publication_cause}"
+                        )
                 else:
                     # `_recall_projection_identity`, `_recall_membership` or the
                     # resolver source versions changed across the pass: Class C,

--- a/tests/test_graph_midflight_external_epoch.py
+++ b/tests/test_graph_midflight_external_epoch.py
@@ -1,0 +1,523 @@
+"""Issue #571: a mid-rebuild external epoch is a supersession, not instability.
+
+`_rebuild_all_locked`'s `_mark_available` returns False purely because
+`freshness.external_pending` was set *during* the pass. The projection identity
+is byte-identical across attempts, membership agrees and the source versions are
+current -- the rebuild is fine. A newer external epoch simply superseded its
+publication.
+
+Nothing inside the stabilization loop can clear that flag: `_mark_unavailable`
+does not, and `find.unload_ram_caches` is only on the `resolver_versions is
+None` branch. So attempt 2 pays a full second rebuild pass and fails at the
+identical guard, deterministically, then raises *out of*
+`_rebuild_all_off_boundary` past the one seam that can clear the condition --
+that loop's `prepare_recall_publication` / `_reconcile_recall_publication` pair.
+
+The reported cell logged 43 of these in ten hours on the interactive write path,
+alongside `VAULT_LOCK_TIMEOUT` deferrals, with two user-facing writes exceeding
+a 120 s client timeout against a ~750 ms budgeted median.
+
+Two halves are tested here:
+
+* **F1** -- refuse early as Class B (`GraphPublicationSuperseded`) instead of
+  paying the second doomed pass.
+* **F2** -- let `_rebuild_all_off_boundary` catch *that* refusal specifically,
+  reconcile, and converge inside the same call rather than deferring to the next
+  reconcile tick ~5 minutes later.
+
+The retry carries its own budget, `REBUILD_SUPERSESSION_RETRIES`, rather than
+the publication one. A superseded publication attempt is not always one pass:
+the marker can fail on stabilization attempt 1 for a reason that has nothing to
+do with an epoch -- the recall projection identity moving between writing the
+availability marker and re-reading it -- which closes the supersession gate for
+that attempt, so the refusal cannot fire until attempt 2. Charging the whole
+`REBUILD_PUBLICATION_ATTEMPTS` budget to this condition would therefore cost
+eight full rebuild passes where the unfixed code costs two, with
+`claim_rebuild_owner` held across all of them, serializing graph rebuilds
+against each other for the duration.
+
+The catch must also be *narrow*. `GraphPublicationUnavailable` is raised for at
+least two other, genuinely doomed conditions -- a lost rebuild owner and a
+marker that will not publish for any other reason -- and those must keep today's
+behaviour. The subtype is what makes them distinguishable; the type alone would
+not.
+
+Scope note. Convergence is gated on `projection_moved` being False, so the
+*mixed* run -- a Class C attempt followed by a supersession -- deliberately
+still raises `GraphProjectionMoved` and still pays the ~5-minute deferral. That
+is the conservative choice: Class C owes the registry exactly one mark, and
+refusing early there would both misname the class and still allocate that epoch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from exomem import epistemic_graph, freshness, graph_sync
+from exomem import find as find_module
+from exomem import vault as vault_module
+from exomem.epistemic_graph import EpistemicGraphIndex
+
+PAGE_A = "Knowledge Base/Notes/Insights/midflight-a.md"
+PAGE_B = "Knowledge Base/Notes/Insights/midflight-b.md"
+
+
+def _page(title: str, body: str) -> str:
+    return f"---\ntype: insight\nstatus: active\n---\n# {title}\n\n## Claim\n\n{body}\n"
+
+
+def _seed_live_freshness(root: Path) -> None:
+    freshness.seed(
+        root,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault_module.walk_vault_md(root)),
+    )
+    kb = root / "Knowledge Base"
+    freshness.seed(
+        root,
+        "kb",
+        ((str(path), freshness.stat_signature(path)) for path in find_module._walk_md(kb)),
+    )
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    root = tmp_path / "vault"
+    (root / "Knowledge Base/Notes/Insights").mkdir(parents=True)
+    (root / PAGE_A).write_text(_page("A", "A claims against [[midflight-b]]."), encoding="utf-8")
+    (root / PAGE_B).write_text(_page("B", "B is a plain claim."), encoding="utf-8")
+    _seed_live_freshness(root)
+    EpistemicGraphIndex(root).rebuild_all()
+    epistemic_graph.clear_publication_memos()
+    yield root
+    epistemic_graph.clear_publication_memos()
+
+
+def _count_rebuild_passes(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record every full `_rebuild_all_pass`, the unit of wasted work at issue."""
+    real = EpistemicGraphIndex._rebuild_all_pass
+    passes: list[str] = []
+
+    def counting_pass(
+        self: EpistemicGraphIndex, resolver: vault_module.WikilinkResolver
+    ) -> dict[str, int]:
+        report = real(self, resolver)
+        passes.append("pass")
+        return report
+
+    monkeypatch.setattr(EpistemicGraphIndex, "_rebuild_all_pass", counting_pass)
+    return passes
+
+
+def _supersede_after_each_pass(
+    monkeypatch: pytest.MonkeyPatch, *, limit: int | None = None
+) -> list[str]:
+    """Land a newer external epoch mid-rebuild, exactly as production does.
+
+    The mark lands after the pass and before `_mark_available`, which is the
+    only window the reported failure can occupy: `_mark_available`'s first
+    false-term is the flag, and the instrumented production attempts showed the
+    projection identity matching on both sides of the pass.
+    """
+    real = EpistemicGraphIndex._rebuild_all_pass
+    passes: list[str] = []
+
+    def superseding_pass(
+        self: EpistemicGraphIndex, resolver: vault_module.WikilinkResolver
+    ) -> dict[str, int]:
+        report = real(self, resolver)
+        passes.append("pass")
+        if limit is None or len(passes) <= limit:
+            freshness.mark_external_pending(self.vault_root)
+        return report
+
+    monkeypatch.setattr(EpistemicGraphIndex, "_rebuild_all_pass", superseding_pass)
+    return passes
+
+
+def _refuse_the_marker_once_per_pair_then_supersede(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cost the worst case: a non-superseded marker failure, then a supersession.
+
+    Every odd `_mark_available` fails the way a projection identity that moved
+    across the marker write fails -- False, no external epoch -- and every even
+    one lands the epoch. So each `_rebuild_all_locked` burns both stabilization
+    passes before it can refuse.
+    """
+    calls = 0
+
+    def marker(
+        self: EpistemicGraphIndex,
+        identity: tuple[tuple[int, int, str], str, str],
+        *,
+        checkpoint: object | None = None,
+    ) -> bool:
+        nonlocal calls
+        calls += 1
+        if calls % 2 == 1:
+            return False
+        freshness.mark_external_pending(self.vault_root)
+        return False
+
+    monkeypatch.setattr(EpistemicGraphIndex, "_mark_available", marker)
+
+
+def _refuse_the_availability_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A genuinely doomed publication: no external epoch, the marker just fails."""
+    monkeypatch.setattr(
+        EpistemicGraphIndex, "_mark_available", lambda *_args, **_kwargs: False
+    )
+
+
+def _move_the_resolver_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Class C: the supplied freshness identity does not name the resolver bytes."""
+    monkeypatch.setattr(
+        EpistemicGraphIndex, "_resolver_source_versions", lambda *_args, **_kwargs: None
+    )
+
+
+def _move_the_resolver_identity_on_the_first_attempt_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Class C on attempt 1; every later attempt resolves its source versions."""
+    real = EpistemicGraphIndex._resolver_source_versions
+    attempts = 0
+
+    def first_attempt_moves(
+        self: EpistemicGraphIndex,
+        resolver: vault_module.WikilinkResolver,
+        expected_membership: frozenset[str],
+    ) -> dict[str, epistemic_graph.GraphSourceSignature] | None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return None
+        return real(self, resolver, expected_membership)
+
+    monkeypatch.setattr(EpistemicGraphIndex, "_resolver_source_versions", first_attempt_moves)
+
+
+# --- F1: one superseded pass, refused, not two -----------------------------
+
+
+def test_a_single_midflight_epoch_costs_one_rebuild_pass_not_two(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The measured waste: one mark is enough to burn a whole second pass.
+
+    Nothing in the stabilization loop can clear `external_pending`, so attempt 2
+    rebuilds the entire graph again only to fail at the identical guard.
+    """
+    passes = _supersede_after_each_pass(monkeypatch, limit=1)
+
+    with pytest.raises(epistemic_graph.GraphPublicationUnavailable):
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    assert len(passes) == 1, (
+        "a superseded publication paid a second, provably doomed full rebuild pass"
+    )
+
+
+def test_the_superseded_refusal_is_a_classified_class_b_failure(
+    vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Correct-by-construction: the subtype must keep the Class B answers."""
+    _supersede_after_each_pass(monkeypatch, limit=1)
+    epoch_probe = tmp_path / "epoch-probe-root"
+    clock_before = freshness.mark_external_pending(epoch_probe)
+
+    with pytest.raises(epistemic_graph.GraphPublicationUnavailable) as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    error = raised.value
+    assert not isinstance(error, epistemic_graph.GraphProjectionMoved)
+    assert epistemic_graph.is_publication_failure(error) is True
+    assert epistemic_graph.may_mark_external_pending(error) is False
+    message = str(error)
+    assert "Class B" in message
+    assert "superseded" in message, (
+        "the refusal reused the generic marker-refusal text: " + message
+    )
+    # `projection_moved` is False here, so the `finally` block's Class C
+    # `mark_external_pending` must stay untouched: the only epoch allocated in
+    # this run is the one the probe planted mid-pass.
+    clock_after = freshness.mark_external_pending(epoch_probe)
+    assert clock_after == clock_before + 2
+
+
+def test_the_refusal_has_its_own_type_so_the_caller_can_catch_only_it(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`GraphPublicationUnavailable` alone cannot separate this from a doomed one.
+
+    The same base type names a lost rebuild owner and a marker that will not
+    publish for any other reason. F2's `continue` must not swallow either, so
+    the supersession needs a distinguishable subtype.
+    """
+    _supersede_after_each_pass(monkeypatch, limit=1)
+
+    with pytest.raises(epistemic_graph.GraphPublicationSuperseded):
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    assert issubclass(
+        epistemic_graph.GraphPublicationSuperseded, epistemic_graph.GraphPublicationUnavailable
+    )
+
+
+# --- F2: the same call converges instead of deferring ~5 minutes -----------
+
+
+def test_the_off_boundary_call_converges_after_a_midflight_supersession(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The half that recovers write latency.
+
+    `_rebuild_all_off_boundary` already begins each attempt with
+    `prepare_recall_publication` and reconciles when it returns `None` -- which
+    is exactly why an epoch marked *before* the call succeeds in one pass. The
+    inner loop's raise is what destroyed that ability.
+    """
+    _supersede_after_each_pass(monkeypatch, limit=1)
+    index = EpistemicGraphIndex(vault)
+
+    report = index._rebuild_all_off_boundary()
+
+    assert report["indexed_files"] == 2
+    assert index.available() is True
+    assert freshness.external_pending(vault) is False
+    assert epistemic_graph.publication_refusal_active(vault) is False
+
+
+def test_a_repeatedly_superseded_publication_terminates_within_the_budget(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The retry is bounded by its own budget, and exhaustion is still Class B.
+
+    Every attempt is superseded, so convergence never happens. The loop must
+    stop after `REBUILD_SUPERSESSION_RETRIES` and re-raise the refusal it
+    already holds -- never an unbounded retry, and never the whole publication
+    budget.
+    """
+    passes = _supersede_after_each_pass(monkeypatch)
+    index = EpistemicGraphIndex(vault)
+
+    with pytest.raises(epistemic_graph.GraphPublicationSuperseded) as raised:
+        index._rebuild_all_off_boundary()
+
+    error = raised.value
+    assert epistemic_graph.is_publication_failure(error) is True
+    assert epistemic_graph.may_mark_external_pending(error) is False
+    assert len(passes) == epistemic_graph.REBUILD_SUPERSESSION_RETRIES + 1, (
+        "a supersession that repeats must not be charged the publication budget"
+    )
+    # R2: the doomed publication is memoized, so the next cycle does not re-pay it.
+    assert epistemic_graph.publication_refusal_active(vault) is True
+    # Even on the give-up path the epoch is reconciled away, so the graph is not
+    # left fenced for the ~5 minutes until the next reconcile tick. Unfixed,
+    # this call leaves the registry cool and the graph unavailable.
+    assert freshness.external_pending(vault) is False
+    assert index.available() is True
+
+
+def test_the_costliest_interleaving_stays_inside_the_supersession_budget(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A superseded attempt is not always one pass -- this is the ceiling.
+
+    `_mark_available` returns False with no external epoch when the recall
+    projection identity moves between writing the availability marker and
+    re-reading it. That closes the supersession gate on stabilization attempt 1,
+    so the refusal cannot fire until attempt 2: two full passes for one
+    publication attempt. It needs no `projection_moved` at any point, so a vault
+    under concurrent writes -- the reported cell's own condition -- reaches it.
+
+    Charged to `REBUILD_PUBLICATION_ATTEMPTS` this would be eight passes against
+    the unfixed code's two. Its own budget holds it to four.
+    """
+    passes = _count_rebuild_passes(monkeypatch)
+    _refuse_the_marker_once_per_pair_then_supersede(monkeypatch)
+    index = EpistemicGraphIndex(vault)
+
+    with pytest.raises(epistemic_graph.GraphPublicationSuperseded):
+        index._rebuild_all_off_boundary()
+
+    ceiling = (
+        epistemic_graph.REBUILD_SUPERSESSION_RETRIES + 1
+    ) * epistemic_graph.REBUILD_STABILIZATION_ATTEMPTS
+    assert len(passes) == ceiling
+    assert len(passes) < (
+        epistemic_graph.REBUILD_PUBLICATION_ATTEMPTS
+        * epistemic_graph.REBUILD_STABILIZATION_ATTEMPTS
+    ), "the supersession retry was charged the whole publication budget"
+
+
+# --- The catch must not widen -----------------------------------------------
+
+
+def test_a_genuinely_doomed_publication_is_not_swallowed_by_the_retry(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A marker that fails with no external epoch keeps today's behaviour."""
+    passes = _count_rebuild_passes(monkeypatch)
+    _refuse_the_availability_marker(monkeypatch)
+
+    with pytest.raises(epistemic_graph.GraphPublicationUnavailable) as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_off_boundary()
+
+    error = raised.value
+    assert not isinstance(error, epistemic_graph.GraphPublicationSuperseded)
+    assert "availability marker" in str(error)
+    assert len(passes) == epistemic_graph.REBUILD_STABILIZATION_ATTEMPTS, (
+        "the doomed publication escaped after one off-boundary attempt, as before"
+    )
+    assert freshness.external_pending(vault) is False
+
+
+def test_a_moved_projection_still_escapes_the_off_boundary_loop_as_class_c(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Class C regression: `GraphProjectionMoved` is not caught or retried."""
+    _move_the_resolver_identity(monkeypatch)
+
+    with pytest.raises(epistemic_graph.GraphProjectionMoved) as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_off_boundary()
+
+    assert type(raised.value) is epistemic_graph.GraphProjectionMoved
+    assert freshness.external_pending(vault) is True
+
+
+def test_a_class_c_attempt_followed_by_a_supersession_stays_class_c(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The mixed run, and the only way the new refusal could mis-fire.
+
+    `projection_moved` is sticky, and the `finally` block owes the registry
+    exactly one mark when it is set. Refusing early on attempt 2 would raise
+    Class B *and* still mark externally pending -- a contract violation. The
+    refusal is therefore gated on `projection_moved` being False.
+    """
+    _move_the_resolver_identity_on_the_first_attempt_only(monkeypatch)
+    _supersede_after_each_pass(monkeypatch)
+
+    with pytest.raises(epistemic_graph.GraphProjectionMoved) as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    error = raised.value
+    assert type(error) is epistemic_graph.GraphProjectionMoved
+    message = str(error)
+    assert "Class C" in message
+    assert "resolver bytes" in message, "the Class C label must quote the Class C cause"
+    assert epistemic_graph.may_mark_external_pending(error) is False
+    assert freshness.external_pending(vault) is True
+
+
+def test_a_supersession_that_coincides_with_a_moved_projection_stays_class_c(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reverse interleaving, and it is byte-identical to before the fix.
+
+    The epoch lands during the pass, but the projection moved across that same
+    pass, so the outer stability triple fails, `_mark_available` is never
+    called, and the supersession gate never opens. Class C wins on both sides.
+    """
+    _supersede_after_each_pass(monkeypatch)
+    monkeypatch.setattr(
+        EpistemicGraphIndex, "_source_versions_current", lambda *_args, **_kwargs: False
+    )
+
+    with pytest.raises(epistemic_graph.GraphProjectionMoved) as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    error = raised.value
+    assert type(error) is epistemic_graph.GraphProjectionMoved
+    assert "Class C" in str(error)
+    assert "resolver source versions" in str(error)
+    assert freshness.external_pending(vault) is True
+
+
+def test_the_retry_does_not_mask_a_class_c_that_lands_after_it(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Publication attempt 1 is superseded; attempt 2's projection genuinely moves.
+
+    The convergence retry must hand the second attempt's verdict through
+    untouched, not absorb it into the Class B lane it came from.
+    """
+    locked_calls = 0
+    real_locked = EpistemicGraphIndex._rebuild_all_locked
+
+    def counting_locked(self: EpistemicGraphIndex) -> dict[str, int]:
+        nonlocal locked_calls
+        locked_calls += 1
+        return real_locked(self)
+
+    monkeypatch.setattr(EpistemicGraphIndex, "_rebuild_all_locked", counting_locked)
+
+    real_pass = EpistemicGraphIndex._rebuild_all_pass
+
+    def superseding_first_pass(
+        self: EpistemicGraphIndex, resolver: vault_module.WikilinkResolver
+    ) -> dict[str, int]:
+        report = real_pass(self, resolver)
+        if locked_calls == 1:
+            freshness.mark_external_pending(self.vault_root)
+        return report
+
+    monkeypatch.setattr(EpistemicGraphIndex, "_rebuild_all_pass", superseding_first_pass)
+    monkeypatch.setattr(
+        EpistemicGraphIndex,
+        "_source_versions_current",
+        lambda *_args, **_kwargs: locked_calls < 2,
+    )
+
+    with pytest.raises(epistemic_graph.GraphProjectionMoved) as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_off_boundary()
+
+    assert type(raised.value) is epistemic_graph.GraphProjectionMoved
+    assert locked_calls == 2, "the supersession must have been retried exactly once"
+    assert freshness.external_pending(vault) is True
+
+
+# --- #479: every refusal this diff can reach names a runnable surface --------
+
+
+def test_the_superseded_refusal_carries_the_runnable_reconcile_command(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A permanently-superseded publication is the terminal the caller sees."""
+    _supersede_after_each_pass(monkeypatch)
+
+    with pytest.raises(epistemic_graph.GraphPublicationSuperseded) as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_off_boundary()
+
+    error = raised.value
+    assert error.code == "GRAPH_SYNC_PUBLICATION_UNAVAILABLE"
+    assert 'maintain_memory(mode="reconcile")' in error.remediation
+    assert "exomem maintain --reconcile" in error.remediation
+
+
+def test_the_publication_exhaustion_names_a_runnable_reconcile_command(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#479 regression: "run reconcile" matches neither the MCP tool nor the CLI.
+
+    This raise stays reachable whenever the publication attempts are spent on
+    the recall-preparation, epoch-coalescing or ticket-refresh paths, and its
+    remediation reaches `graph_sync_remediation` in the mutation terminal
+    verbatim rather than being rebuilt from `_RECONCILE_HINT` downstream.
+    """
+    monkeypatch.setattr(freshness, "prepare_recall_publication", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        EpistemicGraphIndex, "_reconcile_recall_publication", lambda *_a, **_k: None
+    )
+
+    with pytest.raises(graph_sync.GraphRebuildRegistrationError) as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_off_boundary()
+
+    error = raised.value
+    assert error.code == "GRAPH_SYNC_STABILIZATION_EXHAUSTED"
+    assert f"after {epistemic_graph.REBUILD_PUBLICATION_ATTEMPTS} attempts" in str(error)
+    assert "run reconcile to recover the derived graph" not in error.remediation
+    assert 'maintain_memory(mode="reconcile")' in error.remediation
+    assert "exomem maintain --reconcile" in error.remediation


### PR DESCRIPTION
Closes #571.

Rebased onto `main`. The two commits this branch was stacked on landed as `65ad65a7` (#575); they dropped as empty, so this is now one commit on current `main`, and every number below was re-measured against it.

## What was wrong

`_rebuild_all_locked`'s `_mark_available` returns false purely because `freshness.external_pending` is set **mid-rebuild**. The projection identity is byte-identical across attempts, membership agrees, source versions are current — the rebuild is fine. A newer external epoch superseded its publication, and the code reads that as instability.

Nothing inside the attempt loop can clear that flag, so attempt 2 pays a full second rebuild pass and fails at the identical guard, deterministically. It then raises out of `_rebuild_all_off_boundary` past that method's `prepare_recall_publication` / `_reconcile_recall_publication` seam — the only thing that *can* clear the condition.

Established by contrast, not just reproduction:

| perturbation | result |
|---|---|
| none | SUCCESS, 1 pass |
| edit a file during each pass | `GraphProjectionMoved` |
| `mark_external_pending()` during each pass | bare `RuntimeError` — matches production |
| `mark_external_pending()` **before** the call | SUCCESS, 1 pass |
| `mark_external_pending()` **once**, after pass 1 | `RuntimeError`, 2 full passes burned |

Introduced by `167b164d feat(records): add first-class mutable records (#405)`, which added `_mark_available` with the `external_pending` guard as new code.

## What this does

**Refuse early instead of paying a doomed pass.** After `_mark_unavailable()`, a superseded publication raises rather than looping. Gated on `not projection_moved`: a sticky Class C attempt owes the registry exactly one `mark_external_pending` from the `finally` block, and refusing early there would raise Class B *and still* allocate that epoch. With the gate the `finally` block is untouched on the new path, pinned by an epoch-clock probe.

**Converge in the same call.** `_rebuild_all_off_boundary` catches the refusal, reconciles, and retries — running the existing `finally` (owner release, temp unregister/unlink, reap) exactly as every other `continue` in that loop does.

**A new type, because the base type cannot discriminate.** `GraphPublicationUnavailable` is also raised for a lost rebuild owner and for a marker that fails for any other reason, both genuinely doomed for that call. `GraphPublicationSuperseded` subclasses it, inheriting everything the classification contract reads (`is_publication_failure` → True, `may_mark_external_pending` → False) while giving the caller a narrow catch. A test asserts a genuinely doomed publication is not an instance of it and is not swallowed.

**Bounded by its own budget, `REBUILD_SUPERSESSION_RETRIES = 1`, not the publication one.** See below — this is a correction to an earlier revision of this PR.

## Correction: the worst case is two passes per publication attempt, not one

Review caught that an earlier revision under-disclosed the ceiling. `_mark_available` can return false with **no external epoch at all** — the recall projection identity moving between writing the availability marker and re-reading it. That closes the supersession gate on stabilization attempt 1, so the refusal cannot fire until attempt 2: **two** full `_rebuild_all_pass` calls for one publication attempt. It needs no `projection_moved` at any point, so a vault under concurrent writes reaches it.

Charged the full `REBUILD_PUBLICATION_ATTEMPTS`, that is 8 passes where the unfixed code costs 2 — independently measured at 8 passes / 4.4× on a 40-page vault.

I tightened rather than only disclosing, because `claim_rebuild_owner` is held across every one of those passes and serializes graph rebuilds against each other, and #576 has since established the live cell is already in a rebuild livelock. Making a rebuild 4× longer there is not free.

The retry now has a dedicated budget of 1. The evidence supports it: every logged episode cleared on the very next reconcile, and the "epoch marked before the call" control publishes in a single pass — while a supersession that survives one retry is not transient, so re-running the rebuild is not what would fix it. Exhausting the retry reconciles, memoizes, and re-raises the same classified refusal.

Measured ceiling, 400-file vault, that exact interleaving:

| | base | branch |
|---|---|---|
| rebuild passes | 2 | **4** (was 8) |
| call wall | 11 808 ms | 20 862 ms |
| outcome | `GraphPublicationUnavailable` | `GraphPublicationSuperseded` |

Pinned by `test_the_costliest_interleaving_stays_inside_the_supersession_budget`.

## Correction: #479 remediation, and the terminal code does *not* change

Review caught that the earlier revision routed a permanently-superseded publication to the off-boundary exhaustion raise, whose literal still said "run reconcile" — an internal registry name matching neither the MCP tool nor the CLI. That string reaches `graph_sync_remediation` in the mutation terminal verbatim.

Fixed at the source, via the same `graph_sync._RECONCILE_HINT` substitution the class two hundred lines above already makes. Raw before/after on the exhaustion path:

```
base   : graph publication did not stabilize after 4 attempts; run reconcile to recover the derived graph.
branch : graph publication did not stabilize after 4 attempts; run maintain_memory(mode="reconcile") — `exomem maintain --reconcile` from a shell to recover the derived graph.
```

The raise stays reachable whenever the publication attempts are spent on the recall-preparation, epoch-coalescing or ticket-refresh paths, so this is a fix to a pre-existing defect rather than only to a path this diff creates. Pinned by `test_the_publication_exhaustion_names_a_runnable_reconcile_command`, which drives the real raise rather than asserting on source text.

Separately: with the dedicated retry budget, a permanently-superseded publication no longer reaches that raise at all, so the **terminal code is unchanged**. An earlier revision would have flipped it from `GRAPH_SYNC_PUBLICATION_UNAVAILABLE` to `GRAPH_SYNC_STABILIZATION_EXHAUSTED`; it no longer does. Raw:

```
base   : GraphPublicationUnavailable  / GRAPH_SYNC_PUBLICATION_UNAVAILABLE
branch : GraphPublicationSuperseded   / GRAPH_SYNC_PUBLICATION_UNAVAILABLE
```

Same code, same remediation; only the type narrows to a subclass.

## The measurement contradicts the issue's stated premise — disclosed

#571 argued this would recover interactive write latency by freeing the vault lock. **It does not, and the rebuild never holds that lock.**

Re-measured against current `main`, 400-file vault, with a contender thread taking exactly the lock lexstore takes (`vault_creation_lock(root, "lexical-catalog-publication")`):

| | base (once) | branch (once) | base (always) | branch (always) |
|---|---|---|---|---|
| outcome | `GraphPublicationUnavailable` | **converged** | `GraphPublicationUnavailable` | `GraphPublicationSuperseded` |
| rebuild passes | 2 | 2 | 2 | 2 |
| call wall | 11 904 ms | 13 855 ms | 11 728 ms | 12 329 ms |
| `available()` after | false | **true** | false | **true** |
| `external_pending` after | **true** | **false** | **true** | **false** |
| `vault_creation_lock` acquisitions | **0** | **0** | **0** | **0** |
| contender refusals | 0 / 545 | 0 / 639 | 0 / 539 | 0 / 567 |
| contender max wait | 7.54 ms | 4.25 ms | 4.13 ms | 4.43 ms |

The mutation boundary is held ~4 ms around the atomic replace only, and the failing base call never reaches it. What spans the attempts is the graph's own `claim_rebuild_owner`. Corroborated statically: `resume_graph_sync` is invoked at `writer_lease.py:1206` outside any `operation_guard`, and the code says so itself at `writer_lease.py:1315` — *"derived graph work is deliberately not owned by it."*

**So the `VAULT_LOCK_TIMEOUT` correlation in the production log has another explanation and is not addressed here.** Review re-derived this independently by probing `vault_creation_lock` itself across all three namespaces rather than through one contender, and still measured 0 acquisitions on both sides. (Correcting my own earlier wording: `vault.py:478` is not the *sole* `VAULT_LOCK_TIMEOUT` raise site — `:524` is the other, both inside `vault_creation_lock`. The conclusion is unchanged and better supported.)

Note the branch call is **~2 s slower in wall-clock** in the single-supersession case. It is not a faster failure; it is a success that pays for the publication the base skipped by giving up.

## What is recovered

The availability gap. The base call ends failed, `available()` false, registry externally pending until the next reconcile tick (~5 min). The branch call ends published, available, registry clean, **in the same call**.

Stronger than that, and true of **every** superseded path including the one that still raises: the branch ends with `external_pending` false and `available()` true where base leaves them true and false. The give-up path reconciles before re-raising precisely so the graph is not left fenced behind an epoch no later reader can act on.

This is a cleanliness improvement, **not** the fix for #576 — that traced the live write latency to an unbounded join on a full-corpus rebuild, and a separate trace refuted the latch theory. Nothing here is claimed to close it.

**Caveat on "converges in the same call":** the `not projection_moved` gate deliberately excludes the mixed run. A Class C attempt followed by a supersession still raises `GraphProjectionMoved` and still pays the ~5-minute deferral. That is the conservative choice, and it is pinned by three regression guards.

## Verification

Ten tests red on current `main` (`321343f9`) in a disposable worktree; three Class C regression guards green on both sides:

```
FAILED test_a_single_midflight_epoch_costs_one_rebuild_pass_not_two
FAILED test_the_superseded_refusal_is_a_classified_class_b_failure
FAILED test_the_refusal_has_its_own_type_so_the_caller_can_catch_only_it
FAILED test_the_off_boundary_call_converges_after_a_midflight_supersession
FAILED test_a_repeatedly_superseded_publication_terminates_within_the_budget
FAILED test_the_costliest_interleaving_stays_inside_the_supersession_budget
FAILED test_a_genuinely_doomed_publication_is_not_swallowed_by_the_retry
FAILED test_the_retry_does_not_mask_a_class_c_that_lands_after_it
FAILED test_the_superseded_refusal_carries_the_runnable_reconcile_command
FAILED test_the_publication_exhaustion_names_a_runnable_reconcile_command
PASSED test_a_moved_projection_still_escapes_the_off_boundary_loop_as_class_c
PASSED test_a_class_c_attempt_followed_by_a_supersession_stays_class_c
PASSED test_a_supersession_that_coincides_with_a_moved_projection_stays_class_c
10 failed, 3 passed in 4.86s
```

All 13 green here, plus the 11 that came in with #575 (`24 passed in 9.86s`).

**Regression by sorted failure-ID set, not counts.** The first base run disagreed with the branch by one test, so I ran base twice:

```
base  run 1 : 132 failed, 1092 passed, 17 skipped, 2 errors
base  run 2 : 133 failed, 1091 passed, 17 skipped, 2 errors
branch      : 133 failed, 1104 passed, 17 skipped, 2 errors

diff(base run 2, branch) -> IDENTICAL FAILURE SETS
diff(base run 1, base run 2) -> differs by exactly one test
```

The disputed test is `test_graph_rebuild_availability.py::test_rebuild_graph_dry_run_previews_unavailable_reset_without_mutating`, and the instability is base's, not the branch's. In isolation it fails **deterministically on both sides**, three runs each, with `BrokenPipeError: [Errno 32] cannot safely open .graph.sqlite` — a Windows file-sharing artifact. At file level it fails on both sides, with base reporting *more* failures than the branch (16 vs 15). It also failed on both sides in the pre-rebase runs. Base run 1's single pass is the outlier.

+13 passed on the branch = the 13 new tests.

`ruff --select F` clean. The targeted CI ruff gate reports one `E501` at `file_watcher.py:950` — **pre-existing and byte-identical on `main`**, verified by running it there, in a file this diff never touches. Targeted mypy clean over the CI list (`epistemic_graph.py` is in it). Privacy gate `findings: ()`.

Windows-blocked modules excluded identically on both sides and each confirmed pre-existing rather than assumed: `test_protocol_custody.py` (`fcntl`), `test_lme_reader_gate.py` / `test_lme_runner.py` / `test_hosted_restore_candidate.py` (`os.O_DIRECTORY`), and `test_latency_gate.py`, which hard-times out inside `_build_dense_vault`. Linux CI is the authority for those.

## Not chased

Why `external_pending` is set mid-rebuild on a static corpus. The tests plant the epoch themselves, so no production marker fired and nothing here revealed the call site. Still open, and now also relevant to #576.
