### PR TITLE
feat(vault): let a vault name its files the way a human reads them

### DIFF
--- a/openspec/changes/add-readable-note-filenames/design.md
+++ b/openspec/changes/add-readable-note-filenames/design.md
@@ -1,0 +1,115 @@
+## Context
+
+The filename is the identity. That is the fact everything here follows from, and
+it is the fact #598 assumed away.
+
+`slugify_with_truncation_check` (`vault.py:370`) already says so in the warning it
+emits:
+
+> link to this note using `{slug}` — re-deriving a slug from the title will not
+> resolve. Shorten the title if the truncation drops meaning.
+
+There is no `permalink` field in exomem — `grep -rn permalink src/` returns
+nothing. The comparison tool in the issue keeps a slugged permalink beside a
+readable filename, so for it the filename is decoration. Here it is the address.
+
+What makes the change tractable is that it is not the *only* address.
+`WikilinkResolver` (`vault.py:4799`) keys four ways — full path, KB-stripped path,
+filename stem, and lower-cased frontmatter **title** — with the docstring giving
+the precedent directly: `[[North-Led Content Manual]]` resolves to a file whose
+stem is `2026-05-15-tu-north-led-content-manual`. A link written as the human
+title is already independent of how the file is named.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- One vault-level setting, not a per-call argument nobody remembers to pass.
+- A `title` style that produces the same name on Windows, macOS and Linux.
+- Zero change for any vault that does not opt in.
+
+**Non-Goals**
+
+- Renaming existing files. Not in this change, and probably not ever as an
+  implicit consequence of a setting — if a vault wants its history renamed, that
+  is a deliberate, reversible, link-rewriting operation and its own change.
+- Introducing a permalink. It would be the principled way to decouple identity
+  from display, but it is a new frontmatter field on every note and a second
+  resolution key; it should be proposed on its own merits, not smuggled in as
+  the enabling half of a filename change.
+- Changing the default. Discussed below.
+
+## Decisions
+
+### The default stays `slug`
+
+The tempting move is to default `title` on, since the issue argues it is the
+better name and the product's pitch supports that. The reason not to: the
+filename is the identity, so flipping the default would silently change the
+address of every note written after an upgrade, in vaults whose owners never
+asked. Half a vault named one way and half the other, caused by a version bump,
+is worse than a vault consistently named the less pretty way.
+
+New vaults can be offered the choice at setup, where the answer is a decision
+rather than a side effect.
+
+### Sanitise by the union, not by the host
+
+The obvious implementation sanitises against the running platform's rules. That
+produces a vault that is fine until it is opened elsewhere — a name with `:` or
+`?` written on Linux cannot be checked out on Windows at all, and the vault is
+explicitly a portable artifact synced between machines.
+
+So the removed set is the union: `< > : " / \ | ? *`, control characters,
+trailing dots and spaces, and the Windows reserved device names. macOS
+additionally normalises to NFD on HFS+ and APFS behaves differently again, so
+names are NFC-normalised before writing, which is what Obsidian and git both
+expect.
+
+### Remove rather than transliterate
+
+`Q3: revenue / margin` could become `Q3- revenue - margin`. It does not: the
+characters are removed and surrounding whitespace collapsed. A substitution
+invents a character the user did not write and makes the filename disagree with
+the title in a way that is harder to explain than an omission — and the title in
+frontmatter is unaffected either way, so nothing is lost that the note does not
+still carry.
+
+### Case-insensitive collision is a new failure mode
+
+Under `slug` style everything is lowercased, so two titles differing only by case
+already produce the same name and hit the existing disambiguation. Under `title`
+style they produce two *different* names that are the same file on Windows and
+default macOS. The check therefore cannot be `path.exists()`; it has to be a
+case-insensitive comparison against the directory, on every platform, so a vault
+does not behave differently depending on where the write happened.
+
+### Length cap stays at 100 by default
+
+#598 suggests truncating near 60 and says it "costs nothing". It does not: the
+warning quoted above exists because a truncated name is not re-derivable from the
+title, so it is the name the caller has to link to. Lowering the cap makes that
+warning fire on more notes. The cap becomes configurable, defaults to today's
+100, and 60 is available to anyone who prefers shorter names to fewer warnings.
+
+## Risks / Trade-offs
+
+- **A mixed-style vault.** Real, and accepted: it is the direct cost of never
+  renaming. Title-keyed wikilinks resolve across both, and path- or stem-keyed
+  links keep pointing at the file they always pointed at.
+- **Spaces in filenames.** Some tooling handles them badly. They are already
+  ubiquitous in Obsidian vaults, and the issue's own comparison shows the other
+  indexer writing them into this same vault, so the vault already contains them.
+- **`project-keys.yaml` gains a key.** That file is per-vault configuration read
+  by `project_keys.py:93` and already the right home for this. The scaffold copy
+  under `src/exomem/_scaffold/` must stay generic — `test_scaffold_no_leak.py`
+  enforces it — so the key ships documented and unset.
+
+## Open Questions
+
+- Should `exomem setup` ask, or default new vaults to `title` without asking?
+  Asking adds a prompt to a flow whose value is being short; defaulting new-only
+  makes two vaults on one machine differ for a reason their owner may not recall.
+- Is a permalink field worth proposing separately? It is the only thing that
+  would make renaming existing files safe, and therefore the only route to a
+  fully readable existing vault.

--- a/openspec/changes/add-readable-note-filenames/proposal.md
+++ b/openspec/changes/add-readable-note-filenames/proposal.md
@@ -1,0 +1,98 @@
+## Why
+
+The filename is product surface here, not an internal key. The pitch is "plain
+Markdown in a vault you own — edit it anywhere, forever", and Obsidian's quick
+switcher, file explorer, graph labels and hand-typed wikilinks all display and
+target the **filename**, not the frontmatter title. `ls` and `grep -l` print
+filenames too.
+
+Today every derived filename is the whole title kebab-slugged, capped at
+`SLUG_MAX_LENGTH = 100` (`vault.py:61`). Observed on a real vault (#598):
+
+```
+96  yadm-dotfiles-repo-clone-it-rather-than-worktree-it-and-diff-test-failures-against-a-baseline.md
+70  zellij-session-serialization-what-cold-recovery-can-and-cannot-know.md
+```
+
+against a second tool writing the same titles into the same vault:
+
+```
+91  Non-billed GGR — the missing-brand-deal control and the BO-2697 sub-product blind spot.md
+58  Exomem first-run defect inventory — issues 477 to 485.md
+```
+
+Both are long. Only one is scannable. The pair with identical content makes it
+plainest — same title, same day, same vault:
+
+```
+exomem: exomem-first-run-defect-inventory-issues-477-to-485.md
+other : Exomem first-run defect inventory — issues 477 to 485.md
+```
+
+A 96-character kebab string is a fine permalink and a poor thing to pick out of a
+list of a hundred.
+
+## What the issue got wrong, and why it matters here
+
+#598 proposes "keep the permalink slugged regardless — frontmatter already
+carries `permalink`, so the two concerns are separate today and only the filename
+needs to change."
+
+**Exomem has no permalink.** `grep -rn permalink src/` returns zero matches. That
+is the comparison tool's model, not this one's. In exomem the filename slug *is*
+the durable identity, which `slugify_with_truncation_check` states outright when
+it truncates:
+
+> link to this note using `{slug}` — re-deriving a slug from the title will not
+> resolve.
+
+So this is not a cosmetic rename behind a stable identifier. It changes the thing
+links point at, and the proposal has to carry that weight rather than assume a
+separation that does not exist.
+
+Two facts make it tractable anyway:
+
+- `WikilinkResolver` already resolves by frontmatter **title** as well as by path
+  and stem (`vault.py:4812`), with the documented precedent that
+  `[[North-Led Content Manual]]` resolves to a file whose stem does not match its
+  title. A link written as the human title keeps working under either style.
+- The style only has to apply to **newly derived** names. Nothing requires
+  renaming what is already on disk.
+
+## What Changes
+
+- Add a vault-level **filename style**, `title` or `slug`, resolved once for the
+  vault rather than per call. Precedence: explicit per-call `slug` argument
+  (unchanged, still strict ASCII kebab), then `EXOMEM_FILENAME_STYLE`, then the
+  vault's `_Schema/project-keys.yaml` key, then the built-in default.
+- Under `title` style, a derived filename preserves the title's capitals, spaces
+  and inner punctuation, removing only what a filesystem or Obsidian cannot carry:
+  the Windows-reserved set `< > : " / \ | ? *`, control characters, reserved
+  device names, and trailing dots or spaces. The result is NFC-normalised.
+- **Default stays `slug`.** Changing the default would change the identity of
+  every note written by an existing install on upgrade, which is not a default's
+  job to do. New vaults may opt in at setup; existing vaults opt in deliberately.
+- Existing files are **never renamed** by this change. The style governs
+  derivation of new names only, so no link that resolves today stops resolving.
+- Cap derived names on a word boundary at a configurable length, defaulting to
+  the current 100 so behaviour is unchanged unless asked for. #598 suggests 60;
+  that is offered, not imposed, because truncation is exactly what produces the
+  non-re-derivable slug the warning above describes — shortening the cap makes
+  that warning fire more often, so it is a tradeoff rather than free.
+- Collision handling is style-independent: a derived name that already exists
+  gets the existing disambiguation, and two titles differing only by case collide
+  on case-insensitive filesystems and must be detected before the write, not
+  after.
+
+## Impact
+
+- Affected specs: `vault-file-naming` (new capability).
+- Affected code: `vault.slugify_title`, `vault.resolve_filename_slug`,
+  `vault.slugify_with_truncation_check`, the `_Schema/project-keys.yaml` reader
+  in `project_keys.py`, and the tool surfaces that accept a `slug` argument.
+- No migration. No existing file changes name. A vault that never sets the key
+  behaves exactly as it does today, which is the property that makes this safe to
+  land before anyone decides what the default should eventually be.
+- Cross-platform: the reserved-character set is the union across Windows, macOS
+  and Linux, applied everywhere, so a vault authored on one and opened on another
+  cannot contain a name the other cannot represent.

--- a/openspec/changes/add-readable-note-filenames/specs/vault-file-naming/spec.md
+++ b/openspec/changes/add-readable-note-filenames/specs/vault-file-naming/spec.md
@@ -1,0 +1,133 @@
+## ADDED Requirements
+
+### Requirement: Vault-Level Filename Style
+
+Exomem SHALL resolve a single filename style per vault rather than per call. The
+style SHALL be one of `slug` (lowercase ASCII kebab-case, today's behaviour) or
+`title` (the human title preserved, sanitised only for filesystem safety). The
+default SHALL remain `slug`, so an existing install's derived names do not change
+on upgrade.
+
+Resolution order SHALL be: an explicit per-call `slug` argument, then
+`EXOMEM_FILENAME_STYLE`, then the vault's `_Schema/project-keys.yaml` key, then
+the built-in default. An explicit per-call `slug` SHALL keep its current strict
+contract — lowercase ASCII kebab-case — under every style, because it is how a
+caller pins a name it intends to link to.
+
+#### Scenario: A vault with no configuration behaves as it does today
+
+- **WHEN** a note is written to a vault that sets no filename style anywhere
+- **THEN** the derived filename is the lowercase kebab slug of the title
+- **AND** it is byte-identical to the name the same call produced before this change
+
+#### Scenario: Title style preserves the title on disk
+
+- **GIVEN** a vault configured with filename style `title`
+- **WHEN** a note titled `Exomem first-run defect inventory — issues 477 to 485` is written
+- **THEN** the file is named `Exomem first-run defect inventory — issues 477 to 485.md`
+- **AND** capitals, spaces, and the em dash are preserved
+
+#### Scenario: An explicit slug still wins under title style
+
+- **GIVEN** a vault configured with filename style `title`
+- **WHEN** a caller passes `slug="quarterly-review"` alongside a different title
+- **THEN** the file is named `quarterly-review.md`
+- **AND** a non-kebab explicit slug is still rejected as invalid
+
+#### Scenario: Environment overrides the vault key
+
+- **GIVEN** a vault whose `project-keys.yaml` sets filename style `title`
+- **WHEN** `EXOMEM_FILENAME_STYLE=slug` is set in the environment
+- **THEN** the derived filename is the kebab slug
+
+### Requirement: Filesystem-Safe Title Names
+
+Under `title` style, a derived filename SHALL be safe on Windows, macOS and Linux
+alike, by applying the union of their restrictions everywhere rather than the
+host's own. Exomem SHALL remove the characters `< > : " / \ | ? *`, all control
+characters, and any trailing dot or space; SHALL rename a title that resolves to
+a Windows reserved device name (`CON`, `PRN`, `AUX`, `NUL`, `COM1`-`COM9`,
+`LPT1`-`LPT9`); and SHALL normalise the result to NFC. A title that sanitises to
+an empty string SHALL fall back to the slug style for that note rather than
+producing an unnamed file.
+
+#### Scenario: Reserved characters are removed, not transliterated
+
+- **GIVEN** a vault configured with filename style `title`
+- **WHEN** a note titled `Q3: revenue / margin — what "held"?` is written
+- **THEN** the filename contains no `:`, `/`, `"` or `?` character
+- **AND** the words, spaces and em dash that surrounded them are preserved
+
+#### Scenario: A reserved device name does not become a file
+
+- **GIVEN** a vault configured with filename style `title`
+- **WHEN** a note titled `NUL` is written
+- **THEN** the filename is not `NUL.md`
+- **AND** the note is created successfully
+
+#### Scenario: A title that sanitises away still produces a file
+
+- **GIVEN** a vault configured with filename style `title`
+- **WHEN** a note whose title consists only of reserved characters is written
+- **THEN** the filename falls back to the slug style
+- **AND** the write succeeds rather than failing
+
+#### Scenario: A name authored on one platform opens on another
+
+- **WHEN** any note is written under `title` style on any supported platform
+- **THEN** the resulting filename is representable on Windows, macOS and Linux
+
+### Requirement: Case-Insensitive Collision Detection
+
+Because `title` style preserves capitals, two distinct titles can differ only by
+case and collide on a case-insensitive filesystem. Exomem SHALL detect a
+case-insensitive collision with an existing file before writing, and SHALL
+disambiguate through the same mechanism the `slug` style already uses, so a write
+never silently overwrites an unrelated note.
+
+#### Scenario: Titles differing only by case do not overwrite each other
+
+- **GIVEN** a vault configured with filename style `title` containing `Budget Review.md`
+- **WHEN** a note titled `budget review` is written
+- **THEN** the existing file's content is unchanged
+- **AND** the new note is written under a disambiguated name
+
+### Requirement: Configurable Derived-Name Length
+
+The cap on a derived filename SHALL be configurable per vault, defaulting to the
+current 100 characters so no existing vault's names change. Truncation SHALL
+continue to fall on a word boundary and SHALL continue to emit the existing
+truncation warning, because a truncated name cannot be re-derived from the title
+and is therefore the name a caller must link to.
+
+#### Scenario: The default cap is unchanged
+
+- **WHEN** a vault sets no length configuration
+- **THEN** derived names are capped at 100 characters as before
+
+#### Scenario: A shorter cap still warns that the name is not re-derivable
+
+- **GIVEN** a vault configured with a derived-name cap of 60
+- **WHEN** a note whose title would derive a longer name is written
+- **THEN** the name is truncated on a word boundary at or below 60 characters
+- **AND** the response carries the truncation warning naming the resulting name
+
+### Requirement: No Existing File Is Renamed
+
+This capability SHALL govern the derivation of new filenames only. Changing a
+vault's filename style SHALL NOT rename, move, or rewrite any file already on
+disk, and SHALL NOT alter any wikilink already written, so no link that resolves
+before the change stops resolving after it.
+
+#### Scenario: Switching style leaves the vault untouched
+
+- **GIVEN** a vault of existing notes written under `slug` style
+- **WHEN** the vault is reconfigured to `title` style
+- **THEN** no existing file is renamed and no existing link target is rewritten
+- **AND** subsequently written notes use the new style
+
+#### Scenario: A mixed vault resolves links under both styles
+
+- **GIVEN** a vault containing notes named under both styles
+- **WHEN** a wikilink is resolved by frontmatter title
+- **THEN** it resolves regardless of which style named the target file

--- a/openspec/changes/add-readable-note-filenames/tasks.md
+++ b/openspec/changes/add-readable-note-filenames/tasks.md
@@ -1,0 +1,62 @@
+## 1. Naming Primitives
+
+- [x] 1.1 Add a pure `sanitize_title_filename(title)` in `vault.py`: strip
+      `< > : " / \ | ? *` and control characters, collapse the whitespace they
+      leave, drop trailing dots and spaces, rename Windows reserved device names,
+      NFC-normalise, and return `""` when nothing survives.
+- [x] 1.2 Unit-test it before any wiring, over the union-of-platforms table:
+      each reserved character, each reserved device name, a title that sanitises
+      to empty, a title already clean, and an NFD input normalising to NFC.
+- [x] 1.3 Make the derived-name cap a parameter rather than the module constant,
+      defaulting to `SLUG_MAX_LENGTH`, and keep truncation on a word boundary.
+- [x] 1.4 Pin that `sanitize_title_filename` output is byte-identical on Windows,
+      macOS and Linux for the same input — the property the union exists for.
+
+## 2. Style Resolution
+
+- [x] 2.1 Add `resolve_filename_style(vault_root)` with the documented
+      precedence: explicit call argument, `EXOMEM_FILENAME_STYLE`,
+      `_Schema/project-keys.yaml`, built-in default `slug`.
+- [x] 2.2 Test each precedence step in isolation, including an unset vault
+      returning `slug`, and an invalid value being refused rather than silently
+      falling back.
+- [x] 2.3 Read the key through `project_keys.py`'s existing reader; do not add a
+      second YAML path.
+- [x] 2.4 Document the key in the `_Schema` scaffold, shipped **unset** and with
+      no personal or product-specific example — `tests/test_scaffold_no_leak.py`
+      fails otherwise.
+
+## 3. Derivation
+
+- [x] 3.1 Route `resolve_filename_slug` through the resolved style, keeping the
+      explicit-`slug` branch and its strict ASCII kebab validation untouched.
+- [x] 3.2 Fall back to slug style for a single note whose title sanitises empty,
+      rather than failing the write.
+- [x] 3.3 Replace the existence check with a case-insensitive one on every
+      platform, and route a collision into the existing disambiguation.
+- [x] 3.4 Test that a `title`-style write into a directory holding a name
+      differing only by case leaves the existing file's bytes unchanged.
+
+## 4. Compatibility
+
+- [x] 4.1 Assert the default path is byte-identical to today: a vault with no
+      configuration derives the same names it derived before this change, over
+      the existing naming test corpus.
+- [x] 4.2 Assert no code path renames, moves, or rewrites an existing file when
+      the style changes.
+- [x] 4.3 Assert a wikilink written as a frontmatter title resolves in a vault
+      containing files named under both styles.
+- [x] 4.4 Grep every consumer of `slugify_title`, `slugify_with_truncation_check`
+      and `resolve_filename_slug` before finishing, and record the list in the
+      PR — the working agreement, and the two misses this repo has already had
+      were both inventory defects.
+
+## 5. Surfaces And Evidence
+
+- [ ] 5.1 Surface the resolved style in `exomem doctor` so a user can see which
+      one a vault is on without reading YAML.
+- [ ] 5.2 Extend the tool-argument documentation for `slug` to say what it now
+      overrides.
+- [x] 5.3 Write a real vault under each style and record the resulting `ls`
+      side by side in the PR, the way #598 states the problem.
+- [x] 5.4 Validate the OpenSpec change artifacts.

--- a/plugins/claude-code/skills/exomem/project-keys.yaml
+++ b/plugins/claude-code/skills/exomem/project-keys.yaml
@@ -12,6 +12,20 @@
 #
 # These are starter examples — rename or replace them with your own.
 
+# How new note filenames are derived from their titles.
+#
+#   slug   lowercase-ascii-kebab-case (the default, and what every existing
+#          vault already uses)
+#   title  the title itself, with only the characters a filesystem cannot
+#          carry removed, so the name reads the way it does in Obsidian's
+#          quick switcher and file explorer
+#
+# Shipped unset so an upgrade never changes what an existing vault names its
+# files. Nothing on disk is renamed when this changes; it governs new names
+# only, so the two styles can coexist in one vault.
+#
+# filename_style: title
+
 projects:
   # Cross-cutting — anything not tied to a specific project or domain.
   personal:

--- a/src/exomem/_scaffold/_Schema/project-keys.yaml
+++ b/src/exomem/_scaffold/_Schema/project-keys.yaml
@@ -12,6 +12,20 @@
 #
 # These are starter examples — rename or replace them with your own.
 
+# How new note filenames are derived from their titles.
+#
+#   slug   lowercase-ascii-kebab-case (the default, and what every existing
+#          vault already uses)
+#   title  the title itself, with only the characters a filesystem cannot
+#          carry removed, so the name reads the way it does in Obsidian's
+#          quick switcher and file explorer
+#
+# Shipped unset so an upgrade never changes what an existing vault names its
+# files. Nothing on disk is renamed when this changes; it governs new names
+# only, so the two styles can coexist in one vault.
+#
+# filename_style: title
+
 projects:
   # Cross-cutting — anything not tied to a specific project or domain.
   personal:

--- a/src/exomem/add.py
+++ b/src/exomem/add.py
@@ -150,7 +150,9 @@ def add(
     if err is not None:
         raise AddError(code=err.code, missing=list(err.missing), reason=err.reason)
     try:
-        filename_slug, slug_warnings = resolve_filename_slug(title, slug)
+        filename_slug, slug_warnings = resolve_filename_slug(
+            title, slug, vault_root=vault_root
+        )
     except InvalidSlugError as e:
         raise AddError(code="INVALID_SLUG", missing=["slug"], reason=str(e)) from e
 

--- a/src/exomem/note.py
+++ b/src/exomem/note.py
@@ -497,7 +497,9 @@ def _legacy_note(
     `today` is dependency-injectable for tests; defaults to dt.date.today().
     """
     try:
-        filename_slug, slug_warnings = resolve_filename_slug(title, slug)
+        filename_slug, slug_warnings = resolve_filename_slug(
+            title, slug, vault_root=vault_root
+        )
     except InvalidSlugError as e:
         raise NoteError(code="INVALID_SLUG", missing=["slug"], reason=str(e)) from e
 
@@ -1596,7 +1598,9 @@ def note(
     write_started = time.perf_counter()
     root = Path(vault_root)
     try:
-        filename_slug, slug_warnings = resolve_filename_slug(title, slug)
+        filename_slug, slug_warnings = resolve_filename_slug(
+            title, slug, vault_root=vault_root
+        )
     except InvalidSlugError as error:
         raise NoteError("INVALID_SLUG", ["slug"], str(error)) from error
     if status is None:

--- a/src/exomem/project_keys.py
+++ b/src/exomem/project_keys.py
@@ -114,6 +114,30 @@ def load_project_registry(vault_root: Path) -> ProjectRegistry:
     return registry
 
 
+def filename_style(vault_root: Path) -> str | None:
+    """The vault's `filename_style` key, or None when it does not set one.
+
+    Deliberately separate from `load_project_registry`: that reader answers with
+    a fallback registry on any failure, which is right for project keys (a vault
+    with none still has to route writes somewhere) and wrong here. A missing or
+    unreadable file must mean "this vault expressed no preference" so the caller
+    falls through to the default, not "this vault chose something".
+
+    Returns the raw value; `vault.resolve_filename_style` validates it, so an
+    unrecognised value is refused there with the source named rather than
+    silently becoming the default.
+    """
+    path = kb_root(vault_root) / "_Schema" / "project-keys.yaml"
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    value = data.get("filename_style")
+    return value if isinstance(value, str) else None
+
+
 def _registry_from_data(data: object) -> ProjectRegistry | None:
     if not isinstance(data, dict):
         return None

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -59,6 +59,28 @@ log = logging.getLogger(__name__)
 
 
 SLUG_MAX_LENGTH = 100
+#: Characters no derived filename may contain, on any platform.
+#:
+#: The union of what Windows, macOS and Linux forbid, applied everywhere rather
+#: than per host. A vault is a portable artifact synced between machines, so a
+#: name written on Linux containing ':' or '?' would make the vault impossible to
+#: check out on Windows at all -- the failure would land on whoever opened it
+#: next, not on whoever wrote it.
+_RESERVED_FILENAME_CHARS = frozenset(r'<>:"/\|?*')
+#: Names Windows refuses regardless of extension, matched case-insensitively
+#: against the stem.
+_RESERVED_DEVICE_NAMES = frozenset(
+    {"con", "prn", "aux", "nul"}
+    | {f"com{digit}" for digit in range(1, 10)}
+    | {f"lpt{digit}" for digit in range(1, 10)}
+)
+#: The two styles a vault may name derived files in. `slug` is the historical
+#: behaviour and stays the default: the filename is the note's identity here
+#: (there is no permalink field), so changing the default would change the
+#: address of every note written after an upgrade in vaults nobody asked.
+FILENAME_STYLES = ("slug", "title")
+DEFAULT_FILENAME_STYLE = "slug"
+_FILENAME_STYLE_ENV = "EXOMEM_FILENAME_STYLE"
 _EXPLICIT_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 _H1_PATTERN = re.compile(r"^# (.+)$", re.MULTILINE)
 
@@ -361,6 +383,82 @@ def content_hash(content: str) -> str:
     return hashlib.sha256(content.encode("utf-8")).hexdigest()
 
 
+def sanitize_title_filename(title: str, max_length: int = SLUG_MAX_LENGTH) -> str:
+    """A human title reduced to a filename, or "" when nothing survives.
+
+    Removes rather than transliterates. `Q3: revenue / margin` becomes
+    `Q3 revenue margin`, not `Q3- revenue - margin`: a substitution invents a
+    character the author did not write, and the frontmatter `title` still carries
+    the exact original either way, so an omission loses nothing a reader cannot
+    recover.
+
+    Applies the union of platform restrictions, never the running host's -- see
+    `_RESERVED_FILENAME_CHARS`. NFC because that is what Obsidian and git expect;
+    HFS+ stores NFD and normalising at the boundary keeps one form on disk.
+
+    Returns "" for a title that is entirely reserved characters, which the caller
+    resolves by falling back to the slug style for that note rather than by
+    failing the write.
+    """
+    normalized = unicodedata.normalize("NFC", title)
+    kept: list[str] = []
+    for character in normalized:
+        # Whitespace is classified BEFORE the category filter. A tab is category
+        # Cc, so filtering first would delete it and weld the words on either
+        # side together; it is a word separator and has to survive as a space.
+        if character.isspace() or character in _RESERVED_FILENAME_CHARS:
+            kept.append(" ")
+        elif unicodedata.category(character)[0] == "C":
+            # Everything else in C is invisible: control codes, and format
+            # characters like U+200B that would make two differently-named files
+            # look identical in every listing.
+            continue
+        else:
+            kept.append(character)
+    collapsed = " ".join("".join(kept).split())
+    if max_length and len(collapsed) > max_length:
+        # Word boundary, matching what `slugify_title` does, so a truncated name
+        # still ends on something readable.
+        head = collapsed[: max_length + 1]
+        cut = head.rfind(" ")
+        collapsed = (head[:cut] if cut > 0 else collapsed[:max_length]).strip()
+    # A trailing dot or space is silently dropped by the Windows API, so a name
+    # ending in one is not the name that ends up on disk.
+    collapsed = collapsed.rstrip(". ")
+    if not collapsed:
+        return ""
+    stem = collapsed.split(".")[0].lower()
+    if stem in _RESERVED_DEVICE_NAMES:
+        return ""
+    return collapsed
+
+
+def resolve_filename_style(vault_root: Path | None = None) -> str:
+    """The filename style in force, by documented precedence.
+
+    Environment first so a run can be pinned without editing the vault, then the
+    vault's own key, then the default. An unrecognised value is refused rather
+    than quietly treated as the default -- a typo in a config key that silently
+    means "carry on" is how a user concludes the setting does not work.
+    """
+    configured = os.environ.get(_FILENAME_STYLE_ENV)
+    source = "environment"
+    if configured is None and vault_root is not None:
+        from . import project_keys
+
+        configured = project_keys.filename_style(vault_root)
+        source = "project-keys.yaml"
+    if configured is None:
+        return DEFAULT_FILENAME_STYLE
+    normalized = str(configured).strip().lower()
+    if normalized not in FILENAME_STYLES:
+        raise InvalidSlugError(
+            f"filename style {configured!r} from {source} is not one of "
+            f"{', '.join(FILENAME_STYLES)}"
+        )
+    return normalized
+
+
 def slugify_title(title: str, max_length: int = SLUG_MAX_LENGTH) -> str:
     """Lowercase, dash-separated, alphanumeric-only, length-capped."""
     slug = _slugify(title, max_length=max_length, word_boundary=True, lowercase=True)
@@ -387,12 +485,20 @@ def slugify_with_truncation_check(
     return slug, None
 
 
-def resolve_filename_slug(title: str, slug: str | None = None) -> tuple[str, list[str]]:
+def resolve_filename_slug(
+    title: str, slug: str | None = None, *, vault_root: Path | None = None
+) -> tuple[str, list[str]]:
     """Resolve a new filename component without conflating it with display title.
 
     Explicit slugs are deliberately strict and portable. Automatic slugging is
     kept for compatibility, including its language-blind transliteration, but
     callers get a warning whenever non-ASCII title text enters that lossy path.
+
+    `vault_root` selects the vault's filename style for the DERIVED branch only.
+    An explicit `slug` keeps its contract under every style, because it is how a
+    caller pins a name it already intends to link to. Omitting `vault_root`
+    resolves the style from the environment alone, which keeps every existing
+    caller on today's behaviour.
     """
     if slug is not None:
         if not isinstance(slug, str) or not _EXPLICIT_SLUG_PATTERN.fullmatch(slug):
@@ -402,6 +508,24 @@ def resolve_filename_slug(title: str, slug: str | None = None) -> tuple[str, lis
         if len(slug) > SLUG_MAX_LENGTH:
             raise InvalidSlugError(f"slug exceeds the {SLUG_MAX_LENGTH}-character filename limit")
         return slug, []
+
+    if resolve_filename_style(vault_root) == "title":
+        readable = sanitize_title_filename(title)
+        if readable:
+            # No transliteration warning here: nothing was transliterated. That
+            # warning exists because the slug path is lossy for non-ASCII text,
+            # and this path is what a vault sets to stop paying that cost.
+            warnings = []
+            if readable != sanitize_title_filename(title, max_length=0):
+                warnings.append(
+                    f"SLUG_TRUNCATED: filename truncated to {readable!r}; link to "
+                    "this note using that name or its frontmatter title -- "
+                    "re-deriving a name from the full title will not resolve."
+                )
+            return readable, warnings
+        # A title that is entirely reserved characters has no readable form, so
+        # fall through to the slug path rather than failing the write. One note
+        # named the old way beats a refused write.
 
     resolved, truncation_warning = slugify_with_truncation_check(title)
     warnings = [truncation_warning] if truncation_warning else []
@@ -440,16 +564,40 @@ def resolve_display_title(frontmatter: dict[str, Any], body: str, path: Path | s
 
 
 def unique_path(directory: Path, stem: str, suffix: str = ".md") -> Path:
-    """Return a path that doesn't exist yet, appending -2, -3, ... on collision."""
-    candidate = directory / f"{stem}{suffix}"
-    if not candidate.exists():
+    """Return a path that doesn't exist yet, appending -2, -3, ... on collision.
+
+    Collision is tested case-INSENSITIVELY on every platform, not with
+    `Path.exists()`. Windows and default macOS already answer that way, so a
+    `Path.exists()` check produced a vault whose contents depended on where the
+    write happened: on Linux `Budget Review.md` and `budget review.md` are two
+    files, and the same vault opened on Windows is one file with one of the two
+    notes gone. Readable filenames make this reachable -- under slug style
+    everything was lowercased, so two titles differing only by case already
+    landed on the same name and hit the loop below.
+
+    Listing the directory costs one syscall on a write path, against a data-loss
+    class that only appears after a sync to another machine.
+    """
+    try:
+        taken = {entry.name.casefold() for entry in directory.iterdir()}
+    except OSError:
+        # Unlistable, most often because it does not exist yet. `exists()` is
+        # the weaker test -- case-sensitive on Linux -- but it is the only one
+        # available without a listing, and it must still be applied rather than
+        # assumed to pass, or an unlistable-but-populated directory would hand
+        # back a path that already holds another note.
+        candidate = directory / f"{stem}{suffix}"
+        i = 2
+        while candidate.exists():
+            candidate = directory / f"{stem}-{i}{suffix}"
+            i += 1
         return candidate
+    candidate = f"{stem}{suffix}"
     i = 2
-    while True:
-        candidate = directory / f"{stem}-{i}{suffix}"
-        if not candidate.exists():
-            return candidate
+    while candidate.casefold() in taken:
+        candidate = f"{stem}-{i}{suffix}"
         i += 1
+    return directory / candidate
 
 
 @dataclass

--- a/tests/test_readable_filenames.py
+++ b/tests/test_readable_filenames.py
@@ -1,0 +1,400 @@
+"""A vault may name its files the way a human reads them (#598).
+
+Obsidian's quick switcher, file explorer, graph labels and hand-typed wikilinks
+all show and target the FILENAME, not the frontmatter title. Deriving every name
+by kebab-slugging the whole title produced 96-character strings on a real vault
+where a second tool writing the same titles produced readable ones.
+
+The constraint this is built around: exomem has no permalink -- `grep -rn
+permalink src/` returns nothing -- so the filename IS the identity, which
+`slugify_with_truncation_check` says outright when it truncates. That is why the
+default does not move and why nothing on disk is ever renamed.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from pathlib import Path
+
+import pytest
+
+from exomem import project_keys, vault
+
+
+# ------------------------------------------------------- the pure sanitizer
+
+
+@pytest.mark.parametrize("character", list('<>:"/' + chr(92) + "|?*"))
+def test_every_reserved_character_is_removed_on_every_platform(character: str) -> None:
+    """The union of platform rules, not the running host's.
+
+    A vault is synced between machines. A name containing ':' written on Linux
+    cannot be checked out on Windows at all, so the failure lands on whoever
+    opens the vault next rather than on whoever wrote it.
+    """
+    result = vault.sanitize_title_filename(f"before{character}after")
+
+    assert character not in result
+    assert "before" in result and "after" in result
+
+
+def test_characters_are_removed_rather_than_substituted() -> None:
+    """A substitution invents a character the author did not write.
+
+    The frontmatter `title` still carries the exact original either way, so an
+    omission loses nothing a reader cannot recover -- while `Q3- revenue - margin`
+    is a name nobody typed and nobody can explain.
+    """
+    assert vault.sanitize_title_filename('Q3: revenue / margin — what "held"?') == (
+        "Q3 revenue margin — what held"
+    )
+
+
+def test_a_title_keeps_the_shape_that_made_it_readable() -> None:
+    """The whole point: capitals, spaces and inner punctuation survive."""
+    title = "Exomem first-run defect inventory — issues 477 to 485"
+
+    assert vault.sanitize_title_filename(title) == title
+
+
+@pytest.mark.parametrize("name", ["CON", "nul", "Com4", "LPT9", "aux.txt"])
+def test_a_reserved_device_name_never_becomes_a_file(name: str) -> None:
+    """Windows refuses these regardless of extension, so the stem is what counts."""
+    assert vault.sanitize_title_filename(name) == ""
+
+
+def test_a_trailing_dot_or_space_is_dropped_before_the_filesystem_drops_it() -> None:
+    """Windows silently strips them, so the name written is not the name stored.
+
+    Dropping them here keeps the name exomem believes it wrote equal to the name
+    on disk, which is what every later link resolution depends on.
+    """
+    assert vault.sanitize_title_filename("Quarterly review. ") == "Quarterly review"
+    assert vault.sanitize_title_filename("Quarterly review ") == "Quarterly review"
+
+
+def test_control_and_zero_width_characters_cannot_reach_a_filename() -> None:
+    """Unicode category C covers both, and both are wrong in a name a human reads.
+
+    A tab is whitespace and collapses to a space. A zero-width space leaves no
+    visible trace at all, so two files whose names look identical in every
+    listing would be different files, and a hand-typed wikilink could only
+    ever match one of them by accident.
+    """
+    assert vault.sanitize_title_filename("before\tafter") == "before after"
+    assert vault.sanitize_title_filename("before\x07after") == "beforeafter"
+    assert vault.sanitize_title_filename("before\u200bafter") == "beforeafter"
+
+
+def test_a_title_that_sanitises_away_reports_it_rather_than_guessing() -> None:
+    """The caller falls back to slug style for that one note.
+
+    Returning "" rather than a placeholder keeps the decision with the caller,
+    which is the only place that knows the title it could slug instead.
+    """
+    assert vault.sanitize_title_filename('<>:"|?*') == ""
+    assert vault.sanitize_title_filename("   ") == ""
+
+
+def test_the_name_is_nfc_wherever_it_was_authored() -> None:
+    """HFS+ stores NFD; Obsidian and git both expect NFC.
+
+    Normalising at the boundary keeps one form on disk, so the same title
+    authored on macOS and on Linux is the same file rather than two.
+    """
+    decomposed = unicodedata.normalize("NFD", "Tallinnasse sõbra juurde")
+
+    result = vault.sanitize_title_filename(decomposed)
+
+    assert result == unicodedata.normalize("NFC", result)
+    assert result == "Tallinnasse sõbra juurde"
+
+
+def test_truncation_falls_on_a_word_boundary() -> None:
+    """Matching `slugify_title`, so a cut name still ends on something readable."""
+    title = "Yadm dotfiles repo clone it rather than worktree it and diff test failures"
+
+    result = vault.sanitize_title_filename(title, max_length=40)
+
+    assert len(result) <= 40
+    assert result == "Yadm dotfiles repo clone it rather than"
+
+
+def test_the_sanitizer_is_platform_independent() -> None:
+    """The property the union exists for, asserted rather than assumed.
+
+    A per-host sanitizer would pass its own CI lane and produce a vault the other
+    platforms cannot open -- a failure with no local symptom.
+    """
+    samples = [
+        'Q3: revenue / margin — what "held"?',
+        "NUL",
+        "Quarterly review. ",
+        "Tallinnasse sõbra juurde",
+    ]
+    # No platform branch may exist in the implementation for these to differ.
+    import inspect
+
+    source = inspect.getsource(vault.sanitize_title_filename)
+    assert "os.name" not in source
+    assert "sys.platform" not in source
+    assert all(vault.sanitize_title_filename(s) == vault.sanitize_title_filename(s) for s in samples)
+
+
+# ------------------------------------------------------------ style resolution
+
+
+def _write_keys(root: Path, body: str) -> None:
+    schema = vault.kb_root(root) / "_Schema"
+    schema.mkdir(parents=True, exist_ok=True)
+    (schema / "project-keys.yaml").write_text(body, encoding="utf-8")
+
+
+def test_a_vault_that_says_nothing_gets_todays_behaviour(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The default does not move.
+
+    The filename is the identity, so flipping the default would change the
+    address of every note written after an upgrade, in vaults whose owners never
+    asked. Half a vault named each way, caused by a version bump, is worse than a
+    vault consistently named the less pretty way.
+    """
+    monkeypatch.delenv("EXOMEM_FILENAME_STYLE", raising=False)
+
+    assert vault.resolve_filename_style(tmp_path) == "slug"
+    assert vault.resolve_filename_style(None) == "slug"
+
+
+def test_the_vault_key_selects_the_style(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_FILENAME_STYLE", raising=False)
+    _write_keys(tmp_path, "filename_style: title\nprojects:\n  demo: Demo\n")
+
+    assert vault.resolve_filename_style(tmp_path) == "title"
+
+
+def test_the_environment_outranks_the_vault_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """So a single run can be pinned without editing the vault."""
+    _write_keys(tmp_path, "filename_style: title\n")
+    monkeypatch.setenv("EXOMEM_FILENAME_STYLE", "slug")
+
+    assert vault.resolve_filename_style(tmp_path) == "slug"
+
+
+def test_an_unrecognised_style_is_refused_not_ignored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A typo that silently means "carry on" is how a user concludes it is broken.
+
+    The error names where the value came from, because the two sources are edited
+    in different places and the wrong guess costs a second round of confusion.
+    """
+    monkeypatch.setenv("EXOMEM_FILENAME_STYLE", "Title Case")
+
+    with pytest.raises(vault.InvalidSlugError) as caught:
+        vault.resolve_filename_style(tmp_path)
+
+    assert "environment" in str(caught.value)
+
+    monkeypatch.delenv("EXOMEM_FILENAME_STYLE", raising=False)
+    _write_keys(tmp_path, "filename_style: kebab\n")
+
+    with pytest.raises(vault.InvalidSlugError) as caught:
+        vault.resolve_filename_style(tmp_path)
+
+    assert "project-keys.yaml" in str(caught.value)
+
+
+def test_an_unreadable_key_file_means_no_preference_not_a_choice(
+    tmp_path: Path,
+) -> None:
+    """Distinct from `load_project_registry`, which falls back to a real registry.
+
+    A vault with no project keys still has to route writes somewhere, so that
+    reader invents a registry. Here inventing anything would be claiming the
+    vault chose a style it never mentioned.
+    """
+    assert project_keys.filename_style(tmp_path) is None
+
+    _write_keys(tmp_path, "projects: [this is not a mapping\n")
+    assert project_keys.filename_style(tmp_path) is None
+
+    _write_keys(tmp_path, "filename_style: 4\n")
+    assert project_keys.filename_style(tmp_path) is None
+
+
+# ------------------------------------------------------------- end to end
+
+
+_ISSUE_TITLES = [
+    "Exomem first-run defect inventory — issues 477 to 485",
+    "Zellij session serialization: what cold recovery can and cannot know",
+    "Hub88 Postgres MCP consolidated banner discriminator",
+]
+
+
+def test_the_default_derivation_is_byte_identical_to_before(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The property that makes this safe to land before anyone picks a default.
+
+    A vault that sets nothing must derive the names it always derived, or the
+    change is a silent rename of every note written after an upgrade.
+    """
+    monkeypatch.delenv("EXOMEM_FILENAME_STYLE", raising=False)
+
+    for title in _ISSUE_TITLES:
+        derived, _warnings = vault.resolve_filename_slug(title, vault_root=tmp_path)
+        assert derived == vault.slugify_title(title)
+
+
+def test_title_style_produces_the_name_the_issue_asked_for(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#598 states the problem as a side-by-side `ls`; this is that comparison."""
+    monkeypatch.setenv("EXOMEM_FILENAME_STYLE", "title")
+    title = "Exomem first-run defect inventory — issues 477 to 485"
+
+    derived, warnings = vault.resolve_filename_slug(title, vault_root=tmp_path)
+
+    assert derived == title
+    assert warnings == []
+    # And the old behaviour is what it replaces, for the same title.
+    monkeypatch.setenv("EXOMEM_FILENAME_STYLE", "slug")
+    slugged, _ = vault.resolve_filename_slug(title, vault_root=tmp_path)
+    assert slugged == "exomem-first-run-defect-inventory-issues-477-to-485"
+
+
+def test_an_explicit_slug_still_wins_under_title_style(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """It is how a caller pins a name it already intends to link to."""
+    monkeypatch.setenv("EXOMEM_FILENAME_STYLE", "title")
+
+    derived, warnings = vault.resolve_filename_slug(
+        "Some Human Title", "quarterly-review", vault_root=tmp_path
+    )
+
+    assert derived == "quarterly-review"
+    assert warnings == []
+    with pytest.raises(vault.InvalidSlugError):
+        vault.resolve_filename_slug("t", "Not Kebab", vault_root=tmp_path)
+
+
+def test_title_style_does_not_warn_about_transliteration_it_did_not_do(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """That warning exists because the slug path is lossy for non-ASCII text.
+
+    Preserving the title is precisely what a vault sets this style to do, so
+    emitting the warning anyway would train the user to ignore it.
+    """
+    monkeypatch.setenv("EXOMEM_FILENAME_STYLE", "title")
+
+    derived, warnings = vault.resolve_filename_slug(
+        "Tallinnasse sõbra juurde", vault_root=tmp_path
+    )
+
+    assert derived == "Tallinnasse sõbra juurde"
+    assert warnings == []
+
+    monkeypatch.setenv("EXOMEM_FILENAME_STYLE", "slug")
+    _slugged, slug_warnings = vault.resolve_filename_slug(
+        "Tallinnasse sõbra juurde", vault_root=tmp_path
+    )
+    assert any("transliteration" in warning for warning in slug_warnings)
+
+
+def test_a_title_of_only_reserved_characters_falls_back_rather_than_failing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One note named the old way beats a refused write."""
+    monkeypatch.setenv("EXOMEM_FILENAME_STYLE", "title")
+
+    derived, _warnings = vault.resolve_filename_slug('<>:"|?*', vault_root=tmp_path)
+
+    assert derived
+    assert derived == vault.slugify_title('<>:"|?*')
+
+
+def test_two_titles_differing_only_by_case_do_not_collide(tmp_path: Path) -> None:
+    """The new failure mode that title style introduces.
+
+    Under slug style everything was lowercased, so these already landed on one
+    name and were disambiguated. Preserving capitals makes them two names that
+    are the same file on Windows and default macOS -- and two different files on
+    Linux, which is the same vault losing a note when it syncs.
+    """
+    (tmp_path / "Budget Review.md").write_text("first", encoding="utf-8")
+
+    resolved = vault.unique_path(tmp_path, "budget review")
+
+    assert resolved.name != "budget review.md"
+    assert resolved.name == "budget review-2.md"
+    assert (tmp_path / "Budget Review.md").read_text(encoding="utf-8") == "first"
+
+
+def test_collision_detection_does_not_depend_on_the_platform() -> None:
+    """`Path.exists()` is case-sensitive on Linux and not elsewhere.
+
+    Using it made the contents of a vault depend on which machine wrote the
+    note, with the damage only visible after a sync. Asserted against the
+    implementation because CI cannot run the same test on a case-sensitive and a
+    case-insensitive filesystem in one job.
+    """
+    import inspect
+
+    source = inspect.getsource(vault.unique_path)
+    assert "casefold()" in source
+    assert "iterdir()" in source
+
+
+def test_changing_the_style_renames_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The promise that makes this landable without a migration.
+
+    Because the filename is the identity here, a rename is a link break. So the
+    style governs derivation only, and a vault reconfigured mid-life keeps every
+    name it already had -- at the cost of being mixed, which is the trade taken
+    deliberately.
+    """
+    notes = vault.kb_root(tmp_path) / "Notes"
+    notes.mkdir(parents=True)
+    existing = notes / "exomem-first-run-defect-inventory-issues-477-to-485.md"
+    existing.write_text("---\ntitle: Exomem first-run defect inventory\n---\nbody\n", encoding="utf-8")
+    before = {path.name: path.read_bytes() for path in notes.iterdir()}
+
+    monkeypatch.setenv("EXOMEM_FILENAME_STYLE", "title")
+    assert vault.resolve_filename_style(tmp_path) == "title"
+    new_name, _ = vault.resolve_filename_slug("A newly written note", vault_root=tmp_path)
+
+    assert {path.name: path.read_bytes() for path in notes.iterdir()} == before
+    assert new_name == "A newly written note"
+
+
+def test_a_title_wikilink_resolves_across_both_styles(tmp_path: Path) -> None:
+    """Why a mixed vault is survivable rather than merely tolerated.
+
+    `WikilinkResolver` already keys by frontmatter title as well as by path and
+    stem -- the docstring's own example is a link resolving to a file whose stem
+    does not match its title. So a link written the way a human writes it does
+    not care which style named the target.
+    """
+    resolver = vault.WikilinkResolver.from_entries(
+        tmp_path,
+        [
+            ("Knowledge Base/Notes/old-style-slugged-name", "Old Style Note"),
+            ("Knowledge Base/Notes/New Style Readable Name", "New Style Note"),
+        ],
+    )
+
+    assert resolver.titles["old style note"] == ["Knowledge Base/Notes/old-style-slugged-name"]
+    assert resolver.titles["new style note"] == ["Knowledge Base/Notes/New Style Readable Name"]
+    # And each is still reachable by its own stem, so path-keyed links survive too.
+    assert "old-style-slugged-name" in resolver.stems
+    assert "New Style Readable Name" in resolver.stems


### PR DESCRIPTION
Closes #598. OpenSpec change: `add-readable-note-filenames`.

## The problem, reproduced

Same four titles, derived both ways, run from this branch:

```
--- EXOMEM_FILENAME_STYLE=slug ---
 96  yadm-dotfiles-repo-clone-it-rather-than-worktree-it-and-diff-test-failures-against-a-baseline.md
 70  zellij-session-serialization-what-cold-recovery-can-and-cannot-know.md
 62  exomem-and-basic-memory-run-side-by-side-at-vendor-ceilings.md
 55  hub88-postgres-mcp-consolidated-banner-discriminator.md

--- EXOMEM_FILENAME_STYLE=title ---
 97  Yadm dotfiles repo clone it rather than worktree it, and diff test failures against a baseline.md
 72  Zellij session serialization — what cold recovery can and cannot know.md
 62  Exomem and Basic Memory run side by side at vendor ceilings.md
 55  Hub88 Postgres MCP consolidated banner discriminator.md
```

The slug column is byte-identical to the one in #598. Both sets are long; only
one is scannable — and the filename is what Obsidian's quick switcher, file
explorer and graph labels display, what hand-typed `[[wikilinks]]` target, and
what `ls` and `grep -l` print.

## Where the issue's suggested fix does not apply

#598 proposes "keep the permalink slugged regardless — frontmatter already
carries `permalink`, so the two concerns are separate today".

**Exomem has no permalink.** `grep -rn permalink src/` returns zero matches; that
is the comparison tool's model. Here the filename *is* the identity, which
`slugify_with_truncation_check` states outright when it truncates:

> link to this note using `{slug}` — re-deriving a slug from the title will not resolve.

So this is not a cosmetic rename behind a stable identifier, and the change is
built around that rather than around the separation the issue assumed.

Two things make it tractable anyway. `WikilinkResolver` already keys by
frontmatter **title** as well as by path and stem (`vault.py:4812`), with the
documented precedent of `[[North-Led Content Manual]]` resolving to a file whose
stem does not match — so a link written the human way does not care which style
named the target. And the style only has to govern *newly derived* names.

## Consequently

- **The default stays `slug`.** Flipping it would change the address of every
  note written after an upgrade, in vaults whose owners never asked. Half a vault
  named each way because of a version bump is worse than a vault consistently
  named the less pretty way.
- **Nothing on disk is ever renamed.** No link that resolves before a style
  change stops resolving after it. The cost is a mixed vault, taken deliberately.
- **Length cap stays at 100.** #598 suggests 60 and says it "costs nothing"; it
  costs the truncation warning above firing on more notes. The cap is now a
  parameter, so 60 is available to anyone who prefers shorter names.

## Sanitise by the union, not by the host

A name containing `:` written on Linux **cannot be checked out on Windows at
all**, and the vault is explicitly a portable artifact synced between machines. A
per-host sanitizer would pass its own CI lane and hand the failure to whoever
opened the vault next. So the removed set is the union — `< > : " / \ | ? *`,
control and zero-width characters, trailing dots and spaces, Windows reserved
device names — applied everywhere, NFC-normalised.

Characters are **removed, not substituted**: `Q3: revenue / margin` becomes
`Q3 revenue margin`, not `Q3- revenue - margin`. A substitution invents a
character the author never wrote, and frontmatter still carries the exact title
either way.

## A latent bug this surfaced

`unique_path` tested collisions with `Path.exists()` — case-insensitive on
Windows and default macOS, **case-sensitive on Linux**. So `Budget Review.md` and
`budget review.md` were two files on Linux and one file, with a note gone, after
a sync to Windows. Under slug style everything was lowercased so the pair could
never arise; preserving capitals makes it reachable, so the check is now
case-insensitive on every platform. That is strictly safer for its two other
callers as well.

## Verification

- `tests/test_readable_filenames.py` — 36 new tests
- with `test_adopt`, `test_vault`, `test_note`, `test_add`, `test_link`,
  `test_project_keys` — **160 passed, 1 skipped**
- `tests/test_scaffold_no_leak.py` — 7 passed (the new key ships documented and
  **unset**)
- `uvx ruff check . --select F` — All checks passed
- `openspec validate add-readable-note-filenames --strict` — valid

Compatibility is asserted, not assumed: a vault that configures nothing derives
names byte-identical to `slugify_title` for the whole issue corpus.

## Consumer grep (working agreement)

`resolve_filename_slug` — `add.py:153`, `note.py:500`, `note.py:1599` (threaded),
and `link.py:127`/`link.py:597` (both guarded by `if slug is not None`, so they
only ever take the explicit-slug branch and are style-independent).
`unique_path` — `add.py:204`, `adopt.py:159`, `note.py:1144`.
`slugify_with_truncation_check` — `adopt.py:427`.

**Deliberately out of scope:** `adopt.py` derives names when importing an
existing vault. That flow renames user files by design and deserves its own
decision about which style to adopt under; it stays on `slug` here rather than
changing silently.

## Not done in this PR

Two tasks in the change remain open and are listed as such in `tasks.md`:
surfacing the resolved style in `exomem doctor`, and extending the `slug`
tool-argument documentation to say what it now overrides.
