### PR TITLE
fix(edit): refuse pages outside Knowledge Base/ honestly instead of a misleading NOT_FOUND (#599)

### DIFF
--- a/src/exomem/edit.py
+++ b/src/exomem/edit.py
@@ -387,10 +387,40 @@ def edit(
 # ---------------- path resolution ----------------
 
 
+def _existing_page_outside_kb(vault_root: Path, given: str) -> str | None:
+    """The vault-relative page the caller addressed, iff it exists on disk under
+    the vault root but outside ``Knowledge Base/`` — else ``None``.
+
+    Lets `_resolve` tell "you addressed a real page outside the governed root"
+    apart from "no such page". It leaks nothing the read side would not already
+    surface: it only confirms a vault-relative path `get_page` itself resolves,
+    and never a path that escapes the vault. Extension handling mirrors
+    `_resolve` so the two agree on what "the same page" means.
+    """
+    if given.startswith(kb_prefix()):
+        return None  # caller explicitly addressed KB/ — a genuine miss stays one
+    rel = given if given.endswith(".md") else given + ".md"
+    candidate = vault_root / rel
+    try:
+        resolved = candidate.resolve()
+        resolved.relative_to(vault_root.resolve())  # must stay inside the vault
+    except (ValueError, OSError):
+        return None
+    try:
+        resolved.relative_to(kb_root(vault_root).resolve())
+        return None  # already under the governed root — not this case
+    except ValueError:
+        pass
+    # `resolved` has followed symlinks and been confirmed under vault_root
+    # above, so stat the real target rather than the lexical candidate.
+    return rel if resolved.is_file() else None
+
+
 def _resolve(vault_root: Path, path: str) -> tuple[Path, str]:
     if not path or not path.strip():
         raise EditError(code="INVALID_PATH", missing=["path"], reason="path is empty")
-    rel = path.strip().replace("\\", "/").lstrip("/")
+    given = path.strip().replace("\\", "/").lstrip("/")
+    rel = given
     if not rel.startswith(kb_prefix()):
         rel = kb_prefix() + rel
     if not rel.endswith(".md"):
@@ -406,6 +436,26 @@ def _resolve(vault_root: Path, path: str) -> tuple[Path, str]:
             reason=f"path escapes {kb_prefix()}: {e}",
         ) from None
     if not candidate.exists():
+        # The read side (`get_page`) accepts a vault-relative path and will read
+        # a page living OUTSIDE the governed Knowledge Base/ root. Governed edits
+        # re-root every bare path under Knowledge Base/, so a caller re-using
+        # such a path here gets a re-rooted candidate that does not exist. A
+        # plain NOT_FOUND would then name a path the caller never gave and
+        # assert the page is missing when it demonstrably exists — a typo and an
+        # outside-the-root refusal become indistinguishable (issue #599). Detect
+        # that case and refuse honestly; the governance model is intentional, so
+        # we still don't write outside the root.
+        outside = _existing_page_outside_kb(vault_root, given)
+        if outside is not None:
+            raise EditError(
+                code="OUTSIDE_GOVERNED_ROOT",
+                missing=["path"],
+                reason=(
+                    f"page exists at {outside} but is outside {kb_prefix()}"
+                    f" — exomem only edits governed content under {kb_prefix()};"
+                    " move it under the governed root or address it there"
+                ),
+            )
         raise EditError(
             code="NOT_FOUND",
             missing=["path"],

--- a/tests/test_edit_outside_governed_root.py
+++ b/tests/test_edit_outside_governed_root.py
@@ -1,0 +1,82 @@
+"""`edit` refuses a page that exists outside Knowledge Base/ honestly.
+
+Regression for the read/write path-resolution asymmetry (issue #599):
+`read_memory` accepts a vault-relative path and reads a page that lives
+outside the governed `Knowledge Base/` root, but `edit`/`edit_memory`
+silently re-roots the same string under `Knowledge Base/` and then reports
+the *re-rooted* path as missing. The caller is handed a `NOT_FOUND` naming a
+path it never gave, asserting a file does not exist when the page it
+addressed does exist — indistinguishable from a typo.
+
+The governance model is intentional (governed writes only happen under
+`Knowledge Base/`), so the fix is not to write outside the root; it is to
+refuse *honestly* so a caller can tell "outside the governed root" from
+"no such page".
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+from exomem import edit as edit_module
+
+TODAY = dt.date(2026, 6, 1)
+
+
+def _make_page_outside_kb(vault: Path, rel: str, body: str) -> str:
+    """Write a real frontmatter page at a vault-relative path OUTSIDE KB/."""
+    p = vault / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        "---\ntype: decision\nstatus: active\n"
+        "created: 2026-05-29\nupdated: 2026-05-29\ntags: [x]\n---\n" + body,
+        encoding="utf-8",
+    )
+    return rel
+
+
+def test_edit_outside_kb_refuses_honestly_not_as_missing(vault: Path) -> None:
+    # A page the read side can address by its vault-relative path, living
+    # outside the governed Knowledge Base/ root.
+    rel = _make_page_outside_kb(
+        vault, "projects/side-by-side.md", "# Side by side\n\nbody line\n"
+    )
+
+    with pytest.raises(edit_module.EditError) as exc_info:
+        edit_module.edit(
+            vault,
+            path=rel,
+            why="preview",
+            old_string="body line",
+            new_string="changed",
+            validate_only=True,
+            today=TODAY,
+        )
+
+    err = exc_info.value
+    # The refusal is distinct from a genuine miss, and it names the path the
+    # caller actually gave rather than a silently re-rooted Knowledge Base/ one.
+    assert err.code == "OUTSIDE_GOVERNED_ROOT"
+    assert rel in err.reason
+    assert "Knowledge Base/" in err.reason
+    # It must NOT falsely claim the addressed page does not exist.
+    assert "does not exist" not in err.reason
+
+
+def test_edit_genuinely_missing_page_still_not_found(vault: Path) -> None:
+    # Nothing at this path anywhere — the honest answer stays NOT_FOUND so the
+    # new branch does not swallow real misses.
+    with pytest.raises(edit_module.EditError) as exc_info:
+        edit_module.edit(
+            vault,
+            path="Notes/does-not-exist-anywhere.md",
+            why="preview",
+            old_string="x",
+            new_string="y",
+            validate_only=True,
+            today=TODAY,
+        )
+    assert exc_info.value.code == "NOT_FOUND"


### PR DESCRIPTION
Fixes #599.

## Problem
`read_memory` accepts a vault-relative path and reads a page that lives **outside** the governed `Knowledge Base/` root. `edit`/`edit_memory` re-root every bare path under `Knowledge Base/`, so re-using such a path produced:

```
NOT_FOUND: file does not exist: Knowledge Base/projects/<page>.md
```

— naming a path the caller never gave and asserting the page is missing when it demonstrably exists. As the issue says, a caller can't tell "outside the governed root, refused by policy" from "typo, no such page".

## Fix
The governance model — governed writes only under `Knowledge Base/` — is intentional, so this does **not** make `edit` write outside the root. It makes the refusal honest.

`edit._resolve` now, when the re-rooted candidate is absent, checks whether the caller's *original* vault-relative path names a real file inside the vault but outside `Knowledge Base/`. If so it raises a distinct `EditError(code="OUTSIDE_GOVERNED_ROOT")` naming the path the caller actually gave; genuine misses still raise `NOT_FOUND`. A small helper `_existing_page_outside_kb` does the detection — it rejects any path escaping `vault_root` and only confirms a path the read side already resolves, so it adds no new existence signal. The new code maps to HTTP 400 via the existing `status = 404 if code == "NOT_FOUND" else 400`.

## Tests
Added `tests/test_edit_outside_governed_root.py` (reproduce-first):
- `test_edit_outside_kb_refuses_honestly_not_as_missing` — **fails on clean HEAD** (gets `NOT_FOUND`), passes with the fix.
- `test_edit_genuinely_missing_page_still_not_found` — guards against over-broadening.

Verification (core install + pytest, Python 3.11):
- `ruff check` clean on changed files.
- New test file: 2 passed.
- Regression (`test_edit_validate_only`, `test_multi_edit`, `test_edit_surgical_replace`, `test_memory_contract_resolution`, `test_case_insensitive_identity`): 74 passed, 1 env skip (case-insensitive fs).
- One pre-existing, unrelated failure — `test_doctor_write_path.py::test_new_checks_are_wired_into_the_ordered_report` — reproduces identically on clean HEAD in a core-only venv (the ordered doctor report only wires optional checks when their subsystems are installed); not touched here.

I don't have the optional ML extras (embeddings/media/diarization/vision) installed locally, so I exercised the edit/path/resolution suites rather than the whole suite. Happy to adjust the error `code`/wording to match your preference. DCO signed-off.
