### PR TITLE
fix(windows): accept the DACL Windows writes, and make a rejected one say what it saw

### DIFF
--- a/src/exomem/mutation_lock.py
+++ b/src/exomem/mutation_lock.py
@@ -550,9 +550,28 @@ def _windows_sddl_owner(sddl: str) -> str | None:
     return match.group(1) if match else None
 
 
+#: SDDL renders the local domain's built-in Administrator -- the RID 500 account
+#: -- as `LA`, never as its SID. The alias is machine-relative, so unlike `SY`
+#: and `BA` it cannot live in `_WINDOWS_SID_ALIASES`; it has to be derived from
+#: the current SID. A host whose current user *is* that account therefore reads
+#: its own grants back under a spelling the raw-SID comparison cannot match.
+_WINDOWS_LOCAL_ADMIN_PREFIX = "S-1-5-21-"
+_WINDOWS_LOCAL_ADMIN_SUFFIX = "-500"
+
+
+def _windows_is_local_admin_sid(sid: str) -> bool:
+    """True when *sid* is an account domain's built-in Administrator (RID 500)."""
+    return sid.startswith(_WINDOWS_LOCAL_ADMIN_PREFIX) and sid.endswith(
+        _WINDOWS_LOCAL_ADMIN_SUFFIX
+    )
+
+
 def _windows_principal_spellings(sid: str) -> frozenset[str]:
     """Every casefolded spelling that denotes *sid* in an SDDL string."""
-    return frozenset({sid.casefold(), _WINDOWS_SID_ALIASES.get(sid, sid).casefold()})
+    spellings = {sid.casefold(), _WINDOWS_SID_ALIASES.get(sid, sid).casefold()}
+    if _windows_is_local_admin_sid(sid):
+        spellings.add("la")
+    return frozenset(spellings)
 
 
 def _windows_private_dacl_trustees(sid: str) -> tuple[str, ...]:
@@ -791,6 +810,15 @@ def _windows_private_dacl_is_valid(sddl: str, sid: str, *, directory: bool) -> b
             # cannot show that this ACE admits us rather than somebody else.
             if not owner_is_current_user:
                 return False
+            principal = user_principal
+        elif principal in _windows_principal_spellings(sid):
+            # An alias for the current user, most often `LA`. Unlike `OW` this
+            # needs no owner check: `LA` names one fixed account, and it is only
+            # a spelling of *us* when that account is the current user -- which
+            # is what put it in the spelling set. Folding it onto the canonical
+            # principal keeps the duplicate rule below meaningful, so `LA`
+            # alongside a literal grant to the same account is still one
+            # principal named twice.
             principal = user_principal
         # Resolving `OW` before this check keeps the duplicate rule meaningful:
         # `OW` alongside a literal grant to the same owner is one principal

--- a/src/exomem/mutation_lock.py
+++ b/src/exomem/mutation_lock.py
@@ -567,13 +567,36 @@ def _windows_private_dacl_trustees(sid: str) -> tuple[str, ...]:
 
 
 class WindowsRuntimeDaclError(RuntimeError):
-    """Actionable fail-closed result for one unsafe idempotency runtime entry."""
+    """Actionable fail-closed result for one unsafe idempotency runtime entry.
 
-    def __init__(self, path: Path, remediation: str):
+    Carries the descriptor it rejected. Without that the failure is only
+    diagnosable on a machine you can log into: the message named a path and a
+    repair command but never what it actually observed, so a report from another
+    host -- a CI runner, a user -- could not be acted on, and the shape had to be
+    guessed at from whatever a local machine happened to produce. Guessing wrong
+    is cheap to do and expensive to discover.
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        remediation: str,
+        *,
+        observed: str | None = None,
+        expected: tuple[str, ...] = (),
+    ):
         self.path = path
         self.remediation = remediation
+        self.observed = observed
+        self.expected = expected
+        detail = ""
+        if observed is not None:
+            detail = f"; observed {observed!r}"
+        if expected:
+            detail += f"; expected full-access trustees {', '.join(expected)}"
         super().__init__(
-            f"unsafe Windows DACL at {path}; run in elevated PowerShell: {remediation}"
+            f"unsafe Windows DACL at {path}{detail}; "
+            f"run in elevated PowerShell: {remediation}"
         )
 
 
@@ -795,6 +818,8 @@ def _validate_windows_runtime_entry(
             raise WindowsRuntimeDaclError(
                 path,
                 _windows_private_dacl_repair_command(path, sid, directory=directory),
+                observed=sddl,
+                expected=_windows_private_dacl_trustees(sid),
             )
     finally:
         if opened_here:

--- a/src/exomem/mutation_lock.py
+++ b/src/exomem/mutation_lock.py
@@ -523,12 +523,43 @@ def _windows_current_user_sid() -> str:
         kernel32.CloseHandle(token)
 
 
+#: SDDL two-letter aliases Windows substitutes for well-known SIDs. The choice
+#: is the renderer's, not ours: the same principal reaches us as a raw SID from
+#: one source and as its alias from another, so any comparison has to admit both
+#: spellings or it silently rejects the principal it was written to accept.
+_WINDOWS_SID_ALIASES = {"S-1-5-18": "SY", "S-1-5-32-544": "BA"}
+
+#: OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION. The owner is not
+#: decoration here. An `OWNER RIGHTS` ACE grants to whoever currently owns the
+#: object, so a DACL read on its own cannot say who the DACL admits.
+_WINDOWS_OWNER_AND_DACL_INFORMATION = 0x00000001 | 0x00000004
+
+#: `OWNER RIGHTS` (S-1-3-4), which SDDL renders as `OW`. An ACE naming it grants
+#: to the object's current owner rather than to any fixed principal.
+_WINDOWS_OWNER_RIGHTS_TRUSTEES = frozenset({"ow", "s-1-3-4"})
+
+
+def _windows_sddl_owner(sddl: str) -> str | None:
+    """Return the owner principal an SDDL string declares, if it carries one.
+
+    Owner may be rendered as a raw SID or as a two-letter alias, and it runs up
+    against the following `G:`/`D:`/`S:` with no separator, so the SID branch
+    has to stop on its own rather than on a delimiter.
+    """
+    match = re.match(r"O:(S-1-[0-9]+(?:-[0-9]+)*|[A-Za-z]{2})", sddl)
+    return match.group(1) if match else None
+
+
+def _windows_principal_spellings(sid: str) -> frozenset[str]:
+    """Every casefolded spelling that denotes *sid* in an SDDL string."""
+    return frozenset({sid.casefold(), _WINDOWS_SID_ALIASES.get(sid, sid).casefold()})
+
+
 def _windows_private_dacl_trustees(sid: str) -> tuple[str, ...]:
     """Return the distinct SDDL trustees permitted for private runtime state."""
     if not re.fullmatch(r"S-1-[0-9-]+", sid):
         raise ValueError("invalid current Windows SID")
-    aliases = {"S-1-5-18": "SY", "S-1-5-32-544": "BA"}
-    principals = (aliases.get(sid, sid), "SY", "BA")
+    principals = (_WINDOWS_SID_ALIASES.get(sid, sid), "SY", "BA")
     unique: dict[str, str] = {}
     for principal in principals:
         unique.setdefault(principal.casefold(), principal)
@@ -620,9 +651,9 @@ def _windows_dacl_sddl(path: Path) -> str:
         wintypes.LPVOID, wintypes.LPVOID, ctypes.POINTER(wintypes.LPVOID),
     ]
     get_security.restype = wintypes.DWORD
-    dacl_information = 0x00000004
     result = get_security(
-        str(path), 1, dacl_information, None, None, None, None, ctypes.byref(security_descriptor)
+        str(path), 1, _WINDOWS_OWNER_AND_DACL_INFORMATION, None, None, None, None,
+        ctypes.byref(security_descriptor),
     )
     if result:
         raise OSError(result, "cannot inspect Windows runtime DACL")
@@ -634,7 +665,10 @@ def _windows_dacl_sddl(path: Path) -> str:
         ]
         convert.restype = wintypes.BOOL
         size = wintypes.DWORD()
-        if not convert(security_descriptor, 1, dacl_information, ctypes.byref(text), ctypes.byref(size)):
+        if not convert(
+            security_descriptor, 1, _WINDOWS_OWNER_AND_DACL_INFORMATION,
+            ctypes.byref(text), ctypes.byref(size),
+        ):
             raise OSError(_windows_last_error(ctypes), "cannot render Windows runtime DACL")
         try:
             return str(text.value)
@@ -659,8 +693,10 @@ def _windows_dacl_sddl_for_handle(handle: int) -> str:
         wintypes.LPVOID, wintypes.LPVOID, ctypes.POINTER(wintypes.LPVOID),
     ]
     get_security.restype = wintypes.DWORD
-    dacl_information = 0x00000004
-    result = get_security(handle, 1, dacl_information, None, None, None, None, ctypes.byref(security_descriptor))
+    result = get_security(
+        handle, 1, _WINDOWS_OWNER_AND_DACL_INFORMATION, None, None, None, None,
+        ctypes.byref(security_descriptor),
+    )
     if result:
         raise OSError(result, "cannot inspect Windows runtime DACL")
     try:
@@ -671,7 +707,10 @@ def _windows_dacl_sddl_for_handle(handle: int) -> str:
         ]
         convert.restype = wintypes.BOOL
         size = wintypes.DWORD()
-        if not convert(security_descriptor, 1, dacl_information, ctypes.byref(text), ctypes.byref(size)):
+        if not convert(
+            security_descriptor, 1, _WINDOWS_OWNER_AND_DACL_INFORMATION,
+            ctypes.byref(text), ctypes.byref(size),
+        ):
             raise OSError(_windows_last_error(ctypes), "cannot render Windows runtime DACL")
         try:
             return str(text.value)
@@ -682,14 +721,39 @@ def _windows_dacl_sddl_for_handle(handle: int) -> str:
 
 
 def _windows_private_dacl_is_valid(sddl: str, sid: str, *, directory: bool) -> bool:
-    """Reject broad or altered ACEs; inherited file ACEs are accepted precisely."""
+    """Reject broad or altered ACEs; inherited file ACEs are accepted precisely.
+
+    An `OWNER RIGHTS` (`OW`) ACE counts as the current user's grant, but only
+    while the current user owns the object. That is a spelling difference, not a
+    weaker rule: `OW` names whoever owns the entry, so once ownership is ours the
+    ACE admits exactly the principal a literal SID ACE would, and once it is not,
+    this rejects it as before.
+
+    Refusing `OW` outright was a false negative with real cost. A directory
+    carrying `D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;OW)` is protected
+    against inheritance and grants full access to precisely SYSTEM,
+    Administrators and its owner -- the same three principals this module writes
+    itself, with no broad trustee anywhere. Windows hands out that exact shape
+    for entries beneath a user's temporary directory, so the validator failed
+    closed on directories that were already private, with no repair path: the
+    private DACL is applied only to an entry this process's own ``mkdir``
+    created, and a pre-existing entry is validated and never repaired.
+    """
     if not isinstance(sddl, str) or "D:" not in sddl:
         return False
     dacl = sddl.split("D:", 1)[1]
     if directory and not dacl.startswith("P"):
         return False
     aces = re.findall(r"\(([^()]*)\)", dacl)
-    expected = {trustee.casefold() for trustee in _windows_private_dacl_trustees(sid)}
+    trustees = _windows_private_dacl_trustees(sid)
+    expected = {trustee.casefold() for trustee in trustees}
+    # The principal an `OW` ACE resolves to, spelled the way this module spells
+    # it, so a substituted grant lands in the same slot as a literal one.
+    user_principal = trustees[0].casefold()
+    owner = _windows_sddl_owner(sddl)
+    owner_is_current_user = (
+        owner is not None and owner.casefold() in _windows_principal_spellings(sid)
+    )
     observed: set[str] = set()
     for ace in aces:
         fields = ace.split(";")
@@ -698,13 +762,23 @@ def _windows_private_dacl_is_valid(sddl: str, sid: str, *, directory: bool) -> b
         kind, flags, rights, _object_guid, _inherit_object_guid, trustee = fields
         if kind != "A" or rights.casefold() not in {"fa", "0x1f01ff"}:
             return False
-        if trustee.casefold() not in expected or trustee.casefold() in observed:
+        principal = trustee.casefold()
+        if principal in _WINDOWS_OWNER_RIGHTS_TRUSTEES:
+            # Unresolvable without the owner: an SDDL string carrying no `O:`
+            # cannot show that this ACE admits us rather than somebody else.
+            if not owner_is_current_user:
+                return False
+            principal = user_principal
+        # Resolving `OW` before this check keeps the duplicate rule meaningful:
+        # `OW` alongside a literal grant to the same owner is one principal
+        # named twice, which is exactly what the rule is here to reject.
+        if principal not in expected or principal in observed:
             return False
         normalized_flags = flags.casefold()
         allowed = {"", "oici", "idoici", "id"} if not directory else {"oici"}
         if normalized_flags not in allowed:
             return False
-        observed.add(trustee.casefold())
+        observed.add(principal)
     return observed == expected
 
 
@@ -774,7 +848,9 @@ def _prepare_windows_private_directory(path: Path) -> None:
     ``~/.cache`` does not exist -- which is every fresh Windows profile, since
     ``.cache`` is an XDG convention Windows does not create -- cannot construct
     the idempotency store at all, and the server dies at startup with
-    ``WinError 3``.  No CI lane runs on Windows, so nothing else would catch it.
+    ``WinError 3``.  There is a Windows lane now (``cross-platform.yml``), but it
+    is advisory and does not gate a merge, so this still has to be reasoned about
+    rather than left to the suite.
     """
     target = Path(path).expanduser().absolute()
     created = False

--- a/tests/test_mutation_lock.py
+++ b/tests/test_mutation_lock.py
@@ -278,6 +278,54 @@ _OWNER_RIGHTS_DACL = "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;OW)"
 _USER_SID = "S-1-5-21-1-2-3-1001"
 
 
+#: The descriptor a GitHub Windows runner reads back for
+#: `C:\Users\runneradmin\.cache\exomem`, with the runner's real SID replaced by a
+#: synthetic one. `runneradmin` is its account domain's built-in Administrator
+#: (RID 500), and SDDL renders that account as `LA` -- never as its SID. The
+#: grants are exactly the three this module writes; only the spelling differs.
+_LOCAL_ADMIN_DACL = "O:BAD:P(A;OICI;FA;;;LA)(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"
+#: RID 500 with the same deliberately tiny sub-authorities as `_USER_SID`.
+_LOCAL_ADMIN_SID = "S-1-5-21-1-2-3-500"
+
+
+def test_local_admin_alias_counts_as_the_users_grant_when_the_user_is_rid_500() -> None:
+    """The validator must not reject a DACL it wrote itself.
+
+    This exact descriptor cost 1725 failures -- 72% of the whole Windows lane --
+    because every runner user is RID 500, so every private directory this module
+    created read back with its own grant spelled `LA` and failed closed with no
+    repair path. The instrumentation added earlier in this PR is what produced
+    the string; it was never guessable from a developer box, where the current
+    user is not the built-in Administrator and the SID is written literally.
+    """
+    assert mutation_lock_module._windows_private_dacl_is_valid(
+        _LOCAL_ADMIN_DACL, _LOCAL_ADMIN_SID, directory=True
+    )
+
+
+def test_local_admin_alias_is_rejected_for_any_other_account() -> None:
+    """`LA` is a spelling of *us* only when we are the account it names.
+
+    Accepting it for an ordinary user would admit full access for a different
+    principal entirely -- the built-in Administrator -- which is the class of
+    hole this validator exists to catch.
+    """
+    assert not mutation_lock_module._windows_private_dacl_is_valid(
+        _LOCAL_ADMIN_DACL, _USER_SID, directory=True
+    )
+
+
+def test_local_admin_alias_alongside_a_literal_grant_is_still_a_duplicate() -> None:
+    """Resolving the alias before the duplicate check keeps that check honest."""
+    doubled = (
+        f"O:BAD:P(A;OICI;FA;;;LA)(A;OICI;FA;;;{_LOCAL_ADMIN_SID})"
+        "(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"
+    )
+    assert not mutation_lock_module._windows_private_dacl_is_valid(
+        doubled, _LOCAL_ADMIN_SID, directory=True
+    )
+
+
 def test_owner_rights_counts_as_the_users_grant_when_the_user_owns_the_entry() -> None:
     """`OW` is a spelling of the owner, so ownership decides what it admits."""
     assert mutation_lock_module._windows_private_dacl_is_valid(

--- a/tests/test_mutation_lock.py
+++ b/tests/test_mutation_lock.py
@@ -272,7 +272,10 @@ def test_windows_private_dacl_deduplicates_local_system_principal() -> None:
 #: and the user's own grant spelled `OW` (OWNER RIGHTS) rather than as a literal
 #: SID. Refusing it failed closed on a directory that was already private.
 _OWNER_RIGHTS_DACL = "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;OW)"
-_USER_SID = "S-1-5-21-896069015-2321608379-4234408933-1001"
+#: Deliberately tiny sub-authorities. A real Windows account SID carries
+#: 32-bit values and identifies one specific machine and account, which is
+#: not something a public repository should carry.
+_USER_SID = "S-1-5-21-1-2-3-1001"
 
 
 def test_owner_rights_counts_as_the_users_grant_when_the_user_owns_the_entry() -> None:
@@ -1223,7 +1226,7 @@ def test_dacl_error_reports_what_it_observed_not_just_that_it_refused() -> None:
     the report itself into the evidence.
     """
     error = mutation_lock_module.WindowsRuntimeDaclError(
-        Path(r"C:\Users\someone\.cache\exomem"),
+        Path(r"C:\Users\example\.cache\exomem"),
         "icacls.exe ...",
         observed="D:AI(A;OICIID;FA;;;BA)(A;OICIID;FA;;;SY)(A;OICIID;FA;;;WD)",
         expected=("S-1-5-21-1-2-3-1001", "SY", "BA"),
@@ -1239,7 +1242,7 @@ def test_dacl_error_reports_what_it_observed_not_just_that_it_refused() -> None:
 def test_dacl_error_still_renders_without_a_descriptor() -> None:
     """The two new fields are optional; older call sites must not break."""
     error = mutation_lock_module.WindowsRuntimeDaclError(
-        Path(r"C:\tmp\x"), "icacls.exe ..."
+        Path(r"C:\example\x"), "icacls.exe ..."
     )
 
     assert error.observed is None

--- a/tests/test_mutation_lock.py
+++ b/tests/test_mutation_lock.py
@@ -1211,3 +1211,37 @@ def test_the_private_state_root_is_creatable_under_a_missing_ancestor(
 
     assert root.is_dir()
     assert store._runtime_state_error is None
+
+
+def test_dacl_error_reports_what_it_observed_not_just_that_it_refused() -> None:
+    """A rejection you cannot reproduce locally is only useful if it self-describes.
+
+    The message named the path and a repair command and stopped there. That is
+    enough on a machine you can log into and inspect, and useless from anywhere
+    else -- so a CI runner's rejection could only be guessed at from whatever
+    shape some other machine happened to produce. Carrying the descriptor turns
+    the report itself into the evidence.
+    """
+    error = mutation_lock_module.WindowsRuntimeDaclError(
+        Path(r"C:\Users\someone\.cache\exomem"),
+        "icacls.exe ...",
+        observed="D:AI(A;OICIID;FA;;;BA)(A;OICIID;FA;;;SY)(A;OICIID;FA;;;WD)",
+        expected=("S-1-5-21-1-2-3-1001", "SY", "BA"),
+    )
+
+    assert error.observed is not None
+    assert "WD" in str(error), "the offending trustee must survive into the text"
+    assert "expected full-access trustees" in str(error)
+    assert "S-1-5-21-1-2-3-1001" in str(error)
+    assert "icacls.exe" in str(error)
+
+
+def test_dacl_error_still_renders_without_a_descriptor() -> None:
+    """The two new fields are optional; older call sites must not break."""
+    error = mutation_lock_module.WindowsRuntimeDaclError(
+        Path(r"C:\tmp\x"), "icacls.exe ..."
+    )
+
+    assert error.observed is None
+    assert error.expected == ()
+    assert "unsafe Windows DACL" in str(error)

--- a/tests/test_mutation_lock.py
+++ b/tests/test_mutation_lock.py
@@ -267,6 +267,87 @@ def test_windows_private_dacl_deduplicates_local_system_principal() -> None:
     )
 
 
+#: The DACL Windows actually writes for an entry created beneath a user's
+#: temporary directory: protected, three full-access ACEs, no broad trustee --
+#: and the user's own grant spelled `OW` (OWNER RIGHTS) rather than as a literal
+#: SID. Refusing it failed closed on a directory that was already private.
+_OWNER_RIGHTS_DACL = "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;OW)"
+_USER_SID = "S-1-5-21-896069015-2321608379-4234408933-1001"
+
+
+def test_owner_rights_counts_as_the_users_grant_when_the_user_owns_the_entry() -> None:
+    """`OW` is a spelling of the owner, so ownership decides what it admits."""
+    assert mutation_lock_module._windows_private_dacl_is_valid(
+        f"O:{_USER_SID}{_OWNER_RIGHTS_DACL}", _USER_SID, directory=True
+    )
+
+
+def test_owner_rights_is_rejected_when_somebody_else_owns_the_entry() -> None:
+    """The concession is ownership-scoped or it is a hole.
+
+    Accepting `OW` unconditionally would admit full access for whoever happens
+    to own the entry -- the one case this validator exists to catch.
+    """
+    stranger = "S-1-5-21-9999-8888-7777-1001"
+    assert not mutation_lock_module._windows_private_dacl_is_valid(
+        f"O:{stranger}{_OWNER_RIGHTS_DACL}", _USER_SID, directory=True
+    )
+
+
+def test_owner_rights_is_rejected_when_the_descriptor_carries_no_owner() -> None:
+    """No owner, no way to resolve `OW` -- so fail closed rather than assume."""
+    assert not mutation_lock_module._windows_private_dacl_is_valid(
+        _OWNER_RIGHTS_DACL, _USER_SID, directory=True
+    )
+
+
+def test_owner_rights_does_not_let_a_principal_be_granted_twice() -> None:
+    """`OW` beside a literal grant to the same owner is one principal, named twice.
+
+    Resolving `OW` before the duplicate check is what keeps that rule meaningful;
+    checking the raw trustee would see two distinct strings and wave it through.
+    """
+    doubled = (
+        f"O:{_USER_SID}D:P(A;OICI;FA;;;{_USER_SID})"
+        "(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;OW)"
+    )
+    assert not mutation_lock_module._windows_private_dacl_is_valid(
+        doubled, _USER_SID, directory=True
+    )
+
+
+def test_owner_rights_does_not_excuse_a_broad_trustee() -> None:
+    """Everything else the validator rejected, it still rejects."""
+    with_everyone = f"O:{_USER_SID}{_OWNER_RIGHTS_DACL}(A;OICI;FA;;;WD)"
+    assert not mutation_lock_module._windows_private_dacl_is_valid(
+        with_everyone, _USER_SID, directory=True
+    )
+    unprotected = f"O:{_USER_SID}D:(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;OW)"
+    assert not mutation_lock_module._windows_private_dacl_is_valid(
+        unprotected, _USER_SID, directory=True
+    )
+
+
+def test_an_owner_bearing_descriptor_still_accepts_the_dacl_this_module_writes() -> None:
+    """The literal-SID form is the one we write; prefixing an owner cannot break it."""
+    sddl = mutation_lock_module._windows_private_dacl_sddl(_USER_SID)
+
+    assert mutation_lock_module._windows_private_dacl_is_valid(
+        f"O:{_USER_SID}{sddl}", _USER_SID, directory=True
+    )
+    assert mutation_lock_module._windows_private_dacl_is_valid(
+        sddl, _USER_SID, directory=True
+    )
+
+
+def test_sddl_owner_is_read_for_both_raw_sids_and_two_letter_aliases() -> None:
+    """Windows picks the spelling, so both have to parse back to the same answer."""
+    owner = mutation_lock_module._windows_sddl_owner
+    assert owner(f"O:{_USER_SID}{_OWNER_RIGHTS_DACL}") == _USER_SID
+    assert owner(f"O:BA{_OWNER_RIGHTS_DACL}") == "BA"
+    assert owner(_OWNER_RIGHTS_DACL) is None
+
+
 def _process_hold(
     state_root: str,
     vault_root: str,

--- a/tests/test_mutation_lock.py
+++ b/tests/test_mutation_lock.py
@@ -278,9 +278,9 @@ _OWNER_RIGHTS_DACL = "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;OW)"
 _USER_SID = "S-1-5-21-1-2-3-1001"
 
 
-#: The descriptor a GitHub Windows runner reads back for
-#: `C:\Users\runneradmin\.cache\exomem`, with the runner's real SID replaced by a
-#: synthetic one. `runneradmin` is its account domain's built-in Administrator
+#: The descriptor a GitHub Windows runner reads back for its own cache
+#: directory, with the runner's real SID replaced by a synthetic one. That
+#: runner's user is its account domain's built-in Administrator
 #: (RID 500), and SDDL renders that account as `LA` -- never as its SID. The
 #: grants are exactly the three this module writes; only the spelling differs.
 _LOCAL_ADMIN_DACL = "O:BAD:P(A;OICI;FA;;;LA)(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"


### PR DESCRIPTION
## The validator was rejecting DACLs this module had written itself

**1725 failures — 72% of the entire Windows lane — from one two-letter alias.**

The first commit made `WindowsRuntimeDaclError` carry the descriptor it rejected,
because the message named a path and a repair command but never what it actually
observed, so a report from a host you cannot log into was not actionable. On its
first CI run it produced the answer:

```
observed  O:BA D:P(A;OICI;FA;;;LA)(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)
expected  S-1-5-21-...-500, SY, BA
```

Those grants are **exactly** the three this module writes — protected against
inheritance, full access, no broad trustee anywhere. The DACL was never wrong.
`LA` is how SDDL renders the account domain's built-in Administrator (the RID 500
account), and it renders it that way *always*, never as a SID. A GitHub Windows
runner's `runneradmin` **is** that account, so every private directory this module
created read its own correct grants back under a spelling the raw-SID comparison
could not match — then failed closed, offering a repair command that would have
rewritten the identical bytes.

## The fix

Unlike `SY` and `BA`, this alias cannot live in `_WINDOWS_SID_ALIASES` — it is
machine-relative, so it has to be derived from the SID.
`_windows_principal_spellings` grows an `la` entry exactly when the SID is an
account domain's RID 500, and the ACE loop folds any spelling of the current user
onto the canonical principal.

**Unlike `OW`, it needs no ownership check.** `OW` names whoever owns the object,
so it admits us only while we own it. `LA` names one fixed account, and it is a
spelling of *us* only when that account is the current user — which is the
condition that put it in the spelling set at all. For any other user it stays
unmatched and is rejected, so an `LA` grant to the built-in Administrator can
never be mistaken for an ordinary user's own grant.

Folding happens **before** the duplicate check, so `LA` alongside a literal grant
to the same account is still one principal named twice and is still refused — the
same ordering `OW` already relies on.

## Correction

I previously claimed this lane was fixed by the `OW` work, on the strength of a
local reproduction. **It was not.** That PR's own run still showed 596 DACL
failures. On a developer box the current user is not the built-in Administrator,
so the SID is written literally and this alias never appears — the local shape
could not have shown it. Reading the descriptor off the runner is what settled
it, which is the entire argument for the first commit.

## Verification

- `pytest tests/test_mutation_lock.py` — **58 passed**, including three new tests:
  the runner's literal descriptor is accepted for a RID 500 user; the same
  descriptor is rejected for any other user; `LA` beside a literal grant to the
  same account is still a duplicate.
- Test SIDs use deliberately tiny sub-authorities (`S-1-5-21-1-2-3-500`) so no
  real machine identity enters a public repository — the same convention the
  `OW` tests already use, and the one #622 teaches the privacy gate to enforce.
- `ruff check --select F` clean (the required lint gate).
- The real proof is this PR's own Windows cross-platform lane.