### PR TITLE
fix(embeddings): preload the model off the request path and stop revalidating cached weights

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -324,7 +324,13 @@ uv run python -m exomem index --vault "/path/to/your/Obsidian"
 uv run python -m exomem reconcile --vault "/path/to/your/Obsidian"
 ```
 
-Use `performance` only when you explicitly want GPU-capable bulk/model work:
+Use `performance` only when you explicitly want GPU-capable bulk/model work. It
+preloads the models at startup and keeps them resident — idle reclamation still
+evicts caches, but not the preloaded models, because reloading one costs whichever
+request arrives next about half a minute. `exomem doctor --profile hybrid` reports
+that state under `models.residency`: whether a model is loaded, whether its weights
+are in the local HuggingFace cache, and whether the next load resolves from that
+cache instead of revalidating it over the network.
 
 ```bash
 uv run python -m exomem mode performance

--- a/docs/ai-assistant-guide.md
+++ b/docs/ai-assistant-guide.md
@@ -442,7 +442,7 @@ Resource mode is separate from search knobs:
 | --- | --- |
 | `quiet` | Low-resource CPU mode; avoid warm-up and release models when idle |
 | `normal` | CPU-first default; keyword/BM25 recall is ready first |
-| `performance` | Explicit opt-in for GPU-capable steady-state work |
+| `performance` | Explicit opt-in for GPU-capable steady-state work; models preload at startup and stay resident, so no request pays a model load |
 
 Do not interpret a slow diagnostic search with rerank enabled as "Exomem is
 slow" without checking timings, resource mode, cache state, and whether a model

--- a/env.example
+++ b/env.example
@@ -51,12 +51,20 @@ EXOMEM_VAULT_PATH=/path/to/your/Obsidian
 # server reads .env; CLI ops do not). EXOMEM_CONFIG_PATH overrides the file location.
 #   quiet       - CPU everywhere, no model preload, release models when idle.
 #   normal      - default. CPU steady-state (MPS on Apple Silicon); never auto-CUDA.
-#   performance - use the GPU when a capable one is present (aliases: gpu, turbo).
+#   performance - use the GPU when a capable one is present; preloaded models stay
+#                 resident so no request pays a load (aliases: gpu, turbo).
 # EXOMEM_MODE=normal
 #
 # Startup model preload. Normal/quiet default to lazy model load on every OS;
-# performance may preload. Set 1 only when startup latency matters more than RAM.
+# performance preloads. Set 1 only when startup latency matters more than RAM.
+# Preload also PINS the models against the idle reaper — otherwise the reload
+# lands on whichever request arrives after the idle window (~35s inside a write).
 # EXOMEM_PRELOAD_MODELS=1
+#
+# Offline-first weight loading (default on). Weights already in the local HF cache
+# load without revalidating every file against the hub; an absent or unusable cache
+# still falls back to a normal download. Set 0 to always revalidate.
+# EXOMEM_MODEL_OFFLINE=0
 #
 # Explicit device override (wins over the mode). cpu | gpu | auto | cuda | cuda:1 | mps
 #   'gpu'/'auto' opt in with a marginal-VRAM guard; 'cuda' forces it (legacy behavior).
@@ -72,7 +80,10 @@ EXOMEM_VAULT_PATH=/path/to/your/Obsidian
 # EXOMEM_DISABLE_ASR_PREWARM=1
 #
 # Idle-unload reaper: release resident models/caches after N idle minutes.
-# EXOMEM_RELEASE_GPU_WHEN_IDLE=   # on|off; default on in every mode
+# Default on in every mode, except that preloaded MODELS are pinned (caches still
+# reap). Setting this explicitly wins either way — 'on' reaps models even under
+# preload, at the cost of a cold load on the next request.
+# EXOMEM_RELEASE_GPU_WHEN_IDLE=   # on|off
 # EXOMEM_IDLE_MINUTES=15
 # EXOMEM_MEDIA_IDLE_SECONDS=300   # disposable media child exits after this idle window
 # EXOMEM_MEDIA_WORKER_MODE=process # process (product default) | inline (debug rollback)

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -769,6 +769,7 @@ def _mode_main(argv: list[str]) -> int:
             print(f"  retain_cpu_caches:       {policy['retain_cpu_caches']}")
             print(f"  defer_expensive_indexes: {policy['defer_expensive_indexes']}")
             print(f"  release_when_idle:       {policy['release_when_idle']}")
+            print(f"  reap_models_when_idle:   {policy['reap_models_when_idle']}")
             print(f"  bulk_gpu:                {policy['bulk_gpu']}")
             print(f"  config: {policy['config_path']}")
         return 0

--- a/src/exomem/claims.py
+++ b/src/exomem/claims.py
@@ -1129,9 +1129,13 @@ def _get_nli_model():
         try:
             from sentence_transformers import CrossEncoder
 
-            from . import accel
+            from . import accel, model_cache
 
-            _NLI_MODEL = CrossEncoder(name, device=accel.select_device())
+            device = accel.select_device()
+            _NLI_MODEL = model_cache.load_offline_first(
+                name,
+                lambda **kw: CrossEncoder(name, device=device, **kw),
+            )
         except Exception as e:  # noqa: BLE001 — optional path; degrade to heuristic
             log.warning("NLI polarity model unavailable (%s); using heuristic", e)
             _NLI_IMPORT_FAILED = True

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -1397,8 +1397,9 @@ def _check_embedding_sidecar(vault_root: Path | None) -> DoctorCheck | None:
         )
     from . import embeddings
 
-    bge_dir = "models--" + embeddings.MODEL_NAME.replace("/", "--")
-    if not _model_cached(_hf_hub_dir(), bge_dir):
+    from . import model_cache
+
+    if not model_cache.is_cached(embeddings.MODEL_NAME):
         # doctor must never trigger a download — skip the live probe rather than
         # let embed_texts() fetch the model over the network.
         return _check(
@@ -1458,51 +1459,96 @@ def _check_embedding_sidecar(vault_root: Path | None) -> DoctorCheck | None:
 def _hf_hub_dir() -> Path:
     """The local HuggingFace hub cache directory (honors HF_HUB_CACHE / HF_HOME).
 
-    Directory resolution only — never touches the network.
+    Delegates to `model_cache` so doctor reports the directory the RUNTIME will
+    actually load from — two implementations of this would drift.
     """
-    if os.environ.get("HF_HUB_CACHE"):
-        return Path(os.environ["HF_HUB_CACHE"])
-    if os.environ.get("HF_HOME"):
-        return Path(os.environ["HF_HOME"]) / "hub"
-    return Path.home() / ".cache" / "huggingface" / "hub"
+    from . import model_cache
+
+    return model_cache.hub_dir()
 
 
 def _model_cached(hub: Path, dirname: str) -> bool:
     """True if a model's snapshot dir exists and is non-empty — a pure directory
     check, so a caller can gate model-loading work on it WITHOUT risking a
     download (doctor never fetches)."""
-    snapshots = hub / dirname / "snapshots"
-    try:
-        return snapshots.is_dir() and any(snapshots.iterdir())
-    except OSError:
-        return False
+    from . import model_cache
+
+    return model_cache.snapshot_populated(hub, dirname)
+
+
+def _check_model_residency() -> DoctorCheck:
+    """Whether an embed is about to pay a model load, and whether it will hit the network.
+
+    Until this check existed, the only way to know a write was about to pay ~35s
+    was to read the server log after it had already paid it. `loaded` is the model
+    singleton, not the module — `status.models.module_loaded` answers the narrower
+    question and reads as this one. `offline_load` says whether the load resolves
+    purely from the cache directory or revalidates every file against the hub.
+    """
+    from . import embeddings, mode, model_cache
+
+    resident = embeddings._MODEL is not None
+    cached = model_cache.is_cached(embeddings.MODEL_NAME)
+    offline = model_cache.should_load_offline(embeddings.MODEL_NAME)
+    preload = mode.preload_models()
+    details = {
+        "model": embeddings.MODEL_NAME,
+        "loaded": resident,
+        "cache_dir": str(model_cache.hub_dir()),
+        "bi_encoder_cached": cached,
+        "offline_load": offline,
+        "preload_policy": preload,
+        "reap_models_when_idle": mode.reap_models_when_idle(),
+    }
+    if resident:
+        return _check(
+            "models.residency",
+            "pass",
+            f"{embeddings.MODEL_NAME} is resident; embeds pay no load.",
+            details=details,
+        )
+    if not cached:
+        return _check(
+            "models.residency",
+            "pass",
+            f"{embeddings.MODEL_NAME} is not loaded and not cached; the next embed "
+            "downloads it inline.",
+            "Run `exomem warm` to fetch it, then `exomem mode performance` to preload "
+            "it at startup instead of inside a request.",
+            details=details,
+        )
+    where = "from the local cache" if offline else "revalidating every file against the hub"
+    return _check(
+        "models.residency",
+        "pass",
+        f"{embeddings.MODEL_NAME} is cached but not loaded; the next embed loads it {where}.",
+        None
+        if preload
+        else "Run `exomem mode performance` (or set EXOMEM_PRELOAD_MODELS=1) to load it at "
+        "startup instead of inside whichever request arrives first.",
+        details=details,
+    )
 
 
 def _check_models_cache() -> DoctorCheck:
     """Local HF-cache presence for the three search models. Read-only: this
     inspects directories only — doctor never downloads anything."""
-    from . import embeddings
+    from . import embeddings, model_cache
 
     hub = _hf_hub_dir()
     backend = _resolved_embedding_backend()
 
-    expected = {
-        embeddings.MODEL_NAME: "models--" + embeddings.MODEL_NAME.replace("/", "--"),
-    }
+    expected = [embeddings.MODEL_NAME]
     # The reranker and CLIP are sentence-transformers models. On a lane that
     # withholds torch they can never be cached, so listing them as misses is a
     # WARN no action can clear — and `exomem warm`, the remediation, cannot
     # fetch them either.
     if _serves_reranker_and_clip(backend):
-        expected[embeddings.RERANKER_NAME] = "models--" + embeddings.RERANKER_NAME.replace(
-            "/", "--"
-        )
-        # sentence-transformers resolves bare names under its org.
-        expected[embeddings.CLIP_MODEL_NAME] = (
-            "models--sentence-transformers--" + embeddings.CLIP_MODEL_NAME
-        )
+        # `snapshot_dirname` knows that sentence-transformers resolves a bare name
+        # (CLIP) under its own org, so that rule lives in one place.
+        expected.extend([embeddings.RERANKER_NAME, embeddings.CLIP_MODEL_NAME])
 
-    missing = [name for name, dirname in expected.items() if not _model_cached(hub, dirname)]
+    missing = [name for name in expected if not model_cache.is_cached(name, hub)]
     if not missing:
         return _check(
             "models.cache",
@@ -2501,7 +2547,7 @@ def doctor(
         # about an absent framework, not a finding about the configured one.
         if extra == "embeddings":
             checks.extend([_check_torch_cuda(), _check_torch_device()])
-        checks.extend([_check_models_cache(), _check_sqlite_vec()])
+        checks.extend([_check_models_cache(), _check_model_residency(), _check_sqlite_vec()])
         mps_headroom = _check_mps_headroom()
         if mps_headroom is not None:
             checks.append(mps_headroom)

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -1399,7 +1399,7 @@ def _check_embedding_sidecar(vault_root: Path | None) -> DoctorCheck | None:
 
     from . import model_cache
 
-    if not model_cache.is_cached(embeddings.MODEL_NAME):
+    if not _model_cached(_hf_hub_dir(), model_cache.snapshot_dirname(embeddings.MODEL_NAME)):
         # doctor must never trigger a download — skip the live probe rather than
         # let embed_texts() fetch the model over the network.
         return _check(
@@ -1488,7 +1488,7 @@ def _check_model_residency() -> DoctorCheck:
     from . import embeddings, mode, model_cache
 
     resident = embeddings._MODEL is not None
-    cached = model_cache.is_cached(embeddings.MODEL_NAME)
+    cached = _model_cached(_hf_hub_dir(), model_cache.snapshot_dirname(embeddings.MODEL_NAME))
     offline = model_cache.should_load_offline(embeddings.MODEL_NAME)
     preload = mode.preload_models()
     details = {
@@ -1544,11 +1544,15 @@ def _check_models_cache() -> DoctorCheck:
     # WARN no action can clear — and `exomem warm`, the remediation, cannot
     # fetch them either.
     if _serves_reranker_and_clip(backend):
-        # `snapshot_dirname` knows that sentence-transformers resolves a bare name
-        # (CLIP) under its own org, so that rule lives in one place.
         expected.extend([embeddings.RERANKER_NAME, embeddings.CLIP_MODEL_NAME])
 
-    missing = [name for name in expected if not model_cache.is_cached(name, hub)]
+    # `snapshot_dirname` knows that sentence-transformers resolves a bare name
+    # (CLIP) under its own org, so that layout rule lives in one place.
+    missing = [
+        name
+        for name in expected
+        if not _model_cached(hub, model_cache.snapshot_dirname(name))
+    ]
     if not missing:
         return _check(
             "models.cache",

--- a/src/exomem/embedding_backend.py
+++ b/src/exomem/embedding_backend.py
@@ -27,7 +27,7 @@ from typing import Protocol
 
 import numpy as np
 
-from . import accel
+from . import accel, model_cache
 
 log = logging.getLogger(__name__)
 
@@ -126,7 +126,10 @@ class _TorchEncoder:
         # Heavy import stays local — keyword-mode and a lean install must not pay it.
         from sentence_transformers import SentenceTransformer
 
-        model = SentenceTransformer(model_name, device=device)
+        model = model_cache.load_offline_first(
+            model_name,
+            lambda **kw: SentenceTransformer(model_name, device=device, **kw),
+        )
         self._model = _maybe_half(model, device) if half else model
         self.device = device
 
@@ -228,10 +231,13 @@ def _providers(device: str) -> list[str]:
 
 
 def _resolve(model_name: str, filename: str) -> str:
-    """Path to a model file, from the local hub cache when offline."""
+    """Path to a model file, from the local hub cache when the snapshot is resident."""
     from huggingface_hub import hf_hub_download
 
-    return hf_hub_download(model_name, filename)
+    return model_cache.load_offline_first(
+        model_name,
+        lambda **kw: hf_hub_download(model_name, filename, **kw),
+    )
 
 
 def _max_seq_length(model_name: str) -> int:

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -29,7 +29,7 @@ from typing import Any
 
 import numpy as np
 
-from . import accel, embedding_backend, index_paths, recall_policy, vecstore
+from . import accel, embedding_backend, index_paths, model_cache, recall_policy, vecstore
 from .clip_index import CLIP_DIM, ClipIndex
 from .embedding_index import VECTOR_DIM, EmbeddingIndex
 from .vector_index_common import vec_gate as _vec_gate
@@ -245,7 +245,10 @@ def get_reranker():
 
         device = accel.select_device(override_env="EXOMEM_EMBED_DEVICE")
         log.info("loading reranker %s on %s", RERANKER_NAME, device)
-        _RERANKER = CrossEncoder(RERANKER_NAME, device=device)
+        _RERANKER = model_cache.load_offline_first(
+            RERANKER_NAME,
+            lambda **kw: CrossEncoder(RERANKER_NAME, device=device, **kw),
+        )
     RERANKER_GUARD.touch()
     return _RERANKER
 
@@ -301,7 +304,13 @@ def get_clip_model():
 
         device = _clip_device()
         log.info("loading CLIP model %s on %s", CLIP_MODEL_NAME, device)
-        _CLIP_MODEL = _maybe_half(SentenceTransformer(CLIP_MODEL_NAME, device=device), device)
+        _CLIP_MODEL = _maybe_half(
+            model_cache.load_offline_first(
+                CLIP_MODEL_NAME,
+                lambda **kw: SentenceTransformer(CLIP_MODEL_NAME, device=device, **kw),
+            ),
+            device,
+        )
     CLIP_GUARD.touch()
     return _CLIP_MODEL
 

--- a/src/exomem/mode.py
+++ b/src/exomem/mode.py
@@ -13,7 +13,9 @@ Three canonical modes (aliases in `_ALIASES` so whatever a user types works):
                    auto-selects CUDA; bulk index may still use the GPU in a separate
                    process. Models and O(vault) caches stay lazy at boot.
 - **performance** — use my GPU for speed. Steady-state on CUDA when a capable GPU is
-                   present; release when idle. Aliases: `gpu`, `turbo`.
+                   present, and models stay resident: preload is a promise that no
+                   request pays a load, so the idle reaper is not allowed to undo it
+                   (`reap_models_when_idle`). Aliases: `gpu`, `turbo`.
 
 Resolution precedence: `EXOMEM_MODE` env → the per-machine config file
 (`%PROGRAMDATA%/exomem/config.json` on Windows, `~/.exomem/config.json` on POSIX, or
@@ -60,6 +62,7 @@ _MODE_ENV = "EXOMEM_MODE"
 _QUIET_ALIAS_ENV = "EXOMEM_QUIET_MODE"
 _CONFIG_PATH_ENV = "EXOMEM_CONFIG_PATH"
 _RELEASE_ENV = "EXOMEM_RELEASE_GPU_WHEN_IDLE"
+_PRELOAD_ENV = "EXOMEM_PRELOAD_MODELS"
 _WATCHER_MAX_EMBED_FILES_ENV = "EXOMEM_WATCHER_MAX_EMBED_FILES"
 
 
@@ -151,9 +154,18 @@ def resolve_mode() -> str:
     return DEFAULT_MODE
 
 
-def preload_models() -> bool:
-    """Whether policy permits eager model preload (performance only)."""
-    return resolve_mode() == "performance"
+def preload_models(mode_name: str | None = None) -> bool:
+    """Whether policy permits eager model preload (performance, or an explicit opt-in).
+
+    `EXOMEM_PRELOAD_MODELS` (truthy/falsy) overrides the mode default. The override
+    is read HERE rather than only in `warmup` so `resolved()` — and therefore
+    `status.policy` — reports what warm-up will actually do; a process could
+    otherwise preload while reporting `preload_models: false`, or the reverse.
+    """
+    override = os.environ.get(_PRELOAD_ENV)
+    if override is not None and override.strip() != "":
+        return _truthy(override)
+    return (mode_name or resolve_mode()) == "performance"
 
 
 def preload_cpu_caches() -> bool:
@@ -204,6 +216,28 @@ def release_when_idle() -> bool:
     return True
 
 
+def reap_models_when_idle() -> bool:
+    """Whether the idle reaper may unload the MODEL singletons, as opposed to caches.
+
+    Preload and idle-unload are contradictory promises about the same object.
+    Preload says no user request ever pays a model load; the reaper hands exactly
+    that load to whichever request arrives after the idle window closes. That is
+    how a process with `preload_models: true` still reports `module_loaded: false`
+    and still logs cold loads long after boot — the preload ran, and was undone.
+
+    So preload pins the models it loaded. Caches keep reaping either way: they are
+    cheap to rebuild and nothing promised to hold them. An EXPLICIT
+    `EXOMEM_RELEASE_GPU_WHEN_IDLE` stays authoritative in both directions — an
+    operator who asked for the VRAM back gets it, and pays the reload.
+    """
+    if not release_when_idle():
+        return False
+    override = os.environ.get(_RELEASE_ENV)
+    if override is not None and override.strip() != "":
+        return True
+    return not preload_models()
+
+
 def bulk_gpu_opted() -> bool:
     """Whether an in-server bulk index (rebuild_all) may use the GPU.
 
@@ -226,6 +260,7 @@ def resolved() -> dict:
         "defer_expensive_indexes": defer_expensive_indexes(),
         "watcher_policy": watcher_policy().as_dict(),
         "release_when_idle": release_when_idle(),
+        "reap_models_when_idle": reap_models_when_idle(),
         "bulk_gpu": bulk_gpu_opted(),
     }
 

--- a/src/exomem/model_cache.py
+++ b/src/exomem/model_cache.py
@@ -1,0 +1,126 @@
+"""Where model weights live locally, and whether a load may skip the network.
+
+Torch-free and network-free by construction: everything here is a directory
+check or a keyword-argument decision, so `status` and `doctor` can consult it
+without importing a runtime or risking a download.
+
+Why it exists: `sentence-transformers` and `hf_hub_download` revalidate a repo's
+files against the hub on every load, even when the snapshot is already on disk.
+For bge-base that is ~30 HTTP round trips, and because the model loads lazily it
+is paid *inside* whichever user request happens to arrive first — making the
+first write after a restart depend on network reachability for files that never
+left the disk.
+
+The policy is offline-first, never offline-only. When the snapshot is resident we
+ask for it by name alone (`local_files_only=True`); when it is not resident, or
+when that attempt fails for any reason at all, we fall back to the ordinary
+networked load. A first-run user with an empty cache still downloads, a partial
+snapshot still repairs itself, and a runtime that does not accept the keyword
+still loads — the fallback covers all three without needing to tell them apart.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypeVar
+
+log = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+#: Opt out of offline-first loading (``0``/``false``/``no``/``off``). Set this if you
+#: deliberately want every load to revalidate against the hub — a weight-file swap
+#: upstream is then picked up on the next load, at the cost of putting the network
+#: back on the request path.
+OFFLINE_ENV = "EXOMEM_MODEL_OFFLINE"
+
+#: huggingface_hub's own global offline switch. Honoured here so a load stays offline
+#: even with a cold cache: the operator has said the network is not to be used, and a
+#: hopeful fallback would just fail slowly instead of failing fast.
+HF_OFFLINE_ENV = "HF_HUB_OFFLINE"
+
+#: sentence-transformers resolves an unqualified model name under its own org, and the
+#: hub cache records the *resolved* id. `clip-ViT-B-32` therefore lands in
+#: `models--sentence-transformers--clip-ViT-B-32`.
+_IMPLICIT_ORG = "sentence-transformers"
+
+
+def _truthy(value: str | None) -> bool:
+    """Shared truthiness convention (mirrors `mode._truthy`)."""
+    return bool(value) and value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def hub_dir() -> Path:
+    """The local HuggingFace hub cache directory (honors HF_HUB_CACHE / HF_HOME).
+
+    Directory resolution only — never touches the network.
+    """
+    if os.environ.get("HF_HUB_CACHE"):
+        return Path(os.environ["HF_HUB_CACHE"])
+    if os.environ.get("HF_HOME"):
+        return Path(os.environ["HF_HOME"]) / "hub"
+    return Path.home() / ".cache" / "huggingface" / "hub"
+
+
+def snapshot_dirname(model_name: str) -> str:
+    """The hub-cache directory name a model's snapshots live under."""
+    qualified = model_name if "/" in model_name else f"{_IMPLICIT_ORG}/{model_name}"
+    return "models--" + qualified.replace("/", "--")
+
+
+def snapshot_populated(hub: Path, dirname: str) -> bool:
+    """True if `dirname`'s snapshot dir exists under `hub` and is non-empty.
+
+    A pure directory check, so a caller can gate model-loading work on it WITHOUT
+    risking a download — which is what lets `doctor` report residency while keeping
+    its "never fetches anything" guarantee.
+    """
+    snapshots = hub / dirname / "snapshots"
+    try:
+        return snapshots.is_dir() and any(snapshots.iterdir())
+    except OSError:
+        return False
+
+
+def is_cached(model_name: str, hub: Path | None = None) -> bool:
+    """True if `model_name`'s weights are already resident in the local hub cache."""
+    return snapshot_populated(hub or hub_dir(), snapshot_dirname(model_name))
+
+
+def offline_enabled() -> bool:
+    """Whether offline-first loading is switched on at all. Default: yes."""
+    override = os.environ.get(OFFLINE_ENV)
+    if override is not None and override.strip() != "":
+        return _truthy(override)
+    return True
+
+
+def should_load_offline(model_name: str) -> bool:
+    """Whether the next load of `model_name` may skip the hub entirely."""
+    if _truthy(os.environ.get(HF_OFFLINE_ENV)):
+        return True
+    return offline_enabled() and is_cached(model_name)
+
+
+def load_offline_first(model_name: str, loader: Callable[..., T]) -> T:
+    """Load `model_name` from the local cache when it is resident, else normally.
+
+    `loader` is called with ``local_files_only=True`` for the offline attempt and
+    with no arguments at all for the networked one — so a runtime that has never
+    heard of the keyword raises `TypeError` on the first call and is served
+    correctly by the second, with no version probing.
+    """
+    if not should_load_offline(model_name):
+        return loader()
+    try:
+        return loader(local_files_only=True)
+    except Exception as e:  # noqa: BLE001 — any offline failure is a reason to go online
+        log.info(
+            "local-only load of %s failed (%s); retrying with hub access",
+            model_name,
+            e,
+        )
+        return loader()

--- a/src/exomem/model_cache.py
+++ b/src/exomem/model_cache.py
@@ -118,9 +118,8 @@ def load_offline_first(model_name: str, loader: Callable[..., T]) -> T:
     try:
         return loader(local_files_only=True)
     except Exception as e:  # noqa: BLE001 — any offline failure is a reason to go online
-        log.info(
-            "local-only load of %s failed (%s); retrying with hub access",
-            model_name,
-            e,
-        )
+        # Routine during a first-ever population: the snapshot dir exists as soon as
+        # the FIRST file lands, so later files in the same repo see a "cached" model
+        # and miss locally. Cheap (no network) and self-correcting, hence info.
+        log.info("%s not fully resolvable offline (%s); using hub access", model_name, e)
         return loader()

--- a/src/exomem/model_reaper.py
+++ b/src/exomem/model_reaper.py
@@ -42,6 +42,10 @@ class ResourceSlot:
     inflight: Callable[[], int]
     last_activity: Callable[[], float]
     unload: Callable[[], bool]
+    #: True for a model singleton, which policy may pin (see `mode.reap_models_when_idle`).
+    #: Caches are always reclaimable: they rebuild locally and cheaply, whereas a reaped
+    #: model is reloaded from the hub cache on whichever request arrives next.
+    is_model: bool = False
 
 
 def idle_seconds() -> float:
@@ -59,9 +63,22 @@ def idle_seconds() -> float:
 ModelSlot = ResourceSlot
 
 
+def _model_reaping_allowed() -> bool:
+    """Whether policy lets this tick unload model singletons.
+
+    Read per tick rather than captured at `start()`, so a live mode switch takes
+    effect on the next tick without restarting the thread.
+    """
+    from . import mode
+
+    return mode.reap_models_when_idle()
+
+
 def _should_unload(slot: ResourceSlot, now: float, threshold: float) -> bool:
-    """Pure decision: unload iff not warming, loaded, not in-flight, idle-window elapsed."""
+    """Pure decision: unload iff policy allows it and the slot is loaded, quiet, and stale."""
     if readiness.is_warming():
+        return False
+    if slot.is_model and not _model_reaping_allowed():
         return False
     if not slot.is_loaded():
         return False
@@ -97,21 +114,24 @@ def _quiet_cache_slot(
 
 
 def default_slots() -> list[ResourceSlot]:
-    """Default reclaimable resources: models always, CPU caches only in quiet mode."""
+    """Default reclaimable resources: models when policy allows, CPU caches in quiet mode."""
     from . import bm25, embeddings as e, find
 
     return [
         ResourceSlot(
             "embeddings", lambda: e._MODEL is not None,
             e.BGE_GUARD.inflight, e.BGE_GUARD.last_activity, e.unload_model,
+            is_model=True,
         ),
         ResourceSlot(
             "reranker", lambda: e._RERANKER is not None,
             e.RERANKER_GUARD.inflight, e.RERANKER_GUARD.last_activity, e.unload_reranker,
+            is_model=True,
         ),
         ResourceSlot(
             "clip", lambda: e._CLIP_MODEL is not None,
             e.CLIP_GUARD.inflight, e.CLIP_GUARD.last_activity, e.unload_clip_model,
+            is_model=True,
         ),
         _quiet_cache_slot(
             "index-matrices",

--- a/src/exomem/resource_status.py
+++ b/src/exomem/resource_status.py
@@ -28,6 +28,17 @@ def _mode_source() -> str:
 
 
 def _model_residency() -> dict[str, Any]:
+    """Which model singletons are resident, next to what policy promised.
+
+    `module_loaded` answers "is `exomem.embeddings` imported", which is not the
+    same question as "is a model in memory" — reading it as the latter is what made
+    a preloading process look broken. The policy fields sit alongside so the gap
+    between promise and residency is visible here instead of in the log.
+    """
+    policy = {
+        "preload_policy": mode.preload_models(),
+        "reap_when_idle": mode.reap_models_when_idle(),
+    }
     embeddings = sys.modules.get("exomem.embeddings")
     if embeddings is None:
         return {
@@ -35,12 +46,14 @@ def _model_residency() -> dict[str, Any]:
             "embeddings": False,
             "reranker": False,
             "clip": False,
+            **policy,
         }
     return {
         "module_loaded": True,
         "embeddings": getattr(embeddings, "_MODEL", None) is not None,
         "reranker": getattr(embeddings, "_RERANKER", None) is not None,
         "clip": getattr(embeddings, "_CLIP_MODEL", None) is not None,
+        **policy,
     }
 
 

--- a/src/exomem/warmup.py
+++ b/src/exomem/warmup.py
@@ -49,11 +49,14 @@ def model_preload_allowed(mode_name: str | None = None) -> bool:
     Normal and quiet modes default to lazy model loads on every OS. Multiple local
     clients naturally mean multiple Python processes, and eager BGE/CLIP preloads
     multiply memory residency. `EXOMEM_PRELOAD_MODELS=1` explicitly opts in.
+
+    The decision itself lives in `mode.preload_models` so that `mode.resolved()` —
+    and therefore `status.policy` and `doctor` — report the same answer warm-up
+    acts on, rather than the mode default with the override invisibly applied here.
     """
-    override = os.environ.get("EXOMEM_PRELOAD_MODELS")
-    if override is not None and override.strip() != "":
-        return override.strip().lower() not in {"0", "false", "no", "off"}
-    return (mode_name or "normal") == "performance"
+    from . import mode
+
+    return mode.preload_models(mode_name or "normal")
 
 
 def warm_caches(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,17 @@ def _disable_embeddings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
     # and any ambient EXOMEM_MODE/EXOMEM_DEVICE — the suite must resolve to the
     # `normal` default deterministically (device selection now consults mode.py).
     monkeypatch.setenv("EXOMEM_CONFIG_PATH", str(tmp_path / "no-such-exomem-config.json"))
-    for _var in ("EXOMEM_MODE", "EXOMEM_QUIET_MODE", "EXOMEM_DEVICE", "EXOMEM_GPU_MIN_FREE_GB"):
+    for _var in (
+        "EXOMEM_MODE",
+        "EXOMEM_QUIET_MODE",
+        "EXOMEM_DEVICE",
+        "EXOMEM_GPU_MIN_FREE_GB",
+        # Model residency policy derives from these; an ambient value would otherwise
+        # move `mode.resolved()`, `status.models`, and the reaper's decision.
+        "EXOMEM_PRELOAD_MODELS",
+        "EXOMEM_RELEASE_GPU_WHEN_IDLE",
+        "EXOMEM_MODEL_OFFLINE",
+    ):
         monkeypatch.delenv(_var, raising=False)
     monkeypatch.setenv("EXOMEM_DISABLE_RELEVANCE_CHECK", "1")
     # Never spawn the background warm thread from build_server in tests — it

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -279,6 +279,7 @@ def test_resolved_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
             "defer_expensive_indexes": True,
         },
         "release_when_idle": True,
+        "reap_models_when_idle": True,
         "bulk_gpu": False,
     }
 

--- a/tests/test_model_preload_offline.py
+++ b/tests/test_model_preload_offline.py
@@ -1,0 +1,339 @@
+"""The two terms behind a ~35s first-write-after-restart: cold loads, and networked loads.
+
+Both are pinned on seams, never on wall-clock. The offline group asserts on the
+kwargs the loader is CALLED with (so "did it reach the network" is decidable
+without a network), and the preload group asserts on the reaper's pure decision
+function (so "would this model be dropped" is decidable without a clock).
+
+Torch-free: `sentence_transformers` / `huggingface_hub` are injected as fakes, and
+the models are plain sentinels.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from exomem import accel, embedding_backend, embeddings, mode, model_cache, model_reaper, warmup
+
+
+# --------------------------------------------------------------------- fixtures
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutral policy: no inherited mode, preload, release, or HF offline setting."""
+    for var in (
+        "EXOMEM_MODE",
+        "EXOMEM_QUIET_MODE",
+        "EXOMEM_PRELOAD_MODELS",
+        "EXOMEM_RELEASE_GPU_WHEN_IDLE",
+        "EXOMEM_MODEL_OFFLINE",
+        "HF_HUB_OFFLINE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("EXOMEM_CONFIG_PATH", str(Path(__file__).parent / "_no_such_config.json"))
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons() -> None:
+    embeddings._MODEL = embeddings._RERANKER = embeddings._CLIP_MODEL = None
+    yield
+    embeddings._MODEL = embeddings._RERANKER = embeddings._CLIP_MODEL = None
+
+
+@pytest.fixture
+def hub(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """An empty local HF hub cache; `_cache` populates a model into it."""
+    cache = tmp_path / "hub"
+    cache.mkdir()
+    monkeypatch.setenv("HF_HUB_CACHE", str(cache))
+    return cache
+
+
+def _cache(hub: Path, model_name: str) -> None:
+    """Materialize a plausible snapshot for `model_name` in the fake hub cache."""
+    snap = hub / model_cache.snapshot_dirname(model_name) / "snapshots" / "deadbeef"
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}", encoding="utf-8")
+
+
+class _Spy:
+    """Records the kwargs of each load attempt; optionally fails the offline one."""
+
+    def __init__(self, *, fail_offline: bool = False) -> None:
+        self.calls: list[dict] = []
+        self.fail_offline = fail_offline
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append(dict(kwargs))
+        if self.fail_offline and kwargs.get("local_files_only"):
+            raise OSError("snapshot incomplete")
+        return "MODEL"
+
+    @property
+    def offline_flags(self) -> list[bool]:
+        return [bool(c.get("local_files_only")) for c in self.calls]
+
+
+def _fake_sentence_transformers(spy: _Spy) -> types.ModuleType:
+    mod = types.ModuleType("sentence_transformers")
+    mod.SentenceTransformer = spy
+    mod.CrossEncoder = spy
+    return mod
+
+
+# ---------------------------------------------- offline-first weight resolution
+
+
+def test_snapshot_dirname_matches_the_hub_layout() -> None:
+    assert model_cache.snapshot_dirname("BAAI/bge-base-en-v1.5") == "models--BAAI--bge-base-en-v1.5"
+    # sentence-transformers resolves a bare name under its own org.
+    assert (
+        model_cache.snapshot_dirname("clip-ViT-B-32")
+        == "models--sentence-transformers--clip-ViT-B-32"
+    )
+
+
+def test_is_cached_is_a_pure_directory_check(hub: Path) -> None:
+    assert model_cache.is_cached("BAAI/bge-base-en-v1.5") is False
+    _cache(hub, "BAAI/bge-base-en-v1.5")
+    assert model_cache.is_cached("BAAI/bge-base-en-v1.5") is True
+
+
+def test_cached_weights_load_without_touching_the_network(hub: Path) -> None:
+    _cache(hub, "BAAI/bge-base-en-v1.5")
+    spy = _Spy()
+
+    assert model_cache.load_offline_first("BAAI/bge-base-en-v1.5", spy) == "MODEL"
+
+    assert spy.offline_flags == [True], "a cache-resident model must not revalidate over HTTP"
+
+
+def test_missing_weights_still_download(hub: Path) -> None:
+    spy = _Spy()
+
+    assert model_cache.load_offline_first("BAAI/bge-base-en-v1.5", spy) == "MODEL"
+
+    # Nothing in the cache: go straight to the ordinary networked load. A
+    # first-run user with an empty cache must still be able to fetch weights.
+    assert spy.offline_flags == [False]
+    assert spy.calls == [{}]
+
+
+def test_a_broken_snapshot_falls_back_to_the_network(hub: Path) -> None:
+    _cache(hub, "BAAI/bge-base-en-v1.5")
+    spy = _Spy(fail_offline=True)
+
+    assert model_cache.load_offline_first("BAAI/bge-base-en-v1.5", spy) == "MODEL"
+
+    # Directory present but unusable (partial snapshot, or a runtime that does
+    # not accept the kwarg at all) -> retry with network access, kwarg omitted.
+    assert spy.offline_flags == [True, False]
+    assert spy.calls[1] == {}
+
+
+def test_offline_load_can_be_switched_off(hub: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _cache(hub, "BAAI/bge-base-en-v1.5")
+    monkeypatch.setenv("EXOMEM_MODEL_OFFLINE", "0")
+    spy = _Spy()
+
+    model_cache.load_offline_first("BAAI/bge-base-en-v1.5", spy)
+
+    assert spy.offline_flags == [False]
+
+
+def test_hf_hub_offline_forces_offline_even_with_a_cold_cache(
+    hub: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    spy = _Spy()
+
+    model_cache.load_offline_first("BAAI/bge-base-en-v1.5", spy)
+
+    assert spy.offline_flags[0] is True
+
+
+def test_torch_encoder_loads_cached_weights_offline(
+    hub: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _cache(hub, embeddings.MODEL_NAME)
+    spy = _Spy()
+    monkeypatch.setitem(sys.modules, "sentence_transformers", _fake_sentence_transformers(spy))
+    monkeypatch.setattr(accel, "select_device", lambda **_: "cpu")
+
+    embedding_backend.load_encoder(embeddings.MODEL_NAME, backend=embedding_backend.TORCH)
+
+    assert spy.offline_flags == [True], "the write path must not HEAD the hub for cached weights"
+
+
+def test_onnx_file_resolution_prefers_the_local_snapshot(
+    hub: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _cache(hub, embeddings.MODEL_NAME)
+    spy = _Spy()
+    fake = types.ModuleType("huggingface_hub")
+    fake.hf_hub_download = spy
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake)
+
+    embedding_backend._resolve(embeddings.MODEL_NAME, "onnx/model.onnx")
+
+    assert spy.offline_flags == [True]
+
+
+def test_reranker_loads_cached_weights_offline(
+    hub: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _cache(hub, embeddings.RERANKER_NAME)
+    spy = _Spy()
+    monkeypatch.setitem(sys.modules, "sentence_transformers", _fake_sentence_transformers(spy))
+    monkeypatch.setattr(accel, "select_device", lambda **_: "cpu")
+
+    embeddings.get_reranker()
+
+    assert spy.offline_flags == [True]
+
+
+def test_clip_loads_cached_weights_offline(hub: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _cache(hub, embeddings.CLIP_MODEL_NAME)
+    spy = _Spy()
+    monkeypatch.setitem(sys.modules, "sentence_transformers", _fake_sentence_transformers(spy))
+    monkeypatch.setattr(accel, "select_device", lambda **_: "cpu")
+
+    embeddings.get_clip_model()
+
+    assert spy.offline_flags == [True]
+
+
+# ------------------------------------------------- preload vs the idle reaper
+
+
+def test_preload_policy_reports_the_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`resolved()` must report what warm-up will actually do, override included."""
+    assert mode.preload_models() is False
+    assert mode.resolved()["preload_models"] is False
+
+    monkeypatch.setenv("EXOMEM_PRELOAD_MODELS", "1")
+
+    assert mode.preload_models() is True
+    assert mode.resolved()["preload_models"] is True
+    assert warmup.model_preload_allowed(mode.resolve_mode()) is True
+
+
+def test_preload_pins_the_models_it_loaded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reaping a preloaded model hands the reload to the next request — the bug."""
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+
+    assert mode.preload_models() is True
+    assert mode.reap_models_when_idle() is False
+    assert mode.resolved()["reap_models_when_idle"] is False
+
+
+def test_lazy_modes_still_reap_idle_models(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+
+    assert mode.preload_models() is False
+    assert mode.reap_models_when_idle() is True
+
+
+def test_explicit_release_opt_in_beats_preload(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An operator who asked for the VRAM back gets it, and pays the reload."""
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+    monkeypatch.setenv("EXOMEM_RELEASE_GPU_WHEN_IDLE", "1")
+
+    assert mode.reap_models_when_idle() is True
+
+
+def test_release_off_disables_model_reaping(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_RELEASE_GPU_WHEN_IDLE", "0")
+
+    assert mode.reap_models_when_idle() is False
+
+
+def _slot(name: str, *, is_model: bool) -> model_reaper.ResourceSlot:
+    state = {"loaded": True}
+    return model_reaper.ResourceSlot(
+        name,
+        lambda: state["loaded"],
+        lambda: 0,
+        lambda: 0.0,
+        lambda: state.update(loaded=False) or True,
+        is_model=is_model,
+    )
+
+
+def test_reaper_skips_model_slots_under_preload(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+    model = _slot("embeddings", is_model=True)
+    cache = _slot("bm25-cache", is_model=False)
+
+    assert model_reaper._should_unload(model, now=1e6, threshold=1.0) is False
+    # Caches are cheap to rebuild and were never promised to be preloaded.
+    assert model_reaper._should_unload(cache, now=1e6, threshold=1.0) is True
+
+
+def test_reaper_unloads_model_slots_without_preload() -> None:
+    model = _slot("embeddings", is_model=True)
+
+    assert model_reaper._should_unload(model, now=1e6, threshold=1.0) is True
+
+
+def test_default_slots_label_the_model_singletons() -> None:
+    by_name = {s.name: s for s in model_reaper.default_slots()}
+
+    assert [n for n, s in by_name.items() if s.is_model] == ["embeddings", "reranker", "clip"]
+
+
+def test_preloaded_model_survives_a_reap_tick(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End to end over the real slots: preload on, and bge is still resident."""
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+    monkeypatch.setattr(accel, "empty_cache", lambda: None)
+    embeddings._MODEL = object()
+
+    reaped = model_reaper._reap_once(model_reaper.default_slots(), now=1e6, threshold=1.0)
+
+    assert "embeddings" not in reaped
+    assert embeddings._MODEL is not None
+
+
+# ------------------------------------------------------------------- reporting
+
+
+def test_status_models_exposes_the_preload_gap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`status` must show the policy next to residency, so the gap needs no log."""
+    from exomem import resource_status
+
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+
+    models = resource_status.collect()["models"]
+
+    assert models["preload_policy"] is True
+    assert models["reap_when_idle"] is False
+
+
+def test_doctor_reports_model_residency(monkeypatch: pytest.MonkeyPatch, hub: Path) -> None:
+    from exomem import doctor
+
+    _cache(hub, embeddings.MODEL_NAME)
+    check = doctor._check_model_residency()
+
+    assert check.id == "models.residency"
+    assert check.details["cache_dir"] == str(hub)
+    assert check.details["bi_encoder_cached"] is True
+    assert check.details["offline_load"] is True
+    assert check.details["loaded"] is False
+    assert check.details["preload_policy"] is False
+    assert "not loaded" in check.message
+
+
+def test_doctor_flags_an_uncached_model_as_an_inline_download(hub: Path) -> None:
+    from exomem import doctor
+
+    check = doctor._check_model_residency()
+
+    assert check.details["bi_encoder_cached"] is False
+    assert check.details["offline_load"] is False
+    assert "downloads it inline" in check.message

--- a/tests/test_resource_status.py
+++ b/tests/test_resource_status.py
@@ -45,6 +45,10 @@ def test_collect_does_not_import_torch_or_probe_cuda(monkeypatch, tmp_path: Path
         "embeddings": False,
         "reranker": False,
         "clip": False,
+        # Policy sits beside residency so the promise/reality gap is readable here
+        # rather than in the log. Both are pure env/config reads — no import.
+        "preload_policy": False,
+        "reap_when_idle": True,
     }
     assert status["media"]["worker_active"] is False
     assert not (tmp_path / "Knowledge Base" / ".media-jobs.sqlite").exists()


### PR DESCRIPTION
Closes #583

The first write after a service restart paid ~35 s that later writes did not (`preflight_ms` 37,797 cold vs ~2,900 warm on the same corpus). Two independent terms, both addressed here. This does not touch the unbounded graph join (#576) or the advisory pass (#582).

## 1. A cache-resident model still round-tripped to the network

`sentence-transformers` and `hf_hub_download` revalidate every file of a repo against the hub on load, even when the snapshot is already on disk — ~30 HEAD requests for bge-base, paid *inside* whichever user request triggered the lazy load. New `src/exomem/model_cache.py` makes the load offline-first:

- snapshot resident in the local hub cache → `local_files_only=True`, no HTTP at all;
- snapshot absent → straight to the ordinary networked load, no offline attempt;
- offline attempt fails for any reason (partial snapshot, or a runtime that never heard of the keyword) → retry with hub access, keyword omitted.

So a first-run user with an empty cache still downloads, and a half-written snapshot still repairs itself — the missing-weights path is preserved structurally rather than by a probe. Applied to bge, the reranker, CLIP, and the ONNX lane's `hf_hub_download`. `EXOMEM_MODEL_OFFLINE=0` opts out; `HF_HUB_OFFLINE=1` is honoured.

## 2. Why three cold loads happened in one process lifetime

The preload was not broken — it was *undone*. `mode.release_when_idle()` defaults to true in **every** mode, including `performance`, so `model_reaper` unloaded the preloaded bge singleton after 15 minutes idle, and the next request lazily reloaded it on the request thread. Repeat per idle window. That is also why `status` showed `models.module_loaded: false` under `preload_models: true`.

Preload and idle-unload are contradictory promises about the same object. Preload is the stronger, user-visible one, so it now wins: `ResourceSlot` gains `is_model`, and `mode.reap_models_when_idle()` returns false when preload policy is on. Caches keep reaping — they rebuild locally and cheaply. An **explicit** `EXOMEM_RELEASE_GPU_WHEN_IDLE` stays authoritative in both directions, so an operator who wants the VRAM back still gets it (and pays the reload).

## 3. Reporting

- `mode.preload_models()` now reads `EXOMEM_PRELOAD_MODELS`, which only `warmup` honoured before — so `resolved()` / `status.policy` could report the opposite of what warm-up actually did.
- `resolved()` gains `reap_models_when_idle`.
- `status.models` gains `preload_policy` and `reap_when_idle` beside the residency flags. (`module_loaded` answers "is `exomem.embeddings` imported", which is not the question it reads as; the policy fields make the gap legible.)
- New `models.residency` doctor check: loaded state, cache dir, whether the bi-encoder is cached, whether the next load is offline, and both policy flags. Previously the only way to know a write was about to pay 35 s was to read the log after it had.
- `doctor._hf_hub_dir` / `_model_cached` now delegate to `model_cache`, and the "sentence-transformers resolves a bare name under its own org" rule (CLIP) lives in one place instead of two.

## Verification

Assertions are on seams — the kwargs a loader is called with, and the reaper's pure decision function — never on wall-clock.

Red before the fix (23 tests, `tests/test_model_preload_offline.py`), including:

```
>       assert "embeddings" not in reaped
E       AssertionError: assert 'embeddings' not in ['embeddings']
>       assert mode.preload_models() is True
E       assert False is True
>       assert [n for n, s in by_name.items() if s.is_model] == ["embeddings", "reranker", "clip"]
E       AttributeError: 'ResourceSlot' object has no attribute 'is_model'
```

Green after, together with the existing mode / reaper / status / warm-up / backend suites.

## Not fixed here

`mode.apply_live()` drops the model singletons on a live mode switch and does not re-warm them, so a switch *into* a preloading mode still hands the next request a cold load. That path is operator-initiated and rare, unlike a restart; called out rather than papered over.