### PR TITLE
fix(doctor): recommend a lever the reader can actually pull

### DIFF
--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -1360,13 +1360,40 @@ def _check_runtime_processes() -> DoctorCheck | None:
         )
     else:
         memory_message = f"about {memory['rss_mb_total']} MB RSS total"
+    # Name a lever the reader can actually pull. The previous remedy led with
+    # HTTP service mode, which will not start without EXOMEM_BASE_URL, a GitHub
+    # OAuth app and its credentials (#482) -- so a laptop user with seven
+    # sessions and 8 GB resident was told to obtain a public hostname to solve a
+    # purely local memory problem (#597). `mode quiet` is one command, needs
+    # nothing external, and is exactly the policy the old text gestured at:
+    # no boot preload and release models when idle.
+    #
+    # Mode-aware, because recommending quiet to someone already in it is worse
+    # than saying nothing: it reads as "you have not tried the fix" when they
+    # have, and hides that the remaining cost is per-process and structural.
+    from . import mode as mode_module
+
+    current_mode = mode_module.resolve_mode()
+    if current_mode == "quiet":
+        remedy = (
+            "Compute mode is already 'quiet' (no boot preload, models released when "
+            "idle), so the remaining cost is per-process: close sessions you are not "
+            "using, or run one shared HTTP service if this machine has a public base "
+            "URL and a GitHub OAuth app."
+        )
+    else:
+        remedy = (
+            f"Compute mode is '{current_mode}'; `exomem mode quiet` drops boot preload "
+            "and releases models when idle, which is the lever that needs nothing "
+            "external. One shared HTTP service also fixes it, but only where a public "
+            "base URL and a GitHub OAuth app are available."
+        )
     return _check(
         "runtime.processes",
         status,
         f"Detected {count} other exomem server process(es) using {memory_message}. "
-        "Each stdio MCP client/session launches its own process; use HTTP service mode "
-        "or lazy/quiet policies on small-memory Macs.",
-        details={"count": count, **memory, "processes": rows[:8]},
+        f"Each stdio MCP client/session launches its own process. {remedy}",
+        details={"count": count, "mode": current_mode, **memory, "processes": rows[:8]},
     )
 
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1148,6 +1148,68 @@ def test_runtime_process_check_warns_for_multiple_stdio_servers(
     assert check.details["count"] == 2
 
 
+def test_runtime_process_check_recommends_a_lever_the_reader_can_pull(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The remedy has to be reachable from the machine that is running out of memory.
+
+    It used to lead with HTTP service mode, which will not start without
+    EXOMEM_BASE_URL, a GitHub OAuth app and its credentials (#482). So a laptop
+    user with seven sessions and 8 GB resident was told to obtain a public
+    hostname to solve a purely local problem (#597). `mode quiet` needs nothing
+    external and is the policy the old text was gesturing at.
+    """
+    from exomem import mode as mode_module
+
+    monkeypatch.setattr(mode_module, "resolve_mode", lambda: "performance")
+    monkeypatch.setattr(
+        doctor_module,
+        "_list_exomem_processes",
+        lambda: [
+            {"pid": 101, "rss_mb": 4096.0, "command": "python -m exomem --transport stdio"},
+            {"pid": 102, "rss_mb": 4096.0, "command": "python -m exomem --transport stdio"},
+        ],
+    )
+
+    check = doctor_module._check_runtime_processes()
+
+    assert check is not None
+    assert "exomem mode quiet" in check.message
+    assert check.details["mode"] == "performance"
+    # Service mode may still be mentioned, but never without its precondition:
+    # naming it bare is what sent a laptop user after a public hostname.
+    if "HTTP service" in check.message:
+        assert "public base URL" in check.message
+
+
+def test_runtime_process_check_does_not_recommend_the_mode_already_in_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Telling someone already in quiet mode to switch to it is worse than silence.
+
+    It reads as "you have not tried the fix" when they have, and hides that the
+    remaining cost is per-process and structural rather than a setting.
+    """
+    from exomem import mode as mode_module
+
+    monkeypatch.setattr(mode_module, "resolve_mode", lambda: "quiet")
+    monkeypatch.setattr(
+        doctor_module,
+        "_list_exomem_processes",
+        lambda: [
+            {"pid": 101, "rss_mb": 4096.0, "command": "python -m exomem --transport stdio"},
+            {"pid": 102, "rss_mb": 4096.0, "command": "python -m exomem --transport stdio"},
+        ],
+    )
+
+    check = doctor_module._check_runtime_processes()
+
+    assert check is not None
+    assert "exomem mode quiet" not in check.message
+    assert "already" in check.message
+    assert check.details["mode"] == "quiet"
+
+
 def test_runtime_process_check_names_physical_footprint_when_complete(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Refs #597.

## The problem

`runtime.processes` is a good check — it correctly flagged **8.1 GB across seven
stdio sessions** on the reporting box, roughly 1 GB each. Then it recommended
this:

> use HTTP service mode or lazy/quiet policies on small-memory Macs

HTTP service mode **will not start** without `EXOMEM_BASE_URL`,
`GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `EXOMEM_GITHUB_USERNAME` and
`EXOMEM_GITHUB_USER_ID` (#482). So a laptop user with seven sessions open was
told to obtain a public hostname and register a GitHub OAuth app in order to
solve a **purely local memory problem**.

A check whose remedy cannot be followed is worse than one that says nothing: it
spends the reader's time and leaves them with the problem.

## The fix

`exomem mode quiet` is one command, needs nothing external, and is exactly the
policy the old text was gesturing at with "lazy/quiet policies" — CPU
everywhere, no boot preload, models released when idle (`mode.py:10`). It is now
named first. Service mode survives only **with its precondition attached**.

The remedy is **mode-aware**. Recommending quiet to someone already in quiet
reads as "you have not tried the fix" when they have, and hides that the
remaining cost is per-process and structural rather than a setting. That case now
says so and points at session count instead.

The resolved mode joins `details`, so the evidence carries what the advice was
based on.

Also dropped "on small-memory Macs" — the reported measurement was **WSL2 on
Linux**, and one process per session is not a platform quirk.

## What this does not fix

The ~1 GB per process. #597 notes that 1 GB resident for a ~40 MiB ONNX
bi-encoder plus a 115-page index "suggests something else is resident", and that
wants a profile rather than a guess. This PR only stops the check pointing at a
door that is locked; it leaves the room the same size.

## Verification

- `tests/test_doctor.py` — **67 passed, 1 skipped** (the skip is the pre-existing
  `sentence_transformers` one); with `tests/test_mode.py`, **110 passed**.
- Two new tests: that a non-quiet machine is told about `exomem mode quiet` and
  that service mode is never named without its precondition; and that a machine
  already in quiet mode is **not** told to switch to it.
- `uvx ruff check . --select F` clean. `doctor.py` reports the same single
  pre-existing `I001` as `main`, unchanged.
