### PR TITLE
fix(windows): tighten an inherited private DACL instead of refusing it

### DIFF
--- a/src/exomem/mutation_lock.py
+++ b/src/exomem/mutation_lock.py
@@ -713,6 +713,29 @@ def _windows_apply_private_dacl(path: Path, sid: str) -> None:
     _windows_apply_dacl_sddl(path, _windows_private_dacl_sddl(sid))
 
 
+def _windows_tighten_private_directory(
+    target: Path, directory: _SecureDirectory, sid: str
+) -> None:
+    """Protect a directory whose DACL already admits only the private trustees.
+
+    This is not the repair the module declines to perform. That one would rewrite
+    an entry whose ACEs let somebody else in, which cannot help: an ACL change
+    does not close a handle already opened against the old one, so the attacker
+    keeps the access and we would proceed believing otherwise. Here the caller
+    has established the opposite -- every trustee is one this module writes
+    itself -- so there is no such handle to close, and protecting the DACL only
+    removes the parent's future reach into it.
+
+    Applied by path, then proven through the retained handle by the caller's
+    re-validation. A path swapped in between gets our protected DACL, which is
+    harmless to us, while the handle we still hold reports the object we
+    validated -- so a swap fails the re-validation instead of passing it.
+    """
+    if not _same_directory_path(directory):
+        raise OSError("Windows directory changed before its DACL was protected")
+    _windows_apply_private_dacl(target, sid)
+
+
 def _windows_dacl_sddl(path: Path) -> str:
     """Read only the DACL text through native security APIs."""
     import ctypes
@@ -797,8 +820,41 @@ def _windows_dacl_sddl_for_handle(handle: int) -> str:
         kernel32.LocalFree(security_descriptor)
 
 
+_WINDOWS_DACL_PRIVATE = "private"
+_WINDOWS_DACL_INHERITED = "inherited"
+_WINDOWS_DACL_UNSAFE = "unsafe"
+
+
 def _windows_private_dacl_is_valid(sddl: str, sid: str, *, directory: bool) -> bool:
-    """Reject broad or altered ACEs; inherited file ACEs are accepted precisely.
+    """True only for a DACL this module would have written itself."""
+    return _windows_private_dacl_verdict(sddl, sid, directory=directory) == (
+        _WINDOWS_DACL_PRIVATE
+    )
+
+
+def _windows_private_dacl_verdict(sddl: str, sid: str, *, directory: bool) -> str:
+    """Classify one DACL as private, private-but-inheriting, or unsafe.
+
+    The middle verdict is the one that earns its keep. A directory whose ACEs
+    name exactly the private trustee set but arrive by inheritance -- no `P`,
+    every ACE flagged `ID` -- has never admitted anybody outside that set, so
+    nothing can hold a handle to it that this module would refuse to grant. It
+    is private in the sense that matters and wrong only in that a later change
+    to its parent would flow into it. That is repairable, and repairing it is
+    strictly a tightening; refusing it outright is not, because the entry is
+    never repaired and the caller is told to run `icacls` by hand.
+
+    Windows hands out that exact shape constantly: any directory created inside
+    an already-private parent inherits its ACEs rather than getting its own.
+    The CI runner's is `O:BA D:(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)(A;OICIID;FA;;;OW)`
+    -- SYSTEM, Administrators, and an owner in that set, and nothing else.
+
+    Anything else is still `unsafe`: a foreign trustee, a right other than full
+    access, a duplicate principal, a deny ACE, a malformed field count. Those
+    say a principal outside the private set may already hold access, and no
+    later tightening can take back a handle it has already opened.
+
+    Reject broad or altered ACEs; inherited file ACEs are accepted precisely.
 
     An `OWNER RIGHTS` (`OW`) ACE counts as the current user's grant, but only
     while the current user owns the object. That is a spelling difference, not a
@@ -817,10 +873,10 @@ def _windows_private_dacl_is_valid(sddl: str, sid: str, *, directory: bool) -> b
     created, and a pre-existing entry is validated and never repaired.
     """
     if not isinstance(sddl, str) or "D:" not in sddl:
-        return False
+        return _WINDOWS_DACL_UNSAFE
     dacl = sddl.split("D:", 1)[1]
-    if directory and not dacl.startswith("P"):
-        return False
+    protected = dacl.startswith("P")
+    inheriting = False
     aces = re.findall(r"\(([^()]*)\)", dacl)
     trustees = _windows_private_dacl_trustees(sid)
     expected = {trustee.casefold() for trustee in trustees}
@@ -833,16 +889,16 @@ def _windows_private_dacl_is_valid(sddl: str, sid: str, *, directory: bool) -> b
     for ace in aces:
         fields = ace.split(";")
         if len(fields) != 6:
-            return False
+            return _WINDOWS_DACL_UNSAFE
         kind, flags, rights, _object_guid, _inherit_object_guid, trustee = fields
         if kind != "A" or rights.casefold() not in {"fa", "0x1f01ff"}:
-            return False
+            return _WINDOWS_DACL_UNSAFE
         principal = trustee.casefold()
         if principal in _WINDOWS_OWNER_RIGHTS_TRUSTEES:
             # Unresolvable without the owner: an SDDL string carrying no `O:`
             # cannot show that this ACE admits us rather than somebody else.
             if not owner_is_current_user:
-                return False
+                return _WINDOWS_DACL_UNSAFE
             principal = user_principal
         elif principal in _windows_principal_spellings(sid):
             # An alias for the current user, most often `LA`. Unlike `OW` this
@@ -857,13 +913,21 @@ def _windows_private_dacl_is_valid(sddl: str, sid: str, *, directory: bool) -> b
         # `OW` alongside a literal grant to the same owner is one principal
         # named twice, which is exactly what the rule is here to reject.
         if principal not in expected or principal in observed:
-            return False
+            return _WINDOWS_DACL_UNSAFE
         normalized_flags = flags.casefold()
-        allowed = {"", "oici", "idoici", "id"} if not directory else {"oici"}
+        allowed = {"oici", "oiciid"} if directory else {"", "oici", "idoici", "id"}
         if normalized_flags not in allowed:
-            return False
+            return _WINDOWS_DACL_UNSAFE
+        if directory and normalized_flags != "oici":
+            inheriting = True
         observed.add(principal)
-    return observed == expected
+    if observed != expected:
+        return _WINDOWS_DACL_UNSAFE
+    if not directory:
+        return _WINDOWS_DACL_PRIVATE
+    if protected and not inheriting:
+        return _WINDOWS_DACL_PRIVATE
+    return _WINDOWS_DACL_INHERITED
 
 
 def _validate_windows_runtime_entry(
@@ -969,6 +1033,7 @@ def _prepare_windows_private_directory(path: Path) -> None:
             )
             return
         deadline = time.monotonic() + _WINDOWS_DACL_STABILIZATION_SECONDS
+        tightened = False
         while True:
             try:
                 _validate_windows_runtime_entry(
@@ -976,6 +1041,18 @@ def _prepare_windows_private_directory(path: Path) -> None:
                 )
                 return
             except WindowsRuntimeDaclError:
+                observed = _windows_dacl_sddl_for_handle(directory.windows_handle)
+                inherited = (
+                    _windows_private_dacl_verdict(observed, sid, directory=True)
+                    == _WINDOWS_DACL_INHERITED
+                )
+                # Once. A second attempt would mean the write did not take, and
+                # looping on that until the deadline turns a permission problem
+                # into a stall rather than the error it is.
+                if inherited and not tightened:
+                    tightened = True
+                    _windows_tighten_private_directory(target, directory, sid)
+                    continue
                 if time.monotonic() >= deadline:
                     raise
                 time.sleep(_WINDOWS_DACL_STABILIZATION_POLL_SECONDS)

--- a/tests/test_mutation_lock.py
+++ b/tests/test_mutation_lock.py
@@ -1387,3 +1387,218 @@ def test_the_administrators_owner_is_not_a_trustee_spelling() -> None:
     assert mutation_lock_module._windows_private_dacl_is_valid(
         literal, _LOCAL_ADMIN_SID, directory=True
     )
+
+
+# --- an inherited private DACL is tightened, not refused -------------------------
+#
+# Windows gives a directory created inside an already-private parent its
+# parent's ACEs by inheritance rather than a DACL of its own, so the entry is
+# private but unprotected. The validator demanded `D:P` with explicit `OICI`
+# flags and refused everything else, which failed closed on directories that
+# had never admitted anybody outside the private set -- 29 of 241 failures on
+# the Windows lane, all of them state roots created under a pytest temporary
+# directory. `tempfile.mkdtemp` protects its own root as
+# `D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;OW)`, and everything made
+# inside it inherits exactly that.
+
+_INHERITED_DACL = (
+    f"O:{_USER_SID}D:"
+    f"(A;OICIID;FA;;;{_USER_SID})(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)"
+)
+_INHERITED_OWNER_RIGHTS_DACL = (
+    f"O:{_USER_SID}D:(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)(A;OICIID;FA;;;OW)"
+)
+
+
+def test_an_inherited_private_dacl_is_reported_as_inherited_not_unsafe() -> None:
+    """The verdict the repair decision is made on.
+
+    Every trustee is one this module writes itself, so no principal outside the
+    private set can hold a handle to the entry. That is what separates this from
+    a DACL that must be refused: there is nothing to take back.
+    """
+    assert (
+        mutation_lock_module._windows_private_dacl_verdict(
+            _INHERITED_DACL, _USER_SID, directory=True
+        )
+        == mutation_lock_module._WINDOWS_DACL_INHERITED
+    )
+    assert not mutation_lock_module._windows_private_dacl_is_valid(
+        _INHERITED_DACL, _USER_SID, directory=True
+    )
+
+
+def test_the_runners_owner_rights_shape_is_inherited_rather_than_unsafe() -> None:
+    """The exact descriptor the Windows lane fails on, spelled with `OW`."""
+    assert (
+        mutation_lock_module._windows_private_dacl_verdict(
+            _INHERITED_OWNER_RIGHTS_DACL, _USER_SID, directory=True
+        )
+        == mutation_lock_module._WINDOWS_DACL_INHERITED
+    )
+
+
+def test_a_protected_private_dacl_stays_private() -> None:
+    """The verdict split must not disturb the descriptor this module writes."""
+    written = mutation_lock_module._windows_private_dacl_sddl(_USER_SID)
+
+    assert (
+        mutation_lock_module._windows_private_dacl_verdict(
+            f"O:{_USER_SID}{written}", _USER_SID, directory=True
+        )
+        == mutation_lock_module._WINDOWS_DACL_PRIVATE
+    )
+
+
+@pytest.mark.parametrize(
+    "trustee",
+    ["WD", "AU", "BU", "S-1-5-21-1-2-3-1002"],
+    ids=["everyone", "authenticated-users", "users", "another-account"],
+)
+def test_a_foreign_trustee_is_unsafe_however_it_arrived(trustee: str) -> None:
+    """Inheritance is not a defence, and this is the line that matters.
+
+    A trustee outside the private set means somebody else may already hold a
+    handle, and tightening a DACL does not close a handle opened against the
+    old one. So this stays a refusal rather than becoming a repair.
+    """
+    sddl = (
+        f"O:{_USER_SID}D:(A;OICIID;FA;;;{trustee})"
+        f"(A;OICIID;FA;;;{_USER_SID})(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)"
+    )
+
+    assert (
+        mutation_lock_module._windows_private_dacl_verdict(
+            sddl, _USER_SID, directory=True
+        )
+        == mutation_lock_module._WINDOWS_DACL_UNSAFE
+    )
+
+
+def test_partial_rights_are_unsafe_even_for_a_private_trustee() -> None:
+    """Full access is the grant this module writes; anything else is not it."""
+    sddl = (
+        f"O:{_USER_SID}D:(A;OICIID;0x1301bf;;;{_USER_SID})"
+        f"(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)"
+    )
+
+    assert (
+        mutation_lock_module._windows_private_dacl_verdict(
+            sddl, _USER_SID, directory=True
+        )
+        == mutation_lock_module._WINDOWS_DACL_UNSAFE
+    )
+
+
+def test_owner_rights_inherited_under_a_foreign_owner_is_unsafe() -> None:
+    """`OW` names whoever owns the entry, so the owner check still decides it."""
+    sddl = "O:S-1-5-21-9-9-9-1001D:(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)(A;OICIID;FA;;;OW)"
+
+    assert (
+        mutation_lock_module._windows_private_dacl_verdict(
+            sddl, _USER_SID, directory=True
+        )
+        == mutation_lock_module._WINDOWS_DACL_UNSAFE
+    )
+
+
+def test_an_inherited_file_ace_is_still_private() -> None:
+    """Files already accepted inheritance; the directory split must not move them."""
+    sddl = (
+        f"O:{_USER_SID}D:(A;ID;FA;;;{_USER_SID})(A;ID;FA;;;SY)(A;ID;FA;;;BA)"
+    )
+
+    assert (
+        mutation_lock_module._windows_private_dacl_verdict(
+            sddl, _USER_SID, directory=False
+        )
+        == mutation_lock_module._WINDOWS_DACL_PRIVATE
+    )
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows DACL semantics")
+def test_a_directory_inheriting_a_private_dacl_is_protected_in_place(
+    tmp_path: Path,
+) -> None:
+    """End to end on real Windows security, because the verdict is only half of it.
+
+    The entry this observes is built the way the runner's is: a parent carrying
+    the protected private DACL, and a child that inherits it. Before this, the
+    child was refused with a remediation the user had to run by hand in an
+    elevated shell.
+    """
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    sid = mutation_lock_module._windows_current_user_sid()
+    mutation_lock_module._windows_apply_private_dacl(parent, sid)
+    child = parent / "hosted-state"
+    child.mkdir()
+    observed = mutation_lock_module._windows_dacl_sddl(child)
+    assert (
+        mutation_lock_module._windows_private_dacl_verdict(observed, sid, directory=True)
+        == mutation_lock_module._WINDOWS_DACL_INHERITED
+    )
+
+    mutation_lock_module._prepare_windows_private_directory(child)
+
+    after = mutation_lock_module._windows_dacl_sddl(child)
+    assert mutation_lock_module._windows_private_dacl_is_valid(after, sid, directory=True)
+    assert after.split("D:", 1)[1].startswith("P")
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows DACL semantics")
+def test_a_directory_admitting_another_account_is_refused_and_left_alone(
+    tmp_path: Path,
+) -> None:
+    """The refusal path, on real security, including that it writes nothing.
+
+    Tightening here would be worse than refusing: the foreign grant means a
+    handle may already be open, and rewriting the DACL would hide that while
+    changing nothing about the access already obtained.
+    """
+    target = tmp_path / "state"
+    target.mkdir()
+    sid = mutation_lock_module._windows_current_user_sid()
+    mutation_lock_module._windows_apply_dacl_sddl(
+        target,
+        f"D:(A;OICIID;FA;;;AU)(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)(A;OICIID;FA;;;{sid})",
+    )
+    before = mutation_lock_module._windows_dacl_sddl(target)
+
+    with pytest.raises(mutation_lock_module.WindowsRuntimeDaclError):
+        mutation_lock_module._prepare_windows_private_directory(target)
+
+    assert mutation_lock_module._windows_dacl_sddl(target) == before
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows DACL semantics")
+def test_the_tightening_is_attempted_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A write that does not take is an error, not a reason to spin.
+
+    The stabilization wait exists for a creator that has not written its DACL
+    yet. Retrying our own failed write inside it would spend that whole budget
+    re-attempting something already known not to work, and report a timeout
+    instead of the permission failure that caused it.
+    """
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    sid = mutation_lock_module._windows_current_user_sid()
+    mutation_lock_module._windows_apply_private_dacl(parent, sid)
+    child = parent / "hosted-state"
+    child.mkdir()
+    attempts: list[Path] = []
+
+    def refuse(target: Path, directory: object, sid: str) -> None:
+        attempts.append(target)
+
+    monkeypatch.setattr(
+        mutation_lock_module, "_windows_tighten_private_directory", refuse
+    )
+    monkeypatch.setattr(mutation_lock_module, "_WINDOWS_DACL_STABILIZATION_SECONDS", 0.05)
+
+    with pytest.raises(mutation_lock_module.WindowsRuntimeDaclError):
+        mutation_lock_module._prepare_windows_private_directory(child)
+
+    assert attempts == [child]


### PR DESCRIPTION
The largest single cause on the Windows lane: 29 of 241 failures on `main` (run 32223246719), across `test_writer_lease`, `test_deferred_work_drain`, `test_governance_tokens` and `test_governance_receipt_runtime_bootstrap_windows`, all reported as

```
exomem.mutation_lock.WindowsRuntimeDaclError: unsafe Windows DACL at ...\hosted-state;
observed 'O:BAD:(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)(A;OICIID;FA;;;OW)';
expected full-access trustees S-1-5-21-...-500, SY, BA
```

## What that descriptor actually says

SYSTEM, Administrators, and an owner in that same set. Nothing else — no Users, no Authenticated Users, no other account. It is private. Its only defect is that it arrived by inheritance rather than being written: no `P`, every ACE flagged `ID`.

Windows produces that shape constantly, because a directory created inside an already-private parent inherits its parent's ACEs instead of getting a DACL of its own. `tempfile.mkdtemp` protects its own root as `D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;OW)` on Windows, so every runtime state root a test builds under it inherits exactly that — which is why this lands on the CI runner and on a developer box, and why it is 29 failures rather than one.

The validator demanded `D:P` with explicit `OICI` flags and refused everything else. Refusal is terminal: the private DACL is written only to an entry this process's own `mkdir` created, a pre-existing entry is validated and never repaired, and the remediation is an `icacls` command the user has to run in an elevated shell.

## The change

`_windows_private_dacl_verdict` replaces the bool with three answers:

- **private** — what this module writes: protected, explicit `OICI`, exactly the private trustee set. Unchanged.
- **inherited** — the same trustee set, arriving by inheritance. New.
- **unsafe** — everything else. Unchanged.

`inherited` is safe to repair and `unsafe` is not, and the reason is the same fact in both directions. Tightening a DACL does not close a handle already opened against the old one. When a foreign trustee is present, somebody may hold such a handle, so rewriting the ACL would change nothing about the access already obtained while making us believe otherwise — that is why the module declines to repair, and it still declines. When every trustee is one this module writes itself, no such handle can exist, so protecting the entry only removes the parent's future reach into it.

The tightening runs once, after the existing stabilization wait has had its chance at the creator. It is applied by path and then proven through the retained handle by the caller's re-validation, so a path swapped in between gets our protected DACL — harmless to us — while the handle we still hold reports the object we validated, and the swap fails re-validation instead of passing it. Files are untouched; they already accepted inherited ACEs.

## Verification

Measured on Windows, same four suites, branch against `main` at this commit:

```
main    57 failed
branch  12 failed
```

45 fixed, and the set difference is empty in the other direction — no test fails here that passes on `main`. The remaining 12 fail identically on both.

Behaviour confirmed against real Windows security, not only the string parser:

| observed DACL | verdict | outcome |
|---|---|---|
| inherited, exactly `(user)(SY)(BA)` | inherited | tightened to `D:P`, accepted |
| inherited, `(SY)(BA)(OW)` — the runner's shape | inherited | tightened to `D:P`, accepted |
| already `D:P(SY)(BA)(OW)` | private | accepted, untouched |
| `(AU)` Authenticated Users added | unsafe | refused, DACL untouched |
| `(WD)` Everyone added | unsafe | refused |
| `(BU)` Users added | unsafe | refused |
| partial rights `0x1301bf` | unsafe | refused |
| `OW` under a foreign owner | unsafe | refused |
| `OW` duplicating a literal user grant | unsafe | refused |

13 new tests in `tests/test_mutation_lock.py`: eight over the verdict itself (cross-platform, literal descriptors, including that an inherited *file* ACE is still `private` so the directory split does not move files), and five Windows-gated end to end — the tightening happens and the result is protected, a foreign trustee is refused *and left byte-identical*, and the tightening is attempted exactly once so a write that does not take reports the permission failure rather than spending the stabilization budget retrying it.

`uvx ruff check . --select F` clean.

Note this is a different root cause from the 24 `HOSTED_TRANSFER_UNAVAILABLE` failures in the same lane, which are #657.
