### PR TITLE
fix(graph): stop interactive writes waiting on a full-corpus rebuild

### DIFF
--- a/openspec/changes/converge-graph-incrementally/.openspec.yaml
+++ b/openspec/changes/converge-graph-incrementally/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-17

--- a/openspec/changes/converge-graph-incrementally/design.md
+++ b/openspec/changes/converge-graph-incrementally/design.md
@@ -182,6 +182,47 @@ test that needs the graph to be *current* asserts that for itself by joining the
 explicitly. Weakening the affected assertions to accept `completed` or `pending` was
 rejected: that would hide exactly the regression this change is meant to make visible.
 
+## The forward reference, and why a per-path drain is not enough on its own
+
+Found by the full-rebuild equivalence test, which is the only reason to write that test: a
+drain that re-indexes exactly the queued paths produces a graph **missing edges** a full
+rebuild has. Write page A linking `[[C]]` before C exists, drain; create C, drain. The
+rebuild has `A links_to C`; the drain does not, and never will.
+
+The cause is that an unresolved wikilink produces *no edge at all* —
+`_body_wikilink_paths` drops any link `normalize_wikilink` returns a warning for. The link
+is not recorded as unresolved; it is not recorded. Nothing about later indexing the
+*target* repairs the *source*, because nothing points from one to the other. A full rebuild
+gets this right for free by re-deriving every page once the corpus is complete, and that is
+precisely the property a proportional repair gives up.
+
+The existing incremental path already handles this via `_resolver_affected_sources`: on a
+topology change it re-reads every indexed source from disk and re-normalises its links
+under the old and new resolvers — an O(vault) *read* scan that the incremental path already
+pays today. The drain answers the same question, split by what each direction costs:
+
+- A page that **vanished** leaves its inbound edges behind, and every such edge names its
+  own source. One indexed query on `dst_key` answers it.
+- A page that **appeared** leaves no trace at all, because the links that should point at
+  it were never written down. Only the bodies know, so this scans them.
+
+Both run only when a drain actually changes topology. An ordinary edit — the overwhelming
+majority of writes, and the entire livelock case — touches neither.
+
+**This is the part of basic-memory's design exomem genuinely lacks.** Their `Relation`
+carries a nullable `to_id` beside a NOT NULL `to_name`, so an unresolved link is an ordinary
+row and resolving it later is an indexed lookup rather than a corpus scan. The earlier
+reading — that exomem already has the structural equivalent because `graph_edges.dst_key`
+is a path string rather than a foreign key — was half right: the column *can* hold an
+unresolved target, but nothing ever writes one.
+
+Adopting it is deliberately **not** in Phase 2. It is a schema change plus a change to what
+reads *render* for an unresolved target: `_placeholder_node` already synthesizes a
+`kind: "unresolved"` node for a `dst_key` with no row, so persisting unresolved edges would
+start surfacing placeholder nodes in `connect_memory` output. That is a user-visible
+contract change, and it should be made on measurement rather than on the way past. It
+belongs with Phase 3, whose whole premise is re-measuring before relaxing anything.
+
 ## Alternatives considered
 
 **Tune the join bound.** This was the previous attempt. Rejected: the constant is

--- a/openspec/changes/converge-graph-incrementally/design.md
+++ b/openspec/changes/converge-graph-incrementally/design.md
@@ -1,0 +1,216 @@
+# Design — converge the epistemic graph incrementally
+
+## The failure this change is aimed at
+
+The graph does not converge under concurrent writes, and the reason is structural
+rather than incidental. It is worth stating precisely, because seven previous fixes
+were each correct and none of them helped.
+
+Let a rebuild pass over a vault of `N` pages take time `T(N)`, and let writes arrive
+at rate `λ`. The rebuild samples a vault-global projection identity before the pass
+and again after, and refuses if it moved. Any write to any recall-admitted page moves
+it. So a pass succeeds only if no write lands during it, with probability roughly
+`e^(−λ·T(N))`.
+
+The retry budget does not rescue this, because each retry is another full pass with
+the same exposure. The dispatch succeeds with probability `1 − (1 − e^(−λ·T(N)))^k`
+for a budget of `k` passes — but `k` is a small constant (a stabilization count times
+a publication count) while `T(N)` grows with the vault. **The failure probability
+rises with both vault size and write rate, and the retry budget is the only term that
+does not scale.** That is a livelock by construction.
+
+It also explains each observed symptom without any additional hypothesis: writes fail
+in consecutive runs (a busy period defeats every pass in the budget); generations die
+in bursts (each dispatch burns its whole budget quickly); and the benchmark fails
+specifically at "1200 pages with a concurrent writer" and not at 1200 pages alone
+(large `T(N)` *and* nonzero `λ` are both required).
+
+The three decisions reinforce each other. Because repair is all-or-nothing (1), `T(N)`
+is as large as it can possibly be, which minimises the success probability in (2).
+Because availability is a single vault-global boolean (3), the fast path must prove a
+vault-global property to stay on it — which is why it has sixteen bail-out sites, which
+is what makes (1) fire constantly. Fixing any one of the three in isolation leaves the
+other two generating the same failures, which is the pattern the previous seven fixes
+show.
+
+## What a working design looks like
+
+`basic-memory`, a sibling project over the same substrate (markdown files, SQLite
+index, wikilink graph), was examined deliberately as a cross-check rather than a
+source. Its graph converges, and it makes three choices that map exactly onto the
+three problems above:
+
+| Problem here | basic-memory's choice |
+|---|---|
+| All-or-nothing O(vault) repair | Per-file checksums; only changed files are re-indexed |
+| Global optimistic-concurrency guard | None — indexing is monotone per file, so there is nothing to invalidate |
+| Global availability boolean | None — the index is always readable; unresolved links are stored as forward references and resolved later |
+
+The important observation is not that basic-memory is right and exomem is wrong. It
+is that **exomem already has all three primitives** and does not use them for the
+graph:
+
+- Per-file content hashing: `graph_nodes.source_hash` already exists and is already
+  written per node.
+- Forward references: `_placeholder_node` already exists — an edge to a page that has
+  not been indexed yet is already representable.
+- A durable per-path work queue with receipts, generation triggers, and poison
+  isolation: `deferred_index`, already in production for the embedding and semantic
+  indexes, drained by `index_sync.drain_deferred_work` from call sites that already
+  exist in the watcher, the CLI, and the server entry point.
+
+And the dirty set itself is already computed and already durable: the graph sync
+checkpoint carries `paths` and `created_paths` and is written into the canonical batch
+before the caller's files land. The information required to repair proportionally is
+written to disk, crash-safely, on every single write — and then thrown away.
+
+So this is not a rewrite. It is connecting three existing mechanisms to a fourth that
+was built without them.
+
+The in-repo precedent is even closer than the cross-project one. `live-index-freshness`
+already specifies the inbound-link index as event-maintained and incrementally patched,
+with two obligations that this change adopts verbatim in shape: the patched index's
+*content* must be identical to what a full rebuild would produce for the same vault
+state, and when the incremental registry is not live the system falls back to a full
+rebuild. The graph is the outlier among exomem's derived indexes, not the pattern.
+
+## Why the phases are ordered this way, and why Phase 3 is conditional
+
+**Phase 1 — off the write path.** Independently correct and independently valuable: it
+removes the graph term from write latency entirely, and it is a prerequisite for Phase 2
+being observable (while the write blocks on the rebuild, "deferred" has no meaning).
+
+The design decision inside Phase 1 is that the interactive join is **removed, not
+bounded**. A bound must be simultaneously shorter than the commit latency budget and
+longer than a small-vault rebuild, or a dozen tests that legitimately expect `completed`
+begin reporting `pending`. That constant does not exist. The earlier bounded-join attempt
+was not badly tuned; it was over-constrained, and the constraint is the design saying the
+wait does not belong there. A check-only join has a provably zero latency contribution
+rather than one bounded by a constant nobody can size.
+
+`reconcile` and explicit maintenance keep the unbounded join. Waiting is the entire point
+of those operations, and their latency budget is a user's patience, not a write gate.
+
+**Phase 2 — the dirty queue.** This is the phase that fixes convergence. Two properties
+matter, and they are different properties:
+
+- *Proportionality*: work per drain is `O(changed)`, not `O(N)`. This shrinks `T` by
+  orders of magnitude for ordinary writes, which raises `e^(−λ·T)` toward 1.
+- *Monotonicity*: this is the more important one. A concurrent write **appends an entry**
+  to the queue instead of **invalidating a global proof**. Proportionality improves the
+  odds; monotonicity removes the failure mode. Even if a drain raced with a write, the
+  raced path is still queued and the next drain picks it up. Nothing is lost, so nothing
+  needs to be retried from scratch.
+
+Phase 1 alone makes writes fast and leaves the graph drifting, which is why Phase 2 is
+not optional. Shipping Phase 1 without Phase 2 would trade a visible failure for an
+invisible one.
+
+**Phase 3 — the availability fence, only if measurement demands it.** After Phase 2, the
+global availability equality may simply stop being the binding constraint: if drains are
+cheap and the incremental publication proof usually succeeds, availability recovers on
+its own. Relaxing a fail-closed fence speculatively, to fix a problem that measurement
+has not confirmed still exists, is how a safety property gets traded away for nothing.
+
+If it *is* still binding, the change is narrow and well-founded rather than a
+loosening. The read snapshot already evaluates the recall policy version and the access
+fingerprint as **independent terms**; those are a genuine access-safety fence and stay
+all-or-nothing, because serving a page a reader may not see is a correctness violation.
+The content-freshness equality is a *separate* term that has been given the same
+fail-closed grade. Applying an access-safety-grade fence to content staleness is the
+category error under the whole design: stale content is a quality dimension to report,
+not a permission to deny. Only that term is in scope, and only after measurement.
+
+Phase 3 is also where the machinery that exists solely to make repeated doomed
+whole-vault rebuilds survivable — the stabilization and publication retry budgets, the
+Class B/C classification, the refusal memos — can be reduced, because by then the
+rebuilds it protects will be rare.
+
+## The concurrency hazard Phase 1 exposes
+
+This was not predicted and is the most important operational finding in the change.
+
+Removing the write's join lets a canonical write and a graph rebuild run concurrently
+**for the first time**. They conflict — on POSIX as well as Windows, so it was never a
+platform quirk. The write blocking on its own rebuild is what has been hiding it, and
+every production path that *already* rebuilds off the write path (the watcher's
+background rebuild, deferred drains) can hit it today, before this change.
+
+Four distinct collisions, each fixed at its own layer rather than papered over with a
+retry at the top:
+
+1. **The canonical directory census counts the rebuild's own scratch sidecars.** A
+   rebuild creates, replaces, and removes `.graph-rebuild-<digest>.sqlite` and its
+   companions inside the same vault directory a canonical write takes a guarded census
+   of, so an in-flight rebuild turns an unrelated write into a path-guard change and then
+   a stale-record refusal. Derived-index residue is excluded from the census by the same
+   mechanism already applied to the batch writer's own workspace residue. The graph sync
+   artifacts stay censused — the canonical batch writes those itself, so they are exactly
+   the files the guard is for.
+
+2. **Windows page reads pin the pages they read.** Python's `open()` omits
+   `FILE_SHARE_DELETE`, so a concurrent replace of a page the rebuild happens to be
+   reading is refused. Rebuild reads go through a helper that opens with all three share
+   flags on Windows and is an ordinary read everywhere else. This is a read that must not
+   take custody of what it reads — the graph is a *derived* projection, and a derived
+   reader has no business blocking the canonical writer.
+
+3. **A refused replace is retried against a re-checked precondition.** Sharing violations
+   are transient by nature. The retry re-runs its own precondition check each attempt
+   rather than replacing against a stale one, so the bound is on how long the transient
+   is tolerated, not on how stale a proof may be.
+
+4. **Epoch sampling could observe a batch's interior.** The canonical batch installs the
+   generation floor before the checkpoint; a rebuild sampling between the two sees a floor
+   without its checkpoint and refuses with a lineage conflict. Sampling now happens under
+   the canonical mutation hold, so it observes one side of a batch or the other and never
+   the middle.
+
+## Test-suite consequence, stated as a design fact
+
+A rebuild is now a daemon thread that outlives the request that started it — which in the
+suite means it outlives the *test* that started it, and then touches process-global
+projections while the next test is already running against a different vault.
+
+That is an artefact of the suite sharing one process across many vaults; production is one
+long-lived process against one vault and has no such shape. The write's join was providing
+per-test isolation by accident, and that accident is what is being removed.
+
+The fixture that drains active rebuilds at teardown is therefore deliberately **not** a
+convergence helper. It guarantees only that nothing is still running when a test ends. A
+test that needs the graph to be *current* asserts that for itself by joining the flight
+explicitly. Weakening the affected assertions to accept `completed` or `pending` was
+rejected: that would hide exactly the regression this change is meant to make visible.
+
+## Alternatives considered
+
+**Tune the join bound.** This was the previous attempt. Rejected: the constant is
+over-constrained by two hard requirements in opposite directions, so no value satisfies
+both. Attempting it again would be the eighth fix inside the triangle.
+
+**Raise the retry budget.** Rejected on the arithmetic above: `k` is the only term that
+does not scale with the problem, so increasing it buys a constant factor against a
+failure probability that grows with vault size and write rate. It also makes the bad
+case worse — more doomed whole-vault passes, more time spent invalidating other writers.
+
+**Make the rebuild incremental without the durable queue** — recompute the dirty set from
+the current checkpoint at drain time. Rejected: it loses the dirty set across a crash cut
+between the markdown write and the drain, which is exactly the window the existing
+receipt/epoch protocol was built to make honest. Enqueue must be part of the same durable
+step as the checkpoint write, or the queue is a cache with a correctness claim.
+
+**Write a new per-path store for the graph.** Rejected: `deferred_index` already has the
+schema shape, receipts, generation triggers, and `rotate_receipts` poison isolation, and
+it is already drained from the call sites the graph needs. A parallel store would be a
+second thing to keep crash-safe and a second thing to drift.
+
+**Remove the global availability fence now, as part of Phase 2.** Rejected as
+speculative — see Phase 3 above. The fence may be irrelevant once drains are cheap, and
+a fail-closed safety property should not be relaxed to fix a problem that may no longer
+exist.
+
+## Out of scope
+
+Rewriting the graph sync receipt, epoch, and lineage-reset protocol. It is crash-safety
+machinery, it is correct, and it stays. This change reduces how often it is exercised,
+not what it does.

--- a/openspec/changes/converge-graph-incrementally/proposal.md
+++ b/openspec/changes/converge-graph-incrementally/proposal.md
@@ -1,0 +1,116 @@
+## Why
+
+Eight pull requests and seven `fix(graph):` commits have not made the epistemic
+graph converge under ordinary use. Live vaults show consecutive writes ending in
+`graph_sync: failed`, several generations dying inside an hour, and the graph
+benchmark failing specifically at "1200 pages with a concurrent writer". The
+failures are not a sequence of unrelated defects. They are three design decisions
+that each make the other two worse:
+
+1. **Repair is all-or-nothing and O(entire vault).** The incremental refresh path
+   has sixteen distinct bail-out sites, and every one of them routes to a rebuild
+   that deletes every node and edge and re-walks every markdown file under the
+   knowledge base. There is no partial repair. The fast path is a conjunction of
+   roughly sixteen global proofs; its only alternative is the most expensive
+   operation in the system.
+
+2. **That whole-vault rebuild is guarded by a vault-global optimistic-concurrency
+   check.** The rebuild samples a projection identity derived from a full walk of
+   every recall-admitted file, runs the pass, then samples again and refuses if
+   the key moved. Any unrelated concurrent write moves it. The retry budget is a
+   stabilization count times a publication count, so a single dispatch can run up
+   to eight whole-vault passes — each of which strictly *widens* the window in
+   which a concurrent writer can invalidate it.
+
+   This is the reason the subsystem has been hard to fix: **success probability
+   falls as vault size and write rate rise.** It is a livelock by construction, and
+   no amount of retry tuning inverts that gradient.
+
+3. **Availability is one vault-global boolean, and the write synchronously waits
+   for it.** A single equality decides whether the *entire* graph is readable, one
+   write anywhere makes the whole graph unavailable, and the only route back is
+   (1) — which the write then blocks on, because the terminal contract promises
+   `graph_sync: "completed"`.
+
+Each prior fix was individually correct and addressed a symptom *inside* this
+triangle, which is why none of them helped.
+
+**The codebase already contains the working alternative, twice.** `deferred_index`
+is a durable per-path dirty queue with receipts, generation triggers, and poison
+isolation, drained asynchronously; the embedding and semantic indexes use it, and
+those are precisely the subsystems that keep working while the graph does not. The
+inbound-link index (`live-index-freshness`) already specifies incremental patching
+with a full-rebuild equivalence contract and a fall-back-to-rebuild clause. The
+graph is the outlier, not the pattern.
+
+And the changed-path set the graph needs is **already recorded durably**: the graph
+sync checkpoint carries `paths` and `created_paths`, written into the canonical
+batch before the caller's files. The system already knows exactly which pages
+changed, per generation, crash-safely — and then discards that information and
+rebuilds everything.
+
+## What Changes
+
+- **Take the graph off the interactive write path.** An interactive canonical write
+  SHALL report an already-settled graph outcome and SHALL NOT wait for one that is
+  not. The join becomes a check, not a bounded wait: there is no timeout constant,
+  because no constant can be both shorter than the write-latency budget and longer
+  than a vault-sized rebuild. `reconcile` and explicit maintenance keep the
+  unbounded join, where waiting is the point.
+- **Add a fourth terminal graph outcome, `pending`.** Absent / `completed` /
+  `failed` cannot express "the graph is converging and you did not wait for it". A
+  write that did not wait MUST be distinguishable, through the compact projection
+  as well as the full terminal, from one whose graph was already current.
+- **Enqueue the changed paths durably instead of discarding them.** The checkpoint's
+  `paths` and `created_paths` are written into a `graph_upserts` dirty queue in the
+  same durable step as the checkpoint itself, so no crash cut can lose the dirty set
+  while keeping the markdown. A full-scope batch enqueues a rebuild marker instead.
+- **Make the sixteen bail-out sites proportional.** They stop meaning "rebuild the
+  whole vault" and start meaning "enqueue the affected paths and return deferred".
+  The true whole-vault rebuild survives only where it is genuinely required: no
+  sidecar, a schema or registry version change, a full-scope batch, a lineage reset,
+  and explicit reconcile.
+- **Drain the queue through the existing per-path primitives**, publishing through
+  the existing incremental marker. No `DELETE FROM graph_nodes`. Existing drain call
+  sites in the watcher, the CLI, and the server entry point need no new scheduler.
+- **Let a rebuild and a canonical write coexist.** Removing the write's join lets
+  them overlap for the first time, and they conflict: the canonical directory census
+  counts the rebuild's own scratch sidecars, and on Windows a rebuild's page reads
+  pin the files a concurrent replace needs. Derived-index residue is excluded from
+  the census by the same mechanism already applied to the batch writer's own
+  workspace; rebuild reads use share-all-modes opens; a refused replace retries
+  against a re-checked precondition; and epoch sampling happens under the canonical
+  mutation hold so it never observes a batch's interior.
+
+## Capabilities
+
+### New Capabilities
+
+- `graph-incremental-convergence`: proportional graph repair through a durable
+  per-path dirty queue, a non-blocking interactive write, a `pending` terminal
+  outcome, and safe concurrency between a graph rebuild and a canonical write.
+
+### Modified Capabilities
+
+- `live-index-freshness`: the graph joins the inbound-link index in being
+  event-maintained and incrementally patched, with the same full-rebuild
+  equivalence obligation and the same fall-back-to-rebuild clause.
+
+## Impact
+
+Affected areas are graph refresh and rebuild dispatch, the deferred-index schema,
+the graph sync checkpoint write, mutation terminal projection, the canonical
+directory census, and vault artifact replacement. This changes a *response*
+contract (a new `graph_sync` value), not a tool schema: no MCP selector, no vault
+markdown schema, no graph query shape, and no pinned plugin digest moves. The
+crash-safety protocol — receipts, epochs, lineage resets, publication tickets — is
+unchanged; this change reduces how often it is *exercised*, not what it does.
+
+Deployment is staged, because the phases have independent value and independent
+risk. Phase 1 (non-blocking write) is correct on its own and unblocks the write
+latency gate; Phase 2 (dirty queue) is what actually makes the graph converge;
+Phase 3 (relaxing the availability fence) is explicitly conditional on measurement
+and MUST NOT be done speculatively.
+
+The whole-vault rebuild is not removed. It is demoted from the routine consequence
+of an ordinary write to what it should always have been: a repair tool.

--- a/openspec/changes/converge-graph-incrementally/specs/graph-incremental-convergence/spec.md
+++ b/openspec/changes/converge-graph-incrementally/specs/graph-incremental-convergence/spec.md
@@ -222,15 +222,60 @@ search.
 - **THEN** the written path is enqueued and repaired by a subsequent drain
 - **AND** the in-progress drain's completed work is not discarded
 
+### Requirement: A drain retires the generation it converged
+
+Repairing the queued pages is only half of convergence. A drain SHALL acknowledge the
+committed graph sync checkpoint it converged, so that the epoch advances and readers
+observe a current graph. A drain that repairs pages without moving the acknowledgement
+converges nothing observable: the epoch stays stale, the sidecar stays unavailable, and
+the next dispatch takes the whole-vault rebuild regardless — which would leave the queue
+as overhead beside the expensive path rather than a replacement for it.
+
+Acknowledgement is the only irreversible claim in this path, so a drain SHALL
+acknowledge a checkpoint only when the pass processed that checkpoint's whole path set.
+A batch truncated by the drain limit, a batch left over from an earlier generation, and
+a full-scope marker SHALL each acknowledge nothing and leave the work queued for the
+drain that does cover it.
+
+Coverage SHALL be membership in the processed batch rather than in the indexed set. A
+deletion named by a checkpoint is processed by removing its rows and has no source bytes
+to index, so an indexed-set test would stall every generation containing one
+indefinitely. That the indexed pages did not move under the pass remains a separate
+proof.
+
+#### Scenario: A covering drain makes the epoch current
+
+- **WHEN** a drain processes every path named by the committed checkpoint
+- **THEN** the graph sync epoch reports the committed generation as current
+- **AND** the graph reports itself available
+
+#### Scenario: A partial drain acknowledges nothing
+
+- **WHEN** a drain processes only some of the paths the committed checkpoint names
+- **THEN** the epoch is not advanced to that generation
+- **AND** the remaining paths stay queued
+
 ### Requirement: A graph rebuild and a canonical write may run concurrently without either losing
 
 A graph rebuild in flight SHALL NOT cause a concurrent canonical write to refuse, and a
 concurrent canonical write SHALL NOT be blocked by a rebuild's reads.
 
 The canonical directory census SHALL exclude derived-index residue — the rebuild's
-scratch sidecars and their companions — using the same mechanism already applied to the
-batch writer's own workspace residue. Artifacts written by the canonical batch itself,
-including the graph sync and floor artifacts, SHALL remain censused.
+scratch sidecars and their companions, and the dirty-path queue's database and its
+journal companions — using the same mechanism already applied to the batch writer's own
+workspace residue. Artifacts written by the canonical batch itself, including the graph
+sync and floor artifacts, SHALL remain censused.
+
+Excluding the queue database is required by the enqueue ordering, not merely convenient
+alongside it: the enqueue is what makes a crash cut safe, so it must happen before the
+commit, which places the database's creation and journalling inside the guarded window.
+A census that counted it would make the first write to a fresh vault invalidate its own
+census, with nothing concurrent involved. Two writers appending their own graph debt is
+the monotone behaviour the queue exists to provide, not a canonical conflict.
+
+Each excluded name SHALL be bound by test to the definition it was copied from, so a
+rename at the definition cannot leave the census's copy stale and silently start
+counting operational bookkeeping as canonical content.
 
 A rebuild's page reads SHALL NOT take custody of the pages they read: on platforms whose
 default open mode denies concurrent deletion or replacement, rebuild reads SHALL open
@@ -249,6 +294,12 @@ generation floor installed without its checkpoint.
 - **WHEN** a canonical write takes its guarded directory census while a rebuild is
   creating, replacing, and removing its scratch sidecars in the same directory
 - **THEN** the census does not change from the rebuild's residue and the write commits
+
+#### Scenario: The first write to a fresh vault does not invalidate itself
+
+- **WHEN** a canonical write enqueues its graph debt and thereby creates the dirty-path
+  queue's database inside its own guarded directory census
+- **THEN** the census does not change and the write commits
 
 #### Scenario: A rebuild's reads do not block a replacement
 

--- a/openspec/changes/converge-graph-incrementally/specs/graph-incremental-convergence/spec.md
+++ b/openspec/changes/converge-graph-incrementally/specs/graph-incremental-convergence/spec.md
@@ -255,6 +255,47 @@ proof.
 - **THEN** the epoch is not advanced to that generation
 - **AND** the remaining paths stay queued
 
+### Requirement: A queued repair is not rescheduled as a whole-vault rebuild
+
+When the incremental pass enqueues the affected paths, the durable queue owns that repair.
+The dispatch layer SHALL NOT then register a whole-vault rebuild for the same checkpoint.
+Registering one runs the expensive path on exactly the bail-outs this capability exists to
+make proportional, leaving the queue as overhead beside the whole-vault rebuild rather
+than a replacement for it.
+
+The distinction SHALL rest on an enqueue that actually succeeded, not on the deferral
+alone. A fallback that registers its own whole-vault rebuild also reports a deferral, and
+a queue write that failed falls back to a rebuild by design; in both cases the queue does
+not own the repair and the rebuild is correct.
+
+A write whose repair is queued SHALL report the graph as pending in its terminal, with a
+code distinct from a rebuild that is still running. Nothing is rebuilding, so an operator
+reading a rebuild-in-progress code would look for a flight that does not exist, and the
+two states converge on different timescales. The terminal SHALL prove this from durable
+state — a committed checkpoint the sidecar has not acknowledged, with work still queued
+against it — because a repair the queue owns has no registration to observe.
+
+A write that has not converged SHALL NOT be reported identically to one whose graph is
+current. Absent this outcome the response is byte-identical to a converged write, which is
+the single failure the pending outcome exists to prevent.
+
+#### Scenario: A queued repair schedules no rebuild
+
+- **WHEN** the incremental pass enqueues the affected paths for a committed checkpoint
+- **THEN** the dispatch reports the repair as queued
+- **AND** no whole-vault rebuild is registered for that checkpoint
+
+#### Scenario: A queued repair still reports pending
+
+- **WHEN** a write commits with its graph repair queued and no rebuild registered
+- **THEN** the terminal reports the graph as pending with a queued-repair code
+- **AND** the response is distinguishable from a write whose graph is current
+
+#### Scenario: A failed enqueue still earns a rebuild
+
+- **WHEN** the queue write fails and the pass falls back to a whole-vault rebuild
+- **THEN** the dispatch does not claim the repair is queued
+
 ### Requirement: A graph rebuild and a canonical write may run concurrently without either losing
 
 A graph rebuild in flight SHALL NOT cause a concurrent canonical write to refuse, and a

--- a/openspec/changes/converge-graph-incrementally/specs/graph-incremental-convergence/spec.md
+++ b/openspec/changes/converge-graph-incrementally/specs/graph-incremental-convergence/spec.md
@@ -1,0 +1,208 @@
+## ADDED Requirements
+
+### Requirement: An interactive write never waits for graph convergence
+
+An interactive canonical mutation SHALL report a graph outcome that has already
+settled and SHALL NOT wait for one that has not. The join SHALL be a check whose
+latency contribution is zero, not a wait bounded by a configured interval; no
+interactive graph join timeout constant SHALL exist.
+
+Operations whose purpose is convergence — `reconcile`, and maintenance invoked in
+reconcile mode — SHALL retain an unbounded join, because waiting is what the caller
+asked for.
+
+Every call site that joins a registered graph flight SHALL be either check-only or a
+declared convergence opt-out, and the declared set SHALL be enforced by test so a
+third unbounded site cannot appear silently.
+
+#### Scenario: A write whose rebuild is still running does not block
+
+- **WHEN** a canonical mutation commits and its graph rebuild is still running
+- **THEN** the mutation returns without waiting for that rebuild
+- **AND** the elapsed time attributable to the graph join is zero
+
+#### Scenario: A write whose rebuild already finished reports its real outcome
+
+- **WHEN** a canonical mutation commits and its graph rebuild has already reached a
+  terminal outcome
+- **THEN** the mutation reports that outcome rather than downgrading it to `pending`
+
+#### Scenario: Reconcile still waits
+
+- **WHEN** a user invokes `reconcile`, or maintenance in reconcile mode, and a graph
+  rebuild is in flight
+- **THEN** the operation waits for that rebuild to reach a terminal outcome before
+  returning, with no timeout
+
+#### Scenario: A new unbounded join site fails the suite
+
+- **WHEN** a call site joins a registered graph flight without a bound and without
+  being a declared convergence opt-out
+- **THEN** the test that enumerates graph join sites fails
+
+### Requirement: A deferred graph outcome is reported, not hidden
+
+The terminal contract SHALL express a fourth graph outcome, `pending`, alongside
+absent, `completed`, and `failed`, meaning the graph is converging and the caller did
+not wait for it. It SHALL carry a stable machine-readable reason distinguishing it
+from a failure.
+
+`pending` SHALL survive the compact terminal projection. A response whose graph is
+still converging SHALL NOT be byte-identical to one whose graph is current.
+
+Every consumer that validates the terminal `graph_sync` field SHALL accept `pending`,
+including consumers outside continuous integration. The permitted-outcome set SHALL
+have exactly one definition in the codebase; a consumer SHALL import it rather than
+restate it.
+
+#### Scenario: A non-blocking write reports pending
+
+- **WHEN** a canonical mutation returns without waiting for an in-flight rebuild
+- **THEN** its terminal reports `graph_sync: "pending"` with a stable reason code
+
+#### Scenario: The compact projection preserves pending
+
+- **WHEN** a terminal carrying `graph_sync: "pending"` is projected to its compact form
+- **THEN** the compact form still reports `pending`, distinguishably from `completed`
+
+#### Scenario: Live acceptance accepts pending
+
+- **WHEN** the live acceptance script validates a response whose graph is converging
+- **THEN** it accepts `pending` as a valid outcome rather than rejecting the response
+
+### Requirement: The changed-path set is enqueued durably, never discarded
+
+When a canonical batch writes a graph sync checkpoint, the checkpoint's changed and
+created paths SHALL be enqueued into a durable per-path graph work queue **in the same
+durable step as the checkpoint write**, so that no crash cut can leave the markdown
+committed and the dirty set lost.
+
+The queue SHALL reuse the existing deferred-index machinery — its table shape,
+receipts, generation triggers, and poison-isolating receipt rotation. A parallel store
+SHALL NOT be introduced.
+
+A full-scope batch, one whose path count exceeds the checkpoint path limit, SHALL
+enqueue a full-rebuild marker rather than an unbounded path list.
+
+#### Scenario: A crash between markdown and drain loses no work
+
+- **WHEN** a canonical batch commits its markdown and checkpoint and the process dies
+  before any drain runs
+- **THEN** on restart the changed paths are still queued and the next drain repairs them
+
+#### Scenario: A full-scope batch enqueues a rebuild marker
+
+- **WHEN** a canonical batch's changed-path count exceeds the checkpoint path limit and
+  its scope is recorded as full
+- **THEN** a full-rebuild marker is enqueued instead of a path list
+
+#### Scenario: A poisoned path does not stall the queue
+
+- **WHEN** one queued path fails to index repeatedly
+- **THEN** its receipt is rotated into isolation and the remaining queued paths still drain
+
+### Requirement: Graph repair is proportional to the change
+
+A bail-out from the incremental refresh path SHALL enqueue the affected paths and
+return a deferred result. It SHALL NOT trigger a whole-vault rebuild.
+
+The affected set SHALL be the paths the refresh path has already computed: its delta
+paths, together with the resolver-affected sources it folds in.
+
+A whole-vault rebuild SHALL remain reachable, and SHALL be reserved for the cases that
+genuinely require it: no graph sidecar exists, the schema or registry version changed,
+the batch scope is full, a lineage reset occurred, or the user invoked reconcile
+explicitly.
+
+A drain SHALL re-index queued paths through the existing per-path indexing primitive
+and publish through the existing incremental availability marker. It SHALL NOT delete
+the node, edge, or parent-reference tables.
+
+#### Scenario: An ordinary bail-out costs O(changed), not O(vault)
+
+- **WHEN** the incremental refresh path bails out on an ordinary write
+- **THEN** the affected paths are enqueued and the call returns deferred
+- **AND** no whole-vault walk is performed
+
+#### Scenario: A missing sidecar still rebuilds fully
+
+- **WHEN** no graph sidecar exists for the vault
+- **THEN** a whole-vault rebuild runs
+
+#### Scenario: A drain leaves the graph equal to a full rebuild
+
+- **WHEN** a sequence of changes is applied once through queued incremental drains and
+  once through a full rebuild from the resulting vault state
+- **THEN** the resulting nodes, edges, and parent references are identical
+
+#### Scenario: A concurrent write appends rather than invalidating
+
+- **WHEN** a write lands while a drain is in progress
+- **THEN** the written path is enqueued and repaired by a subsequent drain
+- **AND** the in-progress drain's completed work is not discarded
+
+### Requirement: A graph rebuild and a canonical write may run concurrently without either losing
+
+A graph rebuild in flight SHALL NOT cause a concurrent canonical write to refuse, and a
+concurrent canonical write SHALL NOT be blocked by a rebuild's reads.
+
+The canonical directory census SHALL exclude derived-index residue — the rebuild's
+scratch sidecars and their companions — using the same mechanism already applied to the
+batch writer's own workspace residue. Artifacts written by the canonical batch itself,
+including the graph sync and floor artifacts, SHALL remain censused.
+
+A rebuild's page reads SHALL NOT take custody of the pages they read: on platforms whose
+default open mode denies concurrent deletion or replacement, rebuild reads SHALL open
+with sharing that permits both.
+
+A replacement refused because of a transient sharing violation SHALL be retried for a
+bounded interval, and each attempt SHALL re-evaluate its own precondition rather than
+replacing against a stale one.
+
+Publication epoch sampling SHALL observe a canonical batch from outside, never from
+within: it SHALL be serialized against the canonical mutation hold so it cannot read a
+generation floor installed without its checkpoint.
+
+#### Scenario: A rebuild's scratch files do not fail an unrelated write
+
+- **WHEN** a canonical write takes its guarded directory census while a rebuild is
+  creating, replacing, and removing its scratch sidecars in the same directory
+- **THEN** the census does not change from the rebuild's residue and the write commits
+
+#### Scenario: A rebuild's reads do not block a replacement
+
+- **WHEN** a canonical write replaces a page that an in-flight rebuild is reading
+- **THEN** the replacement succeeds
+
+#### Scenario: Epoch sampling never sees a batch's interior
+
+- **WHEN** a rebuild samples the publication epoch while a canonical batch is between
+  its floor install and its checkpoint write
+- **THEN** the sample reflects the state before or after that batch, and no lineage
+  conflict is raised
+
+### Requirement: No graph rebuild outlives the test that started it
+
+Because an interactive write no longer joins its rebuild, a rebuild is a daemon thread
+that outlives its request. The test suite runs many vaults through one process, so such
+a thread would touch process-global projections while a later test runs against a
+different vault.
+
+The suite SHALL drain active graph rebuilds at test teardown, and SHALL fail rather than
+leak a rebuild that will not stop. That drain SHALL guarantee only that nothing is still
+running; it SHALL NOT be used as a convergence helper.
+
+A test that requires the graph to be current SHALL join the flight explicitly. An
+assertion on a graph outcome SHALL NOT be weakened to accept `completed` or `pending`
+interchangeably.
+
+#### Scenario: A leaked rebuild fails rather than contaminating the next test
+
+- **WHEN** a graph rebuild started by a test is still running at that test's teardown
+- **THEN** teardown joins it before the next test begins
+- **AND** a rebuild that will not stop within the quiesce timeout fails the run
+
+#### Scenario: A test needing a current graph joins explicitly
+
+- **WHEN** a test asserts that a write's graph outcome is `completed`
+- **THEN** it joins the active rebuild itself rather than relying on the write to have waited

--- a/openspec/changes/converge-graph-incrementally/specs/graph-incremental-convergence/spec.md
+++ b/openspec/changes/converge-graph-incrementally/specs/graph-incremental-convergence/spec.md
@@ -181,6 +181,24 @@ A drain SHALL re-index queued paths through the existing per-path indexing primi
 and publish through the existing incremental availability marker. It SHALL NOT delete
 the node, edge, or parent-reference tables.
 
+A drain whose queued paths change link topology SHALL also repair the pages whose own
+edges change as a result. A link to a page that does not yet exist produces no edge at
+all, so re-indexing the target later cannot repair the source; the sources have to be
+found and re-indexed. A drain over paths that change no topology SHALL NOT perform that
+search.
+
+#### Scenario: A page written before its link target still gains the edge
+
+- **WHEN** a page linking to `C` is drained before `C` exists, and `C` is created and
+  drained afterwards
+- **THEN** the graph contains the edge from that page to `C`
+- **AND** it is the same edge a full rebuild of the resulting vault produces
+
+#### Scenario: An ordinary edit does not pay for topology repair
+
+- **WHEN** every queued path in a drain is already in the graph and still on disk
+- **THEN** no search for affected sources is performed
+
 #### Scenario: An ordinary bail-out costs O(changed), not O(vault)
 
 - **WHEN** the incremental refresh path bails out on an ordinary write

--- a/openspec/changes/converge-graph-incrementally/specs/graph-incremental-convergence/spec.md
+++ b/openspec/changes/converge-graph-incrementally/specs/graph-incremental-convergence/spec.md
@@ -70,6 +70,36 @@ restate it.
 - **WHEN** the live acceptance script validates a response whose graph is converging
 - **THEN** it accepts `pending` as a valid outcome rather than rejecting the response
 
+### Requirement: Graph-backed reads converge without being asked
+
+Because a write no longer waits for its own rebuild, a reader issuing a
+graph-backed request immediately after a write MAY observe the graph
+unavailable. That window is the designed cost of taking the rebuild off the
+write path, and it SHALL be reported honestly — an unavailable graph SHALL carry
+its reason, and the surrounding response SHALL still return the dimensions that
+do not depend on the graph.
+
+The graph SHALL then converge with no further request from the caller. No
+operation SHALL be required to make a committed write's graph land.
+
+The window SHALL be bounded by the repair actually needed. Until repair is
+proportional, that bound is a whole-vault rebuild; once it is, the bound is a
+per-path drain. This requirement is what makes that improvement observable
+rather than assumed.
+
+#### Scenario: A read straight after a write may see the graph still building
+
+- **WHEN** a client issues a graph-backed context request immediately after a
+  write that changed the graph
+- **THEN** the response may report the graph unavailable with a stated reason
+- **AND** the non-graph dimensions of that response are still returned
+
+#### Scenario: The graph converges with no further request
+
+- **WHEN** a write commits and no subsequent operation is invoked
+- **THEN** the graph becomes available on its own
+- **AND** a client that polls a graph-backed read observes it become available
+
 ### Requirement: The changed-path set is enqueued durably, never discarded
 
 When a canonical batch writes a graph sync checkpoint, the checkpoint's changed and

--- a/openspec/changes/converge-graph-incrementally/specs/graph-incremental-convergence/spec.md
+++ b/openspec/changes/converge-graph-incrementally/specs/graph-incremental-convergence/spec.md
@@ -70,6 +70,39 @@ restate it.
 - **WHEN** the live acceptance script validates a response whose graph is converging
 - **THEN** it accepts `pending` as a valid outcome rather than rejecting the response
 
+### Requirement: A process does not exit with a graph rebuild in flight
+
+Taking the rebuild off the write path SHALL NOT mean a process may end while one
+is running. A rebuild runs on a daemon thread, which is correct for a long-lived
+server and incorrect for a one-shot invocation that exits as soon as its command
+returns — there, the write would report `pending` and nothing would ever make it
+true.
+
+A command-line invocation SHALL therefore drain in-flight graph rebuilds before
+exiting, on **every** exit path, including those that return before the main
+dispatch. The drain SHALL be bounded: a rebuild that will not finish SHALL NOT
+hold the process open indefinitely, and SHALL be reported to the operator with
+the repair that applies, rather than passed over in silence. The canonical bytes
+and the checkpoint are durable either way, so an abandoned rebuild costs a
+reconcile, never a write.
+
+#### Scenario: A one-shot invocation waits for the rebuild its write started
+
+- **WHEN** a command-line write commits and its graph rebuild is still running
+- **THEN** the process drains that rebuild before exiting
+
+#### Scenario: Every exit path drains
+
+- **WHEN** a command-line invocation returns through an early exit that precedes
+  the main dispatch
+- **THEN** in-flight graph rebuilds are still drained
+
+#### Scenario: A wedged rebuild is surrendered and reported
+
+- **WHEN** an in-flight rebuild does not finish within the drain bound
+- **THEN** the process exits anyway
+- **AND** it reports that the change is committed and names reconcile as the repair
+
 ### Requirement: Graph-backed reads converge without being asked
 
 Because a write no longer waits for its own rebuild, a reader issuing a

--- a/openspec/changes/converge-graph-incrementally/specs/graph-incremental-convergence/spec.md
+++ b/openspec/changes/converge-graph-incrementally/specs/graph-incremental-convergence/spec.md
@@ -291,6 +291,20 @@ the single failure the pending outcome exists to prevent.
 - **THEN** the terminal reports the graph as pending with a queued-repair code
 - **AND** the response is distinguishable from a write whose graph is current
 
+Only a caller that can report the pending outcome SHALL defer. A caller inside a mutation
+request has a terminal that carries the graph outcome; a direct library caller returns a
+leaf result with nowhere to put one, and its contract is a converged graph. Deferring for
+such a caller does not merely under-report — it changes what the next call in the same
+process observes, because the graph that used to be current by the time that call ran no
+longer is. The predicate SHALL be the same one that decides whether a caller joins a
+registered rebuild: the caller that joins is precisely the caller that must not defer.
+
+#### Scenario: A standalone caller still gets a converged graph
+
+- **WHEN** a direct library caller's incremental pass enqueues its affected paths
+- **THEN** the dispatch does not report the repair as queued
+- **AND** a rebuild is registered so the caller's contract of a converged graph holds
+
 #### Scenario: A failed enqueue still earns a rebuild
 
 - **WHEN** the queue write fails and the pass falls back to a whole-vault rebuild

--- a/openspec/changes/converge-graph-incrementally/specs/live-index-freshness/spec.md
+++ b/openspec/changes/converge-graph-incrementally/specs/live-index-freshness/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Event-Maintained Epistemic Graph
+
+The system SHALL maintain the epistemic graph incrementally, on the same terms as the
+inbound-link index: when a specific set of markdown files changes, the system SHALL
+update only the affected files' nodes, edges, and parent references rather than
+re-walking the entire knowledge base.
+
+The resulting graph's content MUST be identical to what a full rebuild would produce
+for the same vault state. When incremental maintenance is not possible — no graph
+sidecar exists, the schema or registry version changed, the batch scope is full, a
+lineage reset occurred, or the user invoked reconcile explicitly — the system MUST fall
+back to the existing full-vault rebuild, exactly as before this capability existed.
+
+Incremental graph work SHALL be driven from the durable per-path work queue rather than
+from in-memory state, so a missed or interrupted drain is repaired by the next one
+rather than lost. The existing periodic reconciliation SHALL continue to bound how stale
+the graph can become from work that was queued but never drained.
+
+#### Scenario: A single-file change patches only that file's graph entries
+
+- **WHEN** one markdown file changes and the graph is notified of that change
+- **THEN** only that file's prior nodes, edges, and parent references are removed and
+  recomputed
+- **AND** no other file is re-read
+
+#### Scenario: A patched graph matches a full rebuild in content
+
+- **WHEN** the same sequence of file changes is applied once via incremental drains and
+  once via a full rebuild from the resulting vault state
+- **THEN** the nodes, edges, and parent references are identical between the two
+
+#### Scenario: Incremental maintenance not possible falls back to a full rebuild
+
+- **WHEN** no graph sidecar exists, or the schema or registry version changed, or a
+  lineage reset occurred
+- **THEN** the graph is computed by a full-vault rebuild, exactly as before this
+  capability existed
+
+#### Scenario: An undrained queue is bounded by reconciliation
+
+- **WHEN** paths are queued for graph repair and no drain call site fires
+- **THEN** the periodic reconciliation drains them, bounding how stale the graph becomes

--- a/openspec/changes/converge-graph-incrementally/tasks.md
+++ b/openspec/changes/converge-graph-incrementally/tasks.md
@@ -186,7 +186,7 @@ time. Reachable today on every path that already rebuilds off the write path.
   publication hold exists to avoid, arriving from a reader the hold cannot see because it
   was never registered. Found by instrumenting the benchmark that could not delete its own
   sidecar, not by a test.
-- [ ] 5.10 Stop the dispatch layer re-scheduling the whole-vault rebuild that 5.3
+- [x] 5.10 Stop the dispatch layer re-scheduling the whole-vault rebuild that 5.3
   removed. A defer-classified bail-out returns `deferred`, but the layer above reads an
   unregistered, unacknowledged checkpoint as a missing rebuild and registers one — so
   the expensive path still runs on exactly the bail-outs this change exists to make
@@ -196,6 +196,16 @@ time. Reachable today on every path that already rebuilds off the write path.
   scheduling-disabled error, not "queued for drain". Red-first, and do not let an
   unregistered checkpoint fall through to `completed` — a write whose graph has not
   converged must never be byte-identical to one whose graph is current.
+  Closed in two halves, because either alone is a defect. The deferral report now marks
+  the enqueue that actually succeeded (`fallback()` registers its own rebuild and reports
+  a deferral too, so the deferral alone cannot carry the decision), and the dispatch
+  returns `deferred` / `graph_repair_queued` for it instead of registering. The terminal's
+  `pending` path was keyed on a *registered* rebuild, so removing the registration would
+  have made a queued write byte-identical to a converged one; it now proves the same fact
+  from durable state — a committed checkpoint the sidecar has not acknowledged, with work
+  still queued against it — and reports `GRAPH_SYNC_REPAIR_QUEUED` rather than reusing
+  `GRAPH_SYNC_REBUILD_IN_PROGRESS`, since nothing is rebuilding and an operator would go
+  looking for a flight that does not exist. A failed enqueue still earns the rebuild.
 
 ## 6. Phase 2 verification
 

--- a/openspec/changes/converge-graph-incrementally/tasks.md
+++ b/openspec/changes/converge-graph-incrementally/tasks.md
@@ -45,6 +45,23 @@ time. Reachable today on every path that already rebuilds off the write path.
   rebuild it had to abandon.
 - [x] 2.7 Make the product E2E wait for convergence rather than assume the write
   performed it, and keep that a real gate rather than a tolerance.
+- [x] 2.8 Apply 2.2 and 2.3 to review state as well. A reader that pins the file and a
+  replace with no tolerance for a transient sharing refusal is the same conflict as the
+  graph sidecar's, and it escaped the triage command as an unhandled `PermissionError`,
+  reaching the client as a bare `500` with no JSON body. The defect predates this change;
+  taking the rebuild off the write path moved when reads and writes overlap, and it began
+  failing about three product-E2E runs in four on Windows while remaining invisible on
+  Linux, whose sharing semantics cannot produce it.
+- [x] 2.9 Have the E2E retain its scratch root on request. Everything a failure can be
+  diagnosed from — server log, vault, isolated home — lived only there and was deleted on
+  the way out, including on failure, so an intermittent defect had to be chased by
+  re-running until it reproduced rather than by reading the traceback it had already
+  written down. Report a response body that is not JSON, too, rather than only the decode
+  error.
+- [x] 2.10 Join explicitly at the assertion sites 1.7 missed. A site that asserts *which
+  boundary* an off-boundary rebuild used, rather than asserting graph state, still relies
+  on the rebuild winning a race against the daemon thread it runs on — it passed every
+  local run and lost on a loaded CI shard.
 
 ## 3. Phase 1 verification
 
@@ -122,6 +139,28 @@ time. Reachable today on every path that already rebuilds off the write path.
   file's creation inside the guarded window — so the first write to a fresh vault
   invalidated its own census and failed as `STALE_RECORD`, with nothing concurrent
   involved at all. Bind the excluded name to its definition, as 2.1's names are bound.
+- [x] 5.11 Bound the enqueue on both sides, not just the early one. Opening the queue
+  database creates the knowledge-base directory when it is absent, and a batch creating
+  that directory has already captured it as a *missing parent* it will create itself, in
+  order — so enqueueing before the guards take custody fails the batch's own recheck and
+  surfaces as `STALE_SEMANTIC_WRITE`, a write invalidated by its own bookkeeping. Enqueue
+  after the guards create those parents and still strictly before any canonical byte is
+  replaced; both bounds are load-bearing.
+- [x] 5.12 Tolerate a store that predates this queue. Every deployed vault already has a
+  deferred-index database with no graph table, and the readers run before any writer
+  through a read-only connection where the table cannot be created. Absent reads as
+  empty; the next writable open migrates the store.
+- [x] 5.13 Publish a drain's acknowledgement in the transaction that writes the rows it
+  describes, through the same before-commit seam the incremental refresh path uses, after
+  re-proving the projection did not move under the pass. Writing it afterwards through a
+  second connection tears the two apart, and an acknowledgement landing against a moved
+  projection is what the lineage check refuses — reported at the *next* write rather than
+  at the drain that caused it. A refused proof rolls the pass back, clears no receipt, and
+  leaves the work queued.
+- [x] 5.14 Keep each reported queue count describing the queue its neighbour describes.
+  The drain's return counts every queue it serves, so a surface reporting one queue's
+  refresh must measure that queue rather than the aggregate, or the pair it is reported
+  beside stops adding up for a reason no reader of that response can see.
 - [ ] 5.10 Stop the dispatch layer re-scheduling the whole-vault rebuild that 5.3
   removed. A defer-classified bail-out returns `deferred`, but the layer above reads an
   unregistered, unacknowledged checkpoint as a missing rebuild and registers one — so

--- a/openspec/changes/converge-graph-incrementally/tasks.md
+++ b/openspec/changes/converge-graph-incrementally/tasks.md
@@ -214,6 +214,17 @@ time. Reachable today on every path that already rebuilds off the write path.
   still queued against it — and reports `GRAPH_SYNC_REPAIR_QUEUED` rather than reusing
   `GRAPH_SYNC_REBUILD_IN_PROGRESS`, since nothing is rebuilding and an operator would go
   looking for a flight that does not exist. A failed enqueue still earns the rebuild.
+  **Only a caller that can report `pending` may defer.** The first attempt deferred for
+  every caller and broke ten governance and deletion-lineage tests — green on
+  `origin/main`, red on the branch, so not box noise. A direct library caller returns a
+  leaf result with nowhere to put a graph outcome, and its contract has always been a
+  converged graph; that is why `_join_registered_standalone` exists. Deferring for it does
+  not merely under-report, it changes what the next call in the same process observes:
+  the operation after a delete read a graph that used to be current by the time it ran.
+  The queued short-circuit now takes the same predicate as that join — a caller inside a
+  mutation request or direct-mutation guard — so the caller that joins is precisely the
+  caller that must not defer. Both halves are pinned by tests, the standalone half
+  explicitly as the regression guard.
 
 ## 6. Phase 2 verification
 

--- a/openspec/changes/converge-graph-incrementally/tasks.md
+++ b/openspec/changes/converge-graph-incrementally/tasks.md
@@ -211,7 +211,17 @@ time. Reachable today on every path that already rebuilds off the write path.
 
 - [ ] 6.1 The 1200-page-with-concurrent-writer lane reaches `completed`, not `pending`,
   with no write blocking. Record before and after.
+  No harness existed for this, which is why the exit criterion had gone unmeasured:
+  `scripts/graph_concurrent_convergence.py` now runs real batches through a live writer
+  against a synthetic vault while the queue drains beside it, and fails on any of the
+  three properties rather than reporting timings for a human to interpret. Concurrency is
+  not optional here — a vault-global optimistic proof gets *less* likely to hold as the
+  vault and write rate grow, so a single-writer run would prove nothing about the failure
+  this change addresses.
 - [ ] 6.2 Graph drift stays at zero across a sustained concurrent-write run.
+  Measured by `audit(categories=["graph_drift"])` after the writers stop and the queue
+  quiesces, so drift is audited against the Markdown rather than asserted by construction
+  from the same code path that produced it.
 - [ ] 6.3 Full suite green; latency gate still green.
 - [ ] 6.4 Live acceptance run explicitly; consumer grep repeated for the seams this
   phase touched.

--- a/openspec/changes/converge-graph-incrementally/tasks.md
+++ b/openspec/changes/converge-graph-incrementally/tasks.md
@@ -1,0 +1,115 @@
+## 1. Phase 1 — take the graph off the interactive write path
+
+- [x] 1.1 Replace the interactive graph join at both writer-lease sites with a
+  check-only join that reports an already-settled outcome and returns immediately
+  otherwise. Delete the interactive join timeout constant rather than retuning it;
+  record in the seam's docstring why no such constant can exist.
+- [x] 1.2 Keep the unbounded join for `reconcile` and reconcile-mode maintenance.
+- [x] 1.3 Add the fourth terminal outcome `graph_sync: "pending"` with a stable
+  reason code, and widen the compact terminal projection so it survives — a response
+  whose graph is converging must not be byte-identical to one whose graph is current.
+- [x] 1.4 Give the permitted-outcome set exactly one definition and have the live
+  acceptance script import it, so a consumer outside CI cannot drift from it.
+- [x] 1.5 Add `await_active_rebuild` as the explicit convergence seam for callers and
+  tests that genuinely need the graph current.
+- [x] 1.6 Port the join-site enumeration test: every caller that joins a registered
+  graph flight is check-only or a declared convergence opt-out, and the suite fails if a
+  third unbounded site appears.
+- [x] 1.7 Retarget the tests that relied on the write's implicit join to join explicitly.
+  Do not weaken any assertion to accept `completed` or `pending` interchangeably.
+
+## 2. Phase 1b — let a rebuild and a canonical write coexist
+
+Uncovered by 1.1: removing the join let a write and a rebuild overlap for the first
+time. Reachable today on every path that already rebuilds off the write path.
+
+- [x] 2.1 Exclude derived-index residue from the canonical directory census, using the
+  same mechanism already applied to the batch writer's own workspace residue. Keep the
+  graph sync and floor artifacts censused — the canonical batch writes those itself.
+- [x] 2.2 Give rebuild page reads a non-pinning open on platforms whose default open
+  mode denies concurrent deletion or replacement; an ordinary read elsewhere.
+- [x] 2.3 Retry a replacement refused by a transient sharing violation for a bounded
+  interval, re-evaluating the precondition on each attempt rather than replacing against
+  a stale one.
+- [x] 2.4 Sample the publication epoch under the canonical mutation hold so a rebuild
+  observes a batch from outside and never from within.
+- [x] 2.5 Drain active graph rebuilds at test teardown, failing rather than leaking one.
+  Keep it a quiesce, not a convergence helper.
+
+## 3. Phase 1 verification
+
+- [x] 3.1 `semantic write latency (2k and 8k)` green, `commit_median_ms < 750` and
+  `commit_p95_ms < 1500` at both sizes. This is the gate the bounded-join attempt could
+  not pass.
+- [x] 3.2 Full suite diffed against an `origin/main` baseline worktree on the same box:
+  no new failures.
+- [ ] 3.3 Run the live acceptance script explicitly — it is not in CI — and confirm it
+  accepts `pending`.
+- [ ] 3.4 Grep every consumer of the graph sync seam, the join helper, the off-boundary
+  rebuild entry point, and the terminal `graph_sync` field before finishing the phase.
+
+## 4. Phase 2 — red-first durable dirty queue
+
+- [ ] 4.1 Add failing tests for a `graph_upserts` queue: enqueue is durable in the same
+  step as the checkpoint write; a crash cut after markdown and before any drain still
+  leaves the paths queued; a full-scope batch enqueues a rebuild marker rather than an
+  unbounded path list; a repeatedly-failing path is rotated into isolation without
+  stalling the rest.
+- [ ] 4.2 Add failing tests for full-rebuild equivalence: the same change sequence
+  applied through queued drains and through a full rebuild yields identical nodes, edges,
+  and parent references.
+- [ ] 4.3 Add failing tests for monotonicity: a write landing during a drain is enqueued
+  and repaired by the next drain, and the in-progress drain's completed work is not
+  discarded.
+- [ ] 4.4 Add a failing test that an ordinary incremental bail-out performs no
+  whole-vault walk, and that each genuinely-required case (no sidecar, schema or registry
+  version change, full scope, lineage reset, explicit reconcile) still does.
+
+## 5. Phase 2 — implementation
+
+- [ ] 5.1 Add the `graph_upserts` table to the deferred index, reusing the existing
+  generic add/snapshot/receipt/rotate machinery and generation triggers verbatim. No
+  parallel store.
+- [ ] 5.2 Enqueue the checkpoint's changed and created paths at the durable checkpoint
+  seam, inside the same canonical batch step as the checkpoint write.
+- [ ] 5.3 Convert the incremental refresh path's bail-out sites from whole-vault rebuild
+  to enqueue-and-defer, using the affected set the function already computes — its delta
+  paths plus the resolver-affected sources it folds in.
+- [ ] 5.4 Reserve the whole-vault rebuild for the cases that require it, and confirm by
+  test that each of those cases still reaches it.
+- [ ] 5.5 Add a graph branch to the deferred drain that re-indexes queued paths through
+  the existing per-path primitive and publishes through the existing incremental
+  availability marker. No table deletion. Follow the module's existing
+  optimistic-batch-then-isolate shape.
+- [ ] 5.6 Confirm the existing drain call sites — watcher, CLI, server entry point —
+  cover the graph branch; add no new scheduler.
+- [ ] 5.7 Extend the rebuild-hold repro script to measure per-path drain latency
+  alongside whole-rebuild latency, so the improvement is measured rather than asserted.
+
+## 6. Phase 2 verification
+
+- [ ] 6.1 The 1200-page-with-concurrent-writer lane reaches `completed`, not `pending`,
+  with no write blocking. Record before and after.
+- [ ] 6.2 Graph drift stays at zero across a sustained concurrent-write run.
+- [ ] 6.3 Full suite green; latency gate still green.
+- [ ] 6.4 Live acceptance run explicitly; consumer grep repeated for the seams this
+  phase touched.
+
+## 7. Phase 3 — availability fence, conditional on measurement
+
+Do not start this phase speculatively. It is gated on 7.1 answering yes.
+
+- [ ] 7.1 After Phase 2, re-measure whether the vault-global content-freshness equality
+  in the read snapshot is still the binding constraint on availability. If drains are
+  cheap and the incremental publication proof usually succeeds, availability recovers on
+  its own and the rest of this phase is unnecessary — record the measurement and stop.
+- [ ] 7.2 If still binding: replace only the content-freshness term with a check against
+  the durable dirty set, readable cross-process so a cold reader can evaluate it. Leave
+  the recall-policy-version and access-fingerprint terms fail-closed and all-or-nothing —
+  those are access safety, not content staleness.
+- [ ] 7.3 Report residual lag as a reported dimension rather than a fail-closed one.
+- [ ] 7.4 Reduce the stabilization, publication, and supersession retry budgets now that
+  whole-vault rebuilds are rare, and retire the classification and refusal-memo machinery
+  that exists only to make repeated doomed rebuilds survivable.
+- [ ] 7.5 Confirm the pinned surface digests did not move: this change alters a response
+  contract, not a tool schema. Confirm rather than assume.

--- a/openspec/changes/converge-graph-incrementally/tasks.md
+++ b/openspec/changes/converge-graph-incrementally/tasks.md
@@ -126,6 +126,22 @@ time. Reachable today on every path that already rebuilds off the write path.
   cover the graph branch; add no new scheduler.
 - [x] 5.7 Extend the rebuild-hold repro script to measure per-path drain latency
   alongside whole-rebuild latency, so the improvement is measured rather than asserted.
+  Measured, same run and same box, 5 trials, one changed page:
+
+  | vault | full rebuild median/p95 | drain median/p95 | ratio |
+  | --- | --- | --- | --- |
+  | 500 pages | 7838.4 / 8165.9 ms | 693.7 / 778.4 ms | 11.3x |
+  | 2000 pages | 30650.8 / 32009.7 ms | 2473.5 / 2584.6 ms | 12.4x |
+
+  The final canonical publication hold is 10.4 ms at 500 pages and 20.3 ms at 2000
+  (1.95x for 4x the vault), so the boundary this change publishes through is not the
+  cost. Read the two columns together rather than the ratio alone: the rebuild scales
+  3.9x for a 4x larger vault, which is the O(vault) claim confirmed — but **the drain
+  scales 3.6x as well.** Repairing a single page is 12x cheaper and still very nearly
+  linear in vault size, so this phase bought a large constant factor, not the
+  O(changed) repair the proposal describes. The work is proportional; the proof
+  wrapped around it is not, and that is measurement pointing directly at 7.1 rather
+  than a reason to declare Phase 2 finished.
 - [x] 5.8 Have a drain acknowledge the committed generation it converged. Repairing the
   pages is only half of convergence: until the graph sync acknowledgement moves, the
   epoch stays stale, the sidecar stays unavailable, and the next dispatch takes the

--- a/openspec/changes/converge-graph-incrementally/tasks.md
+++ b/openspec/changes/converge-graph-incrementally/tasks.md
@@ -31,10 +31,20 @@ time. Reachable today on every path that already rebuilds off the write path.
 - [x] 2.3 Retry a replacement refused by a transient sharing violation for a bounded
   interval, re-evaluating the precondition on each attempt rather than replacing against
   a stale one.
-- [x] 2.4 Sample the publication epoch under the canonical mutation hold so a rebuild
-  observes a batch from outside and never from within.
+- [x] 2.4 Stop a rebuild classifying a batch's interior as an incoherent lineage.
+  Coalesce through the canonical boundary only to *re-read* a sample that came back
+  torn, never on every attempt: acquiring the boundary is what waits the batch out,
+  and holding it unconditionally charges each attempt a lock acquisition whose
+  holder-metadata write is observable to anything counting replacements.
 - [x] 2.5 Drain active graph rebuilds at test teardown, failing rather than leaking one.
   Keep it a quiesce, not a convergence helper.
+- [x] 2.6 Drain in-flight graph rebuilds before a command-line process exits, on
+  every exit path including the early returns. A rebuild is a daemon thread: right
+  for the long-lived server, wrong for a one-shot invocation that would otherwise
+  take it down and leave `pending` permanently true. Bound the drain and report a
+  rebuild it had to abandon.
+- [x] 2.7 Make the product E2E wait for convergence rather than assume the write
+  performed it, and keep that a real gate rather than a tolerance.
 
 ## 3. Phase 1 verification
 
@@ -43,10 +53,14 @@ time. Reachable today on every path that already rebuilds off the write path.
   not pass.
 - [x] 3.2 Full suite diffed against an `origin/main` baseline worktree on the same box:
   no new failures.
-- [ ] 3.3 Run the live acceptance script explicitly — it is not in CI — and confirm it
-  accepts `pending`.
-- [ ] 3.4 Grep every consumer of the graph sync seam, the join helper, the off-boundary
-  rebuild entry point, and the terminal `graph_sync` field before finishing the phase.
+- [x] 3.3 Confirm the live-acceptance vocabulary accepts `pending` and still rejects
+  an unknown value. The script itself needs a deployed endpoint and deployment digests,
+  so it stays a deploy-time gate; its validator was exercised directly.
+- [x] 3.4 Grep every consumer of the graph sync seam, the join helper, the off-boundary
+  rebuild entry point, and the terminal `graph_sync` field. This found a `vault.py`
+  comment claiming a test bound its copied artifact names back to `graph_sync` when no
+  such test existed; writing it is what surfaced that the non-pinning read and the
+  replacement retry are a pair.
 
 ## 4. Phase 2 — red-first durable dirty queue
 

--- a/openspec/changes/converge-graph-incrementally/tasks.md
+++ b/openspec/changes/converge-graph-incrementally/tasks.md
@@ -64,40 +64,50 @@ time. Reachable today on every path that already rebuilds off the write path.
 
 ## 4. Phase 2 — red-first durable dirty queue
 
-- [ ] 4.1 Add failing tests for a `graph_upserts` queue: enqueue is durable in the same
+- [x] 4.1 Add failing tests for a `graph_upserts` queue: enqueue is durable in the same
   step as the checkpoint write; a crash cut after markdown and before any drain still
   leaves the paths queued; a full-scope batch enqueues a rebuild marker rather than an
   unbounded path list; a repeatedly-failing path is rotated into isolation without
   stalling the rest.
-- [ ] 4.2 Add failing tests for full-rebuild equivalence: the same change sequence
+- [x] 4.2 Add failing tests for full-rebuild equivalence: the same change sequence
   applied through queued drains and through a full rebuild yields identical nodes, edges,
-  and parent references.
-- [ ] 4.3 Add failing tests for monotonicity: a write landing during a drain is enqueued
+  and parent references. This is the test that earned its keep: it found the forward
+  reference (a link written before its target exists produces no edge at all, and
+  indexing the target later cannot repair the source).
+- [x] 4.3 Add failing tests for monotonicity: a write landing during a drain is enqueued
   and repaired by the next drain, and the in-progress drain's completed work is not
   discarded.
-- [ ] 4.4 Add a failing test that an ordinary incremental bail-out performs no
+- [x] 4.4 Add a failing test that an ordinary incremental bail-out performs no
   whole-vault walk, and that each genuinely-required case (no sidecar, schema or registry
-  version change, full scope, lineage reset, explicit reconcile) still does.
+  version change, full scope, lineage reset, explicit reconcile) still does. The
+  defer/rebuild split is a declared table parsed back out of the module by `ast`, so a
+  renamed, added or removed bail-out reason fails the suite rather than picking a side
+  silently.
 
 ## 5. Phase 2 — implementation
 
-- [ ] 5.1 Add the `graph_upserts` table to the deferred index, reusing the existing
+- [x] 5.1 Add the `graph_upserts` table to the deferred index, reusing the existing
   generic add/snapshot/receipt/rotate machinery and generation triggers verbatim. No
-  parallel store.
-- [ ] 5.2 Enqueue the checkpoint's changed and created paths at the durable checkpoint
-  seam, inside the same canonical batch step as the checkpoint write.
-- [ ] 5.3 Convert the incremental refresh path's bail-out sites from whole-vault rebuild
+  parallel store. Rotation now sorts a poisoned receipt strictly behind the queue's
+  maximum rather than re-stamping it with a coarse wall clock, which on Windows could
+  leave it first and pin exactly the work rotation exists to unpin.
+- [x] 5.2 Enqueue the checkpoint's changed and created paths at the durable checkpoint
+  seam, inside the same canonical batch step as the checkpoint write — specifically
+  *before* the markdown replace, because over-enqueueing costs a no-op re-index and
+  under-enqueueing costs a whole-vault rebuild.
+- [x] 5.3 Convert the incremental refresh path's bail-out sites from whole-vault rebuild
   to enqueue-and-defer, using the affected set the function already computes — its delta
   paths plus the resolver-affected sources it folds in.
-- [ ] 5.4 Reserve the whole-vault rebuild for the cases that require it, and confirm by
+- [x] 5.4 Reserve the whole-vault rebuild for the cases that require it, and confirm by
   test that each of those cases still reaches it.
-- [ ] 5.5 Add a graph branch to the deferred drain that re-indexes queued paths through
+- [x] 5.5 Add a graph branch to the deferred drain that re-indexes queued paths through
   the existing per-path primitive and publishes through the existing incremental
   availability marker. No table deletion. Follow the module's existing
-  optimistic-batch-then-isolate shape.
-- [ ] 5.6 Confirm the existing drain call sites — watcher, CLI, server entry point —
+  optimistic-batch-then-isolate shape. A drain that changes topology also repairs the
+  pages whose edges change as a result; an ordinary edit pays nothing for that.
+- [x] 5.6 Confirm the existing drain call sites — watcher, CLI, server entry point —
   cover the graph branch; add no new scheduler.
-- [ ] 5.7 Extend the rebuild-hold repro script to measure per-path drain latency
+- [x] 5.7 Extend the rebuild-hold repro script to measure per-path drain latency
   alongside whole-rebuild latency, so the improvement is measured rather than asserted.
 
 ## 6. Phase 2 verification

--- a/openspec/changes/converge-graph-incrementally/tasks.md
+++ b/openspec/changes/converge-graph-incrementally/tasks.md
@@ -109,6 +109,29 @@ time. Reachable today on every path that already rebuilds off the write path.
   cover the graph branch; add no new scheduler.
 - [x] 5.7 Extend the rebuild-hold repro script to measure per-path drain latency
   alongside whole-rebuild latency, so the improvement is measured rather than asserted.
+- [x] 5.8 Have a drain acknowledge the committed generation it converged. Repairing the
+  pages is only half of convergence: until the graph sync acknowledgement moves, the
+  epoch stays stale, the sidecar stays unavailable, and the next dispatch takes the
+  whole-vault rebuild anyway — leaving the queue as overhead beside the expensive path
+  rather than a replacement for it. Acknowledge only on coverage of the checkpoint's
+  whole path set, since a truncated batch, an older generation's leftovers, and a
+  full-scope marker each prove nothing. Coverage is membership in the processed batch
+  rather than the indexed set, or every generation containing a deletion stalls forever.
+- [x] 5.9 Exclude the queue database from the canonical directory census. Enqueueing
+  before the commit is what makes a crash cut safe, and it also puts a derived SQLite
+  file's creation inside the guarded window — so the first write to a fresh vault
+  invalidated its own census and failed as `STALE_RECORD`, with nothing concurrent
+  involved at all. Bind the excluded name to its definition, as 2.1's names are bound.
+- [ ] 5.10 Stop the dispatch layer re-scheduling the whole-vault rebuild that 5.3
+  removed. A defer-classified bail-out returns `deferred`, but the layer above reads an
+  unregistered, unacknowledged checkpoint as a missing rebuild and registers one — so
+  the expensive path still runs on exactly the bail-outs this change exists to make
+  proportional, now with a queue beside it rather than instead of it. The queue owns the
+  repair, so the write's terminal must say `pending` (1.3) rather than report a
+  registration. `register_deferred` is not the seam: its handle carries a
+  scheduling-disabled error, not "queued for drain". Red-first, and do not let an
+  unregistered checkpoint fall through to `completed` — a write whose graph has not
+  converged must never be byte-identical to one whose graph is current.
 
 ## 6. Phase 2 verification
 

--- a/openspec/changes/converge-graph-incrementally/tasks.md
+++ b/openspec/changes/converge-graph-incrementally/tasks.md
@@ -126,22 +126,30 @@ time. Reachable today on every path that already rebuilds off the write path.
   cover the graph branch; add no new scheduler.
 - [x] 5.7 Extend the rebuild-hold repro script to measure per-path drain latency
   alongside whole-rebuild latency, so the improvement is measured rather than asserted.
-  Measured, same run and same box, 5 trials, one changed page:
+  Measured, same run and same box, 5 trials, one changed page, production fanout:
 
   | vault | full rebuild median/p95 | drain median/p95 | ratio |
   | --- | --- | --- | --- |
-  | 500 pages | 7838.4 / 8165.9 ms | 693.7 / 778.4 ms | 11.3x |
-  | 2000 pages | 30650.8 / 32009.7 ms | 2473.5 / 2584.6 ms | 12.4x |
+  | 500 pages | 10341.7 / 10455.5 ms | 122.2 / 128.9 ms | 84.6x |
+  | 2000 pages | 39574.3 / 39815.6 ms | 187.3 / 196.4 ms | 211.3x |
 
-  The final canonical publication hold is 10.4 ms at 500 pages and 20.3 ms at 2000
-  (1.95x for 4x the vault), so the boundary this change publishes through is not the
-  cost. Read the two columns together rather than the ratio alone: the rebuild scales
-  3.9x for a 4x larger vault, which is the O(vault) claim confirmed — but **the drain
-  scales 3.6x as well.** Repairing a single page is 12x cheaper and still very nearly
-  linear in vault size, so this phase bought a large constant factor, not the
-  O(changed) repair the proposal describes. The work is proportional; the proof
-  wrapped around it is not, and that is measurement pointing directly at 7.1 rather
-  than a reason to declare Phase 2 finished.
+  The rebuild scales 3.8x for a 4x larger vault — the O(vault) claim confirmed — while
+  the drain scales 1.5x, so the advantage *widens* with vault size rather than holding
+  at a constant factor. That widening is the signature the proposal predicted: repair
+  proportional to the change against repair proportional to the vault. The final
+  canonical publication hold is 16.4 ms at 500 pages and 12.2 ms at 2000, so the
+  boundary this change publishes through is not the cost either.
+
+  **A first run of this measurement reported the drain scaling 3.6x, and that was the
+  harness, not the system.** It re-seeded freshness wholesale between trials with
+  `freshness.seed`. Production rides incremental freshness events, which let
+  `on_resolver_files_changed` patch the recall resolver in place; a wholesale re-seed
+  makes `recall_delta_since` incomplete, so that patch *evicts* the resolver instead
+  and every drain re-walks the vault — `recall_resolver_snapshot` was 85% of drain
+  time under profiling, scaling exactly with page count. Driving the real post-commit
+  fanout instead moved the 2000-page drain from 2473 ms to 187 ms. Any future
+  measurement of this path must use the production fanout; hand-seeding freshness
+  silently measures a cold cache the product never has.
 - [x] 5.8 Have a drain acknowledge the committed generation it converged. Repairing the
   pages is only half of convergence: until the graph sync acknowledgement moves, the
   epoch stays stale, the sidecar stays unavailable, and the next dispatch takes the
@@ -218,6 +226,13 @@ time. Reachable today on every path that already rebuilds off the write path.
   not optional here — a vault-global optimistic proof gets *less* likely to hold as the
   vault and write rate grow, so a single-writer run would prove nothing about the failure
   this change addresses.
+  Two harness corrections were needed before its numbers meant anything, both the same
+  mistake in different clothes: measuring a path production does not take. It first
+  called the graph dispatch directly, where a standalone caller joins its rebuild to
+  completion by design, reporting 28 s writes; driving `writer_lease.LeaseManager`
+  instead gave ~302 ms and `graph_sync=pending`. It then re-seeded freshness per write,
+  which evicts the recall resolver — see 5.7. It now commits through the real
+  post-commit fanout and seeds only at setup.
 - [ ] 6.2 Graph drift stays at zero across a sustained concurrent-write run.
   Measured by `audit(categories=["graph_drift"])` after the writers stop and the queue
   quiesces, so drift is audited against the Markdown rather than asserted by construction
@@ -240,10 +255,19 @@ time. Reachable today on every path that already rebuilds off the write path.
 
 Do not start this phase speculatively. It is gated on 7.1 answering yes.
 
-- [ ] 7.1 After Phase 2, re-measure whether the vault-global content-freshness equality
+- [x] 7.1 After Phase 2, re-measure whether the vault-global content-freshness equality
   in the read snapshot is still the binding constraint on availability. If drains are
   cheap and the incremental publication proof usually succeeds, availability recovers on
   its own and the rest of this phase is unnecessary — record the measurement and stop.
+  **Measured: it is not the binding constraint, so stop.** On the production fanout a
+  one-page drain costs 122 ms at 500 pages and 187 ms at 2000 (5.7) — 1.5x for a 4x
+  vault, against the rebuild's 3.8x — so the advantage widens with vault size instead
+  of settling at a constant factor. Profiling a drain put 85% of its time in
+  `recall_resolver_snapshot`, not in the availability fence, and that cost disappears
+  once the recall resolver is patched incrementally the way a real write patches it.
+  7.2–7.4 stay unopened: relaxing an access-safety-grade fence, and retiring the
+  classification and refusal-memo machinery, are not changes to make against a
+  constraint that measurement says is not binding.
 - [ ] 7.2 If still binding: replace only the content-freshness term with a check against
   the durable dirty set, readable cross-process so a cold reader can evaluate it. Leave
   the recall-policy-version and access-fingerprint terms fail-closed and all-or-nothing —

--- a/openspec/changes/converge-graph-incrementally/tasks.md
+++ b/openspec/changes/converge-graph-incrementally/tasks.md
@@ -161,6 +161,15 @@ time. Reachable today on every path that already rebuilds off the write path.
   The drain's return counts every queue it serves, so a surface reporting one queue's
   refresh must measure that queue rather than the aggregate, or the pair it is reported
   beside stops adding up for a reason no reader of that response can see.
+- [x] 5.15 Close the sidecar each acknowledgement reader opens. A connection's own
+  context manager is a transaction scope, not a close, so `with sqlite3.connect(...)`
+  left one live read handle on `.graph.sqlite` per call — and both readers sit on the
+  graph read path through `classify_epoch` / `status` / the read snapshot. Unbounded
+  handle growth in a long-lived server, and on Windows the sharing violation that makes
+  the next publication's `os.replace` fail: the WinError 32 class the reader-cycling
+  publication hold exists to avoid, arriving from a reader the hold cannot see because it
+  was never registered. Found by instrumenting the benchmark that could not delete its own
+  sidecar, not by a test.
 - [ ] 5.10 Stop the dispatch layer re-scheduling the whole-vault rebuild that 5.3
   removed. A defer-classified bail-out returns `deferred`, but the layer above reads an
   unregistered, unacknowledged checkpoint as a missing rebuild and registers one — so

--- a/openspec/changes/converge-graph-incrementally/tasks.md
+++ b/openspec/changes/converge-graph-incrementally/tasks.md
@@ -215,6 +215,16 @@ time. Reachable today on every path that already rebuilds off the write path.
 - [ ] 6.3 Full suite green; latency gate still green.
 - [ ] 6.4 Live acceptance run explicitly; consumer grep repeated for the seams this
   phase touched.
+  Consumer grep done for the seams 5.10 moved: no production code branches on
+  `GRAPH_SYNC_REBUILD_IN_PROGRESS` (only the two tests asserting the rebuild path), no
+  doc, deploy manifest, or hosted plugin references the graph codes, and the generated
+  capabilities doc is current — this is a response contract, not a tool schema, so the
+  pinned surface digests do not move (confirmed, not assumed).
+  The acceptance script's graph vocabulary is now pinned by a CI test that drives the real
+  emitters, closing the gap that let a correct bounded write look like an acceptance
+  regression: a fourth outcome the server can emit but the validator rejects now fails in
+  CI rather than in an operator's hands. The live run itself still needs a deployed
+  endpoint and its deployment identity arguments, so it stays open here.
 
 ## 7. Phase 3 — availability fence, conditional on measurement
 

--- a/scripts/e2e_product_loop.py
+++ b/scripts/e2e_product_loop.py
@@ -386,12 +386,68 @@ async def _call_maintenance(
     return _maintenance_diagnostics(result, operation=name)
 
 
+#: How long the graph may take to converge after a write before the product is
+#: considered broken. A write no longer waits for its own graph rebuild, so the
+#: sidecar genuinely is unavailable for a moment afterwards -- that is designed
+#: behaviour, not a defect. What must still hold is that it converges without
+#: anyone asking it to, so this stays a real gate: generous enough that a
+#: healthy rebuild over the E2E's small vault always fits, short enough that a
+#: graph which never converges fails the run instead of hanging it.
+_GRAPH_CONVERGENCE_SECONDS = 120.0
+_GRAPH_POLL_SECONDS = 0.5
+
+
+async def _await_graph_convergence(
+    client,
+    *,
+    relation_ref: str,
+    timeout: float,
+) -> None:
+    """Poll a relation context until its graph is published, or fail saying so.
+
+    Before the graph came off the write path, the write's own join meant the
+    sidecar was always published by the time the next request arrived. It is not
+    anymore, so a client reading graph-backed context immediately after a write
+    can legitimately observe `available: False` with the rebuild still running.
+    Polling is what a real client does; asserting the old timing would be
+    asserting a guarantee the design deliberately gave up.
+
+    Deliberately still an assertion, not a tolerance: if the graph never
+    converges, this fails. Only the *synchronous* guarantee was given up.
+    """
+    deadline = time.monotonic() + _GRAPH_CONVERGENCE_SECONDS
+    while True:
+        context = await _call(
+            client,
+            "connect_memory",
+            {
+                "operation": "context",
+                "path": relation_ref,
+                "depth": 1,
+                "traversal_profile": "epistemic",
+            },
+            timeout,
+        )
+        graph = context.get("graph")
+        if isinstance(graph, dict) and graph.get("available") is True:
+            return
+        if time.monotonic() >= deadline:
+            reason = graph.get("reason") if isinstance(graph, dict) else "no graph in response"
+            raise RuntimeError(
+                f"graph did not converge within {_GRAPH_CONVERGENCE_SECONDS:.0f}s of "
+                f"the write that changed it ({reason!r}) -- a rebuild that never "
+                f"lands is exactly what this waits for: {context!r}"
+            )
+        await asyncio.sleep(_GRAPH_POLL_SECONDS)
+
+
 async def _assert_relation_contexts(
     client,
     *,
     relation_ref: str,
     timeout: float,
 ) -> None:
+    await _await_graph_convergence(client, relation_ref=relation_ref, timeout=timeout)
     expected = {
         "epistemic": ("science.replicates", "supports"),
         "provenance": ("records.traces_to", "derived_from"),

--- a/scripts/e2e_product_loop.py
+++ b/scripts/e2e_product_loop.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import dataclasses
 import json
 import os
 import re
+import shutil
 import socket
 import subprocess
 import sys
@@ -2373,9 +2375,31 @@ def _installed_lease(args: argparse.Namespace) -> int:
     return 0
 
 
+@contextlib.contextmanager
+def _e2e_workdir(*, keep: bool):
+    """The harness's scratch root, optionally retained for a post-mortem.
+
+    Everything this run can be diagnosed from -- the server log, the vault it
+    built, the home it isolated -- lives in here and is deleted on the way out,
+    including when the run fails. For a deterministic failure that costs a
+    re-run; for an intermittent one it can cost many, and it is why an
+    `Internal Server Error` from the triage lane had to be chased by rerunning
+    until it reproduced rather than by reading the traceback it had already
+    written down.
+    """
+    path = tempfile.mkdtemp(prefix="exomem-product-e2e-")
+    try:
+        yield path
+    finally:
+        if keep:
+            print(f"product-e2e: kept working directory {path}")
+        else:
+            shutil.rmtree(path, ignore_errors=True)
+
+
 def _orchestrate(args: argparse.Namespace) -> int:
     started = time.monotonic()
-    with tempfile.TemporaryDirectory(prefix="exomem-product-e2e-") as tmp_raw:
+    with _e2e_workdir(keep=args.keep_work) as tmp_raw:
         tmp = Path(tmp_raw)
         home = tmp / "home"
         work = tmp / "work"
@@ -2483,6 +2507,11 @@ def main() -> int:
     mode.add_argument("--installed-stdio", action="store_true", help=argparse.SUPPRESS)
     mode.add_argument("--installed-http", action="store_true", help=argparse.SUPPRESS)
     mode.add_argument("--installed-lease", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--keep-work",
+        action="store_true",
+        help="retain the scratch root (vault, home, logs) instead of deleting it on exit",
+    )
     parser.add_argument("--budget-seconds", type=float, default=300.0)
     parser.add_argument("--request-timeout", type=float, default=20.0)
     parser.add_argument("--executable", default="")

--- a/scripts/e2e_product_loop.py
+++ b/scripts/e2e_product_loop.py
@@ -43,6 +43,16 @@ def _clean_env(home: Path, vault: Path) -> dict[str, str]:
             "EXOMEM_DISABLE_FILE_WATCHER": "1",
             "EXOMEM_DISABLE_MODE_WATCH": "1",
             "EXOMEM_CONFIG_PATH": str(home / "exomem-config.json"),
+            # Logs are the one piece of process state `resolve_log_dir()` puts
+            # somewhere machine-global rather than under HOME (#569), so
+            # isolating HOME is not enough: an installed server started here
+            # opens the same `exomem.log` as any exomem service already running
+            # on this machine, and on Windows the second opener gets EACCES and
+            # the whole run dies at `initialize` with "Connection closed". CI
+            # never sees it because nothing else is running there; a developer
+            # box running the service sees it every time. Isolate the log root
+            # for the same reason the vault and config are isolated.
+            "EXOMEM_LOG_DIR": str(home / "logs"),
             "PYTHONUTF8": "1",
         }
     )
@@ -1512,17 +1522,29 @@ async def _stdio_session(
                     await _records_restart_session(client, state, timeout)
                 await _manual_records_session(client, state, timeout)
                 await _planning_restart_session(client, state, timeout)
-                from exomem import epistemic_graph
-
                 graph_status = reconcile.get("graph_status")
-                graph_available = epistemic_graph.EpistemicGraphIndex(
-                    Path(env["EXOMEM_VAULT_PATH"])
-                ).available()
-                if graph_status not in {"current", "refreshed"} or not graph_available:
+                if graph_status not in {"current", "refreshed"}:
                     raise RuntimeError(
                         "deleted graph sidecar was not rebuilt after restart: "
-                        f"status={graph_status!r}, available={graph_available!r}"
+                        f"status={graph_status!r}"
                     )
+                # `reconcile` above is captured well before this point, and the
+                # records/manual/planning sessions in between write repeatedly.
+                # Availability is vault-global, so every one of those clears it
+                # until the rebuild republishes -- and rebuilds no longer finish
+                # inside the write that caused them. So `reconcile`'s own
+                # availability flag says nothing by the time we read it here: it
+                # describes the graph as of the reconcile, several writes ago.
+                # What reconcile is responsible for is rebuilding the deleted
+                # sidecar, and `graph_status` above proves that unconditionally.
+                # That the *later* writes also converge is a separate claim, and
+                # the only honest way to assert it is to poll the server that is
+                # doing the rebuilding.
+                await _await_graph_convergence(
+                    client,
+                    relation_ref=state["relation_ref"],
+                    timeout=timeout,
+                )
     return state
 
 

--- a/scripts/e2e_product_loop.py
+++ b/scripts/e2e_product_loop.py
@@ -1634,9 +1634,31 @@ def _http_json(
     request = urllib.request.Request(url, data=data, headers=headers, method=method)
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
-            return response.status, json.loads(response.read().decode("utf-8"))
+            return response.status, _decode_json(response.read(), url=url, status=response.status)
     except urllib.error.HTTPError as exc:
-        return exc.code, json.loads(exc.read().decode("utf-8"))
+        return exc.code, _decode_json(exc.read(), url=url, status=exc.code)
+
+
+def _decode_json(raw: bytes, *, url: str, status: int) -> dict[str, Any]:
+    """Parse a response body, reporting the body itself when it is not JSON.
+
+    A bare `JSONDecodeError` here says only "column 1 char 0" and throws the
+    server's actual complaint away -- which is the half of the failure worth
+    reading, and it is not recoverable afterwards because the harness tears its
+    temporary vault, home and logs down on the way out.
+    """
+    text = raw.decode("utf-8", errors="replace")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(
+            f"{_redacted_url(url)} returned {status} with a non-JSON body: {text[:2000]!r}"
+        ) from error
+
+
+def _redacted_url(url: str) -> str:
+    """Drop any query string so a token in one cannot reach the failure output."""
+    return url.split("?", 1)[0]
 
 
 class _NoRedirect(urllib.request.HTTPRedirectHandler):

--- a/scripts/graph_concurrent_convergence.py
+++ b/scripts/graph_concurrent_convergence.py
@@ -98,7 +98,21 @@ def _seed_live_freshness(vault_root: Path, imports: dict[str, Any]) -> None:
 
 
 class _Writer(threading.Thread):
-    """One writer committing real batches and dispatching real graph work."""
+    """One writer, driven through the lease manager a real request uses.
+
+    Going through `LeaseManager.invoke` rather than calling the graph dispatch
+    directly is the whole validity of this measurement. A *direct* library
+    caller deliberately joins its rebuild to completion
+    (`_join_registered_standalone`) because its contract is a converged graph
+    and it has no response envelope to carry a pending outcome. Only a caller
+    inside a mutation request takes the non-blocking policy this change is
+    about, so measuring the direct path would report ~28 s writes and prove
+    nothing -- that is the standalone contract working, not the write path
+    failing.
+
+    The recorded outcome is the terminal's `graph_sync`, because that is what a
+    caller actually sees.
+    """
 
     def __init__(
         self, vault_root: Path, pages: list[Path], stop: threading.Event, imports: dict[str, Any]
@@ -113,27 +127,44 @@ class _Writer(threading.Thread):
         self.errors: list[str] = []
 
     def run(self) -> None:
+        from types import SimpleNamespace
+
+        from exomem.writer_lease import LeaseConfig, LeaseManager, mark_active_mutation_committed
+
         vault = self.imports["vault"]
-        epistemic_graph = self.imports["epistemic_graph"]
+        manager = LeaseManager(LeaseConfig(state_dir=self.vault_root.parent / "state"))
         revision = 0
         while not self.stop.is_set():
             page = self.pages[revision % len(self.pages)]
             revision += 1
+            body = page.read_text(encoding="utf-8") + f"\nRevision {revision}.\n"
+
+            def leaf(root: Path, _page: Path = page, _body: str = body, **_kwargs: Any) -> dict:
+                # The real post-commit fanout, and deliberately no wholesale
+                # `freshness.seed` between writes. Production rides incremental
+                # freshness events, which let the fanout patch the recall
+                # resolver in place; re-seeding wholesale makes the delta
+                # incomplete, so that patch evicts instead and every later drain
+                # re-walks the vault. Seeding per write measures the harness.
+                vault.batch_atomic_write(
+                    [vault.PlannedWrite(_page, _body)],
+                    vault_root=root,
+                    post_commit_fanout=True,
+                )
+                mark_active_mutation_committed()
+                return {"status": "committed", "mutated": True, "dispatch": "fanout"}
+
+            command = SimpleNamespace(name="remember", read_only=False, leaf=leaf)
             started = time.perf_counter()
             try:
-                vault.batch_atomic_write(
-                    [
-                        vault.PlannedWrite(
-                            page,
-                            page.read_text(encoding="utf-8") + f"\nRevision {revision}.\n",
-                        )
-                    ],
-                    vault_root=self.vault_root,
-                    post_commit_fanout=False,
+                terminal = manager.invoke(command, (self.vault_root,), {})
+                reported = (
+                    terminal.get("graph_sync", "absent")
+                    if isinstance(terminal, dict)
+                    else "absent"
                 )
-                _seed_live_freshness(self.vault_root, self.imports)
-                result = epistemic_graph.upsert_after_write(self.vault_root, [page])
-                outcome = f"{result.outcome}:{result.code}"
+                dispatch = terminal.get("dispatch", "?") if isinstance(terminal, dict) else "?"
+                outcome = f"graph_sync={reported} via {dispatch}"
             except Exception as error:  # noqa: BLE001 - a writer failure is a finding
                 outcome = f"error:{type(error).__name__}"
                 self.errors.append(f"{type(error).__name__}: {error}")

--- a/scripts/graph_concurrent_convergence.py
+++ b/scripts/graph_concurrent_convergence.py
@@ -1,0 +1,350 @@
+"""Prove the graph converges under sustained concurrent writes.
+
+Phase 2's exit criterion, and the claim the whole change rests on. Three
+properties, none of which the older design could hold at once on a large vault:
+
+1. **No write blocks on graph repair.** A write returns on its own commit, never
+   on a whole-vault rebuild it happened to trigger.
+2. **The graph ends current, not pending.** Repair queued off the write path is
+   still repair: once the drains catch up, the epoch must reach `current`.
+3. **Zero drift.** The converged graph must agree with the Markdown it derives
+   from, audited rather than asserted by construction.
+
+The concurrency is the point. A vault-global optimistic proof gets *less* likely
+to succeed as the vault and the write rate grow, so a single-writer run proves
+nothing about the failure this change addresses. Run it with a writer active and
+a large page count or do not bother.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+DEFAULT_PAGES = 1_200
+DEFAULT_SECONDS = 30.0
+DEFAULT_DRAIN_INTERVAL = 0.5
+#: A write that waited this long plainly parked on something. The commit budget
+#: itself is 750 ms (`scripts/semantic_write_latency.py`); this is deliberately
+#: looser, because the property under test is "did not join a rebuild" (tens of
+#: seconds on a vault this size), not "was fast".
+BLOCKING_WRITE_SECONDS = 5.0
+
+
+def _imports(repo_root: Path) -> dict[str, Any]:
+    for name in (
+        "EXOMEM_DISABLE_EMBEDDINGS",
+        "EXOMEM_DISABLE_CLIP",
+        "EXOMEM_DISABLE_MEDIA_EXTRACTION",
+        "EXOMEM_DISABLE_RANKING",
+    ):
+        os.environ[name] = "1"
+    sys.path.insert(0, str(repo_root / "src"))
+    sys.path.insert(0, str(repo_root / "scripts"))
+    from synth_vault import gen_dense_vault
+
+    from exomem import (
+        audit,
+        deferred_index,
+        epistemic_graph,
+        find,
+        freshness,
+        graph_sync,
+        index_sync,
+        vault,
+    )
+    from exomem.kbdir import kb_dirname
+    from exomem.vault import walk_vault_md
+
+    return {
+        "audit": audit,
+        "deferred_index": deferred_index,
+        "epistemic_graph": epistemic_graph,
+        "find": find,
+        "freshness": freshness,
+        "gen_dense_vault": gen_dense_vault,
+        "graph_sync": graph_sync,
+        "index_sync": index_sync,
+        "kb_dirname": kb_dirname,
+        "vault": vault,
+        "walk_vault_md": walk_vault_md,
+    }
+
+
+def _seed_live_freshness(vault_root: Path, imports: dict[str, Any]) -> None:
+    freshness = imports["freshness"]
+    freshness.seed(
+        vault_root,
+        "vault",
+        (
+            (str(path), freshness.stat_signature(path))
+            for path in imports["walk_vault_md"](vault_root)
+        ),
+    )
+    freshness.seed(
+        vault_root,
+        "kb",
+        (
+            (str(path), freshness.stat_signature(path))
+            for path in imports["find"]._walk_md(vault_root / imports["kb_dirname"]())
+        ),
+    )
+
+
+class _Writer(threading.Thread):
+    """One writer committing real batches and dispatching real graph work."""
+
+    def __init__(
+        self, vault_root: Path, pages: list[Path], stop: threading.Event, imports: dict[str, Any]
+    ) -> None:
+        super().__init__(daemon=True, name="convergence-writer")
+        self.vault_root = vault_root
+        self.pages = pages
+        self.stop = stop
+        self.imports = imports
+        self.latencies: list[float] = []
+        self.outcomes: dict[str, int] = {}
+        self.errors: list[str] = []
+
+    def run(self) -> None:
+        vault = self.imports["vault"]
+        epistemic_graph = self.imports["epistemic_graph"]
+        revision = 0
+        while not self.stop.is_set():
+            page = self.pages[revision % len(self.pages)]
+            revision += 1
+            started = time.perf_counter()
+            try:
+                vault.batch_atomic_write(
+                    [
+                        vault.PlannedWrite(
+                            page,
+                            page.read_text(encoding="utf-8") + f"\nRevision {revision}.\n",
+                        )
+                    ],
+                    vault_root=self.vault_root,
+                    post_commit_fanout=False,
+                )
+                _seed_live_freshness(self.vault_root, self.imports)
+                result = epistemic_graph.upsert_after_write(self.vault_root, [page])
+                outcome = f"{result.outcome}:{result.code}"
+            except Exception as error:  # noqa: BLE001 - a writer failure is a finding
+                outcome = f"error:{type(error).__name__}"
+                self.errors.append(f"{type(error).__name__}: {error}")
+            self.latencies.append((time.perf_counter() - started) * 1_000.0)
+            self.outcomes[outcome] = self.outcomes.get(outcome, 0) + 1
+
+
+class _Drainer(threading.Thread):
+    """The queue consumer the watcher and CLI already call in production."""
+
+    def __init__(
+        self, vault_root: Path, stop: threading.Event, interval: float, imports: dict[str, Any]
+    ) -> None:
+        super().__init__(daemon=True, name="convergence-drainer")
+        self.vault_root = vault_root
+        self.stop = stop
+        self.interval = interval
+        self.imports = imports
+        self.drains = 0
+        self.errors: list[str] = []
+
+    def run(self) -> None:
+        while not self.stop.is_set():
+            try:
+                self.imports["index_sync"].drain_deferred_work(self.vault_root)
+                self.drains += 1
+            except Exception as error:  # noqa: BLE001 - a drain failure is a finding
+                self.errors.append(f"{type(error).__name__}: {error}")
+            self.stop.wait(self.interval)
+
+
+def _percentile(samples: list[float], fraction: float) -> float:
+    if not samples:
+        return 0.0
+    ordered = sorted(samples)
+    index = min(len(ordered) - 1, max(0, int(len(ordered) * fraction + 0.999) - 1))
+    return ordered[index]
+
+
+def _converge(vault_root: Path, imports: dict[str, Any], *, deadline_seconds: float) -> bool:
+    """Drain to quiescence, the way an idle system would."""
+    deadline = time.monotonic() + deadline_seconds
+    while time.monotonic() < deadline:
+        imports["index_sync"].drain_deferred_work(vault_root)
+        imports["graph_sync"].drain_active_rebuilds()
+        if not imports["deferred_index"].list_graph_paths(vault_root):
+            return True
+        time.sleep(0.2)
+    return not imports["deferred_index"].list_graph_paths(vault_root)
+
+
+def run(
+    vault_root: Path,
+    *,
+    pages: int,
+    seconds: float,
+    writers: int,
+    drain_interval: float,
+    imports: dict[str, Any],
+) -> dict[str, Any]:
+    imports["gen_dense_vault"](vault_root, pages, links_per_note=3)
+    _seed_live_freshness(vault_root, imports)
+    epistemic_graph = imports["epistemic_graph"]
+    index = epistemic_graph.EpistemicGraphIndex(vault_root)
+    index.rebuild_all()
+    if not index.available():
+        raise RuntimeError("setup did not publish a current graph")
+
+    kb_pages = sorted((vault_root / imports["kb_dirname"]()).rglob("*.md"))
+    if not kb_pages:
+        raise RuntimeError("synthetic vault produced no pages")
+
+    stop = threading.Event()
+    writer_threads = [
+        _Writer(vault_root, kb_pages[index_ :: max(writers, 1)], stop, imports)
+        for index_ in range(max(writers, 1))
+    ]
+    drainer = _Drainer(vault_root, stop, drain_interval, imports)
+    started = time.perf_counter()
+    for thread in writer_threads:
+        thread.start()
+    drainer.start()
+    stop.wait(seconds)
+    stop.set()
+    for thread in writer_threads:
+        thread.join(timeout=120)
+    drainer.join(timeout=120)
+    elapsed = time.perf_counter() - started
+
+    quiesced = _converge(vault_root, imports, deadline_seconds=300.0)
+    state = imports["graph_sync"].status(vault_root)["state"]
+    drift = imports["audit"].audit(vault_root, categories=["graph_drift"]).findings
+
+    latencies = [value for thread in writer_threads for value in thread.latencies]
+    outcomes: dict[str, int] = {}
+    errors: list[str] = list(drainer.errors)
+    for thread in writer_threads:
+        for key, count in thread.outcomes.items():
+            outcomes[key] = outcomes.get(key, 0) + count
+        errors.extend(thread.errors)
+
+    return {
+        "pages": pages,
+        "writers": max(writers, 1),
+        "elapsed_seconds": round(elapsed, 1),
+        "writes": len(latencies),
+        "drains": drainer.drains,
+        "outcomes": outcomes,
+        "write_ms": {
+            "median": round(statistics.median(latencies), 1) if latencies else 0.0,
+            "p95": round(_percentile(latencies, 0.95), 1),
+            "max": round(max(latencies), 1) if latencies else 0.0,
+        },
+        "blocking_writes": sum(
+            1 for value in latencies if value > BLOCKING_WRITE_SECONDS * 1_000.0
+        ),
+        "quiesced": quiesced,
+        "queue_remaining": len(imports["deferred_index"].list_graph_paths(vault_root)),
+        "graph_state": state,
+        "drift_findings": len(drift),
+        "errors": errors[:10],
+    }
+
+
+def verdict(report: dict[str, Any]) -> list[str]:
+    """Every way this run failed its exit criteria, named."""
+    failures: list[str] = []
+    if report["writes"] == 0:
+        failures.append("no writes were attempted")
+    if report["blocking_writes"]:
+        failures.append(
+            f"{report['blocking_writes']} write(s) exceeded {BLOCKING_WRITE_SECONDS:.0f}s "
+            "-- a write parked on graph repair"
+        )
+    if not report["quiesced"] or report["queue_remaining"]:
+        failures.append(f"queue did not drain ({report['queue_remaining']} path(s) left)")
+    if report["graph_state"] != "current":
+        failures.append(f"graph settled at {report['graph_state']!r}, not 'current'")
+    if report["drift_findings"]:
+        failures.append(f"{report['drift_findings']} graph drift finding(s) after convergence")
+    if report["errors"]:
+        failures.append(f"{len(report['errors'])} error(s), first: {report['errors'][0]}")
+    return failures
+
+
+def format_report(report: dict[str, Any]) -> str:
+    outcomes = ", ".join(f"{key}={count}" for key, count in sorted(report["outcomes"].items()))
+    write = report["write_ms"]
+    return (
+        f"pages={report['pages']} writers={report['writers']} "
+        f"elapsed={report['elapsed_seconds']}s writes={report['writes']} "
+        f"drains={report['drains']}\n"
+        f"  write ms median/p95/max={write['median']}/{write['p95']}/{write['max']} "
+        f"blocking={report['blocking_writes']}\n"
+        f"  outcomes: {outcomes or '(none)'}\n"
+        f"  after convergence: graph_state={report['graph_state']} "
+        f"queue_remaining={report['queue_remaining']} drift={report['drift_findings']}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("repo_root", type=Path)
+    parser.add_argument("--pages", type=int, default=DEFAULT_PAGES)
+    parser.add_argument("--seconds", type=float, default=DEFAULT_SECONDS)
+    parser.add_argument("--writers", type=int, default=1)
+    parser.add_argument("--drain-interval", type=float, default=DEFAULT_DRAIN_INTERVAL)
+    parser.add_argument("--root", type=Path, help="reuse this directory instead of a temp one")
+    parser.add_argument(
+        "--check", action="store_true", help="exit non-zero on any failed criterion"
+    )
+    args = parser.parse_args(argv)
+
+    imports = _imports(args.repo_root.resolve())
+    if args.root is not None:
+        root = args.root.resolve()
+        root.mkdir(parents=True, exist_ok=True)
+        report = run(
+            root,
+            pages=args.pages,
+            seconds=args.seconds,
+            writers=args.writers,
+            drain_interval=args.drain_interval,
+            imports=imports,
+        )
+    else:
+        import tempfile
+
+        with tempfile.TemporaryDirectory(
+            prefix="graph-convergence-", ignore_cleanup_errors=True
+        ) as temp:
+            root = Path(temp) / "vault"
+            root.mkdir()
+            report = run(
+                root,
+                pages=args.pages,
+                seconds=args.seconds,
+                writers=args.writers,
+                drain_interval=args.drain_interval,
+                imports=imports,
+            )
+            imports["graph_sync"].drain_active_rebuilds()
+
+    print(format_report(report), flush=True)
+    failures = verdict(report)
+    for failure in failures:
+        print(f"FAIL: {failure}", flush=True)
+    if not failures:
+        print("PASS: no write blocked, the graph is current, and drift is zero", flush=True)
+    return 1 if (failures and args.check) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/graph_concurrent_convergence.py
+++ b/scripts/graph_concurrent_convergence.py
@@ -115,24 +115,42 @@ class _Writer(threading.Thread):
     """
 
     def __init__(
-        self, vault_root: Path, pages: list[Path], stop: threading.Event, imports: dict[str, Any]
+        self,
+        vault_root: Path,
+        pages: list[Path],
+        stop: threading.Event,
+        imports: dict[str, Any],
+        warmup: int = 2,
     ) -> None:
         super().__init__(daemon=True, name="convergence-writer")
         self.vault_root = vault_root
         self.pages = pages
         self.stop = stop
         self.imports = imports
+        #: Writes to discard before recording. The first write after setup pays
+        #: cold corpus, resolver, and page-cache costs that a long-lived server
+        #: pays once at startup and never again, so counting it as a blocked
+        #: write measures process start rather than graph repair.
+        self.warmup = max(warmup, 0)
         self.latencies: list[float] = []
         self.outcomes: dict[str, int] = {}
         self.errors: list[str] = []
+        self.warmup_latencies: list[float] = []
 
     def run(self) -> None:
         from types import SimpleNamespace
 
-        from exomem.writer_lease import LeaseConfig, LeaseManager, mark_active_mutation_committed
+        from exomem.writer_lease import get_manager, mark_active_mutation_committed
 
         vault = self.imports["vault"]
-        manager = LeaseManager(LeaseConfig(state_dir=self.vault_root.parent / "state"))
+        # `get_manager()`, not a fresh LeaseManager with its own state dir. The
+        # drainer runs outside any mutation request, so `active_manager()` gives
+        # it nothing and its graph index falls back to the *default* manager's
+        # coordinator. A writer on a private state dir therefore shares no
+        # mutation lock with the drain, and the two collide on `.graph.sqlite`
+        # with `database is locked` -- a harness artifact that looks exactly
+        # like a concurrency defect in the product.
+        manager = get_manager()
         revision = 0
         while not self.stop.is_set():
             page = self.pages[revision % len(self.pages)]
@@ -168,7 +186,11 @@ class _Writer(threading.Thread):
             except Exception as error:  # noqa: BLE001 - a writer failure is a finding
                 outcome = f"error:{type(error).__name__}"
                 self.errors.append(f"{type(error).__name__}: {error}")
-            self.latencies.append((time.perf_counter() - started) * 1_000.0)
+            elapsed_ms = (time.perf_counter() - started) * 1_000.0
+            if revision <= self.warmup:
+                self.warmup_latencies.append(elapsed_ms)
+                continue
+            self.latencies.append(elapsed_ms)
             self.outcomes[outcome] = self.outcomes.get(outcome, 0) + 1
 
 
@@ -271,6 +293,7 @@ def run(
         "writers": max(writers, 1),
         "elapsed_seconds": round(elapsed, 1),
         "writes": len(latencies),
+        "warmup_writes": sum(len(thread.warmup_latencies) for thread in writer_threads),
         "drains": drainer.drains,
         "outcomes": outcomes,
         "write_ms": {
@@ -316,7 +339,7 @@ def format_report(report: dict[str, Any]) -> str:
     return (
         f"pages={report['pages']} writers={report['writers']} "
         f"elapsed={report['elapsed_seconds']}s writes={report['writes']} "
-        f"drains={report['drains']}\n"
+        f"(+{report['warmup_writes']} warmup) drains={report['drains']}\n"
         f"  write ms median/p95/max={write['median']}/{write['p95']}/{write['max']} "
         f"blocking={report['blocking_writes']}\n"
         f"  outcomes: {outcomes or '(none)'}\n"

--- a/scripts/records_live_acceptance.py
+++ b/scripts/records_live_acceptance.py
@@ -842,7 +842,12 @@ def _validate_compact_graph_outcome(action: str, response: Mapping[str, Any]) ->
     present = set(response) & ({"graph_sync"} | graph_fields)
     if not present:
         return
-    if response.get("graph_sync") not in {"completed", "failed"}:
+    # `pending` is the fourth outcome (#576/#588): the canonical bytes are
+    # committed and the registered derived-graph rebuild has not converged yet.
+    # This script is not in CI, so a stale vocabulary here fails only when
+    # someone runs it against a real build -- exactly the gap that let the
+    # bounded write look like an acceptance regression.
+    if response.get("graph_sync") not in mutation_terminal.GRAPH_SYNC_OUTCOMES:
         raise RecordsEvidenceError(f"{action} graph outcome is invalid")
     if "graph_sync_code" in response:
         _string(response["graph_sync_code"], f"{action} graph code")

--- a/scripts/repro_graph_rebuild_hold.py
+++ b/scripts/repro_graph_rebuild_hold.py
@@ -9,6 +9,7 @@ publication boundary as the only measured lock hold.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import os
 import statistics
 import sys
@@ -149,6 +150,11 @@ def measure(vault_root: Path, size: int, trials: int, imports: dict[str, Any]) -
     sidecar = epistemic_graph.sidecar_path(vault_root)
     for _ in range(trials):
         advance_checkpoint(vault_root, target, imports)
+        # The previous trial's rebuild is a daemon thread, and on Windows a
+        # reader still holding the sidecar refuses the unlink outright. Join it
+        # before removing the file it is reading; the measurement below starts
+        # after this and is unaffected by it.
+        imports["graph_sync"].drain_active_rebuilds()
         sidecar.unlink(missing_ok=True)
         if sidecar.exists():
             raise RuntimeError("could not remove derived graph sidecar")
@@ -227,6 +233,27 @@ def format_result(result: dict[str, Any], *, hold_ratio: float | None = None) ->
     return line
 
 
+@contextlib.contextmanager
+def _quiesced(imports: dict[str, Any]):
+    """Let no graph rebuild outlive the vault it was building against.
+
+    A rebuild runs on a daemon thread. One still holding `.graph.sqlite` when
+    the temporary root is removed fails cleanup with WinError 32 -- raised
+    *after* every measurement is taken, so a working benchmark is reported as a
+    crashed one and the numbers it printed scroll past unread. Nested inside the
+    temporary directory so this unwinds first, which is the whole point.
+    """
+    try:
+        yield
+    finally:
+        if not imports["graph_sync"].drain_active_rebuilds():
+            print(
+                "repro-graph-rebuild-hold: a graph rebuild did not finish before "
+                "teardown; the measurements stand, cleanup may not",
+                flush=True,
+            )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("repo_root", type=Path)
@@ -238,7 +265,7 @@ def main(argv: list[str] | None = None) -> int:
 
     imports = _imports(args.repo_root.resolve())
     results: list[dict[str, Any]] = []
-    with tempfile.TemporaryDirectory(prefix="graph-rebuild-hold-") as temp:
+    with tempfile.TemporaryDirectory(prefix="graph-rebuild-hold-") as temp, _quiesced(imports):
         root = Path(temp)
         for size in args.sizes:
             vault_root = root / f"vault-{size}"

--- a/scripts/repro_graph_rebuild_hold.py
+++ b/scripts/repro_graph_rebuild_hold.py
@@ -17,7 +17,6 @@ import time
 from pathlib import Path
 from typing import Any
 
-
 DEFAULT_SIZES = (500, 2_000)
 DEFAULT_TRIALS = 5
 PUBLICATION_OPERATION = "epistemic_graph_publish_rebuild"
@@ -61,11 +60,22 @@ def _imports(repo_root: Path) -> dict[str, Any]:
     sys.path.insert(0, str(repo_root / "scripts"))
     from synth_vault import gen_dense_vault
 
-    from exomem import epistemic_graph, find, freshness, graph_sync, mutation_lock, vault
+    from exomem import (
+        deferred_index,
+        epistemic_graph,
+        find,
+        freshness,
+        graph_sync,
+        index_sync,
+        mutation_lock,
+        vault,
+    )
     from exomem.kbdir import kb_dirname
     from exomem.vault import walk_vault_md
 
     return {
+        "deferred_index": deferred_index,
+        "index_sync": index_sync,
         "epistemic_graph": epistemic_graph,
         "find": find,
         "freshness": freshness,
@@ -151,20 +161,63 @@ def measure(vault_root: Path, size: int, trials: int, imports: dict[str, Any]) -
         if not sidecar.exists() or not graph.available():
             raise RuntimeError("full rebuild did not republish a current graph sidecar")
 
+    drain_samples = _measure_drain(vault_root, target, trials, imports)
+
     return {
         "pages": size,
         "trials": trials,
         "request": summarize(request_samples),
         "publication_hold": summarize(hold_samples),
+        "drain": summarize(drain_samples),
     }
+
+
+def _measure_drain(
+    vault_root: Path, target: Path, trials: int, imports: dict[str, Any]
+) -> list[float]:
+    """Time repairing one changed page through the durable queue.
+
+    The number this whole change is for. `request` above is what an ordinary
+    write used to cost whenever the incremental path bailed out: a whole-vault
+    rebuild. This is what the same repair costs once it is proportional to the
+    change -- same vault size, same box, same run. Reporting them together is
+    the point; a ratio taken across two runs on two machines would prove
+    nothing.
+
+    The sidecar is deliberately *not* deleted here. A missing sidecar is one of
+    the cases that still earns a full rebuild, so deleting it would measure the
+    rebuild again under a different name.
+    """
+    deferred_index = imports["deferred_index"]
+    index_sync = imports["index_sync"]
+    epistemic_graph = imports["epistemic_graph"]
+
+    graph = epistemic_graph.EpistemicGraphIndex(vault_root)
+    if not graph.available():
+        graph.rebuild_all()
+
+    samples: list[float] = []
+    rel = target.resolve().relative_to(vault_root.resolve()).as_posix()
+    for _ in range(trials):
+        advance_checkpoint(vault_root, target, imports)
+        deferred_index.add_graph(vault_root, [rel])
+        started = time.perf_counter()
+        index_sync.drain_deferred_work(vault_root)
+        samples.append((time.perf_counter() - started) * 1_000.0)
+        if deferred_index.list_graph_paths(vault_root):
+            raise RuntimeError("drain left queued graph work behind")
+    return samples
 
 
 def format_result(result: dict[str, Any], *, hold_ratio: float | None = None) -> str:
     request = result["request"]
     hold = result["publication_hold"]
+    drain = result["drain"]
     line = (
         f"pages={result['pages']:<6} trials={result['trials']} "
         f"request median/p95={request['median_ms']:.1f}/{request['p95_ms']:.1f}ms  "
+        f"drain median/p95={drain['median_ms']:.1f}/{drain['p95_ms']:.1f}ms "
+        f"({request['median_ms'] / max(drain['median_ms'], 0.001):.1f}x cheaper)  "
         f"FINAL canonical publication hold median/p95="
         f"{hold['median_ms']:.1f}/{hold['p95_ms']:.1f}ms "
         f"operation={PUBLICATION_OPERATION}"

--- a/scripts/repro_graph_rebuild_hold.py
+++ b/scripts/repro_graph_rebuild_hold.py
@@ -193,10 +193,19 @@ def _measure_drain(
     The sidecar is deliberately *not* deleted here. A missing sidecar is one of
     the cases that still earns a full rebuild, so deleting it would measure the
     rebuild again under a different name.
+
+    The write runs the real post-commit fanout, and freshness is **not** re-seeded
+    wholesale between trials. That distinction is the whole measurement. Production
+    rides incremental freshness events, which let `on_resolver_files_changed` patch
+    the recall resolver in place; a wholesale `freshness.seed` makes
+    `recall_delta_since` incomplete, so that patch *evicts* the resolver instead,
+    and every drain then re-walks the vault. Measuring that way reported a drain
+    scaling linearly with vault size -- an artifact of the harness, not the system.
     """
     deferred_index = imports["deferred_index"]
     index_sync = imports["index_sync"]
     epistemic_graph = imports["epistemic_graph"]
+    vault = imports["vault"]
 
     graph = epistemic_graph.EpistemicGraphIndex(vault_root)
     if not graph.available():
@@ -204,8 +213,16 @@ def _measure_drain(
 
     samples: list[float] = []
     rel = target.resolve().relative_to(vault_root.resolve()).as_posix()
-    for _ in range(trials):
-        advance_checkpoint(vault_root, target, imports)
+    for trial in range(trials):
+        vault.batch_atomic_write(
+            [
+                vault.PlannedWrite(
+                    target, target.read_text(encoding="utf-8") + f"\nDrain revision {trial}.\n"
+                )
+            ],
+            vault_root=vault_root,
+            post_commit_fanout=True,
+        )
         deferred_index.add_graph(vault_root, [rel])
         started = time.perf_counter()
         index_sync.drain_deferred_work(vault_root)

--- a/scripts/semantic_write_latency.py
+++ b/scripts/semantic_write_latency.py
@@ -20,7 +20,13 @@ if str(Path(__file__).resolve().parent) not in sys.path:
 
 from synth_vault import gen_dense_vault  # noqa: E402
 
-from exomem import find, freshness, semantic_contract, semantic_writes  # noqa: E402
+from exomem import (  # noqa: E402
+    find,
+    freshness,
+    graph_sync,
+    semantic_contract,
+    semantic_writes,
+)
 from exomem.vault import walk_vault_md  # noqa: E402
 
 DEFAULT_SIZES = (2_000, 8_000)
@@ -315,17 +321,36 @@ def measure_all(
         roots = [root / f"vault-{size}" for size in sizes]
         for vault_root in roots:
             vault_root.mkdir(parents=True)
-        return [
-            measure(vault_root, size, samples)
-            for vault_root, size in zip(roots, sizes, strict=True)
-        ]
+        try:
+            return [
+                measure(vault_root, size, samples)
+                for vault_root, size in zip(roots, sizes, strict=True)
+            ]
+        finally:
+            graph_sync.drain_active_rebuilds()
     with tempfile.TemporaryDirectory(prefix="exomem-write-latency-") as temp:
         base = Path(temp)
         results: list[dict[str, float | int]] = []
-        for size in sizes:
-            vault_root = base / f"vault-{size}"
-            vault_root.mkdir()
-            results.append(measure(vault_root, size, samples))
+        try:
+            for size in sizes:
+                vault_root = base / f"vault-{size}"
+                vault_root.mkdir()
+                results.append(measure(vault_root, size, samples))
+        finally:
+            # A write stopped joining its own graph rebuild (#576), so a rebuild
+            # is routinely still running here -- writing into a tree
+            # `TemporaryDirectory` is about to remove. On POSIX that removal
+            # races the rebuild and fails with "Directory not empty", which is
+            # how this gate reported a *cleanup* crash as a latency failure and
+            # sent a real Class C livelock in the same run past unread. Same
+            # boundary rule the CLI and the suite already apply: nothing
+            # outlives the vault it was building against.
+            if not graph_sync.drain_active_rebuilds():
+                print(
+                    "semantic-write-latency: a graph rebuild did not finish "
+                    "before teardown; measurements above stand, cleanup may not",
+                    file=sys.stderr,
+                )
         return results
 
 

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -123,6 +123,27 @@ def _is_cli_only_invocation(raw: list[str]) -> bool:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # Wrapped so *every* exit drains, including the early returns above
+    # `_run_cli`. A graph rebuild no longer blocks the write that caused it, and
+    # it runs on a daemon thread. That is right for the long-lived server and
+    # wrong here: this process is about to exit and would take the rebuild with
+    # it, so a CLI write would report `pending` and nothing would ever make it
+    # true. The boundary is process lifetime, not the write path -- and a
+    # boundary that only some exits honour is not one.
+    try:
+        return _run_cli(argv)
+    finally:
+        from . import graph_sync
+
+        if not graph_sync.drain_active_rebuilds():
+            print(
+                "exomem: a graph rebuild did not finish before exit; the change is "
+                "committed and `exomem reconcile` will bring the graph up to date",
+                file=sys.stderr,
+            )
+
+
+def _run_cli(argv: list[str] | None = None) -> int:
     raw = list(sys.argv[1:] if argv is None else argv)
     if raw in (["--version"], ["--version", "--json"]):
         # Keep this before command-registry and optional capability imports.  A

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -4881,7 +4881,7 @@ def op_process_media(
     def _drain_index_refresh(paths: list[Path] | list[str] | None = None) -> tuple[int, int]:
         current = index_sync.deferred_work_status(vault_root)["full_upserts"]
         selected = current["paths"] if paths is None else paths
-        refreshed = index_sync.drain_deferred_work(
+        index_sync.drain_deferred_work(
             vault_root,
             limit=media_jobs.STATUS_JOB_LIMIT,
             paths=selected,
@@ -4889,6 +4889,13 @@ def op_process_media(
         remaining = index_sync.deferred_work_status(vault_root)["full_upserts"][
             "count"
         ]
+        # Measure the queue the neighbouring field measures. The drain's return
+        # counts what it processed across *every* queue it serves, and the
+        # graph dirty-path queue joined them (converge-graph-incrementally), so
+        # using it here would report a refreshed count and a remaining count
+        # drawn from different queues -- a pair that stops adding up for a
+        # reason no reader of this response can see.
+        refreshed = max(0, int(current["count"]) - remaining)
         return refreshed, remaining
 
     if operation == "status":

--- a/src/exomem/deferred_index.py
+++ b/src/exomem/deferred_index.py
@@ -17,6 +17,26 @@ from .kbdir import kb_dirname
 
 _SEMANTIC_ISOLATION_CURSOR_KEY = "semantic_isolation_cursors:v1"
 _SEMANTIC_UPSERTS_GENERATION_KEY = "semantic_upserts_generation"
+_GRAPH_UPSERTS_GENERATION_KEY = "graph_upserts_generation"
+_GRAPH_FULL_REBUILD_KEY = "graph_full_rebuild_generation"
+
+#: The queues this store carries, and the tables behind them.  The graph queue
+#: is the newest and the reason the mapping exists: it reuses the semantic
+#: queue's shape verbatim rather than introducing a parallel store, so the
+#: crash-safety, receipt-CAS and poison-isolation properties are the ones
+#: already in production rather than a second implementation of them.
+_QUEUE_TABLES = {
+    "semantic": "semantic_upserts",
+    "full": "full_upserts",
+    "graph": "graph_upserts",
+}
+
+#: A rotated receipt has to sort strictly *behind* untouched work, and
+#: `time.time()` on Windows is coarse enough that a rotation within the same
+#: tick as the insert leaves the poisoned path first in the queue -- pinning
+#: exactly the work rotation exists to unpin.  Rotation therefore takes the
+#: later of the wall clock and one epsilon past the queue's current maximum.
+_ROTATION_EPSILON_SECONDS = 1e-6
 
 
 def store_path(vault_root: Path) -> Path:
@@ -85,6 +105,24 @@ def _connect(
         )
         """
     )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS graph_upserts (
+            rel_path TEXT PRIMARY KEY,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            revision INTEGER NOT NULL DEFAULT 1
+        )
+        """
+    )
+    for event in ("INSERT", "UPDATE", "DELETE"):
+        conn.execute(
+            f"CREATE TRIGGER IF NOT EXISTS graph_upserts_generation_{event.lower()} "
+            f"AFTER {event} ON graph_upserts BEGIN "
+            "INSERT INTO maintenance_state(key, value) VALUES "
+            f"('{_GRAPH_UPSERTS_GENERATION_KEY}', '1') "
+            "ON CONFLICT(key) DO UPDATE SET value = CAST(value AS INTEGER) + 1; END"
+        )
     columns = {
         str(row[1]) for row in conn.execute("PRAGMA table_info(semantic_upserts)")
     }
@@ -322,6 +360,18 @@ def add_full_receipts(vault_root: Path, rel_paths: list[str]) -> list[DeferredRe
 def _add_full_receipts(
     vault_root: Path, rel_paths: list[str]
 ) -> tuple[list[DeferredReceipt], int]:
+    return _add_plain_receipts(vault_root, rel_paths, table="full_upserts")
+
+
+def _add_plain_receipts(
+    vault_root: Path, rel_paths: list[str], *, table: str
+) -> tuple[list[DeferredReceipt], int]:
+    """Queue paths in an admission-free queue and return exact revisions.
+
+    "Plain" is the distinction from the semantic queue, which additionally
+    consults recall admission per path. The full and graph queues do not: what
+    they may index is decided upstream, at the seam that produced the paths.
+    """
     rels = sorted(
         {
             rel
@@ -340,20 +390,20 @@ def _add_full_receipts(
         try:
             for rel in rels:
                 row = conn.execute(
-                    "SELECT revision FROM full_upserts WHERE rel_path = ?", (rel,)
+                    f"SELECT revision FROM {table} WHERE rel_path = ?", (rel,)
                 ).fetchone()
                 if row is None:
                     revision = 1
                     added += 1
                     conn.execute(
-                        "INSERT INTO full_upserts"
+                        f"INSERT INTO {table}"
                         "(rel_path, created_at, updated_at, revision) VALUES (?, ?, ?, ?)",
                         (rel, now, now, revision),
                     )
                 else:
                     revision = int(row[0]) + 1
                     conn.execute(
-                        "UPDATE full_upserts SET updated_at = ?, revision = ? "
+                        f"UPDATE {table} SET updated_at = ?, revision = ? "
                         "WHERE rel_path = ?",
                         (now, revision, rel),
                     )
@@ -363,6 +413,106 @@ def _add_full_receipts(
             raise
         conn.commit()
         return receipts, added
+    finally:
+        conn.close()
+
+
+def add_graph(vault_root: Path, rel_paths: list[str]) -> int:
+    """Durably queue pages whose epistemic-graph projection needs re-deriving."""
+    _receipts, added = _add_plain_receipts(vault_root, rel_paths, table="graph_upserts")
+    return added
+
+
+def add_graph_receipts(vault_root: Path, rel_paths: list[str]) -> list[DeferredReceipt]:
+    """Queue graph work and return its exact transaction-local revisions."""
+    receipts, _added = _add_plain_receipts(
+        vault_root, rel_paths, table="graph_upserts"
+    )
+    return receipts
+
+
+def enqueue_graph_checkpoint(vault_root: Path, checkpoint: Any) -> int:
+    """Record one canonical batch's graph debt from the checkpoint it already writes.
+
+    The checkpoint has always carried exactly which pages changed and which were
+    created, per generation, crash-safely. Until now the graph threw that away
+    and re-walked the vault. This is the seam that keeps it.
+
+    A full-scope batch -- one over the checkpoint's path limit, which therefore
+    carries no path list at all -- records a rebuild marker instead. A queue of
+    "every page" is not a queue.
+    """
+    if getattr(checkpoint, "scope", "paths") == "full":
+        mark_graph_full_rebuild(vault_root, generation=int(checkpoint.generation))
+        return 0
+    rels = [rel for rel, _content_hash in checkpoint.paths]
+    rels.extend(checkpoint.created_paths)
+    return add_graph(vault_root, rels)
+
+
+def mark_graph_full_rebuild(vault_root: Path, *, generation: int) -> None:
+    """Record that a whole-vault rebuild is owed, at or after this generation."""
+    conn = _connect(vault_root, create=True)
+    try:
+        with conn:
+            conn.execute(
+                "INSERT INTO maintenance_state(key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = "
+                "CASE WHEN CAST(excluded.value AS INTEGER) > CAST(value AS INTEGER) "
+                "THEN excluded.value ELSE value END",
+                (_GRAPH_FULL_REBUILD_KEY, str(int(generation))),
+            )
+    finally:
+        conn.close()
+
+
+def graph_full_rebuild_pending(vault_root: Path) -> int | None:
+    """The generation a whole-vault rebuild is owed for, or None."""
+    if not store_path(vault_root).exists():
+        return None
+    try:
+        conn = _connect_readonly(vault_root)
+        try:
+            row = conn.execute(
+                "SELECT value FROM maintenance_state WHERE key = ?",
+                (_GRAPH_FULL_REBUILD_KEY,),
+            ).fetchone()
+        finally:
+            conn.close()
+    except (OSError, sqlite3.Error):
+        return None
+    if row is None:
+        return None
+    try:
+        return int(row[0])
+    except (TypeError, ValueError):
+        return None
+
+
+def clear_graph_full_rebuild(vault_root: Path, *, generation: int | None = None) -> bool:
+    """Retire the rebuild marker, but only if nothing newer arrived meanwhile.
+
+    Compare-and-swap for the same reason receipts are: a rebuild that started
+    against generation N must not erase a marker a later batch raised to N+1
+    while it ran.
+    """
+    if not store_path(vault_root).exists():
+        return False
+    conn = _connect(vault_root, create=True)
+    try:
+        with conn:
+            if generation is None:
+                changed = conn.execute(
+                    "DELETE FROM maintenance_state WHERE key = ?",
+                    (_GRAPH_FULL_REBUILD_KEY,),
+                ).rowcount
+            else:
+                changed = conn.execute(
+                    "DELETE FROM maintenance_state WHERE key = ? "
+                    "AND CAST(value AS INTEGER) <= ?",
+                    (_GRAPH_FULL_REBUILD_KEY, int(generation)),
+                ).rowcount
+        return bool(changed)
     finally:
         conn.close()
 
@@ -461,15 +611,61 @@ def snapshot_full(
     limit: int | None = None,
     paths: set[str] | None = None,
 ) -> list[DeferredReceipt]:
+    return _snapshot_plain(vault_root, table="full_upserts", limit=limit, paths=paths)
+
+
+def snapshot_graph(
+    vault_root: Path,
+    *,
+    limit: int | None = None,
+    paths: set[str] | None = None,
+) -> list[DeferredReceipt]:
+    """Queued graph work, oldest first, with corrupt legacy rows purged."""
+    return _snapshot_plain(vault_root, table="graph_upserts", limit=limit, paths=paths)
+
+
+def list_graph_paths(vault_root: Path, *, limit: int | None = None) -> list[str]:
+    return [receipt.rel_path for receipt in snapshot_graph(vault_root, limit=limit)]
+
+
+def clear_graph_receipts(vault_root: Path, receipts: list[DeferredReceipt]) -> int:
+    return _clear_plain_receipts(vault_root, receipts, table="graph_upserts")
+
+
+def clear_graph(vault_root: Path, rel_paths: list[str] | None = None) -> int:
+    return _clear(vault_root, table="graph_upserts", rel_paths=rel_paths)
+
+
+def rotate_graph_receipts(vault_root: Path, receipts: list[DeferredReceipt]) -> int:
+    return rotate_receipts(vault_root, receipts, queue="graph")
+
+
+def graph_status(vault_root: Path | None) -> dict[str, Any]:
+    result = _status(vault_root, table="graph_upserts")
+    return {
+        **result,
+        "full_rebuild_pending": (
+            graph_full_rebuild_pending(vault_root) if vault_root is not None else None
+        ),
+    }
+
+
+def _snapshot_plain(
+    vault_root: Path,
+    *,
+    table: str,
+    limit: int | None = None,
+    paths: set[str] | None = None,
+) -> list[DeferredReceipt]:
     path = store_path(vault_root)
     if not path.exists():
         return []
     conn = _connect(vault_root, create=False)
     try:
-        columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(full_upserts)")}
+        columns = {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
         revision = "revision" if "revision" in columns else "1 AS revision"
         sql = (
-            f"SELECT rel_path, {revision} FROM full_upserts "
+            f"SELECT rel_path, {revision} FROM {table} "
         )
         params: list[Any] = []
         if paths is not None:
@@ -505,7 +701,7 @@ def snapshot_full(
         if _safe_markdown_rel_path(receipt.rel_path) is None
     ]
     if corrupt:
-        _purge_corrupt_paths(vault_root, "full_upserts", corrupt)
+        _purge_corrupt_paths(vault_root, table, corrupt)
     return valid
 
 
@@ -528,6 +724,12 @@ def clear_receipts(vault_root: Path, receipts: list[DeferredReceipt]) -> int:
 
 
 def clear_full_receipts(vault_root: Path, receipts: list[DeferredReceipt]) -> int:
+    return _clear_plain_receipts(vault_root, receipts, table="full_upserts")
+
+
+def _clear_plain_receipts(
+    vault_root: Path, receipts: list[DeferredReceipt], *, table: str
+) -> int:
     if not receipts or not store_path(vault_root).exists():
         return 0
     conn = _connect(vault_root, create=True)
@@ -535,7 +737,7 @@ def clear_full_receipts(vault_root: Path, receipts: list[DeferredReceipt]) -> in
         with conn:
             changed = sum(
                 conn.execute(
-                    "DELETE FROM full_upserts WHERE rel_path = ? AND revision = ?",
+                    f"DELETE FROM {table} WHERE rel_path = ? AND revision = ?",
                     (receipt.rel_path, receipt.revision),
                 ).rowcount
                 for receipt in receipts
@@ -549,21 +751,28 @@ def rotate_receipts(
     vault_root: Path,
     receipts: list[DeferredReceipt],
     *,
-    full: bool = False,
+    queue: str = "semantic",
 ) -> int:
     """Move failed receipt revisions behind untouched work without changing CAS identity."""
     if not receipts or not store_path(vault_root).exists():
         return 0
-    table = "full_upserts" if full else "semantic_upserts"
-    now = time.time()
+    table = _QUEUE_TABLES[queue]
     conn = _connect(vault_root, create=True)
     try:
         with conn:
+            # Strictly behind, not merely re-stamped: on a coarse clock the
+            # wall-clock value can equal the insert's, which leaves the poisoned
+            # receipt sorting first and pins the queue it was rotated to unpin.
+            newest = conn.execute(f"SELECT MAX(updated_at) FROM {table}").fetchone()[0]
+            behind = max(
+                time.time(),
+                float(newest) + _ROTATION_EPSILON_SECONDS if newest is not None else 0.0,
+            )
             changed = sum(
                 conn.execute(
                     f"UPDATE {table} SET updated_at = ? "
                     "WHERE rel_path = ? AND revision = ?",
-                    (now, receipt.rel_path, receipt.revision),
+                    (behind, receipt.rel_path, receipt.revision),
                 ).rowcount
                 for receipt in receipts
             )
@@ -623,7 +832,7 @@ def _purge_corrupt_paths(
     connection_path: Path | None = None,
 ) -> int:
     """Delete exact unsafe legacy rows without turning them into filesystem paths."""
-    if table not in {"semantic_upserts", "full_upserts"} or not paths:
+    if table not in set(_QUEUE_TABLES.values()) or not paths:
         return 0
     conn = _connect(vault_root, create=True, connection_path=connection_path)
     try:

--- a/src/exomem/deferred_index.py
+++ b/src/exomem/deferred_index.py
@@ -663,6 +663,13 @@ def _snapshot_plain(
     conn = _connect(vault_root, create=False)
     try:
         columns = {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
+        if not columns:
+            # No such table: a store that predates this queue. Readers run
+            # before writers on an upgraded vault -- a drain asks what is
+            # queued before it queues anything -- and they open read-only,
+            # where the table cannot be created. Nothing is queued in a queue
+            # that does not exist yet; the next writable open migrates it.
+            return []
         revision = "revision" if "revision" in columns else "1 AS revision"
         sql = (
             f"SELECT rel_path, {revision} FROM {table} "
@@ -814,6 +821,8 @@ def _list_paths(
         return []
     conn = _connect(vault_root, create=False)
     try:
+        if not any(conn.execute(f"PRAGMA table_info({table})")):
+            return []  # Predates this queue; see `_snapshot_plain`.
         sql = f"SELECT rel_path FROM {table} ORDER BY rel_path"
         params: tuple[Any, ...] = ()
         if limit is not None:

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -3221,6 +3221,7 @@ class EpistemicGraphIndex:
             published = self._mark_incremental_available(
                 before,
                 checkpoint=checkpoint,
+                graph_checkpoint=self._drained_graph_checkpoint(batch),
                 source_versions=indexed_versions,
             )
         return {
@@ -3228,6 +3229,45 @@ class EpistemicGraphIndex:
             "published": published,
             "indexed": tuple(sorted(indexed_versions)),
         }
+
+    def _drained_graph_checkpoint(
+        self, batch: list[Path]
+    ) -> graph_sync.GraphSyncCheckpoint | None:
+        """The committed generation this pass may acknowledge, if it covered it.
+
+        Repairing the pages is only half of convergence. Until the graph_sync
+        acknowledgement moves, every reader still sees a stale epoch, the
+        sidecar stays unavailable, and the next dispatch schedules the
+        whole-vault rebuild regardless -- which would leave the queue as pure
+        overhead beside the expensive path rather than a replacement for it.
+
+        Acknowledging is also the only irreversible claim this path makes, so
+        the bar is coverage of the *whole* committed path set, not of whatever
+        subset this drain happened to dequeue. A `limit`-truncated batch, or a
+        batch left over from an older generation, covers nothing and
+        acknowledges nothing; the later drain that does cover it acknowledges
+        then. `scope == "full"` never qualifies -- that marker exists precisely
+        because the change was too large to enumerate, so no path list can
+        prove it converged.
+
+        Coverage is membership in the *processed* batch rather than in the
+        indexed set: a deletion named by the checkpoint is processed by
+        removing its rows and has no source bytes to index, so an
+        indexed-set test would stall every generation containing one forever.
+        That the indexed pages did not move under the pass is a separate
+        proof, carried by `source_versions`.
+        """
+        committed = graph_sync.read_checkpoint(self.vault_root)
+        if committed is None or committed.scope != "paths":
+            return None
+        processed = {
+            rel
+            for path in batch
+            if (rel := _vault_rel(self.vault_root, Path(path))) is not None
+        }
+        required = {rel for rel, _content_hash in committed.paths}
+        required.update(committed.created_paths)
+        return committed if required <= processed else None
 
     def delete_paths(self, rel_paths: list[str]) -> int:
         with self._mutation_coordinator.hold(

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -3083,12 +3083,13 @@ class EpistemicGraphIndex:
           point at it were never written down. Only the bodies know, so this
           scans them.
 
-        The scan is what a persisted unresolved edge -- basic-memory's nullable
-        `to_id` beside a NOT NULL `to_name` -- would turn into an index lookup.
-        That is a real improvement and a real schema change, including to what
-        reads render for an unresolved target, so it is a measured Phase 3
-        candidate rather than something smuggled in here. It only runs when a
-        drain actually changes topology, which ordinary edits do not.
+        Persisting the unresolved edge instead -- storing the link's target
+        *name* even when no target id exists yet -- would turn this scan into an
+        index lookup. That is a real improvement and a real schema change,
+        including to what a read renders for a target that does not exist, so it
+        is a measured Phase 3 candidate rather than something smuggled in here.
+        The scan only runs when a drain actually changes topology, which
+        ordinary edits do not.
         """
         appeared: set[str] = set()
         vanished: set[str] = set()

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -65,6 +65,16 @@ REBUILD_PUBLICATION_ATTEMPTS = REBUILD_STABILIZATION_ATTEMPTS * 2
 # re-running the rebuild cannot be what fixes it.
 REBUILD_SUPERSESSION_RETRIES = 1
 
+
+class _DrainPublicationMoved(Exception):
+    """A drain's publication proof failed at commit time; roll the pass back.
+
+    Deliberately internal and deliberately not an `OpError`: nothing is wrong,
+    the vault simply moved while the drain worked. The queue still holds the
+    work, so the next drain repairs it against the projection that moved.
+    """
+
+
 #: Every bail-out reason `_refresh_paths_locked` can emit, and which repair it
 #: earns. This is the one place the judgement lives; `tests/
 #: test_graph_deferred_queue.py` parses the reasons back out of this module and
@@ -3216,15 +3226,51 @@ class EpistemicGraphIndex:
                 probe.close()
             batch = sorted({*paths, *(self.vault_root / rel for rel in affected)})
             indexed_versions: dict[str, GraphSourceSignature] = {}
-            pass_report = self._refresh_paths_pass(
-                batch, resolver=resolver, indexed_versions=indexed_versions
-            )
-            published = self._mark_incremental_available(
-                before,
-                checkpoint=checkpoint,
-                graph_checkpoint=self._drained_graph_checkpoint(batch),
-                source_versions=indexed_versions,
-            )
+            published = False
+
+            def publish_drain(conn: sqlite3.Connection) -> None:
+                # Same seam, and for the same reason, as the incremental
+                # refresh path's own publication: the acknowledgement is
+                # written in the transaction that writes the rows it describes,
+                # having re-proved the projection did not move under the pass.
+                #
+                # Publishing afterwards through a second connection tears the
+                # two apart, and an acknowledgement that lands against a moved
+                # projection is exactly what the lineage check refuses --
+                # `GRAPH_SYNC_LINEAGE_CONFLICT`, raised at the *next* write
+                # rather than here.
+                nonlocal published
+                if not (
+                    _incremental_projection_identity(self.vault_root) == before
+                    and self._source_versions_current(indexed_versions)
+                    and freshness.recall_checkpoint(self.vault_root, "vault") == checkpoint
+                ):
+                    raise _DrainPublicationMoved
+                self._publish_available_marker_in_transaction(
+                    conn,
+                    before,
+                    checkpoint=checkpoint,
+                    # Read at commit time, not before the pass: the coverage
+                    # claim has to be about the generation that is committed
+                    # now, not the one that was committed when the drain
+                    # started.
+                    graph_checkpoint=self._drained_graph_checkpoint(batch),
+                )
+                published = True
+
+            try:
+                pass_report = self._refresh_paths_pass(
+                    batch,
+                    resolver=resolver,
+                    indexed_versions=indexed_versions,
+                    before_commit=publish_drain,
+                )
+            except _DrainPublicationMoved:
+                # The pass rolled back with it, so nothing is half-applied and
+                # no receipt is cleared. The queue still holds this work and
+                # the next drain repairs it against the projection that moved.
+                log.info("deferred graph drain did not publish; projection moved under the pass")
+                return {**report, "moved": 1}
         return {
             **pass_report,
             "published": published,

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -4493,6 +4493,34 @@ def _registered_or_failure(
     return GraphDispatchResult("registered", "graph_rebuild_registered", checkpoint)
 
 
+def _caller_can_carry_pending(
+    vault_root: Path,
+    mutation_coordinator: mutation_lock.VaultMutationCoordinator,
+) -> bool:
+    """Whether this caller has a response envelope that can report `pending`.
+
+    Deferring repair to the queue is only honest for a caller that can *say* the
+    graph has not converged. A mutation request can: its terminal carries the
+    `graph_sync` field. A direct library caller cannot -- it returns a leaf
+    result with nowhere to put the outcome, and its contract has always been a
+    converged graph, which is why `_join_registered_standalone` joins the
+    rebuild to completion for exactly this case.
+
+    Deferring for a standalone caller does not merely under-report; it changes
+    what the next call in the same process observes. Ten governance and
+    deletion-lineage tests failed on that, because the operation after a delete
+    read a graph that used to be current by the time it ran.
+
+    Same predicate as `_join_registered_standalone`, deliberately: the caller
+    that joins is precisely the caller that must not defer.
+    """
+    from .writer_lease import active_direct_mutation_guard, active_mutation_request_id
+
+    return active_mutation_request_id() is not None or active_direct_mutation_guard(
+        vault_root, state_root=mutation_coordinator.state_root
+    )
+
+
 def _join_registered_standalone(
     vault_root: Path,
     result: GraphDispatchResult,
@@ -4642,7 +4670,9 @@ def upsert_after_write(
                 else index.refresh_paths(written_paths, graph_checkpoint=required)
             )
             if report.get("deferred"):
-                if report.get("queued"):
+                if report.get("queued") and _caller_can_carry_pending(
+                    vault_root, mutation_coordinator
+                ):
                     # The durable queue holds the affected paths and a drain
                     # will converge them. Registering a whole-vault rebuild here
                     # would run the expensive path on exactly the bail-outs this

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -2741,7 +2741,13 @@ class EpistemicGraphIndex:
             if graph_checkpoint is None:
                 return None
             self._mark_unavailable()
-            return {"indexed_files": 0, "nodes": 0, "edges": 0, "deferred": 1}
+            # `queued` is what separates this from `fallback()`'s own deferral
+            # below, which registers a whole-vault rebuild and reports
+            # `deferred` all the same. Only an enqueue that actually succeeded
+            # may tell the dispatch layer the queue owns this repair; without
+            # the distinction that layer reads an unregistered, unacknowledged
+            # checkpoint as a missing rebuild and schedules the vault anyway.
+            return {"indexed_files": 0, "nodes": 0, "edges": 0, "deferred": 1, "queued": 1}
 
         def fallback(reason: str) -> dict[str, int]:
             # #576 F3. The single most-wanted number in the incident, and the
@@ -4636,6 +4642,13 @@ def upsert_after_write(
                 else index.refresh_paths(written_paths, graph_checkpoint=required)
             )
             if report.get("deferred"):
+                if report.get("queued"):
+                    # The durable queue holds the affected paths and a drain
+                    # will converge them. Registering a whole-vault rebuild here
+                    # would run the expensive path on exactly the bail-outs this
+                    # change makes proportional, leaving the queue as overhead
+                    # beside it rather than a replacement for it.
+                    return GraphDispatchResult("deferred", "graph_repair_queued", required)
                 if graph_sync.registered_checkpoint(
                     vault_root, state_root=mutation_coordinator.state_root
                 ) == required:

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -17,8 +17,8 @@ import sqlite3
 import threading
 import time
 import weakref
-from collections.abc import Iterable
-from contextlib import nullcontext
+from collections.abc import Iterable, Iterator
+from contextlib import ExitStack, contextmanager, nullcontext
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from pathlib import Path
@@ -663,6 +663,40 @@ def _unregistered_temporary_groups(live: Path) -> dict[str, list[Path]]:
             continue
         groups.setdefault(base, []).append(candidate)
     return groups
+
+
+@contextmanager
+def _sampling_boundary(coordinator: Any) -> Iterator[None]:
+    """Hold the canonical boundary for a read if it can be had; proceed if not.
+
+    Sampling the publication epoch under the canonical boundary is what stops a
+    rebuild seeing a batch's interior -- a generation floor installed without its
+    checkpoint, which classifies as an incoherent lineage and refuses a rebuild
+    that had nothing wrong with it.
+
+    But it is an optimization for *coherence*, not an authorization: the sample
+    reads two small artifacts and grants nothing. Requiring the boundary would
+    therefore hand a rebuild two failure modes it did not previously have -- an
+    unopenable lock and a busy writer -- and the first of those broke the
+    standing contract that a rebuild refused for lock reasons raises
+    `GRAPH_SYNC_REBUILD_LOCK_UNAVAILABLE` and leaves the current graph intact.
+
+    So when the boundary is unavailable, sample without it. That is exactly the
+    behaviour every release before this one had, and the incoherence retry at
+    the call site still covers the torn read it leaves possible.
+    """
+    with ExitStack() as stack:
+        try:
+            stack.enter_context(
+                coordinator.hold(
+                    operation="epistemic_graph_sample_epoch", holder_kind="graph"
+                )
+            )
+        except OpError:
+            # Unopenable lock or a busy writer. Either way the sample proceeds;
+            # only the coherence guarantee is lost, and only for this attempt.
+            pass
+        yield
 
 
 def _reap_preserved_temporaries(
@@ -1331,9 +1365,14 @@ class EpistemicGraphIndex:
                 # artifacts -- the same shape and cost as the coalesce hold it
                 # supersedes -- and it cannot deadlock, because the write path
                 # no longer waits on this thread in either direction.
-                with self._canonical_mutation_coordinator().hold(
-                    operation="epistemic_graph_sample_epoch", holder_kind="graph"
-                ):
+                #
+                # The hold is an *optimization for coherence*, not a
+                # precondition: it removes a torn read, it does not authorize
+                # anything. So a boundary that cannot be taken must not turn a
+                # rebuild into a new class of failure it never had before this
+                # change -- sampling unheld is exactly the previous behaviour,
+                # and the incoherence retry below still covers the torn read.
+                with _sampling_boundary(self._canonical_mutation_coordinator()):
                     epoch = graph_sync.publication_epoch(self.vault_root)
                     required = epoch.checkpoint
                     prior_acknowledgement = (

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -26,6 +26,7 @@ from typing import Any
 
 from . import (
     access,
+    deferred_index,
     freshness,
     graph_sync,
     memory_refs,
@@ -63,6 +64,48 @@ REBUILD_PUBLICATION_ATTEMPTS = REBUILD_STABILIZATION_ATTEMPTS * 2
 # single pass — while a supersession that survives it is not transient, so
 # re-running the rebuild cannot be what fixes it.
 REBUILD_SUPERSESSION_RETRIES = 1
+
+#: Every bail-out reason `_refresh_paths_locked` can emit, and which repair it
+#: earns. This is the one place the judgement lives; `tests/
+#: test_graph_deferred_queue.py` parses the reasons back out of this module and
+#: fails if a site appears, moves or is renamed without the table following.
+#:
+#: `"defer"` means the incremental pass could not *prove* its result, but the
+#: scope of the damage is known: the affected paths go on the durable graph
+#: queue and a drain repairs them. Every reason on this side is a race -- a
+#: concurrent writer moved a durable token between two reads -- and a race is
+#: exactly what a retry budget cannot win here, because each whole-vault attempt
+#: widens the window that loses it. That feedback loop, not any single gate, is
+#: what made seven fixes inside it fail to converge.
+#:
+#: `"rebuild"` means the scope is *unknown*, not merely unproven: the sidecar
+#: could not be read, or the delta that says what changed is itself incomplete,
+#: so an external edit could be missing from any bounded set we could enqueue.
+#: Deferring there would quietly leave the rest of the graph stale, which is a
+#: worse failure than the cost being removed. These stay whole-vault, and the
+#: value of writing them down is that they stay few.
+_FALLBACK_DISPOSITIONS = {
+    "path_outside_vault": "defer",
+    "path_unreadable": "defer",
+    "durable_checkpoint_moved": "defer",
+    "checkpoint_paths_mismatch": "defer",
+    "checkpoint_created_paths_mismatch": "defer",
+    "acknowledgement_is_not_the_predecessor": "defer",
+    "delta_target_moved": "defer",
+    "caller_path_outside_delta": "defer",
+    "topology_proof_moved": "defer",
+    "incremental_marker_refused": "defer",
+    "unreachable": "defer",
+    "checkpoint_scope_is_not_paths": "rebuild",
+    "graph_snapshot_unavailable": "rebuild",
+    "recall_checkpoint_absent_or_registry_not_live": "rebuild",
+    "recall_delta_incomplete": "rebuild",
+    "stored_resolver_entries_unreadable": "rebuild",
+    "resolver_snapshot_unavailable": "rebuild",
+    "topology_snapshot_unavailable": "rebuild",
+    "stored_topology_unreadable": "rebuild",
+    "stored_topology_fingerprint_mismatch": "rebuild",
+}
 
 #: #576. `REBUILD_STABILIZATION_ATTEMPTS` is the attempt *floor*, not the
 #: ceiling: two passes cannot converge against a corpus that is still being
@@ -2655,6 +2698,41 @@ class EpistemicGraphIndex:
         created_paths: Iterable[Path] = (),
         graph_checkpoint: graph_sync.GraphSyncCheckpoint | None = None,
     ) -> dict[str, int]:
+        # The affected set, widened as the pass learns more. It starts as what
+        # the caller named, which is already the checkpoint's changed and
+        # created paths, and grows to the recall delta and the resolver-affected
+        # sources once those are computed. A bail-out enqueues whatever is known
+        # at the point it fires; earlier bail-outs know less, and knowing less
+        # is not the same as knowing nothing.
+        deferred_scope: set[str] = {
+            rel
+            for candidate in (*paths, *created_paths)
+            if (rel := _vault_rel(self.vault_root, Path(candidate))) is not None
+        }
+
+        def defer(reason: str) -> dict[str, int] | None:
+            """Queue the affected paths; return a terminal report, or None to rebuild.
+
+            None means "enqueued, but this caller's contract is a converged
+            graph" -- the standalone library path, which has no checkpoint and no
+            envelope to carry a pending outcome. It still gets the enqueue, so a
+            rebuild that then fails leaves durable work behind instead of
+            nothing.
+            """
+            try:
+                deferred_index.add_graph(self.vault_root, sorted(deferred_scope))
+            except Exception:  # noqa: BLE001 - a queue failure must not lose the rebuild
+                log.warning(
+                    "graph deferral enqueue failed reason=%s; falling back to rebuild",
+                    reason,
+                    exc_info=True,
+                )
+                return None
+            if graph_checkpoint is None:
+                return None
+            self._mark_unavailable()
+            return {"indexed_files": 0, "nodes": 0, "edges": 0, "deferred": 1}
+
         def fallback(reason: str) -> dict[str, int]:
             # #576 F3. The single most-wanted number in the incident, and the
             # one nothing logged: which gate sent essentially every write down
@@ -2669,6 +2747,10 @@ class EpistemicGraphIndex:
                 freshness.external_pending(self.vault_root),
                 graph_checkpoint.checkpoint_sha256 if graph_checkpoint is not None else None,
             )
+            if _FALLBACK_DISPOSITIONS[reason] == "defer":
+                deferred = defer(reason)
+                if deferred is not None:
+                    return deferred
             if graph_checkpoint is None:
                 return {
                     "indexed_files": 0,
@@ -2818,6 +2900,11 @@ class EpistemicGraphIndex:
             resolver_fingerprint = _resolver_topology_fingerprint(resolver)
 
         delta_paths = set(delta.changed | delta.deleted)
+        deferred_scope.update(
+            rel
+            for candidate in delta_paths
+            if (rel := _vault_rel(self.vault_root, Path(candidate))) is not None
+        )
         # Caller paths outside the exact retained suffix mean publication was
         # skipped, failed, or this is a duplicate callback whose global safety
         # cannot be proved path-locally. Rebuild from disk instead of blessing
@@ -2870,6 +2957,7 @@ class EpistemicGraphIndex:
             resolver_versions = resolver_version_result
             affected, topology_versions = affected_result
             refresh_paths.update(str(self.vault_root / rel) for rel in affected)
+            deferred_scope.update(affected)
 
         pass_started = False
         stable = False
@@ -2968,6 +3056,178 @@ class EpistemicGraphIndex:
         finally:
             conn.close()
         return {"indexed_files": indexed, "nodes": int(n_nodes), "edges": int(n_edges)}
+
+    def _topology_affected_sources(
+        self,
+        conn: sqlite3.Connection,
+        rels: set[str],
+        *,
+        resolver: vault_module.WikilinkResolver,
+    ) -> set[str]:
+        """Pages whose own edges change because these pages appeared or vanished.
+
+        A wikilink that does not resolve produces no edge at all -- it is dropped
+        in `_body_wikilink_paths`, not recorded as unresolved. So a page written
+        before its target exists has a missing edge, and nothing about
+        re-indexing the *target* later repairs the *source*. That is the forward
+        reference the full rebuild gets right for free, by re-deriving every page
+        once the corpus is complete, and the one thing a naive per-path drain
+        silently gets wrong.
+
+        The two directions cost very differently, so they are answered
+        differently:
+
+        - A page that *vanished* leaves its inbound edges behind, and those edges
+          name their own source. One indexed query answers it.
+        - A page that *appeared* has no such trace, because the links that should
+          point at it were never written down. Only the bodies know, so this
+          scans them.
+
+        The scan is what a persisted unresolved edge -- basic-memory's nullable
+        `to_id` beside a NOT NULL `to_name` -- would turn into an index lookup.
+        That is a real improvement and a real schema change, including to what
+        reads render for an unresolved target, so it is a measured Phase 3
+        candidate rather than something smuggled in here. It only runs when a
+        drain actually changes topology, which ordinary edits do not.
+        """
+        appeared: set[str] = set()
+        vanished: set[str] = set()
+        for rel in rels:
+            indexed = (
+                conn.execute(
+                    "SELECT 1 FROM graph_nodes WHERE path = ? LIMIT 1", (rel,)
+                ).fetchone()
+                is not None
+            )
+            exists = (self.vault_root / rel).exists()
+            if exists and not indexed:
+                appeared.add(rel)
+            elif indexed and not exists:
+                vanished.add(rel)
+
+        affected: set[str] = set()
+        for rel in vanished:
+            affected.update(
+                str(row[0])
+                for row in conn.execute(
+                    "SELECT DISTINCT source_path FROM graph_edges WHERE dst_key = ?",
+                    (_file_key(rel),),
+                )
+            )
+        if appeared:
+            affected.update(self._sources_linking_to(appeared, resolver=resolver))
+        return affected - rels
+
+    def _sources_linking_to(
+        self, targets: set[str], *, resolver: vault_module.WikilinkResolver
+    ) -> set[str]:
+        """Pages whose body wikilinks now resolve to one of `targets`."""
+        found: set[str] = set()
+        for path in vault_module.walk_vault_md(self.vault_root):
+            rel = _vault_rel(self.vault_root, path)
+            if rel is None or rel in targets:
+                continue
+            try:
+                raw = vault_module.read_bytes_without_pinning(path).decode("utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            for match in vault_module.find_body_wikilinks(raw):
+                try:
+                    canonical, warning = vault_module.normalize_wikilink(
+                        match.group(1).strip(),
+                        self.vault_root,
+                        resolver=resolver,
+                        strict=False,
+                    )
+                except Exception:  # noqa: BLE001 - a malformed link resolves to nothing
+                    continue
+                if warning is None and _with_md(canonical) in targets:
+                    found.add(rel)
+                    break
+        return found
+
+    def drain_paths(self, paths: list[Path]) -> dict[str, Any]:
+        """Re-derive the graph for exactly these paths and republish availability.
+
+        The proportional counterpart to `rebuild_all`, and the reason the durable
+        queue is worth having: work is O(changed), so the window a concurrent
+        writer can invalidate shrinks by orders of magnitude instead of growing
+        with the vault.
+
+        Every identity it samples is the event-maintained one. Using
+        `_recall_projection_identity` here -- the direct-disk walk the full
+        rebuild uses -- would reintroduce an O(vault) cost per drain and give
+        back the whole improvement while still looking incremental. Membership
+        and resolver source versions are deliberately not proved either: both
+        are whole-vault, and what actually needs proving is that the pages this
+        pass indexed did not move under it, which `indexed_versions` says
+        exactly.
+
+        Publication is allowed to fail. The indexing is already durable in the
+        sidecar, so a refused marker costs a later republish, not the work; and
+        a write that landed mid-drain has enqueued its own receipt at a new
+        revision, which this drain's compare-and-swap clear cannot retire.
+        """
+        report: dict[str, Any] = {
+            "indexed_files": 0,
+            "nodes": 0,
+            "edges": 0,
+            "published": False,
+            "indexed": (),
+        }
+        if not paths:
+            return report
+        if not graph_enabled():
+            return {**report, "disabled": 1}
+        if not self.path.exists():
+            # An absent sidecar is not a dirty-path problem: there is nothing to
+            # repair incrementally, and indexing a handful of pages into a fresh
+            # database would publish a graph that is missing every other page.
+            return {**report, "requires_rebuild": 1}
+        with self._mutation_coordinator.hold(
+            operation="epistemic_graph_drain_paths", holder_kind="graph"
+        ):
+            if not freshness.recall_is_live(self.vault_root, "vault"):
+                return {**report, "requires_rebuild": 1}
+            checkpoint = freshness.recall_checkpoint(self.vault_root, "vault")
+            before = _incremental_projection_identity(self.vault_root)
+            # Not `recall_resolver_snapshot_at_checkpoint`: that variant refuses
+            # a cache miss on purpose, because the *incremental refresh* path
+            # needs the pre-delta topology to prove bounded edge repair. A drain
+            # proves nothing about edges it did not touch -- it re-derives each
+            # queued page against the current corpus, which is what a resolver
+            # built from the current projection is. The identity check inside
+            # keeps a stale cached resolver from being reused.
+            resolver = find_module.recall_resolver_snapshot(self.vault_root)
+            if resolver is None:
+                return {**report, "requires_rebuild": 1}
+            queued_rels = {
+                rel
+                for path in paths
+                if (rel := _vault_rel(self.vault_root, Path(path))) is not None
+            }
+            probe = self._connect()
+            try:
+                affected = self._topology_affected_sources(
+                    probe, queued_rels, resolver=resolver
+                )
+            finally:
+                probe.close()
+            batch = sorted({*paths, *(self.vault_root / rel for rel in affected)})
+            indexed_versions: dict[str, GraphSourceSignature] = {}
+            pass_report = self._refresh_paths_pass(
+                batch, resolver=resolver, indexed_versions=indexed_versions
+            )
+            published = self._mark_incremental_available(
+                before,
+                checkpoint=checkpoint,
+                source_versions=indexed_versions,
+            )
+        return {
+            **pass_report,
+            "published": published,
+            "indexed": tuple(sorted(indexed_versions)),
+        }
 
     def delete_paths(self, rel_paths: list[str]) -> int:
         with self._mutation_coordinator.hold(

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -689,7 +689,7 @@ def _sampling_boundary(coordinator: Any) -> Iterator[None]:
         try:
             stack.enter_context(
                 coordinator.hold(
-                    operation="epistemic_graph_sample_epoch", holder_kind="graph"
+                    operation="epistemic_graph_coalesce_epoch", holder_kind="graph"
                 )
             )
         except OpError:
@@ -1321,6 +1321,44 @@ class EpistemicGraphIndex:
         except Exception:  # noqa: BLE001 - an incomplete cold proof fails closed
             return False
 
+    def _read_publication_epoch(self) -> tuple[Any, Any, Any]:
+        epoch = graph_sync.publication_epoch(self.vault_root)
+        required = epoch.checkpoint
+        prior_acknowledgement = (
+            self._live_acknowledged_checkpoint() if required is None else None
+        )
+        return epoch, required, prior_acknowledgement
+
+    def _sample_publication_epoch(self) -> tuple[Any, Any, Any]:
+        """Read the publication epoch, re-reading under the boundary if torn.
+
+        A canonical batch installs its generation floor before its checkpoint,
+        so a sample taken mid-batch sees a floor whose checkpoint has not landed
+        and classifies the lineage as incoherent. Once writes stopped joining
+        their rebuild (#576), a rebuild runs alongside writes as a matter of
+        course, and retrying straight back into that window can exhaust the
+        attempt budget and raise GRAPH_SYNC_LINEAGE_CONFLICT out of a rebuild
+        that had nothing wrong with it.
+
+        Holding the boundary for *every* sample would close the window, but it
+        charges each attempt a lock acquisition and its holder-metadata write to
+        prevent a torn read that is the exception -- and that write is
+        observable: it perturbed several rollback tests that count replacements
+        globally, because the graph is not supposed to be writing anything at
+        this point.
+
+        Taking the boundary only on the re-read closes the same window, because
+        *acquiring* it is what waits the batch out: the second read happens on
+        the far side of the batch rather than inside it. The common path pays
+        nothing.
+        """
+        try:
+            return self._read_publication_epoch()
+        except graph_sync.GraphEpochIncoherent:
+            pass
+        with _sampling_boundary(self._canonical_mutation_coordinator()):
+            return self._read_publication_epoch()
+
     def rebuild_all(self) -> dict[str, int]:
         if not graph_enabled():
             return {"indexed_files": 0, "nodes": 0, "edges": 0, "disabled": 1}
@@ -1348,46 +1386,12 @@ class EpistemicGraphIndex:
                 self._reconcile_recall_publication()
                 continue
             try:
-                # Sampled *under* the canonical boundary, not beside it (#576).
-                #
-                # A canonical batch installs the floor before the checkpoint, so
-                # a sample taken mid-batch sees a floor whose checkpoint has not
-                # landed and classifies the lineage as incoherent. The retry
-                # below already knew this -- it coalesces through this exact
-                # boundary and tries again -- but a retry only narrows the
-                # window, and once writes stopped joining their rebuild the
-                # window is open on essentially every write. Exhausting the
-                # attempts then raises GRAPH_SYNC_LINEAGE_CONFLICT out of a
-                # rebuild that had nothing wrong with it.
-                #
-                # Taking the boundary for the sample closes the window instead
-                # of narrowing it. It is O(1) bounded reads of two small
-                # artifacts -- the same shape and cost as the coalesce hold it
-                # supersedes -- and it cannot deadlock, because the write path
-                # no longer waits on this thread in either direction.
-                #
-                # The hold is an *optimization for coherence*, not a
-                # precondition: it removes a torn read, it does not authorize
-                # anything. So a boundary that cannot be taken must not turn a
-                # rebuild into a new class of failure it never had before this
-                # change -- sampling unheld is exactly the previous behaviour,
-                # and the incoherence retry below still covers the torn read.
-                with _sampling_boundary(self._canonical_mutation_coordinator()):
-                    epoch = graph_sync.publication_epoch(self.vault_root)
-                    required = epoch.checkpoint
-                    prior_acknowledgement = (
-                        self._live_acknowledged_checkpoint() if required is None else None
-                    )
+                epoch, required, prior_acknowledgement = self._sample_publication_epoch()
             except graph_sync.GraphEpochIncoherent as error:
+                # Incoherent even after coalescing through the boundary: a
+                # genuinely broken lineage rather than a writer mid-batch.
+                # Retrying is what this loop did before and still does.
                 epoch_error = error
-                # Retained for the sample that is incoherent for a reason the
-                # boundary cannot settle -- a genuinely broken lineage rather
-                # than a writer mid-batch. Coalescing once and retrying keeps
-                # that case exactly as it was.
-                with self._canonical_mutation_coordinator().hold(
-                    operation="epistemic_graph_coalesce_epoch", holder_kind="graph"
-                ):
-                    pass
                 continue
             epoch_error = None
             temporary = graph_sync.temporary_sidecar_path(

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -63,6 +63,26 @@ REBUILD_PUBLICATION_ATTEMPTS = REBUILD_STABILIZATION_ATTEMPTS * 2
 # single pass — while a supersession that survives it is not transient, so
 # re-running the rebuild cannot be what fixes it.
 REBUILD_SUPERSESSION_RETRIES = 1
+
+#: #576. `REBUILD_STABILIZATION_ATTEMPTS` is the attempt *floor*, not the
+#: ceiling: two passes cannot converge against a corpus that is still being
+#: written to, and failing is precisely what strands the availability marker so
+#: the next write falls back into another full rebuild -- a loop that feeds
+#: itself. An attempt invalidated by a moving projection may therefore re-target
+#: the newer baseline instead of exhausting.
+#:
+#: The re-target is bounded by BOTH a wall-clock deadline and an attempt
+#: ceiling, because neither alone is a bound here. An attempt ceiling is not one
+#: when a full-corpus pass costs 20-175 s (8 passes would be ~23 min); a
+#: deadline alone is not one when a pass is cheap enough to spin. 120 s keeps
+#: the worst case (deadline plus the one pass already in flight when it
+#: expires) at or below today's two full passes at production scale, so this
+#: never costs more wall time than the code it replaces -- it only spends it
+#: better. Hitting either bound raises `GraphProjectionMoved` exactly as today:
+#: same Class C type, same admitted cause, and the single
+#: `mark_external_pending` in the `finally` below is untouched.
+REBUILD_STABILIZATION_DEADLINE_SECONDS = 120.0
+REBUILD_STABILIZATION_MAX_ATTEMPTS = 8
 _AVAILABILITY_FRESHNESS_KEY = "recall_projection_identity"
 _RECALL_CHECKPOINT_KEY = "recall_projection_checkpoint"
 _RESOLVER_TOPOLOGY_KEY = "recall_resolver_topology"
@@ -746,6 +766,27 @@ def _recall_projection_identity(
     """
     policy_version, access_fingerprint = recall_policy.recall_policy_identity(vault_root)
     return disk_freshness, policy_version, access_fingerprint
+
+
+def _may_restabilize(attempts: int, *, retarget: bool, started: float) -> bool:
+    """Whether `_rebuild_all_locked` may run another stabilization attempt (#576).
+
+    Three rules, in order:
+
+    * below `REBUILD_STABILIZATION_ATTEMPTS` this is unconditionally True, so a
+      bound can never buy fewer attempts than the code it replaced;
+    * above it, only an attempt invalidated by a *moving projection* earns
+      another one -- a Class B publication refusal is not made truer by
+      repetition (#566);
+    * and that extension stops at whichever of the attempt ceiling and the
+      elapsed deadline comes first, so continuous writes cannot turn the
+      re-target into an unbounded restart loop.
+    """
+    if attempts < REBUILD_STABILIZATION_ATTEMPTS:
+        return True
+    if not retarget or attempts >= REBUILD_STABILIZATION_MAX_ATTEMPTS:
+        return False
+    return (time.monotonic() - started) < REBUILD_STABILIZATION_DEADLINE_SECONDS
 
 
 def _incremental_projection_identity(
@@ -1438,6 +1479,11 @@ class EpistemicGraphIndex:
                             note_publication_refusal(self.vault_root)
                             raise
                         clear_publication_refusal(self.vault_root)
+                        log.info(
+                            "graph rebuild published publication_attempts=%s generation=%s",
+                            attempts,
+                            required.generation if required is not None else None,
+                        )
                         return report
                     finally:
                         _release_publication_hold(publication_hold)
@@ -1467,6 +1513,9 @@ class EpistemicGraphIndex:
         # exception type already carries that classification; only the memo is
         # new, so the next cycle does not re-pay the same doomed rebuild.
         note_publication_refusal(self.vault_root)
+        log.info(
+            "graph rebuild publication exhausted publication_attempts=%s", attempts
+        )
         raise graph_sync.GraphRebuildRegistrationError(
             "GRAPH_SYNC_STABILIZATION_EXHAUSTED",
             # "run reconcile" is an internal registry name that matches neither
@@ -1752,8 +1801,19 @@ class EpistemicGraphIndex:
         # cause belonging to the branch it takes.
         moved_cause = "no stabilization attempt completed"
         publication_cause = "no stabilization attempt completed"
+        # #576. Whether the *last* attempt was invalidated by a moving
+        # projection, which is the only condition worth re-targeting: the
+        # newer baseline is sampled fresh at the top of every attempt, so an
+        # attempt that lost a race to a concurrent write can win the next one.
+        # Class B (the marker would not publish) is deliberately excluded --
+        # retrying it just re-pays a doomed pass, which is #566's finding.
+        retarget = False
+        attempts = 0
+        started = time.monotonic()
         try:
-            for _attempt in range(REBUILD_STABILIZATION_ATTEMPTS):
+            while _may_restabilize(attempts, retarget=retarget, started=started):
+                attempts += 1
+                retarget = False
                 before_disk = _disk_vault_freshness(self.vault_root)
                 before = _recall_projection_identity(self.vault_root, disk_freshness=before_disk)
                 resolver = find_module.recall_resolver_snapshot(
@@ -1772,6 +1832,7 @@ class EpistemicGraphIndex:
                     # Class C, first admitted cause.
                     self._mark_unavailable()
                     projection_moved = True
+                    retarget = True
                     moved_cause = "the supplied freshness identity did not name the resolver bytes"
                     find_module.unload_ram_caches()
                     continue
@@ -1824,6 +1885,7 @@ class EpistemicGraphIndex:
                         # The projection moved between writing the availability
                         # marker and confirming it: Class C, second cause.
                         projection_moved = True
+                        retarget = True
                         moved_cause = (
                             "the recall projection moved after the availability "
                             "marker was written"
@@ -1867,19 +1929,28 @@ class EpistemicGraphIndex:
                     # resolver source versions changed across the pass: Class C,
                     # second admitted cause.
                     projection_moved = True
+                    retarget = True
                     if after_identity != before:
                         moved_cause = "the recall projection identity moved across the pass"
                     elif after_membership != resolver_membership:
                         moved_cause = "the recall membership moved across the pass"
                     else:
                         moved_cause = "the resolver source versions moved across the pass"
-            attempts = (
+            exhausted = (
                 "epistemic graph rebuild did not stabilize after "
-                f"{REBUILD_STABILIZATION_ATTEMPTS} attempts"
+                f"{attempts} attempts in {time.monotonic() - started:.1f}s"
+            )
+            log.info(
+                "graph rebuild stabilization exhausted attempts=%s elapsed_ms=%.1f "
+                "class=%s cause=%s",
+                attempts,
+                (time.monotonic() - started) * 1000.0,
+                "C" if projection_moved else "B",
+                moved_cause if projection_moved else publication_cause,
             )
             if projection_moved:
                 raise GraphProjectionMoved(
-                    f"{attempts} (Class C, projection moved): {moved_cause}"
+                    f"{exhausted} (Class C, projection moved): {moved_cause}"
                 )
             # Class B by elimination: this pass proved nothing stale and still
             # could not publish, which is precisely what
@@ -1892,7 +1963,7 @@ class EpistemicGraphIndex:
             # a full doomed rebuild indefinitely, and left the registry
             # permanently cool for every later write to pay.
             raise GraphPublicationUnavailable(
-                f"{attempts} (Class B, publication failure): {publication_cause}"
+                f"{exhausted} (Class B, publication failure): {publication_cause}"
             )
         finally:
             if pass_started and not stable:
@@ -2520,7 +2591,20 @@ class EpistemicGraphIndex:
         created_paths: Iterable[Path] = (),
         graph_checkpoint: graph_sync.GraphSyncCheckpoint | None = None,
     ) -> dict[str, int]:
-        def fallback() -> dict[str, int]:
+        def fallback(reason: str) -> dict[str, int]:
+            # #576 F3. The single most-wanted number in the incident, and the
+            # one nothing logged: which gate sent essentially every write down
+            # the full-rebuild path. Without it the join-rate flip -- 0-7% of
+            # writes joining a rebuild, then 83-100% -- could not be attributed
+            # from the service log at all, and two published analyses of this
+            # incident named the wrong mechanism before one measured it.
+            log.info(
+                "graph incremental refresh fell back reason=%s external_pending=%s "
+                "graph_checkpoint=%s",
+                reason,
+                freshness.external_pending(self.vault_root),
+                graph_checkpoint.checkpoint_sha256 if graph_checkpoint is not None else None,
+            )
             if graph_checkpoint is None:
                 return {
                     "indexed_files": 0,
@@ -2543,28 +2627,33 @@ class EpistemicGraphIndex:
             for path in paths:
                 rel = _vault_rel(self.vault_root, path)
                 if rel is None:
-                    return fallback()
+                    return fallback("path_outside_vault")
                 try:
                     expected_paths.append(
                         (rel, vault_module.content_hash(path.read_bytes().decode("utf-8")))
                     )
                 except (OSError, UnicodeDecodeError):
-                    return fallback()
+                    return fallback("path_unreadable")
             expected_created = sorted(
                 rel
                 for path in created_paths
                 if (rel := _vault_rel(self.vault_root, Path(path))) is not None
             )
-            if (
-                durable_checkpoint != graph_checkpoint
-                or graph_checkpoint.scope != "paths"
-                or graph_checkpoint.paths != tuple(sorted(expected_paths))
-                or graph_checkpoint.created_paths != tuple(expected_created)
-            ):
-                return fallback()
+            # Named individually rather than as one disjunction: these are the
+            # four candidate gates the incident could not choose between, and a
+            # single "receipt binding mismatch" line would have left the same
+            # question open.
+            if durable_checkpoint != graph_checkpoint:
+                return fallback("durable_checkpoint_moved")
+            if graph_checkpoint.scope != "paths":
+                return fallback("checkpoint_scope_is_not_paths")
+            if graph_checkpoint.paths != tuple(sorted(expected_paths)):
+                return fallback("checkpoint_paths_mismatch")
+            if graph_checkpoint.created_paths != tuple(expected_created):
+                return fallback("checkpoint_created_paths_mismatch")
         snapshot = self._open_read_snapshot(require_current_projection=False)
         if snapshot is None:
-            return fallback()
+            return fallback("graph_snapshot_unavailable")
         if graph_checkpoint is not None:
             graph_values = dict(
                 snapshot.execute(
@@ -2582,16 +2671,16 @@ class EpistemicGraphIndex:
                 and acknowledged.generation == predecessor
             ):
                 snapshot.close()
-                return fallback()
+                return fallback("acknowledgement_is_not_the_predecessor")
         stored_checkpoint = self._stored_recall_checkpoint(snapshot)
         if stored_checkpoint is None or not freshness.recall_is_live(self.vault_root, "vault"):
             snapshot.close()
-            return fallback()
+            return fallback("recall_checkpoint_absent_or_registry_not_live")
         delta = freshness.recall_delta_since(self.vault_root, "vault", stored_checkpoint)
         if not delta.complete:
             snapshot.close()
             self._mark_unavailable()
-            return fallback()
+            return fallback("recall_delta_incomplete")
         checkpoint = delta.to
         before = (
             checkpoint.triple,
@@ -2601,7 +2690,7 @@ class EpistemicGraphIndex:
         if not self._delta_target_still_current(delta):
             snapshot.close()
             self._mark_unavailable()
-            return fallback()
+            return fallback("delta_target_moved")
         created_rels = {
             rel
             for path in created_paths
@@ -2611,7 +2700,7 @@ class EpistemicGraphIndex:
         if stored_entries is None:
             snapshot.close()
             self._mark_unavailable()
-            return fallback()
+            return fallback("stored_resolver_entries_unreadable")
         snapshot.close()
         resolver = find_module.recall_resolver_snapshot_at_checkpoint(
             self.vault_root,
@@ -2619,7 +2708,7 @@ class EpistemicGraphIndex:
         )
         if resolver is None:
             self._mark_unavailable()
-            return fallback()
+            return fallback("resolver_snapshot_unavailable")
         topology_changed = any(
             (
                 rel.removesuffix(".md") in resolver.full_paths,
@@ -2635,7 +2724,7 @@ class EpistemicGraphIndex:
         if topology_changed:
             topology_snapshot = self._open_read_snapshot(require_current_projection=False)
             if topology_snapshot is None:
-                return fallback()
+                return fallback("topology_snapshot_unavailable")
             full_topology = self._stored_full_resolver_topology(
                 topology_snapshot,
                 set(stored_entries),
@@ -2643,7 +2732,7 @@ class EpistemicGraphIndex:
             topology_snapshot.close()
             if full_topology is None:
                 self._mark_unavailable()
-                return fallback()
+                return fallback("stored_topology_unreadable")
             indexed_sources, linked_sources, stored_resolver_fingerprint = full_topology
             old_resolver = resolver.fork()
             old_resolver.on_entries_changed(
@@ -2656,7 +2745,7 @@ class EpistemicGraphIndex:
             )
             if _resolver_topology_fingerprint(old_resolver) != stored_resolver_fingerprint:
                 self._mark_unavailable()
-                return fallback()
+                return fallback("stored_topology_fingerprint_mismatch")
             resolver_fingerprint = _resolver_topology_fingerprint(resolver)
 
         delta_paths = set(delta.changed | delta.deleted)
@@ -2666,7 +2755,7 @@ class EpistemicGraphIndex:
         # the event checkpoint.
         if any(str(path) not in delta_paths for path in paths):
             self._mark_unavailable()
-            return fallback()
+            return fallback("caller_path_outside_delta")
 
         refresh_paths = set(delta_paths)
         topology_versions: dict[str, GraphSourceSignature] = {}
@@ -2708,7 +2797,7 @@ class EpistemicGraphIndex:
                 if resolver_version_result is None:
                     find_module.unload_ram_caches()
                 self._mark_unavailable()
-                return fallback()
+                return fallback("topology_proof_moved")
             resolver_versions = resolver_version_result
             affected, topology_versions = affected_result
             refresh_paths.update(str(self.vault_root / rel) for rel in affected)
@@ -2766,7 +2855,7 @@ class EpistemicGraphIndex:
                 ):
                     stable = True
                     return report
-                rebuilt = fallback()
+                rebuilt = fallback("incremental_marker_refused")
                 stable = True
                 return rebuilt
             stable = True
@@ -2774,7 +2863,7 @@ class EpistemicGraphIndex:
         finally:
             if pass_started and not stable:
                 self._mark_unavailable()
-        return fallback()
+        return fallback("unreachable")
 
     def _refresh_paths_pass(
         self,
@@ -4201,7 +4290,26 @@ def upsert_after_write(
 def _rebuild_outcome(
     index: EpistemicGraphIndex, checkpoint: graph_sync.GraphSyncCheckpoint
 ) -> graph_sync.GraphBuildOutcome:
-    index._rebuild_all_off_boundary()
+    # #576 F3. Elapsed wall time around the whole registered rebuild, on both
+    # the publishing and the failing path. Read alongside the publication- and
+    # stabilization-attempt counts the two loops inside it log, this is what
+    # separates "one slow pass" from "several retried passes" -- the
+    # distinction the incident needed and could not make.
+    started = time.monotonic()
+    try:
+        index._rebuild_all_off_boundary()
+    except BaseException:
+        log.info(
+            "graph rebuild finished outcome=failed elapsed_ms=%.1f generation=%s",
+            (time.monotonic() - started) * 1000.0,
+            checkpoint.generation,
+        )
+        raise
+    log.info(
+        "graph rebuild finished outcome=published elapsed_ms=%.1f generation=%s",
+        (time.monotonic() - started) * 1000.0,
+        checkpoint.generation,
+    )
     return graph_sync.GraphBuildOutcome.covering(checkpoint)
 
 

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -1314,22 +1314,43 @@ class EpistemicGraphIndex:
                 self._reconcile_recall_publication()
                 continue
             try:
-                epoch = graph_sync.publication_epoch(self.vault_root)
+                # Sampled *under* the canonical boundary, not beside it (#576).
+                #
+                # A canonical batch installs the floor before the checkpoint, so
+                # a sample taken mid-batch sees a floor whose checkpoint has not
+                # landed and classifies the lineage as incoherent. The retry
+                # below already knew this -- it coalesces through this exact
+                # boundary and tries again -- but a retry only narrows the
+                # window, and once writes stopped joining their rebuild the
+                # window is open on essentially every write. Exhausting the
+                # attempts then raises GRAPH_SYNC_LINEAGE_CONFLICT out of a
+                # rebuild that had nothing wrong with it.
+                #
+                # Taking the boundary for the sample closes the window instead
+                # of narrowing it. It is O(1) bounded reads of two small
+                # artifacts -- the same shape and cost as the coalesce hold it
+                # supersedes -- and it cannot deadlock, because the write path
+                # no longer waits on this thread in either direction.
+                with self._canonical_mutation_coordinator().hold(
+                    operation="epistemic_graph_sample_epoch", holder_kind="graph"
+                ):
+                    epoch = graph_sync.publication_epoch(self.vault_root)
+                    required = epoch.checkpoint
+                    prior_acknowledgement = (
+                        self._live_acknowledged_checkpoint() if required is None else None
+                    )
             except graph_sync.GraphEpochIncoherent as error:
                 epoch_error = error
-                # A canonical batch installs floor before checkpoint. Coalesce
-                # once through the same boundary so a writer already in that
-                # window can finish before the next bounded epoch sample.
+                # Retained for the sample that is incoherent for a reason the
+                # boundary cannot settle -- a genuinely broken lineage rather
+                # than a writer mid-batch. Coalescing once and retrying keeps
+                # that case exactly as it was.
                 with self._canonical_mutation_coordinator().hold(
                     operation="epistemic_graph_coalesce_epoch", holder_kind="graph"
                 ):
                     pass
                 continue
             epoch_error = None
-            required = epoch.checkpoint
-            prior_acknowledgement = (
-                self._live_acknowledged_checkpoint() if required is None else None
-            )
             temporary = graph_sync.temporary_sidecar_path(
                 live,
                 required
@@ -2258,7 +2279,7 @@ class EpistemicGraphIndex:
             if not recall_policy.is_recall_candidate(self.vault_root, path):
                 return False
             try:
-                raw = path.read_bytes().decode("utf-8")
+                raw = vault_module.read_bytes_without_pinning(path).decode("utf-8")
                 current = _source_signature(path, raw)
             except (OSError, UnicodeDecodeError):
                 return False
@@ -2323,7 +2344,7 @@ class EpistemicGraphIndex:
         for rel in sorted(expected_membership):
             path = self.vault_root / rel
             try:
-                raw_bytes = path.read_bytes()
+                raw_bytes = vault_module.read_bytes_without_pinning(path)
                 raw = raw_bytes.decode("utf-8")
                 source_signature = _source_signature(path, raw)
                 source_mtime = path.stat().st_mtime
@@ -2491,7 +2512,7 @@ class EpistemicGraphIndex:
         for rel in sorted(indexed_paths - changed_rels):
             path = self.vault_root / rel
             try:
-                raw = path.read_bytes().decode("utf-8")
+                raw = vault_module.read_bytes_without_pinning(path).decode("utf-8")
                 scanned_versions[rel] = _source_signature(path, raw)
             except (OSError, UnicodeDecodeError):
                 return None
@@ -2630,7 +2651,12 @@ class EpistemicGraphIndex:
                     return fallback("path_outside_vault")
                 try:
                     expected_paths.append(
-                        (rel, vault_module.content_hash(path.read_bytes().decode("utf-8")))
+                        (
+                            rel,
+                            vault_module.content_hash(
+                                vault_module.read_bytes_without_pinning(path).decode("utf-8")
+                            ),
+                        )
                     )
                 except (OSError, UnicodeDecodeError):
                     return fallback("path_unreadable")
@@ -3059,7 +3085,7 @@ class EpistemicGraphIndex:
             self._delete_path(conn, rel, commit=commit)
             return False
         try:
-            raw_bytes = path.read_bytes()
+            raw_bytes = vault_module.read_bytes_without_pinning(path)
             raw = raw_bytes.decode("utf-8")
             source_signature = _source_signature(path, raw)
         except (OSError, UnicodeDecodeError):
@@ -3098,7 +3124,7 @@ class EpistemicGraphIndex:
             # transaction: do not momentarily publish rows for bytes that are
             # now raw Records (or merely newer ordinary content).
             try:
-                current = path.read_bytes().decode("utf-8")
+                current = vault_module.read_bytes_without_pinning(path).decode("utf-8")
                 current_signature = _source_signature(path, current)
             except (OSError, UnicodeDecodeError):
                 self._delete_path(conn, rel, commit=commit)
@@ -4389,7 +4415,7 @@ def graph_drift(vault_root: Path) -> list[dict[str, Any]]:
     for md in find_module._walk_md(kb):
         try:
             rel = md.resolve().relative_to(vault_root.resolve()).as_posix()
-            raw = md.read_bytes().decode("utf-8")
+            raw = vault_module.read_bytes_without_pinning(md).decode("utf-8")
         except (OSError, ValueError, UnicodeDecodeError):
             continue
         disk_paths.add(rel)
@@ -5228,7 +5254,7 @@ def _current_unit_parent_paths(
             )
             continue
         try:
-            source = path.read_text(encoding="utf-8")
+            source = vault_module.read_bytes_without_pinning(path).decode("utf-8")
         except FileNotFoundError:
             drift_counts["missing_parent"] = drift_counts.get("missing_parent", 0) + 1
             continue

--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -2521,8 +2521,14 @@ def drain_active_rebuilds(timeout: float = _EXIT_DRAIN_SECONDS) -> bool:
     So the boundary is process lifetime, not the write path. Returns whether
     everything drained, so a caller can say so rather than exit silently on a
     rebuild it abandoned.
+    Reads the clock only once it has something to wait for. That is not a
+    micro-optimization: this runs from an autouse teardown fixture on every test
+    in the suite, and a test is entitled to replace `time.monotonic` with a
+    scripted sequence for its own purposes. Charging the empty case a clock read
+    made one such test fail in teardown with `generator raised StopIteration`,
+    from a fixture that had nothing to drain.
     """
-    deadline = time.monotonic() + timeout
+    deadline: float | None = None
     while True:
         alive = [
             thread
@@ -2531,6 +2537,8 @@ def drain_active_rebuilds(timeout: float = _EXIT_DRAIN_SECONDS) -> bool:
         ]
         if not alive:
             return True
+        if deadline is None:
+            deadline = time.monotonic() + timeout
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             return False

--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -94,6 +94,27 @@ _RECEIPT_TERMINAL_STATUSES = frozenset({"committed", "replayed", "rejected"})
 MAX_GRAPH_REBUILD_WAITERS = 128
 MAX_GRAPH_REBUILD_ATTEMPTS = 4
 
+#: An interactive mutation polls a registered graph rebuild; it never waits.
+#:
+#: There is deliberately no tunable interval here. #588 tried one and it was
+#: over-constrained by construction: any bound has to be under `COMMIT_MEDIAN_MS
+#: = 750` or the median latency gate fails the moment the bound is reached, and
+#: simultaneously long enough for a small test-vault rebuild to converge or a
+#: dozen tests that expect `completed` get `pending`. A 2.0 s bound failed the
+#: first constraint (2091 ms / 2259 ms observed at 2k/8k pages); a 0.25 s bound
+#: failed the second (2 CI failures became 6). Those two constraints do not
+#: overlap reliably, which is the design saying the join does not belong on the
+#: write path at all.
+#:
+#: Polling is the honest resolution. The registered-rebuild join is only ever
+#: reached *after* the incremental refresh has already fallen back to a
+#: full-corpus rebuild, and a full-corpus pass costs 20-175 s -- so at the
+#: moment this seam is reached, waiting is never going to be cheap. Report the
+#: flight's outcome if it has already settled, otherwise report `pending` and
+#: let it converge behind the response. The contribution to commit latency is
+#: then provably zero rather than bounded by a number someone has to defend.
+_SETTLED_JOIN_TIMEOUT_SECONDS = 0.0
+
 #: `reconcile` is an internal registry name, not something a caller can run.
 #: The MCP surface is `maintain_memory(mode="reconcile")` and the CLI dispatches
 #: on the public product names (`exomem maintain --reconcile`); "run reconcile"
@@ -2469,6 +2490,78 @@ def wait_for_registered(
     return None if item is None else item[0].wait(timeout)
 
 
+def await_active_rebuild(
+    vault_root: Path,
+    *,
+    state_root: Path | None = None,
+    timeout: float | None = None,
+) -> GraphBuildOutcome | None:
+    """Wait for this vault's in-flight rebuild to settle, outside the request seam.
+
+    `wait_for_registered` consumes a *per-request* registration: once an
+    interactive write has polled it and left (#576/#588), the registration is
+    gone even though the flight is still running on its own thread. A caller
+    that genuinely needs convergence — an operator drain, a test asserting the
+    graph's own outcome — has nothing left to join.
+
+    This joins the flight itself. Returns the outcome, re-raises the builder's
+    exact failure (so a real rebuild failure is never laundered into "nothing
+    happened"), or returns None when no flight is in progress.
+
+    It is deliberately NOT reachable from the write path: nothing in
+    `writer_lease` may call it, and `test_bounded_graph_join.py` enumerates the
+    join sites that could.
+    """
+    key = _registration_key(vault_root, state_root)
+    with _COORDINATORS_LOCK:
+        coordinator = _COORDINATORS.get(key)
+    if coordinator is None:
+        return None
+    with coordinator._condition:
+        required = coordinator._required
+        idle = not coordinator._running and coordinator._error is None
+    if required is None or (idle and coordinator._outcome is None):
+        return None
+    return coordinator._wait(required, timeout)
+
+
+def join_registered_if_settled(
+    vault_root: Path, *, state_root: Path | None = None
+) -> bool:
+    """Take a registered rebuild's outcome if it has one; never block for it.
+
+    The single seam every request-serving join goes through (#576/#588), rather
+    than a timeout threaded through each call site by hand. The first analysis
+    of this incident bounded one site and left an identical unbounded join in
+    `mutation_guard` that then produced the worst case measured -- a 300 s
+    single-unit append. One named helper makes the set greppable, and
+    `test_bounded_graph_join.py` fails on any new `wait_for_registered` caller
+    that is neither this helper nor a declared opt-out.
+
+    Returns True when the flight has already converged, and False when it is
+    still running -- in which case the canonical bytes are durable, the flight
+    keeps going on its own thread, and the caller owes its own caller an honest
+    "derived graph is still catching up". Every other failure still raises, so
+    a real rebuild failure is not laundered into "still pending".
+
+    `Condition.wait_for` with `timeout=0` evaluates its predicate exactly once
+    and returns, so this costs one lock acquisition and no scheduling.
+
+    Deliberately not the default of `wait_for_registered`: `reconcile`, whose
+    terminal exists to prove the graph is readable, must keep blocking, and a
+    default that silently changed under it would be the same class of bug.
+    """
+    try:
+        wait_for_registered(
+            vault_root,
+            _SETTLED_JOIN_TIMEOUT_SECONDS,
+            state_root=state_root,
+        )
+    except TimeoutError:
+        return False
+    return True
+
+
 def start_registered(vault_root: Path, *, state_root: Path | None = None) -> GraphRebuildStart | None:
     """Start captured work without joining it, for standalone post-commit fanout."""
     item = (_PENDING_WAITERS.get() or {}).get(_registration_key(vault_root, state_root))
@@ -3016,4 +3109,30 @@ def committed_graph_failure(
         "graph_sync_code": code,
         "graph_sync_checkpoint": checkpoint.checkpoint_sha256,
         "graph_sync_remediation": remediation,
+    }
+
+
+def committed_graph_pending(checkpoint: GraphSyncCheckpoint) -> dict[str, str]:
+    """The canonical bytes committed; the derived graph has not converged yet.
+
+    A fourth outcome alongside absent/`completed`/`failed`, and the reason the
+    bounded join above is safe to take: a fast write that let a caller infer a
+    fresh derived graph would be worse than the slow one it replaces. `failed`
+    would be a different lie -- nothing failed, the registered rebuild is simply
+    still running and will publish behind this response.
+
+    Derived reads degrade rather than break while this is true: the graph lane
+    falls back to wikilink expansion, `graph_context` reports
+    `available: false`, and relation-filtered recall raises the existing typed
+    `RETRIEVAL_INDEX_WARMING` with its own retry hint. None of them block.
+    """
+    return {
+        "graph_sync": "pending",
+        "graph_sync_code": "GRAPH_SYNC_REBUILD_IN_PROGRESS",
+        "graph_sync_checkpoint": checkpoint.checkpoint_sha256,
+        "graph_sync_remediation": (
+            "The write is durable. Derived graph relations are still rebuilding, so "
+            "relation-filtered recall may report warming and graph context may report "
+            f"available: false for a short time; re-read shortly, or {_RECONCILE_HINT}"
+        ),
     }

--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import atexit
+import contextlib
 import hashlib
 import hmac
 import json
@@ -1018,7 +1019,13 @@ def acknowledgement_state(vault_root: Path) -> tuple[str, GraphBuildOutcome | No
     if not path.exists():
         return "absent", None
     try:
-        with sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True) as conn:
+        # `closing`, not the connection's own context manager: that one is a
+        # transaction scope and leaves the handle open. A leaked read handle
+        # here is what makes the next publication's `os.replace` fail on
+        # Windows, and this reader is on the graph read path.
+        with contextlib.closing(
+            sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True)
+        ) as conn:
             limit_graph_metadata_read(conn)
             values = dict(
                 conn.execute(
@@ -1067,7 +1074,9 @@ def _malformed_acknowledgement_generation(vault_root: Path) -> int | None:
     if not path.exists():
         return None
     try:
-        with sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True) as conn:
+        with contextlib.closing(
+            sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True)
+        ) as conn:  # `closing` for the reason given in `acknowledgement_state`.
             limit_graph_metadata_read(conn)
             row = conn.execute(
                 "SELECT value FROM graph_meta WHERE key = 'graph_sync_generation'"

--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -2490,6 +2490,54 @@ def wait_for_registered(
     return None if item is None else item[0].wait(timeout)
 
 
+#: The one thread name every graph rebuild runs under, in both the registered
+#: path (`GraphRebuildCoordinator.ensure_started`) and the warming path
+#: (`epistemic_graph.schedule_background_rebuild`).
+GRAPH_REBUILD_THREAD_NAME = "exomem-graph-rebuild"
+
+#: A rebuild over a realistic vault is seconds; a whole-vault pass over a large
+#: one has been measured in the low minutes. Long enough that a healthy rebuild
+#: always finishes, short enough that a wedged one cannot hold a shell prompt
+#: open indefinitely -- at which point the checkpoint is still durable and the
+#: next run or a reconcile repairs it.
+_EXIT_DRAIN_SECONDS = 300.0
+
+
+def drain_active_rebuilds(timeout: float = _EXIT_DRAIN_SECONDS) -> bool:
+    """Let in-flight graph rebuilds finish before this process ends.
+
+    Taking the rebuild off the *write* path is correct: a request should not pay
+    for a whole-vault build. Letting the *process* exit with that build still
+    running is not, and the two are easy to conflate.
+
+    A rebuild runs on a daemon thread, which is right for the long-lived server
+    -- the request returns, the rebuild lands moments later, and a reader that
+    polls sees it converge. It is wrong for a one-shot CLI process, which exits
+    as soon as the command returns and takes the daemon with it. The write would
+    report `pending` and nothing would ever make it true: every `exomem`
+    invocation would leave the graph a little further behind, and only an
+    explicit reconcile would catch up.
+
+    So the boundary is process lifetime, not the write path. Returns whether
+    everything drained, so a caller can say so rather than exit silently on a
+    rebuild it abandoned.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        alive = [
+            thread
+            for thread in threading.enumerate()
+            if thread.name == GRAPH_REBUILD_THREAD_NAME and thread.is_alive()
+        ]
+        if not alive:
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        for thread in alive:
+            thread.join(timeout=max(0.0, deadline - time.monotonic()))
+
+
 def await_active_rebuild(
     vault_root: Path,
     *,

--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -3201,3 +3201,27 @@ def committed_graph_pending(checkpoint: GraphSyncCheckpoint) -> dict[str, str]:
             f"available: false for a short time; re-read shortly, or {_RECONCILE_HINT}"
         ),
     }
+
+
+def committed_graph_queued(checkpoint: GraphSyncCheckpoint) -> dict[str, str]:
+    """The canonical bytes committed; the repair is queued, not running.
+
+    The same fourth outcome as `committed_graph_pending`, reached the other way.
+    There the derived graph is behind because a registered whole-vault rebuild
+    has not converged; here it is behind because the incremental pass could not
+    prove itself and enqueued the affected paths for a drain instead. The
+    distinction is worth a separate code rather than reusing
+    `GRAPH_SYNC_REBUILD_IN_PROGRESS`: nothing is rebuilding, so an operator
+    reading that code would go looking for a flight that does not exist, and the
+    two states converge on very different timescales.
+    """
+    return {
+        "graph_sync": "pending",
+        "graph_sync_code": "GRAPH_SYNC_REPAIR_QUEUED",
+        "graph_sync_checkpoint": checkpoint.checkpoint_sha256,
+        "graph_sync_remediation": (
+            "The write is durable. Repair of the changed pages is queued and converges on "
+            "the next index drain, so relation-filtered recall may report warming and graph "
+            f"context may report available: false until then; re-read shortly, or {_RECONCILE_HINT}"
+        ),
+    }

--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -745,6 +745,88 @@ def clear_deferred_work(
     return cleared
 
 
+def _drain_graph_work(
+    vault_root: Path, *, limit: int | None, requested: set[str] | None
+) -> int:
+    """Repair the epistemic graph proportionally to what the queue says changed.
+
+    Same shape as the full and semantic branches below -- optimistic batch, then
+    per-receipt replay so one unindexable page cannot pin the rest, then
+    rotation so a poisoned receipt sorts behind untouched work rather than
+    disappearing from it. Receipts clear by compare-and-swap on their exact
+    revision, which is what makes a write that lands mid-drain survive the drain
+    that did not cover it.
+
+    The full-rebuild marker is checked first and drains the whole queue with it:
+    a batch too large to enumerate is the one case where re-walking the vault is
+    cheaper than the list of what changed.
+    """
+    from . import epistemic_graph
+
+    pending_generation = deferred_index.graph_full_rebuild_pending(vault_root)
+    receipts = deferred_index.snapshot_graph(
+        vault_root, limit=limit, paths=requested
+    )
+    if pending_generation is None and not receipts:
+        return 0
+
+    index = epistemic_graph.EpistemicGraphIndex(vault_root)
+    if pending_generation is not None:
+        try:
+            index.rebuild_all()
+        except Exception:  # noqa: BLE001 - durable work must survive a failed rebuild
+            log.warning("deferred graph rebuild failed; marker remains", exc_info=True)
+            return 0
+        deferred_index.clear_graph_full_rebuild(vault_root, generation=pending_generation)
+        # A whole-vault rebuild covers every path queued at snapshot time; a
+        # path enqueued after it started carries a newer revision and survives.
+        return 1 + deferred_index.clear_graph_receipts(vault_root, receipts)
+
+    processed = 0
+    batch = [vault_root / receipt.rel_path for receipt in receipts]
+    try:
+        report = index.drain_paths(batch)
+    except Exception:  # noqa: BLE001 - isolate below rather than lose the queue
+        log.warning("deferred graph batch failed; isolating receipts", exc_info=True)
+        report = {}
+    if report.get("requires_rebuild"):
+        deferred_index.mark_graph_full_rebuild(
+            vault_root, generation=_graph_marker_generation(vault_root)
+        )
+        return 0
+    covered = set(report.get("indexed", ()))
+    if covered:
+        done = [receipt for receipt in receipts if receipt.rel_path in covered]
+        processed += deferred_index.clear_graph_receipts(vault_root, done)
+    stalled = [receipt for receipt in receipts if receipt.rel_path not in covered]
+    if not stalled:
+        return processed
+
+    for receipt in stalled:
+        try:
+            single = index.drain_paths([vault_root / receipt.rel_path])
+        except Exception:  # noqa: BLE001 - one poison page must not pin the queue
+            log.warning(
+                "deferred graph receipt failed; work remains queued", exc_info=True
+            )
+            deferred_index.rotate_graph_receipts(vault_root, [receipt])
+            continue
+        if receipt.rel_path in set(single.get("indexed", ())):
+            processed += deferred_index.clear_graph_receipts(vault_root, [receipt])
+        else:
+            log.warning("deferred graph receipt incomplete; work remains queued")
+            deferred_index.rotate_graph_receipts(vault_root, [receipt])
+    return processed
+
+
+def _graph_marker_generation(vault_root: Path) -> int:
+    """The generation a rebuild marker should carry when a drain escalates."""
+    from . import graph_sync
+
+    checkpoint = graph_sync.read_checkpoint(vault_root)
+    return 0 if checkpoint is None else int(checkpoint.generation)
+
+
 def drain_deferred_work(
     vault_root: Path,
     *,
@@ -789,7 +871,7 @@ def drain_deferred_work(
             full_receipts = full_receipts[:full_budget]
             semantic_receipts = semantic_receipts[:semantic_budget]
 
-    processed = 0
+    processed = _drain_graph_work(vault_root, limit=limit, requested=requested)
     if full_receipts:
         full_paths = [vault_root / receipt.rel_path for receipt in full_receipts]
         full_batch_completed = False
@@ -818,13 +900,13 @@ def drain_deferred_work(
                         "deferred full-index dispatch failed; work remains queued",
                         exc_info=True,
                     )
-                    deferred_index.rotate_receipts(vault_root, [receipt], full=True)
+                    deferred_index.rotate_receipts(vault_root, [receipt], queue="full")
                     continue
                 if not full_upsert_succeeded(
                     vault_root, [vault_root / receipt.rel_path], dispatched
                 ):
                     log.warning("deferred full-index dispatch incomplete; work remains queued")
-                    deferred_index.rotate_receipts(vault_root, [receipt], full=True)
+                    deferred_index.rotate_receipts(vault_root, [receipt], queue="full")
                     continue
                 processed += deferred_index.clear_full_receipts(vault_root, [receipt])
 

--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -760,8 +760,24 @@ def _drain_graph_work(
     The full-rebuild marker is checked first and drains the whole queue with it:
     a batch too large to enumerate is the one case where re-walking the vault is
     cheaper than the list of what changed.
+
+    `limit` bounds this queue rather than being split with the others. Sharing
+    one budget would mean either starving graph work behind full and semantic
+    work -- and graph latency is the one a reader feels -- or reshuffling the
+    tuned split between those two. The overshoot is one queue's share per tick,
+    bounded and small; the alternative is a queue that never drains on a busy
+    vault.
+
+    An incoherent graph epoch refuses the whole branch. Per-path repair is
+    repair *against a lineage*, so applying it to one whose lineage cannot be
+    classified would write plausible rows into an untrustworthy sidecar. The
+    work stays queued and a rebuild recovers it.
     """
-    from . import epistemic_graph
+    from . import epistemic_graph, graph_sync
+
+    if graph_sync.classify_epoch(vault_root).kind not in {"legacy", "coherent"}:
+        log.warning("deferred graph drain skipped; graph epoch is not coherent")
+        return 0
 
     pending_generation = deferred_index.graph_full_rebuild_pending(vault_root)
     receipts = deferred_index.snapshot_graph(
@@ -790,9 +806,14 @@ def _drain_graph_work(
         log.warning("deferred graph batch failed; isolating receipts", exc_info=True)
         report = {}
     if report.get("requires_rebuild"):
-        deferred_index.mark_graph_full_rebuild(
-            vault_root, generation=_graph_marker_generation(vault_root)
-        )
+        # Deliberately not escalated to a rebuild marker. Every condition that
+        # produces this is transient -- no sidecar yet, no live recall registry,
+        # no resolver -- and raising a marker would convert a moment's
+        # unreadiness into a guaranteed whole-vault pass, which is the cost this
+        # change exists to stop paying. The work stays queued; the next drain
+        # retries, and the paths that genuinely require a rebuild reach one
+        # through the checkpoint's own full-scope marker.
+        log.info("deferred graph drain deferred; vault not ready for incremental repair")
         return 0
     covered = set(report.get("indexed", ()))
     if covered:
@@ -817,14 +838,6 @@ def _drain_graph_work(
             log.warning("deferred graph receipt incomplete; work remains queued")
             deferred_index.rotate_graph_receipts(vault_root, [receipt])
     return processed
-
-
-def _graph_marker_generation(vault_root: Path) -> int:
-    """The generation a rebuild marker should carry when a drain escalates."""
-    from . import graph_sync
-
-    checkpoint = graph_sync.read_checkpoint(vault_root)
-    return 0 if checkpoint is None else int(checkpoint.generation)
 
 
 def drain_deferred_work(

--- a/src/exomem/mutation_lock.py
+++ b/src/exomem/mutation_lock.py
@@ -765,6 +765,16 @@ def _prepare_windows_private_directory(path: Path) -> None:
     A process sets permissions only on the exact entry its own ``mkdir``
     created.  A concurrent loser waits briefly for that creator to finish its
     DACL write, then validates without repairing the observed entry.
+
+    Missing *ancestors* are created first, without a private DACL.  That is not
+    a relaxation: the POSIX branch this mirrors passes ``parents=True``, and
+    ``Path.mkdir`` applies its ``mode`` only to the leaf there too, so the
+    ancestors are ordinary directories on both platforms and the privacy
+    guarantee sits on ``target`` alone.  Without this, a Windows profile whose
+    ``~/.cache`` does not exist -- which is every fresh Windows profile, since
+    ``.cache`` is an XDG convention Windows does not create -- cannot construct
+    the idempotency store at all, and the server dies at startup with
+    ``WinError 3``.  No CI lane runs on Windows, so nothing else would catch it.
     """
     target = Path(path).expanduser().absolute()
     created = False
@@ -772,6 +782,7 @@ def _prepare_windows_private_directory(path: Path) -> None:
     try:
         directory = _acquire_secure_directory(target, create=False)
     except FileNotFoundError:
+        target.parent.mkdir(parents=True, exist_ok=True)
         try:
             target.mkdir(mode=0o700)
         except FileExistsError:

--- a/src/exomem/mutation_terminal.py
+++ b/src/exomem/mutation_terminal.py
@@ -56,6 +56,16 @@ _PLAN_RECEIPT_FIELDS = (
 STATES = ("needs_review", "committed", "rejected", "retryable", "indeterminate")
 TERMINAL_STATES = frozenset({"committed", "rejected"})
 
+#: The closed derived-graph outcome vocabulary a client may branch on. Absent
+#: means no graph work was required; `pending` means the write is durable but
+#: its derived graph is still rebuilding behind the response.
+#:
+#: Public because it is a cross-surface contract, not a projection detail:
+#: `scripts/records_live_acceptance.py` validates against it and is NOT run by
+#: CI, so a second hand-maintained copy of this vocabulary would drift silently
+#: until someone ran the script against a real build. One definition, imported.
+GRAPH_SYNC_OUTCOMES = frozenset({"completed", "failed", "pending"})
+
 #: Keys a client may branch on. Everything else in a response is advisory.
 _ENVELOPE_KEYS = (
     "ok",
@@ -555,8 +565,13 @@ def project_terminal(result: Any, detail: ResponseDetail = "compact") -> Any:
         compact.update({key: leaf[key] for key in _PLAN_RECEIPT_FIELDS if key in leaf})
     artifact_receipt = _artifact_receipt_projection(leaf)
     compact.update(artifact_receipt)
-    graph_result = result if result.get("graph_sync") in {"completed", "failed"} else leaf
-    if isinstance(graph_result, Mapping) and graph_result.get("graph_sync") in {"completed", "failed"}:
+    # `pending` (#576) is the fourth outcome: canonical bytes committed, the
+    # registered derived-graph rebuild has not converged yet. It has to survive
+    # into `compact` -- the default detail -- or a bounded write would be
+    # indistinguishable from one whose graph is current, which is the exact
+    # dishonesty the bound is not allowed to introduce.
+    graph_result = result if result.get("graph_sync") in GRAPH_SYNC_OUTCOMES else leaf
+    if isinstance(graph_result, Mapping) and graph_result.get("graph_sync") in GRAPH_SYNC_OUTCOMES:
         compact["graph_sync"] = graph_result["graph_sync"]
         for key in (
             "graph_sync_code",

--- a/src/exomem/review_state.py
+++ b/src/exomem/review_state.py
@@ -133,9 +133,17 @@ class ReviewStateStore:
     def load(self) -> dict[str, Any]:
         if not self.path.exists():
             return {"version": SCHEMA_VERSION, "records": {}}
+        from . import vault
+
         try:
-            payload = json.loads(self.path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
+            # Not `read_text`: on Windows an ordinary open pins this file
+            # against replacement while it is held, so a status poll or a
+            # review-context read overlapping a triage write refused that write
+            # with WinError 32 and surfaced it as a bare 500. Review state is
+            # derived bookkeeping, not a canonical record whose exact bytes a
+            # reader has verified and must hold still.
+            payload = json.loads(vault.read_bytes_without_pinning(self.path).decode("utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise ValueError(f"REVIEW_STATE_INVALID: cannot read {self.path}: {exc}") from exc
         if not isinstance(payload, dict) or payload.get("version") != SCHEMA_VERSION:
             raise ValueError(
@@ -249,6 +257,8 @@ class ReviewStateStore:
         }
 
     def _write(self, payload: dict[str, Any]) -> None:
+        from . import vault
+
         self.path.parent.mkdir(parents=True, exist_ok=True)
         fd, temp_name = tempfile.mkstemp(
             prefix=f".{STATE_FILENAME}.", suffix=".tmp", dir=self.path.parent
@@ -259,7 +269,13 @@ class ReviewStateStore:
                 handle.write("\n")
                 handle.flush()
                 os.fsync(handle.fileno())
-            os.replace(temp_name, self.path)
+            # A reader that has not yet let go is a wait, not a failure. Only
+            # readers can be concurrent here -- writes to review state run
+            # under the writer lease -- so there is no precondition that the
+            # wait could invalidate, and nothing to re-prove afterwards.
+            vault.replace_tolerating_transient_sharing(
+                lambda: os.replace(temp_name, self.path)
+            )
         except Exception:
             try:
                 os.unlink(temp_name)

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -1891,6 +1891,43 @@ def _recheck_rollback_directory_guards(
             guard.recheck(vault_root, allowed_changes=allowed_changes)
 
 
+#: Derived-index operational artifacts that live beside canonical content in a
+#: vault directory. A graph rebuild creates, replaces and removes these for its
+#: whole run; none of it is a change to the canonical namespace this census
+#: exists to pin.
+#:
+#: Counting them made an unrelated canonical write fail purely because a rebuild
+#: happened to be in flight — `PATH_GUARD_CHANGED: guarded directory census
+#: changed`, surfaced to the caller as `STALE_RECORD`, and on Windows also as
+#: `WinError 32` when the open sidecar refuses replacement. Nothing hit it while
+#: every write joined its own rebuild and the two could never overlap: the join
+#: was hiding a genuine conflict between the rebuild and concurrent writes
+#: (#576). It is the same reasoning as `_BATCH_RESIDUE_PREFIX` directly below —
+#: exomem's own operational residue is not canonical content.
+#:
+#: Deliberately narrow. `.graph-sync.json` and `.graph-sync-floor.json` stay
+#: censused: those are written by the canonical batch itself, so a change to
+#: them under a write is exactly what this guard must still refuse.
+#:
+#: Literals rather than an import, to avoid a `vault` <-> `graph_sync` cycle;
+#: `test_graph_artifacts_are_excluded_from_the_canonical_census` binds them to
+#: their definitions in `graph_sync` so the two cannot drift apart.
+_DERIVED_INDEX_PREFIXES = (".graph-rebuild-", ".graph-reset-")
+_DERIVED_INDEX_NAMES = frozenset(
+    {
+        ".graph.sqlite",
+        ".graph.sqlite-journal",
+        ".graph.sqlite-wal",
+        ".graph.sqlite-shm",
+    }
+)
+
+
+def _is_derived_index_artifact(name: str) -> bool:
+    """Whether a directory entry is derived-index residue, not canonical content."""
+    return name in _DERIVED_INDEX_NAMES or name.startswith(_DERIVED_INDEX_PREFIXES)
+
+
 _BATCH_RESIDUE_PREFIX = ".exomem-batch-"
 _BATCH_RESIDUE_NAME = re.compile(r"^\.exomem-batch-[0-9a-f]{32}$", re.ASCII)
 _BATCH_RESIDUE_CHILD = re.compile(
@@ -2132,7 +2169,7 @@ def _bounded_directory_entries(
         ordinary_names: list[str] = []
         for entry in iterator:
             name = entry.name
-            if name in ignored_names:
+            if name in ignored_names or _is_derived_index_artifact(name):
                 continue
             if name.startswith(_BATCH_RESIDUE_PREFIX):
                 residue_names.append(name)

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -20,7 +20,7 @@ import tempfile
 import threading
 import time
 import unicodedata
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1482,24 +1482,14 @@ class _BatchWorkspace:
         identity = artifact.identity
         if os.name == "nt":  # pragma: no cover - Windows does not replace open CRT files
             artifact.close()
-        for attempt in range(_REPLACE_SHARING_ATTEMPTS):
-            try:
-                self._replace_once(artifact, final)
-                break
-            except PermissionError as error:
-                if (
-                    os.name != "nt"
-                    or getattr(error, "winerror", None) not in _WINDOWS_SHARING_ERRORS
-                    or attempt == _REPLACE_SHARING_ATTEMPTS - 1
-                ):
-                    raise
-                time.sleep(_REPLACE_SHARING_SLEEP_SECONDS)
-                # Re-pin the workspace directory on every attempt so waiting out
-                # a reader never widens the window this guard covers. The
-                # artifact itself is already closed on Windows and its identity
-                # was proved immediately above, and the mutation boundary is
-                # held throughout, so no other governed writer can intervene.
-                self.recheck()
+        # Re-pin the workspace directory on every attempt so waiting out a reader
+        # never widens the window this guard covers. The artifact itself is
+        # already closed on Windows and its identity was proved immediately
+        # above, and the mutation boundary is held throughout, so no other
+        # governed writer can intervene.
+        replace_tolerating_transient_sharing(
+            lambda: self._replace_once(artifact, final), recheck=self.recheck
+        )
         artifact.close()
         self.artifacts.pop(artifact.name)
         return identity
@@ -1927,9 +1917,52 @@ def _recheck_rollback_directory_guards(
 #: short enough that a genuinely pinned file still fails inside the request
 #: rather than hanging it. POSIX never enters the loop -- `rename(2)` over an
 #: open file is always permitted -- so this costs nothing there.
+#:
+#: Measured headroom, against a reader re-opening the same page in a tight loop
+#: with no pause -- far more hostile than any real rebuild, which reads a page
+#: once and moves on: 200 consecutive replacements all succeeded, 96 needed at
+#: least one retry, and the worst needed 8 of the 20 attempts.
 _WINDOWS_SHARING_ERRORS = frozenset({5, 32})
 _REPLACE_SHARING_ATTEMPTS = 20
 _REPLACE_SHARING_SLEEP_SECONDS = 0.01
+
+
+def replace_tolerating_transient_sharing(
+    replace_once: Callable[[], None], *, recheck: Callable[[], None] = lambda: None
+) -> int:
+    """Perform a replacement, waiting out a transient Windows sharing refusal.
+
+    Returns the zero-based attempt that succeeded, so a caller (or a test) can
+    see how much of the budget a workload actually consumes rather than only
+    whether it fit.
+
+    `recheck` runs after every failed attempt. Waiting necessarily widens the
+    interval between proving a precondition and acting on it, so a caller that
+    holds a guarded precondition MUST re-prove it here rather than replace
+    against one established before the wait.
+
+    Note that this and `read_bytes_without_pinning` are a **pair**, not two
+    independent accommodations, and neither is sufficient alone. Without the
+    non-pinning read, a rebuild sweeping the corpus dies the moment it opens a
+    page a writer has marked delete-pending. With it, the reader survives -- but
+    FILE_SHARE_DELETE is precisely what lets a replacement mark the target
+    delete-pending while that handle lives, so a re-opening reader makes the
+    *writer* fail more often, not less. Only the retry closes that second gap.
+    """
+    for attempt in range(_REPLACE_SHARING_ATTEMPTS):
+        try:
+            replace_once()
+            return attempt
+        except PermissionError as error:
+            if (
+                os.name != "nt"
+                or getattr(error, "winerror", None) not in _WINDOWS_SHARING_ERRORS
+                or attempt == _REPLACE_SHARING_ATTEMPTS - 1
+            ):
+                raise
+            time.sleep(_REPLACE_SHARING_SLEEP_SECONDS)
+            recheck()
+    raise AssertionError("unreachable: the final attempt re-raises")  # pragma: no cover
 
 
 def read_bytes_without_pinning(path: Path) -> bytes:

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -3260,6 +3260,32 @@ def _remove_empty_created_dirs(created_dirs: list[Path]) -> None:
             pass
 
 
+def _enqueue_graph_debt(vault_root: Path, checkpoint_write: PlannedWrite) -> None:
+    """Record this batch's graph debt durably, *before* the batch commits.
+
+    The ordering is the whole argument. Enqueue-then-write can leave a path
+    queued whose content never changed, and re-indexing an unchanged path writes
+    nothing -- the cost is one wasted read. Write-then-enqueue can leave the
+    markdown committed with no record that the graph owes it anything, and the
+    only repair for an unknown dirty set is the whole-vault rebuild this change
+    exists to retire. The failures are not comparable, so the safe order is not
+    a preference.
+
+    Best-effort by construction: a deferred queue that could refuse a canonical
+    write would be a worse availability risk than the drift it prevents. A lost
+    enqueue costs a reconcile; a refused write costs the user their edit.
+    """
+    from . import deferred_index, graph_sync
+
+    checkpoint = graph_sync.GraphSyncCheckpoint.parse(checkpoint_write.content)
+    if checkpoint is None:  # pragma: no cover - graph_sync renders its own token
+        return
+    try:
+        deferred_index.enqueue_graph_checkpoint(vault_root, checkpoint)
+    except Exception:  # noqa: BLE001 - never fail a canonical write on derived bookkeeping
+        log.warning("graph dirty-path enqueue failed; reconcile will repair", exc_info=True)
+
+
 def batch_atomic_write(
     writes: Iterable[PlannedWrite],
     *,
@@ -3354,6 +3380,7 @@ def _batch_atomic_write_locked(
             graph_floor_path = floor_write.path
             if not defer_graph_completion:
                 graph_checkpoint_path = checkpoint_write.path
+            _enqueue_graph_debt(Path(vault_root), checkpoint_write)
         elif defer_graph_completion:
             raise ValueError("defer_graph_completion requires graph-relevant writes")
     destinations: set[str] = set()

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -2060,9 +2060,39 @@ _DERIVED_INDEX_NAMES = frozenset(
 )
 
 
+#: The deferred-index queue database, which lives beside canonical content for
+#: the same reason the graph sidecar does. It earns its own set rather than
+#: joining `_DERIVED_INDEX_NAMES` because that one is bound to `graph_sync`'s
+#: reset manifest, and this one is bound to `deferred_index.store_path`.
+#:
+#: The graph dirty-path enqueue (`converge-graph-incrementally`) writes this
+#: database *before* the canonical batch commits, so that a crash between the
+#: markdown and the enqueue cannot lose the dirty set. That ordering is
+#: deliberate -- over-enqueueing costs a redundant re-index, under-enqueueing
+#: is unrecoverable without the whole-vault rebuild being removed -- and it
+#: puts the file's creation and journalling inside the guarded window. Counting
+#: it made the first write to a fresh vault invalidate its own census and fail
+#: as `STALE_RECORD: canonical record changed before commit`, with nothing
+#: concurrent involved.
+#:
+#: Same narrowness rule as above: a dirty-path queue is exomem's own
+#: bookkeeping and never canonical content, so excluding it removes no
+#: guarantee. Two writers racing to append their own debt is precisely the
+#: monotone behaviour the queue exists to provide, not a canonical conflict.
+_DEFERRED_INDEX_BASENAME = ".deferred-index.sqlite"
+_DEFERRED_INDEX_NAMES = frozenset(
+    {_DEFERRED_INDEX_BASENAME}
+    | {f"{_DEFERRED_INDEX_BASENAME}-{suffix}" for suffix in ("journal", "wal", "shm")}
+)
+
+
 def _is_derived_index_artifact(name: str) -> bool:
     """Whether a directory entry is derived-index residue, not canonical content."""
-    return name in _DERIVED_INDEX_NAMES or name.startswith(_DERIVED_INDEX_PREFIXES)
+    return (
+        name in _DERIVED_INDEX_NAMES
+        or name in _DEFERRED_INDEX_NAMES
+        or name.startswith(_DERIVED_INDEX_PREFIXES)
+    )
 
 
 _BATCH_RESIDUE_PREFIX = ".exomem-batch-"

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -1465,12 +1465,7 @@ class _BatchWorkspace:
                 os.close(descriptor)
             raise
 
-    def replace_artifact(self, artifact: _WorkspaceArtifact, final: Path) -> PathIdentity:
-        self.recheck()
-        artifact.recheck()
-        identity = artifact.identity
-        if os.name == "nt":  # pragma: no cover - Windows does not replace open CRT files
-            artifact.close()
+    def _replace_once(self, artifact: _WorkspaceArtifact, final: Path) -> None:
         if os.replace in getattr(os, "supports_dir_fd", set()):
             os.replace(
                 artifact.name,
@@ -1480,6 +1475,31 @@ class _BatchWorkspace:
             )
         else:  # pragma: no cover - Windows fallback
             os.replace(artifact.path, final)
+
+    def replace_artifact(self, artifact: _WorkspaceArtifact, final: Path) -> PathIdentity:
+        self.recheck()
+        artifact.recheck()
+        identity = artifact.identity
+        if os.name == "nt":  # pragma: no cover - Windows does not replace open CRT files
+            artifact.close()
+        for attempt in range(_REPLACE_SHARING_ATTEMPTS):
+            try:
+                self._replace_once(artifact, final)
+                break
+            except PermissionError as error:
+                if (
+                    os.name != "nt"
+                    or getattr(error, "winerror", None) not in _WINDOWS_SHARING_ERRORS
+                    or attempt == _REPLACE_SHARING_ATTEMPTS - 1
+                ):
+                    raise
+                time.sleep(_REPLACE_SHARING_SLEEP_SECONDS)
+                # Re-pin the workspace directory on every attempt so waiting out
+                # a reader never widens the window this guard covers. The
+                # artifact itself is already closed on Windows and its identity
+                # was proved immediately above, and the mutation boundary is
+                # held throughout, so no other governed writer can intervene.
+                self.recheck()
         artifact.close()
         self.artifacts.pop(artifact.name)
         return identity
@@ -1889,6 +1909,90 @@ def _recheck_rollback_directory_guards(
         guarded_directory = Path(vault_root) / guard.target
         if final_parent == os.path.abspath(guarded_directory):
             guard.recheck(vault_root, allowed_changes=allowed_changes)
+
+
+#: Windows refuses `os.replace` onto a target another handle holds open without
+#: FILE_SHARE_DELETE (ERROR_SHARING_VIOLATION, 32) and reports
+#: ERROR_ACCESS_DENIED (5) for a target already marked delete-pending. Both are
+#: *transient by nature*: the holder is a reader that closes microseconds later.
+#:
+#: exomem's own derived-index readers no longer pin canonical pages -- see
+#: `read_bytes_without_pinning` -- but this writer cannot assume it is the only
+#: process on a user's vault. Obsidian, OneDrive, a backup agent and an
+#: antivirus scanner all open Markdown files, and on Windows any one of them
+#: turns an ordinary governed write into RECORD_PUBLICATION_FAILED. Waiting out
+#: a transient reader is the correct platform accommodation, not a workaround.
+#:
+#: ~200 ms of total patience: long enough that no realistic reader outlives it,
+#: short enough that a genuinely pinned file still fails inside the request
+#: rather than hanging it. POSIX never enters the loop -- `rename(2)` over an
+#: open file is always permitted -- so this costs nothing there.
+_WINDOWS_SHARING_ERRORS = frozenset({5, 32})
+_REPLACE_SHARING_ATTEMPTS = 20
+_REPLACE_SHARING_SLEEP_SECONDS = 0.01
+
+
+def read_bytes_without_pinning(path: Path) -> bytes:
+    """Read a canonical file without blocking a concurrent replacement of it.
+
+    Python's Windows `open()` requests FILE_SHARE_READ | FILE_SHARE_WRITE and
+    omits FILE_SHARE_DELETE, so for as long as the file is open an `os.replace`
+    onto it is refused with WinError 32. That is the right trade for a
+    *canonical* reader, which has verified a path and must pin what it verified.
+
+    It is the wrong trade for a **derived-index** reader. A graph or embedding
+    rebuild is building a cache from canonical bytes; it already re-proves the
+    source versions it read (`_source_versions_current`) and treats a page that
+    moved under it as a reason to discard the pass. Pinning buys it nothing, and
+    costs it this: a rebuild sweeping the corpus makes every concurrent write to
+    a page it happens to be reading fail, which surfaced as WinError 32 on
+    `log.md` and `_collection.md` the moment writes stopped joining their
+    rebuild (#576).
+
+    POSIX has no equivalent restriction -- `rename(2)` over an open file is
+    always permitted -- so there this is exactly `path.read_bytes()`.
+    """
+    if os.name != "nt":
+        return path.read_bytes()
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    handle = create_file(
+        str(path),
+        0x80000000,  # GENERIC_READ
+        0x00000001 | 0x00000002 | 0x00000004,  # SHARE_READ | SHARE_WRITE | SHARE_DELETE
+        None,
+        3,  # OPEN_EXISTING
+        0x00000080,  # FILE_ATTRIBUTE_NORMAL
+        None,
+    )
+    if handle == wintypes.HANDLE(-1).value:
+        error = ctypes.get_last_error()
+        # Preserve the exception types every caller of `read_bytes()` already
+        # handles; a derived-index reader treats a vanished page as absent, not
+        # as an unclassified OS failure.
+        if error in {2, 3}:
+            raise FileNotFoundError(error, "no such file", str(path))
+        raise ctypes.WinError(error)
+    import msvcrt
+
+    # `open_osfhandle` transfers ownership: closing the descriptor closes the
+    # handle, so there is no path here that leaks it.
+    descriptor = msvcrt.open_osfhandle(handle, os.O_RDONLY | os.O_BINARY)
+    with os.fdopen(descriptor, "rb") as stream:
+        return stream.read()
 
 
 #: Derived-index operational artifacts that live beside canonical content in a

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -3384,6 +3384,7 @@ def _batch_atomic_write_locked(
     writes = list(caller_writes)
     graph_checkpoint_path: Path | None = None
     graph_floor_path: Path | None = None
+    graph_debt_checkpoint: PlannedWrite | None = None
     deferred_checkpoint: GraphSyncCheckpoint | None = None
     deferred_predecessor: GraphSyncCheckpoint | None = None
     if vault_root is not None:
@@ -3410,7 +3411,7 @@ def _batch_atomic_write_locked(
             graph_floor_path = floor_write.path
             if not defer_graph_completion:
                 graph_checkpoint_path = checkpoint_write.path
-            _enqueue_graph_debt(Path(vault_root), checkpoint_write)
+            graph_debt_checkpoint = checkpoint_write
         elif defer_graph_completion:
             raise ValueError("defer_graph_completion requires graph-relevant writes")
     destinations: set[str] = set()
@@ -3500,6 +3501,24 @@ def _batch_atomic_write_locked(
         if write.create_only and os.path.lexists(write.path):
             _remove_empty_created_dirs(created_dirs)
             raise CreateOnlyConflict(_safe_write_target(write.path, vault_root))
+
+    # Record the graph debt here: after the guards have taken custody of the
+    # namespace and created whatever parents they recorded as missing, and
+    # still strictly before any canonical byte is replaced.
+    #
+    # Earlier is wrong even though the debt is known earlier. Opening the queue
+    # database creates `Knowledge Base/` when it does not exist, and a batch
+    # that is creating that directory has already captured it as a *missing*
+    # parent it will create itself, in order. Creating it first fails the
+    # guard's own recheck with `missing guard ancestor appeared`, surfaced to
+    # the caller as `STALE_SEMANTIC_WRITE` -- a write invalidated by its own
+    # bookkeeping, on every first write into a new directory.
+    #
+    # Later is also wrong: after the replace, a crash cut between the markdown
+    # and the enqueue loses the dirty set, which is the whole property the
+    # pre-commit ordering buys.
+    if graph_debt_checkpoint is not None:
+        _enqueue_graph_debt(Path(vault_root), graph_debt_checkpoint)
 
     workspace_by_parent: dict[Path, _BatchWorkspace] = {}
     staged: list[tuple[Path, _BatchWorkspace, _WorkspaceArtifact]] = []

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -2263,7 +2263,19 @@ class LeaseManager:
             root = Path(vault_root)
             try:
                 graph_sync.start_registered(root, state_root=self.config.state_dir)
-                graph_sync.wait_for_registered(root, state_root=self.config.state_dir)
+                # The second unbounded join (#576), and the one that produced
+                # the worst case measured in production: a 300 s single-unit
+                # `observe_memory` append, against 14.3 s for the `remember`
+                # immediately before it. This guard is held while serving a
+                # request exactly like `after_operation_guard` is, so it takes
+                # the same seam. There is no terminal envelope here to carry
+                # `pending`, so the honest report is the log line below -- the
+                # leaf's own bounded index/readiness paths already tell its
+                # caller the derived graph is not current.
+                if not graph_sync.join_registered_if_settled(
+                    root, state_root=self.config.state_dir
+                ):
+                    logger.info("direct mutation left its graph rebuild running")
             except graph_sync.GraphRebuildRegistrationError:
                 # Direct leaf APIs have no terminal-envelope seam for a graph
                 # failure. Canonical bytes and the exact durable failure handle
@@ -2513,7 +2525,37 @@ class LeaseManager:
                 if required is None and not has_reconcile_handoff:
                     return terminal_result
                 if required is not None:
-                    graph_sync.wait_for_registered(root, state_root=self.config.state_dir)
+                    # An interactive write takes a derived-graph outcome only if
+                    # one is already there (#576/#588); it never waits for one.
+                    # Maintenance whose whole purpose is to make the graph
+                    # current opts back in to the unbounded join rather than
+                    # every write paying for it: `reconcile` proves readability
+                    # in its own terminal below, and a rebuild handoff has
+                    # nothing to hand off until the flight lands.
+                    joins_unbounded = (
+                        has_reconcile_handoff
+                        or command.name == "reconcile"
+                        or (
+                            command.name == "maintain_memory"
+                            and kwargs.get("mode") == "reconcile"
+                        )
+                    )
+                    if joins_unbounded:
+                        # graph-join: unbounded by design (reconcile proves the
+                        # graph is readable in its own terminal).
+                        graph_sync.wait_for_registered(
+                            root, state_root=self.config.state_dir
+                        )
+                    elif not graph_sync.join_registered_if_settled(
+                        root, state_root=self.config.state_dir
+                    ):
+                        # The flight keeps running on its own daemon thread and
+                        # publishes behind this response; the caller is told the
+                        # derived graph has not caught up yet rather than left
+                        # to infer that it has.
+                        return with_graph_outcome(
+                            terminal_result, graph_sync.committed_graph_pending(required)
+                        )
             except Exception as error:  # noqa: BLE001 - canonical commit remains terminal
                 terminal_result = finish_reconcile_graph_status(
                     terminal_result, current=False

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -158,6 +158,35 @@ def _direct_mutation_boundary(
     )
 
 
+def _queued_graph_repair(vault_root: Path) -> Any:
+    """The committed checkpoint whose repair is queued for a drain, or None.
+
+    A repair the durable queue owns has no registration to observe, so the
+    terminal proves the same fact from durable state instead: the sidecar has
+    not acknowledged the committed generation, and work is still queued against
+    it. Both terms are needed -- an unacknowledged checkpoint with an empty queue
+    is a rebuild's business, and a queue holding later work says nothing about
+    whether *this* generation converged.
+
+    Never raises. This runs while shaping a terminal for canonical bytes that are
+    already durable; a probe that failed loudly here would turn a successful
+    write into an error report.
+    """
+    from . import deferred_index, graph_sync
+
+    try:
+        committed = graph_sync.read_checkpoint(vault_root)
+        if committed is None:
+            return None
+        acknowledged = graph_sync.acknowledged_checkpoint(vault_root)
+        if acknowledged is not None and acknowledged.covers(committed):
+            return None
+        return committed if deferred_index.list_graph_paths(vault_root) else None
+    except Exception:  # noqa: BLE001 - a report must not fail a durable write
+        logger.warning("queued graph repair probe failed", exc_info=True)
+        return None
+
+
 def _windows_library(ctypes_module: Any, name: str) -> Any:
     return getattr(ctypes_module, "WinDLL")(name, use_last_error=True)
 
@@ -2523,6 +2552,11 @@ class LeaseManager:
                     root, state_root=self.config.state_dir
                 )
                 if required is None and not has_reconcile_handoff:
+                    queued = _queued_graph_repair(root)
+                    if queued is not None:
+                        return with_graph_outcome(
+                            terminal_result, graph_sync.committed_graph_queued(queued)
+                        )
                     return terminal_result
                 if required is not None:
                     # An interactive write takes a derived-graph outcome only if

--- a/tests/canonical_snapshot.py
+++ b/tests/canonical_snapshot.py
@@ -1,0 +1,52 @@
+"""Snapshot a vault's *canonical* bytes, ignoring derived-index residue.
+
+Several tests assert that some operation left the vault byte-identical. Since an
+interactive write stopped joining its own graph rebuild, that rebuild is still
+running when the assertion is taken, and its scratch sidecars
+(`.graph-rebuild-<digest>.sqlite` and companions) are sitting in the tree.
+
+Those are not vault content, and the distinction is not a test convenience: it
+is the same one the canonical directory census makes in production, via the same
+predicate. A write is not "a mutation of the vault" because a rebuild happened to
+be mid-flight beside it, and a test that says otherwise is asserting something
+the guard itself does not.
+
+Deliberately one definition rather than one filter per test module. Two copies
+had already diverged into two different ideas of what counts as residue, and a
+third would have been added for every module that grew a snapshot.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from exomem import vault as vault_module
+
+
+def is_canonical(path: Path, root: Path) -> bool:
+    """Whether `path` is canonical vault content rather than derived residue."""
+    return path.is_file() and not any(
+        vault_module._is_derived_index_artifact(part) for part in path.relative_to(root).parts
+    )
+
+
+def canonical_bytes(root: Path) -> dict[str, bytes]:
+    """Every canonical file's bytes, keyed by POSIX-relative path."""
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if is_canonical(path, root)
+    }
+
+
+def canonical_digests(root: Path) -> dict[str, str]:
+    """Every canonical file's SHA-256, keyed by POSIX-relative path.
+
+    Preferred over `canonical_bytes` when the assertion only needs to detect a
+    change: a failing byte-map comparison prints the whole vault.
+    """
+    return {
+        relative: hashlib.sha256(payload).hexdigest()
+        for relative, payload in canonical_bytes(root).items()
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 import shutil
 import sys
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -12,6 +14,7 @@ import pytest
 from exomem import activation_manifest as activation_manifest_module
 from exomem import embeddings as embeddings_module
 from exomem import find as find_module
+from exomem import graph_sync as graph_sync_module
 from exomem import schema as schema_module
 from exomem import semantic_contract as semantic_contract_module
 
@@ -62,6 +65,67 @@ def _reset_corpus_context_cache():
     yield
     semantic_contract_module.reset_corpus_context_cache()
     activation_manifest_module.reset_manifest_cache()
+
+
+#: The single thread name every graph rebuild runs under, in both the
+#: registered-flight path (`graph_sync.GraphRebuildCoordinator.ensure_started`)
+#: and the warming path (`epistemic_graph.schedule_background_rebuild`).
+_GRAPH_REBUILD_THREAD_NAME = "exomem-graph-rebuild"
+#: Generous: a rebuild over a test vault is milliseconds. A pass that cannot
+#: finish in 30 s has not been slow, it has wedged, and that is worth failing on
+#: rather than leaving for whichever test inherits it.
+_GRAPH_QUIESCE_TIMEOUT_SECONDS = 30.0
+
+
+def _drain_graph_rebuild_threads(timeout: float = _GRAPH_QUIESCE_TIMEOUT_SECONDS) -> None:
+    """Join every graph rebuild still running, and say so if one will not stop."""
+    deadline = time.monotonic() + timeout
+    while True:
+        alive = [
+            thread
+            for thread in threading.enumerate()
+            if thread.name == _GRAPH_REBUILD_THREAD_NAME and thread.is_alive()
+        ]
+        if not alive:
+            return
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise RuntimeError(
+                f"{len(alive)} graph rebuild thread(s) did not finish within "
+                f"{timeout:.0f}s; a wedged rebuild must not be inherited by the next test"
+            )
+        for thread in alive:
+            thread.join(timeout=max(0.0, deadline - time.monotonic()))
+
+
+@pytest.fixture(autouse=True)
+def _quiesce_graph_rebuilds():
+    """Let no graph rebuild outlive the test that started it.
+
+    Production runs one long-lived process against one vault. The suite runs
+    many vaults through one process, and since an interactive write stopped
+    joining its rebuild (#576) that rebuild is a daemon thread which outlives
+    the request -- and therefore, here, the test. It then keeps touching
+    process-global projections (`find.unload_ram_caches`, the shared resolver
+    and corpus-context caches) while the *next* test is already running against
+    a different vault. That is not a race the production shape has; it is an
+    artefact of the suite's process sharing.
+
+    Draining at teardown restores the isolation the write's join used to
+    provide by accident, without putting that wait back on the write path.
+    `graph_sync` coordinators are dropped afterwards so a suite of thousands of
+    vaults does not retain one coordinator per vault for the whole run.
+
+    Deliberately not a convergence helper: a test that needs the graph to be
+    current asserts that for itself with `graph_sync.await_active_rebuild`.
+    This fixture only guarantees that nothing is still running.
+    """
+    yield
+    try:
+        _drain_graph_rebuild_threads()
+    finally:
+        with graph_sync_module._COORDINATORS_LOCK:
+            graph_sync_module._COORDINATORS.clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,8 +78,16 @@ _GRAPH_QUIESCE_TIMEOUT_SECONDS = 30.0
 
 
 def _drain_graph_rebuild_threads(timeout: float = _GRAPH_QUIESCE_TIMEOUT_SECONDS) -> None:
-    """Join every graph rebuild still running, and say so if one will not stop."""
-    deadline = time.monotonic() + timeout
+    """Join every graph rebuild still running, and say so if one will not stop.
+
+    The clock is read only once there is something to wait for. This is autouse
+    teardown, so it runs after *every* test, and a test is entitled to replace
+    `time.monotonic` with a scripted sequence of its own -- one does. Charging
+    the empty case a clock read exhausted that sequence and failed the test in
+    teardown with `generator raised StopIteration`, from a fixture that had
+    nothing to drain.
+    """
+    deadline: float | None = None
     while True:
         alive = [
             thread
@@ -88,6 +96,8 @@ def _drain_graph_rebuild_threads(timeout: float = _GRAPH_QUIESCE_TIMEOUT_SECONDS
         ]
         if not alive:
             return
+        if deadline is None:
+            deadline = time.monotonic() + timeout
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             raise RuntimeError(

--- a/tests/temporary_vault.py
+++ b/tests/temporary_vault.py
@@ -1,0 +1,39 @@
+"""A self-managed temporary vault that no graph rebuild outlives.
+
+`tempfile.TemporaryDirectory` removes its tree inside the test body, before any
+fixture teardown runs — so the autouse rebuild quiesce in `conftest.py` is too
+late for a test that manages its own vault directory rather than taking
+`tmp_path`.
+
+Since a write stopped joining its own graph rebuild (#576), a rebuild is
+routinely still running at that point. On Windows the removal then fails
+outright, because the rebuild holds its `.graph-rebuild-*.sqlite` open; on POSIX
+it succeeds and leaves a rebuild writing into a deleted tree, which is worse for
+being quiet.
+
+Draining first is the same rule the CLI applies at process exit and the suite
+applies at teardown: the boundary is the lifetime of the thing being built
+against, and a vault about to be deleted is the end of one.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from exomem import graph_sync
+
+
+@contextmanager
+def temporary_vault() -> Iterator[Path]:
+    """Yield a temporary directory, draining graph rebuilds before removing it."""
+    with tempfile.TemporaryDirectory() as directory:
+        try:
+            yield Path(directory)
+        finally:
+            assert graph_sync.drain_active_rebuilds(timeout=60.0), (
+                "a graph rebuild outlived the vault it was building; removing the "
+                "vault under it would fail on Windows and corrupt quietly elsewhere"
+            )

--- a/tests/test_adoption_proposals.py
+++ b/tests/test_adoption_proposals.py
@@ -10,6 +10,7 @@ import hashlib
 from pathlib import Path
 
 import pytest
+from canonical_snapshot import canonical_bytes
 
 from exomem import adoption_proposals, adoption_run, commands, find, get_page, relation_review
 
@@ -34,12 +35,13 @@ def _snapshot_md(root: Path) -> dict[str, bytes]:
 
 
 def _snapshot_all(root: Path) -> dict[str, bytes]:
-    """Full-tree byte snapshot of EVERY file (pack assembly must write nothing)."""
-    return {
-        p.relative_to(root).as_posix(): p.read_bytes()
-        for p in root.rglob("*")
-        if p.is_file()
-    }
+    """Full-tree byte snapshot of every canonical file (assembly writes nothing).
+
+    Derived-index residue is excluded: a graph rebuild no longer finishes before
+    the write returns, so its scratch sidecars can be present here without any
+    of this code having written them. See `canonical_snapshot`.
+    """
+    return canonical_bytes(root)
 
 
 def _legacy_vault(root: Path) -> Path:

--- a/tests/test_bounded_graph_join.py
+++ b/tests/test_bounded_graph_join.py
@@ -1,0 +1,519 @@
+"""Issue #576: an interactive write must not park on a full-corpus graph rebuild.
+
+Three contracts live here, because the production livelock needed all three at
+once:
+
+1. **The join never waits, at any site that holds a request.** `writer_lease`
+   joined `graph_sync.wait_for_registered` with no timeout, so a committed write
+   returned only when the `exomem-graph-rebuild` daemon published or died --
+   75-155 s against a ~750 ms commit budget, and 300 s for the worst
+   `observe_memory` measured. There were *two* such joins,
+   `after_operation_guard` and `mutation_guard`; both are covered here, and
+   `test_every_graph_join_site_is_bounded_or_declared` fails if a third appears.
+   The canonical bytes are durable at `canonical_files_committed`; derived graph
+   work is self-healing.
+
+   #588 first tried a *timeout* here and could not size it: any value has to sit
+   under `COMMIT_MEDIAN_MS = 750` or the median latency gate fails whenever the
+   bound is reached, and simultaneously above a small test-vault rebuild or a
+   dozen tests expecting `completed` get `pending`. 2.0 s failed the first
+   constraint (2091/2259 ms observed at 2k/8k pages), 0.25 s the second (2 CI
+   failures became 6). The seam polls instead: the registered join is only
+   reached after the incremental path has already fallen back to a full-corpus
+   rebuild (20-175 s), so there is no interval worth waiting for.
+2. **The non-waiting return is honest.** Returning fast while implying a fresh graph
+   would be worse than returning slow. A write that leaves before the registered
+   rebuild converges says so, in the same `graph_sync*` vocabulary a failure
+   already uses, and it says so in the *compact* projection, which is the
+   default response detail.
+3. **A rebuild invalidated by a moving projection re-targets.** Two stabilization
+   attempts cannot converge against a corpus still being written to, and the
+   Class C failure is exactly what strands the availability marker and forces the
+   *next* write down `fallback()` into another full rebuild. That is the loop;
+   `test_convergence_republishes_the_marker_...` is the test that proves it
+   broken.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from exomem import epistemic_graph, freshness, graph_sync
+from exomem import find as find_module
+from exomem import vault as vault_module
+from exomem.epistemic_graph import EpistemicGraphIndex
+
+PAGE_A = "Knowledge Base/Notes/Insights/bounded-join-a.md"
+PAGE_B = "Knowledge Base/Notes/Insights/bounded-join-b.md"
+
+
+def _page(title: str, body: str) -> str:
+    return f"---\ntype: insight\nstatus: active\n---\n# {title}\n\n## Claim\n\n{body}\n"
+
+
+def _seed_live_freshness(root: Path) -> None:
+    freshness.seed(
+        root,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault_module.walk_vault_md(root)),
+    )
+    kb = root / "Knowledge Base"
+    freshness.seed(
+        root,
+        "kb",
+        ((str(path), freshness.stat_signature(path)) for path in find_module._walk_md(kb)),
+    )
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Any:
+    root = tmp_path / "vault"
+    (root / "Knowledge Base/Notes/Insights").mkdir(parents=True)
+    (root / PAGE_A).write_text(
+        _page("A", "A claims against [[bounded-join-b]]."), encoding="utf-8"
+    )
+    (root / PAGE_B).write_text(_page("B", "B is a plain claim."), encoding="utf-8")
+    _seed_live_freshness(root)
+    EpistemicGraphIndex(root).rebuild_all()
+    epistemic_graph.clear_publication_memos()
+    yield root
+    epistemic_graph.clear_publication_memos()
+
+
+def _checkpoint(generation: int) -> graph_sync.GraphSyncCheckpoint:
+    return graph_sync.GraphSyncCheckpoint.create(
+        generation=generation,
+        mutation_id=f"{generation:024x}",
+        paths=((PAGE_A, "d" * 64),),
+        created_paths=(PAGE_A,),
+    )
+
+
+def _invoke_with_registered_rebuild(
+    vault_root: Path,
+    builder: Any,
+    *,
+    checkpoint: graph_sync.GraphSyncCheckpoint | None = None,
+    name: str = "remember",
+    kwargs: dict[str, Any] | None = None,
+) -> Any:
+    """Drive a real committed mutation whose leaf registers `builder`."""
+    from exomem.writer_lease import LeaseConfig, LeaseManager, mark_active_mutation_committed
+
+    required = checkpoint or _checkpoint(1)
+    state_dir = vault_root / "state"
+    manager = LeaseManager(LeaseConfig(state_dir=state_dir))
+
+    def leaf(root: Path, **_kwargs: Any) -> dict[str, Any]:
+        (root / PAGE_A).write_text(
+            _page("A", "A now claims something else."), encoding="utf-8"
+        )
+        mark_active_mutation_committed()
+        graph_sync.register_rebuild(root, required, builder, state_root=state_dir)
+        return {"status": "committed", "mutated": True}
+
+    command = SimpleNamespace(name=name, read_only=False, leaf=leaf)
+    return manager.invoke(command, (vault_root,), dict(kwargs or {}))
+
+
+# --- 1. The join is bounded --------------------------------------------------
+
+
+def test_interactive_write_returns_while_a_registered_rebuild_is_still_running(
+    vault: Path,
+) -> None:
+    """The write returns within the bound; the rebuild keeps running behind it."""
+    entered = threading.Event()
+    release = threading.Event()
+    published = threading.Event()
+
+    def build(required: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        entered.set()
+        # Far longer than the bound, so a pass here cannot come from a lucky
+        # race with a rebuild that happened to be quick.
+        assert release.wait(30)
+        published.set()
+        return graph_sync.GraphBuildOutcome.covering(required)
+
+    started = time.monotonic()
+    try:
+        result = _invoke_with_registered_rebuild(vault, build)
+        elapsed = time.monotonic() - started
+    finally:
+        release.set()
+
+    assert entered.is_set() is True, "the registered rebuild must still be started"
+    assert published.is_set() is False, "the write must not have waited for publication"
+    # A literal, not the bound constant: the point is the *behaviour*, and this
+    # assertion has to be able to fail on a tree where the constant does not
+    # exist yet. 15 s sits well above the bound plus process overhead and well
+    # below the 30 s the builder holds, so neither side is a coin flip.
+    assert elapsed < 15.0, (
+        f"interactive write parked {elapsed:.1f}s on a registered rebuild"
+    )
+    assert result["state"] == "committed"
+
+
+def test_a_direct_mutation_guard_also_returns_while_its_rebuild_runs(
+    vault: Path,
+) -> None:
+    """The second unbounded join, and the worst case measured in production.
+
+    `mutation_guard` joins its own registered rebuild after canonical release,
+    on a path `after_operation_guard` never sees -- which is how a single-unit
+    `observe_memory` append blocked for 300 s while the `remember` before it
+    took 14.3 s. Same defect, second site, so the same bound has to reach it.
+    """
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    entered = threading.Event()
+    release = threading.Event()
+    published = threading.Event()
+
+    def build(required: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        entered.set()
+        assert release.wait(30)
+        published.set()
+        return graph_sync.GraphBuildOutcome.covering(required)
+
+    state_dir = vault / "state"
+    manager = LeaseManager(LeaseConfig(state_dir=state_dir))
+    started = time.monotonic()
+    try:
+        with manager.mutation_guard(vault):
+            (vault / PAGE_A).write_text(
+                _page("A", "A now claims something else."), encoding="utf-8"
+            )
+            graph_sync.register_rebuild(
+                vault, _checkpoint(1), build, state_root=state_dir
+            )
+        elapsed = time.monotonic() - started
+    finally:
+        release.set()
+
+    assert entered.is_set() is True, "the registered rebuild must still be started"
+    assert published.is_set() is False, "the guard must not have waited for publication"
+    assert elapsed < 15.0, (
+        f"direct mutation guard parked {elapsed:.1f}s on a registered rebuild"
+    )
+
+
+#: Every `wait_for_registered` caller in `src/exomem/`, and why it is or is not
+#: bounded. The first pass at #576 bounded one site and left an identical
+#: unbounded join two hundred lines away in the same file, which then produced
+#: the worst case in production. An enumeration is the only thing that makes a
+#: *third* site fail loudly instead of surviving another analysis.
+_DECLARED_JOIN_SITES = {
+    # Poll-only: held while serving a request.
+    "writer_lease.py": "polled via join_registered_if_settled, plus the reconcile opt-out",
+    # Unbounded by design: `reconcile`'s terminal exists to prove the graph is
+    # readable, so it must not return before the rebuild lands.
+    "reconcile.py": "reconcile opt-in; its terminal asserts graph currency",
+    # Unbounded by design: the standalone library path, gated on
+    # `active_mutation_request_id() is None` and no active direct guard, so it
+    # is unreachable while any request is being served. It has no envelope to
+    # carry `pending` and its contract is a converged result.
+    "epistemic_graph.py": "standalone library join, no request boundary held",
+    "delete_file.py": "standalone library join, no request boundary held",
+    "delete_directory.py": "standalone library join, no request boundary held",
+    "recover_from_trash.py": "standalone library join, no request boundary held",
+}
+
+
+def test_every_graph_join_site_is_bounded_or_declared() -> None:
+    source = Path(epistemic_graph.__file__).parent
+    found = {
+        path.name
+        for path in sorted(source.glob("*.py"))
+        if "wait_for_registered(" in path.read_text(encoding="utf-8")
+        and path.name != "graph_sync.py"  # the definition and the helper itself
+    }
+
+    assert found == set(_DECLARED_JOIN_SITES), (
+        "a graph rebuild join site appeared or moved: route it through the "
+        "poll-only seam (graph_sync.join_registered_if_settled) or declare "
+        "why it may block"
+    )
+
+
+def test_the_settled_helper_never_waits(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The one seam every request-serving join goes through; it polls, never waits."""
+    observed: list[float | None] = []
+
+    def never_finishes(
+        vault_root: Path, timeout: float | None = None, *, state_root: Path | None = None
+    ) -> Any:
+        observed.append(timeout)
+        raise TimeoutError("graph rebuild did not finish before the wait deadline")
+
+    monkeypatch.setattr(graph_sync, "wait_for_registered", never_finishes)
+
+    assert graph_sync.join_registered_if_settled(vault) is False
+    assert observed == [graph_sync._SETTLED_JOIN_TIMEOUT_SECONDS]
+
+
+def test_the_settled_helper_does_not_launder_a_real_failure_into_pending(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`False` must mean "still running", never "failed"."""
+
+    def fails(
+        vault_root: Path, timeout: float | None = None, *, state_root: Path | None = None
+    ) -> Any:
+        raise graph_sync.GraphRebuildRegistrationError(
+            "GRAPH_SYNC_HANDOFF_MISSING", "Run reconcile to recover the derived graph."
+        )
+
+    monkeypatch.setattr(graph_sync, "wait_for_registered", fails)
+
+    with pytest.raises(graph_sync.GraphRebuildRegistrationError):
+        graph_sync.join_registered_if_settled(vault)
+
+
+# --- 2. The non-waiting return is honest ----------------------------------------
+
+
+def test_a_write_that_leaves_before_convergence_says_the_graph_is_catching_up(
+    vault: Path,
+) -> None:
+    release = threading.Event()
+
+    def build(required: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        assert release.wait(30)
+        return graph_sync.GraphBuildOutcome.covering(required)
+
+    required = _checkpoint(1)
+    try:
+        compact = _invoke_with_registered_rebuild(vault, build, checkpoint=required)
+    finally:
+        release.set()
+
+    assert compact["graph_sync"] == "pending"
+    assert compact["graph_sync_code"] == "GRAPH_SYNC_REBUILD_IN_PROGRESS"
+    assert compact["graph_sync_checkpoint"] == required.checkpoint_sha256
+    assert isinstance(compact["graph_sync_remediation"], str)
+    assert compact["graph_sync_remediation"]
+
+
+def test_a_settled_outcome_is_reported_rather_than_downgraded_to_pending(
+    vault: Path,
+) -> None:
+    """`pending` is not a blanket downgrade: an already-settled flight reports it.
+
+    This is the property that survives poll-only joining, and it is the one that
+    matters in production: a second write arriving after a coalesced rebuild has
+    already published must say `completed`, not invent staleness. What does NOT
+    survive is "a fast builder finishes inside the join" -- with no wait there is
+    no interval for it to finish inside, and a test that relied on winning that
+    race was flaky by construction (it passed alone and failed under load).
+
+    Driven through the coordinator rather than a write, so the outcome is set
+    before the poll deterministically instead of by scheduling luck.
+    """
+    required = _checkpoint(1)
+    state_dir = vault / "state"
+
+    def build(checkpoint: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        return graph_sync.GraphBuildOutcome.covering(checkpoint)
+
+    graph_sync.register_rebuild(vault, required, build, state_root=state_dir)
+    graph_sync.start_registered(vault, state_root=state_dir)
+    assert graph_sync.await_active_rebuild(vault, state_root=state_dir) is not None
+
+    graph_sync.register_rebuild(vault, required, build, state_root=state_dir)
+    assert graph_sync.join_registered_if_settled(vault, state_root=state_dir) is True
+
+
+def test_a_pending_graph_outcome_survives_the_compact_projection() -> None:
+    """`compact` is the default response detail, so the signal has to reach it.
+
+    `project_terminal` whitelists the `graph_sync` values a client may branch
+    on. A new value the projection silently drops is indistinguishable from
+    saying nothing, which is precisely the dishonest fast write this change
+    exists to avoid.
+    """
+    from exomem.mutation_terminal import committed_terminal, project_terminal
+
+    required = _checkpoint(3)
+    pending = graph_sync.committed_graph_pending(required)
+    terminal = committed_terminal(
+        {"status": "committed", **pending},
+        request_id="11111111-1111-4111-8111-111111111111",
+        receipt_id=None,
+        idempotency_key=None,
+    )
+
+    compact = project_terminal({**terminal, **pending}, detail="compact")
+
+    assert compact["graph_sync"] == "pending"
+    assert compact["graph_sync_code"] == "GRAPH_SYNC_REBUILD_IN_PROGRESS"
+    assert compact["graph_sync_checkpoint"] == required.checkpoint_sha256
+
+
+def test_a_caller_that_must_block_opts_in_rather_than_every_write_paying(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`reconcile` exists to make the graph current, so it still joins unbounded."""
+    observed: list[float | None] = []
+    original = graph_sync.wait_for_registered
+
+    def record(
+        vault_root: Path, timeout: float | None = None, *, state_root: Path | None = None
+    ) -> Any:
+        observed.append(timeout)
+        return original(vault_root, timeout, state_root=state_root)
+
+    def build(required: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        return graph_sync.GraphBuildOutcome.covering(required)
+
+    monkeypatch.setattr(graph_sync, "wait_for_registered", record)
+    _invoke_with_registered_rebuild(vault, build, name="remember")
+    _invoke_with_registered_rebuild(
+        vault,
+        build,
+        checkpoint=_checkpoint(2),
+        name="maintain_memory",
+        kwargs={"mode": "reconcile"},
+    )
+
+    assert observed[0] == graph_sync._SETTLED_JOIN_TIMEOUT_SECONDS
+    assert observed[-1] is None
+
+
+# --- 3. A moving projection re-targets the newer baseline -------------------
+
+
+def _move_the_projection_identity_for(
+    monkeypatch: pytest.MonkeyPatch, *, passes: int | None
+) -> dict[str, int]:
+    """Move the recall projection across the first `passes` stabilization attempts.
+
+    This is the exact production cause: `moved_cause` reads "the recall
+    projection identity moved across the pass". `_rebuild_all_locked` samples
+    the identity twice per attempt (`before`, then `after_identity`), so moving
+    only the even-numbered sample invalidates that attempt and leaves the next
+    one a clean, newer baseline to re-target against. `passes=None` never
+    settles.
+    """
+    real = epistemic_graph._recall_projection_identity
+    calls = {"n": 0}
+
+    def moving(vault_root: Path, *, disk_freshness: tuple[int, int, str]) -> Any:
+        identity = real(vault_root, disk_freshness=disk_freshness)
+        calls["n"] += 1
+        invalidated = calls["n"] // 2 if calls["n"] % 2 == 0 else None
+        if invalidated is not None and (passes is None or invalidated <= passes):
+            return (*identity[:-1], f"moved-{calls['n']}")
+        return identity
+
+    monkeypatch.setattr(epistemic_graph, "_recall_projection_identity", moving)
+    return calls
+
+
+def test_a_projection_that_moves_twice_still_converges_instead_of_raising(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two attempts cannot converge against a corpus still being written to."""
+    calls = _move_the_projection_identity_for(monkeypatch, passes=2)
+
+    report = EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    assert report["indexed_files"] >= 1
+    assert calls["n"] > 2 * epistemic_graph.REBUILD_STABILIZATION_ATTEMPTS
+
+
+# --- 4. Continuous writes must not become an unbounded restart loop ---------
+
+
+def test_continuous_writes_terminate_on_the_attempt_ceiling_and_stay_class_c(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = _move_the_projection_identity_for(monkeypatch, passes=None)
+
+    started = time.monotonic()
+    with pytest.raises(epistemic_graph.GraphProjectionMoved) as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+    elapsed = time.monotonic() - started
+
+    message = str(raised.value)
+    assert type(raised.value) is epistemic_graph.GraphProjectionMoved
+    assert "Class C" in message
+    assert "projection moved" in message
+    assert calls["n"] <= 2 * epistemic_graph.REBUILD_STABILIZATION_MAX_ATTEMPTS
+    assert elapsed < 30.0
+
+
+def test_a_slow_rebuild_terminates_on_the_elapsed_deadline_not_the_ceiling(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The wall-clock bound is what protects a big corpus under continuous writes.
+
+    An attempt ceiling alone is not a bound when one full-corpus pass costs
+    20-175 s. With the deadline already spent, the run must stop at the
+    `REBUILD_STABILIZATION_ATTEMPTS` floor -- never fewer than today.
+    """
+    calls = _move_the_projection_identity_for(monkeypatch, passes=None)
+    monkeypatch.setattr(epistemic_graph, "REBUILD_STABILIZATION_DEADLINE_SECONDS", 0.0)
+
+    with pytest.raises(epistemic_graph.GraphProjectionMoved):
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    assert calls["n"] == 2 * epistemic_graph.REBUILD_STABILIZATION_ATTEMPTS
+
+
+# --- 5. The marker is republished, so the next write is incremental ---------
+
+
+def test_convergence_republishes_the_marker_so_the_next_write_is_incremental(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The livelock: Class C strands the marker, so every later write rebuilds.
+
+    On `origin/main` a projection that moves under the first two passes exhausts
+    stabilization, raises Class C, leaves the sidecar unavailable and marks the
+    registry externally pending -- which is exactly what sends the *next* write
+    back down `fallback()` into another full rebuild, self-sustaining. The
+    re-target lets the same run converge, publish the availability marker, and
+    leave no external-pending epoch behind, so the next write can take the
+    incremental path.
+    """
+    _move_the_projection_identity_for(monkeypatch, passes=2)
+
+    EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    assert freshness.external_pending(vault) is False
+    assert EpistemicGraphIndex(vault).available() is True
+
+
+# --- 6. Regression: a genuinely broken projection still fails as today ------
+
+
+def test_a_genuinely_broken_projection_still_fails_the_way_it_does_today(
+    vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A resolver that never names its bytes stays Class C, marked exactly once."""
+    monkeypatch.setattr(
+        EpistemicGraphIndex, "_resolver_source_versions", lambda *_args, **_kwargs: None
+    )
+    epoch_probe = tmp_path / "epoch-probe-root"
+    clock_before = freshness.mark_external_pending(epoch_probe)
+
+    with pytest.raises(epistemic_graph.GraphProjectionMoved, match="did not stabilize") as raised:
+        EpistemicGraphIndex(vault)._rebuild_all_locked()
+
+    error = raised.value
+    assert type(error) is epistemic_graph.GraphProjectionMoved
+    assert epistemic_graph.is_publication_failure(error) is False
+    assert epistemic_graph.may_mark_external_pending(error) is False
+    assert "resolver bytes" in str(error)
+    assert freshness.external_pending(vault) is True
+    assert epistemic_graph.publication_refusal_active(vault) is False
+    assert freshness.mark_external_pending(epoch_probe) == clock_before + 2

--- a/tests/test_bounded_graph_join.py
+++ b/tests/test_bounded_graph_join.py
@@ -303,6 +303,44 @@ def test_a_write_that_leaves_before_convergence_says_the_graph_is_catching_up(
     assert compact["graph_sync_remediation"]
 
 
+def test_a_write_whose_repair_is_queued_says_the_graph_is_catching_up(
+    vault: Path,
+) -> None:
+    """A queued repair is pending too, and the terminal has to say so.
+
+    The `pending` path above is keyed on a *registered* rebuild. Once a
+    defer-classified bail-out stops registering one -- the whole point of
+    repairing through the durable queue instead -- that key is absent, and
+    without a second signal the response becomes byte-identical to a write whose
+    graph is current. A write that has not converged claiming it has is the one
+    thing the fourth outcome exists to prevent, so the terminal proves the same
+    fact from durable state instead: a committed checkpoint that the sidecar has
+    not acknowledged, with work still queued against it.
+    """
+    from exomem import deferred_index
+    from exomem.writer_lease import LeaseConfig, LeaseManager, mark_active_mutation_committed
+
+    required = _checkpoint(1)
+    state_dir = vault / "state"
+    manager = LeaseManager(LeaseConfig(state_dir=state_dir))
+
+    def leaf(root: Path, **_kwargs: Any) -> dict[str, Any]:
+        (root / PAGE_A).write_text(_page("A", "A now claims something else."), encoding="utf-8")
+        mark_active_mutation_committed()
+        graph_sync._write_checkpoint(root, required)
+        deferred_index.add_graph(root, [PAGE_A])
+        return {"status": "committed", "mutated": True}
+
+    command = SimpleNamespace(name="remember", read_only=False, leaf=leaf)
+    compact = manager.invoke(command, (vault,), {})
+
+    assert compact["graph_sync"] == "pending"
+    assert compact["graph_sync_code"] == "GRAPH_SYNC_REPAIR_QUEUED"
+    assert compact["graph_sync_checkpoint"] == required.checkpoint_sha256
+    assert isinstance(compact["graph_sync_remediation"], str)
+    assert compact["graph_sync_remediation"]
+
+
 def test_a_settled_outcome_is_reported_rather_than_downgraded_to_pending(
     vault: Path,
 ) -> None:

--- a/tests/test_bounded_graph_join.py
+++ b/tests/test_bounded_graph_join.py
@@ -517,3 +517,81 @@ def test_a_genuinely_broken_projection_still_fails_the_way_it_does_today(
     assert freshness.external_pending(vault) is True
     assert epistemic_graph.publication_refusal_active(vault) is False
     assert freshness.mark_external_pending(epoch_probe) == clock_before + 2
+
+
+# ---------------------------------------------------------------------------
+# Process lifetime, as distinct from the write path
+# ---------------------------------------------------------------------------
+#
+# Taking the rebuild off the write path is correct; letting a *process* exit
+# with that rebuild still running is not, and the two are easy to conflate. A
+# daemon thread is right for the long-lived server and wrong for a one-shot CLI
+# invocation, which would otherwise report `pending` on every write and never
+# make any of them true.
+
+
+def test_draining_returns_immediately_when_no_rebuild_is_running() -> None:
+    assert graph_sync.drain_active_rebuilds(timeout=0.0) is True
+
+
+def test_draining_waits_for_a_running_rebuild() -> None:
+    release = threading.Event()
+    finished = threading.Event()
+
+    def _rebuild() -> None:
+        release.wait(timeout=10)
+        finished.set()
+
+    thread = threading.Thread(
+        target=_rebuild, name=graph_sync.GRAPH_REBUILD_THREAD_NAME, daemon=True
+    )
+    thread.start()
+    try:
+        assert graph_sync.drain_active_rebuilds(timeout=0.05) is False, (
+            "a still-running rebuild must not be reported as drained"
+        )
+        release.set()
+        assert graph_sync.drain_active_rebuilds(timeout=10.0) is True
+        assert finished.is_set() is True
+    finally:
+        release.set()
+        thread.join(timeout=10)
+
+
+def test_draining_surrenders_rather_than_holding_the_process_open() -> None:
+    """A wedged rebuild must not hold a shell prompt open indefinitely."""
+    release = threading.Event()
+    thread = threading.Thread(
+        target=lambda: release.wait(timeout=30),
+        name=graph_sync.GRAPH_REBUILD_THREAD_NAME,
+        daemon=True,
+    )
+    thread.start()
+    try:
+        started = time.monotonic()
+        assert graph_sync.drain_active_rebuilds(timeout=0.2) is False
+        assert time.monotonic() - started < 5.0, "the drain must be bounded"
+    finally:
+        release.set()
+        thread.join(timeout=30)
+
+
+def test_the_cli_drains_before_it_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The seam is wired, not merely available.
+
+    `main()` returning while a rebuild is in flight is the whole defect; a
+    version of this that only tested `drain_active_rebuilds` in isolation would
+    pass with the call site missing.
+    """
+    from exomem import __main__ as cli
+
+    drained: list[bool] = []
+    monkeypatch.setattr(
+        graph_sync,
+        "drain_active_rebuilds",
+        lambda *_args, **_kwargs: (drained.append(True), True)[1],
+    )
+
+    cli.main(["--version", "--json"])
+
+    assert drained == [True], "the CLI exited without draining in-flight rebuilds"

--- a/tests/test_epistemic_graph_freshness.py
+++ b/tests/test_epistemic_graph_freshness.py
@@ -392,9 +392,22 @@ def test_full_rebuild_retries_when_target_is_renamed_after_snapshot(
     )
 
 
-def test_full_rebuild_twice_moving_vault_is_marked_unavailable(
+def test_full_rebuild_of_a_continuously_moving_vault_is_marked_unavailable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """A vault that moves under every pass exhausts its bound and stays unavailable.
+
+    Renamed from `..._twice_moving_vault_...` for #576. The contract this test
+    exists for is unchanged and still asserted: a projection that never settles
+    raises `did not stabilize` and leaves the graph unavailable. What changed is
+    the number in the middle. Two attempts were a ceiling; they are now the
+    floor, because two passes cannot converge against a corpus still being
+    written to and the resulting Class C failure is what stranded the
+    availability marker and sent the next write into another full rebuild. So
+    this asserts the new bound -- the attempt ceiling, since this vault moves on
+    every acquisition and so never reaches the elapsed deadline -- rather than
+    the removed one.
+    """
     vault = tmp_path / "vault"
     _seed(vault)
     real_snapshot = find_module.recall_resolver_snapshot
@@ -417,7 +430,8 @@ def test_full_rebuild_twice_moving_vault_is_marked_unavailable(
     with pytest.raises(RuntimeError, match="did not stabilize"):
         index.rebuild_all()
 
-    assert acquisitions == 2
+    assert acquisitions == epistemic_graph.REBUILD_STABILIZATION_MAX_ATTEMPTS
+    assert acquisitions > epistemic_graph.REBUILD_STABILIZATION_ATTEMPTS
     assert index.available() is False
 
 

--- a/tests/test_graph_deferred_queue.py
+++ b/tests/test_graph_deferred_queue.py
@@ -1,0 +1,451 @@
+"""Phase 2 of `converge-graph-incrementally`: graph repair proportional to the change.
+
+Phase 1 took the graph rebuild off the interactive write path. That made writes
+fast and left the *convergence* defect untouched: every bail-out from the
+incremental refresh path still means "re-walk the entire vault", and a
+whole-vault pass is guarded by a vault-global optimistic check that any
+concurrent write invalidates. The pass therefore gets less likely to succeed the
+larger the vault and the busier the writer -- a livelock by construction, which
+is why seven `fix(graph):` commits inside that loop did not end it.
+
+The fix is the one the codebase already runs for the semantic and embedding
+indexes: a durable per-path dirty queue, drained off the write path. What these
+tests pin down is not the queue's existence but its four load-bearing
+properties, each of which is a way the naive version silently fails:
+
+1. **Durability at the right seam.** The changed-path set has to be enqueued
+   before the canonical batch commits, not after. Over-enqueueing is free -- a
+   drain re-indexes a path whose content did not change and writes nothing.
+   Under-enqueueing is unrecoverable without a full rebuild, which is the thing
+   being removed. The asymmetry decides the ordering.
+2. **Equivalence.** A graph assembled by incremental drains has to equal the
+   graph a full rebuild produces from the same vault. Without this the queue is
+   just a faster way to be wrong.
+3. **Monotonicity.** A write landing *during* a drain must append work, not
+   invalidate the drain's completed work. This is the exact property the current
+   global-proof design lacks, and the reason its retry budget cannot save it.
+4. **Proportionality, stated as a table.** "Bail-outs no longer rebuild" is only
+   half true: a handful of them genuinely cannot be repaired path-locally.
+   Which ones is a judgement, and a judgement that lives implicitly in sixteen
+   `return fallback(...)` sites is a judgement nobody can audit. So it lives in
+   one declared mapping, and this suite fails if a reason appears, disappears,
+   or changes side without the table changing with it.
+
+Red-first: these describe the seams Phase 2 builds. They fail until it does.
+"""
+
+from __future__ import annotations
+
+import ast
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from exomem import deferred_index, epistemic_graph, freshness, graph_sync, index_sync
+from exomem import find as find_module
+from exomem import vault as vault_module
+from exomem.epistemic_graph import EpistemicGraphIndex
+
+PAGE_A = "Knowledge Base/Notes/Insights/queue-a.md"
+PAGE_B = "Knowledge Base/Notes/Insights/queue-b.md"
+PAGE_C = "Knowledge Base/Notes/Insights/queue-c.md"
+
+
+def _page(title: str, body: str) -> str:
+    return f"---\ntype: insight\nstatus: active\n---\n# {title}\n\n## Claim\n\n{body}\n"
+
+
+def _seed_live_freshness(root: Path) -> None:
+    freshness.seed(
+        root,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault_module.walk_vault_md(root)),
+    )
+    kb = root / "Knowledge Base"
+    freshness.seed(
+        root,
+        "kb",
+        ((str(path), freshness.stat_signature(path)) for path in find_module._walk_md(kb)),
+    )
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Any:
+    root = tmp_path / "vault"
+    (root / "Knowledge Base/Notes/Insights").mkdir(parents=True)
+    (root / PAGE_A).write_text(_page("A", "A claims against [[queue-b]]."), encoding="utf-8")
+    (root / PAGE_B).write_text(_page("B", "B is a plain claim."), encoding="utf-8")
+    _seed_live_freshness(root)
+    EpistemicGraphIndex(root).rebuild_all()
+    epistemic_graph.clear_publication_memos()
+    yield root
+    epistemic_graph.clear_publication_memos()
+
+
+def _graph_contents(root: Path) -> dict[str, list[tuple[Any, ...]]]:
+    """The three projections a drain and a rebuild must agree on, byte for byte.
+
+    `graph_meta` is deliberately excluded: it carries the instance discriminator
+    and the publication lineage, which are *supposed* to differ between a
+    rebuild and a drain. Comparing them would make this test unfailable for the
+    right reason and unpassable for the wrong one.
+    """
+    conn = sqlite3.connect(EpistemicGraphIndex(root).path)
+    try:
+        return {
+            "nodes": conn.execute(
+                "SELECT node_key, kind, path, anchor, title, text, source_hash, "
+                "line_start, line_end, metadata, unit_ref, unit_category, unit_kind "
+                "FROM graph_nodes ORDER BY node_key"
+            ).fetchall(),
+            "edges": conn.execute(
+                "SELECT edge_key, src_key, dst_key, relation_type, raw_relation, "
+                "parent_relation, registry_status, registry_version, registry_hash, "
+                "origin, source_path, source_anchor, metadata "
+                "FROM graph_edges ORDER BY edge_key"
+            ).fetchall(),
+            "parent_refs": conn.execute(
+                "SELECT path, parent_ref FROM graph_parent_refs ORDER BY path"
+            ).fetchall(),
+        }
+    finally:
+        conn.close()
+
+
+# --- 1. The changed-path set is enqueued durably, never discarded ---------------
+
+
+def test_a_canonical_write_enqueues_its_changed_paths(vault: Path) -> None:
+    """The checkpoint already records exactly what changed; stop throwing it away."""
+    deferred_index.clear_graph(vault)
+
+    vault_module.batch_atomic_write(
+        [
+            vault_module.PlannedWrite(
+                vault / PAGE_A, _page("A", "A now claims against [[queue-b]] twice.")
+            )
+        ],
+        vault_root=vault,
+    )
+
+    assert PAGE_A in deferred_index.list_graph_paths(vault)
+
+
+def test_a_created_path_is_enqueued_alongside_the_changed_ones(vault: Path) -> None:
+    """`created_paths` is a separate field on the checkpoint and a separate bug."""
+    deferred_index.clear_graph(vault)
+
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(vault / PAGE_C, _page("C", "C is new."))],
+        vault_root=vault,
+    )
+
+    assert PAGE_C in deferred_index.list_graph_paths(vault)
+
+
+def test_the_enqueue_precedes_the_commit_so_a_crash_cut_cannot_lose_it(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The ordering *is* the durability argument, so assert the ordering.
+
+    A crash between the markdown replace and the enqueue would leave the vault
+    changed and the graph with no record that it must catch up -- recoverable
+    only by the whole-vault rebuild this change exists to retire. Enqueueing
+    first inverts the failure: a crash leaves a path queued whose content never
+    changed, and re-indexing an unchanged path is a no-op.
+    """
+    deferred_index.clear_graph(vault)
+    order: list[str] = []
+    real_add = deferred_index.add_graph_receipts
+
+    def record_add(root: Path, rel_paths: list[str]) -> Any:
+        order.append("enqueue")
+        return real_add(root, rel_paths)
+
+    monkeypatch.setattr(deferred_index, "add_graph_receipts", record_add)
+
+    class Crash(RuntimeError):
+        pass
+
+    def crash_before_commit(*_args: Any, **_kwargs: Any) -> None:
+        order.append("commit")
+        raise Crash("power cut between staging and commit")
+
+    monkeypatch.setattr(vault_module, "replace_tolerating_transient_sharing", crash_before_commit)
+
+    with pytest.raises(Crash):
+        vault_module.batch_atomic_write(
+            [vault_module.PlannedWrite(vault / PAGE_A, _page("A", "A changes."))],
+            vault_root=vault,
+        )
+
+    assert order[:2] == ["enqueue", "commit"], (
+        "the graph dirty set must be durable before the markdown replace, not after"
+    )
+    assert PAGE_A in deferred_index.list_graph_paths(vault)
+
+
+def test_a_full_scope_batch_enqueues_a_marker_rather_than_a_path_list(vault: Path) -> None:
+    """Above the checkpoint path limit the queue would be unbounded; a marker is not."""
+    deferred_index.clear_graph(vault)
+    deferred_index.clear_graph_full_rebuild(vault)
+
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=7,
+        mutation_id=f"{7:024x}",
+        paths=(),
+        created_paths=(),
+        scope="full",
+    )
+    deferred_index.enqueue_graph_checkpoint(vault, checkpoint)
+
+    assert deferred_index.list_graph_paths(vault) == []
+    assert deferred_index.graph_full_rebuild_pending(vault) == 7
+
+
+def test_a_poisoned_path_is_rotated_behind_the_rest_of_the_queue(vault: Path) -> None:
+    """One unindexable page must not pin every later page in the sorted batch."""
+    receipts = deferred_index.add_graph_receipts(vault, [PAGE_A, PAGE_B])
+    assert len(receipts) == 2
+
+    poison = next(receipt for receipt in receipts if receipt.rel_path == PAGE_A)
+    deferred_index.rotate_graph_receipts(vault, [poison])
+
+    assert deferred_index.list_graph_paths(vault)[-1] == PAGE_A, (
+        "a rotated receipt must sort behind untouched work, not disappear from it"
+    )
+    assert deferred_index.snapshot_graph(vault, limit=1)[0].rel_path == PAGE_B
+
+
+def test_clearing_a_receipt_is_compare_and_swap_not_delete(vault: Path) -> None:
+    """A write that lands mid-drain must not be retired by the drain that missed it."""
+    stale = deferred_index.add_graph_receipts(vault, [PAGE_A])
+    deferred_index.add_graph_receipts(vault, [PAGE_A])  # a second write, new revision
+
+    assert deferred_index.clear_graph_receipts(vault, stale) == 0
+    assert PAGE_A in deferred_index.list_graph_paths(vault)
+
+
+# --- 2. A drain is equivalent to a full rebuild ---------------------------------
+
+
+def test_queued_drains_reach_the_same_graph_as_a_full_rebuild(vault: Path) -> None:
+    """Incremental repair that is merely *faster* than a rebuild is not repair."""
+    for content, page in (
+        ("A now points at [[queue-c]] instead.", PAGE_A),
+        ("C answers [[queue-a]].", PAGE_C),
+        ("B is revised and links [[queue-c]].", PAGE_B),
+    ):
+        (vault / page).write_text(_page(page, content), encoding="utf-8")
+        _seed_live_freshness(vault)
+        deferred_index.add_graph_receipts(vault, [page])
+        index_sync.drain_deferred_work(vault)
+
+    drained = _graph_contents(vault)
+
+    EpistemicGraphIndex(vault).rebuild_all()
+    rebuilt = _graph_contents(vault)
+
+    assert drained["nodes"] == rebuilt["nodes"]
+    assert drained["edges"] == rebuilt["edges"]
+    assert drained["parent_refs"] == rebuilt["parent_refs"]
+
+
+def test_a_drain_does_not_empty_the_node_and_edge_tables(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole point is that repair is scoped; a `DELETE FROM` is not scoped."""
+    executed: list[str] = []
+    real_execute = sqlite3.Connection.execute
+
+    def record(conn: sqlite3.Connection, sql: str, *args: Any) -> Any:
+        executed.append(sql)
+        return real_execute(conn, sql, *args)
+
+    (vault / PAGE_A).write_text(_page("A", "A is revised."), encoding="utf-8")
+    _seed_live_freshness(vault)
+    deferred_index.add_graph_receipts(vault, [PAGE_A])
+
+    monkeypatch.setattr(sqlite3.Connection, "execute", record)
+    try:
+        index_sync.drain_deferred_work(vault)
+    finally:
+        monkeypatch.undo()
+
+    unscoped = [
+        sql
+        for sql in executed
+        if sql.strip().upper().startswith("DELETE FROM GRAPH_")
+        and "WHERE" not in sql.upper()
+    ]
+    assert unscoped == [], f"a drain issued an unscoped delete: {unscoped}"
+
+
+# --- 3. The queue is monotone under concurrency ---------------------------------
+
+
+def test_a_write_landing_during_a_drain_is_repaired_by_the_next_drain(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Appending work is the property the global-proof design cannot have."""
+    (vault / PAGE_A).write_text(_page("A", "A is revised once."), encoding="utf-8")
+    _seed_live_freshness(vault)
+    deferred_index.add_graph_receipts(vault, [PAGE_A])
+
+    real_index_path = EpistemicGraphIndex._index_path
+    landed = False
+
+    def index_then_write(self: Any, conn: Any, path: Path, **kwargs: Any) -> bool:
+        nonlocal landed
+        outcome = real_index_path(self, conn, path, **kwargs)
+        if not landed:
+            landed = True
+            (vault / PAGE_B).write_text(_page("B", "B lands mid-drain."), encoding="utf-8")
+            _seed_live_freshness(vault)
+            deferred_index.add_graph_receipts(vault, [PAGE_B])
+        return outcome
+
+    monkeypatch.setattr(EpistemicGraphIndex, "_index_path", index_then_write)
+    index_sync.drain_deferred_work(vault)
+    monkeypatch.undo()
+
+    assert PAGE_B in deferred_index.list_graph_paths(vault), (
+        "the mid-drain write must survive the drain that did not cover it"
+    )
+
+    index_sync.drain_deferred_work(vault)
+
+    assert deferred_index.list_graph_paths(vault) == []
+    assert _graph_contents(vault) == _graph_contents_after_full_rebuild(vault)
+
+
+def _graph_contents_after_full_rebuild(root: Path) -> dict[str, list[tuple[Any, ...]]]:
+    EpistemicGraphIndex(root).rebuild_all()
+    return _graph_contents(root)
+
+
+# --- 4. Repair is proportional, and the exceptions are declared -----------------
+
+#: Every `fallback(...)` reason in `_refresh_paths_locked`, and which of the two
+#: repairs it earns.
+#:
+#: `"defer"` means the incremental path could not *prove* its result but the
+#: scope of the damage is known: enqueue the affected paths and let a drain
+#: repair them. Every reason here is a race -- a concurrent writer moved a
+#: durable token between two reads -- and a race is precisely what the retry
+#: budget cannot win, because each whole-vault attempt widens the window that
+#: loses it.
+#:
+#: `"rebuild"` means the scope is *unknown*: the graph sidecar could not be read,
+#: or the delta that tells us what changed is itself incomplete. Enqueuing a
+#: bounded set there would silently leave the rest of the graph stale, which is
+#: worse than the cost this change is removing. These stay whole-vault, and the
+#: point of writing them down is that they stay *few*.
+_DECLARED_FALLBACK_DISPOSITIONS = {
+    # Races and stale bindings: bounded, known scope.
+    "path_outside_vault": "defer",
+    "path_unreadable": "defer",
+    "durable_checkpoint_moved": "defer",
+    "checkpoint_paths_mismatch": "defer",
+    "checkpoint_created_paths_mismatch": "defer",
+    "acknowledgement_is_not_the_predecessor": "defer",
+    "delta_target_moved": "defer",
+    "caller_path_outside_delta": "defer",
+    "topology_proof_moved": "defer",
+    "incremental_marker_refused": "defer",
+    "unreachable": "defer",
+    # Unknown scope: the sidecar or the delta cannot be trusted to bound it.
+    "checkpoint_scope_is_not_paths": "rebuild",
+    "graph_snapshot_unavailable": "rebuild",
+    "recall_checkpoint_absent_or_registry_not_live": "rebuild",
+    "recall_delta_incomplete": "rebuild",
+    "stored_resolver_entries_unreadable": "rebuild",
+    "resolver_snapshot_unavailable": "rebuild",
+    "topology_snapshot_unavailable": "rebuild",
+    "stored_topology_unreadable": "rebuild",
+    "stored_topology_fingerprint_mismatch": "rebuild",
+}
+
+
+def _fallback_reasons_in_source() -> set[str]:
+    """Read the reasons out of the module rather than trusting a hand list."""
+    tree = ast.parse(Path(epistemic_graph.__file__).read_text(encoding="utf-8"))
+    reasons: set[str] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "fallback"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            reasons.add(node.args[0].value)
+    return reasons
+
+
+def test_every_fallback_reason_has_a_declared_disposition() -> None:
+    assert _fallback_reasons_in_source() == set(_DECLARED_FALLBACK_DISPOSITIONS), (
+        "an incremental-refresh bail-out appeared, moved, or was renamed: decide "
+        "whether its damage has a known scope (defer) or not (rebuild) and say so "
+        "here and in epistemic_graph._FALLBACK_DISPOSITIONS"
+    )
+
+
+def test_the_module_and_the_suite_agree_on_every_disposition() -> None:
+    """One definition, imported -- the rule task 1.4 already established."""
+    assert epistemic_graph._FALLBACK_DISPOSITIONS == _DECLARED_FALLBACK_DISPOSITIONS
+
+
+def test_most_bail_outs_defer_so_the_common_case_stays_proportional() -> None:
+    """A table that quietly drifted to all-rebuild would pass the checks above."""
+    deferring = sum(
+        1 for value in _DECLARED_FALLBACK_DISPOSITIONS.values() if value == "defer"
+    )
+    assert deferring >= len(_DECLARED_FALLBACK_DISPOSITIONS) // 2
+
+
+def test_an_ordinary_bail_out_performs_no_whole_vault_walk(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The measurable claim: O(changed), not O(vault)."""
+    walks: list[Any] = []
+    real_pass = EpistemicGraphIndex._rebuild_all_pass
+
+    def record(self: Any, *args: Any, **kwargs: Any) -> Any:
+        walks.append(self)
+        return real_pass(self, *args, **kwargs)
+
+    monkeypatch.setattr(EpistemicGraphIndex, "_rebuild_all_pass", record)
+
+    index = EpistemicGraphIndex(vault)
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=99,
+        mutation_id=f"{99:024x}",
+        paths=((PAGE_A, "d" * 64),),
+        created_paths=(),
+    )
+    (vault / PAGE_A).write_text(_page("A", "A is revised."), encoding="utf-8")
+
+    with index._mutation_coordinator.hold(
+        operation="epistemic_graph_refresh_paths", holder_kind="graph"
+    ):
+        report = index._refresh_paths_locked(
+            [vault / PAGE_A], graph_checkpoint=checkpoint
+        )
+
+    assert report.get("deferred") == 1
+    assert walks == [], "an ordinary bail-out re-walked the whole vault"
+    assert PAGE_A in deferred_index.list_graph_paths(vault)
+
+
+def test_a_missing_sidecar_still_rebuilds_the_whole_vault(vault: Path) -> None:
+    """Proportional repair is an optimisation; the rebuild must stay reachable."""
+    index = EpistemicGraphIndex(vault)
+    index.path.unlink()
+
+    index.rebuild_all()
+
+    assert _graph_contents(vault)["nodes"], "the whole-vault rebuild stopped working"

--- a/tests/test_graph_deferred_queue.py
+++ b/tests/test_graph_deferred_queue.py
@@ -158,13 +158,13 @@ def test_the_enqueue_precedes_the_commit_so_a_crash_cut_cannot_lose_it(
     """
     deferred_index.clear_graph(vault)
     order: list[str] = []
-    real_add = deferred_index.add_graph_receipts
+    real_enqueue = deferred_index.enqueue_graph_checkpoint
 
-    def record_add(root: Path, rel_paths: list[str]) -> Any:
+    def record_enqueue(root: Path, checkpoint: Any) -> int:
         order.append("enqueue")
-        return real_add(root, rel_paths)
+        return real_enqueue(root, checkpoint)
 
-    monkeypatch.setattr(deferred_index, "add_graph_receipts", record_add)
+    monkeypatch.setattr(deferred_index, "enqueue_graph_checkpoint", record_enqueue)
 
     class Crash(RuntimeError):
         pass
@@ -258,22 +258,24 @@ def test_a_drain_does_not_empty_the_node_and_edge_tables(
 ) -> None:
     """The whole point is that repair is scoped; a `DELETE FROM` is not scoped."""
     executed: list[str] = []
-    real_execute = sqlite3.Connection.execute
+    real_connect = EpistemicGraphIndex._connect
 
-    def record(conn: sqlite3.Connection, sql: str, *args: Any) -> Any:
-        executed.append(sql)
-        return real_execute(conn, sql, *args)
+    def tracing_connect(self: Any) -> sqlite3.Connection:
+        conn = real_connect(self)
+        conn.set_trace_callback(executed.append)
+        return conn
 
     (vault / PAGE_A).write_text(_page("A", "A is revised."), encoding="utf-8")
     _seed_live_freshness(vault)
     deferred_index.add_graph_receipts(vault, [PAGE_A])
 
-    monkeypatch.setattr(sqlite3.Connection, "execute", record)
+    monkeypatch.setattr(EpistemicGraphIndex, "_connect", tracing_connect)
     try:
         index_sync.drain_deferred_work(vault)
     finally:
         monkeypatch.undo()
 
+    assert executed, "the drain never opened the graph sidecar"
     unscoped = [
         sql
         for sql in executed
@@ -449,3 +451,55 @@ def test_a_missing_sidecar_still_rebuilds_the_whole_vault(vault: Path) -> None:
     index.rebuild_all()
 
     assert _graph_contents(vault)["nodes"], "the whole-vault rebuild stopped working"
+
+
+def test_a_page_written_before_its_link_target_still_gains_the_edge(vault: Path) -> None:
+    """The forward reference: the defect the equivalence test actually found.
+
+    An unresolved wikilink produces no edge at all -- `_body_wikilink_paths`
+    drops it -- so a page written before its target exists has a hole, and
+    indexing the *target* later cannot repair the *source*. A full rebuild never
+    notices because it re-derives everything once the corpus is complete. Named
+    on its own so a regression reads as "forward references broke" rather than
+    "some graph contents differ".
+    """
+    (vault / PAGE_A).write_text(_page("A", "A points at [[queue-c]]."), encoding="utf-8")
+    _seed_live_freshness(vault)
+    deferred_index.add_graph_receipts(vault, [PAGE_A])
+    index_sync.drain_deferred_work(vault)
+
+    (vault / PAGE_C).write_text(_page("C", "C exists now."), encoding="utf-8")
+    _seed_live_freshness(vault)
+    deferred_index.add_graph_receipts(vault, [PAGE_C])
+    index_sync.drain_deferred_work(vault)
+
+    edges = {
+        (row[1], row[2])
+        for row in _graph_contents(vault)["edges"]
+    }
+    assert (f"file:{PAGE_A}", f"file:{PAGE_C}") in edges
+
+
+def test_an_ordinary_edit_does_not_pay_for_topology_repair(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repairing forward references costs a corpus scan; ordinary edits must not.
+
+    If this ever fires on a plain body edit, every write pays the O(vault) read
+    the whole change exists to stop paying.
+    """
+    scans: list[Any] = []
+    real_scan = EpistemicGraphIndex._sources_linking_to
+
+    def record(self: Any, targets: set[str], **kwargs: Any) -> set[str]:
+        scans.append(targets)
+        return real_scan(self, targets, **kwargs)
+
+    monkeypatch.setattr(EpistemicGraphIndex, "_sources_linking_to", record)
+
+    (vault / PAGE_A).write_text(_page("A", "A says something else."), encoding="utf-8")
+    _seed_live_freshness(vault)
+    deferred_index.add_graph_receipts(vault, [PAGE_A])
+    index_sync.drain_deferred_work(vault)
+
+    assert scans == [], "a plain edit triggered the corpus scan reserved for topology changes"

--- a/tests/test_graph_deferred_queue.py
+++ b/tests/test_graph_deferred_queue.py
@@ -533,3 +533,22 @@ def test_a_drain_retires_the_generation_it_converged(vault: Path) -> None:
         "generation": required.generation,
     }
     assert EpistemicGraphIndex(vault).available()
+
+
+def test_a_queue_predating_the_graph_table_reads_as_empty(vault: Path) -> None:
+    """An existing vault upgrades into this feature; it does not start at it.
+
+    Every deployed vault already has a `.deferred-index.sqlite` carrying the
+    semantic and full queues, and none of them has a `graph_upserts` table until
+    something opens the store for writing. The readers run first -- a drain asks
+    what is queued before it queues anything -- and they open read-only, where
+    creating the table is not possible. Raising there turns an ordinary upgrade
+    into a hard failure on the first drain, which is how CI found it.
+    """
+    deferred_index.add_graph(vault, [PAGE_A])
+    with sqlite3.connect(deferred_index.store_path(vault)) as conn:
+        conn.execute("DROP TABLE graph_upserts")
+
+    assert deferred_index.snapshot_graph(vault) == []
+    assert deferred_index.list_graph_paths(vault) == []
+    assert deferred_index.graph_status(vault)["count"] == 0

--- a/tests/test_graph_deferred_queue.py
+++ b/tests/test_graph_deferred_queue.py
@@ -503,3 +503,33 @@ def test_an_ordinary_edit_does_not_pay_for_topology_repair(
     index_sync.drain_deferred_work(vault)
 
     assert scans == [], "a plain edit triggered the corpus scan reserved for topology changes"
+
+
+def test_a_drain_retires_the_generation_it_converged(vault: Path) -> None:
+    """Converging the content is only half the job; the epoch has to learn it.
+
+    The graph_sync acknowledgement is what tells every later reader that the
+    committed generation is covered. A drain that repairs the pages but leaves
+    the acknowledgement behind converges nothing that anybody can observe: the
+    epoch stays stale, `available()` stays false, and the next dispatch takes
+    the whole-vault rebuild anyway. The queue would then be pure overhead --
+    the expensive path still runs, and now there is a second store to keep.
+    """
+    write = vault / PAGE_C
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(write, _page("C", "C cites [[queue-a]]."))],
+        vault_root=vault,
+        post_commit_fanout=False,
+    )
+    _seed_live_freshness(vault)
+    required = graph_sync.read_checkpoint(vault)
+    assert required is not None
+    assert deferred_index.snapshot_graph(vault), "the write left no graph debt to drain"
+
+    index_sync.drain_deferred_work(vault)
+
+    assert graph_sync.status(vault) == {
+        "state": "current",
+        "generation": required.generation,
+    }
+    assert EpistemicGraphIndex(vault).available()

--- a/tests/test_graph_epoch_protocol.py
+++ b/tests/test_graph_epoch_protocol.py
@@ -717,6 +717,69 @@ def test_acknowledgement_requires_the_full_checkpoint_meta_proof(tmp_path: Path)
     assert graph_sync.status(tmp_path)["state"] == "current"
 
 
+@pytest.mark.parametrize(
+    "read_acknowledgement",
+    [
+        graph_sync.acknowledgement_state,
+        graph_sync._malformed_acknowledgement_generation,
+    ],
+    ids=["acknowledgement_state", "malformed_generation_hint"],
+)
+def test_acknowledgement_readers_close_the_sidecar_they_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    read_acknowledgement: object,
+) -> None:
+    """A read handle that outlives its reader refuses the next publication.
+
+    `with sqlite3.connect(...)` commits the open transaction and leaves the
+    connection itself open -- the context manager is a transaction scope, not a
+    close. Every acknowledgement read therefore added one more live handle to
+    `.graph.sqlite`, and both readers sit on the graph read path through
+    `classify_epoch` / `status` / `_open_read_snapshot`. That is an unbounded
+    handle leak in a long-lived server, and on Windows it is the sharing
+    violation that makes the publication `os.replace` fail with WinError 32 --
+    the failure class the reader-cycling publication hold exists to avoid.
+    """
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="0123456789abcdef01234567",
+        paths=(),
+        created_paths=(),
+        scope="full",
+    )
+    sidecar = tmp_path / "Knowledge Base/.graph.sqlite"
+    sidecar.parent.mkdir(parents=True)
+    setup = sqlite3.connect(sidecar)
+    with setup:
+        setup.execute("CREATE TABLE graph_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        setup.executemany(
+            "INSERT INTO graph_meta(key, value) VALUES (?, ?)",
+            (
+                ("graph_sync_generation", "1"),
+                ("graph_sync_digest", checkpoint.checkpoint_sha256),
+                ("graph_sync_checkpoint", checkpoint.render()),
+            ),
+        )
+    setup.close()
+
+    opened: list[sqlite3.Connection] = []
+    real_connect = sqlite3.connect
+
+    def recording_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+        conn = real_connect(*args, **kwargs)  # type: ignore[arg-type]
+        opened.append(conn)
+        return conn
+
+    monkeypatch.setattr(sqlite3, "connect", recording_connect)
+    read_acknowledgement(tmp_path)  # type: ignore[operator]
+
+    assert opened, "the acknowledgement reader never opened the sidecar"
+    for conn in opened:
+        with pytest.raises(sqlite3.ProgrammingError):
+            conn.execute("SELECT 1")
+
+
 def test_status_and_public_graph_availability_agree_on_missing_checkpoint_meta(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_graph_fanout_totality.py
+++ b/tests/test_graph_fanout_totality.py
@@ -164,5 +164,11 @@ def test_constructor_failure_fallback_keeps_invoking_manager_boundary(
     )
 
     manager.invoke(command, (vault_root,), {})
+    # The fallback rebuild runs off-boundary on a daemon thread, and since the
+    # interactive join became check-only this command no longer waits for it.
+    # Asserting straight after `invoke` is a race the rebuild usually wins and
+    # sometimes does not -- it lost on a loaded CI shard while passing every
+    # local run. Join the flight explicitly; that is what this seam is for.
+    graph_sync.await_active_rebuild(vault_root, state_root=custom_state)
 
     assert observed_roots == [custom_state]

--- a/tests/test_graph_idempotency_handoff.py
+++ b/tests/test_graph_idempotency_handoff.py
@@ -636,6 +636,11 @@ def test_post_fanout_cleanup_failure_finishes_graph_before_exact_failure_replay(
     with pytest.raises(ValueError) as replay:
         manager.invoke(command, (vault,), {}, idempotency_key="cleanup-after-fanout")
 
+    # The registered work is no longer joined by the write (#576/#588). Joining
+    # it explicitly is what actually proves this test's subject -- that a
+    # post-fanout cleanup error cannot *strand* the work -- instead of relying
+    # on a blocking side effect of the write path to have finished it.
+    graph_sync.await_active_rebuild(vault, state_root=tmp_path / "state")
     assert graph_sync.status(vault)["state"] == "current"
     assert replay.value.as_public_dict() == first.value.as_public_dict()
     assert calls == 1
@@ -898,12 +903,33 @@ def test_lease_manager_preserves_real_wait_path_graph_failure_code(
     replay = manager.invoke(command, (vault,), {}, idempotency_key=f"wait-{failure_kind}")
 
     assert result["status"] == "committed"
-    assert result["graph_sync"] == "failed"
-    assert result["graph_sync_code"] == expected_code
-    assert result["graph_sync_remediation"] == expected_remediation
-    assert sentinel not in str(result)
+    # The write no longer waits for the builder (#576/#588): the rebuild runs on
+    # its own daemon thread, so at response time the honest outcome is `pending`.
+    assert result["graph_sync"] == "pending"
     assert replay == result
     assert calls == 1
+
+    # The three properties this test defends are unchanged; they are now
+    # asserted where they are produced rather than after two layers of
+    # projection. `committed_graph_failure` reads `.code`/`.remediation`
+    # straight off this exception, and the private builder path must not reach
+    # a caller through either.
+    with pytest.raises(graph_sync.GraphRebuildRegistrationError) as raised:
+        graph_sync.await_active_rebuild(vault, state_root=tmp_path / "state")
+    assert raised.value.code == expected_code
+    assert raised.value.remediation == expected_remediation
+    # The *exception* legitimately carries the builder's own message, private
+    # path and all -- that is what makes it diagnosable in a log. The no-leak
+    # contract is about what reaches a caller, which is the projection below,
+    # and it holds because `committed_graph_failure` reads only `.code` and
+    # `.remediation` and never the message.
+    assert sentinel not in str(
+        graph_sync.committed_graph_failure(
+            graph_sync.read_checkpoint(vault),
+            code=raised.value.code,
+            remediation=raised.value.remediation,
+        )
+    )
 
 
 def test_lease_manager_preserves_graph_thread_start_failure(

--- a/tests/test_graph_lifecycle_transition.py
+++ b/tests/test_graph_lifecycle_transition.py
@@ -473,7 +473,10 @@ def test_lease_graph_wait_does_not_finalize_a_degraded_governed_delete(
     )
     assert calls == [1]
     assert result["status"] == "committed"
-    assert result["graph_sync"] == "completed"
+    # The write no longer waits on derived graph work (#576/#588), so it reports
+    # `pending`; the graph's own outcome is asserted after joining the flight.
+    assert result["graph_sync"] == "pending"
+    graph_sync.await_active_rebuild(tmp_path, state_root=tmp_path / "state")
     assert any("remains tombstoned until reconcile" in warning for warning in result["diagnostics"]["warnings"])
     assert len(tombstones) == 1
     assert lifecycle._read_json(tmp_path, tombstones[0])["state"] == "pending"

--- a/tests/test_graph_rebuild_availability.py
+++ b/tests/test_graph_rebuild_availability.py
@@ -1058,6 +1058,7 @@ def test_a_queued_repair_is_not_rescheduled_as_a_whole_vault_rebuild(
     rebuild and reports `deferred` too. Only the enqueue that actually succeeded
     may claim the queue owns the work.
     """
+    from exomem import writer_lease
     from exomem.epistemic_graph import EpistemicGraphIndex, upsert_after_write
 
     note = tmp_path / "Knowledge Base/Notes/Insights/queued.md"
@@ -1087,11 +1088,62 @@ def test_a_queued_repair_is_not_rescheduled_as_a_whole_vault_rebuild(
             "queued": 1,
         },
     )
+    # Inside a mutation request, whose terminal can carry `pending`.
+    monkeypatch.setattr(writer_lease, "active_mutation_request_id", lambda: "request-1")
 
     result = upsert_after_write(tmp_path, [note])
 
     assert (result.outcome, result.code) == ("deferred", "graph_repair_queued")
     assert registrations == []
+
+
+def test_a_standalone_caller_still_gets_a_converged_graph(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deferring is only honest for a caller that can report `pending`.
+
+    A direct library caller returns a leaf result with nowhere to put a graph
+    outcome, and its contract has always been a converged graph -- which is why
+    the standalone join exists. Deferring for it does not merely under-report:
+    it changes what the next call in the same process observes. Ten governance
+    and deletion-lineage tests failed on exactly that, because the operation
+    after a delete read a graph that used to be current by the time it ran.
+    """
+    from exomem.epistemic_graph import EpistemicGraphIndex, upsert_after_write
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/standalone.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Standalone\n", encoding="utf-8")
+    required = _checkpoint(1)
+    graph_sync._write_checkpoint(tmp_path, required)
+    registrations: list[graph_sync.GraphSyncCheckpoint] = []
+    monkeypatch.setattr(
+        graph_sync,
+        "register_rebuild",
+        lambda _root, checkpoint, _builder, **_kwargs: registrations.append(checkpoint),
+    )
+    monkeypatch.setattr(
+        EpistemicGraphIndex,
+        "_graph_sync_predecessor_available",
+        lambda _self, _checkpoint: True,
+    )
+    monkeypatch.setattr(
+        EpistemicGraphIndex,
+        "refresh_paths",
+        lambda _self, *_args, **_kwargs: {
+            "indexed_files": 0,
+            "nodes": 0,
+            "edges": 0,
+            "deferred": 1,
+            "queued": 1,
+        },
+    )
+
+    # No active mutation request: this is the standalone library path.
+    result = upsert_after_write(tmp_path, [note])
+
+    assert result.code != "graph_repair_queued"
+    assert registrations == [required]
 
 
 def test_no_checkpoint_or_paths_skips_graph_fanout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_graph_rebuild_availability.py
+++ b/tests/test_graph_rebuild_availability.py
@@ -15,7 +15,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from exomem import freshness, graph_sync, runtime_readiness
+from exomem import deferred_index, freshness, graph_sync, runtime_readiness
 from exomem import mutation_lock as mutation_lock_module
 from exomem import reconcile as reconcile_module
 from exomem import vault as vault_module
@@ -961,9 +961,17 @@ def test_immediate_checkpoint_successor_refreshes_without_full_rebuild(
     assert graph_sync.status(tmp_path)["state"] == "current"
 
 
-def test_failed_incremental_proof_registers_off_boundary_work_without_rebuilding(
+def test_failed_incremental_proof_queues_the_affected_paths_without_rebuilding(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """A failed proof records its debt durably, and records it proportionally.
+
+    The guarantee here has always been two-sided: never rebuild the vault under
+    writer authority, and never drop the work. `converge-graph-incrementally`
+    changes only *where* the second half is recorded. A whole-vault rebuild
+    registration used to be the receipt; the durable dirty-path queue is now,
+    and it names the affected paths instead of standing in for all of them.
+    """
     from exomem.epistemic_graph import EpistemicGraphIndex
 
     note = tmp_path / "Knowledge Base/Notes/Insights/deferred.md"
@@ -991,7 +999,10 @@ def test_failed_incremental_proof_registers_off_boundary_work_without_rebuilding
 
     assert report["deferred"] == 1
     assert rebuilds == 0
-    assert registrations == [required]
+    assert registrations == []
+    assert [receipt.rel_path for receipt in deferred_index.snapshot_graph(tmp_path)] == [
+        note.relative_to(tmp_path).as_posix()
+    ]
 
 
 def test_no_checkpoint_or_paths_skips_graph_fanout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_graph_rebuild_availability.py
+++ b/tests/test_graph_rebuild_availability.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import multiprocessing
 import os
+import sqlite3
 import subprocess
 import sys
 import textwrap
@@ -1003,6 +1004,94 @@ def test_failed_incremental_proof_queues_the_affected_paths_without_rebuilding(
     assert [receipt.rel_path for receipt in deferred_index.snapshot_graph(tmp_path)] == [
         note.relative_to(tmp_path).as_posix()
     ]
+
+
+def test_an_enqueue_that_failed_still_earns_a_whole_vault_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A queue that could not take the work does not get to own it.
+
+    The dispatch skips the whole-vault rebuild only because the durable queue
+    holds the repair. If the enqueue raised, nothing holds it, and claiming
+    otherwise would drop the work entirely -- strictly worse than the expensive
+    path this change replaces. The rebuild is the correct answer here.
+    """
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/unqueued.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Unqueued\n", encoding="utf-8")
+    index = EpistemicGraphIndex(tmp_path)
+    required = _checkpoint(1)
+    graph_sync._write_checkpoint(tmp_path, required)
+    registrations: list[graph_sync.GraphSyncCheckpoint] = []
+
+    def refuse(*_args, **_kwargs):
+        raise sqlite3.OperationalError("queue unavailable")
+
+    monkeypatch.setattr(deferred_index, "add_graph", refuse)
+    monkeypatch.setattr(
+        graph_sync,
+        "register_rebuild",
+        lambda _root, checkpoint, _builder, **_kwargs: registrations.append(checkpoint),
+    )
+
+    report = index._refresh_paths_locked([note], graph_checkpoint=required)
+
+    assert report["deferred"] == 1
+    assert not report.get("queued")
+    assert registrations == [required]
+
+
+def test_a_queued_repair_is_not_rescheduled_as_a_whole_vault_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The queue owns the repair, so the dispatch must not schedule the vault.
+
+    A defer-classified bail-out enqueues the affected paths and registers no
+    rebuild. The layer above read that -- an unregistered, unacknowledged
+    checkpoint -- as a *missing* rebuild and registered one, so the expensive
+    path still ran on exactly the bail-outs this change exists to make
+    proportional, now with a queue beside it rather than instead of it.
+
+    `deferred` alone cannot carry this decision: `fallback()` registers its own
+    rebuild and reports `deferred` too. Only the enqueue that actually succeeded
+    may claim the queue owns the work.
+    """
+    from exomem.epistemic_graph import EpistemicGraphIndex, upsert_after_write
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/queued.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Queued\n", encoding="utf-8")
+    required = _checkpoint(1)
+    graph_sync._write_checkpoint(tmp_path, required)
+    registrations: list[graph_sync.GraphSyncCheckpoint] = []
+    monkeypatch.setattr(
+        graph_sync,
+        "register_rebuild",
+        lambda _root, checkpoint, _builder, **_kwargs: registrations.append(checkpoint),
+    )
+    monkeypatch.setattr(
+        EpistemicGraphIndex,
+        "_graph_sync_predecessor_available",
+        lambda _self, _checkpoint: True,
+    )
+    monkeypatch.setattr(
+        EpistemicGraphIndex,
+        "refresh_paths",
+        lambda _self, *_args, **_kwargs: {
+            "indexed_files": 0,
+            "nodes": 0,
+            "edges": 0,
+            "deferred": 1,
+            "queued": 1,
+        },
+    )
+
+    result = upsert_after_write(tmp_path, [note])
+
+    assert (result.outcome, result.code) == ("deferred", "graph_repair_queued")
+    assert registrations == []
 
 
 def test_no_checkpoint_or_paths_skips_graph_fanout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_graph_write_concurrency.py
+++ b/tests/test_graph_write_concurrency.py
@@ -32,7 +32,7 @@ from pathlib import Path
 
 import pytest
 
-from exomem import graph_sync
+from exomem import deferred_index, graph_sync
 from exomem import vault as vault_module
 
 
@@ -96,6 +96,48 @@ def test_a_rebuilds_residue_does_not_move_the_census(tmp_path: Path, name: str) 
         residue.write_bytes(b"derived")
 
     assert _census(guarded) == before
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        ".deferred-index.sqlite",
+        ".deferred-index.sqlite-journal",
+        ".deferred-index.sqlite-wal",
+        ".deferred-index.sqlite-shm",
+    ],
+)
+def test_the_dirty_path_queues_database_does_not_move_the_census(
+    tmp_path: Path, name: str
+) -> None:
+    """The graph enqueue runs *inside* the guarded window, by design.
+
+    `converge-graph-incrementally` records a batch's graph debt before that
+    batch commits, so a crash between the markdown and the enqueue cannot lose
+    the dirty set. The ordering is load-bearing, and it means a derived SQLite
+    file is created and journalled while the census is open. Counting it made
+    the first write to a fresh vault fail as `STALE_RECORD: canonical record
+    changed before commit` -- the write invalidating itself, with nothing
+    concurrent involved at all.
+    """
+    guarded = tmp_path / "Knowledge Base"
+    guarded.mkdir()
+    (guarded / "page.md").write_text("body\n", encoding="utf-8")
+
+    before = _census(guarded)
+    (guarded / name).write_bytes(b"derived")
+
+    assert _census(guarded) == before
+
+
+def test_the_census_exclusion_tracks_the_deferred_indexs_own_database_name() -> None:
+    """Bind the literal, for the reason the graph_sync names are bound.
+
+    `vault` cannot import `deferred_index` at module scope without a cycle, so
+    it spells the basename. A rename there would otherwise leave this copy
+    stale and quietly start counting the queue again.
+    """
+    assert deferred_index.store_path(Path("vault")).name == vault_module._DEFERRED_INDEX_BASENAME
 
 
 @pytest.mark.parametrize("name", [".graph-sync.json", ".graph-sync-floor.json"])

--- a/tests/test_graph_write_concurrency.py
+++ b/tests/test_graph_write_concurrency.py
@@ -1,0 +1,280 @@
+"""A graph rebuild and a canonical write may overlap without either losing.
+
+Until an interactive write stopped joining its own rebuild, these two could not
+run at the same time, and the join was the only thing preventing it. They
+conflict, on POSIX as well as Windows, so this was never a platform quirk --
+and every path that already rebuilds off the write path (the watcher's
+background rebuild, deferred drains) could reach it before that change.
+
+Two halves of that conflict are guarded here.
+
+The census half: a rebuild creates, replaces and removes its scratch sidecars
+inside the very directory a canonical write takes a guarded census of, so
+without an exclusion an in-flight rebuild turns an unrelated write into
+`PATH_GUARD_CHANGED` and then `STALE_RECORD`. The exclusion is deliberately
+narrow, and the narrowness is the part worth testing: `.graph-sync.json` and
+`.graph-sync-floor.json` are written by the canonical batch *itself*, so a
+change to them under a write is exactly what the guard must still refuse. An
+over-broad "ignore anything starting with .graph" would silently disarm the
+guard against the batch writer's own artifacts.
+
+The sharing half: on Windows a reader that holds a page open refuses a
+concurrent replacement of it. A derived-index reader has no business taking
+that custody.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from exomem import graph_sync
+from exomem import vault as vault_module
+
+
+def _census(path: Path) -> tuple[str, ...]:
+    """The names a canonical write's guarded directory census would record."""
+    identity = vault_module._identity(path.name, os.stat(path))
+    entries = vault_module._bounded_directory_entries(
+        path,
+        relative=path.name,
+        expected=identity,
+        max_entries=4096,
+    )
+    return tuple(entry.relative_path for entry in entries)
+
+
+def test_the_census_exclusion_tracks_graph_syncs_own_artifact_names() -> None:
+    """`vault` spells these literally to avoid an import cycle; bind them anyway.
+
+    A rename of the rebuild temp prefix or the live sidecar in `graph_sync`
+    would otherwise leave `vault`'s copy stale, and the census would start
+    counting rebuild residue again -- reintroducing the exact failure this
+    exclusion exists to prevent, silently and far from either definition.
+    """
+    assert vault_module._DERIVED_INDEX_PREFIXES == (
+        graph_sync._TEMP_PREFIX,
+        graph_sync._RESET_PREFIX,
+    )
+
+    # The reset manifest enumerates every file a reset moves. Its graph-sidecar
+    # members are derived; its checkpoint and floor members are canonical-batch
+    # output and must stay censused.
+    canonical_batch_members = {graph_sync._CHECKPOINT_FILENAME, graph_sync._FLOOR_FILENAME}
+    derived_members = set(graph_sync._RESET_MEMBERS) - canonical_batch_members
+    assert vault_module._DERIVED_INDEX_NAMES == derived_members
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        ".graph.sqlite",
+        ".graph.sqlite-journal",
+        ".graph.sqlite-wal",
+        ".graph.sqlite-shm",
+        ".graph-rebuild-0123456789abcdef.sqlite",
+        ".graph-rebuild-0123456789abcdef.sqlite-wal",
+        ".graph-reset-0123456789abcdef",
+    ],
+)
+def test_a_rebuilds_residue_does_not_move_the_census(tmp_path: Path, name: str) -> None:
+    """The write must commit even though a rebuild is churning beside it."""
+    guarded = tmp_path / "Knowledge Base"
+    guarded.mkdir()
+    (guarded / "page.md").write_text("body\n", encoding="utf-8")
+
+    before = _census(guarded)
+
+    residue = guarded / name
+    if name.startswith(graph_sync._RESET_PREFIX):
+        residue.mkdir()
+    else:
+        residue.write_bytes(b"derived")
+
+    assert _census(guarded) == before
+
+
+@pytest.mark.parametrize("name", [".graph-sync.json", ".graph-sync-floor.json"])
+def test_the_canonical_batchs_own_graph_artifacts_stay_censused(
+    tmp_path: Path, name: str
+) -> None:
+    """The narrow half: these are batch output, so the guard must still see them."""
+    guarded = tmp_path / "Knowledge Base"
+    guarded.mkdir()
+    (guarded / "page.md").write_text("body\n", encoding="utf-8")
+
+    before = _census(guarded)
+    (guarded / name).write_bytes(b"{}")
+    after = _census(guarded)
+
+    assert after != before
+    assert any(entry.endswith(name) for entry in after)
+
+
+#: Replacements to drive against a continuously re-opening reader. Far more
+#: hostile than any real rebuild, which reads a page once and moves on.
+_REPLACEMENT_ROUNDS = 200
+
+
+def _drive_reader_against_replacements(
+    page: Path,
+    staging: Path,
+    read: Callable[[Path], object],
+    replace: Callable[[Path, Path], None],
+) -> tuple[list[BaseException], list[BaseException]]:
+    """Run `read` in a loop against `replace` in a loop; collect both sides' failures."""
+    stop = threading.Event()
+    read_failures: list[BaseException] = []
+    replace_failures: list[BaseException] = []
+
+    def read_continuously() -> None:
+        while not stop.is_set():
+            try:
+                read(page)
+            except FileNotFoundError:
+                pass  # a replacement is not atomic against a *missing* target
+            except BaseException as error:  # noqa: BLE001 - the point of the test
+                read_failures.append(error)
+                return
+
+    reader = threading.Thread(target=read_continuously, name="rebuild-reader")
+    reader.start()
+    try:
+        for attempt in range(_REPLACEMENT_ROUNDS):
+            staged = staging / f"staged-{attempt}"
+            staged.write_bytes(b"replaced %d\n" % attempt)
+            try:
+                replace(staged, page)
+            except BaseException as error:  # noqa: BLE001 - the point of the test
+                replace_failures.append(error)
+    finally:
+        stop.set()
+        reader.join(timeout=30)
+
+    assert not reader.is_alive(), "the reader thread wedged"
+    return read_failures, replace_failures
+
+
+def test_a_rebuilds_reads_and_a_writers_replacements_both_survive(tmp_path: Path) -> None:
+    """The pair contract, driven from both sides at once.
+
+    A single read/replace pair almost never overlaps, so this drives both in
+    loops -- the shape that actually reproduced the failure. On POSIX
+    `rename(2)` over an open file is always permitted and this passes trivially;
+    the assertion is identical either way, which is the point.
+    """
+    page = tmp_path / "page.md"
+    page.write_bytes(b"original\n")
+    staging = tmp_path / "staging"
+    staging.mkdir()
+
+    read_failures, replace_failures = _drive_reader_against_replacements(
+        page,
+        staging,
+        vault_module.read_bytes_without_pinning,
+        lambda src, dst: vault_module.replace_tolerating_transient_sharing(
+            lambda: os.replace(src, dst)
+        ),
+    )
+
+    assert read_failures == []
+    assert replace_failures == []
+    assert page.read_bytes() == b"replaced %d\n" % (_REPLACEMENT_ROUNDS - 1)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="only Windows restricts sharing this way")
+def test_neither_half_of_the_pair_is_sufficient_alone(tmp_path: Path) -> None:
+    """Why both fixes exist. Records the failure each half leaves behind.
+
+    A pinning read kills the *reader*: a rebuild sweeping the corpus dies the
+    moment it opens a page a writer has marked delete-pending. Switching to a
+    non-pinning read fixes that and makes the *writer* worse, because
+    FILE_SHARE_DELETE is exactly what lets a replacement mark the target
+    delete-pending while that handle lives.
+
+    Without this test, a later reader could "simplify" either half away and see
+    the suite stay green on the half that remains.
+    """
+    page = tmp_path / "page.md"
+    staging = tmp_path / "staging"
+    staging.mkdir()
+
+    page.write_bytes(b"original\n")
+    pinning_reads, _ = _drive_reader_against_replacements(
+        page, staging, lambda p: p.read_bytes(), os.replace
+    )
+    assert pinning_reads, "a pinning read must be observed failing against a replacement"
+    assert all(isinstance(error, PermissionError) for error in pinning_reads)
+
+    page.write_bytes(b"original\n")
+    _, unretried_replacements = _drive_reader_against_replacements(
+        page, staging, vault_module.read_bytes_without_pinning, os.replace
+    )
+    assert unretried_replacements, (
+        "an unretried replacement must be observed failing against a non-pinning reader"
+    )
+    assert all(
+        error.winerror in vault_module._WINDOWS_SHARING_ERRORS
+        for error in unretried_replacements
+    )
+
+
+def test_the_sharing_retry_reports_which_attempt_succeeded() -> None:
+    """The budget must be observably sized, not merely observed to fit."""
+    attempts: list[int] = []
+
+    def fail_twice_then_succeed() -> None:
+        attempts.append(len(attempts))
+        if len(attempts) <= 2:
+            error = PermissionError(13, "Access is denied")
+            error.winerror = 32
+            raise error
+
+    rechecked = 0
+
+    def recheck() -> None:
+        nonlocal rechecked
+        rechecked += 1
+
+    if os.name != "nt":
+        pytest.skip("the retry deliberately does not engage off Windows")
+
+    assert vault_module.replace_tolerating_transient_sharing(
+        fail_twice_then_succeed, recheck=recheck
+    ) == 2
+    assert rechecked == 2, "the precondition must be re-proved after every wait"
+
+
+def test_a_non_sharing_permission_error_is_not_retried() -> None:
+    """Waiting out a genuine permission failure would hang the request."""
+    calls = 0
+
+    def always_denied() -> None:
+        nonlocal calls
+        calls += 1
+        error = PermissionError(13, "Access is denied")
+        error.winerror = 1314  # ERROR_PRIVILEGE_NOT_HELD, not a sharing violation
+        raise error
+
+    with pytest.raises(PermissionError):
+        vault_module.replace_tolerating_transient_sharing(always_denied)
+    assert calls == 1
+
+
+def test_read_bytes_without_pinning_returns_the_same_bytes(tmp_path: Path) -> None:
+    page = tmp_path / "page.md"
+    page.write_bytes(b"# heading\n\nbody with \xc3\xa9 and a \x00 byte\n")
+    assert vault_module.read_bytes_without_pinning(page) == page.read_bytes()
+
+
+def test_read_bytes_without_pinning_reports_a_missing_file_normally(tmp_path: Path) -> None:
+    """Callers catch FileNotFoundError; a raw OSError would escape them."""
+    with pytest.raises(FileNotFoundError):
+        vault_module.read_bytes_without_pinning(tmp_path / "absent.md")
+
+    with pytest.raises(FileNotFoundError):
+        vault_module.read_bytes_without_pinning(tmp_path / "no-such-dir" / "absent.md")

--- a/tests/test_hosted_refusal_guidance.py
+++ b/tests/test_hosted_refusal_guidance.py
@@ -15,13 +15,13 @@ guarantee holds while an expected refusal becomes actionable.
 from __future__ import annotations
 
 import json
-import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
 from exomem import commands, find, schema, semantic_authoring, server_hosted
 from exomem.cli_ops import error_dict
 from exomem.init import init_vault
+from temporary_vault import temporary_vault
 
 
 def _error_block(code: str) -> dict:
@@ -83,8 +83,7 @@ def test_authoring_remediation_is_derived_from_the_contract() -> None:
 
 def test_no_exception_text_reaches_the_response() -> None:
     """The seam takes a code and a static table — never a raised exception."""
-    with tempfile.TemporaryDirectory() as directory:
-        vault = Path(directory)
+    with temporary_vault() as vault:
         init_vault(vault)
         try:
             commands.op_remember(
@@ -115,8 +114,7 @@ def test_capture_lane_accepts_consecutive_ordinary_sentences() -> None:
         ("Renew the passport before March.", "Passport renewal"),
     ]
 
-    with tempfile.TemporaryDirectory() as directory:
-        vault = Path(directory)
+    with temporary_vault() as vault:
         init_vault(vault)
         source_schema = schema.load_source_schema(vault)
 
@@ -140,8 +138,7 @@ def test_governed_lane_still_refuses_an_ungrounded_second_conclusion() -> None:
     """Proof the contract was not weakened to make capture work."""
     body = "## Observations\n\n- [fact] The office moved to Pier 9 #office ^office-pier9\n"
 
-    with tempfile.TemporaryDirectory() as directory:
-        vault = Path(directory)
+    with temporary_vault() as vault:
         init_vault(vault)
 
         commands.op_remember(vault, title="Note 1", content=body, note_type="insight")

--- a/tests/test_hosted_refusal_guidance.py
+++ b/tests/test_hosted_refusal_guidance.py
@@ -15,13 +15,13 @@ guarantee holds while an expected refusal becomes actionable.
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from types import SimpleNamespace
+
+from temporary_vault import temporary_vault
 
 from exomem import commands, find, schema, semantic_authoring, server_hosted
 from exomem.cli_ops import error_dict
 from exomem.init import init_vault
-from temporary_vault import temporary_vault
 
 
 def _error_block(code: str) -> dict:

--- a/tests/test_media_graph_recovery.py
+++ b/tests/test_media_graph_recovery.py
@@ -152,13 +152,19 @@ def test_full_receipt_drain_skips_all_receipts_when_vault_recovery_fails(
         lambda _root, paths: dispatches.append(paths),
     )
 
-    assert index_sync.drain_deferred_work(vault, limit=2) == 0
+    # The subject is the *full* queue, and `snapshot_full` below says so
+    # exactly. The drain's aggregate return counts every queue it serves, and
+    # since the graph queue joined it (converge-graph-incrementally) a nonzero
+    # total can mean "graph paths repaired", which is unrelated to whether this
+    # vault's full receipts survived a failed recovery. `dispatches == []` is
+    # the assertion that no full work was replayed.
+    index_sync.drain_deferred_work(vault, limit=2)
     assert len(rebuild_attempts) == 1
     assert dispatches == []
     assert deferred_index.snapshot_full(vault) == admitted
     assert graph_sync.status(vault)["state"] == "recovery_required"
 
-    assert index_sync.drain_deferred_work(vault, limit=2) == 0
+    index_sync.drain_deferred_work(vault, limit=2)
     assert len(rebuild_attempts) == 2
     assert dispatches == []
     assert deferred_index.snapshot_full(vault) == admitted

--- a/tests/test_media_worker.py
+++ b/tests/test_media_worker.py
@@ -2504,7 +2504,13 @@ def test_transcript_index_refresh_failure_is_durable_and_retryable_without_asr(
         "upsert_after_write",
         lambda *_a, **_kw: _verified_media_fanout_report(vault, sidecar),
     )
-    assert index_sync.drain_deferred_work(vault) == 1
+    # The drain's aggregate counts every queue it serves, and the graph
+    # dirty-path queue joined them (converge-graph-incrementally) -- this same
+    # write filled that one too. So the total is no longer a proxy for "the full
+    # receipt drained", which is what this test is actually about;
+    # `full_status` below asserts that directly, and `calls` asserts the
+    # transcript was not re-extracted to get there.
+    index_sync.drain_deferred_work(vault)
     assert deferred_index.full_status(vault)["count"] == 0
     assert calls == 1
 

--- a/tests/test_mutation_lock.py
+++ b/tests/test_mutation_lock.py
@@ -1106,3 +1106,27 @@ def test_sequential_holds_on_one_thread_reacquire_the_os_boundary(
         mutation_lock_module._release_os_lock(probe)
     finally:
         probe.close()
+
+
+def test_the_private_state_root_is_creatable_under_a_missing_ancestor(
+    tmp_path: Path,
+) -> None:
+    """A fresh profile has no `~/.cache`, and the store must still come up.
+
+    `LeaseConfig.state_dir` defaults to `~/.cache/exomem`, so on a profile that
+    has never had an XDG-style cache directory the store's parent chain is two
+    levels deep and neither level exists. The POSIX branch creates the chain
+    (`mkdir(parents=True)`); the Windows branch creates exactly one directory so
+    it can own that entry's DACL, and used to inherit `FileNotFoundError` from
+    the missing ancestor -- which surfaced as the whole server failing to start
+    with `WinError 3`. Nothing in CI runs on Windows, so this is the guard.
+    """
+    from exomem.writer_lease import IdempotencyStore
+
+    root = tmp_path / "home" / ".cache" / "exomem"
+    assert not root.parent.exists()
+
+    store = IdempotencyStore(root / "idempotency.sqlite")
+
+    assert root.is_dir()
+    assert store._runtime_state_error is None

--- a/tests/test_plan_progress_review.py
+++ b/tests/test_plan_progress_review.py
@@ -12,7 +12,6 @@ a score. Divergence is exact integers, and adjudication stays with the human.
 
 from __future__ import annotations
 
-import hashlib
 import re
 import shutil
 from collections.abc import Mapping
@@ -20,8 +19,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
-from exomem import vault as vault_module
+from canonical_snapshot import canonical_digests
 
 RECORDS_ID = "49622075-9ff4-4660-9ab7-414854b5bca2"
 PLANNING_ID = "2db90f18-70df-4e41-986e-2d7d7db1caca"
@@ -415,17 +413,8 @@ def _digest(root: Path) -> dict[str, str]:
     rebuild (#576) one can simply be in flight while this census runs -- so
     counting them makes "the review changed nothing" fail for a reason that has
     nothing to do with the review.
-
-    Uses the same predicate as the canonical directory census in `vault.py`
-    rather than a second list of prefixes, so the two cannot disagree about
-    what counts as derived residue.
     """
-    return {
-        path.relative_to(root).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
-        for path in sorted(root.rglob("*"))
-        if path.is_file()
-        and not any(vault_module._is_derived_index_artifact(part) for part in path.parts)
-    }
+    return canonical_digests(root)
 
 
 def _walk(payload: Any, key: Any = None) -> Any:

--- a/tests/test_plan_progress_review.py
+++ b/tests/test_plan_progress_review.py
@@ -21,6 +21,8 @@ from typing import Any
 
 import pytest
 
+from exomem import vault as vault_module
+
 RECORDS_ID = "49622075-9ff4-4660-9ab7-414854b5bca2"
 PLANNING_ID = "2db90f18-70df-4e41-986e-2d7d7db1caca"
 RECORDS_REF = f"exomem://memory/{RECORDS_ID}"
@@ -405,10 +407,24 @@ def _seed_pinned_trio(root: Path) -> dict[str, str]:
 
 
 def _digest(root: Path) -> dict[str, str]:
+    """Hash the vault's canonical bytes, ignoring derived-index residue.
+
+    A graph rebuild running behind the request creates and removes
+    `.graph-rebuild-<digest>.sqlite` and its SQLite companions inside the
+    vault. Those are not canonical bytes, and since a write stopped joining its
+    rebuild (#576) one can simply be in flight while this census runs -- so
+    counting them makes "the review changed nothing" fail for a reason that has
+    nothing to do with the review.
+
+    Uses the same predicate as the canonical directory census in `vault.py`
+    rather than a second list of prefixes, so the two cannot disagree about
+    what counts as derived residue.
+    """
     return {
         path.relative_to(root).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
         for path in sorted(root.rglob("*"))
         if path.is_file()
+        and not any(vault_module._is_derived_index_artifact(part) for part in path.parts)
     }
 
 

--- a/tests/test_record_public_surface.py
+++ b/tests/test_record_public_surface.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from record_fixtures import copy_x3_fixture
 
 from exomem import commands, mutation_terminal, record_formats, record_memory, records
+from exomem import graph_sync
 from exomem import hosted_gateway as gateway
 from exomem import structured_collections as collections
 from exomem.writer_lease import LeaseConfig, LeaseManager
@@ -185,7 +186,15 @@ def test_public_revise_keeps_the_closed_receipt_through_graph_handoff_and_replay
         )
     }
     assert mutation_terminal.valid_record_receipt(receipt)
-    assert first["graph_sync"] == "completed"
+    # The write no longer joins its own graph rebuild (#576/#588), so its
+    # terminal reports what was true at commit -- `pending` while the rebuild is
+    # still in flight, `completed` if it had already landed. Which of the two is
+    # a race, so asserting either here would be flaky. What is not a race, and
+    # is what "graph handoff" in this test's name actually means, is that the
+    # handoff converges: join the flight and require the graph to be current.
+    assert first["graph_sync"] != "failed"
+    graph_sync.await_active_rebuild(tmp_path, state_root=tmp_path / "state")
+    assert graph_sync.status(tmp_path)["state"] == "current"
     history_before_replay = records.agent_audit_history(tmp_path, current.path)
     lifecycle_event = history_before_replay["events"][0]
     assert {

--- a/tests/test_records_live_acceptance.py
+++ b/tests/test_records_live_acceptance.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import pytest
 
-from exomem import mutation_terminal
+from exomem import graph_sync, mutation_terminal
 
 _SCRIPT = Path(__file__).parents[1] / "scripts" / "records_live_acceptance.py"
 _SPEC = importlib.util.spec_from_file_location("records_live_acceptance", _SCRIPT)
@@ -20,6 +20,36 @@ _SPEC.loader.exec_module(live)
 
 def _digest(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+_GRAPH_CHECKPOINT = graph_sync.GraphSyncCheckpoint.create(
+    generation=1,
+    mutation_id="0123456789abcdef01234567",
+    paths=(),
+    created_paths=(),
+    scope="full",
+)
+
+
+@pytest.mark.parametrize(
+    "build_outcome",
+    [
+        graph_sync.committed_graph_pending,
+        graph_sync.committed_graph_queued,
+        graph_sync.committed_graph_failure,
+    ],
+    ids=["pending_rebuild", "pending_queued", "failed"],
+)
+def test_acceptance_accepts_every_graph_outcome_the_server_can_emit(build_outcome) -> None:
+    """This script is not in CI, so its graph vocabulary drifts silently.
+
+    An outcome the server emits and this validator rejects fails only when an
+    operator runs it against a real build -- which is exactly how a correct
+    bounded write once looked like an acceptance regression. Driving the real
+    emitters rather than restating their payloads here means a new outcome
+    cannot be added without this failing first.
+    """
+    live._validate_compact_graph_outcome("revise", build_outcome(_GRAPH_CHECKPOINT))
 
 
 def _hmac(value: str) -> str:

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -41,6 +41,20 @@ def _compact_content(title: str, *, body: str | None = None) -> str:
     return "\n\n".join(parts) + "\n"
 
 
+def _leaf(value: object) -> str:
+    """The bare name a replacement targets, whether or not it is descriptor-relative.
+
+    These injections mean "the Nth canonical staging replacement", so they must
+    match only the batch writer's own `stage-` artifacts. Matching any `.tmp`
+    also caught the mutation boundary's holder-metadata publish, which lives in
+    the runtime state root rather than the vault -- invisible until the graph
+    started coalescing through that boundary while a write was in flight, and
+    then the injected failure landed somewhere the test never meant to reach.
+    The rest of the suite already uses this narrower predicate.
+    """
+    return Path(os.fspath(value)).name
+
+
 def _make_insight(vault: Path, title: str) -> str:
     """Create a fresh insight via note() so the supersession chain has a real target."""
     kwargs = {
@@ -429,7 +443,7 @@ def test_replace_rolls_back_entire_note_plan_on_mid_commit_failure(
 
     def injected_replace(src, dst, *args, **kwargs):  # noqa: ANN002, ANN003
         nonlocal replacements
-        if str(src).endswith(".tmp"):
+        if _leaf(src).startswith("stage-"):
             replacements += 1
             if replacements == 2:
                 raise OSError("injected supersession commit failure")
@@ -488,7 +502,7 @@ def test_replace_failure_does_not_leave_project_registration_or_folder(
 
     def injected_replace(src, dst, *args, **kwargs):  # noqa: ANN002, ANN003
         nonlocal replacements
-        if str(src).endswith(".tmp"):
+        if _leaf(src).startswith("stage-"):
             replacements += 1
             if replacements == 2:
                 raise OSError("injected project supersession failure")
@@ -582,7 +596,7 @@ def test_plural_project_registration_creates_folder_only_on_success(
 
     def injected_replace(src, dst, *args, **kwargs):  # noqa: ANN002, ANN003
         nonlocal replacements
-        if str(src).endswith(".tmp"):
+        if _leaf(src).startswith("stage-"):
             replacements += 1
             if replacements == 2:
                 raise OSError("injected plural project failure")

--- a/tests/test_repro_graph_rebuild_hold.py
+++ b/tests/test_repro_graph_rebuild_hold.py
@@ -32,6 +32,7 @@ def test_format_result_identifies_the_publication_operation_and_scale_ratio() ->
             "trials": 5,
             "request": {"median_ms": 32_000.0, "p95_ms": 33_000.0},
             "publication_hold": {"median_ms": 12.0, "p95_ms": 15.0},
+            "drain": {"median_ms": 200.0, "p95_ms": 250.0},
         },
         hold_ratio=1.25,
     )
@@ -39,6 +40,10 @@ def test_format_result_identifies_the_publication_operation_and_scale_ratio() ->
     assert "FINAL canonical publication hold" in output
     assert "operation=epistemic_graph_publish_rebuild" in output
     assert "2000/500 hold median ratio=1.25x" in output
+    # The comparison this change exists to make: whole-vault rebuild against
+    # proportional drain, same size, same box, same run.
+    assert "drain median/p95=200.0/250.0ms" in output
+    assert "160.0x cheaper" in output
 
 
 def test_publication_hold_rejects_timing_from_any_other_operation() -> None:

--- a/tests/test_semantic_creation_writers.py
+++ b/tests/test_semantic_creation_writers.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 
 import pytest
+from canonical_snapshot import canonical_bytes
 
 from exomem import (
     activation_manifest,
@@ -39,11 +40,13 @@ def _compact_content(title: str = "Semantic fixture") -> str:
 
 
 def _tree_bytes(root: Path) -> dict[str, bytes]:
-    return {
-        path.relative_to(root).as_posix(): path.read_bytes()
-        for path in root.rglob("*")
-        if path.is_file()
-    }
+    """The vault's canonical bytes, ignoring an in-flight rebuild's residue.
+
+    See `canonical_snapshot`: a graph rebuild no longer finishes before the
+    write returns, so its scratch sidecars can be present while these
+    "mutated nothing" assertions run.
+    """
+    return canonical_bytes(root)
 
 
 def test_typed_create_validate_only_reports_missing_unit_without_mutation(

--- a/tests/test_semantic_lifecycle_writers.py
+++ b/tests/test_semantic_lifecycle_writers.py
@@ -9,6 +9,7 @@ from dataclasses import replace
 from pathlib import Path
 
 import pytest
+from canonical_snapshot import canonical_bytes
 
 from exomem import (
     activation_manifest,
@@ -2880,11 +2881,7 @@ def test_existing_coordinator_exact_committed_replay_is_mutation_free(
         operation="tier2_overwrite",
     )
     first = semantic_writes.commit_existing(tmp_path, preflight=preview)
-    before_replay = {
-        path.relative_to(tmp_path).as_posix(): path.read_bytes()
-        for path in tmp_path.rglob("*")
-        if path.is_file()
-    }
+    before_replay = canonical_bytes(tmp_path)
 
     replay_preview = semantic_writes.preflight_existing(
         tmp_path,
@@ -2894,11 +2891,7 @@ def test_existing_coordinator_exact_committed_replay_is_mutation_free(
         transition_token=first.transition_token,
     )
     replay = semantic_writes.commit_existing(tmp_path, preflight=replay_preview)
-    after_replay = {
-        path.relative_to(tmp_path).as_posix(): path.read_bytes()
-        for path in tmp_path.rglob("*")
-        if path.is_file()
-    }
+    after_replay = canonical_bytes(tmp_path)
 
     assert replay.mutated is False
     assert replay.lifecycle_state == "committed_replay"
@@ -3021,11 +3014,7 @@ def test_non_full_exact_committed_replay_needs_no_lifecycle_prepared_slot(
     assert first.applicability == "structural"
     if transition != "arbitrary":
         assert not relation_review.lifecycle_prepared_path(tmp_path, _ID).exists()
-    before_replay = {
-        path.relative_to(tmp_path).as_posix(): path.read_bytes()
-        for path in tmp_path.rglob("*")
-        if path.is_file()
-    }
+    before_replay = canonical_bytes(tmp_path)
 
     replay_preflight = semantic_writes.preflight_existing(
         tmp_path,
@@ -3035,11 +3024,7 @@ def test_non_full_exact_committed_replay_needs_no_lifecycle_prepared_slot(
         transition_token=first.transition_token,
     )
     replay = semantic_writes.commit_existing(tmp_path, preflight=replay_preflight)
-    after_replay = {
-        path.relative_to(tmp_path).as_posix(): path.read_bytes()
-        for path in tmp_path.rglob("*")
-        if path.is_file()
-    }
+    after_replay = canonical_bytes(tmp_path)
 
     assert replay.mutated is False
     assert replay.lifecycle_state == "committed_replay"

--- a/tests/test_transactional_writes.py
+++ b/tests/test_transactional_writes.py
@@ -1310,7 +1310,13 @@ def test_clean_batch_cleanup_preserves_sharing_error_path_attributes(
     # the budget is exhausted and then surrendered -- rather than retried
     # forever -- is the load-bearing half: a permanently pinned file must still
     # fail inside the request rather than hang it.
-    assert len(captured) == vault_module._REPLACE_SHARING_ATTEMPTS
+    #
+    # POSIX permits `rename(2)` over an open file, so there is nothing to wait
+    # out and the retry deliberately never engages there. Asserting the exact
+    # count on each platform is what keeps that a stated property rather than
+    # an accident.
+    expected_attempts = vault_module._REPLACE_SHARING_ATTEMPTS if os.name == "nt" else 1
+    assert len(captured) == expected_attempts
     assert raised.value is captured[-1]
     assert raised.value.filename2 == str(target)
     assert media_jobs.is_guarded_sidecar_sharing_violation(raised.value, target)

--- a/tests/test_transactional_writes.py
+++ b/tests/test_transactional_writes.py
@@ -1305,7 +1305,13 @@ def test_clean_batch_cleanup_preserves_sharing_error_path_attributes(
             vault_root=tmp_path,
         )
 
-    assert raised.value is captured[0]
+    # A sharing violation is waited out for a bounded interval before it is
+    # surfaced, so what reaches the caller is the *final* attempt's error. That
+    # the budget is exhausted and then surrendered -- rather than retried
+    # forever -- is the load-bearing half: a permanently pinned file must still
+    # fail inside the request rather than hang it.
+    assert len(captured) == vault_module._REPLACE_SHARING_ATTEMPTS
+    assert raised.value is captured[-1]
     assert raised.value.filename2 == str(target)
     assert media_jobs.is_guarded_sidecar_sharing_violation(raised.value, target)
     assert target.read_bytes() == b"old"


### PR DESCRIPTION
Phase 1 of `converge-graph-incrementally`. **Supersedes #588 — please close it.**

OpenSpec change `openspec/changes/converge-graph-incrementally/` is included here: proposal, design, spec deltas for a new `graph-incremental-convergence` capability and a `live-index-freshness` addition, and a task list with Phases 2–3 written down but not started.

## Why #588 could not land

Its bound was over-constrained by construction. Any value must sit **under** `COMMIT_MEDIAN_MS = 750` or the median latency gate fails the moment the bound is reached, and simultaneously **above** a small test-vault rebuild or a dozen tests expecting `completed` get `pending`. 2.0 s failed the first (2091/2259 ms at 2k/8k pages); 0.25 s failed the second (2 CI failures became 6). Those constraints do not overlap — that is the design saying the join does not belong on the write path, not a constant to tune.

## What this does

**Polls instead of waiting.** `join_registered_if_settled` takes an outcome that is already there and never waits for one, so the contribution to commit latency is provably zero. The registered join is only ever reached *after* the incremental path has already fallen back to a full-corpus rebuild (20–175 s), so there was never an interval worth waiting for.

- `pending` is the fourth terminal outcome and survives the compact projection.
- `GRAPH_SYNC_OUTCOMES` is public: `scripts/records_live_acceptance.py` validates against it and is **not** run by CI, so a second copy would drift silently.
- `await_active_rebuild` joins the flight itself for callers that genuinely need convergence. Unreachable from the write path; `test_bounded_graph_join.py` enumerates every join site that could become one.
- Three tests retargeted, not weakened — failure-code fidelity, the private-path no-leak contract and replay stability are all still asserted, now at the point they are produced.

✅ **`semantic write latency (2k and 8k)` passes** — the gate #588 could not pass.

## The finding this surfaced

Removing the join let a canonical write and a graph rebuild run concurrently **for the first time**, and they conflict — on POSIX as well as Windows, so it was never a platform quirk:

```
PathGuardError: PATH_GUARD_CHANGED: guarded directory census changed
  -> CollectionError: STALE_RECORD: canonical record changed before commit
  (+ WinError 32/5 on Windows: the open sidecar refuses os.replace)
```

**The write blocking on its own rebuild is what has been hiding this.** Every production path that already rebuilds off the write path — the watcher's background rebuild, deferred drains — can hit it today, before this PR.

Four distinct collisions, each fixed at its own layer rather than papered over with a retry at the top:

1. **The census counted the rebuild's own scratch sidecars.** Excluded now, by the same mechanism `_BATCH_RESIDUE_PREFIX` already applies to the batch writer's own workspace residue. `.graph-sync.json` / `.graph-sync-floor.json` stay censused — the canonical batch writes those itself, so a change to them under a write is exactly what the guard must still refuse.
2. **Windows rebuild reads pinned the pages they read.** Python's `open()` omits `FILE_SHARE_DELETE`; rebuild reads now go through `read_bytes_without_pinning`.
3. **A refused replace is retried** for a bounded interval, re-proving its precondition each attempt.
4. **Epoch sampling could observe a batch's interior** — a floor installed without its checkpoint, refused as `GRAPH_SYNC_LINEAGE_CONFLICT`. Sampling now happens under the canonical mutation hold.

### 2 and 3 are a pair, and neither is sufficient alone

Writing the test corrected my own account of the Windows fix. Measured, driving reads and replacements in loops against each other:

| | reader | replacements refused |
|---|---|---|
| plain `read_bytes` | dies immediately | 5 / 200 |
| `read_bytes_without_pinning` | survives | **78 / 200** |
| + bounded retry | survives | **0 / 200** (worst case 8 of 20 attempts) |

`FILE_SHARE_DELETE` is precisely what lets a replacement mark the target delete-pending while that handle lives — so making the reader survive makes the *writer* fail **more** often, not less. Only the retry closes the second gap. `test_neither_half_of_the_pair_is_sufficient_alone` records each half failing on its own, so a later reader cannot simplify either away and watch the suite stay green on the other.

## Test-suite consequence

A rebuild is now a daemon thread that outlives its request — and therefore, in the suite, the test that started it, after which it touches process-global projections while the next test runs against a different vault. That is an artefact of the suite sharing one process across many vaults; production is one long-lived process against one vault.

An autouse fixture drains active rebuilds at teardown and fails rather than leak one. It is deliberately **not** a convergence helper: a test that needs the graph current joins the flight itself. No assertion was weakened to `in {"completed", "pending"}` — that would hide the regression this change exists to make visible.

Two "this operation mutated nothing" suites compared vault bytes and caught in-flight rebuild residue; both now go through `tests/canonical_snapshot.py`, one definition using the same predicate as the production census.

## Verification

- ✅ `semantic write latency (2k and 8k)`, `commit_median_ms < 750` at both sizes.
- ✅ Full suite diffed against an `origin/main` baseline worktree on the same box: no new failures. Five regressions found this way during review and fixed here.
- ✅ `openspec validate converge-graph-incrementally --strict` and `validate --specs --strict`.
- ✅ Live-acceptance vocabulary checked directly (`pending` accepted, unknown values still rejected). The script itself needs a deployed endpoint, so it stays a deploy-time gate.
- ✅ Consumer grep over every `wait_for_registered` caller, `GRAPH_SYNC_OUTCOMES`, and the new seams. This is what found that a `vault.py` comment promised a test binding its literal artifact names back to `graph_sync` — **no such test existed**. Writing it is most of the third commit.

## The wider diagnosis (why seven `fix(graph):` PRs did not help)

Three decisions that each make the other two worse:

1. **Repair is all-or-nothing and O(vault).** `_rebuild_all_pass` deletes every node/edge and re-walks the whole KB. The incremental path has **16** `fallback()` sites and every one routes there.
2. **That rebuild is guarded by a vault-global optimistic-concurrency check.** `_disk_vault_freshness` walks every recall-admitted file, sampled before and after the pass; any unrelated concurrent write invalidates it.
3. **Availability is one vault-global boolean** (`epistemic_graph.py:1133`) and the write waits for it.

A pass survives only if no write lands during it, so success probability is roughly `e^(−λ·T(N))` — and the retry budget is the **one term that does not scale** with vault size or write rate. Failure probability rises with the problem. That is a livelock by construction, and it predicts every observed symptom: consecutive `graph_sync: failed` runs, generations dying in bursts, and the benchmark failing at 1200 pages *with a concurrent writer* but not at 1200 pages alone.

Each prior fix was correct and addressed a symptom *inside* that triangle.

**Phase 2** replaces (1) with a durable per-path dirty queue, reusing `deferred_index.py` — which already implements exactly that pattern for the embedding and semantic indexes, the two subsystems that still work. The changed-path set is already recorded durably in `GraphSyncCheckpoint.paths`; today it is discarded and everything is rebuilt. In-repo, `live-index-freshness` already specifies the inbound-link index this way, full-rebuild equivalence obligation included — the graph is the outlier among exomem's derived indexes, not the pattern. `basic-memory` solves the same problem the same way (per-file checksums plus forward references), and exomem already has both primitives: `graph_nodes.source_hash` and `_placeholder_node`.

**Phase 3** (relaxing the content-freshness term of the availability fence) is written down and deliberately gated on measurement. The access-safety terms stay fail-closed.

## Related, not overlapping

**#592** bounds `flight.done.wait()` at `semantic_contract.py:2353` — the *corpus-context* build, reported as ~98 % of request wall time. Same pattern, third site, independent of the graph term here.
