### PR TITLE
fix(tests): declare the epistemic harness's openat requirement

### DIFF
--- a/benchmarks/epistemic/broker.py
+++ b/benchmarks/epistemic/broker.py
@@ -30,7 +30,6 @@ from pydantic import Field, field_validator
 from .schema import PrivilegedEndpointMatrixEntry
 from .snapshot import StrictModel
 
-
 _SHA256 = r"^[0-9a-f]{64}$"
 _BROKER_ACTIVE: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "epistemic_broker_active", default=False
@@ -950,6 +949,17 @@ class ProviderBroker:
 
 
 def _read_no_follow(root: Path, relative: str) -> bytes:
+    # `dir_fd` is the whole mechanism here: each component is opened
+    # relative to the previous descriptor so no symlink can redirect the
+    # walk between checks. Windows supports no directory descriptors at all
+    # (`os.supports_dir_fd` is empty), so the flags degrade to a plain
+    # directory open that Windows then refuses outright. Declare that rather
+    # than surface it as a bare PermissionError, which reads like a broken
+    # ACL and would hide real permission defects behind it.
+    if os.open not in os.supports_dir_fd:
+        raise BrokerContractError(
+            "no-follow directory traversal requires POSIX directory descriptors"
+        )
     parts = PurePosixPath(_canonical_path(relative)).parts
     directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
     file_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)

--- a/benchmarks/epistemic/evidence.py
+++ b/benchmarks/epistemic/evidence.py
@@ -15,7 +15,6 @@ from .assertions import AssertionContext, AssertionResult
 from .registry import resolve
 from .snapshot import EpistemicStateSnapshot, StrictModel
 
-
 _SHA256 = r"^[0-9a-f]{64}$"
 
 
@@ -222,6 +221,17 @@ def persist_assertion_evidence(
 
 
 def _read_no_follow(run_root: Path, relative: str, *, label: str) -> bytes:
+    # `dir_fd` is the whole mechanism here: each component is opened
+    # relative to the previous descriptor so no symlink can redirect the
+    # walk between checks. Windows supports no directory descriptors at all
+    # (`os.supports_dir_fd` is empty), so the flags degrade to a plain
+    # directory open that Windows then refuses outright. Declare that rather
+    # than surface it as a bare PermissionError, which reads like a broken
+    # ACL and would hide real permission defects behind it.
+    if os.open not in os.supports_dir_fd:
+        raise EvidenceReplayError(
+            "no-follow directory traversal requires POSIX directory descriptors"
+        )
     parts = PurePosixPath(_canonical_relative_path(relative)).parts
     directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
     file_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)

--- a/tests/benchmark_capabilities.py
+++ b/tests/benchmark_capabilities.py
@@ -134,6 +134,21 @@ def has_bwrap_sandbox() -> bool:
 
 
 @lru_cache(maxsize=1)
+def has_posix_directory_fd_traversal() -> bool:
+    """True where the harness can walk a path with directory descriptors.
+
+    `benchmarks/epistemic` reads evidence and receipts by opening each path
+    component relative to the previous descriptor, so no symlink can redirect
+    the walk between the check and the read. That is `openat`, and Windows has
+    no equivalent -- `os.supports_dir_fd` is empty there, not merely missing a
+    flag. The product's own no-follow traversal lives in `exomem.mutation_lock`
+    and does have a native Windows implementation; this is the benchmark
+    harness, which deliberately depends on nothing but the standard library.
+    """
+    return os.open in os.supports_dir_fd
+
+
+@lru_cache(maxsize=1)
 def has_trusted_system_git() -> bool:
     """True where the harness's trust anchor can actually find Git.
 
@@ -230,6 +245,22 @@ _BROKER_SANDBOX_REFUSAL = re.compile(
 )
 
 
+def declares_absent_directory_fd(error: BaseException | None) -> bool:
+    """True when *error* is the epistemic harness declaring `openat` absent.
+
+    Matched on the declaration, never on a bare `PermissionError`: a raw
+    permission failure on a directory is exactly what a genuinely broken ACL
+    looks like, and this repository has real ones on record.
+    """
+    seen: set[int] = set()
+    while error is not None and id(error) not in seen:
+        seen.add(id(error))
+        if _DIRECTORY_FD_REFUSAL.search(str(error)):
+            return True
+        error = error.__cause__ or error.__context__
+    return False
+
+
 def declares_absent_sandbox(error: BaseException | None) -> bool:
     """True when *error* is the broker refusing to build its pinned sandbox.
 
@@ -253,6 +284,9 @@ def declares_absent_sandbox(error: BaseException | None) -> bool:
 #: The contract harness's refusals for a Git it will not trust. Only the three
 #: that mean "the trust anchor found nothing usable" -- a digest mismatch or a
 #: malformed revision is a real finding and must stay a failure.
+_DIRECTORY_FD_REFUSAL = re.compile(
+    r"no-follow directory traversal requires POSIX directory descriptors"
+)
 _CONTRACT_GIT_REFUSAL = re.compile(
     r"trusted Git executable (is unavailable|cannot be resolved"
     r"|is not an executable file)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,12 +11,13 @@ import time
 from pathlib import Path
 
 import pytest
-
 from benchmark_capabilities import (
+    declares_absent_directory_fd,
     declares_absent_sandbox,
     declares_absent_surface_timers,
     declares_absent_trusted_git,
     has_bwrap_sandbox,
+    has_posix_directory_fd_traversal,
     has_posix_interval_timers,
     has_trusted_system_git,
 )
@@ -208,6 +209,8 @@ def pytest_runtest_makereport(item, call):  # noqa: ANN001, ANN201
         reason = "the pinned bubblewrap sandbox runtime is unavailable here"
     elif not has_trusted_system_git() and declares_absent_trusted_git(error):
         reason = "os.defpath names no trusted system Git on this platform"
+    elif not has_posix_directory_fd_traversal() and declares_absent_directory_fd(error):
+        reason = "POSIX directory descriptors (openat) do not exist on this platform"
     else:
         return
     report.outcome = "skipped"

--- a/tests/test_benchmark_capabilities.py
+++ b/tests/test_benchmark_capabilities.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
-import pytest
+import os
 
-from benchmark_capabilities import declares_absent_sandbox, declares_absent_surface_timers
+import pytest
+from benchmark_capabilities import (
+    declares_absent_directory_fd,
+    declares_absent_sandbox,
+    declares_absent_surface_timers,
+    has_posix_directory_fd_traversal,
+)
 
 
 class BrokerContractError(ValueError):
@@ -164,3 +170,41 @@ def test_the_git_anchor_matches_through_a_wrapping_manifest_error() -> None:
         "pre-registration identity refused: trusted Git executable is unavailable"
     )
     assert declares_absent_trusted_git(wrapped)
+
+
+DIRECTORY_FD_REFUSAL = "no-follow directory traversal requires POSIX directory descriptors"
+
+
+def test_the_directory_fd_capability_is_exactly_what_the_platform_reports() -> None:
+    """The gate must follow `os.supports_dir_fd`, not a guess about the OS.
+
+    On Linux this is True, so the skip branch is unreachable there and cannot
+    quietly hide an epistemic-harness regression on the platform that runs it.
+    """
+    assert has_posix_directory_fd_traversal() == (os.open in os.supports_dir_fd)
+
+
+def test_the_directory_fd_refusal_is_recognised_through_a_cause_chain() -> None:
+    declared = ValueError(DIRECTORY_FD_REFUSAL)
+    assert declares_absent_directory_fd(declared)
+    try:
+        raise AssertionError("re-raised by pytest.raises(match=...)") from declared
+    except AssertionError as wrapped:
+        assert declares_absent_directory_fd(wrapped)
+
+
+def test_a_bare_permission_error_is_never_read_as_an_absent_capability() -> None:
+    """The reason this matcher keys on a declaration and not on the OS error.
+
+    A raw `PermissionError` on a directory is precisely what a genuinely broken
+    ACL looks like, and this repository has real ones on record. Matching it
+    would convert those defects into skips.
+    """
+    assert not declares_absent_directory_fd(PermissionError(13, "Permission denied"))
+    assert not declares_absent_directory_fd(OSError(22, "Invalid argument"))
+
+
+def test_the_directory_fd_capability_is_not_confused_with_the_others() -> None:
+    declared = ValueError(DIRECTORY_FD_REFUSAL)
+    assert not declares_absent_sandbox(declared)
+    assert not declares_absent_surface_timers(declared)

--- a/tests/test_epistemic_report.py
+++ b/tests/test_epistemic_report.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import socket
 from pathlib import Path
 
 import pytest
-
 from epistemic.assertions import AssertionContext
 from epistemic.snapshot import EpistemicStateSnapshot, FieldDeclaration, ProjectorMeta, StateItem
 
@@ -192,6 +192,10 @@ def test_failure_evidence_cannot_be_substituted_across_provider_or_variant(
     assert "INTEGRITY FAIL" not in rendered
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="the fixture needs a filename Windows reserves",
+)
 def test_markdown_cells_and_catastrophic_artifact_paths_are_escaped(tmp_path: Path) -> None:
     from epistemic.report import render_epistemic_report
 


### PR DESCRIPTION
## What

`benchmarks/epistemic` reads evidence and receipts by opening each path
component **relative to the previous descriptor**, so no symlink can redirect
the walk between the check and the read. That is `openat`, and Windows has no
equivalent — `os.supports_dir_fd` is empty there, not merely missing a flag.

So `os.O_DIRECTORY` and `os.O_NOFOLLOW` both degraded to `0` through their
`getattr` guards, leaving a plain directory open that Windows refuses outright:

```
E  PermissionError: [Errno 13] Permission denied:
   '...\pytest-of-runneradmin\pytest-0\test_validated_cohort_has_exac0'
benchmarks\epistemic\evidence.py:228: PermissionError
```

18 of the 23 non-governance permission failures on the `windows-latest` shard,
and at a glance indistinguishable from the DACL defects this repository has
genuinely had.

## Why gate rather than fix

This is the benchmark harness, which deliberately depends on nothing but the
standard library. The **product's** no-follow traversal lives in
`exomem.mutation_lock` and already has a native Windows implementation
(`FlushFileBuffers` / backup-semantics handles); nothing here changes it.
Reimplementing that hardening inside a benchmark harness would duplicate
security-sensitive code for no gain.

This follows the precedent already merged in #636: a harness that needs a
POSIX-only prerequisite declares it, and the gate keys on the declaration.

## The safety property

The matcher deliberately does **not** recognise a raw `PermissionError`. A
permission failure on a directory is exactly what a broken ACL looks like, and
matching it would convert real defects into skips. That is asserted, not merely
intended:

```python
def test_a_bare_permission_error_is_never_read_as_an_absent_capability():
    assert not declares_absent_directory_fd(PermissionError(13, "Permission denied"))
    assert not declares_absent_directory_fd(OSError(22, "Invalid argument"))
```

The capability reads `os.supports_dir_fd` directly rather than testing for
Windows, so on Linux it is `True`, the branch is unreachable, and it cannot
hide a regression on the platform that actually runs this harness — also
asserted, in `test_the_directory_fd_capability_is_exactly_what_the_platform_reports`.

## One unrelated skip

`test_markdown_cells_and_catastrophic_artifact_paths_are_escaped` writes
`fail|proof.json` to prove markdown **table cells** get escaped, and `|` cannot
appear in a Windows filename (`OSError: [Errno 22] Invalid argument`).
Relaxing the character would relax the test, so it is skipped on Windows with
that stated reason.

## Verification (Windows, local)

- `test_epistemic_cohort` + `test_epistemic_report` + `test_epistemic_evidence`:
  **18 failures → 0** (28 passed, 35 skipped, each with an explicit reason)
- `tests/test_benchmark_capabilities.py`: **29 passed** (4 new)
- `tests/test_public_artifact_privacy.py` + `tests/test_scaffold_no_leak.py`:
  **58 passed** — no drive-absolute path introduced (the regression that took
  out #636's required gate)