### PR TITLE
fix(startup): stop the import of a command module needing a home directory

### DIFF
--- a/src/exomem/install_hook.py
+++ b/src/exomem/install_hook.py
@@ -54,14 +54,42 @@ _CONTINUATION_EVENTS = {
 }
 DEFAULT_CLIENT = "claude"
 SUPPORTED_CLIENTS = ("claude", "codex")
-DEFAULT_CLAUDE_HOOK_DIR = Path.home() / ".claude" / "hooks"
-DEFAULT_CLAUDE_SETTINGS = Path.home() / ".claude" / "settings.json"
-DEFAULT_CODEX_HOOK_DIR = Path.home() / ".codex" / "hooks"
-DEFAULT_CODEX_SETTINGS = Path.home() / ".codex" / "hooks.json"
+# Resolved on attribute access rather than at import. `Path.home()` raises
+# when the environment names no home -- a service account, a container
+# started without `HOME`, a child handed a minimal environment -- and these
+# were four import-time calls, so merely importing this module failed there.
+# The names and values are unchanged for every caller that reads them.
+_DEFAULT_PATHS = {
+    "DEFAULT_CLAUDE_HOOK_DIR": (".claude", "hooks"),
+    "DEFAULT_CLAUDE_SETTINGS": (".claude", "settings.json"),
+    "DEFAULT_CODEX_HOOK_DIR": (".codex", "hooks"),
+    "DEFAULT_CODEX_SETTINGS": (".codex", "hooks.json"),
+    # Back-compat for existing tests and callers.
+    "DEFAULT_HOOK_DIR": (".claude", "hooks"),
+    "DEFAULT_SETTINGS": (".claude", "settings.json"),
+}
 
-# Back-compat for existing tests and callers.
-DEFAULT_HOOK_DIR = DEFAULT_CLAUDE_HOOK_DIR
-DEFAULT_SETTINGS = DEFAULT_CLAUDE_SETTINGS
+
+def __getattr__(name: str) -> Path:
+    parts = _DEFAULT_PATHS.get(name)
+    if parts is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return Path.home().joinpath(*parts)
+
+
+def _is_conventional_hook_dir(hook_dir: Path, client: str) -> bool:
+    """True when *hook_dir* is the one `~` would name for *client*.
+
+    Only ever used to decide whether the rendered command may say `~` instead
+    of an absolute path. Where the environment names no home there is no `~`
+    to abbreviate to, so the answer is no and the absolute form is rendered --
+    rather than raising out of a command renderer.
+    """
+    try:
+        home = Path.home()
+    except RuntimeError:
+        return False
+    return hook_dir == home / (".codex" if client == "codex" else ".claude") / "hooks"
 
 # Substrings identifying a previously-installed nudge entry, so re-running is
 # idempotent and supersedes older entries (incl. the absolute-python-path form).
@@ -129,10 +157,10 @@ def _command_for(
     hook_dir = Path(hook_dir).expanduser()
     if client == "codex":
         py_name = script or wrapper.removesuffix(".sh").replace("-", "_") + ".py"
-        if hook_dir == DEFAULT_CODEX_HOOK_DIR:
+        if _is_conventional_hook_dir(hook_dir, "codex"):
             return f"python3 ~/.codex/hooks/{py_name}"
         return f'python3 "{(hook_dir / py_name).as_posix()}"'
-    if hook_dir == DEFAULT_CLAUDE_HOOK_DIR:
+    if _is_conventional_hook_dir(hook_dir, "claude"):
         return f"bash ~/.claude/hooks/{wrapper}"
     return f'bash "{(hook_dir / wrapper).as_posix()}"'
 

--- a/src/exomem/install_skill.py
+++ b/src/exomem/install_skill.py
@@ -33,7 +33,22 @@ _SKILL_SRC = Path(__file__).parent / "_scaffold" / "_Schema"
 
 # Claude Code loads `~/.claude/skills/<name>/SKILL.md`; the folder name must match
 # the skill's `name:` frontmatter (`exomem`).
-DEFAULT_TARGET = Path.home() / ".claude" / "skills" / "exomem"
+# Resolved on attribute access, not at import: see `_DEFAULT_PATHS` in
+# install_hook.py for why an import must not need a home directory.
+_DEFAULT_PATHS = {
+    "DEFAULT_TARGET": (".claude", "skills", "exomem"),
+    "_LEGACY_TARGET": (".claude", "skills", "knowledge-base"),
+}
+
+
+def _default_path(name: str) -> Path:
+    return Path.home().joinpath(*_DEFAULT_PATHS[name])
+
+
+def __getattr__(name: str) -> Path:
+    if name not in _DEFAULT_PATHS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return _default_path(name)
 
 DEFAULT_CLIENT = "claude"
 SUPPORTED_CLIENTS = ("claude", "codex")
@@ -105,7 +120,6 @@ def install_skills(
 # Before the skill was renamed to `exomem` it installed here. Left behind after an
 # upgrade it loads as a stale duplicate, so `remove_legacy_skill` retires it — but
 # only when it is unmistakably ours (see that function).
-_LEGACY_TARGET = Path.home() / ".claude" / "skills" / "knowledge-base"
 _LEGACY_MARKER = "name: knowledge-base"
 _LEGACY_FINGERPRINT = "Exomem"
 
@@ -146,7 +160,9 @@ def install_skill(
             "is the exomem install intact?"
         )
 
-    target = (Path(target) if target is not None else DEFAULT_TARGET).expanduser()
+    target = (
+        Path(target) if target is not None else _default_path("DEFAULT_TARGET")
+    ).expanduser()
     targets = _install_targets(target)
 
     for item in targets:
@@ -255,7 +271,9 @@ def remove_legacy_skill(legacy: Path | None = None) -> Path | None:
 
     Returns the removed path, or ``None`` if there was nothing of ours to remove.
     """
-    legacy = (Path(legacy) if legacy is not None else _LEGACY_TARGET).expanduser()
+    legacy = (
+        Path(legacy) if legacy is not None else _default_path("_LEGACY_TARGET")
+    ).expanduser()
     skill_md = legacy / "SKILL.md"
     if not skill_md.is_file():
         return None

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -28,7 +28,7 @@ import uuid
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager, nullcontext
 from contextvars import ContextVar, Token
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -629,6 +629,25 @@ class _CachedCommittedFailure(ValueError):
         return _serialize_committed_failure_payload(self._payload).decode("utf-8")
 
 
+def _default_state_dir() -> Path:
+    """Where lease state lives when the caller names nowhere else.
+
+    A `default_factory`, not a plain default, because a plain one is
+    evaluated when the class body runs -- at import. `Path.home()` raises
+    `RuntimeError` outright when the environment names no home, which is
+    the ordinary state of a service account, a container started without
+    `HOME`, and any child handed a minimal environment. That made
+    `import exomem.commands` fail there, so the whole command surface was
+    unreachable for want of a directory nothing had asked for yet.
+
+    Resolving it here moves the failure to the caller that actually wants
+    the default path, and leaves every caller that passes its own
+    `state_dir` -- the hosted cell and the service both do -- working with
+    no home at all.
+    """
+    return Path.home() / ".cache" / "exomem"
+
+
 @dataclass(frozen=True)
 class LeaseConfig:
     url: str | None = None
@@ -638,7 +657,7 @@ class LeaseConfig:
     ttl_seconds: float = 30.0
     timeout_seconds: float = 3.0
     preferred_writer: bool = False
-    state_dir: Path = Path.home() / ".cache" / "exomem"
+    state_dir: Path = field(default_factory=_default_state_dir)
     # How long a writer waits for the vault mutation boundary before giving up
     # with MUTATION_BUSY.
     #
@@ -698,7 +717,7 @@ class LeaseConfig:
             ttl_seconds=ttl_seconds,
             timeout_seconds=_positive_float(values, "EXOMEM_WRITER_LEASE_TIMEOUT", 3.0),
             preferred_writer=_truthy(values.get("EXOMEM_WRITER_LEASE_PREFERRED", "")),
-            state_dir=Path(state_raw).expanduser() if state_raw else cls.state_dir,
+            state_dir=Path(state_raw).expanduser() if state_raw else _default_state_dir(),
             mutation_timeout_seconds=_positive_float(values, "EXOMEM_MUTATION_TIMEOUT", 5.0),
             idle_release_seconds=idle_release_seconds,
         )

--- a/tests/test_import_without_a_home.py
+++ b/tests/test_import_without_a_home.py
@@ -1,0 +1,132 @@
+"""Importing the product must not require a home directory.
+
+`Path.home()` raises `RuntimeError` outright when the environment names no
+home. That is the ordinary state of a Windows service account, a container
+started without `HOME`, and any child process handed a minimal environment --
+and three modules called it while their module bodies ran, so `import
+exomem.commands` failed there and the entire command surface was unreachable
+for want of a directory nothing had asked for yet.
+
+These pin the invariant rather than the platform: an import may not resolve a
+home directory, on any operating system. Written as a subprocess with
+`Path.home` replaced by a raising stub, because the failure is an import-time
+one and an already-imported module cannot show it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Every module that sits between an entry point and the command surface. The
+# import chain that actually broke ran commands -> delete_directory ->
+# governance.lifecycle -> governance.receipts -> writer_lease, and failed on
+# the last one's dataclass field default.
+_MODULES = (
+    "exomem",
+    "exomem.__main__",
+    "exomem.commands",
+    "exomem.server",
+    "exomem.writer_lease",
+    "exomem.install_hook",
+    "exomem.install_skill",
+)
+
+_DENY_HOME = (
+    "import pathlib\n"
+    "def _no_home(cls):\n"
+    "    raise RuntimeError('Could not determine home directory.')\n"
+    "pathlib.Path.home = classmethod(_no_home)\n"
+)
+
+
+def _run_without_a_home(body: str) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        path for path in sys.path if path and Path(path).is_dir()
+    )
+    return subprocess.run(
+        [sys.executable, "-c", _DENY_HOME + body],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("module", _MODULES)
+def test_the_module_imports_where_there_is_no_home_directory(module: str) -> None:
+    result = _run_without_a_home(f"import {module}\nprint('imported')\n")
+
+    assert result.returncode == 0, result.stderr
+    assert "imported" in result.stdout
+
+
+def test_a_lease_told_where_its_state_lives_needs_no_home() -> None:
+    """The caller that supplies `state_dir` is every deployed one.
+
+    The hosted cell and the installed service both pass their own path, so the
+    default this used to evaluate at import was never the value they used --
+    it only had to exist for the class body to finish.
+    """
+    result = _run_without_a_home(
+        "from pathlib import PurePosixPath\n"
+        "from exomem.writer_lease import LeaseConfig\n"
+        "config = LeaseConfig(state_dir=PurePosixPath('/srv/exomem/state'))\n"
+        "print(config.state_dir)\n"
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "/srv/exomem/state" in result.stdout
+
+
+def test_asking_for_the_default_without_a_home_still_reports_the_real_reason() -> None:
+    """Deferring the call moves the failure; it does not swallow it.
+
+    A caller that genuinely wants the home-relative default and has no home
+    still gets `RuntimeError` -- now at the point of asking, where it names
+    something the caller can act on, instead of at import of an unrelated
+    module.
+    """
+    result = _run_without_a_home(
+        "from exomem.writer_lease import LeaseConfig\n"
+        "try:\n"
+        "    LeaseConfig()\n"
+        "except RuntimeError as error:\n"
+        "    print('refused:', error)\n"
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "refused:" in result.stdout
+
+
+def test_the_deferred_names_still_resolve_where_there_is_a_home() -> None:
+    """The values callers read are unchanged; only when they resolve moved."""
+    from exomem import install_hook, install_skill
+
+    home = Path.home()
+
+    assert install_hook.DEFAULT_CLAUDE_HOOK_DIR == home / ".claude" / "hooks"
+    assert install_hook.DEFAULT_CLAUDE_SETTINGS == home / ".claude" / "settings.json"
+    assert install_hook.DEFAULT_CODEX_HOOK_DIR == home / ".codex" / "hooks"
+    assert install_hook.DEFAULT_CODEX_SETTINGS == home / ".codex" / "hooks.json"
+    assert install_hook.DEFAULT_HOOK_DIR == home / ".claude" / "hooks"
+    assert install_hook.DEFAULT_SETTINGS == home / ".claude" / "settings.json"
+    assert install_skill.DEFAULT_TARGET == home / ".claude" / "skills" / "exomem"
+    assert (
+        install_skill._LEGACY_TARGET == home / ".claude" / "skills" / "knowledge-base"
+    )
+
+
+def test_an_unknown_name_is_still_an_attribute_error() -> None:
+    """A module `__getattr__` must not turn every typo into a Path."""
+    from exomem import install_hook, install_skill
+
+    with pytest.raises(AttributeError):
+        install_hook.DEFAULT_NOTHING_DIR
+    with pytest.raises(AttributeError):
+        install_skill.DEFAULT_NOTHING_DIR


### PR DESCRIPTION
Closes #665.

`import exomem.commands` raises `RuntimeError: Could not determine home directory.` in any process whose environment names no home — a Windows service account, a container started without `HOME`, any child handed a minimal environment. The whole command surface is unreachable there: not degraded, **unimportable**, for want of a directory nothing had asked for yet.

## Where it died

```
exomem.commands:55 -> delete_directory:25 -> governance.lifecycle:28
                   -> governance.receipts:43 -> writer_lease:633 (class LeaseConfig)
                   -> writer_lease.py:641  state_dir: Path = Path.home() / ".cache" / "exomem"
```

A plain dataclass field default is evaluated when the class body runs — at import. `install_hook.py:57-60` and `install_skill.py:36,108` did the same at module scope.

## What changed

Each resolves on demand instead: a `default_factory` for the field, a module `__getattr__` for the constants. **The values every caller reads are unchanged** — only the moment they are computed moved.

Deferring does not swallow the failure. A caller that genuinely wants the home-relative default and has no home still gets `RuntimeError`, now at the point of asking, where it names something the caller can act on. And every deployed caller passes its own `state_dir` — the hosted cell and the installed service both do — so the default that broke the import was a value none of them used.

Two intra-module references had to move with it, because a module `__getattr__` is consulted for attribute access and not for a bare name in the module's own body: the `~`-abbreviation check in `install_hook` (now `_is_conventional_hook_dir`, which answers *no* rather than raising when there is no `~` to abbreviate to) and the two `_default_path(...)` sites in `install_skill`.

## Verification

`tests/test_import_without_a_home.py` pins the invariant rather than the platform — *an import may not resolve a home directory, on any operating system* — by replacing `Path.home` with a raising stub in a subprocess, since an already-imported module cannot show an import-time failure.

| | on `origin/main` | on this branch |
|---|---|---|
| the new file | 7 failed, 4 passed | **11 passed** |

Modules that go from failing to importing without a home: `exomem.commands`, `exomem.server`, `exomem.writer_lease`, `exomem.install_hook`, `exomem.install_skill`.

Regression check against a disposable `origin/main` worktree **on the same interpreter** (py3.13, which is what the Windows lane runs): `test_install_hook`, `test_install_skill`, `test_writer_lease`, `test_lease_cli`, `test_lease_coordinator` — 5 failures on both sides, branch-only set empty. Those 5 are pre-existing and unrelated.

`uvx ruff check . --select F` passes.

## Not a CI failure today

CI always runs with a home directory, so nothing red pointed at this. It surfaced while giving a membench child process a minimal environment.