### PR TITLE
ci: pay the capped runner on merge, not on every pull request

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -46,7 +46,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest]
+        # macOS on merge; Windows on everything.
+        #
+        # These two runners are not equally scarce and do not buy equally much.
+        # A public repo on the free tier may run 20 jobs at once but only FIVE
+        # on macOS, so a four-shard macOS matrix cannot fit twice: two open PRs
+        # want eight macOS jobs, the second run's shards sit queued, and because
+        # a run's jobs are scheduled together the whole second run stalls behind
+        # the first. Going to four shards halved one run's wall clock and
+        # serialised the runs against each other -- with three PRs in flight the
+        # queue got longer, not shorter. Measured here: 16 runs queued behind 2
+        # in progress, both of them this lane.
+        #
+        # What macOS buys before a merge is also the smaller half. Everything
+        # this lane's header describes -- CPython opening files without
+        # FILE_SHARE_DELETE, WinError 32 refusing os.replace, backslash
+        # separators reaching a dict key -- is Windows behaviour, and Windows is
+        # where every defect this lane has actually caught has been. macOS
+        # shares POSIX file semantics and path separators with the ubuntu lane
+        # in ci.yml that already runs on every PR, so its marginal coverage
+        # pre-merge is thin. Paying the scarcest runner for the thinnest
+        # coverage is backwards.
+        #
+        # So PRs get Windows, where the defects are and where the cap is not,
+        # and pushes to main get both. No commit stops reaching macOS; it
+        # reaches it one merge later, on a lane that is advisory by design.
+        os: ${{ github.event_name == 'pull_request' && fromJSON('["windows-latest"]') || fromJSON('["windows-latest", "macos-latest"]') }}
         # Four shards, matching the Linux lane. This lane still exists to
         # expose platform behaviour rather than to be the fastest path to a
         # result -- but two shards made it the SLOWEST path by a wide margin: a

--- a/tests/test_ci_reliability_contract.py
+++ b/tests/test_ci_reliability_contract.py
@@ -244,3 +244,31 @@ def test_the_release_bot_branch_does_not_launch_the_cross_platform_matrix() -> N
     assert "release-please--branches--" in condition
     # Skipped for that branch's PR, never for a push to main.
     assert "github.event_name != 'pull_request'" in condition
+
+
+def test_the_capped_runner_is_paid_on_merge_not_on_every_pull_request() -> None:
+    """macOS caps at five concurrent jobs; a four-shard matrix cannot fit twice.
+
+    Two open PRs want eight macOS jobs against that cap, so the second run's
+    shards queue -- and a run's jobs are scheduled together, so the whole second
+    run stalls behind the first. That is a throughput cliff with no visible
+    symptom: every run still goes green, just later and later, and the obvious
+    reading is "CI is slow" rather than "these runs cannot overlap".
+
+    Asserted rather than reviewed because the tempting edit -- putting macOS
+    back on the pull_request arm "for parity" -- reintroduces the cliff while
+    looking like strictly more coverage.
+    """
+    matrix = _cross_platform_workflow()["jobs"]["suite"]["strategy"]["matrix"]
+    expression = " ".join(str(matrix["os"]).split())
+    pull_request_arm, _, push_arm = expression.partition("||")
+
+    assert "github.event_name == 'pull_request'" in pull_request_arm
+    assert "windows-latest" in pull_request_arm
+    assert "macos-latest" not in pull_request_arm, (
+        "the capped runner is back on every PR; two concurrent PRs will serialise"
+    )
+    # A push to main still runs both, so no commit stops reaching macOS -- it
+    # reaches it one merge later, on a lane that is advisory by design.
+    assert "macos-latest" in push_arm
+    assert "windows-latest" in push_arm


### PR DESCRIPTION
## The cliff

A public repo on the free tier may run **20 jobs at once but only five on macOS**.
This lane runs four shards on two operating systems, so one run needs four macOS
jobs — and two runs need eight, against a cap of five. The second run's shards
queue, and because a run's jobs are scheduled together, the *whole* second run
stalls behind the first.

Measured on this repo today, mid-session:

```
IN PROGRESS: 2   (both of them this lane)
QUEUED:     16   (including main's own CI, queued 25 minutes)
```

#673 raised the shard count from two to four. That halved a single run's wall
clock — confirmed, macOS shards went from 17m53s to 8m44s–12m1s — and at the same
time serialised the runs against each other. With one PR open it is a clear win;
with three it made the queue longer, not shorter. The per-run number improved and
the thing anyone actually waits for got worse.

## Why Windows keeps the PR slot and macOS does not

Read this lane's own header. Every failure mode it names is Windows behaviour:
CPython opening files without `FILE_SHARE_DELETE`, `WinError 32` refusing
`os.replace`, backslash separators reaching a dict key. Every defect the lane has
actually caught has been a Windows defect — the most recent being #675, where
`str(WindowsPath)` put backslashes into snapshot keys that forward-slash literals
could not read back.

macOS shares POSIX file semantics and path separators with the ubuntu lane in
`ci.yml`, which already runs on every PR across two Python versions and four
shards. Its marginal coverage *before* a merge is thin — and it is the only
runner that caps. Paying the scarcest resource for the thinnest coverage is
backwards.

## The change

`matrix.os` becomes conditional on the event:

- **pull_request** → `windows-latest` (4 jobs). Five PRs can now run this lane
  concurrently before touching the 20-job ceiling, and the macOS cap is not
  involved at all.
- **push to main** → `windows-latest` + `macos-latest` (8 jobs, unchanged).

No commit stops reaching macOS. It reaches it one merge later, on a lane that is
advisory by design and explicitly not the required gate.

## Pinned, not reviewed

`test_the_capped_runner_is_paid_on_merge_not_on_every_pull_request` asserts the
rule in both directions. The tempting future edit — putting macOS back on the
pull_request arm "for parity" — reintroduces the cliff while looking like
strictly more coverage, and a throughput cliff has no visible symptom: every run
still goes green, just later and later.

Verified that the test is load-bearing rather than decorative, against all three
ways the rule can regress:

```
CAUGHT  plain list (macOS back on every PR)
CAUGHT  macOS added to the PR arm
CAUGHT  macOS dropped from the push arm
```

## Verification

- `tests/test_ci_reliability_contract.py` — 10 passed
- `uvx ruff check . --select F` — All checks passed
- Workflow re-parsed with `yaml.safe_load`; `matrix.shard` still `[1, 2, 3, 4]`,
  so `test_the_cross_platform_split_count_matches_its_shard_matrix` is unaffected.
- This PR's own run is the first observation: it should show four Windows shards
  and no macOS jobs.
