### PR TITLE
feat(hooks): uninstall what install-hook wired, yadm sources included

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -527,12 +527,30 @@ hook if it asks. Re-running `install-hook` migrates only exact legacy
 preserves unrelated hooks (including any user-owned Codex `SessionEnd`), backs
 up changed valid config, and is otherwise idempotent.
 
-There is intentionally no uninstall command. To roll back manually, remove only
-the Exomem continuation groups whose commands name
-`exomem_continuation_checkpoint.py` or
-`exomem-continuation-checkpoint.sh` and pass the matching explicit
-`--client`; remove those two deployed files if no group uses them, then reload
-the client. Existing checkpoint state is inert and may be deleted separately.
+To roll it back:
+
+```bash
+uv run python -m exomem install-hook --uninstall
+```
+
+That removes only the entries this installed — recognised the same way the
+idempotent install recognises its own, so a hook you wrote yourself in the same
+group survives — and then deletes the scripts it deployed. Add `--keep-scripts`
+to unwire the config but leave the yadm-synced hook tree in place, `--client
+codex` (or `--client all`) to pick the client, and `--json` for the machine
+report. Restart the client afterwards; it keeps running the hooks it already
+loaded. Existing checkpoint state is inert and may be deleted separately.
+
+**If your dotfiles are yadm-managed, the deployed file is not the file that
+matters.** Where `settings.json` is produced from alternates
+(`settings.json##os.Msys`, `##os.WSL`, and so on), yadm regenerates it from the
+source whenever alternate selection runs — and an ordinary `yadm status` is
+enough to trigger that, so hooks removed from the deployed file reappear with no
+obvious cause. `--uninstall` finds those sources and prunes them too, then tells
+you to commit them: until the change is committed, the next machine to sync
+restores the hooks from the committed copy. A source it cannot parse (a yadm
+template) is named in the report and exits non-zero rather than being rewritten
+blind.
 
 Tune with `EXOMEM_CAPTURE_NUDGE_MIN_CHARS` / `EXOMEM_RETRIEVE_NUDGE_MIN_CHARS` (and the
 matching `_COOLDOWN_SEC`), `EXOMEM_RETRIEVE_NUDGE_CONTROL_MAX_CHARS` for the read

--- a/docs/ai-assistant-guide.md
+++ b/docs/ai-assistant-guide.md
@@ -380,12 +380,13 @@ Re-running installation performs a narrow migration: only exact legacy
 `kb_continuation_checkpoint.py` and `kb-continuation-checkpoint.sh` basenames are
 retired, unrelated hook order is preserved, user-owned Codex `SessionEnd`
 handlers stay untouched, and changed valid config is backed up and replaced
-atomically. Malformed config fails closed. For manual rollback, remove only the
-Exomem groups invoking `exomem_continuation_checkpoint.py` or
-`exomem-continuation-checkpoint.sh` with that group's explicit `--client`, then
-remove the two deployed files if unused and reload the client. The local state
-is inert afterward and can be deleted independently; no uninstall command is
-provided.
+atomically. Malformed config fails closed. `install-hook --uninstall` rolls the
+whole thing back: it removes only the entries this installed and then the
+scripts it deployed, `--keep-scripts` unwires the config alone, and where the
+config is deployed by yadm alternates it prunes the `##os.*` sources as well —
+without that, the next alternate selection regenerates the deployed file and the
+hooks return. The local state is inert afterward and can be deleted
+independently.
 
 Codex reads repository instructions from `AGENTS.md`. Put the instruction block
 there, or keep an equivalent policy. Restart Codex sessions after changing MCP

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -1618,10 +1618,59 @@ def _install_hook_main(argv: list[str]) -> int:
         action="store_true",
         help="Read-only health check for deployed Claude Code/Codex hooks; writes nothing.",
     )
+    parser.add_argument(
+        "--uninstall",
+        action="store_true",
+        help=(
+            "Remove the entries and scripts this installed, and nothing else; "
+            "also edits any yadm alternate sources, which is what makes the "
+            "removal survive the next alternate selection."
+        ),
+    )
+    parser.add_argument(
+        "--keep-scripts",
+        action="store_true",
+        help="With --uninstall: unwire the hook config but leave the scripts on disk.",
+    )
     parser.add_argument("--json", action="store_true", help="emit stable JSON")
     args = parser.parse_args(argv)
 
     from . import install_hook as hook_module
+
+    if args.uninstall:
+        if args.check or args.print_only:
+            parser.error("--uninstall cannot be combined with --check or --print-only")
+        if args.client == "all":
+            if args.hook_dir or args.settings:
+                parser.error("--client all cannot be combined with --hook-dir or --settings")
+            report = hook_module.uninstall_all_hooks(remove_scripts=not args.keep_scripts)
+            if args.json:
+                print(json.dumps(report))
+            else:
+                for row in report["clients"]:
+                    if "result" in row:
+                        print(hook_module.render_uninstall_human(row["result"]))
+                    else:
+                        print(
+                            f"Failed to uninstall hooks for {row['client']}: {row['error']}",
+                            file=sys.stderr,
+                        )
+            return 0 if report["success"] else 1
+        try:
+            report = hook_module.uninstall_hook(
+                hook_dir=args.hook_dir,
+                settings_path=args.settings,
+                client=args.client or "claude",
+                remove_scripts=not args.keep_scripts,
+            )
+        except (OSError, RuntimeError, ValueError) as e:
+            print(f"exomem install-hook --uninstall: {e}", file=sys.stderr)
+            return 1
+        if args.json:
+            print(json.dumps(report))
+        else:
+            print(hook_module.render_uninstall_human(report))
+        return 0 if report["success"] else 1
 
     if args.check:
         if (args.hook_dir or args.settings) and args.client in {None, "all"}:

--- a/src/exomem/install_hook.py
+++ b/src/exomem/install_hook.py
@@ -1196,16 +1196,24 @@ def _write_unique(path: Path, raw: bytes, mode: int) -> None:
         _write_unique_at(directory, path.name, raw, mode)
 
 
-def _merge_hooks(path: Path, installed: list[dict], timeout: int) -> dict:
-    """Fail-closed, drift-aware, same-directory atomic hook-config migration."""
+def _rewrite_hooks(path: Path, transform, *, create: bool = True) -> dict:
+    """Fail-closed, drift-aware, same-directory atomic hook-config migration.
+
+    `transform` maps the config read from disk to the config to write, and
+    returning it unchanged is how "nothing to do" is reported. Install merges
+    its entries in and uninstall prunes them out, but both need precisely this
+    loop -- the retry on concurrent drift, the backup, the same-directory
+    atomic replace -- and a second copy of it would be a second place for
+    those windows to be got wrong.
+    """
     from ._hooks import exomem_continuation_checkpoint as safe
 
     path = Path(path).expanduser()
-    with safe._open_secure_directory(path.parent, create=True) as parent:
+    with safe._open_secure_directory(path.parent, create=create) as parent:
         safe._require_trusted_directory(parent)
         for _attempt in range(3):
             initial = _snapshot_config_at(parent, path.name, path)
-            merged = _merged_config(initial["data"], installed, timeout)
+            merged = transform(initial["data"])
             if merged == initial["data"]:
                 return {"changed": False, "backup": None}
             observed = _snapshot_config_at(parent, path.name, path)
@@ -1250,6 +1258,10 @@ def _merge_hooks(path: Path, installed: list[dict], timeout: int) -> dict:
             backup = path.parent / backup_name if backup_name else None
             return {"changed": True, "backup": str(backup) if backup else None}
     raise RuntimeError(f"concurrent hook config changes persisted at {path}")
+
+
+def _merge_hooks(path: Path, installed: list[dict], timeout: int) -> dict:
+    return _rewrite_hooks(path, lambda data: _merged_config(data, installed, timeout))
 
 
 def _mark_restart_pending(hook_dir: Path) -> None:
@@ -1361,6 +1373,283 @@ def install_all_hooks(*, wire: bool = True, timeout: int = 10) -> dict:
             )
     return {"success": all(row["success"] for row in reports), "clients": reports}
 
+
+# Every file name install-hook has ever deployed, current and legacy. Uninstall
+# has to know the legacy names too: a machine installed before the kb -> exomem
+# rename still has those scripts on disk and those entries in its config, and an
+# uninstall that leaves them behind has not uninstalled anything the user can see.
+_DEPLOYED_NAMES = (
+    *(name for py_name, sh_name, _event in _HOOK_SPECS for name in (py_name, sh_name)),
+    _CONTINUATION_SCRIPT,
+    _CONTINUATION_WRAPPER,
+    *_CONTINUATION_LEGACY,
+    "kb_capture_nudge.py",
+    "kb-capture-nudge.sh",
+    "kb_retrieve_nudge.py",
+    "kb-retrieve-nudge.sh",
+)
+
+
+def _is_exomem_entry(hook: dict) -> bool:
+    """True for an entry install-hook wrote, in any shape it has ever written.
+
+    Deliberately wider than `_is_matching_entry`, which asks "is this the entry
+    I am about to replace?" and so requires the client argument to agree.
+    Uninstall asks a different question -- "did we put this here?" -- and an
+    entry naming our own continuation script is ours whichever client wired it.
+    Narrowing it to one client would strand the other client's entry in a file
+    the user asked to be cleaned out.
+    """
+    if _contains_any(hook, _MARKERS):
+        return True
+    command = f"{hook.get('command', '')} {hook.get('commandWindows', '')}"
+    continuation = {_CONTINUATION_SCRIPT, _CONTINUATION_WRAPPER, *_CONTINUATION_LEGACY}
+    return bool(_command_basenames(command).intersection(continuation))
+
+
+def _pruned_config(source: dict) -> tuple[dict, int]:
+    """Drop every entry we own, and only the containers that became ours-only.
+
+    Walks every event rather than the events the current specs name, because a
+    config wired by an older exomem carries events this build no longer
+    installs -- Claude's `SessionEnd`, the legacy `kb_*` nudges -- and those are
+    exactly the entries a user uninstalling cannot find by hand.
+
+    A group emptied by that removal goes with it, and an event left with no
+    groups goes too: both only existed to hold our entry. A group that was
+    already empty stays, because it was not ours to remove.
+    """
+    data = json.loads(json.dumps(source))
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return data, 0
+    removed = 0
+    for event in list(hooks):
+        groups = hooks[event]
+        if not isinstance(groups, list):
+            continue
+        kept: list = []
+        for group in groups:
+            if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
+                kept.append(group)
+                continue
+            original = group["hooks"]
+            remaining = [
+                hook
+                for hook in original
+                if not (isinstance(hook, dict) and _is_exomem_entry(hook))
+            ]
+            removed += len(original) - len(remaining)
+            if len(remaining) == len(original):
+                kept.append(group)
+            elif remaining:
+                kept.append({**group, "hooks": remaining})
+        if kept:
+            hooks[event] = kept
+        else:
+            del hooks[event]
+    return data, removed
+
+
+def _alternate_sources(path: Path) -> list[Path]:
+    """The yadm alternate sources a deployed config is regenerated from.
+
+    `yadm alt` re-runs alternate selection after ordinary commands -- `yadm
+    status` is enough -- and rewrites the deployed file from these, so an
+    uninstall that edits only the deployed file is silently undone with no
+    visible trigger (#580). Editing the source is the edit that survives.
+
+    Detection is by name (`settings.json##os.Msys`) plus, where yadm links
+    rather than copies, the link target. Whether a source is plain JSON or a
+    template is decided later by trying to parse it, so this does not have to
+    encode yadm's condition grammar to stay correct.
+    """
+    sources: list[Path] = []
+    try:
+        for item in sorted(path.parent.iterdir()):
+            if item.name.startswith(f"{path.name}##") and not item.is_symlink():
+                sources.append(item)
+    except OSError:
+        return []
+    if path.is_symlink():
+        try:
+            target = path.resolve(strict=True)
+        except OSError:
+            target = None
+        if target is not None and "##" in target.name and target not in sources:
+            sources.append(target)
+    return [item for item in sources if item.is_file()]
+
+
+def _prune_one_config(path: Path) -> dict:
+    """Prune one config file, reporting rather than raising on its own failure.
+
+    An uninstall spanning a deployed file and two alternate sources must not
+    stop at the first unreadable one: the whole point is to leave nothing
+    behind, and a template source that cannot be parsed is a thing to name, not
+    a reason to abandon the sources beside it.
+    """
+    counted = {"removed": 0}
+
+    def prune(data: dict) -> dict:
+        pruned, removed = _pruned_config(data)
+        counted["removed"] = removed
+        return pruned
+
+    report: dict = {
+        "path": str(path),
+        "changed": False,
+        "backup": None,
+        "removed": 0,
+        "error": None,
+    }
+    try:
+        migration = _rewrite_hooks(path, prune, create=False)
+    except FileNotFoundError:
+        return report
+    except (OSError, RuntimeError, ValueError) as error:
+        report["error"] = str(error)
+        return report
+    report["changed"] = migration["changed"]
+    report["backup"] = migration["backup"]
+    report["removed"] = counted["removed"]
+    return report
+
+
+def _remove_deployed_scripts(hook_dir: Path) -> list[dict]:
+    """Remove the scripts we deployed, one name at a time, never the directory.
+
+    The hook directory is shared with every other hook the user runs, so this
+    unlinks only names this installer writes. `_unlink_at` refuses anything that
+    is not a regular file, which also means a yadm-linked hook tree is reported
+    rather than broken.
+    """
+    from ._hooks import exomem_continuation_checkpoint as safe
+
+    removed: list[dict] = []
+    try:
+        with safe._open_secure_directory(hook_dir, create=False) as directory:
+            for name in _DEPLOYED_NAMES:
+                if safe._existing_kind(directory, name) is None:
+                    continue
+                entry: dict = {
+                    "path": str(hook_dir / name),
+                    "removed": False,
+                    "error": None,
+                }
+                try:
+                    safe._unlink_at(directory, name)
+                    entry["removed"] = True
+                except OSError as error:
+                    entry["error"] = str(error)
+                removed.append(entry)
+    except OSError:
+        # A hook directory that is gone, or that the secure-open refuses, is a
+        # thing to report through the config side of the report rather than a
+        # reason to fail the unwiring that already succeeded.
+        return removed
+    return removed
+
+
+def uninstall_hook(
+    *,
+    hook_dir: Path | None = None,
+    settings_path: Path | None = None,
+    client: str = DEFAULT_CLIENT,
+    remove_scripts: bool = True,
+) -> dict:
+    """Undo `install_hook`: unwire our entries, then remove our scripts.
+
+    Removes only what this installer wrote -- recognised the same way the
+    idempotent install recognises its own entries -- so a hand-written hook
+    sitting in the same group survives, and so does the rest of the config.
+
+    Returns {"client", "settings", "config_changed", "removed_entries",
+    "backup", "settings_error", "alternates", "hook_dir", "scripts", "success"}.
+    Never raises for a config it could not read: an uninstall reports what it
+    could not reach, because the user still has to go and finish it by hand.
+    """
+    client = _normalize_client(client)
+    hook_dir = Path(hook_dir).expanduser() if hook_dir else _default_hook_dir(client)
+    settings = Path(settings_path).expanduser() if settings_path else _default_settings(client)
+
+    deployed = _prune_one_config(settings)
+    alternates = [_prune_one_config(source) for source in _alternate_sources(settings)]
+    scripts = _remove_deployed_scripts(hook_dir) if remove_scripts else []
+    return {
+        "client": client,
+        "settings": str(settings),
+        "config_changed": deployed["changed"],
+        "removed_entries": deployed["removed"],
+        "backup": deployed["backup"],
+        "settings_error": deployed["error"],
+        "alternates": alternates,
+        "hook_dir": str(hook_dir),
+        "scripts": scripts,
+        "success": deployed["error"] is None
+        and all(row["error"] is None for row in alternates)
+        and all(row["error"] is None for row in scripts),
+    }
+
+
+def uninstall_all_hooks(*, remove_scripts: bool = True) -> dict:
+    reports: list[dict] = []
+    for client in SUPPORTED_CLIENTS:
+        try:
+            result = uninstall_hook(client=client, remove_scripts=remove_scripts)
+            reports.append({"client": client, "success": result["success"], "result": result})
+        except (OSError, RuntimeError, ValueError) as error:
+            reports.append(
+                {
+                    "client": client,
+                    "success": False,
+                    "error": str(error),
+                    "error_class": type(error).__name__,
+                }
+            )
+    return {"success": all(row["success"] for row in reports), "clients": reports}
+
+
+def render_uninstall_human(report: dict) -> str:
+    """The uninstall summary, including the part a user cannot infer.
+
+    An edited alternate source is not yet an uninstall that sticks: yadm
+    regenerates the deployed file from its committed copy, so an uncommitted
+    source edit is undone by the next sync. Saying so here is the difference
+    between this landing and the hooks quietly reappearing later (#580).
+    """
+    lines: list[str] = []
+    label = "Codex" if report["client"] == "codex" else "Claude Code"
+    count = report["removed_entries"]
+    if report["config_changed"]:
+        noun = "entry" if count == 1 else "entries"
+        lines.append(f"Removed {count} exomem hook {noun} from {report['settings']}.")
+    elif report["settings_error"]:
+        lines.append(f"Could not update {report['settings']}: {report['settings_error']}")
+    else:
+        lines.append(f"No exomem hook entries were wired in {report['settings']}.")
+    for row in report["alternates"]:
+        if row["error"]:
+            lines.append(f"  ! yadm alternate {row['path']}: {row['error']}")
+        elif row["changed"]:
+            lines.append(f"  also removed from yadm alternate source {row['path']}")
+        else:
+            lines.append(f"  yadm alternate source {row['path']} had none")
+    if report["alternates"]:
+        lines.append(
+            "Those are yadm alternate sources: commit them, or the next alternate "
+            "selection (an ordinary yadm status triggers one) regenerates the "
+            "deployed file from the committed copy and the hooks come back."
+        )
+    gone = [row for row in report["scripts"] if row["removed"]]
+    stuck = [row for row in report["scripts"] if not row["removed"]]
+    if gone:
+        noun = "script" if len(gone) == 1 else "scripts"
+        lines.append(f"Removed {len(gone)} hook {noun} from {report['hook_dir']}.")
+    for row in stuck:
+        lines.append(f"  ! left {row['path']}: {row['error']}")
+    lines.append(f"Restart {label} to stop running the hooks it already loaded.")
+    return "\n".join(lines)
 
 def _continuation_root(client: str) -> Path:
     """The one place the checkpoint-store layout rule lives for readers."""

--- a/tests/test_install_hook_uninstall.py
+++ b/tests/test_install_hook_uninstall.py
@@ -1,0 +1,361 @@
+"""`install-hook --uninstall`: undo the wiring, including where it hides.
+
+Installing wired entries into the client's config and copied scripts into its
+hook directory; until now the only way back out was hand-editing JSON. That is
+bad on its own, and on a yadm-managed machine it is worse than it looks: the
+deployed config is regenerated from `settings.json##os.*` sources whenever
+alternate selection runs, which ordinary commands like `yadm status` trigger.
+Hooks removed from the deployed file therefore come back with no visible cause,
+and stay gone only once every source is edited too (#580).
+
+So these pin three things: uninstall removes what install added and leaves
+everything else alone, it reaches the alternate sources rather than only the
+file they overwrite, and where it cannot finish the job it says so instead of
+reporting success.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from exomem import install_hook as hook_module
+
+FOREIGN = {
+    "type": "command",
+    "command": "bash ~/.claude/hooks/somebody-elses-hook.sh",
+    "timeout": 7,
+}
+
+
+def _install(tmp_path: Path, client: str = "claude") -> tuple[Path, Path]:
+    hook_dir = tmp_path / "hooks"
+    settings = tmp_path / ("hooks.json" if client == "codex" else "settings.json")
+    hook_module.install_hook(hook_dir=hook_dir, settings_path=settings, client=client)
+    return hook_dir, settings
+
+
+def _entries(data: dict) -> list[dict]:
+    return [
+        hook
+        for groups in data.get("hooks", {}).values()
+        for group in groups
+        if isinstance(group, dict)
+        for hook in group.get("hooks", [])
+    ]
+
+
+def _ours(data: dict) -> list[dict]:
+    return [hook for hook in _entries(data) if hook_module._is_exomem_entry(hook)]
+
+
+def _add_foreign(settings: Path) -> None:
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    data["hooks"]["Stop"][0]["hooks"].append(FOREIGN)
+    data["hooks"]["Notification"] = [{"matcher": "*", "hooks": [FOREIGN]}]
+    data["theme"] = "dark"
+    settings.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def test_uninstall_removes_our_entries_and_leaves_the_rest_of_the_config(
+    tmp_path: Path,
+) -> None:
+    """The whole risk of an automated uninstall is that it takes too much.
+
+    A user's own hook shares the group we wired ours into, so removing the
+    group wholesale -- the obvious implementation -- would delete a hook exomem
+    never installed and cannot restore.
+    """
+    hook_dir, settings = _install(tmp_path)
+    _add_foreign(settings)
+    assert _ours(json.loads(settings.read_text(encoding="utf-8")))
+
+    report = hook_module.uninstall_hook(hook_dir=hook_dir, settings_path=settings)
+
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert report["success"] is True
+    assert report["config_changed"] is True
+    assert report["removed_entries"] == 5
+    assert _ours(data) == []
+    assert FOREIGN in _entries(data)
+    assert data["hooks"]["Notification"] == [{"matcher": "*", "hooks": [FOREIGN]}]
+    assert data["theme"] == "dark"
+
+
+def test_an_event_left_holding_nothing_of_ours_goes_with_the_entry(
+    tmp_path: Path,
+) -> None:
+    """Our own containers are ours to remove; a user's empty one is not.
+
+    `UserPromptSubmit` exists in the config only because we wired the retrieval
+    nudge into it, so leaving `"UserPromptSubmit": [{"matcher": ..., "hooks":
+    []}]` behind is residue of an uninstall, not configuration. An empty group
+    the user wrote is a different thing and stays.
+    """
+    hook_dir, settings = _install(tmp_path)
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    data["hooks"]["PreToolUse"] = [{"matcher": "Bash", "hooks": []}]
+    settings.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    hook_module.uninstall_hook(hook_dir=hook_dir, settings_path=settings)
+
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert "UserPromptSubmit" not in data["hooks"]
+    assert "Stop" not in data["hooks"]
+    assert data["hooks"]["PreToolUse"] == [{"matcher": "Bash", "hooks": []}]
+
+
+def test_uninstall_removes_the_scripts_it_deployed_and_only_those(
+    tmp_path: Path,
+) -> None:
+    """The hook directory belongs to every hook the user runs, not to us."""
+    hook_dir, settings = _install(tmp_path)
+    stranger = hook_dir / "somebody-elses-hook.sh"
+    stranger.write_text("echo hi\n", encoding="utf-8")
+
+    report = hook_module.uninstall_hook(hook_dir=hook_dir, settings_path=settings)
+
+    assert not (hook_dir / "exomem_capture_nudge.py").exists()
+    assert not (hook_dir / "exomem-retrieve-nudge.sh").exists()
+    assert not (hook_dir / "exomem_continuation_checkpoint.py").exists()
+    assert stranger.exists()
+    assert all(row["removed"] for row in report["scripts"])
+    assert hook_dir.is_dir()
+
+
+def test_keep_scripts_unwires_without_deleting_a_synced_hook_tree(
+    tmp_path: Path,
+) -> None:
+    """The hook tree is deliberately yadm-synced, so deleting it is a choice.
+
+    A user turning the hooks off on one machine may well want the scripts to
+    stay -- they are shared across machines by design -- and re-wiring later
+    should not need the package again.
+    """
+    hook_dir, settings = _install(tmp_path)
+
+    report = hook_module.uninstall_hook(
+        hook_dir=hook_dir, settings_path=settings, remove_scripts=False
+    )
+
+    assert report["scripts"] == []
+    assert (hook_dir / "exomem_capture_nudge.py").exists()
+    assert _ours(json.loads(settings.read_text(encoding="utf-8"))) == []
+
+
+def test_a_second_uninstall_changes_nothing_and_writes_no_backup(
+    tmp_path: Path,
+) -> None:
+    """Idempotent in the same sense install is, and quiet about it.
+
+    A no-op that still rewrites the file would churn a yadm-tracked config into
+    a permanent diff, which is precisely the noise this feature exists to end.
+    """
+    hook_dir, settings = _install(tmp_path)
+    hook_module.uninstall_hook(hook_dir=hook_dir, settings_path=settings)
+    before = settings.read_bytes()
+
+    report = hook_module.uninstall_hook(hook_dir=hook_dir, settings_path=settings)
+
+    assert report["config_changed"] is False
+    assert report["removed_entries"] == 0
+    assert report["backup"] is None
+    assert settings.read_bytes() == before
+    assert len(list(tmp_path.glob("settings.json.backup-*"))) == 1
+
+
+def test_an_absent_config_is_nothing_to_do_rather_than_an_error(
+    tmp_path: Path,
+) -> None:
+    """Uninstalling a client that was never installed must not fail the run."""
+    report = hook_module.uninstall_hook(
+        hook_dir=tmp_path / "hooks", settings_path=tmp_path / "settings.json"
+    )
+
+    assert report["success"] is True
+    assert report["config_changed"] is False
+    assert report["scripts"] == []
+
+
+def test_entries_from_the_pre_rename_install_are_removed_too(tmp_path: Path) -> None:
+    """The machines most in need of an uninstall are the oldest ones.
+
+    A config wired before the kb -> exomem rename carries `kb-capture-nudge.sh`
+    and a `SessionEnd` continuation entry this build no longer installs. Both
+    are ours, both are invisible to a user hunting by name, and an uninstall
+    scoped to the events the current specs happen to name would walk past them.
+    """
+    settings = tmp_path / "settings.json"
+    settings.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "Stop": [
+                        {
+                            "matcher": "*",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "bash ~/.claude/hooks/kb-capture-nudge.sh",
+                                    "timeout": 10,
+                                }
+                            ],
+                        }
+                    ],
+                    "SessionEnd": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": (
+                                        "bash ~/.claude/hooks/kb-continuation-checkpoint.sh"
+                                    ),
+                                    "timeout": 5,
+                                }
+                            ]
+                        }
+                    ],
+                }
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = hook_module.uninstall_hook(
+        hook_dir=tmp_path / "hooks", settings_path=settings
+    )
+
+    assert report["removed_entries"] == 2
+    assert json.loads(settings.read_text(encoding="utf-8")) == {"hooks": {}}
+
+
+def test_a_yadm_alternate_source_is_pruned_beside_the_deployed_file(
+    tmp_path: Path,
+) -> None:
+    """The edit that actually sticks.
+
+    Editing only the deployed file is undone the next time alternate selection
+    runs, and that run needs no user intent -- `yadm status` is enough. The
+    reported incident ended exactly here: the hooks stayed removed only once
+    both the Msys and WSL sources were edited directly.
+    """
+    hook_dir, settings = _install(tmp_path)
+    deployed = settings.read_bytes()
+    msys = tmp_path / "settings.json##os.Msys"
+    wsl = tmp_path / "settings.json##os.WSL"
+    msys.write_bytes(deployed)
+    wsl.write_bytes(deployed)
+
+    report = hook_module.uninstall_hook(hook_dir=hook_dir, settings_path=settings)
+
+    assert report["success"] is True
+    assert {Path(row["path"]).name for row in report["alternates"]} == {
+        msys.name,
+        wsl.name,
+    }
+    assert all(row["changed"] for row in report["alternates"])
+    for source in (msys, wsl):
+        assert _ours(json.loads(source.read_text(encoding="utf-8"))) == []
+    assert "yadm alternate source" in hook_module.render_uninstall_human(report)
+    assert "committed copy" in hook_module.render_uninstall_human(report)
+
+
+def test_a_templated_alternate_is_named_rather_than_rewritten(tmp_path: Path) -> None:
+    """A source we cannot parse is an unfinished uninstall, and must read as one.
+
+    yadm templates are not JSON, so pruning them is not on the table -- but
+    reporting success would tell the user the hooks are gone when the next
+    render puts them straight back. Naming the file is the whole remedy
+    available, so it has to survive into the exit status.
+    """
+    hook_dir, settings = _install(tmp_path)
+    template = tmp_path / "settings.json##template.j2"
+    template.write_text("{% if yadm.os %}{ not json {% endif %}\n", encoding="utf-8")
+    before = template.read_bytes()
+
+    report = hook_module.uninstall_hook(hook_dir=hook_dir, settings_path=settings)
+
+    assert report["config_changed"] is True
+    assert report["success"] is False
+    assert len(report["alternates"]) == 1
+    assert report["alternates"][0]["error"]
+    assert template.read_bytes() == before
+    assert "! yadm alternate" in hook_module.render_uninstall_human(report)
+
+
+def test_codex_hooks_json_is_uninstalled_the_same_way(tmp_path: Path) -> None:
+    """Codex wires `command` + `commandWindows` into a different file name."""
+    hook_dir, settings = _install(tmp_path, client="codex")
+    assert _ours(json.loads(settings.read_text(encoding="utf-8")))
+
+    report = hook_module.uninstall_hook(
+        hook_dir=hook_dir, settings_path=settings, client="codex"
+    )
+
+    assert report["success"] is True
+    assert _ours(json.loads(settings.read_text(encoding="utf-8"))) == []
+    assert not (hook_dir / "exomem_capture_nudge.py").exists()
+
+
+def test_the_cli_uninstalls_and_reports_json(tmp_path: Path) -> None:
+    """The surface the issue asked for, exercised end to end."""
+    hook_dir, settings = _install(tmp_path)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "exomem",
+            "install-hook",
+            "--uninstall",
+            "--hook-dir",
+            str(hook_dir),
+            "--settings",
+            str(settings),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    report = json.loads(completed.stdout)
+    assert report["config_changed"] is True
+    assert _ours(json.loads(settings.read_text(encoding="utf-8"))) == []
+
+
+def test_the_cli_refuses_uninstall_combined_with_check(tmp_path: Path) -> None:
+    """Two opposite intents in one invocation is a typo, not a request."""
+    completed = subprocess.run(
+        [sys.executable, "-m", "exomem", "install-hook", "--uninstall", "--check"],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+    assert completed.returncode == 2
+    assert "--uninstall cannot be combined" in completed.stderr
+
+
+@pytest.mark.parametrize("client", ["claude", "codex"])
+def test_install_after_uninstall_wires_a_clean_config(
+    tmp_path: Path, client: str
+) -> None:
+    """Uninstall must leave a shape install can build on, not just an empty one."""
+    hook_dir, settings = _install(tmp_path, client=client)
+    hook_module.uninstall_hook(
+        hook_dir=hook_dir, settings_path=settings, client=client
+    )
+
+    hook_module.install_hook(hook_dir=hook_dir, settings_path=settings, client=client)
+
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    expected = len(hook_module._HOOK_SPECS) + len(hook_module._CONTINUATION_EVENTS[client])
+    assert len(_ours(data)) == expected


### PR DESCRIPTION
Closes #580.

`install-hook` copied scripts into the client's hook directory and merged entries into its config, and there was no way back — removing the hooks meant hand-editing JSON. On a yadm-managed machine that edit does not even hold: the deployed `settings.json` is regenerated from its `##os.*` sources whenever alternate selection runs, and an ordinary `yadm status` triggers one, so hooks removed from the deployed file reappear with no visible cause. The reported incident ended exactly there — the hooks stayed gone only once both the Msys and WSL sources were edited directly.

## What `--uninstall` does

- **Removes only what this installer wrote.** Entries are recognised the same way the idempotent install recognises its own, so a hook you wrote yourself sharing the group survives, as does the rest of the config.
- **Walks every event, not the events the current specs name.** A config wired before the `kb` → `exomem` rename carries legacy nudges and a `SessionEnd` continuation entry this build no longer installs. Those are ours, they are invisible to someone hunting by name, and an uninstall scoped to today's specs walks straight past them.
- **Cleans up its own containers, not yours.** A group emptied by the removal goes with it and so does an event left with no groups — both existed only to hold our entry. A group the user left empty stays.
- **Prunes the yadm alternate sources** beside the deployed file, which is the edit that actually survives, then says to commit them: until the change is committed, the next machine to sync restores the hooks from the committed copy.
- **Names what it cannot finish.** A source that will not parse as JSON (a yadm template) is reported and fails the exit status rather than being rewritten blind — reporting success there would tell the user the hooks are gone when the next render puts them straight back.
- `--keep-scripts` unwires the config but leaves the deliberately yadm-synced hook tree in place. `--client all` and `--json` work as they do elsewhere.

Install and uninstall now share one `_rewrite_hooks` loop taking a transform, so the concurrent-drift retry, the backup, and the same-directory atomic replace have one implementation instead of two — the alternative was a second copy of the trickiest code in the module.

## Verification

- `tests/test_install_hook_uninstall.py` — 14 new tests: foreign hooks and unrelated config survive; the hook directory keeps files we did not deploy; pre-rename entries are removed; alternate sources are pruned and the template case is reported; a second uninstall changes nothing and writes no backup (a no-op rewrite would churn a yadm-tracked config into a permanent diff); install-after-uninstall wires a clean config for both clients; the CLI path end to end, including that `--uninstall --check` is refused.
- `tests/test_install_hook.py` — 105 passed. The 4 local failures (`bash` rc=127 in a path with a space) reproduce identically on `main` at this commit and are unrelated.
- `uvx ruff check . --select F` (the required lint gate) — clean.
- `scripts/generate-capabilities.py --check` — `docs/capabilities.md` is current.
- Docs: QUICKSTART's "There is intentionally no uninstall command" paragraph and the matching passage in `docs/ai-assistant-guide.md` are replaced with the command and the yadm caveat.
