### PR TITLE
fix(scripts): reclaim tool scratch roots instead of suppressing the failure

### DIFF
--- a/scripts/dump-tool-schemas.py
+++ b/scripts/dump-tool-schemas.py
@@ -26,8 +26,12 @@ import json
 import os
 import shutil
 import sys
-import tempfile
 from pathlib import Path
+
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import scratch_root  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_PATH = REPO_ROOT / "tests" / "fixtures" / "mcp_tool_schemas.json"
@@ -79,12 +83,12 @@ def _discovery_contract(mcp) -> dict[str, object]:
 
 def main() -> None:
     # Windows can retain a short-lived SQLite/file handle after lifecycle
-    # shutdown. The fixture capture is already complete at that point, so a
-    # delayed best-effort cleanup must not prevent writing deterministic output.
-    with tempfile.TemporaryDirectory(
-        prefix="exomem-schema-", ignore_cleanup_errors=True
-    ) as temp_dir:
-        temp_root = Path(temp_dir)
+    # shutdown, and the fixture capture is already complete at that point, so a
+    # delayed cleanup must not prevent writing deterministic output. That used
+    # to be spelled `ignore_cleanup_errors=True`, which does not wait for the
+    # handle -- it gives up on the first error and says nothing, leaving a
+    # quarter-gigabyte tree behind every run (#579).
+    with scratch_root.scratch_root("exomem-schema-") as temp_root:
         vault_root = temp_root / "schema_vault"
         shutil.copytree(FIXTURE_VAULT, vault_root)
         try:

--- a/scripts/e2e_product_loop.py
+++ b/scripts/e2e_product_loop.py
@@ -14,7 +14,6 @@ import shutil
 import socket
 import subprocess
 import sys
-import tempfile
 import time
 import urllib.error
 import urllib.request
@@ -22,6 +21,11 @@ from pathlib import Path
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import scratch_root  # noqa: E402
+
 WINDOWS = sys.platform == "win32"
 
 
@@ -2432,17 +2436,12 @@ def _e2e_workdir(*, keep: bool):
     until it reproduced rather than by reading the traceback it had already
     written down.
     """
-    path = tempfile.mkdtemp(prefix="exomem-product-e2e-")
-    try:
-        yield path
-    except BaseException:
-        _publish_server_logs(Path(path))
-        raise
-    finally:
-        if keep:
-            print(f"product-e2e: kept working directory {path}")
-        else:
-            shutil.rmtree(path, ignore_errors=True)
+    with scratch_root.scratch_root("exomem-product-e2e-", keep=keep) as path:
+        try:
+            yield str(path)
+        except BaseException:
+            _publish_server_logs(path)
+            raise
 
 
 def _orchestrate(args: argparse.Namespace) -> int:

--- a/scripts/scratch_root.py
+++ b/scripts/scratch_root.py
@@ -1,0 +1,189 @@
+"""One scratch root per tool run, reclaimed even when a run does not finish.
+
+Every tool here builds a throwaway tree under the system temp directory: a
+synthetic vault, an isolated home, an installed wheel. Each is hundreds of
+megabytes, and each removed itself with cleanup errors suppressed --
+`shutil.rmtree(..., ignore_errors=True)` or
+`TemporaryDirectory(ignore_cleanup_errors=True)`. Suppression was chosen for a
+real reason: on Windows a SQLite or child-process handle can outlive the
+shutdown that released it, and a capture that already succeeded must not fail
+on a slow unlink. But suppression answers "do not raise" by never retrying and
+never saying anything, so the tree simply stays -- and the next run makes
+another one.
+
+That is not hypothetical. A developer laptop reached 58 GB of temp with no
+single large item: hundreds of directories from these tools, spread thin
+enough that ordinary disk-usage inspection looks past them (#579).
+
+Two changes close it, and both are needed:
+
+* Retry the removal against a deadline instead of giving up on the first
+  error, and if it still fails, *say so* naming the path. A transient handle
+  loses to a few hundred milliseconds of patience; a real leak stops being
+  silent.
+* Sweep this tool's own stale roots on the way in. Retrying cannot help a run
+  that was killed -- Ctrl-C, a cancelled CI job -- and that is precisely the
+  case that accumulates. The next run reclaims what the last one could not.
+
+And when a removal genuinely cannot finish, take everything that will go
+rather than abandoning the tree at the first refusal. Some holders are
+permanent by design -- `writer_lease` keeps its owner lock open for the life
+of the process so a liveness probe can see it, which means a tool that builds
+a lease directory can never remove that directory before exiting. The choice
+there is between stranding a few hundred bytes and stranding the vault beside
+it.
+
+The sweep is deliberately narrow: same prefix, directories only, directly
+inside the temp directory, and older than a threshold no live run can reach.
+Anything it cannot remove it leaves alone.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+#: How long to keep retrying one removal. Sized for a handle that is already
+#: being released, not for a process that still holds the tree open: on
+#: Windows the observed window after lifecycle shutdown is well under a
+#: second, and a tool that waits longer than this is waiting on something a
+#: retry will never win.
+REMOVE_DEADLINE_SECONDS = 5.0
+
+#: First backoff step; doubles up to the deadline.
+_FIRST_DELAY_SECONDS = 0.05
+
+#: A root older than this cannot belong to a live run -- these tools take
+#: minutes, not hours -- so it is residue from one that was killed. Generous
+#: on purpose: sweeping is a convenience, and never removing a concurrent
+#: run's tree matters far more than reclaiming its bytes promptly.
+STALE_AGE_SECONDS = 6 * 60 * 60
+
+
+def remove_scratch_tree(path: Path, *, deadline: float = REMOVE_DEADLINE_SECONDS) -> bool:
+    """Remove *path*, retrying a transient failure; report rather than raise.
+
+    Returns whether the tree is gone. A caller that already produced its
+    output must not fail on cleanup, so this never raises -- but it also
+    never stays quiet about a tree it could not remove, which is the whole
+    difference from `ignore_errors=True`.
+    """
+    if not path.exists():
+        return True
+    delay = _FIRST_DELAY_SECONDS
+    give_up_at = time.monotonic() + deadline
+    while True:
+        try:
+            shutil.rmtree(path)
+            return True
+        except FileNotFoundError:
+            return True
+        except OSError as error:
+            if time.monotonic() >= give_up_at:
+                # `rmtree` stops at the first entry it cannot remove, so one
+                # held handle strands the whole tree -- and the tree is the
+                # hundreds of megabytes, while the handle is on a lock file of
+                # a few hundred bytes. Some of these holders are permanent by
+                # design: `writer_lease` keeps its owner lock open for the
+                # life of the process precisely so a liveness probe can see
+                # it, so a tool that builds a lease directory can never remove
+                # that directory before exiting. Take everything else.
+                survivors = _remove_what_we_can(path)
+                if not survivors:
+                    return True
+                print(
+                    f"scratch: could not fully remove {path}: {error}. "
+                    f"{len(survivors)} item(s) left, first {survivors[0]}. "
+                    "A later run of this tool will sweep it.",
+                    flush=True,
+                )
+                return False
+            time.sleep(delay)
+            delay = min(delay * 2, 0.5)
+
+
+def _remove_what_we_can(path: Path) -> list[Path]:
+    """Delete every entry under *path* that will go; return the ones that stayed.
+
+    Bottom-up and per-entry, because `shutil.rmtree` abandons the whole walk
+    at its first failure. Written against `os.walk` rather than `rmtree`'s
+    error hook so it reads the same on 3.11 and 3.13 -- the hook was renamed
+    `onerror` to `onexc` in between.
+    """
+    survivors: list[Path] = []
+    for current, directory_names, file_names in os.walk(path, topdown=False):
+        here = Path(current)
+        for name in file_names:
+            try:
+                (here / name).unlink()
+            except OSError:
+                survivors.append(here / name)
+        for name in directory_names:
+            try:
+                (here / name).rmdir()
+            except OSError:
+                survivors.append(here / name)
+    try:
+        path.rmdir()
+    except OSError:
+        survivors.append(path)
+    return survivors
+
+
+def sweep_stale_scratch_roots(
+    prefix: str, *, older_than: float = STALE_AGE_SECONDS
+) -> list[Path]:
+    """Remove this tool's abandoned roots from a previous, killed run.
+
+    Scoped to directories named with *prefix* directly inside the system temp
+    directory, and only those whose mtime is older than *older_than* -- a live
+    run's root can never be. Whatever cannot be removed (another user's tree,
+    a handle still held) is left where it is.
+    """
+    root = Path(tempfile.gettempdir())
+    cutoff = time.time() - older_than
+    swept: list[Path] = []
+    try:
+        candidates = sorted(root.glob(f"{prefix}*"))
+    except OSError:
+        return swept
+    for candidate in candidates:
+        try:
+            info = candidate.lstat()
+        except OSError:
+            continue
+        if not os.path.isdir(candidate) or candidate.is_symlink():
+            continue
+        if info.st_mtime > cutoff:
+            continue
+        if remove_scratch_tree(candidate, deadline=0.5):
+            swept.append(candidate)
+    return swept
+
+
+@contextmanager
+def scratch_root(prefix: str, *, keep: bool = False) -> Iterator[Path]:
+    """A fresh scratch root for one run, swept in and removed on the way out.
+
+    `keep=True` retains it for a post-mortem and says where it is, so a
+    retained tree is a decision someone can see rather than a leak.
+    """
+    swept = sweep_stale_scratch_roots(prefix)
+    if swept:
+        print(
+            f"scratch: reclaimed {len(swept)} abandoned root(s) from earlier runs",
+            flush=True,
+        )
+    path = Path(tempfile.mkdtemp(prefix=prefix))
+    try:
+        yield path
+    finally:
+        if keep:
+            print(f"scratch: kept working directory {path}", flush=True)
+        else:
+            remove_scratch_tree(path)

--- a/scripts/semantic_write_latency.py
+++ b/scripts/semantic_write_latency.py
@@ -18,6 +18,7 @@ if str(SRC) not in sys.path:
 if str(Path(__file__).resolve().parent) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+import scratch_root  # noqa: E402
 from synth_vault import gen_dense_vault  # noqa: E402
 
 from exomem import (  # noqa: E402
@@ -328,8 +329,7 @@ def measure_all(
             ]
         finally:
             graph_sync.drain_active_rebuilds()
-    with tempfile.TemporaryDirectory(prefix="exomem-write-latency-") as temp:
-        base = Path(temp)
+    with scratch_root.scratch_root("exomem-write-latency-") as base:
         results: list[dict[str, float | int]] = []
         try:
             for size in sizes:

--- a/tests/test_scratch_root.py
+++ b/tests/test_scratch_root.py
@@ -1,0 +1,186 @@
+"""The tool scratch root is reclaimed, and says so when it cannot be.
+
+These tools each build a hundreds-of-megabytes tree under the system temp
+directory and used to remove it with cleanup errors suppressed. Suppression
+never retries and never reports, so a transient Windows handle and a real leak
+looked identical -- and both simply stayed. A laptop reached 58 GB of temp made
+entirely of these (#579).
+
+What follows pins the three behaviours that replace suppression: a removal that
+outlasts a transient failure, a removal that takes everything it can when one
+entry is held for good, and a sweep that reclaims what a killed run could never
+have removed itself.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "scratch_root.py"
+SPEC = importlib.util.spec_from_file_location("scratch_root_under_test", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+scratch_root = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(scratch_root)
+
+
+def _always_busy(path, *args, **kwargs):
+    raise PermissionError(32, "The process cannot access the file")
+
+
+def _tree(path: Path) -> Path:
+    (path / "nested").mkdir(parents=True)
+    (path / "nested" / "page.md").write_text("body", encoding="utf-8")
+    return path
+
+
+def test_a_transient_failure_is_retried_rather_than_suppressed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The case suppression was chosen for, now actually handled.
+
+    A SQLite or child-process handle released moments ago loses to a short
+    retry. `ignore_errors=True` never gave it that chance -- it returned on
+    the first error, leaving the tree.
+    """
+    target = _tree(tmp_path / "scratch")
+    real_rmtree = scratch_root.shutil.rmtree
+    attempts: list[int] = []
+
+    def flaky(path, *args, **kwargs):
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise PermissionError(32, "The process cannot access the file")
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(scratch_root.shutil, "rmtree", flaky)
+
+    assert scratch_root.remove_scratch_tree(target) is True
+    assert not target.exists()
+    assert len(attempts) == 3
+    assert capsys.readouterr().out == ""
+
+
+def test_an_rmtree_that_never_succeeds_still_loses_to_the_per_entry_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`rmtree` failing is not the same as the tree being unremovable.
+
+    It abandons its whole walk at the first refusal, so a single awkward entry
+    -- or a race it lost -- makes it report failure for a tree that would come
+    apart entry by entry. Falling back to that pass is what turns most
+    "permanent" failures into no failure at all, and it is why nothing is
+    printed here: there is nothing left to name.
+    """
+    target = _tree(tmp_path / "scratch")
+
+    monkeypatch.setattr(scratch_root.shutil, "rmtree", _always_busy)
+
+    assert scratch_root.remove_scratch_tree(target, deadline=0.05) is True
+    assert not target.exists()
+    assert capsys.readouterr().out == ""
+
+
+def test_a_single_held_entry_does_not_strand_the_tree_beside_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The megabytes go even when the lock file cannot.
+
+    `shutil.rmtree` abandons the whole walk at its first refusal, so one held
+    handle used to strand everything beside it -- and the ratio is brutal:
+    `writer_lease`'s owner lock is a few hundred bytes and is held for the
+    life of the process by design, while the vault next to it is hundreds of
+    megabytes. Remove what will go, and name only what stayed.
+    """
+    target = _tree(tmp_path / "scratch")
+    held = target / "writer-lease" / "owner.lock"
+    held.parent.mkdir(parents=True)
+    held.write_bytes(b"locked")
+    real_unlink = Path.unlink
+
+    def refuse_the_lock(self, *args, **kwargs):
+        if self.name == "owner.lock":
+            raise PermissionError(32, "The process cannot access the file")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(scratch_root.shutil, "rmtree", _always_busy)
+    monkeypatch.setattr(Path, "unlink", refuse_the_lock)
+
+    assert scratch_root.remove_scratch_tree(target, deadline=0.01) is False
+
+    assert held.exists()
+    assert not (target / "nested").exists()
+    out = capsys.readouterr().out
+    assert str(held) in out
+
+
+def test_the_root_is_removed_even_when_the_run_raises(tmp_path: Path) -> None:
+    """Cleanup is not conditional on success; a failed run leaks the most."""
+    monkeypatched_prefix = f"exomem-scratch-test-{uuid.uuid4().hex}-"
+    seen: list[Path] = []
+
+    with pytest.raises(RuntimeError, match="measurement failed"):
+        with scratch_root.scratch_root(monkeypatched_prefix) as path:
+            seen.append(path)
+            _tree(path / "vault")
+            raise RuntimeError("measurement failed")
+
+    assert seen and not seen[0].exists()
+
+
+def test_keep_retains_the_root_and_says_where_it_is(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A retained tree must be a visible decision, not an invisible leak."""
+    prefix = f"exomem-scratch-test-{uuid.uuid4().hex}-"
+    with scratch_root.scratch_root(prefix, keep=True) as path:
+        _tree(path / "vault")
+    try:
+        assert path.exists()
+        assert str(path) in capsys.readouterr().out
+    finally:
+        scratch_root.remove_scratch_tree(path)
+
+
+def test_the_sweep_reclaims_an_abandoned_root_and_spares_a_live_one() -> None:
+    """The half a retry cannot cover: a run that was killed.
+
+    Ctrl-C and a cancelled CI job leave a root no code of that run will ever
+    remove, and that is exactly the case that accumulates. The next run
+    reclaims it -- but only when age proves it cannot belong to a run still in
+    progress, because deleting a concurrent run's tree would be far worse than
+    leaving bytes on disk.
+
+    The prefix is unique to this test, so the sweep it exercises can only ever
+    see directories this test made.
+    """
+    prefix = f"exomem-scratch-test-{uuid.uuid4().hex}-"
+    temp = Path(scratch_root.tempfile.gettempdir())
+    abandoned = _tree(temp / f"{prefix}abandoned")
+    live = _tree(temp / f"{prefix}live")
+    stale = time.time() - (scratch_root.STALE_AGE_SECONDS + 60)
+    os.utime(abandoned, (stale, stale))
+
+    try:
+        swept = scratch_root.sweep_stale_scratch_roots(prefix)
+
+        assert swept == [abandoned]
+        assert not abandoned.exists()
+        assert live.exists()
+    finally:
+        scratch_root.remove_scratch_tree(abandoned)
+        scratch_root.remove_scratch_tree(live)
+
+
+def test_a_fresh_root_is_not_swept_by_its_own_context_manager() -> None:
+    """The sweep runs on the way in, so it must never see the root it precedes."""
+    prefix = f"exomem-scratch-test-{uuid.uuid4().hex}-"
+    with scratch_root.scratch_root(prefix) as path:
+        assert path.exists()
+        assert scratch_root.sweep_stale_scratch_roots(prefix) == []
+        assert path.exists()


### PR DESCRIPTION
Closes #579.

## What was leaking

`scripts/dump-tool-schemas.py`, `scripts/e2e_product_loop.py` and `scripts/semantic_write_latency.py` each build a hundreds-of-megabytes tree under the system temp directory — a synthetic vault, an isolated home, an installed wheel — and each removed it with cleanup errors suppressed (`shutil.rmtree(..., ignore_errors=True)` / `TemporaryDirectory(ignore_cleanup_errors=True)`).

Suppression was chosen for a real reason, and the comments say so: on Windows a SQLite or child-process handle can outlive the shutdown that released it, and a capture that already succeeded must not fail on a slow unlink. But it answers "do not raise" by *never retrying and never reporting*, so the tree stays and the next run makes another one.

On this box, before the change: **32** leftover `exomem-schema-*` roots, 7 `exomem-write-latency-*`, 4 `exomem-product-e2e-*`.

The issue's original reproducer — an `exomem-native-acceptance-*` fixture builder — is no longer in the tree. These three call sites are the same defect in the code that is.

## Three behaviours replace it

New `scripts/scratch_root.py`, used by all three:

1. **Retry against a deadline.** A handle already being released loses to a few hundred milliseconds. `ignore_errors=True` never gave it that chance.
2. **When one entry is held for good, take everything beside it** and name only what stayed. `rmtree` abandons its whole walk at the first refusal, and the ratio is brutal: `writer_lease` keeps its owner lock open for the life of the process *by design* (so a liveness probe can see it), which means a tool that builds a lease directory can never remove that directory before exiting. That is a few hundred bytes stranding a vault.
3. **Sweep this tool's own stale roots on the way in.** No retry helps a run killed by Ctrl-C or a cancelled CI job, and that is exactly the case that accumulates. The sweep is narrow on purpose: same prefix, directories only, directly inside the temp directory, older than six hours — never removing what it cannot prove is abandoned.

## Measured

`scripts/dump-tool-schemas.py`, run twice:

| | before | after |
|---|---|---|
| leftover `exomem-schema-*` roots | 32 | 1 |
| size of the run's own residue | ~250 MB | ~1 MB (4 held lease entries) |
| residue is named in output | no | yes |

The 31 reclaimed roots were swept on the way in. The remaining ~1 MB is the `writer_lease` owner lock and its parent directories, which the next run's sweep collects.

Generated output is byte-identical — `tests/fixtures/mcp_tool_schemas.json` and `src/exomem/tool_surface_contract.json` were unchanged after both runs.

## Tests

`tests/test_scratch_root.py`, 7 cases, loading the script the way `test_product_e2e_helpers.py` already does:

- a transient failure is retried rather than suppressed, and says nothing when it wins;
- an `rmtree` that never succeeds still loses to the per-entry pass — `rmtree` failing is not the same as the tree being unremovable;
- a single held entry does not strand the tree beside it, and only the held entry is named;
- the root is removed even when the run raises;
- `keep=True` retains it *and says where*, so a retained tree is a visible decision;
- the sweep reclaims an abandoned root and spares a live one;
- a fresh root is never swept by its own context manager.

The two sweep tests use a per-test `uuid` prefix, so what they exercise can only ever see directories they made.

Existing suites that exec these scripts (`test_product_e2e_helpers.py`, `test_semantic_write_latency_gate.py`, `test_mcp_schema_fidelity.py`) pass: 39 passed.

## Noted, not changed

`writer_lease._acquire_own_owner_lock` holds its handle for the process lifetime deliberately. That is why no in-process cleanup can fully remove a state directory on Windows. Changing that lifetime touches mutation-safety machinery and does not belong in a temp-cleanup change; behaviour 2 above makes it cost kilobytes instead of gigabytes.