### PR TITLE
test(ci): convert the remaining contention waits that have cost CI time

### DIFF
--- a/tests/test_command_surface_retry.py
+++ b/tests/test_command_surface_retry.py
@@ -23,6 +23,33 @@ from exomem import server as server_module
 from exomem import vault as vault_module
 from exomem.cli_ops import OpError
 
+#: The wall-clock shape of every contention test in this file.
+#:
+#: A HOLD parks a thread or process while the test observes an ordering; an
+#: OBSERVATION is how long the test waits for that state to be reached. The gap
+#: between them is the entire discriminating power of these tests -- a hold that
+#: does not outlast its observation lets the ordering pass vacuously, and an
+#: observation sized for an idle laptop fails on a loaded shard while the code
+#: under test behaves correctly.
+#:
+#: A NEGATIVE wait (`assert not x.wait(0.1)`) proves something has NOT happened
+#: yet and stays tight: widening one changes the scenario rather than merely
+#: slowing it, because the product's own timeouts run in the same window.
+#:
+#: `join(timeout=N)` followed by `assert t.is_alive()` is the SAME negative
+#: observation in join form, and it is the one shape that consumes its whole
+#: window on every healthy run -- it exists to prove a competitor is still
+#: parked. Widening one from 0.3s to 60s bought nothing and cost a minute a run.
+#:
+#: Both constants stay strictly under pytest's per-test `timeout` (pyproject
+#: `[tool.pytest.ini_options]`). A valve at or above it never gets to fire: the
+#: harness kills the test first and you get a thread dump where a named
+#: assertion should have been. tests/test_timing_assertion_hygiene.py pins that.
+#:
+#: These are not latency claims. Nothing here asserts the product is fast.
+_HOLD_SECONDS = 45.0
+_OBSERVE_SECONDS = 15.0
+
 
 def _write_editable_note(vault: Path, *, body: str = "Before") -> str:
     relative = "Knowledge Base/Notes/Insights/retry-safe-edit.md"
@@ -410,16 +437,16 @@ def test_bound_replace_preview_bypasses_writer_authority_boundary_and_receipts(
     def hold_live_mutation() -> None:
         with coordinator.hold(timeout_seconds=2.0):
             entered.set()
-            assert release.wait(2.0)
+            assert release.wait(_HOLD_SECONDS)
 
     holder = threading.Thread(target=hold_live_mutation)
     holder.start()
-    assert entered.wait(1.0)
+    assert entered.wait(_OBSERVE_SECONDS)
     try:
         preview = bound(validate_only=True)
     finally:
         release.set()
-        holder.join(timeout=2.0)
+        holder.join(timeout=_HOLD_SECONDS)
 
     assert preview["advisory"] is True
     assert "receipt_id" not in preview
@@ -489,11 +516,11 @@ def test_bound_validate_only_edit_bypasses_live_mutation_boundary(
     def hold_live_mutation() -> None:
         with manager.mutation_guard(tmp_path / "vault"):
             entered.set()
-            assert release.wait(2.0)
+            assert release.wait(_HOLD_SECONDS)
 
     holder = threading.Thread(target=hold_live_mutation)
     holder.start()
-    assert entered.wait(1.0)
+    assert entered.wait(_OBSERVE_SECONDS)
     try:
         assert bound(
             operation={
@@ -505,7 +532,7 @@ def test_bound_validate_only_edit_bypasses_live_mutation_boundary(
         ) == {"validate_only": True}
     finally:
         release.set()
-        holder.join(timeout=2.0)
+        holder.join(timeout=_HOLD_SECONDS)
     assert not holder.is_alive()
 
 
@@ -522,7 +549,7 @@ def test_identical_pending_retry_waits_outside_mutation_boundary_and_replays(
         nonlocal calls
         calls += 1
         entered.set()
-        assert release.wait(2.0)
+        assert release.wait(_HOLD_SECONDS)
         return {"value": value}
 
     command = SimpleNamespace(name="edit_memory", leaf=leaf, read_only=False)
@@ -548,12 +575,12 @@ def test_identical_pending_retry_waits_outside_mutation_boundary_and_replays(
     first = threading.Thread(target=invoke)
     retry = threading.Thread(target=invoke)
     first.start()
-    assert entered.wait(1.0)
+    assert entered.wait(_OBSERVE_SECONDS)
     retry.start()
     time.sleep(0.08)
     release.set()
-    first.join(timeout=2.0)
-    retry.join(timeout=2.0)
+    first.join(timeout=_HOLD_SECONDS)
+    retry.join(timeout=_HOLD_SECONDS)
 
     assert not first.is_alive()
     assert not retry.is_alive()

--- a/tests/test_corpus_context_cache.py
+++ b/tests/test_corpus_context_cache.py
@@ -32,6 +32,36 @@ from exomem.vault import WikilinkResolver
 _PAGE_REL = "Knowledge Base/Notes/Insights/one.md"
 
 
+#: The wall-clock shape of every contention test in this file.
+#:
+#: A HOLD parks a thread or process while the test observes an ordering; an
+#: OBSERVATION is how long the test waits for that state to be reached. The gap
+#: between them is the entire discriminating power of these tests -- a hold that
+#: does not outlast its observation lets the ordering pass vacuously, and an
+#: observation sized for an idle laptop fails on a loaded shard while the code
+#: under test behaves correctly.
+#:
+#: A NEGATIVE wait (`assert not x.wait(0.1)`) proves something has NOT happened
+#: yet and stays tight: widening one changes the scenario rather than merely
+#: slowing it, because the product's own timeouts run in the same window.
+#:
+#: `join(timeout=N)` followed by `assert t.is_alive()` is the SAME negative
+#: observation in join form, and it is the one shape that consumes its whole
+#: window on every healthy run -- it exists to prove a competitor is still
+#: parked. Widening one from 0.3s to 60s bought nothing and cost a minute a run.
+#:
+#: Both constants stay strictly under pytest's per-test `timeout` (pyproject
+#: `[tool.pytest.ini_options]`). A valve at or above it never gets to fire: the
+#: harness kills the test first and you get a thread dump where a named
+#: assertion should have been. tests/test_timing_assertion_hygiene.py pins that.
+#:
+#: These are not latency claims. Nothing here asserts the product is fast.
+_HOLD_SECONDS = 45.0
+_OBSERVE_SECONDS = 15.0
+_NO_DUPLICATE_SECONDS = 0.5
+_PUBLISH_BLOCKED_SECONDS = 0.25
+
+
 def _page(*, title: str = "Page", body: str = "Body.\n") -> str:
     return f"---\ntitle: {title}\ntype: insight\nstatus: active\nproject: atlas\n---\n\n{body}"
 
@@ -378,7 +408,7 @@ def test_atomic_event_publish_keeps_concurrent_page_changes(vault: Path) -> None
     start = threading.Barrier(2)
 
     def publish(path: Path) -> None:
-        start.wait(timeout=5)
+        start.wait(timeout=_OBSERVE_SECONDS)
         semantic_contract.publish_corpus_files_changed(vault, changed=(path,))
 
     with ThreadPoolExecutor(max_workers=2) as pool:
@@ -429,13 +459,13 @@ def test_concurrent_cold_builds_share_one_uncached_result(
             calls += 1
             if calls > 1:
                 duplicate_entered.set()
-        assert release_build.wait(timeout=5)
+        assert release_build.wait(timeout=_HOLD_SECONDS)
         return real_build(*args, **kwargs)
 
     monkeypatch.setattr(semantic_contract, "_build_corpus_context_uncached", slow_build)
     with ThreadPoolExecutor(max_workers=2) as pool:
         futures = [pool.submit(semantic_contract.build_corpus_context, vault) for _ in range(2)]
-        duplicated = duplicate_entered.wait(timeout=0.5)
+        duplicated = duplicate_entered.wait(timeout=_NO_DUPLICATE_SECONDS)
         (vault / _PAGE_REL).write_text(_page(title="Current during flight"), encoding="utf-8")
         release_build.set()
         results = [future.result(timeout=10) for future in futures]
@@ -468,7 +498,7 @@ def test_cold_builds_with_different_registry_inputs_serialize_then_refresh(
             if calls == 1:
                 first_build_entered.set()
         if calls == 1:
-            assert release_first_build.wait(timeout=5)
+            assert release_first_build.wait(timeout=_HOLD_SECONDS)
         try:
             return real_build(*args, **kwargs)
         finally:
@@ -488,7 +518,7 @@ def test_cold_builds_with_different_registry_inputs_serialize_then_refresh(
     monkeypatch.setattr(semantic_contract, "_corpus_census", observed_census)
     with ThreadPoolExecutor(max_workers=2) as pool:
         first_future = pool.submit(semantic_contract.build_corpus_context, vault)
-        assert first_build_entered.wait(timeout=5)
+        assert first_build_entered.wait(timeout=_OBSERVE_SECONDS)
         registry_path = vault / "Knowledge Base" / "_Schema" / "relation-registry.yaml"
         registry_path.parent.mkdir(parents=True, exist_ok=True)
         registry_path.write_text(
@@ -498,7 +528,7 @@ def test_cold_builds_with_different_registry_inputs_serialize_then_refresh(
         )
         current_hash = relation_registry.load_registry(vault).extension_hash
         second_future = pool.submit(semantic_contract.build_corpus_context, vault)
-        assert current_census_seen.wait(timeout=5)
+        assert current_census_seen.wait(timeout=_OBSERVE_SECONDS)
         release_first_build.set()
         first = first_future.result(timeout=10)
         second = second_future.result(timeout=10)
@@ -532,15 +562,15 @@ def test_cold_cache_publication_serializes_with_file_events(
         snapshot = real_census(root)
         if census_calls == 2:
             publish_now.set()
-            assert page_written.wait(timeout=5)
+            assert page_written.wait(timeout=_OBSERVE_SECONDS)
             # On the unsafe implementation publication completes here and is
             # then overwritten. The fixed boundary deliberately keeps it
             # waiting until the cold context is captioned and installed.
-            publish_done.wait(timeout=0.25)
+            publish_done.wait(timeout=_PUBLISH_BLOCKED_SECONDS)
         return snapshot
 
     def publish_edit() -> None:
-        assert publish_now.wait(timeout=5)
+        assert publish_now.wait(timeout=_OBSERVE_SECONDS)
         page.write_text(_page(title="Event after cold census"), encoding="utf-8")
         page_written.set()
         semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
@@ -987,14 +1017,14 @@ def test_a_second_publisher_joins_no_second_whole_vault_build(
     def blocking_build(root: Path, cache_key: tuple[str, str]) -> bool:
         calls.append(cache_key)
         entered.set()
-        assert release.wait(10)
+        assert release.wait(_HOLD_SECONDS)
         return False
 
     monkeypatch.setattr(semantic_contract, "_build_and_admit_corpus_context", blocking_build)
 
     with ThreadPoolExecutor(max_workers=1) as pool:
         first = pool.submit(semantic_contract._populate_corpus_context_after_miss, vault)
-        assert entered.wait(10), "the first publisher never reached the build"
+        assert entered.wait(_OBSERVE_SECONDS), "the first publisher never reached the build"
 
         # The second publisher finds the same cold key mid-build and must
         # return rather than start its own.

--- a/tests/test_graph_rebuild_locking.py
+++ b/tests/test_graph_rebuild_locking.py
@@ -116,7 +116,7 @@ def test_legacy_lock_child_has_no_authority_over_the_direct_runtime_lock(
             args=(str(vault_root), str(second), claimed),
         )
         contender.start()
-        contender.join(10)
+        contender.join(_HOLD_SECONDS)
         assert contender.exitcode == 0
         assert claimed.get(timeout=2) is False
     finally:
@@ -146,7 +146,7 @@ def test_explicit_rebuild_runtime_root_overrides_ambient_environment_and_coalesc
             args=(str(vault_root), str(second), str(manager_root), claimed),
         )
         contender.start()
-        contender.join(10)
+        contender.join(_HOLD_SECONDS)
         assert contender.exitcode == 0
         assert claimed.get(timeout=2) is False
     finally:
@@ -210,7 +210,7 @@ def test_overlapping_custom_manager_registrations_do_not_cross_coalesce(tmp_path
     def build_a(checkpoint: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
         observed.append(("a", checkpoint.generation))
         first_started.set()
-        assert release_first.wait(2)
+        assert release_first.wait(_HOLD_SECONDS)
         return graph_sync.GraphBuildOutcome.covering(checkpoint)
 
     def build_b(checkpoint: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
@@ -221,13 +221,13 @@ def test_overlapping_custom_manager_registrations_do_not_cross_coalesce(tmp_path
         vault_root, _checkpoint(1), build_a, state_root=state_a
     )
     first.start()
-    assert first_started.wait(1)
+    assert first_started.wait(_OBSERVE_SECONDS)
     second = graph_sync.register_rebuild(
         vault_root, _checkpoint(2), build_b, state_root=state_b
     )
-    assert second.wait(1).covers(_checkpoint(2))
+    assert second.wait(_REGISTERED_REBUILD_WAIT_SECONDS).covers(_checkpoint(2))
     release_first.set()
-    assert first.wait(1).covers(_checkpoint(1))
+    assert first.wait(_REGISTERED_REBUILD_WAIT_SECONDS).covers(_checkpoint(1))
     assert observed == [("a", 1), ("b", 2)]
 
 
@@ -314,8 +314,8 @@ def test_pending_registrations_are_isolated_by_runtime_root(tmp_path: Path) -> N
     assert graph_sync.start_registered(vault_root, state_root=state_b) is not None
     assert graph_sync.wait_for_registered(vault_root, state_root=state_a).covers(_checkpoint(1))
     assert graph_sync.wait_for_registered(vault_root, state_root=state_b).covers(_checkpoint(2))
-    assert first.wait(1).covers(_checkpoint(1))
-    assert second.wait(1).covers(_checkpoint(2))
+    assert first.wait(_REGISTERED_REBUILD_WAIT_SECONDS).covers(_checkpoint(1))
+    assert second.wait(_REGISTERED_REBUILD_WAIT_SECONDS).covers(_checkpoint(2))
 
 
 def test_registration_start_does_not_consume_waiter_capacity(tmp_path: Path) -> None:
@@ -325,12 +325,12 @@ def test_registration_start_does_not_consume_waiter_capacity(tmp_path: Path) -> 
 
     def build(checkpoint: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
         entered.set()
-        assert release.wait(2)
+        assert release.wait(_HOLD_SECONDS)
         return graph_sync.GraphBuildOutcome.covering(checkpoint)
 
     registration = graph_sync.GraphRebuildRegistration(coordinator, _checkpoint(), build)
     registration.start()
-    assert entered.wait(1)
+    assert entered.wait(_OBSERVE_SECONDS)
     for _ in range(255):
         registration.start()
     assert coordinator.waiter_count == 0
@@ -342,12 +342,12 @@ def test_join_releases_waiter_capacity_after_timeout(tmp_path: Path) -> None:
     release = threading.Event()
 
     def build(checkpoint: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
-        assert release.wait(2)
+        assert release.wait(_HOLD_SECONDS)
         return graph_sync.GraphBuildOutcome.covering(checkpoint)
 
     coordinator.ensure_started(_checkpoint(), build)
     with pytest.raises(TimeoutError):
-        coordinator.join(_checkpoint()).wait(0.01)
+        coordinator.join(_checkpoint()).wait(_JOIN_TIMEOUT_SECONDS)
     assert coordinator.waiter_count == 0
     release.set()
 
@@ -404,18 +404,18 @@ def test_final_graph_publish_uses_the_lease_manager_mutation_boundary(
     def hold_final_publish() -> None:
         with publisher.hold(operation="epistemic_graph_publish_rebuild", holder_kind="graph"):
             entered.set()
-            assert release.wait(2)
+            assert release.wait(_HOLD_SECONDS)
 
     thread = threading.Thread(target=hold_final_publish)
     thread.start()
-    assert entered.wait(1)
+    assert entered.wait(_OBSERVE_SECONDS)
     try:
         with pytest.raises(OpError, match="MUTATION_BUSY"):
             with manager.mutation_guard(vault_root):
                 pytest.fail("writer entered during final graph publication")
     finally:
         release.set()
-        thread.join(timeout=2)
+        thread.join(timeout=_HOLD_SECONDS)
     assert not thread.is_alive()
     assert publisher.state_root == state_root
 
@@ -447,16 +447,39 @@ def test_registered_builder_retains_the_originating_custom_lease_boundary(
         )[1],
     )
 
-    assert registration.wait(1).covers(_checkpoint())
+    assert registration.wait(_REGISTERED_REBUILD_WAIT_SECONDS).covers(_checkpoint())
     assert observed_roots == [state_root]
 
 
-# Deadlock valves for the ordering test below, sized so the hold outlasts the
-# observation. A whole-vault rebuild on a loaded Windows runner is the thing
-# being waited on, and two seconds does not bound it.
+#: The wall-clock shape of every contention test in this file.
+#:
+#: A HOLD parks a thread or process while the test observes an ordering; an
+#: OBSERVATION is how long the test waits for that state to be reached. The gap
+#: between them is the entire discriminating power of these tests -- a hold that
+#: does not outlast its observation lets the ordering pass vacuously, and an
+#: observation sized for an idle laptop fails on a loaded shard while the code
+#: under test behaves correctly.
+#:
+#: A NEGATIVE wait (`assert not x.wait(0.1)`) proves something has NOT happened
+#: yet and stays tight: widening one changes the scenario rather than merely
+#: slowing it, because the product's own timeouts run in the same window.
+#:
+#: `join(timeout=N)` followed by `assert t.is_alive()` is the SAME negative
+#: observation in join form, and it is the one shape that consumes its whole
+#: window on every healthy run -- it exists to prove a competitor is still
+#: parked. Widening one from 0.3s to 60s bought nothing and cost a minute a run.
+#:
+#: Both constants stay strictly under pytest's per-test `timeout` (pyproject
+#: `[tool.pytest.ini_options]`). A valve at or above it never gets to fire: the
+#: harness kills the test first and you get a thread dump where a named
+#: assertion should have been. tests/test_timing_assertion_hygiene.py pins that.
+#:
+#: These are not latency claims. Nothing here asserts the product is fast.
 _HOLD_SECONDS = 45.0
-_OBSERVE_SECONDS = 30.0
+_OBSERVE_SECONDS = 15.0
 _SWAP_WAIT_SECONDS = 30.0
+_REGISTERED_REBUILD_WAIT_SECONDS = 1.0
+_JOIN_TIMEOUT_SECONDS = 0.01
 
 
 def test_graph_swap_waits_for_a_real_lease_manager_writer(
@@ -518,7 +541,7 @@ def test_graph_swap_waits_for_a_real_lease_manager_writer(
         assert not publish_entered.is_set()
     finally:
         release_writer.set()
-        writer.join(timeout=_OBSERVE_SECONDS)
+        writer.join(timeout=_HOLD_SECONDS)
         rebuilder.join(timeout=_HOLD_SECONDS)
     assert not writer.is_alive()
     assert not rebuilder.is_alive()

--- a/tests/test_lexstore_atomic_rebuild.py
+++ b/tests/test_lexstore_atomic_rebuild.py
@@ -42,9 +42,9 @@ from __future__ import annotations
 
 import os
 import sqlite3
-import traceback
 import threading
 import time
+import traceback
 import uuid
 from pathlib import Path
 from typing import Any
@@ -53,6 +53,35 @@ import pytest
 
 from exomem import find as find_module
 from exomem import freshness, lexstore
+
+#: The wall-clock shape of every contention test in this file.
+#:
+#: A HOLD parks a thread or process while the test observes an ordering; an
+#: OBSERVATION is how long the test waits for that state to be reached. The gap
+#: between them is the entire discriminating power of these tests -- a hold that
+#: does not outlast its observation lets the ordering pass vacuously, and an
+#: observation sized for an idle laptop fails on a loaded shard while the code
+#: under test behaves correctly.
+#:
+#: A NEGATIVE wait (`assert not x.wait(0.1)`) proves something has NOT happened
+#: yet and stays tight: widening one changes the scenario rather than merely
+#: slowing it, because the product's own timeouts run in the same window.
+#:
+#: `join(timeout=N)` followed by `assert t.is_alive()` is the SAME negative
+#: observation in join form, and it is the one shape that consumes its whole
+#: window on every healthy run -- it exists to prove a competitor is still
+#: parked. Widening one from 0.3s to 60s bought nothing and cost a minute a run.
+#:
+#: Both constants stay strictly under pytest's per-test `timeout` (pyproject
+#: `[tool.pytest.ini_options]`). A valve at or above it never gets to fire: the
+#: harness kills the test first and you get a thread dump where a named
+#: assertion should have been. tests/test_timing_assertion_hygiene.py pins that.
+#:
+#: These are not latency claims. Nothing here asserts the product is fast.
+_HOLD_SECONDS = 45.0
+_OBSERVE_SECONDS = 15.0
+_FOREGROUND_BOUND_SECONDS = 0.5
+_STILL_BLOCKED_SECONDS = 1.0
 
 
 @pytest.fixture(autouse=True)
@@ -1000,7 +1029,7 @@ def test_await_repairs_idle_waits_for_an_in_flight_repair() -> None:
         released = threading.Event()
 
         def release() -> None:
-            released.wait(30.0)
+            released.wait(_HOLD_SECONDS)
             with lexstore._REPAIRS_LOCK:
                 lexstore._REPAIRS_IN_FLIGHT.discard(key)
 
@@ -1008,7 +1037,7 @@ def test_await_repairs_idle_waits_for_an_in_flight_repair() -> None:
         worker.start()
         released.set()
         assert lexstore.await_repairs_idle(root, timeout=30.0) is True
-        worker.join(timeout=30.0)
+        worker.join(timeout=_HOLD_SECONDS)
         assert not worker.is_alive()
     finally:
         with lexstore._REPAIRS_LOCK:
@@ -1181,13 +1210,13 @@ def test_upsert_declines_fast_on_publication_contention_then_retries(
     worker = threading.Thread(target=do_upsert, daemon=True)
     with vault_creation_lock(tmp_path, "lexical-catalog-publication", timeout=5):
         worker.start()
-        assert started.wait(5)
-        assert finished.wait(0.5)
+        assert started.wait(_OBSERVE_SECONDS)
+        assert finished.wait(_FOREGROUND_BOUND_SECONDS)
         assert outcome["applied"] is False
         assert outcome["elapsed"] < 0.5
         assert scheduled["n"] == 1
 
-    worker.join(5)
+    worker.join(_HOLD_SECONDS)
     assert store.upsert_paths([b]) is True
     contents = {hit.content.strip() for hit in _units_in_category(tmp_path, "config")}
     assert any("upsertadded" in c for c in contents)
@@ -1264,10 +1293,10 @@ def test_exact_stale_parent_under_publication_contention_returns_incomplete(
     worker = threading.Thread(target=query, daemon=True)
     with vault_creation_lock(tmp_path, "lexical-catalog-publication", timeout=5):
         worker.start()
-        assert finished.wait(0.5)
+        assert finished.wait(_FOREGROUND_BOUND_SECONDS)
         assert result["hits"] is None
         assert result["elapsed"] < 0.5
-    worker.join(5)
+    worker.join(_HOLD_SECONDS)
 
 
 def test_upsert_source_disappearing_during_insert_rolls_back_and_defers(
@@ -1458,10 +1487,10 @@ def test_repair_heal_reconcile_serializes_behind_publication_barrier(
         worker.start()
         # The heal must block on the barrier we hold. (Pre-fix, the reconcile
         # rebuilt/healed the live sidecar with no barrier, racing the replace.)
-        assert not healed.wait(1.0)
+        assert not healed.wait(_STILL_BLOCKED_SECONDS)
 
-    assert healed.wait(5)
-    worker.join(5)
+    assert healed.wait(_OBSERVE_SECONDS)
+    worker.join(_HOLD_SECONDS)
     contents = {hit.content.strip() for hit in _units_in_category(tmp_path, "config")}
     assert any("healedtoken" in c for c in contents)
 
@@ -1497,17 +1526,17 @@ def test_foreground_delta_declines_fast_on_contention_and_schedules_repair(
     def hold_barrier() -> None:
         with vault_creation_lock(tmp_path, "lexical-catalog-publication", timeout=5):
             holding.set()
-            release.wait(10)
+            release.wait(_HOLD_SECONDS)
 
     worker = threading.Thread(target=hold_barrier, daemon=True)
     worker.start()
-    assert holding.wait(5)
+    assert holding.wait(_OBSERVE_SECONDS)
 
     start = time.monotonic()
     readiness = store.catalog_readiness("kb", drifted)
     elapsed = time.monotonic() - start
     release.set()
-    worker.join(5)
+    worker.join(_HOLD_SECONDS)
 
     # Declined within the short foreground bound (not the 30s background wait),
     # deferring to a scheduled single-flight repair rather than false-emptying.
@@ -1554,7 +1583,7 @@ def test_repair_search_opens_connection_only_after_publication_barrier(
             worker.start()
             time.sleep(0.1)
             assert not connected.is_set(), "repair opened the pre-publication DB inode"
-        worker.join(timeout=5)
+        worker.join(timeout=_HOLD_SECONDS)
         assert not worker.is_alive()
         assert connected.is_set()
         assert result and result[0] is not None

--- a/tests/test_mutation_concurrency.py
+++ b/tests/test_mutation_concurrency.py
@@ -14,6 +14,34 @@ from exomem import commands, preserve, schema
 from exomem.cli_ops import OpError
 from exomem.writer_lease import LeaseConfig, LeaseManager
 
+#: The wall-clock shape of every contention test in this file.
+#:
+#: A HOLD parks a thread or process while the test observes an ordering; an
+#: OBSERVATION is how long the test waits for that state to be reached. The gap
+#: between them is the entire discriminating power of these tests -- a hold that
+#: does not outlast its observation lets the ordering pass vacuously, and an
+#: observation sized for an idle laptop fails on a loaded shard while the code
+#: under test behaves correctly.
+#:
+#: A NEGATIVE wait (`assert not x.wait(0.1)`) proves something has NOT happened
+#: yet and stays tight: widening one changes the scenario rather than merely
+#: slowing it, because the product's own timeouts run in the same window.
+#:
+#: `join(timeout=N)` followed by `assert t.is_alive()` is the SAME negative
+#: observation in join form, and it is the one shape that consumes its whole
+#: window on every healthy run -- it exists to prove a competitor is still
+#: parked. Widening one from 0.3s to 60s bought nothing and cost a minute a run.
+#:
+#: Both constants stay strictly under pytest's per-test `timeout` (pyproject
+#: `[tool.pytest.ini_options]`). A valve at or above it never gets to fire: the
+#: harness kills the test first and you get a thread dump where a named
+#: assertion should have been. tests/test_timing_assertion_hygiene.py pins that.
+#:
+#: These are not latency claims. Nothing here asserts the product is fast.
+_HOLD_SECONDS = 45.0
+_OBSERVE_SECONDS = 15.0
+_BARRIER_SECONDS = 2.0
+
 
 def _add_command():
     return next(command for command in commands.COMMANDS if command.name == "add")
@@ -44,7 +72,7 @@ def test_twenty_concurrent_real_captures_leave_complete_vault_state(
 
     def capture(number: int, *, synchronize: bool, retry: bool = False) -> dict:
         if synchronize:
-            start.wait(timeout=10.0)
+            start.wait(timeout=_OBSERVE_SECONDS)
         return (retry_manager if retry else manager).invoke(
             command,
             (vault, source_schema),
@@ -54,11 +82,11 @@ def test_twenty_concurrent_real_captures_leave_complete_vault_state(
     def hold_boundary() -> None:
         with holder.mutation_guard(vault, request_id="holder", operation="capture"):
             holding.set()
-            assert release.wait(10.0)
+            assert release.wait(_HOLD_SECONDS)
 
     thread = threading.Thread(target=hold_boundary)
     thread.start()
-    assert holding.wait(10.0)
+    assert holding.wait(_OBSERVE_SECONDS)
     with ThreadPoolExecutor(max_workers=20) as pool:
         first_attempts = [pool.submit(capture, number, synchronize=True) for number in range(20)]
         refused: list[OpError] = []
@@ -72,7 +100,7 @@ def test_twenty_concurrent_real_captures_leave_complete_vault_state(
         assert not list((vault / "Knowledge Base/Sources/Other").glob("concurrent-capture-*.md"))
 
         release.set()
-        thread.join(timeout=10.0)
+        thread.join(timeout=_HOLD_SECONDS)
         assert not thread.is_alive()
         pending = set(range(20))
         results: dict[int, dict] = {}
@@ -123,7 +151,7 @@ class _BarrierStream(io.BytesIO):
     def read(self, size: int = -1) -> bytes:
         if self._first_read:
             self._first_read = False
-            self._barrier.wait(timeout=2.0)
+            self._barrier.wait(timeout=_BARRIER_SECONDS)
         return super().read(size)
 
 

--- a/tests/test_timing_assertion_hygiene.py
+++ b/tests/test_timing_assertion_hygiene.py
@@ -30,6 +30,11 @@ TESTS = Path(__file__).parent
 #: constants. Adding a file here is a promise that it contains no tight
 #: positive wait, so convert it first.
 CONVERTED = (
+    "test_command_surface_retry.py",
+    "test_corpus_context_cache.py",
+    "test_lexstore_atomic_rebuild.py",
+    "test_graph_rebuild_locking.py",
+    "test_mutation_concurrency.py",
     "test_graph_rebuild_availability.py",
     "test_mutation_lock.py",
     "test_epistemic_graph_freshness.py",


### PR DESCRIPTION
Follows #702. A Codex worker lane (`codex/timing-valves`) converted five more files; I verified the result rather than taking the report at face value.

## Why

A wall-clock number that exists so a hang fails instead of blocking forever is a **deadlock valve** and must be generous. Written tightly it becomes a **latency assertion** — a claim that a contended runner is fast — and it fails there while the code is correct. #702 converted five files; 167 literals remained across 38.

`test_mutation_concurrency.py` is first in this batch because it timed out on `windows-latest, py3.13, shard 1/4` during #686 earlier today.

## Converted

| File | Converted | Left tight |
| --- | ---: | ---: |
| `test_mutation_concurrency.py` | 5 | 1 |
| `test_graph_rebuild_locking.py` | 10 | 6 |
| `test_lexstore_atomic_rebuild.py` | 10 | 3 |
| `test_corpus_context_cache.py` | 9 | 2 |
| `test_command_surface_retry.py` | 10 | 0 |

All five are now pinned in `CONVERTED`, so they cannot drift back.

## The three traps, and how they went

The brief named three mistakes that had already shipped and returned as CI failures. All three were handled:

1. **Negative observations stay tight** — `assert not healed.wait(...)` kept, now as a named `_STILL_BLOCKED_SECONDS`.
2. **`join(timeout=N)` + `assert t.is_alive()`** is the same negative observation in join form. I scanned the result for that shape; none was widened.
3. **`.wait(n)` is not always an Event.** `test_graph_rebuild_locking.py:228` is `assert second.wait(1).covers(_checkpoint(2))` — a `GraphRebuildRegistration` returning a build outcome. Correctly left at 1.0s, and now named `_REGISTERED_REBUILD_WAIT_SECONDS` so the next reader does not have to rediscover it.

Every left-tight wait is listed with its reason in the lane's report; that list is the part worth reviewing.

## Verification

The worker's own report said the suite *"completed successfully (the PTY captured only progress dots)"* — i.e. it could not read its own summary line, so that claim was unverified. **I re-ran it here: 151 passed, 4 skipped.**

- `test_timing_assertion_hygiene.py` green, including `test_timing_constants_stay_under_pytests_own_timeout` — every constant is 45.0/15.0 or below, strictly under pytest's 60s per-test `timeout`.
- `ruff check --select F,E9,I` clean over the touched files.

**Declared deviation, carried forward honestly:** repo-wide `ruff check . --select F,E9,I` is *not* clean — 171 pre-existing auto-fixable import-order findings outside this lane. The worker normalized the three inside its allowlist and declined to expand into a repo-wide rewrite. That was the right call.