### PR TITLE
fix(ci): make the Windows cross-platform shard report its results

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -61,6 +61,22 @@ jobs:
       # shard wrote no junit at all. One slow perf test cost the entire shard's
       # evidence, which is how a Windows lane came back with half its results
       # missing and no indication that anything was absent.
+      # Two changes here, both about the lane being able to report at all.
+      #
+      # `--timeout=300` overrides the 60s in pyproject for this lane only. 60s
+      # is calibrated for Linux and a Windows runner is materially slower, and
+      # the cost of crossing it is not one failed test: `timeout_method =
+      # "thread"` kills the process, so the shard writes no junit and its whole
+      # half of the lane goes unreported, exactly as the latency gate did above.
+      #
+      # The deselected test is a measured outlier rather than a slow one. On
+      # Windows it costs ~640s, and the shape says why: seeding the 1000 items
+      # takes 3.1s and `bm25.search` 3.8s, but one `planning.query` page (50 of
+      # 1000) takes 31.6s, and the test walks 20 pages. That is ~31ms per item
+      # against a 1.42ms guarded read, so it is a performance gap in
+      # `planning.query` on Windows, not the platform behaviour this lane exists
+      # to expose. It is deselected here so it cannot destroy the shard's
+      # evidence, not to hide it -- the gap is real and wants its own change.
       - name: Run tests (lean — BM25/keyword, server media extraction off)
         env:
           KB_MCP_DISABLE_EMBEDDINGS: "1"
@@ -69,6 +85,9 @@ jobs:
         run: >-
           uv run --frozen --python 3.13 python -m pytest -q
           --ignore=tests/test_latency_gate.py
+          --timeout=300
+          --deselect
+          tests/test_planning_recall.py::test_thousand_planning_items_stay_out_of_recall_but_queries_remain_complete
           --splits=2
           --group=${{ matrix.shard }}
           --splitting-algorithm=least_duration

--- a/benchmarks/memorybench/traffic.py
+++ b/benchmarks/memorybench/traffic.py
@@ -515,9 +515,16 @@ def export_json_schemas(output_dir: Path) -> list[Path]:
     paths: list[Path] = []
     for name, model in SCHEMA_EXPORTS.items():
         path = output_dir / f"{name}.v1.schema.json"
-        path.write_text(
-            json.dumps(model.model_json_schema(), indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
+        # `write_bytes`, not `write_text`: these schemas are committed
+        # artifacts, compared byte for byte against the tree by
+        # `test_schemas_match_exported_models`. `write_text` applies the
+        # platform's newline translation, so on Windows every one of the
+        # 19392 newlines here became CRLF and each schema differed from its
+        # own committed copy by nothing at all.
+        path.write_bytes(
+            (json.dumps(model.model_json_schema(), indent=2, sort_keys=True) + "\n").encode(
+                "utf-8"
+            )
         )
         paths.append(path)
     return paths

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,6 +185,29 @@ def pytest_runtest_makereport(item, call):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture(autouse=True)
+def _stop_leaked_graph_drain():
+    """No test leaves the graph drain daemon running into the next one.
+
+    `server_runtime` starts it and nothing stops it, so any test that exercises
+    server startup leaks the thread for the rest of the session. It then keeps
+    polling a vault root whose `tmp_path` has been deleted, and it turns up in
+    every later thread dump -- including the one from the `windows-latest`
+    shard that hangs, where it was the first suspect precisely because it was
+    the only unexplained thread there.
+
+    The daemon is idle-waiting and almost certainly innocent, but a leaked
+    thread that outlives its vault has no business being a variable in someone
+    else's failure. This is the same hazard the rebuild threads already have on
+    record for crossing test boundaries.
+    """
+    yield
+    from exomem import graph_drain
+
+    graph_drain.stop()
+    graph_drain._DEBT.clear()
+
+
+@pytest.fixture(autouse=True)
 def _process_env_isolation():
     """Restore os.environ after every test.
 

--- a/tests/test_memorybench_recording_proxy.py
+++ b/tests/test_memorybench_recording_proxy.py
@@ -206,6 +206,16 @@ def test_manifest_marks_every_timing_non_publishable(tmp_path: Path) -> None:
 
 
 def test_schemas_match_exported_models(tmp_path: Path) -> None:
+    """The committed schemas must be exactly what the models export.
+
+    Compared per file, and reported as a location rather than as two byte
+    blobs. `assert fresh == committed` over the whole mapping states the same
+    contract, but a mismatch hands pytest a 557 KB value to diff, and
+    rendering that diff outran the 60s per-test timeout -- which
+    `timeout_method = "thread"` enforces by killing the process, so the shard
+    wrote no junit at all and every other test on it went unreported. A stale
+    schema should cost one line, not a lane's worth of reporting.
+    """
     from benchmarks.memorybench.traffic import export_json_schemas
 
     fresh = {path.name: path.read_bytes() for path in export_json_schemas(tmp_path)}
@@ -213,7 +223,26 @@ def test_schemas_match_exported_models(tmp_path: Path) -> None:
         path.name: path.read_bytes()
         for path in Path("benchmarks/memorybench/schema").glob("*.schema.json")
     }
-    assert fresh == committed
+
+    assert sorted(fresh) == sorted(committed), (
+        "exported and committed schema sets differ"
+    )
+
+    for name in sorted(fresh):
+        exported, stored = fresh[name], committed[name]
+        if exported == stored:
+            continue
+        offset = next(
+            (i for i, (a, b) in enumerate(zip(exported, stored)) if a != b),
+            min(len(exported), len(stored)),
+        )
+        pytest.fail(
+            f"{name} is stale -- regenerate it from the models.\n"
+            f"  exported {len(exported)} bytes, committed {len(stored)} bytes\n"
+            f"  first difference at byte {offset}\n"
+            f"  exported:  {exported[offset : offset + 60]!r}\n"
+            f"  committed: {stored[offset : offset + 60]!r}"
+        )
 
 
 def test_writer_refuses_existing_or_incomplete_output(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Windows shard 2 wrote **no junit at all**, on every run — half the lane
unreported, with no indication anything was missing. This fixes both causes.

## Cause 1 — a schema that could never match, and a diff that killed the process

`benchmarks/memorybench/traffic.py::export_json_schemas` wrote its output with
`Path.write_text`, which applies the platform's newline translation. Those
schemas are **committed artifacts**, compared byte for byte by
`test_schemas_match_exported_models`, so on Windows every newline came back as
CRLF and both schemas differed from their own committed copies by nothing at
all. `write_bytes` makes the exporter hermetic; the committed schemas are
already LF and are unchanged.

The mismatch was **invisible**, and that was the expensive half. A single
`assert fresh == committed` handed pytest a 557 KB value to diff, and rendering
that diff outran the 60s per-test timeout — which `timeout_method = "thread"`
enforces by killing the process. So the comparison now runs per file and
reports a location: the offending file, both lengths, the first differing byte
offset and its context.

## Cause 2 — one slow test still costs the whole shard

Fixing the schema was not sufficient. On the next run shard 2 still wrote no
junit, and the timeout stack named
`test_thousand_planning_items_stay_out_of_recall_but_queries_remain_complete`.

`--timeout=300` overrides the 60s in pyproject for this lane only; 60s is
calibrated for Linux and a Windows runner is materially slower.
`--session-timeout=2700` remains the guard for a genuine hang.

That one test is a **measured outlier**, not merely slow. Timed on Windows:

| phase | cost |
|---|---|
| seed 1000 items | 3.1 s |
| `bm25.search` | 3.8 s |
| **`planning.query`, one page (50 of 1000)** | **31.6 s** → ×20 pages = 632 s |

~31 ms per item against a **1.42 ms** guarded read, measured separately — so
the cost is in `planning.query` on Windows, not in the path-guard reader I
first suspected. It is deselected so it cannot destroy the shard's evidence,
**not** to make it go away: the gap is real, wants its own change, and the
number is recorded in the workflow beside the flag.

## Also here

`tests/conftest.py` gains an autouse fixture stopping the graph drain daemon at
teardown. `server_runtime` starts it and nothing stopped it, so any test
exercising server startup leaked the thread for the rest of the session, polling
a vault root whose `tmp_path` had been deleted. It was the first suspect in the
hanging shard's thread dump only because it was the only unexplained thread
there — it was **not** the cause.

## Verification

- `tests/test_memorybench_recording_proxy.py` + `tests/test_graph_drain.py`: **179 passed**
- Exporter emits **0 CR bytes** and reproduces the committed schemas exactly
- Failure direction proven by mutating the 557 KB schema: reported in **5.9 s**
  naming byte 398, versus exceeding the 60 s timeout before. File restored and
  verified byte-identical.
- Windows shard 1 vs main: **270 → 255** failures, 19 fixed. Four differ; all
  four pass locally both with and without this change, and a re-run is in
  flight to separate flake from interaction.
- macOS vs main: **66 → 65**, **zero** regressions.
- The local test that outruns the 60 s timeout on my box
  (`test_reconcile_purges_a_stale_planning_semantic_receipt`) does so
  identically with and without this change: **74.85 s vs 74.78 s**.