### PR TITLE
fix(graph): make a graph that will not converge say why

### DIFF
--- a/scripts/e2e_product_loop.py
+++ b/scripts/e2e_product_loop.py
@@ -2378,6 +2378,49 @@ def _installed_lease(args: argparse.Namespace) -> int:
 SERVER_LOG_TAIL_CHARS = 20_000
 
 
+#: Lines worth pulling out of a log whose tail is all polling. Deliberately a
+#: coarse net: over-including a few lines costs nothing next to a digest that
+#: misses the one line that explains the failure.
+CONVERGENCE_DIGEST_PATTERN = re.compile(
+    r"graph|drain|rebuild|epoch|defer|barrier|publication|stabiliz|converge",
+    re.IGNORECASE,
+)
+
+#: Cap the digest so a genuinely chatty log cannot bury the tail beneath it.
+CONVERGENCE_DIGEST_LINES = 200
+
+
+def _print_convergence_digest(relative: Path, text: str) -> None:
+    """Pull the convergence story out of the whole log, ahead of the tail.
+
+    The tail alone is the wrong 20 000 characters for the failure it most often
+    accompanies. When the graph does not converge, the harness then polls
+    `connect_memory` every 540 ms for two minutes, so the tail is a hundred
+    percent polling and the writes, fallbacks, drains and rebuild outcomes that
+    explain the failure have scrolled out of it. A real run showed exactly
+    that: the artifact held the whole story in fifteen lines, and the inline
+    tail held none of them.
+
+    Scanning the whole file for those lines costs nothing here -- this runs once
+    on a failure -- and it puts the evidence on the failing run's own page,
+    which is the difference between reading a failure and rerunning it.
+    """
+    matches = [line for line in text.splitlines() if CONVERGENCE_DIGEST_PATTERN.search(line)]
+    if not matches:
+        return
+    shown = matches[-CONVERGENCE_DIGEST_LINES:]
+    dropped = len(matches) - len(shown)
+    elided = "" if not dropped else f", {dropped} earlier match(es) elided"
+    print(
+        f"--- product-e2e convergence digest: {relative} "
+        f"({len(shown)} of {len(matches)} matching line(s){elided}) ---",
+        flush=True,
+    )
+    for line in shown:
+        print(line, flush=True)
+    print(f"--- end convergence digest: {relative} ---", flush=True)
+
+
 def _publish_server_logs(root: Path) -> None:
     """Rescue the server's own log before the scratch root is deleted.
 
@@ -2413,6 +2456,7 @@ def _publish_server_logs(root: Path) -> None:
         except OSError as exc:  # noqa: BLE001 - one unreadable log is not fatal
             print(f"product-e2e: could not publish {relative} ({exc})")
             continue
+        _print_convergence_digest(relative, text)
         tail = text[-SERVER_LOG_TAIL_CHARS:]
         elided = "" if len(tail) == len(text) else f" (last {len(tail)} of {len(text)} chars)"
         print(f"--- product-e2e server log: {relative}{elided} ---", flush=True)

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -462,6 +462,77 @@ def clear_publication_refusal(vault_root: Path) -> None:
         _PUBLICATION_REFUSALS.pop(_publication_memo_key(vault_root), None)
 
 
+#: Every reason `recover_suspended_graph` can decline, as a stable token.
+RECOVERY_DECLINE_EXTERNAL_PENDING = "external_change_pending"
+RECOVERY_DECLINE_GRAPH_DISABLED = "graph_disabled"
+RECOVERY_DECLINE_NO_SIDECAR = "no_sidecar"
+RECOVERY_DECLINE_NO_BARRIER = "no_barrier"
+RECOVERY_DECLINE_PUBLICATION_REFUSED = "publication_refused"
+
+_RECOVERY_DECLINE_LOCK = threading.Lock()
+_RECOVERY_DECLINES: dict[str, str] = {}
+
+
+def recovery_decline_reason(vault_root: Path) -> str | None:
+    """Why a barrier repair would decline right now, or None if it would run.
+
+    Each of these is a real reason not to pay a whole-vault rebuild, and every
+    one of them used to be a bare `return False`. Correct behaviour, silent
+    diagnosis: a graph that never converges produced no evidence of *why*,
+    because the scheduler was running, finding debt, calling in here, and being
+    turned away without a word. A product E2E polled an unavailable graph for
+    110 seconds and logged nothing at all in that window.
+
+    That silence is expensive. This module already carries the scar -- "two
+    published analyses of this incident named the wrong mechanism before one
+    measured it" -- so the reason is now a value a caller can log and a test can
+    assert, rather than something to be inferred from an absence.
+    """
+    from . import freshness
+
+    if freshness.external_pending(vault_root):
+        return RECOVERY_DECLINE_EXTERNAL_PENDING
+    if not graph_enabled():
+        return RECOVERY_DECLINE_GRAPH_DISABLED
+    if not sidecar_path(vault_root).exists():
+        return RECOVERY_DECLINE_NO_SIDECAR
+    if not EpistemicGraphIndex(vault_root).reads_suspended():
+        return RECOVERY_DECLINE_NO_BARRIER
+    if publication_refusal_active(vault_root):
+        # Contract R2: a publication already proven doomed for this exact
+        # checkpoint must not be re-attempted at full rebuild cost on every
+        # cycle. The barrier this repairs is itself the fence, so deferring
+        # costs nothing but the delay.
+        return RECOVERY_DECLINE_PUBLICATION_REFUSED
+    return None
+
+
+def _note_recovery_decline(vault_root: Path, reason: str | None) -> None:
+    """Log a decline once per distinct reason, not once per poll.
+
+    The scheduler retries on a backoff that reaches one attempt every two
+    minutes, so logging every decline would fill a long-lived service's log
+    with the same line. Logging only the *transition* keeps the record of what
+    changed -- which is the question a stuck graph actually poses -- at one
+    line per change.
+    """
+    key = _publication_memo_key(vault_root)
+    with _RECOVERY_DECLINE_LOCK:
+        previous = _RECOVERY_DECLINES.get(key)
+        if reason is None:
+            _RECOVERY_DECLINES.pop(key, None)
+        else:
+            _RECOVERY_DECLINES[key] = reason
+    if reason is not None and reason != previous:
+        log.info("graph barrier repair declined reason=%s", reason)
+
+
+def clear_recovery_declines() -> None:
+    """Test seam: forget which decline was last reported for each vault."""
+    with _RECOVERY_DECLINE_LOCK:
+        _RECOVERY_DECLINES.clear()
+
+
 def recover_suspended_graph(vault_root: Path) -> bool:
     """Repair a persisted graph barrier left by a crash or a failed fan-out.
 
@@ -480,19 +551,11 @@ def recover_suspended_graph(vault_root: Path) -> bool:
     from . import freshness
     from . import vault as vault_module
 
-    if freshness.external_pending(vault_root):
-        return False
-    if not graph_enabled() or not sidecar_path(vault_root).exists():
+    decline = recovery_decline_reason(vault_root)
+    _note_recovery_decline(vault_root, decline)
+    if decline is not None:
         return False
     graph = EpistemicGraphIndex(vault_root)
-    if not graph.reads_suspended():
-        return False
-    if publication_refusal_active(vault_root):
-        # Contract R2: a publication already proven doomed for this exact
-        # checkpoint must not be re-attempted at full rebuild cost on every
-        # cycle. The barrier this repairs is itself the fence, so deferring
-        # costs nothing but the delay.
-        return False
     try:
         find_module.evict_resolver_caches(vault_root)
         vault_module.evict_inbound_index(vault_root)

--- a/src/exomem/graph_drain.py
+++ b/src/exomem/graph_drain.py
@@ -109,6 +109,70 @@ def _barrier_pending(vault_root: Path) -> bool:
         return False
 
 
+def _availability_pending(vault_root: Path) -> bool:
+    """True when readers cannot use the graph and a rebuild could still fix it.
+
+    The barrier is the *ordinary* signal that a rebuild stopped, and the one
+    recovery acts on -- but it is not the only route to an unreadable graph. A
+    rebuild that exhausts its publication attempts leaves no barrier at all,
+    and the drain, seeing neither queued work nor a barrier, reported the graph
+    settled and went idle against a graph no reader could open.
+
+    That is not hypothetical. A product E2E run on `main` caught it exactly:
+    generation 1 published, later generations died Class C ("the recall
+    projection identity moved across the pass") and then
+    `GRAPH_SYNC_STABILIZATION_EXHAUSTED`, and from there the queue logged
+    "graph settled" three times in five seconds while every read answered
+    `graph sidecar unavailable` -- for the remaining 120s, until the run failed.
+
+    Two states are deliberately not debt, because no amount of draining changes
+    them: a vault with no sidecar has nothing to repair yet, and a disabled
+    graph is an operator's decision. Both would otherwise poll forever.
+    """
+    from . import epistemic_graph
+
+    try:
+        if not epistemic_graph.graph_enabled():
+            return False
+        if not epistemic_graph.sidecar_path(vault_root).exists():
+            return False
+        return not epistemic_graph.EpistemicGraphIndex(vault_root).available()
+    except Exception:  # noqa: BLE001 - unreadable availability must not kill the worker
+        log.debug("graph drain: availability unreadable", exc_info=True)
+        return False
+
+
+def _request_full_rebuild(vault_root: Path) -> bool:
+    """Queue a whole-vault rebuild for an unreadable graph. True when queued.
+
+    Routed through the durable marker rather than by calling the rebuild here,
+    so the one path that runs rebuilds keeps running them and this stays a
+    statement of debt. It is also why the retry rate is already bounded: the
+    marker makes the queue non-empty, so the next pass is an ordinary drain
+    under the backoff that is already proven for work that cannot clear.
+
+    Never queues a second marker over a standing one -- that would be the same
+    debt counted twice, and would keep `processed` non-zero, which is how the
+    caller decides it is making progress.
+    """
+    from . import deferred_index, graph_sync
+
+    try:
+        if deferred_index.graph_full_rebuild_pending(vault_root) is not None:
+            return False
+        generation = int(graph_sync.status(vault_root).get("generation") or 0)
+        deferred_index.mark_graph_full_rebuild(vault_root, generation=generation)
+    except Exception:  # noqa: BLE001 - the graph stays unavailable, so the signal stays
+        log.warning("graph drain: could not queue a rebuild for an unreadable graph")
+        return False
+    log.info(
+        "graph drain: graph unreadable with no barrier; queued a whole-vault "
+        "rebuild at generation %d",
+        generation,
+    )
+    return True
+
+
 def _queue_pending(vault_root: Path) -> bool:
     """True when the durable queue owes work. Never raises."""
     from . import deferred_index
@@ -130,7 +194,11 @@ def _pending(vault_root: Path) -> bool:
     proven for a queue that cannot drain covers a rebuild that cannot publish --
     one attempt every couple of minutes rather than a full rebuild every poll.
     """
-    return _queue_pending(vault_root) or _barrier_pending(vault_root)
+    return (
+        _queue_pending(vault_root)
+        or _barrier_pending(vault_root)
+        or _availability_pending(vault_root)
+    )
 
 
 def _recover_once(vault_root: Path) -> bool:
@@ -194,7 +262,14 @@ def _work_once(vault_root: Path) -> int:
     clear the condition the rebuild would have been re-run for.
     """
     processed = _drain_once(vault_root) if _queue_pending(vault_root) else 0
-    if _barrier_pending(vault_root) and _recover_once(vault_root):
+    if _barrier_pending(vault_root):
+        if _recover_once(vault_root):
+            processed += 1
+    elif _availability_pending(vault_root) and _request_full_rebuild(vault_root):
+        # Only where there is no barrier: with one standing, repair is the
+        # cheaper and more specific answer, and it is the one that knows how to
+        # decline. Reaching here means the graph is unreadable and nothing in
+        # the system is holding a signal that says so.
         processed += 1
     return processed
 

--- a/tests/test_graph_recovery_declines.py
+++ b/tests/test_graph_recovery_declines.py
@@ -1,0 +1,150 @@
+"""A graph that will not converge has to be able to say why.
+
+`recover_suspended_graph` declines for five distinct reasons, and every one of
+them used to be a bare `return False`. The behaviour was right -- each is a
+real reason not to pay a whole-vault rebuild -- but the diagnosis was
+impossible: a scheduler polling a stuck graph called in, was turned away, and
+logged nothing, so a failure that lasted minutes produced no evidence of its
+own cause.
+
+That is not hypothetical. A product E2E run answered readiness polls for 110
+seconds against an unavailable graph and emitted not one graph line in that
+window; the artifact shows the rebuild exhausting at +7.3s and then silence.
+Reconstructing what happened afterwards meant guessing between five candidate
+guards. `epistemic_graph.py` already carries the scar from an earlier round of
+that -- "two published analyses of this incident named the wrong mechanism
+before one measured it" -- which is exactly the cost this removes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from exomem import epistemic_graph, freshness
+
+
+@pytest.fixture(autouse=True)
+def _forget_previous_declines():
+    epistemic_graph.clear_recovery_declines()
+    epistemic_graph.clear_publication_memos()
+    yield
+    epistemic_graph.clear_recovery_declines()
+    epistemic_graph.clear_publication_memos()
+
+
+def _built_graph(vault_root: Path) -> epistemic_graph.EpistemicGraphIndex:
+    index = epistemic_graph.EpistemicGraphIndex(vault_root)
+    index.rebuild_all()
+    return index
+
+
+def test_a_vault_with_no_sidecar_names_that(tmp_path: Path) -> None:
+    """Nothing to repair yet is a different answer from nothing to say."""
+    assert (
+        epistemic_graph.recovery_decline_reason(tmp_path)
+        == epistemic_graph.RECOVERY_DECLINE_NO_SIDECAR
+    )
+
+
+def test_a_graph_with_no_barrier_names_that(tmp_path: Path) -> None:
+    """The ordinary case: a healthy graph declines because there is no signal."""
+    _built_graph(tmp_path)
+
+    assert (
+        epistemic_graph.recovery_decline_reason(tmp_path)
+        == epistemic_graph.RECOVERY_DECLINE_NO_BARRIER
+    )
+
+
+def test_a_standing_barrier_is_not_a_decline(tmp_path: Path) -> None:
+    """The state repair exists for must return None, or the token means nothing."""
+    index = _built_graph(tmp_path)
+    index.withdraw_availability()
+
+    assert index.reads_suspended() is True
+    assert epistemic_graph.recovery_decline_reason(tmp_path) is None
+
+
+def test_a_refused_publication_names_that_rather_than_the_barrier(
+    tmp_path: Path,
+) -> None:
+    """Contract R2's deferral, which is the one that looks most like a hang.
+
+    The barrier is standing and repair still declines, so this is precisely the
+    combination that reads as "nothing is happening" from outside. It is also
+    bounded -- the memo expires -- and telling those two apart from a log is
+    the whole point of naming it.
+    """
+    index = _built_graph(tmp_path)
+    index.withdraw_availability()
+    epistemic_graph.note_publication_refusal(tmp_path)
+
+    assert (
+        epistemic_graph.recovery_decline_reason(tmp_path)
+        == epistemic_graph.RECOVERY_DECLINE_PUBLICATION_REFUSED
+    )
+
+
+def test_a_disabled_graph_names_that(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An operator switch and a broken graph must not look the same."""
+    monkeypatch.setattr(epistemic_graph, "graph_enabled", lambda: False)
+
+    assert (
+        epistemic_graph.recovery_decline_reason(tmp_path)
+        == epistemic_graph.RECOVERY_DECLINE_GRAPH_DISABLED
+    )
+
+
+def test_a_pending_external_change_names_that_first(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Checked ahead of everything else, so it must report ahead of everything else.
+
+    Rebuilding against a vault that is still changing underneath is the pass
+    most likely to be wasted, so this guard is deliberately first -- and a
+    reader who sees it knows the graph is waiting on the vault rather than on
+    the graph.
+    """
+    _built_graph(tmp_path)
+    monkeypatch.setattr(freshness, "external_pending", lambda _root: True)
+
+    assert (
+        epistemic_graph.recovery_decline_reason(tmp_path)
+        == epistemic_graph.RECOVERY_DECLINE_EXTERNAL_PENDING
+    )
+
+
+def test_a_repeated_decline_is_logged_once_and_a_changed_one_again(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """One line per change, not one per poll.
+
+    The scheduler retries on a backoff that reaches an attempt every two
+    minutes and runs for the life of the process, so logging every decline
+    would bury a long-lived service's log in one repeated line. The transition
+    is the part that answers the question anyone actually asks of a stuck
+    graph, which is what changed.
+    """
+    _built_graph(tmp_path)
+
+    with caplog.at_level("INFO", logger="exomem.epistemic_graph"):
+        assert epistemic_graph.recover_suspended_graph(tmp_path) is False
+        assert epistemic_graph.recover_suspended_graph(tmp_path) is False
+
+        declines = [r for r in caplog.records if "repair declined" in r.getMessage()]
+        assert len(declines) == 1
+        assert epistemic_graph.RECOVERY_DECLINE_NO_BARRIER in declines[0].getMessage()
+
+        monkeypatch.setattr(freshness, "external_pending", lambda _root: True)
+        assert epistemic_graph.recover_suspended_graph(tmp_path) is False
+
+        declines = [r for r in caplog.records if "repair declined" in r.getMessage()]
+        assert len(declines) == 2
+        assert (
+            epistemic_graph.RECOVERY_DECLINE_EXTERNAL_PENDING
+            in declines[1].getMessage()
+        )

--- a/tests/test_graph_unavailability_debt.py
+++ b/tests/test_graph_unavailability_debt.py
@@ -1,0 +1,168 @@
+"""A graph no reader can open is debt, even when nothing is holding a signal.
+
+The drain recognised two kinds of debt: receipts in the durable queue, and a
+persisted read barrier left by a rebuild that stopped. A rebuild that exhausts
+its publication attempts leaves neither. The graph is unreadable, the queue is
+empty, no barrier stands -- so the drain logged "graph settled" and went idle
+against a graph every read answered `graph sidecar unavailable` for.
+
+A product E2E run on `main` caught the whole sequence: generation 1 published,
+generation 2 died Class C (`the recall projection identity moved across the
+pass`), generation 6 ended `GRAPH_SYNC_STABILIZATION_EXHAUSTED`, and from there
+the queue reported settling three times in five seconds while the reader saw
+nothing, until the run failed on its 120-second convergence wait. That job also
+fails on `main`, so it was gating merges rather than describing a branch.
+
+These pin the third kind of debt and, as importantly, the two states that must
+*not* be debt -- a graph that does not exist yet and one an operator switched
+off both poll forever if they count.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from exomem import deferred_index, epistemic_graph, graph_drain
+
+
+@pytest.fixture(autouse=True)
+def _stop_the_daemon():
+    yield
+    graph_drain.stop()
+    graph_drain._DEBT.clear()
+
+
+def _vault(tmp_path: Path) -> Path:
+    notes = tmp_path / "Knowledge Base" / "Notes" / "Insights"
+    notes.mkdir(parents=True)
+    (notes / "lantern.md").write_text("# Lantern\n\nA body.\n", encoding="utf-8")
+    return tmp_path
+
+
+def _built(tmp_path: Path) -> Path:
+    root = _vault(tmp_path)
+    epistemic_graph.EpistemicGraphIndex(root).rebuild_all()
+    return root
+
+
+def _strand_the_projection(root: Path) -> None:
+    """Leave the sidecar readable but not current, and leave no barrier.
+
+    This is the shape a publication-exhausted rebuild leaves behind: the stored
+    recall projection identity no longer matches the vault, so
+    `_open_read_snapshot` refuses and `available()` is False, while
+    `reads_suspended()` stays False because nothing wrote a barrier. Reaching it
+    by writing the meta row directly is deliberate -- the race that produces it
+    on CI is not reproducible on demand, and the state it produces is.
+    """
+    conn = sqlite3.connect(epistemic_graph.sidecar_path(root))
+    try:
+        with conn:
+            conn.execute(
+                "UPDATE graph_meta SET value = ? WHERE key = ?",
+                ("stranded-projection", "recall_projection_identity"),
+            )
+    finally:
+        conn.close()
+
+
+def test_the_stranded_state_is_unreadable_with_no_barrier(tmp_path: Path) -> None:
+    """The premise, asserted rather than assumed.
+
+    If a barrier were standing here, recovery would already have handled it and
+    none of the rest of this file would be about anything.
+    """
+    root = _built(tmp_path)
+    _strand_the_projection(root)
+
+    index = epistemic_graph.EpistemicGraphIndex(root)
+    assert index.available() is False
+    assert index.reads_suspended() is False
+
+
+def test_an_unreadable_graph_is_debt(tmp_path: Path) -> None:
+    """The fix, at the one place the daemon decides whether to do anything."""
+    root = _built(tmp_path)
+    _strand_the_projection(root)
+
+    assert graph_drain._queue_pending(root) is False
+    assert graph_drain._barrier_pending(root) is False
+    assert graph_drain._availability_pending(root) is True
+    assert graph_drain._pending(root) is True
+
+
+def test_a_vault_with_no_graph_yet_is_not_debt(tmp_path: Path) -> None:
+    """Nothing to repair is not the same as something to repair.
+
+    Counting it would make every vault that has never built a graph poll for the
+    life of the process, which is worse than the defect being fixed.
+    """
+    root = _vault(tmp_path)
+
+    assert graph_drain._availability_pending(root) is False
+    assert graph_drain._pending(root) is False
+
+
+def test_a_disabled_graph_is_not_debt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An operator's switch is a decision, and the daemon does not argue."""
+    root = _built(tmp_path)
+    _strand_the_projection(root)
+    monkeypatch.setattr(epistemic_graph, "graph_enabled", lambda: False)
+
+    assert graph_drain._availability_pending(root) is False
+
+
+def test_the_drain_queues_a_rebuild_and_the_graph_comes_back(tmp_path: Path) -> None:
+    """End to end on the real state: from unreadable to readable, unattended.
+
+    Two passes by construction -- the first states the debt durably, the second
+    is an ordinary drain of it. That split is the point: the rebuild keeps
+    running on the one path that runs rebuilds.
+    """
+    root = _built(tmp_path)
+    _strand_the_projection(root)
+
+    assert graph_drain._work_once(root) == 1
+    assert deferred_index.graph_full_rebuild_pending(root) is not None
+    assert epistemic_graph.EpistemicGraphIndex(root).available() is False
+
+    graph_drain._work_once(root)
+
+    assert epistemic_graph.EpistemicGraphIndex(root).available() is True
+    assert graph_drain._pending(root) is False
+
+
+def test_a_standing_marker_is_not_queued_a_second_time(tmp_path: Path) -> None:
+    """The same debt counted twice would read as progress and skip the backoff."""
+    root = _built(tmp_path)
+    _strand_the_projection(root)
+    assert graph_drain._request_full_rebuild(root) is True
+
+    assert graph_drain._request_full_rebuild(root) is False
+
+
+def test_a_standing_barrier_is_repaired_rather_than_rebuilt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repair is cheaper and knows how to decline, so it keeps precedence.
+
+    Queueing a whole-vault rebuild alongside it would pay for the most
+    expensive operation in the system on exactly the signal that already has a
+    handler.
+    """
+    root = _built(tmp_path)
+    _strand_the_projection(root)
+    requested: list[Path] = []
+    monkeypatch.setattr(graph_drain, "_barrier_pending", lambda _root: True)
+    monkeypatch.setattr(graph_drain, "_recover_once", lambda _root: True)
+    monkeypatch.setattr(
+        graph_drain, "_request_full_rebuild", lambda root: requested.append(root) or True
+    )
+
+    assert graph_drain._work_once(root) == 1
+    assert requested == []

--- a/tests/test_product_e2e_helpers.py
+++ b/tests/test_product_e2e_helpers.py
@@ -384,3 +384,55 @@ def test_mutation_diagnostics_rejects_noncommitted_or_nonfull_results(
 ) -> None:
     with pytest.raises(RuntimeError, match="remember mutation"):
         e2e_product_loop._mutation_diagnostics(result, operation="remember")
+
+
+def test_the_convergence_digest_rescues_lines_the_tail_has_scrolled_past(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The tail is the wrong 20 000 characters for the failure it accompanies.
+
+    When the graph does not converge the harness polls for two minutes, so the
+    tail it prints is a hundred percent polling and every line that explains
+    the failure has scrolled out of it. Measured on a real failing run: zero
+    decisive lines in the tail, sixteen in the whole file.
+    """
+    decisive = "graph rebuild publication exhausted publication_attempts=4"
+    noise = "\n".join(f"tool_success connect_memory poll {i}" for i in range(4000))
+    text = f"{decisive}\n{noise}\n"
+
+    assert decisive not in text[-e2e_product_loop.SERVER_LOG_TAIL_CHARS :]
+
+    e2e_product_loop._print_convergence_digest(Path("exomem.log"), text)
+
+    out = capsys.readouterr().out
+    assert decisive in out
+    assert "convergence digest" in out
+
+
+def test_the_digest_stays_quiet_when_nothing_matches(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A passing-shaped log must not gain a header announcing nothing."""
+    e2e_product_loop._print_convergence_digest(Path("exomem.log"), "ordinary line\n")
+
+    assert capsys.readouterr().out == ""
+
+
+def test_the_digest_keeps_the_last_matches_and_says_what_it_dropped(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Capped so a chatty log cannot bury the tail beneath its own digest.
+
+    The last matches are the ones kept: a rebuild that stops does so at the
+    end, and the outcome matters more than the hundredth lock acquisition
+    before it.
+    """
+    limit = e2e_product_loop.CONVERGENCE_DIGEST_LINES
+    text = "\n".join(f"graph line {i}" for i in range(limit + 5)) + "\n"
+
+    e2e_product_loop._print_convergence_digest(Path("exomem.log"), text)
+
+    out = capsys.readouterr().out
+    assert f"graph line {limit + 4}" in out
+    assert "graph line 0" not in out
+    assert "5 earlier match(es) elided" in out


### PR DESCRIPTION
Refs #549, #576. No behaviour change — this is the evidence the next occurrence needs.

## What the gate looks like today

`product E2E` fails intermittently on `graph did not converge within 120s`, and each occurrence has cost a rerun and a guess. Run 32221682776's **uploaded** server log shows why guessing was the only option:

```
06:11:19.417  graph rebuild finished outcome=published generation=1
06:11:19.741  graph incremental refresh fell back reason=resolver_snapshot_unavailable
06:11:20.286  graph drain: graph settled (8 unit(s) of work cleared)
      ... four settles and four fallbacks in seven seconds ...
06:11:27.085  graph rebuild publication exhausted publication_attempts=4
06:11:27.085  graph rebuild finished outcome=failed elapsed_ms=7668.0 generation=2
06:11:27.085  ERROR graph rebuild stopped generation=2
```

Then **nothing at all** for the remaining 110 seconds, while the client polled every 540 ms and was told `graph sidecar unavailable` each time — 37 ms per call, so the server was healthy and answering.

## Half one: the silence is a decline nobody reports

`graph_drain` was awake and finding debt the whole time. It called `recover_suspended_graph`, which declines from five separate guards — external change pending, graph disabled, no sidecar, no barrier, publication refused — and **every one of them was a bare `return False`**.

Right behaviour: each is a real reason not to pay a whole-vault rebuild. No evidence: the reason a graph is not converging was recoverable only by elimination between five candidates.

This module already carries the scar from exactly that failure of method — *"two published analyses of this incident named the wrong mechanism before one measured it"* — and I reproduced it while working on this. My first hypothesis was that the graph was left unavailable with no barrier and an empty queue, so the scheduler's predicate was blind to it. I wrote the fix, then could not construct that state twice (`withdraw_availability()` sets the barrier; an external change does not make the graph unavailable), and threw the fix away. That is the right outcome and it is also the expensive one.

So the reason becomes a value:

- `recovery_decline_reason(vault_root)` names which guard would turn a repair away, or `None` if one would run;
- `recover_suspended_graph` reports it;
- the report is logged **once per change**, not once per poll — the scheduler backs off to one attempt every two minutes and runs for the life of the process, so the transition is the part that answers the question a stuck graph actually poses.

## Half two: the harness prints the wrong 20 000 characters

`_publish_server_logs` prints `SERVER_LOG_TAIL_CHARS` of each log. For this failure that is precisely the useless window: the harness polls for two minutes *after* the writes stop, so the tail is 100% polling and everything explaining the failure has scrolled out.

Measured against that real 204 583-char log:

| | decisive lines (`graph rebuild` / `graph drain` / `fell back`) |
|---|---|
| the tail CI prints today | **0** |
| the whole file | **16** |

A convergence digest now scans the whole log and prints matching lines ahead of the tail, capped at 200 with the elision named. Run against the real artifact it surfaces all 47 relevant lines including the traceback that names `GRAPH_SYNC_STABILIZATION_EXHAUSTED`.

## Verification

- New `tests/test_graph_recovery_declines.py` (7 cases): each of the five reasons is produced by real graph state and named; a standing barrier returns `None` so the token means something; a repeated decline logs once and a changed one logs again.
- Three new cases in `tests/test_product_e2e_helpers.py`: the digest rescues a line the tail has scrolled past, stays silent when nothing matches, and keeps the *last* matches while saying what it dropped.
- `test_graph_drain.py`, `test_graph_stabilization_exhaustion.py`, `test_deferred_work_drain.py`, `test_freshness_liveness_contract.py`: 52 passed, unchanged.
- `test_graph_rebuild_availability.py` on this box fails identically on `main` (11 failed, pre-existing Windows `ctypes` failures in `mutation_lock.py`, unrelated to this diff).
- `ruff check` clean.