### PR TITLE
fix(codex): give lane workers full access so briefs stop asking the impossible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,10 +117,15 @@ Lane mechanics: one lane = one sibling worktree (`../exomem-<lane>`, branch
 `codex/<lane>`, from `origin/main`) = one self-contained `.task/TASK.md` brief
 (`codex_task.sh template`) naming the OpenSpec artifacts as source of truth,
 a scope allowlist, and exact acceptance commands. `codex exec` runs
-`workspace-write`, sandboxed to the worktree — never on the primary checkout
-(the runner enforces this). Results come back as commits on the lane branch
-plus `.task/RESULT.md`; briefs live under `.task/` (git-excluded, never
-committed). Before merging, `scripts/codex_task.sh verify <worktree>` must
+`danger-full-access`, started only in a linked worktree (the runner enforces
+where a lane *starts*, not where it stays). Full access is deliberate:
+`workspace-write` put a linked worktree's gitdir out of reach, so workers could
+not commit, could not use `~/.cache/uv`, and had no PyPI route — briefs kept
+asking for deliverables the sandbox made impossible. In exchange, nothing but
+the brief's allowlist and `verify` keeps a worker out of the primary checkout,
+and both act after the fact: **read the lane diff before trusting it.** Results
+come back as commits on the lane branch plus `.task/RESULT.md`; briefs live
+under `.task/` (git-excluded, never committed). Before merging, `scripts/codex_task.sh verify <worktree>` must
 pass: clean tree, diff within the brief's allowlist, guarded files untouched
 (`tests/golden/`, gate tests, `.github/`), lean pytest + latency gate green.
 On failure: write `.task/FEEDBACK.md`, retry once, escalate Terra→Sol, then

--- a/scripts/codex_task.sh
+++ b/scripts/codex_task.sh
@@ -10,7 +10,21 @@
 #   codex_task.sh verify <worktree-dir>             run the merge gate in a lane worktree
 #
 # Safety: start/verify refuse to operate on anything that is not a *linked*
-# worktree — the shared primary checkout can never be a Codex workspace.
+# worktree — the shared primary checkout can never be where a Codex lane starts.
+#
+# Workers run `danger-full-access`, not `workspace-write`. A linked worktree's
+# gitdir lives under the primary's `.git/worktrees/`, outside a workspace-write
+# sandbox, so a sandboxed worker could not create `index.lock` and could not
+# commit its own work. The same sandbox blocked `~/.cache/uv` and every PyPI
+# route, so a brief could not name `uvx` in an acceptance command either. Those
+# limits made briefs ask for deliverables the worker was structurally unable to
+# produce.
+#
+# The cost is explicit: the sandbox no longer confines a worker to its worktree.
+# `require_linked_worktree` still decides where a lane may *start*, but nothing
+# stops a worker reaching the primary checkout mid-run. The brief's scope
+# allowlist and `verify` are what catch that, and both run after the fact — so
+# read the diff before you trust it.
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -87,7 +101,7 @@ cmd_start() {
   (cd "$wt" && uv sync)
 
   echo "codex_task: launching codex exec (profile=$profile) in $wt"
-  codex exec --profile "$profile" -s workspace-write -C "$wt" \
+  codex exec --profile "$profile" -s danger-full-access -C "$wt" \
     --json -o "$wt/.task/codex-run.jsonl" "$WORKER_PROMPT"
   echo "codex_task: worker finished — inspect $wt/.task/RESULT.md then run: codex_task.sh verify $wt"
 }


### PR DESCRIPTION
**The Codex worker protocol has been asking for deliverables the sandbox made impossible.**

A linked worktree's gitdir lives under the primary checkout's `.git/worktrees/`,
which is outside a `workspace-write` sandbox. So a worker could not create
`index.lock` and could not commit its own work. The same sandbox blocked
`~/.cache/uv` and every PyPI route, so an acceptance command naming `uvx` could
never pass either.

The brief template and `CLAUDE.md` asked for all three anyway. A worker that
skips a structurally impossible step reads afterwards exactly like one that
ignored its brief — which is how the `export-privacy` lane read until the
sandbox limits were checked against the KB note that already documented them.

## Change

`codex exec` now runs `-s danger-full-access`.

## The cost, stated rather than implied

The sandbox no longer confines a worker to its worktree.
`require_linked_worktree` still decides where a lane may *start*, but nothing
stops a worker reaching the primary checkout mid-run — and this repo has
already had one mid-edit collision. The brief's scope allowlist and
`codex_task.sh verify` are what catch it, and both act after the fact.

`CLAUDE.md` claimed `codex exec` runs "`workspace-write`, sandboxed to the
worktree — never on the primary checkout (the runner enforces this)". The
second half of that is now false, so it is rewritten rather than left standing.

## Alternative considered

`workspace-write` with `writable_roots` pointing at the gitdir would restore
in-lane commits without opening the filesystem, but leaves the uv-cache and
PyPI limits in place. Full access was chosen deliberately; the narrower option
remains available if the isolation loss proves to matter.
