### PR TITLE
fix(governance): make durable governance writes work on Windows

### DIFF
--- a/src/exomem/governance/policy.py
+++ b/src/exomem/governance/policy.py
@@ -756,7 +756,13 @@ def compile_prospective(
                 continue
             target = root / rel
             target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(content, encoding="utf-8")
+            # `write_bytes`, matching the carried-over files six lines above
+            # and the live commit's `_durable_bytes(..., content.encode())`.
+            # This tree exists to predict the fingerprint the live tree will
+            # have after the commit, and `_content_fingerprint` hashes raw
+            # bytes -- so a text-mode write made the prediction wrong on
+            # Windows for exactly the documents being proposed.
+            target.write_bytes(content.encode("utf-8"))
         files = _iter_policy_files(root)
         findings, scopes, rules, grants, release_grants = _compile(root, files)
         fingerprint = _content_fingerprint(root, files)

--- a/src/exomem/governance/tool.py
+++ b/src/exomem/governance/tool.py
@@ -51,7 +51,13 @@ from .principal import (
     RequestPrincipal,
     effective_principal,
 )
-from .transaction import GovernanceCrash, GovernanceError, authorization_row, policy_target
+from .transaction import (
+    GovernanceCrash,
+    GovernanceError,
+    authorization_row,
+    policy_target,
+)
+from .transaction import fsync_directory as _fsync_directory
 
 PENDING_MARKER = ".policy-mutation.pending.json"
 DEFAULT_PROPOSAL_TTL_SECONDS = 900
@@ -634,18 +640,10 @@ def _marker_path(vault_root: Path) -> Path:
     return policy_target(policy_module.governance_root(vault_root), PENDING_MARKER)
 
 
-def _fsync_directory(path: Path) -> None:
-    descriptor = os.open(path, os.O_RDONLY)
-    try:
-        os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
-
-
 def _durable_json(path: Path, value: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
-    with temporary.open("w", encoding="utf-8") as handle:
+    with temporary.open("w", encoding="utf-8", newline="\n") as handle:
         json.dump(value, handle, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
         handle.write("\n")
         handle.flush()

--- a/src/exomem/governance/transaction.py
+++ b/src/exomem/governance/transaction.py
@@ -138,7 +138,26 @@ def policy_target(governance_root: Path, relative: str) -> Path:
 
 
 def fsync_directory(path: Path) -> None:
-    descriptor = os.open(path, os.O_RDONLY)
+    """Flush one directory entry so a completed rename survives a crash.
+
+    Windows has no CRT route to this. `os.open` on a directory raises
+    `PermissionError: [Errno 13]` there, so the POSIX idiom below did not
+    degrade on Windows -- it failed every call, and with it every governance
+    commit that reached `durable_json`. That is 76 of the 82 permission
+    failures on the `windows-latest` shard, and a product defect rather than
+    a test artifact: the governance layer could not commit on Windows at all.
+
+    `governance.lifecycle` and `governance.receipts` already flush a raw
+    directory handle through `mutation_lock`; this module, its `durable_json`,
+    `governance.recovery` and `governance.tool` all shared the unported copy.
+    Both branches raise `OSError` on failure, so the contract is unchanged.
+    """
+    if os.name == "nt":
+        from .. import mutation_lock
+
+        mutation_lock._windows_flush_directory(path)
+        return
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
     try:
         os.fsync(descriptor)
     finally:
@@ -148,7 +167,7 @@ def fsync_directory(path: Path) -> None:
 def durable_json(path: Path, value: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
-    with temporary.open("w", encoding="utf-8") as handle:
+    with temporary.open("w", encoding="utf-8", newline="\n") as handle:
         json.dump(value, handle, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
         handle.write("\n")
         handle.flush()


### PR DESCRIPTION
## Summary

The governance layer could not commit on Windows at all. Three defects on the
same durable-write path, each invisible on Linux and each fatal on Windows.

`tests/test_govern_memory_tool.py` on Windows: **56 failed → 0 failed** (166 passed).

## 1. Directory flush — `transaction.fsync_directory`

Opened the directory with `os.open(path, os.O_RDONLY)`. That is the POSIX idiom
for directory-entry durability, and Windows has no CRT route to it: opening a
directory that way raises `PermissionError: [Errno 13]`. So the call did not
degrade on Windows, it **failed**, and with it every governance commit that
reached `durable_json` — 76 of the 82 permission failures on the
`windows-latest` shard.

`governance.lifecycle` and `governance.receipts` already flush a raw directory
handle via `mutation_lock._windows_flush_directory` (`FlushFileBuffers` on a
backup-semantics handle). `transaction` never got the port, and it is the copy
behind `durable_json`, `governance.recovery` and `governance.tool` — which
carried its own verbatim duplicate. Route the one implementation through the
same helper and let `tool` import it, as `recovery` already does.

Both branches still raise `OSError`, so the contract is unchanged. The POSIX
branch also passes `O_DIRECTORY` where it exists, matching the two siblings.

## 2. Durable JSON was not digest-reproducible

`durable_json` opened its temporary file in text mode, so on Windows the
trailing newline became CRLF. That file is addressed by `content_hash`, a
sha256 over raw bytes, so the durable record did not match the digest of its
own canonical form:

```
bytes on disk : b'{"a":1,"b":"x"}\r\n'
digests agree : False
```

## 3. The prospective fingerprint could never match the live one

`compile_prospective` builds a temporary policy tree and fingerprints it, to
predict the fingerprint the live tree will carry once the proposal commits. It
copied carried-over files with `write_bytes` — byte-exact — but wrote the
*proposed* documents with `write_text`. The live commit persists those same
documents with `_durable_bytes(path, content.encode("utf-8"))`.

So on Windows the prediction was computed over CRLF bytes while the live tree
held LF bytes, for exactly the documents being proposed. The two fingerprints
could never agree, and the proposal guard read that as tampering:

```
GOVERNANCE_BLOCKED: prepared composite does not match
```

Traced by instrumenting `_matches_phase`: the divergence is one component,
`proposal_guard`, differing only in `fingerprint_at_propose`.

## The pattern

All three are one defect: **an artifact whose bytes are digested, written
through a platform-dependent text mode.** A sweep of `src/exomem/` for the same
shape found no other live instance — the other `write_text` sites either write
newline-free content or already pass `newline="\n"`.

## Verification (Windows, local)

- `tests/test_govern_memory_tool.py`: **166 passed, 0 failed** (was 56 failed)
- 9 governance modules vs the same commit without these changes:
  **zero regressions, 4 additional tests fixed** (11 failed → 7; the remaining
  7 fail identically on both and are pre-existing)