### PR TITLE
fix(tests): stop the DNS-bound test racing its own 10ms budget

### DIFF
--- a/tests/test_client_artifacts.py
+++ b/tests/test_client_artifacts.py
@@ -504,6 +504,24 @@ def test_staging_bounds_blocked_dns_resolution(tmp_path: Path, monkeypatch: pyte
 
     release = threading.Event()
     monkeypatch.setattr(client_artifacts, "_RETRIEVAL_DEADLINE_SECONDS", 0.01)
+    # Freeze the budget clock, or this test races itself.
+    #
+    # Three separate sites consume the same 10ms before the resolver's own wait
+    # is reached: the loop-top check in `stage_artifact`, and the two
+    # `remaining_retrieval_timeout` calls in `_bounded_resolve` -- with an idna
+    # encode, a semaphore acquire and a thread start in between. Every one of
+    # them raises "download retrieval timed out" when the budget is already
+    # gone, and only the resolver's `Empty` branch says "could not be
+    # resolved". On a loaded Windows runner setup routinely costs more than
+    # 10ms, so which message wins is a coin flip -- observed on two separate
+    # PRs, on two different shards.
+    #
+    # Freezing `_monotonic` makes the budget non-decaying for those checks, so
+    # the resolver's wait is the only place it can expire. `result.get` still
+    # waits 10ms of REAL time (Queue does not use this clock), and the test's
+    # own `time.monotonic()` below is untouched, so the boundedness assertion
+    # still measures real elapsed time.
+    monkeypatch.setattr(client_artifacts, "_monotonic", lambda: 0.0)
     monkeypatch.setattr(
         client_artifacts.socket,
         "getaddrinfo",


### PR DESCRIPTION
Windows-only, and now blocking two unrelated PRs — #679 (shard 3/4) and #680 (shard 2/4).

```
E   AssertionError: Regex pattern did not match.
E     Expected regex: 'could not be resolved'
E     Actual message: 'download retrieval timed out'
```

## Four sites, one 10ms budget

`test_staging_bounds_blocked_dns_resolution` asserts the blocked resolver fails
with **"download destination could not be resolved"**. Exactly one site produces
that message on a budget expiry — the `Empty` branch of `_bounded_resolve`'s
`result.get`. Three sites reached *before* it produce **"download retrieval timed
out"**:

1. `stage_artifact`'s loop-top `remaining_retrieval_timeout(deadline)`
2. `_bounded_resolve`'s `remaining_retrieval_timeout(deadline)` before the semaphore
3. `_bounded_resolve`'s `remaining_retrieval_timeout(deadline)` passed to `result.get`

Between them: an idna encode, a `_DNS_WORKERS.acquire`, and a thread start. The
budget the test sets is **10ms**. On a loaded Windows runner that setup routinely
costs more, so which of the two messages wins is a coin flip — which is exactly
what two failures on two different PRs on two different shards look like.

## Reproduced, then removed

Injecting a 50ms stall before the resolver — what a loaded runner supplies for
free — makes the CI failure deterministic locally, and the fix flips it just as
deterministically:

```
frozen=False  {'timed out': 15}
frozen=True   {'could not be resolved': 15}
```

## The fix

Freeze `client_artifacts._monotonic` for the duration of the test. The budget
stops decaying across the three checks that are *not* what the test is about,
leaving the resolver's own wait as the only place it can expire.

What this deliberately does not weaken:

- `result.get(timeout=...)` still waits **10ms of real time** — `Queue` does not
  read this clock — so the resolver is genuinely bounded, not skipped.
- The test's own `time.monotonic()` is untouched, so `assert time.monotonic() -
  started < 0.5` still measures real elapsed time and still proves the call does
  not hang.
- The assertion itself is unchanged. It still pins one specific message rather
  than accepting either, which is the part that would have been tempting to
  relax.

Raising the budget instead would only have made the race rarer, and a rarer race
on the lane that exists to catch platform behaviour is worse than a loud one.

## Verification

- `tests/test_client_artifacts.py` — 30 passed
- `uvx ruff check . --select F` — All checks passed
- No product code changes.
