### PR TITLE
fix(tests): write canonical lifecycle artifacts verbatim

### DIFF
--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -104,11 +104,17 @@ def _install_lifecycle_slot(
     )
     prepared_path = relation_review.lifecycle_prepared_path(root, page_id)
     decision_path.parent.mkdir(parents=True, exist_ok=True)
-    decision_path.write_text(
-        relation_review.serialize_lifecycle_decision(decision), encoding="utf-8"
+    # `write_bytes`, because these artifacts are canonical by digest.
+    # `write_text` applies universal-newline translation, so on Windows every
+    # line feed the serializer emitted landed as CRLF and reconcile answered
+    # RELATION_REVIEW_NONCANONICAL to every one of these tests -- a true report
+    # about a file the test never meant to write that way. The product writes
+    # these through binary descriptors and is unaffected.
+    decision_path.write_bytes(
+        relation_review.serialize_lifecycle_decision(decision).encode("utf-8")
     )
-    prepared_path.write_text(
-        relation_review.serialize_lifecycle_prepared(prepared), encoding="utf-8"
+    prepared_path.write_bytes(
+        relation_review.serialize_lifecycle_prepared(prepared).encode("utf-8")
     )
     return page, prepared_path, before, after
 
@@ -479,9 +485,8 @@ def test_reconcile_blocks_prepared_primary_and_trash_races(
                 current,
                 transition_id="00000000-0000-4000-8000-000000000299",
             )
-            prepared_path.write_text(
-                relation_review.serialize_lifecycle_prepared(replacement),
-                encoding="utf-8",
+            prepared_path.write_bytes(
+                relation_review.serialize_lifecycle_prepared(replacement).encode("utf-8")
             )
         elif race == "primary_change":
             page.write_text(after, encoding="utf-8")


### PR DESCRIPTION
Twelve reconcile tests failed on the Windows lane with `RELATION_REVIEW_NONCANONICAL`, and the report was true. `_install_lifecycle_slot` staged its decision and prepared artifacts with `write_text`, whose universal-newline translation turns every line feed the serializer emitted into CRLF. The bytes on disk were then not the canonical bytes their digest covers, so reconcile refused a file the test never meant to write that way.

These artifacts are canonical by digest, so the test has to put the serializer's bytes down unchanged: `write_bytes` on an explicit `.encode("utf-8")`.

**The product is unaffected and unmodified.** `relation_review` writes these artifacts through descriptors that already carry `O_BINARY` (`relation_review.py:1382`, `:2605`), so it never had this defect — only the test fixture did.

## Verification

`tests/test_reconcile.py` on Windows:

| | failed | passed |
|---|---|---|
| `origin/main` | 16 | 20 |
| this branch | 4 | 32 |

The four survivors fail identically on `origin/main` — the branch-only failure set is empty:

```
test_reconcile_clears_deferred_semantic_work_after_embedding_refresh
test_reconcile_preserves_deferred_work_after_embedding_failure
test_reconcile_preserves_exact_trashed_committed_slot
test_reconcile_recognizes_directory_trash_root_suffix_proof
```

`uvx ruff check . --select F` passes.