### PR TITLE
fix(lease): tell a missing coordinator contract from a coordinator that is down

### DIFF
--- a/src/exomem/cli_ops.py
+++ b/src/exomem/cli_ops.py
@@ -64,6 +64,10 @@ _REMEDIATION: dict[str, str] = {
     "WRITER_COORDINATOR_UNAVAILABLE": (
         "Check the coordinator URL, credentials, and service health; reads remain available."
     ),
+    "WRITER_COORDINATOR_CONTRACT_ABSENT": (
+        "Point the writer-lease URL at a service that implements /v1/vaults/<id>/lease, "
+        "or disable coordination; retrying cannot change this answer."
+    ),
     "WRITER_FENCED": "Retry the mutation on the current writer.",
     "INGRESS_BYPASSED": (
         "Public traffic must enter via the HA edge hostname; check DNS, tunnel ingress, "
@@ -118,6 +122,7 @@ _REMEDIATION: dict[str, str] = {
 _SERVICE_UNAVAILABLE_CODES = frozenset(
     {
         "WRITER_COORDINATOR_UNAVAILABLE",
+        "WRITER_COORDINATOR_CONTRACT_ABSENT",
         "MUTATION_LOCK_UNAVAILABLE",
         # Retrieval-index-reliability (restore-indexed-category-recall): a safe
         # exact category/kind plan whose maintained semantic catalog cannot yet

--- a/src/exomem/media_jobs.py
+++ b/src/exomem/media_jobs.py
@@ -44,6 +44,11 @@ _TRANSIENT_OPERATION_CODES = frozenset(
         "MUTATION_BUSY",
         "MUTATION_LOCK_UNAVAILABLE",
         "WRITER_COORDINATOR_UNAVAILABLE",
+        # Deliberately transient too. A misconfigured coordinator URL is not
+        # fixed by asking again, but it IS fixed by an operator without
+        # restarting anything -- so the caller waits rather than crashing. What
+        # changes is only how often it asks; see the recheck cadence below.
+        "WRITER_COORDINATOR_CONTRACT_ABSENT",
         "WRITER_FENCED",
         "WRITER_LEASE_REQUIRED",
     }

--- a/src/exomem/media_processing.py
+++ b/src/exomem/media_processing.py
@@ -41,6 +41,11 @@ _TRANSIENT_COORDINATION_CODES = frozenset(
         "MUTATION_BUSY",
         "MUTATION_LOCK_UNAVAILABLE",
         "WRITER_COORDINATOR_UNAVAILABLE",
+        # Deliberately transient too. A misconfigured coordinator URL is not
+        # fixed by asking again, but it IS fixed by an operator without
+        # restarting anything -- so the caller waits rather than crashing. What
+        # changes is only how often it asks; see the recheck cadence below.
+        "WRITER_COORDINATOR_CONTRACT_ABSENT",
         "WRITER_FENCED",
         "WRITER_LEASE_REQUIRED",
     }

--- a/src/exomem/media_worker.py
+++ b/src/exomem/media_worker.py
@@ -92,11 +92,22 @@ _TRANSIENT_OPERATION_CODES = frozenset(
         "MUTATION_BUSY",
         "MUTATION_LOCK_UNAVAILABLE",
         "WRITER_COORDINATOR_UNAVAILABLE",
+        # Deliberately transient too. A misconfigured coordinator URL is not
+        # fixed by asking again, but it IS fixed by an operator without
+        # restarting anything -- so the caller waits rather than crashing. What
+        # changes is only how often it asks; see the recheck cadence below.
+        "WRITER_COORDINATOR_CONTRACT_ABSENT",
         "WRITER_FENCED",
         "WRITER_LEASE_REQUIRED",
     }
 )
 _FOLLOWER_RECHECK_SECONDS = 5.0
+#: A coordinator URL that answers but does not serve the lease contract returns
+#: the same answer to every request, so the follower cadence buys nothing and
+#: costs a request every five seconds per server process, indefinitely. Slow
+#: enough that a stuck deployment is quiet; short enough that fixing the URL
+#: takes effect without a restart (#550).
+_CONTRACT_ABSENT_RECHECK_SECONDS = 300.0
 _TRANSIENT_EXIT_CODE = 75
 _LOCK_UNAVAILABLE_EXIT_CODE = 76
 _TRANSIENT_RECHECK_SECONDS = 5.0
@@ -104,15 +115,34 @@ _LOCK_UNAVAILABLE_RECHECK_SECONDS = 30.0
 
 
 def _writer_authority_available() -> bool:
+    """Derived from :func:`_probe_writer_authority`, never a second probe.
+
+    The supervisor needs the refusing code to pick a recheck cadence and other
+    callers need only the boolean. Keeping one seam means a test that stubs
+    either reaches both; two independent probes meant a stub of this one left
+    the real one running, and its assertion fired on the supervisor thread
+    where pytest could only report it as a warning.
+    """
+    return _probe_writer_authority() is None
+
+
+def _probe_writer_authority() -> str | None:
+    """The code refusing write authority, or ``None`` when this replica holds it."""
     try:
         # cause="probe": an availability poll must not count as write activity
         # for the lease idle-release timer.
         get_manager().ensure_writer(cause="probe")
     except OpError as exc:
         if exc.code in _TRANSIENT_OPERATION_CODES:
-            return False
+            return exc.code
         raise
-    return True
+    return None
+
+
+def _authority_recheck_seconds(code: str) -> float:
+    if code == "WRITER_COORDINATOR_CONTRACT_ABSENT":
+        return _CONTRACT_ABSENT_RECHECK_SECONDS
+    return _FOLLOWER_RECHECK_SECONDS
 
 
 @dataclass(frozen=True)
@@ -812,8 +842,9 @@ class MediaWorker:
                     and time.monotonic() >= relaunch_after
                     and self._store.needs_worker()
                 ):
-                    if not _writer_authority_available():
-                        relaunch_after = time.monotonic() + _FOLLOWER_RECHECK_SECONDS
+                    refusal = _probe_writer_authority()
+                    if refusal is not None:
+                        relaunch_after = time.monotonic() + _authority_recheck_seconds(refusal)
                     else:
                         try:
                             self._child = self._launch_child()

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -781,6 +781,73 @@ class LeaseRecord:
         )
 
 
+#: Statuses that mean the URL answered and does not implement the lease
+#: contract at this route: 404 (no such route or operation), 405 (route exists,
+#: wrong method), 501 (the server does not implement it). A real coordinator
+#: 404s only for an unknown operation and this client sends none, so a 404 here
+#: is the wrong URL or an incompatible coordinator -- never one that is merely
+#: busy. That distinction is the whole point: an unavailable coordinator is
+#: worth asking again, and one that does not serve the contract will return the
+#: same answer forever. Collapsing them made a misconfigured lease URL look
+#: exactly like a transient outage, and the 5s availability probe polled it
+#: 1,200 times in 25 minutes from seven server processes, none of which ever
+#: said why (#550).
+_CONTRACT_ABSENT_STATUSES = frozenset({404, 405, 501})
+
+
+def _redacted_coordinator_url(url: str) -> str:
+    """The coordinator URL without any embedded credential.
+
+    `https://user:secret@host/` is a legal coordinator URL, and this string
+    reaches logs and, through the error, MCP clients.
+    """
+    try:
+        parts = urllib.parse.urlsplit(str(url))
+    except ValueError:
+        return "<unparsable coordinator url>"
+    host = parts.hostname or ""
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    return urllib.parse.urlunsplit((parts.scheme, host, parts.path, "", ""))
+
+
+def _coordinator_unavailable_error(exc: BaseException) -> OpError:
+    return OpError(
+        "WRITER_COORDINATOR_UNAVAILABLE",
+        f"writer coordinator could not confirm authority: {exc}",
+        "Check the coordinator URL, credentials, and service health; "
+        "reads remain available.",
+    )
+
+
+def _contract_absent_error(url: str, operation: str, status: int) -> OpError:
+    """A URL that answers but does not serve the writer-lease contract.
+
+    Fail-closed exactly like an unavailable coordinator -- authority is still
+    unproven, so writes still refuse. What changes is that the refusal names a
+    configuration fault instead of an outage, and callers that poll can slow
+    down instead of asking a 404 the same question every five seconds.
+    """
+    route = "/v1/vaults/<id>/lease" + (f"/{operation}" if operation else "")
+    safe_url = _redacted_coordinator_url(url)
+    logger.warning(
+        "writer-lease coordinator %s answered %d for %s; "
+        "this URL does not serve the writer-lease contract",
+        safe_url,
+        status,
+        route,
+    )
+    return OpError(
+        "WRITER_COORDINATOR_CONTRACT_ABSENT",
+        f"the configured writer-lease coordinator answered {status} for {route}",
+        "Point the writer-lease URL at a service that implements "
+        "/v1/vaults/<id>/lease, or disable coordination. Retrying cannot "
+        "change this answer; reads remain available and writes stay "
+        "fail-closed until it is corrected.",
+        details={"status": status, "coordinator_url": safe_url},
+    )
+
+
 class LeaseCoordinatorClient:
     """Small stdlib HTTP client for the provider-neutral lease contract."""
 
@@ -846,20 +913,20 @@ class LeaseCoordinatorClient:
             if not isinstance(payload, dict):
                 raise ValueError("response is not an object")
             return LeaseRecord.from_json(payload)
+        except urllib.error.HTTPError as exc:
+            # HTTPError subclasses URLError, so it has to be caught first for
+            # the status to be visible at all.
+            if exc.code in _CONTRACT_ABSENT_STATUSES:
+                raise _contract_absent_error(self.config.url, operation, exc.code) from None
+            raise _coordinator_unavailable_error(exc) from None
         except (
             urllib.error.URLError,
-            urllib.error.HTTPError,
             TimeoutError,
             OSError,
             json.JSONDecodeError,
             ValueError,
         ) as exc:
-            raise OpError(
-                "WRITER_COORDINATOR_UNAVAILABLE",
-                f"writer coordinator could not confirm authority: {exc}",
-                "Check the coordinator URL, credentials, and service health; "
-                "reads remain available.",
-            ) from None
+            raise _coordinator_unavailable_error(exc) from None
 
 
 def _mutation_outcome_unknown_error() -> OpError:

--- a/tests/test_media_worker.py
+++ b/tests/test_media_worker.py
@@ -2078,10 +2078,16 @@ def test_follower_supervisor_does_not_launch_media_child(
         sidecar_path=vault / result.sidecar_path,
         media_type="audio",
     )
+    # `_probe_writer_authority`, not `_writer_authority_available`: the
+    # supervisor asks for the refusing CODE so it can pick a recheck cadence,
+    # and the boolean is derived from it. Stubbing the derived form left the
+    # real probe running and the child launched anyway -- and because the
+    # `pytest.fail` fires on the supervisor THREAD, that regression surfaced
+    # only as a warning, not as a failing test.
     monkeypatch.setattr(
         media_worker,
-        "_writer_authority_available",
-        lambda: False,
+        "_probe_writer_authority",
+        lambda: "WRITER_LEASE_REQUIRED",
     )
     monkeypatch.setattr(
         worker,
@@ -2616,3 +2622,73 @@ def test_find_surfaces_media_fields(vault, monkeypatch: pytest.MonkeyPatch) -> N
     d = media[0].as_dict()
     assert d["media_type"] == "audio"
     assert d["media_file"].endswith("meeting.mp3")
+
+
+# --- the probe that produced the log volume ---------------------------------
+
+
+def test_a_missing_lease_contract_slows_the_availability_probe() -> None:
+    """The 5s follower cadence buys nothing against an answer that never changes.
+
+    A coordinator URL that serves no lease contract returns the same 404 to
+    every request. Polling it at the follower cadence cost one request every
+    five seconds per server process, indefinitely, and seven of them ran at
+    once. The recheck is slow enough that a stuck deployment is quiet, and
+    short enough that correcting the URL takes effect without a restart.
+    """
+    assert (
+        media_worker._authority_recheck_seconds("WRITER_COORDINATOR_CONTRACT_ABSENT")
+        == media_worker._CONTRACT_ABSENT_RECHECK_SECONDS
+    )
+    assert media_worker._CONTRACT_ABSENT_RECHECK_SECONDS > media_worker._FOLLOWER_RECHECK_SECONDS
+
+
+def test_an_ordinary_follower_keeps_the_fast_recheck() -> None:
+    """A replica that is simply not the writer must still take over promptly.
+
+    WRITER_LEASE_REQUIRED is the steady state of a healthy passive replica, and
+    slowing it would add the whole recheck interval to every takeover.
+    """
+    for code in ("WRITER_LEASE_REQUIRED", "WRITER_COORDINATOR_UNAVAILABLE", "MUTATION_BUSY"):
+        assert media_worker._authority_recheck_seconds(code) == (
+            media_worker._FOLLOWER_RECHECK_SECONDS
+        )
+
+
+def test_a_missing_lease_contract_still_leaves_work_queued(monkeypatch) -> None:
+    """Fail-closed is unchanged: a misconfiguration never grants authority.
+
+    It is classified transient on purpose -- an operator can correct the URL
+    without restarting anything, so the caller waits rather than crashing. Only
+    the cadence changes.
+    """
+
+    from exomem.cli_ops import OpError
+
+    class Refusing:
+        def ensure_writer(self, *, cause: str = "mutation"):
+            raise OpError(
+                "WRITER_COORDINATOR_CONTRACT_ABSENT",
+                "the configured writer-lease coordinator answered 404",
+            )
+
+    monkeypatch.setattr(media_worker, "get_manager", lambda: Refusing())
+
+    assert media_worker._writer_authority_available() is False
+    assert media_worker._probe_writer_authority() == "WRITER_COORDINATOR_CONTRACT_ABSENT"
+
+
+def test_the_boolean_probe_is_derived_from_the_code_probe(monkeypatch) -> None:
+    """One seam, so a stub of either reaches the supervisor.
+
+    The supervisor needs the refusing code to choose a recheck cadence; other
+    callers only need the boolean. When those were two independent functions, a
+    test stubbing the boolean left the real probe running -- and its assertion
+    fired on the supervisor THREAD, so the regression showed up as a pytest
+    warning rather than a red test.
+    """
+    monkeypatch.setattr(media_worker, "_probe_writer_authority", lambda: "WRITER_FENCED")
+    assert media_worker._writer_authority_available() is False
+
+    monkeypatch.setattr(media_worker, "_probe_writer_authority", lambda: None)
+    assert media_worker._writer_authority_available() is True

--- a/tests/test_writer_lease.py
+++ b/tests/test_writer_lease.py
@@ -730,6 +730,136 @@ def test_coordinator_requests_use_cloudflare_compatible_user_agent(monkeypatch) 
     assert "Exomem-Coordinator" in seen["user_agent"]
 
 
+def _coordinator_answering(monkeypatch, error: Exception):
+    """Point the lease client at a URL that answers with `error`."""
+
+    def fake_urlopen(request, timeout):  # noqa: ANN001, ARG001
+        raise error
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    from exomem.writer_lease import LeaseCoordinatorClient
+
+    return LeaseCoordinatorClient(
+        LeaseConfig(url="https://lease.example", vault_id="main", replica_id="desktop")
+    )
+
+
+def test_a_url_that_does_not_serve_the_lease_contract_is_not_an_outage(monkeypatch) -> None:
+    """404 is a configuration answer, and it will not change on the next try.
+
+    Collapsing it into WRITER_COORDINATOR_UNAVAILABLE made a misconfigured lease
+    URL indistinguishable from a coordinator that was merely down, so the
+    availability probe kept asking at the follower cadence -- 1,200 requests in
+    25 minutes across seven server processes, every one a 404, none of them ever
+    saying why.
+    """
+    import urllib.error
+
+    client = _coordinator_answering(
+        monkeypatch,
+        urllib.error.HTTPError("https://lease.example", 404, "Not Found", {}, None),
+    )
+
+    with pytest.raises(OpError) as raised:
+        client.acquire()
+
+    error = raised.value
+    assert error.code == "WRITER_COORDINATOR_CONTRACT_ABSENT"
+    assert error.details["status"] == 404
+    # The route it asked for, so the operator can see it is the lease contract
+    # that is missing rather than the whole host.
+    assert "/v1/vaults/<id>/lease/acquire" in error.message
+    assert "Retrying cannot" in (error.remediation or "")
+
+
+@pytest.mark.parametrize("status", [404, 405, 501])
+def test_every_contract_absent_status_is_classified_alike(monkeypatch, status: int) -> None:
+    """405 and 501 say the same thing 404 does: not served here.
+
+    A coordinator that is present answers the lease route; one that is present
+    and refuses the METHOD, or declares the operation unimplemented, is the
+    wrong service or the wrong version. Neither is fixed by waiting.
+    """
+    import urllib.error
+
+    client = _coordinator_answering(
+        monkeypatch,
+        urllib.error.HTTPError("https://lease.example", status, "nope", {}, None),
+    )
+
+    with pytest.raises(OpError) as raised:
+        client.acquire()
+
+    assert raised.value.code == "WRITER_COORDINATOR_CONTRACT_ABSENT"
+
+
+@pytest.mark.parametrize("status", [500, 502, 503, 401, 403])
+def test_a_coordinator_that_is_present_stays_transiently_unavailable(
+    monkeypatch, status: int
+) -> None:
+    """Everything else keeps the old code, and the old fail-closed handling.
+
+    A 5xx is a coordinator having a bad moment and a 401/403 is a credential
+    the operator can fix in place; both are worth asking again, and neither
+    should inherit the slow cadence meant for a URL that serves no contract.
+    """
+    import urllib.error
+
+    client = _coordinator_answering(
+        monkeypatch,
+        urllib.error.HTTPError("https://lease.example", status, "nope", {}, None),
+    )
+
+    with pytest.raises(OpError) as raised:
+        client.acquire()
+
+    assert raised.value.code == "WRITER_COORDINATOR_UNAVAILABLE"
+
+
+def test_an_unreachable_coordinator_stays_transiently_unavailable(monkeypatch) -> None:
+    """A transport failure never reached a service, so it classifies nothing."""
+    import urllib.error
+
+    client = _coordinator_answering(monkeypatch, urllib.error.URLError("connection refused"))
+
+    with pytest.raises(OpError) as raised:
+        client.acquire()
+
+    assert raised.value.code == "WRITER_COORDINATOR_UNAVAILABLE"
+
+
+def test_a_credential_in_the_coordinator_url_is_not_echoed_back(monkeypatch) -> None:
+    """`https://user:secret@host/` is a legal coordinator URL.
+
+    The refusal reaches the server log and, through the error payload, MCP
+    clients. Naming the host is the point of the message; naming the password
+    is a leak.
+    """
+    import urllib.error
+
+    def fake_urlopen(request, timeout):  # noqa: ANN001, ARG001
+        raise urllib.error.HTTPError("https://lease.example", 404, "Not Found", {}, None)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    from exomem.writer_lease import LeaseCoordinatorClient
+
+    client = LeaseCoordinatorClient(
+        LeaseConfig(
+            url="https://operator:hunter2@lease.example:8443",
+            vault_id="main",
+            replica_id="desktop",
+        )
+    )
+
+    with pytest.raises(OpError) as raised:
+        client.acquire()
+
+    rendered = f"{raised.value.message} {raised.value.details}"
+    assert "hunter2" not in rendered
+    assert "operator" not in rendered
+    assert raised.value.details["coordinator_url"] == "https://lease.example:8443"
+
+
 class FakeClient:
     def __init__(self, record: LeaseRecord | Exception):
         self.record = record


### PR DESCRIPTION
Refs #550.

## The defect

Every lease-client failure collapsed into `WRITER_COORDINATOR_UNAVAILABLE` —
including a `404`. Those are not the same fact:

- an **unavailable** coordinator is worth asking again;
- a URL that **does not serve the writer-lease contract** will return the same
  answer forever.

Collapsing them made a misconfigured lease URL indistinguishable from a
transient outage, so the media worker's availability probe kept asking at the 5 s
follower cadence. In the field that was **1,200+ requests in 25 minutes** against
an origin that never mounts the coordinator — seven server processes each
polling, every request a 404 in ~0.4 ms, and not one line anywhere saying why.

## The classification

`404`, `405` and `501` on the lease route now raise
`WRITER_COORDINATOR_CONTRACT_ABSENT`. The real coordinator 404s **only** for an
unknown operation (`lease_coordinator.py:308,358`) and this client sends none, so
a 404 here is the wrong URL or an incompatible coordinator — never one that is
merely busy.

Everything else keeps `WRITER_COORDINATOR_UNAVAILABLE` and its existing
handling: 5xx, `401`/`403` (a credential an operator fixes in place), transport
failures, timeouts, malformed bodies.

## Fail-closed is unchanged

The new code is classified transient in **every** place the old one was
(`media_jobs`, `media_processing`, `media_worker`), so authority stays unproven,
writes still refuse, and nothing crashes. An operator can correct the URL without
restarting anything, so the caller waits rather than dying.

What changes is only:

- **how often it asks** — the media worker rechecks a missing contract every
  **300 s** instead of every 5 s, a 60× reduction, while an ordinary follower
  (`WRITER_LEASE_REQUIRED`) keeps the fast recheck so takeover is still prompt;
- **that the refusal says what is wrong** — the status, the route it asked for,
  and a remediation that states retrying cannot change the answer.

## Credentials

`https://user:secret@host/` is a legal coordinator URL, and this string reaches
the server log and, through the error payload, MCP clients. It is reported with
userinfo stripped, and that is asserted.

## A seam bug found while doing this

The supervisor now asks for the refusing **code** so it can pick a cadence, so
`_writer_authority_available()` is *derived* from `_probe_writer_authority()`
rather than being a second independent probe.

`test_follower_supervisor_does_not_launch_media_child` stubbed the boolean. With
two independent probes it would have kept passing while the real probe ran and
the child launched — because its `pytest.fail` fires on the **supervisor
thread**, where pytest can only surface it as a warning. It is repointed at the
real seam, and a new test pins the two together so they cannot split again.

## Verification

Windows, py3.13, from the feature worktree:

- `tests/test_writer_lease.py` — **189 passed, 5 skipped** (5 POSIX-only skips).
- `tests/test_media_worker.py` + `tests/test_lease_cli.py` — **90 passed**.
- `tests/test_media_jobs.py`, `tests/test_media_processing.py` — green in the
  combined run.
- `uvx ruff check . --select F` clean; the default rule set reports the same
  three pre-existing categories as `main`, no new findings.

Note for anyone reproducing: run with `EXOMEM_VAULT_PATH` cleared. An exported
value makes five `test_writer_lease.py` tests read the operator's real vault as
the receipt root and fail — same class as the `EXOMEM_LOG_DIR` leak fixed in
#570, and fixed for the suite separately.

## Not in this PR

Whether `deploy/cloudflare-ha/` should be deleted — that is a topology call, and
#672 already made the retired configuration safe and explicit.
