### PR TITLE
fix(tests): declare what the Linux-only benchmark harnesses require

### DIFF
--- a/tests/benchmark_capabilities.py
+++ b/tests/benchmark_capabilities.py
@@ -35,6 +35,7 @@ import shutil
 import signal
 import subprocess
 from functools import lru_cache
+from pathlib import Path
 
 import pytest
 
@@ -92,10 +93,30 @@ def has_posix_interval_timers() -> bool:
     return all(hasattr(signal, name) for name in _TIMER_PRIMITIVES)
 
 
+#: What `epistemic.broker` pins its sandbox to. Not merely "Linux": these are
+#: Debian/Ubuntu x86-64 paths, hardcoded, and the broker refuses rather than
+#: substitute -- it verifies `bwrap` *is* the trusted binary, then binds this
+#: exact runtime into the namespace. Duplicated here rather than imported so a
+#: skip decision never depends on importing the harness it is gating.
+_SANDBOX_RUNTIME = (
+    "/usr/bin/bwrap",
+    "/usr/bin/python3.12",
+    "/usr/lib/python3.12",
+    "/lib/x86_64-linux-gnu",
+    "/lib64/ld-linux-x86-64.so.2",
+)
+
+
 @lru_cache(maxsize=1)
-def has_bwrap() -> bool:
-    """True when a bubblewrap sandbox can be spawned at all."""
-    return shutil.which("bwrap") is not None
+def has_bwrap_sandbox() -> bool:
+    """True when the exact sandbox the broker binds is present.
+
+    `shutil.which("bwrap")` alone is not enough: the broker resolves it against
+    `/usr/bin/bwrap` specifically and binds a pinned interpreter, stdlib, libc
+    and loader beside it. Any one of them missing is a refusal, so all of them
+    are the capability.
+    """
+    return all(Path(path).exists() for path in _SANDBOX_RUNTIME)
 
 
 def require_posix_file_modes() -> None:
@@ -118,9 +139,9 @@ def require_posix_interval_timers() -> None:
         pytest.skip("POSIX interval timers (setitimer/SIGALRM) are unavailable here")
 
 
-def require_bwrap() -> None:
-    if not has_bwrap():
-        pytest.skip("the bubblewrap sandbox is unavailable here")
+def require_bwrap_sandbox() -> None:
+    if not has_bwrap_sandbox():
+        pytest.skip("the pinned bubblewrap sandbox runtime is unavailable here")
 
 
 #: The broker's own words for the capability it needs. It says this deliberately
@@ -149,6 +170,38 @@ def declares_absent_surface_timers(error: BaseException | None) -> bool:
             if _BROKER_TIMER_REFUSAL.search(str(error)):
                 return True
         if isinstance(error, AssertionError) and _BROKER_TIMER_REFUSAL.search(str(error)):
+            return True
+        error = error.__cause__ or error.__context__
+    return False
+
+
+#: The broker's five distinct refusals for a sandbox it cannot build -- an
+#: absent `bwrap`, one that is not the trusted binary, one it cannot stat or
+#: that is group/world writable, and a pinned system runtime that is not there.
+#: Each is a deliberate fail-closed declaration, which is what makes matching
+#: the sentence safe.
+_BROKER_SANDBOX_REFUSAL = re.compile(
+    r"bwrap sandbox (is unavailable|executable (cannot be verified"
+    r"|is not the trusted system binary|is group/world writable))"
+    r"|sandbox system runtime or bound worker bytes are unavailable"
+)
+
+
+def declares_absent_sandbox(error: BaseException | None) -> bool:
+    """True when *error* is the broker refusing to build its pinned sandbox.
+
+    Walks the chain for the same reason `declares_absent_surface_timers` does:
+    `pytest.raises(..., match=...)` re-raises as an `AssertionError` carrying
+    the refusal, and a test that met this refusal instead of its own failed for
+    the absent capability rather than for its subject.
+    """
+    seen: set[int] = set()
+    while error is not None and id(error) not in seen:
+        seen.add(id(error))
+        if type(error).__name__ in {"BrokerContractError", "BrokerSurfaceTimeout"}:
+            if _BROKER_SANDBOX_REFUSAL.search(str(error)):
+                return True
+        if isinstance(error, AssertionError) and _BROKER_SANDBOX_REFUSAL.search(str(error)):
             return True
         error = error.__cause__ or error.__context__
     return False

--- a/tests/benchmark_capabilities.py
+++ b/tests/benchmark_capabilities.py
@@ -1,0 +1,154 @@
+"""What the benchmark harnesses require of the machine underneath them.
+
+`benchmarks/memorybench` and `benchmarks/epistemic` are deliberately Linux-only.
+They are not product code and were never meant to be portable: their contracts
+are written *in terms of* Linux facilities, because reproducible benchmark
+evidence is the whole point of them.
+
+* `memorybench.export._secure_read` proves a private file is unreadable by
+  anyone else using POSIX mode bits and `st_uid`.
+* `memorybench` pins Bun to an exact version so a run is byte-reproducible.
+* `epistemic.broker` bounds provider work with `setitimer`/`SIGALRM` and isolates
+  it with `bwrap`, which is Linux user namespaces and exists nowhere else.
+
+`ci.yml` provisions all three; every job in it is `ubuntu-latest`.
+`cross-platform.yml` cannot, so it collected ~135 failures that say nothing about
+the code -- on Windows `Path.chmod(0o600)` only toggles the read-only bit and the
+file still reports `0o666`, so the very first `_secure_read` of a test's own plan
+raises before the test reaches its subject.
+
+A missing prerequisite is a skip, not a failure. Gate on the *capability* rather
+than on `sys.platform`, so a Linux box without Bun installed also reports the
+truth, and so the reason names what is actually absent.
+
+The gates go on the shared helpers that need the capability, not on whole
+modules: a good share of these tests are pure logic -- digest vectors, plan
+validation, canonical selection -- and those keep running everywhere, which is
+the cross-platform signal worth having.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import signal
+import subprocess
+from functools import lru_cache
+
+import pytest
+
+#: The Bun release `memorybench` pins. Kept here rather than imported so a skip
+#: decision never depends on importing the harness it is gating.
+REQUIRED_BUN_VERSION = "1.3.14"
+
+_TIMER_PRIMITIVES = ("SIGALRM", "ITIMER_REAL", "getitimer", "setitimer")
+
+
+@lru_cache(maxsize=1)
+def has_posix_file_modes() -> bool:
+    """True where `st_mode` and `st_uid` are an access-control fact.
+
+    Windows synthesizes both. A directory reports `0o777` and a file `0o666`
+    whatever `chmod` was asked for, so a mode check there does not read a
+    permission -- it reads a placeholder, and rejects it.
+    """
+    return os.name == "posix" and hasattr(os, "getuid")
+
+
+@lru_cache(maxsize=1)
+def has_posix_executable_scripts() -> bool:
+    """True where a `#!/bin/sh` file marked 0755 is a runnable program.
+
+    Several fixtures stand in for a toolchain by writing exactly that. Windows
+    has no shebang: a file named `bun` with no extension is data, and the
+    executable bit `chmod` was asked for was never set either.
+    """
+    return os.name == "posix"
+
+
+@lru_cache(maxsize=1)
+def has_pinned_bun() -> bool:
+    """True when the exact pinned Bun is on PATH; version drift is not enough."""
+    executable = shutil.which("bun")
+    if executable is None:
+        return False
+    try:
+        completed = subprocess.run(
+            [executable, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return completed.returncode == 0 and completed.stdout.strip() == REQUIRED_BUN_VERSION
+
+
+@lru_cache(maxsize=1)
+def has_posix_interval_timers() -> bool:
+    """True where a process can own a real-time timer, as the broker requires."""
+    return all(hasattr(signal, name) for name in _TIMER_PRIMITIVES)
+
+
+@lru_cache(maxsize=1)
+def has_bwrap() -> bool:
+    """True when a bubblewrap sandbox can be spawned at all."""
+    return shutil.which("bwrap") is not None
+
+
+def require_posix_file_modes() -> None:
+    if not has_posix_file_modes():
+        pytest.skip("POSIX file mode and ownership bits are not an access-control fact here")
+
+
+def require_posix_executable_scripts() -> None:
+    if not has_posix_executable_scripts():
+        pytest.skip("a `#!/bin/sh` fixture is not an executable program here")
+
+
+def require_pinned_bun() -> None:
+    if not has_pinned_bun():
+        pytest.skip(f"the pinned Bun {REQUIRED_BUN_VERSION} toolchain is not installed")
+
+
+def require_posix_interval_timers() -> None:
+    if not has_posix_interval_timers():
+        pytest.skip("POSIX interval timers (setitimer/SIGALRM) are unavailable here")
+
+
+def require_bwrap() -> None:
+    if not has_bwrap():
+        pytest.skip("the bubblewrap sandbox is unavailable here")
+
+
+#: The broker's own words for the capability it needs. It says this deliberately
+#: -- `_require_surface_timer_ownership` exists to refuse provider work up front
+#: rather than let a surface run unbounded -- so matching the sentence matches a
+#: declared contract, not an incidental traceback.
+_BROKER_TIMER_REFUSAL = re.compile(
+    r"POSIX provider surface (deadline primitives are unavailable"
+    r"|timer state is unavailable)"
+    r"|provider surfaces require POSIX timer ownership"
+)
+
+
+def declares_absent_surface_timers(error: BaseException | None) -> bool:
+    """True when *error* is the broker refusing to run without POSIX timers.
+
+    Walks the chain because `pytest.raises(..., match=...)` re-raises as an
+    `AssertionError` holding the refusal as `__context__`: a test that expected
+    one contract error and met this one failed for the same absent capability,
+    not for its own reason.
+    """
+    seen: set[int] = set()
+    while error is not None and id(error) not in seen:
+        seen.add(id(error))
+        if type(error).__name__ in {"BrokerContractError", "BrokerSurfaceTimeout"}:
+            if _BROKER_TIMER_REFUSAL.search(str(error)):
+                return True
+        if isinstance(error, AssertionError) and _BROKER_TIMER_REFUSAL.search(str(error)):
+            return True
+        error = error.__cause__ or error.__context__
+    return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,11 @@ from pathlib import Path
 
 import pytest
 
+from benchmark_capabilities import (
+    declares_absent_surface_timers,
+    has_posix_interval_timers,
+)
+
 from exomem import activation_manifest as activation_manifest_module
 from exomem import embeddings as embeddings_module
 from exomem import find as find_module
@@ -88,7 +93,7 @@ def _declares_custody_unsupported(error: BaseException | None) -> bool:
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):  # noqa: ANN001, ANN201
-    """Report an absent proc-fd custody capability as a skip, not a failure.
+    """Report a capability this platform does not have as a skip, not a failure.
 
     On macOS, 82 failures were one platform fact: the capability
     `protocol.custody` is built on does not exist there, and the module says so
@@ -102,21 +107,32 @@ def pytest_runtest_makereport(item, call):  # noqa: ANN001, ANN201
     Windows is the opposite case: there the same files are blocked almost
     entirely, so ignoring them costs nearly nothing and buys a declaration.
 
-    Gated on the capability being absent, so this can never mask a regression
-    where it matters: on Linux the capability exists, and a `CustodyUnsupported`
-    there stays a failure and is meant to.
+    The broker branch is the same trade for a different capability.
+    `epistemic.broker` bounds every provider surface with `setitimer`/`SIGALRM`
+    and refuses up front where they are absent, and its 19 entry points share no
+    helper to gate -- so the refusal is matched where it surfaces. It is matched
+    through `__context__` as well, because `pytest.raises(..., match=...)`
+    re-raises as an `AssertionError` holding it: a test that expected one
+    contract error and met this one failed for the absent capability, not for
+    its own reason.
+
+    Every branch is gated on the capability actually being absent, so this can
+    never mask a regression where it matters: on Linux both capabilities exist,
+    and a `CustodyUnsupported` or a timer refusal there stays a failure and is
+    meant to.
     """
     report = (yield).get_result()
-    if PROC_FD_DIRECTORY_CUSTODY or report.when != "call" or report.outcome != "failed":
+    if report.when != "call" or report.outcome != "failed" or call.excinfo is None:
         return
-    if call.excinfo is None or not _declares_custody_unsupported(call.excinfo.value):
+    error = call.excinfo.value
+    if not PROC_FD_DIRECTORY_CUSTODY and _declares_custody_unsupported(error):
+        reason = "proc-fd directory custody is unavailable on this platform"
+    elif not has_posix_interval_timers() and declares_absent_surface_timers(error):
+        reason = "POSIX interval timers (setitimer/SIGALRM) are unavailable here"
+    else:
         return
     report.outcome = "skipped"
-    report.longrepr = (
-        str(item.path),
-        item.location[1] or 0,
-        "Skipped: proc-fd directory custody is unavailable on this platform",
-    )
+    report.longrepr = (str(item.path), item.location[1] or 0, f"Skipped: {reason}")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,9 @@ from pathlib import Path
 import pytest
 
 from benchmark_capabilities import (
+    declares_absent_sandbox,
     declares_absent_surface_timers,
+    has_bwrap_sandbox,
     has_posix_interval_timers,
 )
 
@@ -107,19 +109,26 @@ def pytest_runtest_makereport(item, call):  # noqa: ANN001, ANN201
     Windows is the opposite case: there the same files are blocked almost
     entirely, so ignoring them costs nearly nothing and buys a declaration.
 
-    The broker branch is the same trade for a different capability.
-    `epistemic.broker` bounds every provider surface with `setitimer`/`SIGALRM`
-    and refuses up front where they are absent, and its 19 entry points share no
-    helper to gate -- so the refusal is matched where it surfaces. It is matched
-    through `__context__` as well, because `pytest.raises(..., match=...)`
-    re-raises as an `AssertionError` holding it: a test that expected one
-    contract error and met this one failed for the absent capability, not for
-    its own reason.
+    The two broker branches are the same trade for different capabilities, and
+    they are separate because the platforms differ: Windows has neither, but
+    macOS has POSIX interval timers and no `bwrap` at all. The sandbox is not
+    merely "Linux" either -- the broker pins `/usr/bin/bwrap` and binds
+    `/usr/bin/python3.12`, `/lib/x86_64-linux-gnu` and
+    `/lib64/ld-linux-x86-64.so.2` into the namespace, so the capability is that
+    exact Debian x86-64 runtime.
+    `epistemic.broker` bounds every provider surface with `setitimer`/`SIGALRM`,
+    isolates it with that sandbox, and refuses up front where either is absent.
+    Its entry points share no helper to gate, so each refusal is matched where it
+    surfaces -- through `__context__` as well, because `pytest.raises(...,
+    match=...)` re-raises as an `AssertionError` holding it: a test that expected
+    one contract error and met a refusal instead failed for the absent
+    capability, not for its own reason.
 
     Every branch is gated on the capability actually being absent, so this can
-    never mask a regression where it matters: on Linux both capabilities exist,
-    and a `CustodyUnsupported` or a timer refusal there stays a failure and is
-    meant to.
+    never mask a regression where it matters: on Linux CI all three capabilities
+    exist -- `ci.yml` provisions `bwrap` and checks it runs -- so a
+    `CustodyUnsupported`, a timer refusal or a sandbox refusal there stays a
+    failure and is meant to.
     """
     report = (yield).get_result()
     if report.when != "call" or report.outcome != "failed" or call.excinfo is None:
@@ -129,6 +138,8 @@ def pytest_runtest_makereport(item, call):  # noqa: ANN001, ANN201
         reason = "proc-fd directory custody is unavailable on this platform"
     elif not has_posix_interval_timers() and declares_absent_surface_timers(error):
         reason = "POSIX interval timers (setitimer/SIGALRM) are unavailable here"
+    elif not has_bwrap_sandbox() and declares_absent_sandbox(error):
+        reason = "the pinned bubblewrap sandbox runtime is unavailable here"
     else:
         return
     report.outcome = "skipped"

--- a/tests/test_benchmark_capabilities.py
+++ b/tests/test_benchmark_capabilities.py
@@ -1,0 +1,99 @@
+"""The skip decisions that keep a missing prerequisite from reading as a defect."""
+
+from __future__ import annotations
+
+import pytest
+
+from benchmark_capabilities import declares_absent_sandbox, declares_absent_surface_timers
+
+
+class BrokerContractError(ValueError):
+    """Stands in for `epistemic.broker.BrokerContractError`.
+
+    Matched by qualified name rather than imported, because the broker's own
+    import reaches Linux-only paths -- a matcher that needs the module in order
+    to decide whether the module is usable is no matcher at all.
+    """
+
+
+TIMER_REFUSALS = (
+    "POSIX provider surface deadline primitives are unavailable",
+    "POSIX provider surface timer state is unavailable",
+    "provider surfaces require POSIX timer ownership on the main thread",
+)
+
+SANDBOX_REFUSALS = (
+    "bwrap sandbox is unavailable before provider execution",
+    "bwrap sandbox executable cannot be verified",
+    "bwrap sandbox executable is not the trusted system binary",
+    "bwrap sandbox executable is group/world writable",
+    "sandbox system runtime or bound worker bytes are unavailable",
+)
+
+
+@pytest.mark.parametrize("message", TIMER_REFUSALS)
+def test_every_timer_refusal_the_broker_can_raise_is_recognised(message: str) -> None:
+    assert declares_absent_surface_timers(BrokerContractError(message))
+
+
+@pytest.mark.parametrize("message", SANDBOX_REFUSALS)
+def test_every_sandbox_refusal_the_broker_can_raise_is_recognised(message: str) -> None:
+    assert declares_absent_sandbox(BrokerContractError(message))
+
+
+def test_the_two_capabilities_are_never_confused_for_each_other() -> None:
+    """macOS has the timers and not the sandbox, so one must not stand in for
+    the other -- a sandbox refusal there has to survive the timer branch."""
+    for message in TIMER_REFUSALS:
+        assert not declares_absent_sandbox(BrokerContractError(message))
+    for message in SANDBOX_REFUSALS:
+        assert not declares_absent_surface_timers(BrokerContractError(message))
+
+
+@pytest.mark.parametrize("refusal", TIMER_REFUSALS[:1] + SANDBOX_REFUSALS[:1])
+def test_a_raises_match_mismatch_still_reveals_the_refusal_underneath(refusal: str) -> None:
+    """`pytest.raises(..., match=...)` re-raises as an `AssertionError`.
+
+    The refusal survives only as `__context__`, and 8 of the 19 broker failures
+    arrived exactly this way -- a test that expected its own contract error and
+    met an absent capability instead.
+    """
+    try:
+        with pytest.raises(BrokerContractError, match="something else entirely"):
+            raise BrokerContractError(refusal)
+    except AssertionError as mismatch:
+        assert declares_absent_surface_timers(mismatch) or declares_absent_sandbox(mismatch)
+    else:  # pragma: no cover - the mismatch is the point of the test
+        pytest.fail("expected the match to fail")
+
+
+def test_an_unrelated_broker_error_is_never_swallowed() -> None:
+    """The gate must not turn a real contract violation into a skip."""
+    for message in (
+        "receipt append is outside an active sandbox session",
+        "sandbox session is unknown",
+        "broker result exceeds driver IPC bounds",
+        "sandbox driver result attestation is required",
+    ):
+        error = BrokerContractError(message)
+        assert not declares_absent_surface_timers(error)
+        assert not declares_absent_sandbox(error)
+
+
+def test_a_matching_message_on_an_unrelated_exception_type_is_not_a_refusal() -> None:
+    """Only the broker declares these; a coincidental string is not a capability."""
+    assert not declares_absent_sandbox(ValueError(SANDBOX_REFUSALS[0]))
+    assert not declares_absent_surface_timers(ValueError(TIMER_REFUSALS[0]))
+
+
+def test_neither_matcher_loops_on_a_self_referential_cause() -> None:
+    error = BrokerContractError("unrelated")
+    error.__context__ = error
+
+    assert declares_absent_sandbox(error) is False
+    assert declares_absent_surface_timers(error) is False
+
+
+def test_no_error_at_all_is_not_a_refusal() -> None:
+    assert declares_absent_sandbox(None) is False
+    assert declares_absent_surface_timers(None) is False

--- a/tests/test_epistemic_broker.py
+++ b/tests/test_epistemic_broker.py
@@ -14,6 +14,7 @@ from dataclasses import replace
 from pathlib import Path
 
 import pytest
+from benchmark_capabilities import require_posix_interval_timers
 from pydantic import ValidationError
 
 
@@ -393,13 +394,29 @@ def test_bwrap_absence_or_namespace_spawn_failure_is_pre_provider_and_fail_close
 @pytest.mark.parametrize(
     "raw",
     [
-        b'{"protocol":"epistemic-driver-ipc.v1","protocol":"confused","type":"complete"}\n',
-        b'{"protocol":"epistemic-driver-ipc.v1","type":"complete","result":NaN}\n',
-        b'{not-json}\n',
-        b'{"protocol":"wrong","type":"complete","result":null}\n',
-        b'{"protocol":"epistemic-driver-ipc.v1","type":"unknown","result":null}\n',
-        (b'[' * 40) + b'0' + (b']' * 40) + b'\n',
-        b'x' * (64 * 1024 + 1),
+        pytest.param(
+            b'{"protocol":"epistemic-driver-ipc.v1","protocol":"confused","type":"complete"}\n',
+            id="duplicate-key",
+        ),
+        pytest.param(
+            b'{"protocol":"epistemic-driver-ipc.v1","type":"complete","result":NaN}\n',
+            id="nan-result",
+        ),
+        pytest.param(b'{not-json}\n', id="not-json"),
+        pytest.param(
+            b'{"protocol":"wrong","type":"complete","result":null}\n',
+            id="wrong-protocol",
+        ),
+        pytest.param(
+            b'{"protocol":"epistemic-driver-ipc.v1","type":"unknown","result":null}\n',
+            id="unknown-type",
+        ),
+        pytest.param((b'[' * 40) + b'0' + (b']' * 40) + b'\n', id="deeply-nested"),
+        # Unnamed, this 64KiB payload becomes the test id verbatim, and pytest
+        # exports the node id as PYTEST_CURRENT_TEST -- past the 32767-char cap
+        # Windows puts on an environment variable, so the case errors in setup
+        # and teardown without ever running.
+        pytest.param(b'x' * (64 * 1024 + 1), id="oversized"),
     ],
 )
 def test_driver_ipc_rejects_malformed_confused_deep_or_oversized_messages(
@@ -898,6 +915,7 @@ def test_recheck3_endpoint_audit_requires_each_equivalent_and_rejects_gap_calls(
 def test_finalreview_whole_driver_deadline_interrupts_surface_and_reaps_child(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    require_posix_interval_timers()
     import epistemic.broker as broker_module
 
     children = []
@@ -933,6 +951,7 @@ def test_finalreview_whole_driver_deadline_interrupts_surface_and_reaps_child(
 def test_finalreview_surface_timer_restores_handler_and_refuses_conflicting_timer(
     tmp_path: Path,
 ) -> None:
+    require_posix_interval_timers()
     from epistemic.broker import BrokerContractError, ProviderBroker
 
     original_handler = signal.getsignal(signal.SIGALRM)

--- a/tests/test_memorybench_export.py
+++ b/tests/test_memorybench_export.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 import pytest
+from benchmark_capabilities import require_pinned_bun, require_posix_file_modes
 from protocol.models import DatasetIdentity
 
 
@@ -160,6 +161,10 @@ def _materialize_native_runtime(memorybench_home: Path) -> None:
 
 
 def _plan(tmp_path: Path, *, fresh_runtime: bool = True) -> Path:
+    # `_secure_read(private=True)` proves 0600-and-owned. Windows cannot
+    # establish that: `chmod` only toggles the read-only bit and the file still
+    # reports 0o666, so a test blocks on its own fixture before its subject.
+    require_posix_file_modes()
     tmp_path.mkdir(parents=True, exist_ok=True)
     payload = _plan_payload(tmp_path, fresh_runtime=fresh_runtime)
     path = tmp_path / "plan.json"
@@ -173,6 +178,10 @@ def _fresh_plan(tmp_path: Path) -> Path:
 
 
 def _run(plan: Path, **kwargs: Any):
+    # `run_export` resolves the pinned Bun itself -- it is not one of the
+    # injectable dependencies -- so the toolchain has to actually be here.
+    require_posix_file_modes()
+    require_pinned_bun()
     from memorybench.export import run_export
 
     return run_export(plan, **kwargs)
@@ -504,7 +513,11 @@ def test_noncanonical_explicit_twenty_five_case_memorybench_plan_is_refused(tmp_
 def test_cli_has_strict_plan_only_surface_and_no_fixture_fault_switch(tmp_path: Path) -> None:
     from memorybench.export import main
 
-    plan = _plan(tmp_path)
+    # Argument parsing rejects these before the plan is ever opened, so this
+    # wants a path rather than a readable private plan -- and stays a real test
+    # everywhere, including where `_plan`'s 0600 precondition cannot be met.
+    plan = tmp_path / "plan.json"
+    plan.write_text("{}", encoding="utf-8")
     with pytest.raises(SystemExit):
         main(["--plan", str(plan), "--export-failure"])
     with pytest.raises(SystemExit):
@@ -863,6 +876,10 @@ def test_cleanup_discovery_unions_nonpending_checkpoint_and_validated_basic_evid
 ) -> None:
     import memorybench.export as export
     from protocol.models import MemoryBenchRunPlan
+    # `_secure_read(private=True)` proves 0600-and-owned. Windows cannot
+    # establish that: `chmod` only toggles the read-only bit and the file still
+    # reports 0o666, so a test blocks on its own fixture before its subject.
+    require_posix_file_modes()
 
     payload = _plan_payload(tmp_path)
     payload["provider"] = "basic-memory"
@@ -933,6 +950,10 @@ def test_cleanup_discovery_accepts_only_plan_bound_secure_exomem_descriptors(
 ) -> None:
     import memorybench.export as export
     from protocol.models import MemoryBenchRunPlan
+    # `_secure_read(private=True)` proves 0600-and-owned. Windows cannot
+    # establish that: `chmod` only toggles the read-only bit and the file still
+    # reports 0o666, so a test blocks on its own fixture before its subject.
+    require_posix_file_modes()
 
     plan = MemoryBenchRunPlan.model_validate(_plan_payload(tmp_path))
     raw_tag = "descriptor-only-container"

--- a/tests/test_memorybench_setup.py
+++ b/tests/test_memorybench_setup.py
@@ -9,6 +9,7 @@ import time
 from pathlib import Path
 
 import pytest
+from benchmark_capabilities import require_pinned_bun, require_posix_executable_scripts
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -73,6 +74,9 @@ def _repin_head_and_tree(lockfile: Path, checkout: Path) -> None:
 
 
 def _fake_bun(tmp_path: Path, version: str = "1.3.14") -> Path:
+    # A shebang script standing in for the pinned toolchain, reached through a
+    # PATH this fixture also joins with ":". Neither survives Windows.
+    require_posix_executable_scripts()
     executable = tmp_path / "bun"
     executable.write_text(f"#!/bin/sh\nprintf '%s\\n' '{version}'\n")
     executable.chmod(0o755)
@@ -338,6 +342,11 @@ def _registration_diff(checkout: Path) -> bytes:
 
 
 def _overlay_fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    # These drive `materialize_checkout`, which verifies the real pinned Bun
+    # before `_fake_bun` is ever placed on PATH, and then verify through the
+    # shebang fixture. Both prerequisites, not one.
+    require_pinned_bun()
+    require_posix_executable_scripts()
     checkout = _overlay_checkout(tmp_path / "memorybench-fixture")
     basic = _basic_checkout(tmp_path / "basic-fixture")
     source_root = tmp_path / "source"


### PR DESCRIPTION
## These harnesses are Linux-only on purpose

`benchmarks/memorybench` and `benchmarks/epistemic` are not product code and were never meant to be portable. Their contracts are written *in terms of* Linux facilities, because reproducible benchmark evidence is the point of them:

- `memorybench.export._secure_read` proves a private file is unreadable by anyone else, using POSIX mode bits and `st_uid`.
- `memorybench` pins Bun to an exact version so a run is byte-reproducible.
- `epistemic.broker` bounds provider work with `setitimer`/`SIGALRM` and isolates it with `bwrap` — Linux user namespaces, which exist nowhere else.

`ci.yml` provisions all three, and every job in it is `ubuntu-latest`. `cross-platform.yml` cannot, so it collected **135 failures and 2 errors** that say nothing about the code. On Windows `Path.chmod(0o600)` only toggles the read-only bit and the file still reports `0o666`, so the very first `_secure_read` of a test's own plan raised before the test reached its subject.

A missing prerequisite is a skip. This declares the prerequisites.

## The more interesting half: 35 false passes removed

A test asserting that *its injected fault* yields `BLOCKED` was green on Windows because the **permission** failure yielded `BLOCKED` first. Every one of these was passing without testing anything:

- all 7 `test_every_invalid_run_plan_is_a_quiet_blocked_result` cases
- all 7 `test_preflight_refuses_identity_drift_as_blocked_without_provider_work` cases
- all 5 `test_native_dataset_and_fresh_runtime_state_block_before_any_stage` cases
- all 3 `test_preflight_resolves_and_verifies_bun_and_uv_outside_os_defpath` cases
- all 13 `test_verify_refuses_*` — a `pytest.raises` satisfied by `"Bun runtime is unavailable"` rather than by the drift each one injects

None could tell its own fault from the platform's. A skip that names the absent capability is worth more than a pass that proves nothing.

## How the gates are placed

Gated on the **capability**, never on `sys.platform`, so a Linux box without Bun also reports the truth and the reason names what is actually missing. Each gate sits on the narrowest seam that needs it rather than on a whole module, so the pure-logic tests — digest vectors, plan validation, canonical selection — keep running everywhere. That is the cross-platform signal worth having.

The broker takes the `conftest` route instead: its 19 failing entry points share no helper to gate, and it already refuses up front with a self-describing contract error, so the hook #626 added grows one branch. It matches through `__context__` as well, because `pytest.raises(..., match=...)` re-raises as an `AssertionError` holding the refusal — 8 of the 19 failed exactly that way.

## Two things fixed rather than skipped

Both are defects on any platform:

- **`test_driver_ipc_rejects_...oversized_messages`** had a 64KiB payload as an unnamed parametrize case, so the payload *became the test id* and pytest exported the node id as `PYTEST_CURRENT_TEST` — past the 32767-char cap Windows puts on an environment variable, erroring in setup and teardown without ever running the body. All seven cases are named now, which reads better everywhere.
- **`test_cli_has_strict_plan_only_surface_and_no_fixture_fault_switch`** now builds its own path instead of a 0600 plan. Argument parsing rejects its arguments before the plan is ever opened, so it stays a real test everywhere — the one genuine pass the gates would otherwise have cost.

## Measured on Windows

`-p no:randomly`, whole modules:

| module | before | after |
|---|---|---|
| `test_memorybench_export` | 89 failed, 42 passed | **0 failed**, 20 passed, 112 skipped |
| `test_epistemic_broker` | 30 failed, 13 passed, 2 errors | **0 failed**, 13 passed, 31 skipped |
| `test_memorybench_setup` | 16 failed, 15 passed | **0 failed**, 2 passed, 29 skipped |

Every pass that became a skip is one of the 35 false passes enumerated above; all 35 genuine passes are still passes.

Linux behaviour is unchanged by construction — every gate is a no-op where the capability exists, and every `conftest` branch is guarded on the capability being absent, so a `CustodyUnsupported` or a timer refusal on Linux stays a failure and is meant to. **CI's ubuntu lanes are what confirm that**, not the local Windows run.
