### PR TITLE
fix(ops): fail the upgrade when the installed version does not change

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -327,10 +327,16 @@ pwsh -File scripts/upgrade.ps1
 # Explicit policy: -CliSync auto|always|never (default: auto)
 ```
 
+Requires PowerShell 7+; Windows PowerShell 5.1 is refused up front rather than
+allowed to fail obscurely partway.
+
 The service runs a PyPI-backed venv that is **not** the repo checkout, so `git pull`
-never touches it. `upgrade.ps1` locates that venv from the NSSM registry, upgrades
-it, repairs the CUDA torch build, gates on `doctor`, restarts, and then asserts the
-**live** `/health` version matches what it just installed. It then records a
+never touches it. `upgrade.ps1` locates that venv from the NSSM registry, prints the
+`target:` version it resolved before touching anything, upgrades it, **fails if the
+venv did not actually end up on that target** (a `uv` that exits 0 having applied
+nothing is the failure this catches — #578), repairs the CUDA torch build, gates on
+`doctor`, restarts, and then asserts the **live** `/health` version matches what it
+just installed. It then records a
 non-secret managed-install manifest and, in the default `auto` mode, aligns an
 existing uv-managed `exomem`/`kb` command to that exact verified release. `auto`
 never installs a command that was absent; `always` may install it; `never` leaves

--- a/scripts/_service-common.ps1
+++ b/scripts/_service-common.ps1
@@ -156,6 +156,69 @@ function Get-ExomemServiceEndpoint {
     return $result
 }
 
+function Assert-ExomemPowerShell7 {
+    <#
+    .SYNOPSIS
+      Refuse to run under Windows PowerShell 5.1, which cannot execute these scripts.
+    .DESCRIPTION
+      Not a style preference: the deploy path calls
+      `Invoke-WebRequest -SkipHttpErrorCheck`, which is PowerShell 7.0+ only. Under
+      5.1 the run used to die partway with a NativeCommandError on an ordinary `uv`
+      banner -- a message that named neither the shell nor the real requirement.
+    #>
+    param([string]$ScriptName)
+
+    if ($PSVersionTable.PSVersion.Major -ge 7) { return }
+    throw "$ScriptName requires PowerShell 7+ (pwsh); this is Windows PowerShell $($PSVersionTable.PSVersion). Re-run with: pwsh -File scripts/$ScriptName"
+}
+
+function Invoke-ExomemNative {
+    <#
+    .SYNOPSIS
+      Run a native command, return its exit code and captured output, and never let
+      its stderr masquerade as a failure.
+    .DESCRIPTION
+      `uv` writes its ENTIRE plan to stderr by design -- the "Using Python 3.13.11
+      environment at: ..." banner, "Resolved N packages", and the "+ exomem==X"
+      lines all arrive there and nothing arrives on stdout. So the streams have to
+      be merged with 2>&1 for the output to be logged at all.
+
+      The hazard is what that merge does under `$ErrorActionPreference = "Stop"`,
+      which every calling script sets: Windows PowerShell 5.1 raises a terminating
+      NativeCommandError on the FIRST merged stderr record, even when the command
+      exits 0. That turned an informational banner into an aborted deploy (#578).
+
+      Both preference assignments below are function-scoped -- PowerShell shadows
+      the caller's value for this frame only and restores it on return -- so the
+      calling script keeps "Stop" semantics everywhere else. $ErrorActionPreference
+      keeps a stderr line from being fatal; $PSNativeCommandUseErrorActionPreference
+      (7.3+; a harmless unused variable on 5.1) keeps a NONZERO EXIT from throwing
+      before the code can be returned, which is what leaves "uv failed" reportable
+      as something other than "uv did nothing".
+    #>
+    param(
+        [string[]]$CommandArgs,
+        [switch]$Quiet
+    )
+
+    $ErrorActionPreference = "Continue"
+    $PSNativeCommandUseErrorActionPreference = $false
+
+    # Without this, a missing executable leaves $LASTEXITCODE at whatever the
+    # previous command set -- readable as success.
+    if (-not (Get-Command $CommandArgs[0] -ErrorAction SilentlyContinue)) {
+        throw "Required command '$($CommandArgs[0])' was not found on PATH."
+    }
+
+    $merged = & $CommandArgs[0] @($CommandArgs[1..($CommandArgs.Count - 1)]) 2>&1
+    $code = $LASTEXITCODE
+    $lines = @(foreach ($item in $merged) {
+        if ($item -is [System.Management.Automation.ErrorRecord]) { $item.ToString() } else { [string]$item }
+    })
+    if (-not $Quiet) { foreach ($line in $lines) { Write-Host $line } }
+    return @{ ExitCode = $code; Lines = $lines }
+}
+
 function Invoke-LoggedNative {
     <#
     .SYNOPSIS
@@ -163,9 +226,7 @@ function Invoke-LoggedNative {
     #>
     param([string[]]$CommandArgs)
 
-    $out = & $CommandArgs[0] @($CommandArgs[1..($CommandArgs.Count - 1)]) 2>&1
-    foreach ($line in $out) { Write-Host $line }
-    return $LASTEXITCODE
+    return (Invoke-ExomemNative -CommandArgs $CommandArgs).ExitCode
 }
 
 function Get-ExomemPackageSpec {
@@ -188,10 +249,98 @@ function Get-ExomemPackageSpec {
     return "exomem$extras$pin"
 }
 
+function Get-ExomemInstallPlanVersion {
+    <#
+    .SYNOPSIS
+      Pull the exomem version out of a `uv pip install` plan, or $null.
+    .DESCRIPTION
+      uv prints its plan as " + exomem==0.52.3" / " - exomem==0.52.2" (extras are
+      normalised away, so the name is bare). It prints NO "+ exomem" line when it
+      would install nothing -- "Would make no changes" / "Audited N packages" --
+      which the caller reads as "the resolved target is what is already there".
+    #>
+    param([string[]]$Lines)
+
+    foreach ($line in $Lines) {
+        if ($line -match '^\s*\+\s*exomem==(\S+)\s*$') { return $Matches[1] }
+    }
+    return $null
+}
+
+function Resolve-ExomemTargetVersion {
+    <#
+    .SYNOPSIS
+      Return the concrete version an install of $PackageSpec would land, or $null.
+    .DESCRIPTION
+      `--dry-run` resolves without writing, so the operator can be told which
+      version the run is about to land BEFORE it lands, and the post-install
+      assertion has something concrete to compare against even when no
+      -PackageVersion was pinned.
+
+      `--refresh-package exomem` is load-bearing, not belt-and-braces: uv serves the
+      package index out of its HTTP cache, so an unpinned `--upgrade` can resolve to
+      a release that is no longer the latest and exit 0 having done nothing. A
+      deploy script must not inherit that, and a target read through a stale cache
+      would agree with the stale install and vouch for it.
+    #>
+    param(
+        [string]$Python,
+        [string]$PackageSpec,
+        [string]$Installed = ""
+    )
+
+    $result = Invoke-ExomemNative -Quiet -CommandArgs @(
+        "uv", "pip", "install", "--dry-run", "--upgrade",
+        "--refresh-package", "exomem", "--python", $Python, $PackageSpec
+    )
+    if ($result.ExitCode -ne 0) {
+        Write-Warning "Could not resolve the target version for $PackageSpec (uv --dry-run exited $($result.ExitCode)):"
+        foreach ($line in $result.Lines) { Write-Host "  uv: $line" }
+        return $null
+    }
+    $planned = Get-ExomemInstallPlanVersion -Lines $result.Lines
+    if ($planned) { return $planned }
+    # uv planned no change to exomem, so the resolved target is the installed one.
+    if ($Installed) { return $Installed }
+    return $null
+}
+
+function Assert-ExomemInstallApplied {
+    <#
+    .SYNOPSIS
+      Fail when an install reported success without changing what is installed.
+    .DESCRIPTION
+      #578: `uv` exited 0 having installed nothing, the script printed
+      "Installed version: 0.52.2 -> 0.52.2" as a REPORT, and the deploy continued.
+      The service restarted cleanly on the old build and every later observation
+      was attributed to a release that was never deployed. before/after were
+      already known; this turns the report into a gate.
+    #>
+    param(
+        [string]$PackageSpec,
+        [string]$Before = "",
+        [string]$After = "",
+        [string]$Target = ""
+    )
+
+    $was = if ($Before) { $Before } else { "not installed" }
+    if (-not $After) {
+        throw "Install of '$PackageSpec' reported success but no exomem version is importable from that interpreter (was: $was). Nothing was deployed."
+    }
+    if (-not $Target) {
+        Write-Warning "Target version unresolved, so this run can only assert that SOMETHING is installed ($After). Re-run with -PackageVersion <version> for a checked upgrade."
+        return
+    }
+    if ($After -ne $Target) {
+        throw "Install did not take: '$PackageSpec' resolved to $Target, but the interpreter still reports $After (was: $was). uv exited 0 without applying the change; re-run with -PackageVersion $Target, and check that uv is not resolving from a stale index cache."
+    }
+}
+
 function Install-ExomemPackage {
     <#
     .SYNOPSIS
-      Install/upgrade exomem into an existing interpreter. Throws on failure.
+      Install/upgrade exomem into an existing interpreter. Throws on failure, and
+      on a "success" that left the interpreter on the version it started on.
     #>
     param(
         [string]$Python,
@@ -200,9 +349,18 @@ function Install-ExomemPackage {
     )
 
     $pkg = Get-ExomemPackageSpec -Profile $Profile -PackageVersion $PackageVersion
+    $before = Get-ExomemInstalledVersion -PythonPath $Python
+    $target = Resolve-ExomemTargetVersion -Python $Python -PackageSpec $pkg -Installed $before
+    # A pin stays assertable even when the resolve could not run at all.
+    if (-not $target -and $PackageVersion) { $target = $PackageVersion }
+    Write-Host "  target:    $(if ($target) { $target } else { 'unresolved' })"
+
     Write-Host "Installing $pkg into $Python..."
-    $code = Invoke-LoggedNative @("uv", "pip", "install", "--upgrade", "--python", $Python, $pkg)
-    if ($code -ne 0) { throw "uv pip install failed for $pkg" }
+    $code = Invoke-LoggedNative @("uv", "pip", "install", "--upgrade", "--refresh-package", "exomem", "--python", $Python, $pkg)
+    if ($code -ne 0) { throw "uv pip install failed for $pkg (uv exit $code)" }
+
+    $after = Get-ExomemInstalledVersion -PythonPath $Python
+    Assert-ExomemInstallApplied -PackageSpec $pkg -Before $before -After $after -Target $target
 }
 
 function Repair-TorchCuda {

--- a/scripts/_service-common.sh
+++ b/scripts/_service-common.sh
@@ -55,6 +55,57 @@ exomem_installed_version() {
     "$python" -c "import importlib.metadata as m; print(m.version('exomem'))" 2>/dev/null
 }
 
+# Pull the exomem version out of a `uv pip install` plan read on stdin, or print
+# nothing. uv prints its plan as " + exomem==0.52.3" (extras normalised away), and
+# prints NO "+ exomem" line when it would install nothing.
+exomem_install_plan_version() {
+    sed -n 's|^[[:space:]]*+[[:space:]]*exomem==\([^[:space:]]*\)[[:space:]]*$|\1|p' | head -n1
+}
+
+# Print the concrete version an install of $2 would land in the interpreter $1, or
+# return nonzero when it cannot be resolved. $3 is the currently-installed version.
+#
+# `--dry-run` resolves without writing, so the target can be shown to the operator
+# BEFORE the install lands and the post-install assertion has something concrete to
+# compare against when no --package-version was pinned. `--refresh-package exomem`
+# is load-bearing: uv serves the package index out of its HTTP cache, so an unpinned
+# `--upgrade` can resolve to a release that is no longer latest and exit 0 having
+# done nothing -- and a target read through the same stale cache would agree with
+# the stale install and vouch for it. uv writes its whole plan to stderr.
+exomem_resolve_target_version() {
+    local python="$1" requirement="$2" installed="${3:-}" plan target
+    plan="$(uv pip install --dry-run --upgrade --refresh-package exomem \
+        --python "$python" "$requirement" 2>&1)" || return 1
+    target="$(printf '%s\n' "$plan" | exomem_install_plan_version)"
+    if [[ -n "$target" ]]; then printf '%s\n' "$target"; return 0; fi
+    # uv planned no change to exomem, so the resolved target is the installed one.
+    if [[ -n "$installed" ]]; then printf '%s\n' "$installed"; return 0; fi
+    return 1
+}
+
+# Fail when an install reported success without changing what is installed.
+# #578: uv exited 0 having installed nothing, the script printed
+# "Installed version: 0.52.2 -> 0.52.2" as a REPORT, and the deploy continued onto
+# a service that restarted cleanly on the old build. before/after were already
+# known; this turns the report into a gate. Args: requirement before after target.
+exomem_assert_install_applied() {
+    local requirement="$1" before="${2:-}" after="${3:-}" target="${4:-}" was
+    was="${before:-not installed}"
+    if [[ -z "$after" ]]; then
+        echo "upgrade: install of '$requirement' reported success but no exomem version is importable from that interpreter (was: $was). Nothing was deployed." >&2
+        return 1
+    fi
+    if [[ -z "$target" ]]; then
+        echo "upgrade: target version unresolved, so this run can only assert that SOMETHING is installed ($after). Re-run with --package-version <version> for a checked upgrade." >&2
+        return 0
+    fi
+    if [[ "$after" != "$target" ]]; then
+        echo "upgrade: install did not take: '$requirement' resolved to $target, but the interpreter still reports $after (was: $was). uv exited 0 without applying the change; re-run with --package-version $target, and check that uv is not resolving from a stale index cache." >&2
+        return 1
+    fi
+    return 0
+}
+
 # Version declared in the repo checkout. Deliberately offline: comparing against
 # the repo rather than PyPI keeps every gate usable on a disconnected box.
 exomem_repo_version() {

--- a/scripts/upgrade.ps1
+++ b/scripts/upgrade.ps1
@@ -10,6 +10,9 @@
 # stop/start, which your user already has rights for (install-service.ps1 grants
 # RPWPCR). Re-registering the service still needs install-service.ps1.
 #
+# Requires PowerShell 7+ (pwsh). Windows PowerShell 5.1 is refused up front rather
+# than allowed to fail obscurely partway: -SkipHttpErrorCheck below is 7.0+ only.
+#
 # Usage:
 #   pwsh -File scripts/upgrade.ps1
 #   pwsh -File scripts/upgrade.ps1 -Profile media
@@ -32,6 +35,8 @@ param(
 $ErrorActionPreference = "Stop"
 
 . "$PSScriptRoot\_service-common.ps1"
+
+Assert-ExomemPowerShell7 -ScriptName "upgrade.ps1"
 
 $RepoRoot = Split-Path -Parent $PSScriptRoot
 
@@ -71,6 +76,9 @@ Write-Host "  repo:      $repoVersion"
 Install-ExomemPackage -Python $ServicePy -Profile $Profile -PackageVersion $PackageVersion
 Repair-TorchCuda -Python $ServicePy -Profile $Profile -CudaTorch $CudaTorch
 
+# Reaching here means Install-ExomemPackage already ASSERTED that $after equals the
+# version it resolved before installing. This line is the receipt for that check,
+# not the check itself -- reading it as the check is what let #578 through.
 $after = Get-ExomemInstalledVersion -PythonPath $ServicePy
 Write-Host "Installed version: $before -> $after"
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -126,8 +126,16 @@ REQUIREMENT="exomem"
 [[ -n "$PACKAGE_VERSION" ]] && REQUIREMENT="$REQUIREMENT==$PACKAGE_VERSION"
 
 command -v uv >/dev/null 2>&1 || die "uv not found on PATH"
+
+# Resolve and SHOW the target before installing, so "installed:/repo:/target:"
+# makes a no-op visible at a glance instead of only in hindsight.
+TARGET="$(exomem_resolve_target_version "$VENV_PYTHON" "$REQUIREMENT" "$BEFORE" || echo "")"
+# A pin stays assertable even when the resolve could not run at all.
+[[ -z "$TARGET" && -n "$PACKAGE_VERSION" ]] && TARGET="$PACKAGE_VERSION"
+echo "  target:    ${TARGET:-unresolved}"
+
 echo "Installing $REQUIREMENT into the service venv..."
-uv pip install --upgrade --python "$VENV_PYTHON" "$REQUIREMENT"
+uv pip install --upgrade --refresh-package exomem --python "$VENV_PYTHON" "$REQUIREMENT"
 
 # No CUDA repair here, unlike the Windows path: PyPI's Linux torch wheels are
 # already CUDA-enabled, and macOS uses Metal/MPS. The Windows-only repair exists
@@ -135,6 +143,10 @@ uv pip install --upgrade --python "$VENV_PYTHON" "$REQUIREMENT"
 
 AFTER="$(exomem_installed_version "$VENV_PYTHON" || echo "")"
 echo "Installed version: ${BEFORE:-unknown} -> ${AFTER:-unknown}"
+# That line is the receipt, not the check. Reading it as the check is what let a
+# silent no-op deploy through on the Windows path (#578).
+exomem_assert_install_applied "$REQUIREMENT" "$BEFORE" "$AFTER" "$TARGET" \
+    || die "the service was NOT restarted."
 
 # --- Preflight against the venv the service actually runs -------------------------
 DOCTOR_ARGS=(-m exomem doctor --profile "$PROFILE")

--- a/tests/test_container_distribution.py
+++ b/tests/test_container_distribution.py
@@ -258,7 +258,10 @@ def test_windows_service_installer_supports_release_env_and_cuda() -> None:
     assert "EXOMEM_MCP_LEGACY_COMPAT" in install
     assert "Test-McpEndpoint -HostName $BindHost -EndpointPort $Port" in install
 
-    assert '"uv", "pip", "install", "--upgrade", "--python", $Python, $pkg' in common
+    # `--refresh-package exomem` is not decoration: uv serves the package index
+    # from its HTTP cache, so an unpinned `--upgrade` can resolve back to the
+    # installed release and exit 0 having done nothing (#578).
+    assert '"uv", "pip", "install", "--upgrade", "--refresh-package", "exomem", "--python", $Python, $pkg' in common
     assert "https://download.pytorch.org/whl/cu132" in common
 
 

--- a/tests/test_service_installers.py
+++ b/tests/test_service_installers.py
@@ -414,8 +414,11 @@ def test_windows_installer_gates_remote_and_verifies_before_success() -> None:
 
     assert "Install-ExomemPackage" in text
     assert '[string]$Profile = "standard"' in text
-    assert '"uv", "pip", "install", "--upgrade", "--python", $Python, $pkg' in common
+    assert '"uv", "pip", "install", "--upgrade", "--refresh-package", "exomem", "--python", $Python, $pkg' in common
     assert '"[embeddings,media]"' in common
+    # #578: installing is not deploying. The installer shares this helper, so a
+    # fresh venv that ends up with nothing in it has to fail here too.
+    assert "Assert-ExomemInstallApplied" in common
     assert "Preflight: exomem doctor --profile remote" in text
     assert "function Test-McpEndpoint" in text
     assert "-SkipHttpErrorCheck" in text

--- a/tests/test_upgrade_guard.py
+++ b/tests/test_upgrade_guard.py
@@ -1,0 +1,537 @@
+"""#578: the deploy script must not report success while installing nothing.
+
+`scripts/upgrade.ps1` printed `Installing exomem[embeddings,media] into ...`,
+continued to the doctor preflight, and left the venv on the previous release. The
+service then restarted cleanly on the old build and every later observation was
+attributed to a release that was never deployed.
+
+Two separable defects, exercised separately here:
+
+1. `Installed version: $before -> $after` was a REPORT, not a check. `uv` exits 0
+   having applied nothing (a stale index cache resolves the unpinned `--upgrade`
+   back to the installed release), and the run carried on.
+2. Windows PowerShell 5.1 raises a terminating NativeCommandError on the first
+   merged stderr record under `$ErrorActionPreference = "Stop"`, even when the
+   command exits 0 -- and `uv` writes its entire plan to stderr by design.
+
+Defect 2 is shell-specific: it cannot reproduce under pwsh 7.x, where merged
+native stderr is not an error. The `windows-powershell-5.1` parametrisation below
+is the only lane that covers it, and it skips wherever `powershell.exe` is absent
+(i.e. all of Linux CI). Both defects are covered on Windows; defect 1 is covered
+everywhere pwsh exists.
+
+`scripts/upgrade.sh` never had defect 2, but carried defect 1 verbatim; its lane is
+at the bottom of this file.
+
+The fakes stand in for `uv` and for the service venv's interpreter, so nothing
+here touches a real environment, index, or service.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMON = ROOT / "scripts" / "_service-common.ps1"
+PWSH = shutil.which("pwsh")
+WINDOWS_POWERSHELL = shutil.which("powershell") if os.name == "nt" else None
+
+SHELLS = [
+    pytest.param(
+        PWSH,
+        id="pwsh",
+        marks=pytest.mark.skipif(PWSH is None, reason="pwsh is not available"),
+    ),
+    pytest.param(
+        WINDOWS_POWERSHELL,
+        id="windows-powershell-5.1",
+        marks=pytest.mark.skipif(
+            WINDOWS_POWERSHELL is None,
+            reason="Windows PowerShell 5.1 is not available",
+        ),
+    ),
+]
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+# `uv` writes its whole plan to stderr and nothing to stdout -- the banner, the
+# resolve line, and the "+ exomem==X" plan lines. That is not incidental: it is
+# what made a merged 2>&1 necessary in the first place, and what made the merge
+# fatal under 5.1. The fakes reproduce it exactly.
+_UV_SH = """
+    #!/bin/sh
+    echo "uv $*" >> "$FAKE_UV_TRACE"
+    echo "Using Python 3.13.11 environment at: fake-venv" >&2
+    case " $* " in
+      *" --dry-run "*)
+        echo "Resolved 135 packages in 1.20s" >&2
+        if [ -n "$FAKE_UV_TARGET" ]; then
+            echo " + exomem==$FAKE_UV_TARGET" >&2
+        else
+            echo "Would make no changes" >&2
+        fi
+        exit ${FAKE_UV_DRYRUN_EXIT:-0}
+        ;;
+    esac
+    echo "Resolved 135 packages in 839ms" >&2
+    if [ -n "$FAKE_UV_INSTALLS" ]; then
+        printf '%s' "$FAKE_UV_INSTALLS" > "$FAKE_VENV_VERSION"
+        echo "Installed 1 package in 429ms" >&2
+        echo " + exomem==$FAKE_UV_INSTALLS" >&2
+    else
+        echo "Audited 135 packages in 12ms" >&2
+    fi
+    exit ${FAKE_UV_EXIT:-0}
+"""
+
+_UV_CMD = """
+    @echo off
+    echo uv %* >> "%FAKE_UV_TRACE%"
+    echo Using Python 3.13.11 environment at: fake-venv 1>&2
+    echo %* | findstr /C:"--dry-run" >nul
+    if not errorlevel 1 (
+        echo Resolved 135 packages in 1.20s 1>&2
+        if defined FAKE_UV_TARGET (
+            echo  + exomem==%FAKE_UV_TARGET% 1>&2
+        ) else (
+            echo Would make no changes 1>&2
+        )
+        exit /b %FAKE_UV_DRYRUN_EXIT%
+    )
+    echo Resolved 135 packages in 839ms 1>&2
+    if defined FAKE_UV_INSTALLS (
+        echo|set /p="%FAKE_UV_INSTALLS%" > "%FAKE_VENV_VERSION%"
+        echo Installed 1 package in 429ms 1>&2
+        echo  + exomem==%FAKE_UV_INSTALLS% 1>&2
+    ) else (
+        echo Audited 135 packages in 12ms 1>&2
+    )
+    exit /b %FAKE_UV_EXIT%
+"""
+
+# Stands in for the service venv's interpreter: `Get-ExomemInstalledVersion` runs
+# `<python> -c "import importlib.metadata ..."` and reads one line of stdout.
+_PYTHON_SH = """
+    #!/bin/sh
+    if [ -s "$FAKE_VENV_VERSION" ]; then cat "$FAKE_VENV_VERSION"; exit 0; fi
+    exit 1
+"""
+
+_PYTHON_CMD = """
+    @echo off
+    if not exist "%FAKE_VENV_VERSION%" exit /b 1
+    for %%A in ("%FAKE_VENV_VERSION%") do if %%~zA==0 exit /b 1
+    type "%FAKE_VENV_VERSION%"
+    exit /b 0
+"""
+
+_DRIVER = """
+    # Mirrors scripts/upgrade.ps1's own preamble: the "Stop" preference is exactly
+    # what turned an informational `uv` banner into an aborted deploy under 5.1.
+    param([string]$Common, [string]$Python, [string]$Profile = "standard", [string]$PackageVersion = "")
+    $ErrorActionPreference = "Stop"
+    . $Common
+    Install-ExomemPackage -Python $Python -Profile $Profile -PackageVersion $PackageVersion
+    Write-Host "DRIVER-COMPLETED"
+"""
+
+
+def _fixture(tmp_path: Path, *, installed: str | None) -> tuple[Path, Path, dict[str, str]]:
+    """Return (fake python path, uv trace path, base environment)."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    version_file = tmp_path / "installed-version.txt"
+    trace = tmp_path / "uv-trace.log"
+    trace.touch()
+    if installed is not None:
+        version_file.write_text(installed, encoding="utf-8")
+
+    # Both forms always, on every platform: PowerShell resolves `uv` through
+    # PATHEXT to uv.cmd and never to the extensionless file, while Git Bash
+    # resolves the shebang script and never the .cmd. Writing only one of them on
+    # Windows would let the bash lane fall through to the REAL uv on PATH.
+    _write_executable(bin_dir / "uv", _UV_SH)
+    _write_executable(bin_dir / "python", _PYTHON_SH)
+    _write_executable(bin_dir / "uv.cmd", _UV_CMD)
+    _write_executable(bin_dir / "python.cmd", _PYTHON_CMD)
+    python = bin_dir / ("python.cmd" if os.name == "nt" else "python")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "FAKE_VENV_VERSION": str(version_file),
+            "FAKE_UV_TRACE": str(trace),
+            "FAKE_UV_TARGET": "",
+            "FAKE_UV_INSTALLS": "",
+            "FAKE_UV_EXIT": "0",
+            "FAKE_UV_DRYRUN_EXIT": "0",
+        }
+    )
+    return python, trace, env
+
+
+def _install(
+    shell: str,
+    tmp_path: Path,
+    *,
+    installed: str | None,
+    resolves_to: str = "",
+    actually_installs: str = "",
+    uv_exit: str = "0",
+    dry_run_exit: str = "0",
+    package_version: str = "",
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    python, trace, env = _fixture(tmp_path, installed=installed)
+    env.update(
+        {
+            "FAKE_UV_TARGET": resolves_to,
+            "FAKE_UV_INSTALLS": actually_installs,
+            "FAKE_UV_EXIT": uv_exit,
+            "FAKE_UV_DRYRUN_EXIT": dry_run_exit,
+        }
+    )
+    driver = tmp_path / "driver.ps1"
+    driver.write_text(textwrap.dedent(_DRIVER).lstrip(), encoding="utf-8")
+    result = subprocess.run(
+        [
+            shell,
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(driver),
+            "-Common",
+            str(COMMON),
+            "-Python",
+            str(python),
+            "-PackageVersion",
+            package_version,
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+    return result, trace
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_install_that_changes_nothing_fails_loudly(shell: str, tmp_path: Path) -> None:
+    """The exact #578 shape: uv exits 0, applies nothing, old version survives."""
+    result, _ = _install(
+        shell, tmp_path, installed="0.52.2", resolves_to="0.52.3", actually_installs=""
+    )
+
+    assert result.returncode != 0, (result.stdout, result.stderr)
+    assert "DRIVER-COMPLETED" not in result.stdout
+    combined = result.stdout + result.stderr
+    assert "Install did not take" in combined
+    assert "0.52.3" in combined and "0.52.2" in combined
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_install_that_lands_the_target_is_accepted(shell: str, tmp_path: Path) -> None:
+    result, trace = _install(
+        shell, tmp_path, installed="0.52.2", resolves_to="0.52.3", actually_installs="0.52.3"
+    )
+
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert "DRIVER-COMPLETED" in result.stdout
+    # Ask 5: the target is shown BEFORE the install, next to installed:/repo:.
+    assert "target:    0.52.3" in result.stdout
+    assert result.stdout.index("target:") < result.stdout.index("Installing exomem")
+    calls = trace.read_text(encoding="utf-8")
+    assert "--dry-run" in calls
+    # A target resolved through uv's cached index would agree with a stale install.
+    assert calls.count("--refresh-package exomem") == 2
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_already_current_is_not_a_failure(shell: str, tmp_path: Path) -> None:
+    """uv plans no change, so before == after == target is the correct outcome.
+
+    Without this the naive "$after -eq $before is fatal" rule would fail every
+    re-run of an up-to-date box.
+    """
+    result, _ = _install(
+        shell, tmp_path, installed="0.52.3", resolves_to="", actually_installs=""
+    )
+
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert "DRIVER-COMPLETED" in result.stdout
+    assert "target:    0.52.3" in result.stdout
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_uv_informational_stderr_never_aborts_the_run(shell: str, tmp_path: Path) -> None:
+    """Defect 2. Under 5.1 this used to die on `Using Python ... environment at:`.
+
+    The fake writes that banner to stderr on every invocation and exits 0, which is
+    what real `uv` does. The run must complete and the banner must still be logged.
+    """
+    result, _ = _install(
+        shell, tmp_path, installed="0.52.2", resolves_to="0.52.3", actually_installs="0.52.3"
+    )
+
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert "DRIVER-COMPLETED" in result.stdout
+    assert "Using Python 3.13.11 environment at: fake-venv" in result.stdout
+    assert "NativeCommandError" not in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_uv_failure_is_reported_as_a_failure_with_its_exit_code(
+    shell: str, tmp_path: Path
+) -> None:
+    """Ask 2: 'uv returned nonzero' must stay distinguishable from 'uv no-oped'."""
+    result, _ = _install(
+        shell,
+        tmp_path,
+        installed="0.52.2",
+        resolves_to="0.52.3",
+        actually_installs="",
+        uv_exit="2",
+    )
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "uv pip install failed" in combined
+    assert "uv exit 2" in combined
+    assert "Install did not take" not in combined
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_nothing_installed_at_all_is_fatal(shell: str, tmp_path: Path) -> None:
+    """A fresh venv (install-service.ps1's path) that ends up empty is not success."""
+    result, _ = _install(
+        shell, tmp_path, installed=None, resolves_to="0.52.3", actually_installs=""
+    )
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "no exomem version is importable" in combined
+    assert "not installed" in combined
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_an_explicit_pin_is_asserted_even_when_the_resolve_fails(
+    shell: str, tmp_path: Path
+) -> None:
+    """The dry-run is a convenience; it must not be the only thing holding the gate."""
+    result, _ = _install(
+        shell,
+        tmp_path,
+        installed="0.52.2",
+        resolves_to="0.52.3",
+        actually_installs="",
+        dry_run_exit="1",
+        package_version="0.52.3",
+    )
+
+    assert result.returncode != 0
+    assert "Install did not take" in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_unresolvable_target_degrades_out_loud_instead_of_silently(
+    shell: str, tmp_path: Path
+) -> None:
+    """No pin and no resolve leaves nothing to compare against. Say so."""
+    result, _ = _install(
+        shell,
+        tmp_path,
+        installed=None,
+        resolves_to="0.52.3",
+        actually_installs="0.52.3",
+        dry_run_exit="1",
+    )
+
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    combined = result.stdout + result.stderr
+    assert "target:    unresolved" in result.stdout
+    assert "Target version unresolved" in combined
+
+
+_PARSE_DRIVER = """
+    param([string]$Common, [string]$LinesJson)
+    $ErrorActionPreference = "Stop"
+    . $Common
+    $lines = @($LinesJson | ConvertFrom-Json)
+    Write-Output (ConvertTo-Json @{ version = (Get-ExomemInstallPlanVersion -Lines $lines) })
+"""
+
+
+def _plan_version(tmp_path: Path, lines: list[str]) -> str | None:
+    assert PWSH is not None
+    driver = tmp_path / "parse-driver.ps1"
+    driver.write_text(textwrap.dedent(_PARSE_DRIVER).lstrip(), encoding="utf-8")
+    result = subprocess.run(
+        [
+            PWSH,
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(driver),
+            "-Common",
+            str(COMMON),
+            "-LinesJson",
+            json.dumps(lines),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    return json.loads(result.stdout)["version"]
+
+
+@pytest.mark.skipif(PWSH is None, reason="pwsh is not available")
+def test_install_plan_parsing_matches_real_uv_output(tmp_path: Path) -> None:
+    """Captured verbatim from `uv 0.11.28`; extras are normalised off the name."""
+    assert (
+        _plan_version(
+            tmp_path,
+            [
+                "Using Python 3.13.11 environment at: .venv",
+                "Resolved 135 packages in 839ms",
+                "Uninstalled 1 package in 183ms",
+                "Installed 1 package in 429ms",
+                " - exomem==0.52.2",
+                " + exomem==0.52.3",
+            ]
+        )
+        == "0.52.3"
+    )
+    assert (
+        _plan_version(
+            tmp_path,
+            [
+                "Resolved 2 packages in 101ms",
+                "Checked 2 packages in 0.33ms",
+                "Would make no changes",
+            ],
+        )
+        is None
+    )
+    # A dependency that merely starts with the same characters is not exomem.
+    assert _plan_version(tmp_path, [" + exomem-plugin==1.0.0", " + colorama==0.4.6"]) is None
+
+
+# --- macOS/Linux parity -------------------------------------------------------
+#
+# scripts/upgrade.sh never had defect 2 -- bash does not treat stderr as failure,
+# and `set -euo pipefail` already stopped a nonzero `uv` -- but it carried defect 1
+# verbatim: it computed BEFORE/AFTER, printed them, and checked nothing.
+
+BASH = shutil.which("bash")
+
+_BASH_HARNESS = """
+set -euo pipefail
+. "{common}"
+{body}
+"""
+
+
+def _bash(tmp_path: Path, body: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    assert BASH is not None
+    script = tmp_path / "harness.sh"
+    script.write_text(
+        _BASH_HARNESS.format(common=(ROOT / "scripts" / "_service-common.sh").as_posix(), body=body),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [BASH, str(script)], text=True, capture_output=True, check=False, env=env or os.environ.copy()
+    )
+    # Codex's Windows sandbox resolves Git Bash but blocks its signal-pipe
+    # bootstrap; that is an execution boundary, not a script result.
+    if result.returncode and "couldn't create signal pipe" in result.stdout + result.stderr:
+        pytest.skip("sandbox blocked Git Bash startup")
+    return result
+
+
+@pytest.mark.skipif(BASH is None, reason="bash is not available")
+def test_unix_assert_rejects_an_install_that_changed_nothing(tmp_path: Path) -> None:
+    result = _bash(
+        tmp_path,
+        'exomem_assert_install_applied "exomem[embeddings,media]" "0.52.2" "0.52.2" "0.52.3"',
+    )
+
+    assert result.returncode != 0
+    assert "install did not take" in result.stderr
+    assert "0.52.3" in result.stderr
+
+
+@pytest.mark.skipif(BASH is None, reason="bash is not available")
+def test_unix_assert_accepts_a_box_that_is_already_current(tmp_path: Path) -> None:
+    result = _bash(
+        tmp_path,
+        'exomem_assert_install_applied "exomem" "0.52.3" "0.52.3" "0.52.3"; echo HARNESS-OK',
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "HARNESS-OK" in result.stdout
+
+
+@pytest.mark.skipif(BASH is None, reason="bash is not available")
+def test_unix_assert_rejects_an_empty_interpreter(tmp_path: Path) -> None:
+    result = _bash(tmp_path, 'exomem_assert_install_applied "exomem" "" "" "0.52.3"')
+
+    assert result.returncode != 0
+    assert "no exomem version is importable" in result.stderr
+    assert "not installed" in result.stderr
+
+
+@pytest.mark.skipif(BASH is None, reason="bash is not available")
+def test_unix_target_resolution_reads_uv_and_refreshes_the_index(tmp_path: Path) -> None:
+    python, trace, env = _fixture(tmp_path, installed="0.52.2")
+    env["FAKE_UV_TARGET"] = "0.52.3"
+    result = _bash(
+        tmp_path,
+        f'exomem_resolve_target_version "{python.as_posix()}" "exomem[embeddings,media]" "0.52.2"',
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "0.52.3"
+    assert "--refresh-package exomem" in trace.read_text(encoding="utf-8")
+
+
+@pytest.mark.skipif(BASH is None, reason="bash is not available")
+def test_unix_target_resolution_falls_back_to_the_installed_version(tmp_path: Path) -> None:
+    """uv planning no change means the resolved target IS what is already there."""
+    python, _, env = _fixture(tmp_path, installed="0.52.3")
+    env["FAKE_UV_TARGET"] = ""
+    result = _bash(
+        tmp_path,
+        f'exomem_resolve_target_version "{python.as_posix()}" "exomem" "0.52.3"',
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "0.52.3"
+
+
+def test_unix_upgrade_wires_the_gate_between_install_and_preflight() -> None:
+    """Ordering matters: a failed assertion must stop the run BEFORE the restart."""
+    upgrade = (ROOT / "scripts" / "upgrade.sh").read_text(encoding="utf-8")
+
+    assert "exomem_resolve_target_version" in upgrade
+    assert "exomem_assert_install_applied" in upgrade
+    assert upgrade.index("exomem_resolve_target_version") < upgrade.index("Installing $REQUIREMENT")
+    assert upgrade.index("Installed version:") < upgrade.index("exomem_assert_install_applied")
+    assert upgrade.index("exomem_assert_install_applied") < upgrade.index("Restarting $SERVICE_NAME")

--- a/tests/test_upgrade_guard.py
+++ b/tests/test_upgrade_guard.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -59,6 +60,7 @@ SHELLS = [
         ),
     ),
 ]
+
 
 def _write_executable(path: Path, body: str) -> None:
     path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
@@ -141,10 +143,32 @@ _DRIVER = """
     # what turned an informational `uv` banner into an aborted deploy under 5.1.
     param([string]$Common, [string]$Python, [string]$Profile = "standard", [string]$PackageVersion = "")
     $ErrorActionPreference = "Stop"
-    . $Common
-    Install-ExomemPackage -Python $Python -Profile $Profile -PackageVersion $PackageVersion
+    try {
+        . $Common
+        Install-ExomemPackage -Python $Python -Profile $Profile -PackageVersion $PackageVersion
+    } catch {
+        # Report the failure ourselves. PowerShell's own error formatter hard-wraps
+        # to the host width and injects ANSI, so asserting on it is console-width
+        # dependent -- which is how this suite passed on a 200-column Windows
+        # console and failed on a CI runner. The error id is kept because the 5.1
+        # lane asserts specifically on NativeCommandError.
+        Write-Host "DRIVER-ERROR[$($_.FullyQualifiedErrorId)]: $($_.Exception.Message)"
+        exit 1
+    }
     Write-Host "DRIVER-COMPLETED"
 """
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _flat(result: subprocess.CompletedProcess[str]) -> str:
+    """Both streams, ANSI stripped and whitespace collapsed.
+
+    Anything PowerShell renders itself (warnings especially) is wrapped to the
+    host width, so a phrase can be split mid-sentence by a newline that depends on
+    the terminal running the suite.
+    """
+    return " ".join(_ANSI.sub("", result.stdout + result.stderr).split())
 
 
 def _fixture(tmp_path: Path, *, installed: str | None) -> tuple[Path, Path, dict[str, str]]:
@@ -237,7 +261,7 @@ def test_install_that_changes_nothing_fails_loudly(shell: str, tmp_path: Path) -
 
     assert result.returncode != 0, (result.stdout, result.stderr)
     assert "DRIVER-COMPLETED" not in result.stdout
-    combined = result.stdout + result.stderr
+    combined = _flat(result)
     assert "Install did not take" in combined
     assert "0.52.3" in combined and "0.52.2" in combined
 
@@ -289,7 +313,7 @@ def test_uv_informational_stderr_never_aborts_the_run(shell: str, tmp_path: Path
     assert result.returncode == 0, (result.stdout, result.stderr)
     assert "DRIVER-COMPLETED" in result.stdout
     assert "Using Python 3.13.11 environment at: fake-venv" in result.stdout
-    assert "NativeCommandError" not in result.stdout + result.stderr
+    assert "NativeCommandError" not in _flat(result)
 
 
 @pytest.mark.parametrize("shell", SHELLS)
@@ -307,7 +331,7 @@ def test_uv_failure_is_reported_as_a_failure_with_its_exit_code(
     )
 
     assert result.returncode != 0
-    combined = result.stdout + result.stderr
+    combined = _flat(result)
     assert "uv pip install failed" in combined
     assert "uv exit 2" in combined
     assert "Install did not take" not in combined
@@ -321,7 +345,7 @@ def test_nothing_installed_at_all_is_fatal(shell: str, tmp_path: Path) -> None:
     )
 
     assert result.returncode != 0
-    combined = result.stdout + result.stderr
+    combined = _flat(result)
     assert "no exomem version is importable" in combined
     assert "not installed" in combined
 
@@ -342,7 +366,7 @@ def test_an_explicit_pin_is_asserted_even_when_the_resolve_fails(
     )
 
     assert result.returncode != 0
-    assert "Install did not take" in result.stdout + result.stderr
+    assert "Install did not take" in _flat(result)
 
 
 @pytest.mark.parametrize("shell", SHELLS)
@@ -360,9 +384,8 @@ def test_unresolvable_target_degrades_out_loud_instead_of_silently(
     )
 
     assert result.returncode == 0, (result.stdout, result.stderr)
-    combined = result.stdout + result.stderr
     assert "target:    unresolved" in result.stdout
-    assert "Target version unresolved" in combined
+    assert "Target version unresolved" in _flat(result)
 
 
 _PARSE_DRIVER = """


### PR DESCRIPTION
Closes #578

`scripts/upgrade.ps1` printed `Installing exomem[embeddings,media] into ...`, continued to the doctor preflight, and left the venv on the previous release. The service then restarted cleanly on the old build and every later observation was attributed to a release that was never deployed — including the verification of the fixes that release contained.

## What the evidence says about ask 2

The issue asks whether `uv` returned nonzero and the code was dropped, or returned zero having done nothing. **It returned zero.** Reproduced with a fake native command under both shells:

| shell | uv exit | `Invoke-LoggedNative` result |
|---|---|---|
| Windows PowerShell 5.1 | 0 | **throws** `NativeCommandError` / `RemoteException` on the stderr banner |
| pwsh 7.6.4 | 0 | returns `0` |
| pwsh 7.6.4 | 1 | returns `1` |

`$PSNativeCommandUseErrorActionPreference` is `False` by default in 7.6, so a nonzero exit does not throw: `Invoke-LoggedNative` returns it, `Install-ExomemPackage` throws `uv pip install failed`, and `$ErrorActionPreference = "Stop"` aborts the script. The failed run *reached the doctor preflight*, so that path did not happen — uv exited 0 without applying the change. The exit code was never dropped; there was no failure to propagate.

*Why* uv no-oped is not recoverable from the artifacts (the run's uv output was not retained). The most likely cause is uv's cached package index: the unpinned `--upgrade` resolved back to 0.52.2, while the manual `==0.52.3` forced a fresh lookup for that exact version and worked immediately. That is a hypothesis, not a finding — so the fix both defends against it (`--refresh-package exomem`) and makes the next occurrence self-diagnosing (the resolved target is printed, and a mismatch names both versions).

## Changes

**1. The report becomes a gate.** `Install-ExomemPackage` now resolves the concrete target with `uv pip install --dry-run --upgrade --refresh-package exomem` before installing, prints it as `target:` under `installed:`/`repo:`, and calls `Assert-ExomemInstallApplied` afterwards. It fails when nothing is importable, and when the interpreter does not end up on the resolved target. An explicit `-PackageVersion` stays assertable even if the resolve itself fails; if the target cannot be resolved at all, the run says so out loud instead of silently skipping the check. `before == after == target` (an already-current box) is correctly *not* a failure.

`--refresh-package exomem` is load-bearing rather than belt-and-braces: a target read through the same stale cache would agree with the stale install and vouch for it.

**2. Native stderr stops being a failure.** `uv` writes its entire plan to stderr and nothing to stdout, so the `2>&1` merge is necessary for any logging at all — the preference is what was wrong. `Invoke-ExomemNative` sets `$ErrorActionPreference = "Continue"` and `$PSNativeCommandUseErrorActionPreference = $false` **function-scoped**, so callers keep `Stop` semantics everywhere else. It also refuses up front when the executable is not on PATH, since `$LASTEXITCODE` would otherwise be left at the previous command's value and read as success.

**3. Ask 4 — the shell gate.** `upgrade.ps1` refuses 5.1 with a message naming the shell and the fix. 7.x is a genuine requirement, not a preference: `Invoke-WebRequest -SkipHttpErrorCheck` is 7.0+ only.

**4. `upgrade.sh`** — checked, not assumed. It never had defect 2 (bash does not treat stderr as failure, and `set -euo pipefail` already stopped a nonzero uv) but carried defect 1 verbatim: it computed `BEFORE`/`AFTER`, printed them, and checked nothing. Same resolve → show → assert sequence added via `_service-common.sh`.

**Skipped:** nothing from the five asks. Ask 2 is answered by evidence rather than by a code change, since the exit code was already propagated correctly.

## Red-then-green

Both defects were run against unmodified `origin/main` in a disposable worktree, using the same test file: **16 failed, 1 passed**. The one pass is `test_uv_informational_stderr_never_aborts_the_run[pwsh]` — defect 2 does not reproduce under pwsh 7, which is exactly why the test is parametrised over both shells.

Defect 1, `[pwsh]`, on `origin/main`:

```
>       assert result.returncode != 0, (result.stdout, result.stderr)
E       AssertionError: ('Installing exomem[embeddings,media] into ...
E         Resolved 135 packages in 839ms
E         Audited 135 packages in 12ms
E         DRIVER-COMPLETED
E         ', '')
E       assert 0 != 0
```

Defect 2, `[windows-powershell-5.1]`, on `origin/main`:

```
>       assert result.returncode == 0, (result.stdout, result.stderr)
E       AssertionError: (... (Using Python 3.... at: fake-venv :String) [], RemoteException
E             + FullyQualifiedErrorId : NativeCommandError
E          ')
E       assert 1 == 0
```

Green on this branch: `23 passed`.

## Coverage honesty

Defect 2 is shell-specific and **cannot** be covered by Linux CI: pwsh 7 does not raise on merged native stderr, so no test running under pwsh can be red for it. The `windows-powershell-5.1` lane skips wherever `powershell.exe` is absent, i.e. all of CI. It is red-then-green **locally on Windows only**, quoted above. Defect 1 and the unix parity run everywhere.

Nothing in the suite touches a real venv, index, or service — `uv` and the service interpreter are both faked, in `.cmd` and shebang form so the PowerShell and bash lanes each resolve the fake rather than the real `uv` on PATH.

## Consumer sweep

`Invoke-LoggedNative` is shared infrastructure. Every caller enumerated with `rg`:

- `scripts/install-service.ps1:176` (`uv venv`) — unchanged contract; also stops dying on `uv venv`'s own banner under 5.1.
- `scripts/_service-common.ps1` `Repair-TorchCuda` — unchanged contract.
- `scripts/_service-common.ps1` `Sync-ExomemUvCli` — unchanged contract.

It keeps returning a bare `Int32`, so all three are untouched. `Install-ExomemPackage` deliberately **does not** return the resolved version: it is called bare inside `Install-ReleaseVenv`, whose return value is assigned to `$python`, and an extra object on the output stream would have turned that into an array and broken the installer.

`install-service.ps1` shares `Install-ExomemPackage`, so a fresh venv that ends up empty now fails there too — which is the same defect class, and desirable.

Tests that pin the script text and had to move with it: `tests/test_container_distribution.py`, `tests/test_service_installers.py` (both pinned the exact `uv pip install` argument list).

## Not fixed here

The issue's closing observation — the doctor orphan gate blocking the deploy that ships the reaper for the condition it gates on — is a real ordering problem and deliberately out of scope for this PR. Worth its own issue.

`scripts/install-service.ps1` has the same latent 7.0+ requirement (`-SkipHttpErrorCheck`) and no shell gate. Left alone to keep this diff scoped to the reported script; a one-line `Assert-ExomemPowerShell7` call would close it.

## Local verification

`23 passed` for `tests/test_upgrade_guard.py`; `tests/test_container_distribution.py` and `tests/test_install_parity.py` green. Eight pre-existing failures in `tests/test_service_installers.py` are the documented native-Windows bash-interop breakage (`/bin/bash: C:UsershugoaDesktop...: No such file or directory`) — `install-service.sh` does not source `_service-common.sh`, so they are untouched by this change. Linux CI is the authority.
