### PR TITLE
perf(find): let a repeated query survive a write that cannot have changed its answer

### DIFF
--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -172,6 +172,9 @@ def auto_rerank_allowed_by_policy() -> bool:
 # --------------------------------------------------------------------------- #
 _FIND_CACHE: OrderedDict[tuple, list[Hit]] = OrderedDict()
 _FIND_CACHE_LOCK = threading.Lock()
+_FIND_CACHE_CHECKPOINTS: dict[
+    tuple, tuple[tuple[str, freshness.RecallFreshnessCheckpoint], ...]
+] = {}
 _DEFAULT_FIND_CACHE_SIZE = 32
 # A request gets a new FreshnessSnapshot, but a live recall projection changes
 # only when its exact checkpoint moves.  Rebuilding the vault-relative allowset
@@ -185,6 +188,7 @@ _RECALL_PATH_CACHE_LOCK = threading.Lock()
 _RECALL_PATH_CACHE_SIZE = 32
 MAX_RERANK_CANDIDATES = 300
 _FOREGROUND_LEXICAL_REPAIR_PAGE_CAP = 64
+_FIND_CACHE_DELTA_PATH_CAP = 64
 
 
 def _bounded_lexical_repair_allowed(freshness_key: tuple | None) -> bool:
@@ -258,6 +262,143 @@ def _find_cache_size() -> int:
     except ValueError:
         log.warning("EXOMEM_FIND_CACHE_SIZE=%r is not an int; using default", raw)
         return _DEFAULT_FIND_CACHE_SIZE
+
+
+def _trim_find_cache(size: int) -> None:
+    """Trim the hot cache and its delta-validation metadata together.
+
+    Caller holds ``_FIND_CACHE_LOCK``.
+    """
+    while len(_FIND_CACHE) > size:
+        evicted, _hits = _FIND_CACHE.popitem(last=False)
+        _FIND_CACHE_CHECKPOINTS.pop(evicted, None)
+
+
+def _recall_checkpoints_for_cache(
+    snapshot: FreshnessSnapshot,
+    *,
+    scope: str,
+    query_norm: str,
+) -> tuple[tuple[str, freshness.RecallFreshnessCheckpoint], ...]:
+    scopes = ["kb"] if scope in ("kb", "kb-only") else []
+    if scope == "vault" or (scope == "kb" and query_norm):
+        scopes.append("vault")
+    return tuple((item, snapshot.recall_checkpoint(item)) for item in scopes)
+
+
+def _freshness_correctness_fences(key: tuple) -> tuple:
+    """Return the all-or-nothing parts of a query freshness key.
+
+    Recall projections and the keyword catalog may be advanced by the same
+    bounded markdown delta. Everything else remains an unconditional fence:
+    date, access policy, semantic registries, and semantic/graph sidecars.
+    """
+    delta_backed = {"kb", "vault", "lexical"}
+    return tuple(
+        part
+        for part in key
+        if not (
+            isinstance(part, tuple)
+            and part
+            and isinstance(part[0], str)
+            and part[0] in delta_backed
+        )
+    )
+
+
+def _keyword_cache_delta_is_safe(
+    vault_root: Path,
+    *,
+    query_norm: str,
+    cached_hits: list[Hit],
+    cached_freshness: tuple,
+    current_freshness: tuple,
+    checkpoints: tuple[tuple[str, freshness.RecallFreshnessCheckpoint], ...],
+    snapshot: FreshnessSnapshot,
+) -> tuple[bool, tuple[tuple[str, freshness.RecallFreshnessCheckpoint], ...]]:
+    """Prove that a bounded recall delta cannot alter one keyword answer.
+
+    This deliberately supports only the exact keyword contract: all query
+    tokens must occur in a page and matches are ordered by page ``updated``.
+    A changed page already in the answer, any deletion, any newly matching
+    page, a scene-frame dependency, an incomplete delta, or a changed global
+    correctness fence misses. Hybrid/vector results retain their sidecar and
+    whole-projection invalidation because a textually unrelated page may still
+    move semantic or corpus-wide ranking.
+    """
+    if _freshness_correctness_fences(cached_freshness) != _freshness_correctness_fences(
+        current_freshness
+    ):
+        return False, ()
+    if freshness.external_pending(vault_root):
+        return False, ()
+
+    changed: set[str] = set()
+    deleted: set[str] = set()
+    target_signatures: dict[str, freshness.FileSignature] = {}
+    advanced: list[tuple[str, freshness.RecallFreshnessCheckpoint]] = []
+    for scope, checkpoint in checkpoints:
+        current_checkpoint = snapshot.recall_checkpoint(scope)
+        delta = freshness.recall_delta_since(vault_root, scope, checkpoint)
+        if not delta.complete or delta.to != current_checkpoint:
+            return False, ()
+        changed.update(delta.changed)
+        deleted.update(delta.deleted)
+        if len(changed) + len(deleted) > _FIND_CACHE_DELTA_PATH_CAP:
+            return False, ()
+        for path, signature in delta.target_signatures:
+            prior = target_signatures.get(path)
+            if prior is not None and prior != signature:
+                return False, ()
+            target_signatures[path] = signature
+        advanced.append((scope, delta.to))
+
+    # A catalog-only generation change has no recall delta proving what moved.
+    # Keep the in-band sidecar token as the unconditional fallback in that case.
+    if not changed and not deleted:
+        return False, ()
+    # Deleted bytes cannot be inspected for a former scene-frame or other
+    # dependency, so deletion remains conservative.
+    if deleted:
+        return False, ()
+
+    root = vault_root.absolute()
+    cached_paths = {hit.path for hit in cached_hits}
+    for raw_path in changed:
+        expected = target_signatures.get(raw_path)
+        if expected is None:
+            return False, ()
+        path = Path(raw_path)
+        try:
+            rel_path = path.absolute().relative_to(root).as_posix()
+            if freshness.stat_signature(path) != expected:
+                return False, ()
+        except (OSError, ValueError):
+            return False, ()
+        if rel_path in cached_paths:
+            return False, ()
+        if any(part.lower().endswith(".frames") for part in Path(rel_path).parts[:-1]):
+            return False, ()
+        if path.name.lower() in _NAVIGATION_BASENAMES:
+            continue
+        if not recall_policy.is_recall_candidate(vault_root, path):
+            continue
+        page = _CACHE.get(path, vault_root)
+        try:
+            if freshness.stat_signature(path) != expected:
+                return False, ()
+        except OSError:
+            return False, ()
+        if page is None:
+            continue
+        if page.parent_media or _make_excerpt(page, query_norm) is not None:
+            return False, ()
+    if freshness.external_pending(vault_root):
+        return False, ()
+    for scope, checkpoint in advanced:
+        if freshness.recall_checkpoint(vault_root, scope) != checkpoint:
+            return False, ()
+    return True, tuple(advanced)
 
 
 class FreshnessSnapshot:
@@ -395,6 +536,11 @@ def _freshness_key(
       independent of content (spurious misses) and leaves an uncheckpointed commit
       unmoved (STALE hits); the in-band generation changes iff the content did.
       See EmbeddingIndex.cache_token / lexstore.cache_token.
+
+    Plain keyword entries may advance across a complete, bounded recall delta
+    only after ``_keyword_cache_delta_is_safe`` proves that every changed page is
+    non-matching. The full key remains the fallback and every global fence above
+    remains unconditional.
     """
     from . import access
 
@@ -831,9 +977,9 @@ def find(
         if unit_cache_key is not None and not degraded and not failed:
             with _FIND_CACHE_LOCK:
                 _FIND_CACHE[unit_cache_key] = copy.deepcopy(unit_hits)
+                _FIND_CACHE_CHECKPOINTS.pop(unit_cache_key, None)
                 _FIND_CACHE.move_to_end(unit_cache_key)
-                while len(_FIND_CACHE) > cache_size:
-                    _FIND_CACHE.popitem(last=False)
+                _trim_find_cache(cache_size)
         return unit_hits
     mixed = effective_result_level == "mixed"
 
@@ -842,6 +988,9 @@ def find(
     # log freshness never has to enter the cache key.
     cache_size = 0 if prefer_used or mixed or retrieval_trace is not None else _find_cache_size()
     cache_key: tuple | None = None
+    cache_checkpoints: tuple[
+        tuple[str, freshness.RecallFreshnessCheckpoint], ...
+    ] | None = None
     if timings is not None:
         timings.cache["enabled"] = cache_size > 0
     if cache_size > 0:
@@ -892,12 +1041,76 @@ def find(
                 ),
                 relation_filter=relation_active,
             )
+        delta_cache_eligible = bool(
+            mode == "keyword"
+            and query_norm
+            and filter_plan.root is None
+            and not relation_active
+            and types is None
+            and projects is None
+            and tags is None
+            and speakers is None
+            and file_types is None
+            and exclude_file_types is None
+            and updated_after is None
+            and updated_before is None
+            and recency_days is None
+        )
+        if delta_cache_eligible:
+            cache_checkpoints = _recall_checkpoints_for_cache(
+                snapshot,
+                scope=scope,
+                query_norm=query_norm,
+            )
         cache_key = (request_key, fresh)
+        prior_key: tuple | None = None
+        prior_hits: list[Hit] | None = None
+        prior_checkpoints: tuple[
+            tuple[str, freshness.RecallFreshnessCheckpoint], ...
+        ] | None = None
         with _span(timings, "cache_lookup"):
             with _FIND_CACHE_LOCK:
                 cached = _FIND_CACHE.get(cache_key)
                 if cached is not None:
                     _FIND_CACHE.move_to_end(cache_key)
+                elif delta_cache_eligible:
+                    for candidate_key in reversed(_FIND_CACHE):
+                        if candidate_key[0] != request_key:
+                            continue
+                        candidate_checkpoints = _FIND_CACHE_CHECKPOINTS.get(candidate_key)
+                        if candidate_checkpoints is None:
+                            continue
+                        prior_key = candidate_key
+                        prior_hits = _FIND_CACHE[candidate_key]
+                        prior_checkpoints = candidate_checkpoints
+                        break
+        if (
+            cached is None
+            and prior_key is not None
+            and prior_hits is not None
+            and prior_checkpoints is not None
+        ):
+            safe, advanced = _keyword_cache_delta_is_safe(
+                vault_root,
+                query_norm=query_norm,
+                cached_hits=prior_hits,
+                cached_freshness=prior_key[1],
+                current_freshness=fresh,
+                checkpoints=prior_checkpoints,
+                snapshot=snapshot,
+            )
+            if safe:
+                with _FIND_CACHE_LOCK:
+                    current = _FIND_CACHE.get(cache_key)
+                    if current is not None:
+                        cached = current
+                        _FIND_CACHE.move_to_end(cache_key)
+                    elif _FIND_CACHE.get(prior_key) is prior_hits:
+                        cached = _FIND_CACHE.pop(prior_key)
+                        _FIND_CACHE_CHECKPOINTS.pop(prior_key, None)
+                        _FIND_CACHE[cache_key] = cached
+                        _FIND_CACHE_CHECKPOINTS[cache_key] = advanced
+                        _FIND_CACHE.move_to_end(cache_key)
         if cached is not None:
             if timings is not None:
                 timings.cache["hit"] = True
@@ -1164,9 +1377,12 @@ def find(
     if cache_key is not None and not degraded and not failed:
         with _FIND_CACHE_LOCK:
             _FIND_CACHE[cache_key] = copy.deepcopy(hits)
+            if cache_checkpoints is not None:
+                _FIND_CACHE_CHECKPOINTS[cache_key] = cache_checkpoints
+            else:
+                _FIND_CACHE_CHECKPOINTS.pop(cache_key, None)
             _FIND_CACHE.move_to_end(cache_key)
-            while len(_FIND_CACHE) > cache_size:
-                _FIND_CACHE.popitem(last=False)
+            _trim_find_cache(cache_size)
     return hits
 
 
@@ -4243,6 +4459,7 @@ def unload_ram_caches() -> dict[str, int]:
     with _FIND_CACHE_LOCK:
         hot_entries = len(_FIND_CACHE)
         _FIND_CACHE.clear()
+        _FIND_CACHE_CHECKPOINTS.clear()
     with _RECALL_PATH_CACHE_LOCK:
         _RECALL_PATH_CACHE.clear()
     return {"pages": page_entries, "resolvers": resolver_entries, "hot_find": hot_entries}
@@ -4265,6 +4482,7 @@ def reset_page_and_result_caches() -> dict[str, int]:
     with _FIND_CACHE_LOCK:
         hot_entries = len(_FIND_CACHE)
         _FIND_CACHE.clear()
+        _FIND_CACHE_CHECKPOINTS.clear()
     return {"pages": page_entries, "hot_find": hot_entries}
 
 

--- a/tests/test_query_cache_scope.py
+++ b/tests/test_query_cache_scope.py
@@ -1,0 +1,236 @@
+"""Query-cache reuse across bounded recall-freshness deltas."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from exomem import bm25, find as find_module, freshness
+from exomem.vault import walk_vault_md
+
+
+def _write_page(root: Path, rel: str, *, body: str, updated: str = "2026-08-20") -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "---\n"
+        "type: insight\n"
+        f"title: {path.stem}\n"
+        f"updated: {updated}\n"
+        "---\n"
+        f"# {path.stem}\n\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _seed(root: Path) -> None:
+    kb = root / "Knowledge Base"
+    freshness.seed(
+        root,
+        "kb",
+        ((str(path), freshness.stat_signature(path)) for path in find_module._walk_md(kb)),
+    )
+    freshness.seed(
+        root,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in walk_vault_md(root)),
+    )
+
+
+def _query(root: Path, query: str = "needle") -> tuple[list, dict]:
+    timings = find_module.FindTimings()
+    hits = find_module.find(
+        root,
+        query=query,
+        limit=10,
+        scope="kb",
+        mode="keyword",
+        graph=False,
+        rerank=False,
+        timings=timings,
+    )
+    return hits, timings.as_dict()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("EXOMEM_LEXICAL_BACKEND", "python")
+    find_module.clear_cache()
+    bm25.clear_cache()
+    yield
+    find_module.clear_cache()
+    bm25.clear_cache()
+
+
+def test_identical_repeated_query_hits_cache_without_intervening_write(tmp_path: Path) -> None:
+    _write_page(tmp_path, "Knowledge Base/Notes/match.md", body="needle target")
+    _seed(tmp_path)
+
+    first, first_timings = _query(tmp_path)
+    second, second_timings = _query(tmp_path)
+
+    assert first_timings["cache"]["hit"] is False
+    assert second_timings["cache"]["hit"] is True
+    assert [hit.as_dict() for hit in second] == [hit.as_dict() for hit in first]
+
+
+def test_freshness_key_is_deterministic_for_identical_inputs(tmp_path: Path) -> None:
+    _write_page(tmp_path, "Knowledge Base/Notes/match.md", body="needle target")
+    _seed(tmp_path)
+
+    def current_key() -> tuple:
+        return find_module._freshness_key(
+            tmp_path,
+            scope="kb",
+            query_norm="needle",
+            mode="keyword",
+            graph=False,
+            snapshot=find_module.FreshnessSnapshot(tmp_path),
+        )
+
+    assert current_key() == current_key()
+
+
+def test_unrelated_write_does_not_evict_cached_query(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_page(tmp_path, "Knowledge Base/Notes/match.md", body="needle target")
+    _seed(tmp_path)
+    calls = {"count": 0}
+    original = find_module._find_keyword
+
+    def counting(*args, **kwargs):
+        calls["count"] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(find_module, "_find_keyword", counting)
+    first, _ = _query(tmp_path)
+    unrelated = _write_page(
+        tmp_path,
+        "Knowledge Base/Notes/unrelated.md",
+        body="orthogonal material with no matching token",
+    )
+    freshness.on_files_changed(tmp_path, changed=[unrelated])
+
+    second, timings = _query(tmp_path)
+
+    assert timings["cache"]["hit"] is True
+    assert calls["count"] == 1
+    assert [hit.as_dict() for hit in second] == [hit.as_dict() for hit in first]
+
+
+def test_matching_write_evicts_cached_query_and_returns_new_page(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_page(
+        tmp_path,
+        "Knowledge Base/Notes/original.md",
+        body="needle original",
+        updated="2026-08-19",
+    )
+    _seed(tmp_path)
+    calls = {"count": 0}
+    original = find_module._find_keyword
+
+    def counting(*args, **kwargs):
+        calls["count"] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(find_module, "_find_keyword", counting)
+    _query(tmp_path)
+    matching = _write_page(
+        tmp_path,
+        "Knowledge Base/Notes/new-match.md",
+        body="needle newly matching page",
+    )
+    freshness.on_files_changed(tmp_path, changed=[matching])
+
+    hits, timings = _query(tmp_path)
+
+    assert timings["cache"]["hit"] is False
+    assert calls["count"] == 2
+    assert any(hit.path.endswith("new-match.md") for hit in hits)
+
+
+def test_scene_frame_change_evicts_cached_emitted_parent(tmp_path: Path) -> None:
+    parent = _write_page(
+        tmp_path,
+        "Knowledge Base/Evidence/video.mp4.md",
+        body="parent transcript",
+    )
+    child = tmp_path / "Knowledge Base/Evidence/video.mp4.frames/scene-000.jpg.md"
+    child.parent.mkdir(parents=True, exist_ok=True)
+    child.write_text(
+        "---\n"
+        "type: source\n"
+        "title: scene frame\n"
+        "updated: 2026-08-20\n"
+        "parent_media: Knowledge Base/Evidence/video.mp4\n"
+        "media_file: Knowledge Base/Evidence/video.mp4.frames/scene-000.jpg\n"
+        "frame_ts: 1.0\n"
+        "---\n"
+        "# scene frame\n\nneedle on the captured slide\n",
+        encoding="utf-8",
+    )
+    _seed(tmp_path)
+    first, _ = _query(tmp_path)
+    assert [hit.path for hit in first] == [parent.relative_to(tmp_path).as_posix()]
+
+    child.write_text(
+        "---\ntype: source\ntitle: retired frame\nupdated: 2026-08-20\n---\n"
+        "# retired frame\n\nno longer contributes to the parent\n",
+        encoding="utf-8",
+    )
+    freshness.on_files_changed(tmp_path, changed=[child])
+
+    second, timings = _query(tmp_path)
+
+    assert timings["cache"]["hit"] is False
+    assert second == []
+
+
+def test_access_policy_change_always_evicts_cached_query(tmp_path: Path) -> None:
+    secret = _write_page(
+        tmp_path,
+        "Knowledge Base/Private/secret.md",
+        body="needle private material",
+    )
+    _write_page(tmp_path, "Knowledge Base/Notes/public.md", body="needle public material")
+    _seed(tmp_path)
+    first, _ = _query(tmp_path)
+    assert any(hit.path == secret.relative_to(tmp_path).as_posix() for hit in first)
+
+    policy = tmp_path / "Knowledge Base" / "_access.yaml"
+    policy.write_text("excluded:\n  - Private\n", encoding="utf-8")
+    freshness.on_files_changed(tmp_path, changed=[policy])
+
+    second, timings = _query(tmp_path)
+
+    assert timings["cache"]["hit"] is False
+    assert all(hit.path != secret.relative_to(tmp_path).as_posix() for hit in second)
+
+
+def test_incomplete_recall_delta_always_misses(tmp_path: Path) -> None:
+    _write_page(tmp_path, "Knowledge Base/Notes/match.md", body="needle target")
+    _seed(tmp_path)
+    _query(tmp_path)
+    with find_module._FIND_CACHE_LOCK:
+        cache_key = next(iter(find_module._FIND_CACHE_CHECKPOINTS))
+        checkpoints = find_module._FIND_CACHE_CHECKPOINTS[cache_key]
+        find_module._FIND_CACHE_CHECKPOINTS[cache_key] = tuple(
+            (scope, checkpoint._replace(instance_id="foreign-instance"))
+            for scope, checkpoint in checkpoints
+        )
+    unrelated = _write_page(
+        tmp_path,
+        "Knowledge Base/Notes/unrelated.md",
+        body="orthogonal material",
+    )
+    freshness.on_files_changed(tmp_path, changed=[unrelated])
+
+    _hits, timings = _query(tmp_path)
+
+    assert timings["cache"]["hit"] is False


### PR DESCRIPTION
The read cache does not work on the real vault. From #283, the *same query,
twice, seconds apart, same session*: `cache: {enabled: true, hit: false}` both
times, 7,024 ms then 6,818 ms. Measured again on 2026-08-20 at ~2,400 pages:
`cache.hit: false` on both of two back-to-back identical calls.

## What actually varied

The brief required this be diagnosed before anything was changed, because a key
that is non-deterministic across calls would be a much simpler and much worse
bug than a key that is merely too broad.

It is not non-determinism. With live-seeded freshness, **two identical no-write
keys compare equal**. One unrelated page write changed exactly **key elements 2
and 3 — the `kb` and `vault` recall projections**. Nothing else moved.

So `_freshness_key` was working as designed, and the design was the problem: a
one-page edit anywhere invalidates the cached answer to every unrelated query.
On a vault written to constantly from inside agent sessions, that is a cache
that never hits.

## The change

Cached entries now carry a durable recall checkpoint alongside them, and a hit
is allowed only when nothing that could alter *this* answer has happened.

**Everything load-bearing in the old key stays.** The sidecar
`(epoch, generation, instance)` write tokens are untouched — the docstring is
explicit that keying on file mtime instead produces both spurious misses and
stale hits, and that stays true. The access-policy fingerprint remains
all-or-nothing, because a policy change can flip admission for every path in
the vault. The daily expiry, the semantic-language and relation registries, and
the graph, embedding and lexical tokens all still gate as before.

What is added is a bounded delta check, and only for plain unfiltered keyword
queries. A cached result is reused only when every represented recall scope
returns a **complete** delta, every global correctness fence is unchanged, and
every changed page is proven unable to affect the answer.

It misses conservatively, on all of: deletions, catalog-only movement, external
pending writes, more than 64 delta paths, missing or unstable signatures,
changes to a page that was in the cached hit, a page that newly matches,
`parent_media`, and scene-frame changes.

**Hybrid and vector queries, and every filtered query, stay on full-key
invalidation**, because a textually unrelated document can still move semantic
or corpus-wide ranking. This optimisation deliberately does not reach them.

## Measured, 2,400 pages, freshness seeded for both scopes

`documents=2400, tokenized_documents=2400` asserted before any timing was
trusted.

| | before | after |
|---|---:|---:|
| repeated identical query | 1.13 ms hit | 1.02 ms hit |
| **after one unrelated write** | **5,391.6 ms miss** | **12.1 ms validated hit** |

The first-request numbers (6,877 ms vs 4,391 ms) include page-cache warming and
are not the comparison that matters; the post-write row is.

## Tests

`tests/test_query_cache_scope.py`, 7 cases: deterministic and repeated hits, an
unrelated write, a *matching* write (the one that makes the optimisation safe
rather than fast), access-policy invalidation, an incomplete delta, and
scene-frame parent invalidation.

## Verification

Draft so CI runs concurrently. Locally: the new file 7 passed;
`tests/test_retrieval_golden.py` 5 passed after `uv sync --extra embeddings`,
with the lean environment restored afterwards and no lockfile change; `ruff
--select F,E9` clean; `validate-public-artifacts --repository` clean; `git diff
--check` clean.

Reported rather than claimed: the full suite exceeded a one-hour bound while
four other workers were running, and `tests/test_latency_gate.py` hit the
repository's 60-second timeout inside unchanged `recall_policy` /
`find_policy` code — note that fixture sets `EXOMEM_FIND_CACHE_SIZE=0`, so the
path added here is disabled there. CI is authoritative for both.

Refs #283.
