### PR TITLE
fix(doctor): run the process census on Windows, where the report came from

### DIFF
--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -1294,38 +1294,121 @@ def _check_media_runtime(vault_root: Path | None) -> DoctorCheck | None:
     )
 
 
-def _list_exomem_processes() -> list[dict[str, object]]:
-    if os.name == "nt":
-        return []
-    ps = shutil.which("ps")
-    if not ps:
-        return []
+#: How long the process census may take before the check gives up on it.
+#:
+#: `ps` answers in milliseconds. Windows has no `ps`, and the only supported way
+#: to read another process's command line is a CIM query, which pays PowerShell
+#: startup first -- typically under a second, but a cold shell on a loaded box is
+#: slower. A doctor check may be slow enough to be worth waiting for and must
+#: never hang, so the two platforms get bounds sized to what they actually do.
+_PROCESS_CENSUS_TIMEOUT_SECONDS = 2.0
+_WINDOWS_PROCESS_CENSUS_TIMEOUT_SECONDS = 8.0
+
+#: One line per process: pid, working set / RSS in bytes, full command line.
+#: Pipe-separated with the command last, so a command containing a pipe still
+#: parses. `$_.CommandLine` is null for processes this session cannot see into;
+#: those print empty and are dropped by the shared filter, exactly as a `ps` line
+#: without a command is.
+_WINDOWS_PROCESS_CENSUS = (
+    "Get-CimInstance Win32_Process | ForEach-Object { "
+    "$_.ProcessId.ToString() + '|' + $_.WorkingSetSize.ToString() + '|' "
+    "+ $_.PrivatePageCount.ToString() + '|' + $_.CommandLine }"
+)
+
+
+def _run_process_census(command: list[str], timeout: float) -> str | None:
+    """Run one census command, or None if it cannot answer."""
     try:
         result = subprocess.run(
-            [ps, "-axo", "pid=,rss=,command="],
+            command,
             capture_output=True,
             text=True,
             encoding="utf-8",
             errors="replace",
-            timeout=2.0,
+            timeout=timeout,
             check=False,
         )
-    except Exception:  # noqa: BLE001
-        return []
+    except Exception:  # noqa: BLE001 - a diagnostic may never raise
+        return None
     if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _posix_process_samples() -> list[tuple[int, int, str, int | None]]:
+    ps = shutil.which("ps")
+    if not ps:
         return []
-    rows: list[dict[str, object]] = []
-    current_pid = os.getpid()
-    for line in result.stdout.splitlines():
+    stdout = _run_process_census(
+        [ps, "-axo", "pid=,rss=,command="], _PROCESS_CENSUS_TIMEOUT_SECONDS
+    )
+    if stdout is None:
+        return []
+    samples: list[tuple[int, int, str, int | None]] = []
+    for line in stdout.splitlines():
         parts = line.strip().split(None, 2)
         if len(parts) < 3:
             continue
         try:
-            pid = int(parts[0])
-            rss_kb = int(parts[1])
+            # `ps` reports RSS in kilobytes; the shared filter takes bytes. No
+            # commit figure: `ps` has no portable column for it, and on Linux
+            # RSS does not evaporate the way a trimmed Windows working set does.
+            samples.append((int(parts[0]), int(parts[1]) * 1024, parts[2], None))
         except ValueError:
             continue
-        command = parts[2]
+    return samples
+
+
+def _windows_process_samples() -> list[tuple[int, int, str, int | None]]:
+    """The same census on Windows, where there is no `ps`.
+
+    `tasklist` cannot report a command line, and the check's whole filter is a
+    command-line filter -- it has to tell an exomem stdio server from any other
+    python.exe, and a media worker child from a session. So this reads
+    `Win32_Process` through CIM, which carries `CommandLine` and
+    `WorkingSetSize` together.
+
+    Windows PowerShell 5.1 ships with every supported Windows and is preferred
+    for that reason; `pwsh` is accepted where it is the only one present.
+    """
+    shell = shutil.which("powershell") or shutil.which("pwsh")
+    if not shell:
+        return []
+    stdout = _run_process_census(
+        [shell, "-NoProfile", "-NonInteractive", "-Command", _WINDOWS_PROCESS_CENSUS],
+        _WINDOWS_PROCESS_CENSUS_TIMEOUT_SECONDS,
+    )
+    if stdout is None:
+        return []
+    samples: list[tuple[int, int, str, int | None]] = []
+    for line in stdout.splitlines():
+        parts = line.strip().split("|", 3)
+        # An empty command field is a process this session cannot read the
+        # command line of. Dropped here so it matches `ps`, where a line without
+        # a command is short and gets dropped for the same reason -- the shared
+        # filter would exclude it anyway, but the two censuses should not differ
+        # about what they even collected.
+        if len(parts) < 4 or not parts[3]:
+            continue
+        try:
+            samples.append((int(parts[0]), int(parts[1]), parts[3], int(parts[2])))
+        except ValueError:
+            continue
+    return samples
+
+
+def _list_exomem_processes() -> list[dict[str, object]]:
+    """Every OTHER exomem session process, with what it costs.
+
+    The census is per-platform because the tools are; the filter is shared,
+    because a lane that selects processes differently from the other reports a
+    different thing under the same check name. `tests/test_doctor.py` pins that
+    both lanes route through this one filter.
+    """
+    samples = _windows_process_samples() if os.name == "nt" else _posix_process_samples()
+    rows: list[dict[str, object]] = []
+    current_pid = os.getpid()
+    for pid, rss_bytes, command, private_bytes in samples:
         if pid == current_pid:
             continue
         command_l = command.lower()
@@ -1335,8 +1418,16 @@ def _list_exomem_processes() -> list[dict[str, object]]:
             continue
         if "--transport" not in command_l and "python -m exomem" not in command_l:
             continue
-        rss_mb = round(rss_kb / 1024, 1)
-        rows.append({"pid": pid, "rss_mb": rss_mb, "command": command[:180], **process_memory.enrich_process_memory(pid, rss_mb)})
+        rss_mb = round(rss_bytes / (1024 * 1024), 1)
+        row: dict[str, object] = {
+            "pid": pid,
+            "rss_mb": rss_mb,
+            "command": command[:180],
+            **process_memory.enrich_process_memory(pid, rss_mb),
+        }
+        if private_bytes is not None:
+            row["private_commit_mb"] = round(private_bytes / (1024 * 1024), 1)
+        rows.append(row)
     return rows
 
 
@@ -1360,6 +1451,16 @@ def _check_runtime_processes() -> DoctorCheck | None:
         )
     else:
         memory_message = f"about {memory['rss_mb_total']} MB RSS total"
+    # Windows trims an idle process's working set aggressively, so the resident
+    # figure above is a reading of this instant rather than of what the process
+    # costs -- one server here measured 1196 MB resident while active and 1.1 MB
+    # minutes later, against a private commit that did not move. Reporting only
+    # the resident number would tell a user their idle sessions are free.
+    private_total = round(
+        sum(float(row.get("private_commit_mb") or 0.0) for row in rows), 1
+    )
+    if private_total:
+        memory_message += f" and {private_total} MB private commit"
     return _check(
         "runtime.processes",
         status,

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1255,3 +1255,200 @@ def test_torch_cuda_escape_hatch_downgrades_the_failure_to_a_warning(
     check = doctor_module._check_torch_cuda()
 
     assert check.status == "warn"
+
+
+# ------------------------------------------ the process census runs everywhere
+
+
+def test_the_process_census_is_not_disabled_on_windows() -> None:
+    """The check exists to surface what per-session servers cost (#597).
+
+    It returned `[]` on Windows unconditionally, so on the platform where the
+    8.1-GB-across-seven measurement was actually taken, the check that reports
+    it never fired. Pinned as a source assertion rather than through a live
+    census because CI's Linux runners cannot exercise the Windows branch.
+    """
+    import inspect
+
+    source = inspect.getsource(doctor_module._list_exomem_processes)
+    assert 'os.name == "nt"' in source
+    assert "return []" not in source, "the Windows branch is back to answering nothing"
+    assert "_windows_process_samples" in source
+
+
+def test_both_platform_censuses_share_one_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lane that selects differently reports a different thing under one name.
+
+    The filter is the check's actual definition of "an exomem session": it has
+    to tell a server from any other python.exe, and a session from a media
+    worker child. Two copies of that would drift, and the drift would be
+    invisible -- each platform would look correct on its own runner.
+    """
+    samples = [
+        (101, 300 * 1024 * 1024, "python -m exomem --transport stdio", None),
+        (102, 50 * 1024 * 1024, "python -m exomem.media_worker_child --parent 101", None),
+        (103, 90 * 1024 * 1024, "python -m http.server", None),
+        (104, 10 * 1024 * 1024, "notepad.exe exomem-notes.txt", None),
+    ]
+
+    seen = []
+    for platform, attribute in (("nt", "_windows_process_samples"), ("posix", "_posix_process_samples")):
+        monkeypatch.setattr(doctor_module.os, "name", platform)
+        monkeypatch.setattr(doctor_module, attribute, lambda: samples)
+        seen.append(doctor_module._list_exomem_processes())
+
+    windows_rows, posix_rows = seen
+    assert windows_rows == posix_rows
+    # Only the session survives: the worker child, the unrelated server, and the
+    # editor that merely has "exomem" in its arguments are all excluded.
+    assert [row["pid"] for row in windows_rows] == [101]
+    assert windows_rows[0]["rss_mb"] == 300.0
+
+
+def _stub_shell_lookup(monkeypatch: pytest.MonkeyPatch, found: str | None) -> None:
+    """Answer only for the shells this census looks for, defer for everything else.
+
+    `doctor_module.shutil` is the global module, and the repo conftest calls
+    `shutil.which("git", path=os.defpath)` while building a failure report -- a
+    stub narrower than that takes down the whole session's teardown, not just
+    this test.
+    """
+    real_which = doctor_module.shutil.which
+
+    def which(name, *args, **kwargs):  # noqa: ANN001, ANN202
+        if name in {"powershell", "pwsh"}:
+            return found
+        return real_which(name, *args, **kwargs)
+
+    monkeypatch.setattr(doctor_module.shutil, "which", which)
+
+
+def test_the_windows_census_parses_pipes_inside_a_command_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The separator is also a legal character in the thing it separates.
+
+    Splitting with a bound keeps the command intact; splitting without one would
+    truncate any command containing a pipe, and the filter reads the command.
+    """
+    _stub_shell_lookup(monkeypatch, "powershell")
+    monkeypatch.setattr(
+        doctor_module,
+        "_run_process_census",
+        lambda _command, _timeout: (
+            "101|314572800|3900000000|python -m exomem --transport stdio --log 'a|b'\n"
+            "notanumber|1|1|python -m exomem\n"
+            "\n"
+            "103|1048576|2048|\n"
+        ),
+    )
+
+    samples = doctor_module._windows_process_samples()
+
+    assert samples == [
+        (101, 314572800, "python -m exomem --transport stdio --log 'a|b'", 3900000000)
+    ]
+
+
+def test_a_census_that_cannot_answer_is_not_a_doctor_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No shell, a non-zero exit, or a timeout all mean "no reading taken".
+
+    A diagnostic that raises is worse than one that declines: it takes down every
+    other check in the same run.
+    """
+    _stub_shell_lookup(monkeypatch, None)
+    assert doctor_module._windows_process_samples() == []
+
+    _stub_shell_lookup(monkeypatch, "powershell")
+    monkeypatch.setattr(doctor_module, "_run_process_census", lambda _c, _t: None)
+    assert doctor_module._windows_process_samples() == []
+
+
+def test_the_census_command_bounds_itself(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Windows pays PowerShell startup before the query, so it gets more room.
+
+    Both bounds still exist, because a doctor check may be slow enough to be
+    worth waiting for and must never hang.
+    """
+    recorded: list[float] = []
+
+    def _record(command, timeout):  # noqa: ANN001, ANN202, ARG001
+        recorded.append(timeout)
+        return None
+
+    monkeypatch.setattr(doctor_module, "_run_process_census", _record)
+    _stub_shell_lookup(monkeypatch, "powershell")
+    doctor_module._windows_process_samples()
+    doctor_module._posix_process_samples()
+
+    assert recorded == [
+        doctor_module._WINDOWS_PROCESS_CENSUS_TIMEOUT_SECONDS,
+        doctor_module._PROCESS_CENSUS_TIMEOUT_SECONDS,
+    ]
+    assert 0 < recorded[1] < recorded[0]
+
+
+def test_a_trimmed_working_set_does_not_read_as_a_free_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows reclaims an idle process's working set; its commit does not move.
+
+    Measured on one box while writing this: the same loaded server read 1195.8 MB
+    resident with 3677 MB committed, and minutes later the whole set of three
+    read 310.5 MB resident. A check that reported only the resident figure would
+    tell a user their idle sessions cost nothing, which is the opposite of what
+    this check exists to say (#597).
+    """
+    monkeypatch.setattr(
+        doctor_module,
+        "_list_exomem_processes",
+        lambda: [
+            {
+                "pid": 101,
+                "rss_mb": 1.1,
+                "memory_mb": 1.1,
+                "memory_metric": "rss",
+                "private_commit_mb": 3677.0,
+                "command": "python -m exomem --transport stdio",
+            }
+        ],
+    )
+
+    check = doctor_module._check_runtime_processes()
+
+    assert check is not None
+    assert "3677.0 MB private commit" in check.message
+    assert check.details["processes"][0]["private_commit_mb"] == 3677.0
+
+
+def test_a_platform_without_a_commit_figure_says_nothing_about_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`ps` has no portable commit column, and Linux RSS does not evaporate.
+
+    The clause has to be absent rather than zero there, or every POSIX run
+    reports a number it never measured.
+    """
+    monkeypatch.setattr(
+        doctor_module,
+        "_list_exomem_processes",
+        lambda: [
+            {
+                "pid": 101,
+                "rss_mb": 300.0,
+                "memory_mb": 300.0,
+                "memory_metric": "rss",
+                "command": "python -m exomem --transport stdio",
+            }
+        ],
+    )
+
+    check = doctor_module._check_runtime_processes()
+
+    assert check is not None
+    assert "private commit" not in check.message
+    assert "about 300.0 MB RSS total" in check.message


### PR DESCRIPTION
Half of #597.

```python
def _list_exomem_processes() -> list[dict[str, object]]:
    if os.name == "nt":
        return []
```

#597 — seven per-session servers at about 1 GB each, 8.1 GB in total — was
measured on Windows. `runtime.processes`, the check whose entire job is to report
that, was disabled on the only platform where anyone had seen it.

## Why CIM rather than tasklist

`tasklist` cannot report a command line, and the command line *is* the filter:
the check has to tell an exomem server from any other `python.exe`, and a session
from a media worker child. `Win32_Process` carries `CommandLine`,
`WorkingSetSize` and `PrivatePageCount` in one query. Windows PowerShell 5.1
ships with every supported Windows; `pwsh` is accepted where it is the only one
present. No shell, a non-zero exit, or a timeout all mean "no reading taken" —
never an exception, because a diagnostic that raises takes down every other check
in the same run.

The filter is now **shared** between the two censuses. Two copies of "what counts
as an exomem session" would drift, and the drift would be invisible — each
platform would look correct on its own runner. A test asserts both lanes route
through the one filter and produce byte-identical rows from identical samples.

## Working set alone would have lied

Windows trims an idle process's working set aggressively. Measured on this box
minutes apart:

```
active :  ws = 1195.8 MB   priv = 3677 MB     (one loaded server)
idle   :  ws =  310.5 MB total across three
```

Private commit did not move while resident memory fell by 4x. A check reporting
only the resident figure would tell a user their idle sessions cost nothing —
the opposite of what this check exists to say. So Windows rows carry both, and
the message names the commit total when it has one.

POSIX reports **no** commit figure rather than a zero: `ps` has no portable
column for it, and Linux RSS does not evaporate the same way. Pinned in both
directions so neither platform reports a number it never measured.

## Verified against live processes

Run against this machine's actual process table:

```
census: 701 processes in 1.00s
filtered rows: 3
  pid=77636   1220.6 MB  ...\exomem.exe --transport ...
status: warn
message: Detected 3 other exomem server process(es) using about 310.5 MB RSS total...
```

The 1.2 GB server that prompted #597 now appears. Before this change the same
call returned `[]`.

## Verification

- `tests/test_doctor.py` — 72 passed, 1 skipped (5 new tests)
- `uvx ruff check . --select F` — All checks passed
- The Windows branch is pinned by source assertion as well as by behaviour,
  because CI's Linux runners cannot exercise it.
