### PR TITLE
perf(recall): stop re-resolving the vault root once per ranking candidate

### DIFF
--- a/scripts/latency_curve.py
+++ b/scripts/latency_curve.py
@@ -47,6 +47,8 @@ import statistics
 import sys
 import tempfile
 import time
+from collections import defaultdict
+from collections.abc import Iterable
 from pathlib import Path
 
 # --- Isolate this benchmark from any host/service config BEFORE importing exomem.
@@ -75,9 +77,11 @@ if str(HERE) not in sys.path:
 
 from synth_vault import gen_dense_vault  # noqa: E402
 
-from exomem import bm25  # noqa: E402
+from exomem import (
+    bm25,  # noqa: E402
+    freshness,  # noqa: E402
+)
 from exomem import find as find_module  # noqa: E402
-from exomem import freshness  # noqa: E402
 from exomem.vault import walk_vault_md  # noqa: E402
 
 DEFAULT_SIZES = [100, 500, 1000, 2000, 5000]
@@ -101,6 +105,25 @@ DEFAULT_QUERIES = [
 # lane visible; on a real vault it was a per-query cost the harness silently
 # omitted (see docs/benchmarks.md, real-vault section).
 LANES = ("vector", "bm25", "keyword", "graph", "outside_kb", "fusion", "rerank")
+
+# Reported after every real stage. Not a stage: it is `FindTimings`' wall time
+# that no span claimed, and a curve that rises here means the next fix should
+# be an instrument, not an optimisation.
+UNATTRIBUTED = "unattributed"
+
+
+def _lane_order(observed: Iterable[str]) -> list[str]:
+    """LANES first, in their fixed order, then anything else alphabetically.
+
+    Keeps the historical columns where readers expect them while guaranteeing a
+    newly-added or newly-expensive stage still gets a column.
+    """
+    seen = set(observed)
+    ordered = [lane for lane in LANES if lane in seen]
+    ordered += sorted(seen - set(LANES) - {UNATTRIBUTED})
+    if UNATTRIBUTED in seen:
+        ordered.append(UNATTRIBUTED)
+    return ordered
 
 
 class _NoEmbeddingIndex:
@@ -230,7 +253,12 @@ def _measure_pass(
     """Warm every lane, then time the query set. Returns `(lanes, total, top10s)`
     where `top10s` is the ordered top-10 path list per query (for cross-backend
     overlap)."""
-    lane_samples: dict[str, list[float]] = {lane: [] for lane in LANES}
+    # Keyed by every stage actually observed, not by a fixed list. LANES only
+    # decides COLUMN ORDER now: a closed list is how a growing stage stays
+    # invisible, which is the harness-level version of the "5ms lie" this file
+    # exists to prevent. `unattributed` rides along as a pseudo-lane so time no
+    # span claimed shows up as a column instead of as a gap you have to notice.
+    lane_samples: dict[str, list[float]] = defaultdict(list)
     total_samples: list[float] = []
 
     # Warm every lane once (bm25 corpus, resolver, model/sidecar/vec tables) so
@@ -255,14 +283,14 @@ def _measure_pass(
             )
             d = t.as_dict()
             total_samples.append(d["total_ms"])
-            for lane in LANES:
-                stage = d["stages"].get(lane, {})
+            for lane, stage in d["stages"].items():
                 # A lane's `_span` finally-block records `ms` even when the
                 # lane body raised (e.g. the model-free vector ImportError),
                 # so exclude any lane that errored or was skipped — it did not
                 # actually run to completion and its ~0ms is not a lane cost.
                 if "ms" in stage and "error" not in stage and "skipped" not in stage:
                     lane_samples[lane].append(stage["ms"])
+            lane_samples[UNATTRIBUTED].append(d["unattributed_ms"])
 
     lanes: dict[str, dict] = {}
     for lane, vals in lane_samples.items():
@@ -586,13 +614,17 @@ def render_markdown(results: list[dict], *, embeddings_on: bool, rerank: bool) -
         label = f" — vector backend: {backend}" if backend != "off" else ""
         lines.append(f"Per-lane latency (ms, median / p90) — mode: {mode}{label}")
         lines.append("")
-        header = ["Notes", *LANES, "total"]
+        observed: set[str] = set()
+        for r in results:
+            observed |= set(r["backends"][backend]["lanes"])
+        columns = _lane_order(observed)
+        header = ["Notes", *columns, "total"]
         lines.append("| " + " | ".join(header) + " |")
         lines.append("|" + "|".join(["---"] * len(header)) + "|")
         for r in results:
             b = r["backends"][backend]
             cells = [str(r["n"])]
-            for lane in LANES:
+            for lane in columns:
                 cells.append(_fmt_cell(b["lanes"].get(lane)))
             cells.append(_fmt_cell(b["total"]))
             lines.append("| " + " | ".join(cells) + " |")

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -1247,8 +1247,11 @@ def op_find(
         include_timings: When true (off by default), the return becomes an
             envelope {"hits": [...], "timings": {...}} (with pack=true the
             envelope also carries "pack"). `timings` reports total_ms,
-            hot-cache status, and per-stage milliseconds for the retrieval
-            lanes (skipped/failed optional lanes are marked, never fatal).
+            unattributed_ms (wall time no stage claimed — a large value means
+            the cost is somewhere not yet instrumented, not that the stages
+            are wrong), hot-cache status, and per-stage milliseconds for the
+            retrieval lanes (skipped/failed optional lanes are marked, never
+            fatal).
             Diagnostics only — timings never include note content. Omitted
             → the response shape is unchanged.
         explain: Add a bounded retrieval profile and per-hit ranking evidence.
@@ -1285,7 +1288,7 @@ def op_find(
         With detail="compact": each hit is the routing stub described under
         `detail` (no excerpt/signals) — same paths, same order.
         With include_timings on: {"hits": [...], ["pack": {...},]
-        "timings": {total_ms, cache, stages}}.
+        "timings": {total_ms, unattributed_ms, cache, stages}}.
         Right after a server start, while models are still warming in the
         background, semantic lanes are skipped rather than blocked on — the
         result is then the envelope {"hits": [...], "warming": {"components":
@@ -1754,6 +1757,11 @@ def _timing_log_summary(timings_dict: dict | None) -> dict | None:
         return None
     return {
         "total_ms": timings_dict.get("total_ms"),
+        # Carried deliberately. This projection is closed, so a field it does
+        # not name never reaches the query log — and the query log is exactly
+        # where a rising uninstrumented term would become visible over time,
+        # which is the thing #283 spent a month unable to see.
+        "unattributed_ms": timings_dict.get("unattributed_ms"),
         "cache_hit": bool(timings_dict.get("cache", {}).get("hit")),
         "stage_ms": {
             name: entry["ms"]

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -4476,6 +4476,10 @@ def unload_ram_caches(*, keep_recall_resolver: bool = False) -> dict[str, int]:
         _FIND_CACHE_CHECKPOINTS.clear()
     with _RECALL_PATH_CACHE_LOCK:
         _RECALL_PATH_CACHE.clear()
+    # Tiny (bounded at 32 paths), but this seam means "drop everything
+    # rebuildable", and a memo left behind by an otherwise-complete eviction is
+    # the kind of exception that later reads as an oversight.
+    recall_policy.clear_resolved_roots()
     return {"pages": page_entries, "resolvers": resolver_entries, "hot_find": hot_entries}
 
 

--- a/src/exomem/find_types.py
+++ b/src/exomem/find_types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
@@ -473,13 +474,26 @@ class SemanticUnitHit:
 
 
 class FindTimings:
-    """Opt-in per-stage timing collector for one find call."""
+    """Opt-in per-stage timing collector for one find call.
+
+    The stage table is only as honest as its coverage. A read whose measured
+    stages summed to 4.4 s of a 6.1 s call (#283) had no defect in any stage —
+    the missing 28 % was work that no `span` wrapped, and nothing in the output
+    said so. `unattributed_ms` closes that: it is wall time inside the call
+    that no span claimed, so an uninstrumented region announces itself instead
+    of waiting to be found by subtracting a table by hand.
+    """
 
     def __init__(self) -> None:
         self._t0 = time.perf_counter()
         self.stages: dict[str, dict[str, Any]] = {}
         self.cache: dict[str, Any] = {"enabled": False, "hit": False}
         self.profile: dict[str, Any] = {}
+        # Every span's (start, end). `unattributed_ms` merges these rather than
+        # summing stage times, so a nested span is not double-counted and a
+        # lane that ever moves to its own thread still accounts correctly.
+        self._intervals: list[tuple[float, float]] = []
+        self._intervals_lock = threading.Lock()
 
     @contextmanager
     def span(self, name: str):
@@ -487,8 +501,21 @@ class FindTimings:
         try:
             yield
         finally:
+            t1 = time.perf_counter()
+            with self._intervals_lock:
+                self._intervals.append((t0, t1))
             entry = self.stages.setdefault(name, {})
-            entry["ms"] = round((time.perf_counter() - t0) * 1000.0, 3)
+            elapsed = round((t1 - t0) * 1000.0, 3)
+            if "ms" in entry:
+                # A stage can run twice in one call — `filter_eligibility` does,
+                # once for the unit lane and once for the page lane, whenever
+                # result_level is "mixed". Assigning would report whichever ran
+                # last and silently drop the other, so accumulate and say how
+                # many calls the number covers.
+                entry["ms"] = round(entry["ms"] + elapsed, 3)
+                entry["calls"] = entry.get("calls", 1) + 1
+            else:
+                entry["ms"] = elapsed
 
     def skipped(self, name: str) -> None:
         self.stages.setdefault(name, {})["skipped"] = True
@@ -496,9 +523,31 @@ class FindTimings:
     def error(self, name: str, exc: BaseException) -> None:
         self.stages.setdefault(name, {})["error"] = type(exc).__name__
 
+    def _covered_seconds(self) -> float:
+        """Wall seconds covered by at least one span, counting overlap once."""
+        with self._intervals_lock:
+            intervals = sorted(self._intervals)
+        covered = 0.0
+        reach: float | None = None  # end of the run being merged
+        for start, end in intervals:
+            if reach is None or start > reach:
+                covered += end - start
+                reach = end
+            elif end > reach:
+                covered += end - reach
+                reach = end
+        return covered
+
     def as_dict(self) -> dict[str, Any]:
+        total = time.perf_counter() - self._t0
         return {
-            "total_ms": round((time.perf_counter() - self._t0) * 1000.0, 3),
+            "total_ms": round(total * 1000.0, 3),
+            # Clamped: `as_dict` reads the clock after the last span closes, so
+            # this cannot legitimately go negative, and a float epsilon that
+            # made it -0.0 would read as a defect rather than as zero.
+            "unattributed_ms": round(
+                max(0.0, total - self._covered_seconds()) * 1000.0, 3
+            ),
             "cache": dict(self.cache),
             "profile": dict(self.profile),
             "stages": {k: dict(v) for k, v in self.stages.items()},

--- a/src/exomem/recall_policy.py
+++ b/src/exomem/recall_policy.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import stat
+import threading
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -17,6 +18,47 @@ from . import access, freshness, vault
 
 RECALL_POLICY_VERSION = "structured-collection-manifest-only-v2"
 _MAX_MANIFEST_BYTES = 512 * 1024
+
+# `_canonical_parts_after_safe_validation` compares a candidate's resolved
+# spelling against the resolved vault root. The candidate side varies; the root
+# side is the same directory for every candidate in a request, and a 600-
+# candidate query paid 600 identical `_getfinalpathname` calls for it (#283).
+# Memoizing only the fixed side keeps the alias check itself untouched: every
+# candidate is still resolved fresh.
+#
+# Safe in the direction that matters. If the root is swapped underneath us, the
+# remembered value no longer prefixes the candidate's freshly-resolved path, so
+# `relative_to` raises and the candidate is REJECTED. A stale entry can refuse a
+# legitimate page; it cannot admit one that escapes the boundary.
+_RESOLVED_ROOTS: dict[str, Path] = {}
+_RESOLVED_ROOTS_LOCK = threading.Lock()
+_MAX_RESOLVED_ROOTS = 32
+
+
+def _resolved_root(root: Path) -> Path:
+    """``root.resolve()``, memoized per vault root."""
+    key = str(root)
+    with _RESOLVED_ROOTS_LOCK:
+        remembered = _RESOLVED_ROOTS.get(key)
+    if remembered is not None:
+        return remembered
+    # Outside the lock: `resolve()` is a syscall, and holding a global lock
+    # across it would serialize every concurrent reader on a cold cache.
+    resolved = root.resolve()
+    with _RESOLVED_ROOTS_LOCK:
+        if len(_RESOLVED_ROOTS) >= _MAX_RESOLVED_ROOTS:
+            # Bounded, and a whole-map clear rather than an LRU: the working set
+            # is one vault in production and a handful of tmp roots in tests, so
+            # eviction never runs hot enough to need finer bookkeeping.
+            _RESOLVED_ROOTS.clear()
+        _RESOLVED_ROOTS[key] = resolved
+    return resolved
+
+
+def clear_resolved_roots() -> None:
+    """Forget memoized root resolutions (test seam; also used by cache eviction)."""
+    with _RESOLVED_ROOTS_LOCK:
+        _RESOLVED_ROOTS.clear()
 
 
 @dataclass(frozen=True, slots=True)
@@ -282,7 +324,7 @@ def _canonical_parts_after_safe_validation(root: Path, parts: list[str]) -> list
     exercises the real 8.3 behaviour where the volume supports it.
     """
     try:
-        resolved = (root.joinpath(*parts)).resolve().relative_to(root.resolve())
+        resolved = (root.joinpath(*parts)).resolve().relative_to(_resolved_root(root))
     except (OSError, ValueError):
         return None
     if not resolved.parts or any(part in {"", ".", ".."} for part in resolved.parts):

--- a/tests/test_read_path_timing_attribution.py
+++ b/tests/test_read_path_timing_attribution.py
@@ -1,0 +1,218 @@
+"""The read path must account for its own wall time, and not re-resolve invariants.
+
+#283 reported a ~7 s warm hybrid search and named vector/BM25 as the cost. By the
+time it was profiled neither was dominant, and the reason the report could be
+stale for a month is that `FindTimings` had no way to say "28 % of this call
+happened somewhere I do not measure". Two things are pinned here:
+
+* `unattributed_ms` — wall time inside the call that no span claimed. An
+  uninstrumented region now shows up in the timings payload itself.
+* the memoized vault-root resolution — the profile showed
+  `_canonical_parts_after_safe_validation` resolving the SAME vault root once
+  per candidate (2,438 `_getfinalpathname` calls for one 588-candidate query).
+
+The root memo is a security-adjacent cache, so its failure direction is pinned
+too: a stale entry must refuse a page, never admit one.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from exomem import commands, recall_policy
+from exomem.find_types import FindTimings
+
+
+def test_unattributed_time_counts_work_no_span_claimed() -> None:
+    timings = FindTimings()
+    with timings.span("measured"):
+        time.sleep(0.05)
+    time.sleep(0.05)  # nothing wraps this
+
+    out = timings.as_dict()
+
+    # Both sleeps are in `total`; only the first is inside a span. Bounds are
+    # deliberately loose in the slow direction — a contended runner can stretch
+    # a sleep but cannot make unattributed work vanish.
+    assert out["stages"]["measured"]["ms"] >= 40.0
+    assert out["unattributed_ms"] >= 40.0
+    assert out["unattributed_ms"] <= out["total_ms"]
+
+
+def test_a_fully_wrapped_call_reports_almost_no_unattributed_time() -> None:
+    timings = FindTimings()
+    with timings.span("everything"):
+        time.sleep(0.05)
+
+    out = timings.as_dict()
+
+    # The only unclaimed time is the collector's own bookkeeping.
+    assert out["unattributed_ms"] < 20.0
+
+
+def test_a_nested_span_is_not_charged_twice() -> None:
+    """Nesting must not make covered time exceed the wall clock.
+
+    `graph` already wraps `graph.seeds` / `graph.expand` / `graph.resolver`, so
+    summing stage times over-counts. `unattributed_ms` merges intervals instead,
+    and would go negative-then-clamped-to-zero if it did not.
+    """
+    timings = FindTimings()
+    with timings.span("outer"):
+        time.sleep(0.03)
+        with timings.span("inner"):
+            time.sleep(0.05)
+    time.sleep(0.06)  # genuinely unattributed, alongside the nesting
+
+    out = timings.as_dict()
+
+    assert out["stages"]["outer"]["ms"] >= out["stages"]["inner"]["ms"]
+    # Summing the table claims ~130 ms of an ~140 ms call, so it would report
+    # ~10 ms unattributed and swallow the 60 ms that really is unmeasured.
+    # Merging claims ~80 ms and reports ~60 ms. Note the assertion has to be
+    # made against a call that HAS unattributed time: with none, an over-count
+    # clamps to zero and reads as correct.
+    summed = sum(stage["ms"] for stage in out["stages"].values())
+    assert summed > out["stages"]["outer"]["ms"]
+    assert out["unattributed_ms"] >= 40.0
+
+
+def test_a_stage_that_runs_twice_reports_both_runs() -> None:
+    """`filter_eligibility` runs once per lane in "mixed" — assigning drops one."""
+    timings = FindTimings()
+    for _ in range(2):
+        with timings.span("filter_eligibility"):
+            time.sleep(0.03)
+
+    stage = timings.as_dict()["stages"]["filter_eligibility"]
+
+    assert stage["calls"] == 2
+    assert stage["ms"] >= 55.0  # both runs, not the last one
+
+
+def test_a_stage_that_runs_once_carries_no_call_count() -> None:
+    """The single-run shape is pinned by exact-dict assertions elsewhere."""
+    timings = FindTimings()
+    with timings.span("keyword"):
+        pass
+
+    assert set(timings.as_dict()["stages"]["keyword"]) == {"ms"}
+
+
+def test_the_query_log_projection_carries_the_unattributed_term() -> None:
+    """A closed projection drops any field it does not name.
+
+    The query log is where a slowly-growing uninstrumented term would become
+    visible across many requests, so the field has to survive the trip. This is
+    the same shape as a response field that never reaches its caller because a
+    compact projection was not widened alongside it.
+    """
+    timings = FindTimings()
+    with timings.span("bm25"):
+        pass
+    payload = timings.as_dict()
+
+    summary = commands._timing_log_summary(payload)
+
+    assert summary is not None
+    assert summary["unattributed_ms"] == payload["unattributed_ms"]
+    assert "bm25" in summary["stage_ms"]
+
+
+def test_the_query_log_projection_tolerates_no_timings() -> None:
+    assert commands._timing_log_summary(None) is None
+
+
+def _kb_page(vault: Path, name: str) -> Path:
+    page = vault / "Knowledge Base" / "Notes" / name
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text("---\ntype: note\n---\n\nbody\n", encoding="utf-8")
+    return page
+
+
+def test_the_vault_root_is_resolved_once_not_once_per_candidate(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The fixed side of the alias comparison must not be a per-candidate syscall."""
+    # The alias check is Windows-only in production; the seam exists so the
+    # behaviour is testable on any platform (see its docstring).
+    monkeypatch.setattr(recall_policy, "_needs_canonical_alias_check", lambda parts: True)
+    recall_policy.clear_resolved_roots()
+
+    pages = [_kb_page(tmp_path, f"page-{i}.md") for i in range(12)]
+
+    resolved: list[str] = []
+    real_resolve = Path.resolve
+
+    def counting_resolve(self, *args, **kwargs):
+        resolved.append(str(self))
+        return real_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", counting_resolve)
+
+    for page in pages:
+        assert recall_policy.is_recall_candidate(tmp_path, page) is True
+
+    root_resolves = [entry for entry in resolved if entry == str(tmp_path)]
+    # Every candidate is still resolved on its own; only the root is remembered.
+    assert len(root_resolves) == 1, f"root resolved {len(root_resolves)}x for 12 candidates"
+    assert len(resolved) - len(root_resolves) == len(pages)
+
+
+def test_a_stale_remembered_root_refuses_a_page_rather_than_admitting_it(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The memo's only failure direction must be refusal.
+
+    A cache that can admit a path outside the vault would turn a latency fix
+    into a boundary hole, so prime it with the wrong root and prove the answer
+    is False.
+    """
+    monkeypatch.setattr(recall_policy, "_needs_canonical_alias_check", lambda parts: True)
+    page = _kb_page(tmp_path, "page.md")
+    assert recall_policy.is_recall_candidate(tmp_path, page) is True
+
+    elsewhere = tmp_path.parent / "somewhere-else"
+    elsewhere.mkdir(exist_ok=True)
+    recall_policy.clear_resolved_roots()
+    monkeypatch.setattr(recall_policy, "_resolved_root", lambda root: elsewhere)
+
+    assert recall_policy.is_recall_candidate(tmp_path, page) is False
+
+
+def test_dropping_rebuildable_caches_drops_the_root_memo_too(tmp_path: Path, monkeypatch) -> None:
+    """`unload_ram_caches` means "everything rebuildable" — no quiet exceptions."""
+    from exomem import find as find_module
+
+    monkeypatch.setattr(recall_policy, "_needs_canonical_alias_check", lambda parts: True)
+    page = _kb_page(tmp_path, "page.md")
+    recall_policy.is_recall_candidate(tmp_path, page)
+    assert recall_policy._RESOLVED_ROOTS
+
+    find_module.unload_ram_caches()
+
+    assert not recall_policy._RESOLVED_ROOTS
+
+
+def test_clearing_the_memo_makes_the_next_lookup_cold(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(recall_policy, "_needs_canonical_alias_check", lambda parts: True)
+    page = _kb_page(tmp_path, "page.md")
+    recall_policy.clear_resolved_roots()
+    assert recall_policy.is_recall_candidate(tmp_path, page) is True
+
+    resolved: list[str] = []
+    real_resolve = Path.resolve
+
+    def counting_resolve(self, *args, **kwargs):
+        resolved.append(str(self))
+        return real_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", counting_resolve)
+
+    recall_policy.is_recall_candidate(tmp_path, page)
+    assert str(tmp_path) not in resolved  # warm
+
+    recall_policy.clear_resolved_roots()
+    recall_policy.is_recall_candidate(tmp_path, page)
+    assert str(tmp_path) in resolved  # cold again


### PR DESCRIPTION
Closes the instrumentation half of #283 and fixes the first thing it exposed.

## Why this issue stayed stale for a month

#283 was filed in July naming `vector 3-6s, BM25 3.2s` as the cost. Re-measured in August, neither was dominant — the top terms were `freshness` (1,451 ms) and `fusion` (825 ms), stages the original report does not even list, plus **~1,700 ms outside every instrumented stage**.

That last number is the actual problem. 28 % of the call was unmeasured and nothing said so; you had to sum a markdown table by hand to notice. So this fixes the accounting first, then the thing the accounting found.

## Accounting

**`FindTimings.unattributed_ms`** — wall time inside the call that no span claimed. It merges span *intervals* rather than summing stage times, so nesting is not double-counted (`graph` already wraps `graph.seeds` / `graph.expand` / `graph.resolver`).

Two adjacent defects fixed while in there:

- A stage that ran **twice in one call overwrote its own first measurement** and reported the cheaper run. `filter_eligibility` does exactly this when `result_level` is `"mixed"` — once for the unit lane, once for the page lane. It now accumulates and reports `calls`.
- `_timing_log_summary` is a **closed projection**. A field it does not name never reaches the query log — which is the one surface where a slowly-rising term becomes visible across many requests. Named it there too; there's a test, because this is the same shape as a response field that never reaches its caller.

**`scripts/latency_curve.py`** reported a hardcoded 7-lane list. That is how a growing stage stays invisible — the harness-level version of the "5ms lie" the file's own docstring exists to prevent. It now reports every stage observed, in the historical column order, plus `unattributed`. That change alone surfaced five stages the table had never printed (`filter_hits`, `date_filter`, `graph.expand`, `graph.resolver`, `graph.seeds`).

## What the accounting found

`fusion` is the term that grows with the corpus, model-free:

| notes | fusion (median) | total |
|---|---|---|
| 100 | 0.2 ms | 106.6 ms |
| 500 | 162.0 ms | 317.4 ms |
| 2,000 | 353.4 ms | 443.9 ms |

It is ~100 % `apply_post_rrf_multipliers`, which calls `page_of` for **every fused candidate** — about 500 pages loaded to rank, in order to return 10. Per-path cost is ~2 µs when the page is memo-warm and ~700 µs when it is cold, so this is page loading, not multiplier arithmetic.

Profiling one 588-candidate query put **1.076 s of a 1.170 s call inside `_page_of`**, and **0.903 s of that inside `recall_policy.is_recall_candidate`** — 2,438 `nt._getfinalpathname` and 3,909 `nt.stat` calls for 598 distinct paths, roughly 4 resolves and 6.5 stats each.

## The fix

Half those resolves were the same directory. `_canonical_parts_after_safe_validation` compares a candidate's resolved spelling against `root.resolve()` — and resolved the root again for every candidate. Memoize only that fixed side. Every candidate is still resolved fresh, so the 8.3-alias check is unchanged.

**The memo can only fail toward refusal.** If the root is swapped underneath us, the remembered value no longer prefixes the candidate's freshly-resolved path, `relative_to` raises, and the candidate is rejected. A stale entry can refuse a legitimate page; it cannot admit one that escapes the boundary. `test_a_stale_remembered_root_refuses_a_page_rather_than_admitting_it` pins that direction explicitly.

Measured on a 2,000-note synthetic vault:

| | before | after |
|---|---|---|
| `nt._getfinalpathname` calls | 2,438 | **1,242** |
| `is_recall_candidate` | 0.903 s | **0.728 s** |
| whole `find()` call | 1.170 s | **0.988 s** |

## Both of #283's dominant terms share this root cause

`is_recall_candidate` is also what `iter_recall_markdown` runs, and `recall_projection_snapshot`'s cold path runs that over **every page in the vault** — twice for `scope="kb"` with a non-empty query. That is what the 1,451 ms `freshness` stage is doing. At 2,444 pages the arithmetic lines up.

It is also **Windows-specific**: `_needs_canonical_alias_check` returns `os.name == "nt"`, so the expensive canonicalization only runs there. The production writer this was measured on is the Windows desktop service.

## Deliberately not included

`_safe_regular_file` re-`lstat`s the same shared parent directories once per candidate — roughly two thirds of the remaining stats, since 598 candidates live in a handful of directories. Caching that widens a symlink-escape window from microseconds to process lifetime. That is a security decision and deserves its own change with its own review, not a ride along a latency fix. Noted on the issue with the profile data.

## Verification

- Every mechanism here was **mutation-tested red before being trusted** — six mutations, six caught. One of them mattered: my first nesting test passed with the merge logic replaced by naive summation, because the `max(0.0, ...)` clamp absorbed the over-count. The scenario had to be rewritten to have nesting *and* genuine unattributed time before it discriminated.
- Full suite green on Windows / py3.13 (`--ignore=tests/test_latency_gate.py`, ubuntu-only by design).
- `uvx ruff check --select F,E9,I` clean on every changed file.
- No generated artifact moved: the pinned MCP tool schemas cover parameter shapes, not the prose I edited, and `tests/fixtures/`, `plugins/`, `deploy/` are all clean.

Refs #283
