### PR TITLE
fix(bootstrap): keep one compact byte budget, in the file that explains it

### DIFF
--- a/tests/test_bootstrap_compact_budget.py
+++ b/tests/test_bootstrap_compact_budget.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import pathlib
 import tempfile
+import warnings
 
 import pytest
 
@@ -65,12 +66,34 @@ def _size(payload: dict) -> int:
     return len(json.dumps(payload))
 
 
+#: Headroom below which the ceiling stops being a budget and becomes a cliff.
+#: Warn rather than fail: the remaining bytes are still legitimately spendable,
+#: and turning "nearly full" into a failure would just be the ceiling moved down
+#: without the argument the ceiling's own docstring demands.
+HEADROOM_WARNING_BYTES = 512
+
+
 def test_compact_stays_under_its_byte_ceiling(payloads):
     size = _size(payloads["compact"])
     assert size <= COMPACT_BYTE_CEILING, (
         f"compact bootstrap is {size:,} bytes (~{size // 4:,} tokens), over the "
-        f"{COMPACT_BYTE_CEILING:,} ceiling"
+        f"{COMPACT_BYTE_CEILING:,} ceiling by {size - COMPACT_BYTE_CEILING:,}"
     )
+    headroom = COMPACT_BYTE_CEILING - size
+    if headroom < HEADROOM_WARNING_BYTES:
+        # The failure mode this catches is not the ceiling being wrong, it is
+        # the ceiling being reached *silently*. Compact grew to 70 bytes of
+        # headroom and nobody knew until an unrelated release PR went red two
+        # merges later, which is a bad place to first read the argument for why
+        # the number is what it is.
+        warnings.warn(
+            f"compact bootstrap is {size:,} bytes with only {headroom:,} bytes "
+            f"under the {COMPACT_BYTE_CEILING:,} ceiling. The next addition of "
+            "any size will trip it. Either trim compact, or raise the ceiling "
+            "with the reasoning the constant's docstring requires -- but decide "
+            "it deliberately rather than discovering it as a red CI run.",
+            stacklevel=2,
+        )
 
 
 def test_compact_is_materially_smaller_than_full(payloads):

--- a/tests/test_record_public_surface.py
+++ b/tests/test_record_public_surface.py
@@ -96,7 +96,17 @@ def test_compact_bootstrap_puts_record_route_before_semantic_authoring() -> None
     assert payload["front_door_actions"]["record"]["primary_tools"] == ["record_memory"]
     assert serialized.find(b'"record"') < 8192
     assert serialized.find(b'"record"') < serialized.find(b'"semantic_authoring"')
-    assert len(serialized) <= 57_344
+    # The compact payload's SIZE budget is not asserted here. It lives in
+    # `tests/test_bootstrap_compact_budget.py::COMPACT_BYTE_CEILING`, which owns
+    # the constraint and records why the number is what it is. This test's
+    # subject is placement -- that `record` is reachable early and ahead of
+    # `semantic_authoring` -- and the `< 8192` offsets above are what pin that.
+    #
+    # A duplicate ceiling used to sit on this line, undocumented and 656 bytes
+    # lower than the real one. The lower number silently became the gate, so
+    # growth that the owning test had deliberately pre-authorised failed here
+    # instead, in a test that says nothing about budgets and offers no rationale
+    # to weigh the failure against. One budget, in the file that explains it.
 
 
 def test_hosted_records_v2_is_additive_and_v1_remains_unchanged() -> None:


### PR DESCRIPTION
## The failure

`tests/test_record_public_surface.py::test_compact_bootstrap_puts_record_route_before_semantic_authoring` is red on the 0.55.0 release PR (#610) and on main:

```
assert 57928 <= 57344
```

It is not a release-bump problem, and it is not #608's fault either.

## Two ceilings, and the wrong one was the gate

| where | value | documented |
|---|---|---|
| `test_bootstrap_compact_budget.py::COMPACT_BYTE_CEILING` | 58,000 | 20 lines of recorded reasoning |
| `test_record_public_surface.py:99` | 57,344 | bare literal, no comment |

The first owns the constraint. Its docstring records what the number was raised from, which bytes earned the raise, which 263-byte trim was possible and declined on the merits, and that a further raise must argue for itself from scratch.

The second was added incidentally by #452 on the last line of a test about **placement**. 57,344 is 56 KiB — not the 56,000 the real ceiling was raised from, just a coincidental neighbour.

Being 656 bytes lower, the undocumented copy was the effective gate. #608 then spent 586 bytes of growth that the owning test had **deliberately pre-authorised** ("pre-authorised 1,925 bytes more"), and CI went red — not on #608, but two merges later on the release PR, in a test that offers no rationale to weigh the failure against. The payload never breached the budget anyone had actually reasoned about: 57,930 ≤ 58,000.

## The fix

Drop the duplicate. The placement assertions that are that test's real subject — including the `< 8192` offsets that pin `record` early and ahead of `semantic_authoring` — are untouched.

## The thing worth knowing

Compact is now at **57,930 of 58,000 — 70 bytes of headroom**. The next addition of any size trips the real ceiling.

So `test_compact_stays_under_its_byte_ceiling` now warns when headroom drops below 512 bytes:

```
UserWarning: compact bootstrap is 57,930 bytes with only 70 bytes under the
58,000 ceiling. The next addition of any size will trip it. Either trim compact,
or raise the ceiling with the reasoning the constant's docstring requires --
but decide it deliberately rather than discovering it as a red CI run.
```

It warns rather than fails: the remaining bytes are still legitimately spendable, and failing on "nearly full" would just move the ceiling down without the argument the constant's docstring demands. **The defect was never the ceiling being wrong — it was the ceiling being reached silently.**

Deciding whether to trim compact or raise to a new documented ceiling is a real call and is deliberately left out of this PR, which only unblocks the release.

## Verification

- `tests/test_bootstrap_compact_budget.py` + `tests/test_record_public_surface.py`: **16 passed, 1 warning** (the headroom warning, as intended).
- Root cause reproduced from CI's job log; the failing assertion and the two ceilings confirmed by reading both tests.
- `ruff check . --select F` clean. The 7 pre-existing errors in `test_record_public_surface.py` under the fuller ruleset are identical at `origin/main` and that file is not in CI's targeted lint list.