### PR TITLE
fix(windows): accept the owner Windows gives a directory an admin created

### DIFF
--- a/src/exomem/mutation_lock.py
+++ b/src/exomem/mutation_lock.py
@@ -574,6 +574,41 @@ def _windows_principal_spellings(sid: str) -> frozenset[str]:
     return frozenset(spellings)
 
 
+#: Every casefolded spelling of BUILTIN\Administrators, the group an account
+#: domain's RID 500 belongs to by construction.
+_WINDOWS_ADMINISTRATORS_SPELLINGS = frozenset({"ba", "s-1-5-32-544"})
+
+
+def _windows_owner_admits_current_user(owner: str | None, sid: str) -> bool:
+    r"""True when an `OW` ACE on an object owned by *owner* grants to *sid*.
+
+    The literal case is an owner spelled as the current user. The other case is
+    a policy default rather than an oddity: where "System objects: Default owner
+    for objects created by members of the Administrators group" names the group,
+    every directory an administrator creates is owned by
+    BUILTIN\Administrators, not by the account. GitHub's `windows-latest`
+    runners are configured that way, so a directory this module created itself
+    -- `D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;OW)`, the exact shape the
+    validator documents as correct -- read back as owned by `BA` and failed.
+
+    The built-in Administrator is a member of that group by construction, so an
+    `OW` ACE there does grant to us. It grants to the rest of the group too, and
+    that is not a widening: `BA` is already one of the three trustees private
+    runtime state permits, so this admits nobody the DACL did not already admit.
+
+    Deliberately not folded into `_windows_principal_spellings`. That set also
+    resolves *literal* ACE trustees, and adding `BA` to it would collapse a real
+    `BA` grant onto the user's slot -- losing the distinction between the two
+    principals the equality check depends on.
+    """
+    if owner is None:
+        return False
+    spelling = owner.casefold()
+    if spelling in _windows_principal_spellings(sid):
+        return True
+    return _windows_is_local_admin_sid(sid) and spelling in _WINDOWS_ADMINISTRATORS_SPELLINGS
+
+
 def _windows_private_dacl_trustees(sid: str) -> tuple[str, ...]:
     """Return the distinct SDDL trustees permitted for private runtime state."""
     if not re.fullmatch(r"S-1-[0-9-]+", sid):
@@ -793,9 +828,7 @@ def _windows_private_dacl_is_valid(sddl: str, sid: str, *, directory: bool) -> b
     # it, so a substituted grant lands in the same slot as a literal one.
     user_principal = trustees[0].casefold()
     owner = _windows_sddl_owner(sddl)
-    owner_is_current_user = (
-        owner is not None and owner.casefold() in _windows_principal_spellings(sid)
-    )
+    owner_is_current_user = _windows_owner_admits_current_user(owner, sid)
     observed: set[str] = set()
     for ace in aces:
         fields = ace.split(";")

--- a/tests/test_mutation_lock.py
+++ b/tests/test_mutation_lock.py
@@ -1296,3 +1296,94 @@ def test_dacl_error_still_renders_without_a_descriptor() -> None:
     assert error.observed is None
     assert error.expected == ()
     assert "unsafe Windows DACL" in str(error)
+
+
+def test_owner_rights_counts_when_the_administrators_group_owns_the_entry() -> None:
+    """The second half of the same descriptor, and 38 more Windows failures.
+
+    `LA` fixed the *trustee* spelling; this is the *owner*. Where the policy
+    "System objects: Default owner for objects created by members of the
+    Administrators group" names the group -- which is how GitHub's
+    `windows-latest` runners are configured -- every directory an administrator
+    creates is owned by `BA`, not by the account. So the descriptor this module
+    writes itself came back as `O:BA` with an `OW` ACE, and `OW` was refused
+    because the owner was not spelled as the current user.
+
+    The built-in Administrator belongs to that group by construction, so the
+    ACE does grant to us.
+    """
+    assert mutation_lock_module._windows_private_dacl_is_valid(
+        f"O:BA{_OWNER_RIGHTS_DACL}", _LOCAL_ADMIN_SID, directory=True
+    )
+
+
+def test_administrators_owner_is_no_concession_to_an_ordinary_account() -> None:
+    """Membership is what carries the grant, and an ordinary user has none.
+
+    Were this unscoped, any account would accept an `OW` ACE on an entry owned
+    by Administrators -- inferring its own access from a group it may not be in.
+    """
+    assert not mutation_lock_module._windows_private_dacl_is_valid(
+        f"O:BA{_OWNER_RIGHTS_DACL}", _USER_SID, directory=True
+    )
+
+
+def test_the_administrators_owner_concession_admits_no_new_principal() -> None:
+    """`BA` already holds full access here, so resolving `OW` to it widens nothing.
+
+    That is the whole justification: the concession cannot admit anyone the
+    descriptor did not already admit, because the group it names is one of the
+    three trustees private runtime state permits.
+    """
+    trustees = mutation_lock_module._windows_private_dacl_trustees(_LOCAL_ADMIN_SID)
+
+    assert "BA" in trustees
+
+
+def test_a_foreign_owner_is_still_refused_for_the_built_in_administrator() -> None:
+    """Being RID 500 does not make every owner ours."""
+    assert not mutation_lock_module._windows_private_dacl_is_valid(
+        f"O:S-1-5-21-9-9-9-1001{_OWNER_RIGHTS_DACL}", _LOCAL_ADMIN_SID, directory=True
+    )
+
+
+def test_the_administrators_owner_does_not_relax_the_trustee_set() -> None:
+    """The owner decides what `OW` means, never who else may be granted."""
+    foreign = (
+        "O:BAD:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;OW)"
+        "(A;OICI;FA;;;S-1-5-21-9-9-9-1001)"
+    )
+    assert not mutation_lock_module._windows_private_dacl_is_valid(
+        foreign, _LOCAL_ADMIN_SID, directory=True
+    )
+
+
+def test_an_inherited_directory_dacl_is_still_refused() -> None:
+    """Protection is a separate requirement and this change does not touch it.
+
+    The other 12 of the 50 runner failures are this: a directory that already
+    existed, so it carries its parent's ACEs and no `P`. Whatever grants it
+    happens to name, an unprotected DACL can change under us when the parent's
+    does -- and this module validates a pre-existing entry rather than
+    repairing it.
+    """
+    inherited = "O:BAD:(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)(A;OICIID;FA;;;OW)"
+
+    assert not mutation_lock_module._windows_private_dacl_is_valid(
+        inherited, _LOCAL_ADMIN_SID, directory=True
+    )
+
+
+def test_the_administrators_owner_is_not_a_trustee_spelling() -> None:
+    """`BA` resolves an owner, never a literal ACE trustee.
+
+    Folding it into the trustee spellings would collapse a real `BA` grant onto
+    the user's slot, and the descriptor below -- which names the user, SYSTEM
+    and Administrators exactly once each -- would read as a duplicate.
+    """
+    literal = (
+        f"O:BAD:P(A;OICI;FA;;;{_LOCAL_ADMIN_SID})(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"
+    )
+    assert mutation_lock_module._windows_private_dacl_is_valid(
+        literal, _LOCAL_ADMIN_SID, directory=True
+    )


### PR DESCRIPTION
## The validator was refusing a descriptor it wrote itself

38 of the 50 `WindowsRuntimeDaclError` failures on the Windows lane carry this:

```
O:BA D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;OW)
```

That is the descriptor `mutation_lock` applies itself, and the one `_windows_private_dacl_is_valid` already documents as correct — protected against inheritance, full access to precisely SYSTEM, Administrators and the owner, no broad trustee anywhere.

**It failed on the owner.** Where the policy *"System objects: Default owner for objects created by members of the Administrators group"* names the group — which is how GitHub's `windows-latest` runners are configured — every directory an administrator creates is owned by `BA`, not by the account. `OW` grants to whoever owns the object, so the ACE was refused: the owner wasn't spelled as the current user, and the validator fails closed on an `OW` it can't resolve.

#618 fixed the same class on the **trustee** side, where the user's own grant came back spelled `LA`. This is the **owner** side of the same descriptor, which that change didn't reach.

## Why it's safe

The built-in Administrator is a member of `BUILTIN\Administrators` by construction, so an `OW` ACE on a `BA`-owned entry does grant to us. It grants to the rest of the group too — and that widens nothing, because **`BA` is already one of the three trustees private runtime state permits**. The concession admits nobody the descriptor did not already admit.

Kept deliberately narrow:

- **Scoped to RID 500.** An ordinary account infers nothing from a group it may not belong to.
- **A separate owner-only helper**, not an entry in `_windows_principal_spellings`. That set also resolves *literal* ACE trustees; adding `BA` would collapse a real `BA` grant onto the user's slot and destroy the distinction the equality check depends on.
- **Nothing else moves.** Foreign owner still refused, foreign trustee still refused, unprotected directory DACL still refused.

Probed directly:

```
runner protected DACL accepted : True
same but non-admin user        : False
foreign owner, OW rejected     : False
foreign trustee still rejected : False
inherited (unprotected) dir    : False
```

## The other 12 — a different bug, not fixed here

```
O:BA D:(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)(A;OICIID;FA;;;OW)
```

No `P`, all ACEs inherited: a directory that already existed when `mutation_lock` reached it. `hosted_security.py:560` creates the hosted state root with a plain `mkdir(parents=True, mode=0o700)` and never applies the private DACL, while `_prepare_windows_private_directory` deliberately validates a pre-existing entry rather than repairing it. There's already a public helper for this (`prepare_windows_private_state_root`). It wants its own change.

## Verification

**7 new tests**: the runner descriptor accepted; no concession for an ordinary account; a foreign owner still refused for RID 500; the trustee set not relaxed by the owner; an inherited DACL still refused; `BA` proven *not* to be a trustee spelling; and the concession shown to admit no new principal. 65 pass in the module.

**A local run cannot measure this.** A developer box produces different trustees entirely — mine has an inherited `CodexSandboxUsers` grant that this fix correctly still rejects. Against the seven affected modules the failure sets are identical either side, 60 each: no regressions, and no local fixes to claim. CI's Windows lane is the measurement.
