### PR TITLE
docs(openspec): propose bounding the corpus-context flight join

### DIFF
--- a/openspec/changes/bound-corpus-context-flight-join/design.md
+++ b/openspec/changes/bound-corpus-context-flight-join/design.md
@@ -1,0 +1,92 @@
+## Context
+
+`build_corpus_context_with_census` uses a single-flight cache. The first caller for a
+cache key constructs a `_CorpusContextFlight`, registers it in `_CORPUS_CONTEXT_FLIGHTS`,
+and owns the build. Every subsequent caller for that key takes the `not owns_flight`
+branch and blocks on `flight.done.wait()` (`semantic_contract.py:2353`). There is no
+timeout on that wait, and `_CorpusContextFlight` exposes no bounded variant.
+
+The owner path is otherwise well behaved: it clears its registry entry and sets
+`flight.done` in both the success and failure paths (lines 2441-2450), so waiters are
+always released eventually. "Eventually" is the defect. On a 3,006-page vault a build is
+tens of seconds; the waiter has no budget of its own.
+
+### Measured evidence
+
+From `C:\ProgramData\exomem\logs`, 61 complete mutation traces:
+
+| metric | value |
+|---|---|
+| median share of mutation spent post-commit | 98% |
+| median post-commit duration | 103.6s |
+| worst post-commit duration | 409.4s (of a 410.3s total) |
+| durable canonical write | ~150ms |
+
+A representative trace: `canonical_files_committed` at `20:41:50.523`, `returned` at
+`20:43:01.490` — 70.97s of a 77.6s call, after the files were already durable.
+
+### Prior art in this repository
+
+- `rebuild-graph-without-blocking-writes` specifies a bounded waiter for the graph
+  rebuild flight; `graph_sync.py:2257` implements "Admit one bounded response waiter for
+  work already registered." The corpus-context flight is the unbounded sibling.
+- `Notes/Patterns/bound-interactive-waits-below-the-work` records the rule, the
+  non-configurable constraint, the do-not-launder-failures constraint, and the
+  enumeration test.
+- `Notes/Insights/the-exomem-graph-rebuild-never-touches-the-vault-creation-lock` is a
+  measured negative result. `VAULT_LOCK_NESTED` and `VAULT_LOCK_TIMEOUT` appear in the
+  same log windows and are correlated symptoms, not the cause. Do not re-derive that.
+
+## Goals / Non-Goals
+
+**Goals.** Bound what an interactive caller waits for. Keep the deferred outcome
+visible. Keep a real error an error. Prevent the next unbounded join from surviving.
+
+**Non-Goals.** Speeding up the build. Changing corpus-context semantics. Fixing the
+restart-triggered fallback that raises build frequency — that is the graph change's
+scope, and it is why this change is framed as blast-radius limitation rather than a cure.
+
+## Decisions
+
+### Bound sized from the caller, not the work
+
+The bound is derived from the interactive latency budget. Sizing it from observed build
+duration reproduces the failure: a bound that usually succeeds will still occasionally
+stall a caller for minutes, which is the behaviour being removed.
+
+### Non-configurable
+
+No environment variable, config key, or parameter raises it. A configurable bound is a
+supported way to restore the stall. Callers that genuinely need convergence get an
+explicit opt-in path instead, which is out of scope here.
+
+### Deferred is a distinct outcome, not a degraded success
+
+The deferred result must survive the default response projection. If it is only visible
+under `response_detail="full"`, the default caller cannot tell a bounded result from a
+completed one, and the bound becomes invisible in exactly the situation it fired.
+
+### The waiter never disturbs the owner
+
+Expiry releases the waiter only. Cancelling the owner would convert one slow caller into
+a build that never completes, which is the livelock this is meant to reduce.
+
+## Risks / Trade-offs
+
+- **A waiter can now return without a corpus context it previously blocked for.** That is
+  the intended trade. Every consumer of the deferred outcome must be checked for a path
+  that assumed a context was always present.
+- **The bound could fire routinely if builds stay slow.** That would be a true signal
+  rather than a regression, but it makes the deferred path hot, so its correctness
+  matters as much as the bound itself.
+- **The enumeration test will flag legitimate background joins** (`file_watcher.py:426`,
+  `media_worker.py:275`). Those need a declaration, not a bound; the declaration must
+  record why the site is background-only.
+
+## Open Questions
+
+- What exact interactive budget? It must be well under the caller's tolerance and well
+  under observed build durations, so the bound is decisive rather than marginal. The
+  value should be justified against measured percentiles, not chosen round.
+- Do any current consumers of `build_corpus_context_with_census` treat a missing corpus
+  context as a hard error today? Those are the migration surface for the deferred outcome.

--- a/openspec/changes/bound-corpus-context-flight-join/proposal.md
+++ b/openspec/changes/bound-corpus-context-flight-join/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+An interactive request that finds a corpus-context build already in flight joins it
+with `flight.done.wait()` and no timeout (`semantic_contract.py:2353`). The waiter
+therefore inherits the owner's entire build duration, and a vault-sized corpus build
+is not bounded by any caller's latency budget.
+
+Measured on a 3,006-page vault over 61 complete mutation traces: the median mutation
+spent **98% of its wall time after `canonical_files_committed`**, a median of 103.6s,
+with a worst case of 409.4s post-commit against a 410.3s total. The durable write
+itself completed in ~150ms. The cost is not the commit; it is the join.
+
+The graph-rebuild path already treats this as a correctness requirement.
+`rebuild-graph-without-blocking-writes` specifies that `join(handle)` SHALL admit a
+**bounded** waiter and release capacity in `finally` on every completion, cancellation,
+and failure path, and `graph_sync.py:2257` implements it. The corpus-context flight is
+the same shape with none of the bounding. This is the second join site the existing
+pattern note predicted would survive a site-by-site fix.
+
+## What Changes
+
+- Bound the corpus-context flight join by a caller-side interactive budget rather than
+  by how long the owner's build takes. A waiter that exceeds the bound returns a typed
+  deferred outcome instead of continuing to block.
+- Keep the bound non-configurable. A knob for raising it is a knob for reintroducing
+  the stall; genuine convergence belongs in an explicit opt-in path, not in the default
+  interactive budget.
+- Return the deferred outcome only on timeout. A real build error MUST continue to
+  propagate as an error, so the bound cannot convert a loud failure into a silent one.
+- Make the deferred outcome visible in the default response projection, so a bounded
+  result is never byte-indistinguishable from a completed one.
+- Audit every remaining unbounded join and require each to be bounded or explicitly
+  declared background-only with a reason, enforced by a test that enumerates call sites
+  rather than asserting on one of them.
+
+## Capabilities
+
+### New Capabilities
+
+- `corpus-context-availability`: an interactive caller joining an in-flight corpus-context
+  build must be bounded by its own latency budget, must observe a typed deferred outcome
+  on timeout, and must never have a build error laundered into a deferral.
+
+### Modified Capabilities
+
+None.
+
+## Non-Goals
+
+- Making the corpus-context build itself faster. This change bounds what a caller waits
+  for, not what the owner does.
+- Changing corpus-context correctness, cache keying, census reconciliation, or the
+  `same_inputs` recomputation path.
+- The restart-triggered rebuild fallback that drives build frequency. That trigger is
+  covered by `rebuild-graph-without-blocking-writes`; this change limits the blast
+  radius when a build is in flight for any reason.

--- a/openspec/changes/bound-corpus-context-flight-join/specs/corpus-context-availability/spec.md
+++ b/openspec/changes/bound-corpus-context-flight-join/specs/corpus-context-availability/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Interactive Corpus-Context Joins Are Bounded
+
+A caller that finds a corpus-context build already registered for its cache key SHALL
+join that flight through a bounded wait sized by the interactive latency budget, not by
+the owner's build duration. The bound MUST be a fixed internal constant with no
+configuration surface, environment override, or per-call parameter. On expiry the waiter
+SHALL stop waiting, release any admitted waiter capacity, and return a typed deferred
+outcome. Flight ownership, cache-key derivation, census capture, `same_inputs`
+recomputation, and the owner's own build path MUST remain unchanged. A waiter that
+expires MUST NOT cancel, disturb, or invalidate the owner's in-flight build.
+
+#### Scenario: A slow owner does not stall an interactive waiter
+
+- **WHEN** a corpus-context build is in flight and a second interactive request joins it
+- **AND** the owner has not completed within the interactive bound
+- **THEN** the waiter returns a typed deferred outcome within the bound
+- **AND** the owner's build continues uninterrupted to its own completion
+- **AND** the waiter's admitted capacity is released
+
+#### Scenario: A fast owner is still joined normally
+
+- **WHEN** a corpus-context build is in flight and completes within the interactive bound
+- **THEN** the joining waiter returns the owner's result exactly as it does today
+- **AND** no deferred outcome is produced
+
+#### Scenario: Changed inputs still recompute rather than defer
+
+- **WHEN** a waiter joins a flight whose census, registry identity, or language identity
+  does not match its own
+- **AND** the flight completes within the bound
+- **THEN** the waiter recomputes its own corpus context as it does today
+- **AND** the bound does not alter that recomputation path
+
+### Requirement: A Bound Never Launders A Failure
+
+The bounded join SHALL return its deferred outcome only when the wait expires. When the
+owner's build fails, the waiter MUST continue to raise that build error. A deferred
+outcome and a build failure MUST be distinguishable by the caller and MUST NOT share a
+representation.
+
+#### Scenario: Owner failure propagates as failure
+
+- **WHEN** a corpus-context flight completes with an error inside the interactive bound
+- **THEN** the joining waiter raises that error
+- **AND** it does not return a deferred outcome
+
+### Requirement: A Deferred Outcome Is Visible In The Default Projection
+
+A bounded corpus-context result SHALL be distinguishable from a completed one in the
+default response projection, without requiring an expanded or diagnostic detail level.
+A deferred outcome MUST NOT be byte-identical to a completed outcome.
+
+#### Scenario: Default response distinguishes deferred from complete
+
+- **WHEN** an interactive request returns a bounded corpus-context result
+- **THEN** the default response projection marks the corpus context as deferred
+- **AND** the marker is present without requesting full or legacy detail
+
+### Requirement: Every Unbounded Join Is Bounded Or Declared
+
+Each blocking join on a background flight or worker in the request path SHALL be either
+bounded by an interactive budget or explicitly declared background-only with a recorded
+reason. A test SHALL enumerate these call sites and fail when a site is neither bounded
+nor declared, so that adding a new unbounded join is a test failure rather than a latent
+regression.
+
+#### Scenario: A new unbounded join fails the suite
+
+- **WHEN** a blocking join with no timeout is added on a request-reachable path
+- **AND** it carries no background-only declaration
+- **THEN** the enumeration test fails and names the offending call site

--- a/openspec/changes/bound-corpus-context-flight-join/tasks.md
+++ b/openspec/changes/bound-corpus-context-flight-join/tasks.md
@@ -1,0 +1,54 @@
+## 1. Establish the failing baseline
+
+- [ ] 1.1 Add a regression test that registers a slow corpus-context flight and asserts a
+  second joining caller returns within the interactive bound. It MUST fail against
+  current `main`, where `flight.done.wait()` blocks for the owner's full duration.
+- [ ] 1.2 Add a test asserting an owner build error still raises for the waiter, so the
+  bound cannot be implemented by swallowing failures.
+- [ ] 1.3 Record the measured baseline (98% post-commit share, 103.6s median) in the test
+  module docstring so a future reader can tell whether the numbers still hold.
+
+## 2. Bound the join
+
+- [ ] 2.1 Introduce the interactive bound as a fixed module-level constant with no
+  configuration surface, justified in a comment against measured percentiles.
+- [ ] 2.2 Replace `flight.done.wait()` at `semantic_contract.py:2353` with a bounded wait
+  that distinguishes "completed" from "expired" by the wait's own return value, not by
+  inspecting flight state afterwards.
+- [ ] 2.3 On expiry, return the typed deferred outcome and release admitted capacity in
+  `finally`, on every completion, cancellation, and failure path.
+- [ ] 2.4 Leave the owner's build, registry cleanup, and `flight.done.set()` paths
+  untouched; assert by test that an expired waiter does not disturb the owner.
+- [ ] 2.5 Preserve the existing `same_inputs` recomputation branch exactly.
+
+## 3. Make the deferred outcome visible
+
+- [ ] 3.1 Represent the deferred corpus context as a typed outcome distinct from both a
+  completed context and an error.
+- [ ] 3.2 Surface it in the default response projection, not only under
+  `response_detail="full"` or `"legacy"`.
+- [ ] 3.3 Add a test asserting a deferred result is not byte-identical to a completed one
+  in the default projection.
+- [ ] 3.4 Audit consumers of `build_corpus_context_with_census` for paths that assume a
+  context is always present, and handle the deferred case explicitly at each.
+
+## 4. Stop the next unbounded join
+
+- [ ] 4.1 Add an enumeration test that walks request-reachable blocking joins and requires
+  each to be bounded or carry an explicit background-only declaration with a reason.
+- [ ] 4.2 Declare `file_watcher.py:426` and `media_worker.py:275` background-only with
+  recorded reasons, or bound them if the audit shows they are request-reachable.
+- [ ] 4.3 Assert the test fails when a new unbounded request-path join is introduced.
+
+## 5. Verify against the real workload
+
+- [ ] 5.1 Run the existing write-latency gates and confirm no regression in commit-path
+  timings, which this change does not target.
+- [ ] 5.2 Re-measure the post-commit share on a vault of comparable size and record the
+  before/after split. The commit itself should be unchanged at ~150ms; the post-commit
+  median is the number this change is accountable for.
+- [ ] 5.3 Confirm on a real deployment that a bounded waiter reports deferred rather than
+  silently returning a stale or empty context, using service logs rather than unit tests
+  as the evidence.
+- [ ] 5.4 Verify the interactive bound holds while a genuine rebuild is in flight, since
+  that is the condition under which the stall was originally observed.


### PR DESCRIPTION
## Why

An interactive caller that finds a corpus-context build already in flight joins it with `flight.done.wait()` and **no timeout** (`semantic_contract.py:2353`). The waiter inherits the owner's entire vault-sized build duration; it has no budget of its own.

## Measured evidence

61 complete mutation traces from a live 3,006-page vault (`C:\ProgramData\exomem\logs`):

| metric | value |
|---|---|
| median share of mutation spent post-commit | **98%** |
| median post-commit duration | **103.6s** |
| worst post-commit duration | 409.4s (of a 410.3s call) |
| durable canonical write | ~150ms |

A representative trace — `canonical_files_committed` at 20:41:50.523, `returned` at 20:43:01.490: **70.97s of a 77.6s call spent after the files were already durable.**

Writes overlapping an in-flight rebuild took 2.2x longer than those that did not (107.6s vs 49.4s median post-commit, n=51 vs n=10).

## Why this is not a duplicate

`rebuild-graph-without-blocking-writes` already specifies that `join(handle)` SHALL admit a **bounded** waiter and release capacity in `finally`, and `graph_sync.py:2257` implements it ("Admit one bounded response waiter for work already registered"). That change is 26/28 tasks done with only Windows verification outstanding.

The corpus-context flight (`_CORPUS_CONTEXT_FLIGHTS`, `semantic_contract.py`) is a **separate** single-flight with none of that bounding — the only `.wait()` in the file, with no timeout anywhere. It is exactly the second join site `Notes/Patterns/bound-interactive-waits-below-the-work` predicted would survive a site-by-site fix.

## What this proposes

Bound the join from the caller's latency budget; keep the bound non-configurable; return the deferred outcome **only** on timeout so a real error is never laundered into a deferral; make deferred visible in the *default* response projection; and add an enumeration test so the next unbounded join fails the suite rather than shipping.

## Scope

**Proposal only** — no code changes, all tasks unstarted. `openspec validate --strict` passes.

Explicitly *not* in scope: making the build faster, changing corpus-context semantics, or fixing the restart-triggered fallback that raises build frequency (that trigger belongs to `rebuild-graph-without-blocking-writes`). This change limits blast radius when a build is in flight for any reason.

## Prior art honored

`Notes/Insights/the-exomem-graph-rebuild-never-touches-the-vault-creation-lock` is a recorded measured negative result. `VAULT_LOCK_NESTED` / `VAULT_LOCK_TIMEOUT` appear in the same log windows and are correlated symptoms, not the cause — the design notes this so the direction is not re-derived.