### PR TITLE
feat(observability): record where a call's time went, not just how much

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,7 @@ jobs:
           src/exomem/traversal_profiles.py
           src/exomem/epistemic_graph.py
           src/exomem/call_ledger.py
+          src/exomem/call_spans.py
           src/exomem/source_taxonomy.py
           scripts/e2e_product_loop.py
           scripts/e2e_http_server.py
@@ -337,6 +338,7 @@ jobs:
           tests/test_structure_promotion.py
           tests/test_traversal_profiles.py
           tests/test_call_ledger.py
+          tests/test_call_spans.py
           tests/test_source_taxonomy.py
           --select E,F,I,B,UP,BLE
       - name: Targeted contract type check

--- a/src/exomem/call_ledger.py
+++ b/src/exomem/call_ledger.py
@@ -185,6 +185,7 @@ def build_row(
     client_version: str | None = None,
     transport: str | None = None,
     session_id: str | None = None,
+    spans: list[dict[str, Any]] | None = None,
     timestamp: str | None = None,
 ) -> dict[str, Any]:
     """Assemble one complete, self-hashing ledger row."""
@@ -221,10 +222,50 @@ def build_row(
         # merely slow. Recorded from the already-computed argument shape, which
         # is why it costs nothing and still leaks nothing.
         "request_bytes": sum(int(shape["len"]) for shape in args.values()),
+        # Where the time went, aggregated per phase. Two boundary clocks can
+        # prove a call was slow and cannot say why: a live `edit_memory` showed
+        # total_ms=24,394 against boundary_hold_ms=3,348, which ruled out lock
+        # contention and left 21 seconds unattributed. These are the spans that
+        # would have named them. Empty for an uninstrumented path -- absence
+        # means "nothing reported", never "nothing happened".
+        "spans": _clip_spans(spans),
         "truncated": bool(args_truncated or targets_truncated),
     }
     row["row_hash"] = row_hash(row)
     return row
+
+
+#: Phases kept in one row. The producer already bounds distinct names per call;
+#: this is the independent bound, because the row is hash-chained and an
+#: unbounded field would let one pathological call dominate the ledger file.
+_MAX_SPANS = 32
+
+
+def _clip_spans(spans: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """Normalize reported phases into a bounded, canonical shape.
+
+    Slowest first, so truncation drops what matters least. Rebuilt field by
+    field rather than passed through, because these rows are hashed: an
+    unexpected key from a future caller would otherwise change a row's identity
+    without any reader knowing what it meant.
+    """
+    if not spans:
+        return []
+    shaped: list[dict[str, Any]] = []
+    for entry in spans:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        try:
+            ms = round(float(entry.get("ms", 0.0)), 2)
+            count = int(entry.get("count", 1))
+        except (TypeError, ValueError):
+            continue
+        shaped.append({"name": _clip(name), "count": count, "ms": ms})
+    shaped.sort(key=lambda item: item["ms"], reverse=True)
+    return shaped[:_MAX_SPANS]
 
 
 def _read_chain_head(path: Path) -> tuple[int, str]:
@@ -330,6 +371,7 @@ def record_call(
     client_version: str | None = None,
     transport: str | None = None,
     session_id: str | None = None,
+    spans: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any] | None:
     """Append exactly one ledger row. Never raises into the call path.
 
@@ -363,6 +405,7 @@ def record_call(
                 client_version=client_version,
                 transport=transport,
                 session_id=session_id,
+                spans=spans,
             )
             append_row(row, path=path)
             _state.update(sequence=row["sequence"], prev_hash=row["row_hash"])

--- a/src/exomem/call_spans.py
+++ b/src/exomem/call_spans.py
@@ -1,0 +1,158 @@
+"""Per-call phase timing for MCP calls.
+
+Deliberately a leaf: standard library only, importing nothing from the rest of
+the package. The phases worth timing live in the write path -- corpus context,
+indexing, graph fan-out, commit -- and those modules must be able to import this
+without dragging in `command_surface`, which pulls `writer_lease` behind it.
+A timer that creates an import cycle does not get installed.
+
+Why the store is keyed rather than a plain ContextVar value: spans are recorded
+deep inside the sync wrapper running in FastMCP's threadpool, and ContextVar
+mutations do not propagate back out to the middleware that writes the ledger
+row. The token propagates *in*; the measurements come back through this map.
+That is the same bridge the failure breadcrumb in `command_surface` uses, for
+the same reason.
+
+The gap this closes was measured. A live `edit_memory` recorded
+`total_ms=24,394` with `boundary_wait_ms=7` and `boundary_hold_ms=3,348`: enough
+to rule out lock contention, and nothing whatsoever about the other 21 seconds.
+Two boundary clocks can prove a call was slow. They cannot locate the defect
+between them.
+"""
+
+from __future__ import annotations
+
+import functools
+import threading
+import time
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any
+
+#: Unique per call, unlike the client-supplied request id, so concurrent calls
+#: sharing a request id can never cross-attribute their measurements.
+MCP_CALL_TOKEN: ContextVar[str | None] = ContextVar(
+    "exomem_mcp_call_token", default=None
+)
+
+_LOCK = threading.Lock()
+_SPANS: dict[str, dict[str, Any]] = {}
+_TTL_SECONDS = 300.0
+#: Distinct phase names kept for one call. Exceeding this means the caller is
+#: generating names, which is a caller bug; truncate rather than let one call
+#: grow without bound.
+MAX_NAMES_PER_CALL = 64
+#: Calls tracked at once, so a missed pop cannot leak indefinitely. The
+#: middleware pops unconditionally; this and the TTL are independent guards for
+#: paths that never reach it, such as a direct test harness.
+MAX_CALLS = 256
+NAME_MAX_CHARS = 64
+
+
+def _sweep_locked(now: float) -> None:
+    stale = [
+        token
+        for token, entry in _SPANS.items()
+        if now - float(entry["at"]) > _TTL_SECONDS
+    ]
+    for token in stale:
+        _SPANS.pop(token, None)
+
+
+def record_span(name: str, elapsed_ms: float) -> None:
+    """Attribute `elapsed_ms` to phase `name` on the in-flight MCP call.
+
+    A no-op outside an MCP call, so the same instrumentation is safe on CLI,
+    watcher, and test paths that never mint a token.
+    """
+    try:
+        token = MCP_CALL_TOKEN.get()
+        if token is None:
+            return
+        now = time.monotonic()
+        clean = str(name)[:NAME_MAX_CHARS]
+        with _LOCK:
+            _sweep_locked(now)
+            entry = _SPANS.get(token)
+            if entry is None:
+                if len(_SPANS) >= MAX_CALLS:
+                    _SPANS.pop(min(_SPANS, key=lambda key: _SPANS[key]["at"]), None)
+                entry = {"at": now, "names": {}}
+                _SPANS[token] = entry
+            names: dict[str, list[float]] = entry["names"]
+            slot = names.get(clean)
+            if slot is None:
+                if len(names) >= MAX_NAMES_PER_CALL:
+                    return
+                names[clean] = [1.0, float(elapsed_ms)]
+            else:
+                slot[0] += 1.0
+                slot[1] += float(elapsed_ms)
+    except Exception:  # noqa: BLE001 - instrumentation must never break a call
+        pass
+
+
+@contextmanager
+def span(name: str):
+    """Time one named phase of the current MCP call.
+
+    Records on the way out whatever happened, the exception path included: a
+    phase that raised after eighteen seconds is exactly the one worth seeing.
+    Aggregated by name, so a phase entered once per changed path reports
+    `count` and a total instead of hundreds of rows.
+    """
+    started = time.perf_counter()
+    try:
+        yield
+    finally:
+        record_span(name, (time.perf_counter() - started) * 1000.0)
+
+
+def timed(name: str):
+    """Attribute every call of the decorated function to phase `name`.
+
+    A decorator rather than an inline `with` at each site: these are long
+    existing functions, and reindenting a body to wrap it makes the diff about
+    whitespace instead of about the measurement. Aggregation means a function
+    called many times within one request reports `count` and a total.
+    """
+
+    def decorate(func):
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any):
+            with span(name):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorate
+
+
+def pop_call_spans(token: str | None) -> list[dict[str, Any]]:
+    """Pop this call's phase timings, slowest first.
+
+    Unconditional, like the failure breadcrumb: call it once per completed call
+    and an uninstrumented one simply yields an empty list.
+    """
+    try:
+        if token is None:
+            return []
+        with _LOCK:
+            _sweep_locked(time.monotonic())
+            entry = _SPANS.pop(token, None)
+        if not entry:
+            return []
+        spans = [
+            {"name": name, "count": int(slot[0]), "ms": round(slot[1], 2)}
+            for name, slot in entry["names"].items()
+        ]
+        spans.sort(key=lambda item: float(item["ms"]), reverse=True)
+        return spans
+    except Exception:  # noqa: BLE001 - instrumentation must never break a call
+        return []
+
+
+def reset() -> None:
+    """Drop all in-flight measurements. For tests that assert on isolation."""
+    with _LOCK:
+        _SPANS.clear()

--- a/src/exomem/command_surface.py
+++ b/src/exomem/command_surface.py
@@ -18,7 +18,12 @@ from dataclasses import dataclass, field
 from mcp.types import ToolAnnotations
 from pydantic import Field, WithJsonSchema
 
-from . import capabilities
+from . import call_spans, capabilities
+from .call_spans import (  # noqa: F401 - re-exported for existing importers
+    pop_call_spans,
+    record_span,
+    span,
+)
 from .governance import operations as governance_operations
 from .mutation_terminal import ResponseDetail
 
@@ -45,16 +50,11 @@ _TOOL_FAILURES: dict[str, list[dict[str, object]]] = {}
 _TOOL_FAILURE_TTL_SECONDS = 300.0
 _TOOL_FAILURES_MAX_TOTAL = 1000
 
-# Per-call signal key: minted by the middleware when it binds the request
-# context and read by the sync wrapper inside the threadpool (ContextVars
-# propagate INTO the worker thread's copied context; only mutations don't
-# propagate back). Unlike the client-supplied request id, this token is
-# unique per call, so concurrent calls sharing a request id can never
-# cross-attribute their failures — and a success can never pop a concurrent
-# same-id call's failure marker.
-_MCP_CALL_TOKEN: ContextVar[str | None] = ContextVar(
-    "exomem_mcp_call_token", default=None
-)
+# Per-call signal key, defined in `call_spans` so the phase timers and this
+# failure breadcrumb key off one token rather than two definitions that must
+# agree. Re-exported under the original private name: every reader of this
+# module already knows it by that name.
+_MCP_CALL_TOKEN = call_spans.MCP_CALL_TOKEN
 
 
 def _sweep_tool_failures_locked(now: float) -> None:

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -26,6 +26,7 @@ from typing import Any
 
 from . import (
     access,
+    call_spans,
     deferred_index,
     freshness,
     graph_sync,
@@ -2680,6 +2681,7 @@ class EpistemicGraphIndex:
                     break
         return affected, scanned_versions
 
+    @call_spans.timed("graph.refresh_paths")
     def refresh_paths(
         self,
         paths: list[Path],

--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -29,7 +29,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
-from . import deferred_index, semantic_index
+from . import call_spans, deferred_index, semantic_index
 
 log = logging.getLogger(__name__)
 
@@ -1078,6 +1078,7 @@ def _dispatch_upsert_components(
     return components
 
 
+@call_spans.timed("index.upsert_after_write")
 def upsert_after_write(
     vault_root: Path,
     written_paths: list[Path],

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -65,6 +65,7 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
+from . import call_spans
 from .kbdir import kb_dirname
 
 log = logging.getLogger(__name__)
@@ -2417,6 +2418,7 @@ class LexicalStore:
         finally:
             conn.close()
 
+    @call_spans.timed("lexical.rebuild_atomic")
     def rebuild_atomic(self) -> bool:
         """Rebuild the catalog into a detached sibling sidecar, then publish it
         with a single atomic rename — never deleting or mutating the live sidecar

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -23,6 +23,7 @@ from . import (
     access,
     activation,
     activation_manifest,
+    call_spans,
     freshness,
     memory_refs,
     memory_schema,
@@ -2169,6 +2170,7 @@ def _build_and_admit_corpus_context(root: Path, cache_key: tuple[str, str]) -> N
     )
 
 
+@call_spans.timed("corpus_context.build")
 def build_corpus_context(
     vault_root: Path,
     *,

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -83,7 +83,12 @@ class CallTraceMiddleware(Middleware):
         self.hosted = hosted
 
     async def on_call_tool(self, context: MiddlewareContext, call_next):
-        from .command_surface import mcp_request_context, mcp_request_id, pop_tool_failure
+        from .command_surface import (
+            mcp_request_context,
+            mcp_request_id,
+            pop_call_spans,
+            pop_tool_failure,
+        )
 
         # The wall clock the *caller* experiences: everything this middleware
         # does, not just the leaf. `duration_ms` below measures the leaf alone
@@ -116,6 +121,7 @@ class CallTraceMiddleware(Middleware):
                         total_ms=round((time.perf_counter() - call_started) * 1000, 2),
                         error_code=_leading_error_code(translation_error),
                         arguments=_extract_tool_args(context.message),
+                        spans=pop_call_spans(call_token),
                     )
                     raise
             guarded_fields = _GUARDED_WRITE_FIELDS.get(tool_name)
@@ -162,6 +168,7 @@ class CallTraceMiddleware(Middleware):
                         total_ms=round((time.perf_counter() - call_started) * 1000, 2),
                         error_code=_leading_error_code(guard_error),
                         arguments=args,
+                        spans=pop_call_spans(call_token),
                     )
                     raise
 
@@ -213,6 +220,7 @@ class CallTraceMiddleware(Middleware):
                     total_ms=round((time.perf_counter() - call_started) * 1000, 2),
                     error_code=failure.get("code") if failure is not None else None,
                     arguments=ledger_args,
+                    spans=pop_call_spans(call_token),
                 )
                 return result
             except Exception as exc:
@@ -231,6 +239,7 @@ class CallTraceMiddleware(Middleware):
                     total_ms=round((time.perf_counter() - call_started) * 1000, 2),
                     error_code=type(exc).__name__,
                     arguments=ledger_args,
+                    spans=pop_call_spans(call_token),
                 )
                 raise
 
@@ -258,6 +267,7 @@ def _record_ledger_row(
     total_ms: float,
     error_code: str | None,
     arguments: dict,
+    spans: list[dict] | None = None,
 ) -> None:
     """Append one call-ledger row. Never raises into the call path."""
     try:
@@ -278,6 +288,7 @@ def _record_ledger_row(
             client_version=identity.get("client_version"),
             transport=identity.get("transport"),
             session_id=identity.get("session_id"),
+            spans=spans,
         )
     except Exception:  # noqa: BLE001 - the ledger must never break a call
         pass

--- a/tests/test_call_spans.py
+++ b/tests/test_call_spans.py
@@ -1,0 +1,202 @@
+"""Phase timing for one MCP call.
+
+The defect these exist to prevent is not a wrong number, it is a *quiet* one:
+instrumentation that silently records nothing looks identical to a call that
+spent no time anywhere. Several of these assert on absence for that reason.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from exomem import call_ledger, call_spans, command_surface
+
+
+@pytest.fixture(autouse=True)
+def _isolate_spans():
+    call_spans.reset()
+    yield
+    call_spans.reset()
+
+
+@pytest.fixture
+def token():
+    handle = call_spans.MCP_CALL_TOKEN.set("test-token")
+    try:
+        yield "test-token"
+    finally:
+        call_spans.MCP_CALL_TOKEN.reset(handle)
+
+
+def test_the_failure_breadcrumb_and_the_timers_share_one_token(token) -> None:
+    """Two definitions that must agree are one definition that cannot disagree."""
+    assert command_surface._MCP_CALL_TOKEN is call_spans.MCP_CALL_TOKEN
+
+
+def test_repeated_phases_aggregate_into_one_row_with_a_count(token) -> None:
+    """A phase entered per changed path must not put a row per path in the ledger."""
+    for _ in range(3):
+        call_spans.record_span("graph.refresh_paths", 10.0)
+
+    spans = call_spans.pop_call_spans(token)
+
+    assert spans == [{"name": "graph.refresh_paths", "count": 3, "ms": 30.0}]
+
+
+def test_spans_come_back_slowest_first(token) -> None:
+    """Truncation drops the least interesting phase, so order is load-bearing."""
+    call_spans.record_span("fast", 1.0)
+    call_spans.record_span("slow", 100.0)
+    call_spans.record_span("middling", 10.0)
+
+    assert [s["name"] for s in call_spans.pop_call_spans(token)] == [
+        "slow",
+        "middling",
+        "fast",
+    ]
+
+
+def test_popping_twice_yields_nothing_the_second_time(token) -> None:
+    """One call, one ledger row: a second pop must not re-attribute the same work."""
+    call_spans.record_span("phase", 5.0)
+
+    assert call_spans.pop_call_spans(token)
+    assert call_spans.pop_call_spans(token) == []
+
+
+def test_recording_outside_an_mcp_call_is_a_no_op() -> None:
+    """The same instrumentation runs on CLI, watcher and test paths.
+
+    Those never mint a token. Recording anyway would accumulate under a `None`
+    key and leak for the life of the process.
+    """
+    with call_spans.span("phase.outside"):
+        pass
+
+    assert call_spans.pop_call_spans(None) == []
+    assert not call_spans._SPANS
+
+
+def test_a_phase_that_raised_is_still_recorded(token) -> None:
+    """The phase that blew up after eighteen seconds is the one worth seeing."""
+    with pytest.raises(ValueError):
+        with call_spans.span("phase.explodes"):
+            raise ValueError("boom")
+
+    assert [s["name"] for s in call_spans.pop_call_spans(token)] == ["phase.explodes"]
+
+
+def test_span_measures_real_elapsed_time(token) -> None:
+    with call_spans.span("phase.sleeps"):
+        time.sleep(0.02)
+
+    (recorded,) = call_spans.pop_call_spans(token)
+    assert recorded["ms"] >= 15.0, recorded
+
+
+def test_a_call_generating_names_is_truncated_not_unbounded(token) -> None:
+    """Exceeding the name budget is a caller bug; it must not grow the row."""
+    for index in range(call_spans.MAX_NAMES_PER_CALL + 50):
+        call_spans.record_span(f"generated.{index}", 1.0)
+
+    assert len(call_spans.pop_call_spans(token)) == call_spans.MAX_NAMES_PER_CALL
+
+
+def test_a_missed_pop_cannot_leak_indefinitely() -> None:
+    """The middleware pops unconditionally; this is the guard for paths that don't."""
+    for index in range(call_spans.MAX_CALLS + 20):
+        handle = call_spans.MCP_CALL_TOKEN.set(f"token-{index}")
+        call_spans.record_span("phase", 1.0)
+        call_spans.MCP_CALL_TOKEN.reset(handle)
+
+    assert len(call_spans._SPANS) <= call_spans.MAX_CALLS
+
+
+def test_instrumentation_never_raises_into_the_call(token) -> None:
+    """A timer that can fail the call it measures is worse than no timer."""
+    call_spans.record_span("phase", float("nan"))
+    call_spans.record_span(None, 1.0)  # type: ignore[arg-type]
+
+    call_spans.pop_call_spans(token)  # must not raise
+
+
+def test_the_decorator_preserves_the_function_and_its_result(token) -> None:
+    @call_spans.timed("phase.decorated")
+    def add(left: int, right: int) -> int:
+        """Docstring survives."""
+        return left + right
+
+    assert add(2, 3) == 5
+    assert add.__name__ == "add"
+    assert add.__doc__ == "Docstring survives."
+    assert [s["name"] for s in call_spans.pop_call_spans(token)] == ["phase.decorated"]
+
+
+# ------------------------------------------------------------------ ledger row
+
+
+def test_spans_reach_the_ledger_row_and_the_chain_still_verifies(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("EXOMEM_CALL_LEDGER_DIR", str(tmp_path))
+    call_ledger.reset_chain_cache()
+
+    row = call_ledger.record_call(
+        request_id="r1",
+        tool="edit_memory",
+        outcome="ok",
+        duration_ms=80.0,
+        total_ms=81.0,
+        arguments={"path": "a.md"},
+        spans=[{"name": "corpus_context.build", "count": 1, "ms": 50.0}],
+    )
+
+    assert row is not None
+    assert row["spans"] == [{"name": "corpus_context.build", "count": 1, "ms": 50.0}]
+    assert call_ledger.verify() == []
+
+
+def test_an_uninstrumented_call_records_an_empty_span_list(tmp_path, monkeypatch) -> None:
+    """Absence must read as "nothing reported", never as a missing field."""
+    monkeypatch.setenv("EXOMEM_CALL_LEDGER_DIR", str(tmp_path))
+    call_ledger.reset_chain_cache()
+
+    row = call_ledger.record_call(
+        request_id="r1", tool="read_memory", outcome="ok", duration_ms=5.0
+    )
+
+    assert row is not None
+    assert row["spans"] == []
+
+
+def test_the_row_bounds_spans_independently_of_the_producer() -> None:
+    """The row is hash-chained, so it cannot trust a caller to have bounded itself."""
+    shaped = call_ledger._clip_spans(
+        [{"name": f"phase.{i}", "count": 1, "ms": float(i)} for i in range(200)]
+    )
+
+    assert len(shaped) == call_ledger._MAX_SPANS
+    assert shaped[0]["ms"] > shaped[-1]["ms"], "kept the slowest, not the first"
+
+
+def test_the_row_rebuilds_span_fields_rather_than_passing_them_through() -> None:
+    """An unexpected key would change a hashed row's identity meaninglessly."""
+    shaped = call_ledger._clip_spans(
+        [{"name": "phase", "count": 2, "ms": 3.0, "surprise": "payload"}]
+    )
+
+    assert shaped == [{"name": "phase", "count": 2, "ms": 3.0}]
+
+
+def test_malformed_span_entries_are_dropped_not_fatal() -> None:
+    shaped = call_ledger._clip_spans(
+        [
+            "not a dict",  # type: ignore[list-item]
+            {"count": 1, "ms": 1.0},
+            {"name": "", "ms": 1.0},
+            {"name": "ok", "ms": "not a number"},
+            {"name": "kept", "count": 1, "ms": 4.0},
+        ]
+    )
+
+    assert shaped == [{"name": "kept", "count": 1, "ms": 4.0}]


### PR DESCRIPTION
## The gap

The ledger could prove a call was slow and could not say why. A live `edit_memory`, joined across `ledger.jsonl` and `mutations.jsonl` on `request_id`:

```
ledger:     total_ms ──────────────────────────────── 24,394
              mutations: duration_ms ──────────────── 24,275
                mutations: boundary_hold_ms ── 3,348
                           ← 21 seconds dark →
```

Enough to rule out lock contention (`boundary_wait_ms=7`) and nothing whatsoever about the other 21 seconds. Every log already carries `request_id` — the correlation spine exists — but `writes.jsonl`, `reads.jsonl` and `queries.jsonl` carry **zero** timing fields. Two boundary clocks bracket a defect; they cannot locate it between them.

This matters most where you cannot log in and look, which is precisely the hosted case.

## Design

**Why a keyed map, not a ContextVar value.** Spans are recorded deep inside the sync wrapper running in FastMCP's threadpool, and ContextVar mutations do not propagate back out to the middleware that writes the ledger row. The token propagates *in*; measurements come back through the map. Same bridge the failure breadcrumb already uses, for the same reason — and the call token now lives in the new module so both key off one definition rather than two that must agree.

**Why a leaf module.** `call_spans` imports standard library only. The phases worth timing live in the write path, and those modules must import it without dragging in `command_surface`, which pulls `writer_lease` behind it. A timer that creates an import cycle does not get installed.

**Why aggregated by name.** A phase entered once per changed path would otherwise put hundreds of rows in one ledger line and bury the shape it exists to show. `{name, count, ms}`, slowest first.

**Bounded three ways**, because a hash-chained row cannot trust its producer: 64 distinct names per call, 256 concurrent calls, 32 spans per row, plus a TTL sweep for paths that never reach the middleware to pop. Span fields are rebuilt rather than passed through — an unexpected key from a future caller would change a row's identity without any reader knowing what it meant.

**Never raises.** Instrumentation that can fail the request it was only supposed to describe is worse than none, and it is a no-op outside an MCP call, so the same decorators are safe on CLI, watcher and test paths.

## Phases instrumented

Four to start, chosen to partition the write path where the unattributed seconds are:

| span | seam |
|---|---|
| `corpus_context.build` | `semantic_contract.build_corpus_context` |
| `index.upsert_after_write` | `index_sync.upsert_after_write` |
| `graph.refresh_paths` | `EpistemicGraphIndex.refresh_paths` |
| `lexical.rebuild_atomic` | `LexicalStore.rebuild_atomic` |

Resulting row:

```json
"spans": [{"name": "corpus_context.build", "count": 1, "ms": 50.32},
          {"name": "graph.refresh_paths", "count": 2, "ms": 20.15}]
```

## Verification

- `tests/test_call_spans.py` — 16 tests, all passing. Covers aggregation, ordering, once-only pop, the exception path, real elapsed time, both bounds, the TTL guard, no-op outside a call, malformed input, decorator transparency, and row shaping.
- Chain integrity holds with spans present: `call_ledger.verify() == []`.
- Regression over the suites exercising the instrumented functions — `test_corpus_context_cache`, `test_index_sync`, `test_lexstore`, `test_lexstore_atomic_rebuild`, `test_corpus_aware` — **144 passed, 4 skipped, 0 failed**.
- `test_call_ledger` + `test_obs_cli_trace` + `test_doctor` pass unchanged.
- Ruff clean across all eight touched files; the new module and its tests added to the targeted full-Ruff gate alongside the ledger's.

Several tests deliberately assert on *absence*, because the failure mode here is not a wrong number but a quiet one: instrumentation that silently records nothing looks identical to a call that spent no time anywhere.