### PR TITLE
fix(census): filter the corpus census before the stat, not after

### DIFF
--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -1376,13 +1376,34 @@ def _corpus_census(root: Path) -> tuple | None:
             if _prune_identity_census_directory(kb, directory, child.name):
                 continue
             path = Path(child.path)
+            # Alias refusal comes first and applies to EVERY entry, exactly as
+            # in the walk this mirrors: an aliased subtree can hide or
+            # duplicate pages whatever its name looks like, so filtering by
+            # suffix ahead of this check would open a hole.
+            if child.is_symlink():
+                raise _CensusUnsafe
+            is_directory = child.is_dir(follow_symlinks=False)
+            # Filter BEFORE the stat -- the half of #528 that fixed
+            # `_build_identity_census` but never reached this mirror. The
+            # Knowledge Base root also holds SQLite's transient sidecars
+            # (`.embeddings.sqlite-wal`, `-shm`), created and dropped as
+            # connections open and close. They are not census input, so
+            # statting them bought nothing and cost a race: one vanishing
+            # between the listing and the stat raised FileNotFoundError, which
+            # the handler below turns into a census of `None` -- degrading
+            # every caller to an uncached full build (#561).
+            if not is_directory and path.suffix.casefold() != ".md":
+                continue
+            # A `.md` that vanishes in that same window still fails closed,
+            # unlike in `_build_identity_census`, which skips it. That walk
+            # reports a snapshot; this one is a cache key, and `None` costs
+            # one uncached build where silently omitting a page could vouch
+            # for a cached context the corpus no longer matches.
             info = child.stat(follow_symlinks=False)
-            if child.is_symlink() or vault._is_reparse(info):
+            if vault._is_reparse(info):
                 raise _CensusUnsafe
             if stat.S_ISDIR(info.st_mode):
                 strict_walk(path)
-                continue
-            if path.suffix.casefold() != ".md":
                 continue
             if not stat.S_ISREG(info.st_mode):
                 raise _CensusUnsafe

--- a/tests/test_corpus_context_cache.py
+++ b/tests/test_corpus_context_cache.py
@@ -176,6 +176,51 @@ def test_reserved_runtime_trees_do_not_enter_identity_census_or_cache_token(
     )
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows answers DirEntry.stat() from the directory listing, so an "
+    "entry deleted after the listing still stats and the race cannot occur",
+)
+def test_a_vanishing_sqlite_sidecar_does_not_degrade_the_census(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A `-wal` that disappears mid-walk must not cost every caller its cache.
+
+    The Knowledge Base root holds SQLite's transient sidecars beside the
+    pages. They are not census input, and the identity census stopped
+    statting them in #528 -- but `_corpus_census` mirrors that walk by hand
+    and kept the stat ahead of the `.md` filter, so one sidecar vanishing in
+    the window between the listing and the stat raised FileNotFoundError and
+    degraded the whole census to `None`. Every caller then rebuilt uncached,
+    on a vault where nothing a caller can see had changed (#561).
+
+    The deletion is driven from `_prune_identity_census_directory`, which the
+    walk calls per child immediately before the stat, so the race is exact
+    rather than timed.
+    """
+    kb = vault / "Knowledge Base"
+    sidecar = kb / ".embeddings.sqlite-wal"
+    sidecar.write_bytes(b"transient")
+
+    baseline = semantic_contract._corpus_census(vault)
+    assert baseline is not None
+
+    real_prune = semantic_contract._prune_identity_census_directory
+
+    def prune_then_vanish(kb_root: Path, directory: Path, name: str) -> bool:
+        if name == sidecar.name:
+            sidecar.unlink(missing_ok=True)
+        return real_prune(kb_root, directory, name)
+
+    monkeypatch.setattr(
+        semantic_contract, "_prune_identity_census_directory", prune_then_vanish
+    )
+
+    # Identical, not merely non-None: the sidecar was never census input, so
+    # its removal may not move the key either.
+    assert semantic_contract._corpus_census(vault) == baseline
+
+
 def test_content_change_rebuilds(vault: Path) -> None:
     first = semantic_contract.build_corpus_context(vault)
     (vault / _PAGE_REL).write_text(


### PR DESCRIPTION
Closes #561.

## The defect

`semantic_contract._corpus_census` mirrors `_build_identity_census` by hand. #528 fixed the *original* walk to decide from the dirent before statting; the mirror never got that change and still stat'd every entry under the Knowledge Base ahead of the `.md` filter.

The KB root also holds SQLite's transient sidecars (`.embeddings.sqlite-wal`, `-shm`), created and dropped as embedding connections open and close. One vanishing between `os.scandir` and `DirEntry.stat` raises `FileNotFoundError`, and `_corpus_census`'s handler turns any `OSError` into `None` — which tells every caller to build uncached. A vault where nothing a caller can observe had changed paid a full corpus rebuild because a sidecar blinked.

## The fix

Order the strict walk exactly as `_build_identity_census` orders it:

1. refuse filesystem aliases — still **before** the suffix filter, or an aliased subtree could hide or duplicate pages behind a non-Markdown name;
2. skip anything that is neither a directory nor `.md`;
3. only then stat.

A `.md` that vanishes in the same window still fails the census closed, deliberately unlike `_build_identity_census`, which skips it. That walk reports a snapshot; this one is a cache key. `None` costs one uncached build, whereas silently omitting a page could vouch for a cached context the corpus no longer matches — so the mirror is allowed to be stricter here, and says why.

## Verification

- New `test_a_vanishing_sqlite_sidecar_does_not_degrade_the_census` drives the deletion from `_prune_identity_census_directory`, which the walk calls per child immediately before the stat, so the race is exact rather than timed. It asserts the census is *identical* to the baseline, not merely non-`None`: the sidecar was never census input, so its removal may not move the key either.
- POSIX-gated, and honestly so: Windows answers `DirEntry.stat()` from the directory listing, so the entry still stats after the unlink and the race cannot occur there. Verified empirically on this box before adding the skip. Linux and macOS shards do exercise it.
- `tests/test_corpus_context_cache.py` + `tests/test_semantic_contract.py`: 155 passed, 1 skipped (the new POSIX-only case).
- `ruff check` clean on both files.