### PR TITLE
fix(windows): close the last four cross-platform failures

### DIFF
--- a/tests/benchmark_capabilities.py
+++ b/tests/benchmark_capabilities.py
@@ -114,6 +114,52 @@ def has_mount_type_inspection() -> bool:
 
 
 @lru_cache(maxsize=1)
+def posix_bash() -> str | None:
+    """An absolute path to a bash that can run a POSIX script, or None.
+
+    `subprocess.run(["bash", ...])` resolves the bare name through
+    `CreateProcess`, which searches the **system directory before PATH**. Where
+    the Windows Subsystem for Linux is registered but has no distribution
+    installed, that directory holds a `bash.exe` which is not a shell at all:
+    it prints "Windows Subsystem for Linux has no installed distributions" in
+    UTF-16 and exits non-zero. A test that asked bash to check a script's
+    syntax got that advertisement back and read it as a syntax error.
+
+    `shutil.which` searches PATH, where the real bash lives (Git for Windows
+    ships one), so resolving the name here and handing over the absolute path
+    is what makes the call mean what it says. Candidates under the system
+    directory are excluded by construction rather than by name, and each one is
+    proved by running it, so a launcher that changes its wording is still
+    rejected.
+
+    Returns None where the only bash is that launcher, so callers declare the
+    missing capability instead of asserting against its output.
+    """
+    if os.name != "nt":
+        return shutil.which("bash")
+    system_root = os.environ.get("SystemRoot")
+    excluded = Path(system_root).resolve() if system_root else None
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        if not entry:
+            continue
+        candidate = shutil.which("bash", path=entry)
+        if candidate is None:
+            continue
+        resolved = Path(candidate).resolve()
+        if excluded is not None and excluded in resolved.parents:
+            continue
+        try:
+            proof = subprocess.run(
+                [str(resolved), "-c", "exit 0"], capture_output=True, timeout=60
+            )
+        except OSError:
+            continue
+        if proof.returncode == 0:
+            return str(resolved)
+    return None
+
+
+@lru_cache(maxsize=1)
 def has_procfs_descriptor_paths() -> bool:
     """True where `/proc/self/fd/<n>` names an open descriptor as a path.
 

--- a/tests/test_continuation_checkpoint.py
+++ b/tests/test_continuation_checkpoint.py
@@ -1121,9 +1121,30 @@ def _init_repo(path: Path) -> None:
     subprocess.run(["git", "-C", str(path), "config", "core.longpaths", "true"], check=True)
     subprocess.run(["git", "-C", str(path), "config", "user.email", "test@example.com"], check=True)
     subprocess.run(["git", "-C", str(path), "config", "user.name", "Test"], check=True)
-    (path / "tracked.txt").write_text("base\n", encoding="utf-8")
+    # A fixture repo has to be clean when it is handed over, and inheriting
+    # the host's line-ending policy is the one way it silently is not. Git
+    # for Windows defaults `core.autocrlf` to true and `write_text` emits
+    # CRLF there, so the combination decides on its own whether the
+    # committed file matches the working tree. A test that then dirties one
+    # path and expects the checkpoint digest to rotate would be comparing
+    # two observations that were already dirty, and reports two equal
+    # hashes with no hint why.
+    subprocess.run(["git", "-C", str(path), "config", "core.autocrlf", "false"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "core.eol", "lf"], check=True)
+    # Bytes, so the newline is the one written here and not the platform's.
+    (path / "tracked.txt").write_bytes(b"base\n")
     subprocess.run(["git", "-C", str(path), "add", "tracked.txt"], check=True)
     subprocess.run(["git", "-C", str(path), "commit", "-qm", "base"], check=True)
+    # Proved, not assumed. A repo that starts dirty makes every downstream
+    # "this change rotated the digest" assertion vacuous, and it fails far
+    # from here when it does.
+    residue = subprocess.run(
+        ["git", "-C", str(path), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert residue == "", f"fixture repo is dirty before the test starts: {residue!r}"
 
 
 def test_git_status_timeout_is_degraded_not_reported_clean(

--- a/tests/test_governance_receipt_runtime_bootstrap_windows.py
+++ b/tests/test_governance_receipt_runtime_bootstrap_windows.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import multiprocessing
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -65,7 +66,24 @@ def _first_use_process(
     def apply(path: Path, sid: str) -> None:
         nonlocal root_dacl_applies
         if path == root and list(root.iterdir()):
-            raise AssertionError("runtime root gained a lock artifact before DACL validation")
+            # A *tightening* pass runs on a root that already holds artifacts,
+            # and that is sound: the verdict it repairs is `inherited`, which
+            # means the ACEs were already exactly the private trustee set and
+            # were merely arriving by inheritance. Nothing was ever created
+            # under a weaker DACL, so no handle outside the set can exist.
+            #
+            # What must never happen is what this assertion was written for:
+            # the private DACL applied to a populated root that was genuinely
+            # unsafe, where a foreign principal had the run of the directory
+            # while artifacts landed in it and may still hold a handle no later
+            # tightening can take back.
+            verdict = mutation_lock._windows_private_dacl_verdict(
+                mutation_lock._windows_dacl_sddl(path), sid, directory=True
+            )
+            if verdict != mutation_lock._WINDOWS_DACL_INHERITED:
+                raise AssertionError(
+                    "runtime root gained a lock artifact before DACL validation"
+                )
         if path == root:
             root_dacl_applies += 1
         original_apply(path, sid)
@@ -175,11 +193,34 @@ def test_windows_receipt_first_refuses_existing_unsafe_runtime_without_lock_chil
     """An inherited legacy root remains untouched and actionable at receipt entry."""
     state_root = tmp_path / "unsafe-existing-state"
     state_root.mkdir()
+    # Built, not inherited. A bare `mkdir` under the temporary directory
+    # produces `(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)(A;OICIID;FA;;;OW)` on both
+    # this machine and the CI runner -- exactly the private trustee set,
+    # arriving by inheritance -- which the validator classifies as `inherited`
+    # and the writer now *repairs* rather than refuses. Depending on the host's
+    # ambient DACL to supply "unsafe" therefore tested whichever verdict the
+    # machine happened to hand out, and stopped meaning anything once
+    # tightening landed.
+    #
+    # Grant a trustee outside the private set instead. `WD` (Everyone) can
+    # never be tightened away safely -- a principal outside the set may already
+    # hold a handle -- so this is the verdict the refusal exists for, and it is
+    # the same on every host.
+    grant = subprocess.run(
+        ["icacls", str(state_root), "/grant", "*S-1-1-0:(OI)(CI)F"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert grant.returncode == 0, grant.stdout + grant.stderr
     monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(state_root))
     before_dacl = mutation_lock._windows_dacl_sddl(state_root)
-    assert not mutation_lock._windows_private_dacl_is_valid(
-        before_dacl, mutation_lock._windows_current_user_sid(), directory=True
-    )
+    assert (
+        mutation_lock._windows_private_dacl_verdict(
+            before_dacl, mutation_lock._windows_current_user_sid(), directory=True
+        )
+        == mutation_lock._WINDOWS_DACL_UNSAFE
+    ), before_dacl
 
     sid = mutation_lock._windows_current_user_sid()
     expected_remediation = mutation_lock._windows_private_dacl_repair_command(

--- a/tests/test_hosted_database_migration.py
+++ b/tests/test_hosted_database_migration.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 from pathlib import Path
 
+import benchmark_capabilities
 import pytest
 import yaml
 
@@ -138,8 +139,15 @@ def test_admin_database_authority_is_ephemeral_and_rotation_gated() -> None:
     # line break and reported a syntax error in a block that is correct --
     # a trailing CR stops `esac` being `esac`. `subprocess.run` has no
     # `newline=` to ask for otherwise, so the encode happens here.
+    bash = benchmark_capabilities.posix_bash()
+    if bash is None:
+        pytest.skip("no POSIX bash on this host to check the block's syntax with")
+    # The resolved absolute path, not the bare name: `CreateProcess` searches
+    # the system directory before PATH, and on a Windows host with WSL
+    # registered but no distribution installed that directory answers `bash`
+    # with a launcher that prints an advertisement and exits non-zero.
     syntax = subprocess.run(
-        ["bash", "-n"],
+        [bash, "-n"],
         input=bootstrap_block.encode("utf-8"),
         capture_output=True,
         check=False,

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -219,9 +219,29 @@ def test_missing_parent_swap_cannot_redirect_nested_directory_creation(
     assert not (outside / "nested").exists()
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows refuses to rename a directory holding an open stage file",
+)
 def test_path_guard_rejects_pending_parent_swap_after_prior_replacement(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """The parent of a pending write is swapped between two flips.
+
+    Not stageable on Windows, and not because of anything this test
+    does wrong: the batch still holds `stage-1.tmp` open inside
+    `pending/` while the first artifact flips, and Windows refuses to
+    rename a directory that contains an open file. The setup's own
+    `pending_dir.rename(...)` raises `PermissionError [WinError 5]`
+    from inside the patched `os.replace`, where the writer correctly
+    classifies it as a transient sharing refusal and retries -- so the
+    test failed on its own injection rather than on the guard.
+
+    The swap this defends against therefore cannot occur there while a
+    batch is in flight: the platform refuses it before the guard is
+    reached. POSIX permits the rename, which is why the guard has to
+    exist, and why this stays asserted there.
+    """
     first_dir = tmp_path / "first"
     pending_dir = tmp_path / "pending"
     first_dir.mkdir()


### PR DESCRIPTION
Windows CI at 8d620cb9: **4 failures in 9,829**. Four distinct causes, none in product logic, and two of them the host's defaults leaking into a test.

## 1. `bash` is not bash

`subprocess.run(["bash", ...])` resolves the bare name through `CreateProcess`, which searches the **system directory before PATH**. On a runner with WSL registered but no distribution installed, that directory holds a `bash.exe` that is not a shell — it printed, in UTF-16:

```
Windows Subsystem for Linux has no installed distributions... <distro> to install.
```

and exited 1, which `test_hosted_database_migration` read as a shell syntax error.

`benchmark_capabilities.posix_bash()` resolves through PATH, excludes candidates under the system directory **structurally** rather than by name, and proves each one by running it — so a launcher that changes its wording is still rejected. Returns `None` where the only bash is that launcher, so the caller declares the missing capability.

## 2. A guard test that could not stage its own attack

`test_path_guard_rejects_pending_parent_swap_after_prior_replacement` renames `pending/` between two flips. The batch still holds `stage-1.tmp` **open inside that directory**, and Windows refuses to rename a directory containing an open file — so the setup's own `rename` raised `PermissionError [WinError 5]` from inside the patched `os.replace`, where the writer correctly classified it as a transient sharing refusal and retried. The test failed on its own injection.

The swap cannot occur there while a batch is in flight: the platform refuses it before the guard is reached. Skipped on Windows with that stated; POSIX permits the rename, which is why the guard exists and why it stays asserted there.

## 3. Two DACL tests encoding the behaviour #658 replaced

A bare `mkdir` under the temporary directory yields `(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)(A;OICIID;FA;;;OW)` — exactly the private trustee set, arriving by inheritance — on this machine **and** the runner. #658 deliberately made that verdict `inherited` and repairable rather than refused.

- The refusal test leaned on the host's ambient DACL to supply "unsafe", so it tested whichever verdict the machine handed out. It now grants `*S-1-1-0` (Everyone) and asserts `_WINDOWS_DACL_UNSAFE` — a trustee outside the set can never be tightened away safely, so this is the verdict the refusal exists for, identically on every host.
- The concurrency test asserted *the root must be empty when the private DACL is applied*. That does not cover a **tightening** pass, which by construction runs on a populated root whose ACEs were never weaker than the private set. It now admits the `inherited` verdict and still refuses a populated root that was genuinely unsafe — where a foreign principal may already hold a handle no tightening can take back.

**CI reported one of these two. Both fail on `main` locally** — the second was hidden by shard placement.

## 4. A fixture repo inheriting the host's line-ending policy

Git for Windows defaults `core.autocrlf` to true and `write_text` emits CRLF, so whether the committed file matched the working tree was the machine's decision, not the fixture's. `_init_repo` now pins `core.autocrlf=false` and `core.eol=lf`, writes bytes, and **proves** the tree is clean before handing it over.

Honest caveat: this one I could not reproduce locally — my `core.autocrlf` is `false`. If the diagnosis is wrong, the added assertion makes the next failure name the real cause at setup, instead of `test_structural_workspace_change_rotates_with_unchanged_transcript` reporting two equal hashes with no hint why.

## Verification

Against a disposable `origin/main` worktree **on the same interpreter** (py3.13, what the Windows lane runs), over the eight affected suites:

| | failed | passed | skipped |
|---|---|---|---|
| `origin/main` | 2 | 371 | 35 |
| this branch | **0** | 372 | 36 |

Zero regressions. `tests/test_continuation_checkpoint.py` 147 passed / 20 skipped, unchanged. `uvx ruff check . --select F` passes.