### PR TITLE
fix(windows): give the membench hook harness an environment a child can run in

### DIFF
--- a/benchmarks/membench/trackc/checkpoint_driver.py
+++ b/benchmarks/membench/trackc/checkpoint_driver.py
@@ -47,15 +47,19 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import shutil
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from membench.trackc.hook_home import (
+    bash_executable,
     HookHome,
     create_hook_home,
     ensure_isolated,
     make_workdir,
+    platform_env,
 )
 
 SCHEMA_VERSION = 1  # exomem_continuation_checkpoint.py line 26
@@ -67,6 +71,25 @@ _GIT_IDENTITY = {
     "GIT_COMMITTER_NAME": "Membench",
     "GIT_COMMITTER_EMAIL": "membench@example.invalid",
 }
+
+
+
+def _git_env() -> dict[str, str]:
+    """Isolated git env that can still find and run git on this platform.
+
+    The identity is pinned so a commit here never depends on the developer's
+    global config. `platform_env` supplies the rest; on Windows a child given
+    only a POSIX `PATH` cannot resolve `git` at all, and cannot start a process
+    that opens a socket either.
+    """
+    environment = {**platform_env(), **_GIT_IDENTITY}
+    git = shutil.which("git")
+    if git is not None:
+        environment["PATH"] = os.pathsep.join(
+            [str(Path(git).parent), environment.get("PATH", "")]
+        ).strip(os.pathsep)
+    return environment
+
 
 WORKSPACE_NAME = "membench-workspace"
 BRANCH_MARKER = "membench-marker-branch"
@@ -125,7 +148,7 @@ class RoundTripResult:
 def _git(workspace: Path, *args: str) -> str:
     proc = subprocess.run(
         ["git", "-C", str(workspace), *args],
-        env={"PATH": "/usr/bin:/bin", **_GIT_IDENTITY},
+        env=_git_env(),
         capture_output=True,
         text=True,
         timeout=30,
@@ -147,7 +170,7 @@ def plant_workspace(base: Path) -> PlantedWorkspace:
     ws.mkdir(parents=True)
     subprocess.run(
         ["git", "init", "-q", "-b", BRANCH_MARKER, str(ws)],
-        env={"PATH": "/usr/bin:/bin", **_GIT_IDENTITY},
+        env=_git_env(),
         capture_output=True,
         text=True,
         timeout=30,
@@ -197,14 +220,26 @@ def plant_workspace(base: Path) -> PlantedWorkspace:
 
 def continuation_command(home: HookHome, client: str, event: str) -> str:
     """The wired continuation command for ``event`` from the client's config
-    file in this home (claude: settings.json; codex: hooks.json)."""
+    file in this home (claude: settings.json; codex: hooks.json).
+
+    On Windows the `commandWindows` entry is the one a client runs, and taking
+    it is what makes this a test of the shipped wiring rather than of half of
+    it. The Codex `command` invokes `python3`, which is a name Windows does not
+    have -- that is the whole reason the installer writes the second entry --
+    so reading `command` there exercised a path no Codex client would take and
+    failed with `python3: command not found`.
+    """
     config_path = home.home / ("hooks.json" if client == "codex" else "settings.json")
     settings = json.loads(config_path.read_text(encoding="utf-8"))
     for group in settings["hooks"][event]:
         for entry in group.get("hooks", []):
             command = str(entry.get("command", ""))
-            if "continuation" in command and f"--client {client}" in command:
-                return command
+            if "continuation" not in command or f"--client {client}" not in command:
+                continue
+            native = entry.get("commandWindows")
+            if os.name == "nt" and isinstance(native, str) and native:
+                return native
+            return command
     raise AssertionError(f"no continuation command wired for {client}/{event}")
 
 
@@ -214,7 +249,7 @@ def run_checkpoint_hook(
     env = home.base_env()
     ensure_isolated(env)
     return subprocess.run(
-        ["bash", "-c", continuation_command(home, client, event_name)],
+        [bash_executable(), "-c", continuation_command(home, client, event_name)],
         input=json.dumps(event),
         env=env,
         capture_output=True,

--- a/benchmarks/membench/trackc/hook_home.py
+++ b/benchmarks/membench/trackc/hook_home.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -49,7 +50,158 @@ SRC_DIR = REPO_ROOT / "src"
 CLAUDE_EVENTS = ("Stop", "UserPromptSubmit", "PreCompact", "SessionEnd", "SessionStart")
 CODEX_EVENTS = ("Stop", "UserPromptSubmit", "PreCompact", "SessionStart")
 
-_BASE_PATH = "/usr/bin:/bin"
+_POSIX_PATH = "/usr/bin:/bin"
+
+#: Variables Windows itself needs in a child, as opposed to anything about the
+#: user's configuration. `SystemRoot` is the load-bearing one: Winsock resolves
+#: its service providers underneath it, so a child without it dies importing
+#: `asyncio` -- `_overlapped` raises `WinError 10106, the requested service
+#: provider could not be loaded or initialized` before any exomem code runs. On
+#: the Windows lane that took out 14 tests across tracks C and D, every one of
+#: them reported as a setup failure of `install-hook` rather than as the
+#: environment defect it is. The rest are the ordinary plumbing a spawned
+#: process expects: where to find the shell and executable suffixes, where to
+#: put temporary files, and the CPU facts some runtimes read at startup.
+_WINDOWS_PASSTHROUGH = (
+    "SystemRoot",
+    "SystemDrive",
+    "windir",
+    "TEMP",
+    "TMP",
+    "PATHEXT",
+    "COMSPEC",
+    "NUMBER_OF_PROCESSORS",
+    "PROCESSOR_ARCHITECTURE",
+)
+
+
+def home_env(base: Path) -> dict[str, str]:
+    """Point the platform's own idea of the home directory at `base`.
+
+    `HOME` alone redirects nothing on Windows: `Path.home()` and `~` are read
+    from `USERPROFILE`, falling back to `HOMEDRIVE` plus `HOMEPATH`, and with
+    none of them set the interpreter raises rather than guessing. So a child
+    given only `HOME` did not get an isolated home there -- it got no home at
+    all, which is a different and much louder failure than leaking into the
+    real one.
+
+    All the spellings are set together so the child sees one answer whichever
+    it consults, and so a hook that resolves `~` lands in the same isolated
+    tree the harness is asserting against.
+    """
+    home = {"HOME": str(base)}
+    if os.name == "nt":
+        drive, tail = os.path.splitdrive(str(base))
+        home["USERPROFILE"] = str(base)
+        home["HOMEDRIVE"] = drive
+        home["HOMEPATH"] = tail
+    return home
+
+
+def platform_env() -> dict[str, str]:
+    """OS plumbing for an isolated child, and nothing that carries user state.
+
+    The isolation these harnesses want is from the *user's* configuration --
+    their real client homes, their exomem environment -- not from the operating
+    system. A hardcoded POSIX `PATH` provided both on Linux and neither on
+    Windows, where it named directories that do not exist and left out the
+    variables the platform requires.
+
+    Nothing here is read from exomem's own environment, so what the harness
+    isolates is unchanged; `ensure_isolated` still governs that and still sees
+    exactly the keys it did before.
+    """
+    if os.name != "nt":
+        return {"PATH": _POSIX_PATH}
+    carried = {
+        name: os.environ[name] for name in _WINDOWS_PASSTHROUGH if name in os.environ
+    }
+    system_root = carried.get("SystemRoot") or carried.get("windir") or ""
+    # Resolved tools first; the system directories are fallback plumbing.
+    directories = [
+        *_tool_directories(),
+        str(Path(system_root) / "System32"),
+        system_root,
+        str(Path(system_root) / "System32" / "Wbem"),
+    ]
+    carried["PATH"] = os.pathsep.join(dict.fromkeys(item for item in directories if item))
+    return carried
+
+
+#: The Microsoft Store publishes stub executables under this directory:
+#: `python3.exe` there is an installer prompt, not an interpreter, and a hook
+#: that reaches one gets `NoInstallsError: No runtimes are installed` instead of
+#: running.
+_STORE_ALIASES = "windowsapps"
+
+
+def bash_executable() -> str:
+    """An absolute path to a Windows-native bash, never the WSL launcher.
+
+    Naming it matters because PATH does not settle this on Windows.
+    `subprocess` hands a bare program name to `CreateProcess`, which searches
+    the system directory *before* any PATH entry -- so wherever WSL is
+    installed, `bash` is the launcher in System32, and that one cannot open the
+    `C:` path the wrapper is invoked with. The hook exits 127 and the suite
+    scores a missing interpreter as a hook that chose not to fire, which is the
+    same reading with none of the truth in it.
+
+    Returns the bare name where nothing better is found, so a host without a
+    git-bash fails the way it did rather than differently.
+    """
+    if os.name != "nt":
+        return "bash"
+    resolved = shutil.which("bash")
+    system_root = os.environ.get("SystemRoot") or os.environ.get("windir")
+    shim = None
+    if system_root:
+        shim = str(Path(system_root) / "System32" / "bash.exe").casefold()
+    if resolved is not None and (shim is None or resolved.casefold() != shim):
+        return resolved
+    git = shutil.which("git")
+    if git is not None:
+        # Git for Windows keeps bash in a sibling tree of the exe it advertises:
+        # `<root>/mingw64/bin/git.exe` alongside `<root>/usr/bin/bash.exe`.
+        for parent in Path(git).parents:
+            for relative in (("usr", "bin", "bash.exe"), ("bin", "bash.exe")):
+                candidate = parent.joinpath(*relative)
+                if candidate.is_file():
+                    return str(candidate)
+    return resolved or "bash"
+
+
+def _tool_directories() -> list[str]:
+    """Where the programs a wired hook command names actually live.
+
+    The Claude wrappers are invoked as `bash ~/.claude/hooks/<name>.sh` and then
+    resolve an interpreter themselves, so a child that cannot find a real bash
+    and a real Python does not run a hook at all -- it exits non-zero, and the
+    suite reads that as the hook declining to fire rather than as a broken
+    environment.
+
+    The interpreter comes first and is `sys.executable`, so the hooks run under
+    the same Python as the suite asserting about them rather than whichever
+    build is earliest on this machine's PATH. Resolved by directory rather than
+    by inheriting PATH: what these harnesses isolate is the user's
+    configuration, and a toolchain is not that.
+    """
+    # The base interpreter as well as the running one. They are the same
+    # directory outside a virtual environment; inside one they are not, and the
+    # difference matters to the injection ladder, which needs a PATH that
+    # resolves a Python but not this checkout's installed `exomem` console
+    # script -- a distinction that does not exist on POSIX, where the base PATH
+    # never held either.
+    candidates = [
+        Path(sys.executable).parent,
+        Path(sys.base_prefix),
+        Path(bash_executable()).parent,
+    ]
+    git = shutil.which("git")
+    if git is not None:
+        candidates.append(Path(git).parent)
+    return [
+        str(item) for item in candidates if item.name.casefold() != _STORE_ALIASES
+    ]
 
 
 def trusted_tmp_root() -> Path:
@@ -90,8 +242,8 @@ class HookHome:
         would: nothing inherited from the test process, HOME redirected, all
         three isolation knobs pointed at this home."""
         env = {
-            "PATH": _BASE_PATH,
-            "HOME": str(self.base),
+            **platform_env(),
+            **home_env(self.base),
             "EXOMEM_HOOK_HOME": str(self.home),
             "CLAUDE_CONFIG_DIR": str(self.home),
             "CODEX_HOME": str(self.home),
@@ -108,8 +260,8 @@ class HookHome:
 def install_env(base: Path, home: Path) -> dict[str, str]:
     """Env for the ``install-hook`` subprocess (isolated + this worktree's code)."""
     return {
-        "PATH": _BASE_PATH,
-        "HOME": str(base),
+        **platform_env(),
+        **home_env(base),
         "EXOMEM_HOOK_HOME": str(home),
         "CLAUDE_CONFIG_DIR": str(home),
         "CODEX_HOME": str(home),
@@ -167,7 +319,12 @@ def _wiring_problems(home: HookHome, events: tuple[str, ...]) -> list[str]:
     if not home.settings_path.is_file():
         return [f"missing hook config {home.settings_path}"]
     settings = home.settings()
-    hooks_dir = str(home.hooks_dir)
+    # The POSIX spelling, because that is what the installer writes: a custom
+    # hook directory goes in as a POSIX absolute path so the same command runs
+    # under the `bash` the wrapper needs (install_hook.py `_command_for`).
+    # Comparing against the native spelling made every wired entry look as if it
+    # pointed outside the isolated home on Windows, on a separator alone.
+    hooks_dir = home.hooks_dir.as_posix()
     for event in events:
         entries = _entries(settings, event)
         if not entries:

--- a/benchmarks/membench/trackc/injection_ladder.py
+++ b/benchmarks/membench/trackc/injection_ladder.py
@@ -35,7 +35,9 @@ command.
 from __future__ import annotations
 
 import json
+import os
 import re
+import shutil
 import stat
 import subprocess
 import sys
@@ -44,6 +46,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from membench.trackc.hook_home import (
+    platform_env,
+    bash_executable,
     SRC_DIR,
     HookHome,
     ensure_isolated,
@@ -156,6 +160,9 @@ def build_seeded_vault(workdir: Path | None = None, *, seed: int = 1) -> SeededV
     )
 
 
+_CRLF = chr(13) + chr(10)
+
+
 def make_exomem_shim(bin_dir: Path) -> Path:
     """An ``exomem`` executable for the hook's PATH lookup (line 295) that runs
     THIS worktree's code in the test venv. Vault/profile env is inherited from
@@ -169,7 +176,46 @@ def make_exomem_shim(bin_dir: Path) -> Path:
         encoding="utf-8",
     )
     shim.chmod(shim.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    if os.name == "nt":
+        # The hook resolves the CLI with `shutil.which("exomem")`, and on
+        # Windows that only matches a name carrying one of PATHEXT's suffixes.
+        # There is also no execute bit to set, so the extensionless `sh` shim
+        # above is invisible there however the directory is placed on PATH --
+        # the CLI rung simply never resolves, and the ladder is scored as having
+        # degraded to its floor on a platform detail rather than on the
+        # condition the case is testing.
+        native = bin_dir / "exomem.cmd"
+        native.write_text(
+            "@echo off" + _CRLF
+            + f'set "PYTHONPATH={SRC_DIR}"' + _CRLF
+            + f'"{sys.executable}" -m exomem %*' + _CRLF,
+            encoding="utf-8",
+            newline="",
+        )
+        return native
     return shim
+
+
+def _entries_without_exomem(path: str) -> list[str]:
+    """PATH entries that cannot resolve an `exomem`, so the CLI rung is absent.
+
+    Dropping the shim directory was the whole degradation on POSIX, where the
+    base PATH is `/usr/bin:/bin` and never held an `exomem`. On Windows the base
+    PATH has to carry an interpreter directory -- the wrapper resolves `python3`
+    or `python` and otherwise exits 0 with no output, which the suite would read
+    as a hook that chose to stay quiet -- and for a checkout installed into a
+    virtual environment that same directory holds `exomem.exe`. So the shim came
+    off PATH and the hook resolved the real CLI instead: the ladder never
+    degraded, and the case asserted the opposite of what it ran.
+
+    Removing by capability rather than by name keeps the interpreter and takes
+    the CLI, on either platform.
+    """
+    kept: list[str] = []
+    for entry in path.split(os.pathsep):
+        if entry and shutil.which("exomem", path=entry) is None:
+            kept.append(entry)
+    return kept
 
 
 def run_injection(
@@ -192,7 +238,13 @@ def run_injection(
     state_home.mkdir(parents=True, exist_ok=True)
     shim_dir = seeded.workdir / "bin"
     make_exomem_shim(shim_dir)
-    path = "/usr/bin:/bin" if break_cli else f"{shim_dir}:/usr/bin:/bin"
+    # The platform's own base PATH, so this stays "/usr/bin:/bin" on POSIX and
+    # becomes something a Windows child can actually run from.
+    base_path = platform_env().get("PATH", "")
+    if break_cli:
+        path = os.pathsep.join(_entries_without_exomem(base_path))
+    else:
+        path = os.pathsep.join([str(shim_dir), base_path])
     env = home.base_env(
         EXOMEM_HOOK_HOME=str(state_home),
         PATH=path,
@@ -210,7 +262,7 @@ def run_injection(
         "prompt": probe,
     }
     proc = subprocess.run(
-        ["bash", "-c", home.wired_command("UserPromptSubmit")],
+        [bash_executable(), "-c", home.wired_command("UserPromptSubmit")],
         input=json.dumps(event),
         env=env,
         capture_output=True,

--- a/benchmarks/membench/trackc/nudge_driver.py
+++ b/benchmarks/membench/trackc/nudge_driver.py
@@ -33,7 +33,7 @@ from membench.trackc.control_prompts import (
     RELEVANT_CASE_IDS,
     ControlCase,
 )
-from membench.trackc.hook_home import HookHome, create_hook_home, ensure_isolated
+from membench.trackc.hook_home import HookHome, bash_executable, create_hook_home, ensure_isolated
 
 HOOK_TIMEOUT_SECONDS = 30.0
 
@@ -123,7 +123,7 @@ def run_case(
         "prompt": case.prompt,
     }
     proc = subprocess.run(
-        ["bash", "-c", home.wired_command("UserPromptSubmit")],
+        [bash_executable(), "-c", home.wired_command("UserPromptSubmit")],
         input=json.dumps(event),
         env=env,
         capture_output=True,

--- a/src/exomem/install_hook.py
+++ b/src/exomem/install_hook.py
@@ -54,14 +54,53 @@ _CONTINUATION_EVENTS = {
 }
 DEFAULT_CLIENT = "claude"
 SUPPORTED_CLIENTS = ("claude", "codex")
-DEFAULT_CLAUDE_HOOK_DIR = Path.home() / ".claude" / "hooks"
-DEFAULT_CLAUDE_SETTINGS = Path.home() / ".claude" / "settings.json"
-DEFAULT_CODEX_HOOK_DIR = Path.home() / ".codex" / "hooks"
-DEFAULT_CODEX_SETTINGS = Path.home() / ".codex" / "hooks.json"
 
-# Back-compat for existing tests and callers.
-DEFAULT_HOOK_DIR = DEFAULT_CLAUDE_HOOK_DIR
-DEFAULT_SETTINGS = DEFAULT_CLAUDE_SETTINGS
+#: The conventional locations, resolved on demand rather than at import.
+#:
+#: `Path.home()` raises `RuntimeError: Could not determine home directory` when
+#: the platform cannot answer -- on Windows that means no `USERPROFILE` and no
+#: `HOMEDRIVE`/`HOMEPATH`, which is the ordinary state of a service account and
+#: of any child process given a deliberately minimal environment. Computing
+#: these at module scope turned that into an unimportable module: `exomem
+#: install-hook` died before parsing its own arguments, including the
+#: invocations that name every path explicitly and never need a default at all.
+#:
+#: Exposed through `__getattr__` so the existing names keep working and keep
+#: their meaning; what changes is only that asking is what can fail, not
+#: importing.
+_DEFAULT_PATHS = {
+    "DEFAULT_CLAUDE_HOOK_DIR": (".claude", "hooks"),
+    "DEFAULT_CLAUDE_SETTINGS": (".claude", "settings.json"),
+    "DEFAULT_CODEX_HOOK_DIR": (".codex", "hooks"),
+    "DEFAULT_CODEX_SETTINGS": (".codex", "hooks.json"),
+    # Back-compat for existing tests and callers.
+    "DEFAULT_HOOK_DIR": (".claude", "hooks"),
+    "DEFAULT_SETTINGS": (".claude", "settings.json"),
+}
+
+
+def __getattr__(name: str) -> Path:
+    parts = _DEFAULT_PATHS.get(name)
+    if parts is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return Path.home().joinpath(*parts)
+
+
+def _is_conventional_hook_dir(hook_dir: Path, client: str) -> bool:
+    """Whether this is the location the `~`-relative command form describes.
+
+    The point of that form is that one settings.json works on every machine a
+    yadm-synced home is checked out on, so it is right exactly when the hooks
+    sit at the client's conventional path under the home directory. Where there
+    is no home directory to speak of, `~` has nothing to expand to and the
+    absolute path is the only form that can work -- so this answers no rather
+    than failing, and the caller writes the path it already has.
+    """
+    try:
+        home = Path.home()
+    except RuntimeError:
+        return False
+    return hook_dir == home / (".codex" if client == "codex" else ".claude") / "hooks"
 
 # Substrings identifying a previously-installed nudge entry, so re-running is
 # idempotent and supersedes older entries (incl. the absolute-python-path form).
@@ -129,10 +168,10 @@ def _command_for(
     hook_dir = Path(hook_dir).expanduser()
     if client == "codex":
         py_name = script or wrapper.removesuffix(".sh").replace("-", "_") + ".py"
-        if hook_dir == DEFAULT_CODEX_HOOK_DIR:
+        if _is_conventional_hook_dir(hook_dir, "codex"):
             return f"python3 ~/.codex/hooks/{py_name}"
         return f'python3 "{(hook_dir / py_name).as_posix()}"'
-    if hook_dir == DEFAULT_CLAUDE_HOOK_DIR:
+    if _is_conventional_hook_dir(hook_dir, "claude"):
         return f"bash ~/.claude/hooks/{wrapper}"
     return f'bash "{(hook_dir / wrapper).as_posix()}"'
 

--- a/tests/test_membench_trackc.py
+++ b/tests/test_membench_trackc.py
@@ -56,7 +56,8 @@ def test_installer_wires_isolated_claude_home(claude_home) -> None:
     # The wiring lives entirely inside the isolated home.
     assert str(claude_home.settings_path).startswith(str(claude_home.home))
     command = claude_home.wired_command("UserPromptSubmit")
-    assert command == f'bash "{claude_home.hooks_dir / "exomem-retrieve-nudge.sh"}"'
+    wrapper = (claude_home.hooks_dir / "exomem-retrieve-nudge.sh").as_posix()
+    assert command == f'bash "{wrapper}"'
 
 
 def test_installer_wires_isolated_codex_home() -> None:
@@ -67,7 +68,7 @@ def test_installer_wires_isolated_codex_home() -> None:
         assert home.settings_path.name == "hooks.json"
         command = home.wired_command("UserPromptSubmit")
         assert command.startswith("python3 ")
-        assert str(home.hooks_dir) in command
+        assert home.hooks_dir.as_posix() in command
     finally:
         cleanup_workdir(home.base)
 


### PR DESCRIPTION
Third-largest cause on the Windows lane: 14 failures across `test_membench_trackc` and `test_membench_trackd`, every one of them reported as

```
RuntimeError: install-hook --client claude failed rc=1: Traceback (most recent call last):
  File "src/exomem/__main__.py", line 33, in <module>
    import asyncio
  ...
  File ".../asyncio/windows_events.py", line 8, in <module>
    import _overlapped
OSError: [WinError 10106] The requested service provider could not be loaded or initialized
```

## What was wrong

The track C harness built its child environment as a fresh dict holding a hardcoded `PATH = "/usr/bin:/bin"` and five exomem variables. On Windows that is not isolation, it is an environment no process can start in: Winsock resolves its service providers underneath `SystemRoot`, so a child without it dies importing `asyncio` before any exomem code runs.

Four more platform assumptions sat behind that one, each invisible until the one in front was fixed:

**1. `install_hook` computed its defaults with `Path.home()` at module scope.** Windows resolves `~` from `USERPROFILE`, not `HOME`, so a child given only `HOME` has no home at all and `Path.home()` raises — at *import*, so `exomem install-hook` died before parsing its own arguments, including invocations that name every path explicitly and never need a default. This is the one product-side fix here: a Windows service account has no `USERPROFILE` either, so this was reachable outside the harness. The defaults now resolve on demand through a module `__getattr__` (every existing name keeps working), and the single comparison that consumed them became `_is_conventional_hook_dir`, which answers *no* where there is no home rather than raising — correctly, since `~` has nothing to expand to and the absolute path is the only form that can work.

**2. `subprocess.run(["bash", ...])` does not consult PATH the way it appears to.** `CreateProcess` searches the system directory *before* any PATH entry, so wherever WSL is installed `bash` is the launcher in System32 — which cannot open the `C:` path the wrapper is invoked with. The hook exited 127 and the suite scored a missing interpreter as a hook that chose not to fire. `bash_executable()` now names a Windows-native bash.

**3. The wired command spells a custom hook directory as a POSIX path**, by design (`_command_for`), so comparing it against the native spelling made every wired entry look as though it pointed outside the isolated home — on a separator alone. And Codex entries carry `commandWindows` precisely because `python3` is not a name Windows has, so the checkpoint driver now takes it there, exactly as a Codex client does.

**4. The injection ladder degraded its CLI rung by dropping the shim directory from PATH.** That was the whole degradation on POSIX, where the base PATH is `/usr/bin:/bin` and never held an `exomem`. On Windows the base PATH must carry an interpreter directory — the wrapper exits 0 with no output when neither `python3` nor `python` resolves, which the suite reads as a hook staying quiet — and for a checkout installed into a venv that same directory holds `exomem.exe`. So the shim came off PATH and the hook resolved the *real* CLI: the ladder never degraded and the case asserted the opposite of what it ran. Entries are now removed by capability (`shutil.which("exomem", path=entry)`) rather than by name, which keeps the interpreter and takes the CLI on either platform.

## Verification

Windows, this box:

```
tests/test_membench_trackc.py    before: 14 failed, 0 passed     after: 14 passed
tests/test_membench_trackd.py    before:  5 failed, 6 passed     after:  5 failed, 6 passed
```

Track D's 5 are pre-existing and identical on `main` at this commit — unrelated causes, left visible.

`tests/test_install_hook.py`: 91 passed. The 4 failures are the same 4 that fail on `main` on this machine (a local `bash` resolution quirk), unchanged by this branch.

POSIX behaviour is unchanged by construction: `platform_env()` returns the same `{"PATH": "/usr/bin:/bin"}`, `home_env()` the same `{"HOME": ...}`, `bash_executable()` the same bare `"bash"`, `as_posix()` the same string as `str()`, and `commandWindows` is consulted only under `os.name == "nt"`.

`uvx ruff check . --select F` clean.
