### PR TITLE
fix(hosted): carry remediation across the hosted refusal boundary

### DIFF
--- a/openspec/changes/hosted-human-capture-and-onboarding/.openspec.yaml
+++ b/openspec/changes/hosted-human-capture-and-onboarding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/openspec/changes/hosted-human-capture-and-onboarding/design.md
+++ b/openspec/changes/hosted-human-capture-and-onboarding/design.md
@@ -2,9 +2,19 @@
 
 ## Context
 
-Reproduced locally on 2026-08-16 against fresh vaults. Scaffolded and un-scaffolded
-vaults behave identically, so vault init is not involved — an earlier hypothesis that it
-was is recorded here as rejected so it is not re-investigated.
+Reproduced locally on 2026-08-16 against fresh vaults, with `relation_review._translate`
+instrumented and `cli_ops.error_dict` called directly — the same function
+`server_hosted._execute_command` calls on the failure path.
+
+Two hypotheses were tested and rejected before the real one held:
+
+1. **Rejected — vault scaffolding.** Scaffolded and un-scaffolded vaults behave
+   identically, so vault init is not involved.
+2. **Rejected — `commands.py` flattening starves `_translate`.** `_translate` runs
+   deeper in the stack than `commands.py`, so it cannot be downstream of the flattening.
+   The instrumented spy never fired on this path. `error_dict` also recovers the code by
+   walking `__cause__`/`__context__` and, failing that, by parsing `CODE: reason` from
+   the message, so the flattening is survivable.
 
 The engine is sound. `capture_source` already accepts ordinary prose repeatedly and the
 result is retrievable:
@@ -15,61 +25,86 @@ OK 'Kim train'        -> Knowledge Base/Sources/Other/2026-08-16-kim-train.md
 find 'dentist'        -> the captured source
 ```
 
-So no new lane is needed. The work is making refusals legible, and specifying the lane
-so the UI has something to be correct against.
+`cli_ops.error_dict` is also sound — it already returns the specific code and the full
+remediation. The loss happens in exactly one place, `server_hosted._error_response`.
 
 ## Goals / Non-Goals
 
 **Goals**
-- A refused write names its cause and carries the evaluator's remediation.
+- A hosted refusal carries a message and remediation the recipient can act on.
 - The capture lane is specified as the supported path for unstructured human capture.
 
 **Non-Goals**
 - Relaxing the semantic contract on `remember`. It is doing its job.
-- Moving contract enforcement from write-time to promotion-time. That remains an open
-  question worth revisiting, but it is a larger change and this one does not need it.
+- Rewriting the 26 flattening sites in `commands.py`. Real fragility, not this bug;
+  changing 26 raise sites that many tests assert message text against is a
+  disproportionate risk for a latent issue.
+- Changing `relation_review._translate`. It is not on this path.
+- Moving contract enforcement from write-time to promotion-time. Still an open question,
+  and this change does not need it.
 - Any UI change; that is the companion `substrate` change.
 
 ## Decisions
 
-### Preserve the structured error rather than re-deriving the code downstream
+### Restore remediation with a static table, not by passing exception text through
 
-`commands.py` raises `ValueError(f"{e.code}: {e.reason}")` at 26 sites. The comment at
-one of them explains why: *"FastMCP serializes raised exceptions; we want a structured
-shape."* The intent was right and the execution loses the structure it was trying to
-create — the code ends up inside a string, and `relation_review._translate` inspects
-`.code`, finds `None`, and falls through to `SEMANTIC_CREATION_FAILED`.
+`_error_response` currently hardcodes `remediation: None` and derives the message from
+`_message_for(code)`. The obvious fix — copy `error["message"]` and
+`error["remediation"]` from the `error_dict` payload — is **rejected**. That payload is
+derived from the exception, and the handler that produced it is explicitly a redaction
+boundary (*"private boundary redacts exception text"*); `error_dict`'s own fallback
+branch returns `{"code": "OP_ERROR", "message": str(exc)}`, so passing the message
+through would send raw exception text to a hosted client for any unclassified failure.
 
-**Decision:** raise an exception type that is still a `ValueError` (so every existing
-`except ValueError` keeps working, and the serialized message is unchanged) but that
-carries `.code`, `.reason` and `.remediation` as attributes.
+**Decision:** add `_remediation_for(code)`, a pure code → static-text lookup mirroring
+the existing `_message_for(code)`, and extend `_message_for` with entries for the
+contract-refusal codes. Nothing derived from an exception crosses the boundary; the code
+was already crossing it. This follows the module's established pattern — `details` is
+likewise filtered through the `_HOSTED_MUTATION_DETAIL_FIELDS` allowlist rather than
+copied wholesale.
 
-*Alternative rejected:* parse the code back out of the message string in `_translate`.
-It would work and it is smaller, but it re-derives structure that was thrown away one
-frame earlier, and the next raise site that formats its message differently breaks it
-silently.
+*Alternative rejected:* allowlist which codes may pass their real message through. It
+gives a better message for the codes in the list, but it makes the redaction guarantee
+conditional on table maintenance — a new code that forgets the list leaks by default.
+A static table fails the other way: a missing entry degrades to today's generic message,
+which is the safe direction.
 
-*Alternative rejected:* change all 26 sites to raise a non-`ValueError`. Larger blast
-radius across callers and tests for no additional benefit.
+### Source the remediation text from the contract definitions
 
-### `remediation: null` must mean "none was produced"
+Where the authoring contract already defines remediation
+(`semantic_authoring.AUTHORING_CONTRACT.findings`), derive the table entry from it at
+import time rather than hand-copying the string, so the two cannot drift. These
+definitions are static module data, not exception-derived, so this respects the boundary.
 
-Today it means "we lost it". Once the code survives, remediation should survive with it;
-where the evaluator genuinely produced none, the response should say so explicitly
-rather than leaving a caller unable to distinguish the two.
+`RELATION_DISPOSITION_MISSING` and `RELATION_DISPOSITION_STALE` are built in
+`semantic_contract._disposition_finding` with per-instance remediation text and are not
+in `AUTHORING_CONTRACT.findings`, so their hosted entries are authored here. Their
+in-contract wording is tuned to an agent retry loop (`validate_only=true`,
+`transition_token=<returned>`); the hosted entry says the equivalent thing to a person.
+
+### The specific code, where we already have it
+
+`missing_semantic_unit` surfaces specifically because `SemanticWriteError.
+as_semantic_validation_error` projects it. `RELATION_DISPOSITION_MISSING` does not — it
+is outside `AUTHORING_CONTRACT.findings`, so the projector returns `None` and the
+envelope code `SEMANTIC_CONTRACT_BLOCKED` surfaces instead.
+
+**Decision:** leave the projector alone and give `SEMANTIC_CONTRACT_BLOCKED` its own
+hosted entry. Widening the canonical projection changes non-hosted callers too, and
+`test_disposition_remediation_is_route_neutral` guards a response-budget ceiling on that
+text. The hosted user gets actionable guidance either way; precision beyond that is not
+worth the blast radius here.
 
 ### The capture lane is specified, not built
 
 `capture_source` exists and works. The spec records it as the supported path for
-unstructured human capture so the UI change is measured against a requirement rather
-than an implementation detail that could drift.
+unstructured human capture so the UI change is measured against a requirement.
 
 ## Risks
 
-- **26 raise sites.** A single mechanical transform keyed on the exact
-  `raise ValueError(f"{e.code}: {e.reason}")` shape, with the count asserted, rather
-  than 26 hand edits — the same discipline used for the nine admission predicates in
-  substrate, where a missed site would have failed only at a later stage.
-- **Message stability.** Some tests likely assert on the flattened message text. Keeping
-  the new type a `ValueError` with an identical `str()` keeps them passing; any that
-  fail are asserting on the bug and should be updated deliberately, not silenced.
+- **Under-fixing.** This makes refusals legible; it does not make the hosted capture box
+  work. That depends entirely on the companion `substrate` routing change. Neither is
+  sufficient alone, and the acceptance test is on the `substrate` side.
+- **Table drift.** A contract code added later without a hosted entry degrades to
+  today's generic message. That is the safe direction, and a test asserts the entries
+  that exist stay wired to their contract-definition source.

--- a/openspec/changes/hosted-human-capture-and-onboarding/design.md
+++ b/openspec/changes/hosted-human-capture-and-onboarding/design.md
@@ -1,0 +1,75 @@
+# Design
+
+## Context
+
+Reproduced locally on 2026-08-16 against fresh vaults. Scaffolded and un-scaffolded
+vaults behave identically, so vault init is not involved — an earlier hypothesis that it
+was is recorded here as rejected so it is not re-investigated.
+
+The engine is sound. `capture_source` already accepts ordinary prose repeatedly and the
+result is retrievable:
+
+```
+OK 'Dentist Thursday' -> Knowledge Base/Sources/Other/2026-08-16-dentist-thursday.md
+OK 'Kim train'        -> Knowledge Base/Sources/Other/2026-08-16-kim-train.md
+find 'dentist'        -> the captured source
+```
+
+So no new lane is needed. The work is making refusals legible, and specifying the lane
+so the UI has something to be correct against.
+
+## Goals / Non-Goals
+
+**Goals**
+- A refused write names its cause and carries the evaluator's remediation.
+- The capture lane is specified as the supported path for unstructured human capture.
+
+**Non-Goals**
+- Relaxing the semantic contract on `remember`. It is doing its job.
+- Moving contract enforcement from write-time to promotion-time. That remains an open
+  question worth revisiting, but it is a larger change and this one does not need it.
+- Any UI change; that is the companion `substrate` change.
+
+## Decisions
+
+### Preserve the structured error rather than re-deriving the code downstream
+
+`commands.py` raises `ValueError(f"{e.code}: {e.reason}")` at 26 sites. The comment at
+one of them explains why: *"FastMCP serializes raised exceptions; we want a structured
+shape."* The intent was right and the execution loses the structure it was trying to
+create — the code ends up inside a string, and `relation_review._translate` inspects
+`.code`, finds `None`, and falls through to `SEMANTIC_CREATION_FAILED`.
+
+**Decision:** raise an exception type that is still a `ValueError` (so every existing
+`except ValueError` keeps working, and the serialized message is unchanged) but that
+carries `.code`, `.reason` and `.remediation` as attributes.
+
+*Alternative rejected:* parse the code back out of the message string in `_translate`.
+It would work and it is smaller, but it re-derives structure that was thrown away one
+frame earlier, and the next raise site that formats its message differently breaks it
+silently.
+
+*Alternative rejected:* change all 26 sites to raise a non-`ValueError`. Larger blast
+radius across callers and tests for no additional benefit.
+
+### `remediation: null` must mean "none was produced"
+
+Today it means "we lost it". Once the code survives, remediation should survive with it;
+where the evaluator genuinely produced none, the response should say so explicitly
+rather than leaving a caller unable to distinguish the two.
+
+### The capture lane is specified, not built
+
+`capture_source` exists and works. The spec records it as the supported path for
+unstructured human capture so the UI change is measured against a requirement rather
+than an implementation detail that could drift.
+
+## Risks
+
+- **26 raise sites.** A single mechanical transform keyed on the exact
+  `raise ValueError(f"{e.code}: {e.reason}")` shape, with the count asserted, rather
+  than 26 hand edits — the same discipline used for the nine admission predicates in
+  substrate, where a missed site would have failed only at a later stage.
+- **Message stability.** Some tests likely assert on the flattened message text. Keeping
+  the new type a `ValueError` with an identical `str()` keeps them passing; any that
+  fail are asserting on the bug and should be updated deliberately, not silenced.

--- a/openspec/changes/hosted-human-capture-and-onboarding/proposal.md
+++ b/openspec/changes/hosted-human-capture-and-onboarding/proposal.md
@@ -7,68 +7,93 @@ first screen they saw was the product's weakest surface.
 
 Typing "Hello there" into the hosted capture box returns
 `400 {"code":"SEMANTIC_CREATION_FAILED","message":"hosted command failed","remediation":null}`.
-Reproduced locally against fresh vaults, the real behaviour is:
 
-| write | content | result |
-| --- | --- | --- |
-| 1st | with `## Observations` | OK — an empty corpus auto-bootstraps |
-| 2nd | with `## Observations` | `RELATION_DISPOSITION_MISSING` |
-| 3rd | plain text, no units | `RELATION_DISPOSITION_MISSING` |
+Two separate defects produce that one response.
 
-**The second memory a hosted user ever saves fails, regardless of what they type.**
+### 1. The hosted UI calls the governed lane for what is plainly capture
 
-The cause is not a defect in the semantic contract. Exomem already has two lanes, and
-they are the right two:
+Exomem already has two lanes, and they are the right two:
 
-- `capture_source` — raw material, no contract. Verified: three ordinary sentences in a
-  row all succeed, and `ask_memory` retrieves them.
+- `capture_source` — raw material, no contract. Verified locally: three ordinary
+  sentences in a row all succeed, and `ask_memory` retrieves them.
 - `remember` — a distilled, governed, citable conclusion. Contract applies, correctly.
   A conclusion that other conclusions cite, supersede and contradict must be
   well-formed or the epistemic layer is mush.
 
-The hosted web UI calls `remember` for what is plainly capture. A person typing
-"dentist on Thursday" is not authoring a governed conclusion. The contract then did
-exactly what it is for, to someone it was never aimed at.
+The hosted web UI calls `remember`. A person typing "dentist on Thursday" is not
+authoring a governed conclusion. The contract then did exactly what it is for, to
+someone it was never aimed at. **That routing bug is the reason a user cannot save**,
+and the fix lives in `substrate`, not here.
 
-Two further problems compound it:
+### 2. Every hosted refusal is unactionable
 
-1. **The diagnosis is destroyed in transit.** `commands.py` flattens structured
-   contract errors into `ValueError(f"{e.code}: {e.reason}")` at 26 sites, so `.code` is
-   lost and `relation_review._translate` falls through to a generic
-   `SEMANTIC_CREATION_FAILED` with `remediation: null` — discarding remediation text
-   that exists inside the exception. This cost two wrong diagnoses during the
-   investigation before the raw response body was read.
-2. **The first run shows a notes app.** Accepting an invitation lands on `/exomem/home`:
-   a capture box and a search box. Stripped of the assistant that invites comparison
-   against general note apps, a comparison Exomem does not win, while the
-   differentiator — memory resident inside Claude and ChatGPT — is invisible.
+`server_hosted._error_response` builds its error block as:
+
+```python
+error = {"code": code, "message": _message_for(code), "remediation": None}
+```
+
+It keeps the code and **hardcodes `remediation: None`**, substituting a generic message
+from a code lookup. `cli_ops.error_dict` — one frame earlier — has already computed the
+specific message and the evaluator's full remediation text, and both are discarded.
+That is precisely the observed `"message": "hosted command failed", "remediation": null`.
+
+The redaction is deliberate: the handler comment reads *"private boundary redacts
+exception text"*, and exception text can carry vault paths and internal detail. The
+boundary is right; the consequence is that a legitimate, expected contract refusal
+reaches a hosted user with nothing they can act on.
+
+## Corrections to the first draft of this change
+
+This change was first written against a causal chain that reproduction falsified. The
+wrong version is recorded here so it is not re-derived:
+
+- **Claimed:** `commands.py` flattens structured errors, so `.code` is lost and
+  `relation_review._translate` falls through to `SEMANTIC_CREATION_FAILED`.
+- **Actual:** `_translate` runs *deeper* in the stack than `commands.py`, so the
+  flattening cannot starve it. Instrumented reproduction shows `_translate` never fires
+  on this path at all. The refusal arrives as `SEMANTIC_CONTRACT_BLOCKED`.
+- **Actual:** the flattening to a bare `ValueError` *is* real (17 plain sites, 1 with a
+  `(missing:)` suffix, 8 further `e.code` formatting sites — 26 in total), but it is
+  survivable. `cli_ops.error_dict` walks the `__cause__`/`__context__` chain for an
+  `as_semantic_validation_error` projector and falls back to parsing `CODE: reason` out
+  of the message string, so the code is recovered either way. It is latent fragility,
+  not the active cause, and rewriting 26 sites is therefore **out of scope** here.
+
+Verified at the boundary on current `main`, calling the exact function the hosted
+handler calls:
+
+```
+op_remember(plain text)  -> error_dict -> code='missing_semantic_unit'  remediation=<full text>
+op_remember(2nd governed)-> error_dict -> code='SEMANTIC_CONTRACT_BLOCKED' remediation=<full text>
+```
+
+So the engine and `cli_ops` already do the right thing. Only the hosted boundary throws
+the answer away.
 
 ## What Changes
 
-- Hosted human capture routes to the capture lane instead of the governed-conclusion
-  lane, so ordinary typed text saves and stays findable.
-- Structured contract errors keep their code and remediation all the way to the caller.
-- The authenticated first run leads with connecting an assistant; web capture and
-  search remain, demoted.
+- Hosted refusals carry an actionable message and a remediation string, drawn from a
+  static code-keyed table in the hosted module. No text derived from an exception
+  crosses the boundary, so the redaction guarantee is preserved exactly as it is.
+- The capture lane is specified as the supported path for unstructured human capture,
+  so the companion UI change is measured against a requirement rather than an
+  implementation detail.
 
 ## Scope: this repository only
 
 The web UI calls `/api/exomem/commands/remember`, so *which* command it calls is a
-`substrate` change, not an `exomem` one. This change covers the engine side and the
-contract that makes the UI fix correct:
-
-- error fidelity, so a refusal names its cause and carries its remediation
-- the capture lane as the specified, supported path for unstructured human capture
+`substrate` change. This change covers the engine side and the contract that makes the
+UI fix correct.
 
 The companion `substrate` change — routing the capture box to `capture_source` and
-making the authenticated first run connect-first — is tracked separately in that repo
-and depends on this one only for the error contract.
+making the authenticated first run connect-first — is tracked separately in that repo.
 
 ## Impact
 
 - **Affected specs:** `command-surface`
-- **Affected code:** `src/exomem/commands.py` (26 sites flattening structured contract
-  errors into `ValueError`), `src/exomem/relation_review.py` (`_translate` fallback)
+- **Affected code:** `src/exomem/server_hosted.py` (`_error_response`, `_message_for`)
 - **Not changed:** the semantic contract itself. Strictness on governed conclusions is
-  correct and stays exactly as it is. This change stops applying it to material that
-  never claimed to be a conclusion, and makes every refusal legible.
+  correct and stays exactly as it is.
+- **Explicitly not changed:** the 26 error-flattening sites in `src/exomem/commands.py`,
+  and `relation_review._translate`. Reproduction showed neither is on the failing path.

--- a/openspec/changes/hosted-human-capture-and-onboarding/proposal.md
+++ b/openspec/changes/hosted-human-capture-and-onboarding/proposal.md
@@ -1,0 +1,74 @@
+# Hosted human capture and first-class onboarding
+
+## Why
+
+The first person to walk Exomem Hosted as a new user could not save anything, and the
+first screen they saw was the product's weakest surface.
+
+Typing "Hello there" into the hosted capture box returns
+`400 {"code":"SEMANTIC_CREATION_FAILED","message":"hosted command failed","remediation":null}`.
+Reproduced locally against fresh vaults, the real behaviour is:
+
+| write | content | result |
+| --- | --- | --- |
+| 1st | with `## Observations` | OK — an empty corpus auto-bootstraps |
+| 2nd | with `## Observations` | `RELATION_DISPOSITION_MISSING` |
+| 3rd | plain text, no units | `RELATION_DISPOSITION_MISSING` |
+
+**The second memory a hosted user ever saves fails, regardless of what they type.**
+
+The cause is not a defect in the semantic contract. Exomem already has two lanes, and
+they are the right two:
+
+- `capture_source` — raw material, no contract. Verified: three ordinary sentences in a
+  row all succeed, and `ask_memory` retrieves them.
+- `remember` — a distilled, governed, citable conclusion. Contract applies, correctly.
+  A conclusion that other conclusions cite, supersede and contradict must be
+  well-formed or the epistemic layer is mush.
+
+The hosted web UI calls `remember` for what is plainly capture. A person typing
+"dentist on Thursday" is not authoring a governed conclusion. The contract then did
+exactly what it is for, to someone it was never aimed at.
+
+Two further problems compound it:
+
+1. **The diagnosis is destroyed in transit.** `commands.py` flattens structured
+   contract errors into `ValueError(f"{e.code}: {e.reason}")` at 26 sites, so `.code` is
+   lost and `relation_review._translate` falls through to a generic
+   `SEMANTIC_CREATION_FAILED` with `remediation: null` — discarding remediation text
+   that exists inside the exception. This cost two wrong diagnoses during the
+   investigation before the raw response body was read.
+2. **The first run shows a notes app.** Accepting an invitation lands on `/exomem/home`:
+   a capture box and a search box. Stripped of the assistant that invites comparison
+   against general note apps, a comparison Exomem does not win, while the
+   differentiator — memory resident inside Claude and ChatGPT — is invisible.
+
+## What Changes
+
+- Hosted human capture routes to the capture lane instead of the governed-conclusion
+  lane, so ordinary typed text saves and stays findable.
+- Structured contract errors keep their code and remediation all the way to the caller.
+- The authenticated first run leads with connecting an assistant; web capture and
+  search remain, demoted.
+
+## Scope: this repository only
+
+The web UI calls `/api/exomem/commands/remember`, so *which* command it calls is a
+`substrate` change, not an `exomem` one. This change covers the engine side and the
+contract that makes the UI fix correct:
+
+- error fidelity, so a refusal names its cause and carries its remediation
+- the capture lane as the specified, supported path for unstructured human capture
+
+The companion `substrate` change — routing the capture box to `capture_source` and
+making the authenticated first run connect-first — is tracked separately in that repo
+and depends on this one only for the error contract.
+
+## Impact
+
+- **Affected specs:** `command-surface`
+- **Affected code:** `src/exomem/commands.py` (26 sites flattening structured contract
+  errors into `ValueError`), `src/exomem/relation_review.py` (`_translate` fallback)
+- **Not changed:** the semantic contract itself. Strictness on governed conclusions is
+  correct and stays exactly as it is. This change stops applying it to material that
+  never claimed to be a conclusion, and makes every refusal legible.

--- a/openspec/changes/hosted-human-capture-and-onboarding/specs/command-surface/spec.md
+++ b/openspec/changes/hosted-human-capture-and-onboarding/specs/command-surface/spec.md
@@ -1,29 +1,39 @@
 ## ADDED Requirements
 
-### Requirement: Contract Failures Keep Their Code And Remediation Across Surfaces
+### Requirement: Hosted Refusals Carry Actionable Guidance
 
-A semantic-contract failure carries a machine-readable code and, where the evaluator produced one, a
-remediation string describing what would make the write succeed. The command surface SHALL preserve
-both to the caller. It MUST NOT flatten a structured contract error into a message-only exception,
-because a downstream translator that inspects `.code` will then fall through to a generic code and
-report `remediation: null` for every distinct cause.
+A refusal returned across the hosted cell boundary SHALL carry a message describing the
+refusal and, where one is defined for its code, a remediation string describing what would
+make the request succeed. It MUST NOT report `remediation: null` for a code that has a
+defined remediation.
 
-Where a stable public code is required at a boundary, the surface SHALL derive it from the original
-error rather than substituting a catch-all, and SHALL carry the remediation alongside it.
+The boundary redacts exception-derived text, and that guarantee is unchanged: the message
+and remediation SHALL be resolved from a static table keyed on the refusal code, never
+copied from the raised exception. A code with no table entry SHALL degrade to the existing
+generic message rather than passing exception text through.
 
-#### Scenario: A blocked write reports the specific cause
+Where the semantic authoring contract already defines remediation for a code, the hosted
+entry SHALL be derived from that definition rather than duplicating its text, so the two
+cannot drift.
 
-- **WHEN** a write is refused because the page has no valid semantic unit
-- **THEN** the caller receives the code `missing_semantic_unit`, not a generic creation-failed code
-- **AND** the response carries the evaluator's remediation text
-- **AND** the same holds for a refusal caused by a missing relation disposition, with its own
-  distinct code
+#### Scenario: A blocked write reports remediation the caller can act on
 
-#### Scenario: An unrecognised failure stays honest
+- **WHEN** a hosted write is refused because the page has no valid semantic unit
+- **THEN** the response carries the code `missing_semantic_unit`
+- **AND** the response carries a non-null remediation describing what to add
+- **AND** the message is specific to the refusal rather than the generic hosted-failure text
 
-- **WHEN** a write fails for a reason the evaluator did not classify
-- **THEN** the caller receives the generic code
-- **AND** the response states that no remediation is available rather than implying none was produced
+#### Scenario: A relation-disposition refusal is equally actionable
+
+- **WHEN** a hosted write is refused because the page needs a qualifying relation or an
+  explicit current review
+- **THEN** the response carries a non-null remediation
+
+#### Scenario: An unrecognised failure stays redacted
+
+- **WHEN** a hosted request fails with a code that has no table entry
+- **THEN** the response carries the generic hosted-failure message and `remediation: null`
+- **AND** no text derived from the raised exception appears in the response
 
 ### Requirement: Human Capture Is Served By The Capture Lane
 

--- a/openspec/changes/hosted-human-capture-and-onboarding/specs/command-surface/spec.md
+++ b/openspec/changes/hosted-human-capture-and-onboarding/specs/command-surface/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Contract Failures Keep Their Code And Remediation Across Surfaces
+
+A semantic-contract failure carries a machine-readable code and, where the evaluator produced one, a
+remediation string describing what would make the write succeed. The command surface SHALL preserve
+both to the caller. It MUST NOT flatten a structured contract error into a message-only exception,
+because a downstream translator that inspects `.code` will then fall through to a generic code and
+report `remediation: null` for every distinct cause.
+
+Where a stable public code is required at a boundary, the surface SHALL derive it from the original
+error rather than substituting a catch-all, and SHALL carry the remediation alongside it.
+
+#### Scenario: A blocked write reports the specific cause
+
+- **WHEN** a write is refused because the page has no valid semantic unit
+- **THEN** the caller receives the code `missing_semantic_unit`, not a generic creation-failed code
+- **AND** the response carries the evaluator's remediation text
+- **AND** the same holds for a refusal caused by a missing relation disposition, with its own
+  distinct code
+
+#### Scenario: An unrecognised failure stays honest
+
+- **WHEN** a write fails for a reason the evaluator did not classify
+- **THEN** the caller receives the generic code
+- **AND** the response states that no remediation is available rather than implying none was produced
+
+### Requirement: Human Capture Is Served By The Capture Lane
+
+Exomem SHALL provide a lane for raw human capture that accepts ordinary prose without requiring
+semantic units, typed relations, or a reviewed relation disposition, and material written to it SHALL
+be retrievable by ordinary recall. `capture_source` is that lane.
+
+The governed-conclusion lane (`remember`) SHALL continue to enforce the semantic contract unchanged.
+A conclusion that other conclusions may cite, supersede, or contradict must be well-formed; this
+requirement does not relax that, it prevents the contract being applied to material that never
+claimed to be a conclusion.
+
+Surfaces offering an unstructured "save this thought" affordance to a human SHALL route it to the
+capture lane.
+
+#### Scenario: Consecutive ordinary sentences all save
+
+- **WHEN** a person saves three ordinary sentences in a row through the capture lane, none containing
+  a heading or a semantic unit
+- **THEN** all three succeed
+- **AND** each is retrievable by keyword recall afterwards
+
+#### Scenario: The governed lane is unchanged
+
+- **WHEN** a second governed conclusion is written with no qualifying typed relation and no reviewed
+  disposition
+- **THEN** it is still refused, with its specific code and remediation

--- a/openspec/changes/hosted-human-capture-and-onboarding/tasks.md
+++ b/openspec/changes/hosted-human-capture-and-onboarding/tasks.md
@@ -1,0 +1,30 @@
+## 1. Error fidelity
+
+- [ ] 1.1 Add a `ValueError` subclass carrying `.code`, `.reason`, `.missing` and `.remediation`, whose `str()` is byte-identical to today's flattened message so existing `except ValueError` handlers and message assertions keep working
+- [ ] 1.2 Replace the 26 `raise ValueError(f"{e.code}: {e.reason}…")` sites in `src/exomem/commands.py` by one deterministic transform keyed on the exact shape; assert the substitution count is exactly 26 and the diff is that many times the clause length
+- [ ] 1.3 Confirm the flattened sites are character-identical modulo the `(missing: …)` variant, and that the variant is handled rather than skipped
+- [ ] 1.4 Make `relation_review._translate` use the preserved `.code` instead of falling through to `SEMANTIC_CREATION_FAILED`, and carry `.remediation` onto the returned error
+- [ ] 1.5 Distinguish "no remediation was produced" from "remediation was lost" in the response shape
+
+## 2. Tests
+
+- [ ] 2.1 A write refused for a missing semantic unit reports `missing_semantic_unit` with remediation text, not a generic code — assert the exact code, since the whole point is that it is specific
+- [ ] 2.2 A write refused for a missing relation disposition reports its own distinct code with remediation
+- [ ] 2.3 An unclassified failure still reports the generic code and states that no remediation is available
+- [ ] 2.4 Three consecutive ordinary sentences through `capture_source` all succeed on a fresh vault, and each is retrievable by keyword recall — this is the behaviour the hosted UI depends on
+- [ ] 2.5 A second governed `remember` with no qualifying relation and no reviewed disposition is still refused, proving the contract was not weakened
+- [ ] 2.6 Run the full pytest suite; any test asserting the old flattened-message behaviour is updated deliberately, with the reason recorded, not silenced
+
+## 3. Verification
+
+- [ ] 3.1 Re-run the local reproduction (`repro_fresh_vault.py`, `repro2.py`, `repro5.py`) and confirm each refusal now names its cause and carries remediation
+- [ ] 3.2 Confirm no change to `remember`'s accept/refuse behaviour — only to what a refusal says
+- [ ] 3.3 Open a PR describing this as an error-contract change and linking the design's Risks section
+- [ ] 3.4 After deploy, confirm the hosted response for an unstructured write names the real cause instead of `SEMANTIC_CREATION_FAILED / remediation: null`
+
+## 4. Companion work (tracked in `substrate`, not this change)
+
+- [ ] 4.1 Route the hosted capture box to `capture_source` instead of `remember`
+- [ ] 4.2 Make the authenticated first run connect-first: server URL, copy button, per-client paths; capture and search demoted below it
+- [ ] 4.3 Replace the `home-client.tsx` placeholder "Kim prefers the morning train" — one of the four alpha invitees is named Kim
+- [ ] 4.4 End-to-end acceptance on a fresh reviewer tenant: connect-first landing, one ordinary sentence saves, and `Find something` returns it

--- a/openspec/changes/hosted-human-capture-and-onboarding/tasks.md
+++ b/openspec/changes/hosted-human-capture-and-onboarding/tasks.md
@@ -1,30 +1,30 @@
-## 1. Error fidelity
+## 1. Hosted refusal guidance
 
-- [ ] 1.1 Add a `ValueError` subclass carrying `.code`, `.reason`, `.missing` and `.remediation`, whose `str()` is byte-identical to today's flattened message so existing `except ValueError` handlers and message assertions keep working
-- [ ] 1.2 Replace the 26 `raise ValueError(f"{e.code}: {e.reason}…")` sites in `src/exomem/commands.py` by one deterministic transform keyed on the exact shape; assert the substitution count is exactly 26 and the diff is that many times the clause length
-- [ ] 1.3 Confirm the flattened sites are character-identical modulo the `(missing: …)` variant, and that the variant is handled rather than skipped
-- [ ] 1.4 Make `relation_review._translate` use the preserved `.code` instead of falling through to `SEMANTIC_CREATION_FAILED`, and carry `.remediation` onto the returned error
-- [ ] 1.5 Distinguish "no remediation was produced" from "remediation was lost" in the response shape
+- [x] 1.1 Add `_HOSTED_REFUSAL_GUIDANCE` in `src/exomem/server_hosted.py`: a static code → (message, remediation) table, with the `missing_semantic_unit` and `empty_rich_unit` entries derived from `semantic_authoring.AUTHORING_CONTRACT.findings` at import time so they cannot drift
+- [x] 1.2 Author hosted entries for `SEMANTIC_CONTRACT_BLOCKED`, `RELATION_DISPOSITION_MISSING` and `RELATION_DISPOSITION_STALE`, phrased for a person rather than for an agent retry loop
+- [x] 1.3 Add `_remediation_for(code)` mirroring `_message_for(code)`; have `_message_for` consult the table before its existing prefix rules
+- [x] 1.4 Replace the hardcoded `"remediation": None` in `_error_response` with `_remediation_for(code)`
+- [x] 1.5 Confirm no exception-derived text is introduced: the table is the only new source of message/remediation text, and `_error_response` still receives only a code plus allowlisted `details`
 
 ## 2. Tests
 
-- [ ] 2.1 A write refused for a missing semantic unit reports `missing_semantic_unit` with remediation text, not a generic code — assert the exact code, since the whole point is that it is specific
-- [ ] 2.2 A write refused for a missing relation disposition reports its own distinct code with remediation
-- [ ] 2.3 An unclassified failure still reports the generic code and states that no remediation is available
-- [ ] 2.4 Three consecutive ordinary sentences through `capture_source` all succeed on a fresh vault, and each is retrievable by keyword recall — this is the behaviour the hosted UI depends on
-- [ ] 2.5 A second governed `remember` with no qualifying relation and no reviewed disposition is still refused, proving the contract was not weakened
-- [ ] 2.6 Run the full pytest suite; any test asserting the old flattened-message behaviour is updated deliberately, with the reason recorded, not silenced
+- [x] 2.1 `_error_response("missing_semantic_unit", …)` returns a non-null remediation and a message other than `hosted command failed`
+- [x] 2.2 `_error_response("RELATION_DISPOSITION_MISSING", …)` returns a non-null remediation
+- [x] 2.3 A code with no table entry still returns the generic message and `remediation: null`
+- [x] 2.4 The `missing_semantic_unit` entry equals the text the authoring contract defines, so the derivation is real and not a copy that can drift
+- [x] 2.5 Three consecutive ordinary sentences through `capture_source` all succeed on a fresh vault, and each is retrievable by keyword recall — the behaviour the hosted UI will depend on
+- [x] 2.6 A second governed `remember` with no qualifying relation and no reviewed disposition is still refused, proving the contract was not weakened
+- [ ] 2.7 Run the full pytest suite
 
 ## 3. Verification
 
-- [ ] 3.1 Re-run the local reproduction (`repro_fresh_vault.py`, `repro2.py`, `repro5.py`) and confirm each refusal now names its cause and carries remediation
-- [ ] 3.2 Confirm no change to `remember`'s accept/refuse behaviour — only to what a refusal says
+- [x] 3.1 Re-run the boundary reproduction and confirm a refused hosted write now names its cause and carries remediation
+- [x] 3.2 Confirm no change to `remember`'s accept/refuse behaviour — only to what a refusal says
 - [ ] 3.3 Open a PR describing this as an error-contract change and linking the design's Risks section
-- [ ] 3.4 After deploy, confirm the hosted response for an unstructured write names the real cause instead of `SEMANTIC_CREATION_FAILED / remediation: null`
 
 ## 4. Companion work (tracked in `substrate`, not this change)
 
-- [ ] 4.1 Route the hosted capture box to `capture_source` instead of `remember`
-- [ ] 4.2 Make the authenticated first run connect-first: server URL, copy button, per-client paths; capture and search demoted below it
-- [ ] 4.3 Replace the `home-client.tsx` placeholder "Kim prefers the morning train" — one of the four alpha invitees is named Kim
+- [x] 4.1 Route the hosted capture box to `capture_source` instead of `remember` — this is the fix that makes a new user able to save at all
+- [x] 4.2 Make the authenticated first run connect-first: server URL, copy button, per-client paths; capture and search demoted below it
+- [x] 4.3 Replace the `home-client.tsx` placeholder "Kim prefers the morning train" — one of the four alpha invitees is named Kim
 - [ ] 4.4 End-to-end acceptance on a fresh reviewer tenant: connect-first landing, one ordinary sentence saves, and `Find something` returns it

--- a/src/exomem/server_hosted.py
+++ b/src/exomem/server_hosted.py
@@ -145,7 +145,73 @@ class HostedJSONResponse(JSONResponse):
         ).encode("utf-8")
 
 
+def _hosted_refusal_guidance() -> dict[str, tuple[str, str]]:
+    """Static code -> (message, remediation) for refusals a person can fix.
+
+    This boundary redacts exception-derived text, and that is not negotiable:
+    `cli_ops.error_dict` falls back to `{"code": "OP_ERROR", "message":
+    str(exc)}`, so copying its message through would hand raw exception text —
+    vault paths included — to a hosted client for any unclassified failure. So
+    the table is keyed on the code alone, which was already crossing.
+
+    The authoring entries are derived from the contract's own definitions
+    rather than transcribed, because a copy drifts the moment the contract's
+    wording is tuned. The disposition entries are authored here: the contract's
+    versions are addressed to an agent that can run a validate/retry loop
+    (`validate_only=true`, `transition_token=<returned>`), which is not
+    something a person typing into a box can do.
+
+    A code absent from this table degrades to the generic message and a null
+    remediation — the safe direction for anything unrecognised.
+    """
+    from . import semantic_authoring
+
+    findings = semantic_authoring.AUTHORING_CONTRACT.findings
+    unit = findings["missing_semantic_unit"]
+    empty = findings["empty_rich_unit"]
+
+    disposition = (
+        "This memory needs a link to something already saved before it can be "
+        "recorded as a conclusion. Add a typed relation to a related memory, or "
+        "save it as a source instead if it is raw material rather than a "
+        "settled conclusion."
+    )
+    return {
+        "missing_semantic_unit": (
+            "the memory has no semantic unit to record",
+            f"{unit['compact_remediation']} {unit['rich_remediation']}",
+        ),
+        "empty_rich_unit": (
+            "the memory has a heading with no content under it",
+            empty["remediation"],
+        ),
+        "SEMANTIC_CONTRACT_BLOCKED": (
+            "the memory does not yet meet the authoring contract",
+            disposition,
+        ),
+        "RELATION_DISPOSITION_MISSING": (
+            "the memory needs a qualifying relation or an explicit review",
+            disposition,
+        ),
+        "RELATION_DISPOSITION_STALE": (
+            "the memory's relation review is out of date",
+            disposition,
+        ),
+    }
+
+
+_HOSTED_REFUSAL_GUIDANCE: dict[str, tuple[str, str]] = _hosted_refusal_guidance()
+
+
+def _remediation_for(code: str) -> str | None:
+    guidance = _HOSTED_REFUSAL_GUIDANCE.get(code)
+    return guidance[1] if guidance is not None else None
+
+
 def _message_for(code: str) -> str:
+    guidance = _HOSTED_REFUSAL_GUIDANCE.get(code)
+    if guidance is not None:
+        return guidance[0]
     if code == "HOSTED_UNAUTHORIZED":
         return "private authentication failed"
     if code == "HOSTED_CELL_CONTEXT_MISMATCH":
@@ -304,7 +370,7 @@ def _error_response(
     error = {
         "code": code,
         "message": _message_for(code),
-        "remediation": None,
+        "remediation": _remediation_for(code),
     }
     if details is not None:
         error.update(

--- a/tests/test_hosted_refusal_guidance.py
+++ b/tests/test_hosted_refusal_guidance.py
@@ -1,0 +1,157 @@
+"""A hosted refusal must tell its recipient what to do about it.
+
+`_error_response` is a redaction boundary: the handler that feeds it converts an
+arbitrary exception into a code, and passing that exception's text onward would
+leak vault paths and internal detail to a hosted client. It used to discharge
+that duty by hardcoding `remediation: None`, which is safe and also useless — a
+person whose write was refused for a nameable, fixable reason got
+`{"message": "hosted command failed", "remediation": null}`.
+
+These tests pin the narrow seam that fixes it: message and remediation resolve
+from a static code-keyed table, never from the exception, so the redaction
+guarantee holds while an expected refusal becomes actionable.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+from exomem import commands, find, schema, semantic_authoring, server_hosted
+from exomem.cli_ops import error_dict
+from exomem.init import init_vault
+
+
+def _error_block(code: str) -> dict:
+    response = server_hosted._error_response(
+        code,
+        config=SimpleNamespace(cell_id="cell-refusal-test"),
+        operation="remember",
+        started=0.0,
+    )
+    return json.loads(response.body)["error"]
+
+
+# --- The refusals a hosted user actually hits ------------------------------
+
+
+def test_missing_semantic_unit_refusal_carries_remediation() -> None:
+    error = _error_block("missing_semantic_unit")
+
+    assert error["code"] == "missing_semantic_unit"
+    assert error["remediation"], "a refusal with a defined remedy must not report null"
+    assert error["message"] != "hosted command failed"
+
+
+def test_relation_disposition_refusal_carries_remediation() -> None:
+    """The second memory a hosted user saves fails here, so it must be legible."""
+    for code in ("RELATION_DISPOSITION_MISSING", "SEMANTIC_CONTRACT_BLOCKED"):
+        error = _error_block(code)
+        assert error["remediation"], f"{code} must carry remediation"
+        assert error["message"] != "hosted command failed", code
+
+
+def test_unknown_code_stays_generic_and_redacted() -> None:
+    """A code with no entry degrades to today's behaviour — the safe direction."""
+    error = _error_block("SOME_UNCLASSIFIED_FAILURE")
+
+    assert error["message"] == "hosted command failed"
+    assert error["remediation"] is None
+
+
+def test_existing_hosted_codes_are_unchanged() -> None:
+    """The table must not shadow the message rules already asserted elsewhere."""
+    assert _error_block("HOSTED_UNAUTHORIZED")["message"] == "private authentication failed"
+    assert _error_block("MUTATION_BUSY")["remediation"] is None
+
+
+# --- The table is derived, not copied -------------------------------------
+
+
+def test_authoring_remediation_is_derived_from_the_contract() -> None:
+    """A hand-copied string would drift from the contract the moment it changed."""
+    definition = semantic_authoring.AUTHORING_CONTRACT.findings["missing_semantic_unit"]
+    expected = f"{definition['compact_remediation']} {definition['rich_remediation']}"
+
+    assert _error_block("missing_semantic_unit")["remediation"] == expected
+
+    empty_rich = semantic_authoring.AUTHORING_CONTRACT.findings["empty_rich_unit"]
+    assert _error_block("empty_rich_unit")["remediation"] == empty_rich["remediation"]
+
+
+def test_no_exception_text_reaches_the_response() -> None:
+    """The seam takes a code and a static table — never a raised exception."""
+    with tempfile.TemporaryDirectory() as directory:
+        vault = Path(directory)
+        init_vault(vault)
+        try:
+            commands.op_remember(
+                vault, title="Hello", content="Hello there", note_type="insight"
+            )
+        except Exception as exc:  # noqa: BLE001 - the refusal under test
+            raised = str(exc)
+            derived = error_dict(exc)
+        else:  # pragma: no cover - the governed lane must refuse this
+            raise AssertionError("plain prose must not satisfy the governed contract")
+
+    error = _error_block(derived["code"])
+
+    # The vault path is in the raised text and must not survive the boundary.
+    assert str(vault) not in json.dumps(error)
+    assert "Knowledge Base/Notes" not in json.dumps(error)
+    assert error["message"] not in raised or error["message"] == "hosted command failed"
+
+
+# --- The two lanes this change is specified against ------------------------
+
+
+def test_capture_lane_accepts_consecutive_ordinary_sentences() -> None:
+    """What the hosted capture box will depend on once it is routed correctly."""
+    sentences = [
+        ("Dentist on Thursday at 3pm.", "Dentist Thursday"),
+        ("The office moved to Pier 9.", "Office moved"),
+        ("Renew the passport before March.", "Passport renewal"),
+    ]
+
+    with tempfile.TemporaryDirectory() as directory:
+        vault = Path(directory)
+        init_vault(vault)
+        source_schema = schema.load_source_schema(vault)
+
+        for content, title in sentences:
+            result = commands.op_capture_source(
+                vault, source_schema, content=content, title=title, source_type="other"
+            )
+            # `capture_source` nests its result under `source`, unlike
+            # `remember` — the companion UI change depends on this shape.
+            assert result["source"]["path"], f"capture refused {title!r}"
+
+        find.clear_cache()
+        hits = json.dumps(
+            commands.op_ask_memory(vault, query="dentist", mode="keyword", limit=5),
+            default=str,
+        )
+        assert "dentist" in hits.lower(), "captured material must be recallable"
+
+
+def test_governed_lane_still_refuses_an_ungrounded_second_conclusion() -> None:
+    """Proof the contract was not weakened to make capture work."""
+    body = "## Observations\n\n- [fact] The office moved to Pier 9 #office ^office-pier9\n"
+
+    with tempfile.TemporaryDirectory() as directory:
+        vault = Path(directory)
+        init_vault(vault)
+
+        commands.op_remember(vault, title="Note 1", content=body, note_type="insight")
+
+        try:
+            commands.op_remember(vault, title="Note 2", content=body, note_type="insight")
+        except Exception as exc:  # noqa: BLE001 - the refusal under test
+            derived = error_dict(exc)
+        else:  # pragma: no cover
+            raise AssertionError("a second ungrounded conclusion must still be refused")
+
+    assert "RELATION_DISPOSITION_MISSING" in json.dumps(derived)
+    assert _error_block(derived["code"])["remediation"]


### PR DESCRIPTION
## Why

A hosted user whose write was refused for a nameable, fixable reason got:

```json
{"code": "SEMANTIC_CREATION_FAILED", "message": "hosted command failed", "remediation": null}
```

`cli_ops.error_dict` — the exact function `server_hosted._execute_command` calls on the failure
path — **already computes** the specific code, the real message and the evaluator's full
remediation. Verified against fresh vaults on `main`:

```
op_remember(plain text)   -> code='missing_semantic_unit'      remediation=<full text>
op_remember(2nd governed) -> code='SEMANTIC_CONTRACT_BLOCKED'  remediation=<full text>
```

One frame later, `_error_response` threw both away:

```python
error = {"code": code, "message": _message_for(code), "remediation": None}
```

## The fix keeps the redaction guarantee intact

The redaction is deliberate — the handler comment reads *"private boundary redacts exception
text"* — and it stays exactly as it is. The obvious fix (copy `error["message"]` and
`error["remediation"]` from the `error_dict` payload) is **rejected**: that payload is derived from
the exception, and `error_dict`'s fallback branch returns `{"code": "OP_ERROR", "message":
str(exc)}`, so passing the message through would send raw exception text — vault paths included —
to a hosted client for any unclassified failure.

Instead, `_remediation_for(code)` mirrors the existing `_message_for(code)`: a pure code → static
text lookup. Nothing exception-derived crosses a boundary the code was already crossing. This
follows the module's own pattern, where `details` is filtered through the
`_HOSTED_MUTATION_DETAIL_FIELDS` allowlist rather than copied wholesale.

A code with no table entry degrades to today's generic message and a null remediation — the safe
direction, and asserted as such.

The `missing_semantic_unit` and `empty_rich_unit` entries are **derived** from
`semantic_authoring.AUTHORING_CONTRACT.findings` at import time rather than transcribed, so they
cannot drift; a test pins that the derivation is real. The disposition entries are authored here,
because the contract's own wording addresses an agent that can run a validate/retry loop
(`validate_only=true`, `transition_token=<returned>`) — not something a person typing into a box
can do.

After:

```json
{"code": "missing_semantic_unit",
 "message": "the memory has no semantic unit to record",
 "remediation": "Add `## Observations` and `- [operating constraint] …`. Alternatively add `## Decision`…"}
```

## The OpenSpec artifacts are rewritten, because reproduction falsified them

They were first written against this chain: `commands.py` flattens structured errors at 26 sites →
`.code` is lost → `relation_review._translate` falls through to `SEMANTIC_CREATION_FAILED`.

That is wrong. **`_translate` runs deeper in the stack than `commands.py`**, so it cannot be
downstream of the flattening; an instrumented spy confirms it never fires on this path. The
flattening is real (17 plain sites, 1 with a `(missing:)` suffix, 8 further formatting sites) but
survivable — `error_dict` walks `__cause__`/`__context__` for a projector and falls back to parsing
`CODE: reason` from the message string. **Rewriting those 26 sites is now an explicit non-goal**:
substantial work, real regression risk against tests that assert message text, and it fixes
nothing. The falsified version is recorded in the proposal so it is not re-derived.

## Scope

This changes only **what a refusal says**. The reason a new hosted user could not save at all is
that the web UI called the governed-conclusion lane (`remember`) for plain human capture — fixed
in **substrate#112**, which is independent of this PR and does not wait on a promotion window.

`remember`'s accept/refuse behaviour is unchanged; a test asserts a second ungrounded conclusion is
still refused.

## Verification

- 24 targeted tests pass (`test_hosted_refusal_guidance.py` + `test_tool_failure_logging.py`)
- Full suite: **10833 passed**, 216 skipped. The 90 failures are all in
  `tests/test_memorybench_export.py` and `tests/test_memorybench_setup.py`, and reproduce
  identically on clean `origin/main` in a throwaway worktree (91 there, of which this run
  deselected 1). Pre-existing, unrelated to `server_hosted`.
- `uvx ruff check --select F` clean on changed files
- `openspec validate hosted-human-capture-and-onboarding` passes