### PR TITLE
perf(find): give the keyword candidate lane the bound every other lane has

### DIFF
--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -3446,6 +3446,7 @@ def _keyword_match_paths(
     freshness: tuple | None = None,
     failed_out: list[str] | None = None,
     repair: bool = True,
+    k: int | None = None,
 ) -> list[str]:
     """Return paths that satisfy keyword mode's all-tokens-present gate.
 
@@ -3459,6 +3460,17 @@ def _keyword_match_paths(
     function's scan (the parity suite), so falling through changes nothing
     but latency. The scan below remains the reference implementation and the
     `EXOMEM_LEXICAL_BACKEND=python` target.
+
+    `k` bounds the candidate set. Every other lane in `find_candidates` already
+    takes one; this one took none, so it answered with every page in the vault
+    that matched, and the fuse and the eligibility filter then paid for all of
+    them on every call (#516). The bound belongs here rather than at the caller
+    because the result is ordered by `updated` desc: a caller that sliced the
+    return value would be slicing recency order, which is only correct if the
+    order was applied first -- which is exactly what the sidecar's `LIMIT` and
+    the truncation below do.
+
+    Both backends truncate identically, so parity holds at any `k`.
     """
     if not query_norm:
         return []
@@ -3470,6 +3482,7 @@ def _keyword_match_paths(
         scope=scope,
         freshness=freshness,
         repair=repair,
+        k=k,
     )
     if indexed is not None:
         return indexed
@@ -3500,7 +3513,8 @@ def _keyword_match_paths(
             continue
         matches.append((page.updated or "0000-00-00", page.rel_path))
     matches.sort(reverse=True)  # most-recent first
-    return [p for _, p in matches]
+    bounded = matches if k is None else matches[: max(0, int(k))]
+    return [p for _, p in bounded]
 
 
 def _outbound_wikilink_paths(

--- a/src/exomem/find_candidates.py
+++ b/src/exomem/find_candidates.py
@@ -452,8 +452,17 @@ def collect_candidates(
         bm25_ranking = _eligible(bm25_ranking)
 
         with _span(timings, "keyword"):
+            # Over-fetch by the same factor the BM25 lane uses, and for the same
+            # reason: `collapse_frame_children` and `_eligible` below can drop
+            # members, so a lane that supplied exactly the fused depth could
+            # arrive under it. Before this the lane supplied *everything* --
+            # every matching page in the vault, on every call (#516).
             keyword_ranking = keyword_match_paths(
-                vault_root, query_norm, scope, freshness=snapshot.for_scope(scope)
+                vault_root,
+                query_norm,
+                scope,
+                freshness=snapshot.for_scope(scope),
+                k=candidate_k * 3,
             )
         keyword_ranking = collapse_frame_children(
             keyword_ranking,

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -485,6 +485,7 @@ def search_substring(
     scope: str = "kb",
     freshness: tuple | None = None,
     repair: bool = True,
+    k: int | None = None,
 ) -> list[str] | None:
     """The keyword lane's match set (every whitespace token a substring of
     title or body), ordered `updated` desc then path desc, navigation files
@@ -498,7 +499,7 @@ def search_substring(
     if not tokens:
         return []
     store = get_store(vault_root)
-    return store.search_substring(tokens, scope, freshness, repair)
+    return store.search_substring(tokens, scope, freshness, repair, k)
 
 
 def search_semantic_units(
@@ -3422,6 +3423,7 @@ class LexicalStore:
         scope: str,
         freshness: tuple | None,
         repair: bool = True,
+        k: int | None = None,
     ) -> list[str] | None:
         if self._failed:
             return None
@@ -3433,7 +3435,7 @@ class LexicalStore:
                 scope,
                 freshness,
                 repair=repair,
-                query_fn=lambda conn: self._substring_query(conn, tokens, scope),
+                query_fn=lambda conn: self._substring_query(conn, tokens, scope, k),
             )
         except sqlite3.Error as e:
             self._note_query_failure(
@@ -3443,12 +3445,19 @@ class LexicalStore:
             return None
 
     def _substring_query(
-        self, conn: sqlite3.Connection, tokens: list[str], scope: str
+        self, conn: sqlite3.Connection, tokens: list[str], scope: str, k: int | None = None
     ) -> list[str]:
         """Exact keyword contract: trigram MATCH narrows (tokens >= 3 chars),
         then instr() verifies EVERY token against the stored raw text — the
         verification is what parity rests on; MATCH is only the accelerator.
-        Needles under the trigram floor rely on the verification alone."""
+        Needles under the trigram floor rely on the verification alone.
+
+        `k` truncates a list that is already totally ordered, so a bounded
+        result is a prefix of the unbounded one and the contract is unchanged.
+        It exists because the ordering makes the *caller* unable to bound this
+        safely: a candidate lane cannot take the first `k` it happens to see
+        and still be reading recency order, so the bound has to be applied
+        where the order is."""
         col = "in_vault" if scope == "vault" else "in_kb"
         clauses: list[str] = [f"p.{col} = 1", "p.is_nav = 0"]
         params: list[object] = []
@@ -3460,10 +3469,14 @@ class LexicalStore:
         for t in tokens:
             clauses.append("(instr(tri.title_lower, ?) > 0 OR instr(tri.body_lower, ?) > 0)")
             params.extend((t, t))
+        limit = ""
+        if k is not None:
+            limit = " LIMIT ?"
+            params.append(max(0, int(k)))
         rows = conn.execute(
             "SELECT p.path FROM tri JOIN pages p ON p.rowid = tri.rowid "
             "WHERE " + " AND ".join(clauses) + " "
-            "ORDER BY p.updated DESC, p.path DESC",
+            "ORDER BY p.updated DESC, p.path DESC" + limit,
             params,
         ).fetchall()
         return [r[0] for r in rows]

--- a/tests/test_lexical_backend_fallback.py
+++ b/tests/test_lexical_backend_fallback.py
@@ -308,6 +308,49 @@ def test_keyword_lane_parity_with_reference_scan(tmp_path, monkeypatch, query):
 
 
 @needs_fts5
+@pytest.mark.parametrize("k", [0, 1, 2, 5, 100])
+def test_a_bounded_keyword_lane_is_the_unbounded_prefix_on_both_backends(
+    tmp_path, monkeypatch, k
+):
+    """The bound may not change the contract, only how much of it is returned.
+
+    The lane answers in `updated` desc order, so a caller cannot bound it by
+    slicing what it gets back -- that would be slicing recency order after the
+    fact only if the order had already been applied, which is the whole reason
+    the bound lives inside the lane. Asserting the bounded result is a literal
+    prefix of the unbounded one is what says it was applied in the right place.
+
+    Both backends are checked at the same `k`, because the sidecar applies it
+    as SQL `LIMIT` and the reference scan applies it as a slice, and the parity
+    gate is worth nothing if it only holds when unbounded.
+    """
+    _parity_corpus(tmp_path)
+
+    monkeypatch.setenv("EXOMEM_LEXICAL_BACKEND", "python")
+    reference_all = find_module._keyword_match_paths(tmp_path, "employment", "kb")
+    reference_k = find_module._keyword_match_paths(tmp_path, "employment", "kb", k=k)
+    find_module.clear_cache()
+    monkeypatch.setenv("EXOMEM_LEXICAL_BACKEND", "fts5")
+    indexed_all = find_module._keyword_match_paths(tmp_path, "employment", "kb")
+    indexed_k = find_module._keyword_match_paths(tmp_path, "employment", "kb", k=k)
+
+    assert reference_k == reference_all[:k]
+    assert indexed_k == indexed_all[:k]
+    assert indexed_k == reference_k
+
+
+@needs_fts5
+def test_an_unbounded_keyword_lane_is_unchanged(tmp_path, monkeypatch):
+    """`k=None` is the existing contract, and every other caller still passes it."""
+    _parity_corpus(tmp_path)
+    monkeypatch.setenv("EXOMEM_LEXICAL_BACKEND", "fts5")
+
+    assert find_module._keyword_match_paths(
+        tmp_path, "employment", "kb", k=None
+    ) == find_module._keyword_match_paths(tmp_path, "employment", "kb")
+
+
+@needs_fts5
 def test_keyword_parity_vault_scope(tmp_path, monkeypatch):
     _parity_corpus(tmp_path)
     _write_page(tmp_path, "Projects/outside.md", "employment beyond the kb", updated="2026-07-01")


### PR DESCRIPTION
Addresses part of #516. **#516 stays open** — see "What this does not fix" below.

## The lane contract

`find_candidates` bounds every lane it fuses — vector at `candidate_k * 3`, BM25 at `candidate_k * 8`, the graph lanes at `candidate_k` — except the keyword one, which took no `k` at all and answered with **every** matching page in the vault. On a 2 900-page corpus that is 2 900 paths through `collapse_frame_children`, `_eligible` and the fuse, on every call, to produce eight suggestions.

The bound has to live inside the lane, not at the caller. The lane answers in `updated` desc order, so slicing the return value would only be reading recency order if the order had already been applied — which is exactly what the sidecar's SQL `LIMIT` and the reference scan's truncation do. Both backends truncate identically, so a bounded result is a literal prefix of the unbounded one and parity holds at any `k`.

Over-fetch is `candidate_k * 3`, matching the BM25 lane and for the same reason: `collapse_frame_children` and `_eligible` can drop members, so a lane supplying exactly the fused depth could arrive under it.

## What this does not fix

`suggest_links` is still slow, and I measured rather than assumed. On a 2 900-page synthetic vault the keyword lane costs **~3.5 s per call with or without the bound** (3531 ms → 3488 ms; a second run 3536 ms → 3107 ms — noise-dominated either way).

The profile says where it actually goes, and it is not the row count:

```
14.838s cumulative over 3 queries
  lexstore.search_substring
  -> _serve_synced_live_catalog -> _ensure_synced        14.786s
     -> freshness.recall_checkpoint -> recall_triple     14.783s
        -> recall_policy.iter_recall_markdown            11.907s   (8 703 calls)
           -> is_recall_candidate                        10.594s   (8 700 calls)
              -> _canonical_parts_after_safe_validation   5.004s
                 -> Path.resolve                          5.760s  (26 115 calls)
                    -> nt._getfinalpathname               4.700s  (52 230 calls)
              -> nt.stat                                  4.692s  (75 864 calls)
```

Every query re-walks the whole corpus through the recall-admission policy, and `_needs_canonical_alias_check` returns `True` **only on `nt`**, so every page pays `Path.resolve` — a `_getfinalpathname` syscall — to catch an 8.3 short-name alias. Roughly 3 resolves and 9 stats per page, per call. That is consistent with the issue's report, which was measured on Windows.

I tried the obvious cheap half — memoizing the resolved vault root, which is invariant across the walk — and **reverted it**: 3443 ms vs 3536 ms, inside noise, for a cache and a lock. Not worth the complexity, and shipping an unmeasured optimization is how this subsystem got hard to reason about in the first place.

The real fix is to stop re-deriving the canonical spelling per page — the alias check for a directory is the same for every file in it — but that is a restructuring of a security-adjacent path and deserves its own change with its own tests. The profile is recorded on #516.

## Tests

- `test_a_bounded_keyword_lane_is_the_unbounded_prefix_on_both_backends`, parametrised over `k` in `{0, 1, 2, 5, 100}`: the bounded result is a literal prefix of the unbounded one *and* the two backends agree at that `k`. The parity gate is worth nothing if it only holds unbounded.
- `test_an_unbounded_keyword_lane_is_unchanged`: `k=None` is the existing contract, which every other caller still passes.
- `tests/test_lexstore.py`, `test_lexical_backend_fallback.py`, `test_find_candidates_architecture.py`, `test_hybrid_search.py`: 70 passed, 1 skipped (no `sentence_transformers` locally).