### PR TITLE
docs(prominence): warn that trimming the capture list silently drops capability

### DIFF
--- a/docs/prominence.md
+++ b/docs/prominence.md
@@ -58,7 +58,23 @@ Each block is self-contained. Paste it into:
 - **ChatGPT** — Settings → Personalization → Custom instructions → *"Anything else
   ChatGPT should know?"* (each field caps around 1500 characters; these fit)
 
-Replace the connector name if you named yours something other than Exomem.
+Replace the connector name if you named yours something other than Exomem. Otherwise
+paste the block as it stands rather than writing your own shorter version of it.
+
+**Each item in the capture list is a separate switch, not an example of a general
+idea.** An assistant treats that list as the definition of what is worth saving, so
+dropping an item deletes that whole class of capture — silently. Nothing errors, no
+warning appears, and the symptom is only that some kind of thing never gets written,
+which is close to impossible to notice from inside a conversation. A shortened list
+has already cost a real user months of uncaptured hands-on results: it kept the four
+knowledge-work items and dropped the rest, so every method actually carried out fell
+through. If a level is nearly right, append a tuning line from the section below
+instead of trimming the block — that keeps the classes intact and changes only the
+threshold.
+
+Watch the recall and capture lines separately, too. A clause such as "stay quiet on
+chit-chat" belongs to recall; moved or generalised to capture, it suppresses exactly
+the casual-looking conversations where a real result tends to arrive.
 
 ### Maximal — recommended for web and hosted
 


### PR DESCRIPTION
Follow-up to #607, from the same dogfooding incident.

## Why

#607 fixed the shipped capture predicate. It could not fix the copy that users actually run, because a web client's operative text is whatever they typed into their own custom instructions — and people paraphrase.

The list reads as illustrative, so it gets trimmed to taste. It is not illustrative. An assistant treats the enumeration as the definition of what is worth saving, so removing an item removes that class of capture. There is no error, no warning, and no symptom except that some kind of thing never gets written — which is close to undetectable from inside a conversation.

This is not hypothetical. A real hand-written variant kept the four knowledge-work items (decision, solved problem, diagnosed failure, recognized pattern), dropped the recurring-entity item, and never had the executed-method item. Every hands-on result fell through for months, surfacing only when the user noticed a cook had not been saved and asked.

The same variant carried `stay quiet on chit-chat` generalised across the whole block rather than scoped to recall, which independently suppressed exactly the casual-looking conversations where hands-on results arrive. Two suppressors, same direction.

## What changes

`docs/prominence.md`, copy-paste section only:

- paste as it stands rather than writing a shorter version
- each capture item is a separate switch, and dropping one deletes that class silently
- the concrete cost, so the warning carries weight
- append a tuning line instead of trimming, with a pointer to the existing tuning section
- watch the recall and capture lines separately, because a chit-chat clause is safe on one and destructive on the other

## Verification

`pytest tests/test_epistemic_bootstrap_contract.py tests/test_prominence.py tests/test_scaffold_no_leak.py` — 78 passed. Prose sits outside the fenced blocks, so block extraction and the character caps are untouched. No code, no spec delta.