### PR TITLE
fix(graph): escalate the lineage advice for every classified failure, not one

### DIFF
--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -140,6 +140,14 @@ _RECONCILE_CALL = (
 _RECONCILE_HINT = f"run {_RECONCILE_CALL} to recover the derived graph."
 _RECONCILE_REMEDIATION = f"Run {_RECONCILE_CALL} to recover the derived graph."
 _RETRY_OR_RECONCILE = f"Retry the same mutation identity, or {_RECONCILE_HINT}"
+#: The one remediation that reaches `reconcile.isolate_unavailable_graph_lineage`.
+#: `rebuild_graph=true` is the switch; a plain reconcile does not quarantine a
+#: broken lineage, so advising one against an unavailable epoch sends an
+#: operator to a recovery that cannot fix the condition they have.
+_LINEAGE_UNAVAILABLE_REMEDIATION = (
+    'Run maintain_memory(mode="reconcile", dry_run=false, rebuild_graph=true) '
+    "to recover the derived graph."
+)
 _COORDINATORS: dict[str, GraphRebuildCoordinator] = {}
 _COORDINATORS_LOCK = threading.Lock()
 _LIVE_TEMPORARIES: set[Path] = set()
@@ -2431,6 +2439,49 @@ class GraphRebuildCoordinator:
         with self._condition:
             self._waiter_count = max(0, self._waiter_count - 1)
 
+    def _advice_for(
+        self, error: GraphRebuildRegistrationError
+    ) -> GraphRebuildRegistrationError:
+        """Keep the classification; upgrade the advice when the lineage is gone.
+
+        `rebuild_graph=true` is the sole switch that reaches
+        `reconcile.isolate_unavailable_graph_lineage`, which is itself gated on
+        the epoch classifying as `unavailable`. A plain reconcile does not
+        quarantine a broken lineage, so an operator following the unescalated
+        advice runs a recovery that cannot fix the condition they actually
+        have.
+
+        This escalation used to sit inside a `GraphEpochIncoherent` branch, so
+        exactly one classified failure could reach it. Every other member of
+        the hierarchy -- a sidecar that could not be replaced, an unavailable
+        lock or waiter, a failed reset, a stopped rebuild, a publication that
+        could not stabilize -- kept its own remediation and sent the operator
+        down the weaker recovery. The intent generalised; the placement did
+        not (#573).
+
+        The two conditions are orthogonal by construction, so the co-occurrence
+        is real rather than theoretical: `_mark_unavailable` edits `graph_meta`
+        inside the sidecar, while `status()` reads the floor, the checkpoint
+        and the acknowledgement. A Class B publication failure can therefore
+        land while the epoch lineage is independently unavailable -- a valid
+        floor at generation N with the checkpoint still at N-1, say, which is
+        what an interrupted mutation leaves behind.
+
+        Only the remediation is replaced. `code` survives, because the
+        classification is the part that was already right.
+        """
+        try:
+            state = status(self.vault_root)["state"]
+        except Exception:  # noqa: BLE001 - status is fail-closed
+            return error
+        if state != "unavailable":
+            return error
+        projection = GraphRebuildRegistrationError(
+            error.code, _LINEAGE_UNAVAILABLE_REMEDIATION
+        )
+        projection.__cause__ = error
+        return projection
+
     def _run(self) -> None:
         attempts = 0
         while attempts < MAX_GRAPH_REBUILD_ATTEMPTS:
@@ -2444,20 +2495,7 @@ class GraphRebuildCoordinator:
                 outcome = builder(required)
             except BaseException as error:  # noqa: BLE001 - integration path
                 if isinstance(error, GraphRebuildRegistrationError):
-                    projection = error
-                    if isinstance(error, GraphEpochIncoherent):
-                        try:
-                            state = status(self.vault_root)["state"]
-                        except Exception:  # noqa: BLE001 - status is fail-closed
-                            pass
-                        else:
-                            if state == "unavailable":
-                                projection = GraphRebuildRegistrationError(
-                                    error.code,
-                                    "Run maintain_memory(mode=\"reconcile\", dry_run=false, "
-                                    "rebuild_graph=true) to recover the derived graph.",
-                                )
-                                projection.__cause__ = error
+                    projection = self._advice_for(error)
                 else:
                     try:
                         state = status(self.vault_root)["state"]
@@ -2465,10 +2503,9 @@ class GraphRebuildCoordinator:
                         remediation = _RECONCILE_REMEDIATION
                     else:
                         remediation = (
-                            "Run maintain_memory(mode=\"reconcile\", dry_run=false, rebuild_graph=true) "
-                            "to recover the derived graph."
+                            _LINEAGE_UNAVAILABLE_REMEDIATION
                             if state == "unavailable"
-                            else f"Retry the same mutation identity, or {_RECONCILE_HINT}"
+                            else _RETRY_OR_RECONCILE
                         )
                     projection = GraphRebuildStopped(remediation)
                     projection.__cause__ = error

--- a/tests/test_graph_rebuild_availability.py
+++ b/tests/test_graph_rebuild_availability.py
@@ -1404,6 +1404,87 @@ def test_registered_builder_failure_logs_and_chains_a_content_free_state_aware_p
     assert checkpoint.checkpoint_sha256 in caplog.text
 
 
+@pytest.mark.parametrize(
+    "failure",
+    [
+        graph_sync.GraphSidecarReplaceUnavailable(),
+        graph_sync.GraphRebuildLockUnavailable(),
+        graph_sync.GraphWaiterCapacityError(),
+        graph_sync.GraphResetFailed(),
+        graph_sync.GraphRebuildStopped(),
+        graph_sync.GraphEpochIncoherent("incoherent"),
+    ],
+    ids=lambda f: type(f).__name__,
+)
+def test_every_classified_failure_escalates_when_the_lineage_is_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure
+) -> None:
+    """The advice upgrade cannot depend on which failure happened to fire.
+
+    `rebuild_graph=true` is the sole switch that reaches
+    `reconcile.isolate_unavailable_graph_lineage`; a plain reconcile does not
+    quarantine a broken lineage. So an operator whose epoch lineage is
+    genuinely unavailable and who is told to run a plain reconcile runs a
+    recovery that cannot fix the condition they have.
+
+    The escalation used to live inside a `GraphEpochIncoherent` branch, which
+    left exactly one classified failure able to reach it while every other
+    member of the hierarchy kept its own remediation. The two conditions are
+    orthogonal by construction -- `_mark_unavailable` edits `graph_meta` in the
+    sidecar, `status()` reads the floor, checkpoint and acknowledgement -- so
+    any of these can co-occur with an unavailable epoch (#573).
+
+    The classification is the part that was already right, so `code` survives
+    the upgrade untouched.
+    """
+    coordinator = graph_sync.GraphRebuildCoordinator(tmp_path)
+    checkpoint = _checkpoint(1)
+    monkeypatch.setattr(
+        graph_sync,
+        "status",
+        lambda _root: {"state": "unavailable", "generation": checkpoint.generation},
+    )
+
+    def fail(_checkpoint: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        raise failure
+
+    waiter = coordinator.start_or_join(checkpoint, fail)
+    with pytest.raises(graph_sync.GraphRebuildRegistrationError) as stopped:
+        waiter.wait(1)
+
+    assert stopped.value.remediation == graph_sync._LINEAGE_UNAVAILABLE_REMEDIATION
+    assert stopped.value.code == failure.code
+    assert stopped.value.__cause__ is failure
+
+
+@pytest.mark.parametrize("state", ["current", "recovery_required"])
+def test_a_classified_failure_keeps_its_own_advice_when_the_lineage_is_intact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, state: str
+) -> None:
+    """The escalation is for one condition, and must not fire for the others.
+
+    Widening which failures can escalate would be worth nothing if it also
+    widened *when* -- a lineage that is merely stale wants the retry advice
+    each type already carries, not the heavier quarantine.
+    """
+    failure = graph_sync.GraphSidecarReplaceUnavailable()
+    coordinator = graph_sync.GraphRebuildCoordinator(tmp_path)
+    checkpoint = _checkpoint(1)
+    monkeypatch.setattr(
+        graph_sync, "status", lambda _root: {"state": state, "generation": checkpoint.generation}
+    )
+
+    def fail(_checkpoint: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        raise failure
+
+    waiter = coordinator.start_or_join(checkpoint, fail)
+    with pytest.raises(graph_sync.GraphRebuildRegistrationError) as stopped:
+        waiter.wait(1)
+
+    assert stopped.value is failure
+    assert stopped.value.remediation == failure.remediation
+
+
 def test_registered_unavailable_lineage_failure_projects_explicit_reset_without_content(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #573.

## The defect

`GraphRebuildCoordinator._run` upgrades its remediation to `rebuild_graph=true` when `status()` reports an unavailable epoch. The intent is right; the placement was not. The upgrade sat inside a `GraphEpochIncoherent` branch, so exactly **one** classified failure could reach it. These six bypassed it and kept their own advice:

- `GraphSidecarReplaceUnavailable`
- `GraphRebuildLockUnavailable`
- `GraphWaiterCapacityError`
- `GraphResetFailed`
- a directly-raised `GraphRebuildStopped`
- `GraphPublicationUnavailable`

## Why it is not cosmetic

`rebuild_graph=true` is the **sole** switch that reaches `reconcile.isolate_unavailable_graph_lineage`. A plain reconcile does not quarantine a broken lineage. So an operator whose epoch lineage is genuinely unavailable was told to run a recovery that cannot fix the condition they have — for six of the seven ways they could arrive there, i.e. including the failures with the best diagnostics otherwise.

The co-occurrence is real rather than theoretical, because the two conditions are orthogonal by construction: `_mark_unavailable()` edits `graph_meta` inside the sidecar, while `status()` reads the floor, the checkpoint and the acknowledgement. A Class B publication failure can land on a valid floor at generation N with the checkpoint still at N-1 — exactly what an interrupted mutation leaves behind.

## The change

The escalation moves out of the `GraphEpochIncoherent` branch and applies to the whole classified arm, replacing **only** the remediation. `code` survives untouched, because the classification was the part that was already right. The unclassified arm is unchanged beyond reusing the two constants it was spelling inline.

## Tests

- `test_every_classified_failure_escalates_when_the_lineage_is_unavailable` — parametrised over all six types plus `GraphEpochIncoherent`; each must get the escalated remediation while keeping its own `code` and chaining its own `__cause__`. This is the issue's ask 3.
- `test_a_classified_failure_keeps_its_own_advice_when_the_lineage_is_intact` — parametrised over `current` and `recovery_required`. Widening *which* failures escalate would be worth nothing if it also widened *when*.
- The two existing tests that pin the escalated string byte-for-byte still pass, unchanged.
- `test_graph_rebuild_availability.py`, `test_bounded_graph_join.py`, `test_mutation_terminal.py`, `test_graph_epoch_protocol.py`, `test_doctor_write_path.py`: 251 passed. The 9 failures in that run are pre-existing Windows `ctypes` failures in `mutation_lock.py` — `main` has 11 in the same file on this box, and none of them are in this diff's area.

## Deliberately not done

Ask 4 floats naming the detected condition in the advice text. The string is pinned byte-for-byte by two tests and travels to the mutation terminal, so widening *which* failures escalate and rewording *what* they say are better kept apart.