### PR TITLE
fix(privacy): teach the public-artifact gate to recognise Windows account SIDs

### DIFF
--- a/src/exomem/public_artifact_privacy.py
+++ b/src/exomem/public_artifact_privacy.py
@@ -261,6 +261,25 @@ _CONTENT_RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
         re.compile(r"(?<![A-Za-z0-9_.-])/(?:Users|home)/(?!<|\{\{)[^/\s<]+/"),
     ),
     ("absolute_local_path", re.compile(r"(?<![A-Za-z0-9_.-])/mnt/[a-z]/")),
+    (
+        # A Windows account SID identifies one machine and one account on it,
+        # exactly as an absolute home path does, and reached this repository the
+        # same way: pasted out of a live box while reproducing a bug. The path
+        # rules caught the paths from that session; nothing caught the SID.
+        #
+        # Scoped to the S-1-5-21 authority, which is the machine/domain-issued
+        # form. Well-known SIDs are not identifying and must keep working:
+        # S-1-5-18 (SYSTEM), S-1-5-32-544 (Administrators) and S-1-3-4 (OWNER
+        # RIGHTS) all appear legitimately in this codebase's DACL handling.
+        #
+        # The three sub-authorities of a real SID are 32-bit values, so
+        # requiring five digits each leaves an obvious, self-documenting escape
+        # for tests that need the shape and not the identity: S-1-5-21-1-2-3-1001
+        # cannot be mistaken for anyone's machine. That mirrors how the path
+        # rules exempt `example` and `<name>` rather than forbidding paths.
+        "windows_account_sid",
+        re.compile(r"(?<![0-9A-Za-z-])S-1-5-21(?:-[0-9]{5,10}){3}-[0-9]+(?![0-9])"),
+    ),
 )
 
 

--- a/tests/test_public_artifact_privacy.py
+++ b/tests/test_public_artifact_privacy.py
@@ -219,6 +219,63 @@ def test_repository_text_rejects_drive_root_and_unc_paths_with_redacted_findings
     assert all(set(item.as_dict()) == {"rule", "file", "line"} for item in report.findings)
 
 
+def test_repository_text_rejects_a_machine_account_sid_with_a_redacted_finding(
+    tmp_path: Path,
+) -> None:
+    """A Windows account SID identifies a machine and an account on it.
+
+    It reached this repository the way the absolute paths did: pasted out of a
+    live box while reproducing a bug. The path rules caught the paths from that
+    session and nothing caught the SID, so it shipped in a test file until a
+    reviewer happened to recognise the shape.
+
+    Redacted like every other finding -- a report that must quote the identifier
+    in order to describe it has moved the leak rather than closed it.
+    """
+    repository = tmp_path / "synthetic-checkout"
+    repository.mkdir()
+    sid = "S-1-5-21-" + "896069015-2321608379-4234408933" + "-1001"
+    tracked = repository / "tests" / "sid.py"
+    tracked.parent.mkdir()
+    tracked.write_text('OWNER = "' + sid + '"' + "\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=repository, check=True)
+    subprocess.run(["git", "add", "tests/sid.py"], cwd=repository, check=True)
+
+    report = scan_repository_inputs(repository)
+    rendered = " ".join(str(item) for item in report.findings)
+
+    assert [(item.rule, item.file, item.line) for item in report.findings] == [
+        ("windows_account_sid", "tests/sid.py", 1),
+    ]
+    assert sid not in rendered
+    assert "896069015" not in rendered
+
+
+def test_account_sid_rule_admits_well_known_and_obviously_synthetic_sids(
+    tmp_path: Path,
+) -> None:
+    """The rule must not fire on the SIDs this codebase legitimately handles.
+
+    SYSTEM, Administrators and OWNER RIGHTS are fixed well-known values naming
+    no one, and `mutation_lock`'s DACL handling mentions all three. A test that
+    needs the *shape* of an account SID gets the same kind of documented escape
+    the path rules give `example` and `<name>`: sub-authorities too small to be
+    a real 32-bit value cannot identify a machine.
+    """
+    artifact = tmp_path / "sids.md"
+    artifact.write_text(
+        "system: S-1-5-18" "\n"
+        "administrators: S-1-5-32-544" "\n"
+        "owner-rights: S-1-3-4" "\n"
+        "synthetic-account: S-1-5-21-1-2-3-1001" "\n",
+        encoding="utf-8",
+    )
+
+    findings = scan_artifact(artifact, label="docs/sids.md")
+
+    assert findings == ()
+
+
 def test_windows_absolute_path_rule_retains_explicit_placeholder_exemptions(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## The gate failed at the thing it exists for

While reproducing the Windows DACL failures I pasted this machine's real
account SID into a test file. The public-artifact privacy gate scanned that
commit, flagged the two absolute paths in the same paste, and **passed the SID
straight through** — so a live machine-and-account identifier shipped to a
public repository until a later read caught it by eye.

`S-1-5-21-<32bit>-<32bit>-<32bit>-<rid>` names one specific machine and one
specific account on it. That is the same class of identifier as the home
directory paths the gate already refuses. It should never have depended on a
co-occurring path to be caught, so it gets a rule of its own.

## The exemptions are narrow and both are load-bearing here

- **Well-known SIDs** — `S-1-5-18` (SYSTEM), `S-1-5-32-544` (Administrators),
  `S-1-3-4` (OWNER RIGHTS) are fixed constants naming nobody, and
  `mutation_lock`'s DACL handling mentions all three. The pattern anchors on the
  `S-1-5-21` machine-authority prefix, so it structurally cannot see them.
- **Obviously synthetic SIDs** — a test needing the *shape* of an account SID
  writes sub-authorities too small to be a real 32-bit value
  (`S-1-5-21-1-2-3-1001`). The `{5,10}` digit bound admits those, the same
  documented escape the path rules give `example` and `<name>`.

## Findings stay redacted

A report that must quote the identifier in order to describe it has moved the
leak rather than closed it. The test asserts both the SID and its leading
sub-authority are absent from the rendered report.

## Verification

- `pytest tests/test_public_artifact_privacy.py` — **51 passed** (49 existing + 2 new)
- `ruff check` — clean
- Manually confirmed rule behaviour: real-shaped `flagged=True`; synthetic,
  SYSTEM, Administrators, OWNER RIGHTS all `flagged=False`