### PR TITLE
fix(benchmarks): scan the public export for what a value is, not just its bytes

### DIFF
--- a/benchmarks/memorybench/export.py
+++ b/benchmarks/memorybench/export.py
@@ -1390,18 +1390,21 @@ def _discover_cleanup_targets(plan: MemoryBenchRunPlan) -> list[dict[str, Any]]:
     )
 
 
-def _privacy_forbidden_values(plan: MemoryBenchRunPlan) -> set[str]:
-    forbidden = {
+def _privacy_forbidden_values(plan: MemoryBenchRunPlan) -> tuple[set[str], set[str]]:
+    opaque = {
         plan.privacy_hmac_key_hex,
         "questionId", "containerTag", "groundTruth",
     }
+    content: set[str] = set()
     try:
         _raw, rows = _native_dataset(plan)
         for row in rows:
-            for key in ("question_id", "answer"):
-                value = row.get(key)
-                if isinstance(value, str) and value:
-                    forbidden.add(value)
+            question_id = row.get("question_id")
+            if isinstance(question_id, str) and question_id:
+                opaque.add(question_id)
+            answer = row.get("answer")
+            if isinstance(answer, str) and answer:
+                content.add(answer)
     except Exception:
         pass
     try:
@@ -1409,13 +1412,27 @@ def _privacy_forbidden_values(plan: MemoryBenchRunPlan) -> set[str]:
         if isinstance(checkpoint, dict) and isinstance(checkpoint.get("questions"), list):
             for question in checkpoint["questions"]:
                 if isinstance(question, dict):
-                    for key in ("questionId", "containerTag", "groundTruth", "resultFile"):
+                    for key in ("questionId", "containerTag", "resultFile"):
                         value = question.get(key)
                         if isinstance(value, str) and value:
-                            forbidden.add(value)
+                            opaque.add(value)
+                    ground_truth = question.get("groundTruth")
+                    if isinstance(ground_truth, str) and ground_truth:
+                        content.add(ground_truth)
     except Exception:
         pass
-    return forbidden
+    return opaque, content
+
+
+def _json_string_leaves(value: Any):
+    if isinstance(value, dict):
+        for child in value.values():
+            yield from _json_string_leaves(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _json_string_leaves(child)
+    elif isinstance(value, str):
+        yield value
 
 
 def _validate_public_privacy(payload: bytes, plan: MemoryBenchRunPlan) -> None:
@@ -1424,7 +1441,12 @@ def _validate_public_privacy(payload: bytes, plan: MemoryBenchRunPlan) -> None:
 
     if _scan_text(text, "memorybench-export.v1.json"):
         raise ValueError("public export failed shared privacy validation")
-    if any(value and value in text for value in _privacy_forbidden_values(plan)):
+    opaque, content = _privacy_forbidden_values(plan)
+    if any(value and value in text for value in opaque):
+        raise ValueError("public export contains private runtime material")
+    # Answers can be quoted by required public question text and retrieved hit
+    # content. Equality still rejects carrying a gold value as a public field.
+    if any(value in content for value in _json_string_leaves(_load_json_bytes(payload, "public export"))):
         raise ValueError("public export contains private runtime material")
 
 

--- a/tests/test_memorybench_export.py
+++ b/tests/test_memorybench_export.py
@@ -1630,7 +1630,7 @@ def test_symlinked_results_directory_ancestor_cannot_supply_canonical_hits(
 
 @pytest.mark.parametrize(
     "private_value",
-    [HMAC_KEY_HEX, RAW_QID, RAW_TAG, RAW_GOLD, "results/q-01.json", "groundTruth"],
+    [HMAC_KEY_HEX, RAW_QID, RAW_TAG, "results/q-01.json", "groundTruth"],
 )
 def test_runtime_privacy_leak_in_an_otherwise_agreeing_hit_prevents_public_persistence(
     tmp_path: Path, private_value: str,
@@ -1656,6 +1656,79 @@ def test_runtime_privacy_leak_in_an_otherwise_agreeing_hit_prevents_public_persi
     assert not (tmp_path / "output/memorybench-export.v1.json").exists()
     manifest = json.loads((tmp_path / "output/manifest.json").read_text())
     assert manifest["status"] == "started" and manifest["finalized_at"] is None
+
+
+def _privacy_plan(tmp_path: Path, *, gold: str = RAW_GOLD):
+    from protocol.models import MemoryBenchRunPlan
+
+    payload = _plan_payload(tmp_path)
+    dataset_path = Path(payload["dataset_path"])
+    dataset = json.loads(dataset_path.read_text(encoding="utf-8"))
+    dataset[0]["answer"] = gold
+    dataset_path.write_text(json.dumps(dataset) + "\n", encoding="utf-8")
+    payload["dataset"]["sha256"] = _sha(dataset_path)
+    return MemoryBenchRunPlan.model_validate(payload)
+
+
+def test_public_privacy_rejects_raw_question_id_anywhere_in_payload(tmp_path: Path) -> None:
+    from memorybench.export import _validate_public_privacy
+
+    with pytest.raises(ValueError, match="private runtime material"):
+        _validate_public_privacy(
+            json.dumps({"unexpected": f"prefix-{RAW_QID}-suffix"}).encode(),
+            _privacy_plan(tmp_path),
+        )
+
+
+def test_public_privacy_rejects_gold_answer_as_a_string_leaf(tmp_path: Path) -> None:
+    from memorybench.export import _validate_public_privacy
+
+    with pytest.raises(ValueError, match="private runtime material"):
+        _validate_public_privacy(
+            json.dumps({"unexpected": RAW_GOLD}).encode(),
+            _privacy_plan(tmp_path),
+        )
+
+
+def test_public_privacy_allows_gold_answer_inside_public_question_text(tmp_path: Path) -> None:
+    from memorybench.export import _validate_public_privacy
+
+    _validate_public_privacy(
+        json.dumps({"question": {"text": f"The answer is {RAW_GOLD}."}}).encode(),
+        _privacy_plan(tmp_path),
+    )
+
+
+def test_public_privacy_allows_gold_answer_inside_public_hit_content(tmp_path: Path) -> None:
+    from memorybench.export import _validate_public_privacy
+
+    _validate_public_privacy(
+        json.dumps({"hits": [{"content": f"The answer is {RAW_GOLD}."}]}).encode(),
+        _privacy_plan(tmp_path),
+    )
+
+
+def test_public_privacy_allows_numeric_gold_collisions_in_public_metadata(tmp_path: Path) -> None:
+    from memorybench.export import _validate_public_privacy
+
+    _validate_public_privacy(
+        json.dumps({
+            "case_ordinal": 2,
+            "sha256": "d2" + "0" * 62,
+            "question": {"date": "2026-01-02"},
+        }).encode(),
+        _privacy_plan(tmp_path, gold="2"),
+    )
+
+
+def test_public_privacy_keeps_the_shared_scan_gate(tmp_path: Path) -> None:
+    from memorybench.export import _validate_public_privacy
+
+    with pytest.raises(ValueError, match="shared privacy validation"):
+        _validate_public_privacy(
+            json.dumps({"trace": "/" + "home/private-user/runtime"}).encode(),
+            _privacy_plan(tmp_path),
+        )
 
 
 def test_cleanup_retains_checkpoint_target_after_late_private_projection_write_failure(


### PR DESCRIPTION
**The guest lane's public-export privacy check could not pass on real data.**

`_validate_public_privacy` substring-matched every dataset row's gold `answer`
against the whole serialized export. Two independent reasons that can never
succeed:

1. **Low-entropy gold.** LongMemEval answers include bare numbers — `2`, `10`,
   `500`, `856`. Substring-matched against the whole JSON they hit sha256
   digits, `case_ordinal` integers, and date strings.
2. **Gold legitimately appears in public content.** `MemoryBenchHit.content` is
   a public schema field carrying retrieved text, so a *correct* retrieval
   necessarily surfaces the answer-bearing session. `MemoryBenchQuestion.text`
   is likewise required and public.

Measured on a real 25-case run: 28 forbidden values matched. 26 were bare
numbers; the other two were `Alex` and `Hawaii` inside `question.text`. **Zero
`question_id`s were present and no JSON string leaf equalled any forbidden
value** — nothing was carried. The export was clean; the assertion was wrong.

## The fix

Forbidden values split by what they *are*.

| Kind | Values | Test |
|---|---|---|
| Opaque identifier | `question_id`, `containerTag`, `resultFile`, HMAC key | whole-payload containment — **unchanged** |
| Natural-language content | `answer`, `groundTruth` | JSON string-leaf equality |

Equality still refuses the export carrying gold as a field value — the only way
gold can actually leak, since the schema types `private_gold` as an
`ArtifactReference` and never a string. It stops refusing gold *quoted by* the
public text that legitimately contains it.

The hit-leak parameterization loses its gold case for the same reason: gold in
retrieved content is retrieval working, not material escaping. Every opaque
value in that test still fails.

## Testing

Six invariants, each written red-first:

| Invariant | Expected |
|---|---|
| raw `question_id` anywhere in the payload | rejects |
| gold answer as a string leaf | rejects |
| gold inside `question.text` | allows |
| gold inside `hits[].content` | allows |
| numeric gold colliding with `case_ordinal` / digest / date | allows |
| shared `_scan_text` gate | still rejects |

Mutation-tested in both directions: reverting content to containment fails the
public-question, public-hit and numeric cases; reverting identifiers to equality
fails the raw-ID test with `DID NOT RAISE`. The raw-ID test embeds the id inside
a longer string, so it pins containment rather than passing on equality.

`tests/test_memorybench_export.py` + `tests/test_protocol_schema_conformance.py`:
**204 passed**. Latency gate: **4 passed**.

The full local suite is not clean evidence right now — this host is running
several concurrent agent sessions at load ~4.6, and `pytest-timeout`
(`timeout_method = "thread"`) fires in a different unrelated stack each run
(`test_planning_recall`, `test_access`). Neither touches the export. Deferring
to CI's shards for the whole-suite verdict.

## Provenance

Implemented in a Codex lane (Sol xhigh) against a brief carrying the measured
evidence and the six invariants; reviewed and committed by the orchestrator.
