### PR TITLE
fix(nudge): give supersession a route from the hook that drives captures

### DIFF
--- a/plugins/claude-code/hooks/exomem_capture_nudge.py
+++ b/plugins/claude-code/hooks/exomem_capture_nudge.py
@@ -62,8 +62,11 @@ REMINDER = (
     "central, and useful beyond this source may you call "
     'connect_memory(operation="create-entity"). A single incidental mention, unresolved '
     "identity, or transient participant stays in source/note context. Capture conclusions "
-    "as distilled compiled notes, not transcripts, then report Saved -> path. If neither "
-    "case applies, or no Knowledge Base is configured, do nothing and stop."
+    "as distilled compiled notes, not transcripts, then report Saved -> path. Where the "
+    "turn contradicted a conclusion an active page already states, supersede that page "
+    "with replace_memory instead of appending a correction beside it: nothing is "
+    "deleted either way, but two live versions of one conclusion both read as current. "
+    "If neither case applies, or no Knowledge Base is configured, do nothing and stop."
 )
 
 

--- a/src/exomem/_hooks/exomem_capture_nudge.py
+++ b/src/exomem/_hooks/exomem_capture_nudge.py
@@ -62,8 +62,11 @@ REMINDER = (
     "central, and useful beyond this source may you call "
     'connect_memory(operation="create-entity"). A single incidental mention, unresolved '
     "identity, or transient participant stays in source/note context. Capture conclusions "
-    "as distilled compiled notes, not transcripts, then report Saved -> path. If neither "
-    "case applies, or no Knowledge Base is configured, do nothing and stop."
+    "as distilled compiled notes, not transcripts, then report Saved -> path. Where the "
+    "turn contradicted a conclusion an active page already states, supersede that page "
+    "with replace_memory instead of appending a correction beside it: nothing is "
+    "deleted either way, but two live versions of one conclusion both read as current. "
+    "If neither case applies, or no Knowledge Base is configured, do nothing and stop."
 )
 
 

--- a/tests/test_prominence.py
+++ b/tests/test_prominence.py
@@ -9,6 +9,7 @@ would report one cadence while the hooks ran another.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -260,3 +261,52 @@ def test_levels_are_monotonic_in_eagerness():
     capture_cooldowns = [capture_hook._PROMINENCE_PRESETS[x][1] for x in levels]
     for series in (retrieve_floors, retrieve_cooldowns, capture_floors, capture_cooldowns):
         assert series == sorted(series, reverse=True), series
+# --- the reminder has to name every route it expects to be taken ------------
+
+
+def test_the_capture_reminder_names_supersession_and_its_tool() -> None:
+    """The headline behaviour needs a route from the hook that drives captures.
+
+    "Nothing is deleted, it is superseded" is documented in the shipped schema
+    references and is what `replace_memory` exists for -- but the reminder that
+    fires on every substantial turn instructed create, edit and entity paths and
+    never named it. Observed live: a governed conclusion was contradicted and the
+    agent appended a `[correction]` observation beside the original, leaving two
+    live versions of one conclusion both reading as current.
+
+    Asserted as the tool plus the distinction it turns on, rather than as a
+    frozen sentence, so the wording stays free to improve.
+    """
+    reminder = capture_hook.REMINDER
+
+    assert "replace_memory" in reminder
+    assert "supersede" in reminder
+    # The failure mode is specifically appending beside the wrong version, so
+    # the reminder has to contrast the two rather than merely offer the tool.
+    assert "correction" in reminder
+
+
+def test_the_capture_reminder_stays_one_paragraph_of_instruction() -> None:
+    """It is injected on every substantial turn, so length is a real cost.
+
+    No hard limit worth defending, but a reminder that grows without anyone
+    noticing stops being read. This is the tripwire, not the budget.
+    """
+    reminder = capture_hook.REMINDER
+
+    assert len(reminder) < 1600, len(reminder)
+    assert reminder.startswith("[Exomem capture check]")
+
+
+def test_the_deployed_copy_matches_the_packaged_hook() -> None:
+    """`plugins/claude-code/hooks/` holds a verbatim copy, not a variant.
+
+    The reminder is the part most likely to be edited in one place only, and a
+    client running the deployed copy would then be told something the package
+    no longer says.
+    """
+    root = Path(__file__).resolve().parents[1]
+    packaged = root / "src" / "exomem" / "_hooks" / "exomem_capture_nudge.py"
+    deployed = root / "plugins" / "claude-code" / "hooks" / "exomem_capture_nudge.py"
+
+    assert deployed.read_bytes() == packaged.read_bytes()


### PR DESCRIPTION
Closes #601.

The Stop capture reminder instructed the create, edit and entity paths and **never named supersession** — so the product's headline behaviour, *nothing is deleted, it is superseded*, had no route from the hook that fires on most captures.

Observed live: a governed conclusion was contradicted, and the agent appended a `[correction]` observation beside the original. Both are now live in the same `## Observations` block, and the wrong one still reads as current.

The rule was not missing. It is in `Knowledge Base/_Schema/references/supersession.md`, it is in the plugin description, and `replace_memory` exists to do it. What was missing was a mention in the one surface an agent reads on every substantial turn.

## The change

One clause, placed before the terminator rather than after it, naming the tool **and the distinction it turns on**:

> Where the turn contradicted a conclusion an active page already states, supersede that page with `replace_memory` instead of appending a correction beside it: nothing is deleted either way, but two live versions of one conclusion both read as current.

The "instead of appending a correction beside it" half is the part that matters — offering the tool without contrasting it against the observed failure mode would not have changed the behaviour that produced this issue.

`_KB_WRITE` already recognises `replace_memory` (via the `replace` alternation), so a supersession correctly suppresses the next reminder.

## Tests

Three, in `test_prominence.py` beside the existing hook drift guards:

- the reminder names `replace_memory`, `supersede`, **and** `correction` — asserted as the tool plus the contrast, not as a frozen sentence, so the wording stays free to improve
- a length tripwire (< 1600 chars), because it is injected on every substantial turn and a reminder that grows unnoticed stops being read
- the deployed `plugins/claude-code/hooks/` copy stays **byte-identical** to the packaged hook — the reminder is exactly the text most likely to be edited in one place only, and a client running the deployed copy would then be told something the package no longer says

The first fails on `origin/main` and passes here; verified by reverting just the hook and re-running.

## Verification

279 passed / 11 skipped across `test_prominence`, `test_retrieve_inject`, `test_install_hook`, `test_install_hook_uninstall`, `test_windows_machine_wide_root`, `test_epistemic_bootstrap_contract`, `test_client_artifacts`, `test_scaffold_no_leak`. `uvx ruff check . --select F` passes.