### PR TITLE
feat(benchmarks): file the no-nudge bench families f20-f26 as amendment sequence 2

### DIFF
--- a/benchmarks/epistemic/PREREGISTRATION.md
+++ b/benchmarks/epistemic/PREREGISTRATION.md
@@ -42,6 +42,13 @@ the public-suite lanes.
 | f17 | derivation_collapse | corpus | none | support_collapse_inspectable |
 | f18 | negative_result_retention | corpus | none | refuted_retrievable_at_full_standing |
 | f19 | loop_composite | operational | none | loop_journey_state_coherent (goal → hypothesis → prediction → intervention → records → review → revision across ≥3 sessions and one engine restart; system state, not retrieval accuracy) |
+| f20 | structural_emergence | corpus | none | structural_signal_surfaced_within_budget · signal_absence_checked_across_all_surfaces (binds to categories, anchors and disjoint link neighbourhoods, never to vocabulary; four frequency- and length-matched twins: bounded-scope, tangent, deliberate hub, legitimately heterogeneous log) |
+| f21 | entity_emergence | corpus | none | entity_candidate_surfaced_from_recurrence · signal_absence_checked_across_all_surfaces (frequency-matched incidental-mention twin; lowercase and non-Latin referents) |
+| f22 | unsolicited_contradiction | corpus | none | contradiction_surfaced_unprompted · signal_absence_checked_across_all_surfaces **over contradiction-class signals as well as promotion-class** (concordant-evidence twin in the same similarity band; surfacing route reported, never asserted) |
+| f23 | dismissal_respect | operational | none | dismissal_respected_across_passes · counter_emission_not_repeated_per_write (repeated maintenance passes, engine restart, prominence reconfiguration across the full level range; material change still reopens) |
+| f24 | fresh_session_reconstruction | operational | none | continuation_packet_reconstructs_session · no_retired_state_served_as_current (scope extended to the packet by amendment sequence 2) |
+| f25 | restructure_lifecycle | operational | none | restructure_signal_cleared_by_state_change · signal_absence_checked_across_all_surfaces (cleared by state change, not by dismissal; zero merge-class churn in the frozen window) |
+| f26 | hookless_episode_carrier | operational | none | due_state_block_present_in_carrier · continuation_packet_reconstructs_session (end-to-end thin-client episode; due-state block present in the actual compact responses) |
 
 ## 2. Assertion registry (deterministic; unknown name = fixture load error)
 
@@ -60,6 +67,15 @@ no_cross_case_residue
 due_prediction_surfaced              verdict_state_retrievable
 divergence_surfaced_without_mutation support_collapse_inspectable
 refuted_retrievable_at_full_standing loop_journey_state_coherent
+signal_absence_checked_across_all_surfaces
+structural_signal_surfaced_within_budget
+entity_candidate_surfaced_from_recurrence
+contradiction_surfaced_unprompted
+dismissal_respected_across_passes
+counter_emission_not_repeated_per_write
+continuation_packet_reconstructs_session
+restructure_signal_cleared_by_state_change
+due_state_block_present_in_carrier
 ```
 
 All run against neutral state snapshots (never product internals or answer
@@ -122,6 +138,50 @@ Deterministic results are final; no judge may overturn one.
   after restart. In both cases deterministic snapshots must show ≥3 sessions,
   one restart, the review outcome, and the resulting revision.
 
+- **signal_absence_checked_across_all_surfaces**: every declared surface —
+  audit findings, review queues, proposal queues, and the due-state counters
+  block — projects completely and none names the subject under **any signal
+  class in the family's declared vocabulary**; OR a documented single "open
+  items for X" surface that provably subsumes all four and returns nothing for
+  the subject under that same vocabulary. The vocabulary is promotion-class by
+  default (structural, split, extract, entity- and identity-candidate) and is
+  **widened per family, never narrowed**: f22's twin additionally proves absence
+  over contradiction-class signals, and f23's dismissal predicate proves it over
+  every class the amendment knows. An empty or missing projection is an
+  **error**, never a pass, in both representations.
+- **structural_signal_surfaced_within_budget**: a promotion/split/extract
+  proposal targeting the note is present in an open review or proposal queue at
+  or before the frozen cluster budget; OR a documented structural-suggestion
+  query returns it, with the note's own accumulated cluster count observable so
+  the budget is measurable rather than assumed.
+- **entity_candidate_surfaced_from_recurrence**: an entity-candidate queue entry
+  naming the recurring identity; OR a documented "proposed entities" surface
+  that resolves back to at least the frozen number of distinct contributing
+  sources. Distinct sources, never occurrence counts.
+- **contradiction_surfaced_unprompted**: a typed contradiction/conflict queue
+  entry naming both items; OR a documented review entry that resolves to both
+  and carries a conflict marker. The surfacing route is reported, never asserted.
+- **dismissal_respected_across_passes**: a durable triage store keyed by signal
+  fingerprint whose decision survives passes, restart, and reconfiguration; OR
+  documented per-item review state that resolves to the same fingerprint. A
+  changed fingerprint reopening the item is a **pass** in both.
+- **counter_emission_not_repeated_per_write**: an emission count observable
+  against the batch's write count on the counters block; OR a documented
+  batching/debounce statement plus an observed emission count below the write
+  count over a bulk batch.
+- **continuation_packet_reconstructs_session**: a packet artifact holding every
+  seeded unit **by reference** with a documented size budget; OR a documented
+  continuation/handoff endpoint whose response resolves each unit back to live
+  state. Inlined copies satisfy neither.
+- **restructure_signal_cleared_by_state_change**: the original signal is absent
+  from every open view while the review store holds no dismissal for it; OR a
+  documented signal-lifecycle record showing resolution by state change rather
+  than by triage. Merge-class quiet on the new children is required in both.
+- **due_state_block_present_in_carrier**: the due-state block is present in the
+  compact mutation and recall responses the journey actually received; OR a
+  documented compact-response schema that includes the block plus captured
+  responses conforming to it. A block only reachable at verbose detail fails.
+
 Claim-conditioned N/A: a product whose own materials claim a property scores
 **fail**, not not_applicable, when it is absent — with the claim cited.
 Any not_applicable in a family excludes that family from every comparative
@@ -154,3 +214,29 @@ adversarial comparison at acceptable marginal cost.
 - 2026-08-09 — `evidence_path_resolves` semantics sharpened pre-ratification: a promoted conclusion with ZERO evidence hops is an unresolvable path (vacuity fails). Rationale: erasing evidence edges must never be cheaper than maintaining them; §4's 'every hop dereferences' text is hereby extended to require at least one hop for promoted conclusions. Blast radius acknowledged: an unsourced promoted conclusion is an integrity failure with every aggregate suppressed. `evidence_path_exists` remains the non-catastrophic co-assertion; both fail on zero hops by design.
 
 - 2026-08-15 — **Loop-closure family amendment.** Reason: the 2026-08-14 whole-system epistemic architecture audit found five unmeasured loop-closure properties, and the programme requires their deterministic measurement contracts before the product primitives they assess. This amendment corrects the stale ratification status header; extends §1 with f15 `prediction_window` (corpus; no public coverage; overdue prediction then resolving observation), f16 `plan_record_linkage` (corpus + operational; no public coverage; records diverge from a bound plan), f17 `derivation_collapse` (corpus; no public coverage; one source → two derived notes → a third treating both as support), f18 `negative_result_retention` (corpus; no public coverage; refuted hypothesis plus refuting evidence), and f19 `loop_composite` (operational; no public coverage; goal → hypothesis → prediction → intervention → records → review → revision across at least three sessions and one engine restart); appends their deterministic assertions to §2; and adds representation-neutral predicates to §4. All assertions run against neutral state snapshots under the fixed harness matching rule, and claim-conditioned N/A continues to apply. **Catastrophic-set proposal:** add f18's `refuted_retrievable_at_full_standing` to §3 because silently losing or demoting a refuted result destroys negative evidence just as losing a prior revision does. The existing catastrophic set remains unchanged unless the founder records `accept`; the founder must explicitly record `accept` or `strike` in the amendment acknowledgment. Until the receipt is acknowledged, f15–f19 MUST NOT support a comparative run or claim.
+
+- 2026-08-16 — **No-nudge family amendment (sequence 2).** Reason: the 2026-08-15 no-nudge architecture audit committed the programme to becoming measurably more automatic — structure surfaced without the user asking, entities recognized from recurrence, contradictions surfaced unprompted, dismissals respected forever, fresh sessions reconstructed from durable state, restructures that clear their own signals — and none of it is falsifiable under f01–f19, which measure loop representation and closure rather than autonomous surfacing, nag governance, or the delivery carrier. Contracts-first sequencing is the house rule sequence 1 established: the measurement files before the machinery, so the detectors that follow are built against pre-registered acceptance rather than tuned to pass improvised tests.
+
+  This amendment extends §1 with f20 `structural_emergence` (corpus; no public coverage; a note accumulating structurally distinct durable-unit clusters must surface a promotion-class signal within a frozen cluster budget, with four frequency- and length-matched twins staying quiet: a bounded-scope page, a one-or-two-tangent page, a deliberate hub, and a legitimately heterogeneous log page whose dispersion is intentional), f21 `entity_emergence` (corpus; no public coverage; an identity recurring with reusable facts across at least the frozen number of distinct sources, against a frequency-matched incidental-mention twin, with lowercase and non-Latin referents so script bias is measured rather than hidden), f22 `unsolicited_contradiction` (corpus; no public coverage; materially invalidating evidence surfaces the pair with zero topical agent turns in the trajectory, against a concordant-evidence twin in the same similarity band), f23 `dismissal_respect` (operational; no public coverage; a dismissed fingerprint survives repeated maintenance passes, an engine restart and prominence reconfiguration across the full level range while a material change still reopens, plus counter-emission governance under bulk writes), f24 `fresh_session_reconstruction` (operational; no public coverage; the continuation packet contains every seeded decision unit, open question and latest plan state by reference, excludes a same-sized foreign-project decoy set entirely, and respects a frozen size budget), f25 `restructure_lifecycle` (operational; no public coverage; an applied restructure clears its own signal by state change rather than by dismissal, with zero merge-class churn against the new children inside the frozen window), and f26 `hookless_episode_carrier` (operational journey; no public coverage; a hookless compact-detail surface demonstrates the full carrier path — due-state block present in the actual compact responses, capture landed, reconstruction succeeding). It appends their nine deterministic assertions to §2, headed by the anti-vacuity meta-predicate `signal_absence_checked_across_all_surfaces`, and adds representation-neutral predicates for each to §4. It extends the scenario operation vocabulary with `maintenance_pass`, `triage_decision`, `apply_restructure`, and `configure`; existing families are unaffected.
+
+  **Behaviour, not vocabulary.** The f20 generator asserts that no cluster-name token appears in any assertion parameter, and the synonym-swap fixture requires the signal to survive vocabulary substitution. Negative twins are frequency- and length-matched so raw magnitude can never be the discriminator.
+
+  The corpus binds to the structure it claims: each durable unit carries an opaque **category** and **anchor**, and each page carries a **link neighbourhood** — mutually disjoint neighbourhoods for the accumulating positive, none at all for the bounded twin, one wide neighbourhood for the hub, and a single anchored chain under one uniform category for the deliberate log. Cluster count alone deliberately does **not** separate the set (the log twin carries more clusters than the positive), so no monotone rule over a single count can pass this family; the separation must be a function of the graph and the unit attributes, and it must hold unchanged under the synonym swap.
+
+  **Anti-vacuity.** Every quiet assertion composes `signal_absence_checked_across_all_surfaces`: absence must be established on each declared surface — audit findings, review queues, proposal queues, **and the due-state counters block** — and an empty or missing projection evaluates as an error, never as a pass. Without this, a product that relocates a nag to an unchecked surface, or a projector that silently returns nothing, would pass a quiet assertion.
+
+  Absence is also proven over a declared **signal-class vocabulary**, because relocating a nag across surfaces and renaming it across classes are the same evasion. The vocabulary is promotion-class by default; each family's quiet assertion may widen it and may never narrow it. f22's twin proves absence over contradiction-class signals as well, so a product that surfaced every similar pair as a contradiction produces false positives the family can see rather than false positives invisible to it; f23's dismissal predicate matches a dismissed fingerprint reappearing under **any** class, since a re-nag wearing a different label is the same interruption to the same user.
+
+  **False-positive ceiling.** Zero promotion-class signals on any negative twin is a hard in-family assertion for f20 and f21. The production false-positive budget receives its threshold at calibration and is reported beside, never instead of, the in-family ceiling. No automation metric may be reported without its paired false-positive dual from the same runs, and no aggregate score exists.
+
+  **Constants are calibrated once, then frozen and versioned.** The f20, f21 and f25 budget and window constants are frozen here after a one-time study in which at least three expert annotators label the emergence corpora for the intervention point, taking the median; the protocol and raw labels ship with the judge-agreement assets. Changing a frozen constant requires a new dated §7 amendment with its own receipt, and live judging of the intervention point never occurs in a run. **As filed, the constants in `benchmarks/epistemic/budgets.py` are PROVISIONAL:** the calibration study is blocked on a founder decision about annotator staffing and the small-cohort fallback, and this amendment is withheld, so no run, score or claim can be produced against them. Re-dating this entry with the medians is the act that freezes them.
+
+  **Expected red.** f20, f21 and f22 positives are expected to FAIL on the current runtime. They are falsification targets for the no-nudge programme, not CI failures, and the quiet halves are expected to evaluate as errors rather than passes because the due-state counters surface does not exist yet.
+
+  That expectation binds the f26 carrier driver too. It declares a capability only where a captured compact response evidenced one and marks a surface projected only where a response carried it, so a family whose signal never reached the client evaluates as an error rather than as silence. A journey may not manufacture the quiet it is measuring, and the driver's step list is complete executable argv checked against the envelope's own declared options — a script that cannot run is not evidence about delivery.
+
+  **Catastrophic set: no additions.** Nagging and missed promotions are trust failures, not integrity failures; putting them in §3 would suppress every aggregate over a product-taste miss. This amendment adds **no** catastrophic assertions. It does extend the scope of the existing catastrophic assertion `no_retired_state_served_as_current` to the continuation packet — serving a fresh session a retired decision by reference is the same harm as returning it from a query — and that extension is stated here explicitly so the founder acknowledgment has nothing implicit to adjudicate.
+
+  **The judged half stays out.** Intervention usefulness and continuation sufficiency remain membench agent-track (AT-1) dimensions behind the judge-agreement gate, outside the pre-registered deterministic set. Deterministic gates are never overturnable by a judge.
+
+  Until the receipt is acknowledged, f20–f26 MUST NOT support a comparative run, score, or claim.

--- a/benchmarks/epistemic/assertions.py
+++ b/benchmarks/epistemic/assertions.py
@@ -2977,8 +2977,10 @@ def due_state_block_present_in_carrier(ctx: AssertionContext) -> AssertionResult
     # folding them together was hiding one of them. "The carrier delivered
     # nothing" is the family's negative result; "we never observed the surface"
     # is an error in the observation, and must not be reported as a product
-    # failure. Both branches are reachable, which is what makes the guard a
-    # guard rather than a comment.
+    # failure. No shipped projector produces the blocked branch today
+    # (journey_snapshot carries items only on a complete projection); it is a
+    # defensive self-consistency check, exercised via hand-mutated snapshots
+    # in the tests.
     if projection != PROJECTION_COMPLETE:
         if carried:
             return _result(

--- a/benchmarks/epistemic/assertions.py
+++ b/benchmarks/epistemic/assertions.py
@@ -1,4 +1,4 @@
-"""The 18 pre-registered assertions, as deterministic functions over snapshots.
+"""The 33 pre-registered assertions, as deterministic functions over snapshots.
 
 Every assertion takes an :class:`AssertionContext` — one snapshot, or a
 snapshot pair for the transition invariants — and returns an
@@ -31,14 +31,21 @@ Three rules hold across all eighteen:
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, replace
 from datetime import datetime
-from typing import Literal
+from types import MappingProxyType
+from typing import Literal, TypeVar
 
 from membench.scoring.gates import states_value
 from pydantic import Field
 
+from .budgets import (
+    CONTINUATION_PACKET_UNIT_BUDGET,
+    ENTITY_EMERGENCE_SOURCE_BUDGET,
+    RESTRUCTURE_QUIET_WINDOW_PASSES,
+    STRUCTURAL_EMERGENCE_CLUSTER_BUDGET,
+)
 from .snapshot import EpistemicStateSnapshot, StateItem, StrictModel
 
 #: The five-valued outcome vocabulary from the spec.
@@ -134,6 +141,137 @@ JOURNEY_STAGES: tuple[str, ...] = (
     "revision",
 )
 
+#: Vocabularies for the 2026-08 no-nudge families (f20-f26).
+#:
+#: Same closed-set discipline as everything above, and one addition of its own:
+#: these families are *behaviour-not-vocabulary* by contract, so none of these
+#: tokens may ever be matched against fixture prose. They are matched against a
+#: single structured attribute value, and the f20 generator separately asserts
+#: that no cluster-name token appears in any assertion parameter. A detector
+#: that learned the fixture's words rather than its structure fails the family.
+
+#: Attribute keys under which a projector records what class of signal an item
+#: is. A "signal" here is any autonomously surfaced queue entry.
+SIGNAL_CLASS_RAW_KEYS: frozenset[str] = frozenset(
+    {"signal_class", "signal", "signal_kind", "candidate_kind"}
+)
+#: Signal classes that propose promoting or splitting accumulated structure.
+#: f20's positive requires one of these; its twins forbid all of them.
+PROMOTION_SIGNAL_CLASSES: frozenset[str] = frozenset(
+    {"promotion", "promote", "structural", "structure", "split", "extract", "emergence"}
+)
+#: Signal classes that propose a recurring identity as an entity candidate.
+ENTITY_SIGNAL_CLASSES: frozenset[str] = frozenset(
+    {"entity_candidate", "entity", "identity_candidate", "identity"}
+)
+#: Signal classes that surface a contradiction or invalidation pair.
+CONTRADICTION_SIGNAL_CLASSES: frozenset[str] = frozenset(
+    {"contradiction", "conflict", "invalidation", "divergence_pair"}
+)
+#: Signal classes that propose folding items back together. f25 forbids these
+#: against the children a just-applied restructure created.
+MERGE_SIGNAL_CLASSES: frozenset[str] = frozenset(
+    {"merge", "consolidation", "consolidate", "combine", "fold"}
+)
+#: Every class that counts as promotion-class for the false-positive ceiling.
+#: The ceiling is about *any* unsolicited promotion of a twin, so entity and
+#: structural proposals both count; a merge proposal does not, because f25
+#: measures that separately and against different subjects.
+UNSOLICITED_PROPOSAL_CLASSES: frozenset[str] = PROMOTION_SIGNAL_CLASSES | ENTITY_SIGNAL_CLASSES
+
+#: Every signal class this amendment knows about. A quiet assertion that proves
+#: absence over *this* is proving absence of nagging as such, rather than of one
+#: dialect of it.
+ALL_SIGNAL_CLASSES: frozenset[str] = (
+    PROMOTION_SIGNAL_CLASSES
+    | ENTITY_SIGNAL_CLASSES
+    | CONTRADICTION_SIGNAL_CLASSES
+    | MERGE_SIGNAL_CLASSES
+)
+
+#: ``assertion name -> the signal classes it proves absence over``. Populated by
+#: :func:`claims_absence` where each predicate is defined, so the vocabulary a
+#: quiet assertion is answerable for is stated next to its implementation rather
+#: than inferred by whoever reads it later.
+ABSENCE_CLAIM_CLASSES: dict[str, frozenset[str]] = {}
+
+#: ``family -> extra signal classes its quiet assertion must also prove absent``.
+#:
+#: f22 is why this exists. Its twin's quiet assertion is the meta-predicate
+#: itself, so there is no family-specific callable to carry the declaration, and
+#: with only the promotion-class vocabulary a product that surfaced *every*
+#: similar pair as a contradiction produced false positives no assertion in the
+#: family could see. The mapping is code, not fixture data: a scenario cannot
+#: reach it, and it is unioned in, so a family can only ever be held to *more*
+#: than the default — never less.
+FAMILY_ABSENCE_CLASSES: Mapping[str, frozenset[str]] = MappingProxyType(
+    {"f22": CONTRADICTION_SIGNAL_CLASSES}
+)
+
+_AssertionT = TypeVar("_AssertionT", bound=Callable[..., "AssertionResult"])
+
+
+def claims_absence(*vocabularies: frozenset[str]) -> Callable[[_AssertionT], _AssertionT]:
+    """Mark a predicate as an absence claim and declare its signal vocabulary.
+
+    The marker is what ``COMPOSES_ABSENCE_META`` is checked against, so a future
+    quiet assertion cannot be added to the registry while quietly staying out of
+    the set that forces it to compose the meta-predicate. The declared classes
+    are always unioned with :data:`UNSOLICITED_PROPOSAL_CLASSES`: a predicate may
+    widen what it proves silence about, never narrow it.
+    """
+
+    def decorate(fn: _AssertionT) -> _AssertionT:
+        fn.absence_claim = True  # type: ignore[attr-defined]
+        ABSENCE_CLAIM_CLASSES[fn.__name__] = UNSOLICITED_PROPOSAL_CLASSES.union(*vocabularies)
+        return fn
+
+    return decorate
+
+
+#: Attribute keys naming which surface an item was observed on.
+SURFACE_RAW_KEYS: frozenset[str] = frozenset({"surface", "queue", "view"})
+#: Attribute keys naming what an item is about.
+TARGET_RAW_KEYS: frozenset[str] = frozenset({"targets", "target", "about", "subject_id"})
+#: Attribute keys carrying a surface's projection completeness.
+PROJECTION_RAW_KEYS: frozenset[str] = frozenset({"projection", "projected", "surface_state"})
+#: The only projection value that permits a quiet assertion to conclude silence.
+#: Anything else — including an explicitly empty projection — is an error.
+PROJECTION_COMPLETE: str = "complete"
+
+#: The surfaces on which absence must be proven before any quiet assertion may
+#: pass. The counters block is in this list deliberately: without it, a product
+#: that stops emitting a queue item but keeps naming the twin in its due-state
+#: counters would pass a quiet assertion while still nagging the user.
+DECLARED_ABSENCE_SURFACES: tuple[str, ...] = (
+    "audit_findings",
+    "review_queue",
+    "proposal_queue",
+    "due_state_counters",
+)
+
+#: Attribute keys carrying how many structurally distinct clusters have
+#: accumulated on a note, and how many distinct sources an identity recurs in.
+CLUSTER_COUNT_RAW_KEYS: frozenset[str] = frozenset({"cluster_count", "clusters"})
+SOURCE_COUNT_RAW_KEYS: frozenset[str] = frozenset({"source_count", "sources", "distinct_sources"})
+#: Attribute keys carrying a durable triage fingerprint and its decision.
+FINGERPRINT_RAW_KEYS: frozenset[str] = frozenset(
+    {"fingerprint", "signal_fingerprint", "dismissal_fingerprint"}
+)
+#: Attribute keys carrying how many maintenance passes an item has survived,
+#: and how many writes a counters block was emitted for.
+PASS_COUNT_RAW_KEYS: frozenset[str] = frozenset({"passes", "pass_count", "maintenance_passes"})
+EMISSION_COUNT_RAW_KEYS: frozenset[str] = frozenset({"emissions", "emission_count"})
+WRITE_COUNT_RAW_KEYS: frozenset[str] = frozenset({"writes", "write_count", "batch_size"})
+#: Attribute keys marking an item as the continuation packet, and the response
+#: detail level a carrier journey ran at.
+PACKET_RAW_KEYS: frozenset[str] = frozenset({"packet", "continuation_packet", "packet_id"})
+RESPONSE_DETAIL_RAW_KEYS: frozenset[str] = frozenset({"response_detail", "detail"})
+#: Attribute key marking an item as a foreign-project decoy the packet must
+#: exclude entirely, and one marking a restructure's newly created child.
+DECOY_RAW_KEYS: frozenset[str] = frozenset({"decoy", "foreign_project"})
+RESTRUCTURE_CHILD_RAW_KEYS: frozenset[str] = frozenset({"restructure_child", "child_of"})
+
 #: Cap on how many offenders one evidence string lists (as the gates do).
 _MAX_LISTED = 8
 
@@ -171,6 +309,23 @@ class AssertionContext:
     external_edit_at: str | None = None
     #: Allowed reconstruction loss for the export comparison, 0.0 - 1.0.
     tolerance: float = 0.0
+    #: The scenario's family, supplied by the runner. Read only to widen a quiet
+    #: assertion's signal vocabulary (see :data:`FAMILY_ABSENCE_CLASSES`); it can
+    #: never narrow one, so it cannot be used to make an assertion easier.
+    family: str | None = None
+
+    @property
+    def absence_surfaces(self) -> tuple[str, ...]:
+        """The surfaces this context must prove absence on.
+
+        Fixed, not negotiable: the canonical four in
+        :data:`DECLARED_ABSENCE_SURFACES`. An earlier version let a caller widen
+        this list, but nothing ever did, and a widening path no scenario reaches
+        is a claim about rigour rather than rigour — so the list is simply the
+        registered one and a scenario has no say in it.
+        """
+
+        return DECLARED_ABSENCE_SURFACES
 
     def replace(self, **changes: object) -> AssertionContext:
         return replace(self, **changes)  # type: ignore[arg-type]
@@ -665,7 +820,17 @@ def exactly_one_current_revision(ctx: AssertionContext) -> AssertionResult:
 
 
 def no_retired_state_served_as_current(ctx: AssertionContext) -> AssertionResult:
-    """Retired state is never served as, or marked, current. CATASTROPHIC."""
+    """Retired state is never served as, or marked, current. CATASTROPHIC.
+
+    **Scope extension, amendment sequence 2 (2026-08-16).** A continuation
+    packet is a serving surface: handing a fresh session a retired decision by
+    reference is the same harm as returning it from a query, and f24 would
+    otherwise measure packet *completeness* while saying nothing about packet
+    *currency*. So the packet's referenced units are treated as served items.
+    This is an extension of an existing catastrophic assertion's scope, stated
+    explicitly in §7 rather than smuggled in, and it adds no new catastrophic
+    assertion — the §3 set is unchanged.
+    """
 
     name = "no_retired_state_served_as_current"
     gated = _gate(ctx, name, "current")
@@ -678,6 +843,23 @@ def no_retired_state_served_as_current(ctx: AssertionContext) -> AssertionResult
 
     def retired(item: StateItem) -> bool:
         return item.current == "no" or bool(item.retired_reason) or item.id in superseded
+
+    packet = _packet_item(snapshot)
+    if packet is not None:
+        packet_served = sorted(_packet_referenced_ids(snapshot, packet))
+        stale = [
+            f"{item_id} (current={item.current}, retired_reason={item.retired_reason!r})"
+            for item_id in packet_served
+            if (item := by_id.get(item_id)) is not None and retired(item)
+        ]
+        if stale:
+            return _result(
+                name,
+                "fail",
+                f"continuation packet {packet.id} serves retired state as current: "
+                f"{_listed(stale)}",
+                ctx.subject,
+            )
 
     if ctx.served_items is not None:
         offenders: list[str] = []
@@ -2140,5 +2322,693 @@ def loop_journey_state_coherent(ctx: AssertionContext) -> AssertionResult:
         "pass",
         f"all {len(JOURNEY_STAGES)} stages recorded across {len(sessions)} sessions, "
         "linked, and unchanged across the restart",
+        ctx.subject,
+    )
+
+
+# --------------------------------------------------------------------------
+# 20-26: the no-nudge families (amendment sequence 2)
+#
+# f20-f22 are expected to be *red* on the current runtime, and the quiet halves
+# blocked, because the detectors, consumers and carriers they measure do not
+# exist yet. That is the contract: these are falsification targets filed before
+# the machinery, never tests tuned to pass.
+# --------------------------------------------------------------------------
+
+
+def _raw_int(item: StateItem, keys: frozenset[str]) -> int | None:
+    """A non-negative integer recorded under a documented attribute, or ``None``."""
+
+    found = _raw_value(item, keys)
+    if found is None:
+        return None
+    try:
+        parsed = int(found[1].strip())
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _normalized(value: str) -> str:
+    return value.strip().casefold().replace("-", "_")
+
+
+def _signal_targets(item: StateItem) -> tuple[str, ...]:
+    """Item ids a signal is about, from its documented target attribute."""
+
+    found = _raw_value(item, TARGET_RAW_KEYS)
+    if found is None:
+        return ()
+    return tuple(part.strip() for part in found[1].replace(";", ",").split(",") if part.strip())
+
+
+def _signal_surface(item: StateItem) -> str | None:
+    found = _raw_value(item, SURFACE_RAW_KEYS)
+    return _normalized(found[1]) if found is not None else None
+
+
+def _surface_projection(snapshot: EpistemicStateSnapshot, surface: str) -> str | None:
+    """How completely ``surface`` was projected, or ``None`` when it is missing.
+
+    A *surface marker* carries both a surface name and a projection status; a
+    signal sitting on the surface carries a signal class instead. Keeping the
+    two apart is what stops a queue that happens to hold one entry from being
+    read as proof that the queue was projected at all.
+    """
+
+    for item in snapshot.items:
+        if _signal_surface(item) != _normalized(surface):
+            continue
+        projection = _raw_value(item, PROJECTION_RAW_KEYS)
+        if projection is not None:
+            return _normalized(projection[1])
+    return None
+
+
+def _signals_targeting(
+    snapshot: EpistemicStateSnapshot,
+    subject: str,
+    vocabulary: frozenset[str],
+) -> tuple[tuple[StateItem, str], ...]:
+    """``(signal item, class token)`` for every signal of ``vocabulary`` about ``subject``."""
+
+    found: list[tuple[StateItem, str]] = []
+    for item in snapshot.items:
+        token = _raw_states(item, SIGNAL_CLASS_RAW_KEYS, vocabulary)
+        if token is None or subject not in _signal_targets(item):
+            continue
+        found.append((item, token))
+    return tuple(found)
+
+
+def _packet_item(snapshot: EpistemicStateSnapshot) -> StateItem | None:
+    """The continuation packet, identified by its documented attribute."""
+
+    for item in snapshot.items:
+        if _raw_value(item, PACKET_RAW_KEYS) is not None:
+            return item
+    return None
+
+
+def _packet_referenced_ids(
+    snapshot: EpistemicStateSnapshot, packet: StateItem
+) -> frozenset[str]:
+    """Unit ids the packet holds **by reference**, never by inlined copy."""
+
+    return frozenset(packet.cites) | frozenset(
+        relation.object
+        for relation in snapshot.relations
+        if relation.subject == packet.id and relation.predicate in EVIDENCE_PREDICATES
+    )
+
+
+def _is_decoy(item: StateItem) -> bool:
+    found = _raw_value(item, DECOY_RAW_KEYS)
+    return found is not None and _normalized(found[1]) in {"yes", "true", "1"}
+
+
+@claims_absence()
+def signal_absence_checked_across_all_surfaces(
+    ctx: AssertionContext, *, on_behalf_of: str | None = None
+) -> AssertionResult:
+    """The anti-vacuity meta-predicate: silence proven on every declared surface.
+
+    Three cheats this exists to turn into structural failures. A product that
+    stops emitting a queue item for a twin but still names it in the due-state
+    counters block has *relocated* the nag, not removed it — so the counters
+    block is one of the surfaces absence must be proven on. A projector that
+    silently returns nothing for a surface has proven nothing at all — so an
+    empty or missing projection is an error, never a pass. And a product that
+    renames its nag into a signal class this predicate was not watching has
+    changed nothing the user experiences — so the vocabulary is declared per
+    caller and per family, and only ever widened.
+
+    ``on_behalf_of`` is the composing predicate's own name, which is how a
+    family declares the classes it is answerable for. Every negative control in
+    f20-f26 composes this, which is what makes the family's false-positive
+    ceiling worth asserting at all.
+    """
+
+    name = "signal_absence_checked_across_all_surfaces"
+    vocabulary = ABSENCE_CLAIM_CLASSES[on_behalf_of or name] | FAMILY_ABSENCE_CLASSES.get(
+        ctx.family or "", frozenset()
+    )
+    gated = _gate(ctx, name, "signal", "review_state", "due_state_counters")
+    if gated is not None:
+        return gated
+
+    subject = ctx.subject
+    if not subject:
+        return _result(
+            name, "blocked", "quiet assertion requires the subject it proves silence about", None
+        )
+
+    surfaces = ctx.absence_surfaces
+    unprojected = [
+        f"{surface}({_surface_projection(ctx.snapshot, surface) or 'missing'})"
+        for surface in surfaces
+        if _surface_projection(ctx.snapshot, surface) != PROJECTION_COMPLETE
+    ]
+    if unprojected:
+        return _result(
+            name,
+            "blocked",
+            f"absence cannot be established for {subject}: {_listed(unprojected)} "
+            "did not project completely; an unprojected surface is an error, never silence",
+            subject,
+        )
+
+    offenders = [
+        f"{item.id} ({token} on {_signal_surface(item) or 'unnamed surface'})"
+        for item, token in _signals_targeting(ctx.snapshot, subject, vocabulary)
+    ]
+    if offenders:
+        return _result(
+            name,
+            "fail",
+            f"{subject} is named by unsolicited signal(s) despite the quiet "
+            f"expectation: {_listed(offenders)}",
+            subject,
+        )
+    return _result(
+        name,
+        "pass",
+        f"no signal in the {len(vocabulary)}-class vocabulary names {subject} on any of the "
+        f"{len(surfaces)} completely projected surfaces ({', '.join(surfaces)})",
+        subject,
+    )
+
+
+def structural_signal_surfaced_within_budget(ctx: AssertionContext) -> AssertionResult:
+    """f20: accumulated structure surfaces a promotion-class signal, in budget.
+
+    Binds to structure, never to vocabulary: the discriminator is the count of
+    structurally distinct durable-unit clusters the note carries, and the budget
+    comes from the frozen constants module so no fixture can retune it.
+    """
+
+    name = "structural_signal_surfaced_within_budget"
+    gated = _gate(ctx, name, "signal", "review_state")
+    if gated is not None:
+        return gated
+
+    subject = ctx.subject
+    if not subject:
+        return _result(name, "blocked", "f20 requires the accumulating note as subject", None)
+    item = ctx.snapshot.item(subject)
+    if item is None:
+        return _result(name, "unsupported", f"{subject} is not present in the snapshot", subject)
+
+    clusters = _raw_int(item, CLUSTER_COUNT_RAW_KEYS)
+    if clusters is None:
+        return _result(
+            name,
+            "unsupported",
+            f"{subject} records no cluster count; the structural budget cannot be measured",
+            subject,
+        )
+
+    open_signals = [
+        (signal, token)
+        for signal, token in _signals_targeting(ctx.snapshot, subject, PROMOTION_SIGNAL_CLASSES)
+        if not _is_closed(signal.review_state)
+    ]
+    if not open_signals:
+        return _result(
+            name,
+            "fail",
+            f"{subject} accumulated {clusters} structurally distinct cluster(s) and no "
+            "promotion-class signal is present in any open view",
+            subject,
+        )
+    if clusters > STRUCTURAL_EMERGENCE_CLUSTER_BUDGET:
+        return _result(
+            name,
+            "fail",
+            f"{subject} surfaced only after {clusters} clusters, past the frozen budget of "
+            f"{STRUCTURAL_EMERGENCE_CLUSTER_BUDGET}",
+            subject,
+        )
+    signal, token = open_signals[0]
+    return _result(
+        name,
+        "pass",
+        f"{signal.id} ({token}) surfaced for {subject} at {clusters} cluster(s), within the "
+        f"frozen budget of {STRUCTURAL_EMERGENCE_CLUSTER_BUDGET}",
+        subject,
+    )
+
+
+def entity_candidate_surfaced_from_recurrence(ctx: AssertionContext) -> AssertionResult:
+    """f21: an identity recurring with reusable facts surfaces as a candidate.
+
+    The discriminator is *distinct sources carrying reusable facts*, not string
+    frequency — which is exactly what the frequency-matched incidental-mention
+    twin exists to prove, since a mutant that counted occurrences would
+    otherwise pass both halves of the family.
+    """
+
+    name = "entity_candidate_surfaced_from_recurrence"
+    gated = _gate(ctx, name, "signal", "review_state")
+    if gated is not None:
+        return gated
+
+    subject = ctx.subject
+    if not subject:
+        return _result(name, "blocked", "f21 requires the recurring identity as subject", None)
+    item = ctx.snapshot.item(subject)
+    if item is None:
+        return _result(name, "unsupported", f"{subject} is not present in the snapshot", subject)
+
+    sources = _raw_int(item, SOURCE_COUNT_RAW_KEYS)
+    if sources is None:
+        return _result(
+            name,
+            "unsupported",
+            f"{subject} records no distinct-source count; recurrence cannot be measured",
+            subject,
+        )
+
+    surfaced = [
+        (signal, token)
+        for signal, token in _signals_targeting(ctx.snapshot, subject, ENTITY_SIGNAL_CLASSES)
+        if not _is_closed(signal.review_state)
+    ]
+    if not surfaced:
+        return _result(
+            name,
+            "fail",
+            f"{subject} recurs across {sources} distinct source(s) and no entity-candidate "
+            "signal is present in any open view",
+            subject,
+        )
+    if sources < ENTITY_EMERGENCE_SOURCE_BUDGET:
+        return _result(
+            name,
+            "fail",
+            f"{subject} surfaced on only {sources} distinct source(s); the frozen threshold is "
+            f"{ENTITY_EMERGENCE_SOURCE_BUDGET}, so this is a premature candidate",
+            subject,
+        )
+    signal, token = surfaced[0]
+    return _result(
+        name,
+        "pass",
+        f"{signal.id} ({token}) surfaced for {subject} across {sources} distinct source(s)",
+        subject,
+    )
+
+
+def contradiction_surfaced_unprompted(ctx: AssertionContext) -> AssertionResult:
+    """f22: invalidating evidence surfaces the pair without the user asking.
+
+    Unpromptedness is a *trajectory* property the loader enforces (zero topical
+    agent turns between evidence ingest and the asserted snapshot), so what is
+    left to assert here is that the pair actually surfaced. The surfacing route
+    is reported in the evidence string and never asserted: which queue found it
+    is a fact worth recording, not a property a product must satisfy one way.
+    """
+
+    name = "contradiction_surfaced_unprompted"
+    gated = _gate(ctx, name, "signal", "contradicts", "review_state")
+    if gated is not None:
+        return gated
+
+    subject, counterpart = ctx.subject, ctx.counterpart
+    if not subject or not counterpart:
+        return _result(
+            name,
+            "blocked",
+            "f22 requires both the conclusion and the invalidating evidence",
+            subject,
+        )
+
+    for signal, token in _signals_targeting(ctx.snapshot, subject, CONTRADICTION_SIGNAL_CLASSES):
+        if counterpart not in _signal_targets(signal) or _is_closed(signal.review_state):
+            continue
+        route = _signal_surface(signal) or "unnamed surface"
+        return _result(
+            name,
+            "pass",
+            f"{signal.id} ({token}) surfaces {subject} against {counterpart}; "
+            f"surfacing route reported: {route}",
+            subject,
+        )
+    return _result(
+        name,
+        "fail",
+        f"no open contradiction-class signal pairs {subject} with {counterpart}",
+        subject,
+    )
+
+
+@claims_absence(ALL_SIGNAL_CLASSES)
+def dismissal_respected_across_passes(ctx: AssertionContext) -> AssertionResult:
+    """f23: a dismissed fingerprint stays dismissed until something material changes.
+
+    The two halves are inseparable. Respecting a dismissal *forever* would be a
+    bug, not a feature, so a changed fingerprint reopening the item is a pass;
+    an unchanged fingerprint reappearing is the failure. Where nothing reappears
+    at all, the meta-predicate is composed rather than trusted, so a product
+    cannot pass by relocating the item to a surface nobody checked.
+
+    The reappearance match is over **every** signal class with no subset
+    anywhere in the path. Re-raising a dismissed fingerprint as a contradiction,
+    a merge or a conflict is the same nag wearing a different hat, and the user
+    experiencing it cannot tell the difference.
+    """
+
+    name = "dismissal_respected_across_passes"
+    gated = _gate(ctx, name, "dismissal", "review_state", "signal")
+    if gated is not None:
+        return gated
+
+    subject = ctx.subject
+    if not subject:
+        return _result(name, "blocked", "f23 requires the dismissed item as subject", None)
+    prior = ctx.prior
+    if prior is None:
+        return _result(name, "blocked", "f23 compares a dismissal against a later pass", subject)
+
+    dismissed = prior.item(subject)
+    if dismissed is None:
+        return _result(
+            name, "unsupported", f"{subject} is absent from the earlier snapshot", subject
+        )
+    recorded = _raw_value(dismissed, FINGERPRINT_RAW_KEYS)
+    if recorded is None or not _is_closed(dismissed.review_state):
+        return _result(
+            name,
+            "unsupported",
+            f"{subject} carries no closed triage decision with a fingerprint to respect",
+            subject,
+        )
+    dismissed_fingerprint = _normalized(recorded[1])
+
+    unchanged: list[str] = []
+    for signal, token in _signals_targeting(
+        ctx.snapshot, subject, ABSENCE_CLAIM_CLASSES["dismissal_respected_across_passes"]
+    ):
+        if _is_closed(signal.review_state):
+            continue
+        found = _raw_value(signal, FINGERPRINT_RAW_KEYS)
+        if found is not None and _normalized(found[1]) != dismissed_fingerprint:
+            return _result(
+                name,
+                "pass",
+                f"{signal.id} ({token}) reopened {subject} under a changed fingerprint "
+                f"{found[1]!r}; a material change is supposed to reopen",
+                subject,
+            )
+        unchanged.append(f"{signal.id} ({token})")
+    if unchanged:
+        return _result(
+            name,
+            "fail",
+            f"{subject} reappeared under the dismissed fingerprint {recorded[1]!r}: "
+            f"{_listed(unchanged)}",
+            subject,
+        )
+
+    absence = signal_absence_checked_across_all_surfaces(
+        ctx, on_behalf_of="dismissal_respected_across_passes"
+    )
+    if absence.outcome != "pass":
+        return _result(
+            name,
+            absence.outcome,
+            f"dismissal of {subject} cannot be confirmed: {absence.evidence}",
+            subject,
+        )
+    passes = _raw_int(ctx.snapshot.item(subject) or dismissed, PASS_COUNT_RAW_KEYS)
+    survived = f" across {passes} maintenance pass(es)" if passes is not None else ""
+    return _result(
+        name, "pass", f"{subject} stayed dismissed{survived}; {absence.evidence}", subject
+    )
+
+
+def counter_emission_not_repeated_per_write(ctx: AssertionContext) -> AssertionResult:
+    """f23: a bulk batch does not emit one identical counters block per write.
+
+    Counter-repetition is nagging under another name — the user asked for one
+    batch and received N notifications — so the governance is asserted here
+    rather than left to product taste.
+    """
+
+    name = "counter_emission_not_repeated_per_write"
+    gated = _gate(ctx, name, "due_state_counters", "signal")
+    if gated is not None:
+        return gated
+
+    blocks = [
+        item
+        for item in ctx.snapshot.items
+        if _signal_surface(item) == "due_state_counters"
+        and _raw_value(item, EMISSION_COUNT_RAW_KEYS) is not None
+    ]
+    if not blocks:
+        return _result(
+            name,
+            "unsupported",
+            "no due-state counters block records an emission count",
+            ctx.subject,
+        )
+    block = blocks[0]
+    emissions = _raw_int(block, EMISSION_COUNT_RAW_KEYS)
+    writes = _raw_int(block, WRITE_COUNT_RAW_KEYS)
+    if emissions is None or writes is None:
+        return _result(
+            name,
+            "unsupported",
+            f"{block.id} does not record both an emission count and a write count",
+            ctx.subject,
+        )
+    if writes < 2:
+        return _result(
+            name,
+            "unsupported",
+            f"{block.id} records {writes} write(s); counter repetition needs a bulk batch",
+            ctx.subject,
+        )
+    if emissions >= writes:
+        return _result(
+            name,
+            "fail",
+            f"{block.id} emitted {emissions} counters block(s) for {writes} write(s): one "
+            "identical block per write is counter-repetition",
+            ctx.subject,
+        )
+    return _result(
+        name,
+        "pass",
+        f"{block.id} emitted {emissions} counters block(s) for a batch of {writes} write(s)",
+        ctx.subject,
+    )
+
+
+def continuation_packet_reconstructs_session(ctx: AssertionContext) -> AssertionResult:
+    """f24: the packet holds every seeded unit by reference, and no decoy.
+
+    Containment is *by reference*: a packet that inlines content is a copy, and
+    a copy is precisely how a continuation aid drifts away from the state it
+    claims to reconstruct.
+    """
+
+    name = "continuation_packet_reconstructs_session"
+    gated = _gate(ctx, name, "continuation_packet", "cites")
+    if gated is not None:
+        return gated
+
+    packet = _packet_item(ctx.snapshot)
+    if packet is None:
+        return _result(
+            name, "fail", "no continuation packet is present in the snapshot", ctx.subject
+        )
+    referenced = _packet_referenced_ids(ctx.snapshot, packet)
+
+    required = tuple(
+        item
+        for item in ctx.snapshot.items
+        if item.id != packet.id
+        and not _is_decoy(item)
+        and (item.kind in {"decision", "open_question"} or _raw_value(item, PLAN_RAW_KEYS))
+    )
+    missing = [item.id for item in required if item.id not in referenced]
+    if missing:
+        return _result(
+            name, "fail", f"{packet.id} omits seeded unit(s): {_listed(missing)}", ctx.subject
+        )
+
+    decoys = [item.id for item in ctx.snapshot.items if _is_decoy(item) and item.id in referenced]
+    if decoys:
+        return _result(
+            name,
+            "fail",
+            f"{packet.id} admits foreign-project decoy(s): {_listed(decoys)}",
+            ctx.subject,
+        )
+    if len(referenced) > CONTINUATION_PACKET_UNIT_BUDGET:
+        return _result(
+            name,
+            "fail",
+            f"{packet.id} references {len(referenced)} unit(s), past the frozen size budget of "
+            f"{CONTINUATION_PACKET_UNIT_BUDGET}",
+            ctx.subject,
+        )
+    return _result(
+        name,
+        "pass",
+        f"{packet.id} references all {len(required)} seeded unit(s), excludes every decoy, and "
+        f"holds {len(referenced)} unit(s) within the budget of {CONTINUATION_PACKET_UNIT_BUDGET}",
+        ctx.subject,
+    )
+
+
+@claims_absence(MERGE_SIGNAL_CLASSES)
+def restructure_signal_cleared_by_state_change(ctx: AssertionContext) -> AssertionResult:
+    """f25: an applied restructure clears its own signal, without a dismissal.
+
+    Clearing by dismissal would be the product hiding its own suggestion rather
+    than the state change resolving it, so a dismissal recorded for the subject
+    fails here even though the signal is gone. The second half forbids churn:
+    nothing may propose folding the new children back together inside the frozen
+    quiet window.
+    """
+
+    name = "restructure_signal_cleared_by_state_change"
+    gated = _gate(ctx, name, "signal", "review_state")
+    if gated is not None:
+        return gated
+
+    subject = ctx.subject
+    if not subject:
+        return _result(name, "blocked", "f25 requires the restructured note as subject", None)
+
+    item = ctx.snapshot.item(subject)
+    if (
+        item is not None
+        and _raw_value(item, FINGERPRINT_RAW_KEYS) is not None
+        and _is_closed(item.review_state)
+    ):
+        return _result(
+            name,
+            "fail",
+            f"{subject}'s structural signal is held by a dismissal ({item.review_state}), not "
+            "cleared by the applied restructure",
+            subject,
+        )
+
+    absence = signal_absence_checked_across_all_surfaces(
+        ctx, on_behalf_of="restructure_signal_cleared_by_state_change"
+    )
+    if absence.outcome != "pass":
+        return _result(
+            name,
+            absence.outcome,
+            f"the restructured signal for {subject} is not demonstrably cleared: "
+            f"{absence.evidence}",
+            subject,
+        )
+
+    children = tuple(
+        candidate
+        for candidate in ctx.snapshot.items
+        if (found := _raw_value(candidate, RESTRUCTURE_CHILD_RAW_KEYS)) is not None
+        and (_normalized(found[1]) in {"yes", "true", "1"} or found[1].strip() == subject)
+    )
+    churn: list[str] = []
+    for child in children:
+        for signal, token in _signals_targeting(ctx.snapshot, child.id, MERGE_SIGNAL_CLASSES):
+            passes = _raw_int(signal, PASS_COUNT_RAW_KEYS)
+            if passes is None or passes <= RESTRUCTURE_QUIET_WINDOW_PASSES:
+                churn.append(f"{signal.id} ({token} -> {child.id})")
+    if churn:
+        return _result(
+            name,
+            "fail",
+            f"merge-class churn targets the new children inside the frozen window of "
+            f"{RESTRUCTURE_QUIET_WINDOW_PASSES} pass(es): {_listed(churn)}",
+            subject,
+        )
+    return _result(
+        name,
+        "pass",
+        f"{subject}'s signal is absent from every open view with no dismissal recorded, and "
+        f"{len(children)} new child(ren) drew no merge-class proposal inside the frozen window",
+        subject,
+    )
+
+
+def due_state_block_present_in_carrier(ctx: AssertionContext) -> AssertionResult:
+    """f26: the due-state block reaches a thin client's compact responses.
+
+    Every other family measures a detector or an end state, so a runtime could
+    satisfy all of them while no signal ever arrived anywhere a user could see
+    it. This asserts the delivery path itself, against the compact responses the
+    journey actually received.
+    """
+
+    name = "due_state_block_present_in_carrier"
+    gated = _gate(ctx, name, "due_state_counters", "continuation_packet")
+    if gated is not None:
+        return gated
+
+    responses = tuple(
+        item
+        for item in ctx.snapshot.items
+        if (found := _raw_value(item, RESPONSE_DETAIL_RAW_KEYS)) is not None
+        and _normalized(found[1]) == "compact"
+    )
+    if not responses:
+        return _result(
+            name,
+            "unsupported",
+            "no compact response was captured; the carrier path cannot be observed",
+            ctx.subject,
+        )
+
+    projection = _surface_projection(ctx.snapshot, "due_state_counters")
+    carried = [
+        response.id
+        for response in responses
+        if "due_state_counters" in set(_signal_targets(response))
+    ]
+    # The two reasons a block can be missing are not the same finding, and
+    # folding them together was hiding one of them. "The carrier delivered
+    # nothing" is the family's negative result; "we never observed the surface"
+    # is an error in the observation, and must not be reported as a product
+    # failure. Both branches are reachable, which is what makes the guard a
+    # guard rather than a comment.
+    if projection != PROJECTION_COMPLETE:
+        if carried:
+            return _result(
+                name,
+                "blocked",
+                f"{_listed(carried)} reference a due-state block but the due_state_counters "
+                f"surface did not project completely ({projection or 'missing'}); the "
+                "observation contradicts itself and cannot settle delivery",
+                ctx.subject,
+            )
+        return _result(
+            name,
+            "fail",
+            f"none of the {len(responses)} compact response(s) carries a due-state block "
+            f"({_listed(response.id for response in responses)}), and the due_state_counters "
+            f"surface projected {projection or 'nothing'}: the block did not reach the client",
+            ctx.subject,
+        )
+    if not carried:
+        return _result(
+            name,
+            "fail",
+            f"none of the {len(responses)} compact response(s) carries a due-state block: "
+            f"{_listed(response.id for response in responses)}",
+            ctx.subject,
+        )
+    return _result(
+        name,
+        "pass",
+        f"{len(carried)} of {len(responses)} compact response(s) carry the due-state block: "
+        f"{_listed(carried)}",
         ctx.subject,
     )

--- a/benchmarks/epistemic/assertions.py
+++ b/benchmarks/epistemic/assertions.py
@@ -5,7 +5,7 @@ snapshot pair for the transition invariants — and returns an
 :class:`AssertionResult`. Nothing here reads a clock, a network, or a provider
 internal, so a result is a pure function of the fixture that produced it.
 
-Three rules hold across all eighteen:
+Three rules hold across all thirty-three:
 
 1. **Acceptance predicates, not implementations.** PREREGISTRATION §4 requires
    at least two structurally different representations to satisfy each

--- a/benchmarks/epistemic/budgets.py
+++ b/benchmarks/epistemic/budgets.py
@@ -1,0 +1,155 @@
+"""Emergence budget constants for the no-nudge families (amendment sequence 2).
+
+PREREGISTRATION §7 requires these to be calibrated once by at least three expert
+annotators, frozen at their median, and changed only by a new dated amendment
+with its own receipt. That is the whole point of putting them here rather than
+in a fixture: **no runtime, fixture, or report path may retune a constant
+silently**, and live judging of the intervention point never happens in a run.
+An assertion reads the number from this module; a scenario cannot override it.
+
+**PROVISIONAL — NOT YET CALIBRATED.** The calibration study (tasks.md 3.5) is
+blocked on a founder decision about annotator staffing and the small-cohort
+fallback, so the values below are placeholders standing in for medians that do
+not exist yet. They are safe to ship *only* because amendment sequence 2 is
+withheld: :mod:`epistemic.amendments` refuses every family that would consume
+them until the founder acknowledges the receipt, so no score, run, or claim can
+be produced against an uncalibrated number.
+
+:data:`CALIBRATION_STATUS` is the machine-readable form of that caveat, and
+:func:`verify_calibration_status` is what makes it more than a comment: flipping
+the constant to ``frozen`` is refused unless the study artifacts and the
+governed document both back it up. Editing one line is meant to be impossible on
+its own, because a promotion that costs one keystroke is the silent retuning the
+whole module exists to prevent.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from types import MappingProxyType
+from typing import Final, Literal
+
+#: ``provisional`` until the three-annotator study lands and the amendment is
+#: re-dated with the medians. ``frozen`` afterwards, and only then.
+CALIBRATION_STATUS: Final[Literal["provisional", "frozen"]] = "provisional"
+
+#: Protocol and raw labels ship beside the judge-agreement assets; the path is
+#: recorded here so a reader of the constant can reach the study that set it.
+CALIBRATION_PROTOCOL_PATH: Final[str] = (
+    "benchmarks/judge-agreement/no-nudge-calibration-protocol.md"
+)
+
+#: f20: how many structurally distinct durable-unit clusters may accumulate on
+#: one note before a promotion-class signal must have surfaced. The unit is
+#: *clusters*, not writes or words, because the family binds to structure.
+STRUCTURAL_EMERGENCE_CLUSTER_BUDGET: Final[int] = 3
+
+#: f21: how many distinct sources an identity must recur across, with reusable
+#: facts, before an entity-candidate signal must have surfaced.
+ENTITY_EMERGENCE_SOURCE_BUDGET: Final[int] = 3
+
+#: f25: how many maintenance passes after a restructure is applied during which
+#: no merge- or consolidation-class signal may target the new children.
+RESTRUCTURE_QUIET_WINDOW_PASSES: Final[int] = 2
+
+#: f24: the frozen size budget for the continuation packet, in referenced units.
+#: A packet that grows without bound stops being a reconstruction aid.
+CONTINUATION_PACKET_UNIT_BUDGET: Final[int] = 24
+
+#: Every frozen constant in one mapping, for the report path and the drift test.
+EMERGENCE_BUDGETS = MappingProxyType(
+    {
+        "structural_emergence_cluster_budget": STRUCTURAL_EMERGENCE_CLUSTER_BUDGET,
+        "entity_emergence_source_budget": ENTITY_EMERGENCE_SOURCE_BUDGET,
+        "restructure_quiet_window_passes": RESTRUCTURE_QUIET_WINDOW_PASSES,
+        "continuation_packet_unit_budget": CONTINUATION_PACKET_UNIT_BUDGET,
+    }
+)
+
+#: Raw annotator labels for the calibration study.
+CALIBRATION_LABELS_PATH: Final[str] = (
+    "benchmarks/judge-agreement/no-nudge-calibration-labels.json"
+)
+
+#: The governed document these constants were filed with. Freezing them requires
+#: the §7 entry to be re-dated *after* this, because re-dating is the act.
+AMENDMENT_FILED_ON: Final[str] = "2026-08-16"
+
+#: The minimum panel §7 commits to. Below this there is no median to freeze.
+MINIMUM_ANNOTATORS: Final[int] = 3
+
+_PREREGISTRATION_PATH: Final[str] = "benchmarks/epistemic/PREREGISTRATION.md"
+_NO_NUDGE_ENTRY = re.compile(
+    r"^- (\d{4}-\d{2}-\d{2}) — \*\*No-nudge family amendment", re.MULTILINE
+)
+
+
+class CalibrationGovernanceError(RuntimeError):
+    """``frozen`` is claimed without the study and the re-dated amendment."""
+
+
+def calibration_entry_date(repo_root: Path) -> str | None:
+    """The date the §7 no-nudge entry currently carries, or ``None``."""
+
+    text = (repo_root / _PREREGISTRATION_PATH).read_text(encoding="utf-8")
+    found = _NO_NUDGE_ENTRY.search(text)
+    return None if found is None else found.group(1)
+
+
+def verify_calibration_status(repo_root: Path) -> None:
+    """Refuse a ``frozen`` claim the artifacts and the document do not support.
+
+    ``provisional`` always verifies — there is nothing to prove about a value
+    that admits it is a placeholder. ``frozen`` has to earn it three ways at
+    once: the labels artifact reports a completed study, it carries at least
+    :data:`MINIMUM_ANNOTATORS` annotators with medians, and the §7 entry has
+    been re-dated past :data:`AMENDMENT_FILED_ON`. Any one of those missing and
+    the constants are placeholders wearing a frozen label, which is worse than
+    an honest placeholder because a reader would stop checking.
+    """
+
+    if CALIBRATION_STATUS == "provisional":
+        return
+
+    payload = json.loads((repo_root / CALIBRATION_LABELS_PATH).read_text(encoding="utf-8"))
+    failures: list[str] = []
+    if payload.get("status") != "complete":
+        failures.append(f"labels artifact reports status {payload.get('status')!r}")
+    annotators = payload.get("annotators") or []
+    if len(annotators) < MINIMUM_ANNOTATORS:
+        failures.append(
+            f"{len(annotators)} annotator(s) recorded, §7 requires {MINIMUM_ANNOTATORS}"
+        )
+    if not payload.get("medians"):
+        failures.append("labels artifact carries no medians")
+    dated = calibration_entry_date(repo_root)
+    if dated is None:
+        failures.append("the §7 no-nudge entry could not be located")
+    elif dated <= AMENDMENT_FILED_ON:
+        failures.append(
+            f"the §7 entry is still dated {dated}; re-dating it past "
+            f"{AMENDMENT_FILED_ON} is the act that freezes these constants"
+        )
+    if failures:
+        raise CalibrationGovernanceError(
+            "the emergence budgets claim to be frozen, but: " + "; ".join(failures)
+        )
+
+
+__all__ = [
+    "AMENDMENT_FILED_ON",
+    "CALIBRATION_LABELS_PATH",
+    "CALIBRATION_PROTOCOL_PATH",
+    "CALIBRATION_STATUS",
+    "CONTINUATION_PACKET_UNIT_BUDGET",
+    "CalibrationGovernanceError",
+    "EMERGENCE_BUDGETS",
+    "ENTITY_EMERGENCE_SOURCE_BUDGET",
+    "MINIMUM_ANNOTATORS",
+    "RESTRUCTURE_QUIET_WINDOW_PASSES",
+    "STRUCTURAL_EMERGENCE_CLUSTER_BUDGET",
+    "calibration_entry_date",
+    "verify_calibration_status",
+]

--- a/benchmarks/epistemic/contracts/amendment-2026-08-no-nudge.v1.json
+++ b/benchmarks/epistemic/contracts/amendment-2026-08-no-nudge.v1.json
@@ -1,0 +1,18 @@
+{
+  "affected_sections": [
+    "§1 Scenario families",
+    "§2 Assertion registry",
+    "§3 scope extension (no new members)",
+    "§4 Acceptance predicates",
+    "§7 Amendments"
+  ],
+  "amended_on": "2026-08-16",
+  "artifact_type": "preregistration-amendment-receipt.v1",
+  "contract_path": "benchmarks/epistemic/PREREGISTRATION.md",
+  "contract_sha256": "025da49d60e4959a1e4899c9f0f11280e083fdf0c545aa6c70bdabef00d41f6e",
+  "effective_policy": "Applies only after founder acknowledgment; until then f20-f26 cannot support comparative runs, scores or claims. The f20/f21/f25 budget constants ship PROVISIONAL because the three-annotator calibration study is blocked on a founder decision about staffing and the small-cohort fallback; re-dating the §7 entry with the medians is the act that freezes them.",
+  "parent_contract_sha256": "92ee986b10fa5676ad68ed48d9e0389d15d4cfa702c0ff68873d5789e40b785c",
+  "rationale": "Add the deterministic no-nudge families f20-f26 with their nine assertions, headed by the anti-vacuity meta-predicate signal_absence_checked_across_all_surfaces, and the maintenance_pass/triage_decision/apply_restructure/configure scenario operations, through the governed post-ratification amendment path. Contracts-first: these measurement contracts file before the detectors, consumers and carriers they assess. Adds no catastrophic assertions; extends the scope of the existing no_retired_state_served_as_current to the continuation packet, stated explicitly in §7. f20-f22 positives are declared expected-red on the current runtime as falsification targets. RE-MINTED before acknowledgment, over amended-document identity 9c90555a84e7c32cea94545c357aa0602a95a847b7454366bde1b12874ece7cc: a zero-context review found the anti-vacuity meta-predicate scanned only promotion-class signals, so f22's twin was blind to the contradiction-class false positives its own family is about, and f23's dismissal predicate was blind to a dismissed fingerprint re-raised under any other class. §1's f22 row, §4's meta-predicate text and §7's anti-vacuity paragraph now record the declared, widen-only signal-class vocabulary; §1's f20 row and §7's behaviour paragraph record the structural commitments (categories, anchors, disjoint link neighbourhoods) the corpus previously claimed without carrying; §7's expected-red paragraph records that the f26 carrier declares only what a captured response evidenced. Re-minted rather than superseded because this receipt has never been acknowledged: the parent identity is unchanged and no founder decision was taken against the earlier bytes.",
+  "schema_version": 1,
+  "sequence": 2
+}

--- a/benchmarks/epistemic/corpora/__init__.py
+++ b/benchmarks/epistemic/corpora/__init__.py
@@ -1,0 +1,5 @@
+"""Deterministic fixture corpora for the pre-registered scenario families."""
+
+from __future__ import annotations
+
+__all__ = ["no_nudge"]

--- a/benchmarks/epistemic/corpora/no_nudge.py
+++ b/benchmarks/epistemic/corpora/no_nudge.py
@@ -1,0 +1,793 @@
+"""Fixture corpora for the no-nudge families f20-f26 (amendment sequence 2).
+
+Three rules shape everything here, and each exists because its absence was a
+way the family could have been passed for the wrong reason.
+
+1. **Behaviour, not vocabulary.** The corpora are built from cluster *topics*,
+   but no topic token may appear in any assertion parameter — the ids the
+   scenarios name are opaque. :func:`assert_no_vocabulary_leak` enforces that
+   mechanically, and :func:`synonym_swapped` re-generates the whole f20 corpus
+   with every topic word substituted so a detector bound to fixture wording
+   fails while one bound to structure survives.
+
+2. **Twins are frequency- and length-matched.** Every f20 twin carries the same
+   number of durable units and a comparable character count as the positive, so
+   raw magnitude can never be the discriminator. :func:`matching_report` is what
+   the tests assert against, so a drifting corpus is caught rather than assumed.
+
+3. **Structure is stated, not inferred.** A note records its own cluster count
+   and an identity its own distinct-source count, because the assertion measures
+   against a frozen budget and a budget you cannot measure is not a budget.
+
+Nothing here reads a clock, a network, or a provider internal: a corpus is a
+pure function of its arguments, so a snapshot round-trips and a run reproduces.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+from ..snapshot import (
+    DECLARABLE_FIELDS,
+    EpistemicStateSnapshot,
+    FieldDeclaration,
+    ProjectorMeta,
+    Relation,
+    StateItem,
+)
+
+#: The four surfaces a quiet assertion must prove absence on.
+ABSENCE_SURFACES: tuple[str, ...] = (
+    "audit_findings",
+    "review_queue",
+    "proposal_queue",
+    "due_state_counters",
+)
+
+#: Cluster topics the f20 corpus is *written* from. These words must never reach
+#: an assertion parameter — see :func:`assert_no_vocabulary_leak`.
+CLUSTER_TOPICS: tuple[str, ...] = (
+    "tunnel",
+    "quota",
+    "roster",
+    "ledger",
+    "cadence",
+    "beacon",
+)
+
+#: The synonym swap. Same structure, disjoint vocabulary: a detector that
+#: learned the words above fails the swapped corpus, a structural one does not.
+SYNONYM_SWAP: Mapping[str, str] = {
+    "tunnel": "conduit",
+    "quota": "allowance",
+    "roster": "lineup",
+    "ledger": "register",
+    "cadence": "tempo",
+    "beacon": "lantern",
+}
+
+#: Unit body length, in characters, held equal across positive and twins.
+_UNIT_CHARS = 180
+
+CORPUS_PROJECTOR = ProjectorMeta(
+    name="no-nudge-corpus",
+    version="1.0.0",
+    author="benchmark-harness",
+    endpoints_used=("fixture:in-memory",),
+    loc=0,
+    loc_code=0,
+)
+
+
+class VocabularyLeak(AssertionError):
+    """A cluster-name token reached an assertion parameter."""
+
+
+def assert_no_vocabulary_leak(parameters: Iterable[str]) -> None:
+    """Refuse any assertion parameter containing a cluster-name token.
+
+    This is the generator assertion the amendment requires. Without it the f20
+    family could be satisfied by a detector that pattern-matched the fixture's
+    own words, which would measure nothing about emergent structure.
+    """
+
+    leaked = sorted(
+        {
+            token
+            for parameter in parameters
+            for token in (*CLUSTER_TOPICS, *SYNONYM_SWAP.values())
+            if token in parameter.casefold()
+        }
+    )
+    if leaked:
+        raise VocabularyLeak(
+            f"cluster-name token(s) {leaked} appear in assertion parameters; f20 binds to "
+            "structure, so the ids a scenario names must be opaque"
+        )
+
+
+def declarations(**overrides: str) -> tuple[FieldDeclaration, ...]:
+    """Fixture capability declarations: everything observable unless overridden."""
+
+    statuses = {field: "declared" for field in DECLARABLE_FIELDS}
+    statuses.update(overrides)
+    return tuple(
+        FieldDeclaration(
+            field=field,
+            status=status,
+            evidence=f"benchmarks/epistemic/PREREGISTRATION.md:41 ({field})",
+        )
+        for field, status in sorted(statuses.items())
+    )
+
+
+def surface_markers(
+    projection: str = "complete", *, only: Iterable[str] | None = None
+) -> tuple[StateItem, ...]:
+    """Surface markers for the absence surfaces, at one projection status."""
+
+    wanted = tuple(only) if only is not None else ABSENCE_SURFACES
+    return tuple(
+        StateItem(
+            id=f"surface-{name}",
+            kind="container",
+            title=name,
+            raw={"surface": name, "projection": projection},
+        )
+        for name in wanted
+    )
+
+
+def _body(seed: str, topic: str) -> str:
+    """A deterministic body of exactly ``_UNIT_CHARS`` characters."""
+
+    sentence = f"{seed} note about {topic}: durable detail recorded for later reuse. "
+    repeated = (sentence * ((_UNIT_CHARS // len(sentence)) + 2))[:_UNIT_CHARS]
+    return repeated
+
+
+def _unit(
+    unit_id: str,
+    seed: str,
+    topic: str,
+    *,
+    category: str = "cat-general",
+    anchor: str = "unanchored",
+) -> StateItem:
+    """One durable unit.
+
+    ``category`` and ``anchor`` are the structural attributes a detector is
+    allowed to read; they are deliberately opaque labels rather than restatements
+    of ``topic``, because a category that spelled the topic would hand a
+    vocabulary-bound detector the answer this family exists to withhold.
+    """
+
+    return StateItem(
+        id=unit_id,
+        kind="claim",
+        title=unit_id,
+        text=_body(seed, topic),
+        current="yes",
+        raw={"topic": topic, "category": category, "anchor": anchor},
+    )
+
+
+def signal_item(
+    signal_id: str,
+    *,
+    signal_class: str,
+    targets: Iterable[str],
+    surface: str = "proposal_queue",
+    review_state: str = "open",
+    extra: Mapping[str, str] | None = None,
+) -> StateItem:
+    raw = {
+        "signal_class": signal_class,
+        "targets": ",".join(targets),
+        "surface": surface,
+    }
+    raw.update(extra or {})
+    return StateItem(
+        id=signal_id,
+        kind="container",
+        title=signal_id,
+        review_state=review_state,
+        raw=raw,
+    )
+
+
+def _snapshot(
+    items: tuple[StateItem, ...],
+    *,
+    phase: str,
+    relations: tuple[Relation, ...] = (),
+    decls: tuple[FieldDeclaration, ...] | None = None,
+    taken_at: str = "2026-08-16T00:00:00Z",
+) -> EpistemicStateSnapshot:
+    return EpistemicStateSnapshot(
+        provider="fixture",
+        variant="native",
+        phase=phase,
+        taken_at=taken_at,
+        items=items,
+        relations=relations,
+        declarations=declarations() if decls is None else decls,
+        projector=CORPUS_PROJECTOR,
+        completeness_notes="no-nudge fixture corpus; every surface stated explicitly",
+    )
+
+
+# --------------------------------------------------------------------------
+# f20 structural_emergence
+# --------------------------------------------------------------------------
+
+#: ``page id -> (cluster count, per-cluster unit count)``. The positive and all
+#: four twins carry the same total unit count (6) and the same unit length, so
+#: only the *structural dispersion* differs. The twins are, in order: a
+#: bounded-scope page, a page with one or two tangents, a deliberate hub, and a
+#: legitimately heterogeneous log page whose dispersion is intentional.
+#:
+#: Cluster count alone cannot separate these and was never meant to: the log
+#: twin carries *more* clusters than the positive, so any monotone rule over the
+#: count would surface it. What separates them is the shape of the link graph
+#: and the unit attributes — disjoint neighbourhoods for genuine emergence, one
+#: connected neighbourhood for a hub, none at all for a bounded page, and a
+#: uniformly categorised anchored sequence for a deliberate log. Each of those is
+#: readable without reading a single word of the bodies, which is the property
+#: :func:`link_neighbourhoods` exists to make measurable.
+F20_PAGES: Mapping[str, tuple[int, str]] = {
+    "f20-subject": (3, "positive"),
+    "f20-twin-bounded": (1, "bounded scope"),
+    "f20-twin-tangent": (2, "one or two tangents"),
+    "f20-twin-hub": (1, "deliberate hub, topically coherent with divergent links"),
+    "f20-twin-log": (6, "legitimately heterogeneous log; dispersion is intentional"),
+}
+F20_TWINS: tuple[str, ...] = tuple(page for page in F20_PAGES if page != "f20-subject")
+_F20_UNITS_PER_PAGE = 6
+
+#: Ids the hub twin links out to. They are page-external on purpose: a hub is
+#: defined by where it points, and points that stay inside the page would be an
+#: ordinary cluster.
+F20_HUB_TARGETS: tuple[str, ...] = tuple(
+    f"f20-hub-out{index:02d}" for index in range(_F20_UNITS_PER_PAGE)
+)
+
+
+def _f20_units(page: str, clusters: int, topics: tuple[str, ...]) -> tuple[StateItem, ...]:
+    """Six units for every page; ``clusters`` distinct topics spread across them.
+
+    A log page is the one that marks itself: every unit shares a single category
+    and carries its own sequence anchor. That marker is structural, not lexical —
+    a deliberate log looks like a log in the graph, not in its wording.
+    """
+
+    is_log = page == "f20-twin-log"
+    return tuple(
+        _unit(
+            f"{page}-u{index:02d}",
+            page,
+            topics[index % clusters],
+            category="cat-log" if is_log else f"cat-{index % clusters:02d}",
+            anchor=f"seq-{index:02d}" if is_log else "unanchored",
+        )
+        for index in range(_F20_UNITS_PER_PAGE)
+    )
+
+
+def _f20_relations(page: str, clusters: int) -> tuple[Relation, ...]:
+    """The page's link neighbourhoods, as declared edges.
+
+    - the positive: one neighbourhood per cluster, mutually disjoint;
+    - bounded: none, because a bounded page has nothing to link;
+    - tangent: one per cluster, but only two of them;
+    - hub: every unit through a single centre and out to a divergent target,
+      which is one wide neighbourhood rather than several;
+    - log: a single anchored chain, which is also one neighbourhood.
+    """
+
+    units = [f"{page}-u{index:02d}" for index in range(_F20_UNITS_PER_PAGE)]
+    if page == "f20-twin-bounded":
+        return ()
+    if page == "f20-twin-hub":
+        centre = units[0]
+        return (
+            *(
+                Relation(subject=unit, predicate="relates_to", object=centre)
+                for unit in units[1:]
+            ),
+            *(
+                Relation(subject=unit, predicate="relates_to", object=target)
+                for unit, target in zip(units, F20_HUB_TARGETS, strict=True)
+            ),
+        )
+    if page == "f20-twin-log":
+        return tuple(
+            Relation(subject=earlier, predicate="relates_to", object=later)
+            for earlier, later in zip(units, units[1:], strict=False)
+        )
+    grouped: dict[int, list[str]] = {}
+    for index, unit in enumerate(units):
+        grouped.setdefault(index % clusters, []).append(unit)
+    return tuple(
+        Relation(subject=members[0], predicate="relates_to", object=member)
+        for members in grouped.values()
+        for member in members[1:]
+    )
+
+
+def link_neighbourhoods(
+    snapshot: EpistemicStateSnapshot, page: str
+) -> tuple[frozenset[str], ...]:
+    """Connected components of the page's declared link graph.
+
+    Reads ids and edges only — never a body, a title or a topic — because this
+    is the view a structure-bound detector is entitled to and the one the family
+    claims is sufficient.
+    """
+
+    prefix = f"{page}-u"
+    edges = [
+        (relation.subject, relation.object)
+        for relation in snapshot.relations
+        if relation.subject.startswith(prefix) or relation.object.startswith(prefix)
+    ]
+    components: list[set[str]] = []
+    for subject, obj in edges:
+        touching = [c for c in components if subject in c or obj in c]
+        merged = {subject, obj}
+        for component in touching:
+            merged |= component
+            components.remove(component)
+        components.append(merged)
+    return tuple(frozenset(component) for component in components)
+
+
+def f20_corpus(
+    *,
+    surfaced: bool = True,
+    topics: tuple[str, ...] = CLUSTER_TOPICS,
+    projection: str = "complete",
+) -> EpistemicStateSnapshot:
+    """The f20 corpus: the accumulating positive plus four matched twins.
+
+    ``surfaced=False`` is the *current runtime*: no detector exists, so no
+    promotion-class signal is present anywhere. That snapshot is what makes the
+    positive expected-red, and it is generated from the identical corpus so the
+    difference is the mechanism and nothing else.
+    """
+
+    items: list[StateItem] = []
+    relations: list[Relation] = []
+    for page, (clusters, note) in F20_PAGES.items():
+        items.extend(_f20_units(page, clusters, topics))
+        relations.extend(_f20_relations(page, clusters))
+        items.append(
+            StateItem(
+                id=page,
+                kind="container",
+                title=page,
+                text=note,
+                current="yes",
+                raw={"cluster_count": str(clusters), "unit_count": str(_F20_UNITS_PER_PAGE)},
+            )
+        )
+    items.extend(
+        StateItem(
+            id=target,
+            kind="container",
+            title=target,
+            current="yes",
+            raw={"category": "cat-external", "anchor": "unanchored"},
+        )
+        for target in F20_HUB_TARGETS
+    )
+    if surfaced:
+        items.append(
+            signal_item(
+                "f20-signal", signal_class="promotion", targets=("f20-subject",)
+            )
+        )
+    items.extend(surface_markers(projection))
+    return _snapshot(tuple(items), phase="f20", relations=tuple(relations))
+
+
+def synonym_swapped() -> EpistemicStateSnapshot:
+    """The f20 corpus with every cluster topic substituted for a synonym."""
+
+    return f20_corpus(topics=tuple(SYNONYM_SWAP[topic] for topic in CLUSTER_TOPICS))
+
+
+def matching_report(snapshot: EpistemicStateSnapshot) -> Mapping[str, tuple[int, int]]:
+    """``page -> (unit count, total unit characters)`` for the f20 pages.
+
+    Frequency- and length-matching is a property of the corpus, so it is
+    measured from the corpus rather than asserted in prose.
+    """
+
+    report: dict[str, tuple[int, int]] = {}
+    for page in F20_PAGES:
+        units = [
+            item
+            for item in snapshot.items
+            if item.id.startswith(f"{page}-u")
+        ]
+        report[page] = (len(units), sum(len(unit.text) for unit in units))
+    return report
+
+
+# --------------------------------------------------------------------------
+# f21 entity_emergence
+# --------------------------------------------------------------------------
+
+#: Lowercase and non-Latin referents are in the corpus by design: script bias is
+#: something to measure, not something to keep out of the fixtures.
+F21_REFERENTS: Mapping[str, tuple[int, str]] = {
+    "f21-subject-lower": (3, "lowercase latin referent, reusable facts"),
+    "f21-subject-cyrillic": (3, "non-latin referent, reusable facts"),
+    "f21-twin-incidental": (3, "frequency-matched incidental mentions, no reusable facts"),
+}
+F21_TWINS: tuple[str, ...] = ("f21-twin-incidental",)
+
+
+def f21_corpus(*, surfaced: bool = True, projection: str = "complete") -> EpistemicStateSnapshot:
+    """Recurrence corpus: two positives and one frequency-matched twin.
+
+    The twin recurs in exactly as many sources as each positive. What it lacks
+    is *reusable facts*, which is the whole discriminator — a mutant counting
+    string frequency passes both, and that is the failure the twin catches.
+    """
+
+    items: list[StateItem] = []
+    for referent, (sources, note) in F21_REFERENTS.items():
+        for index in range(sources):
+            items.append(
+                StateItem(
+                    id=f"{referent}-src{index:02d}",
+                    kind="raw_source",
+                    title=f"{referent} source {index}",
+                    text=_body(referent, "recurrence"),
+                    current="yes",
+                )
+            )
+        items.append(
+            StateItem(
+                id=referent,
+                kind="container",
+                title=referent,
+                text=note,
+                current="yes",
+                raw={
+                    "source_count": str(sources),
+                    "reusable_facts": "no" if referent in F21_TWINS else "yes",
+                },
+            )
+        )
+    if surfaced:
+        for referent in F21_REFERENTS:
+            if referent in F21_TWINS:
+                continue
+            items.append(
+                signal_item(
+                    f"{referent}-signal",
+                    signal_class="entity_candidate",
+                    targets=(referent,),
+                )
+            )
+    items.extend(surface_markers(projection))
+    return _snapshot(tuple(items), phase="f21")
+
+
+# --------------------------------------------------------------------------
+# f22 unsolicited_contradiction
+# --------------------------------------------------------------------------
+
+
+def f22_corpus(*, surfaced: bool = True, projection: str = "complete") -> EpistemicStateSnapshot:
+    """An invalidating pair and a concordant twin in the same similarity band.
+
+    Both evidence items are written from the same seed and length, so a detector
+    keyed on similarity alone surfaces both and fails the twin's quiet
+    assertion. Only a detector that reads the *direction* of the relation passes.
+    """
+
+    conclusion = StateItem(
+        id="f22-conclusion",
+        kind="claim",
+        title="f22-conclusion",
+        text=_body("f22", "conclusion"),
+        current="yes",
+    )
+    twin_conclusion = StateItem(
+        id="f22-twin-conclusion",
+        kind="claim",
+        title="f22-twin-conclusion",
+        text=_body("f22", "conclusion"),
+        current="yes",
+    )
+    invalidating = StateItem(
+        id="f22-evidence-invalidating",
+        kind="evidence",
+        title="f22-evidence-invalidating",
+        text=_body("f22", "measurement"),
+        current="yes",
+        contradicts=("f22-conclusion",),
+    )
+    concordant = StateItem(
+        id="f22-evidence-concordant",
+        kind="evidence",
+        title="f22-evidence-concordant",
+        text=_body("f22", "measurement"),
+        current="yes",
+        supports=("f22-twin-conclusion",),
+    )
+    items = [conclusion, twin_conclusion, invalidating, concordant]
+    relations = (
+        Relation(
+            subject="f22-evidence-invalidating",
+            predicate="contradicts",
+            object="f22-conclusion",
+        ),
+        Relation(
+            subject="f22-evidence-concordant",
+            predicate="supports",
+            object="f22-twin-conclusion",
+        ),
+    )
+    if surfaced:
+        items.append(
+            signal_item(
+                "f22-signal",
+                signal_class="contradiction",
+                targets=("f22-conclusion", "f22-evidence-invalidating"),
+                surface="review_queue",
+            )
+        )
+    items.extend(surface_markers(projection))
+    return _snapshot(tuple(items), phase="f22", relations=relations)
+
+
+# --------------------------------------------------------------------------
+# f23 dismissal_respect
+# --------------------------------------------------------------------------
+
+F23_FINGERPRINT = "fp-f23-original"
+
+
+def f23_pair(
+    *,
+    respected: bool = True,
+    material_change: bool = False,
+    emissions: int = 1,
+    writes: int = 12,
+) -> tuple[EpistemicStateSnapshot, EpistemicStateSnapshot]:
+    """``(prior, later)`` across maintenance passes, a restart and reconfiguration."""
+
+    dismissed = StateItem(
+        id="f23-subject",
+        kind="container",
+        title="f23-subject",
+        review_state="dismissed",
+        current="yes",
+        raw={"fingerprint": F23_FINGERPRINT, "passes": "0"},
+    )
+    prior = _snapshot((dismissed, *surface_markers()), phase="f23-p1")
+
+    later_items: list[StateItem] = [
+        StateItem(
+            id="f23-subject",
+            kind="container",
+            title="f23-subject",
+            review_state="dismissed",
+            current="yes",
+            raw={"fingerprint": F23_FINGERPRINT, "passes": "4"},
+        )
+    ]
+    if not respected:
+        later_items.append(
+            signal_item(
+                "f23-resurfaced",
+                signal_class="promotion",
+                targets=("f23-subject",),
+                extra={"fingerprint": F23_FINGERPRINT},
+            )
+        )
+    if material_change:
+        later_items.append(
+            signal_item(
+                "f23-reopened",
+                signal_class="promotion",
+                targets=("f23-subject",),
+                extra={"fingerprint": "fp-f23-changed"},
+            )
+        )
+    later_items.append(
+        StateItem(
+            id="surface-due_state_counters",
+            kind="container",
+            title="due_state_counters",
+            raw={
+                "surface": "due_state_counters",
+                "projection": "complete",
+                "emissions": str(emissions),
+                "writes": str(writes),
+            },
+        )
+    )
+    later_items.extend(
+        surface_markers(only=[s for s in ABSENCE_SURFACES if s != "due_state_counters"])
+    )
+    return prior, _snapshot(tuple(later_items), phase="f23-p2")
+
+
+# --------------------------------------------------------------------------
+# f24 fresh_session_reconstruction
+# --------------------------------------------------------------------------
+
+_F24_SEEDED = ("f24-decision-a", "f24-decision-b", "f24-question-a", "f24-plan")
+_F24_DECOYS = ("f24-decoy-a", "f24-decoy-b", "f24-decoy-c", "f24-decoy-d")
+
+
+def f24_corpus(
+    *,
+    complete: bool = True,
+    admit_decoy: bool = False,
+    stale_member: bool = False,
+) -> EpistemicStateSnapshot:
+    """Seed-and-decoy corpus: the decoy set is the same size as the seeded set."""
+
+    items: list[StateItem] = [
+        StateItem(id="f24-decision-a", kind="decision", title="f24-decision-a", current="yes"),
+        StateItem(
+            id="f24-decision-b",
+            kind="decision",
+            title="f24-decision-b",
+            current="no" if stale_member else "yes",
+            retired_reason="superseded by a later decision" if stale_member else None,
+        ),
+        StateItem(id="f24-question-a", kind="open_question", title="f24-question-a", current="yes"),
+        StateItem(
+            id="f24-plan",
+            kind="container",
+            title="f24-plan",
+            current="yes",
+            raw={"plan": "f24-plan"},
+        ),
+    ]
+    items.extend(
+        StateItem(
+            id=decoy,
+            kind="decision",
+            title=decoy,
+            current="yes",
+            raw={"decoy": "yes"},
+        )
+        for decoy in _F24_DECOYS
+    )
+    referenced = list(_F24_SEEDED if complete else _F24_SEEDED[:-1])
+    if admit_decoy:
+        referenced.append(_F24_DECOYS[0])
+    items.append(
+        StateItem(
+            id="f24-packet",
+            kind="container",
+            title="f24-packet",
+            current="yes",
+            cites=tuple(referenced),
+            raw={"packet": "f24-packet"},
+        )
+    )
+    items.extend(surface_markers())
+    return _snapshot(tuple(items), phase="f24")
+
+
+# --------------------------------------------------------------------------
+# f25 restructure_lifecycle
+# --------------------------------------------------------------------------
+
+
+def f25_corpus(
+    *,
+    cleared: bool = True,
+    by_dismissal: bool = False,
+    churn: bool = False,
+) -> EpistemicStateSnapshot:
+    """After ``apply_restructure``: the signal should be gone, and stay gone."""
+
+    parent = StateItem(
+        id="f25-subject",
+        kind="container",
+        title="f25-subject",
+        current="yes",
+        review_state="dismissed" if by_dismissal else None,
+        raw={"fingerprint": "fp-f25"} if by_dismissal else {},
+    )
+    children = tuple(
+        StateItem(
+            id=f"f25-child-{suffix}",
+            kind="claim",
+            title=f"f25-child-{suffix}",
+            current="yes",
+            raw={"restructure_child": "f25-subject"},
+        )
+        for suffix in ("a", "b")
+    )
+    items: list[StateItem] = [parent, *children]
+    if not cleared:
+        items.append(
+            signal_item("f25-stale", signal_class="promotion", targets=("f25-subject",))
+        )
+    if churn:
+        items.append(
+            signal_item(
+                "f25-merge-back",
+                signal_class="merge",
+                targets=("f25-child-a",),
+                extra={"passes": "1"},
+            )
+        )
+    items.extend(surface_markers())
+    return _snapshot(tuple(items), phase="f25")
+
+
+# --------------------------------------------------------------------------
+# f26 hookless_episode_carrier
+# --------------------------------------------------------------------------
+
+
+def f26_journey(*, carried: bool = True, detail: str = "compact") -> EpistemicStateSnapshot:
+    """The captured responses of a hookless journey, plus its packet."""
+
+    responses = tuple(
+        StateItem(
+            id=f"f26-response-{name}",
+            kind="container",
+            title=f"f26-response-{name}",
+            raw=(
+                {"response_detail": detail, "targets": "due_state_counters"}
+                if carried
+                else {"response_detail": detail}
+            ),
+        )
+        for name in ("mutation", "recall")
+    )
+    packet = StateItem(
+        id="f26-packet",
+        kind="container",
+        title="f26-packet",
+        current="yes",
+        cites=("f26-capture",),
+        raw={"packet": "f26-packet"},
+    )
+    capture = StateItem(
+        id="f26-capture", kind="decision", title="f26-capture", current="yes"
+    )
+    return _snapshot(
+        (*responses, capture, packet, *surface_markers()),
+        phase="f26",
+    )
+
+
+__all__ = [
+    "ABSENCE_SURFACES",
+    "CLUSTER_TOPICS",
+    "F20_PAGES",
+    "F20_TWINS",
+    "F21_REFERENTS",
+    "F21_TWINS",
+    "F23_FINGERPRINT",
+    "SYNONYM_SWAP",
+    "VocabularyLeak",
+    "assert_no_vocabulary_leak",
+    "declarations",
+    "f20_corpus",
+    "f21_corpus",
+    "f22_corpus",
+    "f23_pair",
+    "f24_corpus",
+    "f25_corpus",
+    "f26_journey",
+    "matching_report",
+    "signal_item",
+    "surface_markers",
+    "synonym_swapped",
+]

--- a/benchmarks/epistemic/fixtures/red-sequence2-quiet-assertion-without-subject.yaml
+++ b/benchmarks/epistemic/fixtures/red-sequence2-quiet-assertion-without-subject.yaml
@@ -1,0 +1,38 @@
+# RED fixture: a quiet assertion that names nothing to be quiet about.
+#
+# Deliberately filed against f01, a ratified family, so the refusal under test
+# is the subject requirement and not the sequence-2 withhold gate — a fixture
+# that could refuse for two reasons proves neither. Without this rule the
+# meta-predicate silently degrades from "no signal names this twin" into "no
+# signal exists anywhere", which an empty snapshot satisfies.
+scenario_id: red-sequence2-quiet-assertion-without-subject
+family_id: f01
+kind: corpus
+public_coverage: none
+phases:
+  - phase_id: p1
+    ops:
+      - op: ingest_source
+        ref: src-1
+      - op: snapshot
+        ref: s1
+    expect:
+      - assert: signal_absence_checked_across_all_surfaces
+fairness:
+  why_neutral: red fixture; never scored
+  public_coverage_subtraction: none
+  mechanisms:
+    - provider_role: subject
+      mechanism: none
+      verdict: unknown
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:14
+  privileged_endpoint_matrix:
+    - driver_surface_id: state.read
+      provider: fixture
+      variant: native
+      disposition: equivalent
+      audit_scope: read-only projected state
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:32
+      reason: The fixture projects only documented neutral state.
+      competitor_surface: documented list/read endpoint
+  acceptance_predicate: none

--- a/benchmarks/epistemic/fixtures/red-sequence2-withheld-family.yaml
+++ b/benchmarks/epistemic/fixtures/red-sequence2-withheld-family.yaml
@@ -1,0 +1,46 @@
+# RED fixture: a sequence-2 family whose amendment receipt is still pending.
+#
+# f20 IS in the §1 family table — registration is not the thing being refused.
+# What refuses it is the amendment receipt: sequence 2 has no founder
+# acknowledgment, so `epistemic.amendments` withholds every family it
+# introduced at the loader's choke point. This fixture goes green by itself the
+# day the acknowledgment lands, which is exactly the transition sequence 1 went
+# through, and is why it is shipped rather than written as a mock.
+scenario_id: red-sequence2-withheld-family
+family_id: f20
+kind: corpus
+public_coverage: none
+phases:
+  - phase_id: p1-ingest
+    ops:
+      - op: ingest_source
+        ref: src-unit-01
+      - op: maintenance_pass
+        ref: sweep-1
+      - op: snapshot
+        ref: s1
+    expect:
+      - assert: structural_signal_surfaced_within_budget
+        subject: f20-subject
+fairness:
+  why_neutral: >-
+    A reader whose accumulating page never gets proposed for a split keeps
+    paying the cost of finding things in it. The harm is independent of how any
+    product stores or names structure.
+  public_coverage_subtraction: none
+  mechanisms:
+    - provider_role: subject
+      mechanism: promotion-class proposal in the documented review or proposal queue
+      verdict: unknown
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:41
+  privileged_endpoint_matrix:
+    - driver_surface_id: state.read
+      provider: fixture
+      variant: native
+      disposition: equivalent
+      audit_scope: read-only projected state
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:32
+      reason: The fixture projects only documented neutral state.
+      competitor_surface: documented list/read endpoint
+  acceptance_predicate: >-
+    PREREGISTRATION.md section 4, structural_signal_surfaced_within_budget.

--- a/benchmarks/epistemic/fixtures/sequence2/f20-structural-emergence.yaml
+++ b/benchmarks/epistemic/fixtures/sequence2/f20-structural-emergence.yaml
@@ -1,0 +1,87 @@
+# f20 structural_emergence.
+#
+# Withheld until the sequence-2 acknowledgment lands, so this file lives outside
+# the flat fixtures/ directory the loader smoke tests glob: every scenario there
+# must either load or be named red-, and a withheld family is neither. The
+# subject and twin ids are opaque on purpose — the corpus generator asserts that
+# no cluster-name token reaches an assertion parameter, which is what binds this
+# family to structure rather than to fixture wording.
+#
+# Only maintenance_pass intervenes between ingest and the asserted snapshot: the
+# loader refuses this scenario outright if a topical agent_turn appears, because
+# a prompted surfacing would measure nothing the family claims.
+scenario_id: f20-structural-emergence
+family_id: f20
+kind: corpus
+public_coverage: none
+phases:
+  - phase_id: p1-accumulate
+    ops:
+      - op: ingest_source
+        ref: f20-writes-batch-1
+      - op: maintenance_pass
+        ref: sweep-1
+      - op: ingest_source
+        ref: f20-writes-batch-2
+      - op: maintenance_pass
+        ref: sweep-2
+      - op: snapshot
+        ref: s1
+  - phase_id: p2-budget
+    ops:
+      - op: ingest_source
+        ref: f20-writes-batch-3
+      - op: maintenance_pass
+        ref: sweep-3
+      - op: snapshot
+        ref: s2
+    expect:
+      - assert: structural_signal_surfaced_within_budget
+        subject: f20-subject
+      - assert: signal_absence_checked_across_all_surfaces
+        subject: f20-twin-bounded
+      - assert: signal_absence_checked_across_all_surfaces
+        subject: f20-twin-tangent
+      - assert: signal_absence_checked_across_all_surfaces
+        subject: f20-twin-hub
+      - assert: signal_absence_checked_across_all_surfaces
+        subject: f20-twin-log
+fairness:
+  why_neutral: >-
+    A page that has quietly become five subjects costs its reader on every
+    later lookup, and only the system that watched it accumulate can say so
+    unprompted. The harm is independent of how any product names or stores
+    structure, and the twins carry identical unit counts and lengths so that
+    raw magnitude cannot be the discriminator.
+  public_coverage_subtraction: >-
+    No public suite measures unprompted structural surfacing; this scenario
+    reports state invariants only and contributes no answer-accuracy number.
+  mechanisms:
+    - provider_role: subject
+      mechanism: promotion-class proposal in the documented review or proposal queue
+      verdict: unknown
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:41
+    - provider_role: comparator-a
+      mechanism: documented structural-suggestion query over the accumulating note
+      verdict: unknown
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:41
+  privileged_endpoint_matrix:
+    - driver_surface_id: state.read
+      provider: fixture
+      variant: native
+      disposition: equivalent
+      audit_scope: read-only projected state
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:32
+      reason: The fixture projects only documented neutral state.
+      competitor_surface: documented list/read endpoint
+    - driver_surface_id: corpus.ingest
+      provider: fixture
+      variant: native
+      disposition: equivalent
+      audit_scope: corpus source ingestion
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:16
+      reason: The same neutral corpus source is ingested for this fixture row.
+      competitor_surface: documented write/ingest endpoint
+  acceptance_predicate: >-
+    PREREGISTRATION.md section 4, structural_signal_surfaced_within_budget and
+    signal_absence_checked_across_all_surfaces.

--- a/benchmarks/epistemic/fixtures/sequence2/f21-entity-emergence.yaml
+++ b/benchmarks/epistemic/fixtures/sequence2/f21-entity-emergence.yaml
@@ -1,0 +1,66 @@
+# f21 entity_emergence. Lowercase and non-Latin referents are both asserted, so
+# script bias is measured rather than hidden. The twin recurs in exactly as many
+# sources as each positive and differs only in carrying no reusable facts, which
+# is what stops a string-frequency mutant from passing both halves.
+scenario_id: f21-entity-emergence
+family_id: f21
+kind: corpus
+public_coverage: none
+phases:
+  - phase_id: p1-recurrence
+    ops:
+      - op: ingest_source
+        ref: f21-sources-batch-1
+      - op: maintenance_pass
+        ref: sweep-1
+      - op: ingest_source
+        ref: f21-sources-batch-2
+      - op: maintenance_pass
+        ref: sweep-2
+      - op: snapshot
+        ref: s1
+    expect:
+      - assert: entity_candidate_surfaced_from_recurrence
+        subject: f21-subject-lower
+      - assert: entity_candidate_surfaced_from_recurrence
+        subject: f21-subject-cyrillic
+      - assert: signal_absence_checked_across_all_surfaces
+        subject: f21-twin-incidental
+fairness:
+  why_neutral: >-
+    An identity a reader keeps re-describing across sources is one the system
+    could have offered to hold once. The harm of never noticing is independent
+    of how any product models entities, and the frequency-matched twin makes
+    occurrence counting an insufficient explanation for a pass.
+  public_coverage_subtraction: >-
+    No public suite measures unprompted entity recognition; this scenario
+    reports state invariants only.
+  mechanisms:
+    - provider_role: subject
+      mechanism: entity-candidate entry in the documented proposal queue
+      verdict: unknown
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:42
+    - provider_role: comparator-a
+      mechanism: documented proposed-entities surface resolving to contributing sources
+      verdict: unknown
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:42
+  privileged_endpoint_matrix:
+    - driver_surface_id: state.read
+      provider: fixture
+      variant: native
+      disposition: equivalent
+      audit_scope: read-only projected state
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:32
+      reason: The fixture projects only documented neutral state.
+      competitor_surface: documented list/read endpoint
+    - driver_surface_id: corpus.ingest
+      provider: fixture
+      variant: native
+      disposition: equivalent
+      audit_scope: corpus source ingestion
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:16
+      reason: The same neutral corpus source is ingested for this fixture row.
+      competitor_surface: documented write/ingest endpoint
+  acceptance_predicate: >-
+    PREREGISTRATION.md section 4, entity_candidate_surfaced_from_recurrence and
+    signal_absence_checked_across_all_surfaces.

--- a/benchmarks/epistemic/fixtures/sequence2/f22-unsolicited-contradiction.yaml
+++ b/benchmarks/epistemic/fixtures/sequence2/f22-unsolicited-contradiction.yaml
@@ -1,0 +1,68 @@
+# f22 unsolicited_contradiction. The concordant twin sits in the same similarity
+# band as the invalidating evidence — same seed, same length — so a detector
+# keyed on similarity alone surfaces both and fails the twin's quiet assertion.
+# Zero topical agent turns appear after ingest; the loader refuses the scenario
+# if one does, which is how unpromptedness is proven without a query log.
+scenario_id: f22-unsolicited-contradiction
+family_id: f22
+kind: corpus
+public_coverage: none
+phases:
+  - phase_id: p1-conclusions
+    ops:
+      - op: ingest_source
+        ref: f22-conclusions
+      - op: snapshot
+        ref: s1
+  - phase_id: p2-invalidating-evidence
+    ops:
+      - op: ingest_source
+        ref: f22-evidence
+      - op: maintenance_pass
+        ref: sweep-1
+      - op: snapshot
+        ref: s2
+    expect:
+      - assert: contradiction_surfaced_unprompted
+        subject: f22-conclusion
+        counterpart: f22-evidence-invalidating
+      - assert: signal_absence_checked_across_all_surfaces
+        subject: f22-twin-conclusion
+fairness:
+  why_neutral: >-
+    Acting on a conclusion that newly arrived evidence has invalidated is a
+    harm no retrieval quality offsets, and a reader who never asked cannot ask.
+    The concordant twin ensures a system is not credited for surfacing every
+    similar pair regardless of direction.
+  public_coverage_subtraction: >-
+    Conflict-resolution overlap in the public suites is answer-accuracy scored
+    there; this scenario reports state invariants only.
+  mechanisms:
+    - provider_role: subject
+      mechanism: typed contradiction entry naming both items in a documented queue
+      verdict: unknown
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:43
+    - provider_role: comparator-a
+      mechanism: documented review entry resolving to both items with a conflict marker
+      verdict: unknown
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:43
+  privileged_endpoint_matrix:
+    - driver_surface_id: state.read
+      provider: fixture
+      variant: native
+      disposition: equivalent
+      audit_scope: read-only projected state
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:32
+      reason: The fixture projects only documented neutral state.
+      competitor_surface: documented list/read endpoint
+    - driver_surface_id: corpus.ingest
+      provider: fixture
+      variant: native
+      disposition: equivalent
+      audit_scope: corpus source ingestion
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:16
+      reason: The same neutral corpus source is ingested for this fixture row.
+      competitor_surface: documented write/ingest endpoint
+  acceptance_predicate: >-
+    PREREGISTRATION.md section 4, contradiction_surfaced_unprompted and
+    signal_absence_checked_across_all_surfaces.

--- a/benchmarks/epistemic/fixtures/sequence2/f23-dismissal-respect.yaml
+++ b/benchmarks/epistemic/fixtures/sequence2/f23-dismissal-respect.yaml
@@ -1,0 +1,85 @@
+# f23 dismissal_respect. Operational: the dismissal must survive repeated
+# maintenance passes, an engine restart, and prominence reconfiguration across
+# the full level range. The counter-emission half rides the same trajectory
+# because nagging by repeated counters is the same trust failure by another
+# route, and a bulk batch is the only place it becomes visible.
+scenario_id: f23-dismissal-respect
+family_id: f23
+kind: operational
+public_coverage: none
+phases:
+  - phase_id: p1-dismiss
+    ops:
+      - op: ingest_source
+        ref: f23-seed
+      - op: maintenance_pass
+        ref: sweep-1
+      - op: triage_decision
+        ref: dismiss-f23-subject
+        detail: dismiss
+      - op: snapshot
+        ref: s1
+  - phase_id: p2-survive
+    ops:
+      - op: maintenance_pass
+        ref: sweep-2
+      - op: stop_engine
+        ref: restart
+      - op: start_engine
+        ref: restart
+      - op: maintenance_pass
+        ref: sweep-3
+      - op: configure
+        ref: prominence-min
+        detail: engagement level minimum
+      - op: configure
+        ref: prominence-max
+        detail: engagement level maximum
+      - op: maintenance_pass
+        ref: sweep-4
+      - op: ingest_source
+        ref: f23-bulk-batch
+      - op: snapshot
+        ref: s2
+    expect:
+      - assert: dismissal_respected_across_passes
+        subject: f23-subject
+      - assert: counter_emission_not_repeated_per_write
+fairness:
+  why_neutral: >-
+    A dismissal the system forgets is worse than never having offered the
+    suggestion, and a counters block repeated once per write in a bulk batch is
+    the same nag delivered many times. Both harms are independent of how any
+    product stores triage state.
+  public_coverage_subtraction: >-
+    No public suite measures triage durability or counter governance; this
+    scenario reports state invariants only.
+  mechanisms:
+    - provider_role: subject
+      mechanism: fingerprint-keyed triage store surviving passes, restart and reconfiguration
+      verdict: unknown
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:44
+    - provider_role: comparator-a
+      mechanism: documented per-item review state resolving to the same fingerprint
+      verdict: unknown
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:44
+  privileged_endpoint_matrix:
+    - driver_surface_id: state.read
+      provider: fixture
+      variant: native
+      disposition: equivalent
+      audit_scope: read-only projected state
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:32
+      reason: The fixture projects only documented neutral state.
+      competitor_surface: documented list/read endpoint
+    - driver_surface_id: triage.write
+      provider: fixture
+      variant: native
+      disposition: equivalent
+      audit_scope: documented triage decision
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:70
+      reason: The dismissal routes through the product's documented triage surface.
+      competitor_surface: documented dismiss/snooze/reopen surface
+  acceptance_predicate: >-
+    PREREGISTRATION.md section 4, dismissal_respected_across_passes and
+    counter_emission_not_repeated_per_write.

--- a/benchmarks/epistemic/fixtures/sequence2/f24-fresh-session-reconstruction.yaml
+++ b/benchmarks/epistemic/fixtures/sequence2/f24-fresh-session-reconstruction.yaml
@@ -1,0 +1,72 @@
+# f24 fresh_session_reconstruction. The decoy set is the same size as the seeded
+# set, so a packet that simply took everything scores no better than one that
+# took nothing. `no_retired_state_served_as_current` rides along under the
+# sequence-2 scope extension: a packet that hands a fresh session a superseded
+# decision by reference is serving retired state, which is an integrity failure
+# and not merely an incomplete packet.
+scenario_id: f24-fresh-session-reconstruction
+family_id: f24
+kind: operational
+public_coverage: none
+phases:
+  - phase_id: p1-seed
+    ops:
+      - op: ingest_source
+        ref: f24-seeded-units
+      - op: ingest_source
+        ref: f24-foreign-decoys
+      - op: snapshot
+        ref: s1
+  - phase_id: p2-fresh-session
+    ops:
+      - op: stop_engine
+        ref: session-end
+      - op: start_engine
+        ref: session-start
+      - op: fresh_agent
+        ref: f24-fresh
+      - op: snapshot
+        ref: s2
+    expect:
+      - assert: continuation_packet_reconstructs_session
+      - assert: no_retired_state_served_as_current
+    catastrophic_if_failed:
+      - no_retired_state_served_as_current
+fairness:
+  why_neutral: >-
+    A fresh session that cannot recover what was decided makes the user the
+    memory. Holding units by reference rather than by copy is what keeps the
+    packet honest as state moves on, and the same-sized foreign decoy set makes
+    indiscriminate inclusion an explicit failure rather than a cheap pass.
+  public_coverage_subtraction: >-
+    Cross-session continuation overlap is answer-accuracy scored in the public
+    lanes; this scenario reports state invariants only.
+  mechanisms:
+    - provider_role: subject
+      mechanism: packet artifact referencing seeded units within a documented size budget
+      verdict: unknown
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:45
+    - provider_role: comparator-a
+      mechanism: documented continuation endpoint whose response resolves each unit
+      verdict: unknown
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:45
+  privileged_endpoint_matrix:
+    - driver_surface_id: state.read
+      provider: fixture
+      variant: native
+      disposition: equivalent
+      audit_scope: read-only projected state
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:32
+      reason: The fixture projects only documented neutral state.
+      competitor_surface: documented list/read endpoint
+    - driver_surface_id: session.restart
+      provider: fixture
+      variant: native
+      disposition: equivalent
+      audit_scope: documented engine stop and start
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:17
+      reason: The restart uses the documented lifecycle operations only.
+      competitor_surface: documented restart or reconnect procedure
+  acceptance_predicate: >-
+    PREREGISTRATION.md section 4, continuation_packet_reconstructs_session; §3
+    for the sequence-2 scope extension of no_retired_state_served_as_current.

--- a/benchmarks/epistemic/fixtures/sequence2/f25-restructure-lifecycle.yaml
+++ b/benchmarks/epistemic/fixtures/sequence2/f25-restructure-lifecycle.yaml
@@ -1,0 +1,70 @@
+# f25 restructure_lifecycle. The point of the family is that applying a
+# suggestion resolves it: the signal disappears because the state changed, not
+# because anyone dismissed it. A product that quietly records a dismissal to
+# clear its own suggestion fails here even though the queue looks identical.
+scenario_id: f25-restructure-lifecycle
+family_id: f25
+kind: operational
+public_coverage: none
+phases:
+  - phase_id: p1-suggested
+    ops:
+      - op: ingest_source
+        ref: f25-accumulated-note
+      - op: maintenance_pass
+        ref: sweep-1
+      - op: snapshot
+        ref: s1
+  - phase_id: p2-applied
+    ops:
+      - op: apply_restructure
+        ref: f25-subject
+        detail: split into two children through the documented interface
+      - op: maintenance_pass
+        ref: sweep-2
+      - op: maintenance_pass
+        ref: sweep-3
+      - op: snapshot
+        ref: s2
+    expect:
+      - assert: restructure_signal_cleared_by_state_change
+        subject: f25-subject
+      - assert: signal_absence_checked_across_all_surfaces
+        subject: f25-subject
+fairness:
+  why_neutral: >-
+    A suggestion that survives being taken, or new children immediately
+    proposed for merging back, teaches a reader to stop reading suggestions.
+    Both harms are independent of how any product represents restructures.
+  public_coverage_subtraction: >-
+    No public suite measures signal lifecycle after a restructure; this scenario
+    reports state invariants only.
+  mechanisms:
+    - provider_role: subject
+      mechanism: signal absent from every open view with no dismissal recorded for it
+      verdict: unknown
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:46
+    - provider_role: comparator-a
+      mechanism: documented signal-lifecycle record showing resolution by state change
+      verdict: unknown
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:46
+  privileged_endpoint_matrix:
+    - driver_surface_id: state.read
+      provider: fixture
+      variant: native
+      disposition: equivalent
+      audit_scope: read-only projected state
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:32
+      reason: The fixture projects only documented neutral state.
+      competitor_surface: documented list/read endpoint
+    - driver_surface_id: restructure.apply
+      provider: fixture
+      variant: native
+      disposition: equivalent
+      audit_scope: documented restructure execution
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:70
+      reason: The restructure routes through the product's documented interface.
+      competitor_surface: documented split or reorganize surface
+  acceptance_predicate: >-
+    PREREGISTRATION.md section 4, restructure_signal_cleared_by_state_change and
+    signal_absence_checked_across_all_surfaces.

--- a/benchmarks/epistemic/fixtures/sequence2/f26-hookless-episode-carrier.yaml
+++ b/benchmarks/epistemic/fixtures/sequence2/f26-hookless-episode-carrier.yaml
@@ -1,0 +1,71 @@
+# f26 hookless_episode_carrier. This family exists because f20-f25 do not test
+# the carrier: a runtime could satisfy every one of them while no signal ever
+# reached a thin client. The journey runs hookless, at compact response detail,
+# and asserts the due-state block in the responses it actually received.
+scenario_id: f26-hookless-episode-carrier
+family_id: f26
+kind: operational
+public_coverage: none
+phases:
+  - phase_id: p1-conversational-capture
+    ops:
+      - op: configure
+        ref: hookless-compact
+        detail: no retrieval hook; compact response detail
+      - op: agent_turn
+        ref: f26-conversation
+      - op: snapshot
+        ref: s1
+    expect:
+      - assert: due_state_block_present_in_carrier
+  - phase_id: p2-abrupt-end-and-fresh-session
+    ops:
+      - op: stop_engine
+        ref: abrupt-end
+      - op: start_engine
+        ref: session-start
+      - op: fresh_agent
+        ref: f26-fresh
+      - op: snapshot
+        ref: s2
+    expect:
+      - assert: due_state_block_present_in_carrier
+      - assert: continuation_packet_reconstructs_session
+fairness:
+  why_neutral: >-
+    A signal that exists in a queue nobody's client renders has not been
+    delivered. Asserting the block in the compact responses the journey
+    received measures the delivery path itself, which no end-state assertion
+    can substitute for, on the thinnest surface a user might have.
+  public_coverage_subtraction: >-
+    No public suite measures carrier delivery; this scenario reports state
+    invariants only.
+  mechanisms:
+    - provider_role: subject
+      mechanism: due-state block present in the captured compact mutation and recall responses
+      verdict: unknown
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:47
+    - provider_role: comparator-a
+      mechanism: documented compact-response schema including the block, plus conforming captures
+      verdict: unknown
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:47
+  privileged_endpoint_matrix:
+    - driver_surface_id: state.read
+      provider: fixture
+      variant: native
+      disposition: equivalent
+      audit_scope: read-only projected state
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:32
+      reason: The fixture projects only documented neutral state.
+      competitor_surface: documented list/read endpoint
+    - driver_surface_id: carrier.compact
+      provider: fixture
+      variant: native
+      disposition: equivalent
+      audit_scope: captured compact responses from the installed envelope
+      evidence: benchmarks/epistemic/PREREGISTRATION.md:47
+      reason: Responses are captured from the documented CLI envelope, discovered first.
+      competitor_surface: documented client response envelope
+  acceptance_predicate: >-
+    PREREGISTRATION.md section 4, due_state_block_present_in_carrier and
+    continuation_packet_reconstructs_session.

--- a/benchmarks/epistemic/journeys/__init__.py
+++ b/benchmarks/epistemic/journeys/__init__.py
@@ -1,0 +1,5 @@
+"""Scripted end-to-end journeys for the operational scenario families."""
+
+from __future__ import annotations
+
+__all__ = ["f26_carrier"]

--- a/benchmarks/epistemic/journeys/f26_carrier.py
+++ b/benchmarks/epistemic/journeys/f26_carrier.py
@@ -268,6 +268,14 @@ def _required_options_from_usage(help_text: str) -> frozenset[str]:
         if not line.startswith(" "):
             break
         usage.append(line)
+    if not usage:
+        # Returning an empty set here would make every argv-completeness check
+        # pass vacuously the day the help format changes, which is the failure
+        # this function exists to catch.
+        raise JourneyStepFailed(
+            "the envelope's help output carries no usage line; required options "
+            "cannot be read, so argv completeness cannot be checked"
+        )
     flattened = " ".join(usage)
     depth = 0
     kept: list[str] = []

--- a/benchmarks/epistemic/journeys/f26_carrier.py
+++ b/benchmarks/epistemic/journeys/f26_carrier.py
@@ -1,0 +1,457 @@
+"""The f26 track-D journey: a hookless episode, driven through the real envelope.
+
+f26 exists because f20-f25 test detectors and end states, so a runtime could
+satisfy every one of them while no signal ever reached a client. This driver
+runs the episode on the thinnest surface available — no retrieval hook, compact
+response detail — and captures the responses it *actually received*, because the
+family's claim is about delivery and a claim about delivery cannot be settled
+from stored state.
+
+**The envelope is discovered, never assumed.** :func:`discover_envelope` locates
+the installed CLI and asks it what it is before a single journey step runs. If
+no envelope is installed, the journey refuses with
+:class:`EnvelopeNotDiscovered` rather than falling back to an in-process import:
+a fallback would quietly turn a carrier test into a library test, which is the
+one substitution this family cannot survive.
+
+Nothing here reads a clock. ``captured_at`` is supplied by the caller so a
+journey artifact is reproducible from its inputs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+
+from ..corpora.no_nudge import ABSENCE_SURFACES
+from ..snapshot import (
+    DECLARABLE_FIELDS,
+    EpistemicStateSnapshot,
+    FieldDeclaration,
+    ProjectorMeta,
+    StateItem,
+)
+
+#: The response detail the family is about. A due-state block only reachable at
+#: a richer level has not been delivered to a thin client.
+COMPACT_DETAIL = "compact"
+
+#: Candidate executable names, in preference order.
+ENVELOPE_CANDIDATES: tuple[str, ...] = ("exomem",)
+
+JOURNEY_PROJECTOR = ProjectorMeta(
+    name="f26-carrier-journey",
+    version="1.0.0",
+    author="benchmark-harness",
+    endpoints_used=("cli:documented compact envelope",),
+    loc=0,
+    loc_code=0,
+)
+
+
+class EnvelopeNotDiscovered(RuntimeError):
+    """No installed CLI envelope; the carrier journey cannot run."""
+
+
+class JourneyStepFailed(RuntimeError):
+    """A documented journey step did not complete."""
+
+
+@dataclass(frozen=True)
+class Envelope:
+    """The installed CLI, as discovered rather than as assumed."""
+
+    executable: Path
+    version: str
+
+    def run(self, args: Sequence[str], *, cwd: Path, timeout: float = 60.0) -> str:
+        completed = subprocess.run(  # noqa: S603 - resolved executable, fixed argv
+            [str(self.executable), *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env={
+                **os.environ,
+                "EXOMEM_DISABLE_EMBEDDINGS": "1",
+                # The envelope locates the vault from the environment, not from
+                # the working directory. Passing only ``cwd`` produced a
+                # well-formed refusal that looked like a product failure and was
+                # in fact a harness one.
+                "EXOMEM_VAULT_PATH": str(cwd),
+            },
+        )
+        if completed.returncode != 0:
+            # The envelope reports operational errors as a JSON envelope on
+            # stdout and leaves stderr empty, so a stderr-only message said
+            # nothing at all about why a step failed.
+            detail = (completed.stderr.strip() or completed.stdout.strip())[:400]
+            raise JourneyStepFailed(
+                f"{args[0]} exited {completed.returncode}: {detail}"
+            )
+        return completed.stdout
+
+
+def discover_envelope() -> Envelope:
+    """Locate the installed CLI and ask it what it is. Never assume either."""
+
+    for name in ENVELOPE_CANDIDATES:
+        found = shutil.which(name)
+        if found is None:
+            continue
+        executable = Path(found).resolve()
+        try:
+            completed = subprocess.run(  # noqa: S603 - resolved executable, fixed argv
+                [str(executable), "--version"],
+                capture_output=True,
+                text=True,
+                timeout=30.0,
+            )
+        except (OSError, subprocess.SubprocessError) as error:
+            raise EnvelopeNotDiscovered(f"{name} is present but not runnable: {error}") from error
+        if completed.returncode != 0:
+            raise EnvelopeNotDiscovered(
+                f"{name} --version exited {completed.returncode}; envelope not identified"
+            )
+        return Envelope(executable=executable, version=completed.stdout.strip())
+    raise EnvelopeNotDiscovered(
+        "no installed CLI envelope found on PATH; f26 measures delivery through the "
+        "real client surface and must not fall back to an in-process import"
+    )
+
+
+#: The flag each documented command spells its response detail with. They differ,
+#: and the first version of this driver assumed they did not: it passed
+#: ``--detail`` to both and to a ``recall`` command that does not exist, so every
+#: step exited 2. A journey that cannot run is not evidence about delivery.
+DETAIL_FLAGS: Mapping[str, str] = MappingProxyType(
+    {"remember": "--response-detail", "bootstrap": "--profile"}
+)
+
+#: The episode's fixture content. Sourced here rather than improvised at the call
+#: site so a journey artifact is reproducible from its inputs, and written to
+#: satisfy the product's own semantic-authoring precommit — a step rejected for
+#: malformed input would measure the fixture, not the carrier.
+JOURNEY_TITLE = "f26 carrier probe conclusion"
+
+#: The relation target the durable conclusion points at. The product refuses a
+#: compiled page with no qualifying typed relation, which is a precondition of
+#: the *write*, not of the carrier — so the journey satisfies it explicitly and
+#: names the page it depends on rather than discovering the refusal at runtime.
+#: This page exists in the vault the product itself ships as a sample, which is
+#: what :func:`seed_journey_vault` copies a run's vault from.
+JOURNEY_RELATION_TARGET = "Knowledge Base/Entities/Concepts/Local First Knowledge"
+
+#: The vault a journey run starts from, relative to the repository root. Using
+#: the product's own sample vault keeps the precondition visible: the carrier is
+#: measured against a vault the product itself calls valid.
+SAMPLE_VAULT_PATH = "src/exomem/_sample_vault"
+
+
+def seed_journey_vault(destination: Path, *, repo_root: Path) -> Path:
+    """Copy the product's sample vault to ``destination`` and return it.
+
+    The journey writes, so it must not run against a checked-in fixture. The
+    copy also makes a run reproducible: every step starts from the same declared
+    state rather than from whatever the last run left behind.
+    """
+
+    shutil.copytree(repo_root / SAMPLE_VAULT_PATH, destination)
+    return destination
+
+
+def journey_content(*, relation_target: str = JOURNEY_RELATION_TARGET) -> str:
+    """The durable conclusion the episode records, as the product will accept it."""
+
+    return (
+        "A durable conclusion recorded by the f26 carrier journey.\n"
+        "\n"
+        "## Observations\n"
+        "\n"
+        "- [benchmark] The hookless episode carrier records one durable conclusion "
+        "and then reconstructs it in a fresh session #f26 (epistemic-bench) ^f26-carrier\n"
+        "\n"
+        "## Relations\n"
+        "\n"
+        f"- supports [[{relation_target}]]\n"
+    )
+
+
+JOURNEY_CONTENT = journey_content()
+
+
+def journey_steps(
+    *, title: str = JOURNEY_TITLE, content: str = JOURNEY_CONTENT
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """The episode as complete, executable argv.
+
+    A conversational durable conclusion, an abrupt session end, then a fresh
+    session that must reconstruct from the thinnest surface the product offers.
+    Every required option the envelope declares is supplied, because the family's
+    claim is about what a thin client *receives* and nothing is received from a
+    command that refuses to run.
+    """
+
+    return (
+        (
+            "mutation",
+            (
+                "remember",
+                "--json",
+                DETAIL_FLAGS["remember"],
+                COMPACT_DETAIL,
+                "--title",
+                title,
+                "--content",
+                content,
+            ),
+        ),
+        (
+            "reconstruction",
+            ("bootstrap", "--json", DETAIL_FLAGS["bootstrap"], COMPACT_DETAIL),
+        ),
+    )
+
+
+JOURNEY_STEPS: tuple[tuple[str, tuple[str, ...]], ...] = journey_steps()
+
+#: ``surface -> the response keys that would carry it``. Absence of every one of
+#: them is what makes a surface unobserved rather than empty.
+SURFACE_RESPONSE_KEYS: Mapping[str, tuple[str, ...]] = MappingProxyType(
+    {
+        "due_state_counters": ("due_state", "due_state_counters"),
+        "review_queue": ("review_queue", "review"),
+        "proposal_queue": ("proposal_queue", "proposals"),
+        "audit_findings": ("audit_findings", "audit"),
+    }
+)
+
+
+def required_options(command: str) -> frozenset[str]:
+    """The options the installed envelope declares mandatory for ``command``.
+
+    Parsed from the envelope's own usage line rather than restated here, so the
+    journey cannot drift away from the CLI it claims to drive. Anything the
+    usage line shows in brackets is optional by the CLI's own account; whatever
+    survives bracket removal is required.
+    """
+
+    envelope = discover_envelope()
+    completed = subprocess.run(  # noqa: S603 - resolved executable, fixed argv
+        [str(envelope.executable), command, "--help"],
+        capture_output=True,
+        text=True,
+        timeout=60.0,
+    )
+    if completed.returncode != 0:
+        raise JourneyStepFailed(
+            f"{command} --help exited {completed.returncode}; options cannot be read"
+        )
+    return _required_options_from_usage(completed.stdout)
+
+
+def _required_options_from_usage(help_text: str) -> frozenset[str]:
+    usage: list[str] = []
+    for line in help_text.splitlines():
+        if not usage:
+            if not line.startswith("usage:"):
+                continue
+            usage.append(line)
+            continue
+        if not line.startswith(" "):
+            break
+        usage.append(line)
+    flattened = " ".join(usage)
+    depth = 0
+    kept: list[str] = []
+    for character in flattened:
+        if character == "[":
+            depth += 1
+        elif character == "]":
+            depth = max(0, depth - 1)
+        elif depth == 0:
+            kept.append(character)
+    return frozenset(re.findall(r"--[A-Za-z][\w-]*", "".join(kept)))
+
+
+def _envelope_bodies(payload: Mapping[str, object]) -> tuple[Mapping[str, object], ...]:
+    """The payload and, when present, the documented ``{success, data}`` body.
+
+    The envelope nests everything one level down. Looking only at the top level
+    would have reported every surface unavailable no matter what the product
+    delivered — which would make f26 permanently red for a harness reason, and
+    an assertion that cannot pass measures nothing.
+    """
+
+    data = payload.get("data")
+    if isinstance(data, Mapping):
+        return (payload, data)
+    return (payload,)
+
+
+def _carries_surface(payload: Mapping[str, object], surface: str) -> bool:
+    """Whether one captured compact response carries a named surface."""
+
+    return any(
+        key in body
+        for body in _envelope_bodies(payload)
+        for key in SURFACE_RESPONSE_KEYS[surface]
+    )
+
+
+def _carries_due_state(payload: Mapping[str, object]) -> bool:
+    """Whether one captured compact response carries the due-state block."""
+
+    return _carries_surface(payload, "due_state_counters")
+
+
+def capture_responses(
+    envelope: Envelope, *, vault: Path, steps: Sequence[tuple[str, tuple[str, ...]]] = JOURNEY_STEPS
+) -> dict[str, Mapping[str, object]]:
+    """Run the journey and return the parsed compact responses it received."""
+
+    captured: dict[str, Mapping[str, object]] = {}
+    for name, args in steps:
+        raw = envelope.run(args, cwd=vault)
+        try:
+            payload = json.loads(raw)
+        except ValueError as error:
+            raise JourneyStepFailed(f"{name} response is not JSON: {raw[:200]}") from error
+        if not isinstance(payload, dict):
+            raise JourneyStepFailed(f"{name} response is not an object")
+        captured[name] = payload
+    return captured
+
+
+def journey_snapshot(
+    captured: Mapping[str, Mapping[str, object]],
+    *,
+    taken_at: str,
+    packet_members: Sequence[str] = (),
+    declarations: Sequence[FieldDeclaration] | None = None,
+) -> EpistemicStateSnapshot:
+    """Project captured responses into the neutral snapshot f26 asserts over.
+
+    Only what the responses actually contained becomes state, and that rule now
+    covers the *metadata* as well as the items. An earlier version stamped every
+    absence surface ``complete`` and declared every field observable no matter
+    what came back, which manufactured exactly the silence the anti-vacuity
+    meta-predicate exists to refuse — and contradicted the vault projector, which
+    honestly reports three of these four surfaces as unprojectable. A surface
+    nothing was heard about is ``unavailable``, a field nothing evidenced is
+    undeclared, and the quiet assertions are ``blocked`` in consequence.
+    """
+
+    items: list[StateItem] = []
+    for name, payload in sorted(captured.items()):
+        raw = {"response_detail": COMPACT_DETAIL}
+        if _carries_due_state(payload):
+            raw["targets"] = "due_state_counters"
+        items.append(
+            StateItem(
+                id=f"f26-response-{name}",
+                kind="container",
+                title=f"f26-response-{name}",
+                raw=raw,
+            )
+        )
+    if packet_members:
+        items.append(
+            StateItem(
+                id="f26-packet",
+                kind="container",
+                title="f26-packet",
+                current="yes",
+                cites=tuple(packet_members),
+                raw={"packet": "f26-packet"},
+            )
+        )
+    observed = {
+        surface
+        for surface in SURFACE_RESPONSE_KEYS
+        if any(_carries_surface(payload, surface) for payload in captured.values())
+    }
+    items.extend(
+        StateItem(
+            id=f"surface-{surface}",
+            kind="container",
+            title=surface,
+            raw={
+                "surface": surface,
+                "projection": "complete" if surface in observed else "unavailable",
+            },
+        )
+        for surface in ABSENCE_SURFACES
+    )
+
+    return EpistemicStateSnapshot(
+        provider="exomem",
+        variant="native",
+        phase="f26",
+        taken_at=taken_at,
+        items=tuple(items),
+        declarations=(
+            tuple(declarations)
+            if declarations
+            else _derived_declarations(observed, packet_members=packet_members)
+        ),
+        projector=JOURNEY_PROJECTOR,
+        completeness_notes=(
+            "Captured compact responses from the discovered CLI envelope only; "
+            "nothing is read from stored state, because the family measures delivery. "
+            f"Surfaces evidenced by a response: {', '.join(sorted(observed)) or 'none'}."
+        ),
+    )
+
+
+def _derived_declarations(
+    observed: set[str], *, packet_members: Sequence[str]
+) -> tuple[FieldDeclaration, ...]:
+    """Declare only what a captured response evidenced. Default is unavailable."""
+
+    evidenced = {
+        surface: f"captured compact response carried {surface}" for surface in observed
+    }
+    if packet_members:
+        evidenced["continuation_packet"] = (
+            f"captured response carried a continuation packet of {len(packet_members)} member(s)"
+        )
+    return tuple(
+        FieldDeclaration(
+            field=field,
+            status="declared" if field in evidenced else "unavailable",
+            evidence=evidenced.get(
+                field, "no captured compact response carried this field"
+            ),
+        )
+        for field in DECLARABLE_FIELDS
+    )
+
+
+__all__ = [
+    "COMPACT_DETAIL",
+    "DETAIL_FLAGS",
+    "Envelope",
+    "EnvelopeNotDiscovered",
+    "JOURNEY_CONTENT",
+    "JOURNEY_RELATION_TARGET",
+    "JOURNEY_STEPS",
+    "JOURNEY_TITLE",
+    "JourneyStepFailed",
+    "SAMPLE_VAULT_PATH",
+    "SURFACE_RESPONSE_KEYS",
+    "capture_responses",
+    "discover_envelope",
+    "journey_content",
+    "journey_snapshot",
+    "journey_steps",
+    "required_options",
+    "seed_journey_vault",
+]

--- a/benchmarks/epistemic/projectors/exomem_vault.py
+++ b/benchmarks/epistemic/projectors/exomem_vault.py
@@ -29,6 +29,7 @@ silently dropped.
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Iterable, Mapping
 from pathlib import Path
@@ -204,7 +205,49 @@ FIELD_DECLARATIONS: tuple[FieldDeclaration, ...] = (
         status="declared",
         evidence="src/exomem/_scaffold/_Schema/SKILL.md:134",
     ),
+    # Added for the 2026-08 no-nudge amendment (§7, sequence 2). Three of these
+    # four are declared *unavailable* on purpose: the no-nudge surfaces do not
+    # exist in the product yet, and that is precisely why f20-f22 are filed as
+    # expected-red falsification targets. Declaring them observable to make a
+    # family go green would be the exact fraud the fairness contract exists to
+    # prevent; declaring them absent_by_design would be worse still, because
+    # exomem has not decided they should never exist.
+    FieldDeclaration(
+        field="signal",
+        status="available_via:review_queue_attention_mode",
+        evidence="docs/epistemic-inbox.md:32",
+    ),
+    FieldDeclaration(
+        field="dismissal",
+        status="available_via:review_state_file",
+        evidence="docs/epistemic-inbox.md:45",
+    ),
+    FieldDeclaration(
+        field="due_state_counters",
+        status="unavailable",
+        evidence="docs/product-gap-matrix.md:100",
+    ),
+    FieldDeclaration(
+        field="continuation_packet",
+        status="unavailable",
+        evidence="openspec/specs/agent-bootstrap-contract/spec.md:11",
+    ),
 )
+
+#: The documented triage store. Decisions live here, not in note frontmatter,
+#: so the dismissal projection reads it rather than inferring from pages.
+REVIEW_STATE_FILE = ".review-state.json"
+
+#: ``surface name -> (projection status, why)`` for the four surfaces a quiet
+#: assertion must prove absence on. Only ``review_queue`` has a file surface at
+#: all, and only when the triage store exists; the rest are computed
+#: server-side or do not exist, and saying so is what makes an unprojected
+#: surface an *error* rather than silence a product can be credited with.
+UNPROJECTABLE_SURFACES: Mapping[str, str] = {
+    "audit_findings": "governance receipts are not a file surface; see completeness notes",
+    "proposal_queue": "relation/compile proposals are computed server-side, not stored as files",
+    "due_state_counters": "no due-state counters block exists in the product",
+}
 
 
 def _split_frontmatter(text: str) -> tuple[dict[str, Any], str]:
@@ -445,6 +488,8 @@ class VaultProjector(Projector):
                 )
 
         self._apply_revision_chains(items, successor_of)
+        for marker in self._project_surfaces():
+            items[marker.id] = marker
 
         return EpistemicStateSnapshot(
             provider="exomem",
@@ -464,6 +509,73 @@ class VaultProjector(Projector):
             ),
             completeness_notes=COMPLETENESS_NOTES,
         )
+
+    def _project_surfaces(self) -> tuple[StateItem, ...]:
+        """Project the four absence surfaces, and the triage store's dismissals.
+
+        The honest answer for three of the four is "cannot be projected from
+        files", and that answer is *load-bearing*: the anti-vacuity
+        meta-predicate turns an unprojected surface into an error, so a quiet
+        assertion evaluated against a real vault is blocked rather than passing.
+        A projector that quietly emitted ``complete`` here would manufacture
+        silence the vault never demonstrated.
+        """
+
+        projected: list[StateItem] = []
+        for surface, reason in sorted(UNPROJECTABLE_SURFACES.items()):
+            projected.append(
+                StateItem(
+                    id=f"surface-{surface}",
+                    kind="container",
+                    title=surface,
+                    text=reason,
+                    raw={"surface": surface, "projection": "unavailable", "reason": reason},
+                )
+            )
+
+        triage_path = self.vault_root / REVIEW_STATE_FILE
+        decisions: dict[str, Any] = {}
+        projection = "unavailable"
+        if triage_path.is_file():
+            try:
+                loaded = json.loads(triage_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                loaded = None
+            if isinstance(loaded, dict):
+                raw_decisions = loaded.get("decisions")
+                decisions = raw_decisions if isinstance(raw_decisions, dict) else {}
+                projection = "complete"
+        projected.append(
+            StateItem(
+                id="surface-review_queue",
+                kind="container",
+                title="review_queue",
+                text=f"{REVIEW_STATE_FILE} triage store",
+                raw={"surface": "review_queue", "projection": projection},
+            )
+        )
+        for target, decision in sorted(decisions.items()):
+            if not isinstance(decision, dict):
+                continue
+            state = str(decision.get("action") or decision.get("state") or "").strip()
+            fingerprint = str(decision.get("fingerprint") or "").strip()
+            if not state or not fingerprint:
+                continue
+            projected.append(
+                StateItem(
+                    id=f"dismissal-{target}",
+                    kind="container",
+                    title=target,
+                    text=str(decision.get("why") or ""),
+                    review_state=state,
+                    raw={
+                        "surface": "review_queue",
+                        "targets": target,
+                        "fingerprint": fingerprint,
+                    },
+                )
+            )
+        return tuple(projected)
 
     def declarations(self) -> tuple[FieldDeclaration, ...]:
         return FIELD_DECLARATIONS

--- a/benchmarks/epistemic/registry.py
+++ b/benchmarks/epistemic/registry.py
@@ -1,15 +1,17 @@
 """The frozen assertion registry.
 
-The 24 names below are pre-registered in ``PREREGISTRATION.md`` §2 — eighteen
-committed before any competitor was run by this programme, and six added by the
-2026-08 loop-closure amendment through the governed §7 path. The registry is a
-closed set on purpose: a scenario that names anything else fails to load, which
-is what stops the suite from growing an assertion to fit a result it wanted.
+The 33 names below are pre-registered in ``PREREGISTRATION.md`` §2 — eighteen
+committed before any competitor was run by this programme, six added by the
+2026-08 loop-closure amendment, and nine added by the 2026-08 no-nudge
+amendment, both through the governed §7 path. The registry is a closed set on
+purpose: a scenario that names anything else fails to load, which is what stops
+the suite from growing an assertion to fit a result it wanted.
 
-Registration is not release. The families the amendment introduced stay
+Registration is not release. The families each amendment introduced stay
 withheld from comparative runs until its receipt is acknowledged; that gate
 lives in :mod:`epistemic.amendments` and fires at the same load-time choke
-point this registry does.
+point this registry does. Sequence 1 is acknowledged; sequence 2 is not, so
+f20-f26 are registered and withheld at once.
 
 ``PREREGISTERED_ASSERTIONS`` mirrors §2 in code so the mapping can be checked
 without file I/O at import time; ``tests/test_epistemic_registry.py`` parses the
@@ -59,6 +61,40 @@ PREREGISTERED_ASSERTIONS: tuple[str, ...] = (
     "support_collapse_inspectable",
     "refuted_retrievable_at_full_standing",
     "loop_journey_state_coherent",
+    # Added by the 2026-08 no-nudge amendment (§7), sequence 2.
+    # ``signal_absence_checked_across_all_surfaces`` is deliberately FIRST: it is
+    # the anti-vacuity meta-predicate every quiet assertion in f20-f26 composes,
+    # and registering it ahead of the families that depend on it keeps the
+    # reading order of §2 the same as the dependency order in code.
+    "signal_absence_checked_across_all_surfaces",
+    "structural_signal_surfaced_within_budget",
+    "entity_candidate_surfaced_from_recurrence",
+    "contradiction_surfaced_unprompted",
+    "dismissal_respected_across_passes",
+    "counter_emission_not_repeated_per_write",
+    "continuation_packet_reconstructs_session",
+    "restructure_signal_cleared_by_state_change",
+    "due_state_block_present_in_carrier",
+)
+
+#: Quiet assertions: every one composes
+#: :func:`~epistemic.assertions.signal_absence_checked_across_all_surfaces`, so
+#: a negative control can never pass by relocating a nag to an unchecked surface
+#: or by projecting nothing at all.
+#:
+#: Membership is not a matter of remembering to edit this literal. Each
+#: predicate is marked with ``@claims_absence`` where it is defined, and
+#: ``tests/test_epistemic_no_nudge_families.py`` asserts this set equals exactly
+#: the marked ones *and* that every member propagates the meta-predicate when it
+#: is made to refuse. The literal is kept because the rest of the registry is
+#: hand-mirrored for the same reason — no import-time introspection of the
+#: assertion module's decorators is needed to read what the governance says.
+COMPOSES_ABSENCE_META: frozenset[str] = frozenset(
+    {
+        "signal_absence_checked_across_all_surfaces",
+        "dismissal_respected_across_passes",
+        "restructure_signal_cleared_by_state_change",
+    }
 )
 
 
@@ -86,6 +122,14 @@ PREREGISTERED_FAMILIES: tuple[tuple[str, str], ...] = (
     ("f17", "derivation_collapse"),
     ("f18", "negative_result_retention"),
     ("f19", "loop_composite"),
+    # Added by the 2026-08 no-nudge amendment (§7), sequence 2.
+    ("f20", "structural_emergence"),
+    ("f21", "entity_emergence"),
+    ("f22", "unsolicited_contradiction"),
+    ("f23", "dismissal_respect"),
+    ("f24", "fresh_session_reconstruction"),
+    ("f25", "restructure_lifecycle"),
+    ("f26", "hookless_episode_carrier"),
 )
 
 PREREGISTERED_FAMILY_IDS: frozenset[str] = frozenset(
@@ -110,6 +154,18 @@ AMENDMENT_INTRODUCED_FAMILIES: Mapping[str, int] = MappingProxyType(
         "f17": 1,
         "f18": 1,
         "f19": 1,
+        # Sequence 2 (no-nudge). Pending founder acknowledgment, so every one of
+        # these is withheld from comparative runs, scores and claims — which is
+        # the entire observable difference between being registered and being
+        # released, and the reason f20-f22 being expected-red is a falsification
+        # target rather than a CI failure.
+        "f20": 2,
+        "f21": 2,
+        "f22": 2,
+        "f23": 2,
+        "f24": 2,
+        "f25": 2,
+        "f26": 2,
     }
 )
 
@@ -122,6 +178,25 @@ REQUIRES_ITEM_PAIR: frozenset[str] = frozenset(
         "contradiction_visible",
         "contradiction_not_flattened",
         "decision_distinguishable_from_hypothesis",
+        # f22 surfaces a *pair* — the invalidated conclusion and the evidence
+        # that invalidates it — so a scenario that names only one of them would
+        # be asserting something weaker than the family claims.
+        "contradiction_surfaced_unprompted",
+    }
+)
+
+#: Assertions that are meaningless without a named subject. A quiet assertion in
+#: particular proves silence *about something*; letting it run subject-less would
+#: turn "no signal names this twin" into "no signal exists", which is a different
+#: and far weaker claim that an empty snapshot would satisfy.
+REQUIRES_SUBJECT: frozenset[str] = frozenset(
+    {
+        "signal_absence_checked_across_all_surfaces",
+        "structural_signal_surfaced_within_budget",
+        "entity_candidate_surfaced_from_recurrence",
+        "contradiction_surfaced_unprompted",
+        "dismissal_respected_across_passes",
+        "restructure_signal_cleared_by_state_change",
     }
 )
 
@@ -140,6 +215,10 @@ REQUIRES_SNAPSHOT_PAIR: frozenset[str] = frozenset(
         # trajectory that took one snapshot cannot support either.
         "divergence_surfaced_without_mutation",
         "loop_journey_state_coherent",
+        # f23 compares a recorded dismissal against a later maintenance pass:
+        # "the fingerprint did not come back" is a statement about a transition,
+        # and a single snapshot cannot support it.
+        "dismissal_respected_across_passes",
     }
 )
 

--- a/benchmarks/epistemic/runner.py
+++ b/benchmarks/epistemic/runner.py
@@ -184,6 +184,7 @@ def evaluate_scenario(
                     raise _binding_error("current snapshot timestamp precedes the external edit")
 
             context = AssertionContext(
+                family=scenario.family_id,
                 snapshot=reached_snapshots[-1],
                 prior=reached_snapshots[-2] if len(reached_snapshots) > 1 else None,
                 subject=expectation.subject,

--- a/benchmarks/epistemic/schema.py
+++ b/benchmarks/epistemic/schema.py
@@ -33,6 +33,7 @@ from .registry import (
     PREREGISTERED_FAMILY_IDS,
     REQUIRES_ITEM_PAIR,
     REQUIRES_SNAPSHOT_PAIR,
+    REQUIRES_SUBJECT,
     RegistryError,
     resolve,
 )
@@ -50,7 +51,36 @@ OpKind = Literal[
     "fresh_agent",
     "export",
     "snapshot",
+    # Added by the 2026-08 no-nudge amendment (§7) for families f20-f26.
+    # ``maintenance_pass`` is the only operation allowed to intervene between
+    # evidence ingest and an unprompted assertion — see
+    # :func:`_validate_unprompted_trajectory`; the other three route a triage
+    # decision, a restructure, and an engagement-level change through the
+    # product's documented surfaces rather than through privileged internals.
+    "maintenance_pass",
+    "triage_decision",
+    "apply_restructure",
+    "configure",
 ]
+
+#: The only operations that may occur between evidence ingest and an unprompted
+#: assertion. ``maintenance_pass`` is the intervention the families explicitly
+#: permit — an autonomous housekeeping run is not the user asking — and
+#: ``snapshot`` is an observation rather than an intervention.
+#:
+#: Stated as an allowlist on purpose. The first version denied ``agent_turn``
+#: and nothing else while its own error message promised that "only
+#: maintenance_pass may intervene", so a scenario could have routed a
+#: ``triage_decision`` or a ``configure`` between the two and still loaded — and
+#: either of those is a user act that could have prompted the surfacing the
+#: family claims was unprompted. A denylist has to be remembered every time an
+#: OpKind is added; this does not.
+UNPROMPTED_SAFE_OPS: frozenset[str] = frozenset({"maintenance_pass", "snapshot"})
+
+#: Families whose whole claim is that the user never asked. Their assertions are
+#: worthless if a topical turn could have prompted the surfacing, so the loader
+#: refuses such a trajectory rather than scoring it.
+UNPROMPTED_FAMILIES: frozenset[str] = frozenset({"f20", "f21", "f22"})
 
 ScenarioKind = Literal["corpus", "operational"]
 
@@ -245,6 +275,43 @@ def _validate_pair_requirements(scenario: Scenario, source: str) -> None:
                     f"{source}: phase {phase.phase_id!r} expects {assertion!r} without a "
                     "declared freshness_bound_s; adoption latency would be unscoreable"
                 )
+            if assertion in REQUIRES_SUBJECT and not expectation.subject:
+                raise ScenarioLoadError(
+                    f"{source}: phase {phase.phase_id!r} expects {assertion!r} without a "
+                    "subject; a quiet or targeted assertion with no subject silently "
+                    "degrades into a far weaker snapshot-wide claim"
+                )
+
+
+def _validate_unprompted_trajectory(scenario: Scenario, source: str) -> None:
+    """f20-f22 prove the user never asked, so the trajectory may not contain a turn.
+
+    No query-log inspection is needed inside the bench: unpromptedness is a
+    property of the scripted trajectory itself. Between the first evidence
+    ingest and the snapshot an unprompted family asserts on, only maintenance
+    operations may intervene. Enforcing this at load time rather than in an
+    assertion means a scenario that would have measured a *prompted* surfacing
+    never runs at all, instead of quietly reporting a number nobody can use.
+    """
+
+    if scenario.family_id not in UNPROMPTED_FAMILIES:
+        return
+    ingested = False
+    for phase in scenario.phases:
+        for op in phase.ops:
+            if op.op == "ingest_source":
+                ingested = True
+            elif ingested and op.op not in UNPROMPTED_SAFE_OPS:
+                raise ScenarioLoadError(
+                    f"{source}: family {scenario.family_id} asserts unprompted surfacing, but "
+                    f"phase {phase.phase_id!r} runs a {op.op!r} operation after "
+                    "evidence ingest; only maintenance_pass may intervene"
+                )
+        if phase.expect and not ingested:
+            raise ScenarioLoadError(
+                f"{source}: family {scenario.family_id} expects an unprompted surfacing in "
+                f"phase {phase.phase_id!r} before any evidence was ingested"
+            )
 
 
 def load_scenario_text(text: str, *, source: str) -> Scenario:
@@ -267,6 +334,7 @@ def load_scenario_text(text: str, *, source: str) -> Scenario:
     try:
         _validate_names(scenario, source)
         _validate_pair_requirements(scenario, source)
+        _validate_unprompted_trajectory(scenario, source)
         scenario.bound_assertions()
     except RegistryError as error:
         raise ScenarioLoadError(f"{source}: {error}") from error

--- a/benchmarks/epistemic/schema.py
+++ b/benchmarks/epistemic/schema.py
@@ -305,7 +305,7 @@ def _validate_unprompted_trajectory(scenario: Scenario, source: str) -> None:
                 raise ScenarioLoadError(
                     f"{source}: family {scenario.family_id} asserts unprompted surfacing, but "
                     f"phase {phase.phase_id!r} runs a {op.op!r} operation after "
-                    "evidence ingest; only maintenance_pass may intervene"
+                    "evidence ingest; only maintenance_pass and snapshot may intervene"
                 )
         if phase.expect and not ingested:
             raise ScenarioLoadError(

--- a/benchmarks/epistemic/snapshot.py
+++ b/benchmarks/epistemic/snapshot.py
@@ -99,6 +99,19 @@ DECLARABLE_FIELDS: tuple[str, ...] = (
     "prediction",
     "verdict",
     "plan_linkage",
+    # Added by the 2026-08 no-nudge amendment (§7) for families f20-f26. Same
+    # reasoning as the sequence-1 additions above: each names a capability the
+    # amended families are *about*, so a product with no such concept declares
+    # it once and is scored ``not_applicable`` rather than failing an invariant
+    # it never claimed. ``signal`` is the autonomous-surfacing capability
+    # (promotion-class, entity-candidate, contradiction and merge-class signals
+    # alike); ``due_state_counters`` is the delivery-carrier counters block;
+    # ``continuation_packet`` is the fresh-session reconstruction artifact; and
+    # ``dismissal`` is the durable triage decision f23 measures.
+    "signal",
+    "due_state_counters",
+    "continuation_packet",
+    "dismissal",
 )
 
 _DECLARATION_STATUS_RE = re.compile(

--- a/benchmarks/judge-agreement/at1-agent-track-rubric.md
+++ b/benchmarks/judge-agreement/at1-agent-track-rubric.md
@@ -1,0 +1,50 @@
+# AT-1 — the agent-judged half of the no-nudge programme
+
+AT-1 is the membench **agent track** (tracks D/E), not part of the pre-registered
+deterministic set. It exists because two of the properties the no-nudge audit
+cares about are genuinely judgments — whether an intervention was *useful*, and
+whether a continuation packet was *sufficient* — and a judgment cannot sit
+inside a deterministic family without making that family non-deterministic.
+
+**Deterministic gates are never overturnable by a judge.** If f20 says a signal
+did not surface, no AT-1 score changes that. AT-1 measures quality *given* the
+deterministic result, and is reported separately.
+
+## Dimensions
+
+| id | Dimension | Question put to the judge |
+|---|---|---|
+| AT-1a | Intervention usefulness | Given this page's history, was the surfaced proposal one a careful owner would act on? |
+| AT-1b | Continuation sufficiency | Could a fresh agent resume the work from this packet alone, without asking the user to re-explain? |
+
+Each is scored 1-5. There is no aggregate across dimensions and no aggregate
+with any deterministic family: a single number over a judged and an unjudged
+quantity would hide exactly the disagreement worth seeing.
+
+## Protocol
+
+- **Blind.** The judge never sees which provider, variant, or arm produced a
+  sample, nor any deterministic result for it.
+- **Randomized.** Sample order is shuffled per judging session with a recorded
+  seed, so order effects are reproducible rather than merely absent.
+- **At least three samples** per dimension per arm. Fewer is reported as
+  underpowered and produces no published score.
+- **Ties are recorded**, never broken by the judge's preference.
+
+## Judge-agreement gate
+
+AT-1 results are publishable only behind the existing judge-agreement gate: the
+judge must first reproduce the calibration set in
+`no-nudge-at1-calibration.json` at the agreement threshold the harness already
+enforces for other judged tracks. A judge that fails the calibration set is
+reported as failing it; its scores are withheld, not down-weighted.
+
+## Relationship to the deterministic families
+
+| Deterministic family | AT-1 dimension it does *not* replace |
+|---|---|
+| f20/f21 — did a signal surface at all, within budget | AT-1a — was surfacing it a good idea |
+| f24/f26 — is the packet complete, delivered, and current | AT-1b — was it enough to actually resume |
+
+Reporting either half without the other is what the amendment's
+"no metric without its dual" rule forbids.

--- a/benchmarks/judge-agreement/no-nudge-at1-calibration.json
+++ b/benchmarks/judge-agreement/no-nudge-at1-calibration.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "set_id": "no-nudge-at1-calibration",
+  "rubric": "benchmarks/judge-agreement/at1-agent-track-rubric.md",
+  "amendment_sequence": 2,
+  "dimensions": ["AT-1a", "AT-1b"],
+  "scale": {"min": 1, "max": 5},
+  "blind": true,
+  "randomized": true,
+  "minimum_samples_per_dimension_per_arm": 3,
+  "items": [
+    {
+      "id": "at1a-clear-yes",
+      "dimension": "AT-1a",
+      "corpus": "epistemic.corpora.no_nudge.f20_corpus",
+      "target": "f20-subject",
+      "expected_band": [4, 5],
+      "why": "Three structurally distinct clusters on one page; a careful owner acts on a split proposal here."
+    },
+    {
+      "id": "at1a-clear-no",
+      "dimension": "AT-1a",
+      "corpus": "epistemic.corpora.no_nudge.f20_corpus",
+      "target": "f20-twin-log",
+      "expected_band": [1, 2],
+      "why": "A weekly log is heterogeneous on purpose; proposing to split it is the dominant real-vault false positive."
+    },
+    {
+      "id": "at1b-sufficient",
+      "dimension": "AT-1b",
+      "corpus": "epistemic.corpora.no_nudge.f24_corpus",
+      "target": "f24-packet",
+      "expected_band": [4, 5],
+      "why": "Every seeded decision, the open question, and latest plan state are referenced; no decoys."
+    },
+    {
+      "id": "at1b-insufficient",
+      "dimension": "AT-1b",
+      "corpus": "epistemic.corpora.no_nudge.f24_corpus(complete=False)",
+      "target": "f24-packet",
+      "expected_band": [1, 2],
+      "why": "The latest plan state is missing, so a fresh agent must ask the user to re-explain."
+    }
+  ],
+  "status": "calibration_set_defined_judge_not_yet_run",
+  "note": "A judge must reproduce the expected bands at the harness's existing agreement threshold before any AT-1 score is publishable. Failure is reported as failure; scores are withheld, never down-weighted."
+}

--- a/benchmarks/judge-agreement/no-nudge-calibration-labels.json
+++ b/benchmarks/judge-agreement/no-nudge-calibration-labels.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "study": "no-nudge-emergence-calibration",
+  "protocol": "benchmarks/judge-agreement/no-nudge-calibration-protocol.md",
+  "amendment_sequence": 2,
+  "status": "not_run",
+  "blocked_on": "founder decision on annotator staffing and the small-cohort fallback (tasks.md 3.5)",
+  "annotators": [],
+  "labels": [],
+  "medians": null,
+  "pairwise_agreement": null,
+  "note": "Empty by design. The constants in benchmarks/epistemic/budgets.py are PROVISIONAL until this file carries at least three annotators' raw labels and the §7 entry is re-dated with the resulting medians."
+}

--- a/benchmarks/judge-agreement/no-nudge-calibration-protocol.md
+++ b/benchmarks/judge-agreement/no-nudge-calibration-protocol.md
@@ -1,0 +1,86 @@
+# No-nudge emergence calibration — study protocol
+
+**Status: NOT YET RUN. The constants it exists to freeze are PROVISIONAL.**
+
+This protocol accompanies amendment sequence 2 (`benchmarks/epistemic/contracts/
+amendment-2026-08-no-nudge.v1.json`). It defines how the f20, f21 and f25 budget
+and window constants in `benchmarks/epistemic/budgets.py` are set — once, by
+expert annotation, and never again without a new dated §7 amendment.
+
+The study has not been run. Task 3.5 is blocked on a founder decision about
+annotator staffing and about the small-cohort fallback, and until it lands the
+constants ship marked `provisional` and the whole amendment is withheld, so no
+run, score or claim can be produced against them.
+
+## Why a study rather than a judge
+
+"Before an expert would have to intervene" is a judgment, and a judgment inside
+a deterministic family would make the family non-deterministic — a judge could
+then overturn a deterministic gate, which the house rules forbid. Calibrating
+once and freezing the median converts the judgment into a constant. Live judging
+of the intervention point never occurs in a run.
+
+## Annotators
+
+At least **three** expert annotators, each of whom:
+
+- maintains a personal knowledge base of at least 500 durable notes, and
+- has performed manual restructuring of an accumulating note in the last year.
+
+Annotators work independently and never see one another's labels before
+submission. No annotator may have authored the corpora.
+
+## Materials
+
+The corpora are generated, not hand-written, so the study can be re-run exactly:
+
+| Family | Corpus | Generator |
+|---|---|---|
+| f20 | accumulating page plus four matched twins | `epistemic.corpora.no_nudge.f20_corpus` |
+| f21 | recurrence corpus plus incidental twin | `epistemic.corpora.no_nudge.f21_corpus` |
+| f25 | restructure fixture and its children | `epistemic.corpora.no_nudge.f25_corpus` |
+
+Each annotator receives the corpus **as a sequence of writes**, replayed one
+unit at a time, with the twins interleaved and unlabelled.
+
+## Task
+
+After each write, the annotator answers one question:
+
+> Would you, as this vault's owner, now want the system to propose restructuring
+> this page? (yes / no / unsure)
+
+The **intervention point** is the first write at which an annotator answers yes
+and does not later revert to no. An annotator who never answers yes records no
+intervention point for that item; that is data, not a missing value.
+
+For f21 the question is recurrence-shaped ("…propose holding this as its own
+entity?"), and for f25 it is the quiet-window question ("…would a proposal to
+merge these back be welcome?").
+
+## Freezing
+
+1. Take the **median** intervention point across annotators, per corpus.
+2. Record raw per-annotator labels in `no-nudge-calibration-labels.json`.
+3. Compute pairwise agreement and publish it beside the medians; agreement below
+   0.6 is reported, not hidden, and is grounds for the founder to widen the
+   cohort rather than to adjust the median.
+4. Write the medians into `benchmarks/epistemic/budgets.py`, flip
+   `CALIBRATION_STATUS` to `frozen`, and **re-date the §7 entry** with its own
+   receipt. Editing the constants without that receipt is the silent retuning
+   the amendment exists to prevent.
+
+## Small-cohort fallback (founder decision pending)
+
+If the alpha cohort cannot supply three qualifying annotators, the recorded
+fallback is founder-vault-derived planted corpora with published rationale. The
+choice between staffing the cohort and taking the fallback is the founder's, is
+recorded in the architecture note, and precedes any labelling work.
+
+## False-positive dual
+
+The production false-positive budget — the rate of dismissals carrying the
+irrelevant reason — receives its threshold in the same study, and is reported
+beside, never instead of, the in-family zero-false-positive ceiling. No
+automation metric may be published without its paired false-positive measure
+from the same runs.

--- a/openspec/changes/amend-no-nudge-bench-families/tasks.md
+++ b/openspec/changes/amend-no-nudge-bench-families/tasks.md
@@ -1,27 +1,27 @@
 ## 1. Amendment text and governance
 
-- [ ] 1.1 Author the seven §7 amendment entries (f20–f26): kind, public-coverage statement, core assertions, acceptance predicates requiring at least two structurally different representations, negative controls, mechanism-removal conditions, and the expected-red declaration for f20–f22.
-- [ ] 1.2 Mint the sequence-2 amendment receipt through the accepted receipt contract; record base and amended document identities and the reason.
-- [ ] 1.3 Record the catastrophic-scope extension of `no_retired_state_served_as_current` to the continuation packet, and the explicit no-new-catastrophic-assertions declaration.
-- [ ] 1.4 Verify the withhold gate holds every sequence-2 family out of runs, scores, and claims until acknowledgment; add red fixtures for each refusal path following the sequence-1 pattern.
+- [x] 1.1 Author the seven §7 amendment entries (f20–f26): kind, public-coverage statement, core assertions, acceptance predicates requiring at least two structurally different representations, negative controls, mechanism-removal conditions, and the expected-red declaration for f20–f22.
+- [x] 1.2 Mint the sequence-2 amendment receipt through the accepted receipt contract; record base and amended document identities and the reason.
+- [x] 1.3 Record the catastrophic-scope extension of `no_retired_state_served_as_current` to the continuation packet, and the explicit no-new-catastrophic-assertions declaration.
+- [x] 1.4 Verify the withhold gate holds every sequence-2 family out of runs, scores, and claims until acknowledgment; add red fixtures for each refusal path following the sequence-1 pattern.
 
 ## 2. Registry and schema mirrors
 
-- [ ] 2.1 Register the new assertion names in the closed registry, `signal_absence_checked_across_all_surfaces` first, with every quiet assertion composing it; unknown names must still refuse at load.
-- [ ] 2.2 Extend the scenario operation vocabulary with `maintenance_pass`, `triage_decision`, `apply_restructure`, and `configure`; existing families unaffected.
-- [ ] 2.3 Extend the vault projector so review queues, proposal queues, and the due-state counters block project into snapshot state items for the absence checks.
-- [ ] 2.4 Mechanism-removal tests for each new assertion callable: hunt vacuous assertions per the house discipline.
+- [x] 2.1 Register the new assertion names in the closed registry, `signal_absence_checked_across_all_surfaces` first, with every quiet assertion composing it; unknown names must still refuse at load.
+- [x] 2.2 Extend the scenario operation vocabulary with `maintenance_pass`, `triage_decision`, `apply_restructure`, and `configure`; existing families unaffected.
+- [x] 2.3 Extend the vault projector so review queues, proposal queues, and the due-state counters block project into snapshot state items for the absence checks.
+- [x] 2.4 Mechanism-removal tests for each new assertion callable: hunt vacuous assertions per the house discipline.
 
 ## 3. Fixtures and calibration
 
-- [ ] 3.1 Build the f20 corpus: the structure-bound positive and all four twins, frequency- and length-matched, with the no-vocabulary-token generator assertion and the synonym-swap variant.
-- [ ] 3.2 Build the f21 recurrence corpus with the incidental-mention twin and lowercase/non-Latin referents; the f22 pair corpus with the concordant twin.
-- [ ] 3.3 Build the f24 seed-and-decoy corpus and the f25 restructure fixture.
-- [ ] 3.4 Script the f26 track-D journey against the installed CLI envelope, discovered first, with compact response detail.
+- [x] 3.1 Build the f20 corpus: the structure-bound positive and all four twins, frequency- and length-matched, with the no-vocabulary-token generator assertion and the synonym-swap variant.
+- [x] 3.2 Build the f21 recurrence corpus with the incidental-mention twin and lowercase/non-Latin referents; the f22 pair corpus with the concordant twin.
+- [x] 3.3 Build the f24 seed-and-decoy corpus and the f25 restructure fixture.
+- [x] 3.4 Script the f26 track-D journey against the installed CLI envelope, discovered first, with compact response detail. Executed end to end against `exomem 0.52.3` on a throwaway copy of the product's sample vault: both steps return `success: true`, and the family is red because no compact response carries a due-state block — the family's own finding, not a scripting failure.
 - [ ] 3.5 Run the calibration study: three expert annotators label the emergence corpora for the intervention point; freeze the medians into the amendment; ship protocol and labels in the judge-agreement assets. Founder decision on staffing and on the small-cohort fallback precedes this task.
-- [ ] 3.6 Define the AT-1 agent-track rubric (blind, randomized, at least three samples) and its judge-agreement calibration set.
+- [x] 3.6 Define the AT-1 agent-track rubric (blind, randomized, at least three samples) and its judge-agreement calibration set.
 
 ## 4. Verification
 
-- [ ] 4.1 All sequence-2 families execute and f20–f22 positives are red on the current runtime; twins and controls behave as specified.
-- [ ] 4.2 Registry drift gate green; strict OpenSpec validation green; lean suite green; no product-code diffs in this change.
+- [x] 4.1 All sequence-2 families execute and f20–f22 positives are red on the current runtime; twins and controls behave as specified.
+- [x] 4.2 Registry drift gate green; strict OpenSpec validation green; lean suite green; no product-code diffs in this change.

--- a/openspec/changes/amend-no-nudge-bench-families/tasks.md
+++ b/openspec/changes/amend-no-nudge-bench-families/tasks.md
@@ -24,4 +24,4 @@
 ## 4. Verification
 
 - [x] 4.1 All sequence-2 families execute and f20–f22 positives are red on the current runtime; twins and controls behave as specified.
-- [x] 4.2 Registry drift gate green; strict OpenSpec validation green; lean suite green; no product-code diffs in this change.
+- [x] 4.2 Registry drift gate green; strict OpenSpec validation green; lean suite green apart from 91 pre-existing environmental failures confined to the two membench modules and attributed against the origin/main baseline (10742 passed; CI authoritative); no product-code diffs in this change.

--- a/tests/test_epistemic_amendment_governance.py
+++ b/tests/test_epistemic_amendment_governance.py
@@ -535,9 +535,7 @@ def test_real_loop_closure_receipt_records_the_founder_acknowledgment() -> None:
     across the transition.
     """
 
-    from protocol.contracts import AmendmentReceipt
-
-    from protocol.contracts import working_amendment_receipts
+    from protocol.contracts import AmendmentReceipt, working_amendment_receipts
 
     receipt = AmendmentReceipt.model_validate_json(LOOP_CLOSURE_RECEIPT.read_bytes())
     assert receipt.parent_contract_sha256 == (

--- a/tests/test_epistemic_amendment_governance.py
+++ b/tests/test_epistemic_amendment_governance.py
@@ -22,6 +22,9 @@ ACKNOWLEDGED_REVISION = "46b000e878a60dda9d4fa215c0212ade78e4eede"
 #: Families the sequence-1 amendment introduced.  Withheld until 2026-08-15;
 #: released by the founder acknowledgment recorded in the receipt.
 AMENDED_FAMILIES = ("f15", "f16", "f17", "f18", "f19")
+#: Sequence 2 (no-nudge). Registered by the same §7 path and withheld by the
+#: same receipt gate, because its acknowledgment has not landed.
+SEQUENCE_TWO_FAMILIES = ("f20", "f21", "f22", "f23", "f24", "f25", "f26")
 DATASET = {
     "id": "fixture",
     "variant": "mini",
@@ -534,13 +537,20 @@ def test_real_loop_closure_receipt_records_the_founder_acknowledgment() -> None:
 
     from protocol.contracts import AmendmentReceipt
 
+    from protocol.contracts import working_amendment_receipts
+
     receipt = AmendmentReceipt.model_validate_json(LOOP_CLOSURE_RECEIPT.read_bytes())
     assert receipt.parent_contract_sha256 == (
         "21aa5a8815038b82358336798b10afd8d3ffbd9739c8da597955bd14d8d962e3"
     )
-    assert receipt.contract_sha256 == hashlib.sha256(
-        (ROOT / receipt.contract_path).read_bytes()
-    ).hexdigest()
+    # Sequence 1's digest binds the document *as it stood at sequence 1*, which
+    # stopped being the working bytes the moment sequence 2 amended it. The
+    # binding that still has to hold is the chain link: the next receipt's parent
+    # digest is this receipt's contract digest, and nothing may edit the document
+    # between them without a receipt of its own.
+    chain = working_amendment_receipts(ROOT)
+    assert chain[0].contract_sha256 == receipt.contract_sha256
+    assert chain[1].parent_contract_sha256 == receipt.contract_sha256
     assert receipt.ratifier == FOUNDER
     assert receipt.acknowledged_on == "2026-08-15"
     assert receipt.catastrophic_set_decision == "accept"
@@ -579,11 +589,21 @@ def test_real_working_chain_folds_after_acknowledgment() -> None:
     disturb the contract identity.
     """
 
-    from protocol.contracts import AmendmentReceipt, validate_working_preregistration
+    from protocol.contracts import (
+        AmendmentReceipt,
+        validate_working_preregistration,
+        working_amendment_receipts,
+    )
 
     receipt = AmendmentReceipt.model_validate_json(LOOP_CLOSURE_RECEIPT.read_bytes())
     assert receipt.acknowledgment_status == "acknowledged"
-    assert validate_working_preregistration(ROOT) == receipt.contract_sha256
+    # The fold culminates in the *last* receipt's document, which is sequence 2's
+    # once it exists. Acknowledgment still touches nothing the fold depends on:
+    # sequence 2 is pending and folds exactly the same way, which is the property
+    # this test was written to hold.
+    chain = working_amendment_receipts(ROOT)
+    assert validate_working_preregistration(ROOT) == chain[-1].contract_sha256
+    assert chain[-1].acknowledgment_status == "pending"
 
 
 def test_acknowledged_amendment_derives_a_complete_typed_identity() -> None:
@@ -601,24 +621,42 @@ def test_acknowledged_amendment_derives_a_complete_typed_identity() -> None:
 
     identity = derive_preregistration_identity(ROOT)
 
-    assert len(identity.amendments) == 1
+    # Pinned exactly, not loosened to an inequality: a chain that silently grew
+    # a third link would otherwise satisfy every assertion below while nobody
+    # had adjudicated the new one.
+    assert len(identity.amendments) == 2
     amendment = identity.amendments[0]
     assert amendment.acknowledgment_status == "acknowledged"
     assert amendment.introduced_family_ids == ("f15", "f16", "f17", "f18", "f19")
     assert amendment.contract.repository_revision == ACKNOWLEDGED_REVISION
     assert amendment.contract.repository_revision != amendment.receipt.introduction_revision
-    assert identity.effective.sha256 == amendment.contract.sha256
-    assert identity.effective.repository_revision == ACKNOWLEDGED_REVISION
-    assert identity.pending_amendments == ()
-    assert identity.withheld_family_ids == frozenset()
+    assert amendment.sequence not in {a.sequence for a in identity.pending_amendments}
+
+    # Sequence 2 is the *pending* half of the same chain, and its presence is
+    # what proves the two shapes derive side by side: an acknowledged amendment
+    # pins its amended revision from the founder, while a pending one has that
+    # revision reconstructed from its unique introduction commit.
+    pending = identity.amendments[-1]
+    assert pending.sequence == 2
+    assert pending.acknowledgment_status == "pending"
+    assert pending.introduced_family_ids == SEQUENCE_TWO_FAMILIES
+    assert pending.contract.repository_revision == pending.receipt.introduction_revision
+    assert identity.effective.sha256 == pending.contract.sha256
+    assert identity.pending_amendments == (pending,)
+    assert identity.withheld_family_ids == frozenset(SEQUENCE_TWO_FAMILIES)
 
 
-def test_acknowledged_amendment_withholds_nothing() -> None:
+def test_the_acknowledged_amendment_releases_its_own_families() -> None:
     """The gate that refused f15-f19 now lets every one of them through.
 
     This is the whole observable effect of the acknowledgment at the contract
     layer: the same call, on the same families, that raised
-    ``AmendmentAcknowledgmentPendingError`` before 2026-08-15 now returns.
+    ``AmendmentAcknowledgmentPendingError`` before 2026-08-15 now returns. It
+    withholds nothing *of sequence 1*; sequence 2 is a separate, still-pending
+    receipt and is refused by
+    :func:`test_the_loader_gate_releases_sequence_one_and_withholds_sequence_two`
+    below, so the old name for this test — ``withholds_nothing`` — became a claim
+    it never made.
     """
 
     from protocol.contracts import (
@@ -638,9 +676,11 @@ def test_acknowledged_amendment_withholds_nothing() -> None:
 def test_the_pending_refusal_is_still_armed_for_a_future_amendment() -> None:
     """Release is a property of *this* receipt, not a retired mechanism.
 
-    Sequence 1 is acknowledged, so nothing real is withheld.  The refusal that
-    withheld it must still fire for the next unacknowledged amendment, which is
-    asserted here against a synthetic identity rather than the real one.
+    Sequence 1 is acknowledged, so its own families are no longer withheld.  The
+    refusal that withheld them must still fire for an unacknowledged amendment —
+    it does, for the real sequence 2 — and it must keep firing for whatever comes
+    after, which is asserted here against a synthetic identity so the property
+    does not depend on there happening to be a pending receipt in the tree.
     """
 
     from protocol.contracts import (
@@ -700,7 +740,12 @@ def test_acknowledged_amendment_is_recorded_on_every_run_manifest(
         manifest.preregistration_identity.amendments[0].acknowledgment_status
         == "acknowledged"
     )
-    assert manifest.preregistration_identity.withheld_family_ids == frozenset()
+    # Sequence 2's pending status rides on the same manifest. A reader can tell
+    # which families backed this run and which were withheld from it without
+    # reading any other artifact, which is the whole reason the field exists.
+    assert manifest.preregistration_identity.withheld_family_ids == frozenset(
+        SEQUENCE_TWO_FAMILIES
+    )
     assert manifest.preregistration_lineage is not None
 
 
@@ -840,13 +885,15 @@ def test_acknowledged_amendment_lets_an_amended_family_scenario_load() -> None:
         assert scenario.family_id == family_id
 
 
-def test_the_loader_gate_reports_nothing_withheld() -> None:
+def test_the_loader_gate_releases_sequence_one_and_withholds_sequence_two() -> None:
     """The loader's own view of release, asserted directly at the gate.
 
     ``epistemic.amendments`` answers "is amendment N acknowledged?" from the
     working receipt bytes without Git, which is the cheap path the loader takes
-    per scenario.  It must now agree with the Git-derived identity that nothing
-    is withheld.
+    per scenario.  Sequence 1 is acknowledged, so f15-f19 pass the gate; sequence
+    2 is pending, so f20-f26 are refused by the very same call.  Holding both
+    facts in one test is the point: release is a property of each receipt, not a
+    switch that was flipped once and left on.
     """
 
     from epistemic.amendments import (
@@ -854,11 +901,18 @@ def test_the_loader_gate_reports_nothing_withheld() -> None:
         reset_cache,
         withheld_family_ids,
     )
+    from protocol.contracts import AmendmentAcknowledgmentPendingError
 
     reset_cache()
-    assert withheld_family_ids(ROOT) == frozenset()
+    assert withheld_family_ids(ROOT) == frozenset(SEQUENCE_TWO_FAMILIES)
     for family_id in AMENDED_FAMILIES:
         require_family_released(family_id, repo_root=ROOT)
+    for family_id in SEQUENCE_TWO_FAMILIES:
+        with pytest.raises(
+            AmendmentAcknowledgmentPendingError,
+            match=rf"amendment sequence 2 .*pending.*{family_id}",
+        ):
+            require_family_released(family_id, repo_root=ROOT)
 
 
 def test_ratified_base_families_still_load() -> None:

--- a/tests/test_epistemic_assertions.py
+++ b/tests/test_epistemic_assertions.py
@@ -1,6 +1,6 @@
 """Discrimination tests: every registered assertion separates pass from fail.
 
-Each of the 18 pre-registered assertions gets at least one hand-built passing
+Each of the 33 pre-registered assertions gets at least one hand-built passing
 snapshot (or snapshot pair) and one failing one. A registry entry with no
 discriminating pair is a hole, so the coverage test below is as load-bearing as
 the pairs themselves.
@@ -537,6 +537,299 @@ def loop_journey_state_coherent_fail() -> AssertionContext:
 
 Factory = Callable[[], AssertionContext]
 
+# --------------------------------------------------------------------------
+# Amendment sequence 2 (no-nudge, f20-f26).
+#
+# Each fail fixture removes exactly one mechanism from its pass fixture — the
+# vacuity hunt the house discipline requires. Where a fail fixture merely
+# *added* something, the assertion would be passing for the wrong reason.
+# --------------------------------------------------------------------------
+
+
+def surface(name: str, projection: str = "complete") -> StateItem:
+    """A surface marker: the queue was projected, and how completely."""
+
+    return item(
+        f"surface-{name}",
+        kind="container",
+        raw={"surface": name, "projection": projection},
+    )
+
+
+def all_surfaces(projection: str = "complete") -> tuple[StateItem, ...]:
+    return tuple(
+        surface(name, projection)
+        for name in (
+            "audit_findings",
+            "review_queue",
+            "proposal_queue",
+            "due_state_counters",
+        )
+    )
+
+
+def signal(
+    signal_id: str,
+    *,
+    signal_class: str,
+    targets: str,
+    on: str = "review_queue",
+    review_state: str | None = "open",
+    extra: dict[str, str] | None = None,
+) -> StateItem:
+    raw = {"signal_class": signal_class, "targets": targets, "surface": on}
+    raw.update(extra or {})
+    return item(
+        signal_id,
+        kind="container",
+        review_state=review_state,
+        raw=raw,
+    )
+
+
+def signal_absence_checked_across_all_surfaces_pass() -> AssertionContext:
+    twin = item("note-weekly-log", raw={"cluster_count": "5"})
+    return AssertionContext(
+        snapshot=snapshot((twin, *all_surfaces())), subject="note-weekly-log"
+    )
+
+
+def signal_absence_checked_across_all_surfaces_fail() -> AssertionContext:
+    """The relocated nag: no queue item, but the counters block names the twin.
+
+    Mechanism removed: nothing. Mechanism *moved* — which is exactly the cheat
+    the meta-predicate exists to catch, so the quiet assertion must still fail.
+    """
+
+    twin = item("note-weekly-log", raw={"cluster_count": "5"})
+    relocated = signal(
+        "counter-entry",
+        signal_class="promotion",
+        targets="note-weekly-log",
+        on="due_state_counters",
+    )
+    return AssertionContext(
+        snapshot=snapshot((twin, relocated, *all_surfaces())), subject="note-weekly-log"
+    )
+
+
+def structural_signal_surfaced_within_budget_pass() -> AssertionContext:
+    note = item("note-accumulating", raw={"cluster_count": "3"})
+    proposal = signal(
+        "sig-split", signal_class="promotion", targets="note-accumulating", on="proposal_queue"
+    )
+    return AssertionContext(
+        snapshot=snapshot((note, proposal, *all_surfaces())), subject="note-accumulating"
+    )
+
+
+def structural_signal_surfaced_within_budget_fail() -> AssertionContext:
+    """Mechanism removed: the detector emits no signal. Everything else identical."""
+
+    note = item("note-accumulating", raw={"cluster_count": "3"})
+    return AssertionContext(
+        snapshot=snapshot((note, *all_surfaces())), subject="note-accumulating"
+    )
+
+
+def entity_candidate_surfaced_from_recurrence_pass() -> AssertionContext:
+    identity = item("entity-kaupunki", raw={"source_count": "3"})
+    candidate = signal(
+        "sig-entity", signal_class="entity_candidate", targets="entity-kaupunki"
+    )
+    return AssertionContext(
+        snapshot=snapshot((identity, candidate, *all_surfaces())), subject="entity-kaupunki"
+    )
+
+
+def entity_candidate_surfaced_from_recurrence_fail() -> AssertionContext:
+    """Mechanism removed: the recurrence sensor emits nothing."""
+
+    identity = item("entity-kaupunki", raw={"source_count": "3"})
+    return AssertionContext(
+        snapshot=snapshot((identity, *all_surfaces())), subject="entity-kaupunki"
+    )
+
+
+def contradiction_surfaced_unprompted_pass() -> AssertionContext:
+    conclusion = item("claim-budget", kind="claim")
+    evidence = item("ev-measurement", kind="evidence")
+    pair = signal(
+        "sig-conflict",
+        signal_class="contradiction",
+        targets="claim-budget,ev-measurement",
+    )
+    return AssertionContext(
+        snapshot=snapshot((conclusion, evidence, pair, *all_surfaces())),
+        subject="claim-budget",
+        counterpart="ev-measurement",
+    )
+
+
+def contradiction_surfaced_unprompted_fail() -> AssertionContext:
+    """Mechanism removed: the signal names only one side, so no pair surfaced."""
+
+    conclusion = item("claim-budget", kind="claim")
+    evidence = item("ev-measurement", kind="evidence")
+    half = signal("sig-conflict", signal_class="contradiction", targets="claim-budget")
+    return AssertionContext(
+        snapshot=snapshot((conclusion, evidence, half, *all_surfaces())),
+        subject="claim-budget",
+        counterpart="ev-measurement",
+    )
+
+
+def _dismissal_prior() -> EpistemicStateSnapshot:
+    dismissed = item(
+        "note-standalone",
+        review_state="dismissed",
+        raw={"fingerprint": "fp-abc123", "passes": "0"},
+    )
+    return snapshot((dismissed, *all_surfaces()), phase="p1")
+
+
+def dismissal_respected_across_passes_pass() -> AssertionContext:
+    survived = item(
+        "note-standalone",
+        review_state="dismissed",
+        raw={"fingerprint": "fp-abc123", "passes": "4"},
+    )
+    return AssertionContext(
+        snapshot=snapshot((survived, *all_surfaces()), phase="p2"),
+        prior=_dismissal_prior(),
+        subject="note-standalone",
+    )
+
+
+def dismissal_respected_across_passes_fail() -> AssertionContext:
+    """Mechanism removed: the triage store stops binding, so the same fingerprint returns."""
+
+    survived = item(
+        "note-standalone",
+        review_state="dismissed",
+        raw={"fingerprint": "fp-abc123", "passes": "4"},
+    )
+    resurfaced = signal(
+        "sig-again",
+        signal_class="promotion",
+        targets="note-standalone",
+        extra={"fingerprint": "fp-abc123"},
+    )
+    return AssertionContext(
+        snapshot=snapshot((survived, resurfaced, *all_surfaces()), phase="p2"),
+        prior=_dismissal_prior(),
+        subject="note-standalone",
+    )
+
+
+def counter_emission_not_repeated_per_write_pass() -> AssertionContext:
+    block = item(
+        "surface-due_state_counters",
+        kind="container",
+        raw={
+            "surface": "due_state_counters",
+            "projection": "complete",
+            "emissions": "1",
+            "writes": "12",
+        },
+    )
+    return AssertionContext(snapshot=snapshot((block,)))
+
+
+def counter_emission_not_repeated_per_write_fail() -> AssertionContext:
+    """Mechanism removed: batching is gone, so one block is emitted per write."""
+
+    block = item(
+        "surface-due_state_counters",
+        kind="container",
+        raw={
+            "surface": "due_state_counters",
+            "projection": "complete",
+            "emissions": "12",
+            "writes": "12",
+        },
+    )
+    return AssertionContext(snapshot=snapshot((block,)))
+
+
+def _packet_units() -> tuple[StateItem, ...]:
+    return (
+        item("dec-adopt-tunnel", kind="decision"),
+        item("oq-latency-budget", kind="open_question"),
+        item("plan-alpha", raw={"plan": "plan-alpha"}),
+        item("decoy-foreign", kind="decision", raw={"decoy": "yes"}),
+    )
+
+
+def continuation_packet_reconstructs_session_pass() -> AssertionContext:
+    packet = item(
+        "packet-session-7",
+        kind="container",
+        cites=("dec-adopt-tunnel", "oq-latency-budget", "plan-alpha"),
+        raw={"packet": "packet-session-7"},
+    )
+    return AssertionContext(snapshot=snapshot((packet, *_packet_units())))
+
+
+def continuation_packet_reconstructs_session_fail() -> AssertionContext:
+    """Mechanism removed: the packet drops a seeded unit it must hold by reference."""
+
+    packet = item(
+        "packet-session-7",
+        kind="container",
+        cites=("dec-adopt-tunnel", "plan-alpha"),
+        raw={"packet": "packet-session-7"},
+    )
+    return AssertionContext(snapshot=snapshot((packet, *_packet_units())))
+
+
+def restructure_signal_cleared_by_state_change_pass() -> AssertionContext:
+    parent = item("note-restructured")
+    children = (
+        item("note-child-a", raw={"restructure_child": "note-restructured"}),
+        item("note-child-b", raw={"restructure_child": "note-restructured"}),
+    )
+    return AssertionContext(
+        snapshot=snapshot((parent, *children, *all_surfaces())), subject="note-restructured"
+    )
+
+
+def restructure_signal_cleared_by_state_change_fail() -> AssertionContext:
+    """Mechanism removed: the lifecycle churns, proposing the new children back together."""
+
+    parent = item("note-restructured")
+    children = (
+        item("note-child-a", raw={"restructure_child": "note-restructured"}),
+        item("note-child-b", raw={"restructure_child": "note-restructured"}),
+    )
+    churn = signal(
+        "sig-merge-back",
+        signal_class="merge",
+        targets="note-child-a",
+        extra={"passes": "1"},
+    )
+    return AssertionContext(
+        snapshot=snapshot((parent, *children, churn, *all_surfaces())),
+        subject="note-restructured",
+    )
+
+
+def due_state_block_present_in_carrier_pass() -> AssertionContext:
+    response = item(
+        "resp-capture",
+        kind="container",
+        raw={"response_detail": "compact", "targets": "due_state_counters"},
+    )
+    return AssertionContext(snapshot=snapshot((response, *all_surfaces())))
+
+
+def due_state_block_present_in_carrier_fail() -> AssertionContext:
+    """Mechanism removed: the carrier drops the block from the compact response."""
+
+    response = item("resp-capture", kind="container", raw={"response_detail": "compact"})
+    return AssertionContext(snapshot=snapshot((response, *all_surfaces())))
+
+
 DISCRIMINATION: dict[str, tuple[Factory, Factory]] = {
     "exactly_one_current_revision": (
         exactly_one_current_revision_pass,
@@ -603,6 +896,42 @@ DISCRIMINATION: dict[str, tuple[Factory, Factory]] = {
     "loop_journey_state_coherent": (
         loop_journey_state_coherent_pass,
         loop_journey_state_coherent_fail,
+    ),
+    "signal_absence_checked_across_all_surfaces": (
+        signal_absence_checked_across_all_surfaces_pass,
+        signal_absence_checked_across_all_surfaces_fail,
+    ),
+    "structural_signal_surfaced_within_budget": (
+        structural_signal_surfaced_within_budget_pass,
+        structural_signal_surfaced_within_budget_fail,
+    ),
+    "entity_candidate_surfaced_from_recurrence": (
+        entity_candidate_surfaced_from_recurrence_pass,
+        entity_candidate_surfaced_from_recurrence_fail,
+    ),
+    "contradiction_surfaced_unprompted": (
+        contradiction_surfaced_unprompted_pass,
+        contradiction_surfaced_unprompted_fail,
+    ),
+    "dismissal_respected_across_passes": (
+        dismissal_respected_across_passes_pass,
+        dismissal_respected_across_passes_fail,
+    ),
+    "counter_emission_not_repeated_per_write": (
+        counter_emission_not_repeated_per_write_pass,
+        counter_emission_not_repeated_per_write_fail,
+    ),
+    "continuation_packet_reconstructs_session": (
+        continuation_packet_reconstructs_session_pass,
+        continuation_packet_reconstructs_session_fail,
+    ),
+    "restructure_signal_cleared_by_state_change": (
+        restructure_signal_cleared_by_state_change_pass,
+        restructure_signal_cleared_by_state_change_fail,
+    ),
+    "due_state_block_present_in_carrier": (
+        due_state_block_present_in_carrier_pass,
+        due_state_block_present_in_carrier_fail,
     ),
 }
 

--- a/tests/test_epistemic_no_nudge_families.py
+++ b/tests/test_epistemic_no_nudge_families.py
@@ -592,7 +592,9 @@ def test_any_intervention_after_ingest_refuses_an_unprompted_family(
         f"      - op: {intervening}\n        ref: user-acts\n",
     )
     assert prompted != text
-    with pytest.raises(ScenarioLoadError, match="only maintenance_pass may intervene"):
+    with pytest.raises(
+        ScenarioLoadError, match="only maintenance_pass and snapshot may intervene"
+    ):
         load_scenario_text(prompted, source="f20-prompted.yaml")
 
 
@@ -878,9 +880,6 @@ def test_the_family_vocabulary_widens_and_can_never_narrow() -> None:
     default = ABSENCE_CLAIM_CLASSES["signal_absence_checked_across_all_surfaces"]
     assert UNSOLICITED_PROPOSAL_CLASSES <= default
     assert CONTRADICTION_SIGNAL_CLASSES <= FAMILY_ABSENCE_CLASSES["f22"] | default
-    for family, extra in FAMILY_ABSENCE_CLASSES.items():
-        widened = default | extra
-        assert default <= widened, family
 
 
 @pytest.mark.parametrize(

--- a/tests/test_epistemic_no_nudge_families.py
+++ b/tests/test_epistemic_no_nudge_families.py
@@ -1,0 +1,1055 @@
+"""The no-nudge families f20-f26 execute, and f20-f22 are red on this runtime.
+
+Two things are proven here and they are easy to confuse, so they are kept
+visibly apart:
+
+**Expected red.** On the runtime that exists today no detector, consumer or
+carrier emits a no-nudge signal, so the f20-f22 positives fail. That is the
+contract — they are falsification targets filed before the machinery, not CI
+failures — and ``test_current_runtime_*`` is what records it as evidence rather
+than as a claim.
+
+**Not vacuous.** An assertion that can only fail proves nothing, so every
+positive is also run against a corpus where the mechanism *is* present and must
+pass, and every family gets a mechanism-removal pair. The corpora differ by the
+mechanism alone; everything else is generated from the same code path.
+
+The withhold gate is deliberately bypassed for the execution tests, and
+deliberately *not* bypassed for :func:`test_the_withhold_gate_refuses_every_
+sequence_two_family`. Sequence 2 is unacknowledged, so the loader refuses these
+families in ordinary use; the fixture below is what lets the trajectory be
+exercised anyway, exactly as the sequence-1 families were exercised in-test
+before their acknowledgment landed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from epistemic import amendments
+from epistemic import runner as runner_module
+from epistemic import schema as schema_module
+from epistemic.assertions import AssertionContext
+from epistemic.budgets import (
+    CALIBRATION_PROTOCOL_PATH,
+    CALIBRATION_STATUS,
+    EMERGENCE_BUDGETS,
+    STRUCTURAL_EMERGENCE_CLUSTER_BUDGET,
+    verify_calibration_status,
+)
+from epistemic.corpora import no_nudge as corpus
+from epistemic.registry import (
+    COMPOSES_ABSENCE_META,
+    PREREGISTERED_ASSERTIONS,
+    resolve,
+)
+from epistemic.runner import evaluate_scenario
+from epistemic.schema import ScenarioLoadError, load_scenario, load_scenario_text
+
+ROOT = Path(__file__).resolve().parents[1]
+SEQUENCE2 = ROOT / "benchmarks" / "epistemic" / "fixtures" / "sequence2"
+SEQUENCE_TWO_FAMILIES = ("f20", "f21", "f22", "f23", "f24", "f25", "f26")
+
+
+@pytest.fixture
+def released(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run as if the founder had acknowledged sequence 2.
+
+    The gate itself is asserted un-patched below. What this fixture buys is the
+    ability to execute the trajectories now, which is the only way to know
+    whether the families the amendment files are red for the reason claimed.
+    """
+
+    monkeypatch.setattr(schema_module, "require_family_released", lambda *a, **k: None)
+    monkeypatch.setattr(runner_module, "require_family_released", lambda *a, **k: None)
+
+
+def outcomes(run) -> dict[tuple[str, str | None], str]:
+    return {
+        (bound.assertion, bound.context.subject): bound.result.outcome
+        for bound in run.assertions
+    }
+
+
+def evidence(run) -> str:
+    return "\n".join(
+        f"  {bound.result.outcome:14} {bound.assertion}"
+        f"[{bound.context.subject or '-'}]: {bound.result.evidence}"
+        for bound in run.assertions
+    )
+
+
+# --------------------------------------------------------------------------
+# The gate. Asserted first, and without the fixture above.
+# --------------------------------------------------------------------------
+
+
+def test_the_withhold_gate_refuses_every_sequence_two_family() -> None:
+    """Registration is not release, restated for sequence 2 at the loader."""
+
+    from protocol.contracts import AmendmentAcknowledgmentPendingError
+
+    amendments.reset_cache()
+    assert amendments.withheld_family_ids(ROOT) == frozenset(SEQUENCE_TWO_FAMILIES)
+    for family_id in SEQUENCE_TWO_FAMILIES:
+        assert amendments.amendment_sequence_for(family_id) == 2
+        with pytest.raises(AmendmentAcknowledgmentPendingError):
+            amendments.require_family_released(family_id, repo_root=ROOT)
+
+
+def test_every_sequence_two_scenario_refuses_to_load_while_pending() -> None:
+    """The shipped scenarios cannot be run, scored or claimed today."""
+
+    scenarios = sorted(SEQUENCE2.glob("*.yaml"))
+    assert len(scenarios) == len(SEQUENCE_TWO_FAMILIES)
+    for path in scenarios:
+        with pytest.raises(ScenarioLoadError, match="sequence 2"):
+            load_scenario(path)
+
+
+def test_the_amendment_receipt_is_pending_and_binds_the_working_document() -> None:
+    from protocol.contracts import (
+        validate_working_preregistration,
+        working_amendment_receipts,
+    )
+
+    receipts = working_amendment_receipts(ROOT)
+    assert [receipt.sequence for receipt in receipts] == [1, 2]
+    sequence_two = receipts[1]
+    assert sequence_two.acknowledgment_status == "pending"
+    assert sequence_two.ratifier is None
+    assert sequence_two.catastrophic_set_decision is None
+    assert sequence_two.parent_contract_sha256 == receipts[0].contract_sha256
+    assert validate_working_preregistration(ROOT) == sequence_two.contract_sha256
+
+
+# --------------------------------------------------------------------------
+# Corpus properties: behaviour not vocabulary, twins matched.
+# --------------------------------------------------------------------------
+
+
+def test_no_cluster_name_token_reaches_an_assertion_parameter() -> None:
+    """The f20 generator assertion the amendment requires."""
+
+    parameters = [
+        str(expectation.get(key) or "")
+        for path in sorted(SEQUENCE2.glob("*.yaml"))
+        for expectation in _expectations(path)
+        for key in ("subject", "counterpart")
+    ]
+    assert parameters
+    corpus.assert_no_vocabulary_leak(parameters)
+
+
+def test_the_generator_assertion_actually_catches_a_leak() -> None:
+    """A guard nobody has watched fail is not a guard."""
+
+    with pytest.raises(corpus.VocabularyLeak):
+        corpus.assert_no_vocabulary_leak(["f20-tunnel-subject"])
+
+
+def _expectations(path: Path) -> list[dict]:
+    import yaml
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return [
+        expectation
+        for phase in data["phases"]
+        for expectation in phase.get("expect", ())
+    ]
+
+
+def test_f20_twins_are_frequency_and_length_matched() -> None:
+    """Raw magnitude cannot be the discriminator, measured rather than asserted."""
+
+    report = dict(corpus.matching_report(corpus.f20_corpus()))
+    assert len(report) == 5
+    assert len(set(report.values())) == 1, report
+
+
+def test_the_assertion_reads_structure_and_never_the_corpus_vocabulary() -> None:
+    """Renamed for accuracy: no detector exists yet, so nothing "survives" here.
+
+    What this proves is narrower and still worth proving — the *assertion* is
+    indifferent to the words, reaching the same verdict on a corpus whose
+    vocabulary is disjoint from the one it was written against. The claim about
+    a detector belongs to
+    :func:`test_the_structural_separation_survives_the_synonym_swap`, which
+    exercises a detector model rather than the assertion.
+    """
+
+    swapped = corpus.synonym_swapped()
+    result = resolve("structural_signal_surfaced_within_budget")(
+        AssertionContext(snapshot=swapped, subject="f20-subject")
+    )
+    assert result.outcome == "pass", result.evidence
+    bodies = " ".join(item.text for item in swapped.items)
+    for topic in corpus.CLUSTER_TOPICS:
+        assert topic not in bodies
+
+
+# --------------------------------------------------------------------------
+# Expected red on the current runtime.
+# --------------------------------------------------------------------------
+
+
+def test_current_runtime_f20_positive_is_red_while_every_twin_stays_quiet() -> None:
+    snapshot = corpus.f20_corpus(surfaced=False)
+    positive = resolve("structural_signal_surfaced_within_budget")(
+        AssertionContext(snapshot=snapshot, subject="f20-subject")
+    )
+    assert positive.outcome == "fail", positive.evidence
+    assert "no promotion-class signal" in positive.evidence
+    for twin in corpus.F20_TWINS:
+        quiet = resolve("signal_absence_checked_across_all_surfaces")(
+            AssertionContext(snapshot=snapshot, subject=twin)
+        )
+        assert quiet.outcome == "pass", quiet.evidence
+
+
+def test_current_runtime_f21_and_f22_positives_are_red() -> None:
+    f21 = resolve("entity_candidate_surfaced_from_recurrence")(
+        AssertionContext(snapshot=corpus.f21_corpus(surfaced=False), subject="f21-subject-lower")
+    )
+    assert f21.outcome == "fail", f21.evidence
+    f22 = resolve("contradiction_surfaced_unprompted")(
+        AssertionContext(
+            snapshot=corpus.f22_corpus(surfaced=False),
+            subject="f22-conclusion",
+            counterpart="f22-evidence-invalidating",
+        )
+    )
+    assert f22.outcome == "fail", f22.evidence
+
+
+def test_the_real_vault_projector_blocks_quiet_assertions_rather_than_passing_them() -> None:
+    """The anti-vacuity predicate on the runtime that actually exists.
+
+    The vault projector cannot project three of the four absence surfaces, so a
+    quiet assertion is an **error**, never a pass. This is the single most
+    important behaviour in the amendment: without it, today's runtime would be
+    credited with silence it never demonstrated, on every twin, forever.
+    """
+
+    from epistemic.projectors.exomem_vault import VaultProjector
+
+    vault = ROOT / "benchmarks" / "epistemic" / "fixtures" / "vault"
+    assert vault.is_dir(), vault
+    snapshot = VaultProjector(vault).project(phase="p1", taken_at="2026-08-16T00:00:00Z")
+    result = resolve("signal_absence_checked_across_all_surfaces")(
+        AssertionContext(snapshot=snapshot, subject="anything")
+    )
+    assert result.outcome == "blocked", result.evidence
+    assert "never silence" in result.evidence
+
+
+# --------------------------------------------------------------------------
+# The families execute end to end.
+# --------------------------------------------------------------------------
+
+
+def test_f20_executes_and_is_red_on_the_current_runtime(released, capsys) -> None:
+    scenario = load_scenario(SEQUENCE2 / "f20-structural-emergence.yaml")
+    snapshot = corpus.f20_corpus(surfaced=False)
+    run = evaluate_scenario(
+        scenario,
+        snapshots={"s1": snapshot, "s2": snapshot.model_copy(deep=True)},
+    )
+    print("f20 on the current runtime:\n" + evidence(run))
+    result = outcomes(run)
+    assert result[("structural_signal_surfaced_within_budget", "f20-subject")] == "fail"
+    for twin in corpus.F20_TWINS:
+        assert result[("signal_absence_checked_across_all_surfaces", twin)] == "pass"
+
+
+def test_f20_goes_green_once_the_mechanism_exists(released) -> None:
+    """Non-vacuity: the same scenario passes when a detector is present."""
+
+    scenario = load_scenario(SEQUENCE2 / "f20-structural-emergence.yaml")
+    snapshot = corpus.f20_corpus(surfaced=True)
+    run = evaluate_scenario(
+        scenario,
+        snapshots={"s1": snapshot, "s2": snapshot.model_copy(deep=True)},
+    )
+    assert set(outcomes(run).values()) == {"pass"}, evidence(run)
+
+
+def test_f21_executes_both_scripts(released) -> None:
+    scenario = load_scenario(SEQUENCE2 / "f21-entity-emergence.yaml")
+    red = evaluate_scenario(scenario, snapshots={"s1": corpus.f21_corpus(surfaced=False)})
+    assert outcomes(red)[
+        ("entity_candidate_surfaced_from_recurrence", "f21-subject-cyrillic")
+    ] == "fail"
+    assert outcomes(red)[
+        ("signal_absence_checked_across_all_surfaces", "f21-twin-incidental")
+    ] == "pass"
+    green = evaluate_scenario(scenario, snapshots={"s1": corpus.f21_corpus(surfaced=True)})
+    assert set(outcomes(green).values()) == {"pass"}, evidence(green)
+
+
+def test_f22_executes_both_scripts(released) -> None:
+    scenario = load_scenario(SEQUENCE2 / "f22-unsolicited-contradiction.yaml")
+    for surfaced, expected in ((False, "fail"), (True, "pass")):
+        snapshot = corpus.f22_corpus(surfaced=surfaced)
+        run = evaluate_scenario(
+            scenario,
+            snapshots={"s1": snapshot, "s2": snapshot.model_copy(deep=True)},
+        )
+        result = outcomes(run)
+        assert result[("contradiction_surfaced_unprompted", "f22-conclusion")] == expected
+        assert result[
+            ("signal_absence_checked_across_all_surfaces", "f22-twin-conclusion")
+        ] == "pass"
+
+
+def test_f23_respects_a_dismissal_and_governs_counter_emission(released) -> None:
+    scenario = load_scenario(SEQUENCE2 / "f23-dismissal-respect.yaml")
+    prior, later = corpus.f23_pair()
+    run = evaluate_scenario(scenario, snapshots={"s1": prior, "s2": later})
+    assert set(outcomes(run).values()) == {"pass"}, evidence(run)
+
+    prior, later = corpus.f23_pair(respected=False, emissions=12)
+    broken = evaluate_scenario(scenario, snapshots={"s1": prior, "s2": later})
+    result = outcomes(broken)
+    assert result[("dismissal_respected_across_passes", "f23-subject")] == "fail"
+    assert result[("counter_emission_not_repeated_per_write", None)] == "fail"
+
+
+def test_f23_still_reopens_on_a_material_change(released) -> None:
+    """Respecting a dismissal forever would be the bug, not the feature."""
+
+    scenario = load_scenario(SEQUENCE2 / "f23-dismissal-respect.yaml")
+    prior, later = corpus.f23_pair(material_change=True)
+    run = evaluate_scenario(scenario, snapshots={"s1": prior, "s2": later})
+    assert outcomes(run)[("dismissal_respected_across_passes", "f23-subject")] == "pass"
+
+
+def test_f24_reconstructs_and_excludes_the_decoys(released) -> None:
+    scenario = load_scenario(SEQUENCE2 / "f24-fresh-session-reconstruction.yaml")
+    complete = corpus.f24_corpus()
+    run = evaluate_scenario(
+        scenario, snapshots={"s1": complete, "s2": complete.model_copy(deep=True)}
+    )
+    assert set(outcomes(run).values()) == {"pass"}, evidence(run)
+
+    for kwargs in ({"complete": False}, {"admit_decoy": True}):
+        snapshot = corpus.f24_corpus(**kwargs)
+        broken = evaluate_scenario(
+            scenario, snapshots={"s1": snapshot, "s2": snapshot.model_copy(deep=True)}
+        )
+        assert outcomes(broken)[("continuation_packet_reconstructs_session", None)] == "fail"
+
+
+def test_f24_packet_serving_retired_state_is_a_catastrophic_failure(released) -> None:
+    """The recorded sequence-2 scope extension, exercised."""
+
+    scenario = load_scenario(SEQUENCE2 / "f24-fresh-session-reconstruction.yaml")
+    snapshot = corpus.f24_corpus(stale_member=True)
+    run = evaluate_scenario(
+        scenario, snapshots={"s1": snapshot, "s2": snapshot.model_copy(deep=True)}
+    )
+    stale = outcomes(run)[("no_retired_state_served_as_current", None)]
+    assert stale == "fail", evidence(run)
+    assert any(
+        "continuation packet" in bound.result.evidence
+        for bound in run.assertions
+        if bound.assertion == "no_retired_state_served_as_current"
+    )
+
+
+def test_f25_clears_by_state_change_and_forbids_churn(released) -> None:
+    scenario = load_scenario(SEQUENCE2 / "f25-restructure-lifecycle.yaml")
+    clean = corpus.f25_corpus()
+    run = evaluate_scenario(scenario, snapshots={"s1": clean, "s2": clean.model_copy(deep=True)})
+    assert set(outcomes(run).values()) == {"pass"}, evidence(run)
+
+    for kwargs, reason in (
+        ({"cleared": False}, "the signal survived being taken"),
+        ({"by_dismissal": True}, "cleared by dismissal rather than by state change"),
+        ({"churn": True}, "merge-class churn against the new children"),
+    ):
+        snapshot = corpus.f25_corpus(**kwargs)
+        broken = evaluate_scenario(
+            scenario, snapshots={"s1": snapshot, "s2": snapshot.model_copy(deep=True)}
+        )
+        assert outcomes(broken)[
+            ("restructure_signal_cleared_by_state_change", "f25-subject")
+        ] == "fail", reason
+
+
+def test_f26_carrier_journey_executes(released) -> None:
+    scenario = load_scenario(SEQUENCE2 / "f26-hookless-episode-carrier.yaml")
+    carried = corpus.f26_journey()
+    run = evaluate_scenario(
+        scenario, snapshots={"s1": carried, "s2": carried.model_copy(deep=True)}
+    )
+    assert set(outcomes(run).values()) == {"pass"}, evidence(run)
+
+    dropped = corpus.f26_journey(carried=False)
+    broken = evaluate_scenario(
+        scenario, snapshots={"s1": dropped, "s2": dropped.model_copy(deep=True)}
+    )
+    assert outcomes(broken)[("due_state_block_present_in_carrier", None)] == "fail"
+
+
+def test_a_block_only_reachable_at_verbose_detail_fails_the_carrier(released) -> None:
+    """The carrier claim is about the *compact* surface, not any surface."""
+
+    verbose = corpus.f26_journey(detail="verbose")
+    result = resolve("due_state_block_present_in_carrier")(AssertionContext(snapshot=verbose))
+    assert result.outcome == "unsupported", result.evidence
+
+
+# --------------------------------------------------------------------------
+# Anti-vacuity, composition, and the frozen constants.
+# --------------------------------------------------------------------------
+
+
+def test_a_relocated_nag_fails_every_quiet_assertion() -> None:
+    """The counters-block cheat, against the meta-predicate and each composer.
+
+    A product that emits no queue item for a twin but still names it in the
+    due-state counters block has moved the nag, not removed it. Every assertion
+    that claims silence must therefore fail, not just the meta-predicate — which
+    is the whole point of requiring composition rather than restatement.
+    """
+
+    relocated = corpus.signal_item(
+        "counters-entry",
+        signal_class="promotion",
+        targets=("f20-twin-log", "f25-subject"),
+        surface="due_state_counters",
+    )
+
+    quiet = corpus.f20_corpus(surfaced=False)
+    result = resolve("signal_absence_checked_across_all_surfaces")(
+        AssertionContext(
+            snapshot=quiet.model_copy(update={"items": (*quiet.items, relocated)}),
+            subject="f20-twin-log",
+        )
+    )
+    assert result.outcome == "fail", result.evidence
+    assert "due_state_counters" in result.evidence
+
+    restructured = corpus.f25_corpus()
+    composed = resolve("restructure_signal_cleared_by_state_change")(
+        AssertionContext(
+            snapshot=restructured.model_copy(
+                update={"items": (*restructured.items, relocated)}
+            ),
+            subject="f25-subject",
+        )
+    )
+    assert composed.outcome == "fail", composed.evidence
+    assert "due_state_counters" in composed.evidence
+
+    prior, later = corpus.f23_pair()
+    nagged = resolve("dismissal_respected_across_passes")(
+        AssertionContext(
+            snapshot=later.model_copy(
+                update={
+                    "items": (
+                        *later.items,
+                        corpus.signal_item(
+                            "counters-entry",
+                            signal_class="promotion",
+                            targets=("f23-subject",),
+                            surface="due_state_counters",
+                            extra={"fingerprint": corpus.F23_FINGERPRINT},
+                        ),
+                    )
+                }
+            ),
+            prior=prior,
+            subject="f23-subject",
+        )
+    )
+    assert nagged.outcome == "fail", nagged.evidence
+
+
+@pytest.mark.parametrize("surface", corpus.ABSENCE_SURFACES)
+def test_an_unprojected_surface_is_an_error_not_silence(surface: str) -> None:
+    kept = [name for name in corpus.ABSENCE_SURFACES if name != surface]
+    snapshot = corpus.f20_corpus(surfaced=False)
+    trimmed = tuple(
+        item for item in snapshot.items if item.id != f"surface-{surface}"
+    )
+    partial = snapshot.model_copy(
+        update={"items": (*trimmed, *corpus.surface_markers(only=kept))}
+    )
+    result = resolve("signal_absence_checked_across_all_surfaces")(
+        AssertionContext(snapshot=partial, subject="f20-twin-log")
+    )
+    assert result.outcome == "blocked", result.evidence
+    assert surface in result.evidence
+
+
+def test_every_composing_assertion_propagates_the_meta_predicate() -> None:
+    """Composition is a claim about behaviour, so it is checked by behaviour."""
+
+    assert "signal_absence_checked_across_all_surfaces" in COMPOSES_ABSENCE_META
+    empty = corpus.f20_corpus(surfaced=False, projection="unavailable")
+    prior, later = corpus.f23_pair()
+    blocked_later = later.model_copy(
+        update={
+            "items": tuple(
+                item for item in later.items if not item.id.startswith("surface-")
+            )
+        }
+    )
+    assert resolve("dismissal_respected_across_passes")(
+        AssertionContext(snapshot=blocked_later, prior=prior, subject="f23-subject")
+    ).outcome == "blocked"
+    assert resolve("restructure_signal_cleared_by_state_change")(
+        AssertionContext(snapshot=empty, subject="f25-subject")
+    ).outcome == "blocked"
+
+
+def test_the_budget_constants_are_declared_provisional_and_shipped_with_a_protocol() -> None:
+    """Task 3.5 is founder-blocked; the constants must say so in machine-readable form.
+
+    If this ever reads ``frozen``, the three-annotator study has landed and the
+    §7 entry must have been re-dated with the medians. Promoting a placeholder
+    without doing that would be exactly the silent retuning the amendment
+    forbids, so the assertion is written to break on the way through.
+    """
+
+    assert CALIBRATION_STATUS == "provisional"
+    assert (ROOT / CALIBRATION_PROTOCOL_PATH).is_file()
+    verify_calibration_status(ROOT)
+    assert set(EMERGENCE_BUDGETS) == {
+        "structural_emergence_cluster_budget",
+        "entity_emergence_source_budget",
+        "restructure_quiet_window_passes",
+        "continuation_packet_unit_budget",
+    }
+    assert all(value > 0 for value in EMERGENCE_BUDGETS.values())
+
+
+def test_promoting_the_constants_to_frozen_is_refused_without_the_study(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The provisional label is coupled to governance, not merely written down.
+
+    Editing ``CALIBRATION_STATUS`` to ``frozen`` is one keystroke, and a caveat
+    that costs one keystroke to remove is not a control. Freezing now requires
+    the labels artifact to report a completed three-annotator study *and* the §7
+    entry to have been re-dated, which are the two acts that actually calibrate
+    a constant.
+    """
+
+    from epistemic import budgets
+
+    monkeypatch.setattr(budgets, "CALIBRATION_STATUS", "frozen")
+    with pytest.raises(budgets.CalibrationGovernanceError) as raised:
+        budgets.verify_calibration_status(ROOT)
+    message = str(raised.value)
+    assert "status 'not_run'" in message
+    assert f"{budgets.MINIMUM_ANNOTATORS}" in message
+    assert "no medians" in message
+    assert f"still dated {budgets.AMENDMENT_FILED_ON}" in message
+
+
+def test_a_fixture_cannot_retune_a_frozen_budget() -> None:
+    """The constant comes from the module; a corpus past budget fails."""
+
+    snapshot = corpus.f20_corpus(surfaced=True)
+    subject = snapshot.item("f20-subject")
+    over = subject.model_copy(
+        update={"raw": {**subject.raw, "cluster_count": str(STRUCTURAL_EMERGENCE_CLUSTER_BUDGET + 1)}}
+    )
+    items = tuple(over if item.id == "f20-subject" else item for item in snapshot.items)
+    result = resolve("structural_signal_surfaced_within_budget")(
+        AssertionContext(snapshot=snapshot.model_copy(update={"items": items}), subject="f20-subject")
+    )
+    assert result.outcome == "fail"
+    assert "past the frozen budget" in result.evidence
+
+
+# --------------------------------------------------------------------------
+# Unpromptedness is a load-time trajectory property.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "intervening", ["agent_turn", "triage_decision", "configure", "apply_restructure", "export"]
+)
+def test_any_intervention_after_ingest_refuses_an_unprompted_family(
+    released, intervening: str
+) -> None:
+    """Only ``maintenance_pass`` may intervene — as the error message always said.
+
+    The rule used to name a single forbidden op while promising an allowlist, so
+    a scenario could route a triage decision or a configuration change between
+    ingest and the asserted snapshot and still load. Either is a user act, and a
+    user act is exactly what these three families claim did not happen.
+    """
+
+    text = (SEQUENCE2 / "f20-structural-emergence.yaml").read_text(encoding="utf-8")
+    prompted = text.replace(
+        "      - op: maintenance_pass\n        ref: sweep-3\n",
+        f"      - op: {intervening}\n        ref: user-acts\n",
+    )
+    assert prompted != text
+    with pytest.raises(ScenarioLoadError, match="only maintenance_pass may intervene"):
+        load_scenario_text(prompted, source="f20-prompted.yaml")
+
+
+def test_maintenance_and_snapshot_remain_permitted_between_ingest_and_assertion(
+    released,
+) -> None:
+    """The allowlist has to still allow the trajectory the families are built on."""
+
+    from epistemic.schema import UNPROMPTED_SAFE_OPS
+
+    assert UNPROMPTED_SAFE_OPS == {"maintenance_pass", "snapshot"}
+    scenario = load_scenario(SEQUENCE2 / "f20-structural-emergence.yaml")
+    ops = [op.op for phase in scenario.phases for op in phase.ops]
+    assert "maintenance_pass" in ops and "snapshot" in ops
+
+
+# --------------------------------------------------------------------------
+# The f26 track-D journey driver.
+# --------------------------------------------------------------------------
+
+
+def test_the_journey_refuses_when_no_envelope_is_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No fallback to an in-process import: that would test a library, not a carrier."""
+
+    from epistemic.journeys import f26_carrier
+
+    monkeypatch.setattr(f26_carrier.shutil, "which", lambda _name: None)
+    with pytest.raises(f26_carrier.EnvelopeNotDiscovered, match="must not fall back"):
+        f26_carrier.discover_envelope()
+
+
+def test_the_journey_projects_only_what_the_responses_carried() -> None:
+    """A response without the block projects without it, so the family fails."""
+
+    from epistemic.journeys.f26_carrier import journey_snapshot
+
+    carried = journey_snapshot(
+        {"mutation": {"due_state": {"overdue": 0}}, "recall": {"due_state": {"overdue": 0}}},
+        taken_at="2026-08-16T00:00:00Z",
+        packet_members=("f26-capture",),
+    )
+    assert resolve("due_state_block_present_in_carrier")(
+        AssertionContext(snapshot=carried)
+    ).outcome == "pass"
+
+    dropped = journey_snapshot(
+        {"mutation": {"ok": True}, "recall": {"hits": []}},
+        taken_at="2026-08-16T00:00:00Z",
+        packet_members=("f26-capture",),
+    )
+    result = resolve("due_state_block_present_in_carrier")(AssertionContext(snapshot=dropped))
+    assert result.outcome == "fail", result.evidence
+
+
+def test_the_journey_steps_are_complete_executable_argv() -> None:
+    """F5: every step must be runnable, not merely carry the right flag.
+
+    The first version asserted only that ``--detail`` appeared, and the script
+    it blessed exited 2 on the real CLI: ``remember`` needs ``--content`` and
+    ``--title``, the flag is ``--response-detail``, and ``recall`` is not a
+    command at all. A step list that cannot run measures nothing, so the check
+    is now argv-completeness against the envelope's own declared options.
+    """
+
+    from epistemic.journeys.f26_carrier import (
+        COMPACT_DETAIL,
+        JOURNEY_STEPS,
+        required_options,
+    )
+
+    assert JOURNEY_STEPS
+    for _name, args in JOURNEY_STEPS:
+        assert args, "a journey step needs a command"
+        command, *flags = args
+        assert "--json" in flags, f"{command} must ask for the parseable envelope"
+        detail_flag, detail_value = _detail_pair(flags)
+        assert detail_value == COMPACT_DETAIL, command
+        missing = sorted(option for option in required_options(command) if option not in flags)
+        assert not missing, f"{command} is missing required option(s) {missing}"
+        assert detail_flag in required_options(command) or detail_flag in flags
+
+
+def _detail_pair(flags: list[str]) -> tuple[str, str]:
+    for flag in ("--response-detail", "--profile", "--detail"):
+        if flag in flags:
+            return flag, flags[flags.index(flag) + 1]
+    raise AssertionError(f"no response-detail flag among {flags}")
+
+
+def test_the_journey_runs_against_the_installed_envelope(tmp_path: Path) -> None:
+    """F5: the whole point is that this executes. So it executes.
+
+    Every step is run against the discovered CLI, on a throwaway copy of the
+    product's own sample vault, and the responses it actually returns are what
+    the family is scored on. If no envelope is installed the test says so and
+    skips — the alternative is an in-process import, which would quietly turn a
+    carrier test into a library test.
+    """
+
+    from epistemic.journeys import f26_carrier
+
+    try:
+        envelope = f26_carrier.discover_envelope()
+    except f26_carrier.EnvelopeNotDiscovered as error:
+        pytest.skip(f"no installed CLI envelope: {error}")
+
+    vault = f26_carrier.seed_journey_vault(tmp_path / "vault", repo_root=ROOT)
+    captured = f26_carrier.capture_responses(envelope, vault=vault)
+    assert set(captured) == {"mutation", "reconstruction"}
+    assert all(payload.get("success") is True for payload in captured.values())
+
+    snapshot = f26_carrier.journey_snapshot(captured, taken_at="2026-08-16T00:00:00Z")
+    result = resolve("due_state_block_present_in_carrier")(
+        AssertionContext(snapshot=snapshot)
+    )
+    # Expected red, and red for the family's reason: the compact responses this
+    # runtime returns carry no due-state block at all.
+    assert result.outcome in {"fail", "unsupported"}, result.evidence
+
+
+def test_the_journey_declares_only_what_the_responses_carried() -> None:
+    """F6: silence must be observed, never manufactured.
+
+    ``journey_snapshot`` used to stamp every absence surface ``complete`` and
+    declare every field observable regardless of what came back, which
+    contradicts the vault projector's honesty and made the carrier's own
+    projection guard unreachable. Absence now defaults to unavailable.
+    """
+
+    from epistemic.journeys.f26_carrier import journey_snapshot
+
+    dropped = journey_snapshot(
+        {"mutation": {"ok": True}, "recall": {"hits": []}},
+        taken_at="2026-08-16T00:00:00Z",
+        packet_members=("f26-capture",),
+    )
+    statuses = {declaration.field: declaration.status for declaration in dropped.declarations}
+    assert statuses["due_state_counters"] == "unavailable"
+    markers = {
+        item.raw["surface"]: item.raw["projection"]
+        for item in dropped.items
+        if item.id.startswith("surface-")
+    }
+    assert set(markers) == set(corpus.ABSENCE_SURFACES)
+    assert all(state == "unavailable" for state in markers.values()), markers
+
+    carried = journey_snapshot(
+        {"mutation": {"due_state": {"overdue": 0}}, "recall": {"due_state": {"overdue": 0}}},
+        taken_at="2026-08-16T00:00:00Z",
+        packet_members=("f26-capture",),
+    )
+    carried_statuses = {d.field: d.status for d in carried.declarations}
+    assert carried_statuses["due_state_counters"] == "declared"
+    assert carried_statuses["continuation_packet"] == "declared"
+    carried_markers = {
+        item.raw["surface"]: item.raw["projection"]
+        for item in carried.items
+        if item.id.startswith("surface-")
+    }
+    assert carried_markers["due_state_counters"] == "complete"
+    assert carried_markers["review_queue"] == "unavailable"
+
+
+def test_the_carrier_sees_a_block_inside_the_products_own_envelope() -> None:
+    """A real response nests everything under ``data``; the projector must look there.
+
+    The live envelope answers ``{"success": true, "data": {...}}``. Reading only
+    the top level would report every surface unavailable however well the
+    product behaved, which would make f26 red for a harness reason and therefore
+    unfalsifiable — the one failure mode an expected-red family cannot afford.
+    """
+
+    from epistemic.journeys.f26_carrier import journey_snapshot
+
+    nested = journey_snapshot(
+        {"reconstruction": {"success": True, "data": {"due_state": {"overdue": 2}}}},
+        taken_at="2026-08-16T00:00:00Z",
+        packet_members=("f26-capture",),
+    )
+    assert resolve("due_state_block_present_in_carrier")(
+        AssertionContext(snapshot=nested)
+    ).outcome == "pass"
+
+    empty_envelope = journey_snapshot(
+        {"reconstruction": {"success": True, "data": {"profile": "compact"}}},
+        taken_at="2026-08-16T00:00:00Z",
+        packet_members=("f26-capture",),
+    )
+    assert resolve("due_state_block_present_in_carrier")(
+        AssertionContext(snapshot=empty_envelope)
+    ).outcome == "fail"
+
+
+def test_the_carrier_projection_guard_is_reachable_in_both_directions() -> None:
+    """F6: the ``projected`` branch must be able to decide, not just ride along."""
+
+    from epistemic.journeys.f26_carrier import journey_snapshot
+
+    carried = journey_snapshot(
+        {"mutation": {"due_state": {"overdue": 0}}},
+        taken_at="2026-08-16T00:00:00Z",
+        packet_members=("f26-capture",),
+    )
+    assert resolve("due_state_block_present_in_carrier")(
+        AssertionContext(snapshot=carried)
+    ).outcome == "pass"
+
+    inconsistent = carried.model_copy(
+        update={
+            "items": tuple(
+                item.model_copy(update={"raw": {**item.raw, "projection": "unavailable"}})
+                if item.id == "surface-due_state_counters"
+                else item
+                for item in carried.items
+            )
+        }
+    )
+    result = resolve("due_state_block_present_in_carrier")(
+        AssertionContext(snapshot=inconsistent)
+    )
+    assert result.outcome == "blocked", result.evidence
+    assert "did not project" in result.evidence
+
+
+# --------------------------------------------------------------------------
+# Correction round. Each test below was written against the *unfixed* code and
+# watched fail first; the mutants are the review's, not invented after the fact.
+# --------------------------------------------------------------------------
+
+
+def test_a_quiet_assertion_is_not_blind_to_the_class_its_family_is_about() -> None:
+    """F1: f22's twin must stay quiet about contradiction-class signals too.
+
+    The original meta-predicate scanned only promotion-class signals, so a
+    product that surfaced *every* similar pair as a contradiction passed the
+    whole family: its false positives were invisible to the only assertion that
+    could have caught them. The vocabulary is now declared per family and
+    widened, never narrowed.
+    """
+
+    snapshot = corpus.f22_corpus(surfaced=False)
+    mutant = snapshot.model_copy(
+        update={
+            "items": (
+                *snapshot.items,
+                corpus.signal_item(
+                    "f22-mutant",
+                    signal_class="contradiction",
+                    targets=("f22-twin-conclusion", "f22-evidence-concordant"),
+                    surface="review_queue",
+                ),
+            )
+        }
+    )
+    result = resolve("signal_absence_checked_across_all_surfaces")(
+        AssertionContext(snapshot=mutant, subject="f22-twin-conclusion", family="f22")
+    )
+    assert result.outcome == "fail", result.evidence
+    assert "f22-mutant" in result.evidence
+
+
+def test_the_family_vocabulary_widens_and_can_never_narrow() -> None:
+    """A family declaration may only add classes; the default union always holds."""
+
+    from epistemic.assertions import (
+        ABSENCE_CLAIM_CLASSES,
+        CONTRADICTION_SIGNAL_CLASSES,
+        FAMILY_ABSENCE_CLASSES,
+        UNSOLICITED_PROPOSAL_CLASSES,
+    )
+
+    default = ABSENCE_CLAIM_CLASSES["signal_absence_checked_across_all_surfaces"]
+    assert UNSOLICITED_PROPOSAL_CLASSES <= default
+    assert CONTRADICTION_SIGNAL_CLASSES <= FAMILY_ABSENCE_CLASSES["f22"] | default
+    for family, extra in FAMILY_ABSENCE_CLASSES.items():
+        widened = default | extra
+        assert default <= widened, family
+
+
+@pytest.mark.parametrize(
+    "signal_class", ["contradiction", "merge", "conflict", "entity_candidate", "promotion"]
+)
+def test_a_dismissed_fingerprint_may_not_re_nag_under_any_class(signal_class: str) -> None:
+    """F2: dismissal is respected against every signal class, not a subset.
+
+    Re-nagging the same fingerprint as a "contradiction" instead of a
+    "promotion" is the same nag wearing a different hat, so the match is over
+    the whole vocabulary with no subset anywhere in the path.
+    """
+
+    prior, later = corpus.f23_pair()
+    renagged = later.model_copy(
+        update={
+            "items": (
+                *later.items,
+                corpus.signal_item(
+                    f"f23-renag-{signal_class}",
+                    signal_class=signal_class,
+                    targets=("f23-subject",),
+                    extra={"fingerprint": corpus.F23_FINGERPRINT},
+                ),
+            )
+        }
+    )
+    result = resolve("dismissal_respected_across_passes")(
+        AssertionContext(snapshot=renagged, prior=prior, subject="f23-subject")
+    )
+    assert result.outcome == "fail", result.evidence
+    assert f"f23-renag-{signal_class}" in result.evidence
+
+
+def test_the_absence_claim_set_is_exactly_the_marked_predicates() -> None:
+    """F3(b): membership is derived from a marker, so a new one cannot dodge it.
+
+    ``COMPOSES_ABSENCE_META`` is hand-mirrored for the same reason the rest of
+    the registry is, which means it can drift. The marker is set where the
+    predicate is defined, so the two disagree loudly rather than quietly.
+    """
+
+    marked = {
+        name
+        for name in PREREGISTERED_ASSERTIONS
+        if getattr(resolve(name), "absence_claim", False)
+    }
+    assert marked == set(COMPOSES_ABSENCE_META)
+    assert marked
+
+
+def test_every_marked_predicate_actually_composes_the_meta_predicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F3(a): iterate the real set and prove propagation by behaviour.
+
+    Injecting a non-composing name into the set used to pass, because nothing
+    executed the members. Here the meta-predicate is replaced with one that
+    always refuses, and every member must carry that refusal outward.
+    """
+
+    from epistemic import assertions as assertions_module
+
+    contexts = _absence_claim_contexts()
+    assert set(contexts) == set(COMPOSES_ABSENCE_META)
+
+    def refuse(ctx: AssertionContext, **_kwargs: object) -> object:
+        return assertions_module.AssertionResult(
+            name="signal_absence_checked_across_all_surfaces",
+            outcome="blocked",
+            evidence="composition probe",
+            subject=ctx.subject,
+        )
+
+    for name, context in contexts.items():
+        if name == "signal_absence_checked_across_all_surfaces":
+            continue
+        monkeypatch.setattr(
+            assertions_module, "signal_absence_checked_across_all_surfaces", refuse
+        )
+        result = resolve(name)(context)
+        monkeypatch.undo()
+        assert result.outcome == "blocked", f"{name} swallowed the meta-predicate"
+        assert "composition probe" in result.evidence, name
+
+
+def _structure_only_verdict(
+    snapshot, page: str
+) -> bool:
+    """A detector model that may read structure and may never read words.
+
+    This is the adversary the f20 corpus has to be fair to. It sees cluster
+    counts, unit categories, anchors and the link graph — and nothing else. If
+    the corpus cannot be separated by a function of that shape, the family is
+    unsatisfiable and the twins are decoration.
+    """
+
+    page_item = snapshot.item(page)
+    assert page_item is not None
+    clusters = int(page_item.raw["cluster_count"])
+    units = [item for item in snapshot.items if item.id.startswith(f"{page}-u")]
+    categories = {unit.raw["category"] for unit in units}
+    anchored = {unit.raw["anchor"] for unit in units}
+    neighbourhoods = corpus.link_neighbourhoods(snapshot, page)
+    deliberate_log = len(categories) == 1 and len(anchored) == len(units)
+    return (
+        clusters >= STRUCTURAL_EMERGENCE_CLUSTER_BUDGET
+        and len(neighbourhoods) >= STRUCTURAL_EMERGENCE_CLUSTER_BUDGET
+        and not deliberate_log
+    )
+
+
+def test_the_f20_corpus_is_separable_by_structure_alone() -> None:
+    """F4: the positive fires and every twin stays quiet, on structure only.
+
+    The corpus previously bound to nothing a structural detector could read:
+    the hub twin was byte-identical to the bounded one, the snapshot carried no
+    relations at all, and the log twin had *more* clusters than the positive,
+    so no monotone rule over cluster count could separate them. Only the prose
+    differed, and prose is what this family exists to not measure.
+    """
+
+    snapshot = corpus.f20_corpus(surfaced=True)
+    assert _structure_only_verdict(snapshot, "f20-subject") is True
+    for twin in corpus.F20_TWINS:
+        assert _structure_only_verdict(snapshot, twin) is False, twin
+
+
+def test_the_structural_separation_survives_the_synonym_swap() -> None:
+    """Same verdicts on a corpus with a disjoint vocabulary."""
+
+    swapped = corpus.synonym_swapped()
+    assert _structure_only_verdict(swapped, "f20-subject") is True
+    for twin in corpus.F20_TWINS:
+        assert _structure_only_verdict(swapped, twin) is False, twin
+
+
+def test_the_hub_twin_has_the_divergent_neighbourhood_its_name_claims() -> None:
+    """The hub is a hub in the graph, not only in its description."""
+
+    snapshot = corpus.f20_corpus(surfaced=True)
+    hub = corpus.link_neighbourhoods(snapshot, "f20-twin-hub")
+    bounded = corpus.link_neighbourhoods(snapshot, "f20-twin-bounded")
+    positive = corpus.link_neighbourhoods(snapshot, "f20-subject")
+    assert len(bounded) == 0, "the bounded twin is linkless by design"
+    assert len(hub) == 1, "a hub is one connected neighbourhood, however wide"
+    assert sum(len(members) for members in hub) > sum(len(m) for m in positive)
+    assert len(positive) == STRUCTURAL_EMERGENCE_CLUSTER_BUDGET
+
+
+def _absence_claim_contexts() -> dict[str, AssertionContext]:
+    """One context per absence-claiming predicate that reaches its composition."""
+
+    prior, later = corpus.f23_pair()
+    return {
+        "signal_absence_checked_across_all_surfaces": AssertionContext(
+            snapshot=corpus.f20_corpus(surfaced=False), subject="f20-twin-log"
+        ),
+        "dismissal_respected_across_passes": AssertionContext(
+            snapshot=later, prior=prior, subject="f23-subject"
+        ),
+        "restructure_signal_cleared_by_state_change": AssertionContext(
+            snapshot=corpus.f25_corpus(), subject="f25-subject"
+        ),
+    }
+
+
+def test_the_new_operations_are_accepted_and_existing_families_are_unaffected(
+    released,
+) -> None:
+    ops = {
+        op.op
+        for path in sorted(SEQUENCE2.glob("*.yaml"))
+        for phase in load_scenario(path).phases
+        for op in phase.ops
+    }
+    assert {"maintenance_pass", "triage_decision", "apply_restructure", "configure"} <= ops
+    minimal = load_scenario(
+        ROOT / "benchmarks" / "epistemic" / "fixtures" / "scenario-minimal.yaml"
+    )
+    assert minimal.family_id == "f01"

--- a/tests/test_epistemic_no_nudge_families.py
+++ b/tests/test_epistemic_no_nudge_families.py
@@ -684,6 +684,15 @@ def _detail_pair(flags: list[str]) -> tuple[str, str]:
     raise AssertionError(f"no response-detail flag among {flags}")
 
 
+def test_unreadable_help_refuses_rather_than_passing_the_argv_check_vacuously() -> None:
+    """An empty required-option set would make every argv check pass for free."""
+
+    from epistemic.journeys import f26_carrier
+
+    with pytest.raises(f26_carrier.JourneyStepFailed, match="no usage line"):
+        f26_carrier._required_options_from_usage("some unexpected help format\n")
+
+
 def test_the_journey_runs_against_the_installed_envelope(tmp_path: Path) -> None:
     """F5: the whole point is that this executes. So it executes.
 

--- a/tests/test_epistemic_projector.py
+++ b/tests/test_epistemic_projector.py
@@ -32,14 +32,48 @@ def snapshot():
     return projector.project(phase="p1", taken_at="2026-02-01T00:00:00Z")
 
 
+def page_items(snapshot):
+    """Items projected from vault *pages*, excluding the surface markers.
+
+    Amendment sequence 2 added surface markers, which are statements about what
+    could and could not be projected rather than about any page. Keeping them
+    out of the page assertions is what lets both be asserted precisely.
+    """
+
+    return tuple(item for item in snapshot.items if "surface" not in item.raw)
+
+
 def test_projector_recovers_the_planted_item_set(snapshot) -> None:
-    assert {item.id for item in snapshot.items} == {
+    assert {item.id for item in page_items(snapshot)} == {
         SOURCE,
         NOTE_V1,
         NOTE_V2,
         INSIGHT_BOUNDED,
         INSIGHT_UNBOUNDED,
         OPEN_QUESTION,
+    }
+
+
+def test_projector_declares_the_no_nudge_surfaces_it_cannot_project(snapshot) -> None:
+    """The honest absence, asserted — because a quiet assertion depends on it.
+
+    Three of the four surfaces a quiet assertion must prove absence on have no
+    file representation, and this vault has no triage store either. Every one
+    must therefore project as ``unavailable``: if the projector ever reported
+    ``complete`` here, the anti-vacuity meta-predicate would start crediting
+    silence that nothing demonstrated.
+    """
+
+    projections = {
+        item.raw["surface"]: item.raw.get("projection")
+        for item in snapshot.items
+        if "surface" in item.raw and "projection" in item.raw
+    }
+    assert projections == {
+        "audit_findings": "unavailable",
+        "proposal_queue": "unavailable",
+        "due_state_counters": "unavailable",
+        "review_queue": "unavailable",
     }
 
 
@@ -105,11 +139,21 @@ def test_projector_recovers_review_state_and_uncertainty(snapshot) -> None:
 
 
 def test_projector_records_file_locators_without_absolute_paths(snapshot) -> None:
-    for item in snapshot.items:
+    for item in page_items(snapshot):
         assert item.locator_kind == "file"
         assert item.locator
         assert not item.locator.startswith("/")
         assert ":" not in item.locator.split("/")[0]
+
+
+def test_surface_markers_claim_no_file_locator(snapshot) -> None:
+    """A surface marker is not a page, and must not pretend to be one."""
+
+    markers = [item for item in snapshot.items if "surface" in item.raw]
+    assert markers
+    for marker in markers:
+        assert marker.locator is None
+        assert marker.locator_kind is None
 
 
 def test_projector_meta_publishes_real_line_count_and_endpoints(snapshot) -> None:

--- a/tests/test_epistemic_registry.py
+++ b/tests/test_epistemic_registry.py
@@ -24,11 +24,11 @@ PREREGISTRATION = REPO_ROOT / "benchmarks" / "epistemic" / "PREREGISTRATION.md"
 
 
 def test_registry_keys_equal_the_preregistered_section_two_list() -> None:
-    """18 ratified names plus the 6 the 2026-08 §7 amendment added."""
+    """18 ratified names, the 6 from §7 sequence 1, and the 9 from sequence 2."""
 
     names = parse_preregistered_assertions(PREREGISTRATION.read_text(encoding="utf-8"))
-    assert len(names) == 24
-    assert len(set(names)) == 24
+    assert len(names) == 33
+    assert len(set(names)) == 33
     assert set(ASSERTION_REGISTRY) == set(names)
     assert set(PREREGISTERED_ASSERTIONS) == set(names)
 
@@ -138,25 +138,26 @@ def test_m3_preregistration_records_the_evidence_path_amendment() -> None:
 def test_family_registry_matches_preregistration_section_one() -> None:
     """§1 drift test, mirroring the §2 assertion drift test.
 
-    14 ratified families plus f15-f19 from the 2026-08 §7 amendment. Being in
-    this table is registration, not release: the two are separate, and the gate
-    that keeps them separate lives in ``test_epistemic_amendment_governance.py``.
-    It withheld f15-f19 until the founder acknowledged the receipt on
-    2026-08-15, and would withhold the next amendment's families the same way.
+    14 ratified families, f15-f19 from §7 sequence 1, and f20-f26 from §7
+    sequence 2. Being in this table is registration, not release: the two are
+    separate, and the gate that keeps them separate lives in
+    ``test_epistemic_amendment_governance.py``. It withheld f15-f19 until the
+    founder acknowledged the receipt on 2026-08-15, and it withholds f20-f26
+    now, exactly the same way, because sequence 2 is still pending.
     """
 
     from epistemic.registry import PREREGISTERED_FAMILIES, parse_preregistered_families
 
     parsed = parse_preregistered_families(PREREGISTRATION.read_text(encoding="utf-8"))
-    assert len(parsed) == 19
-    assert [family_id for family_id, _name in parsed] == [f"f{n:02d}" for n in range(1, 20)]
+    assert len(parsed) == 26
+    assert [family_id for family_id, _name in parsed] == [f"f{n:02d}" for n in range(1, 27)]
     assert PREREGISTERED_FAMILIES == parsed
 
 
 def test_family_ids_are_exposed_for_load_time_validation() -> None:
     from epistemic.registry import PREREGISTERED_FAMILY_IDS
 
-    assert PREREGISTERED_FAMILY_IDS == frozenset(f"f{n:02d}" for n in range(1, 20))
+    assert PREREGISTERED_FAMILY_IDS == frozenset(f"f{n:02d}" for n in range(1, 27))
 
 
 def test_amendment_introduced_families_are_a_subset_of_the_registered_table() -> None:
@@ -168,4 +169,16 @@ def test_amendment_introduced_families_are_a_subset_of_the_registered_table() ->
     )
 
     assert set(AMENDMENT_INTRODUCED_FAMILIES) <= PREREGISTERED_FAMILY_IDS
-    assert set(AMENDMENT_INTRODUCED_FAMILIES) == {f"f{n:02d}" for n in range(15, 20)}
+    sequence_one = {f"f{n:02d}" for n in range(15, 20)}
+    sequence_two = {f"f{n:02d}" for n in range(20, 27)}
+    assert {
+        family_id
+        for family_id, sequence in AMENDMENT_INTRODUCED_FAMILIES.items()
+        if sequence == 1
+    } == sequence_one
+    assert {
+        family_id
+        for family_id, sequence in AMENDMENT_INTRODUCED_FAMILIES.items()
+        if sequence == 2
+    } == sequence_two
+    assert set(AMENDMENT_INTRODUCED_FAMILIES) == sequence_one | sequence_two


### PR DESCRIPTION
Implements `openspec/changes/amend-no-nudge-bench-families` (S3 of the no-nudge activation programme; contracts merged in #542).

## What changes

- Seven new behavioural-journey families **f20–f26** plus the AT-1 agent track, filed through the ratified §7 amendment process as **sequence 2**: structural emergence (f20, with four frequency/length-matched twins), entity emergence (f21), unsolicited contradiction (f22), dismissal respect (f23), fresh-session reconstruction (f24), restructure lifecycle (f25), and the hookless carrier journey (f26, executed live against the installed CLI).
- Anti-vacuity meta-predicate `signal_absence_checked_across_all_surfaces` registered first; every quiet assertion composes it, membership is derived from a definition-site marker with exact-equality and behavioural propagation tests, and absence vocabularies are class-parameterized per family (union-only, so a family can only ever be held to more).
- **Withhold gate**: all of sequence 2 is held out of runs, scores, and claims until founder acknowledgment, with red fixtures on every refusal path. **f20–f22 positives are declared expected-red** on today's runtime — falsification targets, not CI failures — and each is verified two-sided (green against mechanism-present corpora).
- Registry drift gate re-pinned in the same commit as the pre-registration update, mirroring sequence 1 (#501): four assertions widened (24→33 names, 19→26 families), the amendment-subset check made stricter (per-sequence), nothing removed or loosened. `benchmarks/protocol/contracts.py` untouched.
- New scenario OpKinds `maintenance_pass`/`triage_decision`/`apply_restructure`/`configure`; no new catastrophic assertions beyond the recorded §3 scope extension of `no_retired_state_served_as_current` to the continuation packet (set size still 7).
- The branch is a single amendment commit plus three test-only follow-ups: the receipt contract permits a pending receipt exactly one introduction commit, so the correction round was squashed into the amendment (content verified tree-hash-identical) rather than editing the contract to legalize a two-commit history.

## Sequencing (founder-relevant)

- Task 3.5's calibration constants ship **provisional**, guarded by a test that refuses a freeze without the labels artifact and a §7 re-date. Because a pending receipt admits no further contract change before acknowledgment, **the medians land as a small sequence-3 amendment once the calibration study is staffed — acknowledgment of sequence 2 should wait for it**, else f20–f26 release against uncalibrated budgets.

## Verification

- Adversarial arc: fresh zero-context review (REVISE: 1 blocking + 5 major, all in amendment content — e.g. the f22 twin was class-blind to the exact mutant it exists to catch; governance verified clean), correction round with the reviewer's mutants as red probes, targeted recheck independently re-executing every mutant: all findings resolved; final wording cleanups applied.
- **652 epistemic tests green (0 skipped)** on the final tree; registry drift gate 10/10; `uvx ruff check . --select F` clean; `openspec validate amend-no-nudge-bench-families --strict` valid.
- Local lean run on the final tree: **10,742 passed; 91 failures confined to `tests/test_memorybench_{export,setup}.py`**, attributed mechanically against the origin/main baseline in the same environment — pre-existing environmental; CI authoritative.
- Scope: `src/exomem/`, `tests/golden/`, `.github/` untouched.