### PR TITLE
feat(graph): re-arm a rebuild that stopped, not just a queue that stalled

### DIFF
--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -462,6 +462,58 @@ def clear_publication_refusal(vault_root: Path) -> None:
         _PUBLICATION_REFUSALS.pop(_publication_memo_key(vault_root), None)
 
 
+def recover_suspended_graph(vault_root: Path) -> bool:
+    """Repair a persisted graph barrier left by a crash or a failed fan-out.
+
+    A rebuild that stops is terminal: `graph_sync` records the error, clears
+    `_running` and returns, so the barrier it leaves behind *is* the retry
+    signal and something has to act on it. This is that action, lifted out of
+    `file_watcher` so more than one scheduler can own it -- the watcher's
+    periodic reconcile is 300s and optional, which left the barrier standing
+    indefinitely wherever the watcher was absent.
+
+    Returns True when the graph is available afterwards. Never raises: a failed
+    recovery re-suspends reads so the barrier survives as a signal for the next
+    attempt, which is the whole point of it being persisted.
+    """
+    from . import find as find_module
+    from . import freshness
+    from . import vault as vault_module
+
+    if freshness.external_pending(vault_root):
+        return False
+    if not graph_enabled() or not sidecar_path(vault_root).exists():
+        return False
+    graph = EpistemicGraphIndex(vault_root)
+    if not graph.reads_suspended():
+        return False
+    if publication_refusal_active(vault_root):
+        # Contract R2: a publication already proven doomed for this exact
+        # checkpoint must not be re-attempted at full rebuild cost on every
+        # cycle. The barrier this repairs is itself the fence, so deferring
+        # costs nothing but the delay.
+        return False
+    try:
+        find_module.evict_resolver_caches(vault_root)
+        vault_module.evict_inbound_index(vault_root)
+        graph.withdraw_availability()
+        if freshness.external_pending(vault_root):
+            return False
+        graph.rebuild_all()
+        if not graph.available():
+            raise GraphPublicationUnavailable(
+                "recovered graph did not publish an available marker"
+            )
+    except Exception:  # noqa: BLE001 - persisted barrier remains a retry signal
+        try:
+            graph.suspend_reads()
+        except Exception:  # noqa: BLE001 - the unavailable marker still fails closed
+            pass
+        log.exception("persisted graph barrier recovery failed")
+        return False
+    return True
+
+
 def publication_refusal_active(vault_root: Path) -> bool:
     """Whether the same publication was refused recently enough to skip a retry."""
     key = _publication_memo_key(vault_root)

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -619,43 +619,16 @@ class FileWatcher:
             log.exception("file watcher: pending epoch graph recovery failed")
 
     def _recover_suspended_graph(self) -> None:
-        """Repair a persisted graph barrier left by a crash or failed fan-out."""
-        if freshness.external_pending(self._vault_root):
-            return
-        from . import epistemic_graph
-        from . import find as find_module
-        from . import vault as vault_module
+        """Repair a persisted graph barrier left by a crash or failed fan-out.
 
-        if not epistemic_graph.graph_enabled() or not epistemic_graph.sidecar_path(
-            self._vault_root
-        ).exists():
-            return
-        graph = epistemic_graph.EpistemicGraphIndex(self._vault_root)
-        if not graph.reads_suspended():
-            return
-        if epistemic_graph.publication_refusal_active(self._vault_root):
-            # Contract R2: a publication already proven doomed for this exact
-            # checkpoint must not be re-attempted at full rebuild cost on every
-            # 300 s cycle. The barrier this method repairs is itself the fence,
-            # so deferring costs nothing but the delay.
-            return
-        try:
-            find_module.evict_resolver_caches(self._vault_root)
-            vault_module.evict_inbound_index(self._vault_root)
-            graph.withdraw_availability()
-            if freshness.external_pending(self._vault_root):
-                return
-            graph.rebuild_all()
-            if not graph.available():
-                raise epistemic_graph.GraphPublicationUnavailable(
-                    "recovered graph did not publish an available marker"
-                )
-        except Exception:  # noqa: BLE001 - persisted barrier remains a retry signal
-            try:
-                graph.suspend_reads()
-            except Exception:  # noqa: BLE001 - the unavailable marker still fails closed
-                pass
-            log.exception("file watcher: persisted graph barrier recovery failed")
+        The body moved to `epistemic_graph.recover_suspended_graph` so the graph
+        drain daemon can run it too: a stopped rebuild is terminal, and this
+        periodic lane is 300s and optional, which left the barrier standing
+        indefinitely wherever the watcher was absent.
+        """
+        from . import epistemic_graph
+
+        epistemic_graph.recover_suspended_graph(self._vault_root)
 
     def _validate_existing_graph_on_seed(self) -> bool:
         """Rebuild an existing graph after startup's exact disk baselines.

--- a/src/exomem/graph_drain.py
+++ b/src/exomem/graph_drain.py
@@ -89,7 +89,27 @@ def disabled() -> bool:
     return bool(os.environ.get("EXOMEM_DISABLE_GRAPH_DRAIN"))
 
 
-def _pending(vault_root: Path) -> bool:
+def _barrier_pending(vault_root: Path) -> bool:
+    """True when a stopped rebuild left a barrier to repair. Never raises.
+
+    Debt the queue cannot express. A rebuild that stops is terminal --
+    `graph_sync` records the error, clears `_running` and returns -- and the
+    persisted barrier it leaves behind is the retry signal.
+    """
+    from . import epistemic_graph
+
+    try:
+        if not epistemic_graph.graph_enabled():
+            return False
+        if not epistemic_graph.sidecar_path(vault_root).exists():
+            return False
+        return bool(epistemic_graph.EpistemicGraphIndex(vault_root).reads_suspended())
+    except Exception:  # noqa: BLE001 - an unreadable barrier must not kill the worker
+        log.debug("graph drain: barrier state unreadable", exc_info=True)
+        return False
+
+
+def _queue_pending(vault_root: Path) -> bool:
     """True when the durable queue owes work. Never raises."""
     from . import deferred_index
 
@@ -102,6 +122,43 @@ def _pending(vault_root: Path) -> bool:
         return False
 
 
+def _pending(vault_root: Path) -> bool:
+    """True when the graph owes work of either kind.
+
+    Folding the barrier in here rather than giving recovery its own schedule is
+    deliberate: it makes a stopped rebuild ordinary debt, so the backoff already
+    proven for a queue that cannot drain covers a rebuild that cannot publish --
+    one attempt every couple of minutes rather than a full rebuild every poll.
+    """
+    return _queue_pending(vault_root) or _barrier_pending(vault_root)
+
+
+def _recover_once(vault_root: Path) -> bool:
+    """Re-arm a rebuild that stopped. Never raises; True when it recovered.
+
+    Draining the queue is not the whole of convergence. When the incremental
+    path falls back, the whole-vault rebuild that replaces it is terminal if it
+    stops: `graph_sync` records the error, clears `_running` and returns. The
+    persisted barrier it leaves is the retry signal, and until now the only
+    thing that acted on it was the watcher's reconcile -- 300s, and skipped
+    entirely under `EXOMEM_DISABLE_FILE_WATCHER`.
+
+    A product E2E run showed the cost exactly: the queue settled four times in
+    seven seconds, the rebuild stopped at +7.3s, and the server then answered
+    readiness polls for the remaining 120s without ever attempting another one.
+    `recover_suspended_graph` declines by itself when the barrier is absent or
+    when a publication is already proven doomed for this checkpoint, so calling
+    it on a settled queue costs a few cheap checks in the ordinary case.
+    """
+    from . import epistemic_graph
+
+    try:
+        return bool(epistemic_graph.recover_suspended_graph(vault_root))
+    except Exception:  # noqa: BLE001 - the barrier stays, so the signal stays
+        log.warning("graph drain: barrier recovery failed; barrier remains", exc_info=True)
+        return False
+
+
 def _drain_once(vault_root: Path) -> int:
     """One bounded drain. Never raises; returns receipts cleared."""
     from . import index_sync
@@ -111,6 +168,35 @@ def _drain_once(vault_root: Path) -> int:
     except Exception:  # noqa: BLE001 - queued work stays durable and retryable
         log.warning("graph drain: pass failed; work remains queued", exc_info=True)
         return 0
+
+
+def _recover_once(vault_root: Path) -> bool:
+    """Re-arm a rebuild that stopped. Never raises; True when it recovered.
+
+    `recover_suspended_graph` declines on its own when the barrier is absent, a
+    fresh external change is pending, or a publication is already proven doomed
+    for this exact checkpoint (contract R2) -- so this is safe to reach on any
+    pass that finds a barrier.
+    """
+    from . import epistemic_graph
+
+    try:
+        return bool(epistemic_graph.recover_suspended_graph(vault_root))
+    except Exception:  # noqa: BLE001 - the barrier stays, so the signal stays
+        log.warning("graph drain: barrier recovery failed; barrier remains", exc_info=True)
+        return False
+
+
+def _work_once(vault_root: Path) -> int:
+    """Drain what is queued, then repair a barrier if one is still standing.
+
+    Both in one pass, in that order: draining is proportional and may itself
+    clear the condition the rebuild would have been re-run for.
+    """
+    processed = _drain_once(vault_root) if _queue_pending(vault_root) else 0
+    if _barrier_pending(vault_root) and _recover_once(vault_root):
+        processed += 1
+    return processed
 
 
 def _run(vault_root: Path) -> None:
@@ -127,9 +213,9 @@ def _run(vault_root: Path) -> None:
         if not _pending(vault_root):
             interval = IDLE_POLL_SECONDS
             continue
-        processed = _drain_once(vault_root)
+        processed = _work_once(vault_root)
         if not _pending(vault_root):
-            log.info("graph drain: queue settled (%d receipt(s) cleared)", processed)
+            log.info("graph drain: graph settled (%d unit(s) of work cleared)", processed)
             interval = IDLE_POLL_SECONDS
         elif processed:
             # Progress with work left: come straight back for the remainder.

--- a/tests/test_graph_drain.py
+++ b/tests/test_graph_drain.py
@@ -19,6 +19,17 @@ def _stop_the_daemon():
     graph_drain._DEBT.clear()
 
 
+@pytest.fixture(autouse=True)
+def _no_standing_barrier(monkeypatch: pytest.MonkeyPatch):
+    """Default to a graph with no stopped rebuild to repair.
+
+    `_pending` is the union of queued receipts and a persisted barrier, so a
+    test about the queue has to say the barrier is absent or it is quietly
+    testing both.
+    """
+    monkeypatch.setattr(graph_drain, "_barrier_pending", lambda _root: False)
+
+
 def _wait_for(predicate, timeout: float = 5.0) -> bool:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -47,7 +58,7 @@ def test_a_queued_write_is_drained_without_waiting_for_the_reconcile_tick(
         return 1
 
     monkeypatch.setattr(index_sync, "drain_graph_work", drain)
-    monkeypatch.setattr(graph_drain, "_pending", lambda _root: not drained.is_set())
+    monkeypatch.setattr(graph_drain, "_queue_pending", lambda _root: not drained.is_set())
     monkeypatch.setattr(graph_drain, "DEBOUNCE_SECONDS", 0.01)
 
     graph_drain.start(tmp_path)
@@ -69,7 +80,7 @@ def test_the_debt_signal_wakes_a_sleeping_drain(
     monkeypatch.setattr(graph_drain, "DEBOUNCE_SECONDS", 0.01)
     pending = threading.Event()
     drained = threading.Event()
-    monkeypatch.setattr(graph_drain, "_pending", lambda _root: pending.is_set())
+    monkeypatch.setattr(graph_drain, "_queue_pending", lambda _root: pending.is_set())
 
     def drain(_root: Path, *, limit: int | None = None) -> int:
         pending.clear()
@@ -100,7 +111,7 @@ def test_a_queue_that_cannot_drain_backs_off_instead_of_spinning(
     monkeypatch.setattr(graph_drain, "DEBOUNCE_SECONDS", 0.0)
     monkeypatch.setattr(graph_drain, "RETRY_SECONDS", 0.01)
     monkeypatch.setattr(graph_drain, "MAX_RETRY_SECONDS", 0.05)
-    monkeypatch.setattr(graph_drain, "_pending", lambda _root: True)
+    monkeypatch.setattr(graph_drain, "_queue_pending", lambda _root: True)
     attempts: list[float] = []
 
     def drain(_root: Path, *, limit: int | None = None) -> int:
@@ -126,7 +137,7 @@ def test_a_failing_drain_never_kills_the_daemon(
     monkeypatch.setattr(graph_drain, "DEBOUNCE_SECONDS", 0.0)
     monkeypatch.setattr(graph_drain, "RETRY_SECONDS", 0.01)
     monkeypatch.setattr(graph_drain, "MAX_RETRY_SECONDS", 0.05)
-    monkeypatch.setattr(graph_drain, "_pending", lambda _root: True)
+    monkeypatch.setattr(graph_drain, "_queue_pending", lambda _root: True)
     attempts: list[int] = []
 
     def explode(_root: Path, *, limit: int | None = None) -> int:
@@ -150,7 +161,7 @@ def test_an_unreadable_queue_is_not_pending_and_does_not_raise(
 
     monkeypatch.setattr(deferred_index, "graph_full_rebuild_pending", explode)
 
-    assert graph_drain._pending(tmp_path) is False
+    assert graph_drain._queue_pending(tmp_path) is False
 
 
 def test_a_whole_vault_marker_counts_as_pending(
@@ -164,7 +175,7 @@ def test_a_whole_vault_marker_counts_as_pending(
     monkeypatch.setattr(deferred_index, "graph_full_rebuild_pending", lambda _root: 7)
     monkeypatch.setattr(deferred_index, "graph_status", lambda _root: {"count": 0})
 
-    assert graph_drain._pending(tmp_path) is True
+    assert graph_drain._queue_pending(tmp_path) is True
 
 
 def test_start_is_idempotent_and_stop_ends_the_thread(tmp_path: Path) -> None:
@@ -201,3 +212,136 @@ def test_a_whole_vault_marker_signals_the_drain(tmp_path: Path) -> None:
     deferred_index.mark_graph_full_rebuild(tmp_path, generation=3)
 
     assert graph_drain._DEBT.is_set()
+
+
+def test_a_stopped_rebuild_is_re_armed_without_the_watcher(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The half of convergence the queue cannot express.
+
+    A rebuild that stops is terminal -- `graph_sync` records the error, clears
+    `_running` and returns -- so its debt lives in a persisted barrier, not in
+    `graph_upserts`. A product E2E run showed the cost: the queue settled four
+    times in seven seconds, the rebuild stopped at +7.3s, and the server then
+    answered readiness polls for the remaining 120s without ever attempting
+    another. The only lane that would have retried is the watcher's 300s
+    reconcile, which that run disables outright.
+    """
+    from exomem import epistemic_graph
+
+    barrier = threading.Event()
+    barrier.set()
+    recovered = threading.Event()
+
+    def recover(_root: Path) -> bool:
+        barrier.clear()
+        recovered.set()
+        return True
+
+    monkeypatch.setattr(graph_drain, "_queue_pending", lambda _root: False)
+    monkeypatch.setattr(graph_drain, "_barrier_pending", lambda _root: barrier.is_set())
+    monkeypatch.setattr(epistemic_graph, "recover_suspended_graph", recover)
+    monkeypatch.setattr(graph_drain, "DEBOUNCE_SECONDS", 0.01)
+
+    graph_drain.start(tmp_path)
+
+    assert recovered.wait(timeout=5.0), "the stopped rebuild was never re-armed"
+
+
+def test_a_barrier_alone_is_enough_to_count_as_pending(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty queue is not the same as a converged graph."""
+    monkeypatch.setattr(graph_drain, "_queue_pending", lambda _root: False)
+    monkeypatch.setattr(graph_drain, "_barrier_pending", lambda _root: True)
+
+    assert graph_drain._pending(tmp_path) is True
+
+
+def test_a_rebuild_that_cannot_publish_backs_off_like_a_queue_that_cannot_drain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Folding the barrier into `_pending` is what buys this.
+
+    Recovery is a *whole-vault* rebuild. Retrying one every idle poll would cost
+    far more than the queue thrash the backoff was written for, so a barrier
+    that will not clear has to be as bounded as a queue that will not drain.
+    """
+    from exomem import epistemic_graph
+
+    monkeypatch.setattr(graph_drain, "DEBOUNCE_SECONDS", 0.0)
+    monkeypatch.setattr(graph_drain, "RETRY_SECONDS", 0.01)
+    monkeypatch.setattr(graph_drain, "MAX_RETRY_SECONDS", 0.05)
+    monkeypatch.setattr(graph_drain, "_queue_pending", lambda _root: False)
+    monkeypatch.setattr(graph_drain, "_barrier_pending", lambda _root: True)
+    attempts: list[float] = []
+
+    def never_recovers(_root: Path) -> bool:
+        attempts.append(time.monotonic())
+        return False
+
+    monkeypatch.setattr(epistemic_graph, "recover_suspended_graph", never_recovers)
+
+    graph_drain.start(tmp_path)
+    assert _wait_for(lambda: len(attempts) >= 4, timeout=5.0)
+    graph_drain.stop()
+
+    gaps = [b - a for a, b in zip(attempts, attempts[1:], strict=False)]
+    assert gaps, "expected repeated attempts"
+    assert max(gaps) <= 1.0, f"backoff exceeded its ceiling: {gaps}"
+
+
+def test_a_raising_recovery_never_kills_the_daemon(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The barrier is persisted, so it survives to be retried -- the thread must too."""
+    from exomem import epistemic_graph
+
+    monkeypatch.setattr(graph_drain, "DEBOUNCE_SECONDS", 0.0)
+    monkeypatch.setattr(graph_drain, "RETRY_SECONDS", 0.01)
+    monkeypatch.setattr(graph_drain, "MAX_RETRY_SECONDS", 0.05)
+    monkeypatch.setattr(graph_drain, "_queue_pending", lambda _root: False)
+    monkeypatch.setattr(graph_drain, "_barrier_pending", lambda _root: True)
+    attempts: list[int] = []
+
+    def explode(_root: Path) -> bool:
+        attempts.append(1)
+        raise RuntimeError("recovery exploded")
+
+    monkeypatch.setattr(epistemic_graph, "recover_suspended_graph", explode)
+
+    thread = graph_drain.start(tmp_path)
+    assert _wait_for(lambda: len(attempts) >= 3, timeout=5.0)
+    assert thread is not None and thread.is_alive()
+
+
+def test_the_queue_is_drained_before_a_barrier_is_repaired(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Order matters: the proportional repair may clear the expensive one.
+
+    Draining queued paths can publish the incremental marker the barrier was
+    waiting on, which is cheaper than the whole-vault rebuild recovery runs.
+    """
+    from exomem import epistemic_graph, index_sync
+
+    order: list[str] = []
+    queued = threading.Event()
+    queued.set()
+
+    def drain(_root: Path, *, limit: int | None = None) -> int:
+        order.append("drain")
+        queued.clear()
+        return 1
+
+    def recover(_root: Path) -> bool:
+        order.append("recover")
+        return True
+
+    monkeypatch.setattr(index_sync, "drain_graph_work", drain)
+    monkeypatch.setattr(epistemic_graph, "recover_suspended_graph", recover)
+    monkeypatch.setattr(graph_drain, "_queue_pending", lambda _root: queued.is_set())
+    monkeypatch.setattr(graph_drain, "_barrier_pending", lambda _root: True)
+
+    assert graph_drain._work_once(tmp_path) == 2
+    assert order == ["drain", "recover"]


### PR DESCRIPTION
## What the server log actually showed

#630 gave the graph a scheduler, and on the evidence **that half works**. The product E2E server log — captured for the first time by #625 — shows the drain settling the queue four times in seven seconds:

```
graph drain started on /tmp/.../vault
graph drain: queue settled (8 receipt(s) cleared)   14:07:35.663
graph drain: queue settled (8 receipt(s) cleared)   14:07:37.024
graph drain: queue settled (7 receipt(s) cleared)   14:07:38.449
graph drain: queue settled (7 receipt(s) cleared)   14:07:40.048
```

The same log shows what it does not cover:

```
graph rebuild publication exhausted publication_attempts=4
graph rebuild finished outcome=failed elapsed_ms=5556.6 generation=2
ERROR graph rebuild stopped ... GRAPH_SYNC_STABILIZATION_EXHAUSTED
```

and then, for the remaining **120 seconds** of the readiness wait, the server answers `connect_memory` polls and never attempts another rebuild. The log spans 14:07:33 → 14:09:40; the rebuild died at **+7.3s** and nothing followed it.

## Why

Not a livelock and not a refusal — the run records neither a `class=B`/`class=C` classification nor a publication refusal. Simply **nothing scheduled**.

A stopped rebuild is terminal by construction: `graph_sync._run` records the error, clears `_running`, and returns. Its debt lives in a **persisted barrier**, not in `graph_upserts` — so the queue drains to empty while the graph stays fenced. The one lane that repairs that barrier is `file_watcher._recover_suspended_graph`, on a 300s reconcile, in a component the E2E disables outright with `EXOMEM_DISABLE_FILE_WATCHER=1`.

## The change

Lift that recovery out of `FileWatcher` into `epistemic_graph.recover_suspended_graph`, and let the drain daemon run it too. The watcher keeps its method as a delegate — it's a seam several tests monkeypatch, and the periodic lane is still the cross-process backstop.

**The barrier is folded into `_pending` rather than given its own schedule.** That's the design point: a stopped rebuild becomes ordinary debt, so the backoff already proven for a queue that cannot drain covers a rebuild that cannot publish. Recovery is a *whole-vault* rebuild — retrying one on every 30s idle poll would cost far more than the thrash the backoff was written for — so a barrier that won't clear costs one attempt every couple of minutes, exactly like a queue that won't drain.

Draining runs first within a pass, because the proportional repair can publish the marker the barrier was waiting on and save the expensive one.

`recover_suspended_graph` keeps every guard it had, **contract R2 included**: a publication already proven doomed for this exact checkpoint is still refused rather than re-attempted at full rebuild cost.

## Verification

- **5 new tests**: a stopped rebuild re-armed with no watcher present; a barrier alone counting as pending; a rebuild that cannot publish backing off like a queue that cannot drain; a raising recovery not killing the daemon; and the queue draining before the barrier is repaired.
- The **10 existing drain tests** still pass, re-pointed at the narrower `_queue_pending` seam, with an autouse fixture asserting no barrier stands — otherwise a test about the queue is quietly testing both.
- Eight graph/watcher/index suites against an `origin/main` baseline worktree: **byte-identical failure sets**, 34 either side.

The measurement is CI's E2E, not a local run. This PR should be checked against it once merged, the same way #630 was.
