### PR TITLE
fix(census): pin an enumerated entry to an identity that exists

### DIFF
--- a/src/exomem/semantic_census.py
+++ b/src/exomem/semantic_census.py
@@ -43,6 +43,27 @@ def _is_reparse(info: os.stat_result) -> bool:
     return bool(getattr(info, "st_file_attributes", 0) & marker)
 
 
+def _identity_bearing_stat(entry: os.DirEntry[str]) -> os.stat_result:
+    """A stat result that actually carries this entry's identity.
+
+    `os.DirEntry.stat()` answers from the directory-enumeration record. On
+    Windows that record holds no volume serial and no file index, so `st_dev`
+    and `st_ino` both come back 0 -- while every re-check in this module reads
+    them through `lstat` or `fstat`, which open the object and get the real
+    pair. Pinning an entry to the enumeration record there pins it to an
+    identity nothing can match: the census counted every subdirectory as having
+    changed under it, descended into none of them, and reported an empty vault
+    to a scan-only adopt.
+
+    So take one real look, at the two places an identity is about to be pinned.
+    POSIX fills both fields during enumeration, so the record is returned
+    unchanged and no extra call is made there.
+    """
+    if os.name != "nt":  # pragma: no cover - the Windows branch is the fix
+        return entry.stat(follow_symlinks=False)
+    return os.lstat(entry.path)
+
+
 def _same_identity(left: os.stat_result, right: os.stat_result) -> bool:
     return (
         getattr(left, "st_dev", None) == getattr(right, "st_dev", None)
@@ -59,6 +80,36 @@ def _same_file_state(left: os.stat_result, right: os.stat_result) -> bool:
         == getattr(right, "st_mtime_ns", None)
         and getattr(left, "st_ctime_ns", None)
         == getattr(right, "st_ctime_ns", None)
+    )
+
+
+def _same_file_state_across_stat_apis(
+    left: os.stat_result, right: os.stat_result
+) -> bool:
+    """`_same_file_state` minus the one field the two stat APIs disagree on.
+
+    The read below compares an `fstat` on its own open handle against an
+    `lstat` on the path, to prove nothing swapped the file underneath it. On
+    Windows `st_ctime` is the *creation* time, and it is served from the
+    directory entry, which the filesystem updates lazily -- so those two calls
+    come back a millisecond apart for a file nothing has touched, and every
+    markdown page in the vault read back as "changed during the read".
+
+    Dropping it across that boundary costs nothing. Creation time cannot change
+    for a live inode: producing a new one moves `st_dev`/`st_ino` and a content
+    change moves `st_size`/`st_mtime_ns`, all of which stay compared. On POSIX
+    `st_ctime` is the inode-change time -- it catches a chmod or a link-count
+    change that the other fields miss -- so it is kept there.
+
+    The handle-to-handle comparison keeps the full state on both platforms:
+    both sides come from the same API, so every field means the same thing.
+    """
+    if os.name != "nt":
+        return _same_file_state(left, right)
+    return (
+        _same_identity(left, right)
+        and left.st_size == right.st_size
+        and getattr(left, "st_mtime_ns", None) == getattr(right, "st_mtime_ns", None)
     )
 
 
@@ -250,7 +301,7 @@ def _read_regular_file_bounded(
         not _directory_identities_current(root, expected_ancestors)
         or _is_reparse(current)
         or not vault._same_identity(expected_file, current)
-        or not _same_file_state(opened, current)
+        or not _same_file_state_across_stat_apis(opened, current)
     ):
         return "unsafe", None
     return "ok", b"".join(chunks)
@@ -608,9 +659,23 @@ def scan(
                     hidden_omitted += 1
                     continue
                 child_path = Path(entry.path)
+                try:
+                    pinned = _identity_bearing_stat(entry)
+                except OSError:
+                    unreadable_directories += 1
+                    enumeration_incomplete = True
+                    continue
+                if (
+                    not stat.S_ISDIR(pinned.st_mode)
+                    or stat.S_ISLNK(pinned.st_mode)
+                    or _is_reparse(pinned)
+                ):
+                    unreadable_directories += 1
+                    enumeration_incomplete = True
+                    continue
                 child_identity = vault._identity(
                     child_path.relative_to(root_path).as_posix(),
-                    entry_info,
+                    pinned,
                 )
                 child_directories.append(
                     (child_path, (*expected_ancestors, child_identity))
@@ -626,9 +691,15 @@ def scan(
                 markdown_omitted += 1
                 continue
             disk_path = Path(entry.path)
+            try:
+                pinned_file = _identity_bearing_stat(entry)
+            except OSError:
+                unreadable_files += 1
+                markdown_omitted += 1
+                continue
             expected_file = vault._identity(
                 disk_path.relative_to(root_path).as_posix(),
-                entry_info,
+                pinned_file,
             )
             read_status, raw = _read_regular_file_bounded(
                 root_path,

--- a/tests/test_adopt.py
+++ b/tests/test_adopt.py
@@ -14,6 +14,7 @@ import yaml
 
 from exomem import adopt as adopt_module
 from exomem import commands, knowledge_packs, semantic_census
+from exomem import vault as vault_module
 from exomem.__main__ import main
 
 
@@ -637,7 +638,10 @@ tags: []
 - [before] Exact scanned bytes.
 """
     replacement = original.replace("[before] Exact scanned bytes", "[after] Replaced")
-    page.write_text(original, encoding="utf-8")
+    # This test is about the exact bytes the census read, so it has to put
+    # exact bytes down. `write_text` applies universal-newline translation, so
+    # on Windows it wrote CRLF and then demanded the census hand back LF.
+    page.write_bytes(original.encode("utf-8"))
     relative = page.relative_to(vault).as_posix()
     real_build_page_state = semantic_census.semantic_contract.build_page_state
     observed_texts: list[str] = []
@@ -647,7 +651,7 @@ tags: []
         if str(args[1]) == relative:
             observed_texts.append(str(args[2]))
             if len(observed_texts) == 1:
-                page.write_text(replacement, encoding="utf-8")
+                page.write_bytes(replacement.encode("utf-8"))
         return state
 
     monkeypatch.setattr(
@@ -1302,3 +1306,94 @@ def test_run_manifest_body_carries_counts_and_the_run_reference_only(
     assert leaked == [], f"run manifest body names per-item detail: {leaked}"
     assert "```json" not in body
     assert "Machine-Readable" not in body
+
+# --- the census runs on a platform whose directory entries carry no identity ---
+#
+# Two defects made `adopt(mode="scan-only")` report an empty vault on Windows,
+# and the second was invisible until the first was fixed: an identity pinned
+# from the enumeration record, and a file-state comparison across two stat APIs
+# that disagree about one field. Ten tests in this file failed there.
+
+
+def test_an_enumerated_entry_is_pinned_to_an_identity_that_exists(
+    tmp_path: Path,
+) -> None:
+    """The defect that made the census refuse the whole vault.
+
+    `os.DirEntry.stat()` answers from the directory-enumeration record, and on
+    Windows that record carries no volume serial and no file index -- `st_dev`
+    and `st_ino` both come back 0. Every re-check in the census reads them
+    through `lstat` or `fstat`, which get the real pair, so a directory pinned
+    to the enumeration record could never match itself: the census counted
+    every subdirectory as having changed underneath it and descended into none.
+
+    What this pins is not the platform detail but the invariant it broke -- an
+    entry's pinned identity has to be the one a later look will find.
+    """
+    (tmp_path / "Sub").mkdir()
+    (tmp_path / "Sub" / "page.md").write_bytes(b"---\ntype: note\n---\n# P\n\nBody.\n")
+
+    with os.scandir(tmp_path) as iterator:
+        entry = next(item for item in iterator if item.name == "Sub")
+    pinned = semantic_census._identity_bearing_stat(entry)
+
+    assert vault_module._same_identity(
+        vault_module._identity("Sub", pinned), (tmp_path / "Sub").lstat()
+    )
+
+
+def test_creation_time_is_the_only_field_dropped_across_the_two_stat_apis() -> None:
+    """The narrowing has to stay narrow, and only where the APIs disagree.
+
+    Windows disagrees with itself about `st_ctime` between a handle stat and a
+    path stat -- by a millisecond, for a file nothing touched -- because it is
+    the creation time and it comes from the directory entry. Comparing them
+    made every page read back as "changed during the read". Dropping it there
+    costs nothing: a new inode moves `st_dev`/`st_ino` and a content change
+    moves `st_size`/`st_mtime_ns`, and all four stay compared. Dropping it on
+    POSIX, where it is the inode-change time, would be a real loss.
+    """
+    def _stat(*, size: int, ctime_ns: int) -> os.stat_result:
+        return os.stat_result(
+            (0o100644, 7, 3, 1, 0, 0, size, 0, 100, ctime_ns // 10**9),
+            {"st_mtime_ns": 100 * 10**9, "st_ctime_ns": ctime_ns},
+        )
+
+    base = _stat(size=41, ctime_ns=200 * 10**9)
+    same_but_for_ctime = _stat(size=41, ctime_ns=999 * 10**9)
+    bigger = _stat(size=42, ctime_ns=200 * 10**9)
+
+    tolerated = semantic_census._same_file_state_across_stat_apis(
+        base, same_but_for_ctime
+    )
+
+    assert tolerated is (os.name == "nt")
+    assert semantic_census._same_file_state(base, same_but_for_ctime) is False
+    # A real change is refused on both platforms, which is the point of keeping
+    # every other field in the comparison.
+    assert semantic_census._same_file_state_across_stat_apis(base, bigger) is False
+
+
+def test_a_scan_only_adopt_finds_the_pages_that_are_there(tmp_path: Path) -> None:
+    """The end-to-end statement, which is what actually regressed.
+
+    Both defects were silent: the census reported a coherent, complete-looking
+    report with every count at zero. Nothing raised, nothing warned, and adopt
+    told the user their vault held no markdown at all.
+    """
+    vault_root = tmp_path / "vault"
+    (vault_root / "Knowledge Base" / "Notes").mkdir(parents=True)
+    (vault_root / "Knowledge Base" / "Notes" / "alpha.md").write_bytes(
+        b"---\ntype: note\n---\n# Alpha\n\n## Finding\n- category: Rule\n\nBody.\n"
+    )
+    (vault_root / "Knowledge Base" / "Notes" / "beta.md").write_bytes(
+        b"---\ntype: note\n---\n# Beta\n\nPlain body.\n"
+    )
+
+    census = semantic_census.scan(vault_root)
+
+    coverage = census["coverage"]
+    assert coverage["markdown_files_scanned"] == 2
+    assert coverage["unreadable_files"] == 0
+    assert coverage["unreadable_directories"] == 0
+    assert coverage["complete"] is True


### PR DESCRIPTION
`adopt(mode="scan-only")` reported an **empty vault on Windows** — zero markdown files, every governance count at zero, `saved_contracts: partial`. Nothing raised and nothing warned; the report was coherent and wrong. Two defects, the second invisible until the first was fixed.

## 1. The identity was pinned to a record that carries no identity

The census pinned each enumerated entry with `os.DirEntry.stat()`. That answers from the directory-enumeration record, and on Windows the record carries no volume serial and no file index — `st_dev` and `st_ino` both come back `0`:

```
DirEntry.stat()  st_dev 0           st_ino 0
Path.lstat()     st_dev 2633241797  st_ino 48132221025888579
```

Every re-check in the module reads them through `lstat` or `fstat`, which open the object and get the real pair, so a pinned directory could **never** match itself. The census counted every subdirectory as having changed underneath it and descended into none of them.

`semantic_census.py:591` was the only DirEntry-derived identity in the product — it fed both the ancestor chain and the per-file identity, so directories and files were both affected. It now takes one real look where the identity is pinned. POSIX fills both fields during enumeration, so the record is returned unchanged and no extra call is made there.

## 2. Then the read compared two stat APIs that disagree

Once the walk descended, every page came back `unsafe`. The post-read check compares the `fstat` taken on its own open handle against an `lstat` on the path, via `_same_file_state` — which includes `st_ctime_ns`. On Windows `st_ctime` is the *creation* time, served from the directory entry the filesystem updates lazily, so those two calls differ by a millisecond for a file nothing touched.

This is the same defect class as #661 (`hosted_portability`), at a second site. The narrowing stays narrow:

- **handle-to-handle** (`_same_file_state(opened, after)`) keeps every field, on both platforms — both sides come from the same API.
- **handle-to-path** drops only `st_ctime`, only on Windows. A new inode still moves `st_dev`/`st_ino`; a content change still moves `st_size`/`st_mtime_ns`.
- **POSIX keeps `st_ctime` everywhere**, where it is the inode-change time and catches a chmod or link-count change the other fields miss.

## 3. One test-side defect went with them

`test_adopt_semantic_census_governance_uses_exact_scanned_page_state` wrote its page with `write_text`, so on Windows it laid down CRLF and then demanded the census hand back LF. A test about exact bytes has to write exact bytes.

## Verification

`tests/test_adopt.py` on Windows:

| | failed | passed |
|---|---|---|
| `origin/main` | 10 | 36 |
| this branch | 0 | 49 |

Three added tests pin the invariants: that an enumerated entry's pinned identity is the one a later look finds, that `st_ctime` is the *only* field dropped and only across the two APIs, and the end-to-end statement that a scan-only adopt finds the pages that are there.

Ten adjacent adoption and census suites: **15 failures before, the same 15 after** — the branch-only set is empty.

`uvx ruff check . --select F` passes.