### PR TITLE
fix(ci): stop the cross-platform lane and the write-latency gate asserting a fast runner

### DIFF
--- a/plugins/claude-code/hooks/exomem_continuation_checkpoint.py
+++ b/plugins/claude-code/hooks/exomem_continuation_checkpoint.py
@@ -39,6 +39,15 @@ MAX_ARTIFACT_CANDIDATE_READS = 64
 MAX_ARTIFACT_METADATA_CANDIDATES = 512
 MAX_DIRTY_ARTIFACT_CANDIDATES = MAX_ARTIFACTS
 MAX_PRUNE_CANDIDATES = 16
+# How long a metadata writer waits for the log lock before giving up.
+#
+# Sized against the operation the lock actually guards, which is not the append
+# fast path: when the log is full the holder also rotates it, measured at 78 ms
+# on a warm box before this module stopped re-encoding the retained records,
+# and ~47 ms after. Losing the wait costs a diagnostics row and nothing else --
+# every caller in `_dispatch` swallows it, because a hook must not fail a
+# session over its own telemetry.
+METADATA_LOG_LOCK_SECONDS = 0.5
 MAX_PRUNE_LOCK_SECONDS = 0.05
 MAX_PRUNE_ENUM_ENTRIES = 16
 MAX_STATE_ENUM_ENTRIES = 32
@@ -3820,12 +3829,13 @@ def _metadata_log(
         raise ValueError("invalid continuation metadata record")
     with _open_secure_directory(root, create=create_root) as root_handle:
         _require_private_state_directory(root_handle)
-        with _advisory_lock_at(root_handle, ".events.lock", timeout=0.5):
+        with _advisory_lock_at(
+            root_handle, ".events.lock", timeout=METADATA_LOG_LOCK_SECONDS
+        ):
             row_bytes = _canonical_bytes(row) + b"\n"
             if _append_metadata_if_room(root_handle, row_bytes):
                 return
-            records = _read_metadata_records(root_handle)
-            encoded = [_canonical_bytes(record) + b"\n" for record in records]
+            encoded = _read_metadata_lines(root_handle)
             encoded.append(row_bytes)
             if sum(map(len, encoded)) > MAX_METADATA_LOG_BYTES:
                 retained: list[bytes] = []
@@ -3916,7 +3926,17 @@ def _valid_metadata_record(value: object) -> bool:
     )
 
 
-def _read_metadata_records(root_handle: _SecureDirectory) -> list[dict[str, object]]:
+def _read_metadata_lines(root_handle: _SecureDirectory) -> list[bytes]:
+    """Validated log lines, as the bytes already on disk.
+
+    Rotation used to parse every retained record and then re-encode it. That
+    round trip measured 31 ms of a 78 ms critical section on a warm box -- half
+    the time this lock is held, spent reproducing bytes the writer had already
+    written in canonical form, while every other writer waits. Validation is
+    unchanged; only the re-encode is gone. A line that parses and validates is
+    now kept verbatim, so a record written by a different version survives
+    rotation as itself instead of being silently rewritten.
+    """
     kind = _existing_kind(root_handle, "events.log")
     if kind is None:
         return []
@@ -3939,15 +3959,15 @@ def _read_metadata_records(root_handle: _SecureDirectory) -> list[dict[str, obje
     if raw and not raw.endswith(b"\n"):
         separator = raw.rfind(b"\n")
         raw = raw[: separator + 1] if separator >= 0 else b""
-    records: list[dict[str, object]] = []
+    lines: list[bytes] = []
     for line in raw.splitlines():
         try:
             record = json.loads(line)
         except (UnicodeDecodeError, json.JSONDecodeError):
             continue
         if _valid_metadata_record(record):
-            records.append(record)
-    return records
+            lines.append(line + b"\n")
+    return lines
 
 
 def _disabled(environ: Mapping[str, str]) -> bool:

--- a/scripts/semantic_write_latency.py
+++ b/scripts/semantic_write_latency.py
@@ -37,6 +37,25 @@ COMMIT_MEDIAN_MS = 750.0
 COMMIT_P95_MS = 1_500.0
 SCALING_RATIO = 2.0
 SCALING_SLACK_MS = 200.0
+# The scaling bound is derived from the SMALL corpus measurement, and on this
+# shared runner that measurement is the noisiest number the gate produces.
+# Across twelve consecutive CI runs the 2k commit median ranged 110.1-519.0ms
+# (median 129.8) while the 8k median it is supposed to bound stayed inside
+# 265.7-454.7ms (median 331.1). So the thing being measured is roughly stable
+# and the ruler is not: `small * 2 + 200` put four of those twelve runs within
+# 100ms of failing and one at -3.9ms, which is how a green tree gets a red
+# required gate. Sampling more is not available here -- a `--root` run gets one
+# attempt per size.
+#
+# Floor the bound at a fraction of the operation's own absolute ceiling so a
+# lucky-fast small sample cannot make it tighter than an unregressed large
+# sample can satisfy. At 0.8 the commit floor is 600ms (32% clear of the worst
+# 8k median observed) and validate's is 400ms (58% clear of its worst, 253.2ms)
+# -- while both stay strictly below their ceilings, so the scaling check still
+# fails a real super-linear regression before the absolute ceiling does. Only
+# the two operations expected to stay FLAT with corpus size get this; the
+# read/cold rows are deliberately O(N) and carry their own ratios.
+SCALING_BOUND_CEILING_FRACTION = 0.8
 
 # --- Read-after-write budget (warm path). A governed write normally PATCHES
 # the corpus-context cache and the live freshness registry, so the very next
@@ -263,9 +282,15 @@ def check(results: list[dict[str, float | int]]) -> None:
     if len(results) >= 2:
         ordered = sorted(results, key=lambda item: int(item["pages"]))
         small, large = ordered[0], ordered[-1]
-        for operation in ("validate", "commit"):
+        for operation, operation_ceiling in (
+            ("validate", VALIDATE_MEDIAN_MS),
+            ("commit", COMMIT_MEDIAN_MS),
+        ):
             key = f"{operation}_median_ms"
-            bound = float(small[key]) * SCALING_RATIO + SCALING_SLACK_MS
+            bound = max(
+                float(small[key]) * SCALING_RATIO + SCALING_SLACK_MS,
+                operation_ceiling * SCALING_BOUND_CEILING_FRACTION,
+            )
             if float(large[key]) >= bound:
                 failures.append(
                     f"{operation} scaling: {large[key]}ms >= {bound:.1f}ms "

--- a/src/exomem/_hooks/exomem_continuation_checkpoint.py
+++ b/src/exomem/_hooks/exomem_continuation_checkpoint.py
@@ -39,6 +39,15 @@ MAX_ARTIFACT_CANDIDATE_READS = 64
 MAX_ARTIFACT_METADATA_CANDIDATES = 512
 MAX_DIRTY_ARTIFACT_CANDIDATES = MAX_ARTIFACTS
 MAX_PRUNE_CANDIDATES = 16
+# How long a metadata writer waits for the log lock before giving up.
+#
+# Sized against the operation the lock actually guards, which is not the append
+# fast path: when the log is full the holder also rotates it, measured at 78 ms
+# on a warm box before this module stopped re-encoding the retained records,
+# and ~47 ms after. Losing the wait costs a diagnostics row and nothing else --
+# every caller in `_dispatch` swallows it, because a hook must not fail a
+# session over its own telemetry.
+METADATA_LOG_LOCK_SECONDS = 0.5
 MAX_PRUNE_LOCK_SECONDS = 0.05
 MAX_PRUNE_ENUM_ENTRIES = 16
 MAX_STATE_ENUM_ENTRIES = 32
@@ -3820,12 +3829,13 @@ def _metadata_log(
         raise ValueError("invalid continuation metadata record")
     with _open_secure_directory(root, create=create_root) as root_handle:
         _require_private_state_directory(root_handle)
-        with _advisory_lock_at(root_handle, ".events.lock", timeout=0.5):
+        with _advisory_lock_at(
+            root_handle, ".events.lock", timeout=METADATA_LOG_LOCK_SECONDS
+        ):
             row_bytes = _canonical_bytes(row) + b"\n"
             if _append_metadata_if_room(root_handle, row_bytes):
                 return
-            records = _read_metadata_records(root_handle)
-            encoded = [_canonical_bytes(record) + b"\n" for record in records]
+            encoded = _read_metadata_lines(root_handle)
             encoded.append(row_bytes)
             if sum(map(len, encoded)) > MAX_METADATA_LOG_BYTES:
                 retained: list[bytes] = []
@@ -3916,7 +3926,17 @@ def _valid_metadata_record(value: object) -> bool:
     )
 
 
-def _read_metadata_records(root_handle: _SecureDirectory) -> list[dict[str, object]]:
+def _read_metadata_lines(root_handle: _SecureDirectory) -> list[bytes]:
+    """Validated log lines, as the bytes already on disk.
+
+    Rotation used to parse every retained record and then re-encode it. That
+    round trip measured 31 ms of a 78 ms critical section on a warm box -- half
+    the time this lock is held, spent reproducing bytes the writer had already
+    written in canonical form, while every other writer waits. Validation is
+    unchanged; only the re-encode is gone. A line that parses and validates is
+    now kept verbatim, so a record written by a different version survives
+    rotation as itself instead of being silently rewritten.
+    """
     kind = _existing_kind(root_handle, "events.log")
     if kind is None:
         return []
@@ -3939,15 +3959,15 @@ def _read_metadata_records(root_handle: _SecureDirectory) -> list[dict[str, obje
     if raw and not raw.endswith(b"\n"):
         separator = raw.rfind(b"\n")
         raw = raw[: separator + 1] if separator >= 0 else b""
-    records: list[dict[str, object]] = []
+    lines: list[bytes] = []
     for line in raw.splitlines():
         try:
             record = json.loads(line)
         except (UnicodeDecodeError, json.JSONDecodeError):
             continue
         if _valid_metadata_record(record):
-            records.append(record)
-    return records
+            lines.append(line + b"\n")
+    return lines
 
 
 def _disabled(environ: Mapping[str, str]) -> bool:

--- a/src/exomem/mode.py
+++ b/src/exomem/mode.py
@@ -394,5 +394,23 @@ def start_config_watch(interval: float = 10.0) -> threading.Thread | None:
     return t
 
 
-def stop_config_watch() -> None:
+def stop_config_watch(timeout: float = 5.0) -> None:
+    """Stop the watch and wait for the thread to leave.
+
+    Setting the event alone left "stopped" unobservable, and that is not a
+    cosmetic gap: `start_config_watch` hands back the existing thread whenever
+    one is still alive, so a stop/start cycle inside a single tick returned a
+    thread that was already exiting on the stop flag. The caller held a live
+    `Thread` object, its new interval never took effect, and no watcher was
+    running -- a config-driven mode change would then never be applied, which is
+    the one thing this daemon exists to do.
+
+    Joining is cheap because the loop waits on the event rather than sleeping:
+    the tick returns as soon as the flag is set, whatever the interval.
+    """
+    global _watch_thread
+    thread = _watch_thread
     _watch_stop.set()
+    if thread is not None and thread is not threading.current_thread():
+        thread.join(timeout)
+    _watch_thread = None

--- a/tests/test_continuation_checkpoint.py
+++ b/tests/test_continuation_checkpoint.py
@@ -2869,6 +2869,12 @@ def test_prune_skips_multiprocess_writer_then_removes_after_release(
             child.kill()
 
 
+# Headroom over the prune's lock budget for the writer to land in. Wide enough
+# that a slow runner cannot fail it, narrow enough that a writer which genuinely
+# queued behind the whole prune still does.
+_WRITER_OVERTAKE_SLACK_SECONDS = 5.0
+
+
 def test_many_busy_prune_candidates_do_not_starve_supported_writer(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -2967,7 +2973,15 @@ def test_many_busy_prune_candidates_do_not_starve_supported_writer(
     with busy_guard:
         observed_busy = len(busy_entries)
     assert observed_busy >= 1, "prune never contended with the writer"
-    assert elapsed < checkpoint.MAX_PRUNE_ENUM_ENTRIES * busy_hold + 0.3
+    # Starvation means the writer waits out the prune's whole budget instead of
+    # overtaking it. `MAX_PRUNE_ENUM_ENTRIES * busy_hold + 0.3` -- 0.46s -- was
+    # not that bound: it was the theoretical contention cost plus a slice of
+    # runner speed, and a Windows runner spent 1.06s on file locking alone while
+    # behaving perfectly. Bound it against the only thing that would actually be
+    # wrong: waiting for the prune's own lock budget to expire. Anything faster
+    # than that overtook the prune, which is the property. The status assertion
+    # above remains the primary check, as its comment says.
+    assert elapsed < checkpoint.MAX_PRUNE_LOCK_SECONDS + _WRITER_OVERTAKE_SLACK_SECONDS
 
 
 def test_prune_respects_total_budget_when_root_lock_is_held(tmp_path: Path) -> None:

--- a/tests/test_continuation_checkpoint.py
+++ b/tests/test_continuation_checkpoint.py
@@ -101,9 +101,30 @@ def _prune_until_swept(*args, **kwargs) -> int:
 
     Returns the total removed, so `== 1` still means exactly one directory
     went away.
+
+    The pass count above is derived from slots-per-call, so it only sweeps the
+    ring if every call really does inspect a full window. It does not:
+    `prune_expired` also bounds itself by wall clock
+    (`MAX_PRUNE_LOCK_SECONDS`, 50 ms), and a truncated window advances the
+    cursor only past the slots it actually read -- correct for the product,
+    fatal for this arithmetic. On a loaded Windows runner the 33 calls covered
+    a fraction of the 512 slots and the expired entry was simply never reached,
+    which is how `test_prune_refuses_copied_checkpoint_in_arbitrary_user_-
+    directory` failed with `0 == 1` on CI while passing everywhere else.
+
+    So the latency bound is lifted for the duration of the sweep. That bound is
+    a production property -- keep the hook's share of a write small -- and it
+    stays pinned by `test_prune_respects_total_budget_when_root_lock_is_held`.
+    A test asserting the *outcome* of a complete sweep is the one caller that
+    must not be cut short part way through it.
     """
     passes = -(-checkpoint.MAX_PRUNE_CATALOG_ENTRIES // checkpoint.MAX_PRUNE_ENUM_ENTRIES) + 1
-    return sum(checkpoint.prune_expired(*args, **kwargs) for _ in range(passes))
+    original = checkpoint.MAX_PRUNE_LOCK_SECONDS
+    checkpoint.MAX_PRUNE_LOCK_SECONDS = 60.0
+    try:
+        return sum(checkpoint.prune_expired(*args, **kwargs) for _ in range(passes))
+    finally:
+        checkpoint.MAX_PRUNE_LOCK_SECONDS = original
 
 
 @pytest.mark.parametrize("client", ["claude", "codex"])
@@ -2218,6 +2239,17 @@ def test_metadata_rotation_replace_failure_preserves_log_and_removes_temp(
 
 
 def test_metadata_log_rotation_serializes_concurrent_process_writers(tmp_path: Path) -> None:
+    """Four processes writing at once must produce one well-formed log.
+
+    The children raise `METADATA_LOG_LOCK_SECONDS` because this test builds a
+    contention level production does not: four writers queued behind a full-log
+    rotation, deliberately, so that serialization is what is being observed. The
+    shipped budget is sized to give up rather than delay a hook -- losing it
+    costs one diagnostics row, and every caller in `_dispatch` swallows that --
+    so at the shipped value a loaded runner makes this assert the give-up rather
+    than the serialization, which is how it failed on Windows CI with
+    `TimeoutError: timed out acquiring .events.lock`.
+    """
     home = tmp_path / "home"
     root = checkpoint.client_state_root(home, "codex")
     root.mkdir(parents=True)
@@ -2233,6 +2265,7 @@ def test_metadata_log_rotation_serializes_concurrent_process_writers(tmp_path: P
     code = (
         "import sys; from pathlib import Path; "
         "from exomem._hooks import exomem_continuation_checkpoint as c; "
+        "c.METADATA_LOG_LOCK_SECONDS = 30.0; "
         "[(c._metadata_log(Path(sys.argv[1]),'codex','SessionStart','empty',i)) "
         "for i in range(20)]"
     )

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -701,6 +701,11 @@ def test_delete_then_recreate_only_upserts(vault, monkeypatch: pytest.MonkeyPatc
     assert ups == [[p]]
 
 
+# How long a test will wait for a background flush before calling it hung.
+# Generous on purpose: see the note at its use site.
+_FLUSH_VALVE_SECONDS = 30.0
+
+
 def test_dispatch_thread_coalesces_within_debounce(vault, monkeypatch: pytest.MonkeyPatch) -> None:
     ups, _dels = _stub_embeddings(monkeypatch)
     w = file_watcher.FileWatcher(vault, debounce_seconds=0.05)
@@ -714,7 +719,13 @@ def test_dispatch_thread_coalesces_within_debounce(vault, monkeypatch: pytest.Mo
         b.write_text("# B\n", encoding="utf-8")
         w._record(a, deleted=False)
         w._record(b, deleted=False)
-        deadline = time.monotonic() + 2.0
+        # A deadlock valve, not a latency assertion. What is under test is that
+        # the dispatch thread flushes at all and that the two saves coalesce
+        # into one batch -- neither claim is about how quickly a CI runner gets
+        # round to scheduling the thread. Two seconds was tight enough to fire
+        # on a loaded Windows runner, reporting a coalescing defect that was
+        # really a busy machine.
+        deadline = time.monotonic() + _FLUSH_VALVE_SECONDS
         while not ups and time.monotonic() < deadline:
             time.sleep(0.02)
         assert ups, "dispatch thread should flush after the debounce window"

--- a/tests/test_governance_receipt_runtime_bootstrap_windows.py
+++ b/tests/test_governance_receipt_runtime_bootstrap_windows.py
@@ -77,12 +77,22 @@ def _first_use_process(
             # unsafe, where a foreign principal had the run of the directory
             # while artifacts landed in it and may still hold a handle no later
             # tightening can take back.
+            observed = mutation_lock._windows_dacl_sddl(path)
             verdict = mutation_lock._windows_private_dacl_verdict(
-                mutation_lock._windows_dacl_sddl(path), sid, directory=True
+                observed, sid, directory=True
             )
             if verdict != mutation_lock._WINDOWS_DACL_INHERITED:
+                # Carry the SDDL and the trustee. This assertion has fired on a
+                # CI runner without reproducing locally, and the previous time
+                # something in this family did (#658) the cause was the DACL the
+                # runner's own %TEMP% hands down, not the code under test -- a
+                # distinction only the observed descriptor can make. Without it
+                # the failure says a security invariant broke and gives nothing
+                # to check that claim against.
                 raise AssertionError(
-                    "runtime root gained a lock artifact before DACL validation"
+                    "runtime root gained a lock artifact before DACL validation; "
+                    f"verdict={verdict!r} sid={sid!r} entries={sorted(p.name for p in root.iterdir())!r} "
+                    f"sddl={observed!r}"
                 )
         if path == root:
             root_dacl_applies += 1

--- a/tests/test_governance_receipts.py
+++ b/tests/test_governance_receipts.py
@@ -24,6 +24,13 @@ from exomem import audit, delete_directory, delete_file, embeddings, index_sync,
 from exomem import reconcile as reconcile_module
 from exomem.governance import egress, receipts, store
 
+#: How long a deadlock valve waits before declaring a thread stuck.
+#:
+#: Not a latency assertion -- the operations it guards should take no measurable
+#: time. It is far above any legitimate slowness so that reaching it still means
+#: something is genuinely stuck, rather than that a CI runner was busy.
+_STUCK_SECONDS = 60.0
+
 _PRIOR = "a" * 64
 _TARGET = "b" * 64
 _MEMORY_REF = "exomem://memory/12345678-1234-1234-1234-123456789abc"
@@ -434,6 +441,16 @@ def test_receipt_connection_quiesce_closes_descriptors_and_reopens(
 def test_receipt_connection_lru_evicts_and_closes_idle_handles(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """The connection cache evicts and closes the least recently used handle.
+
+    The timeouts below are deadlock valves, not assertions about speed: this
+    test is about which handle survives eviction, and nothing here should take
+    any measurable time. At five seconds they were close enough to the cost of
+    creating three receipt databases on a loaded Windows runner to fire, and a
+    single late thread breaks the barrier for all of them
+    (`threading.BrokenBarrierError` on CI). They are now far enough above any
+    legitimate slowness that reaching one still means something is stuck.
+    """
     receipts._close_receipt_connections()
     monkeypatch.setattr(receipts, "_RECEIPT_CONNECTIONS_MAX", 2)
     roots = [tmp_path / f"lru-{index}" for index in range(3)]
@@ -446,17 +463,17 @@ def test_receipt_connection_lru_evicts_and_closes_idle_handles(
     def hold(root: Path) -> None:
         with receipts._receipt_connection(root) as connection:
             opened.append(connection)
-            ready.wait(timeout=5)
-            assert release.wait(timeout=5)
+            ready.wait(timeout=_STUCK_SECONDS)
+            assert release.wait(timeout=_STUCK_SECONDS)
 
     threads = [threading.Thread(target=hold, args=(root,)) for root in roots]
     for thread in threads:
         thread.start()
-    ready.wait(timeout=5)
+    ready.wait(timeout=_STUCK_SECONDS)
     assert len(receipts._RECEIPT_CONNECTIONS) == 3
     release.set()
     for thread in threads:
-        thread.join(timeout=5)
+        thread.join(timeout=_STUCK_SECONDS)
         assert not thread.is_alive()
 
     assert len(receipts._RECEIPT_CONNECTIONS) == 2

--- a/tests/test_governance_tokens.py
+++ b/tests/test_governance_tokens.py
@@ -538,9 +538,19 @@ def test_sweep_is_safe_on_a_vault_with_no_sidecar(vault: Path) -> None:
 
 
 def test_minting_sweeps_opportunistically(vault: Path) -> None:
+    """Minting sweeps tokens that have already expired.
+
+    Pinned to an explicit clock. Reading the stale token back with the wall
+    clock meant the one-second TTL had to outlive everything between the mint
+    and the read, which a loaded Windows runner does not guarantee -- it failed
+    on CI with `TOKEN_EXPIRED` raised by the setup rather than by the subject.
+    What this test is about is the sweep, and the sweep's own clock is already
+    a parameter.
+    """
     govern(vault)
-    stale = _mint(vault, ttl_seconds=1)
-    stale_claim = tokens.verify(vault, stale, audience=EXTERNAL)
+    minted_at = int(time.time())
+    stale = _mint(vault, ttl_seconds=1, now=minted_at)
+    stale_claim = tokens.verify(vault, stale, audience=EXTERNAL, now=minted_at)
     _mint(vault, now=stale_claim.expires_at + 1)
     with sqlite3.connect(sidecar_path(vault)) as conn:
         rows = conn.execute("SELECT COUNT(*) FROM withhold_tokens").fetchone()[0]

--- a/tests/test_graph_idempotency_handoff.py
+++ b/tests/test_graph_idempotency_handoff.py
@@ -10,6 +10,13 @@ import pytest
 # copies: the wording is allowed to change, the semantics are not.
 from exomem import graph_sync
 
+#: How long a thread is given to reach a point it should reach immediately.
+#: A deadlock valve, not a latency budget.
+_OBSERVE_SECONDS = 30.0
+#: How long a stage is deliberately held open. Must exceed _OBSERVE_SECONDS, or
+#: the ordering assertion could be satisfied by the hold simply expiring.
+_GRAPH_HOLD_SECONDS = 60.0
+
 
 def _receipt(root: Path, *, digest: str, attempt: object) -> None:
     from exomem import graph_sync
@@ -113,21 +120,27 @@ def test_canonical_result_is_handed_off_before_derived_wait(tmp_path: Path) -> N
                 operation_guard=Guard,
                 after_canonical_persisted=lambda result: result,
                 after_operation_guard=lambda result: (
-                    allow_graph_completion.wait(2) and {**result, "graph_sync": "completed"}
+                    allow_graph_completion.wait(_GRAPH_HOLD_SECONDS)
+                    and {**result, "graph_sync": "completed"}
                 ),
             )
         )
 
     worker = threading.Thread(target=invoke)
     worker.start()
-    assert canonical_guard_released.wait(1)
+    # The property is an ordering, not a latency: the canonical guard must be
+    # released while the graph stage is still blocked. Both waits were budgets
+    # a loaded Windows runner could exhaust -- the outer one did, on CI -- so
+    # they are now far above any legitimate scheduling delay, and the hold
+    # stays longer than the observation so the assertion cannot pass vacuously.
+    assert canonical_guard_released.wait(_OBSERVE_SECONDS)
     with store._connect() as conn:
         assert conn.execute("SELECT state, owner FROM mutations").fetchone() == (
             "canonically_committed",
             None,
         )
     allow_graph_completion.set()
-    worker.join(2)
+    worker.join(_OBSERVE_SECONDS)
     assert results == [{"canonical": "committed", "graph_sync": "completed"}]
 
 

--- a/tests/test_graph_rebuild_availability.py
+++ b/tests/test_graph_rebuild_availability.py
@@ -2237,6 +2237,14 @@ def test_reconcile_recovers_an_unacknowledged_checkpoint_without_rewriting_markd
     assert report.graph_status == "refreshed"
 
 
+# Deadlock valves for the ordering test below. The hold must outlast both the
+# observation and the admission timeout, or the ordering it pins can resolve
+# itself by expiry and the assertions stop meaning anything.
+_HOLD_SECONDS = 60.0
+_OBSERVE_SECONDS = 30.0
+_ADMIT_SECONDS = 15.0
+
+
 def test_manager_reconcile_releases_canonical_boundary_before_graph_rebuild(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2260,16 +2268,23 @@ def test_manager_reconcile_releases_canonical_boundary_before_graph_rebuild(
 
     def slow_rebuild(index: EpistemicGraphIndex) -> dict[str, int]:
         rebuild_started.set()
-        assert release_rebuild.wait(2)
+        assert release_rebuild.wait(_HOLD_SECONDS)
         return original(index)
 
     monkeypatch.setattr(EpistemicGraphIndex, "_rebuild_all_locked", slow_rebuild)
     state_dir = tmp_path / "state"
     reconcile_manager = LeaseManager(
-        LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=1
+        LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=_ADMIT_SECONDS
     )
+    # The second mutation must be ADMITTED, and it is admitted only because the
+    # reconcile released the canonical boundary before rebuilding. A tenth of a
+    # second said "admitted promptly", which is a claim about runner speed; the
+    # claim under test is "admitted at all". A retained boundary still fails,
+    # because the boundary is not released until the `finally` below -- so a
+    # timeout that is shorter than the hold keeps the failure a failure rather
+    # than a deadlock.
     mutation_manager = LeaseManager(
-        LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=0.1
+        LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=_ADMIT_SECONDS
     )
     reconcile_command = next(
         command
@@ -2305,13 +2320,13 @@ def test_manager_reconcile_releases_canonical_boundary_before_graph_rebuild(
 
     reconcile_thread = threading.Thread(target=run_reconcile)
     reconcile_thread.start()
-    assert rebuild_started.wait(1)
+    assert rebuild_started.wait(_OBSERVE_SECONDS)
     try:
         mutation_manager.invoke(second_command, (tmp_path,), {})
         assert second_admitted.is_set()
     finally:
         release_rebuild.set()
-        reconcile_thread.join(timeout=3)
+        reconcile_thread.join(timeout=_HOLD_SECONDS)
 
     assert not reconcile_thread.is_alive()
     assert reconcile_result[0]["graph_status"] == "refreshed", reconcile_result

--- a/tests/test_graph_rebuild_locking.py
+++ b/tests/test_graph_rebuild_locking.py
@@ -451,6 +451,14 @@ def test_registered_builder_retains_the_originating_custom_lease_boundary(
     assert observed_roots == [state_root]
 
 
+# Deadlock valves for the ordering test below, sized so the hold outlasts the
+# observation. A whole-vault rebuild on a loaded Windows runner is the thing
+# being waited on, and two seconds does not bound it.
+_HOLD_SECONDS = 60.0
+_OBSERVE_SECONDS = 30.0
+_SWAP_WAIT_SECONDS = 30.0
+
+
 def test_graph_swap_waits_for_a_real_lease_manager_writer(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -461,8 +469,13 @@ def test_graph_swap_waits_for_a_real_lease_manager_writer(
     note = vault_root / "Knowledge Base/Notes/graph-race.md"
     note.parent.mkdir(parents=True)
     note.write_text("# Graph race\n", encoding="utf-8")
+    # How long the graph swap will wait for the writer's lease. It only has to
+    # outlast the gap between the private build finishing and this thread
+    # getting scheduled to release the writer -- microseconds when the machine
+    # is idle, and unbounded when it is not. One second made a busy runner look
+    # like a swap that refused to wait.
     manager = LeaseManager(
-        LeaseConfig(state_dir=state_root), mutation_timeout_seconds=1
+        LeaseConfig(state_dir=state_root), mutation_timeout_seconds=_SWAP_WAIT_SECONDS
     )
     monkeypatch.setattr(writer_lease, "get_manager", lambda: manager)
     index = epistemic_graph.EpistemicGraphIndex(vault_root)
@@ -475,7 +488,11 @@ def test_graph_swap_waits_for_a_real_lease_manager_writer(
     def hold_writer() -> None:
         with manager.mutation_guard(vault_root):
             writer_entered.set()
-            assert release_writer.wait(2)
+            # The hold has to outlast the observation below. If it expires
+            # first the writer releases on its own, the swap publishes, and
+            # `assert not publish_entered.is_set()` fails -- reporting a
+            # publication that raced the writer when really the test let go.
+            assert release_writer.wait(_HOLD_SECONDS)
 
     def publication_seam(_temporary: Path, _live: Path) -> None:
         publish_entered.set()
@@ -493,16 +510,16 @@ def test_graph_swap_waits_for_a_real_lease_manager_writer(
     )
     writer = threading.Thread(target=hold_writer)
     writer.start()
-    assert writer_entered.wait(1)
+    assert writer_entered.wait(_OBSERVE_SECONDS)
     rebuilder = threading.Thread(target=lambda: rebuilt.append(index.rebuild_all()))
     rebuilder.start()
     try:
-        assert private_build_finished.wait(2)
+        assert private_build_finished.wait(_OBSERVE_SECONDS)
         assert not publish_entered.is_set()
     finally:
         release_writer.set()
-        writer.join(timeout=2)
-        rebuilder.join(timeout=5)
+        writer.join(timeout=_OBSERVE_SECONDS)
+        rebuilder.join(timeout=_HOLD_SECONDS)
     assert not writer.is_alive()
     assert not rebuilder.is_alive()
     assert publish_entered.is_set()

--- a/tests/test_lexstore_atomic_rebuild.py
+++ b/tests/test_lexstore_atomic_rebuild.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import os
 import sqlite3
+import traceback
 import threading
 import time
 import uuid
@@ -998,16 +999,27 @@ def test_live_wal_not_blindly_deleted_and_unsafe_publish_declines(
     # the live main file (and thus without ever reaching a post-replace unlink of
     # the live -wal/-shm). An os.replace spy proves no main-file swap happened.
     replaced = {"n": 0}
+    callers: list[str] = []
     real_replace = lexstore.os.replace
 
     def _spy_replace(src: Any, dst: Any) -> Any:
         replaced["n"] += 1
+        # Named, not just counted. This fired once on a Windows CI runner and
+        # could not be reproduced locally; with only a count there was no way to
+        # tell an unsafe live-main swap from some unrelated rename inside the
+        # build, which is the difference between a data-safety defect and a
+        # test that spies too widely. `rebuild_atomic` has two publish paths --
+        # the quarantine branch replaces before `_quiesce_live_wal` is ever
+        # consulted -- so the caller is exactly what the next failure needs.
+        frame = traceback.extract_stack()[-2]
+        callers.append(f"{frame.filename}:{frame.lineno} in {frame.name} -> {dst}")
         return real_replace(src, dst)
 
     monkeypatch.setattr(lexstore.os, "replace", _spy_replace)
     monkeypatch.setattr(store, "_quiesce_live_wal", lambda: False)
     assert store.rebuild_atomic() is False
-    assert replaced["n"] == 0  # live main never replaced; live -wal/-shm never touched
+    # live main never replaced; live -wal/-shm never touched
+    assert replaced["n"] == 0, callers
     monkeypatch.undo()
     assert store.catalog_checkpoint("kb") == before
     assert any("livecontent" in hit.content for hit in _units_in_category(tmp_path, "config"))

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -341,7 +341,46 @@ def test_config_watch_applies_on_change(monkeypatch: pytest.MonkeyPatch) -> None
         time.sleep(0.06)
         assert applied == []  # baseline normal, no change yet
         mode.write_mode("quiet")
-        time.sleep(0.12)
+        # Wait on the outcome, not on a fixed budget. The positive half of this
+        # test asserts that a change IS eventually applied, so a deadline that
+        # ends the moment it happens is both faster on a quiet machine and
+        # immune to a loaded runner starving six 20 ms ticks -- which is how it
+        # failed on macOS. The negative half above is the opposite shape and
+        # correctly stays a fixed sleep: there is no event to wait for.
+        deadline = time.monotonic() + 10.0
+        while not applied and time.monotonic() < deadline:
+            time.sleep(0.01)
+    finally:
+        mode.stop_config_watch()
+    assert "quiet" in applied
+
+
+def test_restarting_the_watch_leaves_a_watcher_running(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stop/start cycle must not hand back a thread that is already leaving.
+
+    `start_config_watch` returns the existing thread when one is alive. Before
+    `stop_config_watch` joined, a restart inside a single tick returned the
+    outgoing thread -- so the caller held a live `Thread`, its new interval was
+    silently ignored, and moments later nothing was watching the config at all.
+    """
+    import time
+
+    monkeypatch.delenv("EXOMEM_DISABLE_MODE_WATCH", raising=False)
+    monkeypatch.delenv("EXOMEM_MODE", raising=False)
+    applied: list[str] = []
+    monkeypatch.setattr(mode, "apply_live", lambda: applied.append(mode.resolve_mode()))
+    try:
+        first = mode.start_config_watch(interval=30.0)
+        assert first is not None
+        mode.stop_config_watch()
+        assert not first.is_alive()  # stopped means stopped, not "asked to stop"
+
+        second = mode.start_config_watch(interval=0.02)
+        assert second is not None and second is not first
+        mode.write_mode("quiet")
+        deadline = time.monotonic() + 10.0
+        while not applied and time.monotonic() < deadline:
+            time.sleep(0.01)
     finally:
         mode.stop_config_watch()
     assert "quiet" in applied

--- a/tests/test_semantic_write_latency_gate.py
+++ b/tests/test_semantic_write_latency_gate.py
@@ -6,8 +6,33 @@ scaling bound is anchored to the same run's small-corpus median, so both ends
 moved the wrong way at once and the gate failed a release PR that had touched
 nothing but a version string. A re-run passed with ordinary numbers.
 
-These tests pin that arithmetic (so the sensitivity stays visible rather than
-being rediscovered under time pressure) and pin the confirmation behaviour.
+That was mitigated by re-measuring on failure, and the sensitivity itself was
+pinned here rather than removed. On 2026-08-20 it recurred and the mitigation
+did not hold: both attempts failed on a branch whose only product changes were
+a thread join on shutdown and a hook that does not run on the write path.
+
+Twelve consecutive CI runs sampled at that point put the numbers beyond
+argument. The 8k commit median -- the quantity the scaling rule bounds -- ranged
+265.7-454.7ms. The bound it was compared against ranged 420.6-488.2ms across the
+same runs (excluding one 1238.0ms outlier). The bound sat INSIDE the natural
+spread of the thing it bounds, so which side of it a run landed on was decided
+by the runner, not by the code. Four of the twelve came within 100ms of failing
+and one landed at -3.9ms.
+
+The observed ratio tells the same story: 8k/2k commit ran a median 2.55x against
+a SCALING_RATIO of 2.0, so the rule was already carried entirely by
+SCALING_SLACK_MS. Commit really does scale about 2.5x over a 4x corpus here.
+
+So the bound is now floored at a fraction of each operation's own absolute
+ceiling. That is a deliberate, narrowed claim: on this runner the scaling check
+discriminates only ABOVE the noise floor -- between 600ms and the 750ms ceiling
+for commit -- and the absolute ceilings are the primary bound below that.
+Claiming finer resolution than the measurement supports is what produced two
+false failures.
+
+These tests pin the floor, pin that both historical false-failure sample sets
+now pass, and pin that genuine super-linear growth still fails before the
+absolute ceiling catches it.
 """
 
 from __future__ import annotations
@@ -55,6 +80,22 @@ def result(
 HEALTHY = [result(2_000, commit=51.5), result(8_000, commit=191.7)]
 # The numbers from the 2026-07-27 false failure.
 NOISY = [result(2_000, commit=42.3), result(8_000, commit=365.6)]
+# The 2026-08-20 recurrence, both attempts, measured on a branch that changed
+# nothing on the write path.
+RECURRENCE = [
+    [result(2_000, commit=125.4, validate=37.0), result(8_000, commit=454.7, validate=142.3)],
+    [result(2_000, commit=117.2, validate=40.0), result(8_000, commit=482.7, validate=134.9)],
+]
+# The widest validate spread seen in the same twelve runs: a 253.2ms 8k median
+# against a 38.7ms baseline cleared its bound by 24.2ms. Validate carries the
+# same defect as commit; it had simply not landed on the wrong side yet.
+VALIDATE_MARGIN = [
+    result(2_000, commit=115.9, validate=38.7),
+    result(8_000, commit=287.8, validate=253.2),
+]
+# Genuine super-linear growth: above the floor, still under the absolute
+# ceiling, so only the scaling rule can catch it.
+SUPERLINEAR = [result(2_000, commit=130.0), result(8_000, commit=700.0)]
 
 
 def test_healthy_scaling_passes() -> None:
@@ -89,21 +130,62 @@ def test_missing_new_key_fails_loudly(key: str) -> None:
 
 
 def test_superlinear_scaling_fails() -> None:
+    """Growth the runner cannot explain still fails, and fails on scaling.
+
+    700ms at 8k is under COMMIT_MEDIAN_MS, so the absolute ceiling cannot catch
+    it -- if this passes, the scaling rule has stopped doing anything.
+    """
     with pytest.raises(SystemExit, match="commit scaling"):
-        load_module().check(NOISY)
+        load_module().check(SUPERLINEAR)
 
 
-def test_a_faster_baseline_tightens_the_bound() -> None:
-    """The documented sensitivity: a quick 2k run makes the gate stricter."""
+@pytest.mark.parametrize("sample", [NOISY, *RECURRENCE, VALIDATE_MARGIN])
+def test_measured_false_failures_pass(sample: list[dict[str, float | int]]) -> None:
+    """Every sample set that has ever failed this gate falsely now passes.
 
+    All four came off contended runners on trees with no write-path change.
+    """
+    load_module().check(sample)
+
+
+def test_a_fast_baseline_cannot_tighten_the_bound_below_the_floor() -> None:
+    """The 2026-07-27 sensitivity, now bounded rather than merely documented.
+
+    A quicker small-corpus run still lowers the ratio term -- that part is
+    arithmetic and unchanged -- but it can no longer drag the effective bound
+    underneath what an unregressed large-corpus measurement produces on this
+    runner.
+    """
     module = load_module()
-    bound = lambda small: small * module.SCALING_RATIO + module.SCALING_SLACK_MS  # noqa: E731
 
-    # The real incident: baseline 42.3ms yielded a 284.6ms bound, while the
-    # ordinary 51.5ms baseline would have allowed 303.0ms.
-    assert bound(42.3) == pytest.approx(284.6)
-    assert bound(51.5) == pytest.approx(303.0)
-    assert bound(42.3) < bound(51.5)
+    def ratio_term(small: float) -> float:
+        return small * module.SCALING_RATIO + module.SCALING_SLACK_MS
+
+    def bound(small: float, ceiling: float) -> float:
+        return max(ratio_term(small), ceiling * module.SCALING_BOUND_CEILING_FRACTION)
+
+    # The ratio term still moves with the baseline, as it always did.
+    assert ratio_term(42.3) == pytest.approx(284.6)
+    assert ratio_term(51.5) == pytest.approx(303.0)
+    assert ratio_term(42.3) < ratio_term(51.5)
+
+    # The bound the gate actually applies does not follow it down.
+    floor = module.COMMIT_MEDIAN_MS * module.SCALING_BOUND_CEILING_FRACTION
+    assert bound(42.3, module.COMMIT_MEDIAN_MS) == pytest.approx(floor)
+    assert bound(125.4, module.COMMIT_MEDIAN_MS) == pytest.approx(floor)
+
+    # 454.7ms is the worst 8k commit median observed across twelve runs on an
+    # unregressed tree. The floor has to clear it, or the gate is still inside
+    # its own noise.
+    assert floor > 454.7
+
+    # And the floor must stay strictly under the absolute ceiling, or the
+    # scaling rule has been reduced to a duplicate of it.
+    assert floor < module.COMMIT_MEDIAN_MS
+    assert (
+        module.VALIDATE_MEDIAN_MS * module.SCALING_BOUND_CEILING_FRACTION
+        < module.VALIDATE_MEDIAN_MS
+    )
 
 
 def test_check_failure_is_confirmed_by_a_second_measurement(monkeypatch) -> None:
@@ -114,7 +196,7 @@ def test_check_failure_is_confirmed_by_a_second_measurement(monkeypatch) -> None
 
     def fake_measure_all(sizes, samples, root):
         attempts.append(len(attempts) + 1)
-        return NOISY if len(attempts) == 1 else HEALTHY
+        return SUPERLINEAR if len(attempts) == 1 else HEALTHY
 
     monkeypatch.setattr(module, "measure_all", fake_measure_all)
     assert module.main(["--check"]) == 0
@@ -129,7 +211,7 @@ def test_a_reproducible_failure_still_fails(monkeypatch) -> None:
 
     def fake_measure_all(sizes, samples, root):
         attempts.append(len(attempts) + 1)
-        return NOISY
+        return SUPERLINEAR
 
     monkeypatch.setattr(module, "measure_all", fake_measure_all)
     with pytest.raises(SystemExit, match="commit scaling"):
@@ -143,7 +225,7 @@ def test_attempts_one_disables_confirmation(monkeypatch) -> None:
 
     def fake_measure_all(sizes, samples, root):
         attempts.append(len(attempts) + 1)
-        return NOISY
+        return SUPERLINEAR
 
     monkeypatch.setattr(module, "measure_all", fake_measure_all)
     with pytest.raises(SystemExit, match="commit scaling"):
@@ -153,5 +235,5 @@ def test_attempts_one_disables_confirmation(monkeypatch) -> None:
 
 def test_no_check_flag_never_fails(monkeypatch) -> None:
     module = load_module()
-    monkeypatch.setattr(module, "measure_all", lambda sizes, samples, root: NOISY)
+    monkeypatch.setattr(module, "measure_all", lambda sizes, samples, root: SUPERLINEAR)
     assert module.main([]) == 0

--- a/tests/test_upload_endpoint.py
+++ b/tests/test_upload_endpoint.py
@@ -180,6 +180,12 @@ def test_upload_reconciles_when_media_worker_is_unavailable(
     )
 
 
+# Deadlock valves for the concurrency tests below. The hold outlasts the
+# observation so an ordering assertion cannot be satisfied by an expiry.
+_HOLD_SECONDS = 60.0
+_OBSERVE_SECONDS = 30.0
+
+
 def test_upload_reconciliation_does_not_block_async_event_loop(
     vault, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -220,7 +226,11 @@ def test_upload_reconciliation_does_not_block_async_event_loop(
                     headers={"Authorization": "Bearer sekret"},
                 )
             )
-            deadline = asyncio.get_running_loop().time() + 2.0
+            # A deadlock valve. The claim is that the reconcile runs off the
+            # event loop, not that a threadpool worker starts within two
+            # seconds of being asked -- which on a loaded Windows runner it
+            # need not.
+            deadline = asyncio.get_running_loop().time() + _OBSERVE_SECONDS
             while not entered.is_set() and asyncio.get_running_loop().time() < deadline:
                 await asyncio.sleep(0.01)
             assert entered.is_set(), "reconciliation never started"
@@ -374,7 +384,7 @@ def test_identical_concurrent_uploads_serialize_before_append_only_check(
             call = calls
         if call == 1:
             first_entered.set()
-            assert release_first.wait(3.0)
+            assert release_first.wait(_HOLD_SECONDS)
         else:
             second_entered.set()
         return original(*args, **kwargs)
@@ -388,7 +398,7 @@ def test_identical_concurrent_uploads_serialize_before_append_only_check(
 
     with ThreadPoolExecutor(max_workers=2) as pool:
         first = pool.submit(first_client.post, "/upload", **request)
-        assert first_entered.wait(2.0)
+        assert first_entered.wait(_OBSERVE_SECONDS)
         second = pool.submit(second_client.post, "/upload", **request)
         try:
             assert not second_entered.wait(0.15), "second upload entered commit concurrently"


### PR DESCRIPTION
Eleven cross-platform failures and one required-gate failure, all one defect:
a wall-clock number written as a deadlock valve and then read by CI as a
latency assertion. Plus one real product bug found inside them.

## The defect

A test that waits on a background thread needs a timeout so a hang fails
instead of blocking the runner forever. That number is a **deadlock valve** and
should be generous. The same number written tightly becomes a **latency
assertion** — a claim that a shared, contended CI runner is fast — and CI reads
it that way. Where a test also holds a lock while observing an ordering, the
hold has to outlast the observation, or the ordering assertion is satisfied by
an expiry and passes vacuously.

## The product bug

`mode.stop_config_watch` set the stop event and returned. "Stopped" was
therefore unobservable, and that is not cosmetic: `start_config_watch` hands
back the existing thread whenever one is still alive, so a stop/start cycle
inside a single tick returned a thread that was already exiting on the flag.
The caller held a live `Thread`, its new interval never took effect, and no
watcher was running — so a config-driven mode change would never be applied,
which is the one thing that daemon exists to do. It now joins.

## The required gate

`semantic write latency (2k and 8k)` failed twice here on `commit scaling`,
on a tree whose only product changes are the join above and a hook that does
not run on the write path. Before touching the threshold I sampled twelve
consecutive CI runs:

- the 8k commit median — the quantity the rule bounds — ranged **265.7-454.7ms**
- the bound it is compared against ranged **420.6-488.2ms** over the same runs

The bound sits *inside* the natural spread of the thing it bounds, so which
side a run lands on is decided by the runner. Four of twelve came within 100ms
of failing; one landed at -3.9ms. The ratio agrees: 8k/2k commit ran a median
**2.55x** against a `SCALING_RATIO` of 2.0, so the rule was already carried
entirely by the constant slack term.

The bound is now floored at 0.8 of each operation's own absolute ceiling —
600ms for commit, 400ms for validate. That is a deliberately narrowed claim:
the scaling check discriminates only above the noise floor, and the absolute
ceilings are the primary bound below it. Replaying the twelve runs: one failed
before, none after, and genuine super-linear growth still fails before the
absolute ceiling catches it.

This is the same incident as 2026-07-27, whose mitigation — re-measure once on
failure — did not hold: both attempts failed today. Its sensitivity had been
*pinned* in the gate's own tests rather than removed, so those tests moved with
it, including a new parametrized case asserting that all four measured
false-failure sample sets now pass.

## Also here, not timing

- `test_lexstore_atomic_rebuild` and the Windows governance bootstrap test are
  **instrumented, not fixed**: the `os.replace` spy now names its caller and the
  DACL assertion carries the observed SDDL, trustee and verdict. Both had fired
  on CI without reproducing locally, and the last time something in that family
  did (#658) the cause was the runner's own `%TEMP%` descriptor rather than the
  code — a distinction only the observed descriptor can make.
- `_hooks/exomem_continuation_checkpoint` drops a 31ms re-encode out of a 78ms
  lock-held critical section by keeping validated raw bytes.

## Not fixed here

`test_public_revise_keeps_the_closed_receipt_through_graph_handoff_and_replay`
hit `GRAPH_SYNC_PLATFORM_SHARING_REFUSED` — an open reader on the live graph
sidecar refusing `os.replace`. That is the leftover-rebuild-thread class already
tracked against the graph work, not a valve.

## Verification

All 26 checks green, including every Windows and Linux shard, `required CI
gate`, and `semantic write latency (2k and 8k)`. Locally: the five affected
files 170 passed / 20 skipped; the gate's own suite 16 passed.
