### PR TITLE
fix(tests): compare recorded provenance against the source that produced it

### DIFF
--- a/tests/test_media_processing.py
+++ b/tests/test_media_processing.py
@@ -167,18 +167,40 @@ def test_prose_only_sidecar_is_repaired_without_losing_notes(vault: Path) -> Non
     assert media_jobs.status(vault)["counts"]["pending"] == 1
 
 
+def _handle_stat(path: Path) -> os.stat_result:
+    """Stat through an open handle, the way `_read_provenance` does.
+
+    Not interchangeable with `Path.stat()`. On Windows `st_ctime` is the
+    creation time and the two calls read it from different places, so a test
+    that records one and asserts the other is asserting a coincidence.
+    """
+    with path.open("rb") as stream:
+        return os.fstat(stream.fileno())
+
+
 def test_reconciliation_records_binary_provenance_without_mutating_evidence(vault: Path) -> None:
     media_processing = _media_processing()
     payload = b"immutable voice evidence\x00\x01"
     binary = _drop_media(vault, "Voice Memo.M4A", payload)
     os.utime(binary, ns=(1_700_000_000_000_000_000, 1_700_000_123_456_789_000))
     before = binary.stat()
+    # The recorded provenance has to be compared against the SOURCE that
+    # produced it. `_read_provenance` reads `os.fstat` on an open handle, and
+    # `_verify_binary_identity` says why in as many words: on Windows,
+    # `stat(path)` and `fstat(handle)` report different `st_ctime_ns` for the
+    # same unchanged file. `st_ctime` there is the creation time, served from a
+    # lazily-refreshed directory entry, so two reads of a just-created file can
+    # differ -- on CI they differed by 2ms and this assertion failed with the
+    # file provably unmutated. Comparing a path-stat against the product's
+    # fstat is the exact cross-source comparison the product code avoids.
+    handle_before = _handle_stat(binary)
     digest = hashlib.sha256(payload).hexdigest()
 
     media_processing.reconcile_media(vault, binary)
 
     after = binary.stat()
     assert binary.read_bytes() == payload
+    # Same source on both sides, so this still pins "the evidence did not move".
     assert (after.st_size, after.st_mtime_ns, after.st_ctime_ns) == (
         before.st_size,
         before.st_mtime_ns,
@@ -188,8 +210,8 @@ def test_reconciliation_records_binary_provenance_without_mutating_evidence(vaul
     assert frontmatter["original_filename"] == "Voice Memo.M4A"
     assert frontmatter["binary_sha256"] == digest
     assert frontmatter["binary_size"] == len(payload)
-    assert frontmatter["binary_mtime_ns"] == before.st_mtime_ns
-    assert frontmatter["binary_ctime_ns"] == before.st_ctime_ns
+    assert frontmatter["binary_mtime_ns"] == handle_before.st_mtime_ns
+    assert frontmatter["binary_ctime_ns"] == handle_before.st_ctime_ns
 
 
 def test_valid_completed_transcript_is_preserved_and_not_requeued(vault: Path) -> None:


### PR DESCRIPTION
Windows-only failure on the cross-platform lane, seen on run 32262091614 shard 4/4:

```
assert frontmatter["binary_ctime_ns"] == before.st_ctime_ns
E   assert 1787149550841922500 == 1787149550839909900
```

Same file, same size, same mtime, same bytes. The creation time moved 2ms between two reads.

## Not a flake — a cross-source comparison

`test_reconciliation_records_binary_provenance_without_mutating_evidence` read
`binary.stat()` and asserted the result against `binary_ctime_ns`, which
`_read_provenance` takes from `os.fstat` on an open handle. Those are different
sources, and `_verify_binary_identity` already documents exactly this:

```python
# Keep the identity source consistent with _read_provenance. On Windows,
# stat(path) and fstat(open_handle) can report different st_ctime_ns
# precision for the same unchanged file.
```

On Windows `st_ctime` is the **creation** time, served from a lazily-refreshed
directory entry, so two reads of a just-created file need not agree. The product
is consistent about this — it records *and* verifies through the handle. Only the
test crossed the sources.

## Measured, not reasoned

400 freshly created files on Windows 11:

```
trials                       : 400
stat(path) != fstat(handle)  : 151
fstat(handle) != fstat(again): 0
```

So the assertion was a coin flip weighted 62/38 — which is why it read as a flake,
passing the earlier cross-platform run and failing this one. Handle-to-handle is
stable across all 400, so comparing like with like removes the failure rather
than retrying past it.

## Scope

Only the two assertions that compare against recorded frontmatter change source.
The unmutated-evidence assertion above them keeps `Path.stat()` on **both** sides
— same source, so it still pins what it claims, which is that reconciliation did
not touch the file.

No product code changes. The product was already right; the test was asserting a
coincidence.

## Verification

- `tests/test_media_processing.py` — 68 passed
- `uvx ruff check . --select F` — All checks passed
