### PR TITLE
fix(portability): make the quiesced export work on a non-POSIX filesystem

### DIFF
--- a/src/exomem/governance/lifecycle.py
+++ b/src/exomem/governance/lifecycle.py
@@ -628,7 +628,10 @@ def _read_json(vault_root: Path, path: Path) -> dict[str, Any] | None:
             "LIFECYCLE_PATH_UNSAFE", "lifecycle marker is not a regular file"
         )
     try:
-        fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        fd = os.open(
+            path,
+            os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
     except OSError as exc:
         raise LifecycleError(
             "LIFECYCLE_PATH_UNSAFE", "lifecycle marker could not be opened safely"

--- a/src/exomem/hosted_operator.py
+++ b/src/exomem/hosted_operator.py
@@ -593,7 +593,12 @@ def read_offline_request(
     ):
         _fail()
     _reject_symlink_components(supplied)
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
     try:
         descriptor = os.open(supplied, flags)
     except OSError:

--- a/src/exomem/hosted_portability.py
+++ b/src/exomem/hosted_portability.py
@@ -518,6 +518,33 @@ def _source_signature(source_stat: os.stat_result) -> tuple[int, int, int, int, 
     )
 
 
+def _comparable_across_stat_apis(
+    signature: tuple[int, int, int, int, int],
+) -> tuple[int, ...]:
+    """The fields a path stat and a handle stat may be compared on.
+
+    Everywhere except Windows that is the whole signature. On Windows it is not:
+    `st_ctime` there is the *creation* time, and it is served from the directory
+    entry, which the filesystem updates lazily -- so a file written moments ago
+    reads back as one value by path and another by handle, a millisecond apart,
+    with nothing having touched it. That is what made every quiesced export fail
+    on the Windows lane with "a source file changed during export".
+
+    Dropping it costs nothing there. Creation time cannot change for a live
+    inode: producing a new one moves `st_dev`/`st_ino`, which stay compared, and
+    a content change moves `st_size`/`st_mtime_ns`, which also stay compared. On
+    POSIX `st_ctime` is the inode-change time and does catch what those miss --
+    a chmod, a chown, a link count change -- so it is kept.
+
+    This narrowing applies only across the two APIs. The before/after-read
+    comparison uses the full signature from `fstat` on both sides, where every
+    field is produced the same way and every one of them means something.
+    """
+    if os.name == "nt":
+        return signature[:4]
+    return signature
+
+
 def _open_regular_source(
     path: Path,
     *,
@@ -529,7 +556,13 @@ def _open_regular_source(
     if not stat.S_ISREG(before.st_mode):
         _fail("UNSAFE_SOURCE_ENTRY", "vault exports accept regular files only")
 
-    flags = os.O_RDONLY
+    # `O_BINARY` or the digest is not of this file. Windows opens a descriptor
+    # in text mode by default, so every CRLF read back as a bare LF: a 20-byte
+    # source yielded 18 bytes, the size check below called that "a source file
+    # changed during export", and had the sizes ever agreed the manifest would
+    # have carried a SHA-256 of translated bytes instead of the file's. It is
+    # 0 on POSIX, so this changes nothing there.
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
     try:
@@ -542,7 +575,9 @@ def _open_regular_source(
             _fail("UNSAFE_SOURCE_ENTRY", "vault exports accept regular files only")
         before_signature = _source_signature(before)
         opened_signature = _source_signature(opened)
-        if before_signature != opened_signature or (
+        if _comparable_across_stat_apis(before_signature) != _comparable_across_stat_apis(
+            opened_signature
+        ) or (
             expected_signature is not None and opened_signature != expected_signature
         ):
             _fail("SOURCE_CHANGED_DURING_EXPORT", "a source file changed during export")
@@ -856,8 +891,16 @@ def _hash_file(path: Path) -> str:
 
 
 def _fsync_regular_file(path: Path) -> None:
+    # Windows will not flush a read-only handle: `os.fsync` there is `_commit`,
+    # which needs write access and returns EBADF without it, so every completed
+    # export failed its own durability step with "completed artifact could not
+    # be made durable". POSIX accepts a read-only descriptor, which is why
+    # opening for reading was right until this ran somewhere else. The artifact
+    # was written moments ago by this process, so opening it for update is
+    # available by construction.
+    mode = "r+b" if os.name == "nt" else "rb"
     try:
-        with path.open("rb") as handle:
+        with path.open(mode) as handle:
             os.fsync(handle.fileno())
     except OSError:
         _fail("ARTIFACT_PUBLICATION_FAILED", "completed artifact could not be made durable")

--- a/src/exomem/hosted_restore.py
+++ b/src/exomem/hosted_restore.py
@@ -246,7 +246,10 @@ def _hash_archive(path: Path) -> str:
             raise OperatorFailure("HOSTED_ARCHIVE_INVALID")
         descriptor = os.open(
             path,
-            os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+            os.O_RDONLY
+            | getattr(os, "O_BINARY", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
         )
         try:
             before = os.fstat(descriptor)

--- a/src/exomem/hosted_runtime.py
+++ b/src/exomem/hosted_runtime.py
@@ -1540,7 +1540,10 @@ def _read_marker_payload(
     try:
         descriptor = os.open(
             marker,
-            os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+            os.O_RDONLY
+            | getattr(os, "O_BINARY", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
         )
     except OSError as exc:
         raise HostedConfigError(

--- a/src/exomem/hosted_security.py
+++ b/src/exomem/hosted_security.py
@@ -318,6 +318,7 @@ def _load_projected_credential_bundle_at(
 
     flags = (
         os.O_RDONLY
+        | getattr(os, "O_BINARY", 0)
         | getattr(os, "O_CLOEXEC", 0)
         | getattr(os, "O_NOFOLLOW", 0)
         | getattr(os, "O_NONBLOCK", 0)

--- a/tests/test_hosted_portability.py
+++ b/tests/test_hosted_portability.py
@@ -927,3 +927,74 @@ def test_concurrent_checkpoint_commit_adopts_one_atomic_result(tmp_path: Path) -
     assert not artifact.exists()
     assert unrelated.read_bytes() == b"another export"
     assert not list((tmp_path / "state").rglob(".*.json.partial"))
+
+
+# --- the export runs on a platform whose descriptors are not POSIX -----------
+#
+# Three separate defects made `export_quiesced_vault` impossible on Windows, and
+# each one hid the next: descriptors opened in text mode, a cross-API stat
+# comparison on a field Windows serves from a lazily-updated directory entry,
+# and a durability flush through a read-only handle. Sixteen tests in this file
+# failed there; all of them pass now.
+
+
+def test_a_crlf_source_is_digested_exactly_as_it_sits_on_disk(tmp_path: Path) -> None:
+    """The defect that would have been worse than the failure it caused.
+
+    A descriptor opened without `O_BINARY` translates every CRLF to a bare LF on
+    Windows, so the export read 18 bytes of a 20-byte file. The size check
+    caught that and refused -- but a manifest is a promise about bytes, and had
+    the sizes ever agreed the export would have published a SHA-256 of text the
+    file does not contain. That is what this pins: not that the export
+    succeeds, but that what it recorded is a digest of what is on disk.
+    """
+    vault = tmp_path / "vault"
+    _seed_vault(vault, "ALPHA")
+    crlf = vault / "Knowledge Base/Notes/Insights/windows-authored.md"
+    raw = b"---\r\ntype: insight\r\n---\r\n# Windows authored\r\n\r\nCRLF body.\r\n"
+    crlf.write_bytes(raw)
+
+    result = portability.export_quiesced_vault(
+        vault, tmp_path / "artifacts", context=_context(), exomem_release="9.9.9"
+    )
+
+    records = {record["path"]: record for record in result.manifest["files"]}
+    recorded = records["Knowledge Base/Notes/Insights/windows-authored.md"]
+    assert recorded["sha256"] == hashlib.sha256(raw).hexdigest()
+    assert recorded["size"] == len(raw)
+
+
+def test_creation_time_is_the_only_field_dropped_across_the_two_stat_apis() -> None:
+    """The narrowing has to stay narrow, on both platforms.
+
+    Windows disagrees with itself about `st_ctime` between a path stat and a
+    handle stat -- by a millisecond, for a file nothing touched -- because it is
+    the creation time and it comes from the directory entry. Dropping it there
+    costs nothing, since a new inode moves `st_dev`/`st_ino` and a content
+    change moves `st_size`/`st_mtime_ns`. Dropping anything else, or dropping it
+    on POSIX where it is the inode-change time, would be a real loss.
+    """
+    signature = (1, 2, 3, 4, 5)
+
+    comparable = portability._comparable_across_stat_apis(signature)
+
+    assert comparable == ((1, 2, 3, 4) if os.name == "nt" else (1, 2, 3, 4, 5))
+
+
+def test_a_completed_artifact_is_flushed_rather_than_refused(tmp_path: Path) -> None:
+    """`os.fsync` needs a writable handle on Windows and a readable one anywhere.
+
+    The export wrote the artifact, digested it, and then failed its own
+    durability step with `ARTIFACT_PUBLICATION_FAILED` -- on a file it had just
+    produced. Reaching a readable artifact at all is the assertion.
+    """
+    vault = tmp_path / "vault"
+    _seed_vault(vault, "ALPHA")
+
+    result = portability.export_quiesced_vault(
+        vault, tmp_path / "artifacts", context=_context(), exomem_release="9.9.9"
+    )
+
+    archive = result.archive_path
+    assert archive.is_file()
+    assert archive.stat().st_size > 0


### PR DESCRIPTION
`export_quiesced_vault` could not complete on Windows at all — 16 of 241 failures on the cross-platform lane, in **three** separate defects that each hid the next. Fixing one only revealed the following one.

## 1. Descriptors opened in text mode

`_open_regular_source` built its flags as `os.O_RDONLY` plus `O_NOFOLLOW` where available. Windows opens a descriptor in **text mode** by default, so every CRLF read back as a bare LF:

```
on disk    20  b'line one\r\nline two\r\n'
os.read    18  b'line one\nline two\n'
+O_BINARY  20  b'line one\r\nline two\r\n'
```

The size check is the only reason this surfaced as a failure rather than as silence. **A manifest is a promise about bytes**, and had the sizes ever agreed, the export would have published a SHA-256 of text the file does not contain.

The same flag was missing at five other descriptor reads — `governance/lifecycle`, `hosted_operator`, `hosted_restore`, `hosted_runtime`, `hosted_security` — all fixed, since it is one defect class. `getattr(os, "O_BINARY", 0)` is `0` on POSIX, so none of it changes anything there.

## 2. A cross-API stat comparison on a field Windows caches

The guard against a file changing between the path stat and the handle stat compared the full signature, including `st_ctime_ns`. On Windows that is the **creation** time, and it is served from the directory entry, which the filesystem updates lazily. A file written moments ago:

```
lstat  (…, 57, 1787130382508331800, 1787130382507331400)
fstat  (…, 57, 1787130382508331800, 1787130382508331800)
```

A millisecond apart, with nothing having touched it.

`_comparable_across_stat_apis` now drops that field on Windows only, where it can detect nothing the others miss: a new inode moves `st_dev`/`st_ino`, a content change moves `st_size`/`st_mtime_ns`, and creation time cannot change for a live inode. On POSIX it is the inode-change time — it catches a chmod, a chown, a link-count change — and stays.

The narrowing applies **only** across the two APIs. The before-and-after-read comparison is untouched: both sides come from `fstat`, and every field there means something.

## 3. Durability flushed through a read-only handle

`_fsync_regular_file` opened `"rb"`. `os.fsync` on Windows is `_commit`, which needs write access and returns `EBADF` without it, so a completed export failed `ARTIFACT_PUBLICATION_FAILED: completed artifact could not be made durable` — on a file it had written seconds earlier. POSIX accepts a read-only descriptor, which is why this was correct until it ran somewhere else.

## Verification

`tests/test_hosted_portability.py` on Windows:

```
main    16 failed, 61 passed
branch   0 failed, 80 passed
```

Three of those 80 are new:

- a CRLF source is digested **exactly as it sits on disk** — asserting the recorded `sha256` and `size` against the raw bytes, so the wrong-digest failure mode is pinned rather than just the refusal it happened to cause;
- creation time is the only field the cross-API comparison drops, and only on Windows;
- a completed artifact is reachable and non-empty.

`test_hosted_operator`, `test_hosted_security` and `test_governance_receipt_runtime_bootstrap_windows`: set difference empty in both directions against `main` (the 10-vs-11 count moves run to run on a known-flaky concurrent bootstrap test).

`uvx ruff check . --select F` clean.