### PR TITLE
feat(graph): own the schedule that settles queued graph repair

### DIFF
--- a/src/exomem/deferred_index.py
+++ b/src/exomem/deferred_index.py
@@ -417,9 +417,30 @@ def _add_plain_receipts(
         conn.close()
 
 
+def _note_graph_debt() -> None:
+    """Tell the drain daemon this process just queued graph repair.
+
+    Imported here rather than at module scope: `graph_drain` reaches back into
+    `index_sync`, which imports this module. Best-effort by design -- queueing
+    the work is the durable part, and a missed signal costs at worst the
+    daemon's idle poll rather than the repair itself.
+    """
+    try:
+        from . import graph_drain
+
+        graph_drain.note_graph_debt()
+    except Exception:  # noqa: BLE001 - never let signalling break an enqueue
+        # Silent on purpose: this module keeps no logger, and a missed signal is
+        # already covered by the daemon's idle poll. The enqueue itself, which
+        # is the part that must not be lost, has already committed.
+        pass
+
+
 def add_graph(vault_root: Path, rel_paths: list[str]) -> int:
     """Durably queue pages whose epistemic-graph projection needs re-deriving."""
     _receipts, added = _add_plain_receipts(vault_root, rel_paths, table="graph_upserts")
+    if added:
+        _note_graph_debt()
     return added
 
 
@@ -428,6 +449,8 @@ def add_graph_receipts(vault_root: Path, rel_paths: list[str]) -> list[DeferredR
     receipts, _added = _add_plain_receipts(
         vault_root, rel_paths, table="graph_upserts"
     )
+    if receipts:
+        _note_graph_debt()
     return receipts
 
 
@@ -464,6 +487,9 @@ def mark_graph_full_rebuild(vault_root: Path, *, generation: int) -> None:
             )
     finally:
         conn.close()
+    # A whole-vault marker is graph debt too, and the one the drain most needs
+    # to hear about: it is raised exactly when the changed scope is unknown.
+    _note_graph_debt()
 
 
 def graph_full_rebuild_pending(vault_root: Path) -> int | None:

--- a/src/exomem/graph_drain.py
+++ b/src/exomem/graph_drain.py
@@ -1,0 +1,179 @@
+"""Background drain for the durable epistemic-graph repair queue.
+
+The queue and the incremental drain that consumes it both work. What was never
+wired is a *scheduler*: every call site of the graph drain lived inside
+``file_watcher._reconcile_once``, which runs on ``reconcile_interval_seconds`` --
+300s by default, 900s in quiet mode -- and the watcher is optional. It returns
+``False`` and logs a no-op when ``watchdog`` is absent, and the server skips it
+entirely under ``EXOMEM_DISABLE_FILE_WATCHER``.
+
+So graph convergence depended on an optional component, and where that component
+was missing nothing drained the queue at all. A write left ``graph_sync.status()``
+reporting ``recovery_required`` and readers getting ``graph sidecar unavailable``,
+with the repair already queued, already admissible, and nothing scheduled to run
+it. The product E2E proved it: ``epoch_kind='coherent'``,
+``external_pending=False``, ``graph_queue_depth=13``, unchanged across the whole
+120s it waits.
+
+This owns that schedule and nothing else. It does not repair anything itself --
+``index_sync.drain_graph_work`` does the work, unchanged. It decides *when*.
+
+Three properties the timing has to have:
+
+* **Prompt.** A signal fires when debt is enqueued, so repair follows the write
+  that caused it rather than the next tick of a five-minute clock.
+* **Settled.** A short debounce after that signal lets a burst of writes finish.
+  Draining into a live batch wastes a pass: the epoch will not admit incremental
+  repair mid-flight, and a whole-vault rebuild loses its optimistic
+  concurrency check to whichever write lands next. Repair wants the quiet moment
+  just after a burst, not the middle of one.
+* **Bounded.** Debt that cannot be drained -- an unsettled epoch, a vault not yet
+  ready -- must not spin. The retry interval backs off to a ceiling, so a queue
+  that is stuck costs one attempt every couple of minutes rather than one per
+  second.
+
+The periodic reconcile stays exactly as it was. It remains the cross-process
+backstop for debt this process never observed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+#: Let a burst of writes settle before draining. Repair dispatched into a live
+#: canonical batch is a wasted pass, not a faster one.
+DEBOUNCE_SECONDS = 1.0
+
+#: Fallback poll with no local signal, so debt enqueued by another process (a
+#: CLI `exomem index`, a second server) is still picked up here.
+IDLE_POLL_SECONDS = 30.0
+
+#: First retry after a drain that made no progress.
+RETRY_SECONDS = 5.0
+
+#: Ceiling for that retry. A queue that cannot drain costs one attempt every two
+#: minutes, not one per second.
+MAX_RETRY_SECONDS = 120.0
+
+#: Paths per drain. Bounds one pass so a large queue cannot hold the worker in a
+#: single call, matching the cap the periodic reconcile already applies.
+DRAIN_LIMIT = 64
+
+_LOCK = threading.Lock()
+_thread: threading.Thread | None = None
+_stop = threading.Event()
+
+#: Set whenever graph debt is enqueued in this process. Module-level rather than
+#: per-vault: a server serves one vault, and a cross-vault signal costs at worst
+#: one extra drain that finds an empty queue and goes back to sleep.
+_DEBT = threading.Event()
+
+
+def note_graph_debt() -> None:
+    """Wake the drain: this process just queued epistemic-graph repair."""
+    _DEBT.set()
+
+
+def disabled() -> bool:
+    """True when the operator has turned the drain off.
+
+    A kill switch rather than a config knob. The failure this exists to prevent
+    is silence, so the lever to turn it off should be as blunt and as visible as
+    the one for the watcher beside it.
+    """
+    return bool(os.environ.get("EXOMEM_DISABLE_GRAPH_DRAIN"))
+
+
+def _pending(vault_root: Path) -> bool:
+    """True when the durable queue owes work. Never raises."""
+    from . import deferred_index
+
+    try:
+        if deferred_index.graph_full_rebuild_pending(vault_root) is not None:
+            return True
+        return int(deferred_index.graph_status(vault_root).get("count") or 0) > 0
+    except Exception:  # noqa: BLE001 - an unreadable queue must not kill the worker
+        log.debug("graph drain: queue depth unreadable", exc_info=True)
+        return False
+
+
+def _drain_once(vault_root: Path) -> int:
+    """One bounded drain. Never raises; returns receipts cleared."""
+    from . import index_sync
+
+    try:
+        return int(index_sync.drain_graph_work(vault_root, limit=DRAIN_LIMIT) or 0)
+    except Exception:  # noqa: BLE001 - queued work stays durable and retryable
+        log.warning("graph drain: pass failed; work remains queued", exc_info=True)
+        return 0
+
+
+def _run(vault_root: Path) -> None:
+    interval = IDLE_POLL_SECONDS
+    while not _stop.is_set():
+        signalled = _DEBT.wait(timeout=interval)
+        if _stop.is_set():
+            break
+        _DEBT.clear()
+        if signalled:
+            # Settle. `wait` returning True here means a stop was requested.
+            if _stop.wait(DEBOUNCE_SECONDS):
+                break
+        if not _pending(vault_root):
+            interval = IDLE_POLL_SECONDS
+            continue
+        processed = _drain_once(vault_root)
+        if not _pending(vault_root):
+            log.info("graph drain: queue settled (%d receipt(s) cleared)", processed)
+            interval = IDLE_POLL_SECONDS
+        elif processed:
+            # Progress with work left: come straight back for the remainder.
+            interval = RETRY_SECONDS
+        else:
+            # No progress. The ordinary cause is an epoch that is not settled
+            # yet, which the next pass clears -- so retry, but back off, because
+            # the other cause is a queue that cannot drain at all and must not
+            # become a busy loop.
+            interval = min(
+                MAX_RETRY_SECONDS, RETRY_SECONDS if interval >= IDLE_POLL_SECONDS else interval * 2
+            )
+
+
+def start(vault_root: Path) -> threading.Thread | None:
+    """Start the drain daemon. Idempotent -- a second call returns the live one."""
+    global _thread
+    if disabled():
+        log.info("graph drain disabled by EXOMEM_DISABLE_GRAPH_DRAIN")
+        return None
+    with _LOCK:
+        if _thread is not None and _thread.is_alive():
+            return _thread
+        _stop.clear()
+        _DEBT.set()  # Drain once at startup: debt can outlive the process that queued it.
+        thread = threading.Thread(
+            target=_run,
+            args=(Path(vault_root),),
+            name="exomem-graph-drain",
+            daemon=True,
+        )
+        _thread = thread
+        thread.start()
+        log.info("graph drain started on %s", vault_root)
+        return thread
+
+
+def stop(timeout: float = 2.0) -> None:
+    """Stop the drain daemon and wait briefly for it to finish."""
+    global _thread
+    with _LOCK:
+        thread = _thread
+        _thread = None
+    _stop.set()
+    _DEBT.set()
+    if thread is not None:
+        thread.join(timeout=timeout)

--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -843,6 +843,18 @@ def _drain_graph_work(
     return processed
 
 
+def drain_graph_work(vault_root: Path, *, limit: int | None = None) -> int:
+    """Drain queued epistemic-graph repair without touching the other queues.
+
+    `drain_deferred_work` runs all three queues because its callers -- the
+    periodic reconcile, `maintain`, the CLI -- want all three. The graph drain
+    daemon wants only this one: it fires within a second of the write that
+    queued the debt, and replaying embeddings that often is a different cost
+    decision from repairing the graph.
+    """
+    return _drain_graph_work(vault_root, limit=limit, requested=None)
+
+
 def drain_deferred_work(
     vault_root: Path,
     *,

--- a/src/exomem/server_runtime.py
+++ b/src/exomem/server_runtime.py
@@ -76,6 +76,7 @@ def initialize_runtime(*, load_dotenv_func: Callable[..., object]) -> ServerRunt
     _start_compute_runtime(vault_root)
     media_worker = _start_media_worker(vault_root)
     file_watcher = _start_file_watcher(vault_root)
+    _start_graph_drain(vault_root)
 
     base_url = os.environ.get("EXOMEM_BASE_URL", "").strip().rstrip("/")
     return ServerRuntime(
@@ -427,6 +428,26 @@ def _create_media_worker(vault_root: Path) -> Any | None:
         return media_worker_module.MediaWorker(vault_root)
     except Exception as exc:  # noqa: BLE001 - media must never deny the core service
         log.warning("media runtime unavailable; core service continuing: %s", exc)
+        return None
+
+
+def _start_graph_drain(vault_root: Path) -> Any | None:
+    """Start the drain that settles queued epistemic-graph repair.
+
+    Deliberately not folded into the file watcher, even though the watcher is
+    where the only existing drain call sites live. The watcher is optional -- it
+    no-ops without `watchdog` and is skipped entirely under
+    `EXOMEM_DISABLE_FILE_WATCHER` -- and graph convergence must not be optional
+    with it. Where the watcher was absent, nothing drained the queue at all and
+    the graph stayed `recovery_required` indefinitely with the repair already
+    queued and admissible.
+    """
+    from . import graph_drain
+
+    try:
+        return graph_drain.start(vault_root)
+    except Exception as exc:  # noqa: BLE001 - convergence must not break startup
+        log.warning("graph drain start failed: %s", exc)
         return None
 
 

--- a/tests/test_graph_drain.py
+++ b/tests/test_graph_drain.py
@@ -1,0 +1,203 @@
+"""The daemon that decides *when* queued epistemic-graph repair runs."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from exomem import deferred_index, graph_drain, index_sync
+
+
+@pytest.fixture(autouse=True)
+def _stop_the_daemon():
+    """No test may leave a drain thread running into the next one."""
+    yield
+    graph_drain.stop()
+    graph_drain._DEBT.clear()
+
+
+def _wait_for(predicate, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+def test_a_queued_write_is_drained_without_waiting_for_the_reconcile_tick(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole point: repair follows the write, not a five-minute clock.
+
+    Before this daemon the only drain call sites were inside
+    `file_watcher._reconcile_once`, which runs on `reconcile_interval_seconds` --
+    300s by default. Between ticks the graph reported `recovery_required` and
+    readers got `graph sidecar unavailable`, with the repair already queued.
+    """
+    drained = threading.Event()
+    calls: list[int | None] = []
+
+    def drain(_root: Path, *, limit: int | None = None) -> int:
+        calls.append(limit)
+        drained.set()
+        return 1
+
+    monkeypatch.setattr(index_sync, "drain_graph_work", drain)
+    monkeypatch.setattr(graph_drain, "_pending", lambda _root: not drained.is_set())
+    monkeypatch.setattr(graph_drain, "DEBOUNCE_SECONDS", 0.01)
+
+    graph_drain.start(tmp_path)
+
+    assert drained.wait(timeout=5.0), "queued repair was never drained"
+    assert calls == [graph_drain.DRAIN_LIMIT]
+
+
+def test_the_debt_signal_wakes_a_sleeping_drain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An enqueue must wake the worker rather than wait out its idle poll.
+
+    The idle poll is a backstop for debt queued by another process. If a local
+    enqueue had to wait for it, this would reintroduce the same latency in a
+    smaller unit.
+    """
+    monkeypatch.setattr(graph_drain, "IDLE_POLL_SECONDS", 3600.0)
+    monkeypatch.setattr(graph_drain, "DEBOUNCE_SECONDS", 0.01)
+    pending = threading.Event()
+    drained = threading.Event()
+    monkeypatch.setattr(graph_drain, "_pending", lambda _root: pending.is_set())
+
+    def drain(_root: Path, *, limit: int | None = None) -> int:
+        pending.clear()
+        drained.set()
+        return 1
+
+    monkeypatch.setattr(index_sync, "drain_graph_work", drain)
+
+    graph_drain.start(tmp_path)
+    assert _wait_for(lambda: not graph_drain._DEBT.is_set())  # startup pass done
+    drained.clear()
+
+    pending.set()
+    graph_drain.note_graph_debt()
+
+    assert drained.wait(timeout=5.0), "the enqueue signal did not wake the drain"
+
+
+def test_a_queue_that_cannot_drain_backs_off_instead_of_spinning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No-progress is the mid-batch case, so it retries -- but bounded.
+
+    An epoch that is not settled refuses the drain and the next pass clears it,
+    which is why this retries at all. The other cause is a queue that cannot
+    drain, and that must not become a busy loop against the sidecar.
+    """
+    monkeypatch.setattr(graph_drain, "DEBOUNCE_SECONDS", 0.0)
+    monkeypatch.setattr(graph_drain, "RETRY_SECONDS", 0.01)
+    monkeypatch.setattr(graph_drain, "MAX_RETRY_SECONDS", 0.05)
+    monkeypatch.setattr(graph_drain, "_pending", lambda _root: True)
+    attempts: list[float] = []
+
+    def drain(_root: Path, *, limit: int | None = None) -> int:
+        attempts.append(time.monotonic())
+        return 0  # never any progress
+
+    monkeypatch.setattr(index_sync, "drain_graph_work", drain)
+
+    graph_drain.start(tmp_path)
+    assert _wait_for(lambda: len(attempts) >= 4, timeout=5.0)
+    graph_drain.stop()
+
+    gaps = [b - a for a, b in zip(attempts, attempts[1:], strict=False)]
+    assert gaps, "expected repeated attempts"
+    assert max(gaps) <= 1.0, f"backoff exceeded its ceiling: {gaps}"
+    assert gaps[-1] >= gaps[0], f"expected backoff to grow, got {gaps}"
+
+
+def test_a_failing_drain_never_kills_the_daemon(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The queue is durable; one bad pass must not end scheduling forever."""
+    monkeypatch.setattr(graph_drain, "DEBOUNCE_SECONDS", 0.0)
+    monkeypatch.setattr(graph_drain, "RETRY_SECONDS", 0.01)
+    monkeypatch.setattr(graph_drain, "MAX_RETRY_SECONDS", 0.05)
+    monkeypatch.setattr(graph_drain, "_pending", lambda _root: True)
+    attempts: list[int] = []
+
+    def explode(_root: Path, *, limit: int | None = None) -> int:
+        attempts.append(1)
+        raise RuntimeError("drain exploded")
+
+    monkeypatch.setattr(index_sync, "drain_graph_work", explode)
+
+    thread = graph_drain.start(tmp_path)
+    assert _wait_for(lambda: len(attempts) >= 3, timeout=5.0)
+    assert thread is not None and thread.is_alive()
+
+
+def test_an_unreadable_queue_is_not_pending_and_does_not_raise(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Queue-depth is a scheduling hint, not a contract."""
+
+    def explode(_root: Path) -> int | None:
+        raise RuntimeError("sidecar unreadable")
+
+    monkeypatch.setattr(deferred_index, "graph_full_rebuild_pending", explode)
+
+    assert graph_drain._pending(tmp_path) is False
+
+
+def test_a_whole_vault_marker_counts_as_pending(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The marker is raised exactly when the changed scope is unknown.
+
+    That is the case the drain most needs to hear about, and it carries no
+    per-path receipts, so a depth-only check would call the queue empty.
+    """
+    monkeypatch.setattr(deferred_index, "graph_full_rebuild_pending", lambda _root: 7)
+    monkeypatch.setattr(deferred_index, "graph_status", lambda _root: {"count": 0})
+
+    assert graph_drain._pending(tmp_path) is True
+
+
+def test_start_is_idempotent_and_stop_ends_the_thread(tmp_path: Path) -> None:
+    """Hosted quiesce/resume reuses the process; a second start must not stack."""
+    first = graph_drain.start(tmp_path)
+    second = graph_drain.start(tmp_path)
+
+    assert first is not None and first is second
+
+    graph_drain.stop()
+    assert _wait_for(lambda: not first.is_alive())
+
+
+def test_the_kill_switch_declines_to_start(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_DISABLE_GRAPH_DRAIN", "1")
+
+    assert graph_drain.disabled() is True
+    assert graph_drain.start(tmp_path) is None
+
+
+def test_enqueuing_graph_work_signals_the_drain(tmp_path: Path) -> None:
+    """The seam that makes repair prompt: `add_graph` wakes the daemon."""
+    graph_drain._DEBT.clear()
+
+    added = deferred_index.add_graph(tmp_path, ["Knowledge Base/Notes/a.md"])
+
+    assert added
+    assert graph_drain._DEBT.is_set()
+
+
+def test_a_whole_vault_marker_signals_the_drain(tmp_path: Path) -> None:
+    deferred_index.mark_graph_full_rebuild(tmp_path, generation=3)
+
+    assert graph_drain._DEBT.is_set()


### PR DESCRIPTION
## The gap

The durable per-path queue and the incremental drain that consumes it both work. What was never wired is a **scheduler**.

Every call site of the graph drain lived inside `file_watcher._reconcile_once`, which runs on `reconcile_interval_seconds` — 300s by default, 900s in quiet mode. And the watcher is *optional*: it returns `False` and logs a no-op when `watchdog` is absent, and the server skips it entirely under `EXOMEM_DISABLE_FILE_WATCHER`.

So graph convergence depended on an optional component, and wherever that component was absent **nothing drained the queue at all**. A write left `graph_sync.status()` reporting `recovery_required` and readers getting `graph sidecar unavailable`, with the repair already queued and already admissible.

## What the server log showed

#625 captured the E2E server log for the first time, and it ends like this:

```
graph incremental refresh fell back reason=resolver_snapshot_unavailable
graph rebuild stabilization exhausted attempts=8 class=C
    cause=the recall projection identity moved across the pass
graph rebuild finished outcome=failed generation=2
ERROR graph rebuild stopped generation=2
```

and then nothing, for the whole 120s the E2E waits. A transient `resolver_snapshot_unavailable` dispositions to `"rebuild"` (correctly — the changed scope is unknown), the whole-vault rebuild loses its vault-global optimistic check eight times to concurrent writes, and it stops **permanently** with nothing scheduled to retry.

## What this changes

This owns the schedule and nothing else. It does not repair anything — `index_sync.drain_graph_work` does the work, unchanged. It decides *when*:

- **Prompt.** A signal fires on every graph enqueue, so repair follows the write that caused it instead of the next tick of a five-minute clock. `enqueue_graph_checkpoint` is the seam every canonical batch already calls (`vault.py:3319`), and both of its branches — `add_graph` for a path list, `mark_graph_full_rebuild` for a full-scope batch — now raise it.
- **Settled.** A one-second debounce after that signal lets a burst finish. Draining into a live batch wastes the pass: the epoch will not admit incremental repair mid-flight, and a whole-vault rebuild loses its optimistic concurrency check to whichever write lands next. Repair wants the quiet moment *after* a burst, not the middle of one — which is exactly what the Class C exhaustion above is.
- **Bounded.** Debt that cannot drain backs off to a two-minute ceiling, so a stuck queue costs one attempt every couple of minutes rather than one per second.

Deliberately a separate daemon rather than another hook in the watcher: the whole point is that convergence stops being conditional on the watcher existing. The periodic reconcile is untouched and remains the cross-process backstop for debt this process never observed. `EXOMEM_DISABLE_GRAPH_DRAIN` turns it off, as blunt a lever as the one beside it for the watcher.

Scoped to the standard server runtime. The hosted path gates its workers behind feature flags with lifecycle registration — a different contract that wants its own change.

## Verification

- **10 new tests** (`tests/test_graph_drain.py`), all passing: prompt drain without waiting for the reconcile tick, a signal waking a sleeping worker, bounded backoff under no progress, a raising drain never killing the daemon, an unreadable queue not counting as pending, a whole-vault marker counting as pending, idempotent `start`, the kill switch, and both enqueue seams raising the signal.
- **Zero regressions.** Graph, index-sync, reconcile, watcher and deferred-drain suites against an `origin/main` baseline worktree: **byte-identical failure sets**, 34 failed / 257 passed either side.
- `ruff check --select F` clean on all four changed files.

### The honest limit

The product E2E passes locally on this branch (`PASS 137.6s`) — **but it also passes on plain `main` locally** (`PASS 129.4s`), so the local run is not evidence of anything. The failure reproduces only on CI's slower runners, where concurrent-write pressure is higher. **CI is the measurement**, and #625 (E2E server logs) is what will show whether the drain actually settles the queue there.
