### PR TITLE
fix(tests): stop the suite reading whatever vault the shell points at

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -522,6 +522,20 @@ def _disable_embeddings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
     # unrelated to their change. Tests that exercise the override set it
     # themselves; a test-body or module-fixture setenv still wins over this.
     monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
+    # Same defect class as EXOMEM_LOG_DIR above, one layer deeper. An exported
+    # EXOMEM_VAULT_PATH is the documented way to point the CLI and the service
+    # at a real vault, and `LeaseManager._receipt_vault_root` falls back to it
+    # whenever a mutation names no vault of its own. So on a configured machine
+    # `_durable_graph_outcome` read the OPERATOR'S live vault and stamped its
+    # graph state onto a terminal the test asserts is bare -- five
+    # test_writer_lease.py tests failed that way, in isolation, on a checkout
+    # with no defect in it.
+    #
+    # Worse than a false failure: the ambient value made every unscoped test a
+    # reader of real user data, and CI never sees it because the variable is
+    # unset there. The `vault` fixture sets it explicitly for tests that want
+    # one, and autouse setup runs first, so that setenv still wins.
+    monkeypatch.delenv("EXOMEM_VAULT_PATH", raising=False)
     # The watcher now starts independently of embeddings (it maintains the
     # freshness/inbound registries too), so build_server would spawn a real
     # watchdog observer in the suite without this. Watcher tests opt back in.

--- a/tests/test_suite_env_isolation.py
+++ b/tests/test_suite_env_isolation.py
@@ -1,0 +1,47 @@
+"""The suite must not read whatever vault the developer's shell points at.
+
+EXOMEM_VAULT_PATH and EXOMEM_LOG_DIR are the two documented ways to aim a real
+Exomem at real data, and both are exported on a configured machine. Both also
+serve as fallbacks deep inside the product -- `LeaseManager._receipt_vault_root`
+and `query_log._target` -- reached whenever a call names no destination of its
+own. An unscoped test on such a machine therefore read and wrote the operator's
+live vault and log directory.
+
+CI never sees this: the variables are unset there, so the suite is green while
+being wrong for everyone running it on a working install. #570 fixed the log
+directory after three tests wrote into it; the vault path is the same defect one
+layer deeper, and it made five test_writer_lease.py tests fail in isolation on a
+checkout with nothing wrong in it.
+
+Asserted here rather than left to the conftest comment, because the symptom is
+invisible in the only environment that gates merges.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+#: Every variable that names a real destination outside the test's tmp_path.
+#: A test that wants one sets it explicitly; autouse setup runs before
+#: test-requested fixtures, so `monkeypatch.setenv` in a fixture still wins.
+AMBIENT_DESTINATION_VARS = ("EXOMEM_VAULT_PATH", "EXOMEM_LOG_DIR")
+
+
+@pytest.mark.parametrize("name", AMBIENT_DESTINATION_VARS)
+def test_no_ambient_destination_reaches_a_test(name: str) -> None:
+    assert os.environ.get(name) is None, (
+        f"{name} leaked into the suite; a test would read or write a real "
+        "destination instead of its tmp_path"
+    )
+
+
+def test_a_test_that_asks_for_a_vault_still_gets_one(vault) -> None:
+    """The isolation must not break the fixture it exists to protect.
+
+    `vault` sets EXOMEM_VAULT_PATH deliberately, and that has to survive the
+    autouse delenv -- otherwise clearing the ambient value would silently
+    un-configure every test that actually wants a vault.
+    """
+    assert os.environ["EXOMEM_VAULT_PATH"] == str(vault)


### PR DESCRIPTION
## The leak

`EXOMEM_VAULT_PATH` is the documented way to aim a real Exomem at real data, so
it is exported on any configured machine. It is also a **fallback deep inside the
product**: `LeaseManager._receipt_vault_root` (`writer_lease.py:3118`) consults it
whenever a mutation names no vault of its own.

So on a working install, `_durable_graph_outcome` read the **operator's live
vault** and stamped its graph state onto a terminal the test asserts is bare:

```
def test_uncommitted_result_is_completed_without_a_graph_receipt(...):
    ...
E   AssertionError: assert {'committed': False, 'validate_only': True}
                        == {'committed': False, 'validate_only': True}
E     Left contains 1 more item:
E     {'graph_sync': 'completed'}
```

Five `test_writer_lease.py` tests fail that way — **in isolation, on a checkout
with nothing wrong in it**. Clearing the variable, all five pass. And the failure
is the visible half: the ambient value made every unscoped test a *reader of real
user data*.

## Why CI never caught it

The variable is unset on the runners, so the suite is green there while being
wrong for everyone running it on a configured machine. That is exactly the
defect #570 fixed for `EXOMEM_LOG_DIR` after three tests wrote into the
operator's real log directory — `query_log._target` consults it per call, ahead
of the module-level paths tests monkeypatch. This is the same class, one layer
deeper, and the fix goes in beside it.

## The fix

The autouse env fixture clears it. The `vault` fixture sets it deliberately and
still wins, because autouse setup runs before test-requested fixtures — that
ordering is what the existing `_process_env_isolation` docstring already relies
on, and it is now asserted.

A new `tests/test_suite_env_isolation.py` pins both ambient destination
variables, because the symptom is invisible in the only environment that gates
merges.

## Verification

- `tests/test_suite_env_isolation.py` — **3 passed**, run with both
  `EXOMEM_VAULT_PATH` and `EXOMEM_LOG_DIR` deliberately exported to hostile
  values.
- `tests/test_writer_lease.py` — **178 passed, 5 skipped** with
  `EXOMEM_VAULT_PATH` still exported in the shell. Before this change, five of
  those failed.
- Full local suite reached 50 % with zero failures before I stopped it; the
  remainder is left to CI deliberately, because **CI already runs with the
  variable unset**. This change makes a local run match the CI environment
  exactly, so it cannot break a test that passes on the runners — it can only
  stop one from passing for the wrong reason.
