### PR TITLE
fix(ops): make the deploy gates observe the running process

### DIFF
--- a/scripts/_service-common.ps1
+++ b/scripts/_service-common.ps1
@@ -595,3 +595,139 @@ function Assert-ExomemVisibleCliVersions {
         Write-Host "Verified $executable -> exomem $($identity.version)"
     }
 }
+
+function Get-ExomemServiceWorkerPid {
+    <#
+    .SYNOPSIS
+      Return the pid of the interpreter the service actually runs, or 0.
+    .DESCRIPTION
+      NSSM is the service process; the Python worker is its child, and the child
+      is what holds loaded code. Returns 0 rather than throwing whenever the
+      service is stopped, the platform is not Windows, or CIM is unavailable, so
+      callers can treat 0 as "no baseline" instead of handling an exception.
+    #>
+    param([string]$ServiceName = "exomem")
+
+    if ($env:OS -ne "Windows_NT") { return 0 }
+    try {
+        $service = Get-CimInstance Win32_Service -Filter "Name='$ServiceName'" -ErrorAction Stop
+    } catch {
+        return 0
+    }
+    if (-not $service -or -not $service.ProcessId) { return 0 }
+    try {
+        $child = Get-CimInstance Win32_Process -Filter "ParentProcessId=$($service.ProcessId)" -ErrorAction Stop |
+            Select-Object -First 1
+    } catch {
+        return 0
+    }
+    if (-not $child) { return 0 }
+    return [int]$child.ProcessId
+}
+
+function Assert-ExomemServiceRestarted {
+    <#
+    .SYNOPSIS
+      Fail when a deploy reports success without the worker process changing.
+    .DESCRIPTION
+      `/health` reports `importlib.metadata.version("exomem")`, read from disk at
+      request time with no relation to the code the running interpreter loaded.
+      So when `uv pip install` swapped the wheel under a live process, /health
+      served the new version while the interpreter still ran the old one -- and
+      worse, a mixed-version process, because modules imported lazily after the
+      swap came from the new wheel.
+
+      That makes every version-vs-version gate blind by construction: both
+      `install-info --json` and `/health` read the same distribution metadata, so
+      comparing them compares disk with disk. The worker's process identity is
+      the only observable that separates "restarted onto the new code" from
+      "still running the old code".
+
+      A pid of 0 means "not observed". An unknown baseline degrades to a warning,
+      because refusing a deploy for lack of a baseline would strand any box where
+      the probe is unavailable; a *known* baseline that did not change is fatal.
+    #>
+    param(
+        [int]$Before = 0,
+        [int]$After = 0,
+        [string]$ServiceName = "exomem"
+    )
+
+    if (-not $After) {
+        throw "Service '$ServiceName' has no running worker process after the restart. Nothing is serving the deployed version; check logs\service.err.log."
+    }
+    if (-not $Before) {
+        Write-Warning "No pre-restart worker pid was observed, so this run can only assert that a worker is running now (pid $After), not that it restarted onto the new code."
+        return
+    }
+    if ($After -eq $Before) {
+        throw "Service '$ServiceName' is still running the same worker process (pid $After) that was live before the upgrade. The wheel on disk changed but the interpreter did not reload it, so /health now reports the new version from disk metadata while the process serves the old code. Restart the service and re-verify."
+    }
+    Write-Host "Worker process restarted: pid $Before -> $After"
+}
+
+function Get-ExomemLogDir {
+    <#
+    .SYNOPSIS
+      Return the log directory the app actually writes to, or $null.
+    .DESCRIPTION
+      Ask `logging_config.resolve_log_dir()` rather than deriving a second
+      constant here. #569 moved logs off `<repo>/logs` for wheel installs, and a
+      script that kept its own copy of the old path pruned and tailed a directory
+      nothing writes to -- reporting "No log file at ..." while the service
+      logged normally somewhere else.
+
+      Resolution runs in this process, so it sees this process's EXOMEM_LOG_DIR.
+      That matches the service whenever the variable is unset in both (the common
+      case) or set identically; it is the same assumption the doctor check makes.
+    #>
+    param([string]$PythonPath)
+
+    if (-not $PythonPath -or -not (Test-Path $PythonPath)) { return $null }
+    $out = & $PythonPath -c "from exomem.logging_config import resolve_log_dir; print(resolve_log_dir())" 2>$null
+    if ($LASTEXITCODE -ne 0) { return $null }
+    $dir = ($out | Select-Object -First 1)
+    if (-not $dir) { return $null }
+    return $dir.Trim()
+}
+
+function Test-ExomemAcceleratedTorch {
+    <#
+    .SYNOPSIS
+      True when the torch installed in an interpreter is an accelerator build.
+    .DESCRIPTION
+      Read the local version tag from distribution metadata, never by importing
+      torch: the probe must stay fast and must not fail on a broken ML stack.
+      Default PyPI wheels carry no local tag, which on Windows means CPU-only.
+
+      This exists because the deploy accelerator gate read `.accelerated` off
+      `install-info --json`, which has never emitted that key. The property was
+      always $null, `[bool]$null` is $false, and the guard documented as "a hard
+      failure by default" could not fire at all. `/health` does expose it, but
+      only while the service is up -- and the gate has to run mid-deploy, so it
+      cannot depend on that.
+    #>
+    param([string]$PythonPath)
+
+    $version = Get-ExomemTorchVersion -PythonPath $PythonPath
+    if (-not $version) { return $false }
+    foreach ($tag in @("+cu", "+rocm", "+xpu")) {
+        if ($version.Contains($tag)) { return $true }
+    }
+    return $false
+}
+
+function Get-ExomemTorchVersion {
+    <#
+    .SYNOPSIS
+      Return the torch version string from distribution metadata, or $null.
+    #>
+    param([string]$PythonPath)
+
+    if (-not $PythonPath -or -not (Test-Path $PythonPath)) { return $null }
+    $out = & $PythonPath -c "import importlib.metadata as m; print(m.version('torch'))" 2>$null
+    if ($LASTEXITCODE -ne 0) { return $null }
+    $version = ($out | Select-Object -First 1)
+    if (-not $version) { return $null }
+    return $version.Trim()
+}

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -29,6 +29,8 @@ param(
 $ErrorActionPreference = "Stop"
 $RepoRoot = Split-Path -Parent $PSScriptRoot
 
+. "$PSScriptRoot\_service-common.ps1"
+
 function Fail($msg) {
     Write-Host "DEPLOY FAILED: $msg" -ForegroundColor Red
     exit 1
@@ -57,16 +59,18 @@ function Get-Provenance {
     try { return $raw | ConvertFrom-Json } catch { return $null }
 }
 
+# The accelerator baseline comes from torch's own distribution metadata, not
+# from `install-info --json`. That payload has never carried `accelerated` or
+# `torch`: the property read $null, `[bool]$null` is $false, and so the gate at
+# step 3 -- documented as "a hard failure by default" -- could never fire. The
+# CUDA build surviving previous deploys was luck, not the guard working.
+$torchBefore = Get-ExomemTorchVersion -PythonPath $servicePython
+$accelBefore = Test-ExomemAcceleratedTorch -PythonPath $servicePython
+
 $before = Get-Provenance
 if ($before) {
-    $accelBefore = [bool]$before.accelerated
-    Write-Host "Currently deployed: $($before.version) ($($before.install_source)), torch $($before.torch)"
+    Write-Host "Currently deployed: $($before.version) ($($before.install_source)), torch $torchBefore"
 } else {
-    # A pre-provenance build cannot self-report; fall back to metadata so the
-    # accelerator comparison still has a baseline.
-    $accelBefore = $false
-    $torchBefore = & $servicePython -c "import importlib.metadata as m; print(m.version('torch'))" 2>$null
-    if ($torchBefore -and ($torchBefore -match '\+(cu|rocm|xpu)')) { $accelBefore = $true }
     Write-Host "Currently deployed: (pre-provenance build), torch $torchBefore"
 }
 
@@ -84,8 +88,9 @@ if ($LASTEXITCODE -ne 0) { Fail "uv pip install returned $LASTEXITCODE." }
 # The cu132 pin lives in the repo's [tool.uv.sources], which a PyPI-backed venv
 # cannot see, so an upgrade silently resolves the default CPU wheel on Windows.
 $after = Get-Provenance
-$accelAfter = if ($after) { [bool]$after.accelerated } else { $false }
-$torchAfter = if ($after) { $after.torch } else { "unknown" }
+$torchAfter = Get-ExomemTorchVersion -PythonPath $servicePython
+if (-not $torchAfter) { $torchAfter = "unknown" }
+$accelAfter = Test-ExomemAcceleratedTorch -PythonPath $servicePython
 
 if ($accelBefore -and -not $accelAfter) {
     Write-Host ""
@@ -113,6 +118,13 @@ if ($LASTEXITCODE -ne 0) { Fail "restart returned $LASTEXITCODE." }
 # --- 5. Verify the RUNNING process, not the installer ------------------------
 # An installer that succeeded only proves the venv changed. The deploy is not
 # done until the live process serves the requested version.
+#
+# This check is necessary but NOT sufficient, and used to be treated as both.
+# /health reports `importlib.metadata.version("exomem")`, read from disk per
+# request, so it starts answering with the new version as soon as the wheel is
+# replaced -- whether or not anything restarted. It caught a wrong version; it
+# could not catch a stale process. The proof that the interpreter reloaded is
+# the worker-pid change asserted inside restart.ps1, which step 4 just ran.
 Write-Host "`nVerifying deployed version at $HealthUrl ..." -ForegroundColor Cyan
 $observed = $null
 $source = $null

--- a/scripts/restart.ps1
+++ b/scripts/restart.ps1
@@ -119,6 +119,13 @@ if (-not (Test-VenvInterpreter)) {
 
 Invoke-DoctorGate -Profile $Profile
 
+# Captured before the stop so the verification below can prove the interpreter
+# actually reloaded. A version comparison cannot: /health reports distribution
+# metadata read from disk, so it serves a new version the moment the wheel
+# changes, restart or no restart.
+$workerBefore = Get-ExomemServiceWorkerPid -ServiceName $ServiceName
+if ($workerBefore) { Write-Host "Worker process before restart: pid $workerBefore" }
+
 Write-Host "Stopping $ServiceName..."
 sc.exe stop $ServiceName | Out-Null
 Wait-ServiceState -Name $ServiceName -Target 'Stopped'
@@ -136,7 +143,11 @@ if ($Force) {
 # only this session while the previous session's diagnostics are still
 # recoverable from logs\archive\. Also prune NSSM's uncapped service.out/err
 # rotation pile.
-$logDir = Join-Path (Split-Path -Parent $PSScriptRoot) "logs"
+$logDir = Get-ExomemLogDir -PythonPath $VenvPy
+if (-not $logDir) {
+    $logDir = Join-Path (Split-Path -Parent $PSScriptRoot) "logs"
+    Write-Warning "Could not resolve the app log directory from the service interpreter; falling back to $logDir. Archiving and the tail below may target a directory nothing writes to."
+}
 $logPath = Join-Path $logDir "exomem.log"
 Backup-ExomemAppLog -LogPath $logPath -ArchiveDir (Join-Path $logDir "archive") -Keep 10
 Limit-ExomemServiceLogPile -LogDir $logDir -Keep 20
@@ -145,6 +156,16 @@ Write-Host "Starting $ServiceName..."
 sc.exe start $ServiceName | Out-Null
 Wait-ServiceState -Name $ServiceName -Target 'Running'
 Write-Host "  running."
+
+# `Running` is NSSM's state, not the worker's: the Python child is spawned just
+# after, so poll for it rather than reading once and concluding it is absent.
+$workerAfter = 0
+foreach ($attempt in 1..25) {
+    Start-Sleep -Milliseconds 400
+    $workerAfter = Get-ExomemServiceWorkerPid -ServiceName $ServiceName
+    if ($workerAfter -and $workerAfter -ne $workerBefore) { break }
+}
+Assert-ExomemServiceRestarted -Before $workerBefore -After $workerAfter -ServiceName $ServiceName
 
 # Give the app a beat to write its startup banner.
 Start-Sleep -Seconds 2

--- a/tests/test_deploy_restart_gate.py
+++ b/tests/test_deploy_restart_gate.py
@@ -1,0 +1,219 @@
+"""A deploy must not report success while the old interpreter is still serving.
+
+`scripts/deploy.ps1` step 5 is titled "Verify the RUNNING process, not the
+installer" and polls `/health`. But `/health` reports
+`importlib.metadata.version("exomem")`, read from disk at request time with no
+relation to the code the running interpreter loaded. Observed live: `uv pip
+install` swapped the wheel under a process that had been up since 12:20:10Z;
+`/health` answered `0.53.0` while the interpreter still ran 0.52.3, and in fact
+ran a *mixed* build, because modules imported lazily after the swap came from
+the new wheel. Every latency measurement taken that day was attributed to a
+release that was never running.
+
+The same blindness is structural, not incidental: `install-info --json` and
+`/health` both read the same distribution metadata, so any gate comparing one
+against the other compares disk with disk and cannot fail for this reason. The
+worker process identity is the only observable that separates "restarted onto
+the new code" from "still running the old code".
+
+Two gates are exercised here, both as pure before/after assertions so they run
+everywhere pwsh does rather than needing a real Windows service:
+
+1. `Assert-ExomemServiceRestarted` — the restart gate this adds.
+2. `Test-ExomemAcceleratedTorch` — the accelerator gate, which read
+   `.accelerated` off `install-info --json`. That key has never been emitted, so
+   the property was always $null, `[bool]$null` is $false, and the guard
+   documented as "a hard failure by default" could not fire at all.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMON = ROOT / "scripts" / "_service-common.ps1"
+RESTART = ROOT / "scripts" / "restart.ps1"
+DEPLOY = ROOT / "scripts" / "deploy.ps1"
+PWSH = shutil.which("pwsh")
+
+pytestmark = pytest.mark.skipif(PWSH is None, reason="pwsh is not available")
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+_RESTART_DRIVER = """
+    param([string]$Common, [int]$Before, [int]$After)
+    $ErrorActionPreference = "Stop"
+    try {
+        . $Common
+        Assert-ExomemServiceRestarted -Before $Before -After $After -ServiceName "exomem"
+    } catch {
+        Write-Host "DRIVER-ERROR: $($_.Exception.Message)"
+        exit 1
+    }
+    Write-Host "DRIVER-COMPLETED"
+"""
+
+_TORCH_DRIVER = """
+    param([string]$Common, [string]$Python)
+    $ErrorActionPreference = "Stop"
+    . $Common
+    $version = Get-ExomemTorchVersion -PythonPath $Python
+    $accel = Test-ExomemAcceleratedTorch -PythonPath $Python
+    Write-Host "VERSION=$version"
+    Write-Host "ACCEL=$accel"
+"""
+
+# Stands in for the service venv's interpreter: the probes run
+# `<python> -c "import importlib.metadata ..."` and read one line of stdout.
+_PYTHON_SH = """
+    #!/bin/sh
+    if [ -n "$FAKE_TORCH_VERSION" ]; then echo "$FAKE_TORCH_VERSION"; exit 0; fi
+    exit 1
+"""
+
+_PYTHON_CMD = """
+    @echo off
+    if not defined FAKE_TORCH_VERSION exit /b 1
+    echo %FAKE_TORCH_VERSION%
+    exit /b 0
+"""
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _flat(result: subprocess.CompletedProcess[str]) -> str:
+    """Both streams, ANSI stripped and whitespace collapsed.
+
+    PowerShell wraps what it renders itself to the host width, so a phrase can be
+    split mid-sentence by a newline that depends on the terminal running it.
+    """
+    return " ".join(_ANSI.sub("", result.stdout + result.stderr).split())
+
+
+def _run(script: Path, *args: str, env: dict[str, str] | None = None):
+    assert PWSH is not None
+    return subprocess.run(
+        [PWSH, "-NoProfile", "-File", str(script), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180,
+    )
+
+
+@pytest.fixture()
+def restart_driver(tmp_path: Path) -> Path:
+    script = tmp_path / "restart-driver.ps1"
+    _write_executable(script, _RESTART_DRIVER)
+    return script
+
+
+class TestRestartGate:
+    def test_an_unchanged_worker_pid_fails_the_deploy(self, restart_driver: Path) -> None:
+        """The live defect: wheel replaced, process never reloaded."""
+        result = _run(restart_driver, "-Common", str(COMMON), "-Before", "27372", "-After", "27372")
+        flat = _flat(result)
+        assert result.returncode == 1, flat
+        assert "still running the same worker process" in flat, flat
+        assert "27372" in flat, flat
+
+    def test_a_changed_worker_pid_is_accepted(self, restart_driver: Path) -> None:
+        result = _run(restart_driver, "-Common", str(COMMON), "-Before", "27372", "-After", "31005")
+        flat = _flat(result)
+        assert result.returncode == 0, flat
+        assert "DRIVER-COMPLETED" in flat, flat
+        assert "27372 -> 31005" in flat, flat
+
+    def test_no_worker_after_restart_is_fatal(self, restart_driver: Path) -> None:
+        """A service that came back with nothing running is not a success."""
+        result = _run(restart_driver, "-Common", str(COMMON), "-Before", "27372", "-After", "0")
+        flat = _flat(result)
+        assert result.returncode == 1, flat
+        assert "no running worker process" in flat, flat
+
+    def test_an_unknown_baseline_warns_instead_of_stranding_the_box(
+        self, restart_driver: Path
+    ) -> None:
+        """Refusing every deploy where the probe is unavailable is worse."""
+        result = _run(restart_driver, "-Common", str(COMMON), "-Before", "0", "-After", "31005")
+        flat = _flat(result)
+        assert result.returncode == 0, flat
+        assert "DRIVER-COMPLETED" in flat, flat
+        assert "No pre-restart worker pid" in flat, flat
+
+
+class TestAcceleratorProbe:
+    @pytest.fixture()
+    def probe(self, tmp_path: Path):
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        # Both forms on every platform: PowerShell resolves through PATHEXT to
+        # the .cmd and never the extensionless file.
+        _write_executable(bin_dir / "python", _PYTHON_SH)
+        _write_executable(bin_dir / "python.cmd", _PYTHON_CMD)
+        python = bin_dir / ("python.cmd" if os.name == "nt" else "python")
+        script = tmp_path / "torch-driver.ps1"
+        _write_executable(script, _TORCH_DRIVER)
+
+        def run(torch_version: str | None):
+            env = os.environ.copy()
+            env["FAKE_TORCH_VERSION"] = torch_version or ""
+            return _flat(_run(script, "-Common", str(COMMON), "-Python", str(python), env=env))
+
+        return run
+
+    @pytest.mark.parametrize(
+        "version",
+        ["2.13.0+cu132", "2.9.1+rocm6.2", "2.8.0+xpu"],
+    )
+    def test_an_accelerator_build_is_detected(self, probe, version: str) -> None:
+        flat = probe(version)
+        assert "ACCEL=True" in flat, flat
+        assert f"VERSION={version}" in flat, flat
+
+    def test_a_plain_pypi_wheel_reads_as_cpu_only(self, probe) -> None:
+        """No local tag is exactly what a silent CPU downgrade looks like."""
+        flat = probe("2.13.0")
+        assert "ACCEL=False" in flat, flat
+
+    def test_absent_torch_is_not_an_accelerator(self, probe) -> None:
+        flat = probe(None)
+        assert "ACCEL=False" in flat, flat
+
+
+class TestScriptsAreWired:
+    """The helpers only matter if the scripts actually call them."""
+
+    def test_restart_asserts_the_worker_changed_around_the_restart(self) -> None:
+        body = RESTART.read_text(encoding="utf-8")
+        assert "Get-ExomemServiceWorkerPid" in body
+        assert "Assert-ExomemServiceRestarted" in body
+        # The baseline is worthless if it is read after the stop.
+        assert body.index("$workerBefore = Get-ExomemServiceWorkerPid") < body.index(
+            "sc.exe stop"
+        ), "the pre-restart worker pid must be captured before the service stops"
+
+    def test_restart_resolves_the_log_dir_instead_of_assuming_the_checkout(self) -> None:
+        """#569 moved logs off <repo>/logs; the script kept its own stale copy."""
+        body = RESTART.read_text(encoding="utf-8")
+        assert "Get-ExomemLogDir" in body
+        assert '$logDir = Join-Path (Split-Path -Parent $PSScriptRoot) "logs"' not in body.split(
+            "Write-Warning"
+        )[0], "the checkout path must be a fallback, not the primary resolution"
+
+    def test_deploy_probes_torch_rather_than_a_key_install_info_never_emits(self) -> None:
+        body = DEPLOY.read_text(encoding="utf-8")
+        assert "Test-ExomemAcceleratedTorch" in body
+        assert "$before.accelerated" not in body
+        assert "$after.accelerated" not in body


### PR DESCRIPTION
## Why

Two gates in the deploy path cannot fail for the reasons they document, and one
script prunes a directory nothing writes to.

### 1. The version gate is blind

`deploy.ps1` step 5 is titled *"Verify the RUNNING process, not the installer"*
and polls `/health`. But `/health` reports
`importlib.metadata.version("exomem")` — read from disk at request time, with no
relation to the code the interpreter loaded.

This bit us. `uv pip install` swapped the wheel under a process that had been up
since `12:20:10Z`. `/health` reported `0.53.0` while the interpreter still ran
`0.52.3` — and worse, a **mixed-version process**, because modules imported
lazily after the swap came from the new wheel. Every write-latency number
measured that day was taken against a release that was never running.

The blindness is structural, not a typo: `install-info --json` and `/health`
read the same distribution metadata, so any gate comparing one against the other
compares disk with disk. `upgrade.ps1:141` has the same shape — it can only
catch "something else is bound to the port", never a stale process.

The worker process identity is the only observable that separates *restarted
onto the new code* from *still running the old code*. This asserts on that, in
`restart.ps1` where the restart actually happens, so both deploy paths inherit
the guarantee rather than each growing its own copy.

### 2. The accelerator gate is unreachable code

It branches on `$before.accelerated` / `$after.accelerated` from
`install-info --json`. That payload has **never** emitted either key:

```
{"version": "0.53.0", "python_executable": "...", "install_source": "wheel",
 "local_profile": "lean", "managed_service_version": "0.51.0", ...}
```

So the property read `$null`, `[bool]$null` is `$false`, and the guard
documented as *"a hard failure by default"* could not fire at all. The CUDA
build surviving previous deploys was luck.

`/health` does expose `accelerated`, but the gate runs mid-deploy when the
service may be down, so it cannot depend on that. Probe torch's distribution
metadata instead — never importing torch, which is `deploy_provenance`'s own
stated constraint.

Verified against the live venv: the new probe reports `accelerated=True`
(`torch 2.13.0+cu132`) where the old expression computed `False` unconditionally.

### 3. Stale log path

#569 moved logs off `<repo>/logs`, but `restart.ps1:139` kept its own copy of
the old path. It archived and pruned a directory nothing writes to, and reported
`No log file at ...` while the service logged normally to
`C:\ProgramData\exomem\logs`. Now asks `logging_config.resolve_log_dir()` rather
than maintaining a second constant.

## Design notes

- An **unknown** pre-restart pid degrades to a warning, not a refusal — stranding
  a box where the probe is unavailable is worse than the gap it leaves. A
  **known** baseline that did not change is fatal.
- `Running` is NSSM's state, not the worker's; the Python child is spawned just
  after, so the post-restart pid is polled rather than read once and concluded
  absent.
- The gate logic is split from the CIM probe so it is a pure before/after
  assertion, matching `Assert-ExomemInstallApplied` and running everywhere pwsh
  does rather than needing a real Windows service.
- `deploy.ps1` now dot-sources `_service-common.ps1`; it was the only deploy
  script that did not, which is why it had reinvented this logic without the
  gates `upgrade.ps1` already had.

## Verification

- New `tests/test_deploy_restart_gate.py`: 12 tests, all passing. Covers the
  unchanged-pid failure, the changed-pid success, no-worker-after-restart,
  unknown-baseline degradation, accelerator detection across `+cu`/`+rocm`/`+xpu`,
  a plain PyPI wheel reading as CPU-only, and wiring assertions that the scripts
  actually call the helpers with the baseline captured *before* the stop.
- Live read-only probe against the running service: worker pid `27372`,
  `torch 2.13.0+cu132`, log dir `C:\ProgramData\exomem\logs` — all correct.
- `tests/test_upgrade_guard.py`, `tests/test_deploy_provenance.py`,
  `tests/test_install_parity.py` pass. `tests/test_service_installers.py` has 8
  failures which reproduce identically on a pristine `origin/main` worktree —
  Windows-only, bash-dependent, pre-existing.

**Not verified end to end:** running `restart.ps1` against the live service
would restart it, which is the documented trigger for the write livelock
currently under investigation. The probes are verified read-only and the gate
logic by test; the stop/start sequencing is not exercised live here.

## Follow-up not taken

`upgrade.ps1:141` still compares installed-version against served-version. It now
inherits the pid assertion via `restart.ps1`, so it is no longer blind in
practice, but that specific comparison is still misleading about what it proves.
