### PR TITLE
fix(platform): decode captured subprocess output as UTF-8, not the code page

### DIFF
--- a/plugins/claude-code/hooks/exomem_continuation_checkpoint.py
+++ b/plugins/claude-code/hooks/exomem_continuation_checkpoint.py
@@ -447,6 +447,15 @@ def _git_probe(cwd: Path, *args: str) -> tuple[str | None, int | None]:
             ],
             capture_output=True,
             text=True,
+            # Pinned, not inherited: without it the pipe is decoded with
+            # the host's active code page, and git happily emits a branch
+            # name or a repository path this hook cannot spell in cp1252.
+            # The resulting UnicodeDecodeError is raised inside subprocess's
+            # reader, so no `except OSError` here would have caught it.
+            # `replace` because a checkpoint hook must degrade, never abort
+            # the session it is recording.
+            encoding="utf-8",
+            errors="replace",
             env=_git_environment(),
             timeout=GIT_TIMEOUT_SECONDS,
             check=False,

--- a/src/exomem/_hooks/exomem_continuation_checkpoint.py
+++ b/src/exomem/_hooks/exomem_continuation_checkpoint.py
@@ -447,6 +447,15 @@ def _git_probe(cwd: Path, *args: str) -> tuple[str | None, int | None]:
             ],
             capture_output=True,
             text=True,
+            # Pinned, not inherited: without it the pipe is decoded with
+            # the host's active code page, and git happily emits a branch
+            # name or a repository path this hook cannot spell in cp1252.
+            # The resulting UnicodeDecodeError is raised inside subprocess's
+            # reader, so no `except OSError` here would have caught it.
+            # `replace` because a checkpoint hook must degrade, never abort
+            # the session it is recording.
+            encoding="utf-8",
+            errors="replace",
             env=_git_environment(),
             timeout=GIT_TIMEOUT_SECONDS,
             check=False,

--- a/src/exomem/deploy_provenance.py
+++ b/src/exomem/deploy_provenance.py
@@ -95,6 +95,8 @@ def _revision(root: Path | None) -> str | None:
             ["git", "-C", str(root), "rev-parse", "--short", "HEAD"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=5,
             check=False,
         )

--- a/src/exomem/extract.py
+++ b/src/exomem/extract.py
@@ -726,6 +726,8 @@ def _run_diarization(path: Path) -> list[tuple[float, float, str]] | None:
                 [str(py), str(_diarizer_worker_script()), str(path), str(out_path)],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=_diarizer_timeout(path),
                 env=_diarizer_child_env(),
             )

--- a/src/exomem/package_skills.py
+++ b/src/exomem/package_skills.py
@@ -56,6 +56,8 @@ def _exomem_checkout_containing(path: Path) -> Path | None:
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
     except OSError:
         return None

--- a/src/exomem/resource_status.py
+++ b/src/exomem/resource_status.py
@@ -187,6 +187,8 @@ def _probe_nvidia_smi() -> dict[str, Any]:
             capture_output=True,
             check=False,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=2,
         )
     except Exception as e:  # noqa: BLE001

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -1,0 +1,107 @@
+"""Every captured subprocess pipe must name its encoding.
+
+`subprocess.run(..., text=True)` without `encoding=` decodes the child's
+output with `locale.getencoding()`. On a Windows-native Python that is the
+active code page -- cp1252 on a Western install, cp932/cp949/cp936 elsewhere --
+so any byte the child emits outside that page raises `UnicodeDecodeError`
+*inside the reader*, not at the call site. The traceback names `subprocess`,
+never the caller, and the caller's `except OSError` does not catch it.
+
+The bytes that trigger it are ordinary: a repository path under a user name
+that is not Latin-1, a git branch or commit message with a typographic quote, a
+worker's traceback quoting a page title. `git` and every Python child speak
+UTF-8, so the encoding is not in doubt -- it was simply left unstated, and the
+platform filled it in with the wrong answer.
+
+Asserted over the source rather than by provoking a decode, because the failure
+depends on the host's active code page: a check that only fires under cp1252
+proves nothing on the Linux runners where most of CI lives, and `errors=` is a
+policy this repo makes deliberately (`replace`, so a hook degrades instead of
+crashing) rather than something a runtime probe can observe.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1] / "src" / "exomem"
+
+
+def _captures_text(call: ast.Call) -> bool:
+    """Whether this call decodes a child's output into `str`."""
+    keywords = {k.arg: k.value for k in call.keywords if k.arg}
+    if not isinstance(keywords.get("text"), ast.Constant):
+        return False
+    if keywords["text"].value is not True:
+        return False
+    # `encoding=` implies text mode on its own, so a call that already names one
+    # is compliant whatever `text=` says.
+    return "encoding" not in keywords
+
+
+def _subprocess_calls(tree: ast.AST) -> list[ast.Call]:
+    """Calls into `subprocess`'s process-spawning surface."""
+    spawners = {"run", "Popen", "check_output", "call", "check_call"}
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        function = node.func
+        if isinstance(function, ast.Attribute) and function.attr in spawners:
+            value = function.value
+            if isinstance(value, ast.Name) and value.id == "subprocess":
+                found.append(node)
+    return found
+
+
+def _offenders() -> list[str]:
+    offending = []
+    for path in sorted(SOURCE_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for call in _subprocess_calls(tree):
+            if _captures_text(call):
+                offending.append(f"{path.relative_to(SOURCE_ROOT).as_posix()}:{call.lineno}")
+    return offending
+
+
+def test_every_text_mode_subprocess_pins_its_encoding() -> None:
+    assert _offenders() == [], (
+        "these calls decode a child's output with the host's active code page; "
+        'add encoding="utf-8" (and an explicit errors= policy)'
+    )
+
+
+def test_the_guard_recognises_an_unpinned_call() -> None:
+    """A source-shape assertion is only worth its ability to fail."""
+    unpinned = ast.parse(
+        "import subprocess\n"
+        "subprocess.run(['git', 'status'], capture_output=True, text=True)\n"
+    )
+    pinned = ast.parse(
+        "import subprocess\n"
+        "subprocess.run(\n"
+        "    ['git', 'status'], capture_output=True, text=True, encoding='utf-8'\n"
+        ")\n"
+    )
+
+    assert [_captures_text(call) for call in _subprocess_calls(unpinned)] == [True]
+    assert [_captures_text(call) for call in _subprocess_calls(pinned)] == [False]
+
+
+@pytest.mark.parametrize(
+    "relative",
+    [
+        "_hooks/exomem_continuation_checkpoint.py",
+        "deploy_provenance.py",
+        "extract.py",
+        "package_skills.py",
+        "resource_status.py",
+    ],
+)
+def test_the_repaired_callers_still_name_utf8(relative: str) -> None:
+    """Name them, so a later edit that drops the encoding is a named regression."""
+    source = (SOURCE_ROOT / relative).read_text(encoding="utf-8")
+    assert 'encoding="utf-8"' in source


### PR DESCRIPTION
## What

Five `subprocess.run(..., text=True)` call sites in `src/exomem` never named an encoding, so the child's output was decoded with `locale.getencoding()` — the active code page on a Windows-native Python.

| site | what it reads |
|---|---|
| `_hooks/exomem_continuation_checkpoint.py` | `git` status/rev-parse on every session boundary |
| `deploy_provenance.py` | `git rev-parse --short HEAD` |
| `package_skills.py` | `git rev-parse --show-toplevel` (the repository path) |
| `extract.py` | the diarizer worker's stdout/stderr |
| `resource_status.py` | `nvidia-smi` |

## Why it matters

The bytes that break this are ordinary: an account name that is not spellable in cp1252, a branch name with a typographic quote, a worker traceback quoting a page title. `UnicodeDecodeError` is then raised inside subprocess's reader thread, so the traceback names `subprocess` rather than the caller and the caller's `except OSError` does not catch it. For the checkpoint hook that means the hook is lost, not merely its output.

`errors="replace"` alongside `encoding="utf-8"`, matching the policy `setup_wizard` and `doctor` already state: provenance, diagnostics and a session hook must degrade rather than abort what they describe.

## Verification

- New `tests/test_subprocess_text_encoding.py` walks the source tree and fails on any `subprocess` spawn that captures text without naming an encoding. Pointed at `origin/main` it reports exactly these five (`_hooks/exomem_continuation_checkpoint.py:437`, `deploy_provenance.py:94`, `extract.py:725`, `package_skills.py:53`, `resource_status.py:181`); pointed here it reports none. It carries its own positive and negative control so it cannot rot into a test that always passes.
- Asserted over the AST rather than by provoking a decode: the failure only reproduces under a non-UTF-8 code page, and `errors=` is a deliberate policy a runtime probe cannot observe.
- `tests/test_continuation_checkpoint.py`, `test_install_hook.py`, `test_package_skills.py`, `test_resource_envelope.py`, `test_deploy_provenance.py` on Windows: 26 failed / 244 passed, against 25 failed / 245 passed for the same selection on `origin/main`. The one difference is `test_prune_skips_multiprocess_writer_then_removes_after_release`, which fails nondeterministically on `origin/main` too (a different parameter each run, reproduced in isolation) and is separately repaired in #642.
- `uvx ruff check --select F` clean.
- The packaged plugin copy of the hook is resynced to match its source, as previous hook edits have done.