### PR TITLE
fix(tests): key the vault snapshot by posix path so Windows can read it back

### DIFF
--- a/tests/test_studio_adoption_flows.py
+++ b/tests/test_studio_adoption_flows.py
@@ -81,10 +81,19 @@ def _write(root: Path, rel: str, content: str) -> Path:
 
 
 def _snapshot(root: Path) -> dict[str, bytes]:
+    """Byte-for-byte vault contents outside the KB, keyed by posix relative path.
+
+    `as_posix()`, not `str()`: tests index this dict with forward-slash literals
+    like "Old Notes/a.md", and `str()` on a WindowsPath yields backslashes, so
+    the lookup raised KeyError on the Windows lane only. The separator also
+    decided the exclusion below -- `split("/")[0]` returns the WHOLE path on
+    Windows, turning a first-segment test into a substring test that would
+    exempt any file with "Knowledge Base" anywhere in its path.
+    """
     return {
-        str(p.relative_to(root)): p.read_bytes()
+        p.relative_to(root).as_posix(): p.read_bytes()
         for p in root.rglob("*")
-        if p.is_file() and "Knowledge Base" not in str(p.relative_to(root)).split("/")[0]
+        if p.is_file() and p.relative_to(root).as_posix().split("/")[0] != "Knowledge Base"
     }
 
 


### PR DESCRIPTION
The **only** Windows failure left on `main` at `4fc7c5ea`, out of **10,078** tests
across both shards. macOS passed both shards on the same commit.

```
after["Old Notes/a.md"] = before["Old Notes/a.md"]  # exempt the deliberate edit
E       KeyError: 'Old Notes/a.md'
tests\test_studio_adoption_flows.py:294
```

## Two defects, one separator

`_snapshot` keyed by `str(p.relative_to(root))`. On a `WindowsPath` that is
backslash-separated, while every test indexes the dict with a forward-slash
literal. The snapshot was *correct* — it was simply unreachable by the name the
test knows it by.

The same separator also decided the exclusion:

```python
if p.is_file() and "Knowledge Base" not in str(p.relative_to(root)).split("/")[0]
```

On Windows `split("/")` never splits, so `[0]` is the **whole path** and a
first-segment test silently became a substring test — exempting any file with
`Knowledge Base` anywhere in its path from the byte-identical assertion, on the
platform where that assertion is hardest to satisfy. It happened to exclude the
right files here, for the wrong reason.

`as_posix()` fixes both: the key matches the literals, and the exclusion compares
the first segment as an exact segment.

## Verification

Windows, py3.13:

- Before (at `origin/main`): `test_stale_source_returns_409_and_leaves_vault_byte_identical`
  **fails locally**, reproducing the CI failure exactly.
- After: `tests/test_studio_adoption_flows.py` — **8 passed**.

Evidence source: `crossplat-windows-latest-shard-{1,2}-junit` from run
`32253205719`, totals `{'total': 10078, 'skipped': 754, 'passed': 9323, 'failure': 1}`.
