### PR TITLE
fix(doctor): name the command that actually reclaims rebuild temporaries

### DIFF
--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -66,11 +66,19 @@ HA_AUTH_ENV_KEYS = (
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
-#: How a user actually rebuilds vectors from a shell. `reconcile` and `audit_fix`
+#: How a user actually reconciles from a shell. `reconcile` and `audit_fix`
 #: are internal registry names, not CLI surface — the CLI dispatches on the
 #: PRODUCT_PUBLIC_NAMES, where this operation is `maintain_memory --mode
 #: reconcile` (or the `maintain` alias). Remediation strings named the internal
 #: ops, so every one of them fell through to the server argument parser.
+#:
+#: The `--reconcile` is not decoration, and the name here understates the reach:
+#: this is also how the derived graph is recovered and how orphaned rebuild
+#: temporaries are reclaimed. Bare `exomem maintain` is the read-only audit. It
+#: parses, runs, and exits 0 without repairing anything, which is the worse of
+#: the two failure modes — an operator who follows it sees success and concludes
+#: the diagnosis was wrong. Every remediation that asks for repair routes
+#: through this constant so no site can drift back to the audit.
 _REBUILD_VECTORS_CMD = "exomem maintain --reconcile"
 
 #: Absolute deferred-queue FAIL threshold (total semantic_upserts + full_upserts
@@ -837,8 +845,15 @@ def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
     (every matching name, regardless of age) and `stale_count`/`stale_bytes`
     (age-gated, the population thresholds actually act on), plus
     `stale_age_seconds`. Reclaiming a stale file requires the service stopped
-    and no rebuild in flight, so remediation names `exomem maintain` run
+    and no rebuild in flight, so remediation names `_REBUILD_VECTORS_CMD` run
     out-of-process (it reads the vault from EXOMEM_VAULT_PATH, not `--vault`).
+    That command must be the reconciling one: the sweeper that actually unlinks
+    these files (`graph_sync.sweep_abandoned_temporaries`) has exactly one
+    caller, inside `reconcile.reconcile()` and gated on `not dry_run`. Plain
+    `exomem maintain` runs the read-only audit, so naming it told an operator
+    to run something that exits 0 having reclaimed nothing -- a worse failure
+    than naming no command at all, because success is indistinguishable from
+    the remedy not applying.
     """
     from . import vault as vault_module
 
@@ -931,10 +946,10 @@ def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
             details=details,
         )
     remediation = (
-        "Stop the exomem service, then run `exomem maintain` out-of-process "
-        "(it reads the vault from EXOMEM_VAULT_PATH, not --vault) to reclaim "
-        "orphaned rebuild temporaries — reclaim is only safe once no rebuild is "
-        "in flight."
+        f"Stop the exomem service, then run `{_REBUILD_VECTORS_CMD}` "
+        "out-of-process (it reads the vault from EXOMEM_VAULT_PATH, not "
+        "--vault) to reclaim orphaned rebuild temporaries — reclaim is only "
+        "safe once no rebuild is in flight."
     )
     summary = (
         f"graph={graph_stats['stale_count']}/{graph_stats['count']}, "

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 import pytest
 
 from exomem import doctor as doctor_module
+from exomem import vault
 from exomem.__main__ import main
 
 
@@ -879,6 +880,67 @@ def test_rebuild_remediations_name_a_command_the_cli_actually_dispatches() -> No
     source = Path(doctor_module.__file__).read_text(encoding="utf-8")
     assert "kb reconcile" not in source
     assert "kb audit_fix" not in source
+
+
+def test_orphan_remediation_names_the_command_that_actually_reclaims(
+    tmp_path: Path,
+) -> None:
+    """The orphan fix pointed at the audit, which cannot unlink anything.
+
+    `graph_sync.sweep_abandoned_temporaries` is the only thing that removes
+    these files, and it has exactly one caller: inside `reconcile.reconcile()`,
+    gated on `not dry_run`. Bare `exomem maintain` is the read-only audit, so an
+    operator who followed the old text watched it exit 0, saw nothing reclaimed,
+    and had no reason to suspect the command rather than the diagnosis. A remedy
+    that reports success while doing nothing is worse than naming no remedy.
+
+    Asserted through the check itself rather than by reading the source: what
+    matters is the string an operator is handed, not how it gets assembled.
+    """
+    kb = tmp_path / doctor_module.kb_dirname()
+    kb.mkdir(parents=True)
+    stale = time.time() - (vault.REBUILD_TEMP_STALE_AGE_SECONDS + 600)
+    # FAIL takes either count or bytes. The live incident tripped it on bytes
+    # (one 131 MB file); tripping it on count here buys the same tier without
+    # writing 50 MB to disk in a unit test.
+    for index in range(doctor_module._REBUILD_TEMP_ORPHAN_FAIL_COUNT + 1):
+        orphan = kb / f".lexical.sqlite.rebuild-{index:032x}.tmp"
+        orphan.write_bytes(b"x" * 4096)
+        os.utime(orphan, (stale, stale))
+
+    check = doctor_module._check_rebuild_temp_orphans(tmp_path)
+
+    assert check.status == "fail", check.message
+    assert check.remediation is not None
+    assert doctor_module._REBUILD_VECTORS_CMD in check.remediation
+    assert "--reconcile" in check.remediation
+    # Order matters as much as the verb: reclaiming under a live rebuild would
+    # delete a temporary that is still being written.
+    assert "Stop the exomem service" in check.remediation
+
+
+def test_a_fresh_rebuild_temporary_is_not_reported_as_an_orphan(
+    tmp_path: Path,
+) -> None:
+    """Otherwise the remediation would create the orphan it claims to clean up.
+
+    A live rebuild's temporary is identical by name to an abandoned one and can
+    legitimately be large, so only mtime separates them. If a fresh one tripped
+    the check, an operator following the remediation would stop the service
+    mid-rebuild and delete a file that was still being written.
+    """
+    kb = tmp_path / doctor_module.kb_dirname()
+    kb.mkdir(parents=True)
+    (kb / ".lexical.sqlite.rebuild-29cf190343754d70ac4bdf2e40358384.tmp").write_bytes(
+        b"x" * 4096
+    )
+
+    check = doctor_module._check_rebuild_temp_orphans(tmp_path)
+
+    assert check.status == "pass", check.message
+    assert check.details is not None
+    assert check.details["count"] == 1
+    assert check.details["stale_count"] == 0
 
 
 def test_warm_exits_zero_when_only_the_withheld_torch_models_are_unavailable(


### PR DESCRIPTION
## The defect

The `rebuild_temp.orphans` remediation read:

> Stop the exomem service, then run `exomem maintain` out-of-process … to reclaim orphaned rebuild temporaries

`exomem maintain` is the read-only audit. It parses, runs, and exits 0 without unlinking anything.

`graph_sync.sweep_abandoned_temporaries` is the only thing that removes these files, and it has exactly one caller — inside `reconcile.reconcile()`, gated on `not dry_run`. Reaching it requires `exomem maintain --reconcile`.

## Why this is the worse failure mode

`_REBUILD_VECTORS_CMD`'s own comment already documents this bug class: remediations that named internal registry ops (`kb reconcile`, `kb audit_fix`) fell through to the server argument parser. Those at least fail loudly.

This one named a *real* command that **succeeds while doing nothing**. An operator who follows it sees exit 0, sees the orphan still there, and has no reason to suspect the command rather than the diagnosis.

Hit live during the 0.55.0 deploy: a 131 MB lexical rebuild temporary failed the doctor gate, and the prescribed remedy left it exactly where it was. `exomem maintain --reconcile` cleared it.

## Changes

- Route the remediation through `_REBUILD_VECTORS_CMD` so the site cannot drift back to the audit.
- Widen that constant's comment — its name understates its reach; the same command also recovers the derived graph and now reclaims these temporaries.
- Two tests, asserted through the check rather than by scanning source, because what matters is the string an operator is handed:
  - the orphan remediation names the reconciling command;
  - a *fresh* rebuild temporary is not reported as an orphan — a live rebuild's temp is identical by name to an abandoned one, so if a fresh one tripped the check, following the remediation would stop the service mid-rebuild and delete a file still being written.

## Verification

- `tests/test_doctor.py` — 65 passed, 1 skipped (`sentence_transformers` not installed in the lean lane).
- New tests fail against the old string, pass against the new.
- Confirmed against the live vault: `exomem maintain` left the 131 MB orphan; `exomem maintain --reconcile` reclaimed it.

Note: `ruff` reports a pre-existing `I001` at `doctor.py:1413` (unsorted function-scope imports). It is present on `origin/main`, untouched by this diff, and `doctor.py` is not in CI's full-ruff file list — left alone rather than widening this PR.