### PR TITLE
fix(census): answer the read window the way the stat window already answers

### DIFF
--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -2615,6 +2615,24 @@ def _build_identity_census(
             rel = path.relative_to(root).as_posix()
             try:
                 source = path.read_text(encoding="utf-8")
+            except FileNotFoundError:
+                # Deleted between the stat and the read: the same window #528
+                # closed one call earlier, and the same answer. Splitting the
+                # two would make the census's verdict depend on which
+                # microsecond a deletion landed in, and that says nothing about
+                # the vault -- a page that no longer exists is simply not in
+                # this snapshot, and change detection belongs to freshness.
+                #
+                # Only absence is tolerated. Every other OSError and any decode
+                # failure still fails closed below, because those mean the page
+                # is there and cannot be trusted, which is a different fact
+                # about the tree and one the census exists to refuse on.
+                #
+                # `_stable_identity_for_path` keeps the strict behaviour: a
+                # caller that named one page is owed an answer about that page,
+                # so a vanished one is a real result there rather than an entry
+                # missing from a snapshot.
+                continue
             except (OSError, UnicodeDecodeError) as error:
                 code = (
                     "ACTIVATION_MANIFEST_PAGE_UNREADABLE"

--- a/tests/test_identity_census_walk.py
+++ b/tests/test_identity_census_walk.py
@@ -182,6 +182,73 @@ def test_an_unreadable_markdown_page_still_fails_closed(tmp_path: Path, monkeypa
     assert raised.value.code == "IDENTITY_CENSUS_ENTRY_UNREADABLE"
 
 
+def _fail_read_of(monkeypatch, name: str, error: OSError) -> list[str]:
+    """Make `read_text` raise for one page, after its stat has already passed."""
+    reads: list[str] = []
+    real_read_text = Path.read_text
+
+    def read_text(self, *args, **kwargs):  # noqa: ANN001, ANN202
+        if self.name == name:
+            reads.append(self.name)
+            raise error
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+    return reads
+
+
+def test_a_markdown_page_deleted_between_the_stat_and_the_read_is_skipped(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The residual half of the same race, one call later.
+
+    The stat window has tolerated this since #528. Leaving the read window
+    fail-closed made the census's verdict depend on which microsecond the
+    deletion landed in -- absent from the snapshot if it beat the stat, a hard
+    `IDENTITY_CENSUS_PAGE_UNREADABLE` if it lost by a hair. That distinction
+    describes the timing, not the vault.
+    """
+    _seed(tmp_path, GHOST_REL)
+    reads = _fail_read_of(
+        monkeypatch,
+        "ghost.md",
+        FileNotFoundError(2, "No such file or directory", "ghost.md"),
+    )
+
+    census = semantic_contract.build_stable_identity_census(tmp_path)
+
+    # The page survived the stat, so the read was genuinely attempted.
+    assert reads == ["ghost.md"]
+    paths = {entry.path for entry in census.entries}
+    assert PAGE_REL in paths
+    assert GHOST_REL not in paths
+
+
+def test_an_unreadable_page_still_fails_closed_at_the_read(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Only absence is tolerated, at the read exactly as at the stat.
+
+    A page that is present and cannot be read is a different fact from one that
+    is gone: it says the tree holds something this census cannot vouch for, and
+    refusing is the whole point of a fail-closed census.
+    """
+    _seed(tmp_path, GHOST_REL)
+    _fail_read_of(
+        monkeypatch,
+        "ghost.md",
+        PermissionError(13, "Permission denied", "ghost.md"),
+    )
+
+    with pytest.raises(activation_manifest.ActivationManifestError) as raised:
+        semantic_contract.build_stable_identity_census(tmp_path)
+
+    assert raised.value.code in {
+        "IDENTITY_CENSUS_PAGE_UNREADABLE",
+        "ACTIVATION_MANIFEST_PAGE_UNREADABLE",
+    }
+
+
 def test_a_non_markdown_alias_still_refuses_the_census(tmp_path: Path, monkeypatch) -> None:
     """Filtering before the stat must not open an alias-refusal hole.
 


### PR DESCRIPTION
Closes #529 — the policy decision that issue asked for, made and implemented.

A `.md` page that survived the pre-filter and the `stat()` could still vanish before `path.read_text()`, raising `IDENTITY_CENSUS_PAGE_UNREADABLE` and failing the whole census. The **stat** window has tolerated exactly this since #528.

So the census's verdict depended on which microsecond a deletion landed in:

| deletion lands | before #528 | on `main` | here |
|---|---|---|---|
| between listing and stat | hard failure | absent from snapshot | absent from snapshot |
| between stat and read | hard failure | **hard failure** | absent from snapshot |

That middle row describes the timing, not the vault.

## The decision

The issue laid out both sides. I went with skip-and-continue, for the reason the stat-window fix already recorded: **the census is a snapshot, not a lock.** A page that no longer exists is not in it, and change detection belongs to the freshness machinery. Keeping the two windows inconsistent does not surface concurrent mutation — it surfaces which of two adjacent syscalls the race happened to land between, which no caller can act on.

## What stays fail-closed

**Only absence is tolerated.** Every other `OSError` and any `UnicodeDecodeError` still refuses, because those mean the page is *present and cannot be trusted* — a different fact about the tree, and the one a fail-closed census exists to refuse on.

`_stable_identity_for_path` is deliberately unchanged. A caller that named one page is owed an answer about that page, so a vanished one is a real result there rather than a gap in a snapshot. This change is scoped to the walk.

## Tests

Two, mirroring the stat-window pair that already exists directly above them:

- `test_a_markdown_page_deleted_between_the_stat_and_the_read_is_skipped` — asserts the read was genuinely attempted (`reads == ["ghost.md"]`), so it cannot pass by the page being filtered earlier
- `test_an_unreadable_page_still_fails_closed_at_the_read` — `PermissionError` still refuses

The first fails on `origin/main` and passes here; verified by reverting just `semantic_contract.py` and re-running.

## Verification

193 passed / 2 skipped across `test_identity_census_walk`, `test_corpus_context_cache`, `test_case_insensitive_identity`, `test_semantic_contract`. `uvx ruff check . --select F` passes.