### PR TITLE
feat(ops): let the origin notice it is answering probes and nothing else

### DIFF
--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -30,6 +30,7 @@ import subprocess
 import sys
 import time
 import urllib.parse
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -2248,6 +2249,50 @@ def _check_probe_local(port: int = 8765) -> DoctorCheck:
     )
 
 
+def _check_silent_traffic_payload(body: object) -> DoctorCheck:
+    traffic = body.get("traffic") if isinstance(body, Mapping) else None
+    if not isinstance(traffic, Mapping):
+        return _check(
+            "probe.traffic",
+            "warn",
+            "The origin readiness payload does not report MCP traffic shape.",
+            "Upgrade and restart the origin, then re-run doctor --probe.",
+        )
+    details = dict(traffic)
+    if traffic.get("suspected_silent_outage") is True:
+        seconds = float(traffic.get("probe_window_seconds") or 0.0)
+        probes = int(traffic.get("health_probes_since_last_tool_call") or 0)
+        return _check(
+            "probe.traffic",
+            "warn",
+            f"The origin has answered {probes} health probes across {seconds / 3600:.1f}h "
+            "without a successful MCP tool call.",
+            "Check the edge, tunnel, and route for refusals, misrouting, or auth "
+            "failures before requests reach the origin.",
+            details=details,
+        )
+    return _check(
+        "probe.traffic",
+        "pass",
+        "The origin is not reporting sustained probes without MCP tool traffic.",
+        details=details,
+    )
+
+
+def _check_probe_traffic(port: int = 8765) -> DoctorCheck:
+    url = f"http://127.0.0.1:{port}/health/ready"
+    try:
+        _status, body = _probe_get(url)
+    except Exception as e:  # noqa: BLE001 - transport failure is diagnostic state
+        return _check(
+            "probe.traffic",
+            "fail",
+            f"Could not inspect origin traffic state at {url}: {e}",
+            "Start the server or installed service, then re-run doctor --probe.",
+        )
+    return _check_silent_traffic_payload(body)
+
+
 def _check_probe_oauth_discovery(base_url: str) -> DoctorCheck:
     url = f"{base_url}/.well-known/oauth-authorization-server"
     try:
@@ -2316,7 +2361,7 @@ def _check_probe_protected_resource(base_url: str) -> DoctorCheck:
 
 
 def _check_remote_probes() -> list[DoctorCheck]:
-    checks = [_check_probe_local()]
+    checks = [_check_probe_local(), _check_probe_traffic()]
     base_url = os.environ.get("EXOMEM_BASE_URL", "").strip().rstrip("/")
     if base_url:
         checks.append(_check_probe_oauth_discovery(base_url))

--- a/src/exomem/runtime_readiness.py
+++ b/src/exomem/runtime_readiness.py
@@ -2,16 +2,144 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import re
+import threading
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any
 
 RUNTIME_CONTRACT = 1
 HTTP_TRANSPORT = "streamable-http-stateless"
+
+log = logging.getLogger(__name__)
+
+# The incident behind #581 lasted roughly three days, and its stale poller hit
+# readiness every few seconds.  A full day avoids treating an ordinary quiet
+# night on a personal KB as an outage; 288 probes prove a sustained average
+# cadence of at least one probe per five minutes rather than one late burst.
+SILENT_TRAFFIC_WINDOW_SECONDS = 24 * 60 * 60
+SILENT_TRAFFIC_MINIMUM_HEALTH_PROBES = 288
+
+
+class SilentTrafficMonitor:
+    """Process-local relationship between health probes and successful tools."""
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        window_seconds: float = SILENT_TRAFFIC_WINDOW_SECONDS,
+        minimum_health_probes: int = SILENT_TRAFFIC_MINIMUM_HEALTH_PROBES,
+    ) -> None:
+        self.clock = clock
+        self.window_seconds = float(window_seconds)
+        self.minimum_health_probes = int(minimum_health_probes)
+        self.process_started_at = float(clock())
+        self.last_successful_tool_call_at: float | None = None
+        self.last_health_probe_at: float | None = None
+        self.successful_tool_call_count = 0
+        self.health_probe_count = 0
+        self._health_probe_count_at_last_tool_call = 0
+        self._first_health_probe_after_tool_call_at: float | None = None
+        self._suspected_silent_outage = False
+        self._lock = threading.Lock()
+
+    def record_health_probe(self) -> dict[str, Any]:
+        with self._lock:
+            now = float(self.clock())
+            self.last_health_probe_at = now
+            self.health_probe_count += 1
+            if self._first_health_probe_after_tool_call_at is None:
+                self._first_health_probe_after_tool_call_at = now
+            self._enter_suspicious_state_if_due(now)
+            return self._snapshot(now)
+
+    def record_successful_tool_call(self) -> dict[str, Any]:
+        with self._lock:
+            now = float(self.clock())
+            self.last_successful_tool_call_at = now
+            self.successful_tool_call_count += 1
+            self._health_probe_count_at_last_tool_call = self.health_probe_count
+            self._first_health_probe_after_tool_call_at = None
+            if self._suspected_silent_outage:
+                self._suspected_silent_outage = False
+                log.info(
+                    "event=silent_traffic_outage_cleared successful MCP tool "
+                    "traffic reached the origin; the edge, tunnel, and route are "
+                    "delivering calls again"
+                )
+            return self._snapshot(now)
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            return self._snapshot(float(self.clock()))
+
+    def _enter_suspicious_state_if_due(self, now: float) -> None:
+        first_probe = self._first_health_probe_after_tool_call_at
+        probes = self.health_probe_count - self._health_probe_count_at_last_tool_call
+        if (
+            self._suspected_silent_outage
+            or first_probe is None
+            or probes < self.minimum_health_probes
+            or now - first_probe < self.window_seconds
+        ):
+            return
+        self._suspected_silent_outage = True
+        log.warning(
+            "event=silent_traffic_outage_suspected health probes have continued "
+            "for %.0fs (%d probes) without a successful MCP tool call; check the "
+            "edge, tunnel, and route",
+            max(0.0, now - first_probe),
+            probes,
+        )
+
+    def _snapshot(self, now: float) -> dict[str, Any]:
+        first_probe = self._first_health_probe_after_tool_call_at
+        last_tool = self.last_successful_tool_call_at
+        last_probe = self.last_health_probe_at
+        return {
+            "suspected_silent_outage": self._suspected_silent_outage,
+            "successful_tool_call_count": self.successful_tool_call_count,
+            "health_probe_count": self.health_probe_count,
+            "health_probes_since_last_tool_call": (
+                self.health_probe_count - self._health_probe_count_at_last_tool_call
+            ),
+            "seconds_without_successful_tool_call": round(
+                max(
+                    0.0,
+                    now
+                    - (
+                        last_tool
+                        if last_tool is not None
+                        else self.process_started_at
+                    ),
+                ),
+                3,
+            ),
+            "probe_window_seconds": round(
+                max(0.0, now - first_probe) if first_probe is not None else 0.0,
+                3,
+            ),
+            "last_successful_tool_call_age_seconds": (
+                round(max(0.0, now - last_tool), 3) if last_tool is not None else None
+            ),
+            "last_health_probe_age_seconds": (
+                round(max(0.0, now - last_probe), 3) if last_probe is not None else None
+            ),
+            "window_seconds": self.window_seconds,
+            "minimum_health_probes": self.minimum_health_probes,
+        }
+
+
+_SILENT_TRAFFIC_MONITOR = SilentTrafficMonitor()
+
+
+def get_silent_traffic_monitor() -> SilentTrafficMonitor:
+    return _SILENT_TRAFFIC_MONITOR
 
 
 def _instance_id() -> str | None:
@@ -170,6 +298,7 @@ def build_runtime_readiness(
     mcp_tool_surface_sha256: str | None,
     session_store: Mapping[str, Any] | None = None,
     observability: Mapping[str, Any] | None = None,
+    traffic: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the public readiness payload from already-measured coordination state."""
     enabled = bool(coordination.get("enabled"))
@@ -212,7 +341,7 @@ def build_runtime_readiness(
     graph_sync = _public_graph_sync(coordination.get("graph_sync"))
     if graph_sync is not None:
         coordination_payload["graph_sync"] = graph_sync
-    return {
+    payload = {
         "status": "ready" if takeover_eligible else "not_ready",
         "service": "exomem",
         "release": release,
@@ -230,6 +359,9 @@ def build_runtime_readiness(
         "takeover_eligible": takeover_eligible,
         "reasons": reasons,
     }
+    if traffic is not None:
+        payload["traffic"] = dict(traffic)
+    return payload
 
 
 def _measure_observability() -> dict[str, Any]:
@@ -281,7 +413,11 @@ def _measure_observability() -> dict[str, Any]:
     }
 
 
-def runtime_readiness(*, mcp_tool_surface_sha256: str | None) -> dict[str, Any]:
+def runtime_readiness(
+    *,
+    mcp_tool_surface_sha256: str | None,
+    traffic: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
     """Measure this process's eligibility without exposing vault or credential state."""
     from .session_validation_cache import session_store_readiness
     from .writer_lease import coordination_status
@@ -315,4 +451,9 @@ def runtime_readiness(*, mcp_tool_surface_sha256: str | None) -> dict[str, Any]:
         mcp_tool_surface_sha256=mcp_tool_surface_sha256,
         session_store=session_store_readiness(),
         observability=_measure_observability(),
+        traffic=(
+            traffic
+            if traffic is not None
+            else get_silent_traffic_monitor().snapshot()
+        ),
     )

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -79,8 +79,13 @@ class ExomemFastMCP(FastMCP):
 class CallTraceMiddleware(Middleware):
     """Per-call traceability: log every tool invocation with name + duration."""
 
-    def __init__(self, *, hosted: bool = False) -> None:
+    def __init__(self, *, hosted: bool = False, traffic_monitor=None) -> None:
         self.hosted = hosted
+        if traffic_monitor is None:
+            from .runtime_readiness import get_silent_traffic_monitor
+
+            traffic_monitor = get_silent_traffic_monitor()
+        self.traffic_monitor = traffic_monitor
 
     async def on_call_tool(self, context: MiddlewareContext, call_next):
         from .command_surface import (
@@ -207,6 +212,10 @@ class CallTraceMiddleware(Middleware):
                         f"event={event_prefix}tool_success tool={tool_name} "
                         f"request_id={request_id} duration_ms={dur}{extras}"
                     )
+                    try:
+                        self.traffic_monitor.record_successful_tool_call()
+                    except Exception:  # noqa: BLE001 - telemetry must not break a call
+                        log.debug("silent traffic tool tracking failed", exc_info=True)
                 # One row, at the one point where both the duration and the
                 # outcome are known. A refusal returns an envelope rather than
                 # raising, so inferring the outcome from control flow alone is

--- a/src/exomem/server_assets.py
+++ b/src/exomem/server_assets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 from pathlib import Path
 
 import mcp.types
@@ -14,6 +15,8 @@ from starlette.responses import FileResponse, JSONResponse, RedirectResponse
 from . import runtime_readiness as runtime_readiness_module
 from . import tool_surface as tool_surface_module
 from .session_oauth import OAUTH_AUTHORIZATION_SCOPES, OAUTH_RESOURCE_SCOPES
+
+log = logging.getLogger(__name__)
 
 _STUDIO_SECURITY_HEADERS = {
     "Content-Security-Policy": (
@@ -84,9 +87,18 @@ def server_icons() -> list[mcp.types.Icon]:
     ]
 
 
-def register_asset_routes(mcp_app: FastMCP) -> None:
+def register_asset_routes(mcp_app: FastMCP, *, traffic_monitor=None) -> None:
     """Serve inert public assets outside MCP auth; vault data stays behind REST."""
     asset_dir = Path(__file__).parent
+    if traffic_monitor is None:
+        traffic_monitor = runtime_readiness_module.get_silent_traffic_monitor()
+
+    def _record_health_probe() -> dict:
+        try:
+            return traffic_monitor.record_health_probe()
+        except Exception:  # noqa: BLE001 - telemetry must never fail a probe
+            log.debug("silent traffic health tracking failed", exc_info=True)
+            return {}
 
     @mcp_app.custom_route("/health", methods=["GET"])
     async def _health(request: Request) -> JSONResponse:  # noqa: ARG001
@@ -99,6 +111,7 @@ def register_asset_routes(mcp_app: FastMCP) -> None:
         manager. Host-identifying detail (interpreter path, checkout location) is
         deliberately withheld here because this route is publicly reachable; use
         the local `provenance` command for that."""
+        _record_health_probe()
         payload: dict[str, object] = {"status": "ok", "service": "exomem"}
         try:
             from . import deploy_provenance
@@ -111,6 +124,7 @@ def register_asset_routes(mcp_app: FastMCP) -> None:
     @mcp_app.custom_route("/health/ready", methods=["GET"])
     async def _runtime_ready(request: Request) -> JSONResponse:  # noqa: ARG001
         """Content-free admission probe; liveness remains the separate /health route."""
+        traffic = _record_health_probe()
         digest = getattr(mcp_app, "_exomem_tool_surface_sha256", None)
         if digest is None:
             try:
@@ -120,7 +134,8 @@ def register_asset_routes(mcp_app: FastMCP) -> None:
             except Exception:  # noqa: BLE001 - readiness must stay structured
                 digest = None
         snapshot = runtime_readiness_module.runtime_readiness(
-            mcp_tool_surface_sha256=digest
+            mcp_tool_surface_sha256=digest,
+            traffic=traffic,
         )
         status_code = 200 if snapshot["status"] == "ready" else 503
         return JSONResponse(

--- a/tests/test_silent_traffic_outage.py
+++ b/tests/test_silent_traffic_outage.py
@@ -1,0 +1,191 @@
+"""Origin-side detection for probes continuing without successful MCP traffic."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+
+from fastmcp import FastMCP
+from starlette.testclient import TestClient
+
+from exomem import doctor as doctor_module
+from exomem import runtime_readiness, server, server_assets
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _monitor(clock: Clock):
+    return runtime_readiness.SilentTrafficMonitor(
+        clock=clock,
+        window_seconds=10.0,
+        minimum_health_probes=3,
+    )
+
+
+def _raise_signal(monitor, clock: Clock) -> dict:
+    monitor.record_health_probe()
+    clock.advance(5.0)
+    monitor.record_health_probe()
+    clock.advance(5.0)
+    return monitor.record_health_probe()
+
+
+def test_probes_without_tool_traffic_raise_the_signal() -> None:
+    clock = Clock()
+    monitor = _monitor(clock)
+
+    snapshot = _raise_signal(monitor, clock)
+
+    assert snapshot["suspected_silent_outage"] is True
+    assert snapshot["health_probe_count"] == 3
+    assert snapshot["successful_tool_call_count"] == 0
+    assert snapshot["health_probes_since_last_tool_call"] == 3
+    assert monitor.last_health_probe_at == 10.0
+    assert monitor.last_successful_tool_call_at is None
+
+
+def test_genuinely_idle_server_does_not_raise_the_signal() -> None:
+    clock = Clock()
+    monitor = _monitor(clock)
+
+    clock.advance(100.0)
+    snapshot = monitor.snapshot()
+
+    assert snapshot["suspected_silent_outage"] is False
+    assert snapshot["health_probe_count"] == 0
+    assert snapshot["successful_tool_call_count"] == 0
+
+
+def test_successful_tool_traffic_clears_signal_and_logs_once(
+    caplog, monkeypatch
+) -> None:
+    clock = Clock()
+    monitor = _monitor(clock)
+    _raise_signal(monitor, clock)
+    monkeypatch.setattr(server, "_record_ledger_row", lambda **_kwargs: None)
+    middleware = server.CallTraceMiddleware(traffic_monitor=monitor)
+    context = SimpleNamespace(
+        message={"params": {"name": "ask_memory", "arguments": {}}}
+    )
+
+    async def call_next(_context):
+        return {"ok": True}
+
+    caplog.set_level(logging.INFO, logger="exomem.runtime_readiness")
+    asyncio.run(middleware.on_call_tool(context, call_next))
+    asyncio.run(middleware.on_call_tool(context, call_next))
+
+    snapshot = monitor.snapshot()
+    assert snapshot["suspected_silent_outage"] is False
+    assert snapshot["successful_tool_call_count"] == 2
+    assert caplog.text.count("event=silent_traffic_outage_cleared") == 1
+
+
+def test_signal_is_reported_but_readiness_stays_ready() -> None:
+    clock = Clock()
+    traffic = _raise_signal(_monitor(clock), clock)
+
+    snapshot = runtime_readiness.build_runtime_readiness(
+        coordination={
+            "enabled": False,
+            "role": "standalone",
+            "replica_id": None,
+            "coordinator_healthy": True,
+        },
+        release="1.2.3",
+        mcp_tool_surface_sha256="a" * 64,
+        traffic=traffic,
+    )
+
+    assert snapshot["status"] == "ready"
+    assert snapshot["reasons"] == []
+    assert snapshot["traffic"]["suspected_silent_outage"] is True
+
+    check = doctor_module._check_silent_traffic_payload(snapshot)
+    rendered = doctor_module.render_human(
+        doctor_module.DoctorReport(profile="remote", checks=[check])
+    )
+    assert check.status == "warn"
+    assert "edge" in rendered.lower()
+    assert "tunnel" in rendered.lower()
+    assert "route" in rendered.lower()
+
+
+def test_warning_does_not_repeat_per_probe(caplog) -> None:
+    clock = Clock()
+    monitor = _monitor(clock)
+    caplog.set_level(logging.WARNING, logger="exomem.runtime_readiness")
+
+    _raise_signal(monitor, clock)
+    for _ in range(20):
+        clock.advance(1.0)
+        monitor.record_health_probe()
+
+    assert caplog.text.count("event=silent_traffic_outage_suspected") == 1
+
+
+def test_health_routes_record_probes_with_the_injected_monitor(monkeypatch) -> None:
+    clock = Clock()
+    monitor = _monitor(clock)
+    mcp = FastMCP("traffic-test")
+
+    def fake_readiness(*, mcp_tool_surface_sha256, traffic):
+        assert mcp_tool_surface_sha256 is not None
+        return {"status": "ready", "reasons": [], "traffic": traffic}
+
+    monkeypatch.setattr(runtime_readiness, "runtime_readiness", fake_readiness)
+    server_assets.register_asset_routes(mcp, traffic_monitor=monitor)
+    client = TestClient(mcp.http_app())
+
+    assert client.get("/health").status_code == 200
+    response = client.get("/health/ready")
+
+    assert response.status_code == 200
+    assert response.json()["traffic"]["health_probe_count"] == 2
+
+
+def test_doctor_probe_renders_signal_up_and_down(monkeypatch) -> None:
+    healthy = {
+        "status": "ready",
+        "reasons": [],
+        "traffic": {
+            "suspected_silent_outage": False,
+            "health_probe_count": 8,
+            "successful_tool_call_count": 2,
+            "health_probes_since_last_tool_call": 1,
+            "probe_window_seconds": 0.0,
+            "window_seconds": 86_400.0,
+            "minimum_health_probes": 288,
+        },
+    }
+    suspicious = {
+        **healthy,
+        "traffic": {
+            **healthy["traffic"],
+            "suspected_silent_outage": True,
+            "health_probe_count": 19_000,
+            "health_probes_since_last_tool_call": 19_000,
+            "probe_window_seconds": 90_000.0,
+        },
+    }
+    responses = iter(((200, healthy), (200, suspicious)))
+    monkeypatch.setattr(doctor_module, "_probe_get", lambda _url: next(responses))
+
+    down = doctor_module._check_probe_traffic()
+    up = doctor_module._check_probe_traffic()
+
+    assert down.status == "pass"
+    assert up.status == "warn"
+    assert "edge" in (up.remediation or "").lower()
+    assert "tunnel" in (up.remediation or "").lower()
+    assert "route" in (up.remediation or "").lower()


### PR DESCRIPTION
## What broke, and what this fixes

During the #581 outage every MCP call — including read-only ones — was refused at
the Cloudflare edge with `both Exomem replicas are ineligible`. It lasted about
three days.

**The origin never learned of it.** From its own logs the service was healthy the
whole time: `status: ready`, `reasons: []`, no errors, health probes answering
200. `doctor` passed. Readiness passed. The only place the reason existed was a
503 body returned to a client.

The gap is that the origin could not tell these two states apart:

- nobody is asking me anything
- everything I am asked is being refused before it reaches me

Both look identical from inside: probes arriving on schedule, no tool calls.

## The signal

`SilentTrafficMonitor` (`runtime_readiness.py`) records health probes and
successful tool calls against each other. After a sustained day of probes with no
tool call reaching the origin it logs the suspicion **once** and reports it on
`/health/ready`. A successful call clears it and logs that too.

Two thresholds, both deliberate:

- `SILENT_TRAFFIC_WINDOW_SECONDS = 24h` — a quiet night on a personal KB is not
  an outage. The real incident ran three days.
- `SILENT_TRAFFIC_MINIMUM_HEALTH_PROBES = 288` — proves a *sustained* cadence of
  at least one probe per five minutes, so a single late burst cannot trip it.

## Reported, never enforced

Readiness stays `ready` when the signal is up, and
`test_signal_is_reported_but_readiness_stays_ready` pins that.

An origin that is being bypassed is still a healthy origin. Failing its own
admission probe over a telemetry *inference* would convert a diagnosis into a
second outage — and worse, one that a load balancer would act on. The signal's
job is to be visible, not to be obeyed.

Telemetry is also wrapped so it can never fail a call or a probe: both call sites
swallow and debug-log rather than propagate.

## Where you see it

`doctor --probe` gains a `probe.traffic` check that reads the same field and names
the edge, tunnel and route as where to look — which is the sentence that was
missing for three days.

## Verification

- `tests/test_silent_traffic_outage.py` — 7 tests: signal raises, genuine idle
  does *not* raise, success clears and logs once, readiness stays ready, the
  warning does not repeat per probe, both health routes record, doctor renders it
  up and down.
- `tests/test_runtime_readiness.py`, `test_readiness_honesty.py`,
  `test_call_ledger.py`, `test_tool_failure_logging.py` — 79 passed, 1 skipped.
- `uvx ruff check . --select F,E9` clean.
- Grepped every consumer of the three changed signatures
  (`CallTraceMiddleware`, `register_asset_routes`, `build_runtime_readiness`);
  all new parameters are keyword-only with defaults and no existing caller moves.

Closes the last code ask on #581. Asks 1 and 2 there remain deployment decisions.