### PR TITLE
ci(cross-platform): drop the latency gate so one slow test stops erasing a shard

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -52,6 +52,15 @@ jobs:
       # that dependency is itself a finding this lane exists to surface.
       - name: Verify lockfile is current
         run: uv lock --check
+      # The latency gate is dropped here for two reasons. It asserts *scaling*,
+      # which a shared runner cannot measure meaningfully, and this lane exists
+      # to expose platform behaviour rather than performance -- it already has
+      # its own dedicated job. More importantly it was destructive: building a
+      # dense vault takes longer than the 60s per-test timeout on a Windows
+      # runner, and `timeout_method = "thread"` kills the whole process, so the
+      # shard wrote no junit at all. One slow perf test cost the entire shard's
+      # evidence, which is how a Windows lane came back with half its results
+      # missing and no indication that anything was absent.
       - name: Run tests (lean — BM25/keyword, server media extraction off)
         env:
           KB_MCP_DISABLE_EMBEDDINGS: "1"
@@ -59,6 +68,7 @@ jobs:
           PYTHONDONTWRITEBYTECODE: "1"
         run: >-
           uv run --frozen --python 3.13 python -m pytest -q
+          --ignore=tests/test_latency_gate.py
           --splits=2
           --group=${{ matrix.shard }}
           --splitting-algorithm=least_duration


### PR DESCRIPTION
## A shard came back with no results and said nothing about it

The Windows shard 2 job on #618 reported **nothing at all** — no failure
summary, no junit. The upload step logged `No files were found with the provided
path`, and the lane returned with half its results missing and no indication that
anything was absent.

**Cause:** `test_warm_graph_lane_does_not_scale_linearly` builds a dense vault,
which takes longer than the 60 s per-test timeout on a Windows runner, and
`timeout_method = "thread"` kills the *whole process* rather than the test. junit
is written at session end, so it is never written at all. One slow performance
test costs the entire shard's evidence.

That bit exactly when it mattered: the DACL fix took Windows shard 1 from **1584
failures to 282**, and shard 2 could not be compared to anything.

## The gate does not belong on this lane anyway

- It asserts **scaling**, which a shared CI runner cannot measure meaningfully.
- This lane exists to expose **platform behaviour**, not performance — its own
  comments say so.
- It already has a dedicated job (`ci.yml`) that runs
  `pytest tests/test_latency_gate.py` directly, so nothing here is its only
  coverage. This is the same arrangement the `embeddings` marker already uses to
  keep heavy tests out of the lean matrix.

## Scope

Only the cross-platform lane changes. Linux still runs the gate both in the
ordinary suite and in its own job.

The next cross-platform run should therefore produce a Windows shard 2 junit for
the first time, which is what makes the remaining Windows failures measurable.