### PR TITLE
fix(hosted): give a fresh cell ownership of the scaffold provisioning wrote for it

### DIFF
--- a/src/exomem/hosted_runtime.py
+++ b/src/exomem/hosted_runtime.py
@@ -2164,6 +2164,24 @@ def initialize_hosted_cell_v2(
                 _write_v2_marker(stage, "vault", binding)
                 init_module.init_vault(stage)
                 _sync_tree(stage)
+            # The chown above lands on the staging directory alone, and at that
+            # point the directory is empty. `init_vault` then writes the entire
+            # scaffold as whoever runs provisioning — root — so every
+            # scaffolded directory was left root-owned at mode 755 inside a
+            # root the runtime does own. The cell runs as `runtime_uid`, which
+            # makes the whole Knowledge Base readable and traversable but not
+            # writable: reads and `bootstrap` answered normally while every
+            # write failed, and the tenant reported itself healthy having never
+            # stored anything.
+            #
+            # This sits outside the `else` deliberately. A run that died between
+            # `init_vault` and the publish leaves a staging root that the branch
+            # above accepts as complete, and converging only on the branch that
+            # created it would publish that one unconverged. Convergence is
+            # idempotent — an already-owner-only tree reconverges to itself — so
+            # the retry costs a walk and nothing else.
+            if os.geteuid() == 0:
+                _converge_tree_ownership(_preflight_migration_tree(stage, limits), binding)
             if binding.vault_root.exists():
                 binding.vault_root.rmdir()
             os.replace(stage, binding.vault_root)

--- a/tests/test_hosted_binding_v2.py
+++ b/tests/test_hosted_binding_v2.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import socket
@@ -8,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from exomem import __version__, hosted_runtime
+from exomem import __version__, hosted_runtime, init
 from exomem.hosted_runtime import (
     HOSTED_PROTOCOL_VERSION,
     HostedBindingV2,
@@ -448,3 +449,98 @@ def test_descriptor_migration_rejects_replacement_race_without_following_symlink
 
     assert error.value.code == "HOSTED_ROOT_UNSAFE_ENTRY"
     assert outside.read_text(encoding="utf-8") == "must remain untouched"
+
+
+def test_fresh_provisioning_converges_the_scaffold_it_wrote_as_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fresh cell must own every page it was given, not just its vault root.
+
+    Provisioning chowns the staging directory while it is still empty, and
+    `init_vault` then writes the whole Knowledge Base as whoever runs
+    provisioning. In production that is root, so the scaffold landed root-owned
+    at mode 755 inside a root the runtime did own. The cell runs as
+    `runtime_uid`: 755 grants it read and traverse but not write, so reads and
+    `bootstrap` answered normally while every single write failed, and the
+    tenant reported itself healthy having never stored anything.
+
+    Ownership itself is not observable here, because the test's `runtime_uid`
+    is the test user and a chown to yourself is a no-op. Convergence is
+    observable through the modes it normalizes: directories to owner-only
+    `rwx` and files to owner-only `rw`. Any group or other bit left anywhere
+    under the vault means the tree was published exactly as `init_vault`
+    wrote it.
+    """
+    monkeypatch.setattr(hosted_runtime.os, "geteuid", lambda: 0)
+    binding = _binding(tmp_path)
+
+    result = initialize_hosted_cell_v2(
+        binding,
+        expected_release=__version__,
+        expected_protocol=HOSTED_PROTOCOL_VERSION,
+        active_credential_version="credential-v1",
+        bootstrap_security=_bootstrap,
+    )
+    assert result.status in {"provisioned", "existing", "migrated"}
+    validate_hosted_binding_v2(binding, require_scaffold=True)
+
+    knowledge_base = binding.vault_root / "Knowledge Base"
+    assert knowledge_base.is_dir(), "the scaffold must exist to be worth converging"
+
+    shared = {}
+    for path in [binding.vault_root, *binding.vault_root.rglob("*")]:
+        mode = stat.S_IMODE(path.lstat().st_mode)
+        if mode & 0o077:
+            shared[str(path.relative_to(binding.vault_root))] = oct(mode)
+    assert shared == {}, f"vault entries still readable or worse beyond the owner: {shared}"
+
+    # The three directories every hosted write actually targets. Each one was
+    # `drwxr-xr-x root root` on the live alpha tenant.
+    for relative in ("Sources", "Evidence", "Notes/Insights"):
+        target = knowledge_base / relative
+        assert target.is_dir(), f"{relative} missing from the scaffold"
+        assert stat.S_IMODE(target.lstat().st_mode) == 0o700, f"{relative} is not owner-only"
+
+
+def test_resumed_staging_is_converged_before_it_is_published(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A crash between `init_vault` and publish must not ship an unowned tree.
+
+    The staging branch that finds an existing directory accepts it as complete
+    on the strength of its marker and scaffold, and never wrote the scaffold
+    itself. If convergence lived only on the branch that creates the stage,
+    this retry would publish exactly the tree that broke the alpha tenant.
+    """
+    monkeypatch.setattr(hosted_runtime.os, "geteuid", lambda: 0)
+    binding = _binding(tmp_path)
+
+    # Build the staging root the way a first attempt does, then stop, standing
+    # in for a process that died before it could publish.
+    stage = binding.vault_root.parent / (
+        f".{binding.vault_root.name}.hosted-v2-stage-"
+        f"{hashlib.sha256(binding.cell_id.encode()).hexdigest()[:12]}"
+    )
+    stage.parent.mkdir(parents=True, exist_ok=True)
+    stage.mkdir(mode=0o700)
+    hosted_runtime._write_v2_marker(stage, "vault", binding)
+    init.init_vault(stage)
+    assert any(
+        stat.S_IMODE(path.lstat().st_mode) & 0o077 for path in stage.rglob("*")
+    ), "the staged scaffold should start group/other-readable, or this proves nothing"
+
+    initialize_hosted_cell_v2(
+        binding,
+        expected_release=__version__,
+        expected_protocol=HOSTED_PROTOCOL_VERSION,
+        active_credential_version="credential-v1",
+        bootstrap_security=_bootstrap,
+    )
+
+    validate_hosted_binding_v2(binding, require_scaffold=True)
+    leaked = {
+        str(path.relative_to(binding.vault_root)): oct(stat.S_IMODE(path.lstat().st_mode))
+        for path in binding.vault_root.rglob("*")
+        if stat.S_IMODE(path.lstat().st_mode) & 0o077
+    }
+    assert leaked == {}, f"resumed staging published unconverged entries: {leaked}"


### PR DESCRIPTION
## The failure

A hosted tenant could not save anything, and never could have.

Confirmed on the live alpha cell today. `Knowledge Base/` and every directory beneath it is `drwxr-xr-x root root`; the cell runs as uid 10001 (`exomem`). Mode 755 gives the runtime read and traverse but not write, so the tenant looks completely healthy from outside — `/api/exomem/status` returns `CELL_READY`, reads, `bootstrap` and `coordination_status` all answer normally — while every write fails.

Driven against the real gateway with a signed-in session:

| command | target | result |
|---|---|---|
| `capture_source` | creates `Sources/Other/` | `INTERNAL` |
| `preserve_evidence` | creates `Evidence/<scope>/…` | `INTERNAL` |
| `remember` (valid unit) | existing `Notes/Insights/` | `SEMANTIC_CREATION_FAILED` |

All three with `remediation: null`. The clincher is `graph_sync: {state: "unavailable", generation: 0}` — a fresh local vault reports exactly that, and one successful write moves it to `{current, 1}`. Generation 0 is proof that nothing has ever been stored in this tenant.

`touch` inside the pod as the runtime user:

```
touch: cannot touch '/var/lib/exomem/vault/Knowledge Base/Sources/.probe': Permission denied
touch: cannot touch '/var/lib/exomem/vault/Knowledge Base/Notes/Insights/.probe': Permission denied
```

The vault root itself is fine (`drwx------ 10001 10001`) and the volume has 9.8G free, so this is neither quota nor the mount.

## The cause

`initialize_hosted_cell_v2` chowns the staging directory while it is still empty, then calls `init_vault(stage)`, which writes the entire scaffold as whoever runs provisioning — root. The chown is never repeated, so the tree is published exactly as root wrote it. The file timestamps say the same thing: `index.md` is dated from the image build, the directories from provisioning.

`_converge_tree_ownership` already existed for exactly this job, with the TOCTOU-guarded descriptor walk, and was only ever wired into the version-one migration path.

## The change

One call, placed **outside** the `else` on purpose. A run that dies between `init_vault` and the publish leaves a staging root that the resume branch accepts as complete on the strength of its marker and scaffold; converging only on the branch that creates the stage would publish that one unconverged. Convergence is idempotent — an already-owner-only tree reconverges to itself — so the retry costs a walk and nothing else.

## Tests

Ownership is not observable in-test: `runtime_uid` is the test user, and a chown to yourself is a no-op. So the tests assert the modes convergence normalizes — directories to owner-only `rwx`, files to owner-only `rw` — and fail if any group or other bit survives anywhere under the vault. That is a real tenant-privacy property in its own right.

- `test_fresh_provisioning_converges_the_scaffold_it_wrote_as_root` — also asserts Sources, Evidence and `Notes/Insights` are `0o700`, the three directories every hosted write targets and the exact ones that refused in production.
- `test_resumed_staging_is_converged_before_it_is_published` — covers the crash-and-retry path, and first asserts the staged scaffold *starts* group-readable so the test proves something.

Both fail without the change, reporting the `0o755` tree from production.

## Verification

- `pytest -k "hosted or provision or binding"` — **879 passed, 73 skipped, 0 failed**
- `ruff check` clean on both files

## Note

This fixes new tenants. The existing alpha tenant still needs its tree converged in place; that is a one-off `chown` on the volume and is not part of this change.