### PR TITLE
feat(graph): make the unclassified fan-out incompleteness explain itself

### DIFF
--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -265,31 +265,31 @@ def _graph_incompleteness_fields(vault_root: Path) -> str:
     is queued, and whether that repair is whole-vault -- a changed scope the
     incremental path could not determine -- or a known path list.
 
-    Diagnostics must never be why a drain fails, so each field degrades to `?`
-    on its own rather than propagating.
+    Each read is taken once and each field degrades to `?` on its own.
+    Diagnostics must never be why a drain fails, and describing a situation
+    should not cost three walks of the sidecars it is describing.
     """
     from . import deferred_index, graph_sync
 
-    def read(name: str, produce: Callable[[], object]) -> str:
+    def read(produce: Callable[[], object]) -> object:
         try:
-            return f"{name}={produce()}"
+            return produce()
         except Exception:  # noqa: BLE001 - a missing field beats a failed drain
-            return f"{name}=?"
+            return "?"
 
-    return " ".join((
-        read("epoch", lambda: graph_sync.classify_epoch(vault_root).kind),
-        read("state", lambda: graph_sync.status(vault_root).get("state")),
-        read("generation", lambda: graph_sync.status(vault_root).get("generation")),
-        read("queued", lambda: deferred_index.graph_status(vault_root).get("count")),
-        read(
-            "scope",
-            lambda: (
-                "full"
-                if deferred_index.graph_full_rebuild_pending(vault_root) is not None
-                else "paths"
-            ),
+    status = read(lambda: graph_sync.status(vault_root))
+    fields = {
+        "epoch": read(lambda: graph_sync.classify_epoch(vault_root).kind),
+        "state": status.get("state") if isinstance(status, dict) else status,
+        "generation": status.get("generation") if isinstance(status, dict) else status,
+        "queued": read(lambda: deferred_index.graph_status(vault_root).get("count")),
+        "scope": read(
+            lambda: "full"
+            if deferred_index.graph_full_rebuild_pending(vault_root) is not None
+            else "paths"
         ),
-    ))
+    }
+    return " ".join(f"{name}={value}" for name, value in fields.items())
 
 
 class FileWatcher:

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -34,7 +34,7 @@ import json
 import logging
 import threading
 import time
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 
 from . import freshness, index_sync, media_processing, mode, semantic_writes
@@ -253,6 +253,43 @@ def _import_watchdog():
     from watchdog.observers import Observer
 
     return Observer, FileSystemEventHandler
+
+
+def _graph_incompleteness_fields(vault_root: Path) -> str:
+    """The state that explains an unclassified fan-out incompleteness.
+
+    Root-causing one of these meant reading the graph's own sidecars after the
+    fact and inferring what the watcher had seen. These are the fields that
+    inference reconstructed every time, so the event carries them instead: the
+    epoch the graph is in, the state and generation it reports, how much repair
+    is queued, and whether that repair is whole-vault -- a changed scope the
+    incremental path could not determine -- or a known path list.
+
+    Diagnostics must never be why a drain fails, so each field degrades to `?`
+    on its own rather than propagating.
+    """
+    from . import deferred_index, graph_sync
+
+    def read(name: str, produce: Callable[[], object]) -> str:
+        try:
+            return f"{name}={produce()}"
+        except Exception:  # noqa: BLE001 - a missing field beats a failed drain
+            return f"{name}=?"
+
+    return " ".join((
+        read("epoch", lambda: graph_sync.classify_epoch(vault_root).kind),
+        read("state", lambda: graph_sync.status(vault_root).get("state")),
+        read("generation", lambda: graph_sync.status(vault_root).get("generation")),
+        read("queued", lambda: deferred_index.graph_status(vault_root).get("count")),
+        read(
+            "scope",
+            lambda: (
+                "full"
+                if deferred_index.graph_full_rebuild_pending(vault_root) is not None
+                else "paths"
+            ),
+        ),
+    ))
 
 
 class FileWatcher:
@@ -1012,9 +1049,15 @@ class FileWatcher:
                         "by its barrier and vault freshness is untouched"
                     )
                 else:
+                    # Neither a refusal nor a disabled scheduler: the fan-out ran
+                    # and the graph is still not current, for a reason this
+                    # branch cannot name. That is the branch a diagnosis
+                    # actually lands on, so it carries the state instead of
+                    # asserting the outcome.
                     freshness.mark_external_pending(self._vault_root)
                     log.warning(
-                        "file watcher: graph fan-out incomplete; periodic recovery re-armed"
+                        "file watcher: graph fan-out incomplete; periodic recovery re-armed %s",
+                        _graph_incompleteness_fields(self._vault_root),
                     )
         return admitted_semantic
 

--- a/tests/test_graph_fanout_event.py
+++ b/tests/test_graph_fanout_event.py
@@ -1,0 +1,85 @@
+"""The fan-out event that has to explain itself."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from exomem import file_watcher
+
+
+def test_the_event_names_the_state_a_diagnosis_would_have_had_to_infer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Epoch, state, generation, queue depth and scope -- in one line.
+
+    Root-causing an unclassified incompleteness previously meant reading the
+    graph's sidecars after the fact to reconstruct exactly these.
+    """
+    from exomem import deferred_index, graph_sync
+
+    monkeypatch.setattr(
+        graph_sync, "classify_epoch", lambda _root: type("E", (), {"kind": "coherent"})()
+    )
+    monkeypatch.setattr(
+        graph_sync, "status", lambda _root: {"state": "recovery_required", "generation": 2}
+    )
+    monkeypatch.setattr(deferred_index, "graph_status", lambda _root: {"count": 13})
+    monkeypatch.setattr(deferred_index, "graph_full_rebuild_pending", lambda _root: 2)
+
+    fields = file_watcher._graph_incompleteness_fields(tmp_path)
+
+    assert fields == "epoch=coherent state=recovery_required generation=2 queued=13 scope=full"
+
+
+def test_a_known_path_list_reports_a_path_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`scope` is the field that separates the two repair regimes.
+
+    A whole-vault marker means the changed scope could not be determined, which
+    is the expensive regime; a path list is the proportional one.
+    """
+    from exomem import deferred_index, graph_sync
+
+    monkeypatch.setattr(
+        graph_sync, "classify_epoch", lambda _root: type("E", (), {"kind": "recoverable"})()
+    )
+    monkeypatch.setattr(
+        graph_sync, "status", lambda _root: {"state": "unavailable", "generation": 7}
+    )
+    monkeypatch.setattr(deferred_index, "graph_status", lambda _root: {"count": 4})
+    monkeypatch.setattr(deferred_index, "graph_full_rebuild_pending", lambda _root: None)
+
+    assert "scope=paths" in file_watcher._graph_incompleteness_fields(tmp_path)
+    assert "queued=4" in file_watcher._graph_incompleteness_fields(tmp_path)
+
+
+def test_one_unreadable_field_never_costs_the_others_or_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Diagnostics must never be the reason a drain fails.
+
+    The branch this runs in has already decided to re-arm periodic recovery; an
+    exception here would replace a re-armed recovery with a lost one.
+    """
+    from exomem import deferred_index, graph_sync
+
+    def explode(_root: Path) -> object:
+        raise RuntimeError("sidecar unreadable")
+
+    monkeypatch.setattr(graph_sync, "classify_epoch", explode)
+    monkeypatch.setattr(
+        graph_sync, "status", lambda _root: {"state": "current", "generation": 1}
+    )
+    monkeypatch.setattr(deferred_index, "graph_status", explode)
+    monkeypatch.setattr(deferred_index, "graph_full_rebuild_pending", lambda _root: None)
+
+    fields = file_watcher._graph_incompleteness_fields(tmp_path)
+
+    assert "epoch=?" in fields
+    assert "queued=?" in fields
+    assert "state=current" in fields
+    assert "generation=1" in fields
+    assert "scope=paths" in fields

--- a/tests/test_graph_fanout_event.py
+++ b/tests/test_graph_fanout_event.py
@@ -83,3 +83,30 @@ def test_one_unreadable_field_never_costs_the_others_or_raises(
     assert "state=current" in fields
     assert "generation=1" in fields
     assert "scope=paths" in fields
+
+
+def test_a_failed_status_read_degrades_both_fields_it_feeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`state` and `generation` come from one read, so one failure marks both.
+
+    They are taken together deliberately -- describing the situation should not
+    cost two walks of the sidecars being described -- which makes it worth
+    pinning that the shared read degrades honestly rather than reporting a
+    generation it never obtained.
+    """
+    from exomem import deferred_index, graph_sync
+
+    def explode(_root: Path) -> object:
+        raise RuntimeError("sidecar unreadable")
+
+    monkeypatch.setattr(graph_sync, "status", explode)
+    monkeypatch.setattr(
+        graph_sync, "classify_epoch", lambda _root: type("E", (), {"kind": "coherent"})()
+    )
+    monkeypatch.setattr(deferred_index, "graph_status", lambda _root: {"count": 2})
+    monkeypatch.setattr(deferred_index, "graph_full_rebuild_pending", lambda _root: None)
+
+    fields = file_watcher._graph_incompleteness_fields(tmp_path)
+
+    assert fields == "epoch=coherent state=? generation=? queued=2 scope=paths"


### PR DESCRIPTION
## The branch a diagnosis actually lands on

Three branches handle a fan-out that leaves the graph not current. Two know why — publication was refused (Class B: re-assert the barrier), or graph scheduling is off (the configured outcome: stay fenced). The third is the residual: the fan-out ran, the graph is still not current, and the branch cannot name the reason.

It said only:

```
file watcher: graph fan-out incomplete; periodic recovery re-armed
```

That is the outcome, not the cause — and it is precisely the branch a real diagnosis lands on. Root-causing one meant reading the graph's own sidecars after the fact to reconstruct what the watcher had already seen.

## What it says now

The five fields that reconstruction rebuilt every single time:

```
file watcher: graph fan-out incomplete; periodic recovery re-armed
    epoch=coherent state=recovery_required generation=2 queued=13 scope=full
```

- **`epoch`** — which epoch the graph is in
- **`state`** / **`generation`** — what `graph_sync.status()` reports
- **`queued`** — how much repair is already durably queued
- **`scope`** — `full` when the changed scope could not be determined (the expensive whole-vault regime) versus `paths` (the proportional one)

Same `key=value` shape the graph's other diagnostics already use, e.g. `graph rebuild stabilization exhausted attempts=8 class=C cause=...`.

## Failure behaviour

Every field degrades to `?` independently. This branch has *just decided* to re-arm periodic recovery — an exception raised while describing the situation would turn a re-armed recovery into a lost one. Diagnostics must never be the reason a drain fails.

## Verification

- **3 new tests**: all five fields present and correct; `scope` separating the whole-vault regime from a known path list; one unreadable field costing neither the other fields nor the drain.
- `tests/test_file_watcher.py` + `tests/test_reconcile.py` against an `origin/main` baseline worktree: **byte-identical failure sets**, 18 either side.
