### PR TITLE
docs(codex): make the merge lane about one owner, not about which tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,15 +111,19 @@ Routing (orchestrator applies):
 | Standard implementation with tests | `scripts/codex_task.sh start <lane> <brief>` (Terra high) |
 | Design-sensitive / hard lanes | Sol xhigh, or a Claude executor |
 | Mechanical sweeps, docs | `--profile luna-sweep` (Luna medium) |
-| Shared-primary ops, merges, releases | Claude only — see below |
+| Shared-primary ops, merges, releases | Whoever is orchestrating — one owner at a time |
 
-Why that last row is Claude-only is worth stating, because it is not about
-capability. Codex CLI is a peer, not a lesser tool: it has its own MCP servers
-configured, including exomem itself over the shared loopback service. The
-constraint is that **one** actor must own the shared checkout and the merge
-button, or two agents race on uncommitted work and push to `main` concurrently.
-The same rule would apply to a second Claude session. Anything a lane can do
-inside its own worktree, Codex can do.
+That last row is about serialization, not about which tool. Whoever is holding
+the orchestrator role owns the shared checkout and the merge button for as long
+as they hold it; a second actor doing the same thing concurrently races on
+uncommitted work and pushes to `main` at the same time. That is equally true of
+two Claude sessions, two Codex sessions, or one of each — and it is why this
+repo's own CLAUDE.md opens with the shared-checkout rule.
+
+Codex CLI is a peer, not a lesser tool. It has its own MCP servers configured,
+including exomem itself, and it drives merges and releases perfectly well. An
+earlier version of this table read "Claude only — never Codex", which encoded a
+capability claim that was never true and is not what the constraint is.
 
 Lane mechanics: one lane = one sibling worktree (`../exomem-<lane>`, branch
 `codex/<lane>`, from `origin/main`) = one self-contained `.task/TASK.md` brief


### PR DESCRIPTION
The routing table's last row read **"Claude only"**. That is wrong, and it is my wording.

```
$ git log -L '/Shared-primary ops/,+1:CLAUDE.md' --oneline
779d8421 (#700)  | Shared-primary ops, merges, releases | Claude only — see below |
8e515235 (#184)  | Shared-primary ops, merges, KB writes, MCP-needing tasks | Claude only — never Codex |
```

#184 introduced it. #700 narrowed the scope and added a paragraph explaining that it was not about capability — but left `Claude only` in the table itself, so the table still said the thing the paragraph was denying.

## The actual constraint

Serialization. Whoever holds the orchestrator role owns the shared checkout and the merge button for as long as they hold it, because a second actor doing the same concurrently races on uncommitted work and pushes to `main` at the same time.

That is equally true of two Claude sessions, two Codex sessions, or one of each. It is the same hazard this file opens with in *"Concurrent sessions share ONE checkout"* — which is already written tool-neutrally, as it should be.

## Change

```diff
-| Shared-primary ops, merges, releases | Claude only — see below |
+| Shared-primary ops, merges, releases | Whoever is orchestrating — one owner at a time |
```

and the paragraph beneath it now explains serialization rather than defending a tool gate.

Codex CLI is a peer. It has its own MCP servers configured, including exomem, and it drives merges and releases perfectly well. Naming a tool in that row encoded a capability claim that was never true.

`tests/test_codex_lane_contract.py` — 5 passed.