### PR TITLE
fix(tests): run the rotation gate through sys.executable and declare POSIX ops

### DIFF
--- a/tests/test_database_bootstrap_rotation_gate.py
+++ b/tests/test_database_bootstrap_rotation_gate.py
@@ -5,11 +5,13 @@ import json
 import os
 import stat
 import subprocess
+import sys
 import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
+from benchmark_capabilities import require_posix_file_modes
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "infra/scripts/database_bootstrap_rotation_gate.py"
@@ -48,8 +50,21 @@ def _run(
     version: str = "credential-v2",
     boundary_ns: int,
 ) -> subprocess.CompletedProcess[str]:
+    # The gate under test refuses a receipt whose `st_uid != os.getuid()` or
+    # whose `S_IMODE` is not private. Windows has neither as an access-control
+    # fact -- `os.getuid` does not exist there at all -- so the script exits 1
+    # on `AttributeError` before reaching any of its own logic. Four of these
+    # tests assert only "non-zero", "not in {0, 124}", or "== job_status" with
+    # job_status 1, so that crash read as a pass. A crash must not stand in for
+    # a refusal.
+    require_posix_file_modes()
     return subprocess.run(
         [
+            # `sys.executable`, not the script path: this is a Python program,
+            # and only POSIX consults its shebang. Invoking it directly gave
+            # Windows `OSError: [WinError 193] %1 is not a valid Win32
+            # application` -- the gate was never exercised there at all.
+            sys.executable,
             str(SCRIPT),
             "--receipt",
             str(receipt),

--- a/tests/test_hosted_ansible_secret_runner.py
+++ b/tests/test_hosted_ansible_secret_runner.py
@@ -7,9 +7,19 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from benchmark_capabilities import has_posix_executable_scripts
 
 ROOT = Path(__file__).resolve().parents[1]
 RUNNER = ROOT / "infra" / "scripts" / "ansible_with_sops.sh"
+
+# Every test here runs that shell script as a program. Windows has no shebang,
+# so `subprocess` reports `OSError: [WinError 193] %1 is not a valid Win32
+# application` before the runner's own refusals are ever reached. The runner is
+# Linux/macOS operator tooling; there is nothing here for Windows to check.
+pytestmark = pytest.mark.skipif(
+    not has_posix_executable_scripts(),
+    reason="the ansible runner is a shebang script, which is not a program here",
+)
 
 
 def _write_executable(path: Path, body: str) -> None:

--- a/tests/test_hosted_platform_operations.py
+++ b/tests/test_hosted_platform_operations.py
@@ -15,6 +15,7 @@ from types import ModuleType
 
 import pytest
 import yaml
+from benchmark_capabilities import require_posix_executable_scripts
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -2776,6 +2777,9 @@ def test_network_probe_plan_contains_every_denied_boundary() -> None:
 def test_network_probe_executor_fails_if_any_denied_connection_succeeds(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    # The probe executor runs `kubectl`; this stands one in with a shebang,
+    # which Windows cannot execute as a program.
+    require_posix_executable_scripts()
     module = _load("infra/scripts/network_policy_probes.py", "network_policy_executor_test")
     kubectl = tmp_path / "kubectl"
     calls = tmp_path / "calls.jsonl"


### PR DESCRIPTION
## What

Three ops-tooling modules produced **every** `OSError: [WinError 193] %1 is not
a valid Win32 application` on the Windows shard — 12 failures — because each
handed a script path straight to `subprocess`, and only POSIX consults a
shebang.

They do not all deserve the same treatment, so they don't get it.

## The rotation gate was a real portability defect

`infra/scripts/database_bootstrap_rotation_gate.py` is a **Python** program,
invoked as `subprocess.run([str(SCRIPT), ...])`. Passing `sys.executable` is
simply the correct way to run it — and doing so is what surfaced the actual
reason it cannot run on Windows:

```
AttributeError: module 'os' has no attribute 'getuid'
```

The gate refuses any receipt whose `st_uid != os.getuid()` or whose `S_IMODE`
is not private. Windows has neither as an access-control fact.

### That mattered more than the 193 did

With the invocation fixed, the script exits 1 on `AttributeError` before
reaching any of its own logic. Four of these tests assert only `!= 0`,
`not in {0, 124}`, or `== job_status` with `job_status` 1 — so **the crash read
as a pass**:

| test | asserts | crash gives | verdict |
|---|---|---|---|
| `...returns_original_job_outcome[1]` | `== job_status` (1) | 1 | false pass |
| `...must_match_current_attempt...` ×2 | `not in {0, 124}` | 1 | false pass |
| `...rejects_symlink_and_non_private_mode` | `!= 0` | 1 | false pass |
| `...rejects_stale_file_even_when_readable` | `!= 1` | 1 | correctly failed |

Fixing only the invocation would have moved this module from
unexercised-and-loud to unexercised-and-quiet, which is worse. So `_run` now
requires `has_posix_file_modes` — the capability whose docstring already states
that Windows synthesizes `st_mode` and `st_uid`. The one test that genuinely
works there, importing the module without executing the CLI, still runs.

## The other two are shebang programs and stay that way

- `infra/scripts/ansible_with_sops.sh` — Linux/macOS operator tooling needing
  `sh`, `sops` and a tmpfs mount. Every test in the module runs it, so the
  module declares the requirement.
- `test_network_probe_executor_fails_if_any_denied_connection_succeeds` stands
  in a `#!/usr/bin/env python3` fake `kubectl` for the probe executor to
  invoke — also not a program on Windows.

## Safety

Every gate keys on an existing capability predicate (`has_posix_file_modes`,
`has_posix_executable_scripts`) that is `True` on POSIX, so none of this is
reachable on the platforms that actually run these suites.

## Verification (Windows, local)

- The three modules: **12 failures → 0** (22 skipped each with an explicit
  reason, 1 genuine pass)
- `tests/test_hosted_platform_operations.py` still collects all 61 tests
- `tests/test_public_artifact_privacy.py` + `tests/test_scaffold_no_leak.py`:
  **58 passed** — no drive-absolute path introduced