### PR TITLE
fix(lexstore): key the store cache on the same path repair state keys on

### DIFF
--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -385,12 +385,31 @@ def catalog_semantic_identity(vault_root: Path) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _store_key(vault_root: Path) -> Path:
+    """Canonical `_STORES` key.
+
+    `_schedule_repair` has always keyed its state on `vault_root.resolve()`
+    while `_STORES` keyed on whatever spelling the caller passed. Two spellings
+    of one vault -- a symlinked path, a relative path, a differently-cased drive
+    letter on Windows -- therefore produced two `LexicalStore` objects for a
+    single sidecar, and repair state that correctly treated them as one.
+
+    That is not only duplicated work. `_failed` lives on the instance, so a
+    store that has fallen back to Python scoring is invisible to a lookup made
+    through the other spelling, and `cache_token` then answers "fts5" for a
+    store that is not serving FTS5. Cache keys built from that token collide
+    across two different scorers.
+    """
+    return vault_root.resolve()
+
+
 def get_store(vault_root: Path) -> LexicalStore:
+    key = _store_key(vault_root)
     with _STORES_LOCK:
-        store = _STORES.get(vault_root)
+        store = _STORES.get(key)
         if store is None:
             store = LexicalStore(vault_root)
-            _STORES[vault_root] = store
+            _STORES[key] = store
         return store
 
 
@@ -909,7 +928,7 @@ def cache_token(vault_root: Path) -> str:
     if not _usable():
         return "python"
     with _STORES_LOCK:
-        store = _STORES.get(vault_root)
+        store = _STORES.get(_store_key(vault_root))
     if store is not None and store._failed:
         return "python"
     return "fts5"
@@ -920,7 +939,7 @@ def catalog_cache_token(vault_root: Path) -> str:
     if not _catalog_usable():
         return "python"
     with _STORES_LOCK:
-        store = _STORES.get(vault_root)
+        store = _STORES.get(_store_key(vault_root))
     if store is not None and store._failed:
         return "unavailable"
     return "metadata_only"

--- a/tests/test_lexstore.py
+++ b/tests/test_lexstore.py
@@ -839,3 +839,46 @@ def test_deleting_sidecar_is_always_safe(tmp_path):
     lexstore.lexical_path(tmp_path).unlink()
     hits = lexstore.search_bm25(tmp_path, "resilient", k=3, scope="kb")
     assert hits and hits[0][0] == "Knowledge Base/a.md"
+
+
+def test_one_vault_reached_two_ways_shares_a_single_store(tmp_path: Path) -> None:
+    """`_STORES` must key on the same thing repair state keys on.
+
+    `_schedule_repair` has always keyed on `vault_root.resolve()`; `_STORES`
+    keyed on whatever spelling the caller happened to pass. Two spellings of a
+    single vault -- a symlink, a relative path, a `..` segment -- produced two
+    `LexicalStore` objects over one sidecar, against repair state that
+    correctly treated them as one.
+
+    The visible consequence is the scorer token, not just duplicated work.
+    `_failed` lives on the instance, so a store that has fallen back is
+    invisible through the other spelling and the token still advertises the
+    fast backend. Cache keys built from it then collide across two scorers.
+    """
+    lexstore.clear_stores()
+    if not lexstore._catalog_usable():
+        pytest.skip("metadata catalog unavailable, so the token cannot discriminate")
+
+    vault = tmp_path / "vault"
+    (vault / "sub").mkdir(parents=True)
+    detour = vault / "sub" / ".."
+
+    assert detour != vault, "this fixture needs two distinct spellings"
+    assert detour.resolve() == vault.resolve()
+
+    try:
+        direct = lexstore.get_store(vault)
+        via_detour = lexstore.get_store(detour)
+
+        assert via_detour is direct, (
+            "the same vault produced two stores, so they hold independent "
+            "failure state over one sidecar"
+        )
+
+        direct._failed = True
+        assert lexstore.catalog_cache_token(detour) == "unavailable", (
+            "the store had fallen back, but the token reached through the "
+            "other spelling still advertised the exact scorer"
+        )
+    finally:
+        lexstore.clear_stores()


### PR DESCRIPTION
Closes #704.

## The inconsistency

`_schedule_repair` has always keyed its state on `vault_root.resolve()`:

```python
key = vault_root.resolve()
```

`_STORES` keyed on whatever spelling the caller passed:

```python
store = _STORES.get(vault_root)   # raw
```

So two spellings of a single vault — a symlink, a relative path, a `..` segment, a differently-cased drive letter on Windows — produced **two `LexicalStore` objects over one sidecar**, against repair state that correctly treated them as one.

## Why it is more than duplicated work

I filed this as "wasted work and confusing state". Reading it again, there is a correctness edge: `_failed` lives on the *instance*. A store that has fallen back to Python scoring is invisible to a lookup made through the other spelling, so `cache_token` keeps answering `fts5` for a store that is not serving FTS5.

That token exists specifically to pin the scorer into find's hot-cache key, "so a mid-process backend flip can't serve results cached under the other scorer" (its own docstring). When the token lies, cache keys collide across two different scorers and results computed by one are served under the other's key.

## Change

`_store_key` canonicalises all four `_STORES` accesses. `LexicalStore` keeps its unresolved `vault_root` — only the dict key needs to be canonical, and the relative-path helpers already resolve at the point of use.

## Verification

- Mutation-tested: keying on the raw path again takes the new test red with *"the same vault produced two stores, so they hold independent failure state over one sidecar"*.
- The test skips rather than passing vacuously if the metadata catalog is unavailable, since the token could not discriminate then.
- **150 passed** across all eight lexstore suites.
- `ruff check --select F,E9,I` clean.