### PR TITLE
docs(openspec): scope the unchanged-log-default guarantee to a checkout

### DIFF
--- a/openspec/changes/add-docker-distribution/specs/distribution-surfaces/spec.md
+++ b/openspec/changes/add-docker-distribution/specs/distribution-surfaces/spec.md
@@ -56,8 +56,21 @@ The system SHALL honor an `EXOMEM_LOG_DIR` environment variable that overrides w
 rotating application log (`exomem.log`) and the query/write/read JSONL audit logs
 (`queries.jsonl`, `writes.jsonl`, `reads.jsonl`) are written. Both `server.run()`'s log
 directory resolution and `query_log.py`'s log paths SHALL honor the same override, so no
-log path stays hardcoded under the package install location. When `EXOMEM_LOG_DIR` is
-unset, behavior SHALL be unchanged from today's repo-relative default.
+log path stays hardcoded under the package install location.
+
+When `EXOMEM_LOG_DIR` is unset, the default SHALL depend on whether the package is
+running from a source checkout. From a checkout, logs SHALL be written to the
+checkout-relative `<repo>/logs`, unchanged. From a wheel or service install, logs
+SHALL be written to a per-platform location outside the install:
+`%PROGRAMDATA%\exomem\logs` on Windows, `~/Library/Logs/Exomem` on macOS, and
+`$XDG_STATE_HOME/exomem/logs` (falling back to `~/.local/state`) on Linux.
+
+Naming the wheel default explicitly, rather than deferring to "today's" behavior, is a
+wording correction and not a reversal of intent: the earlier default derived the
+checkout root unconditionally, so on a wheel install the same two-hop climb landed
+inside the venv at `<venv>/Lib/logs` -- under the very install location the first half
+of this requirement forbids. Scoping the guarantee to a checkout is what lets both
+halves hold at once.
 
 #### Scenario: Override honored for the application log
 
@@ -71,11 +84,18 @@ unset, behavior SHALL be unchanged from today's repo-relative default.
 - **THEN** `queries.jsonl`, `writes.jsonl`, and `reads.jsonl` are written under
   `/data/logs`, not the repo-relative default
 
-#### Scenario: Default is unchanged when unset
+#### Scenario: Default is unchanged when unset in a checkout
 
-- **WHEN** `EXOMEM_LOG_DIR` is not set
-- **THEN** logs are written to the existing default location exactly as before this
-  change, for both the application log and the JSONL audit logs
+- **WHEN** `EXOMEM_LOG_DIR` is not set and the package runs from a source checkout
+- **THEN** logs are written to `<repo>/logs` exactly as before this change, for both
+  the application log and the JSONL audit logs
+
+#### Scenario: Default for a wheel or service install stays outside the install
+
+- **WHEN** `EXOMEM_LOG_DIR` is not set and the package is not a source checkout
+- **THEN** logs are written to the per-platform location for that OS, for both the
+  application log and the JSONL audit logs, and nothing is written under the package
+  install location
 
 #### Scenario: Non-root container process can always write its log directory
 


### PR DESCRIPTION
Closes #565.

## The contradiction

`add-docker-distribution`'s **Configurable Log Directory** requirement promises the unset default "SHALL be unchanged from today's repo-relative default", with a matching *Default is unchanged when unset* scenario.

#552 deliberately changed exactly that. The old default climbed two directories from `logging_config.py` unconditionally — correct for `<repo>/src/exomem/logging_config.py`, but from `<venv>/Lib/site-packages/exomem/logging_config.py` it lands at `<venv>/Lib/logs`, i.e. **under the package install location the same requirement's first half forbids**. `resolve_log_dir()` now detects the checkout case positively (`_is_source_checkout`) and otherwise uses a per-platform location.

For a checkout the two are byte-identical, so the guarantee still holds there. Only the wheel/service install diverges — and that is the case #552 exists to fix.

## The amendment

- Scope the unchanged-default guarantee to a **source checkout**, where it remains exactly true.
- State the wheel/service default explicitly instead of by reference to "today": `%PROGRAMDATA%\exomem\logs` on Windows, `~/Library/Logs/Exomem` on macOS, `$XDG_STATE_HOME/exomem/logs` (falling back to `~/.local/state`) on Linux — matching `logging_config._user_log_dir()`.
- Split the one scenario into two, so both install shapes are pinned rather than one being left implicit. Both cover the JSONL audit logs as well as the application log, which co-locate by the invariant `resolve_log_dir()`'s docstring states: every process-role log and every JSONL sidecar routes through that one function.
- Record that this is a wording correction, not a reversal — the "nothing hardcoded under the install location" half is *better* satisfied after #552 than before it.

Landing this before `add-docker-distribution` is archived is the point: `ci.yml`'s `openspec validate --specs --strict` gates `openspec/specs/` only, so an active change's text is ungated until archive time, and archiving as-is would promote contradicted text into the specs tree.

## Verification

- `openspec validate add-docker-distribution --strict` → `Change 'add-docker-distribution' is valid`
- `openspec validate --specs --strict` (the CI gate) → 36 passed, 0 failed
- `tests/test_benchmarks_privacy.py` → 3 passed (the `%PROGRAMDATA%` spelling carries no drive-absolute literal)
- Swept `openspec/changes/add-docker-distribution/` and `docs/` for the same "unchanged from today" / "existing default location" phrasing; the one remaining "repo-relative default" mention is inside an override scenario, where it is still accurate.