### PR TITLE
fix(recall): a sidecar that could not check is not a sidecar that found nothing

### DIFF
--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -3487,10 +3487,31 @@ def _keyword_match_paths(
     if indexed is not None:
         return indexed
     if lexstore.backend() != "python":
+        # The sidecar declined. `search_substring` documents exactly one meaning
+        # for None -- "fall back" -- and its causes are a retired store, a
+        # catalog that is not on disk, a sqlite error, or a sync that could not
+        # take the publication lock. Every one of those is "I could not check".
+        #
+        # Answering [] said "there is nothing", which is a different claim, and
+        # for a page a governed write has just committed it is a false empty:
+        # the lexical upsert defers while the write holds the vault lock
+        # (#526), so the one moment the catalog is most likely to decline is the
+        # moment right after a write, on exactly the page the caller is most
+        # likely to be looking for. Recall going silently blank on the newest
+        # content is the worst possible failure for a memory system, and the
+        # only evidence was a trace marker nobody reads mid-query.
+        #
+        # So the marker stays -- the lane really did degrade and the counter
+        # should say so -- and the answer comes from the reference scan below
+        # instead of from an empty list. That is not a second implementation of
+        # the contract: `test_keyword_lane_parity_with_reference_scan` asserts
+        # the sidecar and this scan return IDENTICAL ordered lists across 15
+        # query shapes, so falling through costs latency and changes nothing
+        # else. On a healthy sidecar this branch never runs, so no warm read
+        # pays for it.
         if failed_out is not None:
             failed_out.append("keyword_lexical")
         _record_degradation("keyword_lexical")
-        return []
     if scope == "kb":
         kb = vault_root / kb_dirname()
         if not kb.is_dir():

--- a/tests/test_lexical_backend_fallback.py
+++ b/tests/test_lexical_backend_fallback.py
@@ -487,3 +487,114 @@ def test_nonrepairing_search_serves_an_already_fresh_sidecar(tmp_path):
     )
 
     assert hits and hits[0][0] == "Knowledge Base/a.md"
+
+
+# ------------------------------------------- a declined sidecar is not "empty"
+
+
+def _declining_sidecar(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The catalog says "I could not check", on a backend that is not python.
+
+    Patched at `lexstore.search_substring` rather than deeper, because None is
+    that function's whole documented contract ("None -> fall back") and every
+    deeper cause -- a retired store, a missing catalog file, a sqlite error, a
+    sync that could not take the publication lock -- funnels into it.
+    """
+    monkeypatch.setattr(lexstore, "backend", lambda: "fts5")
+    monkeypatch.setattr(lexstore, "search_substring", lambda *a, **k: None)
+
+
+def test_a_declined_sidecar_answers_from_the_scan_not_with_an_empty_lane(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The false empty (#526 ask 2), at the seam where it was produced.
+
+    A governed write's lexical upsert defers while the write still holds the
+    vault lock, so the catalog is most likely to decline in the moment right
+    after a write -- on exactly the page the caller is most likely to want.
+    Returning [] there reports "no such memory" for content that was just
+    committed, which is the worst answer this system can give.
+    """
+    _write_page(tmp_path, "Knowledge Base/just-written.md", "kubernetes ingress configuration")
+    _fill_corpus(tmp_path)
+    _declining_sidecar(monkeypatch)
+
+    paths = find_module._keyword_match_paths(tmp_path, "kubernetes ingress", "kb")
+
+    assert paths == ["Knowledge Base/just-written.md"]
+
+
+def test_a_declined_sidecar_is_still_reported_as_a_degradation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Correct AND loud, not correct instead of loud.
+
+    The lane really did fall off its fast rung, and the counter is how a
+    persistently broken sidecar becomes visible rather than merely slow. The
+    marker was the only thing the old branch got right; the fix keeps it and
+    changes the answer, not the reporting.
+    """
+    _write_page(tmp_path, "Knowledge Base/just-written.md", "kubernetes ingress configuration")
+    _declining_sidecar(monkeypatch)
+    failed: list[str] = []
+
+    paths = find_module._keyword_match_paths(
+        tmp_path, "kubernetes ingress", "kb", failed_out=failed
+    )
+
+    assert paths == ["Knowledge Base/just-written.md"]
+    assert failed == ["keyword_lexical"]
+    assert find_module.degradation_counts().get("keyword_lexical") == 1
+
+
+def test_the_python_rung_is_not_a_degradation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On `EXOMEM_LEXICAL_BACKEND=python` the scan IS the lane, not a fallback.
+
+    Both rungs now reach the same scan, so the marker is the only thing that
+    still distinguishes them -- and counting the configured backend as a
+    degradation would make the counter fire constantly and mean nothing.
+    """
+    monkeypatch.setenv("EXOMEM_LEXICAL_BACKEND", "python")
+    _write_page(tmp_path, "Knowledge Base/just-written.md", "kubernetes ingress configuration")
+    failed: list[str] = []
+
+    paths = find_module._keyword_match_paths(
+        tmp_path, "kubernetes ingress", "kb", failed_out=failed
+    )
+
+    assert paths == ["Knowledge Base/just-written.md"]
+    assert failed == []
+    assert "keyword_lexical" not in find_module.degradation_counts()
+
+
+@needs_fts5
+def test_a_page_written_this_second_is_visible_when_the_catalog_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Read-after-write on the fts5 lane (#526 ask 3), through the real store.
+
+    The write gate pins `EXOMEM_LEXICAL_BACKEND=python` to keep its visibility
+    assertion deterministic, so no CI surface measured this window on the
+    backend that actually ships. Patched at `_serve_synced_live_catalog` rather
+    than at the module function so the None travels the production route --
+    `LexicalStore.search_substring`'s own `sqlite3.Error` handler, which retires
+    the store for this process and is one of the documented causes.
+    """
+    _write_page(tmp_path, "Knowledge Base/older.md", "gardening tips for spring")
+    # Materialize a real catalog first, so the store is healthy up to this read.
+    assert bm25.search(tmp_path, "gardening tips", k=5, scope="kb")
+    assert lexstore.lexical_path(tmp_path).exists()
+
+    _write_page(tmp_path, "Knowledge Base/just-written.md", "kubernetes ingress configuration")
+
+    def erroring(self, *args, **kwargs):  # noqa: ANN001, ANN202, ARG001
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(lexstore.LexicalStore, "_serve_synced_live_catalog", erroring)
+
+    assert lexstore.search_substring(tmp_path, "kubernetes ingress", scope="kb") is None
+    assert find_module._keyword_match_paths(tmp_path, "kubernetes ingress", "kb") == [
+        "Knowledge Base/just-written.md"
+    ]


### PR DESCRIPTION
Closes the ask-2 and ask-3 halves of #526. (Ask 1 — the O(vault) repair from an
O(1) cause — is #680.)

## The defect

`lexstore.search_substring` documents exactly one meaning for `None`:

```python
"""... exactly `_keyword_match_paths`' contract. None → fall back."""
```

Its causes are a retired store, a catalog that is not on disk, a `sqlite3.Error`,
or a sync that could not take the publication lock. Every one of those is **"I
could not check."** The one caller that matters answered `[]` — the different
claim **"there is nothing"** — on every backend except the one where the
fallback happens to be the primary:

```python
if indexed is not None:
    return indexed
if lexstore.backend() != "python":
    _record_degradation("keyword_lexical")
    return []          # <-- the reference scan is the next 20 lines
```

## Why it mattered most at the worst moment

A governed write's lexical upsert cannot take the publication barrier while the
write still holds the vault lock, so it defers (#526). That means the catalog is
most likely to decline **in the second right after a write** — on exactly the
page the caller is most likely to be asking for.

Recall going silently blank on the newest content is the worst answer a memory
system can give, and the only evidence was a trace marker nobody reads
mid-query.

## The fix

Delete the `return []`. The degradation marker stays; the answer comes from the
reference scan that was already sitting immediately below it.

This is not a second implementation of the contract.
`test_keyword_lane_parity_with_reference_scan` already asserts the sidecar and
this scan return **identical ordered lists** across 15 query shapes — multi-token,
mid-word, LIKE metacharacters, non-ASCII, case-folding, tie-breaks, empty
results. Falling through costs latency and changes nothing else. On a healthy
sidecar the branch never runs, so no warm read pays for it.

Correct **and** loud, not correct instead of loud: the lane really did fall off
its fast rung, the counter is how a persistently broken sidecar becomes visible
rather than merely slow, and `find` already declines to cache any request with a
`failed` marker (`find.py:831`, `:1164`) — so a scan-served answer cannot poison
the hot query cache either.

## Verification

The three tests that assert the fix fail against `origin/main` with the literal
false empty, and the fourth passes on both because it pins unchanged behaviour:

```
FAILED test_a_declined_sidecar_answers_from_the_scan_not_with_an_empty_lane
FAILED test_a_declined_sidecar_is_still_reported_as_a_degradation
FAILED test_a_page_written_this_second_is_visible_when_the_catalog_errors
3 failed, 3 passed
E       AssertionError: assert [] == ['Knowledge Base/just-written.md']
```

`test_a_page_written_this_second_is_visible_when_the_catalog_errors` is ask 3 —
the read-after-write visibility test the write gate cannot carry, because it pins
`EXOMEM_LEXICAL_BACKEND=python` to keep its own assertion deterministic and so no
CI surface measured this window on the backend that actually ships. It patches
`_serve_synced_live_catalog` rather than the module function, so the `None`
travels the production route through `LexicalStore.search_substring`'s own
`sqlite3.Error` handler.

- `tests/test_lexical_backend_fallback.py` — 38 passed (34 before)
- with `test_find_transcript_match.py`, `test_lexstore.py`,
  `test_deferred_work_drain.py` — 105 passed
- `uvx ruff check . --select F` — All checks passed
- Consumer grep: `keyword_lexical` and `_keyword_match_paths` have no consumers
  outside `find.py`, and none asserted the empty-list behaviour.
