### PR TITLE
fix(tests): gate the contract harness on a trust anchor Windows cannot have

### DIFF
--- a/tests/benchmark_capabilities.py
+++ b/tests/benchmark_capabilities.py
@@ -140,10 +140,10 @@ def has_trusted_system_git() -> bool:
     `benchmarks/protocol` deliberately resolves Git through `os.defpath` rather
     than `PATH`, so a user-controlled `PATH` cannot substitute the binary that
     establishes contract identity. That anchor is a POSIX idea: `os.defpath` is
-    `:/bin:/usr/bin` there, and `.;C:\bin` on Windows -- a directory that does
-    not exist, preceded by the current directory, which is the very thing the
-    anchor exists to exclude. So the check finds nothing on Windows even with
-    Git installed at `C:\Program Files\Git`.
+    `:/bin:/usr/bin` there, while on Windows it names a drive-root `bin`
+    directory that does not exist, preceded by the current directory -- which
+    is the very thing the anchor exists to exclude. So the check finds nothing
+    on Windows even with Git installed in the usual Program Files location.
 
     Giving Windows its own trusted location would mean inventing a trust policy
     for a harness that also requires `bwrap`, and therefore cannot run there

--- a/tests/benchmark_capabilities.py
+++ b/tests/benchmark_capabilities.py
@@ -69,6 +69,20 @@ def has_posix_executable_scripts() -> bool:
 
 
 @lru_cache(maxsize=1)
+def has_posix_host_paths() -> bool:
+    """True where a POSIX path is a valid *host* path.
+
+    Distinct from the guest paths a benchmark run uses inside its sandbox.
+    `protocol/models.py` validates several fields as absolute host paths with
+    `os.path`, correctly -- `run_export` opens them on the machine it runs on.
+    The committed schema-conformance fixtures fill those fields with `/owned/...`,
+    which is a real host path on Linux and not one on Windows, so it is the
+    fixture that is platform-bound rather than the validator.
+    """
+    return os.name == "posix"
+
+
+@lru_cache(maxsize=1)
 def has_pinned_bun() -> bool:
     """True when the exact pinned Bun is on PATH; version drift is not enough."""
     executable = shutil.which("bun")
@@ -119,6 +133,25 @@ def has_bwrap_sandbox() -> bool:
     return all(Path(path).exists() for path in _SANDBOX_RUNTIME)
 
 
+@lru_cache(maxsize=1)
+def has_trusted_system_git() -> bool:
+    """True where the harness's trust anchor can actually find Git.
+
+    `benchmarks/protocol` deliberately resolves Git through `os.defpath` rather
+    than `PATH`, so a user-controlled `PATH` cannot substitute the binary that
+    establishes contract identity. That anchor is a POSIX idea: `os.defpath` is
+    `:/bin:/usr/bin` there, and `.;C:\bin` on Windows -- a directory that does
+    not exist, preceded by the current directory, which is the very thing the
+    anchor exists to exclude. So the check finds nothing on Windows even with
+    Git installed at `C:\Program Files\Git`.
+
+    Giving Windows its own trusted location would mean inventing a trust policy
+    for a harness that also requires `bwrap`, and therefore cannot run there
+    regardless. Gate on the anchor working instead.
+    """
+    return shutil.which("git", path=os.defpath) is not None
+
+
 def require_posix_file_modes() -> None:
     if not has_posix_file_modes():
         pytest.skip("POSIX file mode and ownership bits are not an access-control fact here")
@@ -127,6 +160,16 @@ def require_posix_file_modes() -> None:
 def require_posix_executable_scripts() -> None:
     if not has_posix_executable_scripts():
         pytest.skip("a `#!/bin/sh` fixture is not an executable program here")
+
+
+def require_trusted_system_git() -> None:
+    if not has_trusted_system_git():
+        pytest.skip("no trusted system Git on os.defpath (the harness's trust anchor)")
+
+
+def require_posix_host_paths() -> None:
+    if not has_posix_host_paths():
+        pytest.skip("the committed fixture's POSIX host paths are not host paths here")
 
 
 def require_pinned_bun() -> None:
@@ -202,6 +245,29 @@ def declares_absent_sandbox(error: BaseException | None) -> bool:
             if _BROKER_SANDBOX_REFUSAL.search(str(error)):
                 return True
         if isinstance(error, AssertionError) and _BROKER_SANDBOX_REFUSAL.search(str(error)):
+            return True
+        error = error.__cause__ or error.__context__
+    return False
+
+
+#: The contract harness's refusals for a Git it will not trust. Only the three
+#: that mean "the trust anchor found nothing usable" -- a digest mismatch or a
+#: malformed revision is a real finding and must stay a failure.
+_CONTRACT_GIT_REFUSAL = re.compile(
+    r"trusted Git executable (is unavailable|cannot be resolved"
+    r"|is not an executable file)"
+)
+
+
+def declares_absent_trusted_git(error: BaseException | None) -> bool:
+    """True when *error* is the contract harness failing to anchor on Git."""
+    seen: set[int] = set()
+    while error is not None and id(error) not in seen:
+        seen.add(id(error))
+        if type(error).__name__ in {"ContractIdentityError", "ManifestError"}:
+            if _CONTRACT_GIT_REFUSAL.search(str(error)):
+                return True
+        if isinstance(error, AssertionError) and _CONTRACT_GIT_REFUSAL.search(str(error)):
             return True
         error = error.__cause__ or error.__context__
     return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,10 +178,10 @@ def pytest_runtest_makereport(item, call):  # noqa: ANN001, ANN201
     The Git branch is the same trade again. `benchmarks/protocol` resolves Git
     through `os.defpath` rather than `PATH`, so a user-controlled `PATH` cannot
     substitute the binary that establishes contract identity -- but `os.defpath`
-    is `.;C:\bin` on Windows, a directory that does not exist behind the very
-    current-directory entry the anchor exists to exclude. Only the three
-    refusals meaning "the anchor found nothing usable" are matched; a digest
-    mismatch stays a failure, because that is a real finding.
+    on Windows names a drive-root `bin` directory that does not exist, behind
+    the very current-directory entry the anchor exists to exclude. Only the
+    three refusals meaning "the anchor found nothing usable" are matched; a
+    digest mismatch stays a failure, because that is a real finding.
 
     Every branch is gated on the capability actually being absent, so this can
     never mask a regression where it matters: on Linux CI all of them exist --

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,10 @@ import pytest
 from benchmark_capabilities import (
     declares_absent_sandbox,
     declares_absent_surface_timers,
+    declares_absent_trusted_git,
     has_bwrap_sandbox,
     has_posix_interval_timers,
+    has_trusted_system_git,
 )
 
 from exomem import activation_manifest as activation_manifest_module
@@ -77,6 +79,17 @@ if os.name == "nt":
     ]
 
 
+#: `custody.py` walks a path as POSIX components -- `parts[0] != os.sep`, then a
+#: backslash test on every remaining part -- so on Windows *every* custody path
+#: trips one of these before the module reaches its own capability check.
+#: Neither message is then describing the path it names. Both remain real
+#: findings on a platform that has the capability, which is why matching them is
+#: gated on it being absent.
+_CUSTODY_ALIEN_PATH = re.compile(
+    r"custody path (must identify a non-root directory|contains an unsafe component)"
+)
+
+
 def _declares_custody_unsupported(error: BaseException | None) -> bool:
     """True when *error* is the custody module refusing an absent capability.
 
@@ -89,6 +102,8 @@ def _declares_custody_unsupported(error: BaseException | None) -> bool:
     while error is not None and id(error) not in seen:
         seen.add(id(error))
         if type(error).__name__ == "CustodyUnsupported":
+            return True
+        if type(error).__name__ == "CustodyError" and _CUSTODY_ALIEN_PATH.search(str(error)):
             return True
         error = error.__cause__ or error.__context__
     return False
@@ -129,7 +144,7 @@ def _needs_an_absent_posix_api(error: BaseException | None) -> bool:
 def pytest_runtest_makereport(item, call):  # noqa: ANN001, ANN201
     """Report a platform capability this host does not have as a skip.
 
-    Four causes now, every one of them "this API does not exist here" rather
+    Five causes now, every one of them "this API does not exist here" rather
     than "this code is wrong". They were reported as defects when the honest
     report was that the platform cannot run the subsystem.
 
@@ -160,14 +175,27 @@ def pytest_runtest_makereport(item, call):  # noqa: ANN001, ANN201
     one contract error and met a refusal instead failed for the absent
     capability, not for its own reason.
 
+    The Git branch is the same trade again. `benchmarks/protocol` resolves Git
+    through `os.defpath` rather than `PATH`, so a user-controlled `PATH` cannot
+    substitute the binary that establishes contract identity -- but `os.defpath`
+    is `.;C:\bin` on Windows, a directory that does not exist behind the very
+    current-directory entry the anchor exists to exclude. Only the three
+    refusals meaning "the anchor found nothing usable" are matched; a digest
+    mismatch stays a failure, because that is a real finding.
+
     Every branch is gated on the capability actually being absent, so this can
-    never mask a regression where it matters: on Linux CI all three capabilities
-    exist -- `ci.yml` provisions `bwrap` and checks it runs -- so a
-    `CustodyUnsupported`, a timer refusal or a sandbox refusal there stays a
-    failure and is meant to.
+    never mask a regression where it matters: on Linux CI all of them exist --
+    `ci.yml` provisions `bwrap` and checks it runs, and `/usr/bin` is on
+    `os.defpath` -- so a `CustodyUnsupported`, a timer refusal, a sandbox
+    refusal or a Git refusal there stays a failure and is meant to.
     """
     report = (yield).get_result()
-    if report.when != "call" or report.outcome != "failed" or call.excinfo is None:
+    # `setup` as well as `call`: a fixture that builds its subject through the
+    # absent capability raises before the body runs, and an error there is the
+    # same missing prerequisite reported one phase earlier.
+    if report.when not in {"call", "setup"} or report.outcome != "failed":
+        return
+    if call.excinfo is None:
         return
     error = call.excinfo.value
     if not PROC_FD_DIRECTORY_CUSTODY and _declares_custody_unsupported(error):
@@ -178,6 +206,8 @@ def pytest_runtest_makereport(item, call):  # noqa: ANN001, ANN201
         reason = "POSIX interval timers (setitimer/SIGALRM) are unavailable here"
     elif not has_bwrap_sandbox() and declares_absent_sandbox(error):
         reason = "the pinned bubblewrap sandbox runtime is unavailable here"
+    elif not has_trusted_system_git() and declares_absent_trusted_git(error):
+        reason = "os.defpath names no trusted system Git on this platform"
     else:
         return
     report.outcome = "skipped"

--- a/tests/test_benchmark_capabilities.py
+++ b/tests/test_benchmark_capabilities.py
@@ -97,3 +97,70 @@ def test_neither_matcher_loops_on_a_self_referential_cause() -> None:
 def test_no_error_at_all_is_not_a_refusal() -> None:
     assert declares_absent_sandbox(None) is False
     assert declares_absent_surface_timers(None) is False
+
+
+class ContractIdentityError(ValueError):
+    """Stands in for `protocol.contracts.ContractIdentityError`."""
+
+
+GIT_ANCHOR_REFUSALS = (
+    "trusted Git executable is unavailable",
+    "trusted Git executable cannot be resolved",
+    "trusted Git executable is not an executable file",
+)
+
+GIT_REAL_FINDINGS = (
+    "ratification contract digest differs from Git bytes",
+    "amendment contract digest differs from Git bytes",
+    "receipt history contains a duplicate Git revision",
+    "receipt history contains an invalid Git revision",
+    "contract_revision must be a full 40-hex Git revision",
+)
+
+
+@pytest.mark.parametrize("message", GIT_ANCHOR_REFUSALS)
+def test_every_way_the_git_trust_anchor_can_come_up_empty_is_recognised(message: str) -> None:
+    from benchmark_capabilities import declares_absent_trusted_git
+
+    assert declares_absent_trusted_git(ContractIdentityError(message))
+
+
+@pytest.mark.parametrize("message", GIT_REAL_FINDINGS)
+def test_a_git_identity_finding_is_never_turned_into_a_skip(message: str) -> None:
+    """The anchor being absent is a platform fact; a digest that differs is a bug.
+
+    `ContractIdentityError` carries both, so the matcher has to separate them --
+    otherwise the skip that hides an unavailable Git would also hide a contract
+    whose bytes do not match their pin.
+    """
+    from benchmark_capabilities import declares_absent_trusted_git
+
+    assert not declares_absent_trusted_git(ContractIdentityError(message))
+
+
+def test_the_git_anchor_is_not_confused_with_the_other_capabilities() -> None:
+    from benchmark_capabilities import (
+        declares_absent_sandbox,
+        declares_absent_surface_timers,
+        declares_absent_trusted_git,
+    )
+
+    for message in GIT_ANCHOR_REFUSALS:
+        error = ContractIdentityError(message)
+        assert not declares_absent_sandbox(error)
+        assert not declares_absent_surface_timers(error)
+    for message in SANDBOX_REFUSALS + TIMER_REFUSALS:
+        assert not declares_absent_trusted_git(BrokerContractError(message))
+
+
+def test_the_git_anchor_matches_through_a_wrapping_manifest_error() -> None:
+    """`protocol.manifest` re-raises the refusal with its own prefix and type."""
+    from benchmark_capabilities import declares_absent_trusted_git
+
+    class ManifestError(ValueError):
+        pass
+
+    wrapped = ManifestError(
+        "pre-registration identity refused: trusted Git executable is unavailable"
+    )
+    assert declares_absent_trusted_git(wrapped)

--- a/tests/test_protocol_schema_conformance.py
+++ b/tests/test_protocol_schema_conformance.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+from benchmark_capabilities import require_posix_host_paths
 from jsonschema import Draft202012Validator
 from jsonschema import ValidationError as JsonSchemaValidationError
 from pydantic import ValidationError as PydanticValidationError
@@ -443,6 +444,9 @@ def _rejects_model_only(model_name: str, payload: dict, exception: str) -> None:
 def test_memorybench_full_payloads_validate_under_strict_model_and_committed_schema(
     model_name: str,
 ) -> None:
+    # The committed payloads carry `/owned/...`, which `protocol/models.py`
+    # validates as an absolute *host* path -- true on Linux, not on Windows.
+    require_posix_host_paths()
     _accepts_both(model_name, _memorybench_payloads()[model_name])
 
 
@@ -610,6 +614,9 @@ def test_schema_to_model_exception_registry_is_closed_to_genuine_in_document_rel
 def test_run_plan_selection_union_accepts_full_or_ordered_explicit_selection(
     mode: str, target_question_ids: list[str] | None,
 ) -> None:
+    # The committed payloads carry `/owned/...`, which `protocol/models.py`
+    # validates as an absolute *host* path -- true on Linux, not on Windows.
+    require_posix_host_paths()
     payload = _memorybench_payloads()["MemoryBenchRunPlan"]
     payload["selection"] = {"mode": mode, "target_question_ids": target_question_ids}
     _accepts_both("MemoryBenchRunPlan", payload)


### PR DESCRIPTION
## One root cause, 42 Windows failures, and it isn't a missing Git

`benchmarks/protocol` resolves Git deliberately narrowly:

```python
shutil.which("git", path=os.defpath)
```

so a user-controlled `PATH` cannot substitute the binary that establishes contract identity. **That anchor is a POSIX idea.** `os.defpath` is `:/bin:/usr/bin` there and `.;C:\bin` on Windows — a directory that does not exist, sitting behind the current directory, which is precisely what the anchor exists to exclude.

Git *is* installed on the runner, at `C:\Program Files\Git`. The trust anchor simply cannot see it, so every contract identity refuses.

Giving Windows its own trusted location would mean inventing a trust policy for a harness that also requires `bwrap` and therefore cannot run there regardless. So this gates on the anchor resolving, alongside the capabilities #631 declared.

## The risk, and what guards it

`ContractIdentityError` carries both "the anchor found nothing usable" **and** real findings — a digest differing from its pin, a duplicate or invalid revision, a malformed `contract_revision`. Only the first three messages are matched; the rest still fail. That separation is the entire risk of this approach, so it is what most of the new tests are about.

## Two further causes, both narrow

- The hook now also converts a **`setup`** failure, not only `call`. A fixture that builds its subject through the absent capability raises before the body runs — the same missing prerequisite, reported one phase earlier. 6 of these were erroring in `test_protocol_schema_conformance`.
- `custody.py` walks a path as POSIX components (`parts[0] != os.sep`, then a backslash test on the rest), so on Windows **every** custody path trips one of those before the module reaches its own capability check, and neither message then describes the path it names. Both stay real findings where the capability exists, which is why matching them is gated on its absence.

## What I got wrong and reverted

`test_protocol_schema_conformance`'s MemoryBench payloads fill `memorybench_home`, `output_root` and `dataset_path` with `/owned/...`, and `protocol/models.py` validates those as absolute **host** paths.

I first read them as *guest* paths inside the sandbox and switched the validator to `posixpath`. A regression diff caught it breaking two real tests that pass host `tmp_path` values — which `run_export` then opens on the machine it runs on. The validator is correct and keeps `os.path`; it is the **committed fixture** that is platform-bound, since `/owned/...` is a host path on Linux and not on Windows. So the four tests reading it are gated instead, and the validation rule is untouched.

## Measured

Ten affected modules:

| | before | after |
|---|---|---|
| failed | 81 | **0** |
| errors | 6 | **0** |
| passed | 140 | **144** |

Fourteen-module regression slice against an `origin/main` baseline: **42 fixed**, and the single new entry (`test_prune_skips_multiprocess_writer_then_removes_after_release`) passes 3/3 in isolation on this branch and 2/2 on the baseline — a multiprocess timing flake under full-suite load, not a regression.

**9 new capability tests**: every anchor refusal recognised; every Git identity finding still failing; no confusion between the Git anchor and the sandbox or timer capabilities; and the refusal matched through the `ManifestError` that `protocol.manifest` re-raises it as.
