### PR TITLE
fix(collections): stop a letterless audit head being read back as an integer

### DIFF
--- a/src/exomem/record_formats.py
+++ b/src/exomem/record_formats.py
@@ -1176,6 +1176,33 @@ def render_markdown_item_update(
     return bom + rebuilt
 
 
+def _yaml_head_scalar(transition_id: str) -> str:
+    """Render an audit head so YAML reads it back as the string it is.
+
+    The head is 24 characters of `uuid4().hex`, so about one draw in 79,000
+    contains no letter at all. Written bare, YAML types
+    `head: 123456789012345678901234` as an integer, and the reader -- which
+    requires a str -- rejects the manifest with INVALID_COLLECTION_AUDIT. The
+    collection is unreadable from then on. It surfaced as a single product-E2E
+    failure on main that passed on a rerun of the identical tree, because the
+    rerun drew a different id (#549).
+
+    Quoting only the ids that need it keeps the renderer's style contract: a
+    manifest is user-visible, its existing spelling and trailing comments are
+    preserved elsewhere in this function, and quoting all of them would rewrite
+    every manifest in the vault on its next mutation to fix one in 79,000.
+
+    Asking the parser is the check, rather than reasoning about which literals
+    YAML claims. That reasoning is what produced the bug.
+    """
+    try:
+        if vault.yaml.safe_load(f"v: {transition_id}")["v"] == transition_id:
+            return transition_id
+    except (vault.yaml.YAMLError, KeyError, TypeError):
+        pass
+    return f"'{transition_id}'"
+
+
 def render_manifest_audit_head(
     source: str,
     transition_id: str,
@@ -1228,7 +1255,8 @@ def render_manifest_audit_head(
         raise collections.CollectionError("INVALID_RECORD_AUDIT", "audit reader version is invalid")
     if audit_node is None:
         frontmatter += (
-            f"{profile.manifest_audit_property}: {{version: {reader_version or 1}, head: {transition_id}}}{newline}"
+            f"{profile.manifest_audit_property}: "
+            f"{{version: {reader_version or 1}, head: {_yaml_head_scalar(transition_id)}}}{newline}"
         )
     else:
         values = {
@@ -1242,7 +1270,11 @@ def render_manifest_audit_head(
             raise collections.CollectionError(
                 "INVALID_RECORD_AUDIT", "record audit head is invalid"
             )
-        replacements = [(head.start_mark.index, head.end_mark.index, transition_id)]
+        # The marks span any quotes the existing scalar had, so the
+        # replacement has to supply its own.
+        replacements = [
+            (head.start_mark.index, head.end_mark.index, _yaml_head_scalar(transition_id))
+        ]
         if reader_version is not None:
             replacements.append((version.start_mark.index, version.end_mark.index, str(reader_version)))
         for start_index, end_index, replacement in sorted(replacements, reverse=True):

--- a/src/exomem/structured_collections.py
+++ b/src/exomem/structured_collections.py
@@ -1510,6 +1510,10 @@ def plan_audit_head(frontmatter: Mapping[str, Any]) -> str | None:
     return _audit_head(frontmatter, "plan_audit")
 
 
+_AUDIT_HEAD_LENGTH = 24
+_AUDIT_HEAD_PATTERN = re.compile(r"[0-9a-f]{24}")
+
+
 def _audit_head(frontmatter: Mapping[str, Any], name: str) -> str | None:
     code = "INVALID_RECORD_AUDIT" if name == "record_audit" else "INVALID_COLLECTION_AUDIT"
     audit = frontmatter.get(name)
@@ -1518,6 +1522,18 @@ def _audit_head(frontmatter: Mapping[str, Any], name: str) -> str | None:
     if not isinstance(audit, Mapping) or set(audit) != {"version", "head"}:
         raise CollectionError(code, "collection audit state is invalid")
     head = audit.get("head")
+    if type(head) is int:
+        # Recover a head written before it was quoted. The id is 24 characters
+        # of uuid4 hex, so about one in 79,000 contains no letter and YAML typed
+        # the bare scalar as an integer -- and the collection has been unreadable
+        # ever since, because the check below requires a str (#549). The width is
+        # fixed at 24, so zero-padding restores the original exactly.
+        #
+        # Not recoverable: an id that began with 0 and used only digits 0-7 was
+        # read as octal, and its decimal rendering is a different string. That is
+        # far rarer still, and it keeps failing here rather than loading a head
+        # that was never written.
+        head = str(head).zfill(_AUDIT_HEAD_LENGTH)
     supported_versions = {1, 2} if name == "record_audit" else {1}
     if (
         type(audit.get("version")) is not int
@@ -1525,7 +1541,7 @@ def _audit_head(frontmatter: Mapping[str, Any], name: str) -> str | None:
         or not isinstance(head, str)
     ):
         raise CollectionError(code, "collection audit state is invalid")
-    if re.fullmatch(r"[0-9a-f]{24}", head) is None:
+    if _AUDIT_HEAD_PATTERN.fullmatch(head) is None:
         raise CollectionError(code, "collection audit head is invalid")
     return head
 

--- a/tests/test_planning_profile.py
+++ b/tests/test_planning_profile.py
@@ -291,3 +291,68 @@ def test_planning_saved_views_use_plan_id_not_records_identity(tmp_path: Path) -
     invalid = load_manifest(tmp_path, path)
     with pytest.raises(CollectionError, match="INVALID_SAVED_VIEW"):
         resolve_saved_view(invalid, "pinned")
+
+
+def test_an_all_digit_audit_head_survives_a_yaml_round_trip() -> None:
+    """A head with no letters in it must not come back as an integer.
+
+    The head is 24 characters of `uuid4().hex`, so roughly one in 79,000 draws
+    contains no letter at all. Written bare into a YAML flow mapping, that one
+    is typed as an integer rather than a string, and the reader -- which
+    requires a str -- rejects the manifest with INVALID_COLLECTION_AUDIT. The
+    collection is then unreadable for good.
+
+    It is nondeterministic per write, which is exactly how it presented in
+    #549: a single product-E2E failure on main that passed on a rerun of the
+    identical tree, because the rerun drew a different id.
+
+    Both writer branches are covered here. The append branch adds the mapping;
+    the update branch rewrites the head scalar in place, and its replacement
+    span includes the surrounding quotes -- so an unquoted replacement would
+    strip them and reintroduce the defect on the very next mutation.
+    """
+    from exomem import record_formats, structured_collections, vault
+
+    all_digits = "123456789012345678901234"
+    successor = "987654321098765432109876"
+    source = "---\ntype: plan\nsemantic_profile: planning\n---\nbody\n"
+
+    appended = record_formats.render_manifest_audit_head(
+        source, all_digits, semantic_profile="planning"
+    )
+    updated = record_formats.render_manifest_audit_head(
+        appended, successor, semantic_profile="planning"
+    )
+
+    for stage, document, expected in (
+        ("append", appended, all_digits),
+        ("update", updated, successor),
+    ):
+        parsed, _body, _marker = vault.parse_frontmatter(document, strict=True)
+        head = parsed["plan_audit"]["head"]
+        assert isinstance(head, str), (
+            f"{stage} wrote the head unquoted, so YAML typed it as "
+            f"{type(head).__name__} and the manifest no longer loads"
+        )
+        assert structured_collections.plan_audit_head(parsed) == expected
+
+
+def test_a_manifest_already_written_with_a_bare_all_digit_head_still_loads() -> None:
+    """Recovery for manifests written before the head was quoted.
+
+    Quoting stops new occurrences; it does nothing for a collection that
+    already has one on disk, and that collection is otherwise permanently
+    unreadable. The width is fixed at 24, so the integer YAML handed back
+    zero-pads to exactly the string that was written.
+    """
+    from exomem import structured_collections, vault
+
+    bare = "plan_audit: {version: 1, head: 123456789012345678901234}"
+    document = f"---\ntype: plan\nsemantic_profile: planning\n{bare}\n---\nbody\n"
+
+    parsed, _body, _marker = vault.parse_frontmatter(document, strict=True)
+
+    assert not isinstance(parsed["plan_audit"]["head"], str), (
+        "this fixture is meant to reproduce the untyped-scalar shape"
+    )
+    assert structured_collections.plan_audit_head(parsed) == "123456789012345678901234"


### PR DESCRIPTION
Fixes #549 — filed as an unreproduced one-shot, now root-caused and reproduced deterministically.

## What happens

The manifest audit head is `uuid4().hex[:24]`, written **bare** into a YAML flow mapping:

```yaml
plan_audit: {version: 1, head: a868831e43eed8a1c0ffee12}
```

About **one draw in 79,000** contains no letter at all. YAML types that one as an *integer*:

```python
>>> yaml.safe_load("plan_audit: {version: 1, head: 123456789012345678901234}")["plan_audit"]["head"]
123456789012345678901234          # int, not str
```

`_audit_head` requires `isinstance(head, str)`, so it raises `INVALID_COLLECTION_AUDIT / 'collection audit state is invalid'` — the exact code and message in the report. And it does not heal: the manifest on disk keeps the same bare digits, so the collection stays unreadable.

That matches the report precisely — one product-E2E failure on main, green on a rerun of the **identical tree**. The rerun drew an id with a letter in it.

## The hypothesis in the issue is wrong

The description proposed a local-vs-UTC day seam, reasonably, since the failure landed at 23:37Z and this codebase has a prior confirmed midnight-window class. There is **no clock, date, or timezone anywhere in the audit path** — it is pure YAML shape validation. The timing is a coincidence. [Ruled out on the issue](https://github.com/Artexis10/exomem/issues/549#issuecomment-5358089871) so nobody restarts there.

## Why conditional quoting

The renderer has a deliberate style-preservation contract — two existing tests pin it, one down to preserving a trailing comment on the same line. Manifests are user-visible, and quoting all of them would rewrite every manifest in the vault on its next mutation to fix one in 79,000. So `_yaml_head_scalar` quotes only ids that need it, and decides by **asking the parser whether the bare form round-trips** rather than reasoning about which literals YAML claims — that reasoning is what produced the bug.

## Recovery for manifests already on disk

Quoting stops new occurrences and does nothing for a collection that already has one, which is otherwise permanently unreadable. The width is fixed at 24, so zero-padding the integer restores the original string exactly. An id that began with `0` and used only digits `0-7` was read as **octal** and is genuinely unrecoverable — it keeps failing rather than silently loading a head that was never written. Stated in the code rather than glossed.

## Verification

- **55 passed** across `test_planning_profile.py`, `test_structured_collections.py`, `test_record_task3_regressions.py` — including both style-preservation tests, unchanged.
- Mutation-tested: reverting to a bare write takes the new test red with `append wrote the head unquoted, so YAML typed it as int`.
- Both writer branches covered — append, and the in-place update whose replacement span includes the surrounding quotes (an unquoted replacement there would strip them and reintroduce the defect on the very next mutation).
- `ruff check --select F,E9,I` clean.