### PR TITLE
test(logs): stop an exported EXOMEM_LOG_DIR from deciding where records land

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -392,6 +392,17 @@ def _disable_embeddings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
     # default tests. Tests that exercise these gates set them explicitly.
     monkeypatch.delenv("EXOMEM_SEMANTIC_SEGMENTS", raising=False)
     monkeypatch.delenv("EXOMEM_VIDEO_SCENE_FRAMES", raising=False)
+    # An exported EXOMEM_LOG_DIR must not decide where a test's records land.
+    # `query_log._target` consults it per call and short-circuits ahead of the
+    # module-level QUERIES_PATH/WRITES_PATH/READS_PATH that tests monkeypatch,
+    # so three tests in test_query_log.py wrote into the operator's real log
+    # directory and then failed reading their own tmp sidecar (#570). CI never
+    # saw it -- the variable is unset there -- but the project's own Docker
+    # images set it and the documented contract tells operators to export it,
+    # so anyone running the suite on a configured machine got failures
+    # unrelated to their change. Tests that exercise the override set it
+    # themselves; a test-body or module-fixture setenv still wins over this.
+    monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
     # The watcher now starts independently of embeddings (it maintains the
     # freshness/inbound registries too), so build_server would spawn a real
     # watchdog observer in the suite without this. Watcher tests opt back in.


### PR DESCRIPTION
Closes #570.

## Item 2 — `tests/test_query_log.py` under an exported `EXOMEM_LOG_DIR`

`query_log._target` consults `EXOMEM_LOG_DIR` per call and short-circuits **ahead of** the module-level `QUERIES_PATH` / `WRITES_PATH` / `READS_PATH` that tests monkeypatch. With the variable exported, three tests write into the operator's real log directory and then fail reading their own `tmp_path` sidecar.

CI never sees this — the variable is unset on the runners — but the project's own Docker images set it and the documented contract tells operators to export it, so anyone running the suite on a configured machine collects three failures unrelated to their change.

### Why the fixture, not three `delenv` calls

The issue asks for `monkeypatch.delenv` in the three tests. The seam is not specific to them: *any* test that redirects a log path by monkeypatching a module attribute has the same exposure, which is why the issue also asks for "a quick scan for the same seam elsewhere". Clearing it once in the suite-wide isolation fixture covers the scan and prevents the next occurrence. Tests that exercise the override still set it themselves — a test body, or a module-level autouse fixture like the ones in `test_mutation_journal.py` and `test_obs_cli_trace.py`, runs after the conftest fixture and wins.

It is a no-op on CI by construction, since the variable is already unset there.

## Item 1 — `scripts/restart.ps1` — already fixed

Verified on `main`: `restart.ps1` no longer hardcodes `<repo>/logs`. It calls `Get-ExomemLogDir -PythonPath $VenvPy`, which asks the service interpreter for `logging_config.resolve_log_dir()` and only falls back to the checkout-relative path with an explicit warning. That landed with #569. Nothing to do here.

## Verification

With `EXOMEM_LOG_DIR` exported:

| tree | result |
|---|---|
| `main` (negative control), `tests/test_query_log.py` | **3 failed**, 3 passed — the exact three the issue names |
| this branch, ten log-related suites | 189 passed, 2 skipped |

The ten suites are every module that reads or sets `EXOMEM_LOG_DIR`: `test_query_log`, `test_log_dir_override`, `test_mutation_journal`, `test_obs_cli_trace`, `test_jsonl_rotation`, `test_log_process_files`, `test_log_thread_identity`, `test_doctor`, `test_call_ledger`, `test_resolve_log_dir_wheel_fallback` — including both modules whose own autouse fixtures set the variable, which confirms the ordering.