### PR TITLE
test(writes): stop telling the product it has a kernel feature the platform lacks

### DIFF
--- a/tests/test_transactional_writes.py
+++ b/tests/test_transactional_writes.py
@@ -52,7 +52,24 @@ def _replace_capability_member(
     original: object,
     replacement: object | None,
 ) -> None:
+    """Re-register a capability under a patched function, where it exists.
+
+    These tests replace `os.open`, `os.stat` or `os.scandir` and then need the
+    product to keep taking its descriptor-relative branch, which it selects by
+    membership in `os.supports_dir_fd` / `os.supports_fd`. Rewriting that set
+    cannot conjure the kernel feature. On Windows it is empty, and telling the
+    product otherwise sent it into `os.open(..., dir_fd=...)` for a
+    `NotImplementedError` -- against a platform the product itself handles,
+    through exactly the path fallback these tests are not about. Seven failures
+    on the cross-platform lane were that, reported as defects in code that has a
+    Windows implementation and takes it correctly when not lied to.
+
+    Removing a member is a different question and stays available everywhere:
+    a capability that is already absent is the state those tests want.
+    """
     members = set(getattr(os, capability, set()))
+    if replacement is not None and original not in members:
+        pytest.skip(f"os.{capability} traversal is unavailable on this platform")
     members.discard(original)
     if replacement is not None:
         members.add(replacement)


### PR DESCRIPTION
16 of the 22 `test_transactional_writes` failures on the Windows lane, and none of them were about the product.

## What the tests were doing

They replace `os.open`, `os.stat` or `os.scandir` with an observer, then call `_replace_capability_member` to re-register the observer in `os.supports_dir_fd` / `os.supports_fd` so the product keeps taking its descriptor-relative branch.

That set is not a preference. It is the platform reporting a kernel feature. On Windows it is **empty**, so rewriting it told the product it had `openat` and sent it straight into

```
os.open(name, flags, dir_fd=parent_descriptor)
NotImplementedError: dir_fd unavailable on this platform
```

`vault.py` handles Windows perfectly well here — `_open_batch_residue_directory` checks `os.open in os.supports_dir_fd` and falls back to a path open. The tests were failing on a branch the product only ever takes because they forced it to.

## The change

`_replace_capability_member` skips when it is asked to *add* a member for a capability this platform does not have.

**Removing** a member stays available everywhere — a capability that is already absent is exactly the state those tests want, which is why `test_directory_census_classifies_residue_through_path_fallbacks` and its siblings still run on Windows and still cover the fallback there. That asymmetry is the whole of the fix.

## Verification

```
main    22 failed, 42 passed,  2 skipped
branch   6 failed, 47 passed, 13 skipped
```

Eleven became honest skips; **five now pass** — they had been failing on the forced branch and are fine on the real one. The remaining six fail identically on `main` for unrelated causes (`DID NOT RAISE PermissionError`, timestamp assertions) and stay visible; set difference against `main` is empty in both directions.

`uvx ruff check . --select F` clean.