### PR TITLE
fix(records): decide the splice newline per span, and refuse a splice that loses a field

### DIFF
--- a/src/exomem/record_formats.py
+++ b/src/exomem/record_formats.py
@@ -986,6 +986,38 @@ def splice_record_presentation(
     return bom + text[:close_end] + newline + block + text[close_end:]
 
 
+def _span_terminator(yaml_text: str, span: tuple[int, int]) -> str:
+    r"""The line ending a compose span already swallowed, or "" if it swallowed none.
+
+    Block-style nodes -- a literal or folded scalar, a nested mapping, a block
+    sequence -- end their span *after* their own trailing newline. Plain, flow
+    and quoted scalars stop at the last content byte. Every splice decision
+    below turns on that difference, and it has to be read off the span itself:
+    a single CRLF anywhere in the document used to make the answer
+    `"\r\n"` for the whole file, so an LF-terminated span looked as though
+    it had swallowed nothing and its line ending was never restored.
+    """
+    text = yaml_text[span[0] : span[1]]
+    if text.endswith("\r\n"):
+        return "\r\n"
+    if text.endswith("\n"):
+        return "\n"
+    return ""
+
+
+def _line_terminator(text: str, index: int) -> str:
+    r"""The line ending that terminates the line holding `index`.
+
+    Searches for the LF that both conventions end with, so a `"\r\n"` document
+    with one LF-terminated line -- or the reverse -- is read as it actually is
+    rather than as its majority. Returns "" when nothing terminates the line.
+    """
+    stop = text.find("\n", index)
+    if stop == -1:
+        return ""
+    return "\r\n" if stop and text[stop - 1] == "\r" else "\n"
+
+
 def render_markdown_item_update(
     source: str,
     changes: Mapping[str, Any],
@@ -1022,18 +1054,44 @@ def render_markdown_item_update(
         if key_node.value in spans:
             raise collections.CollectionError("DUPLICATE_FRONTMATTER_KEY", "item key is duplicated")
         spans[key_node.value] = (key_node.start_mark.index, value_node.end_mark.index)
+    # Everything appended below lands after the final frontmatter line, so it
+    # takes that line's ending. Falling back to the document newline only
+    # matters for a frontmatter block that is not newline-terminated at all.
+    trailing = _span_terminator(yaml_text, (0, len(yaml_text))) or newline
     replacements: list[tuple[int, int, str]] = []
     for name in delete_fields:
         span = spans.get(name)
         if span is None:
             continue
-        end = yaml_text.find(newline, span[1])
-        replacements.append((span[0], len(yaml_text) if end == -1 else end + len(newline), ""))
+        if _span_terminator(yaml_text, span):
+            # The span already covers this field's own line ending. Searching
+            # forward from here lands on the *next* field's terminator, and the
+            # deletion range then swallows that field whole -- valid YAML with a
+            # governed key silently gone, which no parse-level guard can see.
+            replacements.append((span[0], span[1], ""))
+            continue
+        # A plain, flow or quoted scalar stops at its last content byte, so the
+        # line ending after it is still ours to remove. Search for the LF both
+        # conventions end with rather than for the document's majority newline.
+        stop = yaml_text.find("\n", span[1])
+        replacements.append((span[0], len(yaml_text) if stop == -1 else stop + 1, ""))
     for name, value in changes.items():
         span = spans.get(name)
-        rendered = vault.serialize_frontmatter({name: value}).replace("\n", newline)
+        # Render with the line ending in force where this field actually lives,
+        # not the document's majority: one CRLF anywhere used to decide it for
+        # every line, which is what left a mixed-ending page unwritable.
+        local = (
+            newline
+            if span is None
+            else (
+                _span_terminator(yaml_text, span)
+                or _line_terminator(yaml_text, span[1])
+                or newline
+            )
+        )
+        rendered = vault.serialize_frontmatter({name: value}).replace("\n", local)
         if span is None:
-            replacements.append((len(yaml_text), len(yaml_text), rendered + newline))
+            replacements.append((len(yaml_text), len(yaml_text), rendered + trailing))
         else:
             # Block-style original values (dict/list-with-nested-items, or a
             # literal/folded scalar) end their compose span *after* their own
@@ -1046,8 +1104,9 @@ def render_markdown_item_update(
             # another key's span replacement, an appended new field, or the
             # closing `---` fence. Reproduce that swallowed newline so the
             # splice always lands on its own line.
-            if yaml_text[span[0] : span[1]].endswith(newline) and not rendered.endswith(newline):
-                rendered += newline
+            consumed = _span_terminator(yaml_text, span)
+            if consumed and not rendered.endswith(consumed):
+                rendered += consumed
             replacements.append((*span, rendered))
     updated_yaml = yaml_text
     for start, end, rendered in sorted(replacements, reverse=True):
@@ -1055,13 +1114,46 @@ def render_markdown_item_update(
     profile = profile_for(semantic_profile)
     marker = re.escape(profile.item_audit_marker)
     updated_yaml = re.sub(rf"(?m)^# {marker}: [0-9a-f]{{24}}\r?\n?", "", updated_yaml)
+    # Field-set fidelity, checked before the parse guard below because the
+    # failure this closes leaves *valid* YAML: a deletion range that ran past
+    # its own field takes the next one with it, and nothing downstream can tell
+    # a key that was never asked for from a key that was silently dropped.
+    expected_keys = [name for name in spans if name not in set(delete_fields)]
+    expected_keys += [name for name in changes if name not in spans]
+    try:
+        spliced = vault.yaml.compose(updated_yaml)
+    except vault.yaml.YAMLError as error:
+        raise collections.CollectionError(
+            "INVALID_RECORD_ITEM", "spliced item frontmatter is not valid YAML"
+        ) from error
+    if spliced is None:
+        observed: list[str] = []
+    elif isinstance(spliced, vault.yaml.nodes.MappingNode):
+        observed = [node.value for node, _value in spliced.value]
+    else:
+        raise collections.CollectionError(
+            "INVALID_RECORD_ITEM", "spliced item frontmatter is not a mapping"
+        )
+    if observed != expected_keys:
+        raise collections.CollectionError(
+            "INVALID_RECORD_ITEM",
+            "spliced item frontmatter did not preserve the requested field set",
+        )
     audit_line = (
-        f"# {profile.item_audit_marker}: {audit_correlation}{newline}"
+        f"# {profile.item_audit_marker}: {audit_correlation}{trailing}"
         if audit_correlation
         else ""
     )
     close_end = close_start + len(closing.group(0))
-    suffix = text[close_end:] if body is None else newline + body
+    # `^---\r?$` matches *before* the LF, so a CRLF fence leaves its CR inside
+    # `closing.group(0)` and only the LF after `close_end`. Prefixing a replaced
+    # body with the document newline therefore wrote `---\r\r\n` on a CRLF page
+    # -- a fence line the self-check below then refused, which is the same
+    # unwritable-page failure by a different route. Keep the source's own
+    # terminator instead.
+    fence_end = text.find("\n", close_end)
+    fence_terminator = newline if fence_end == -1 else text[close_end : fence_end + 1]
+    suffix = text[close_end:] if body is None else fence_terminator + body
     rebuilt = text[: opening.end()] + updated_yaml + audit_line + text[close_start:close_end] + suffix
     # Post-write self-check: a splice bug that glues a field into whatever
     # follows it must fail loudly here, not persist an unreadable page for a

--- a/tests/test_span_splice_field_set_and_line_endings.py
+++ b/tests/test_span_splice_field_set_and_line_endings.py
@@ -1,0 +1,160 @@
+"""Regression coverage for issues #559 and #560.
+
+Both live in `record_formats.render_markdown_item_update`, and both are the
+same discriminator #546 already keys on -- whether a compose span swallowed
+its own trailing newline -- read off the wrong thing.
+
+#559: for a block-style node `end_mark` lands *after* that node's newline, so
+the `delete_fields` branch's forward search for the next newline found the
+*following* field's terminator and deleted that field with it. The result is
+valid, parseable YAML with a governed key silently gone, which the #546
+post-write reparse guard cannot see.
+
+#560: the newline was decided per *document* -- one CRLF anywhere selected
+`\r\n` for every line -- so on a mixed-ending page an LF-terminated span was
+not recognised as newline-consuming and its line ending was never restored.
+After #546 that is a refusal rather than corruption, which leaves the page
+permanently unwritable through this path.
+
+The CRLF body-replacement case below is the same class found while fixing
+those two: `^---\r?$` matches before the LF, so a CRLF fence keeps its CR
+inside the match and prefixing a replaced body with the document newline
+wrote `---\r\r\n`. That one committed silently.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from exomem import record_formats, vault
+from exomem import structured_collections as collections
+
+LF = chr(10)
+CR = chr(13)
+CRLF = CR + LF
+
+_HEAD = (
+    "type: plan",
+    "collection_id: 11111111-1111-4111-8111-111111111111",
+    "plan_id: 22222222-2222-4222-8222-222222222222",
+    "schema_version: 1",
+)
+
+
+def _document(*, block: str, newline: str = LF) -> str:
+    lines = ["---", *_HEAD, *block.split(LF), "status: active", "owner: hugo", "---", "Body.", ""]
+    return newline.join(lines)
+
+
+@pytest.mark.parametrize(
+    ("label", "block"),
+    [
+        ("literal-scalar", "label: |" + LF + "  change 1"),
+        ("folded-scalar", "label: >" + LF + "  change 1"),
+        ("block-sequence", "label:" + LF + "- a" + LF + "- b"),
+        ("block-mapping", "label:" + LF + "  k: v"),
+    ],
+)
+def test_deleting_a_block_valued_mid_document_field_keeps_the_next_field(
+    label: str, block: str
+) -> None:
+    """#559: the deletion range must stop at the span, not at the next newline."""
+    source = _document(block=block)
+
+    updated = record_formats.render_markdown_item_update(
+        source, {}, semantic_profile="planning", delete_fields=("label",)
+    )
+
+    parsed, _body, _fm = vault.parse_frontmatter(updated, strict=True)
+    assert "label" not in parsed, f"{label}: the field asked for was not removed"
+    assert parsed["status"] == "active", f"{label}: the following field was deleted too"
+    assert parsed["owner"] == "hugo"
+
+
+def test_deleting_a_plain_scalar_mid_document_field_keeps_the_next_field() -> None:
+    """The control that pins the discriminator: a plain scalar consumes nothing."""
+    source = _document(block="label: change 1")
+
+    updated = record_formats.render_markdown_item_update(
+        source, {}, semantic_profile="planning", delete_fields=("label",)
+    )
+
+    parsed, _body, _fm = vault.parse_frontmatter(updated, strict=True)
+    assert "label" not in parsed
+    assert parsed["status"] == "active"
+    assert "label:" not in updated, f"the deleted line's remains survived: {updated!r}"
+
+
+def test_deleting_the_last_block_valued_field_leaves_a_well_formed_fence() -> None:
+    source = LF.join(["---", *_HEAD, "label: |", "  change 1", "---", "Body.", ""])
+
+    updated = record_formats.render_markdown_item_update(
+        source, {}, semantic_profile="planning", delete_fields=("label",)
+    )
+
+    parsed, body, _fm = vault.parse_frontmatter(updated, strict=True)
+    assert "label" not in parsed and parsed["type"] == "plan"
+    assert body == "Body." + LF
+
+
+def test_a_mixed_line_ending_page_is_writable_and_keeps_its_own_endings() -> None:
+    """#560: one CRLF line must not decide the newline for every other line."""
+    source = (
+        "---" + LF
+        + "type: plan" + CRLF
+        + "collection_id: 11111111-1111-4111-8111-111111111111" + LF
+        + "label: |" + LF
+        + "  change 1" + LF
+        + "---" + LF
+        + "Body." + LF
+    )
+
+    updated = record_formats.render_markdown_item_update(
+        source, {"label": "change 2", "tags": ["urgent"]}, semantic_profile="planning"
+    )
+
+    parsed, body, _fm = vault.parse_frontmatter(updated, strict=True)
+    assert parsed["label"] == "change 2"
+    assert parsed["tags"] == ["urgent"]
+    assert body == "Body." + LF
+    # Untouched lines keep exactly the ending they had.
+    assert "type: plan" + CRLF in updated
+    assert "collection_id: 11111111-1111-4111-8111-111111111111" + LF in updated
+
+
+def test_a_crlf_page_keeps_one_carriage_return_when_the_body_is_replaced() -> None:
+    source = CRLF.join(["---", *_HEAD, "---", "Old body.", ""])
+
+    updated = record_formats.render_markdown_item_update(
+        source, {}, semantic_profile="planning", body="New body." + CRLF
+    )
+
+    assert CR + CR not in updated, f"a doubled carriage return was written: {updated!r}"
+    parsed, body, _fm = vault.parse_frontmatter(updated, strict=True)
+    assert parsed["type"] == "plan"
+    assert body == "New body." + CRLF
+
+
+def test_a_splice_that_drops_a_field_is_refused_rather_than_committed() -> None:
+    """#559 ask 3: the guard has to see field loss, not only parse failure.
+
+    Forcing the pre-#559 deletion range reproduces exactly the shape that used
+    to commit cleanly -- valid YAML, one governed key gone.
+    """
+    source = _document(block="label: |" + LF + "  change 1")
+    real_span_terminator = record_formats._span_terminator
+
+    def blind_to_block_spans(yaml_text: str, span: tuple[int, int]) -> str:
+        return ""
+
+    record_formats._span_terminator = blind_to_block_spans
+    try:
+        with pytest.raises(collections.CollectionError) as raised:
+            record_formats.render_markdown_item_update(
+                source, {}, semantic_profile="planning", delete_fields=("label",)
+            )
+    finally:
+        record_formats._span_terminator = real_span_terminator
+
+    assert raised.value.code == "INVALID_RECORD_ITEM"
+    assert "field set" in str(raised.value)


### PR DESCRIPTION
Closes #559. Closes #560.

Both issues live in `record_formats.render_markdown_item_update`, and both are the discriminator #546 already keys on — whether a compose span swallowed its own trailing newline — read off the wrong thing.

## #559 — silent data loss

For a block-style node `end_mark` lands *after* that node's newline, so `span[1]` sits at the first byte of the next field. The `delete_fields` branch searched forward for the next newline, found the **following** field's terminator, and deleted that field with it.

```
delete_fields=("label",)  →  label AND status: active both gone
```

The result is valid, parseable YAML with a governed key missing, so #546's post-write reparse guard cannot see it and the write commits cleanly.

A span that already carries its own terminator now ends the deletion range where the span ends. Only a plain, flow or quoted scalar — which stops at its last content byte — extends to the end of its line, and it finds that by searching for the LF both conventions end with rather than for the document's majority newline.

## #560 — a permanently unwritable page

The newline was decided per document (`"\r\n" if "\r\n" in text else "\n"`), so one CRLF line anywhere selected CRLF for every line. On a mixed-ending page an LF-terminated span failed its `endswith("\r\n")` test, no separator was restored, and the fields glued together — caught by #546's guard, which turns it into a refusal with no self-repair.

Each field now renders and re-terminates with the ending in force where that field actually lives. That keeps the module's stated contract (replace complete nodes, retain every other source byte) rather than normalising the page, which would rewrite bytes the caller never asked to change.

## A third case, found while fixing those two — and worse than either

`^---\r?$` matches *before* the LF, so a CRLF fence keeps its CR inside `closing.group(0)` and leaves only the LF after it. Prefixing a replaced body with the document newline therefore wrote `---\r\r\n` — and unlike #560 that one **passed the guard and committed**. Replacing the body of any CRLF page corrupted its closing fence. The fence's own terminator is now carried through verbatim.

## Closing the class, not just the instances (#559 ask 3)

The reparse guard checks that the splice still parses; it cannot check that the splice kept the fields it was asked to keep. A field-set check now runs first, comparing the spliced block's top-level keys against the requested mutation, so a range that runs past its own field is refused instead of committed.

## Verification

`tests/test_span_splice_field_set_and_line_endings.py` — 9 tests, run against `origin/main` as well as this branch:

- **7 fail on `origin/main`, all pass here.**
- The 2 that pass on both are the deliberate controls: a plain scalar consumes no newline, and a block field that is last in the frontmatter has no following field to swallow.

Neighbouring suites green: `test_span_splice_trailing_newline`, `test_record_representation_matrix`, `test_schema_field_exclusion`, `test_record_formats`, `test_plan_memory_command`, `test_planning_mutation`, `test_record_audit_protocol` (146 passed). `test_record_lifecycle::test_v1_append_after_revision_keeps_v2_marker_and_v1_event_shape` fails identically on `origin/main` — pre-existing, unrelated.