### PR TITLE
fix(tests): report an absent proc-fd custody capability instead of failing on it

### DIFF
--- a/benchmarks/protocol/custody.py
+++ b/benchmarks/protocol/custody.py
@@ -41,7 +41,12 @@ class PublishedFile:
 
 _DIRECTORY_FLAGS = (
     os.O_RDONLY
-    | os.O_DIRECTORY
+    # Guarded like every other flag here. Unguarded it raised `AttributeError`
+    # at *import* on Windows, so callers got a missing-attribute crash instead
+    # of this module's own `CustodyUnsupported` -- an absent capability
+    # reported as a bug in `os`. The refusal is in `prove_supported`, which is
+    # where it belongs and where it can say what is missing.
+    | getattr(os, "O_DIRECTORY", 0)
     | getattr(os, "O_NOFOLLOW", 0)
     | getattr(os, "O_NONBLOCK", 0)
     | getattr(os, "O_CLOEXEC", 0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,16 @@ if _BENCHMARKS_DIR.is_dir() and str(_BENCHMARKS_DIR) not in sys.path:
 # and a single unimportable module interrupts the entire run. Declaring them
 # here rather than passing `--ignore` on the command line keeps `pytest` one
 # command on every platform, for CI and for a developer on Windows alike.
+#: `benchmarks/protocol/custody.py` is a *Linux* capability, not merely POSIX
+#: code. It builds directory custody on proc-fd magic symlinks: `capability_path`
+#: is `/proc/self/fd/<n>`, and both the module and its callers path-walk through
+#: it -- `capability_path / "child"`, `.iterdir()`, `symlink_to`. macOS has no
+#: `/proc`, and its `/dev/fd/<n>` is not a substitute: fdesc resolves the fd
+#: itself but supports no directory lookup, so `/dev/fd/<n>/child` cannot
+#: resolve. The module already says this itself by raising `CustodyUnsupported`
+#: rather than degrading into a weaker guarantee.
+PROC_FD_DIRECTORY_CUSTODY = os.name == "posix" and Path("/proc/self/fd").is_dir()
+
 collect_ignore: list[str] = []
 if os.name == "nt":
     collect_ignore += [
@@ -41,7 +51,72 @@ if os.name == "nt":
         "test_lme_reader_gate.py",  # -> lme.runner -> protocol.custody
         "test_lme_runner.py",  # -> lme.runner -> protocol.custody
         "test_protocol_custody.py",  # imports fcntl directly
+        # Same subsystem, same reason, and the list was simply incomplete: these
+        # import `protocol.custody` inside the test body rather than at module
+        # scope, so collection succeeded and they failed one by one at run time
+        # instead of being declared unsupported here. On Windows the custody
+        # capability blocks them almost entirely -- 17/17, 8/8, 3/3, 1/1, 11/11
+        # and 75 of 83 -- so ignoring the file costs a handful of cases in a
+        # subsystem this platform cannot run, which is the trade the entries
+        # above already make.
+        "test_lme_basic_memory_direct.py",
+        "test_lme_cli_provider_choices.py",
+        "test_lme_direct_lifecycle.py",
+        "test_lme_hybrid_rag.py",
+        "test_lme_providers.py",
+        "test_lme_runner_protocol.py",
+        "test_protocol_manifest_trace.py",
     ]
+
+
+def _declares_custody_unsupported(error: BaseException | None) -> bool:
+    """True when *error* is the custody module refusing an absent capability.
+
+    Matched by qualified name rather than by importing `protocol.custody`: on
+    Windows that import is itself one of the things that fails, and a hook that
+    needs the module in order to decide whether the module is usable is no hook
+    at all.
+    """
+    seen: set[int] = set()
+    while error is not None and id(error) not in seen:
+        seen.add(id(error))
+        if type(error).__name__ == "CustodyUnsupported":
+            return True
+        error = error.__cause__ or error.__context__
+    return False
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):  # noqa: ANN001, ANN201
+    """Report an absent proc-fd custody capability as a skip, not a failure.
+
+    On macOS, 82 failures were one platform fact: the capability
+    `protocol.custody` is built on does not exist there, and the module says so
+    in the way it was designed to. A missing capability is what `skip` means.
+
+    Deliberately *not* `collect_ignore` here, which is why macOS is handled
+    differently from Windows above. These modules are only *partly* custody
+    -dependent on macOS -- it collects 162 tests from `test_lme_direct_lifecycle`
+    and only 50 of them need proc-fd -- so ignoring whole files to silence the
+    minority would drop 100+ tests that pass and genuinely cover this platform.
+    Windows is the opposite case: there the same files are blocked almost
+    entirely, so ignoring them costs nearly nothing and buys a declaration.
+
+    Gated on the capability being absent, so this can never mask a regression
+    where it matters: on Linux the capability exists, and a `CustodyUnsupported`
+    there stays a failure and is meant to.
+    """
+    report = (yield).get_result()
+    if PROC_FD_DIRECTORY_CUSTODY or report.when != "call" or report.outcome != "failed":
+        return
+    if call.excinfo is None or not _declares_custody_unsupported(call.excinfo.value):
+        return
+    report.outcome = "skipped"
+    report.longrepr = (
+        str(item.path),
+        item.location[1] or 0,
+        "Skipped: proc-fd directory custody is unavailable on this platform",
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_custody_capability_skip.py
+++ b/tests/test_custody_capability_skip.py
@@ -1,0 +1,69 @@
+"""The conftest hook that reports an absent custody capability as a skip."""
+
+from __future__ import annotations
+
+from conftest import PROC_FD_DIRECTORY_CUSTODY, _declares_custody_unsupported
+
+
+class CustodyUnsupported(Exception):
+    """Same name as `protocol.custody`'s, deliberately not the same class.
+
+    The predicate matches by qualified name rather than by importing that
+    module, because on Windows the import is itself one of the things that
+    fails -- a check that needs the module in order to decide whether the
+    module is usable would be no check at all. This stand-in is what proves
+    the matching is by name.
+    """
+
+
+class CustodyError(Exception):
+    pass
+
+
+def test_the_refusal_itself_is_recognised() -> None:
+    assert _declares_custody_unsupported(CustodyUnsupported("no proc-fd"))
+
+
+def test_an_unrelated_failure_is_not_recognised() -> None:
+    assert not _declares_custody_unsupported(CustodyError("something else"))
+    assert not _declares_custody_unsupported(AssertionError("assert 1 == 2"))
+    assert not _declares_custody_unsupported(None)
+
+
+def test_a_refusal_wrapped_by_raise_from_is_recognised() -> None:
+    """`custody.py` re-raises through `from exc` in several places."""
+    try:
+        try:
+            raise CustodyUnsupported("no proc-fd")
+        except CustodyUnsupported as exc:
+            raise RuntimeError("runner failed") from exc
+    except RuntimeError as outer:
+        assert _declares_custody_unsupported(outer)
+
+
+def test_a_refusal_wrapped_by_implicit_chaining_is_recognised() -> None:
+    """A handler that raises while the refusal is live chains via __context__."""
+    try:
+        try:
+            raise CustodyUnsupported("no proc-fd")
+        except CustodyUnsupported:
+            raise RuntimeError("cleanup failed")
+    except RuntimeError as outer:
+        assert _declares_custody_unsupported(outer)
+
+
+def test_a_self_referential_chain_terminates() -> None:
+    """Never loop: a chain can be made to point at itself."""
+    error = CustodyError("loop")
+    error.__cause__ = error
+    assert not _declares_custody_unsupported(error)
+
+
+def test_the_capability_flag_matches_this_platform() -> None:
+    """The gate is the capability itself, not a platform name."""
+    import os
+    from pathlib import Path
+
+    assert PROC_FD_DIRECTORY_CUSTODY == (
+        os.name == "posix" and Path("/proc/self/fd").is_dir()
+    )


### PR DESCRIPTION
## 219 cross-platform failures, one platform fact

`benchmarks/protocol/custody.py` is a **Linux** capability, not merely POSIX
code. It builds directory custody on proc-fd magic symlinks: `capability_path` is
`/proc/self/fd/<n>`, and both the module and its callers path-walk *through* it —
`capability_path / "child"`, `.iterdir()`, `symlink_to`.

macOS has no `/proc`, and `/dev/fd/<n>` is **not** a substitute: fdesc resolves the
fd itself but supports no directory lookup, so `/dev/fd/<n>/child` cannot resolve.
The module already says this, by raising `CustodyUnsupported` rather than degrading
into a weaker guarantee. 98 macOS + 121 Windows failures were that refusal being
reported as if the code were broken.

## Three changes, and the platforms are treated differently on purpose

**1. `os.O_DIRECTORY` gets the same guard as every flag beside it.** Unguarded it
raised `AttributeError` at import on Windows, so callers got a missing-attribute
crash *in `os`* instead of this module's own refusal — an absent capability
reported as a bug in the standard library.

**2. Windows extends `collect_ignore`.** The existing list was simply incomplete:
the added modules import `protocol.custody` inside the test body rather than at
module scope, so collection succeeded and they failed one at a time at run time.
On Windows the capability blocks them almost entirely — **17/17, 8/8, 3/3, 1/1,
11/11, and 75 of 83** — so ignoring the file costs a handful of cases in a
subsystem the platform cannot run. That is the trade the existing entries already
make.

**3. macOS gets a `pytest_runtest_makereport` hook instead** — because there the
same files are only *partly* blocked. macOS collects **162** tests from
`test_lme_direct_lifecycle` and only **50** need proc-fd; ignoring whole files to
silence the minority would drop 100+ tests that pass and genuinely cover that
platform. The hook turns the module's own refusal into a skip, which is precisely
what a missing capability means.

## Why this cannot hide a real regression

The hook is **gated on the capability being absent**. On Linux the capability
exists, so it returns immediately and a `CustodyUnsupported` there stays a failure
— which is the only place that signal carries information.

It matches by qualified name rather than by importing `protocol.custody`, since on
Windows that import is itself one of the things that fails. A check that needs the
module in order to decide whether the module is usable would be no check at all.

## Verification — run on Windows, one of the affected platforms

- A raised `CustodyUnsupported` is reported `SKIPPED` with the reason, while a
  `RuntimeError` in the same run still **fails**.
- The seven newly-ignored modules collect **zero** tests; whole-suite collection
  still yields **11 202**.
- Six new tests cover the predicate: direct match, `raise ... from`, implicit
  `__context__` chaining, an unrelated error, a self-referential chain (no
  infinite loop), and that the gate tracks the capability rather than a platform
  name.
- **Linux is unchanged on every path**: the hook returns immediately,
  `collect_ignore` is `nt`-only, and `getattr` resolves to the real flag.

## Not in scope

The stragglers this deliberately leaves alone, because they are separate bugs
rather than this capability: `test_transactional_writes` (macOS `DID NOT RAISE
PermissionError`), `test_hosted_platform_operations` (non-writable-regular-file
check), `test_report_offline`, `test_records_recall_reconcile`.