### PR TITLE
perf(recall): stop rebuilding the projected resolver on a reader's thread

### DIFF
--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -3591,6 +3591,32 @@ _RESOLVER_CHECKPOINTS: dict[Path, freshness.FreshnessCheckpoint] = {}
 _RECALL_RESOLVER_CHECKPOINTS: dict[Path, freshness.RecallFreshnessCheckpoint] = {}
 _RESOLVER_LOCK = threading.Lock()
 
+#: Vaults with a projected-resolver build already running.
+#:
+#: `recall_resolver_snapshot` builds from a full `walk_vault_md` plus a parse
+#: per admitted page -- O(vault), and measured at 30.7s of a 34s `ask_memory`
+#: call on a 2.4k-page vault, which is 90% of that read (#676). Nothing bounded
+#: it: eviction is cheap and asynchronous while the rebuild is expensive and
+#: synchronous, so the whole cost landed on whichever caller asked first, and
+#: on the read path that is a reader.
+#:
+#: Two things use this. Concurrent callers on a cold cache wait for one build
+#: instead of each running their own, and `_evict_recall_resolver` starts a
+#: background rebuild so the gap between an eviction and the next warm cache is
+#: closed by a daemon thread rather than by the next query. Neither changes what
+#: a caller gets -- a build still returns the same resolver, and a caller that
+#: arrives mid-build still waits -- so ranking is untouched.
+_RECALL_RESOLVER_BUILDS: dict[Path, threading.Event] = {}
+#: Its own lock, NOT `_RESOLVER_LOCK`: `_evict_recall_resolver` runs while that
+#: one is held, and the build below must be able to register itself without
+#: holding a lock across a whole-vault walk.
+_RECALL_REBUILD_LOCK = threading.Lock()
+#: Long enough that a follower waits out a real build on a large vault rather
+#: than duplicating it, short enough that a wedged leader cannot hold a reader
+#: indefinitely -- the follower simply builds its own after this.
+_RECALL_RESOLVER_BUILD_WAIT_SECONDS = 120.0
+_RECALL_RESOLVER_REBUILDS: set[Path] = set()
+
 
 def _recall_checkpoint_identity(
     checkpoint: freshness.RecallFreshnessCheckpoint,
@@ -3603,8 +3629,82 @@ def _recall_checkpoint_identity(
 
 
 def _evict_recall_resolver(root: Path) -> None:
+    """Drop the projected resolver, and start rebuilding it off the read path.
+
+    Callers hold `_RESOLVER_LOCK`; the rebuild is scheduled, never run, here.
+
+    Every eviction site in `on_resolver_files_changed` is a correctness refusal
+    -- an incomplete event delta, a moved path guard, a policy identity that
+    advanced -- and each is right to drop the cache. What they cannot do is
+    leave the vault with no resolver and no plan to get one, because the next
+    caller to need it pays a whole-vault walk and parse in the foreground.
+    Scheduling the rebuild here is what makes the eviction cheap for everyone
+    except a daemon thread.
+    """
     _RECALL_RESOLVER_CACHE.pop(root, None)
     _RECALL_RESOLVER_CHECKPOINTS.pop(root, None)
+    _schedule_recall_resolver_rebuild(root)
+
+
+def _schedule_recall_resolver_rebuild(root: Path) -> None:
+    """Start at most one background projected-resolver build per vault.
+
+    Best-effort and deliberately silent on failure: this exists to make the
+    next reader fast, and a vault that cannot be walked right now will simply
+    be built by whoever needs it, exactly as before. Never blocks the caller,
+    which may be holding `_RESOLVER_LOCK` or serving a request.
+    """
+    if os.environ.get("EXOMEM_DISABLE_RESOLVER_WARM"):
+        return
+    key = Path(root)
+    with _RECALL_REBUILD_LOCK:
+        if key in _RECALL_RESOLVER_REBUILDS:
+            return
+        _RECALL_RESOLVER_REBUILDS.add(key)
+
+    def _run() -> None:
+        try:
+            recall_resolver_snapshot(key)
+        except Exception as error:  # noqa: BLE001 - a daemon must not escape
+            log.warning("projected resolver background rebuild skipped (%s)", error)
+        finally:
+            with _RECALL_REBUILD_LOCK:
+                _RECALL_RESOLVER_REBUILDS.discard(key)
+
+    # A literal thread name, like every other exomem thread: names reach the
+    # log through `JsonLinesFormatter`, and hosted-cell redaction blanks a
+    # record's fields rather than rebuilding it from an allowlist, so a vault
+    # path encoded in a thread name would survive that boundary.
+    thread = threading.Thread(
+        target=_run,
+        name="exomem-recall-resolver-warm",
+        daemon=True,
+    )
+    try:
+        thread.start()
+    except RuntimeError:
+        with _RECALL_REBUILD_LOCK:
+            _RECALL_RESOLVER_REBUILDS.discard(key)
+
+
+def await_recall_resolver_warm(timeout: float = 30.0) -> bool:
+    """Block until no background projected-resolver build is running.
+
+    A quiesce seam, not a convergence helper: it says nothing about whether a
+    resolver is now cached, only that no daemon thread is still walking a
+    vault. Production is one long-lived process where a warm thread outliving
+    its trigger is the point; a test suite is many vaults in one process,
+    where a thread outliving the tmp vault that started it is a cross-test
+    leak. Mirrors `graph_sync.await_active_rebuild`.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        with _RECALL_REBUILD_LOCK:
+            if not _RECALL_RESOLVER_REBUILDS:
+                return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.01)
 
 
 def _evict_resolver(root: Path) -> None:
@@ -3716,24 +3816,65 @@ def recall_resolver_snapshot(vault_root: Path, freshness: tuple | None = None):
         if cached and cached[0] == identity:
             return cached[1].fork()
 
-    entries: list[tuple[str, str | None]] = []
-    for path in walk_vault_md(root):
-        if not recall_policy.is_recall_candidate(root, path):
-            continue
-        page = _CACHE.get(path, root)
-        if page is not None:
-            entries.append((page.rel_path, page.title))
-    resolver = WikilinkResolver.from_entries(root, entries)
-    with _RESOLVER_LOCK:
-        # The supplied freshness key names this immutable resolver snapshot.
-        # A later caller with changed disk/policy identity cannot reuse it;
-        # graph rebuild performs its stronger direct before/after proof around
-        # sidecar publication.
-        _RECALL_RESOLVER_CACHE[root] = (identity, resolver)
-        if checkpoint is not None:
-            _RECALL_RESOLVER_CHECKPOINTS[root] = checkpoint
-        else:
-            _RECALL_RESOLVER_CHECKPOINTS.pop(root, None)
+    # Single-flight. The build below is a full vault walk plus a parse per
+    # admitted page, so N callers arriving on a cold cache used to run N of
+    # them concurrently -- each reading the same files, each producing a
+    # resolver N-1 of them would discard. Followers wait on the leader's event
+    # and then re-check the cache, which is where the leader publishes.
+    #
+    # A follower whose wait times out, or whose leader published a different
+    # identity, falls through and builds its own. That is the pre-existing
+    # behaviour and it stays correct; the wait is an optimisation, never a
+    # dependency.
+    leader = False
+    while True:
+        with _RECALL_REBUILD_LOCK:
+            building = _RECALL_RESOLVER_BUILDS.get(root)
+            if building is None:
+                building = threading.Event()
+                _RECALL_RESOLVER_BUILDS[root] = building
+                leader = True
+        if leader:
+            break
+        if not building.wait(_RECALL_RESOLVER_BUILD_WAIT_SECONDS):
+            break
+        with _RESOLVER_LOCK:
+            cached = _RECALL_RESOLVER_CACHE.get(root)
+            if cached and cached[0] == identity:
+                return cached[1].fork()
+        # The leader finished with a different identity, or its result was
+        # evicted before this thread looked. Try to become the leader.
+
+    # The publication is INSIDE the try, so the leader's event is released only
+    # once the cache actually holds the result. Signalling at the end of the
+    # build instead would wake every follower onto a still-empty cache, and each
+    # would then elect itself leader and rebuild -- reintroducing the stampede
+    # this exists to prevent, just narrowed to a race window.
+    try:
+        entries: list[tuple[str, str | None]] = []
+        for path in walk_vault_md(root):
+            if not recall_policy.is_recall_candidate(root, path):
+                continue
+            page = _CACHE.get(path, root)
+            if page is not None:
+                entries.append((page.rel_path, page.title))
+        resolver = WikilinkResolver.from_entries(root, entries)
+        with _RESOLVER_LOCK:
+            # The supplied freshness key names this immutable resolver snapshot.
+            # A later caller with changed disk/policy identity cannot reuse it;
+            # graph rebuild performs its stronger direct before/after proof
+            # around sidecar publication.
+            _RECALL_RESOLVER_CACHE[root] = (identity, resolver)
+            if checkpoint is not None:
+                _RECALL_RESOLVER_CHECKPOINTS[root] = checkpoint
+            else:
+                _RECALL_RESOLVER_CHECKPOINTS.pop(root, None)
+    finally:
+        if leader:
+            with _RECALL_REBUILD_LOCK:
+                done = _RECALL_RESOLVER_BUILDS.pop(root, None)
+            if done is not None:
+                done.set()
     return resolver.fork()
 
 
@@ -4069,6 +4210,11 @@ def unload_ram_caches() -> dict[str, int]:
     _CACHE.clear()
     with _RESOLVER_LOCK:
         resolver_entries = len(_RESOLVER_CACHE) + len(_RECALL_RESOLVER_CACHE)
+        # Deliberately clears the maps directly rather than going through
+        # `_evict_recall_resolver`: this is the idle reaper handing memory back,
+        # and immediately spending a thread to rebuild what it just released
+        # would defeat the whole point of releasing it. The next caller builds,
+        # single-flighted.
         _RESOLVER_CACHE.clear()
         _RECALL_RESOLVER_CACHE.clear()
         _RESOLVER_CHECKPOINTS.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -535,6 +535,13 @@ def _disable_embeddings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
     # filesystem census can observe. Default it off in the suite;
     # test_corpus_context_cache.py deletes this var to exercise it.
     monkeypatch.setenv("EXOMEM_DISABLE_CORPUS_CACHE", "1")
+    # The projected-resolver warm thread is a production optimisation: it walks
+    # the vault after an eviction so the next reader does not pay for it. In the
+    # suite it would outlive the tmp vault that started it -- production is one
+    # long-lived process, the suite is hundreds of vaults in one -- and touch
+    # process-global caches from a test that has already finished.
+    # `tests/test_recall_resolver_warm.py` deletes this var to exercise it.
+    monkeypatch.setenv("EXOMEM_DISABLE_RESOLVER_WARM", "1")
 
 
 @pytest.fixture

--- a/tests/test_recall_resolver_warm.py
+++ b/tests/test_recall_resolver_warm.py
@@ -1,0 +1,249 @@
+"""The projected recall resolver is never rebuilt on a reader's thread.
+
+`find.recall_resolver_snapshot` builds from a full `walk_vault_md` plus a parse
+per admitted page. Measured on a 2.4k-page production vault it cost 30.7s of a
+34s `ask_memory` call -- 90% of that read (#676), while every retrieval lane in
+the same call finished in under half a second.
+
+The warm path was already careful: `on_resolver_files_changed` patches the cache
+incrementally from the exact event checkpoint. What had no bound was the miss.
+Eviction is cheap and asynchronous; the rebuild behind it was expensive and
+synchronous, so the entire cost landed on whichever caller asked first -- and on
+the read path that is a reader.
+
+These tests pin the two halves that fix it, and the two places it must NOT fire.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from exomem import find as find_module
+from exomem import vault as vault_module
+
+
+@pytest.fixture(autouse=True)
+def _enable_resolver_warm(monkeypatch: pytest.MonkeyPatch):
+    """This suite exists to exercise the warm thread; the suite defaults it off."""
+    monkeypatch.delenv("EXOMEM_DISABLE_RESOLVER_WARM", raising=False)
+    yield
+    # Never leave a daemon thread walking this test's tmp vault.
+    assert find_module.await_recall_resolver_warm(timeout=30.0)
+    find_module.unload_ram_caches()
+
+
+def _seed(root: Path, count: int = 3) -> Path:
+    notes = root / "Knowledge Base" / "Notes" / "Insights"
+    notes.mkdir(parents=True, exist_ok=True)
+    for index in range(count):
+        (notes / f"page-{index}.md").write_text(
+            f"---\ntitle: Page {index}\ntype: insight\nstatus: active\n---\n\nBody {index}.\n",
+            encoding="utf-8",
+        )
+    return root
+
+
+def _count_builds(monkeypatch: pytest.MonkeyPatch, *, delay: float = 0.0) -> list[float]:
+    """Record one entry per resolver BUILD, optionally slowing each.
+
+    `WikilinkResolver.from_entries` rather than `walk_vault_md`: the freshness
+    key this function needs walks the vault too, so counting walks would count
+    work that is not the build under test.
+    """
+    builds: list[float] = []
+    real_from_entries = vault_module.WikilinkResolver.from_entries
+
+    def counted(vault_root, entries):  # noqa: ANN001, ANN202
+        builds.append(time.monotonic())
+        if delay:
+            time.sleep(delay)
+        return real_from_entries(vault_root, entries)
+
+    monkeypatch.setattr(vault_module.WikilinkResolver, "from_entries", counted)
+    return builds
+
+
+def test_eviction_warms_the_cache_instead_of_leaving_it_for_a_reader(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every eviction site is a correctness refusal, and each is right to refuse.
+
+    What they could not do is leave the vault with no resolver and no plan to
+    get one. That is what put a whole-vault walk in front of the next query.
+    """
+    root = _seed(tmp_path)
+    find_module.recall_resolver_snapshot(root)
+    assert Path(root) in find_module._RECALL_RESOLVER_CACHE
+
+    builds = _count_builds(monkeypatch)
+    with find_module._RESOLVER_LOCK:
+        find_module._evict_recall_resolver(Path(root))
+
+    assert find_module.await_recall_resolver_warm(timeout=30.0)
+    assert len(builds) == 1, "the eviction did not rebuild exactly once off the read path"
+    assert Path(root) in find_module._RECALL_RESOLVER_CACHE
+
+
+def test_a_cold_burst_of_readers_walks_the_vault_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """N readers arriving cold used to run N whole-vault walks concurrently.
+
+    Each read the same files and produced a resolver N-1 of them discarded. The
+    single-flight does not make any one caller faster -- it stops the vault
+    being walked once per caller, which is what turns a slow read into a slow
+    server.
+    """
+    root = _seed(tmp_path, count=8)
+    builds = _count_builds(monkeypatch, delay=0.25)
+    results: list[object] = []
+    barrier = threading.Barrier(4)
+
+    def reader() -> None:
+        barrier.wait(timeout=10)
+        results.append(find_module.recall_resolver_snapshot(root))
+
+    threads = [threading.Thread(target=reader) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert len(results) == 4
+    assert all(result is not None for result in results)
+    assert len(builds) == 1, f"expected one build for four cold readers, got {len(builds)}"
+
+
+def test_the_idle_reaper_does_not_rebuild_what_it_just_released(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`unload_ram_caches` is memory being handed back, not a correctness refusal.
+
+    Spending a thread to rebuild the structure it just released would defeat the
+    point of releasing it. The next caller builds, single-flighted.
+    """
+    root = _seed(tmp_path)
+    find_module.recall_resolver_snapshot(root)
+    builds = _count_builds(monkeypatch)
+
+    find_module.unload_ram_caches()
+    # Long enough that a scheduled thread would have started and been recorded.
+    time.sleep(0.2)
+
+    assert builds == []
+    assert Path(root) not in find_module._RECALL_RESOLVER_CACHE
+
+
+def test_the_warm_thread_can_be_switched_off(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A background walk of the operator's vault has to be refusable.
+
+    Same shape as every other EXOMEM_DISABLE_* switch: off restores the previous
+    behaviour exactly -- the cache stays cold and the next caller builds it.
+    """
+    root = _seed(tmp_path)
+    find_module.recall_resolver_snapshot(root)
+    monkeypatch.setenv("EXOMEM_DISABLE_RESOLVER_WARM", "1")
+    builds = _count_builds(monkeypatch)
+
+    with find_module._RESOLVER_LOCK:
+        find_module._evict_recall_resolver(Path(root))
+    time.sleep(0.2)
+
+    assert builds == []
+    assert Path(root) not in find_module._RECALL_RESOLVER_CACHE
+
+    # And the reader still gets a correct resolver, the slow way.
+    assert find_module.recall_resolver_snapshot(root) is not None
+    assert len(builds) == 1
+
+
+def test_a_rebuilt_resolver_still_resolves_the_same_links(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The bound may not change what a caller gets.
+
+    Single-flight and background warming only decide WHO pays for the build and
+    WHEN; a resolver from either path has to answer identically, or this traded
+    latency for wrong recall.
+    """
+    root = _seed(tmp_path, count=4)
+    rels = [f"Knowledge Base/Notes/Insights/page-{index}.md" for index in range(4)]
+    direct = find_module.recall_resolver_snapshot(root)
+    baseline = (
+        set(direct.full_paths),
+        set(direct.kb_stripped),
+        {key: sorted(value) for key, value in direct.stems.items()},
+        {key: sorted(value) for key, value in direct.titles.items()},
+        {rel: direct.title_key_for_path(rel) for rel in rels},
+    )
+    assert baseline[4] == {rel: f"page {rel[-4]}" for rel in rels}, baseline[4]
+
+    with find_module._RESOLVER_LOCK:
+        find_module._evict_recall_resolver(Path(root))
+    assert find_module.await_recall_resolver_warm(timeout=30.0)
+
+    warmed = find_module.recall_resolver_snapshot(root)
+    assert (
+        set(warmed.full_paths),
+        set(warmed.kb_stripped),
+        {key: sorted(value) for key, value in warmed.stems.items()},
+        {key: sorted(value) for key, value in warmed.titles.items()},
+        {rel: warmed.title_key_for_path(rel) for rel in rels},
+    ) == baseline
+
+
+def test_a_follower_never_rebuilds_what_the_leader_just_published(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The leader's signal has to mean "cached", not "finished building".
+
+    Signalling at the end of the build wakes every follower onto a still-empty
+    cache; each then elects itself leader and rebuilds, which is the stampede
+    the single-flight exists to prevent, narrowed to a race window instead of
+    removed. Pinning it deterministically because the window is small enough
+    that a timing-based test would pass by luck.
+    """
+    root = _seed(tmp_path, count=6)
+    release = threading.Event()
+    builds: list[int] = []
+    real_from_entries = vault_module.WikilinkResolver.from_entries
+
+    def gated(vault_root, entries):  # noqa: ANN001, ANN202
+        builds.append(1)
+        assert release.wait(20)
+        return real_from_entries(vault_root, entries)
+
+    monkeypatch.setattr(vault_module.WikilinkResolver, "from_entries", gated)
+
+    results: list[object] = []
+
+    def reader() -> None:
+        results.append(find_module.recall_resolver_snapshot(root))
+
+    leader = threading.Thread(target=reader)
+    leader.start()
+    deadline = time.monotonic() + 20
+    while not builds and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert builds, "the leader never entered the build"
+
+    followers = [threading.Thread(target=reader) for _ in range(3)]
+    for thread in followers:
+        thread.start()
+    # Parked on the leader's event, not building.
+    time.sleep(0.3)
+    assert len(builds) == 1
+
+    release.set()
+    for thread in [leader, *followers]:
+        thread.join(timeout=30)
+
+    assert len(results) == 4
+    assert all(result is not None for result in results)
+    assert len(builds) == 1, "a follower rebuilt after the leader published"


### PR DESCRIPTION
Refs #676.

## Measured

Production vault, 0.55.0, ~2.4k pages, `ask_memory(include_timings=true)`:

```
total: 34,052 ms
  graph: 30,787 ms
    graph.resolver: 30,763 ms     <- 90% of the read
  vector: 317 ms   bm25: 24 ms   keyword: 121 ms   fusion: 74 ms
```

Every retrieval lane finished in under half a second. The 30.8 s was
`recall_resolver_snapshot` on a cache miss: a full `walk_vault_md` plus a parse
per admitted page — O(vault), synchronously, in the foreground.

## The warm path was never the problem

`on_resolver_files_changed` already patches `_RECALL_RESOLVER_CACHE` incrementally
from the exact event checkpoint, with path guards and a re-check before
publication. A vault that is merely being *edited* does not pay this.

What had no bound was the **miss**. Eviction is cheap and asynchronous; the
rebuild behind it was expensive and synchronous. So the entire cost landed on
whichever caller asked first — and on the read path that is a reader.

## Two bounds, neither changing what a caller gets

**Eviction schedules the rebuild.** Every eviction site in
`on_resolver_files_changed` is a correctness refusal — an incomplete event delta,
a moved path guard, an advanced policy identity — and each is right to drop the
cache. What they could not do is leave the vault with no resolver *and no plan to
get one*. A daemon thread now closes that gap instead of the next query.

**The build is single-flighted.** N callers arriving cold ran N concurrent
whole-vault walks, each reading the same files to produce a resolver N-1 of them
discarded. Followers wait on the leader and re-read the cache; one whose wait
expires, or whose leader published a different identity, still builds its own —
so the wait is an optimisation, never a dependency.

**Publication is inside the single-flight guard.** I had this wrong first: with
the signal at the end of the *build*, every follower wakes onto a still-empty
cache and elects itself leader — the same stampede, narrowed to a race window
rather than removed. `test_a_follower_never_rebuilds_what_the_leader_just_published`
pins the ordering deterministically, because the window is small enough that a
timing-based test passes by luck.

## Two places it must NOT fire

- `unload_ram_caches` deliberately does not schedule a rebuild. That is the idle
  reaper handing memory back; spending a thread to rebuild what it just released
  would defeat the point. Pinned by a test.
- `EXOMEM_DISABLE_RESOLVER_WARM` switches the thread off, and **the suite sets it
  by default**. Production is one long-lived process where a warm thread
  outliving its trigger is exactly the point; the suite is hundreds of vaults in
  one process, where the same thread is a cross-test leak walking a `tmp_path`
  that no longer belongs to anyone. `await_recall_resolver_warm` is the quiesce
  seam, mirroring `graph_sync.await_active_rebuild`; this PR's own suite opts
  back in and quiesces in teardown.

## Verification

Windows, py3.13:

- `tests/test_recall_resolver_warm.py` — **6 passed** (new).
- `test_deferred_work_drain`, `test_epistemic_graph_freshness`, `test_file_watcher`,
  `test_find_overhead`, `test_graph_lane_perf`, `test_index_sync`,
  `test_index_trash_exclusion`, `test_records_recall_graph`,
  `test_records_recall_index_sync`, `test_reconcile`, plus the new suite —
  **279 passed, 1 skipped** (the skip is the pre-existing Unix-symlink one).
- `uvx ruff check .` and `--select F` clean.
- A resolver produced through the background rebuild is asserted equal to a
  directly-built one across `full_paths`, `kb_stripped`, `stems`, `titles` and
  `title_key_for_path` — this trades *when* and *who pays*, never what recall
  returns.

## What this does not do

It does not reduce how often the fallback lane is taken. Graph availability is
still one vault-global equality (`epistemic_graph.py:1133`), so a single write
anywhere sends every subsequent recall down this path until a rebuild lands.
That is the second half of #676 and it is much better judged after this one,
since a cheap fallback makes the fence far less costly — the same argument the
incremental-graph plan makes for deferring its Phase 3.
