### PR TITLE
fix(hosted): declare the runtime temp's POSIX isolation instead of failing on it

### DIFF
--- a/src/exomem/hosted_runtime_temp.py
+++ b/src/exomem/hosted_runtime_temp.py
@@ -24,6 +24,33 @@ class HostedRuntimeTempUnavailable(RuntimeError):
     code = "HOSTED_RUNTIME_TEMP_UNAVAILABLE"
 
 
+#: Named, because "unavailable" was covering three unrelated conditions.
+#: Tenant isolation here *is* POSIX ownership and mode: every entry is checked
+#: against an expected uid and gid and required to be `0700`, and a hosted cell
+#: is a Linux container by construction -- it is only ever reached through a
+#: `HostedCellConfig`, which carries the `runtime_uid` and `runtime_gid` those
+#: checks compare against. Windows has no equivalent in this module, and
+#: `mkdir(mode=0o700)` does not produce mode `0o700` for a directory there, so
+#: the mode check failed and the gateway reported `HOSTED_TRANSFER_UNAVAILABLE`
+#: -- the same message it gives for a real ownership breach or a blown quota,
+#: with the cause dropped at the boundary. Refusing up front says which of the
+#: three it is.
+POSIX_PRIVACY_REFUSAL = (
+    "hosted runtime temp requires POSIX ownership and mode semantics; "
+    "a hosted cell runs as a Linux container"
+)
+
+
+def posix_privacy_available() -> bool:
+    """Whether this platform has the ownership semantics the isolation needs."""
+    return os.name != "nt"
+
+
+def _require_posix_privacy() -> None:
+    if not posix_privacy_available():
+        raise HostedRuntimeTempUnavailable(POSIX_PRIVACY_REFUSAL)
+
+
 def _private_directory(path: Path, *, expected_uid: int, expected_gid: int) -> None:
     try:
         path.mkdir(mode=0o700, parents=False, exist_ok=True)
@@ -100,6 +127,7 @@ def prepare_hosted_runtime_temp(
 ) -> Path:
     """Create and no-follow clear the disposable runtime root during locked startup."""
 
+    _require_posix_privacy()
     root = ensure_hosted_runtime_temp(
         state_root,
         expected_uid=expected_uid,
@@ -121,6 +149,7 @@ def ensure_hosted_runtime_temp(
 ) -> Path:
     """Validate or create the private runtime root without deleting any entry."""
 
+    _require_posix_privacy()
     state = Path(state_root)
     if not state.is_absolute():
         raise HostedRuntimeTempUnavailable

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,33 @@ def _needs_an_absent_posix_api(error: BaseException | None) -> bool:
     return False
 
 
+#: The hosted cell's runtime temp refusing a platform it cannot isolate on.
+#: Matched on the module's own refusal text rather than on the exception type
+#: alone, because `HostedRuntimeTempUnavailable` is also how a real ownership
+#: breach, an escaped symlink and a blown quota are reported -- and those stay
+#: failures wherever they happen.
+_POSIX_RUNTIME_TEMP = re.compile(
+    r"hosted runtime temp requires POSIX ownership and mode semantics"
+)
+
+
+def _declares_posix_runtime_temp(error: BaseException | None) -> bool:
+    """True when the hosted runtime temp refuses this platform by name.
+
+    Walked through the cause chain because the gateway wraps it: a test sees
+    `HostedGatewayError: HOSTED_TRANSFER_UNAVAILABLE` and the reason is one link
+    down, which is exactly why this was being counted as 24 Windows defects
+    instead of one platform fact.
+    """
+    seen: set[int] = set()
+    while error is not None and id(error) not in seen:
+        seen.add(id(error))
+        if _POSIX_RUNTIME_TEMP.search(str(error)):
+            return True
+        error = error.__cause__ or error.__context__
+    return False
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):  # noqa: ANN001, ANN201
     """Report a platform capability this host does not have as a skip.
@@ -203,6 +230,8 @@ def pytest_runtest_makereport(item, call):  # noqa: ANN001, ANN201
         reason = "proc-fd directory custody is unavailable on this platform"
     elif os.name == "nt" and _needs_an_absent_posix_api(error):
         reason = "the hosted cell runtime's POSIX APIs do not exist on Windows"
+    elif os.name == "nt" and _declares_posix_runtime_temp(error):
+        reason = "the hosted cell's runtime temp isolates by POSIX ownership and mode"
     elif not has_posix_interval_timers() and declares_absent_surface_timers(error):
         reason = "POSIX interval timers (setitimer/SIGALRM) are unavailable here"
     elif not has_bwrap_sandbox() and declares_absent_sandbox(error):


### PR DESCRIPTION
Closes #657.

Second-largest cause on the Windows lane: 24 of 241 failures on `main`, every one of them at hosted server construction with

```
exomem.hosted_gateway.HostedGatewayError: HOSTED_TRANSFER_UNAVAILABLE: hosted runtime temp is unavailable
```

## What the module actually requires

Tenant isolation in `hosted_runtime_temp` **is** POSIX ownership and mode — every entry is checked against an expected uid and gid and required to be `0700`. A hosted cell is a Linux container by construction: the module is only reachable through a `HostedCellConfig`, which is what carries the `runtime_uid` and `runtime_gid` those checks compare against. A personal deployment never constructs one.

Windows has no equivalent in this module, and `mkdir(mode=0o700)` does not produce mode `0o700` for a directory there, so `_private_directory`'s final check failed and the `OSError` became `HostedRuntimeTempUnavailable`.

Building a second, Windows-specific privacy model for a component that will not run in production on Windows would add security surface that nothing exercises. The honest answer is to say what the capability requires.

## The change

- `hosted_runtime_temp` refuses up front, by name, with `POSIX_PRIVACY_REFUSAL`. That is worth having on its own: `HOSTED_TRANSFER_UNAVAILABLE: hosted runtime temp is unavailable` was the message for a platform mismatch, a real ownership breach *and* a blown quota alike, and the gateway drops the `from exc` cause at its boundary — so a reader had no way to tell them apart.
- `tests/conftest.py` turns that named refusal into a skip on Windows, as the seventh entry in the capability-declaration hook that already handles proc-fd custody, the hosted cell's POSIX APIs, interval timers, the bubblewrap sandbox, trusted system Git, and directory descriptors.

Matched on the **refusal text**, not on the exception type: `HostedRuntimeTempUnavailable` is also how a genuine ownership breach, an escaped symlink and an exceeded quota are reported, and those stay failures wherever they occur. Gated on `os.name == "nt"`, so the same refusal on Linux or macOS — where the semantics exist and their absence would be a real defect — stays a failure and is meant to.

## Verification

`tests/test_hosted_private_routes.py` on Windows:

```
main    27 failed,  2 passed, 1 skipped
branch   0 failed,  5 passed, 25 skipped
```

Three of those 27 were passing tests that had been failing on the shared construction path, so coverage went *up*, not down.

`test_hosted_transfer_v2`, `test_hosted_adoption_staging` and `test_governance_tokens` are unchanged on this box (31 failures on both sides, set difference empty in each direction) because their remaining failures are all `WindowsRuntimeDaclError` — the separate cluster #658 fixes. The two are complementary; neither masks the other.

POSIX is untouched by construction: `posix_privacy_available()` is True there, so the new guard is a no-op, and the conftest branch never runs.

`uvx ruff check . --select F` clean.