### PR TITLE
fix(tests): give the idempotency store a directory it owns

### DIFF
--- a/tests/test_graph_idempotency_handoff.py
+++ b/tests/test_graph_idempotency_handoff.py
@@ -92,7 +92,7 @@ def test_canonical_result_is_handed_off_before_derived_wait(tmp_path: Path) -> N
     """The graph wait cannot retain execution ownership of the leaf."""
     from exomem.writer_lease import IdempotencyStore
 
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite")
     canonical_guard_released = threading.Event()
     allow_graph_completion = threading.Event()
     results: list[object] = []
@@ -138,7 +138,7 @@ def test_exact_receipt_recovers_same_process_canonical_persistence_failure(
     from exomem.writer_lease import IdempotencyStore, OpError
 
     root = tmp_path / "vault"
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite")
     digest = "d" * 64
     calls = 0
     original = store._persist_canonically_committed
@@ -980,8 +980,8 @@ def test_live_attempt_wins_over_exact_receipt_until_it_exits(tmp_path: Path) -> 
 
     root = tmp_path / "vault"
     digest = "e" * 64
-    owner = IdempotencyStore(tmp_path / "idempotency.sqlite")
-    observer = IdempotencyStore(tmp_path / "idempotency.sqlite", wait_seconds=0)
+    owner = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite")
+    observer = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite", wait_seconds=0)
     assert owner._claim_or_inspect("live", digest, None) == ("owner", None)
     attempt = owner._attempts["live"]
     _receipt(root, digest=digest, attempt=attempt)
@@ -1006,7 +1006,7 @@ def test_legacy_graph_pending_migrates_only_with_an_exact_coherent_checkpoint(
 
     from exomem.writer_lease import IdempotencyStore
 
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite")
     vault = tmp_path / "vault"
     checkpoint = _legacy_graph_pending_checkpoint(vault)
     with store._connect() as conn:
@@ -1061,7 +1061,7 @@ def test_legacy_graph_pending_without_a_strict_checkpoint_binding_fails_closed(
 
     from exomem.writer_lease import IdempotencyStore, OpError
 
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite")
     vault = tmp_path / "vault"
     _legacy_graph_pending_checkpoint(vault, generation=generation, mutation_id=mutation_id)
     with store._connect() as conn:
@@ -1092,7 +1092,7 @@ def test_legacy_graph_pending_checkpoint_mismatch_never_replays_the_leaf(
 
     from exomem.writer_lease import IdempotencyStore, OpError
 
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite")
     vault = tmp_path / "vault"
     current = _legacy_graph_pending_checkpoint(vault, generation=2, mutation_id="2" * 24)
     if kind == "stale":
@@ -1135,7 +1135,7 @@ def test_legacy_graph_pending_checkpoint_mismatch_never_replays_the_leaf(
 def test_corrupt_legacy_graph_pending_pickle_fails_closed_before_resume(tmp_path: Path) -> None:
     from exomem.writer_lease import IdempotencyStore, OpError
 
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite")
     vault = tmp_path / "vault"
     _legacy_graph_pending_checkpoint(vault)
     with store._connect() as conn:
@@ -1208,7 +1208,7 @@ def test_v1_receipt_is_advisory_and_a_copied_v2_receipt_cannot_authorize_without
 
     root = tmp_path / "vault"
     digest = "a" * 64
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite")
     assert store._claim_or_inspect("copied", digest, None) == ("owner", None)
     local_attempt = store._attempts["copied"]
     copied = graph_sync.GraphCommitReceipt.create(
@@ -1237,7 +1237,7 @@ def test_v1_receipt_is_advisory_and_a_copied_v2_receipt_cannot_authorize_without
     ) is False
 
     store._release_attempt("copied", local_attempt)
-    observer = IdempotencyStore(tmp_path / "idempotency.sqlite", wait_seconds=0)
+    observer = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite", wait_seconds=0)
     with pytest.raises(OpError) as blocked:
         observer.run(
             "copied",
@@ -1255,7 +1255,7 @@ def test_v1_receipt_is_advisory_and_a_copied_v2_receipt_cannot_authorize_without
         )
     assert blocked.value.code == "MUTATION_OUTCOME_UNKNOWN"
 
-    empty_store = IdempotencyStore(tmp_path / "fresh-idempotency.sqlite")
+    empty_store = IdempotencyStore(tmp_path / "state" / "fresh-idempotency.sqlite")
     leaf_calls: list[str] = []
     evidence_calls: list[str] = []
     assert empty_store.run(

--- a/tests/test_graph_rebuild_availability.py
+++ b/tests/test_graph_rebuild_availability.py
@@ -2552,7 +2552,7 @@ def test_unacknowledged_checkpoint_requires_recovery_and_preserves_committed_ter
 def test_committed_derived_failure_is_idempotently_replayed(tmp_path: Path) -> None:
     from exomem.writer_lease import IdempotencyStore
 
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite")
     required = _checkpoint(2)
     calls = 0
 
@@ -2580,7 +2580,7 @@ def test_canonical_handoff_is_non_owned_until_off_boundary_graph_work_completes(
 ) -> None:
     from exomem.writer_lease import IdempotencyStore
 
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite", wait_seconds=1)
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite", wait_seconds=1)
     released_guard = threading.Event()
     release_graph = threading.Event()
     result: list[dict[str, object]] = []
@@ -2643,7 +2643,7 @@ def test_dead_graph_pending_owner_resumes_only_derived_graph_work(
     from exomem.writer_lease import IdempotencyStore
 
     monkeypatch.setenv("EXOMEM_DISABLE_GRAPH_SCHEDULING", "1")
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite")
     vault = tmp_path / "vault"
     checkpoint = _checkpoint(1)
     graph_sync._write_floor(vault, graph_sync.GraphSyncGenerationFloor.create(1))
@@ -2682,7 +2682,7 @@ def test_dead_graph_pending_owner_resumes_only_derived_graph_work(
 def test_dead_pending_without_an_exact_receipt_is_outcome_unknown(tmp_path: Path) -> None:
     from exomem.writer_lease import IdempotencyStore, OpError
 
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite")
     with store._connect() as conn:
         conn.execute(
             "INSERT INTO mutations(key, digest, state, updated_at, owner) VALUES (?, ?, ?, ?, ?)",

--- a/tests/test_writer_lease.py
+++ b/tests/test_writer_lease.py
@@ -226,7 +226,7 @@ class _FixedCiphertextProtector:
 
 def test_protected_attempt_secret_never_writes_plaintext_to_sqlite(tmp_path: Path) -> None:
     protector = _EnvelopeProtector()
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite", secret_protector=protector)
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite", secret_protector=protector)
     digest = "a" * 64
 
     assert store._claim_or_inspect("protected", digest, None) == ("owner", None)
@@ -291,7 +291,7 @@ def test_protected_attempt_secret_rejects_non_exact_envelopes(
     tmp_path: Path, stored: bytes
 ) -> None:
     protector = _EnvelopeProtector()
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite", secret_protector=protector)
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite", secret_protector=protector)
     attempt = writer_lease_module._ExecutionAttempt("a" * 24, "b" * 24, stored, None)
 
     assert store._unprotected_commit_secret("e" * 64, attempt) is None
@@ -302,7 +302,7 @@ def test_protected_attempt_secret_rejects_non_exact_envelopes(
 def test_malformed_or_legacy_protected_attempt_secret_fails_closed(
     tmp_path: Path, replacement: bytes
 ) -> None:
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite", secret_protector=_EnvelopeProtector())
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite", secret_protector=_EnvelopeProtector())
     digest = "b" * 64
     assert store._claim_or_inspect("protected", digest, None) == ("owner", None)
     attempt = store._attempts["protected"]
@@ -318,7 +318,7 @@ def test_malformed_or_legacy_protected_attempt_secret_fails_closed(
 
 def test_protected_attempt_secret_binds_the_attempt_identity(tmp_path: Path) -> None:
     protector = _EnvelopeProtector()
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite", secret_protector=protector)
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite", secret_protector=protector)
     digest = "c" * 64
     assert store._claim_or_inspect("one", digest, None) == ("owner", None)
     assert store._claim_or_inspect("two", digest, None) == ("owner", None)
@@ -349,7 +349,7 @@ def test_protection_failure_refuses_before_creating_an_execution_row(tmp_path: P
         def protect(self, _secret: bytes, _entropy: bytes) -> bytes:
             raise OSError("DPAPI unavailable")
 
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite", secret_protector=BrokenProtector())
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite", secret_protector=BrokenProtector())
 
     with pytest.raises(OpError) as error:
         store.run("unprotected", "d" * 64, lambda: pytest.fail("leaf ran"))
@@ -359,7 +359,7 @@ def test_protection_failure_refuses_before_creating_an_execution_row(tmp_path: P
 
 
 def test_legacy_raw_attempt_secret_never_heals_a_dead_execution(tmp_path: Path) -> None:
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite", secret_protector=_EnvelopeProtector())
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite", secret_protector=_EnvelopeProtector())
     digest = "e" * 64
     with sqlite3.connect(store.path) as connection:
         connection.execute(
@@ -533,7 +533,7 @@ def test_lifecycle_idempotency_replay_keeps_committed_receipt_and_replays_termin
         "minimum_reader_version": 2,
     }
     terminal = committed_terminal(receipt, request_id="first", receipt_id="r", idempotency_key="same")
-    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite")
     assert store.run("same", "digest", lambda: terminal) == terminal
     replay = store.run("same", "digest", lambda: pytest.fail("lifecycle leaf reran"))
     assert replay["status"] == "replayed" and replay["mutated"] is False


### PR DESCRIPTION
## The store was validating pytest's directory, not its own

`IdempotencyStore(tmp_path / "idempotency.sqlite")` makes the store's runtime state
root the **pytest temp directory itself**. `prepare_windows_idempotency_runtime_paths`
then validates a directory neither it nor the store created — and
`_prepare_windows_private_directory` is explicit about what that means:

> A process sets permissions only on the exact entry its own `mkdir` created. A
> concurrent loser … validates without repairing the observed entry.

So the check runs against whatever ACL the platform happened to give pytest's
directory.

## Why it reproduced so unevenly

What that ACL *is* depends on the interpreter:

| Interpreter | `mkdir(mode=0o700)` on Windows produces |
|---|---|
| **3.13** | protected: `D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;OW)` |
| **3.11** | mode ignored — the inherited ACL, which on a real workstation admits principals that are neither the user, SYSTEM, nor Administrators |

The validator is right to refuse the second, and it did. Neither shape is the
store's own DACL, and neither is what the module writes.

## The fix

Point the store at a subdirectory. The module then **creates** that directory and
applies its own descriptor — explicit SIDs for the current user, SYSTEM and
Administrators — so validation compares the module's output against the module's
expectation rather than against the platform's temp-directory policy. Ownership
stops mattering entirely, because there is no `OWNER RIGHTS` ACE left to resolve.

This is not a new convention: `test_windows_idempotency_trust.py` and one site in
`test_writer_lease.py` already pass `tmp_path / "state" / …`, and **those two do
not fail**. The other 22 sites are brought in line with them.

## Verification, and an honest limit

Run on Windows under both interpreters over the whole affected suites:

- py3.13 — **14 failed / 299 passed**, identical before and after
- py3.11 — **5 failed / 210 passed**, identical before and after

The remaining failures are the pre-existing `graph_sync` terminal-field ones and
are unrelated.

**This change is a no-op on my machine by construction.** Locally-created objects
are owned by the current user, so the `OWNER RIGHTS` ACE resolves to the user and
the shape already validates. It only bites where **Administrators** owns created
objects — as on a GitHub Windows runner. I could not reproduce that condition
locally, so the cross-platform lane is the measurement, which is what that lane
is for.