### PR TITLE
feat(vault): move the shipped contract out of the note namespace

### DIFF
--- a/docs/workflow-skills.md
+++ b/docs/workflow-skills.md
@@ -39,7 +39,7 @@ src/exomem/_scaffold/_Schema/workflow-skills/
 ```
 
 `exomem init` copies them into new vaults under
-`Knowledge Base/_Schema/workflow-skills/`.
+`.exomem/schema/workflow-skills/`, outside the note namespace.
 
 `exomem install-skill` installs the core `exomem` skill and also installs each
 workflow skill as a sibling Claude Code skill folder, so clients that support

--- a/openspec/changes/move-shipped-schema-out-of-the-note-namespace/proposal.md
+++ b/openspec/changes/move-shipped-schema-out-of-the-note-namespace/proposal.md
@@ -1,0 +1,78 @@
+## Why
+
+`Knowledge Base/_Schema/` holds 17 product-owned markdown files — 265 KB in the
+package, 404 KB as observed on a real vault — inside the user's note directory.
+Exomem excludes them from its own index (`VAULT_SCAN_SKIP_DIRS`, `vault.py:203`).
+Nothing else can.
+
+Every other member of that skip set is a dot-directory: `.obsidian`, `.git`,
+`.graph-coordination`, `.graph-commit-receipts`, `.trash`. `_Schema` is the only
+non-dot member, and the only one sitting where Obsidian's quick switcher, graph
+view, and any second indexer treat it as user notes. #488 measured the
+consequence: a natural-language query against the same vault returned three
+scaffold documents ahead of every real note.
+
+The product has already decided this content is not user notes. It just placed
+it where every other vault consumer decides otherwise.
+
+## What #488 asked for that is already done
+
+The issue's headline pairs two harms: the location, and a second copy that had
+drifted against `install-skill`. **The drift half is fixed.**
+`init.refresh_shipped_schema` re-deploys the product-owned files from the bundled
+package on every setup, byte-comparing first so a current vault is untouched, and
+`_SHIPPED_SCHEMA_GLOBS` names exactly the product-owned set so the per-vault YAML
+registries are never overwritten. There is one source of truth today:
+`src/exomem/_scaffold/_Schema/`.
+
+What that leaves is the location, and it is now a smaller change than the issue
+frames, because the vault copy is already a redeployable cache of the package
+rather than an independent original.
+
+## The constraint the issue did not account for
+
+`vault._is_vault` is, literally:
+
+```python
+def _is_vault(path: Path) -> bool:
+    return (path / kb_dirname() / "_Schema" / "SKILL.md").exists()
+```
+
+`SKILL.md` is the **vault sentinel**. "Stop copying them into the vault", taken at
+face value, un-identifies every existing vault — `resolve_vault`, `product_invoke`,
+`doctor` and the hosted runtime all key off this. Any move has to carry the
+sentinel deliberately rather than discover it in production.
+
+## What Changes
+
+- Deploy the product-owned markdown to **`<vault>/.exomem/schema/`** — a
+  dot-directory, so it inherits the treatment every other non-note directory in
+  the vault already gets, from Obsidian and from any other indexer, without
+  exomem having to ask for it.
+- **Per-vault configuration stays** in `Knowledge Base/_Schema/`:
+  `project-keys.yaml`, `relation-registry.yaml`,
+  `semantic-language-registry.yaml`, `traversal-profiles.yaml`,
+  `source-taxonomy.yaml`, `contracts/`, `relation-reviews/`, `private-skills/`,
+  and the activation manifest. These are the user's, they are small, they are not
+  markdown, and #488 explicitly scopes them out. Only the shipped markdown moves.
+- Readers resolve **new location first, legacy second**, so an existing vault
+  keeps working untouched until something migrates it.
+- `_is_vault` accepts **either** sentinel, so a vault is still a vault before and
+  after.
+- Reclaiming the 404 KB is a **separate, explicit step**, not a side effect of an
+  upgrade: a migration removes the legacy copies only after verifying the new
+  location holds the same bytes, and only for paths matching
+  `_SHIPPED_SCHEMA_GLOBS`. Nothing else in `_Schema/` is ever touched.
+
+## Impact
+
+- Affected specs: `vault-scaffold-layout` (new capability).
+- Affected code: `init.py` (`refresh_shipped_schema`, `init_vault`), `vault.py`
+  (`_is_vault`), `schema.py:62`, `hosted_runtime.py:1352`, `doctor.py:321`/`:419`,
+  and the setup wizard.
+- **Deliberately not a silent migration.** An upgrade that deletes 404 KB from
+  inside a user's Obsidian vault without being asked is the wrong default, even
+  when the bytes are reproducible — the vault is the artifact the product
+  promises the user owns.
+- Rollback is a redeploy: the package is the source, so the legacy location can
+  be repopulated by `refresh_shipped_schema` at any time.

--- a/openspec/changes/move-shipped-schema-out-of-the-note-namespace/specs/vault-scaffold-layout/spec.md
+++ b/openspec/changes/move-shipped-schema-out-of-the-note-namespace/specs/vault-scaffold-layout/spec.md
@@ -1,0 +1,143 @@
+## ADDED Requirements
+
+### Requirement: Product-Owned Markdown Lives Outside The Note Namespace
+
+Exomem SHALL deploy the product-owned governance markdown — the files matched by
+`_SHIPPED_SCHEMA_GLOBS` — to `<vault>/.exomem/schema/` rather than to
+`<vault>/Knowledge Base/_Schema/`. A dot-directory is used so the content
+inherits the same treatment from Obsidian and from any other indexer that every
+other non-note directory in the vault already receives, without exomem needing
+each of those consumers to be configured.
+
+Per-vault configuration and state SHALL remain in `Knowledge Base/_Schema/`. That
+covers `project-keys.yaml`, `relation-registry.yaml`,
+`semantic-language-registry.yaml`, `traversal-profiles.yaml`,
+`source-taxonomy.yaml`, `contracts/`, `relation-reviews/`, `private-skills/`, and
+the activation manifest. These belong to the user, are not markdown, and are not
+what pollutes a note index.
+
+#### Scenario: A new vault has no shipped markdown in its note directory
+
+- **WHEN** a vault is initialised
+- **THEN** `Knowledge Base/_Schema/SKILL.md` is not created
+- **AND** `.exomem/schema/SKILL.md` is created
+- **AND** `Knowledge Base/_Schema/project-keys.yaml` is created as before
+
+#### Scenario: Refreshing deploys to the new location
+
+- **WHEN** the shipped schema is refreshed for a vault
+- **THEN** the product-owned markdown is written under `.exomem/schema/`
+- **AND** no per-vault YAML registry is overwritten
+
+#### Scenario: Only product-owned paths are governed by this layout
+
+- **WHEN** the shipped schema is deployed or migrated
+- **THEN** only paths matching `_SHIPPED_SCHEMA_GLOBS` are written or removed
+- **AND** any other file under `Knowledge Base/_Schema/` is left exactly as it was
+
+### Requirement: A Vault Is Identified By Either Sentinel
+
+`vault._is_vault` currently returns whether `Knowledge Base/_Schema/SKILL.md`
+exists, which makes that file the vault sentinel for `resolve_vault`,
+`product_invoke`, `doctor` and the hosted runtime. Exomem SHALL treat a directory
+as a vault when **either** the legacy sentinel or the new
+`.exomem/schema/SKILL.md` is present, so that vault identity is unchanged both
+for a vault that has migrated and for one that has not.
+
+#### Scenario: A legacy vault is still a vault
+
+- **GIVEN** a vault containing `Knowledge Base/_Schema/SKILL.md` and no `.exomem/`
+- **WHEN** vault identity is tested
+- **THEN** the directory is recognised as a vault
+
+#### Scenario: A migrated vault is still a vault
+
+- **GIVEN** a vault containing `.exomem/schema/SKILL.md` and no
+  `Knowledge Base/_Schema/SKILL.md`
+- **WHEN** vault identity is tested
+- **THEN** the directory is recognised as a vault
+
+#### Scenario: A directory with neither is not a vault
+
+- **GIVEN** a directory containing neither sentinel
+- **WHEN** vault identity is tested
+- **THEN** the directory is not recognised as a vault
+
+### Requirement: Readers Prefer The New Location And Accept The Legacy One
+
+Every consumer of the shipped governance markdown SHALL resolve the new location
+first and fall back to the legacy one, so an existing vault continues to work
+with no migration and a migrated vault never reads a stale copy.
+
+#### Scenario: A migrated vault is read from the new location
+
+- **GIVEN** a vault whose shipped markdown is only under `.exomem/schema/`
+- **WHEN** a consumer reads the governance contract or its references
+- **THEN** the content is served from `.exomem/schema/`
+
+#### Scenario: An unmigrated vault is read from the legacy location
+
+- **GIVEN** a vault whose shipped markdown is only under `Knowledge Base/_Schema/`
+- **WHEN** a consumer reads the governance contract or its references
+- **THEN** the content is served from `Knowledge Base/_Schema/`
+
+#### Scenario: The new location wins when both are present
+
+- **GIVEN** a vault holding the shipped markdown in both locations
+- **WHEN** a consumer reads the governance contract
+- **THEN** the content is served from `.exomem/schema/`
+
+### Requirement: Reclaiming The Legacy Copy Is Explicit And Verified
+
+Removing the legacy copy SHALL be an explicit operation, never a side effect of
+an upgrade, a refresh, or a read. It SHALL remove a legacy file only after
+confirming the new location holds a file with identical bytes, and only for paths
+matching `_SHIPPED_SCHEMA_GLOBS`. It SHALL report what it removed and what it
+declined to remove.
+
+#### Scenario: Migration removes only verified duplicates
+
+- **GIVEN** a vault holding the shipped markdown in both locations with identical bytes
+- **WHEN** the migration runs
+- **THEN** the legacy product-owned markdown files are removed
+- **AND** the new location still holds every one of them
+
+#### Scenario: A modified legacy file is kept, not deleted
+
+- **GIVEN** a legacy shipped file whose bytes differ from the new location
+- **WHEN** the migration runs
+- **THEN** that file is not removed
+- **AND** the result names it as declined
+
+#### Scenario: An upgrade never removes anything on its own
+
+- **WHEN** a vault is refreshed or read without the migration being requested
+- **THEN** no file under `Knowledge Base/_Schema/` is removed
+
+#### Scenario: User content beside the shipped markdown survives
+
+- **GIVEN** a vault with a user-authored file inside `Knowledge Base/_Schema/`
+- **WHEN** the migration runs
+- **THEN** that file is left in place
+
+### Requirement: The Index Exclusion Moves With The Content
+
+`Knowledge Base/_Schema/` was excluded from exomem's own vault-wide walk
+(`VAULT_SCAN_SKIP_DIRS`, reached through `find(scope="vault")`). The new location
+SHALL carry that exclusion, in the full walk and in the incremental per-path
+predicate alike. Without it the move would relocate the pollution rather than
+remove it: the same product-owned markdown would start ranking against real notes
+in exomem's own search instead of in the third-party indexer that motivated the
+change.
+
+#### Scenario: The vault-wide walk does not yield shipped markdown
+
+- **GIVEN** a vault whose shipped markdown is under `.exomem/schema/`
+- **WHEN** the vault-wide markdown walk runs
+- **THEN** no path under `.exomem/` is yielded
+
+#### Scenario: The incremental patcher agrees with the full walk
+
+- **WHEN** a path under `.exomem/schema/` is tested against the scan exclusion
+- **THEN** it is excluded
+- **AND** an ordinary note path is not

--- a/openspec/changes/move-shipped-schema-out-of-the-note-namespace/tasks.md
+++ b/openspec/changes/move-shipped-schema-out-of-the-note-namespace/tasks.md
@@ -1,0 +1,65 @@
+## 1. Location Resolution
+
+- [x] 1.1 Add `vault.shipped_schema_root(vault_root)` returning the directory the
+      shipped markdown should be READ from: `.exomem/schema/` when it holds
+      `SKILL.md`, else the legacy `Knowledge Base/_Schema/`.
+- [x] 1.2 Add `vault.shipped_schema_target(vault_root)` returning where it should
+      be WRITTEN — always the new location, so a refresh migrates the read path
+      forward without deleting anything.
+- [x] 1.3 Unit-test both against the three vault shapes: legacy only, new only,
+      both present (new wins).
+
+## 2. Vault Identity
+
+- [x] 2.1 Widen `_is_vault` to accept either sentinel.
+- [x] 2.2 Test all three shapes plus a directory with neither, because this
+      function decides whether `resolve_vault`, `product_invoke`, `doctor` and the
+      hosted runtime will speak to a directory at all.
+- [x] 2.3 Grep every `_is_vault` caller and confirm none re-derives the sentinel
+      path itself instead of asking.
+
+## 3. Deployment
+
+- [x] 3.1 Point `refresh_shipped_schema` at `shipped_schema_target`, keeping its
+      byte-compare so a current vault is still a no-op and the file watcher sees
+      no churn.
+- [x] 3.2 Point `init_vault` at the same target, and stop creating
+      `Knowledge Base/_Schema/SKILL.md` for a new vault.
+- [x] 3.3 Keep the per-vault YAML registries, `contracts/`, `relation-reviews/`,
+      `private-skills/` and the activation manifest exactly where they are.
+- [x] 3.4 Test that a fresh vault has no product-owned markdown under
+      `Knowledge Base/` and still has its registries there.
+
+## 4. Readers
+
+- [x] 4.1 Route `schema.py` (references), `hosted_runtime.py` (SKILL.md) and
+      `doctor.py` (both checks) through `shipped_schema_root`.
+- [x] 4.2 Grep every remaining `"_Schema"` path construction and classify each as
+      product-owned (route it) or per-vault (leave it); record the classification
+      in the PR.
+- [x] 4.3 Test a migrated vault reads from the new location and an unmigrated one
+      from the legacy location, through the real consumers rather than only the
+      resolver.
+- [x] 4.4 Carry the index exclusion across: add the new directory to
+      `VAULT_SCAN_SKIP_DIRS` so `find(scope="vault")` and the incremental
+      patcher both skip it, and test both walks.
+
+## 5. Explicit Migration
+
+- [x] 5.1 Add a migration that removes legacy product-owned markdown only when
+      the new location holds identical bytes, restricted to
+      `_SHIPPED_SCHEMA_GLOBS`, returning what it removed and what it declined.
+- [x] 5.2 Test the declined path: a legacy file whose bytes differ is kept and
+      named.
+- [x] 5.3 Test that a user-authored file inside `Knowledge Base/_Schema/` is never
+      touched.
+- [x] 5.4 Test that refresh and read paths remove nothing, so an upgrade cannot
+      delete from a user's vault as a side effect.
+- [x] 5.5 Expose it as an explicit command and report the bytes reclaimed.
+
+## 6. Evidence
+
+- [x] 6.1 Build a vault before and after, and record the `Knowledge Base/`
+      markdown count and byte total in the PR — the measurement #488 opens with.
+- [x] 6.2 Confirm the scaffold leak guard still passes.
+- [x] 6.3 Validate the OpenSpec change artifacts.

--- a/scripts/product_flow_benchmark.py
+++ b/scripts/product_flow_benchmark.py
@@ -399,10 +399,12 @@ def flow_fresh_setup(ctx: HarnessContext, runner: FlowRunner, bm: dict) -> FlowR
         home=home,
     )
     kb = vault / "Knowledge Base"
+    contract = vault / ".exomem" / "schema" / "SKILL.md"
     skill = home / ".claude" / "skills" / "exomem" / "SKILL.md"
     checks = [
         Check("setup exits successfully", run.ok, f"exit={run.returncode}"),
-        Check("Knowledge Base scaffold exists", (kb / "_Schema" / "SKILL.md").is_file(), str(kb)),
+        Check("vault scaffold exists", contract.is_file(), str(contract)),
+        Check("note scaffold exists", (kb / "index.md").is_file(), str(kb)),
         Check("skill install isolated to temp HOME", skill.is_file(), str(skill)),
     ]
     evidence = [

--- a/scripts/time-to-value.py
+++ b/scripts/time-to-value.py
@@ -140,8 +140,12 @@ def main() -> int:
                 raise RuntimeError(
                     f"setup exited {proc.returncode}:\n{proc.stdout}\n{proc.stderr}"
                 )
-            if not (vault / "Knowledge Base" / "_Schema" / "SKILL.md").is_file():
-                raise RuntimeError("setup did not initialize the Knowledge Base scaffold")
+            # The shipped contract lives outside the note namespace, and this gate
+            # deliberately checks the vault from the outside rather than importing
+            # exomem to resolve the path -- the whole point is that the wheel alone
+            # produced it.
+            if not (vault / ".exomem" / "schema" / "SKILL.md").is_file():
+                raise RuntimeError("setup did not initialize the vault scaffold")
 
         step("exomem setup --yes (wheel)", _setup)
 

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -85,6 +85,7 @@ _CLI_ONLY_SUBCOMMANDS: frozenset[str] = frozenset(
     {
         "setup",
         "init",
+        "reclaim-schema",
         "install-skill",
         "package-skills",
         "personalize",
@@ -179,6 +180,8 @@ def _dispatch_main(raw: list[str]) -> int:
         return setup_main(raw[1:])
     if raw and raw[0] == "init":
         return _init_main(raw[1:])
+    if raw and raw[0] == "reclaim-schema":
+        return _reclaim_schema_main(raw[1:])
     if raw and raw[0] == "install-skill":
         return _install_skill_main(raw[1:])
     if raw and raw[0] == "package-skills":
@@ -1411,6 +1414,55 @@ def _lease_main(argv: list[str]) -> int:
     if args.command == "status":
         return _lease_status_main(config, as_json=args.json)
     return _lease_release_main(config, confirmed=args.yes, as_json=args.json)
+
+
+def _reclaim_schema_main(argv: list[str]) -> int:
+    """Remove the pre-#488 copy of the shipped contract from the note namespace.
+
+    A separate command, and a preview by default, because the alternative is an
+    upgrade that silently deletes a few hundred kilobytes from inside a user's
+    Obsidian vault. The bytes are reproducible from the package, but the vault is
+    the artifact the product promises the user owns, so a deletion inside it is
+    something they ask for rather than something they discover.
+    """
+    parser = argparse.ArgumentParser(
+        prog="exomem reclaim-schema",
+        description=(
+            f"Remove the superseded copy of the shipped schema from "
+            f"{kb_prefix()}_Schema/ once it has been redeployed to .exomem/schema/."
+        ),
+    )
+    parser.add_argument(
+        "--vault",
+        help="Vault root (default: $EXOMEM_VAULT_PATH, else current dir).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually delete. Without this the command reports what it would do.",
+    )
+    args = parser.parse_args(argv)
+
+    from . import init as init_module
+
+    vault = Path(args.vault or os.environ.get("EXOMEM_VAULT_PATH") or ".")
+    report = init_module.reclaim_legacy_shipped_schema(vault, apply=args.apply)
+
+    if not report["removed"] and not report["declined"]:
+        print(f"Nothing to reclaim: {vault} has no superseded schema copy.")
+        return 0
+
+    verb = "Removed" if report["applied"] else "Would remove"
+    print(f"{verb} {len(report['removed'])} file(s), {report['reclaimed_kb']} KB:")
+    for relative in report["removed"]:
+        print(f"  {kb_prefix()}_Schema/{relative}")
+    if report["declined"]:
+        print(f"Kept {len(report['declined'])} file(s):")
+        for entry in report["declined"]:
+            print(f"  {kb_prefix()}_Schema/{entry['path']} — {entry['reason']}")
+    if not report["applied"]:
+        print("Re-run with --apply to delete.")
+    return 0
 
 
 def _init_main(argv: list[str]) -> int:

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -318,12 +318,15 @@ def _resolve_vault(vault: str | None) -> tuple[Path | None, DoctorCheck]:
         )
 
     path = Path(raw).expanduser()
-    skill = path / kb_dirname() / "_Schema" / "SKILL.md"
+    from .vault import shipped_schema_root
+
+    skill = shipped_schema_root(path) / "SKILL.md"
     if not skill.exists():
         return path, _check(
             "vault.path",
             "fail",
-            f"{path} does not contain {kb_prefix()}_Schema/SKILL.md.",
+            f"{path} contains no exomem schema contract "
+            f"(looked in .exomem/schema/ and {kb_prefix()}_Schema/).",
             f"Pass the vault root, not the {kb_dirname()} folder. For a new vault, run "
             "`uv run python -m exomem init --vault <path>`.",
         )
@@ -413,10 +416,12 @@ def _check_repo_env() -> DoctorCheck:
 def _check_schema_files(vault_root: Path | None) -> list[DoctorCheck]:
     if vault_root is None:
         return []
+    from .vault import shipped_schema_root
+
     kb = vault_root / kb_dirname()
     checks: list[DoctorCheck] = []
     required = [
-        ("vault.schema", kb / "_Schema" / "SKILL.md", f"{kb_dirname()} schema contract"),
+        ("vault.schema", shipped_schema_root(vault_root) / "SKILL.md", "schema contract"),
         ("vault.index", kb / "index.md", f"{kb_prefix()}index.md"),
         ("vault.log", kb / "log.md", f"{kb_prefix()}log.md"),
         (

--- a/src/exomem/hosted_portability.py
+++ b/src/exomem/hosted_portability.py
@@ -201,6 +201,22 @@ def _is_hosted_runtime_state(_path: str, parts: tuple[str, ...]) -> bool:
     )
 
 
+def _is_shipped_schema(_path: str, parts: tuple[str, ...]) -> bool:
+    """The governance contract, which moved to `.exomem/schema/` (#488).
+
+    Registered explicitly because the rule below fails ALL hidden state closed,
+    and this content used to live under `Knowledge Base/` where it was canonical
+    by default. Without this the move would silently change portability
+    semantics: the archive would drop the schema, and `_valid_vault_scaffold`
+    requires `SKILL.md`, so the restored vault would be refused.
+
+    Canonical rather than rebuildable even though the package can redeploy it,
+    because that is what it was before the move. Changing where a file lives
+    should not also change whether it survives an export.
+    """
+    return len(parts) >= 2 and parts[0].casefold() == ".exomem" and parts[1].casefold() == "schema"
+
+
 def _is_unregistered_hidden_state(_path: str, parts: tuple[str, ...]) -> bool:
     # New machine-local sidecars are conventionally hidden.  Defaulting them to
     # disposable prevents a new cache/database from silently entering exports;
@@ -260,6 +276,12 @@ _CLASSIFICATION_RULES = (
         ArtifactClass.DISPOSABLE_RUNTIME,
         "Cell binding, writer leases, and request idempotency are runtime control state.",
         _is_hosted_runtime_state,
+    ),
+    _ClassificationRule(
+        "portable-shipped-schema",
+        ArtifactClass.CANONICAL,
+        "The governance contract is vault content wherever it is stored.",
+        _is_shipped_schema,
     ),
     _ClassificationRule(
         "unregistered-hidden-state",
@@ -1187,8 +1209,11 @@ def verify_export_archive(
 
 def _verify_required_scaffold(records: Iterable[Mapping[str, Any]]) -> None:
     paths = {str(record["path"]) for record in records}
+    # The schema is accepted at either location: `Knowledge Base/_Schema/` for an
+    # archive taken before #488, `.exomem/schema/` for one taken after.
     if not any(path.startswith("Knowledge Base/") for path in paths) or not any(
-        path.startswith("Knowledge Base/_Schema/") for path in paths
+        path.startswith("Knowledge Base/_Schema/") or path.startswith(".exomem/schema/")
+        for path in paths
     ):
         _fail("INVALID_VAULT_STRUCTURE", "archive does not contain the required vault scaffold")
 

--- a/src/exomem/hosted_runtime.py
+++ b/src/exomem/hosted_runtime.py
@@ -1345,11 +1345,17 @@ def _validate_binding_marker(root: Path, kind: str, config: HostedCellConfig) ->
 
 
 def _valid_vault_scaffold(vault_root: Path) -> bool:
+    from .vault import shipped_schema_root
+
     kb = vault_root / kb_dirname()
     required = (
         kb / "index.md",
         kb / "log.md",
-        kb / "_Schema" / "SKILL.md",
+        # Resolved rather than constructed: the shipped contract moved out of the
+        # note namespace (#488) and this check gates whether the hosted runtime
+        # will serve a vault at all, so hard-coding the legacy path would refuse
+        # every migrated vault.
+        shipped_schema_root(vault_root) / "SKILL.md",
         kb / "Sources" / "index.md",
         kb / "Notes" / "index.md",
         kb / "Entities" / "index.md",

--- a/src/exomem/init.py
+++ b/src/exomem/init.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from . import indexes
 from .entity_types import ENTITY_TYPE_REGISTRY
 from .kbdir import kb_dirname
-from .vault import render_wikilinks_for_vault
+from .vault import render_wikilinks_for_vault, shipped_schema_target
 
 _SCAFFOLD = Path(__file__).parent / "_scaffold"
 
@@ -48,6 +48,12 @@ _SHIPPED_SCHEMA_GLOBS = (
     "_Schema/SKILL.md",
     "_Schema/references/*.md",
     "_Schema/workflow-skills/*/SKILL.md",
+    # The registry of those skills. Product-owned for the same reason they are,
+    # and it has to travel with them: a reader resolving a skill path relative to
+    # this file would otherwise look in the directory the skills just left. It
+    # was also absent from this list before, which meant `refresh_shipped_schema`
+    # never updated it and a vault's index could drift from the skills it names.
+    "_Schema/workflow-skills/index.yaml",
 )
 
 
@@ -76,7 +82,12 @@ def refresh_shipped_schema(vault_root: Path) -> list[str]:
         return []
     refreshed: list[str] = []
     for src in shipped_schema_sources():
-        dest = kb / src.relative_to(_SCAFFOLD)
+        # `_Schema/SKILL.md` -> `<vault>/.exomem/schema/SKILL.md`. The scaffold
+        # keeps its `_Schema/` prefix because that is the shape the claude.ai
+        # `.skill` zip and `install-skill` both deploy; only the vault's copy
+        # moves out of the note namespace (#488).
+        relative = src.relative_to(_SCAFFOLD).as_posix().split("/", 1)[1]
+        dest = shipped_schema_target(vault_root) / relative
         try:
             if dest.is_file() and dest.read_bytes() == src.read_bytes():
                 continue
@@ -105,10 +116,23 @@ def init_vault(vault_root: Path, *, force: bool = False) -> dict:
         )
 
     created: list[str] = []
+    # The product-owned markdown lands outside the note namespace; everything
+    # else -- index.md, log.md, the typed tree, and the per-vault YAML registries
+    # that also live under `_Schema/` -- is the user's and stays in the Knowledge
+    # Base where they can see and edit it (#488).
+    product_owned = {source.relative_to(_SCAFFOLD) for source in shipped_schema_sources()}
     for src in sorted(_SCAFFOLD.rglob("*")):
         scaffold_rel = src.relative_to(_SCAFFOLD)
-        dest = kb / scaffold_rel
+        if scaffold_rel in product_owned:
+            dest = shipped_schema_target(vault_root) / scaffold_rel.as_posix().split("/", 1)[1]
+        else:
+            dest = kb / scaffold_rel
         if src.is_dir():
+            # A directory that exists only to hold product-owned markdown is not
+            # created in the Knowledge Base at all; its files carry their own
+            # `mkdir(parents=True)` at the new location.
+            if any(str(candidate).startswith(str(scaffold_rel)) for candidate in product_owned):
+                continue
             dest.mkdir(parents=True, exist_ok=True)
             continue
         dest.parent.mkdir(parents=True, exist_ok=True)
@@ -142,3 +166,70 @@ def init_vault(vault_root: Path, *, force: bool = False) -> dict:
         created.append(activation_path.relative_to(vault_root).as_posix())
 
     return {"vault": str(vault_root), "kb": str(kb), "created": created}
+
+
+def reclaim_legacy_shipped_schema(vault_root: Path, *, apply: bool = False) -> dict:
+    """Remove the pre-#488 copy of the shipped markdown from the note namespace.
+
+    Explicit by design, and `apply=False` by default. An upgrade that silently
+    deletes 265 KB from inside a user's Obsidian vault is the wrong behaviour
+    even when every byte is reproducible from the package -- the vault is the
+    artifact the product promises the user owns, and a deletion inside it should
+    be something they asked for.
+
+    Removes a legacy file ONLY when the new location holds one with identical
+    bytes, and only for paths matching `_SHIPPED_SCHEMA_GLOBS`. A legacy file the
+    user has edited is reported as declined rather than deleted, because the edit
+    is the only copy of whatever they changed. Everything else under `_Schema/` --
+    the YAML registries, `contracts/`, `relation-reviews/`, `private-skills/`, the
+    activation manifest, and anything they put there themselves -- is out of
+    scope and never inspected.
+    """
+    vault_root = Path(vault_root)
+    legacy_root = vault_root / kb_dirname() / "_Schema"
+    target_root = shipped_schema_target(vault_root)
+    removed: list[str] = []
+    declined: list[dict[str, str]] = []
+    reclaimed_bytes = 0
+
+    for source in shipped_schema_sources():
+        relative = source.relative_to(_SCAFFOLD).as_posix().split("/", 1)[1]
+        legacy = legacy_root / relative
+        current = target_root / relative
+        if not legacy.is_file():
+            continue
+        if not current.is_file():
+            declined.append({"path": relative, "reason": "not yet deployed to .exomem/schema"})
+            continue
+        try:
+            if legacy.read_bytes() != current.read_bytes():
+                declined.append({"path": relative, "reason": "differs from the deployed copy"})
+                continue
+            size = legacy.stat().st_size
+            if apply:
+                legacy.unlink()
+            removed.append(relative)
+            reclaimed_bytes += size
+        except OSError as error:
+            declined.append({"path": relative, "reason": f"unreadable ({error})"})
+
+    if apply:
+        # Only directories the removals emptied, and only if they are empty --
+        # never a directory still holding anything, which by definition is not
+        # product-owned.
+        for candidate in sorted(
+            (path for path in legacy_root.rglob("*") if path.is_dir()),
+            key=lambda path: len(path.parts),
+            reverse=True,
+        ):
+            try:
+                candidate.rmdir()
+            except OSError:
+                pass
+
+    return {
+        "applied": apply,
+        "removed": removed,
+        "declined": declined,
+        "reclaimed_kb": round(reclaimed_bytes / 1024, 1),
+    }

--- a/src/exomem/product_invoke.py
+++ b/src/exomem/product_invoke.py
@@ -84,7 +84,7 @@ def resolve_vault_for(op: str, kwargs: dict, vault_root: Path | str | None) -> P
             return root
         raise RuntimeError(
             f"{str(root)!r} does not look like a vault "
-            f"(no {kb_prefix()}_Schema/SKILL.md found)"
+            f"(no schema contract in .exomem/schema/ or {kb_prefix()}_Schema/)"
         )
     try:
         return vault_module.resolve_vault()

--- a/src/exomem/schema.py
+++ b/src/exomem/schema.py
@@ -25,7 +25,6 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from .kbdir import kb_dirname
 
 # Required fields appear in the source frontmatter section as "| <field> | yes |".
 REQUIRED_FIELD_ROW_PATTERN = re.compile(
@@ -59,7 +58,9 @@ def load_source_schema(vault_path: Path) -> SourceSchema:
 
     Raises SchemaParseError if anything looks wrong.
     """
-    schema_dir = vault_path / kb_dirname() / "_Schema" / "references"
+    from .vault import shipped_schema_root
+
+    schema_dir = shipped_schema_root(vault_path) / "references"
     frontmatter_doc = schema_dir / "frontmatter.md"
     page_types_doc = schema_dir / "page-types.md"
 

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -180,6 +180,24 @@ def governed_frontmatter_reason(field: str, value: Any, page_type: Any) -> str |
     return None
 
 
+#: Where the PRODUCT-owned governance markdown lives in a vault.
+#:
+#: A dot-directory, so it inherits the treatment every other non-note directory
+#: in the vault already gets -- from Obsidian, and from any other indexer the
+#: user runs -- instead of exomem having to ask each of them separately.
+#: `VAULT_SCAN_SKIP_DIRS` already excludes `_Schema` from exomem's own index, but
+#: nothing else honours that, so 265 KB of shipped documentation sat in the note
+#: namespace and ranked above real notes in a second tool's search (#488).
+#:
+#: Per-vault configuration -- the YAML registries, `contracts/`,
+#: `relation-reviews/`, `private-skills/`, the activation manifest -- deliberately
+#: stays under `Knowledge Base/_Schema/`. It belongs to the user, it is small, and
+#: it is not markdown, so it is not what pollutes a note index.
+SHIPPED_SCHEMA_DIRNAME = ".exomem"
+_SHIPPED_SCHEMA_SUBDIR = "schema"
+_SCHEMA_SENTINEL = "SKILL.md"
+
+
 # When scanning the full vault for inbound wikilinks, skip these.
 #
 # `_Governance` and `_Adoption` are operational state, not knowledge: they name
@@ -201,6 +219,12 @@ VAULT_SCAN_SKIP_DIRS = frozenset(
         "_archive",
         "_trash",
         "_Schema",
+        # The shipped contract's new home (#488). It has to be skipped here for
+        # the same reason `_Schema` is: `find(scope="vault")` reaches through
+        # this walk, and moving 265 KB of product-owned markdown out of the note
+        # namespace would only relocate the pollution if exomem's own vault-wide
+        # search started indexing it at the new path.
+        SHIPPED_SCHEMA_DIRNAME,
         "_Governance",
         "_Adoption",
     }
@@ -337,13 +361,53 @@ def resolve_vault(env_var: str = "EXOMEM_VAULT_PATH") -> Path:
     if not _is_vault(path):
         raise RuntimeError(
             f"{env_var}={override!r} does not look like a vault "
-            f"(no {kb_prefix()}_Schema/SKILL.md found)"
+            f"(no schema contract in .exomem/schema/ or {kb_prefix()}_Schema/)"
         )
     return path
 
 
+def shipped_schema_target(vault_root: Path) -> Path:
+    """Where shipped governance markdown is WRITTEN. Always the new location.
+
+    Separate from `shipped_schema_root` so a refresh moves the read path forward
+    without deleting anything: after it runs, both locations hold the content and
+    the resolver prefers the new one. Reclaiming the old copy is its own explicit
+    step, because an upgrade that silently deletes 404 KB from inside a user's
+    Obsidian vault is the wrong default even when the bytes are reproducible.
+    """
+    return Path(vault_root) / SHIPPED_SCHEMA_DIRNAME / _SHIPPED_SCHEMA_SUBDIR
+
+
+def legacy_shipped_schema_root(vault_root: Path) -> Path:
+    """The pre-#488 location, still read and still valid."""
+    return Path(vault_root) / kb_dirname() / "_Schema"
+
+
+def shipped_schema_root(vault_root: Path) -> Path:
+    """Where shipped governance markdown is READ from.
+
+    New location when it holds the sentinel, else the legacy one. Preferring the
+    new location matters when both exist: a refresh writes the new one, so
+    reading the old one would serve the bytes the refresh just superseded.
+    """
+    target = shipped_schema_target(vault_root)
+    if (target / _SCHEMA_SENTINEL).exists():
+        return target
+    return legacy_shipped_schema_root(vault_root)
+
+
 def _is_vault(path: Path) -> bool:
-    return (path / kb_dirname() / "_Schema" / "SKILL.md").exists()
+    """Whether this directory is an exomem vault.
+
+    Either sentinel counts. This function decides whether `resolve_vault`,
+    `product_invoke`, `doctor` and the hosted runtime will speak to a directory
+    at all, so a vault has to stay a vault across the move in both directions --
+    one that has migrated, and one that never will.
+    """
+    return (
+        (path / kb_dirname() / "_Schema" / _SCHEMA_SENTINEL).exists()
+        or (shipped_schema_target(path) / _SCHEMA_SENTINEL).exists()
+    )
 
 
 def kb_root(vault: Path) -> Path:

--- a/src/exomem/workflow_skills.py
+++ b/src/exomem/workflow_skills.py
@@ -13,7 +13,7 @@ from typing import Any
 import yaml
 
 from . import semantic_authoring
-from .kbdir import kb_dirname
+from .vault import SHIPPED_SCHEMA_DIRNAME
 
 WORKFLOW_SKILLS_DIR = Path(__file__).parent / "_scaffold" / "_Schema" / "workflow-skills"
 WORKFLOW_SKILLS_INDEX = WORKFLOW_SKILLS_DIR / "index.yaml"
@@ -80,7 +80,11 @@ def bootstrap_entries() -> list[dict[str, Any]]:
                 "name": name,
                 "purpose": str(skill.get("purpose", "")),
                 "triggers": [str(t) for t in skill.get("triggers", [])],
-                "path": f"{kb_dirname()}/_Schema/workflow-skills/{name}/SKILL.md",
+                # Vault-relative, and it moved out of the note namespace with
+                # the rest of the shipped markdown (#488). A stale path here is
+                # not a cosmetic defect: it is the address the agent is told to
+                # read the skill from.
+                "path": f"{SHIPPED_SCHEMA_DIRNAME}/schema/workflow-skills/{name}/SKILL.md",
             }
         )
     return entries

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -66,7 +66,9 @@ def test_bootstrap_compact_contract_is_public_safe(vault: Path) -> None:
         "exomem-review",
         "exomem-media",
     ]
-    assert out["workflow_skills"][0]["path"].startswith("Knowledge Base/_Schema/")
+    # The shipped skills moved out of the note namespace (#488). Still pinned,
+    # because this path is the address the agent is told to read a skill from.
+    assert out["workflow_skills"][0]["path"].startswith(".exomem/schema/workflow-skills/")
     assert out["knowledge_packs"]["selected"]["selected_pack_ids"] == ["personal-records"]
     assert out["knowledge_packs"]["available"][0]["beginner_description"]
     assert [item["id"] for item in out["entity_registry"]["types"]] == list(

--- a/tests/test_hosted_cell.py
+++ b/tests/test_hosted_cell.py
@@ -835,7 +835,7 @@ def test_provisioning_is_idempotent_machine_readable_and_non_destructive(
 
     assert first.status == "provisioned"
     assert second.status == "existing"
-    assert (config.vault_root / "Knowledge Base" / "_Schema" / "SKILL.md").is_file()
+    assert (config.vault_root / ".exomem" / "schema" / "SKILL.md").is_file()
     assert (config.vault_root / "Knowledge Base" / "Sources" / "index.md").is_file()
     assert (config.vault_root / "Knowledge Base" / "Notes" / "index.md").is_file()
     assert (config.vault_root / "Knowledge Base" / "Entities" / "index.md").is_file()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -23,16 +23,18 @@ def test_init_scaffolds_a_fresh_vault(tmp_path: Path) -> None:
     # The three load-bearing files exist.
     assert (kb / "index.md").exists()
     assert (kb / "log.md").exists()
-    assert (kb / "_Schema" / "SKILL.md").exists()
-    assert (kb / "_Schema" / "workflow-skills" / "index.yaml").exists()
+    # The shipped contract and the skill registry moved out of the note
+    # namespace (#488); asserted at the new location, not merely dropped.
+    shipped = vault_module.shipped_schema_target(tmp_path)
+    assert (shipped / "SKILL.md").exists()
+    assert (shipped / "workflow-skills" / "index.yaml").exists()
+    assert not (kb / "_Schema" / "SKILL.md").exists()
     semantic_registry = kb / "_Schema" / "semantic-language-registry.yaml"
     assert semantic_registry.exists()
     assert semantic_registry.read_text(encoding="utf-8") == (
         "schema_version: 1\ncategories: {}\nkinds: {}\n"
     )
-    assert (
-        kb / "_Schema" / "workflow-skills" / "exomem-capture" / "SKILL.md"
-    ).exists()
+    assert (shipped / "workflow-skills" / "exomem-capture" / "SKILL.md").exists()
 
     # log.md carries the `---` separator the writers prepend after.
     assert "---" in (kb / "log.md").read_text(encoding="utf-8")
@@ -123,7 +125,7 @@ def test_init_via_cli(tmp_path: Path) -> None:
     from exomem.__main__ import main
 
     assert main(["init", "--vault", str(tmp_path)]) == 0
-    assert (tmp_path / "Knowledge Base" / "_Schema" / "SKILL.md").exists()
+    assert (vault_module.shipped_schema_target(tmp_path) / "SKILL.md").exists()
     # idempotency guard: second run refuses without --force.
     assert main(["init", "--vault", str(tmp_path)]) == 1
 
@@ -165,7 +167,9 @@ def test_init_vault_accepts_writes_and_stays_clean(
 
 
 def _shipped(kb: Path) -> Path:
-    return kb / "_Schema" / "SKILL.md"
+    # `kb` is the Knowledge Base; the shipped contract now sits beside the vault
+    # root rather than inside it (#488).
+    return vault_module.shipped_schema_target(kb.parent) / "SKILL.md"
 
 
 def test_refresh_rewrites_a_stale_shipped_doc(tmp_path: Path) -> None:
@@ -182,7 +186,7 @@ def test_refresh_rewrites_a_stale_shipped_doc(tmp_path: Path) -> None:
 
     refreshed = init_module.refresh_shipped_schema(vault)
 
-    assert "Knowledge Base/_Schema/SKILL.md" in refreshed
+    assert ".exomem/schema/SKILL.md" in refreshed
     packaged = (Path(init_module.__file__).parent / "_scaffold" / "_Schema" / "SKILL.md")
     assert _shipped(kb).read_bytes() == packaged.read_bytes()
 

--- a/tests/test_kb_dirname.py
+++ b/tests/test_kb_dirname.py
@@ -38,7 +38,10 @@ def test_init_creates_custom_dir(monkeypatch, tmp_path: Path) -> None:
     from exomem import init as init_module
 
     init_module.init_vault(tmp_path)
-    assert (tmp_path / "Brain" / "_Schema" / "SKILL.md").exists()
+    # The shipped contract sits outside the note namespace, so its path does not
+    # follow the note directory that `EXOMEM_KB_DIRNAME` renames.
+    assert (tmp_path / ".exomem" / "schema" / "SKILL.md").exists()
+    assert (tmp_path / "Brain" / "_Schema" / "project-keys.yaml").exists()
     assert not (tmp_path / "Knowledge Base").exists()
 
 

--- a/tests/test_shipped_schema_location.py
+++ b/tests/test_shipped_schema_location.py
@@ -1,0 +1,413 @@
+"""Shipped governance markdown leaves the user's note namespace (#488).
+
+`Knowledge Base/_Schema/` held 17 product-owned markdown files -- 265 KB in the
+package, 404 KB as observed on a real vault -- inside the directory Obsidian and
+every other indexer treat as notes. Exomem skipped them in its own index
+(`VAULT_SCAN_SKIP_DIRS`); nothing else could, and a second tool ranked three
+scaffold documents above every real note for a natural-language query.
+
+Every other member of that skip set is a dot-directory. `_Schema` was the only
+non-dot member, and the only one in the note namespace.
+
+The constraint the move had to carry: `_is_vault` was literally
+`_Schema/SKILL.md exists`, so that file is the vault sentinel for
+`resolve_vault`, `product_invoke`, `doctor` and the hosted runtime.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from exomem import init as init_module
+from exomem import vault as vault_module
+
+
+def _legacy_vault(root: Path) -> Path:
+    """A vault as it existed before this change: shipped markdown in the KB."""
+    schema = root / "Knowledge Base" / "_Schema"
+    (schema / "references").mkdir(parents=True)
+    (schema / "SKILL.md").write_text("legacy contract", encoding="utf-8")
+    (schema / "references" / "frontmatter.md").write_text("legacy fm", encoding="utf-8")
+    (schema / "project-keys.yaml").write_text("projects: {}\n", encoding="utf-8")
+    return root
+
+
+def _migrated_vault(root: Path) -> Path:
+    target = vault_module.shipped_schema_target(root)
+    (target / "references").mkdir(parents=True)
+    (target / "SKILL.md").write_text("current contract", encoding="utf-8")
+    (root / "Knowledge Base" / "_Schema").mkdir(parents=True, exist_ok=True)
+    return root
+
+
+# --------------------------------------------------------------- resolution
+
+
+def test_the_new_location_is_a_dot_directory(tmp_path: Path) -> None:
+    """That is the whole mechanism.
+
+    Obsidian, git and every other vault consumer already skip dot-directories, so
+    the content inherits the treatment rather than exomem having to persuade each
+    consumer separately -- which it cannot do for tools it does not ship.
+    """
+    target = vault_module.shipped_schema_target(tmp_path)
+
+    assert target.relative_to(tmp_path).as_posix() == ".exomem/schema"
+    assert target.relative_to(tmp_path).parts[0].startswith(".")
+
+
+def test_an_unmigrated_vault_still_reads_from_the_legacy_location(tmp_path: Path) -> None:
+    _legacy_vault(tmp_path)
+
+    assert vault_module.shipped_schema_root(tmp_path) == (
+        tmp_path / "Knowledge Base" / "_Schema"
+    )
+
+
+def test_a_migrated_vault_reads_from_the_new_location(tmp_path: Path) -> None:
+    _migrated_vault(tmp_path)
+
+    assert vault_module.shipped_schema_root(tmp_path) == vault_module.shipped_schema_target(
+        tmp_path
+    )
+
+
+def test_the_new_location_wins_when_both_are_present(tmp_path: Path) -> None:
+    """The state a refresh leaves behind, before anything is reclaimed.
+
+    Reading the legacy copy here would serve exactly the bytes the refresh just
+    superseded, which is the drift this change exists to end rather than move.
+    """
+    _legacy_vault(tmp_path)
+    _migrated_vault(tmp_path)
+
+    root = vault_module.shipped_schema_root(tmp_path)
+
+    assert root == vault_module.shipped_schema_target(tmp_path)
+    assert (root / "SKILL.md").read_text(encoding="utf-8") == "current contract"
+
+
+# ----------------------------------------------------------- vault identity
+
+
+def test_a_legacy_vault_is_still_a_vault(tmp_path: Path) -> None:
+    """The failure mode of getting this wrong is total.
+
+    `_is_vault` decides whether `resolve_vault`, `product_invoke`, `doctor` and
+    the hosted runtime will speak to a directory at all, so a vault that has not
+    migrated must not stop being one.
+    """
+    _legacy_vault(tmp_path)
+
+    assert vault_module._is_vault(tmp_path) is True
+
+
+def test_a_migrated_vault_is_still_a_vault(tmp_path: Path) -> None:
+    _migrated_vault(tmp_path)
+
+    assert vault_module._is_vault(tmp_path) is True
+
+
+def test_a_directory_with_neither_sentinel_is_not_a_vault(tmp_path: Path) -> None:
+    (tmp_path / "Knowledge Base").mkdir()
+
+    assert vault_module._is_vault(tmp_path) is False
+
+
+# ---------------------------------------------------------------- deployment
+
+
+def test_a_fresh_vault_has_no_shipped_markdown_in_its_notes(tmp_path: Path) -> None:
+    """The measurement #488 opens with, asserted rather than described."""
+    init_module.init_vault(tmp_path)
+    schema = tmp_path / "Knowledge Base" / "_Schema"
+
+    stray = sorted(path.name for path in schema.rglob("*.md"))
+
+    assert stray == []
+    deployed = sorted(vault_module.shipped_schema_target(tmp_path).rglob("*.md"))
+    assert len(deployed) == 17
+
+
+def test_a_fresh_vault_keeps_its_registries_where_the_user_can_see_them(
+    tmp_path: Path,
+) -> None:
+    """Only the shipped markdown moves.
+
+    The YAML registries are per-vault configuration the user is expected to edit,
+    they are small, and they are not markdown -- so they are not what pollutes a
+    note index, and hiding them in a dot-directory would cost discoverability for
+    no benefit.
+    """
+    init_module.init_vault(tmp_path)
+    schema = tmp_path / "Knowledge Base" / "_Schema"
+
+    present = sorted(path.name for path in schema.iterdir())
+
+    assert "project-keys.yaml" in present
+    assert "relation-registry.yaml" in present
+    assert "traversal-profiles.yaml" in present
+
+
+def test_refresh_deploys_to_the_new_location_and_removes_nothing(
+    tmp_path: Path,
+) -> None:
+    """An upgrade may add, never delete. Reclaiming is its own explicit step."""
+    init_module.init_vault(tmp_path)
+    legacy = tmp_path / "Knowledge Base" / "_Schema"
+    legacy.mkdir(parents=True, exist_ok=True)
+    stale = legacy / "SKILL.md"
+    stale.write_text("an older copy this vault still has", encoding="utf-8")
+
+    init_module.refresh_shipped_schema(tmp_path)
+
+    assert stale.is_file(), "a refresh deleted from the user's note namespace"
+    assert (vault_module.shipped_schema_target(tmp_path) / "SKILL.md").is_file()
+
+
+def test_the_skill_index_travels_with_the_skills_it_indexes(tmp_path: Path) -> None:
+    """A registry left behind would point into a directory its entries left.
+
+    It was also absent from the product-owned set before, so a vault's copy was
+    never refreshed and could name skills whose shipped definitions had changed.
+    """
+    init_module.init_vault(tmp_path)
+    target = vault_module.shipped_schema_target(tmp_path)
+
+    assert (target / "workflow-skills" / "index.yaml").is_file()
+    assert not (tmp_path / "Knowledge Base" / "_Schema" / "workflow-skills").exists()
+
+
+def test_the_agent_is_told_where_the_skill_actually_is() -> None:
+    """`bootstrap` hands the agent a vault-relative path to read.
+
+    A stale path here is not cosmetic: it is the address the agent is told to
+    open, so it would fail on every migrated vault while every test that only
+    checked the filesystem stayed green.
+    """
+    from exomem import workflow_skills
+
+    for entry in workflow_skills.bootstrap_entries():
+        assert entry["path"].startswith(".exomem/schema/workflow-skills/")
+        assert entry["path"].endswith("/SKILL.md")
+
+
+# ----------------------------------------------------------------- reclaim
+
+
+def test_reclaim_previews_before_it_deletes(tmp_path: Path) -> None:
+    """`apply=False` is the default, and it must not touch the vault.
+
+    A dry run is what makes the deletion something the user agrees to rather than
+    something they discover.
+    """
+    init_module.init_vault(tmp_path)
+    init_module.refresh_shipped_schema(tmp_path)
+    legacy = tmp_path / "Knowledge Base" / "_Schema"
+    legacy.mkdir(parents=True, exist_ok=True)
+    duplicate = legacy / "SKILL.md"
+    duplicate.write_bytes(
+        (vault_module.shipped_schema_target(tmp_path) / "SKILL.md").read_bytes()
+    )
+
+    result = init_module.reclaim_legacy_shipped_schema(tmp_path)
+
+    assert result["applied"] is False
+    assert "SKILL.md" in result["removed"]
+    assert result["reclaimed_kb"] > 0
+    assert duplicate.is_file(), "a preview deleted a file"
+
+
+def test_reclaim_removes_only_verified_duplicates(tmp_path: Path) -> None:
+    init_module.init_vault(tmp_path)
+    legacy = tmp_path / "Knowledge Base" / "_Schema"
+    legacy.mkdir(parents=True, exist_ok=True)
+    duplicate = legacy / "SKILL.md"
+    duplicate.write_bytes(
+        (vault_module.shipped_schema_target(tmp_path) / "SKILL.md").read_bytes()
+    )
+
+    result = init_module.reclaim_legacy_shipped_schema(tmp_path, apply=True)
+
+    assert result["applied"] is True
+    assert "SKILL.md" in result["removed"]
+    assert not duplicate.exists()
+    # And the content is still available from the location that now serves it.
+    assert (vault_module.shipped_schema_target(tmp_path) / "SKILL.md").is_file()
+
+
+def test_an_edited_legacy_file_is_declined_not_deleted(tmp_path: Path) -> None:
+    """The edit is the only copy of whatever the user changed.
+
+    Deleting it because the product could regenerate the ORIGINAL destroys work
+    the product cannot regenerate at all.
+    """
+    init_module.init_vault(tmp_path)
+    legacy = tmp_path / "Knowledge Base" / "_Schema"
+    legacy.mkdir(parents=True, exist_ok=True)
+    edited = legacy / "SKILL.md"
+    edited.write_text("the user changed this", encoding="utf-8")
+
+    result = init_module.reclaim_legacy_shipped_schema(tmp_path, apply=True)
+
+    assert edited.read_text(encoding="utf-8") == "the user changed this"
+    assert result["removed"] == []
+    assert [entry["path"] for entry in result["declined"]] == ["SKILL.md"]
+
+
+def test_reclaim_never_touches_anything_it_does_not_own(tmp_path: Path) -> None:
+    """`_Schema/` also holds registries, contracts, reviews and user files.
+
+    The glob is the whole safety property: a reclaim that walked the directory
+    instead would delete a user's private skill because it happened to sit
+    beside product content.
+    """
+    init_module.init_vault(tmp_path)
+    schema = tmp_path / "Knowledge Base" / "_Schema"
+    mine = schema / "my-own-notes-about-the-schema.md"
+    mine.write_text("mine", encoding="utf-8")
+    registry = schema / "project-keys.yaml"
+    registry_before = registry.read_bytes()
+
+    init_module.reclaim_legacy_shipped_schema(tmp_path, apply=True)
+
+    assert mine.read_text(encoding="utf-8") == "mine"
+    assert registry.read_bytes() == registry_before
+
+
+def test_reclaim_declines_when_nothing_has_been_deployed_yet(tmp_path: Path) -> None:
+    """Removing the only copy because the replacement is missing is data loss."""
+    _legacy_vault(tmp_path)
+
+    result = init_module.reclaim_legacy_shipped_schema(tmp_path, apply=True)
+
+    assert result["removed"] == []
+    assert (tmp_path / "Knowledge Base" / "_Schema" / "SKILL.md").is_file()
+    assert any("not yet deployed" in entry["reason"] for entry in result["declined"])
+
+
+# ------------------------------------------------------------- portability
+
+
+def test_the_moved_schema_still_survives_a_hosted_export() -> None:
+    """Moving a file must not also change whether it survives an export.
+
+    `_is_unregistered_hidden_state` fails ALL dot-prefixed paths closed --
+    deliberately, so a new machine-local cache cannot silently enter an archive.
+    The shipped contract used to live under `Knowledge Base/` and was canonical
+    by default; putting it in a dot-directory without registering it would have
+    dropped it from every hosted export, and `_valid_vault_scaffold` requires
+    `SKILL.md`, so the restored vault would then be refused outright.
+    """
+    from exomem import hosted_portability
+
+    classification = hosted_portability.classify_artifact(
+        ".exomem/schema/SKILL.md"
+    )
+
+    assert classification.artifact_class is hosted_portability.ArtifactClass.CANONICAL
+    assert classification.rule_id == "portable-shipped-schema"
+
+
+def test_an_unregistered_dot_directory_is_still_disposable() -> None:
+    """The rule this one is threaded in front of has to keep working.
+
+    Registering the schema must not turn the fail-closed default into a
+    fail-open one for the next hidden sidecar somebody adds.
+    """
+    from exomem import hosted_portability
+
+    classification = hosted_portability.classify_artifact(
+        ".some-new-cache/state.bin"
+    )
+
+    assert classification.artifact_class is hosted_portability.ArtifactClass.DISPOSABLE_RUNTIME
+
+
+def test_an_archive_from_either_layout_passes_the_scaffold_check() -> None:
+    """A vault exported before the move must still restore after it."""
+    from exomem import hosted_portability
+
+    legacy = [{"path": "Knowledge Base/index.md"}, {"path": "Knowledge Base/_Schema/SKILL.md"}]
+    migrated = [{"path": "Knowledge Base/index.md"}, {"path": ".exomem/schema/SKILL.md"}]
+
+    hosted_portability._verify_required_scaffold(legacy)
+    hosted_portability._verify_required_scaffold(migrated)
+
+
+def test_the_real_schema_reader_works_on_both_layouts(tmp_path: Path) -> None:
+    """`load_source_schema` parses the references, and it is a real read.
+
+    Routing the resolver is not the same as proving the consumer uses it: a
+    reader that kept its own hard-coded path would still pass every resolver
+    test while failing on every vault of the other shape.
+    """
+    from exomem import schema as schema_module
+
+    init_module.init_vault(tmp_path)
+    migrated = schema_module.load_source_schema(tmp_path)
+    assert migrated.source_types
+
+    # Now make the same vault look pre-#488: references only in the old place.
+    target = vault_module.shipped_schema_target(tmp_path)
+    legacy = tmp_path / "Knowledge Base" / "_Schema"
+    (legacy / "references").mkdir(parents=True, exist_ok=True)
+    for name in ("frontmatter.md", "page-types.md"):
+        (legacy / "references" / name).write_bytes((target / "references" / name).read_bytes())
+    (legacy / "SKILL.md").write_bytes((target / "SKILL.md").read_bytes())
+    import shutil
+
+    shutil.rmtree(target)
+
+    assert vault_module.shipped_schema_root(tmp_path) == legacy
+    legacy_schema = schema_module.load_source_schema(tmp_path)
+    assert legacy_schema.source_types == migrated.source_types
+
+
+def test_the_hosted_scaffold_check_accepts_both_layouts(tmp_path: Path) -> None:
+    """It gates whether the hosted runtime will serve a vault at all."""
+    from exomem import hosted_runtime
+
+    init_module.init_vault(tmp_path)
+    assert hosted_runtime._valid_vault_scaffold(tmp_path) is True
+
+    target = vault_module.shipped_schema_target(tmp_path)
+    legacy = tmp_path / "Knowledge Base" / "_Schema"
+    legacy.mkdir(parents=True, exist_ok=True)
+    (legacy / "SKILL.md").write_bytes((target / "SKILL.md").read_bytes())
+    import shutil
+
+    shutil.rmtree(target)
+
+    assert hosted_runtime._valid_vault_scaffold(tmp_path) is True
+
+
+def test_the_new_location_is_skipped_by_the_vault_wide_walk(tmp_path: Path) -> None:
+    """Otherwise the move relocates the pollution instead of removing it.
+
+    `_Schema` was in `VAULT_SCAN_SKIP_DIRS` because `find(scope="vault")` reaches
+    through `walk_vault_md`. Writing the same markdown to a path that set does
+    not cover would leave exomem's own vault-wide search ranking the shipped
+    contract above real notes -- the #488 symptom, moved rather than fixed.
+    """
+    init_module.init_vault(tmp_path)
+    target = vault_module.shipped_schema_target(tmp_path)
+    assert list(target.rglob("*.md")), "fixture is empty; the assertion would be vacuous"
+
+    walked = {
+        path.relative_to(tmp_path).as_posix()
+        for path in vault_module.walk_vault_md(tmp_path)
+    }
+    assert not [rel for rel in walked if rel.startswith(vault_module.SHIPPED_SCHEMA_DIRNAME)]
+
+
+def test_the_incremental_patcher_skips_the_new_location_too(tmp_path: Path) -> None:
+    """The event-driven counterpart of the full walk, and it must agree with it.
+
+    `in_excluded_scan_dir` is what the watcher consults per path. A path the full
+    rebuild skips but the patcher indexes is the exact bypass that predicate
+    exists to prevent.
+    """
+    assert vault_module.in_excluded_scan_dir(".exomem/schema/SKILL.md") is True
+    assert vault_module.in_excluded_scan_dir(".exomem/schema/references/frontmatter.md") is True
+    assert vault_module.in_excluded_scan_dir("Knowledge Base/Notes/real-note.md") is False


### PR DESCRIPTION
## The measurement #488 opens with

`Knowledge Base/_Schema/` held **17 product-owned markdown files** — 265 KB in
the package, 404 KB as observed on a real vault — inside the directory Obsidian
and every other indexer treat as notes. Exomem skipped them in its own index via
`VAULT_SCAN_SKIP_DIRS`; nothing else could, and a second tool ranked three
scaffold documents above every real note for a natural-language query.

Every other member of that skip set is a dot-directory. `_Schema` was the only
non-dot member, and the only one inside the note namespace.

## What changed

The shipped markdown deploys to `<vault>/.exomem/schema/`, where it inherits the
treatment every other non-note directory already gets from every consumer —
instead of exomem having to ask each of them separately.

**Per-vault configuration does not move.** `project-keys.yaml`,
`relation-registry.yaml`, `semantic-language-registry.yaml`,
`traversal-profiles.yaml`, `source-taxonomy.yaml`, `contracts/`,
`relation-reviews/`, `private-skills/` and the activation manifest stay under
`Knowledge Base/_Schema/`. They belong to the user, they are small, and they are
not markdown — they are not what pollutes a note index.

### The constraint the move had to carry

`vault._is_vault` was literally `Knowledge Base/_Schema/SKILL.md exists`, which
makes that file the vault sentinel for `resolve_vault`, `product_invoke`,
`doctor` and the hosted runtime. Either sentinel now counts, so a vault stays a
vault in both directions: one that has migrated, and one that never will.

### Read, write and reclaim are three different things

- **Read** (`shipped_schema_root`) prefers the new location, falls back to the
  legacy one. An existing vault needs no migration; a migrated vault never
  serves the copy a refresh just superseded.
- **Write** (`shipped_schema_target`) always targets the new location, so a
  refresh moves the read path forward without deleting anything.
- **Reclaim** is a separate explicit command, `exomem reclaim-schema`, preview by
  default. It removes a legacy file only after confirming the new location holds
  identical bytes, only for paths matching `_SHIPPED_SCHEMA_GLOBS`, and reports
  what it declined. The bytes are reproducible from the package, but the vault is
  the artifact the product promises the user owns, so a deletion inside it is
  something they ask for rather than something they discover after an upgrade.

### The exclusion moves with the content

`_Schema` was in `VAULT_SCAN_SKIP_DIRS` because `find(scope="vault")` reaches
through `walk_vault_md`. `.exomem` now joins that set, covering the full walk and
the incremental per-path predicate (`in_excluded_scan_dir`) the watcher consults.
Without this the change would have relocated the pollution into exomem's own
search rather than removing it — the same symptom, a different indexer.

## Consumer classification (task 4.2)

Grepped all 27 remaining `"_Schema"` path constructions in `src/exomem/`.

**Routed through the resolver** — product-owned markdown:
`schema.py` (references), `hosted_runtime.py` (`_valid_vault_scaffold`),
`doctor.py` (`vault.path` and the required-file list), `workflow_skills.py`
(bootstrap entry paths), `hosted_portability.py` (scaffold check + a new
`portable-shipped-schema` CANONICAL rule).

**Left in place** — per-vault state that stays in the KB:
`activation_manifest.py:164`, `memory_schema.py:1139,1978`, `note.py:108`,
`project_keys.py:93,278`, `relation_registry.py:168`,
`relation_review.py:646,2461,2463`, `semantic_contract.py:1519`,
`semantic_language_registry.py:392`, `set_frontmatter_field.py:326`,
`source_taxonomy.py:579`, `traversal_profiles.py:120`, `doctor.py:429`
(`project-keys.yaml`), `package_skills.py:116,345` (registry overlay and the
private-skills output dir).

**Left in place** — package-side scaffold source, not a vault path:
`install_skill.py:32`, `package_skills.py:27`, `workflow_skills.py:18`.

**Left in place** — exclusion sets that still need the legacy name for vaults
that have not migrated: `vault.py:203`, `find_corpus.py:29`, `audit_fix.py:85`.

Two would-be regressions came out of this grep: `hosted_portability` classified
`.exomem/schema/` as DISPOSABLE_RUNTIME (every dot-prefixed path fails closed),
which would have dropped it from hosted exports and made restore fail its own
scaffold check; and the scan-exclusion gap above.

## Evidence

Built a vault, refreshed, reclaimed, on a real tree:

- `Knowledge Base/` markdown: **23 files / 269 KB → 6 files / 4 KB**, with
  `_Schema/` holding only the six YAML registries.
- `reclaim-schema --apply`: `Removed 18 file(s), 267.0 KB`.
- User content and every registry survived; `is_vault: True` throughout.

Tests: `tests/test_shipped_schema_location.py` (24 new), plus the updated
`test_bootstrap.py` / `test_init.py` pins. Full local suite sweep and
`uvx ruff check . --select F,E9` clean. OpenSpec change
`move-shipped-schema-out-of-the-note-namespace` validates `--strict`.

Closes #488
