### PR TITLE
fix(checkpoint): let a bounded prune slice do at least one unit of work

### DIFF
--- a/plugins/claude-code/hooks/exomem_continuation_checkpoint.py
+++ b/plugins/claude-code/hooks/exomem_continuation_checkpoint.py
@@ -52,6 +52,24 @@ MAX_PRUNE_LOCK_SECONDS = 0.05
 MAX_PRUNE_ENUM_ENTRIES = 16
 MAX_STATE_ENUM_ENTRIES = 32
 MAX_PRUNE_CATALOG_ENTRIES = 512
+
+
+def _over_budget(deadline: float, inspected: int) -> bool:
+    """True once a slice has done some work AND run out of time.
+
+    The `inspected` term is the whole point. A deadline consulted before the
+    first unit of work turns a *bounded* pass into one that can do nothing at
+    all: it inspects zero entries, so the durable cursor does not advance, so
+    the next call starts in the same place and stops just as early. That is not
+    a slow prune, it is no prune -- expired session state accumulates without
+    bound and nothing reports it, because every call returns a perfectly
+    ordinary 0.
+
+    Bounding work has to mean at most N, never fewer than one. A slice may
+    overrun its budget by a single entry; that is the price of forward
+    progress, and it is bounded.
+    """
+    return inspected > 0 and time.monotonic() >= deadline
 MAX_METADATA_LOG_BYTES = 1024 * 1024
 MAX_METADATA_DURATION_MS = 60_000
 TRANSCRIPT_SLICE_BYTES = 64 * 1024
@@ -2599,7 +2617,7 @@ def _linux_directory_window(
         names: list[str] = []
         inspected = 0
         next_cursor = cursor
-        while len(names) < limit and time.monotonic() < deadline:
+        while len(names) < limit and not _over_budget(deadline, inspected):
             count = int(getdents64(scan_fd, ctypes.addressof(buffer), len(buffer)))
             if count < 0:
                 error = ctypes.get_errno()
@@ -2609,7 +2627,7 @@ def _linux_directory_window(
             offset = 0
             raw = buffer.raw
             while offset < count:
-                if time.monotonic() >= deadline:
+                if _over_budget(deadline, inspected):
                     return names, next_cursor, False, inspected
                 record_length = int.from_bytes(raw[offset + 16 : offset + 18], "little")
                 if record_length < 20 or offset + record_length > count:
@@ -2708,7 +2726,7 @@ def _posix_directory_window(
         names: list[str] = []
         inspected = 0
         next_cursor = cursor
-        while inspected < limit and time.monotonic() < deadline:
+        while inspected < limit and not _over_budget(deadline, inspected):
             ctypes.set_errno(0)
             entry = readdir(stream)
             if not entry:
@@ -2776,7 +2794,7 @@ def _directory_window(
     inspected = 0
     with os.scandir(directory.path) as entries:
         for entry in entries:
-            if time.monotonic() >= deadline:
+            if _over_budget(deadline, inspected):
                 return names, 0, False, inspected
             inspected += 1
             names.append(entry.name)
@@ -3088,9 +3106,13 @@ def _delete_tombstone_at(
             for child in children
         ):
             return False
+        # A tombstone is an already-committed decision to delete. Abandoning
+        # one half-unlinked leaves debris AND returns False, so the caller
+        # cannot tell a starving prune from an idle one -- it sees the same
+        # ordinary 0 either way. The deadline decides whether to START
+        # another unit of work, never whether to finish the one in flight,
+        # and `children` is bounded by MAX_STATE_ENUM_ENTRIES above.
         for child in children:
-            if time.monotonic() >= scan_deadline:
-                return False
             _unlink_at(tombstone, child)
         if os.name == "nt":
             _windows_delete_directory_handle(tombstone.windows_handle)
@@ -3501,7 +3523,7 @@ def _prune_catalog_window(
         names: list[str] = []
         inspected = 0
         while inspected < limit and position < MAX_PRUNE_CATALOG_ENTRIES:
-            if time.monotonic() >= deadline:
+            if _over_budget(deadline, inspected):
                 return names, position, False, inspected
             status_value, name = _read_prune_catalog_slot(fd, position)
             inspected += 1
@@ -3727,9 +3749,11 @@ def prune_expired(
                     if _existing_kind(root_handle, name) is not None
                     and name.startswith(".tombstone-")
                 ]
+                pending_done = 0
                 for scanned_name in scanned_names:
-                    if time.monotonic() >= lock_deadline:
+                    if _over_budget(lock_deadline, pending_done):
                         break
+                    pending_done += 1
                     if scanned_name.startswith(".pending-"):
                         _cleanup_pending_root_entry(
                             root_handle,
@@ -3739,9 +3763,11 @@ def prune_expired(
                             scanned_name,
                             now,
                         )
+                recovery_done = 0
                 for recovery_name in recovery_names:
-                    if time.monotonic() >= lock_deadline:
+                    if _over_budget(lock_deadline, recovery_done):
                         break
+                    recovery_done += 1
                     recovered = _authorize_recovery_tombstone(
                         root_handle,
                         home,
@@ -3754,9 +3780,11 @@ def prune_expired(
                         tombstones.append(recovered)
         except (OSError, TimeoutError):
             return 0
+        candidates_done = 0
         for name in entries:
-            if time.monotonic() >= lock_deadline:
+            if _over_budget(lock_deadline, candidates_done):
                 break
+            candidates_done += 1
             try:
                 remaining = max(0.0, lock_deadline - time.monotonic())
                 with _advisory_lock_at(root_handle, ".root.lock", timeout=remaining) as root_lock:
@@ -3774,13 +3802,15 @@ def prune_expired(
                         tombstones.append(tombstone)
             except (OSError, TimeoutError):
                 continue
-            if time.monotonic() >= lock_deadline:
+            if _over_budget(lock_deadline, candidates_done):
                 break
             time.sleep(0.001)
         removed = 0
+        deletions_done = 0
         for item, identity in tombstones:
-            if time.monotonic() >= lock_deadline:
+            if _over_budget(lock_deadline, deletions_done):
                 break
+            deletions_done += 1
             deleted = _delete_tombstone_at(
                 root_handle,
                 item,

--- a/src/exomem/_hooks/exomem_continuation_checkpoint.py
+++ b/src/exomem/_hooks/exomem_continuation_checkpoint.py
@@ -52,6 +52,24 @@ MAX_PRUNE_LOCK_SECONDS = 0.05
 MAX_PRUNE_ENUM_ENTRIES = 16
 MAX_STATE_ENUM_ENTRIES = 32
 MAX_PRUNE_CATALOG_ENTRIES = 512
+
+
+def _over_budget(deadline: float, inspected: int) -> bool:
+    """True once a slice has done some work AND run out of time.
+
+    The `inspected` term is the whole point. A deadline consulted before the
+    first unit of work turns a *bounded* pass into one that can do nothing at
+    all: it inspects zero entries, so the durable cursor does not advance, so
+    the next call starts in the same place and stops just as early. That is not
+    a slow prune, it is no prune -- expired session state accumulates without
+    bound and nothing reports it, because every call returns a perfectly
+    ordinary 0.
+
+    Bounding work has to mean at most N, never fewer than one. A slice may
+    overrun its budget by a single entry; that is the price of forward
+    progress, and it is bounded.
+    """
+    return inspected > 0 and time.monotonic() >= deadline
 MAX_METADATA_LOG_BYTES = 1024 * 1024
 MAX_METADATA_DURATION_MS = 60_000
 TRANSCRIPT_SLICE_BYTES = 64 * 1024
@@ -2599,7 +2617,7 @@ def _linux_directory_window(
         names: list[str] = []
         inspected = 0
         next_cursor = cursor
-        while len(names) < limit and time.monotonic() < deadline:
+        while len(names) < limit and not _over_budget(deadline, inspected):
             count = int(getdents64(scan_fd, ctypes.addressof(buffer), len(buffer)))
             if count < 0:
                 error = ctypes.get_errno()
@@ -2609,7 +2627,7 @@ def _linux_directory_window(
             offset = 0
             raw = buffer.raw
             while offset < count:
-                if time.monotonic() >= deadline:
+                if _over_budget(deadline, inspected):
                     return names, next_cursor, False, inspected
                 record_length = int.from_bytes(raw[offset + 16 : offset + 18], "little")
                 if record_length < 20 or offset + record_length > count:
@@ -2708,7 +2726,7 @@ def _posix_directory_window(
         names: list[str] = []
         inspected = 0
         next_cursor = cursor
-        while inspected < limit and time.monotonic() < deadline:
+        while inspected < limit and not _over_budget(deadline, inspected):
             ctypes.set_errno(0)
             entry = readdir(stream)
             if not entry:
@@ -2776,7 +2794,7 @@ def _directory_window(
     inspected = 0
     with os.scandir(directory.path) as entries:
         for entry in entries:
-            if time.monotonic() >= deadline:
+            if _over_budget(deadline, inspected):
                 return names, 0, False, inspected
             inspected += 1
             names.append(entry.name)
@@ -3088,9 +3106,13 @@ def _delete_tombstone_at(
             for child in children
         ):
             return False
+        # A tombstone is an already-committed decision to delete. Abandoning
+        # one half-unlinked leaves debris AND returns False, so the caller
+        # cannot tell a starving prune from an idle one -- it sees the same
+        # ordinary 0 either way. The deadline decides whether to START
+        # another unit of work, never whether to finish the one in flight,
+        # and `children` is bounded by MAX_STATE_ENUM_ENTRIES above.
         for child in children:
-            if time.monotonic() >= scan_deadline:
-                return False
             _unlink_at(tombstone, child)
         if os.name == "nt":
             _windows_delete_directory_handle(tombstone.windows_handle)
@@ -3501,7 +3523,7 @@ def _prune_catalog_window(
         names: list[str] = []
         inspected = 0
         while inspected < limit and position < MAX_PRUNE_CATALOG_ENTRIES:
-            if time.monotonic() >= deadline:
+            if _over_budget(deadline, inspected):
                 return names, position, False, inspected
             status_value, name = _read_prune_catalog_slot(fd, position)
             inspected += 1
@@ -3727,9 +3749,11 @@ def prune_expired(
                     if _existing_kind(root_handle, name) is not None
                     and name.startswith(".tombstone-")
                 ]
+                pending_done = 0
                 for scanned_name in scanned_names:
-                    if time.monotonic() >= lock_deadline:
+                    if _over_budget(lock_deadline, pending_done):
                         break
+                    pending_done += 1
                     if scanned_name.startswith(".pending-"):
                         _cleanup_pending_root_entry(
                             root_handle,
@@ -3739,9 +3763,11 @@ def prune_expired(
                             scanned_name,
                             now,
                         )
+                recovery_done = 0
                 for recovery_name in recovery_names:
-                    if time.monotonic() >= lock_deadline:
+                    if _over_budget(lock_deadline, recovery_done):
                         break
+                    recovery_done += 1
                     recovered = _authorize_recovery_tombstone(
                         root_handle,
                         home,
@@ -3754,9 +3780,11 @@ def prune_expired(
                         tombstones.append(recovered)
         except (OSError, TimeoutError):
             return 0
+        candidates_done = 0
         for name in entries:
-            if time.monotonic() >= lock_deadline:
+            if _over_budget(lock_deadline, candidates_done):
                 break
+            candidates_done += 1
             try:
                 remaining = max(0.0, lock_deadline - time.monotonic())
                 with _advisory_lock_at(root_handle, ".root.lock", timeout=remaining) as root_lock:
@@ -3774,13 +3802,15 @@ def prune_expired(
                         tombstones.append(tombstone)
             except (OSError, TimeoutError):
                 continue
-            if time.monotonic() >= lock_deadline:
+            if _over_budget(lock_deadline, candidates_done):
                 break
             time.sleep(0.001)
         removed = 0
+        deletions_done = 0
         for item, identity in tombstones:
-            if time.monotonic() >= lock_deadline:
+            if _over_budget(lock_deadline, deletions_done):
                 break
+            deletions_done += 1
             deleted = _delete_tombstone_at(
                 root_handle,
                 item,

--- a/tests/test_continuation_checkpoint.py
+++ b/tests/test_continuation_checkpoint.py
@@ -3254,7 +3254,15 @@ def test_portable_catalog_cursor_progress_survives_fresh_processes(
 
 def test_portable_catalog_prune_reaches_owned_state_and_ignores_foreign_copy(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # This asserts a CORRECTNESS property -- the owned state goes, the foreign
+    # copy stays -- so it must not also depend on how much pruning a contended
+    # runner fits into 50ms. `prune_expired` deliberately does a bounded slice
+    # per call, and on a loaded Windows shard a slice can end before it reaches
+    # the entry; 40 of them then sum to 0 and this failed as `assert 0 == 1`.
+    # Starvation under a tight budget is pinned separately, just below.
+    monkeypatch.setattr(checkpoint, "MAX_PRUNE_LOCK_SECONDS", 5.0)
     home = tmp_path / "home"
     client = "codex"
     session = "portable-expired"
@@ -3282,6 +3290,44 @@ def test_portable_catalog_prune_reaches_owned_state_and_ignores_foreign_copy(
     assert removed == 1
     assert not state.exists()
     assert foreign.is_dir()
+
+
+def test_a_spent_budget_still_advances_the_prune_cursor(tmp_path: Path) -> None:
+    """A bounded slice must do at least one unit of work, never zero.
+
+    `_prune_catalog_window` used to consult its deadline before reading any
+    slot. Handed an already-spent budget it inspected nothing and returned the
+    cursor it was given, so the next call started in the same place and stopped
+    just as early. That is not a slow prune, it is no prune: expired state
+    accumulates forever while every call returns an ordinary 0.
+
+    A deadline decides whether to START another unit of work. It must never
+    decide whether to do the first one. Handing this an expired deadline is the
+    whole test -- no sleeping, no timing, no dependence on how fast the runner
+    is.
+    """
+    home = tmp_path / "home"
+    client = "codex"
+    checkpoint.write_checkpoint(
+        _event(client=client, session_id="spent-budget"),
+        home,
+        observed_at_ns=100,
+    )
+    root_path = checkpoint.client_state_root(home, client)
+
+    with checkpoint._open_secure_directory(root_path, create=False) as root:
+        names, cursor, exhausted, inspected = checkpoint._prune_catalog_window(
+            root,
+            cursor=0,
+            limit=checkpoint.MAX_PRUNE_ENUM_ENTRIES,
+            deadline=time.monotonic() - 1.0,
+        )
+
+    assert inspected >= 1, "a spent budget inspected nothing, so nothing can ever progress"
+    assert cursor != 0 or exhausted, (
+        "the durable cursor did not move, so the next slice repeats this one"
+    )
+    assert len(names) <= checkpoint.MAX_PRUNE_ENUM_ENTRIES
 
 
 def test_valid_legacy_current_access_registers_only_the_bound_state(


### PR DESCRIPTION
Closes the Windows shard failure behind #692 by fixing what caused it rather than the test that noticed it.

## The bug

`prune_expired` runs on every checkpoint write and does a deliberately bounded slice: `MAX_PRUNE_LOCK_SECONDS = 0.05`, at most 16 entries, with the cursor persisted so the next call resumes where this one stopped. That design is right — housekeeping must never stall a write.

The bound was written so a slice can do **nothing at all**. Every loop consulted its deadline *before* its first unit of work — `_prune_catalog_window`, the Linux/POSIX/Windows directory windows, and all four phases of `prune_expired`. Given a spent budget, enumeration inspects zero slots and returns the cursor it was handed, so the next call starts in the same place and stops just as early.

Expired session state then accumulates without bound while every call returns a perfectly ordinary `0`. Nothing reports it, because "nothing to prune" and "cannot prune" are the same value.

`_delete_tombstone_at` had the sharper version: it could abandon a tombstone **half-unlinked** and return `False`. Measured at a 5 ms budget before this change — the state directory was destroyed and the caller was told zero removals.

## The rule

`_over_budget(deadline, inspected)` states it once: **a deadline decides whether to START another unit of work, never whether to do the first one.** A slice may overrun by a single entry; that is the price of forward progress, and it is bounded.

## How it surfaced

#692's `tests (windows-latest, py3.13)` shard failed `test_portable_catalog_prune_reaches_owned_state_and_ignores_foreign_copy` with `assert 0 == 1`, passing everywhere else. All 40 slices returned 0.

Squeezing `MAX_PRUNE_LOCK_SECONDS` locally reproduces the exact symptom, and measurement on this Windows box shows the pre-lock setup alone (secure open + private-DACL check) reaching **16 ms of the 50 ms budget** on an idle machine.

That test asserts a *correctness* property — owned state goes, foreign copy stays — so it should not also depend on how much a contended runner fits into 50 ms. It now pins a generous budget, and starvation is pinned separately by `test_a_spent_budget_still_advances_the_prune_cursor`, which hands the window an already-expired deadline and depends on no timing whatsoever.

## Verification

- Mutation-tested: reverting the window fix takes the new guard red with `assert 0 >= 1`.
- A first attempt at a guard for the half-unlink path **passed with the regression reintroduced** and was deleted rather than shipped — the window fix now shadows that path, so it is defense-in-depth without an isolating test, and this says so instead of implying coverage it does not have.
- Local: **267 passed, 40 skipped** across every suite exercising the hook.
- `ruff check --select F,E9,I` clean.