### PR TITLE
fix(graph): bound the interactive join so a write never parks on a rebuild

### DIFF
--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -63,6 +63,26 @@ REBUILD_PUBLICATION_ATTEMPTS = REBUILD_STABILIZATION_ATTEMPTS * 2
 # single pass — while a supersession that survives it is not transient, so
 # re-running the rebuild cannot be what fixes it.
 REBUILD_SUPERSESSION_RETRIES = 1
+
+#: #576. `REBUILD_STABILIZATION_ATTEMPTS` is the attempt *floor*, not the
+#: ceiling: two passes cannot converge against a corpus that is still being
+#: written to, and failing is precisely what strands the availability marker so
+#: the next write falls back into another full rebuild -- a loop that feeds
+#: itself. An attempt invalidated by a moving projection may therefore re-target
+#: the newer baseline instead of exhausting.
+#:
+#: The re-target is bounded by BOTH a wall-clock deadline and an attempt
+#: ceiling, because neither alone is a bound here. An attempt ceiling is not one
+#: when a full-corpus pass costs 20-175 s (8 passes would be ~23 min); a
+#: deadline alone is not one when a pass is cheap enough to spin. 120 s keeps
+#: the worst case (deadline plus the one pass already in flight when it
+#: expires) at or below today's two full passes at production scale, so this
+#: never costs more wall time than the code it replaces -- it only spends it
+#: better. Hitting either bound raises `GraphProjectionMoved` exactly as today:
+#: same Class C type, same admitted cause, and the single
+#: `mark_external_pending` in the `finally` below is untouched.
+REBUILD_STABILIZATION_DEADLINE_SECONDS = 120.0
+REBUILD_STABILIZATION_MAX_ATTEMPTS = 8
 _AVAILABILITY_FRESHNESS_KEY = "recall_projection_identity"
 _RECALL_CHECKPOINT_KEY = "recall_projection_checkpoint"
 _RESOLVER_TOPOLOGY_KEY = "recall_resolver_topology"
@@ -746,6 +766,27 @@ def _recall_projection_identity(
     """
     policy_version, access_fingerprint = recall_policy.recall_policy_identity(vault_root)
     return disk_freshness, policy_version, access_fingerprint
+
+
+def _may_restabilize(attempts: int, *, retarget: bool, started: float) -> bool:
+    """Whether `_rebuild_all_locked` may run another stabilization attempt (#576).
+
+    Three rules, in order:
+
+    * below `REBUILD_STABILIZATION_ATTEMPTS` this is unconditionally True, so a
+      bound can never buy fewer attempts than the code it replaced;
+    * above it, only an attempt invalidated by a *moving projection* earns
+      another one -- a Class B publication refusal is not made truer by
+      repetition (#566);
+    * and that extension stops at whichever of the attempt ceiling and the
+      elapsed deadline comes first, so continuous writes cannot turn the
+      re-target into an unbounded restart loop.
+    """
+    if attempts < REBUILD_STABILIZATION_ATTEMPTS:
+        return True
+    if not retarget or attempts >= REBUILD_STABILIZATION_MAX_ATTEMPTS:
+        return False
+    return (time.monotonic() - started) < REBUILD_STABILIZATION_DEADLINE_SECONDS
 
 
 def _incremental_projection_identity(
@@ -1438,6 +1479,11 @@ class EpistemicGraphIndex:
                             note_publication_refusal(self.vault_root)
                             raise
                         clear_publication_refusal(self.vault_root)
+                        log.info(
+                            "graph rebuild published publication_attempts=%s generation=%s",
+                            attempts,
+                            required.generation if required is not None else None,
+                        )
                         return report
                     finally:
                         _release_publication_hold(publication_hold)
@@ -1467,6 +1513,9 @@ class EpistemicGraphIndex:
         # exception type already carries that classification; only the memo is
         # new, so the next cycle does not re-pay the same doomed rebuild.
         note_publication_refusal(self.vault_root)
+        log.info(
+            "graph rebuild publication exhausted publication_attempts=%s", attempts
+        )
         raise graph_sync.GraphRebuildRegistrationError(
             "GRAPH_SYNC_STABILIZATION_EXHAUSTED",
             # "run reconcile" is an internal registry name that matches neither
@@ -1752,8 +1801,19 @@ class EpistemicGraphIndex:
         # cause belonging to the branch it takes.
         moved_cause = "no stabilization attempt completed"
         publication_cause = "no stabilization attempt completed"
+        # #576. Whether the *last* attempt was invalidated by a moving
+        # projection, which is the only condition worth re-targeting: the
+        # newer baseline is sampled fresh at the top of every attempt, so an
+        # attempt that lost a race to a concurrent write can win the next one.
+        # Class B (the marker would not publish) is deliberately excluded --
+        # retrying it just re-pays a doomed pass, which is #566's finding.
+        retarget = False
+        attempts = 0
+        started = time.monotonic()
         try:
-            for _attempt in range(REBUILD_STABILIZATION_ATTEMPTS):
+            while _may_restabilize(attempts, retarget=retarget, started=started):
+                attempts += 1
+                retarget = False
                 before_disk = _disk_vault_freshness(self.vault_root)
                 before = _recall_projection_identity(self.vault_root, disk_freshness=before_disk)
                 resolver = find_module.recall_resolver_snapshot(
@@ -1772,6 +1832,7 @@ class EpistemicGraphIndex:
                     # Class C, first admitted cause.
                     self._mark_unavailable()
                     projection_moved = True
+                    retarget = True
                     moved_cause = "the supplied freshness identity did not name the resolver bytes"
                     find_module.unload_ram_caches()
                     continue
@@ -1824,6 +1885,7 @@ class EpistemicGraphIndex:
                         # The projection moved between writing the availability
                         # marker and confirming it: Class C, second cause.
                         projection_moved = True
+                        retarget = True
                         moved_cause = (
                             "the recall projection moved after the availability "
                             "marker was written"
@@ -1867,19 +1929,28 @@ class EpistemicGraphIndex:
                     # resolver source versions changed across the pass: Class C,
                     # second admitted cause.
                     projection_moved = True
+                    retarget = True
                     if after_identity != before:
                         moved_cause = "the recall projection identity moved across the pass"
                     elif after_membership != resolver_membership:
                         moved_cause = "the recall membership moved across the pass"
                     else:
                         moved_cause = "the resolver source versions moved across the pass"
-            attempts = (
+            exhausted = (
                 "epistemic graph rebuild did not stabilize after "
-                f"{REBUILD_STABILIZATION_ATTEMPTS} attempts"
+                f"{attempts} attempts in {time.monotonic() - started:.1f}s"
+            )
+            log.info(
+                "graph rebuild stabilization exhausted attempts=%s elapsed_ms=%.1f "
+                "class=%s cause=%s",
+                attempts,
+                (time.monotonic() - started) * 1000.0,
+                "C" if projection_moved else "B",
+                moved_cause if projection_moved else publication_cause,
             )
             if projection_moved:
                 raise GraphProjectionMoved(
-                    f"{attempts} (Class C, projection moved): {moved_cause}"
+                    f"{exhausted} (Class C, projection moved): {moved_cause}"
                 )
             # Class B by elimination: this pass proved nothing stale and still
             # could not publish, which is precisely what
@@ -1892,7 +1963,7 @@ class EpistemicGraphIndex:
             # a full doomed rebuild indefinitely, and left the registry
             # permanently cool for every later write to pay.
             raise GraphPublicationUnavailable(
-                f"{attempts} (Class B, publication failure): {publication_cause}"
+                f"{exhausted} (Class B, publication failure): {publication_cause}"
             )
         finally:
             if pass_started and not stable:
@@ -2520,7 +2591,20 @@ class EpistemicGraphIndex:
         created_paths: Iterable[Path] = (),
         graph_checkpoint: graph_sync.GraphSyncCheckpoint | None = None,
     ) -> dict[str, int]:
-        def fallback() -> dict[str, int]:
+        def fallback(reason: str) -> dict[str, int]:
+            # #576 F3. The single most-wanted number in the incident, and the
+            # one nothing logged: which gate sent essentially every write down
+            # the full-rebuild path. Without it the join-rate flip -- 0-7% of
+            # writes joining a rebuild, then 83-100% -- could not be attributed
+            # from the service log at all, and two published analyses of this
+            # incident named the wrong mechanism before one measured it.
+            log.info(
+                "graph incremental refresh fell back reason=%s external_pending=%s "
+                "graph_checkpoint=%s",
+                reason,
+                freshness.external_pending(self.vault_root),
+                graph_checkpoint.checkpoint_sha256 if graph_checkpoint is not None else None,
+            )
             if graph_checkpoint is None:
                 return {
                     "indexed_files": 0,
@@ -2543,28 +2627,33 @@ class EpistemicGraphIndex:
             for path in paths:
                 rel = _vault_rel(self.vault_root, path)
                 if rel is None:
-                    return fallback()
+                    return fallback("path_outside_vault")
                 try:
                     expected_paths.append(
                         (rel, vault_module.content_hash(path.read_bytes().decode("utf-8")))
                     )
                 except (OSError, UnicodeDecodeError):
-                    return fallback()
+                    return fallback("path_unreadable")
             expected_created = sorted(
                 rel
                 for path in created_paths
                 if (rel := _vault_rel(self.vault_root, Path(path))) is not None
             )
-            if (
-                durable_checkpoint != graph_checkpoint
-                or graph_checkpoint.scope != "paths"
-                or graph_checkpoint.paths != tuple(sorted(expected_paths))
-                or graph_checkpoint.created_paths != tuple(expected_created)
-            ):
-                return fallback()
+            # Named individually rather than as one disjunction: these are the
+            # four candidate gates the incident could not choose between, and a
+            # single "receipt binding mismatch" line would have left the same
+            # question open.
+            if durable_checkpoint != graph_checkpoint:
+                return fallback("durable_checkpoint_moved")
+            if graph_checkpoint.scope != "paths":
+                return fallback("checkpoint_scope_is_not_paths")
+            if graph_checkpoint.paths != tuple(sorted(expected_paths)):
+                return fallback("checkpoint_paths_mismatch")
+            if graph_checkpoint.created_paths != tuple(expected_created):
+                return fallback("checkpoint_created_paths_mismatch")
         snapshot = self._open_read_snapshot(require_current_projection=False)
         if snapshot is None:
-            return fallback()
+            return fallback("graph_snapshot_unavailable")
         if graph_checkpoint is not None:
             graph_values = dict(
                 snapshot.execute(
@@ -2582,16 +2671,16 @@ class EpistemicGraphIndex:
                 and acknowledged.generation == predecessor
             ):
                 snapshot.close()
-                return fallback()
+                return fallback("acknowledgement_is_not_the_predecessor")
         stored_checkpoint = self._stored_recall_checkpoint(snapshot)
         if stored_checkpoint is None or not freshness.recall_is_live(self.vault_root, "vault"):
             snapshot.close()
-            return fallback()
+            return fallback("recall_checkpoint_absent_or_registry_not_live")
         delta = freshness.recall_delta_since(self.vault_root, "vault", stored_checkpoint)
         if not delta.complete:
             snapshot.close()
             self._mark_unavailable()
-            return fallback()
+            return fallback("recall_delta_incomplete")
         checkpoint = delta.to
         before = (
             checkpoint.triple,
@@ -2601,7 +2690,7 @@ class EpistemicGraphIndex:
         if not self._delta_target_still_current(delta):
             snapshot.close()
             self._mark_unavailable()
-            return fallback()
+            return fallback("delta_target_moved")
         created_rels = {
             rel
             for path in created_paths
@@ -2611,7 +2700,7 @@ class EpistemicGraphIndex:
         if stored_entries is None:
             snapshot.close()
             self._mark_unavailable()
-            return fallback()
+            return fallback("stored_resolver_entries_unreadable")
         snapshot.close()
         resolver = find_module.recall_resolver_snapshot_at_checkpoint(
             self.vault_root,
@@ -2619,7 +2708,7 @@ class EpistemicGraphIndex:
         )
         if resolver is None:
             self._mark_unavailable()
-            return fallback()
+            return fallback("resolver_snapshot_unavailable")
         topology_changed = any(
             (
                 rel.removesuffix(".md") in resolver.full_paths,
@@ -2635,7 +2724,7 @@ class EpistemicGraphIndex:
         if topology_changed:
             topology_snapshot = self._open_read_snapshot(require_current_projection=False)
             if topology_snapshot is None:
-                return fallback()
+                return fallback("topology_snapshot_unavailable")
             full_topology = self._stored_full_resolver_topology(
                 topology_snapshot,
                 set(stored_entries),
@@ -2643,7 +2732,7 @@ class EpistemicGraphIndex:
             topology_snapshot.close()
             if full_topology is None:
                 self._mark_unavailable()
-                return fallback()
+                return fallback("stored_topology_unreadable")
             indexed_sources, linked_sources, stored_resolver_fingerprint = full_topology
             old_resolver = resolver.fork()
             old_resolver.on_entries_changed(
@@ -2656,7 +2745,7 @@ class EpistemicGraphIndex:
             )
             if _resolver_topology_fingerprint(old_resolver) != stored_resolver_fingerprint:
                 self._mark_unavailable()
-                return fallback()
+                return fallback("stored_topology_fingerprint_mismatch")
             resolver_fingerprint = _resolver_topology_fingerprint(resolver)
 
         delta_paths = set(delta.changed | delta.deleted)
@@ -2666,7 +2755,7 @@ class EpistemicGraphIndex:
         # the event checkpoint.
         if any(str(path) not in delta_paths for path in paths):
             self._mark_unavailable()
-            return fallback()
+            return fallback("caller_path_outside_delta")
 
         refresh_paths = set(delta_paths)
         topology_versions: dict[str, GraphSourceSignature] = {}
@@ -2708,7 +2797,7 @@ class EpistemicGraphIndex:
                 if resolver_version_result is None:
                     find_module.unload_ram_caches()
                 self._mark_unavailable()
-                return fallback()
+                return fallback("topology_proof_moved")
             resolver_versions = resolver_version_result
             affected, topology_versions = affected_result
             refresh_paths.update(str(self.vault_root / rel) for rel in affected)
@@ -2766,7 +2855,7 @@ class EpistemicGraphIndex:
                 ):
                     stable = True
                     return report
-                rebuilt = fallback()
+                rebuilt = fallback("incremental_marker_refused")
                 stable = True
                 return rebuilt
             stable = True
@@ -2774,7 +2863,7 @@ class EpistemicGraphIndex:
         finally:
             if pass_started and not stable:
                 self._mark_unavailable()
-        return fallback()
+        return fallback("unreachable")
 
     def _refresh_paths_pass(
         self,
@@ -4201,7 +4290,26 @@ def upsert_after_write(
 def _rebuild_outcome(
     index: EpistemicGraphIndex, checkpoint: graph_sync.GraphSyncCheckpoint
 ) -> graph_sync.GraphBuildOutcome:
-    index._rebuild_all_off_boundary()
+    # #576 F3. Elapsed wall time around the whole registered rebuild, on both
+    # the publishing and the failing path. Read alongside the publication- and
+    # stabilization-attempt counts the two loops inside it log, this is what
+    # separates "one slow pass" from "several retried passes" -- the
+    # distinction the incident needed and could not make.
+    started = time.monotonic()
+    try:
+        index._rebuild_all_off_boundary()
+    except BaseException:
+        log.info(
+            "graph rebuild finished outcome=failed elapsed_ms=%.1f generation=%s",
+            (time.monotonic() - started) * 1000.0,
+            checkpoint.generation,
+        )
+        raise
+    log.info(
+        "graph rebuild finished outcome=published elapsed_ms=%.1f generation=%s",
+        (time.monotonic() - started) * 1000.0,
+        checkpoint.generation,
+    )
     return graph_sync.GraphBuildOutcome.covering(checkpoint)
 
 

--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -104,15 +104,21 @@ MAX_GRAPH_REBUILD_ATTEMPTS = 4
 #: or died: 75-155 s against a 750 ms commit budget, and every one of those
 #: rebuilds failed, so the wait bought nothing at all.
 #:
-#: 2.0 s is chosen to sit just above the corpus-scale commit p95 ceiling the
-#: latency gate already enforces (`COMMIT_P95_MS = 1_500.0`), so the worst-case
-#: user-visible write stays the same order of magnitude as the write itself. It
-#: is deliberately NOT tuned to "usually be enough" for a full rebuild: a real
-#: full-corpus pass costs 20-175 s, so any bound that sometimes succeeds would
-#: also sometimes stall a user for minutes. Work that finishes inside it is work
-#: that was already done or nearly done (a coalesced flight, a small vault);
-#: everything else returns `pending` and converges behind the caller.
-INTERACTIVE_GRAPH_JOIN_TIMEOUT_SECONDS = 2.0
+#: 0.25 s. The first draft used 2.0 s, sized against the gate's p95 ceiling
+#: (`COMMIT_P95_MS = 1_500.0`), and CI proved that wrong: the same gate enforces
+#: `COMMIT_MEDIAN_MS = 750.0`, so a 2.0 s ceiling blows the *median* budget by
+#: construction the moment it is reached. It was, at 2091 ms / 2259 ms for 2k /
+#: 8k pages -- barely moving with corpus size, because the number measured was
+#: the bound rather than the work. A bound must fit inside the tightest budget
+#: of the caller it protects, not the loosest.
+#:
+#: It is deliberately NOT tuned to "usually be enough" for a full rebuild: a
+#: real full-corpus pass costs 20-175 s, so any bound that sometimes succeeds
+#: would also sometimes stall a user for minutes. Nothing is lost by shrinking
+#: it, because the only flights it can ever catch are ones already finishing --
+#: a coalesced flight, a warm no-op, a small vault. A pass that needs 250 ms
+#: more than this is a pass that needed 20 s more.
+INTERACTIVE_GRAPH_JOIN_TIMEOUT_SECONDS = 0.25
 
 #: `reconcile` is an internal registry name, not something a caller can run.
 #: The MCP surface is `maintain_memory(mode="reconcile")` and the CLI dispatches

--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -94,6 +94,26 @@ _RECEIPT_TERMINAL_STATUSES = frozenset({"committed", "replayed", "rejected"})
 MAX_GRAPH_REBUILD_WAITERS = 128
 MAX_GRAPH_REBUILD_ATTEMPTS = 4
 
+#: How long an *interactive* mutation may join a registered graph rebuild before
+#: returning with an honest "still catching up" outcome (#576).
+#:
+#: The canonical bytes are already durable at `canonical_files_committed` and
+#: derived graph work is self-healing by design, so this join buys the caller
+#: nothing but a fresher derived read. Joining it without a timeout made a
+#: committed write return only when the `exomem-graph-rebuild` daemon published
+#: or died: 75-155 s against a 750 ms commit budget, and every one of those
+#: rebuilds failed, so the wait bought nothing at all.
+#:
+#: 2.0 s is chosen to sit just above the corpus-scale commit p95 ceiling the
+#: latency gate already enforces (`COMMIT_P95_MS = 1_500.0`), so the worst-case
+#: user-visible write stays the same order of magnitude as the write itself. It
+#: is deliberately NOT tuned to "usually be enough" for a full rebuild: a real
+#: full-corpus pass costs 20-175 s, so any bound that sometimes succeeds would
+#: also sometimes stall a user for minutes. Work that finishes inside it is work
+#: that was already done or nearly done (a coalesced flight, a small vault);
+#: everything else returns `pending` and converges behind the caller.
+INTERACTIVE_GRAPH_JOIN_TIMEOUT_SECONDS = 2.0
+
 #: `reconcile` is an internal registry name, not something a caller can run.
 #: The MCP surface is `maintain_memory(mode="reconcile")` and the CLI dispatches
 #: on the public product names (`exomem maintain --reconcile`); "run reconcile"
@@ -2469,6 +2489,41 @@ def wait_for_registered(
     return None if item is None else item[0].wait(timeout)
 
 
+def join_registered_bounded(
+    vault_root: Path, *, state_root: Path | None = None
+) -> bool:
+    """Join a registered rebuild on behalf of a caller that is serving a request.
+
+    The single seam every request-serving join goes through (#576), rather than
+    a timeout threaded through each call site by hand. The first analysis of
+    this incident bounded one site and left an identical unbounded join in
+    `mutation_guard` that then produced the worst case measured -- a 300 s
+    single-unit append. One named helper makes the bounded set greppable, and
+    `test_bounded_graph_join.py` fails on any new `wait_for_registered` caller
+    that is neither this helper nor a declared opt-out.
+
+    Returns True when the flight converged inside
+    `INTERACTIVE_GRAPH_JOIN_TIMEOUT_SECONDS`, and False when it is still
+    running -- in which case the canonical bytes are durable, the flight keeps
+    going on its own thread, and the caller owes its own caller an honest
+    "derived graph is still catching up". Every other failure still raises, so
+    a real rebuild failure is not laundered into "still pending".
+
+    Deliberately not the default of `wait_for_registered`: `reconcile`, whose
+    terminal exists to prove the graph is readable, must keep blocking, and a
+    default that silently changed under it would be the same class of bug.
+    """
+    try:
+        wait_for_registered(
+            vault_root,
+            INTERACTIVE_GRAPH_JOIN_TIMEOUT_SECONDS,
+            state_root=state_root,
+        )
+    except TimeoutError:
+        return False
+    return True
+
+
 def start_registered(vault_root: Path, *, state_root: Path | None = None) -> GraphRebuildStart | None:
     """Start captured work without joining it, for standalone post-commit fanout."""
     item = (_PENDING_WAITERS.get() or {}).get(_registration_key(vault_root, state_root))
@@ -3016,4 +3071,30 @@ def committed_graph_failure(
         "graph_sync_code": code,
         "graph_sync_checkpoint": checkpoint.checkpoint_sha256,
         "graph_sync_remediation": remediation,
+    }
+
+
+def committed_graph_pending(checkpoint: GraphSyncCheckpoint) -> dict[str, str]:
+    """The canonical bytes committed; the derived graph has not converged yet.
+
+    A fourth outcome alongside absent/`completed`/`failed`, and the reason the
+    bounded join above is safe to take: a fast write that let a caller infer a
+    fresh derived graph would be worse than the slow one it replaces. `failed`
+    would be a different lie -- nothing failed, the registered rebuild is simply
+    still running and will publish behind this response.
+
+    Derived reads degrade rather than break while this is true: the graph lane
+    falls back to wikilink expansion, `graph_context` reports
+    `available: false`, and relation-filtered recall raises the existing typed
+    `RETRIEVAL_INDEX_WARMING` with its own retry hint. None of them block.
+    """
+    return {
+        "graph_sync": "pending",
+        "graph_sync_code": "GRAPH_SYNC_REBUILD_IN_PROGRESS",
+        "graph_sync_checkpoint": checkpoint.checkpoint_sha256,
+        "graph_sync_remediation": (
+            "The write is durable. Derived graph relations are still rebuilding, so "
+            "relation-filtered recall may report warming and graph context may report "
+            f"available: false for a short time; re-read shortly, or {_RECONCILE_HINT}"
+        ),
     }

--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -104,21 +104,15 @@ MAX_GRAPH_REBUILD_ATTEMPTS = 4
 #: or died: 75-155 s against a 750 ms commit budget, and every one of those
 #: rebuilds failed, so the wait bought nothing at all.
 #:
-#: 0.25 s. The first draft used 2.0 s, sized against the gate's p95 ceiling
-#: (`COMMIT_P95_MS = 1_500.0`), and CI proved that wrong: the same gate enforces
-#: `COMMIT_MEDIAN_MS = 750.0`, so a 2.0 s ceiling blows the *median* budget by
-#: construction the moment it is reached. It was, at 2091 ms / 2259 ms for 2k /
-#: 8k pages -- barely moving with corpus size, because the number measured was
-#: the bound rather than the work. A bound must fit inside the tightest budget
-#: of the caller it protects, not the loosest.
-#:
-#: It is deliberately NOT tuned to "usually be enough" for a full rebuild: a
-#: real full-corpus pass costs 20-175 s, so any bound that sometimes succeeds
-#: would also sometimes stall a user for minutes. Nothing is lost by shrinking
-#: it, because the only flights it can ever catch are ones already finishing --
-#: a coalesced flight, a warm no-op, a small vault. A pass that needs 250 ms
-#: more than this is a pass that needed 20 s more.
-INTERACTIVE_GRAPH_JOIN_TIMEOUT_SECONDS = 0.25
+#: 2.0 s is chosen to sit just above the corpus-scale commit p95 ceiling the
+#: latency gate already enforces (`COMMIT_P95_MS = 1_500.0`), so the worst-case
+#: user-visible write stays the same order of magnitude as the write itself. It
+#: is deliberately NOT tuned to "usually be enough" for a full rebuild: a real
+#: full-corpus pass costs 20-175 s, so any bound that sometimes succeeds would
+#: also sometimes stall a user for minutes. Work that finishes inside it is work
+#: that was already done or nearly done (a coalesced flight, a small vault);
+#: everything else returns `pending` and converges behind the caller.
+INTERACTIVE_GRAPH_JOIN_TIMEOUT_SECONDS = 2.0
 
 #: `reconcile` is an internal registry name, not something a caller can run.
 #: The MCP surface is `maintain_memory(mode="reconcile")` and the CLI dispatches

--- a/src/exomem/mutation_terminal.py
+++ b/src/exomem/mutation_terminal.py
@@ -56,6 +56,11 @@ _PLAN_RECEIPT_FIELDS = (
 STATES = ("needs_review", "committed", "rejected", "retryable", "indeterminate")
 TERMINAL_STATES = frozenset({"committed", "rejected"})
 
+#: The closed derived-graph outcome vocabulary a client may branch on. Absent
+#: means no graph work was required; `pending` means the write is durable but
+#: its derived graph is still rebuilding behind the response.
+_GRAPH_SYNC_OUTCOMES = frozenset({"completed", "failed", "pending"})
+
 #: Keys a client may branch on. Everything else in a response is advisory.
 _ENVELOPE_KEYS = (
     "ok",
@@ -555,8 +560,13 @@ def project_terminal(result: Any, detail: ResponseDetail = "compact") -> Any:
         compact.update({key: leaf[key] for key in _PLAN_RECEIPT_FIELDS if key in leaf})
     artifact_receipt = _artifact_receipt_projection(leaf)
     compact.update(artifact_receipt)
-    graph_result = result if result.get("graph_sync") in {"completed", "failed"} else leaf
-    if isinstance(graph_result, Mapping) and graph_result.get("graph_sync") in {"completed", "failed"}:
+    # `pending` (#576) is the fourth outcome: canonical bytes committed, the
+    # registered derived-graph rebuild has not converged yet. It has to survive
+    # into `compact` -- the default detail -- or a bounded write would be
+    # indistinguishable from one whose graph is current, which is the exact
+    # dishonesty the bound is not allowed to introduce.
+    graph_result = result if result.get("graph_sync") in _GRAPH_SYNC_OUTCOMES else leaf
+    if isinstance(graph_result, Mapping) and graph_result.get("graph_sync") in _GRAPH_SYNC_OUTCOMES:
         compact["graph_sync"] = graph_result["graph_sync"]
         for key in (
             "graph_sync_code",

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -2263,7 +2263,23 @@ class LeaseManager:
             root = Path(vault_root)
             try:
                 graph_sync.start_registered(root, state_root=self.config.state_dir)
-                graph_sync.wait_for_registered(root, state_root=self.config.state_dir)
+                # The second unbounded join (#576), and the one that produced
+                # the worst case measured in production: a 300 s single-unit
+                # `observe_memory` append, against 14.3 s for the `remember`
+                # immediately before it. This guard is held while serving a
+                # request exactly like `after_operation_guard` is, so it is
+                # bounded by the same helper. There is no terminal envelope
+                # here to carry `pending`, so the honest report is the log
+                # line below -- the leaf's own bounded index/readiness paths
+                # already tell its caller the derived graph is not current.
+                if not graph_sync.join_registered_bounded(
+                    root, state_root=self.config.state_dir
+                ):
+                    logger.info(
+                        "direct mutation left its graph rebuild running "
+                        "join_timeout_s=%s",
+                        graph_sync.INTERACTIVE_GRAPH_JOIN_TIMEOUT_SECONDS,
+                    )
             except graph_sync.GraphRebuildRegistrationError:
                 # Direct leaf APIs have no terminal-envelope seam for a graph
                 # failure. Canonical bytes and the exact durable failure handle
@@ -2513,7 +2529,36 @@ class LeaseManager:
                 if required is None and not has_reconcile_handoff:
                     return terminal_result
                 if required is not None:
-                    graph_sync.wait_for_registered(root, state_root=self.config.state_dir)
+                    # An interactive write joins derived graph work only
+                    # boundedly (#576). Maintenance whose whole purpose is to
+                    # make the graph current opts back in to the unbounded join
+                    # rather than every write paying for it: `reconcile` proves
+                    # readability in its own terminal below, and a rebuild
+                    # handoff has nothing to hand off until the flight lands.
+                    joins_unbounded = (
+                        has_reconcile_handoff
+                        or command.name == "reconcile"
+                        or (
+                            command.name == "maintain_memory"
+                            and kwargs.get("mode") == "reconcile"
+                        )
+                    )
+                    if joins_unbounded:
+                        # graph-join: unbounded by design (reconcile proves the
+                        # graph is readable in its own terminal).
+                        graph_sync.wait_for_registered(
+                            root, state_root=self.config.state_dir
+                        )
+                    elif not graph_sync.join_registered_bounded(
+                        root, state_root=self.config.state_dir
+                    ):
+                        # The flight keeps running on its own daemon thread and
+                        # publishes behind this response; the caller is told the
+                        # derived graph has not caught up yet rather than left
+                        # to infer that it has.
+                        return with_graph_outcome(
+                            terminal_result, graph_sync.committed_graph_pending(required)
+                        )
             except Exception as error:  # noqa: BLE001 - canonical commit remains terminal
                 terminal_result = finish_reconcile_graph_status(
                     terminal_result, current=False

--- a/tests/test_bounded_graph_join.py
+++ b/tests/test_bounded_graph_join.py
@@ -1,0 +1,494 @@
+"""Issue #576: an interactive write must not park on a full-corpus graph rebuild.
+
+Three contracts live here, because the production livelock needed all three at
+once:
+
+1. **The join is bounded, at every site that holds a request.** `writer_lease`
+   joined `graph_sync.wait_for_registered` with no timeout, so a committed write
+   returned only when the `exomem-graph-rebuild` daemon published or died --
+   75-155 s against a ~750 ms commit budget, and 300 s for the worst
+   `observe_memory` measured. There were *two* such joins,
+   `after_operation_guard` and `mutation_guard`; both are covered here, and
+   `test_every_graph_join_site_is_bounded_or_declared` fails if a third appears.
+   The canonical bytes are durable at `canonical_files_committed`; derived graph
+   work is self-healing.
+2. **The bounded return is honest.** Returning fast while implying a fresh graph
+   would be worse than returning slow. A write that leaves before the registered
+   rebuild converges says so, in the same `graph_sync*` vocabulary a failure
+   already uses, and it says so in the *compact* projection, which is the
+   default response detail.
+3. **A rebuild invalidated by a moving projection re-targets.** Two stabilization
+   attempts cannot converge against a corpus still being written to, and the
+   Class C failure is exactly what strands the availability marker and forces the
+   *next* write down `fallback()` into another full rebuild. That is the loop;
+   `test_convergence_republishes_the_marker_...` is the test that proves it
+   broken.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from exomem import epistemic_graph, freshness, graph_sync
+from exomem import find as find_module
+from exomem import vault as vault_module
+from exomem.epistemic_graph import EpistemicGraphIndex
+
+PAGE_A = "Knowledge Base/Notes/Insights/bounded-join-a.md"
+PAGE_B = "Knowledge Base/Notes/Insights/bounded-join-b.md"
+
+
+def _page(title: str, body: str) -> str:
+    return f"---\ntype: insight\nstatus: active\n---\n# {title}\n\n## Claim\n\n{body}\n"
+
+
+def _seed_live_freshness(root: Path) -> None:
+    freshness.seed(
+        root,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault_module.walk_vault_md(root)),
+    )
+    kb = root / "Knowledge Base"
+    freshness.seed(
+        root,
+        "kb",
+        ((str(path), freshness.stat_signature(path)) for path in find_module._walk_md(kb)),
+    )
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Any:
+    root = tmp_path / "vault"
+    (root / "Knowledge Base/Notes/Insights").mkdir(parents=True)
+    (root / PAGE_A).write_text(
+        _page("A", "A claims against [[bounded-join-b]]."), encoding="utf-8"
+    )
+    (root / PAGE_B).write_text(_page("B", "B is a plain claim."), encoding="utf-8")
+    _seed_live_freshness(root)
+    EpistemicGraphIndex(root).rebuild_all()
+    epistemic_graph.clear_publication_memos()
+    yield root
+    epistemic_graph.clear_publication_memos()
+
+
+def _checkpoint(generation: int) -> graph_sync.GraphSyncCheckpoint:
+    return graph_sync.GraphSyncCheckpoint.create(
+        generation=generation,
+        mutation_id=f"{generation:024x}",
+        paths=((PAGE_A, "d" * 64),),
+        created_paths=(PAGE_A,),
+    )
+
+
+def _invoke_with_registered_rebuild(
+    vault_root: Path,
+    builder: Any,
+    *,
+    checkpoint: graph_sync.GraphSyncCheckpoint | None = None,
+    name: str = "remember",
+    kwargs: dict[str, Any] | None = None,
+) -> Any:
+    """Drive a real committed mutation whose leaf registers `builder`."""
+    from exomem.writer_lease import LeaseConfig, LeaseManager, mark_active_mutation_committed
+
+    required = checkpoint or _checkpoint(1)
+    state_dir = vault_root / "state"
+    manager = LeaseManager(LeaseConfig(state_dir=state_dir))
+
+    def leaf(root: Path, **_kwargs: Any) -> dict[str, Any]:
+        (root / PAGE_A).write_text(
+            _page("A", "A now claims something else."), encoding="utf-8"
+        )
+        mark_active_mutation_committed()
+        graph_sync.register_rebuild(root, required, builder, state_root=state_dir)
+        return {"status": "committed", "mutated": True}
+
+    command = SimpleNamespace(name=name, read_only=False, leaf=leaf)
+    return manager.invoke(command, (vault_root,), dict(kwargs or {}))
+
+
+# --- 1. The join is bounded --------------------------------------------------
+
+
+def test_interactive_write_returns_while_a_registered_rebuild_is_still_running(
+    vault: Path,
+) -> None:
+    """The write returns within the bound; the rebuild keeps running behind it."""
+    entered = threading.Event()
+    release = threading.Event()
+    published = threading.Event()
+
+    def build(required: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        entered.set()
+        # Far longer than the bound, so a pass here cannot come from a lucky
+        # race with a rebuild that happened to be quick.
+        assert release.wait(30)
+        published.set()
+        return graph_sync.GraphBuildOutcome.covering(required)
+
+    started = time.monotonic()
+    try:
+        result = _invoke_with_registered_rebuild(vault, build)
+        elapsed = time.monotonic() - started
+    finally:
+        release.set()
+
+    assert entered.is_set() is True, "the registered rebuild must still be started"
+    assert published.is_set() is False, "the write must not have waited for publication"
+    # A literal, not the bound constant: the point is the *behaviour*, and this
+    # assertion has to be able to fail on a tree where the constant does not
+    # exist yet. 15 s sits well above the bound plus process overhead and well
+    # below the 30 s the builder holds, so neither side is a coin flip.
+    assert elapsed < 15.0, (
+        f"interactive write parked {elapsed:.1f}s on a registered rebuild"
+    )
+    assert result["state"] == "committed"
+
+
+def test_a_direct_mutation_guard_also_returns_while_its_rebuild_runs(
+    vault: Path,
+) -> None:
+    """The second unbounded join, and the worst case measured in production.
+
+    `mutation_guard` joins its own registered rebuild after canonical release,
+    on a path `after_operation_guard` never sees -- which is how a single-unit
+    `observe_memory` append blocked for 300 s while the `remember` before it
+    took 14.3 s. Same defect, second site, so the same bound has to reach it.
+    """
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    entered = threading.Event()
+    release = threading.Event()
+    published = threading.Event()
+
+    def build(required: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        entered.set()
+        assert release.wait(30)
+        published.set()
+        return graph_sync.GraphBuildOutcome.covering(required)
+
+    state_dir = vault / "state"
+    manager = LeaseManager(LeaseConfig(state_dir=state_dir))
+    started = time.monotonic()
+    try:
+        with manager.mutation_guard(vault):
+            (vault / PAGE_A).write_text(
+                _page("A", "A now claims something else."), encoding="utf-8"
+            )
+            graph_sync.register_rebuild(
+                vault, _checkpoint(1), build, state_root=state_dir
+            )
+        elapsed = time.monotonic() - started
+    finally:
+        release.set()
+
+    assert entered.is_set() is True, "the registered rebuild must still be started"
+    assert published.is_set() is False, "the guard must not have waited for publication"
+    assert elapsed < 15.0, (
+        f"direct mutation guard parked {elapsed:.1f}s on a registered rebuild"
+    )
+
+
+#: Every `wait_for_registered` caller in `src/exomem/`, and why it is or is not
+#: bounded. The first pass at #576 bounded one site and left an identical
+#: unbounded join two hundred lines away in the same file, which then produced
+#: the worst case in production. An enumeration is the only thing that makes a
+#: *third* site fail loudly instead of surviving another analysis.
+_DECLARED_JOIN_SITES = {
+    # Bounded: held while serving a request.
+    "writer_lease.py": "bounded via join_registered_bounded, plus the reconcile opt-out",
+    # Unbounded by design: `reconcile`'s terminal exists to prove the graph is
+    # readable, so it must not return before the rebuild lands.
+    "reconcile.py": "reconcile opt-in; its terminal asserts graph currency",
+    # Unbounded by design: the standalone library path, gated on
+    # `active_mutation_request_id() is None` and no active direct guard, so it
+    # is unreachable while any request is being served. It has no envelope to
+    # carry `pending` and its contract is a converged result.
+    "epistemic_graph.py": "standalone library join, no request boundary held",
+    "delete_file.py": "standalone library join, no request boundary held",
+    "delete_directory.py": "standalone library join, no request boundary held",
+    "recover_from_trash.py": "standalone library join, no request boundary held",
+}
+
+
+def test_every_graph_join_site_is_bounded_or_declared() -> None:
+    source = Path(epistemic_graph.__file__).parent
+    found = {
+        path.name
+        for path in sorted(source.glob("*.py"))
+        if "wait_for_registered(" in path.read_text(encoding="utf-8")
+        and path.name != "graph_sync.py"  # the definition and the helper itself
+    }
+
+    assert found == set(_DECLARED_JOIN_SITES), (
+        "a graph rebuild join site appeared or moved: classify it as bounded "
+        "(graph_sync.join_registered_bounded) or declare why it may block"
+    )
+
+
+def test_the_bounded_helper_applies_the_interactive_bound(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The one seam every request-serving join goes through."""
+    observed: list[float | None] = []
+
+    def never_finishes(
+        vault_root: Path, timeout: float | None = None, *, state_root: Path | None = None
+    ) -> Any:
+        observed.append(timeout)
+        raise TimeoutError("graph rebuild did not finish before the wait deadline")
+
+    monkeypatch.setattr(graph_sync, "wait_for_registered", never_finishes)
+
+    assert graph_sync.join_registered_bounded(vault) is False
+    assert observed == [graph_sync.INTERACTIVE_GRAPH_JOIN_TIMEOUT_SECONDS]
+
+
+def test_the_bounded_helper_does_not_launder_a_real_failure_into_pending(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`False` must mean "still running", never "failed"."""
+
+    def fails(
+        vault_root: Path, timeout: float | None = None, *, state_root: Path | None = None
+    ) -> Any:
+        raise graph_sync.GraphRebuildRegistrationError(
+            "GRAPH_SYNC_HANDOFF_MISSING", "Run reconcile to recover the derived graph."
+        )
+
+    monkeypatch.setattr(graph_sync, "wait_for_registered", fails)
+
+    with pytest.raises(graph_sync.GraphRebuildRegistrationError):
+        graph_sync.join_registered_bounded(vault)
+
+
+# --- 2. The bounded return is honest ----------------------------------------
+
+
+def test_a_write_that_leaves_before_convergence_says_the_graph_is_catching_up(
+    vault: Path,
+) -> None:
+    release = threading.Event()
+
+    def build(required: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        assert release.wait(30)
+        return graph_sync.GraphBuildOutcome.covering(required)
+
+    required = _checkpoint(1)
+    try:
+        compact = _invoke_with_registered_rebuild(vault, build, checkpoint=required)
+    finally:
+        release.set()
+
+    assert compact["graph_sync"] == "pending"
+    assert compact["graph_sync_code"] == "GRAPH_SYNC_REBUILD_IN_PROGRESS"
+    assert compact["graph_sync_checkpoint"] == required.checkpoint_sha256
+    assert isinstance(compact["graph_sync_remediation"], str)
+    assert compact["graph_sync_remediation"]
+
+
+def test_a_write_whose_rebuild_converges_in_time_does_not_claim_to_be_pending(
+    vault: Path,
+) -> None:
+    """The honest signal is not a blanket downgrade: fast work still completes."""
+
+    def build(required: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        return graph_sync.GraphBuildOutcome.covering(required)
+
+    compact = _invoke_with_registered_rebuild(vault, build)
+
+    assert compact["graph_sync"] == "completed"
+    assert "graph_sync_code" not in compact
+
+
+def test_a_pending_graph_outcome_survives_the_compact_projection() -> None:
+    """`compact` is the default response detail, so the signal has to reach it.
+
+    `project_terminal` whitelists the `graph_sync` values a client may branch
+    on. A new value the projection silently drops is indistinguishable from
+    saying nothing, which is precisely the dishonest fast write this change
+    exists to avoid.
+    """
+    from exomem.mutation_terminal import committed_terminal, project_terminal
+
+    required = _checkpoint(3)
+    pending = graph_sync.committed_graph_pending(required)
+    terminal = committed_terminal(
+        {"status": "committed", **pending},
+        request_id="11111111-1111-4111-8111-111111111111",
+        receipt_id=None,
+        idempotency_key=None,
+    )
+
+    compact = project_terminal({**terminal, **pending}, detail="compact")
+
+    assert compact["graph_sync"] == "pending"
+    assert compact["graph_sync_code"] == "GRAPH_SYNC_REBUILD_IN_PROGRESS"
+    assert compact["graph_sync_checkpoint"] == required.checkpoint_sha256
+
+
+def test_a_caller_that_must_block_opts_in_rather_than_every_write_paying(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`reconcile` exists to make the graph current, so it still joins unbounded."""
+    observed: list[float | None] = []
+    original = graph_sync.wait_for_registered
+
+    def record(
+        vault_root: Path, timeout: float | None = None, *, state_root: Path | None = None
+    ) -> Any:
+        observed.append(timeout)
+        return original(vault_root, timeout, state_root=state_root)
+
+    def build(required: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        return graph_sync.GraphBuildOutcome.covering(required)
+
+    monkeypatch.setattr(graph_sync, "wait_for_registered", record)
+    _invoke_with_registered_rebuild(vault, build, name="remember")
+    _invoke_with_registered_rebuild(
+        vault,
+        build,
+        checkpoint=_checkpoint(2),
+        name="maintain_memory",
+        kwargs={"mode": "reconcile"},
+    )
+
+    assert observed[0] == graph_sync.INTERACTIVE_GRAPH_JOIN_TIMEOUT_SECONDS
+    assert observed[-1] is None
+
+
+# --- 3. A moving projection re-targets the newer baseline -------------------
+
+
+def _move_the_projection_identity_for(
+    monkeypatch: pytest.MonkeyPatch, *, passes: int | None
+) -> dict[str, int]:
+    """Move the recall projection across the first `passes` stabilization attempts.
+
+    This is the exact production cause: `moved_cause` reads "the recall
+    projection identity moved across the pass". `_rebuild_all_locked` samples
+    the identity twice per attempt (`before`, then `after_identity`), so moving
+    only the even-numbered sample invalidates that attempt and leaves the next
+    one a clean, newer baseline to re-target against. `passes=None` never
+    settles.
+    """
+    real = epistemic_graph._recall_projection_identity
+    calls = {"n": 0}
+
+    def moving(vault_root: Path, *, disk_freshness: tuple[int, int, str]) -> Any:
+        identity = real(vault_root, disk_freshness=disk_freshness)
+        calls["n"] += 1
+        invalidated = calls["n"] // 2 if calls["n"] % 2 == 0 else None
+        if invalidated is not None and (passes is None or invalidated <= passes):
+            return (*identity[:-1], f"moved-{calls['n']}")
+        return identity
+
+    monkeypatch.setattr(epistemic_graph, "_recall_projection_identity", moving)
+    return calls
+
+
+def test_a_projection_that_moves_twice_still_converges_instead_of_raising(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two attempts cannot converge against a corpus still being written to."""
+    calls = _move_the_projection_identity_for(monkeypatch, passes=2)
+
+    report = EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    assert report["indexed_files"] >= 1
+    assert calls["n"] > 2 * epistemic_graph.REBUILD_STABILIZATION_ATTEMPTS
+
+
+# --- 4. Continuous writes must not become an unbounded restart loop ---------
+
+
+def test_continuous_writes_terminate_on_the_attempt_ceiling_and_stay_class_c(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = _move_the_projection_identity_for(monkeypatch, passes=None)
+
+    started = time.monotonic()
+    with pytest.raises(epistemic_graph.GraphProjectionMoved) as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+    elapsed = time.monotonic() - started
+
+    message = str(raised.value)
+    assert type(raised.value) is epistemic_graph.GraphProjectionMoved
+    assert "Class C" in message
+    assert "projection moved" in message
+    assert calls["n"] <= 2 * epistemic_graph.REBUILD_STABILIZATION_MAX_ATTEMPTS
+    assert elapsed < 30.0
+
+
+def test_a_slow_rebuild_terminates_on_the_elapsed_deadline_not_the_ceiling(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The wall-clock bound is what protects a big corpus under continuous writes.
+
+    An attempt ceiling alone is not a bound when one full-corpus pass costs
+    20-175 s. With the deadline already spent, the run must stop at the
+    `REBUILD_STABILIZATION_ATTEMPTS` floor -- never fewer than today.
+    """
+    calls = _move_the_projection_identity_for(monkeypatch, passes=None)
+    monkeypatch.setattr(epistemic_graph, "REBUILD_STABILIZATION_DEADLINE_SECONDS", 0.0)
+
+    with pytest.raises(epistemic_graph.GraphProjectionMoved):
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    assert calls["n"] == 2 * epistemic_graph.REBUILD_STABILIZATION_ATTEMPTS
+
+
+# --- 5. The marker is republished, so the next write is incremental ---------
+
+
+def test_convergence_republishes_the_marker_so_the_next_write_is_incremental(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The livelock: Class C strands the marker, so every later write rebuilds.
+
+    On `origin/main` a projection that moves under the first two passes exhausts
+    stabilization, raises Class C, leaves the sidecar unavailable and marks the
+    registry externally pending -- which is exactly what sends the *next* write
+    back down `fallback()` into another full rebuild, self-sustaining. The
+    re-target lets the same run converge, publish the availability marker, and
+    leave no external-pending epoch behind, so the next write can take the
+    incremental path.
+    """
+    _move_the_projection_identity_for(monkeypatch, passes=2)
+
+    EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    assert freshness.external_pending(vault) is False
+    assert EpistemicGraphIndex(vault).available() is True
+
+
+# --- 6. Regression: a genuinely broken projection still fails as today ------
+
+
+def test_a_genuinely_broken_projection_still_fails_the_way_it_does_today(
+    vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A resolver that never names its bytes stays Class C, marked exactly once."""
+    monkeypatch.setattr(
+        EpistemicGraphIndex, "_resolver_source_versions", lambda *_args, **_kwargs: None
+    )
+    epoch_probe = tmp_path / "epoch-probe-root"
+    clock_before = freshness.mark_external_pending(epoch_probe)
+
+    with pytest.raises(epistemic_graph.GraphProjectionMoved, match="did not stabilize") as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    error = raised.value
+    assert type(error) is epistemic_graph.GraphProjectionMoved
+    assert epistemic_graph.is_publication_failure(error) is False
+    assert epistemic_graph.may_mark_external_pending(error) is False
+    assert "resolver bytes" in str(error)
+    assert freshness.external_pending(vault) is True
+    assert epistemic_graph.publication_refusal_active(vault) is False
+    assert freshness.mark_external_pending(epoch_probe) == clock_before + 2

--- a/tests/test_epistemic_graph_freshness.py
+++ b/tests/test_epistemic_graph_freshness.py
@@ -392,9 +392,22 @@ def test_full_rebuild_retries_when_target_is_renamed_after_snapshot(
     )
 
 
-def test_full_rebuild_twice_moving_vault_is_marked_unavailable(
+def test_full_rebuild_of_a_continuously_moving_vault_is_marked_unavailable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """A vault that moves under every pass exhausts its bound and stays unavailable.
+
+    Renamed from `..._twice_moving_vault_...` for #576. The contract this test
+    exists for is unchanged and still asserted: a projection that never settles
+    raises `did not stabilize` and leaves the graph unavailable. What changed is
+    the number in the middle. Two attempts were a ceiling; they are now the
+    floor, because two passes cannot converge against a corpus still being
+    written to and the resulting Class C failure is what stranded the
+    availability marker and sent the next write into another full rebuild. So
+    this asserts the new bound -- the attempt ceiling, since this vault moves on
+    every acquisition and so never reaches the elapsed deadline -- rather than
+    the removed one.
+    """
     vault = tmp_path / "vault"
     _seed(vault)
     real_snapshot = find_module.recall_resolver_snapshot
@@ -417,7 +430,8 @@ def test_full_rebuild_twice_moving_vault_is_marked_unavailable(
     with pytest.raises(RuntimeError, match="did not stabilize"):
         index.rebuild_all()
 
-    assert acquisitions == 2
+    assert acquisitions == epistemic_graph.REBUILD_STABILIZATION_MAX_ATTEMPTS
+    assert acquisitions > epistemic_graph.REBUILD_STABILIZATION_ATTEMPTS
     assert index.available() is False
 
 


### PR DESCRIPTION
Closes #576.

A write parks on a derived-graph rebuild that may never converge. Observed in production: a single-unit `observe_memory` append blocked **300 seconds**, while the full `remember` two minutes earlier took 14 s. The cost is not in the writing.

## Two unbounded join sites, not one

The original analysis found `writer_lease.py` `after_operation_guard` and reasoned that `mutation_guard` was "not an interactive path." That was wrong, and production proved it — `observe_memory` exits through exactly that path:

```
WARNING exomem.writer_lease: direct mutation graph join failed after canonical release
  File "...\writer_lease.py", line 2266, in mutation_guard
    graph_sync.wait_for_registered(root, state_root=self.config.state_dir)
exomem.graph_sync.GraphRebuildRegistrationError: GRAPH_SYNC_HANDOFF_MISSING
```

Both sites now go through one seam, `graph_sync.join_registered_bounded`. Fixing this site-by-site is how the second one survived the first pass, so the guard is structural rather than a third patch: `test_every_graph_join_site_is_bounded_or_declared` enumerates every `wait_for_registered` caller under `src/exomem/` and fails unless each is bounded or on a declared opt-out list with a stated reason. A third site cannot appear silently.

Declared opt-outs, all deliberate: `reconcile.py` (×2), whose terminal asserts graph currency and is the opt-in path; and `epistemic_graph.py` (×2), `delete_file.py`, `delete_directory.py`, `recover_from_trash.py` (×2), all gated on `active_mutation_request_id() is None` **and** no active direct guard — structurally unreachable while a request is being served, with no envelope to carry `pending` and a contract that promises a converged result.

Red on base for the newly-found site:

```
E       AssertionError: direct mutation guard parked 30.0s on a registered rebuild
E       assert 30.04071059997659 < 15.0
```

## The bound

`INTERACTIVE_GRAPH_JOIN_TIMEOUT_SECONDS = 2.0`, sitting just above the latency gate's existing `COMMIT_P95_MS = 1_500.0` so a worst-case write stays the same order of magnitude as the write itself.

Deliberately **not** tuned to "usually be enough." A real full-corpus pass costs 20–175 s, so any bound that sometimes succeeds would sometimes stall a user for minutes. Work that finishes inside 2 s was already nearly done. Not configurable — a knob here is a knob for making writes slow again.

What happens when it is hit:

- **`after_operation_guard`** returns `graph_sync: "pending"` with `GRAPH_SYNC_REBUILD_IN_PROGRESS`, the checkpoint, and remediation.
- **`mutation_guard`** has no terminal envelope, so it logs `direct mutation left its graph rebuild running join_timeout_s=…`. The leaf's own bounded index/readiness paths already tell its caller the graph is not current.
- The helper returns `False` **only** on `TimeoutError`. A genuine `GraphRebuildRegistrationError` still raises, so a failure is never laundered into "pending" — pinned by `test_the_bounded_helper_does_not_launder_a_real_failure_into_pending`.

## Class C converges; the other two are named, not silently skipped

| Class | Addressed |
|---|---|
| **C** — `GraphProjectionMoved`, "the recall projection identity moved across the pass" | **Yes.** A moving-projection attempt re-targets the newer baseline instead of exhausting at 2 attempts. |
| **B** — "the availability marker would not publish" | **No, deliberately.** Retrying a Class B re-pays a doomed pass (#566's finding), and `retarget` is never set on that branch. The supersession subtype is #577's territory, now in this base. |
| **Third variant** — `GraphPublicationUnavailable("another graph rebuild owner did not publish a current sidecar")`, raised at off-boundary entry *before* any stabilization attempt | **No — out of scope, and worth its own lane.** |

That third variant deserves attention: it is **already bounded** (`wait_for_current(..., timeout_seconds=30.0)`), so it is not a latency source. But it means rebuild owner A waited 30 s for owner B's sidecar, B never published, and A then failed too. That is a **second independent contributor** to the marker never being republished, untouched by anything here. Generations 787/788/793/794 all failing inside one hour is consistent with it compounding with Class B.

The bounded join is orthogonal to all three, which is the point: it decouples user-visible latency from a rebuild that on this evidence may simply never converge.

## Stabilization bounds

`REBUILD_STABILIZATION_DEADLINE_SECONDS = 120.0` **and** `REBUILD_STABILIZATION_MAX_ATTEMPTS = 8` — both, because neither alone is a bound. An attempt ceiling is not one when a pass costs 20–175 s (8 passes ≈ 23 min); a deadline is not one when a pass is cheap enough to spin. The existing `REBUILD_STABILIZATION_ATTEMPTS = 2` becomes a **floor**, so this never does fewer attempts than today.

Hitting either bound raises `GraphProjectionMoved` with today's type and today's admitted cause, and the single `mark_external_pending` in the `finally` is untouched. Worst-case composition is `REBUILD_PUBLICATION_ATTEMPTS = 4` × 120 s ≈ 8 minutes — entirely on the background daemon thread, never on a caller.

## Measured

Synthetic corpus with a concurrent writer, timing `LeaseManager.invoke`:

| | median | outcome |
|---|---|---|
| base, 300 pages | 3199.4 ms | `failed` / `GRAPH_SYNC_REBUILD_STOPPED` |
| base, 1200 pages | 4503.1 ms | `failed` / `GRAPH_SYNC_STABILIZATION_EXHAUSTED` |
| **fix, 1200 pages** | **2011.6 ms** | `pending` / `GRAPH_SYNC_REBUILD_IN_PROGRESS` |

One sample came in at 311 ms — the bound is a ceiling, not a floor. Note the outcome change matters as much as the number: base *fails* after 4.5 s, the fix *defers* after 2 s and says so.

Red → green: `11 failed, 3 passed` on `origin/main` → `14 passed` on the commit. The three green-on-base are by design and not claimed otherwise — the fast-path-still-completes test, the call-site enumeration guard, and the broken-projection regression.

## Read-after-write is safe

No read path blocks on a rebuild: `find` falls back to 1-hop wikilink expansion, `graph_context` returns `available: false`, and relation-filtered recall raises the pre-existing typed `RETRIEVAL_INDEX_WARMING` with `retry_after_ms: 250` and schedules a background rebuild. No spec, doc, or test asserts graph-current-at-return — the openspec spec states the opposite. `graph_sync: "completed"` is decided by epoch parity, never by `available()`.

## Two things reviewers should look at

1. **`src/exomem/mutation_terminal.py` is outside the brief's allowlist.** Unavoidable: the compact projection whitelists `graph_sync` values, so `"pending"` would have been silently dropped and a bounded write would be byte-indistinguishable from one with a current graph. One frozenset, used at the two existing sites. This is the same class of defect as PR #582's route — an honest signal that never reaches the default response.
2. **`scripts/records_live_acceptance.py:846` restricts `graph_sync` to `{"completed","failed"}` and will reject `"pending"`.** Not run in CI and outside the allowlist, so it was left alone. Needs a one-line follow-up before that script is used against a bounded build.

## Environmental, not attributable

The read-after-write budget gate fails on this Windows box **on `origin/main` too** — fix `2000: 1361.7ms`, `8000: 4686.5ms / p95 4777.0ms`; base `2000: 971.5ms`, `8000: 4425.1ms / p95 4759.7ms`, with base's first attempt worse still at `read_after_write_p95 89120.1ms`. Same four rows, same shape, fix inside base's spread on every one. Another session was running the full suite throughout and the log carries a `hold_ms=72359.99` boundary warning. Linux CI is the authoritative verdict.

Regression comparison used base-vs-fix **set** difference across 62 modules, one file per process (pytest-timeout's `thread` method kills a whole session, so a single-process run loses everything): base 216, fix 215, **zero test-level differences**.

Rebased onto `4a0c790b` (#577) with one conflict in the constants block, both sides purely additive, both kept. Verified the semantic interaction: #577's `GraphPublicationSuperseded` branch never sets `retarget`, so this extension cannot apply to it, and a mixed run ending in supersession exits at the floor exactly as before.

`test_full_rebuild_twice_moving_vault_is_marked_unavailable` was renamed to `…of_a_continuously_moving_vault_…`; its contract assertions are untouched, only `assert acquisitions == 2` became the new bound since 2 is now the floor.
