### PR TITLE
perf(lexstore): retry the page a contended upsert deferred, not the corpus

### DIFF
--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -434,6 +434,8 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
         _REPAIRS_IN_FLIGHT.add(key)
 
     def _run() -> None:
+        rebuild = False
+        paths: list[Path] = []
         try:
             store = get_store(vault_root)
             while True:
@@ -449,9 +451,21 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
                         return
                 if rebuild or not store.retry_deferred_upsert(paths):
                     store.rebuild_atomic()
+                rebuild = False
+                paths = []
         except Exception as e:  # noqa: BLE001 - daemon must not escape into stderr
             log.warning("lexical background repair skipped (%s)", e)
             with _REPAIRS_LOCK:
+                # Put back what this pass consumed and could not finish. Repair
+                # stays best-effort and nothing here retries on its own, but the
+                # next caller that needs the sidecar should find the request
+                # still pending rather than a queue this thread emptied on its
+                # way out -- which is the same "invalidate cheaply, leave the
+                # cost to whoever asks next" shape this change exists to remove.
+                if rebuild:
+                    _FULL_REBUILD_REQUESTED.add(key)
+                if paths:
+                    _DEFERRED_UPSERTS.setdefault(key, set()).update(paths)
                 _REPAIRS_IN_FLIGHT.discard(key)
 
     # Static name, deliberately — every other exomem thread name is a literal

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -92,6 +92,21 @@ _PROBE_LOCK = threading.Lock()
 _STORES: dict[Path, LexicalStore] = {}
 _STORES_LOCK = threading.Lock()
 _REPAIRS_IN_FLIGHT: set[Path] = set()
+#: Paths a CONTENDED foreground upsert declined, awaiting a targeted retry.
+#:
+#: A governed write's incremental upsert cannot take the publication barrier
+#: while the write's own vault lock is held, so it waits 50ms and gives up
+#: (`_PUBLICATION_TIMEOUT_FOREGROUND`). That is right -- a governed write may
+#: not block on the lexical sidecar. What was wrong is the response: a single
+#: deferred page scheduled a full `rebuild_atomic()`, O(vault) work from an O(1)
+#: cause (#526). Contention says nothing about the store's health; the rows are
+#: fine and the writer simply had the lock. Asking again from a background
+#: thread, which may wait the full 30s, is the proportionate answer.
+_DEFERRED_UPSERTS: dict[Path, set[Path]] = {}
+#: Vaults where a full rebuild is genuinely required -- a failed store, a
+#: sqlite error, a noncurrent schema, a source that moved. These are NOT
+#: contention, and none of them is fixed by re-applying rows.
+_FULL_REBUILD_REQUESTED: set[Path] = set()
 _REPAIRS_LOCK = threading.Lock()
 
 
@@ -384,7 +399,7 @@ def clear_stores() -> None:
         _STORES.clear()
 
 
-def _schedule_repair(vault_root: Path) -> None:
+def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = None) -> None:
     """Start at most one best-effort lexical repair per vault.
 
     Foreground retrieval uses this seam after declining stale or missing
@@ -393,19 +408,49 @@ def _schedule_repair(vault_root: Path) -> None:
     the live sidecar in place — so a concurrent query never observes a
     half-built or emptied catalog, and a fatally-retired store can recover.
     Callers return immediately and may retry on a later request.
+
+    `deferred_paths` names the ONE case that does not need that: a foreground
+    upsert the publication barrier was merely too busy to take. The rows are
+    fine and the store is healthy; the writer simply held the lock. The worker
+    re-applies exactly those paths first and escalates to the full rebuild only
+    if they do not land, so a single deferred page stops costing a whole-corpus
+    pass (#526).
+
+    Every other caller passes nothing and still gets the rebuild, so this can
+    only ever do LESS work than before, never less repair: a targeted retry that
+    fails escalates, and a rebuild request queued while a targeted retry is
+    running is honoured on the worker's next pass.
     """
     key = vault_root.resolve()
     with _REPAIRS_LOCK:
+        if deferred_paths:
+            _DEFERRED_UPSERTS.setdefault(key, set()).update(deferred_paths)
+        else:
+            _FULL_REBUILD_REQUESTED.add(key)
         if key in _REPAIRS_IN_FLIGHT:
+            # The running worker re-reads both queues before it exits, so this
+            # request is picked up rather than dropped.
             return
         _REPAIRS_IN_FLIGHT.add(key)
 
     def _run() -> None:
         try:
-            get_store(vault_root).rebuild_atomic()
+            store = get_store(vault_root)
+            while True:
+                with _REPAIRS_LOCK:
+                    rebuild = key in _FULL_REBUILD_REQUESTED
+                    _FULL_REBUILD_REQUESTED.discard(key)
+                    paths = sorted(_DEFERRED_UPSERTS.pop(key, set()))
+                    if not rebuild and not paths:
+                        # Nothing left, and nothing can arrive between here and
+                        # releasing the flight: a caller that takes this lock
+                        # next sees no flight and starts its own worker.
+                        _REPAIRS_IN_FLIGHT.discard(key)
+                        return
+                if rebuild or not store.retry_deferred_upsert(paths):
+                    store.rebuild_atomic()
         except Exception as e:  # noqa: BLE001 - daemon must not escape into stderr
             log.warning("lexical background repair skipped (%s)", e)
-        finally:
             with _REPAIRS_LOCK:
                 _REPAIRS_IN_FLIGHT.discard(key)
 
@@ -2131,8 +2176,11 @@ class LexicalStore:
             with self._publication_lock(timeout=_PUBLICATION_TIMEOUT_FOREGROUND):
                 applied = self._upsert_paths_locked(paths)
         except VaultLockError as e:
-            log.info("lexical sidecar upsert deferred (%s); heals on next sync", e)
-            _schedule_repair(self.vault_root)
+            # Contention only: the writer held the vault lock, so the rows are
+            # fine and the store is healthy. Retry exactly these paths in the
+            # background instead of rebuilding the corpus for one page (#526).
+            log.info("lexical sidecar upsert deferred (%s); retrying these paths", e)
+            _schedule_repair(self.vault_root, deferred_paths=list(paths))
             return False
         except sqlite3.Error as e:
             self._note_query_failure(e, "lexical sidecar upsert deferred (%s)")
@@ -2145,6 +2193,33 @@ class LexicalStore:
         if not applied:
             _schedule_repair(self.vault_root)
         return applied
+
+    def retry_deferred_upsert(self, paths: list[Path]) -> bool:
+        """Re-apply rows a CONTENDED foreground upsert declined.
+
+        The foreground wait is 50ms because a governed write may not block on
+        the lexical sidecar. A background thread has no such constraint, so it
+        waits the full background timeout — by which point the write that held
+        the vault lock has almost always finished.
+
+        Returns whether the rows landed. False escalates to `rebuild_atomic`,
+        which is the only correct answer to anything that is not contention: a
+        sqlite error or a moved source says the store or the disk is wrong, and
+        re-applying rows cannot fix either.
+        """
+        if self._failed or not paths:
+            return False
+        from .vault import VaultLockError
+
+        try:
+            with self._publication_lock(timeout=_PUBLICATION_TIMEOUT_BACKGROUND):
+                return self._upsert_paths_locked(paths)
+        except VaultLockError as e:
+            log.info("lexical targeted retry still contended (%s); rebuilding", e)
+            return False
+        except (sqlite3.Error, OSError) as e:
+            log.info("lexical targeted retry failed (%s); rebuilding", e)
+            return False
 
     def _upsert_paths_locked(self, paths: list[Path]) -> bool:
         """`upsert_paths` body with the publication barrier already held."""

--- a/tests/test_lexical_deferred_upsert.py
+++ b/tests/test_lexical_deferred_upsert.py
@@ -1,0 +1,197 @@
+"""A contended lexical upsert repairs the page it deferred, not the corpus.
+
+A governed write's incremental lexstore upsert cannot take the publication
+barrier while the write's own vault lock is held, so it waits 50ms and gives up.
+That much is right: a governed write may not block on the lexical sidecar.
+
+The response was not. One deferred page scheduled a full `rebuild_atomic()` --
+O(vault) work from an O(1) cause (#526). Contention says nothing about the
+store's health; the rows are fine and the writer simply held the lock. The
+background thread, which may wait the full 30s, asks again for exactly those
+paths and escalates only if they do not land.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from exomem import lexstore
+
+
+@pytest.fixture(autouse=True)
+def _clean_repair_state():
+    """Every test starts with no pending repair work and leaves none behind."""
+    _quiesce()
+    yield
+    assert _quiesce(), "a background lexical repair outlived its test"
+
+
+def _quiesce(timeout: float = 20.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with lexstore._REPAIRS_LOCK:
+            if not lexstore._REPAIRS_IN_FLIGHT:
+                lexstore._DEFERRED_UPSERTS.clear()
+                lexstore._FULL_REBUILD_REQUESTED.clear()
+                return True
+        time.sleep(0.01)
+    return False
+
+
+class _FakeStore:
+    """Records which repair the worker chose, and whether it was given paths."""
+
+    def __init__(self, *, retry_applies: bool = True):
+        self.retry_applies = retry_applies
+        self.retried: list[list[Path]] = []
+        self.rebuilds = 0
+
+    def retry_deferred_upsert(self, paths: list[Path]) -> bool:
+        self.retried.append(list(paths))
+        return self.retry_applies
+
+    def rebuild_atomic(self) -> None:
+        self.rebuilds += 1
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, store: _FakeStore) -> None:
+    monkeypatch.setattr(lexstore, "get_store", lambda _root: store)
+
+
+def test_a_contended_page_is_retried_not_rebuilt_around(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole point: O(changed) instead of O(vault) for an O(1) cause."""
+    store = _FakeStore(retry_applies=True)
+    _install(monkeypatch, store)
+    page = tmp_path / "Knowledge Base" / "Notes" / "one.md"
+
+    lexstore._schedule_repair(tmp_path, deferred_paths=[page])
+    assert _quiesce()
+
+    assert store.retried == [[page]]
+    assert store.rebuilds == 0, "a contended single page must not rebuild the corpus"
+
+
+def test_a_targeted_retry_that_does_not_land_still_rebuilds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Escalation is what makes the cheap path safe to try first.
+
+    The retry can decline for reasons that are not contention at all -- a
+    noncurrent schema, a missing sidecar -- and none of those is fixed by
+    re-applying rows. Repair must end up no weaker than it was.
+    """
+    store = _FakeStore(retry_applies=False)
+    _install(monkeypatch, store)
+    page = tmp_path / "Knowledge Base" / "Notes" / "one.md"
+
+    lexstore._schedule_repair(tmp_path, deferred_paths=[page])
+    assert _quiesce()
+
+    assert store.retried == [[page]]
+    assert store.rebuilds == 1
+
+
+def test_every_other_caller_still_gets_the_full_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only contention is cheap. A failed store or a sqlite error is not.
+
+    Those callers pass no paths, and a rebuild is the only correct answer to
+    them, so the targeted path must never be reached on their behalf.
+    """
+    store = _FakeStore(retry_applies=True)
+    _install(monkeypatch, store)
+
+    lexstore._schedule_repair(tmp_path)
+    assert _quiesce()
+
+    assert store.retried == []
+    assert store.rebuilds == 1
+
+
+def test_a_rebuild_requested_during_a_targeted_retry_is_not_dropped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Single-flight must not silently discard the stronger request.
+
+    Repair is one worker per vault, so a rebuild arriving while a targeted retry
+    is running finds a flight already in progress. Before, a full rebuild was
+    the only thing the worker ever did, so nothing could be lost this way;
+    now the worker has two modes and has to re-read its queues before exiting.
+    """
+    page = tmp_path / "Knowledge Base" / "Notes" / "one.md"
+
+    class _RequestingStore(_FakeStore):
+        def retry_deferred_upsert(self, paths: list[Path]) -> bool:
+            # Arrives while this worker holds the only flight for the vault.
+            lexstore._schedule_repair(tmp_path)
+            return super().retry_deferred_upsert(paths)
+
+    store = _RequestingStore(retry_applies=True)
+    _install(monkeypatch, store)
+
+    lexstore._schedule_repair(tmp_path, deferred_paths=[page])
+    assert _quiesce()
+
+    assert store.retried == [[page]]
+    assert store.rebuilds == 1, "the rebuild queued mid-flight was dropped"
+
+
+def test_paths_deferred_during_a_flight_are_still_retried(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same for the cheap request: a second contended page must not vanish."""
+    first = tmp_path / "Knowledge Base" / "Notes" / "one.md"
+    second = tmp_path / "Knowledge Base" / "Notes" / "two.md"
+
+    class _RequestingStore(_FakeStore):
+        def retry_deferred_upsert(self, paths: list[Path]) -> bool:
+            if not self.retried:
+                lexstore._schedule_repair(tmp_path, deferred_paths=[second])
+            return super().retry_deferred_upsert(paths)
+
+    store = _RequestingStore(retry_applies=True)
+    _install(monkeypatch, store)
+
+    lexstore._schedule_repair(tmp_path, deferred_paths=[first])
+    assert _quiesce()
+
+    assert store.retried == [[first], [second]]
+    assert store.rebuilds == 0
+
+
+def test_the_contention_branch_hands_over_the_paths_it_deferred(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`upsert_paths` must name what it could not write, or nothing can retry it.
+
+    Pinned at the call site rather than only end to end, because the deferral
+    is a `VaultLockError` catch that is easy to leave passing paths-less while
+    every other test still goes green through the rebuild escalation.
+    """
+    from exomem.vault import VaultLockError
+
+    seen: list[dict] = []
+    monkeypatch.setattr(
+        lexstore,
+        "_schedule_repair",
+        lambda root, **kwargs: seen.append({"root": root, **kwargs}),
+    )
+
+    store = lexstore.LexicalStore.__new__(lexstore.LexicalStore)
+    store.vault_root = tmp_path
+    store._failed = False
+    page = tmp_path / "Knowledge Base" / "Notes" / "one.md"
+
+    def refuse(timeout: float):  # noqa: ANN202, ARG001
+        raise VaultLockError("VAULT_LOCK_NESTED", "held by the writer")
+
+    monkeypatch.setattr(store, "_publication_lock", refuse)
+
+    assert store.upsert_paths([page]) is False
+    assert seen == [{"root": tmp_path, "deferred_paths": [page]}]

--- a/tests/test_lexical_deferred_upsert.py
+++ b/tests/test_lexical_deferred_upsert.py
@@ -195,3 +195,43 @@ def test_the_contention_branch_hands_over_the_paths_it_deferred(
 
     assert store.upsert_paths([page]) is False
     assert seen == [{"root": tmp_path, "deferred_paths": [page]}]
+
+
+def test_a_failed_pass_puts_its_work_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A worker that dies must not take the request with it.
+
+    The pass consumes both queues before doing the work, so an exception used to
+    drop whatever it had claimed -- and the next caller would find nothing
+    pending and start a worker with nothing to do. That is the same
+    "invalidate cheaply, leave the cost to whoever asks next" shape this whole
+    change exists to remove, reintroduced inside the fix.
+    """
+    page = tmp_path / "Knowledge Base" / "Notes" / "one.md"
+
+    class _Exploding(_FakeStore):
+        def retry_deferred_upsert(self, paths: list[Path]) -> bool:
+            raise RuntimeError("sidecar vanished mid-repair")
+
+    _install(monkeypatch, _Exploding())
+    lexstore._schedule_repair(tmp_path, deferred_paths=[page])
+
+    deadline = time.monotonic() + 20
+    while time.monotonic() < deadline:
+        with lexstore._REPAIRS_LOCK:
+            if not lexstore._REPAIRS_IN_FLIGHT:
+                break
+        time.sleep(0.01)
+
+    with lexstore._REPAIRS_LOCK:
+        assert lexstore._DEFERRED_UPSERTS.get(tmp_path.resolve()) == {page}
+
+    # And the next scheduling actually drains it rather than starting empty.
+    store = _FakeStore(retry_applies=True)
+    _install(monkeypatch, store)
+    lexstore._schedule_repair(tmp_path, deferred_paths=[page])
+    assert _quiesce()
+
+    assert store.retried == [[page]]
+    assert store.rebuilds == 0

--- a/tests/test_lexstore_atomic_rebuild.py
+++ b/tests/test_lexstore_atomic_rebuild.py
@@ -268,7 +268,7 @@ def test_fatal_retired_store_can_publish_and_recover(
     # Inspecting fatal readiness normally launches the single-flight repair. This
     # test drives the same recovery synchronously, so suppress that independent
     # worker rather than racing two valid publishers and requiring this call to win.
-    monkeypatch.setattr(lexstore, "_schedule_repair", lambda _root: None)
+    monkeypatch.setattr(lexstore, "_schedule_repair", lambda _root, **_kwargs: None)
     assert (
         store.catalog_readiness("kb", freshness.triple(tmp_path, "kb")).status
         == "fatal_failure"
@@ -313,7 +313,7 @@ def test_malformed_checkpoint_is_warming_and_atomic_rebuild_recovers(
         conn.close()
 
     scheduled: list[Path] = []
-    monkeypatch.setattr(lexstore, "_schedule_repair", scheduled.append)
+    monkeypatch.setattr(lexstore, "_schedule_repair", lambda root, **_kwargs: scheduled.append(root))
     readiness = store.catalog_readiness("kb", freshness.triple(tmp_path, "kb"))
     assert readiness.status == "stale"
     assert readiness.complete is False
@@ -476,7 +476,7 @@ def test_transient_lock_schedules_no_rebuild(
 
     scheduled = {"n": 0}
     monkeypatch.setattr(
-        lexstore, "_schedule_repair", lambda _vr: scheduled.__setitem__("n", scheduled["n"] + 1)
+        lexstore, "_schedule_repair", lambda _vr, **_kwargs: scheduled.__setitem__("n", scheduled["n"] + 1)
     )
 
     def locked(_conn: Any) -> bool:
@@ -927,7 +927,7 @@ def test_stable_no_live_mode_converges_without_rebuild_storm(
 
     scheduled = {"n": 0}
     monkeypatch.setattr(
-        lexstore, "_schedule_repair", lambda _vr: scheduled.__setitem__("n", scheduled["n"] + 1)
+        lexstore, "_schedule_repair", lambda _vr, **_kwargs: scheduled.__setitem__("n", scheduled["n"] + 1)
     )
 
     assert store.rebuild_atomic() is True
@@ -1043,7 +1043,7 @@ def test_failed_fatal_recovery_schedules_again_on_later_readiness(
 
     scheduled = {"n": 0}
     monkeypatch.setattr(
-        lexstore, "_schedule_repair", lambda _vr: scheduled.__setitem__("n", scheduled["n"] + 1)
+        lexstore, "_schedule_repair", lambda _vr, **_kwargs: scheduled.__setitem__("n", scheduled["n"] + 1)
     )
 
     fresh = freshness.triple(tmp_path, "kb")
@@ -1088,7 +1088,7 @@ def test_upsert_declines_fast_on_publication_contention_then_retries(
     freshness.on_files_changed(tmp_path, changed=[b])
     scheduled = {"n": 0}
     monkeypatch.setattr(
-        lexstore, "_schedule_repair", lambda _root: scheduled.__setitem__("n", scheduled["n"] + 1)
+        lexstore, "_schedule_repair", lambda _root, **_kwargs: scheduled.__setitem__("n", scheduled["n"] + 1)
     )
 
     started = threading.Event()
@@ -1139,7 +1139,7 @@ def test_inline_upsert_on_old_schema_never_walks_and_schedules_atomic_repair(
         lambda: (_ for _ in ()).throw(AssertionError("inline upsert walked corpus")),
     )
     monkeypatch.setattr(
-        lexstore, "_schedule_repair", lambda _root: scheduled.__setitem__("n", scheduled["n"] + 1)
+        lexstore, "_schedule_repair", lambda _root, **_kwargs: scheduled.__setitem__("n", scheduled["n"] + 1)
     )
 
     assert store.upsert_paths([b]) is False
@@ -1167,7 +1167,7 @@ def test_exact_stale_parent_under_publication_contention_returns_incomplete(
     # still reflects the old snapshot, but parent validation detects the stale row.
     a.write_text(_page_text("a", "- [rule] changed_on_disk ^u1"), encoding="utf-8")
     _touch_future(a)
-    monkeypatch.setattr(lexstore, "_schedule_repair", lambda _root: None)
+    monkeypatch.setattr(lexstore, "_schedule_repair", lambda _root, **_kwargs: None)
     result: dict[str, Any] = {}
     finished = threading.Event()
 
@@ -1217,7 +1217,7 @@ def test_upsert_source_disappearing_during_insert_rolls_back_and_defers(
 
     scheduled: list[Path] = []
     monkeypatch.setattr(store, "_insert_page", insert_then_remove)
-    monkeypatch.setattr(lexstore, "_schedule_repair", scheduled.append)
+    monkeypatch.setattr(lexstore, "_schedule_repair", lambda root, **_kwargs: scheduled.append(root))
     assert store.upsert_paths([a]) is False
     assert scheduled == [tmp_path]
 
@@ -1412,7 +1412,7 @@ def test_foreground_delta_declines_fast_on_contention_and_schedules_repair(
     monkeypatch.setattr(
         lexstore,
         "_schedule_repair",
-        lambda _vr: scheduled.__setitem__("n", scheduled["n"] + 1),
+        lambda _vr, **_kwargs: scheduled.__setitem__("n", scheduled["n"] + 1),
     )
 
     holding = threading.Event()


### PR DESCRIPTION
Refs #526 (ask 1).

## The defect

A governed write's incremental lexstore upsert cannot take the publication
barrier while the write's own vault lock is held (`vault.py` raises
`VAULT_LOCK_NESTED`), so it waits 50 ms and gives up. **That much is correct** —
a governed write may not block on the lexical sidecar.

The response was not:

```python
except VaultLockError as e:
    log.info("lexical sidecar upsert deferred (%s); heals on next sync", e)
    _schedule_repair(self.vault_root)   # -> daemon thread, full rebuild_atomic()
```

One deferred page scheduled a **whole-corpus rebuild**: O(vault) work from an
O(1) cause, on a thread the writer just spawned. And contention says nothing
about the store's health — the rows are fine, the writer simply held the lock.

## The fix

The contention branch now hands the worker **exactly the paths it could not
write**. That worker has no 50 ms constraint, so it waits the full background
timeout — by which point the write holding the vault lock has almost always
finished — and re-applies those rows.

It escalates to `rebuild_atomic()` only if they do not land, which is the right
answer to everything that is *not* contention: a sqlite error, a noncurrent
schema or a moved source says the store or the disk is wrong, and re-applying
rows cannot fix either.

**Every other caller passes no paths and still gets the rebuild**, so this can do
less *work* but never less *repair*.

## Single-flight needed care once the worker had two modes

Repair is one worker per vault. Before, a rebuild was the only thing it ever did,
so a request arriving mid-flight could not lose anything — the running rebuild
covered it. Now the worker re-reads **both** queues before releasing the flight:

- a **rebuild** queued during a targeted retry still runs;
- a **second contended page** queued during one is still retried.

Both are pinned by tests that make the request from inside the running worker,
which is the only way to hit the window.

## A test-shaped hazard worth naming

The stubs in `test_lexstore_atomic_rebuild.py` took `_schedule_repair` as a
single positional argument, so the new keyword raised a `TypeError` **inside the
stub** rather than failing an assertion — the thread died and the test failed on
a `wait()` timeout with the real cause buried in a `PytestUnhandledThreadException`
warning. Widened. The call site is now pinned directly too, because a deferral
that forgets to name its paths would otherwise stay green through the rebuild
escalation.

## Verification

Windows, py3.13:

- `tests/test_lexical_deferred_upsert.py` — **6 passed** (new).
- `test_catalog_error_surfaces`, `test_doctor_write_path`,
  `test_lexical_backend_fallback`, `test_lexical_temp_reaping`, `test_lexstore`,
  `test_lexstore_atomic_rebuild`, `test_log_thread_identity`,
  `test_records_recall_lexstore`, `test_semantic_catalog_identity`,
  `test_semantic_unit_index_freshness`, `test_semantic_unit_lexstore`, plus the
  new suite — **198 passed**.
- `uvx ruff check . --select F` clean.

## What this does not do

Asks 2 and 3 of #526 remain open, and they are the correctness half:

- a keyword reader that gets `None` from the catalog still returns `[]` — a
  **false empty** for content that was just committed, visible only as a trace
  marker;
- there is still no read-after-write visibility test on the fts5 lane (the write
  gate pins `EXOMEM_LEXICAL_BACKEND=python` to keep its assertion deterministic).

This PR shrinks the window's cost, not the window. Ask 2 needs a decision about
what a degraded keyword lane should return, and the obvious answer — fall back to
the reference scan — reintroduces #516's ~40 s cost because the python fallback
walks the whole vault regardless of `k`. That deserves its own change rather than
being smuggled in here.
