### PR TITLE
perf(recall): build the cold resolver from the lexical sidecar instead of the vault

### DIFF
--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -4021,6 +4021,7 @@ def recall_resolver_snapshot(vault_root: Path, freshness: tuple | None = None):
     an ordinary note in the graph lane.
     """
     from . import freshness as freshness_module
+    from . import lexstore
     from .vault import WikilinkResolver, walk_vault_md
 
     root = Path(vault_root)
@@ -4088,13 +4089,17 @@ def recall_resolver_snapshot(vault_root: Path, freshness: tuple | None = None):
     # would then elect itself leader and rebuild -- reintroducing the stampede
     # this exists to prevent, just narrowed to a race window.
     try:
-        entries: list[tuple[str, str | None]] = []
-        for path in walk_vault_md(root):
-            if not recall_policy.is_recall_candidate(root, path):
-                continue
-            page = _CACHE.get(path, root)
-            if page is not None:
-                entries.append((page.rel_path, page.title))
+        entries = lexstore.get_store(root).recall_resolver_entries(
+            "vault", checkpoint.triple if checkpoint is not None else None
+        )
+        if entries is None:
+            entries = []
+            for path in walk_vault_md(root):
+                if not recall_policy.is_recall_candidate(root, path):
+                    continue
+                page = _CACHE.get(path, root)
+                if page is not None:
+                    entries.append((page.rel_path, page.title))
         resolver = WikilinkResolver.from_entries(root, entries)
         with _RESOLVER_LOCK:
             # The supplied freshness key names this immutable resolver snapshot.

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -71,7 +71,7 @@ from .kbdir import kb_dirname
 log = logging.getLogger(__name__)
 
 _NAV_BASENAMES = frozenset({"index.md", "log.md"})
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 CATALOG_FOREGROUND_DELTA_CAP = 32
 
 # Publication-barrier timeouts. Every LIVE-sidecar mutation and journal-mode
@@ -1406,19 +1406,16 @@ class LexicalStore:
             except OSError:
                 pass
 
-    # The current normal-table shape sentinel: an older (v4) `pages` table lacks
-    # this column, so its presence distinguishes a mutation-safe current shape
-    # from a legacy shape a new-column index/INSERT would fault against.
-    _CURRENT_PAGES_COLUMN = "emitted_parent_path"
+    # The current normal-table shape sentinels. An older `pages` table lacks
+    # one or more of these, so it must be rebuilt before a new-column INSERT.
+    _CURRENT_PAGES_COLUMNS = frozenset({"emitted_parent_path", "title"})
 
     @staticmethod
-    def _pages_has_emitted_parent(conn: sqlite3.Connection) -> bool:
-        """Read-only: does the `pages` table carry the current emitted-parent
-        column? False when the table is absent or is an old (v4) shape."""
-        return any(
-            row[1] == LexicalStore._CURRENT_PAGES_COLUMN
-            for row in conn.execute("PRAGMA table_info(pages)")
-        )
+    def _pages_has_current_columns(conn: sqlite3.Connection) -> bool:
+        """Read-only: does `pages` carry every current schema sentinel?"""
+        return LexicalStore._CURRENT_PAGES_COLUMNS <= {
+            row[1] for row in conn.execute("PRAGMA table_info(pages)")
+        }
 
     def _schema_is_current(self, conn: sqlite3.Connection) -> bool:
         """Read-only probe: is the catalog schema at the current version AND the
@@ -1435,12 +1432,13 @@ class LexicalStore:
             return False  # no `meta` table yet
         if not (row and row[0] == str(SCHEMA_VERSION)):
             return False
-        return self._pages_has_emitted_parent(conn)
+        return self._pages_has_current_columns(conn)
 
     def _create_catalog_tables(self, conn: sqlite3.Connection) -> None:
         conn.execute(
             "CREATE TABLE IF NOT EXISTS pages("
             " path TEXT PRIMARY KEY,"
+            " title TEXT,"
             " mtime_ns INTEGER NOT NULL,"
             " updated TEXT NOT NULL DEFAULT '0000-00-00',"
             " in_kb INTEGER NOT NULL DEFAULT 0,"
@@ -1527,7 +1525,7 @@ class LexicalStore:
         place while never faulting on the legacy shape. The read paths never
         reach here — they use the read-only `_schema_is_current` probe."""
         self._create_catalog_tables(conn)
-        if not self._pages_has_emitted_parent(conn):
+        if not self._pages_has_current_columns(conn):
             self._drop_catalog_tables(conn)
             self._create_catalog_tables(conn)
         self._create_catalog_indexes(conn)
@@ -2013,9 +2011,10 @@ class LexicalStore:
         page = find_module._CACHE.get(path, self.vault_root)
         if page is not None:
             rel = page.rel_path
-            title_lower = page.title_norm
+            title = page.title
+            title_lower = page.title_norm if title else ""
             body_lower = page.body_norm
-            stemmed = " ".join(bm25_module.tokenize(page.title + " " + page.body))
+            stemmed = " ".join(bm25_module.tokenize((title or "") + " " + page.body))
             updated = page.updated or "0000-00-00"
             # Scene-frame children carry the parent video they collapse into;
             # unparseable rows (page is None) stay NULL like ordinary pages.
@@ -2025,15 +2024,17 @@ class LexicalStore:
                 rel = path.resolve().relative_to(self.vault_root.resolve()).as_posix()
             except ValueError:
                 return
+            title = None
             title_lower = body_lower = stemmed = ""
             updated = "0000-00-00"
             emitted_parent_path = None
         is_nav = path.name.lower() in _NAV_BASENAMES
         cur = conn.execute(
-            "INSERT INTO pages(path, mtime_ns, updated, in_kb, in_vault, is_nav, "
-            "emitted_parent_path) VALUES(?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO pages(path, title, mtime_ns, updated, in_kb, in_vault, is_nav, "
+            "emitted_parent_path) VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 rel,
+                title,
                 mtime_ns,
                 updated,
                 int(in_kb),
@@ -3137,6 +3138,50 @@ class LexicalStore:
             return CatalogReadiness("stale", False, backend_name)
         except sqlite3.Error as e:
             return self._catalog_readiness_error(e, backend_name)
+
+    def recall_resolver_entries(
+        self, scope: str, freshness: tuple | None
+    ) -> list[tuple[str, str | None]] | None:
+        """Return exact resolver `(path, title)` entries from a current sidecar.
+
+        A resolver cannot safely omit a page, so this deliberately declines a
+        sidecar that needs even a bounded foreground delta. The caller then uses
+        the established walk-and-parse fallback while the repair worker rebuilds
+        the disposable sidecar. A current stored checkpoint includes the recall
+        policy/access identity; `_walk_entries` and `_insert_page` both apply
+        that policy before any row receives its scope flag. The sidecar test
+        pins the resulting `in_vault` row set against a fresh full policy walk.
+        """
+        from . import freshness as freshness_module
+
+        backend_name = backend()
+        if backend_name == "python":
+            return None
+        if self._failed:
+            return None
+        if not self.path.exists():
+            return None
+        try:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN")
+                target = freshness_module.recall_checkpoint(self.vault_root, scope)
+                if (
+                    not self._schema_is_current(conn)
+                    or _checkpoint_state(self._meta_checkpoint(conn, scope))
+                    != _checkpoint_state(target)
+                ):
+                    return None
+                col = "in_vault" if scope == "vault" else "in_kb"
+                rows = conn.execute(
+                    f"SELECT path, title FROM pages WHERE {col} = 1 ORDER BY path"
+                ).fetchall()
+                return [(str(path), title) for path, title in rows]
+            finally:
+                conn.close()
+        except sqlite3.Error as error:
+            self._catalog_readiness_error(error, backend_name)
+            return None
 
     def _serve_from_ready_catalog_result(self, scope, freshness, query_fn, failure_message):
         """Validate readiness AND run `query_fn(conn)` bound to ONE connection and

--- a/tests/test_resolver_from_sidecar.py
+++ b/tests/test_resolver_from_sidecar.py
@@ -1,0 +1,221 @@
+"""Recall resolver construction from the lexical sidecar."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from exomem import freshness, lexstore
+from exomem import find as find_module
+from exomem import recall_policy
+from exomem.vault import walk_vault_md
+
+
+@pytest.fixture(autouse=True)
+def _fresh_process_state(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("EXOMEM_DISABLE_RESOLVER_WARM", "1")
+    freshness.clear()
+    lexstore.reset_memo()
+    lexstore.clear_stores()
+    find_module.clear_cache()
+    yield
+    freshness.clear()
+    lexstore.reset_memo()
+    lexstore.clear_stores()
+    find_module.clear_cache()
+
+
+def _write(root: Path, rel: str, text: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _seed_live_freshness(root: Path) -> None:
+    freshness.seed(
+        root,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in walk_vault_md(root)),
+    )
+    kb = root / "Knowledge Base"
+    freshness.seed(
+        root,
+        "kb",
+        ((str(path), freshness.stat_signature(path)) for path in find_module._walk_md(kb)),
+    )
+
+
+def _expected_entries(root: Path) -> set[tuple[str, str | None]]:
+    entries: set[tuple[str, str | None]] = set()
+    for path in walk_vault_md(root):
+        if not recall_policy.is_recall_candidate(root, path):
+            continue
+        page = find_module._CACHE.get(path, root)
+        if page is not None:
+            entries.add((page.rel_path, page.title))
+    return entries
+
+
+def _seed_sidecar(root: Path) -> None:
+    _seed_live_freshness(root)
+    lexstore.ensure_fresh(root)
+    find_module.clear_cache()
+    find_module._RECALL_RESOLVER_CACHE.clear()
+
+
+def _resolver_entries(resolver) -> set[tuple[str, str | None]]:
+    return {
+        (rel + ".md", resolver.title_key_for_path(rel))
+        for rel in resolver.full_paths
+    }
+
+
+def test_sidecar_entries_match_walk_and_preserve_exact_title_bytes(tmp_path: Path) -> None:
+    root = tmp_path / "vault"
+    _write(
+        root,
+        "Knowledge Base/Notes/Mixed.md",
+        "---\ntitle: \"MiXeD, punctuation: café ☃\"\n---\n# ignored heading\n",
+    )
+    _write(root, "Knowledge Base/Notes/Plain.md", "# Plain title\n")
+    _seed_sidecar(root)
+
+    store = lexstore.get_store(root)
+    entries = store.recall_resolver_entries("vault", freshness.triple(root, "vault"))
+
+    assert entries is not None
+    assert set(entries) == _expected_entries(root)
+    assert ("Knowledge Base/Notes/Mixed.md", "MiXeD, punctuation: café ☃") in entries
+    assert _resolver_entries(find_module.recall_resolver_snapshot(root)) == {
+        (path, title.lower() if title else None) for path, title in entries
+    }
+
+
+def test_resolver_build_from_current_sidecar_does_not_read_pages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "vault"
+    _write(root, "Knowledge Base/Notes/One.md", "# One\n")
+    _write(root, "Knowledge Base/Notes/Two.md", "# Two\n")
+    _seed_sidecar(root)
+
+    reads = 0
+    real_get = find_module._CACHE.get
+
+    def counting_get(path: Path, vault_root: Path):
+        nonlocal reads
+        reads += 1
+        return real_get(path, vault_root)
+
+    monkeypatch.setattr(find_module._CACHE, "get", counting_get)
+    resolver = find_module.recall_resolver_snapshot(root)
+
+    assert resolver is not None
+    assert reads == 0
+
+
+def test_sidecar_title_null_round_trips_and_exact_title_survives(tmp_path: Path) -> None:
+    root = tmp_path / "vault"
+    page = _write(
+        root,
+        "Knowledge Base/Notes/Exact.md",
+        "---\ntitle: MiXeD -- café / 東京\n---\n# ignored\n",
+    )
+    _seed_sidecar(root)
+    store = lexstore.get_store(root)
+    rel = page.relative_to(root).as_posix()
+
+    assert store.recall_resolver_entries("vault", freshness.triple(root, "vault")) == [
+        (rel, "MiXeD -- café / 東京")
+    ]
+    conn = sqlite3.connect(store.path)
+    try:
+        with conn:
+            conn.execute("UPDATE pages SET title = NULL WHERE path = ?", (rel,))
+    finally:
+        conn.close()
+
+    assert store.recall_resolver_entries("vault", freshness.triple(root, "vault")) == [
+        (rel, None)
+    ]
+
+
+@pytest.mark.parametrize("state", ["absent", "stale", "wrong-version"])
+def test_unusable_sidecar_falls_back_to_complete_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, state: str
+) -> None:
+    root = tmp_path / "vault"
+    _write(root, "Knowledge Base/Notes/Visible.md", "# Visible\n")
+    _seed_sidecar(root)
+    store = lexstore.get_store(root)
+    scheduled: list[Path] = []
+    monkeypatch.setattr(
+        lexstore,
+        "_schedule_repair",
+        lambda vault_root, **_kwargs: scheduled.append(vault_root),
+    )
+
+    if state == "absent":
+        store.path.unlink()
+    else:
+        conn = sqlite3.connect(store.path)
+        try:
+            with conn:
+                if state == "stale":
+                    conn.execute(
+                        "UPDATE meta SET value = ? WHERE key = 'recall_checkpoint:vault'",
+                        ("not a checkpoint",),
+                    )
+                else:
+                    conn.execute(
+                        "UPDATE meta SET value = ? WHERE key = 'schema_version'", ("0",)
+                    )
+        finally:
+            conn.close()
+
+    reads = 0
+    real_get = find_module._CACHE.get
+
+    def counting_get(path: Path, vault_root: Path):
+        nonlocal reads
+        reads += 1
+        return real_get(path, vault_root)
+
+    monkeypatch.setattr(find_module._CACHE, "get", counting_get)
+    resolver = find_module.recall_resolver_snapshot(root)
+
+    assert reads > 0
+    assert scheduled == []
+    assert _resolver_entries(resolver) == {
+        (path, title.lower() if title else None) for path, title in _expected_entries(root)
+    }
+
+
+def test_access_policy_change_is_not_served_from_stale_sidecar(tmp_path: Path) -> None:
+    root = tmp_path / "vault"
+    _write(root, "Knowledge Base/Notes/Visible.md", "# Visible\n")
+    _seed_sidecar(root)
+
+    access = root / "Knowledge Base" / "_access.yaml"
+    access.write_text("excluded:\n  - Notes\n", encoding="utf-8")
+    find_module._RECALL_RESOLVER_CACHE.clear()
+
+    resolver = find_module.recall_resolver_snapshot(root)
+
+    assert "Knowledge Base/Notes/Visible" not in resolver.full_paths
+
+
+def test_sidecar_unknown_page_falls_back_and_still_resolves(tmp_path: Path) -> None:
+    root = tmp_path / "vault"
+    _write(root, "Knowledge Base/Notes/Known.md", "# Known\n")
+    _seed_sidecar(root)
+    unknown = _write(root, "Knowledge Base/Notes/Unknown.md", "# Unknown\n")
+    freshness.on_files_changed(root, changed=[unknown])
+    find_module._RECALL_RESOLVER_CACHE.clear()
+
+    resolver = find_module.recall_resolver_snapshot(root)
+
+    assert "Knowledge Base/Notes/Unknown" in resolver.full_paths

--- a/tests/test_semantic_unit_reconcile.py
+++ b/tests/test_semantic_unit_reconcile.py
@@ -84,7 +84,7 @@ def _seed_sidecars(
 def test_hierarchy_parser_and_sidecar_versions_are_incremented() -> None:
     assert semantic_index.PARSER_VERSION == 4
     assert embedding_index.SEMANTIC_UNIT_SCHEMA_VERSION == 3
-    assert lexstore.SCHEMA_VERSION == 6
+    assert lexstore.SCHEMA_VERSION == 7
     assert epistemic_graph.SCHEMA_VERSION == 8
 
 


### PR DESCRIPTION
Closes #676 — a cold recall resolver rebuilt the whole vault on the reader's thread, measured at 30.7s of a 34s call.

Implemented by a Codex worker lane (`codex/resolver-titles`) under the protocol in CLAUDE.md; reviewed and pushed here.

## Change

The resolver needs `(rel_path, title)` for every recall-admitted page. It got them by walking the vault and parsing every page — on the reader's thread, on a cold cache. The lexical sidecar already stores a row per page, so the titles can come from one SQLite query instead.

- Lexical sidecar schema 6 → 7, adding nullable `pages.title`, persisting the parser-produced `page.title` unchanged under the canonical `page.rel_path` key.
- `find.recall_resolver_snapshot` reads `(path, title)` in a single query and **retains the walk-and-parse implementation as its fallback**.
- No handwritten migration: `_schema_is_current()` rejects a non-current version and the ordinary repair path rebuilds the disposable sidecar.

## Measured — 2,400 pages

| path | cold resolver build | `find._CACHE.get` | retained resolver bytes |
| --- | ---: | ---: | ---: |
| forced legacy walk | 4.991 s | 2,400 | 1,461,009 |
| sidecar SQL | **0.097 s** | **0** | 1,460,993 |

**51× faster, 2,400 page reads down to zero, and the same ~1.39 MiB retained** — this trades no memory for the time.

## Correctness

- `pages.title` is the exact parser value including case and Unicode; SQL `NULL` stays Python `None`.
- Scope flags are honoured only once the stored projected checkpoint equals the current checkpoint, which includes policy and access identity. Both the sidecar walk and the insert path apply `is_recall_candidate`, and the regression test compares every `in_vault` resolver row against a fresh policy walk.
- Missing, stale, wrong-schema, or SQLite-failed sidecar → `None`, and `find` runs the original complete walk. That fallback deliberately does **not** kick off an async rebuild, so a read-only resolver call never creates temporary SQLite files.

## Verification

`tests/test_resolver_from_sidecar.py` (8 new tests): title parity and exact casing/Unicode, no parser calls on the fast path, `NULL` title, absent/stale/wrong-schema fallback, policy change, unknown sidecar page, and no background repair from a fallback.

- `tests/test_lexstore_atomic_rebuild.py` — 40 passed
- `ruff check . --select F,E9` — clean
- `tests/test_retrieval_golden.py` — skipped, `sentence_transformers` absent in that environment

The lane's full local suite did **not** reach a terminal state on that host and the worker correctly declined to claim it green. The merge gate is running locally; CI here is the real check.