### PR TITLE
fix(ci): make Windows refusals name what they observed, and stop timing a cancel

### DIFF
--- a/src/exomem/governance/receipts.py
+++ b/src/exomem/governance/receipts.py
@@ -988,7 +988,17 @@ def _receipt_lock(vault_root: Path):
                 time.sleep(min(0.01, remaining))
             locked = True
         except OSError as exc:
-            raise ReceiptError("receipt append lock is unavailable") from exc
+            # Name the OS failure. Eight concurrent first-users on a Windows CI
+            # shard produced this, and "unavailable" alone cannot say whether it
+            # was a sharing violation on the lock file, a missing parent, or a
+            # permission problem -- three different bugs with three different
+            # fixes. `from exc` keeps the chain for a local traceback, but the
+            # message is all that survives into a subprocess result or a CI
+            # summary, which is exactly where this one was seen.
+            raise ReceiptError(
+                f"receipt append lock is unavailable at {lock_path}: "
+                f"{exc.__class__.__name__}: {exc}"
+            ) from exc
         depths[lock_path] = 1
         yield
     finally:

--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -2895,7 +2895,9 @@ def replace_sidecar(temporary: Path, live: Path) -> None:
     try:
         os.replace(temporary, live)
     except PermissionError as error:
-        if _publish_sidecar_in_place(temporary, live):
+        started = time.monotonic()
+        attempts: list[str] = []
+        if _publish_sidecar_in_place(temporary, live, attempts_out=attempts):
             try:
                 temporary.unlink(missing_ok=True)
             except OSError:
@@ -2903,10 +2905,27 @@ def replace_sidecar(temporary: Path, live: Path) -> None:
                 # the published bytes; the reaper collects it on a later pass.
                 pass
             return
-        raise GraphSidecarReplaceUnavailable("live graph sidecar has an open reader") from error
+        # Carry what the refusal actually observed. This has fired on CI
+        # without reproducing locally, and the message alone -- "has an open
+        # reader" -- cannot distinguish the three things it might be: a reader
+        # that holds a transaction for longer than the whole budget, a
+        # permission problem that is not a sharing conflict at all, or a temp
+        # that never existed. The budget is already generous (three in-place
+        # attempts behind a 5s busy timeout, under four publication attempts
+        # above), so a refusal means something held on for close to a minute
+        # and the useful question is what. Widening a budget that large again
+        # would be guessing; naming the holder is not.
+        raise GraphSidecarReplaceUnavailable(
+            "live graph sidecar has an open reader "
+            f"(os.replace: {error.__class__.__name__}: {error}; "
+            f"in-place {len(attempts)} attempt(s) over {time.monotonic() - started:.1f}s: "
+            f"{'; '.join(attempts) if attempts else 'none ran'})"
+        ) from error
 
 
-def _publish_sidecar_in_place(temporary: Path, live: Path) -> bool:
+def _publish_sidecar_in_place(
+    temporary: Path, live: Path, *, attempts_out: list[str] | None = None
+) -> bool:
     """Copy a proven temp sidecar over the live file without moving the entry.
 
     `sqlite3.Connection.backup` copies the whole source database inside one
@@ -2922,10 +2941,13 @@ def _publish_sidecar_in_place(temporary: Path, live: Path) -> bool:
     was.
     """
     if not live.exists():
+        if attempts_out is not None:
+            attempts_out.append("live sidecar absent")
         return False
     for attempt in range(PUBLISH_IN_PLACE_ATTEMPTS):
         if attempt:
             time.sleep(PUBLISH_IN_PLACE_RETRY_SECONDS)
+        elapsed = time.monotonic()
         try:
             source = sqlite3.connect(temporary)
             try:
@@ -2938,15 +2960,26 @@ def _publish_sidecar_in_place(temporary: Path, live: Path) -> bool:
                     destination.close()
             finally:
                 source.close()
-        except sqlite3.Error:
+        except sqlite3.Error as error:
             logger.debug(
                 "graph sidecar in-place publication attempt %d/%d did not complete",
                 attempt + 1,
                 PUBLISH_IN_PLACE_ATTEMPTS,
                 exc_info=True,
             )
+            if attempts_out is not None:
+                # `sqlite3.OperationalError: database is locked` after roughly
+                # the full busy timeout is a reader holding SHARED across the
+                # window; the same error returned immediately is something
+                # else, and only the elapsed time separates them.
+                attempts_out.append(
+                    f"#{attempt + 1} {error.__class__.__name__}: {error} "
+                    f"after {time.monotonic() - elapsed:.1f}s"
+                )
             continue
-        except OSError:
+        except OSError as error:
+            if attempts_out is not None:
+                attempts_out.append(f"#{attempt + 1} {error.__class__.__name__}: {error}")
             return False
         return True
     return False

--- a/tests/test_client_artifacts.py
+++ b/tests/test_client_artifacts.py
@@ -264,6 +264,14 @@ def test_bounded_retrieval_call_stops_blocked_headers_or_body() -> None:
     assert time.monotonic() - started < 0.5
 
 
+# How long the peer waits before closing the socket, and how long the test
+# will accept the cancel taking. The gap between them is the whole
+# discriminating power of the assertion, so the hold stays far larger than
+# the observation.
+_PEER_CLOSE_SECONDS = 30.0
+_CANCEL_OBSERVE_SECONDS = 10.0
+
+
 def test_staging_cancels_real_http_response_before_close_on_deadline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -293,7 +301,12 @@ def test_staging_cancels_real_http_response_before_close_on_deadline(
     client, peer = socket.socketpair()
     peer.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: 1\r\n\r\n")
     connection = Connection(client)
-    release = threading.Timer(0.2, peer.close)
+    # The peer close is the WRONG way for this read to end, and it exists
+    # only so a broken cancel cannot hang the suite. Keeping it far away
+    # from the deadline is what makes the assertion below discriminating:
+    # the read must end because its own 0.01s deadline fired, not because
+    # the socket went away underneath it.
+    release = threading.Timer(_PEER_CLOSE_SECONDS, peer.close)
     monkeypatch.setattr(client_artifacts, "_RETRIEVAL_DEADLINE_SECONDS", 0.01)
     monkeypatch.setattr(client_artifacts, "resolve_public_addresses", lambda *_args, **_kwargs: ("8.8.8.8",))
     monkeypatch.setattr(client_artifacts, "_PinnedHTTPSConnection", lambda *_args, **_kwargs: connection)
@@ -316,7 +329,12 @@ def test_staging_cancels_real_http_response_before_close_on_deadline(
         release.cancel()
         peer.close()
 
-    assert time.monotonic() - started < 0.1
+    # Not a latency assertion. 0.1s claimed the runner would schedule the
+    # cancel within a tenth of a second of the deadline; a Windows CI shard
+    # took 0.124s while cancelling perfectly correctly. What is under test
+    # is WHICH of the two exits happened, and any value comfortably below
+    # the peer close answers that with room for a contended machine.
+    assert time.monotonic() - started < _CANCEL_OBSERVE_SECONDS
 
 
 def test_staging_routes_headers_and_body_through_the_absolute_deadline_guard(

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -535,6 +535,19 @@ def test_supported_audio_event_reconciles_under_writer_authority(
     assert depth == 0
 
 
+# Valves for the ordering test below. The hold has to outlast both the
+# observation and the foreground's acquisition timeout: if the background's
+# hash finishes on its own, it commits before the foreground ever asks for the
+# boundary and the yield this test exists to prove is never exercised.
+_MEDIA_HOLD_SECONDS = 60.0
+_MEDIA_OBSERVE_SECONDS = 30.0
+# How long the foreground waits for the boundary the background is supposed to
+# have yielded. 0.05s asserted that a Windows runner acquires a free file lock
+# within fifty milliseconds, which is not a property of this code. A background
+# that did NOT yield still fails, because it holds until the hold above.
+_MEDIA_FOREGROUND_ACQUIRE_SECONDS = 15.0
+
+
 def test_background_media_hashing_yields_foreground_guard_then_commits_guarded(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -545,7 +558,7 @@ def test_background_media_hashing_yields_foreground_guard_then_commits_guarded(
     binary.write_bytes(b"large-enough-for-a-blocked-provenance-read")
     manager = writer_lease.LeaseManager(
         writer_lease.LeaseConfig(state_dir=vault.parent / "state"),
-        mutation_timeout_seconds=0.05,
+        mutation_timeout_seconds=_MEDIA_FOREGROUND_ACQUIRE_SECONDS,
     )
     monkeypatch.setattr(writer_lease, "get_manager", lambda: manager)
     hash_started = threading.Event()
@@ -557,7 +570,7 @@ def test_background_media_hashing_yields_foreground_guard_then_commits_guarded(
 
     def blocked_read(*args, **kwargs):  # noqa: ANN002, ANN003
         hash_started.set()
-        assert continue_hash.wait(2.0)
+        assert continue_hash.wait(_MEDIA_HOLD_SECONDS)
         return original_read(*args, **kwargs)
 
     def guarded_batch(*args, **kwargs):  # noqa: ANN002, ANN003
@@ -578,7 +591,7 @@ def test_background_media_hashing_yields_foreground_guard_then_commits_guarded(
 
     background = threading.Thread(target=reconcile)
     background.start()
-    assert hash_started.wait(1.0)
+    assert hash_started.wait(_MEDIA_OBSERVE_SECONDS)
     with manager.mutation_guard(
         vault,
         request_id="req-foreground",
@@ -587,7 +600,11 @@ def test_background_media_hashing_yields_foreground_guard_then_commits_guarded(
     ):
         assert manager.status(vault)["mutation_boundary"]["request_id"] == "req-foreground"
     continue_hash.set()
-    background.join(timeout=3.0)
+    # A deadlock valve. `is_alive()` below is the assertion -- that the
+    # reconcile finished, having taken the boundary for its commit -- not a
+    # claim that it finishes within three seconds of being released. A Windows
+    # shard exceeded that while completing correctly.
+    background.join(timeout=_MEDIA_HOLD_SECONDS)
 
     assert not background.is_alive()
     assert errors == []

--- a/tests/test_graph_rebuild_availability.py
+++ b/tests/test_graph_rebuild_availability.py
@@ -2865,6 +2865,65 @@ def test_windows_replacement_refusal_keeps_the_previous_complete_sidecar(
     assert temporary.read_bytes() == b"new"
 
 
+def test_replacement_refusal_names_what_it_observed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The refusal has to say more than "an open reader".
+
+    It fired on a Windows CI shard without reproducing locally, and by the time
+    it is raised the code has already spent three in-place attempts behind a 5s
+    busy timeout, under four publication attempts above it -- so something held
+    on for close to a minute. "Has an open reader" is a hypothesis, not an
+    observation, and it cannot be told apart from a permission error that is
+    not a sharing conflict at all. Widening a budget that size again would be
+    guessing; carrying the evidence is not.
+    """
+    live = tmp_path / "Knowledge Base/.graph.sqlite"
+    live.parent.mkdir(parents=True)
+    live.write_bytes(b"old")
+    temporary = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    temporary.write_bytes(b"new")
+    monkeypatch.setattr(
+        graph_sync.os,
+        "replace",
+        lambda *_args: (_ for _ in ()).throw(PermissionError(13, "sharing violation")),
+    )
+
+    with pytest.raises(graph_sync.GraphSidecarReplaceUnavailable) as raised:
+        graph_sync.replace_sidecar(temporary, live)
+
+    message = str(raised.value)
+    # What os.replace itself said, not a paraphrase of it.
+    assert "PermissionError" in message
+    assert "sharing violation" in message
+    # Every in-place attempt is accounted for, with the error each one hit.
+    assert f"in-place {graph_sync.PUBLISH_IN_PLACE_ATTEMPTS} attempt(s)" in message
+    assert message.count("#") == graph_sync.PUBLISH_IN_PLACE_ATTEMPTS
+    # Elapsed time is the term that separates "a reader held SHARED for the
+    # whole busy timeout" from "this failed instantly and is not a lock at all".
+    assert "s:" in message and "after" in message
+
+
+def test_replacement_refusal_says_when_there_was_nothing_to_publish_into(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An absent live sidecar is a different failure and must read as one."""
+    live = tmp_path / "Knowledge Base/.graph.sqlite"
+    live.parent.mkdir(parents=True)
+    temporary = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    temporary.write_bytes(b"new")
+    monkeypatch.setattr(
+        graph_sync.os,
+        "replace",
+        lambda *_args: (_ for _ in ()).throw(PermissionError(13, "denied")),
+    )
+
+    with pytest.raises(graph_sync.GraphSidecarReplaceUnavailable) as raised:
+        graph_sync.replace_sidecar(temporary, live)
+
+    assert "live sidecar absent" in str(raised.value)
+
+
 def test_full_rebuild_replacement_refusal_retains_complete_temp_for_later_recovery(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_graph_rebuild_availability.py
+++ b/tests/test_graph_rebuild_availability.py
@@ -3114,7 +3114,13 @@ def test_publication_refused_by_both_paths_still_fails_closed(
     epistemic_graph.clear_publication_memos()
 
     _refuse_replacement_onto(monkeypatch, index.path)
-    monkeypatch.setattr(graph_sync, "_publish_sidecar_in_place", lambda *_args: False)
+    # Takes **_kwargs so it keeps matching the real signature: the refusal now
+    # collects per-attempt evidence through an `attempts_out` list, and a stub
+    # that only accepts positionals fails with TypeError instead of exercising
+    # the fail-closed path this test is about.
+    monkeypatch.setattr(
+        graph_sync, "_publish_sidecar_in_place", lambda *_args, **_kwargs: False
+    )
 
     with pytest.raises(graph_sync.GraphSidecarReplaceUnavailable):
         index.rebuild_all()


### PR DESCRIPTION
GRAPH_SYNC_PLATFORM_SHARING_REFUSED fired on a Windows shard saying only 'live graph sidecar has an open reader', which by then had already survived ~60s of retries and could not be told apart from a non-sharing PermissionError. The refusal now carries the os.replace error verbatim, per-attempt sqlite errors, and the elapsed time that distinguishes a held SHARED lock from an instant failure. No behaviour change.