### PR TITLE
perf(corpus): bound the populate-on-miss a writer pays for

### DIFF
--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -1205,6 +1205,36 @@ _CORPUS_CONTEXT_CACHE_LOCK = threading.Lock()
 _CORPUS_CONTEXT_UPDATE_LOCK = threading.RLock()
 _CORPUS_CONTEXT_CACHE_MAX_VAULTS = 2
 
+#: Bounds populate-on-miss (#539). Both halves exist because that build is
+#: paid by a WRITER: without them, a state that keeps the cache cold -- a
+#: projection patch that fails and evicts on every publish, or external churn
+#: that discards every admission -- makes every governed write pay a full
+#: census and parse of the whole vault that cannot land. Each occurrence is
+#: individually bounded, so this is amplification rather than livelock, but at
+#: thousands of pages it is the dominant cost moved onto writers.
+#:
+#: Single-flight collapses the concurrent case: a second publisher that finds
+#: the same cold key returns instead of starting a second whole-vault build.
+_CORPUS_POPULATE_LOCK = threading.Lock()
+_CORPUS_POPULATE_IN_FLIGHT: set[tuple[str, str]] = set()
+
+#: The memo collapses the sequential case, and is deliberately measured in the
+#: cost of the attempt that just failed rather than in a fixed number of
+#: seconds. A populate that discarded after eight seconds of walking is
+#: evidence the vault is still moving; retrying immediately spends the next
+#: eight the same way. Waiting at least as long as the attempt cost caps
+#: populate at roughly half of wall-clock in the worst state and scales itself
+#: to vault size, which no constant here could. The floor keeps a fast vault's
+#: memo from being a no-op; the ceiling keeps one pathological build from
+#: silencing populate for minutes.
+#:
+#: Deliberately NOT cleared by :func:`evict_corpus_context`: eviction is the
+#: front half of the exact loop being bounded, so letting it reset the memo
+#: would hand back the amplification this removes.
+_CORPUS_POPULATE_MEMO: dict[tuple[str, str], float] = {}
+_CORPUS_POPULATE_MEMO_MIN_SECONDS = 1.0
+_CORPUS_POPULATE_MEMO_MAX_SECONDS = 30.0
+
 
 @dataclass(slots=True)
 class _CorpusContextFlight:
@@ -1226,6 +1256,9 @@ def corpus_context_cache_enabled() -> bool:
 
 def reset_corpus_context_cache() -> None:
     """Drop every cached corpus context; intentionally public for tests."""
+    with _CORPUS_POPULATE_LOCK:
+        _CORPUS_POPULATE_MEMO.clear()
+        _CORPUS_POPULATE_IN_FLIGHT.clear()
     with _CORPUS_CONTEXT_CACHE_LOCK:
         _CORPUS_CONTEXT_CACHE.clear()
         _CORPUS_CONTEXT_EVENT_TOKENS.clear()
@@ -2115,11 +2148,15 @@ def _populate_corpus_context_after_miss(root: Path) -> None:
     cannot complete simply leaves the cache cold, which is exactly today's
     behavior.
 
-    Deliberately NOT single-flighted and NOT memoized on failure: a state that
-    keeps the cache cold (persistent projection-publish failure, or external
-    churn that discards every admission) makes every publish pay a build that
-    cannot land. Bounding that is tracked as #539; the shape to copy is
-    ``lexstore._REPAIRS_IN_FLIGHT``.
+    Single-flighted, and memoized whenever an attempt did not stamp: see
+    ``_CORPUS_POPULATE_IN_FLIGHT`` and ``_CORPUS_POPULATE_MEMO`` for why the
+    unbounded version made writers pay for builds that could not land (#539).
+
+    Neither bound can make the cache wrong. Both only ever decline to *start*
+    a build, and declining leaves the cache cold -- which is precisely the
+    state a publish onto a cold cache produced before populate-on-miss existed,
+    and which every reader already handles by building. The first publish that
+    finds the vault settled populates honestly.
     """
     if not corpus_context_cache_enabled():
         return
@@ -2130,14 +2167,46 @@ def _populate_corpus_context_after_miss(root: Path) -> None:
     with _CORPUS_CONTEXT_CACHE_LOCK:
         if _CORPUS_CONTEXT_CACHE.get(cache_key) is not None:
             return
+    started = time.monotonic()
+    with _CORPUS_POPULATE_LOCK:
+        # Expired entries are dropped here rather than left to accumulate: the
+        # context cache is bounded to `_CORPUS_CONTEXT_CACHE_MAX_VAULTS`, and a
+        # memo that outlived its own quiet window should not be the one piece
+        # of per-vault state that grows without limit in a long-lived server.
+        for key, deadline in list(_CORPUS_POPULATE_MEMO.items()):
+            if started >= deadline:
+                del _CORPUS_POPULATE_MEMO[key]
+        if cache_key in _CORPUS_POPULATE_IN_FLIGHT:
+            return
+        if cache_key in _CORPUS_POPULATE_MEMO:
+            return
+        _CORPUS_POPULATE_IN_FLIGHT.add(cache_key)
+    admitted = False
     try:
-        _build_and_admit_corpus_context(root, cache_key)
+        admitted = _build_and_admit_corpus_context(root, cache_key)
     except Exception:  # noqa: BLE001 - the publish itself already succeeded
         log.warning("semantic corpus populate-on-miss failed", exc_info=True)
+    finally:
+        elapsed = time.monotonic() - started
+        with _CORPUS_POPULATE_LOCK:
+            _CORPUS_POPULATE_IN_FLIGHT.discard(cache_key)
+            if admitted:
+                _CORPUS_POPULATE_MEMO.pop(cache_key, None)
+            else:
+                _CORPUS_POPULATE_MEMO[cache_key] = time.monotonic() + min(
+                    _CORPUS_POPULATE_MEMO_MAX_SECONDS,
+                    max(_CORPUS_POPULATE_MEMO_MIN_SECONDS, elapsed),
+                )
 
 
-def _build_and_admit_corpus_context(root: Path, cache_key: tuple[str, str]) -> None:
-    """The L2 body of :func:`_populate_corpus_context_after_miss`."""
+def _build_and_admit_corpus_context(root: Path, cache_key: tuple[str, str]) -> bool:
+    """The L2 body of :func:`_populate_corpus_context_after_miss`.
+
+    Returns whether this call stamped a context. A discard is not an error --
+    it is the admission proof correctly refusing a build the vault moved out
+    from under -- but the caller has to tell a discard apart from a stamp to
+    know whether retrying immediately would be productive.
+    """
     relation_definitions = relation_registry.load_registry(root)
     language = semantic_language_registry.load_registry(root)
     # L2/L3: the admission decision is made against this, captured before the
@@ -2145,7 +2214,7 @@ def _build_and_admit_corpus_context(root: Path, cache_key: tuple[str, str]) -> N
     before = freshness.consumer_checkpoint(root, "vault")
     census = _timed_corpus_census(root, "populate")
     if census is None:
-        return
+        return False
     # The registries were loaded BEFORE this walk, and the walk stats the two
     # `_Schema` files at its END. A registry rewritten in between therefore
     # produces a census that records the NEW file while the build below would
@@ -2157,7 +2226,7 @@ def _build_and_admit_corpus_context(root: Path, cache_key: tuple[str, str]) -> N
     # the same two files.
     if not _registries_match_disk(root, relation_definitions, language):
         log.info("semantic corpus populate discarded: registry moved during the walk")
-        return
+        return False
     started = time.perf_counter()
     context = _build_corpus_context_uncached(
         root,
@@ -2177,16 +2246,16 @@ def _build_and_admit_corpus_context(root: Path, cache_key: tuple[str, str]) -> N
         after = freshness.consumer_checkpoint(root, "vault")
         if after != before:
             log.info("semantic corpus populate discarded: registry advanced mid-walk")
-            return
+            return False
         with _CORPUS_CONTEXT_CACHE_LOCK:
             if _CORPUS_CONTEXT_CACHE.get(cache_key) is not None:
-                return
+                return False
         if _deferred_corpus_census(root, walk_log, "census") != census:
             log.info("semantic corpus populate discarded: corpus moved mid-build")
-            return
+            return False
         with _CORPUS_CONTEXT_CACHE_LOCK:
             if _CORPUS_CONTEXT_CACHE.get(cache_key) is not None:
-                return
+                return False
             _CORPUS_CONTEXT_CACHE[cache_key] = (census, context)
             _CORPUS_CONTEXT_LANGUAGE_HASHES[cache_key] = (
                 f"{language.schema_version}:{language.content_hash}"
@@ -2203,6 +2272,7 @@ def _build_and_admit_corpus_context(root: Path, cache_key: tuple[str, str]) -> N
         len(context.pages),
         build_ms,
     )
+    return True
 
 
 @call_spans.timed("corpus_context.build")

--- a/tests/test_corpus_context_cache.py
+++ b/tests/test_corpus_context_cache.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import dataclasses
 import os
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
@@ -945,3 +946,231 @@ def test_census_refuses_rather_than_omits_a_page_that_vanishes_mid_walk(
     _vanish_on_listing(monkeypatch, "doomed.md")
 
     assert semantic_contract._corpus_census(vault) is None
+
+
+# --- populate-on-miss is paid by a writer, so it has to be bounded (#539) ----
+
+
+def _discarding_populate(monkeypatch: pytest.MonkeyPatch, seconds: float = 0.0) -> list[tuple]:
+    """Stand in for a build that runs and then legitimately refuses to stamp.
+
+    Every discard route inside `_build_and_admit_corpus_context` -- registry
+    moved, checkpoint advanced, census moved -- reaches the caller as the same
+    `False`, so one stub covers them all. What matters to the caller is only
+    that the attempt did not land.
+    """
+    calls: list[tuple] = []
+
+    def build(root: Path, cache_key: tuple[str, str]) -> bool:
+        calls.append(cache_key)
+        if seconds:
+            time.sleep(seconds)
+        return False
+
+    monkeypatch.setattr(semantic_contract, "_build_and_admit_corpus_context", build)
+    return calls
+
+
+def test_a_second_publisher_joins_no_second_whole_vault_build(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Single-flight, the concurrent half of the bound.
+
+    Two governed writes landing on the same cold vault used to start two
+    independent full censuses and parses of it. Only one can stamp; the other
+    pays the whole cost to discard.
+    """
+    entered = threading.Event()
+    release = threading.Event()
+    calls: list[tuple] = []
+
+    def blocking_build(root: Path, cache_key: tuple[str, str]) -> bool:
+        calls.append(cache_key)
+        entered.set()
+        assert release.wait(10)
+        return False
+
+    monkeypatch.setattr(semantic_contract, "_build_and_admit_corpus_context", blocking_build)
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        first = pool.submit(semantic_contract._populate_corpus_context_after_miss, vault)
+        assert entered.wait(10), "the first publisher never reached the build"
+
+        # The second publisher finds the same cold key mid-build and must
+        # return rather than start its own.
+        semantic_contract._populate_corpus_context_after_miss(vault)
+        assert len(calls) == 1
+
+        release.set()
+        first.result(timeout=10)
+
+    assert len(calls) == 1
+
+
+def test_a_discarded_populate_quiets_the_next_publisher(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The memo, the sequential half of the bound.
+
+    A vault that keeps discarding -- external churn, or a projection patch that
+    fails and evicts on every publish -- otherwise makes *every* governed write
+    pay a full build that cannot land.
+    """
+    calls = _discarding_populate(monkeypatch)
+    cache_key = semantic_contract._corpus_cache_key(vault)
+
+    for _ in range(3):
+        semantic_contract._populate_corpus_context_after_miss(vault)
+
+    assert len(calls) == 1
+    assert cache_key in semantic_contract._CORPUS_POPULATE_MEMO
+
+
+def test_a_populate_that_raised_is_quieted_like_one_that_discarded(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A raise is "did not stamp" too, and is the more expensive one to repeat.
+
+    The caller already swallows it so the publish it belongs to still succeeds;
+    swallowing it without memoizing would leave the loudest failure the only
+    unbounded one.
+    """
+    calls: list[tuple] = []
+
+    def failing_build(root: Path, cache_key: tuple[str, str]) -> bool:
+        calls.append(cache_key)
+        raise RuntimeError("projection unavailable")
+
+    monkeypatch.setattr(semantic_contract, "_build_and_admit_corpus_context", failing_build)
+
+    for _ in range(3):
+        semantic_contract._populate_corpus_context_after_miss(vault)
+
+    assert len(calls) == 1
+
+
+def test_the_quiet_window_ends_and_the_next_publisher_tries_again(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Suppression is a delay, never a decision.
+
+    A vault that settles has to repopulate on its own; nothing else re-arms
+    populate-on-miss for it.
+    """
+    calls = _discarding_populate(monkeypatch)
+    cache_key = semantic_contract._corpus_cache_key(vault)
+
+    semantic_contract._populate_corpus_context_after_miss(vault)
+    assert len(calls) == 1
+
+    semantic_contract._CORPUS_POPULATE_MEMO[cache_key] = time.monotonic() - 1.0
+    semantic_contract._populate_corpus_context_after_miss(vault)
+
+    assert len(calls) == 2
+    # The expired entry is dropped rather than accumulated: a long-lived server
+    # must not grow one float per vault it ever failed to populate.
+    assert list(semantic_contract._CORPUS_POPULATE_MEMO) == [cache_key]
+
+
+@pytest.mark.parametrize(
+    ("attempt_seconds", "at_least", "at_most"),
+    [
+        # Instant discard: the floor keeps the memo from being a no-op.
+        (0.0, 0.0, 0.05),
+        # A real attempt: the window is the attempt's own cost, which is what
+        # makes it scale with vault size where no constant here could.
+        (0.12, 0.05, 0.30),
+        # A pathological build: the ceiling keeps one of them from silencing
+        # populate for minutes.
+        (0.40, 0.05, 0.30),
+    ],
+)
+def test_the_quiet_window_is_the_clamped_cost_of_the_attempt(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    attempt_seconds: float,
+    at_least: float,
+    at_most: float,
+) -> None:
+    """Measured in the failed attempt, not in a number someone picked.
+
+    A populate that discarded after eight seconds of walking is evidence the
+    vault is still moving; retrying it immediately spends the next eight the
+    same way. Waiting at least as long as the attempt cost caps populate at
+    roughly half of wall-clock in the worst state.
+    """
+    monkeypatch.setattr(semantic_contract, "_CORPUS_POPULATE_MEMO_MIN_SECONDS", 0.05)
+    monkeypatch.setattr(semantic_contract, "_CORPUS_POPULATE_MEMO_MAX_SECONDS", 0.30)
+    _discarding_populate(monkeypatch, seconds=attempt_seconds)
+    cache_key = semantic_contract._corpus_cache_key(vault)
+
+    semantic_contract._populate_corpus_context_after_miss(vault)
+    remaining = semantic_contract._CORPUS_POPULATE_MEMO[cache_key] - time.monotonic()
+
+    # Read after the fact, so `remaining` can only understate the window.
+    assert remaining <= at_most
+    assert remaining > at_least
+
+
+def test_a_quieted_publish_leaves_the_cache_cold_not_wrong(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The bound may only ever decline to start a build.
+
+    Declining leaves the cache empty, which is exactly the state a publish onto
+    a cold cache produced before populate-on-miss existed, and which every
+    reader already handles by building. So a suppressed populate can cost a
+    reader time; it can never cost it correctness.
+    """
+    calls = _discarding_populate(monkeypatch)
+    cache_key = semantic_contract._corpus_cache_key(vault)
+    semantic_contract._populate_corpus_context_after_miss(vault)
+    assert len(calls) == 1
+
+    page = vault / _PAGE_REL
+    page.write_text(_page(title="Edited while quiet"), encoding="utf-8")
+    semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
+
+    # The publish took the miss branch and was turned away there, not earlier.
+    assert len(calls) == 1
+    assert cache_key not in semantic_contract._CORPUS_CONTEXT_CACHE
+
+    context = semantic_contract.build_corpus_context(vault)
+    assert context.pages[_PAGE_REL].title == "Edited while quiet"
+
+
+def test_resetting_the_cache_re_arms_populate(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`reset_corpus_context_cache` means cold *and* unquieted.
+
+    It is the seam tests use to start from scratch, so a memo surviving it
+    would leak one test's suppression into the next.
+    """
+    calls = _discarding_populate(monkeypatch)
+    semantic_contract._populate_corpus_context_after_miss(vault)
+    assert len(calls) == 1
+
+    semantic_contract.reset_corpus_context_cache()
+    semantic_contract._populate_corpus_context_after_miss(vault)
+
+    assert len(calls) == 2
+
+
+def test_eviction_does_not_re_arm_populate(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Eviction is the front half of the loop being bounded.
+
+    "Patch fails -> evict -> populate -> discard" is the exact cycle that made
+    every write pay a doomed build. Letting the evict clear the memo would hand
+    that amplification straight back.
+    """
+    calls = _discarding_populate(monkeypatch)
+    semantic_contract._populate_corpus_context_after_miss(vault)
+    assert len(calls) == 1
+
+    semantic_contract.evict_corpus_context(vault)
+    semantic_contract._populate_corpus_context_after_miss(vault)
+
+    assert len(calls) == 1


### PR DESCRIPTION
Closes #539.

## What was unbounded

`_populate_corpus_context_after_miss` builds the corpus context a publish
found no warm entry to patch. The walk and parse of the whole vault is paid
by a **writer**, and it was deliberately left unbounded — the reason and the
shape of the fix were recorded in its own docstring as #539.

Two states make every governed write pay a full build that cannot land:

- a projection patch that fails and evicts on each publish, and
- external churn that moves the vault out from under each admission proof.

Each occurrence is individually bounded, so this is amplification rather than
livelock — but at thousands of pages it is the dominant cost moved onto the
write path, and it grows with vault size.

## The bound

- **Single-flight** (`_CORPUS_POPULATE_IN_FLIGHT`) collapses the concurrent
  case: a second publisher on the same cold key returns instead of starting a
  second whole-vault build.
- **A memo** (`_CORPUS_POPULATE_MEMO`) collapses the sequential case, and is
  measured in the cost of the attempt that just failed rather than in a
  constant. A populate that discarded after eight seconds of walking is
  evidence the vault is still moving; retrying it immediately spends the next
  eight the same way. Waiting at least as long as the attempt cost caps
  populate at roughly half of wall-clock in the worst state and scales itself
  to vault size, which no constant here could. A floor (1 s) keeps a fast
  vault's memo from being a no-op; a ceiling (30 s) keeps one pathological
  build from silencing populate for minutes.

**Neither bound can make the cache wrong.** Both only ever decline to *start*
a build, and declining leaves the cache cold — exactly the state a publish onto
a cold cache produced before populate-on-miss existed, and one every reader
already handles by building. A suppressed populate can cost a reader time,
never correctness.

## Supporting changes

- `_build_and_admit_corpus_context` now returns whether it stamped, so the
  caller can tell a discard (the admission proof correctly refusing a build the
  vault moved out from under) apart from a stamp. All eight existing early
  returns are discards; the tail is the only stamp. No external consumers —
  both functions are module-private.
- A raise counts as "did not stamp" too. The caller already swallows it so the
  publish it belongs to still succeeds; memoizing it keeps the loudest failure
  from being the only unbounded one.
- `reset_corpus_context_cache` clears the memo (it is the seam that means
  "start from scratch"). `evict_corpus_context` deliberately does **not** —
  eviction is the front half of the very loop being bounded, so letting it
  reset the memo would hand the amplification straight back. Both are pinned by
  tests.
- Expired memo entries are dropped on the next attempt rather than accumulated,
  so the memo cannot become the one piece of per-vault state that grows without
  limit in a long-lived server.

## Verification

Run on Windows, py3.13, from the feature worktree.

- `tests/test_corpus_context_cache.py` — **41 passed, 1 skipped** (the skip is
  the pre-existing Windows `DirEntry.stat()` one). 10 new tests cover
  single-flight, the memo on discard and on raise, expiry and purge, the clamp
  at floor / proportional / ceiling, cache-cold-not-wrong, and the
  reset-vs-evict asymmetry.
- Every suite that touches the corpus publish path — `test_activation_manifest`,
  `test_call_spans`, `test_corpus_context_cache`, `test_doctor_write_path`,
  `test_file_watcher`, `test_find_scene_frames`, `test_freshness_liveness_contract`,
  `test_identity_census_walk`, `test_index_sync`, `test_instant_start`,
  `test_mutation_timings`, `test_relation_review`, `test_semantic_contract`,
  `test_semantic_lifecycle_writers`, `test_semantic_posthoc`,
  `test_windows_case_insensitive_paths` — **628 passed, 1 skipped**.
- `uvx ruff check .` and `uvx ruff check . --select F` clean.
