### PR TITLE
fix(graph): drain queued graph repair on dispatch instead of the 300s reconcile

### DIFF
--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -377,8 +377,48 @@ class FileWatcher:
         return media, ups, del_rels, pending_epoch, access_policy
 
     def _flush(self) -> None:
-        """Dispatch the coalesced batch: publish freshness/inbound for every
-        changed path (vault-wide), and re-embed only the Knowledge Base subset."""
+        """Dispatch the coalesced batch, then settle whatever graph debt it left.
+
+        The drain runs in a `finally` and on every dispatch, including the three
+        paths that return early: graph debt is enqueued by the write itself, so
+        a batch with nothing left to dispatch here can still have left the graph
+        owing work.
+        """
+        try:
+            self._dispatch_coalesced_batch()
+        finally:
+            self._drain_graph_debt()
+
+    def _drain_graph_debt(self) -> None:
+        """Repair the graph within a debounce window of the write that dirtied it.
+
+        Deferred graph work used to drain only from `_reconcile_once`, which runs
+        on `reconcile_interval_seconds` -- 300s by default, 900s in quiet mode.
+        Until that tick fired, `graph_sync.status()` reported `recovery_required`
+        and readers got `graph sidecar unavailable`, so an ordinary write left the
+        graph unreadable for up to five minutes with the repair already queued,
+        already admissible, and nothing scheduled to run it. The product E2E
+        proved it: `state='recovery_required' epoch_kind='coherent'
+        external_pending=False graph_queue_depth=13`, held for the whole 120s the
+        loop waits -- a wait that could not succeed against a 300s cadence.
+
+        The dispatch thread is the right seam. It already runs off the write path
+        (so this does not undo taking the graph off it) and it already coalesces
+        bursts, so a batch of saves settles the graph once rather than per file.
+        The periodic reconcile stays as the cross-process backstop for debt this
+        process never observed.
+        """
+        try:
+            index_sync.drain_graph_work(
+                self._vault_root,
+                limit=self._watcher_policy().max_reconcile_embed_files,
+            )
+        except Exception:  # noqa: BLE001 - queued work stays retryable
+            log.exception("file watcher: deferred graph drain failed")
+
+    def _dispatch_coalesced_batch(self) -> None:
+        """Publish freshness/inbound for every changed path (vault-wide), and
+        re-embed only the Knowledge Base subset."""
         media, ups, del_rels, pending_epoch, access_policy = self._drain()
         if access_policy:
             self._reconcile_access_policy(pending_epoch)

--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -843,6 +843,19 @@ def _drain_graph_work(
     return processed
 
 
+def drain_graph_work(vault_root: Path, *, limit: int | None = None) -> int:
+    """Drain queued epistemic-graph repair without touching the other queues.
+
+    `drain_deferred_work` runs all three queues because its callers -- the
+    periodic reconcile, `maintain`, the CLI -- want all three. The watcher's
+    dispatch path wants only this one. It fires within a debounce window of
+    every write, and replaying embeddings that often is a different cost
+    decision from repairing the graph; coupling them would make the cheap
+    repair pay for the expensive one.
+    """
+    return _drain_graph_work(vault_root, limit=limit, requested=None)
+
+
 def drain_deferred_work(
     vault_root: Path,
     *,

--- a/tests/test_deferred_work_drain.py
+++ b/tests/test_deferred_work_drain.py
@@ -595,6 +595,112 @@ def test_quiet_reconcile_passes_converge_a_corpus_scale_backlog(
     )
 
 
+def test_dispatch_drains_graph_debt_without_waiting_for_the_reconcile_tick(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A write's graph debt must settle on the debounce window, not the 300s tick.
+
+    Deferred graph work used to drain only from `_reconcile_once`. Between one
+    tick and the next -- 300s by default, 900s quiet -- `graph_sync.status()`
+    reported `recovery_required` and readers got `graph sidecar unavailable`,
+    with the repair already queued and already admissible. The product E2E
+    showed exactly that: `epoch_kind='coherent'`, `external_pending=False`,
+    `graph_queue_depth=13`, unchanged across the 120s it waits.
+
+    The empty batch is the case that matters. `_flush` returns early when the
+    coalesced batch has nothing left to dispatch, and the debt is enqueued by
+    the write rather than by this batch, so a drain guarded behind that return
+    would still be waiting for the tick.
+    """
+    policy = mode.WatcherPolicy(0.5, 300.0, 32, 25, False)
+    watcher = file_watcher.FileWatcher(vault)
+    monkeypatch.setattr(watcher, "_watcher_policy", lambda: policy)
+    limits: list[int | None] = []
+    monkeypatch.setattr(
+        index_sync,
+        "drain_graph_work",
+        lambda _root, *, limit=None: limits.append(limit) or 0,
+    )
+
+    watcher._flush()
+
+    assert limits == [25]
+
+
+def test_dispatch_settles_graph_debt_even_when_the_batch_dispatch_raises(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed batch must not strand the graph in `recovery_required`.
+
+    The dispatch and the drain fail independently: whatever killed the batch
+    (a poison media file, a bad upsert) says nothing about whether the queued
+    per-path graph repair can land. Leaving it queued would hand back the same
+    five-minute unreadable window this drain exists to close.
+    """
+    policy = mode.WatcherPolicy(0.5, 300.0, 32, 25, False)
+    watcher = file_watcher.FileWatcher(vault)
+    monkeypatch.setattr(watcher, "_watcher_policy", lambda: policy)
+    drained: list[int | None] = []
+    monkeypatch.setattr(
+        index_sync,
+        "drain_graph_work",
+        lambda _root, *, limit=None: drained.append(limit) or 0,
+    )
+
+    def explode() -> None:
+        raise RuntimeError("batch dispatch failed")
+
+    monkeypatch.setattr(watcher, "_dispatch_coalesced_batch", explode)
+
+    with pytest.raises(RuntimeError, match="batch dispatch failed"):
+        watcher._flush()
+
+    assert drained == [25]
+
+
+def test_graph_drain_failure_never_kills_the_watcher_dispatch(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The drain is best-effort; the queue is durable and the next flush retries."""
+    policy = mode.WatcherPolicy(0.5, 300.0, 32, 25, False)
+    watcher = file_watcher.FileWatcher(vault)
+    monkeypatch.setattr(watcher, "_watcher_policy", lambda: policy)
+
+    def explode(_root: Path, *, limit: int | None = None) -> int:
+        raise RuntimeError("graph drain failed")
+
+    monkeypatch.setattr(index_sync, "drain_graph_work", explode)
+
+    watcher._flush()
+
+
+def test_drain_graph_work_leaves_the_other_deferred_queues_alone(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The dispatch-path drain must not replay embeddings on every write.
+
+    `drain_deferred_work` runs all three queues because the reconcile wants all
+    three. This seam fires within a debounce window instead, so it takes the
+    graph queue only -- the cheap repair must not start paying for the
+    expensive one.
+    """
+    seen: list[tuple[int | None, set[str] | None]] = []
+    monkeypatch.setattr(
+        index_sync,
+        "_drain_graph_work",
+        lambda _root, *, limit=None, requested=None: seen.append((limit, requested)) or 0,
+    )
+    replayed: list[Path] = []
+    monkeypatch.setattr(
+        index_sync, "replay_deferred_embedding", lambda *a, **kw: replayed.append(a)
+    )
+
+    index_sync.drain_graph_work(vault, limit=9)
+
+    assert seen == [(9, None)]
+    assert replayed == []
+
+
 def test_reconcile_drift_spends_budget_before_deferred_drain(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
> **Draft — correction.** I claimed this PR's own `product E2E` job would be the
> proof. It ran and **disproved it**: the E2E still times out at 120 s with
> `'graph': {'available': False, 'reason': 'graph sidecar unavailable'}`. Two
> reasons, both of which I should have checked before claiming it:
>
> 1. `_record` drops server-authored writes via `_is_self_write_event`, so an
>    MCP write never wakes the dispatch thread this change hooks.
> 2. The E2E sets `EXOMEM_DISABLE_FILE_WATCHER=1`, so in that run there is no
>    watcher at all and *nothing* drains the queue by any path.
>
> What is below is still true and still worth landing — out-of-band edits
> currently wait up to 300 s and after this they do not — but it does **not**
> fix the E2E or the MCP-write case, and this PR should not be merged as if it
> did. Holding it in draft until #625 lands the server log and the real deferral
> reason is visible rather than guessed at.

## The queue was built. Nothing was scheduled to drain it.

Phase 2 shipped the durable per-path `graph_upserts` queue and the incremental
drain that consumes it, and both work. What was never wired is a **scheduler**.
Every call site of the graph drain lives inside `_reconcile_once`, and that runs
from `self._stop.wait(self._reconcile_interval_seconds())` — **300 s** by
default, **900 s** in quiet mode.

So between one tick and the next, an out-of-band edit left the graph owing work
with nothing scheduled to do it: `graph_sync.status()` reported
`recovery_required` and readers got `graph sidecar unavailable`.

## The evidence

#620's diagnostic printed:

```
state='recovery_required'   epoch_kind='coherent'
external_pending=False      graph_queue_depth=13
```

`coherent` is in `REPAIRABLE_EPOCH_KINDS`, so the drain would have admitted this
queue on sight. It held unchanged for the full 120 s the E2E waits.

**What that evidence does and does not establish:** it proves the queue is
non-empty and admissible, and that nothing drained it. It does *not* prove the
cause was the reconcile cadence — in that run the watcher was disabled outright.
The cadence gap is real and this fixes it; the E2E's failure has a different
proximate cause still to be identified from the server log.

## What this changes

The watcher's dispatch thread already runs **off the write path**, so this does
not undo Phase 1 taking the graph off it, and it already **coalesces bursts**, so
a batch of saves settles the graph once rather than once per file. The periodic
reconcile is untouched and stays as the cross-process backstop.

- **The drain runs in a `finally`, on every dispatch** — including the three
  paths where `_flush` returns early. The debt is enqueued by the *write*, not by
  this batch, so a batch with nothing left to dispatch can still have left the
  graph owing work. `_flush`'s body moves to `_dispatch_coalesced_batch` so that
  ordering is explicit rather than implied.
- **It takes the graph queue alone**, via a new `index_sync.drain_graph_work`,
  rather than `drain_deferred_work`. The reconcile wants all three queues because
  it runs every 300 s; this seam fires within a debounce window, and replaying
  embeddings that often is a different cost decision.

## Verification

- Graph, index-sync, reconcile, watcher and deferred-drain suites run against
  this branch **and** against an `origin/main` baseline worktree produce
  **byte-identical failure sets** (`comm` diff empty both directions; 37
  pre-existing Windows DACL failures either side), with 4 new tests on top.
- New tests: the drain fires on an empty batch with the policy limit; it still
  fires when the batch dispatch raises; a failing drain never kills the dispatch
  thread; `drain_graph_work` leaves the semantic/full queues alone.
- `ruff check` clean.