### PR TITLE
fix(lexstore): stop a background repair being charged to a declining publish

### DIFF
--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -61,6 +61,7 @@ import logging
 import os
 import sqlite3
 import threading
+import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -489,6 +490,49 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
         with _REPAIRS_LOCK:
             _REPAIRS_IN_FLIGHT.discard(key)
         log.warning("lexical background repair could not start for %s", key)
+
+
+#: Deadlock valve for `await_repairs_idle`. Repair is bounded work, so
+#: exceeding this means something is wedged, not that the machine is busy.
+REPAIR_IDLE_TIMEOUT_SECONDS = 120.0
+
+
+def await_repairs_idle(
+    vault_root: Path, timeout: float = REPAIR_IDLE_TIMEOUT_SECONDS
+) -> bool:
+    """Block until no background lexical repair is in flight for `vault_root`.
+
+    `_schedule_repair` runs on a daemon thread and can perform a complete
+    `rebuild_atomic`, live-sidecar `os.replace` included. That is correct in
+    production -- the whole point is that a request does not wait for it -- but
+    it means anything observing live-sidecar mutation is racing a publish it did
+    not start, and will attribute it to itself.
+
+    That is not hypothetical. `test_live_wal_not_blindly_deleted_and_unsafe_publish_declines`
+    spies on `os.replace` process-wide to prove a declining publish never swaps
+    the live main file. A repair thread finishing its own legitimate publish
+    inside that window trips the spy, and the test reports a data-safety defect
+    that did not happen. It fired on a Windows runner, could not be reproduced,
+    and fired again on macOS months later.
+
+    Returns True when idle, False if `timeout` elapsed first -- the caller
+    decides whether that is fatal. Keyed on the resolved path, matching how
+    `_schedule_repair` keys the in-flight set.
+    """
+    key = vault_root.resolve()
+    deadline = time.monotonic() + float(timeout)
+    waiter = threading.Event()
+    while True:
+        with _REPAIRS_LOCK:
+            if key not in _REPAIRS_IN_FLIGHT:
+                return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        # A condition variable would be tidier, but the in-flight set is
+        # discarded under `_REPAIRS_LOCK` from several exit paths including
+        # failure ones; polling cannot miss a wakeup the way a notify can.
+        waiter.wait(min(0.01, remaining))
 
 
 # ------------------------------------------------------------------ policy

--- a/tests/test_lexstore_atomic_rebuild.py
+++ b/tests/test_lexstore_atomic_rebuild.py
@@ -982,6 +982,57 @@ def test_temp_wal_fold_failure_preserves_live_and_does_not_publish(
     assert any("livecontent" in hit.content for hit in _units_in_category(tmp_path, "config"))
 
 
+def test_await_repairs_idle_waits_for_an_in_flight_repair() -> None:
+    """The seam must report busy while a repair holds the key, idle after."""
+    import threading
+
+    root = Path("nonexistent-vault-for-key-only")
+    key = root.resolve()
+
+    with lexstore._REPAIRS_LOCK:
+        lexstore._REPAIRS_IN_FLIGHT.add(key)
+    try:
+        # Busy: it must not claim idle, and must honour its own timeout rather
+        # than block the suite. This is the property that makes it usable as a
+        # precondition assertion.
+        assert lexstore.await_repairs_idle(root, timeout=0.05) is False
+
+        released = threading.Event()
+
+        def release() -> None:
+            released.wait(30.0)
+            with lexstore._REPAIRS_LOCK:
+                lexstore._REPAIRS_IN_FLIGHT.discard(key)
+
+        worker = threading.Thread(target=release, daemon=True)
+        worker.start()
+        released.set()
+        assert lexstore.await_repairs_idle(root, timeout=30.0) is True
+        worker.join(timeout=30.0)
+        assert not worker.is_alive()
+    finally:
+        with lexstore._REPAIRS_LOCK:
+            lexstore._REPAIRS_IN_FLIGHT.discard(key)
+
+    # Idle on a key nobody ever registered.
+    assert lexstore.await_repairs_idle(root, timeout=30.0) is True
+
+
+def test_await_repairs_idle_keys_on_the_resolved_path(tmp_path: Path) -> None:
+    """`_schedule_repair` keys the in-flight set on `.resolve()`, so this must too.
+
+    On macOS `/var` is a symlink to `/private/var`, so an unresolved and a
+    resolved spelling of the same vault are different dict keys. A seam that
+    disagreed with the scheduler would report idle while a repair ran.
+    """
+    with lexstore._REPAIRS_LOCK:
+        lexstore._REPAIRS_IN_FLIGHT.add(tmp_path.resolve())
+    try:
+        assert lexstore.await_repairs_idle(tmp_path, timeout=0.05) is False
+    finally:
+        with lexstore._REPAIRS_LOCK:
+            lexstore._REPAIRS_IN_FLIGHT.discard(tmp_path.resolve())
+
 def test_live_wal_not_blindly_deleted_and_unsafe_publish_declines(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -998,6 +1049,19 @@ def test_live_wal_not_blindly_deleted_and_unsafe_publish_declines(
     # (a) Unsafe: the live WAL cannot be safely folded → decline WITHOUT replacing
     # the live main file (and thus without ever reaching a post-replace unlink of
     # the live -wal/-shm). An os.replace spy proves no main-file swap happened.
+    # The spy below is process-wide, but `_schedule_repair` runs publishes on a
+    # daemon thread that this test did not start. One finishing inside the spied
+    # window is a legitimate publish attributed to this test's declining call --
+    # which is precisely the "data-safety defect vs. a test that spies too
+    # widely" ambiguity the caller list was added to resolve. It resolved it:
+    # the named caller was the normal `os.replace` at the end of
+    # `_build_and_publish`, reachable only when `_quiesce_live_wal` returned
+    # True, i.e. from an instance this test had not patched yet.
+    assert lexstore.await_repairs_idle(tmp_path), (
+        "a background lexical repair was still running; its publish would be "
+        "counted against the declining publish under test"
+    )
+
     replaced = {"n": 0}
     callers: list[str] = []
     real_replace = lexstore.os.replace


### PR DESCRIPTION
## The failure

`tests/test_lexstore_atomic_rebuild.py::test_live_wal_not_blindly_deleted_and_unsafe_publish_declines`
failed on a **macOS** shard on `main`:

```
assert replaced["n"] == 0, callers
E  AssertionError: ['.../src/exomem/lexstore.py:2748 in _build_and_publish -> .../Knowledge Base/.lexical.sqlite']
E  assert 1 == 0
```

The test proves that a publish which cannot safely fold the live WAL **declines
without replacing the live main file**, and spies on `os.replace` to prove no
swap happened.

## What the caller list settled

Whoever hit this on a Windows runner previously could not reproduce it, and left
a comment saying exactly what the next failure would need:

> `rebuild_atomic` has two publish paths — the quarantine branch replaces before
> `_quiesce_live_wal` is ever consulted — so the caller is exactly what the next
> failure needs.

It worked. The named caller is `lexstore.py:2748`, the **ordinary** `os.replace`
at the end of `_build_and_publish`:

```python
if self._live_set_disposition() == "quarantine":
    return self._publish_over_quarantined_set(temp_path)   # the dangerous branch
if not self._quiesce_live_wal():
    return False
os.replace(temp_path, self.path)                            # <- 2748, the named one
```

Reaching 2748 requires `_quiesce_live_wal()` to have returned **True** — but the
test patched it to return False. So the replace came from a call the patch did
not cover.

`_schedule_repair` starts a **daemon thread** that can run a whole
`rebuild_atomic`, `os.replace` included. The spy is installed one line before the
`_quiesce_live_wal` patch, so a repair thread finishing its own legitimate
publish in that window gets counted against the declining call.

**This is the "test that spies too widely" case, not a data-safety defect.** A
real one would have named the quarantine branch.

## The fix

`lexstore.await_repairs_idle(vault_root, timeout=120.0)`.

There was no way to ask whether a background repair was running — tests
observing live-sidecar mutation had to hope none was, and a benchmark harness
reached into `_REPAIRS_IN_FLIGHT` directly. Both want the same thing.

It is keyed on `vault_root.resolve()`, matching how `_schedule_repair` keys the
in-flight set. That matters here specifically: on macOS `/var` is a symlink to
`/private/var`, so an unresolved and a resolved spelling of the same vault are
different dict keys, and a seam that disagreed with the scheduler would report
idle while a repair ran.

It returns a `bool` rather than raising, so the caller decides whether a timeout
is fatal. The test asserts it as a **precondition** before installing the spy, so
the window cannot reopen silently.

## Verification

- `tests/test_lexstore_atomic_rebuild.py`: 42 passed (40 before, plus 2 new).
- Two tests pin the seam itself: that it reports busy while a repair holds the
  key and honours its own timeout rather than blocking the suite, and that it
  keys on the resolved path.
- `uvx ruff check --select F,E9,I` clean.

## Noted, deliberately not fixed here

`_STORES` is keyed on the **raw** `vault_root` (`get_store`, line 389) while
`_REPAIRS_IN_FLIGHT` / `_DEFERRED_UPSERTS` / `_FULL_REBUILD_REQUESTED` are keyed
on `vault_root.resolve()`. Two aliased spellings of one vault therefore mint two
`LexicalStore` instances but share one repair key.

That is a latent inconsistency of the same class as the Windows 8.3 short-name
aliasing that previously minted dual registry keys. It is a **product** change on
a file `#694` is currently modifying, so it belongs in its own PR with its own
test rather than bundled into a flake fix. Filing separately.