### PR TITLE
fix(platform): encode the machine-wide-base constraint instead of exemplifying it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,42 @@ declare the same version, and
 `tests/test_uv_lock_policy.py::test_uv_writer_version_is_pinned_across_repository_surfaces`
 fails if any of the four drifts. Bumping uv means bumping all four together.
 
+## The privacy gate runs anywhere — run it before you push
+
+`public_artifact_privacy` refuses a drive-absolute path literal in any
+repository input or shipped wheel member. Docstrings count: they travel inside
+the wheel.
+
+```
+uv run python scripts/validate-public-artifacts.py --repository
+```
+
+It is pure Python over files and takes a couple of seconds on any platform. It
+is worth running deliberately because the CI job that enforces it is
+Linux-only, so a Windows-only contributor's first encounter with it is a red
+PR. That is not hypothetical: a branch that had passed two independent clean
+reviews landed 16 findings and six red checks this way (#574).
+
+### The %PROGRAMDATA% fallback: import it, don't retype it
+
+The Windows machine-wide base genuinely needs `ProgramData`, so the last tier
+of the fallback chain is written as a concatenation, which keeps the literal
+from ever appearing contiguously. Read quickly that looks like odd formatting,
+which is exactly how it gets dropped when the chain is reproduced by hand.
+
+- **Python inside the package:** import `mode.windows_machine_wide_root()`.
+  Nothing else may re-derive the chain; `tests/test_windows_machine_wide_root.py`
+  fails if a new file does.
+- **The standalone hook scripts** under `src/exomem/_hooks/` run as bare files
+  under the client's interpreter and cannot import the package, so they carry a
+  deliberate mirror. The same test pins their spelling.
+- **PowerShell** cannot import a Python helper either. Use the same split --
+  `"C:" + "\ProgramData"` -- as `scripts/install-service.ps1` does, or
+  `$env:SystemDrive`.
+- **Prose and docstrings:** write `%PROGRAMDATA%`. The gate permits the
+  environment-variable spelling, and one canonical form is what makes the
+  convention imitable.
+
 ## Installing the service on a CPU-only host
 
 `scripts/install-service.sh --profile hybrid` pulls `torch`, which is pinned to

--- a/src/exomem/logging_config.py
+++ b/src/exomem/logging_config.py
@@ -89,8 +89,8 @@ def _user_log_dir() -> Path:
     `Lib`/`site-packages` directory is not writable by convention and not
     where a log directory belongs.
 
-    Windows is machine-wide (`%PROGRAMDATA%/exomem/logs`, with the same
-    `%ALLUSERSPROFILE%` / hardcoded-`ProgramData` fallback chain and lowercase
+    Windows is machine-wide (`%PROGRAMDATA%/exomem/logs`, through the same
+    `mode.windows_machine_wide_root()` fallback chain and the same lowercase
     `exomem` directory name as `mode.config_path()`), NOT the user profile:
     the exomem service commonly runs as `LocalSystem` while an operator's
     `exomem` CLI runs as their own logged-in user, and a home- or
@@ -108,12 +108,9 @@ def _user_log_dir() -> Path:
     Linux — state, not configuration, per the XDG Base Directory spec.
     """
     if sys.platform == "win32":
-        base = (
-            os.environ.get("PROGRAMDATA")
-            or os.environ.get("ALLUSERSPROFILE")
-            or "C:" + r"\ProgramData"
-        )
-        return Path(base) / "exomem" / "logs"
+        from .mode import windows_machine_wide_root
+
+        return windows_machine_wide_root() / "exomem" / "logs"
     if sys.platform == "darwin":
         home = _safe_home()
         if home is not None:

--- a/src/exomem/mode.py
+++ b/src/exomem/mode.py
@@ -108,6 +108,37 @@ def normalize(value: str | None) -> str | None:
     return _ALIASES.get(v)
 
 
+def windows_machine_wide_root() -> Path:
+    r"""The Windows machine-wide base every shared exomem path hangs off.
+
+    Exported so callers import the fallback chain instead of re-deriving it,
+    because the chain carries a constraint that is invisible once copied. The
+    last tier is written as a concatenation on purpose: it keeps the
+    drive-absolute literal from ever appearing contiguously, which
+    `public_artifact_privacy`'s `absolute_local_path` rule forbids in any
+    repository input or shipped wheel member -- docstrings included, since
+    they travel inside the wheel. Read quickly the split looks like odd
+    formatting, so reproducing "the %PROGRAMDATA% fallback" by hand
+    reintroduces the defect: it did exactly that once already, for 16
+    findings and six red checks on a branch that had passed two clean
+    reviews (#574).
+
+    Resolved per call rather than frozen into a constant, because the
+    environment is what tests vary to exercise each tier.
+
+    The two standalone hook scripts under `_hooks/` cannot import this --
+    they run as bare files under whatever interpreter the client provides --
+    so they carry a deliberate mirror, pinned by
+    `tests/test_windows_machine_wide_root.py`.
+    """
+    base = (
+        os.environ.get("PROGRAMDATA")
+        or os.environ.get("ALLUSERSPROFILE")
+        or "C:" + r"\ProgramData"
+    )
+    return Path(base)
+
+
 def config_path() -> Path:
     """Per-machine config file. `EXOMEM_CONFIG_PATH` overrides (tests/multi-instance).
 
@@ -123,12 +154,7 @@ def config_path() -> Path:
     if override:
         return Path(override)
     if os.name == "nt":
-        base = (
-            os.environ.get("PROGRAMDATA")
-            or os.environ.get("ALLUSERSPROFILE")
-            or "C:" + r"\ProgramData"
-        )
-        return Path(base) / "exomem" / "config.json"
+        return windows_machine_wide_root() / "exomem" / "config.json"
     return Path.home() / ".exomem" / "config.json"
 
 

--- a/src/exomem/public_artifact_privacy.py
+++ b/src/exomem/public_artifact_privacy.py
@@ -232,6 +232,16 @@ DEFAULT_BINARY_PROVENANCE: tuple[BinaryProvenance, ...] = (
     BinaryProvenance("*.ico", "repository-authored Exomem application icon"),
 )
 
+#: Named in every refusal, because this gate historically only ran on Linux
+#: CI: a Windows contributor met it for the first time on a red PR, after two
+#: clean reviews, rather than in their own lane (#574). It is pure Python over
+#: files and runs anywhere.
+LOCAL_COMMAND_HINT = (
+    "Run this gate locally before pushing: "
+    "uv run python scripts/validate-public-artifacts.py --repository"
+)
+
+
 _CONTENT_RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "absolute_local_path",
@@ -650,5 +660,5 @@ def assert_public_artifacts_clean(
         diagnostics = "\n".join(str(finding) for finding in unique)
         raise PublicArtifactPrivacyError(
             f"public artifact privacy validation failed ({len(unique)} findings):\n"
-            f"{diagnostics}"
+            f"{diagnostics}\n" + LOCAL_COMMAND_HINT
         )

--- a/tests/test_windows_machine_wide_root.py
+++ b/tests/test_windows_machine_wide_root.py
@@ -1,0 +1,143 @@
+r"""The Windows machine-wide base is derived in one place, or in a pinned mirror.
+
+`public_artifact_privacy`'s `absolute_local_path` rule forbids a contiguous
+drive-absolute literal in any repository input or shipped wheel member --
+docstrings included, because they travel inside the wheel. The Windows
+machine-wide fallback genuinely needs `ProgramData`, so the final tier is
+written as a concatenation (`"C:" + r"\ProgramData"`), which keeps the literal
+from ever appearing whole.
+
+That constraint lived only as an example. Nothing imported it, nothing refused
+a violation, and read quickly the split looks like odd formatting -- so the
+#552 lane, reproducing "the %PROGRAMDATA% fallback" faithfully in prose, a
+PowerShell tier and twelve test sites, reintroduced it in every one: 16
+findings and six red checks on a branch that had already passed two
+independent clean reviews (#574). Neither review could have caught it; the gate
+only ran on Linux CI.
+
+So the constraint is encoded here instead of exemplified. `mode` owns the one
+derivation, callers import it, and the standalone hook scripts -- which run as
+bare files under whatever interpreter the client provides and therefore cannot
+import anything from `exomem` -- carry mirrors this file pins by behaviour.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+from exomem import mode
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1] / "src" / "exomem"
+
+#: Files allowed to spell the fallback chain themselves. `mode` is the single
+#: source; the rest are standalone hook scripts that cannot import it.
+DERIVERS = {
+    "mode.py",
+    "_hooks/exomem_capture_nudge.py",
+    "_hooks/exomem_retrieve_nudge.py",
+}
+
+TIERS = ("PROGRAMDATA", "ALLUSERSPROFILE")
+
+
+def _reads_both_tiers(tree: ast.AST) -> bool:
+    """Whether this module reads the machine-wide environment tiers itself."""
+    named = {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+    return all(tier in named for tier in TIERS)
+
+
+def test_only_the_named_files_derive_the_machine_wide_base() -> None:
+    """A new caller must import `windows_machine_wide_root`, not copy it."""
+    derivers = set()
+    for path in sorted(SOURCE_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        if _reads_both_tiers(tree):
+            derivers.add(path.relative_to(SOURCE_ROOT).as_posix())
+
+    assert derivers == DERIVERS, (
+        "import exomem.mode.windows_machine_wide_root instead of re-deriving the "
+        "%PROGRAMDATA% chain; copying it drops the constraint that keeps the "
+        "drive-absolute literal from ever appearing contiguously"
+    )
+
+
+def test_no_source_file_spells_the_literal_contiguously() -> None:
+    """The rule the split exists to satisfy, asserted where authors will see it.
+
+    `public_artifact_privacy` already refuses this, but only on Linux CI and
+    only over the whole repository. Naming it here means a Windows contributor
+    running the ordinary suite finds it in the lane.
+    """
+    contiguous = "C:" + chr(92) + "ProgramData"
+    offenders = [
+        path.relative_to(SOURCE_ROOT).as_posix()
+        for path in sorted(SOURCE_ROOT.rglob("*.py"))
+        if contiguous.casefold() in path.read_text(encoding="utf-8").casefold()
+    ]
+    assert offenders == [], offenders
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected"),
+    [
+        ({"PROGRAMDATA": "P:" + chr(92) + "Data"}, "P:" + chr(92) + "Data"),
+        (
+            {"ALLUSERSPROFILE": "Q:" + chr(92) + "All"},
+            "Q:" + chr(92) + "All",
+        ),
+        ({}, "C:" + chr(92) + "ProgramData"),
+    ],
+    ids=["programdata", "allusersprofile", "hardcoded"],
+)
+def test_each_tier_of_the_chain_answers(
+    monkeypatch: pytest.MonkeyPatch, environment: dict[str, str], expected: str
+) -> None:
+    for tier in TIERS:
+        monkeypatch.delenv(tier, raising=False)
+    for name, value in environment.items():
+        monkeypatch.setenv(name, value)
+
+    assert mode.windows_machine_wide_root() == Path(expected)
+
+
+def test_config_and_log_paths_share_the_one_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reuse the helper exists for, asserted rather than assumed."""
+    from exomem import logging_config
+
+    monkeypatch.setenv("PROGRAMDATA", "P:" + chr(92) + "Data")
+    monkeypatch.delenv("ALLUSERSPROFILE", raising=False)
+    monkeypatch.delenv("EXOMEM_CONFIG_PATH", raising=False)
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(logging_config.sys, "platform", "win32")
+
+    base = mode.windows_machine_wide_root()
+
+    assert mode.config_path() == base / "exomem" / "config.json"
+    assert logging_config._user_log_dir() == base / "exomem" / "logs"
+
+
+@pytest.mark.parametrize(
+    "relative",
+    ["_hooks/exomem_capture_nudge.py", "_hooks/exomem_retrieve_nudge.py"],
+)
+def test_the_standalone_hook_mirrors_keep_the_split(relative: str) -> None:
+    """Mirrors are allowed; a mirror that drops the split is not.
+
+    These files are copied verbatim into `plugins/claude-code/hooks/` and run
+    outside the package, so they cannot import the helper. What they can do is
+    stay spelled the same way.
+    """
+    source = (SOURCE_ROOT / relative).read_text(encoding="utf-8")
+
+    assert '"C:" + r"' + chr(92) + 'ProgramData"' in source
+    assert all(tier in source for tier in TIERS)

--- a/tests/test_windows_machine_wide_root.py
+++ b/tests/test_windows_machine_wide_root.py
@@ -108,17 +108,24 @@ def test_each_tier_of_the_chain_answers(
     assert mode.windows_machine_wide_root() == Path(expected)
 
 
+@pytest.mark.skipif(os.name != "nt", reason="the shared base is a Windows path")
 def test_config_and_log_paths_share_the_one_base(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The reuse the helper exists for, asserted rather than assumed."""
+    """The reuse the helper exists for, asserted rather than assumed.
+
+    Windows-only rather than platform-faked. Both callers branch on
+    `os.name` / `sys.platform`, and monkeypatching those is not a local act:
+    they are read by the whole process, including pytest's own reporting
+    hooks. Faking them here made `shutil.which` take its win32 branch on a
+    Linux runner and brought the session down with an INTERNALERROR, which
+    is a far worse failure than the one it was checking for.
+    """
     from exomem import logging_config
 
     monkeypatch.setenv("PROGRAMDATA", "P:" + chr(92) + "Data")
     monkeypatch.delenv("ALLUSERSPROFILE", raising=False)
     monkeypatch.delenv("EXOMEM_CONFIG_PATH", raising=False)
-    monkeypatch.setattr(os, "name", "nt")
-    monkeypatch.setattr(logging_config.sys, "platform", "win32")
 
     base = mode.windows_machine_wide_root()
 


### PR DESCRIPTION
Closes #574.

## The problem

The Windows machine-wide fallback genuinely needs `ProgramData`, and `public_artifact_privacy` forbids a contiguous drive-absolute literal in any repository input or shipped wheel member — docstrings included, because they travel inside the wheel. `mode.config_path()` reconciled the two by writing the last tier as a concatenation.

That constraint existed only as an *example*. Nothing imported it, nothing refused a violation, and read quickly the split looks like odd formatting. So the #552 lane, faithfully reproducing "the %PROGRAMDATA% fallback" in prose, a PowerShell tier and twelve test sites, dropped it in every one: **16 findings and six red checks on a branch that had already passed two independent clean reviews.** Neither review could have caught it — the gate only runs on Linux CI, and no local gate list mentions it.

## What changed

| ask (#574) | change |
|---|---|
| 1. single exported source | `mode.windows_machine_wide_root()`; `logging_config._user_log_dir()` imports it |
| 2. one canonical prose spelling | `%PROGRAMDATA%` everywhere, including the `logging_config` docstring that previously spelled out the chain |
| 3. gate runnable where an author will see it | CONTRIBUTING.md documents `uv run python scripts/validate-public-artifacts.py --repository`, and every refusal from `assert_public_artifacts_clean` now names that command |
| 4. one gate-safe PowerShell idiom | recorded in CONTRIBUTING.md: the same split as `scripts/install-service.ps1`, or `$env:SystemDrive` |

The enforcement is `tests/test_windows_machine_wide_root.py`, which:

- fails when any file under `src/exomem` other than `mode.py` derives the chain itself (the two standalone `_hooks/` scripts are named exceptions — they run as bare files under the client's interpreter and genuinely cannot import the package);
- pins the spelling of those two mirrors, so a mirror may exist but may not drop the split;
- exercises all three tiers of the chain;
- asserts config and log paths resolve off the one base — the reuse the helper exists for;
- and asserts no source file spells the literal contiguously, so a Windows contributor running the ordinary suite meets the rule in their lane rather than on a red PR.

## Verification

- `tests/test_windows_machine_wide_root.py` (8), plus `test_resolve_log_dir_wheel_fallback`, `test_public_artifact_privacy`, `test_scaffold_no_leak`, `test_mode`, `test_log_dir_override`, `test_prominence`, `test_package_skills`: **197 passed** on Windows.
- `uv run python scripts/validate-public-artifacts.py --repository` clean.
- `uvx ruff check --select F` clean.