### PR TITLE
ci: cut the cross-platform feedback loop

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -29,16 +29,33 @@ concurrency:
 
 jobs:
   suite:
-    name: tests (${{ matrix.os }}, py3.13, shard ${{ matrix.shard }}/2)
+    name: tests (${{ matrix.os }}, py3.13, shard ${{ matrix.shard }}/4)
+    # Not for the release bot's version-bump PR. Its diff is a version string
+    # and a changelog; it carries no code this lane could say anything about,
+    # and `main` runs the lane on push immediately after it merges. The bot
+    # force-pushes that branch on every merge to main -- twenty times in one
+    # release cycle here -- and each force-push relaunched the whole matrix
+    # into a queue that real PRs were waiting in. macOS runners cap at five
+    # concurrent jobs for a public repo on the free tier, so those launches
+    # were not free capacity; they were the queue.
+    if: >-
+      github.event_name != 'pull_request'
+      || !startsWith(github.head_ref, 'release-please--branches--')
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
-        # Two shards, not the Linux lane's four. This lane exists to expose
-        # platform behaviour, not to be the fastest path to a result.
-        shard: [1, 2]
+        # Four shards, matching the Linux lane. This lane still exists to
+        # expose platform behaviour rather than to be the fastest path to a
+        # result -- but two shards made it the SLOWEST path by a wide margin: a
+        # macOS shard measured 17m53s of execution and Windows shards ran past
+        # 20 minutes, against a Linux lane finishing in a few. That is not a
+        # neutral cost. It is the feedback delay on every change to this repo,
+        # and it is paid on platforms whose defects are the hardest to
+        # reproduce locally, which is exactly where a slow loop hurts most.
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -103,7 +120,7 @@ jobs:
           tests/test_governance_overhead.py::test_governed_receipt_append_overhead_under_budget
           --deselect
           tests/test_governance_overhead.py::test_scrubber_throughput_under_budget
-          --splits=2
+          --splits=4
           --group=${{ matrix.shard }}
           --splitting-algorithm=least_duration
           --durations-path=.test_durations.json

--- a/tests/test_ci_reliability_contract.py
+++ b/tests/test_ci_reliability_contract.py
@@ -12,6 +12,12 @@ def _workflow() -> dict:
     return yaml.safe_load((ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8"))
 
 
+def _cross_platform_workflow() -> dict:
+    return yaml.safe_load(
+        (ROOT / ".github/workflows/cross-platform.yml").read_text(encoding="utf-8")
+    )
+
+
 def test_lean_python_lanes_have_time_bounds_and_versioned_timing_evidence() -> None:
     workflow = _workflow()
     job = workflow["jobs"]["test"]
@@ -204,3 +210,37 @@ def test_superseded_pr_runs_cancel_and_one_stable_gate_requires_every_ci_job() -
     assert gate["if"] == "${{ !cancelled() }}"
     assert set(gate["needs"]) == set(workflow["jobs"]) - {"gate"}
     assert gate["steps"][0]["env"]["RESULTS"] == "${{ join(needs.*.result, ' ') }}"
+
+
+def test_the_cross_platform_split_count_matches_its_shard_matrix() -> None:
+    """A mismatch here loses coverage without losing green.
+
+    `--splits=N` and the shard matrix are two independent numbers that have to
+    agree. Raise the matrix without the flag and the extra groups error; raise
+    the flag without the matrix and the tests in the missing groups are simply
+    never run, on a lane that still reports success. The second failure is
+    invisible, which is why it is asserted rather than reviewed.
+    """
+    job = _cross_platform_workflow()["jobs"]["suite"]
+    shards = job["strategy"]["matrix"]["shard"]
+    run_step = next(step for step in job["steps"] if step.get("name", "").startswith("Run tests"))
+
+    assert shards == list(range(1, len(shards) + 1))
+    assert f"--splits={len(shards)}" in run_step["run"]
+    assert "--group=${{ matrix.shard }}" in run_step["run"]
+    assert job["name"].endswith(f"shard ${{{{ matrix.shard }}}}/{len(shards)})")
+
+
+def test_the_release_bot_branch_does_not_launch_the_cross_platform_matrix() -> None:
+    """Its diff is a version string; `main` runs this lane on push regardless.
+
+    The bot force-pushes that branch on every merge to main, and each push
+    relaunched the whole matrix into a queue real PRs were waiting in. macOS
+    runners cap at five concurrent jobs for a public repo on the free tier, so
+    those launches were not spare capacity -- they were the queue.
+    """
+    condition = " ".join(_cross_platform_workflow()["jobs"]["suite"]["if"].split())
+
+    assert "release-please--branches--" in condition
+    # Skipped for that branch's PR, never for a push to main.
+    assert "github.event_name != 'pull_request'" in condition


### PR DESCRIPTION
## Measured

One release cycle, from the runs' own timestamps:

| | |
|---|---|
| macOS shard 2/2 (on `main`) | started 12:38:15, finished 12:56:08 — **17m53s of execution**, no queueing |
| Windows shards | past **20 minutes** and still running |
| Linux lane | a few minutes |
| Jobs queued behind them | **19** |

Two independent causes.

## 1. Two shards where Linux uses four

The lane split into two, by an explicit decision recorded in the file: it
*"exists to expose platform behaviour, not to be the fastest path to a result."*

That reasoning holds for **what** the lane tests. It does not hold for how long
it takes — two shards made it the *slowest* path by a wide margin, and the delay
is paid on exactly the platforms whose defects are hardest to reproduce locally.
That is where a slow loop hurts most.

Now four shards, matching the Linux lane. Same total runner minutes, roughly half
the wall-clock.

## 2. The release bot relaunched the whole matrix on every force-push

`release-please--branches--main` was force-pushed **20 times** in this cycle, and
each push relaunched 4 cross-platform jobs. Its diff is a version string and a
changelog — no code this lane can say anything about — and `main` runs the lane
on push the moment it merges.

macOS runners cap at **five concurrent jobs** for a public repository on the free
tier, so those launches were not spare capacity; they were the queue real PRs
were waiting in. The job is now skipped for that branch's PR, and never for a
push to `main`.

## Two contract tests, because one of these fails silently

`--splits=N` and the shard matrix are independent numbers that have to agree:

- raise the matrix without the flag → the extra groups error, loudly;
- raise the flag without the matrix → the tests in the missing groups are **never
  run**, and the lane still reports success.

The second is invisible, so it is asserted rather than left to review. The second
test pins the release-bot skip to the PR event only, so it can never start
skipping a push to `main`.

## Verification

- `tests/test_ci_reliability_contract.py` — **9 passed** (7 pre-existing, 2 new).
- `uvx ruff check . --select F` — clean.
- YAML parses; job renders as `tests (${{ matrix.os }}, py3.13, shard ${{ matrix.shard }}/4)`.
