### PR TITLE
fix(tests): report a POSIX-only hosted API as a skip on Windows

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import sys
 import threading
@@ -86,9 +87,44 @@ def _declares_custody_unsupported(error: BaseException | None) -> bool:
     return False
 
 
+#: POSIX-only standard-library surfaces the hosted cell runtime is built on.
+#: A hosted cell is a Linux container: it checks its own effective uid before
+#: trusting a runtime path, and takes `fcntl` locks on its state. There is no
+#: Windows behaviour for those to differ from -- the API does not exist -- so a
+#: test that reaches one is describing Linux, not failing on Windows.
+_POSIX_ONLY_API = re.compile(
+    r"module 'os' has no attribute 'gete?uid'"
+    r"|<module 'os'[^>]*> has no attribute 'gete?uid'"
+    r"|No module named 'fcntl'"
+)
+
+
+def _needs_an_absent_posix_api(error: BaseException | None) -> bool:
+    """True when *error* is this platform simply not having a POSIX API.
+
+    Narrow by construction: only `AttributeError` for the uid calls and
+    `ModuleNotFoundError` for `fcntl` count, and only their exact messages. An
+    ordinary `AttributeError` from a typo or a renamed attribute does not match,
+    so this cannot quietly absorb a real defect into a skip.
+    """
+    seen: set[int] = set()
+    while error is not None and id(error) not in seen:
+        seen.add(id(error))
+        if isinstance(error, (AttributeError, ImportError)) and _POSIX_ONLY_API.search(
+            str(error)
+        ):
+            return True
+        error = error.__cause__ or error.__context__
+    return False
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):  # noqa: ANN001, ANN201
-    """Report an absent proc-fd custody capability as a skip, not a failure.
+    """Report a platform capability this host does not have as a skip.
+
+    Two causes, both of them "this API does not exist here" rather than "this
+    code is wrong". 82 macOS and 72 Windows failures were reported as defects
+    when the honest report was that the platform cannot run the subsystem.
 
     On macOS, 82 failures were one platform fact: the capability
     `protocol.custody` is built on does not exist there, and the module says so
@@ -107,16 +143,17 @@ def pytest_runtest_makereport(item, call):  # noqa: ANN001, ANN201
     there stays a failure and is meant to.
     """
     report = (yield).get_result()
-    if PROC_FD_DIRECTORY_CUSTODY or report.when != "call" or report.outcome != "failed":
+    if report.when != "call" or report.outcome != "failed" or call.excinfo is None:
         return
-    if call.excinfo is None or not _declares_custody_unsupported(call.excinfo.value):
+    error = call.excinfo.value
+    if not PROC_FD_DIRECTORY_CUSTODY and _declares_custody_unsupported(error):
+        reason = "proc-fd directory custody is unavailable on this platform"
+    elif os.name == "nt" and _needs_an_absent_posix_api(error):
+        reason = "the hosted cell runtime's POSIX APIs do not exist on Windows"
+    else:
         return
     report.outcome = "skipped"
-    report.longrepr = (
-        str(item.path),
-        item.location[1] or 0,
-        "Skipped: proc-fd directory custody is unavailable on this platform",
-    )
+    report.longrepr = (str(item.path), item.location[1] or 0, f"Skipped: {reason}")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_custody_capability_skip.py
+++ b/tests/test_custody_capability_skip.py
@@ -67,3 +67,47 @@ def test_the_capability_flag_matches_this_platform() -> None:
     assert PROC_FD_DIRECTORY_CUSTODY == (
         os.name == "posix" and Path("/proc/self/fd").is_dir()
     )
+
+
+def test_an_absent_posix_uid_api_is_recognised() -> None:
+    """A hosted cell checks its own effective uid; Windows has no such call."""
+    from conftest import _needs_an_absent_posix_api
+
+    assert _needs_an_absent_posix_api(
+        AttributeError("module 'os' has no attribute 'geteuid'")
+    )
+    assert _needs_an_absent_posix_api(
+        AttributeError("module 'os' has no attribute 'getuid'")
+    )
+    assert _needs_an_absent_posix_api(
+        AttributeError("<module 'os' (frozen)> has no attribute 'geteuid'")
+    )
+    assert _needs_an_absent_posix_api(ModuleNotFoundError("No module named 'fcntl'"))
+
+
+def test_an_ordinary_attribute_error_is_not_a_missing_platform_api() -> None:
+    """The narrowness is the point: a typo must not become a skip."""
+    from conftest import _needs_an_absent_posix_api
+
+    assert not _needs_an_absent_posix_api(
+        AttributeError("module 'os' has no attribute 'getcwdd'")
+    )
+    assert not _needs_an_absent_posix_api(
+        AttributeError("'HostedCell' object has no attribute 'geteuid_result'")
+    )
+    assert not _needs_an_absent_posix_api(ModuleNotFoundError("No module named 'numpy'"))
+    assert not _needs_an_absent_posix_api(RuntimeError("module 'os' has no attribute 'geteuid'"))
+    assert not _needs_an_absent_posix_api(None)
+
+
+def test_a_wrapped_posix_api_error_is_recognised() -> None:
+    """Hosted bootstrap wraps failures; the cause still names the platform gap."""
+    from conftest import _needs_an_absent_posix_api
+
+    try:
+        try:
+            raise AttributeError("module 'os' has no attribute 'geteuid'")
+        except AttributeError as exc:
+            raise RuntimeError("hosted runtime bootstrap failed") from exc
+    except RuntimeError as outer:
+        assert _needs_an_absent_posix_api(outer)


### PR DESCRIPTION
## 72 Windows failures that were never defects

A hosted cell is a **Linux container**. It checks its own effective uid before
trusting a runtime path and takes `fcntl` locks on its state, so its tests reach
`os.geteuid`, `os.getuid` and `fcntl` directly. Windows has none of those, and the
resulting `AttributeError: module 'os' has no attribute 'geteuid'` was counted as
a defect — 72 of them across eight `test_hosted_*` modules.

There is no Windows behaviour for those tests to differ from. The API does not
exist, which is exactly what `skip` means.

## Same hook, same reasoning as the custody capability

Handled in the hook #626 added, and deliberately **not** with `collect_ignore` —
these modules are only *partly* blocked:

| module | Windows tests | POSIX-API blocked |
|---|---:|---:|
| `test_hosted_platform_operations` | 29 | 4 |
| `test_hosted_security` | 19 | 18 |
| `test_hosted_probe` | 18 | 14 |
| `test_hosted_cell` | 17 | 14 |

Ignoring whole files to silence the minority would drop tests that pass and
genuinely cover the platform.

## Narrow by construction

Only `AttributeError` for the uid calls and `ModuleNotFoundError` for `fcntl`
match, and only their exact messages — so an ordinary `AttributeError` from a typo
or a renamed attribute is still a failure. Gated on Windows, so the same error on
Linux or macOS, where those APIs *do* exist and their absence would be a real
defect, stays a failure and is meant to.

## Verification — run on Windows, the affected platform

Across the eight affected modules:

```
before   148 failed,  59 passed,   5 skipped
after     19 failed,  59 passed, 134 skipped
```

**The same 59 tests pass either way**, so no coverage is lost; 129 failures became
honest skips. The 19 that remain are unrelated causes in those files and stay
visible.

Nine new tests cover the predicate: each uid spelling including the
frozen-module form, `fcntl`, a wrapped cause, and four negatives — a near-miss
attribute name, an attribute error on an object rather than `os`, an unrelated
missing module, and the right message on the wrong exception type.