### PR TITLE
fix(edge): make a standalone origin representable and name the gate that refused

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,21 @@ jobs:
       - name: Validate specs
         run: npm exec --yes @fission-ai/openspec -- validate --specs --strict
 
+  edge-worker:
+    name: edge worker (cloudflare-ha)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      # This worker sits in front of every MCP call when it is deployed, and it
+      # can refuse a healthy origin without the origin ever learning of it. It
+      # shipped untested; #581 is what that cost.
+      - name: Worker routing and readiness-admission suite
+        run: node --test deploy/cloudflare-ha/test/worker.test.mjs
+
   build:
     name: package build
     runs-on: ubuntu-latest
@@ -381,6 +396,7 @@ jobs:
       - onboarding
       - docker
       - specs
+      - edge-worker
       - build
       - capabilities
       - lint

--- a/deploy/cloudflare-ha/README.md
+++ b/deploy/cloudflare-ha/README.md
@@ -1,7 +1,7 @@
-# One connector, two Exomem replicas
+# One connector, one or two Exomem replicas
 
-This optional Cloudflare Worker keeps a single public MCP/OAuth URL in front of
-desktop and laptop replicas. A SQLite Durable Object stores only:
+This Cloudflare Worker keeps a single public MCP/OAuth URL in front of desktop
+and laptop replicas. A SQLite Durable Object stores only:
 
 - writer identity, expiry, and fencing counter;
 - opaque OAuth records encrypted by Exomem before upload.
@@ -10,8 +10,29 @@ Vault files and search results are proxied, never stored at the edge. Syncthing,
 Obsidian Sync, a NAS, or any other replication mechanism remains a separate
 operator choice.
 
-Copy `wrangler.toml.example` to `wrangler.toml`, set both private origin hostnames
-and the stable route, then deploy:
+## It is opt-in, and a deployed route outlives the replicas behind it
+
+Nothing installs or requires this worker. A single-node Exomem is served
+perfectly well by the tunnel alone, and that is the simpler deployment: the
+origin answers `/mcp` directly and there is no edge policy to keep in step with
+the machines behind it.
+
+Deploying it is therefore a decision to keep a second thing in sync with your
+topology, because **the route survives the replicas**. Decommissioning a replica
+does not remove the worker from `/mcp`; it leaves an HA policy in front of a
+deployment that is no longer HA. That is not hypothetical -- it is exactly how a
+routine laptop shutdown produced a total MCP outage while the surviving origin
+kept answering `/health/ready` with `200` and `reasons: []` (#581). If you take
+this worker out of service, take it out of the **route**, not just out of use.
+
+The single-origin topology below is now representable rather than merely
+tolerated, so the failure mode is a bad deployment rather than a bad
+architecture. It is still one more moving part than not deploying it at all.
+
+## Deploying
+
+Copy `wrangler.toml.example` to `wrangler.toml`, set the private origin
+hostname(s) and the stable route, then deploy:
 
 ```powershell
 npx wrangler login
@@ -30,6 +51,23 @@ npx wrangler secret put STATE_TOKEN
 endpoint (gated by the same bearer as the coordinator endpoints) reports which
 commit is live instead of `"git_sha": "unlabeled"`. A bare `wrangler deploy`
 still works; it just leaves the deploy unlabeled.
+
+### One origin (standalone)
+
+Configure `DESKTOP_ORIGIN` and `DESKTOP_REPLICA_ID` and leave the `LAPTOP_*`
+pair unset. A standalone Exomem reports `replica_id: null` and
+`coordination: {"enabled": false, "role": "standalone"}` -- correctly, since
+there is no second writer to hold an identity against or to coordinate with --
+and the edge accepts that as eligible when it is the only origin configured.
+
+The relaxation requires **both** sides to say so: exactly one origin configured
+here *and* the origin self-reporting standalone. Dropping one origin from a live
+pair by mistake therefore still refuses, because the survivor keeps reporting
+its replica id and its coordination as enabled. `REQUIRE_COORDINATION` stays at
+its default; it governs replica pairs and has nothing to require of a single
+node.
+
+### Two origins (replica pair)
 
 Configure both replicas with the same stable `EXOMEM_BASE_URL`, GitHub OAuth app,
 `EXOMEM_JWT_SIGNING_KEY`, state URL/token, vault ID, and lease token. Give each a
@@ -59,10 +97,32 @@ expected replica identity, healthy coordination, and takeover eligibility. The
 admission is bound to the lease fencing token in the Durable Object, so steady
 state does not add a readiness round trip to every MCP call.
 
-With no holder, both origins are probed concurrently and the mutation-capable
-request is forwarded exactly once to the first eligible replica. A live but stale
-service that lacks the readiness contract is skipped instead of becoming the
-failover writer.
+With no holder, every configured origin is probed concurrently and the
+mutation-capable request is forwarded exactly once to the first eligible one. A
+live but stale service that lacks the readiness contract is skipped instead of
+becoming the failover writer.
+
+A refusal reports the gate that refused it, per origin:
+
+```json
+{
+  "error": "the configured Exomem origin is ineligible",
+  "refusals": [
+    {
+      "origin": "https://exomem-desktop.example.com",
+      "replica_id": "desktop",
+      "reason": "unsupported_runtime_contract"
+    }
+  ]
+}
+```
+
+`reason` is the readiness gate (`replica_identity_mismatch`,
+`coordination_required`, `unsupported_transport`, ...), or
+`health_status_<code>` / `health_probe_unreachable` when the probe itself did
+not produce a verdict. The worker always computed this and used to discard it,
+leaving a 503 that named replicas as the only symptom -- which, on a deployment
+that no longer had two, pointed triage at an architecture that was not there.
 
 Configure `SUPPORTED_RUNTIME_CONTRACTS` with behavioral contract versions, not
 package versions. Compatible releases can differ during a rolling deployment.

--- a/deploy/cloudflare-ha/src/worker.js
+++ b/deploy/cloudflare-ha/src/worker.js
@@ -286,7 +286,11 @@ export default {
         // Try the passive replica. Its writer guard still fails closed until takeover.
       }
     }
-    return lastResponse || json({ error: "both Exomem replicas are unavailable" }, 503);
+    return lastResponse || json({
+      error: configuredCandidates(env).length === 1
+        ? "the configured Exomem origin is unavailable"
+        : "no configured Exomem origin is available",
+    }, 503);
   },
 };
 
@@ -333,16 +337,30 @@ async function proxyMutationRequest(request, env, lease) {
   }
   if (holder) {
     if (!admissionEligible(lease.admission, env, holder, lease.fencing_token)) {
-      candidate = await probeCandidateReadiness(candidate, env, shortTimeout);
+      const probe = await probeCandidateReadiness(candidate, env, shortTimeout);
+      candidate = probe.candidate;
       if (!candidate) {
-        return json({ error: "active Exomem replica is not runtime-ready" }, 503);
+        return json({
+          error: "the active Exomem origin is not runtime-ready",
+          refusals: [{ origin: probe.origin, replica_id: holder, reason: probe.reason }],
+        }, 503);
       }
       const stored = await recordAdmission(env, lease, candidate.readiness);
       if (!stored) return json({ error: "writer lease changed during runtime admission" }, 503);
     }
   } else {
-    candidate = await selectEligibleOrigin(env, shortTimeout);
-    if (!candidate) return json({ error: "both Exomem replicas are ineligible" }, 503);
+    const selection = await selectEligibleOrigin(env, shortTimeout);
+    candidate = selection.candidate;
+    if (!candidate) {
+      // Name the gate. `evaluateReadiness` computes exactly why each origin was
+      // refused and this used to discard it, so the only symptom was a 503
+      // naming replicas -- which, on a deployment that no longer has two, sent
+      // triage after an architecture that was not there (#581).
+      return json({
+        error: refusalSummary(selection.refusals),
+        refusals: selection.refusals,
+      }, 503);
+    }
   }
 
   try {
@@ -441,26 +459,54 @@ function configuredCandidates(env) {
 }
 
 async function selectEligibleOrigin(env, timeoutMs) {
+  const candidates = configuredCandidates(env);
   const checked = await Promise.all(
-    configuredCandidates(env).map((candidate) => probeCandidateReadiness(candidate, env, timeoutMs)),
+    candidates.map((candidate) => probeCandidateReadiness(candidate, env, timeoutMs)),
   );
-  return checked.find(Boolean) || null;
+  const accepted = checked.find((result) => result.candidate);
+  if (accepted) return { candidate: accepted.candidate, refusals: [] };
+  return {
+    candidate: null,
+    refusals: checked.map((result) => ({
+      origin: result.origin,
+      replica_id: result.replicaId,
+      reason: result.reason,
+    })),
+  };
 }
 
 async function probeCandidateReadiness(candidate, env, timeoutMs) {
+  const refused = (reason) => ({
+    candidate: null,
+    origin: candidate.origin,
+    replicaId: candidate.replicaId,
+    reason,
+  });
   try {
     const target = new URL("/health/ready", candidate.origin);
     const response = await fetch(new Request(target), {
       signal: AbortSignal.timeout(timeoutMs),
       redirect: "manual",
     });
-    if (response.status !== 200) return null;
+    if (response.status !== 200) return refused(`health_status_${response.status}`);
     const readiness = await response.json();
     const evaluation = evaluateReadiness(readiness, env, candidate.replicaId);
-    return evaluation.eligible ? { ...candidate, readiness } : null;
+    if (!evaluation.eligible) return refused(evaluation.reason);
+    return {
+      candidate: { ...candidate, readiness },
+      origin: candidate.origin,
+      replicaId: candidate.replicaId,
+      reason: null,
+    };
   } catch {
-    return null;
+    return refused("health_probe_unreachable");
   }
+}
+
+function refusalSummary(refusals) {
+  if (refusals.length === 0) return "no Exomem origin is configured";
+  if (refusals.length === 1) return "the configured Exomem origin is ineligible";
+  return "no configured Exomem origin is eligible";
 }
 
 export function evaluateReadiness(readiness, env, expectedReplicaId) {
@@ -481,14 +527,28 @@ export function evaluateReadiness(readiness, env, expectedReplicaId) {
   if (readiness.transport !== requiredTransport) {
     return { eligible: false, reason: "unsupported_transport" };
   }
-  if (readiness.replica_id !== expectedReplicaId) {
+  // Both gates below encode "HA is mandatory", and on a deployment with one
+  // configured origin each could only ever refuse: a standalone server reports
+  // `replica_id: null` -- no configured value equals null -- and
+  // `coordination.enabled: false`, because there is no second writer to
+  // coordinate with. A correct standalone origin was therefore unrepresentable,
+  // and decommissioning the second replica took the whole MCP surface down
+  // while the surviving origin's own health stayed green (#581).
+  //
+  // The relaxation needs BOTH sides to say so: exactly one origin configured
+  // here AND the origin self-reporting standalone. Dropping one origin from a
+  // live pair by mistake therefore still refuses, because the survivor keeps
+  // reporting its replica id and its coordination as enabled.
+  const standalone = isSingleOriginDeployment(env) && declaresStandalone(readiness);
+  const unidentified = readiness.replica_id === null || readiness.replica_id === undefined;
+  if (readiness.replica_id !== expectedReplicaId && !(standalone && unidentified)) {
     return { eligible: false, reason: "replica_identity_mismatch" };
   }
   if (readiness.takeover_eligible !== true) {
     return { eligible: false, reason: "takeover_ineligible" };
   }
   const coordination = readiness.coordination;
-  if (requireCoordination(env)) {
+  if (requireCoordination(env) && !standalone) {
     if (!coordination || coordination.enabled !== true) {
       return { eligible: false, reason: "coordination_required" };
     }
@@ -505,6 +565,21 @@ function supportedRuntimeContracts(env) {
     .map((value) => Number(value.trim()))
     .filter(Number.isInteger);
   return new Set(values);
+}
+
+function isSingleOriginDeployment(env) {
+  return configuredCandidates(env).length === 1;
+}
+
+function declaresStandalone(readiness) {
+  const coordination = readiness.coordination;
+  return Boolean(
+    coordination
+      && typeof coordination === "object"
+      && !Array.isArray(coordination)
+      && coordination.enabled === false
+      && coordination.role === "standalone",
+  );
 }
 
 function requireCoordination(env) {

--- a/deploy/cloudflare-ha/test/worker.test.mjs
+++ b/deploy/cloudflare-ha/test/worker.test.mjs
@@ -761,3 +761,191 @@ test("safe MCP initialization retains short-timeout fallback", async () => {
     AbortSignal.timeout = originalTimeout;
   }
 });
+
+
+// --- a single-origin deployment is a topology, not a half-configured pair ---
+
+const standaloneEnv = (overrides = {}) => {
+  const env = edgeEnv(null);
+  delete env.LAPTOP_ORIGIN;
+  delete env.LAPTOP_REPLICA_ID;
+  return { ...env, ...overrides };
+};
+
+const standaloneReadiness = (overrides = {}) => readiness("desktop", {
+  replica_id: null,
+  instance_id: null,
+  coordination: { enabled: false, role: "standalone", coordinator_healthy: true },
+  ...overrides,
+});
+
+test("a standalone origin is eligible when it is the only one configured", () => {
+  // Neither gate could ever pass for it: no configured value equals `null`, and
+  // a standalone server reports coordination disabled by design. That made a
+  // correct single-node deployment unrepresentable, and decommissioning the
+  // second replica took every MCP call down -- read-only ones included -- while
+  // the surviving origin kept answering /health/ready with 200 and `reasons: []`.
+  assert.deepEqual(
+    evaluateReadiness(standaloneReadiness(), standaloneEnv(), "desktop"),
+    { eligible: true, reason: null },
+  );
+});
+
+test("a standalone claim from one origin of a configured pair is still refused", () => {
+  // The relaxation needs both sides to agree. If it keyed off the origin's
+  // claim alone, a replica that lost its coordinator would announce itself
+  // standalone and take writes while its peer was still live.
+  assert.equal(
+    evaluateReadiness(standaloneReadiness(), edgeEnv(), "desktop").reason,
+    "replica_identity_mismatch",
+  );
+  assert.equal(
+    evaluateReadiness(
+      readiness("desktop", {
+        coordination: { enabled: false, role: "standalone", coordinator_healthy: true },
+      }),
+      edgeEnv(),
+      "desktop",
+    ).reason,
+    "coordination_required",
+  );
+});
+
+test("a single configured origin that still claims a replica identity is refused", () => {
+  // The other half of "both sides agree": dropping one origin from a live pair
+  // by mistake must not silently promote the survivor past the coordination
+  // gate. It keeps reporting its replica id and enabled coordination, so it
+  // keeps being judged as a replica.
+  assert.equal(
+    evaluateReadiness(readiness("laptop"), standaloneEnv(), "desktop").reason,
+    "replica_identity_mismatch",
+  );
+  assert.equal(
+    evaluateReadiness(readiness("desktop"), standaloneEnv(), "desktop").eligible,
+    true,
+  );
+});
+
+test("a standalone origin serves a tool call end to end", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (request) => {
+    const url = new URL(request.url);
+    calls.push(url.href);
+    if (url.pathname === "/health/ready") return Response.json(standaloneReadiness());
+    return new Response("ok", { status: 200 });
+  };
+  try {
+    const response = await worker.fetch(toolCall(), standaloneEnv());
+    assert.equal(response.status, 200);
+    assert.deepEqual(calls, [
+      "https://desktop.example.com/health/ready",
+      "https://desktop.example.com/mcp",
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+// --- a refusal has to say which gate refused --------------------------------
+
+test("a refused selection names the failing gate per origin", async () => {
+  // The worker computes the reason and used to throw it away, so the only
+  // symptom was a 503 naming replicas -- on a deployment that no longer had
+  // two, that sent triage after an architecture which was not there.
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (request) => {
+    const url = new URL(request.url);
+    if (url.origin.includes("laptop")) return new Response("nope", { status: 503 });
+    return Response.json(readiness("desktop", { runtime_contract: 99 }));
+  };
+  try {
+    const response = await worker.fetch(toolCall(), edgeEnv(null));
+    assert.equal(response.status, 503);
+    const payload = await response.json();
+    assert.equal(payload.error, "no configured Exomem origin is eligible");
+    assert.deepEqual(payload.refusals, [
+      {
+        origin: "https://desktop.example.com",
+        replica_id: "desktop",
+        reason: "unsupported_runtime_contract",
+      },
+      {
+        origin: "https://laptop.example.com",
+        replica_id: "laptop",
+        reason: "health_status_503",
+      },
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("a refused single-origin deployment does not report itself as replicas", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => Response.json(standaloneReadiness({ status: "starting" }));
+  try {
+    const response = await worker.fetch(toolCall(), standaloneEnv());
+    assert.equal(response.status, 503);
+    const payload = await response.json();
+    assert.equal(payload.error, "the configured Exomem origin is ineligible");
+    assert.deepEqual(payload.refusals, [
+      {
+        origin: "https://desktop.example.com",
+        replica_id: "desktop",
+        reason: "runtime_not_ready",
+      },
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("an unreachable origin is reported as unreachable, not as ineligible", async () => {
+  // A probe that throws and a probe that is refused used to collapse into the
+  // same null, so the 503 could not tell "the origin never answered" from "the
+  // origin answered and I turned it away".
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new Error("connection refused");
+  };
+  try {
+    const response = await worker.fetch(toolCall(), standaloneEnv());
+    assert.equal(response.status, 503);
+    const payload = await response.json();
+    assert.deepEqual(payload.refusals, [
+      {
+        origin: "https://desktop.example.com",
+        replica_id: "desktop",
+        reason: "health_probe_unreachable",
+      },
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("a refused active holder names its gate too", async () => {
+  const lease = {
+    holder: "desktop",
+    expires_at: Date.now() / 1000 + 30,
+    fencing_token: 12,
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => Response.json(readiness("desktop", { runtime_contract: 99 }));
+  try {
+    const response = await worker.fetch(toolCall(), edgeEnv(lease));
+    assert.equal(response.status, 503);
+    const payload = await response.json();
+    assert.equal(payload.error, "the active Exomem origin is not runtime-ready");
+    assert.deepEqual(payload.refusals, [
+      {
+        origin: "https://desktop.example.com",
+        replica_id: "desktop",
+        reason: "unsupported_runtime_contract",
+      },
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/deploy/cloudflare-ha/wrangler.toml.example
+++ b/deploy/cloudflare-ha/wrangler.toml.example
@@ -5,8 +5,13 @@ compatibility_date = "2026-07-12"
 [vars]
 VAULT_ID = "personal-main"
 DESKTOP_REPLICA_ID = "desktop"
-LAPTOP_REPLICA_ID = "laptop"
 DESKTOP_ORIGIN = "https://exomem-desktop.example.com"
+# The LAPTOP_* pair is optional. Leave both unset for a standalone deployment:
+# a single-node Exomem reports replica_id null and coordination disabled, and
+# the edge accepts that as eligible only when it is the sole configured origin.
+# Comment them out when you decommission the second replica -- and take the
+# worker out of the route if nothing is left for it to arbitrate (#581).
+LAPTOP_REPLICA_ID = "laptop"
 LAPTOP_ORIGIN = "https://exomem-laptop.example.com"
 ORIGIN_TIMEOUT_MS = "2500"
 # MCP tools can legitimately take longer than a connectivity probe. Keep this


### PR DESCRIPTION
Refs #581, #550.

## The defect

The edge worker refused the only running server **because that server correctly
reported itself standalone**. Every MCP call — read-only ones included — came
back `both Exomem replicas are ineligible`, while the origin answered
`/health/ready` with `200`, `takeover_eligible: true` and `reasons: []`.

Two gates in `evaluateReadiness` encode "HA is mandatory", and on a deployment
with one configured origin each could only ever refuse:

- `replica_identity_mismatch` — a standalone server reports `replica_id: null`,
  and **no configured value can equal `null`**.
- `coordination_required` — a standalone server reports
  `coordination.enabled: false`, by design.

So a correct single-node deployment was **unrepresentable**. That is a missing
topology, not a misconfiguration, which is why no amount of `wrangler` variable
tuning could have fixed it.

## Standalone is now a topology

Both gates relax for a single-origin deployment — and only when **both sides say
so**: exactly one origin configured in the worker *and* the origin
self-reporting `role: "standalone"` with `enabled: false`.

That conjunction is the safety property. Dropping one origin from a live pair by
mistake still refuses, because the survivor keeps reporting its replica id and
its coordination as enabled. The relaxation therefore cannot promote a replica
that merely lost its coordinator into an unarbitrated writer.

## A refusal now says what refused it

`evaluateReadiness` always computed the reason and the caller discarded it, so
the only symptom was a 503 naming replicas — on a deployment that no longer had
two, that pointed triage at an architecture which was not there.

```json
{
  "error": "the configured Exomem origin is ineligible",
  "refusals": [
    {
      "origin": "https://exomem-desktop.example.com",
      "replica_id": "desktop",
      "reason": "unsupported_runtime_contract"
    }
  ]
}
```

A probe that never produced a verdict is now distinguishable from one that was
judged and turned away: `health_status_<code>` and `health_probe_unreachable`
versus a named readiness gate. The read-path fallback stops naming replicas too,
and the holder-probe refusal carries its gate as well.

## The suite runs in CI

New job `edge worker (cloudflare-ha)`, added to the required gate. This worker
sits in front of every MCP call when it is deployed and can refuse a healthy
origin without the origin ever learning of it. It shipped untested; #581 is what
that cost.

## Docs

`README.md` and `wrangler.toml.example` now document both topologies, the
refusal payload, and the part that actually caused the outage: **the route
survives the replicas.** Decommissioning a replica does not remove the worker
from `/mcp` — it leaves an HA policy in front of a deployment that is no longer
HA. This answers the open question in #550 by making the retired configuration
safe and explicit rather than by deleting the directory; deletion remains
available and is a topology call, not a code one.

## Verification

- `node --test deploy/cloudflare-ha/test/worker.test.mjs` — **37 passed** (29
  pre-existing, all still green; 8 new).
- New coverage: standalone eligible when sole origin; a standalone *claim* from
  one origin of a configured pair still refused on both gates; a single
  configured origin that still claims a replica identity still refused; a
  standalone origin serving a tool call end to end (exactly one probe, exactly
  one forward); per-origin refusal reasons for selection, for the holder probe,
  and for an unreachable probe.
- Live check before writing any of this: `POST https://exomem.substratesystems.io/mcp`
  now returns `401` with `www-authenticate: Bearer` **and** an
  `x-exomem-request-id` header — the origin's own — so the worker is already out
  of that route and the outage itself is resolved operationally. This change is
  the recurrence fix.

## Not in this PR

- **Ask 4 of #581** — giving the origin a way to know it is receiving no traffic
  while its health stays green. That is a server-side observability feature, not
  an edge fix, and it deserves its own change.
- **Deleting `deploy/cloudflare-ha/`** — a live deployment's source; removing it
  is your call on topology, and it should follow taking the worker out of the
  route, not precede it.
