### PR TITLE
fix(governance): add held filesystem substrate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,60 @@ jobs:
         if: matrix.shard == 1
         run: uv run --frozen --python ${{ matrix.python-version }} exomem demo --json
 
+  windows-held-filesystem:
+    name: Windows held filesystem (native NTFS)
+    runs-on: windows-latest
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Verify lockfile is current
+        run: uv lock --check
+      - name: Require NTFS and 8.3 aliases
+        shell: pwsh
+        run: |
+          $drive = (Get-Item $env:GITHUB_WORKSPACE).PSDrive.Name
+          $volume = Get-Volume -DriveLetter $drive
+          if ($volume.FileSystem -ne "NTFS") {
+            throw "held-filesystem verification requires NTFS"
+          }
+          $writableNtfs = @()
+          foreach ($candidate in Get-Volume | Where-Object { $_.DriveLetter -and $_.FileSystem -eq "NTFS" }) {
+            $probe = "$($candidate.DriveLetter):\exomem-held-volume-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
+            try {
+              New-Item -ItemType Directory -Path $probe -ErrorAction Stop | Out-Null
+              Remove-Item -LiteralPath $probe -Force -ErrorAction Stop
+              $writableNtfs += $candidate.DriveLetter
+            } catch {
+              # The native test will report which volume was unavailable.
+            }
+          }
+          if (@($writableNtfs | Sort-Object -Unique).Count -lt 2) {
+            throw "held-filesystem verification requires at least two writable NTFS volumes"
+          }
+          fsutil.exe 8dot3name set "$drive`:" 0
+          if ($LASTEXITCODE -ne 0) {
+            throw "failed to enable per-volume 8.3 alias creation"
+          }
+          fsutil.exe 8dot3name query "$drive`:"
+          if ($LASTEXITCODE -ne 0) {
+            throw "failed to verify per-volume 8.3 alias creation"
+          }
+      - name: Native held-filesystem gate
+        env:
+          KB_MCP_DISABLE_EMBEDDINGS: "1"
+          KB_MCP_DISABLE_MEDIA_EXTRACTION: "1"
+          EXOMEM_DISABLE_CLIP: "1"
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: >-
+          uv run --frozen --python 3.13 python -m pytest -q
+          tests/test_held_fs_contract.py
+          tests/test_held_fs_windows.py
+          --session-timeout=600
+
   tui:
     name: terminal UI (textual, headless + snapshots)
     runs-on: ubuntu-latest
@@ -374,6 +428,7 @@ jobs:
     if: ${{ !cancelled() }}
     needs:
       - test
+      - windows-held-filesystem
       - tui
       - product-e2e
       - retrieval-quality

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -196,7 +196,7 @@ made before both PRs and their combined verification are complete.
   Pair absent/present fixtures for every graph-sync/floor/receipt descendant,
   review-state/temp, and lexical rebuild/quarantine member and require stable list/walk/
   search/get/download/dataset/export/transfer envelopes.
-- [ ] 4.4a **PR A:** Add red native primitive/API fixture tests, independent of the
+- [x] 4.4a **PR A:** Add red native primitive/API fixture tests, independent of the
   closed registry and public leaves: held no-follow parent acquisition, relative
   read/write/rename/link/unlink API behaviour, same-device versus cross-device result,
   destination-only copy publication, ordered per-entry saga records, stable identity
@@ -241,7 +241,7 @@ made before both PRs and their combined verification are complete.
   symlink/reparse/hardlink/physical aliases. Also cover case/NFKC/separators/prefix/dot/
   drive/UNC/ADS, short names, refs, and managed aliases; do not claim universal detection
   or zero effect for direct OS-vault-owner filesystem/block access.
-- [ ] 4.7 **PR A:** Provide and verify the shared native held-handle primitive used later
+- [x] 4.7 **PR A:** Provide and verify the shared native held-handle primitive used later
   by every leaf and internal-store lifecycle: publish SQLite primary/WAL/SHM stable
   identities before releasing cooperative coordination, not before filesystem
   reachability; hold no-follow vault/parent traversal through primitive operations,

--- a/src/exomem/_held_fs_posix.py
+++ b/src/exomem/_held_fs_posix.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import ctypes
 import errno
 import os
 import secrets
 import stat
+import sys
+from ctypes import Structure, byref, c_char_p, c_int, c_long, c_size_t, c_uint64
 from pathlib import Path
 
 from .held_fs import (
     Capabilities,
     HeldDirectory,
+    HeldFile,
     HeldFilesystem,
     HeldFsError,
     HeldResult,
@@ -18,13 +22,27 @@ from .held_fs import (
     StableIdentity,
 )
 
-_DIRECTORY_FLAGS = os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_CLOEXEC", 0) | getattr(
-    os, "O_NOFOLLOW", 0
+RESOLVE_NO_XDEV = 0x01
+RESOLVE_NO_MAGICLINKS = 0x02
+RESOLVE_NO_SYMLINKS = 0x04
+RESOLVE_BENEATH = 0x08
+_OPENAT2_RESOLVE = RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS | RESOLVE_NO_MAGICLINKS | RESOLVE_NO_XDEV
+_SYS_OPENAT2 = 437
+
+_DIRECTORY_FLAGS = (
+    os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
 )
 _READ_FLAGS = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
-_WRITE_FLAGS = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_CLOEXEC", 0) | getattr(
-    os, "O_NOFOLLOW", 0
-)
+_WRITE_FLAGS = os.O_RDWR | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+
+
+class _OpenHow(Structure):
+    _fields_ = [("flags", c_uint64), ("mode", c_uint64), ("resolve", c_uint64)]
+
+
+_LIBC = ctypes.CDLL(None, use_errno=True)
+_LIBC.syscall.argtypes = None
+_LIBC.syscall.restype = c_long
 
 
 def _identity(info: os.stat_result) -> StableIdentity:
@@ -37,12 +55,20 @@ def _identity(info: os.stat_result) -> StableIdentity:
     return StableIdentity(info.st_dev, info.st_ino, kind, info.st_nlink)
 
 
+def _same_object(left: StableIdentity, right: StableIdentity) -> bool:
+    return (left.device, left.inode, left.kind) == (right.device, right.inode, right.kind)
+
+
 def _error(error: OSError) -> HeldFsError:
     if error.errno == errno.EXDEV:
         return HeldFsError("CROSS_DEVICE", "operation requires one filesystem")
     if error.errno in {errno.ELOOP, errno.ENOTDIR}:
         return HeldFsError("UNSAFE_PATH", "unsafe filesystem object")
-    if error.errno in {errno.ENOENT, errno.ESTALE}:
+    if error.errno == errno.ESTALE:
+        return HeldFsError("IDENTITY_CHANGED", "held filesystem identity changed")
+    if error.errno == errno.EEXIST:
+        return HeldFsError("DESTINATION_EXISTS", "destination already exists")
+    if error.errno == errno.ENOENT:
         return HeldFsError("MISSING", "filesystem object is unavailable")
     return HeldFsError("IO_REFUSED", "held filesystem operation was refused")
 
@@ -63,65 +89,38 @@ def _parts(relative: str) -> tuple[str, ...] | None:
 
 
 def _leaf(name: str) -> bool:
-    return isinstance(name, str) and name not in {"", ".", ".."} and "/" not in name and "\\" not in name and "\x00" not in name
+    return (
+        isinstance(name, str)
+        and name not in {"", ".", ".."}
+        and "/" not in name
+        and "\\" not in name
+        and "\x00" not in name
+    )
 
 
-def _probe(root: Path) -> Capabilities:
-    if not all((getattr(os, "O_NOFOLLOW", 0), os.open in os.supports_dir_fd, os.rename in os.supports_dir_fd, os.unlink in os.supports_dir_fd)):
-        return Capabilities.disabled("descriptor-relative no-follow operations are unavailable")
-    try:
-        descriptor = os.open(os.fspath(root), _DIRECTORY_FLAGS)
-    except OSError:
-        return Capabilities.disabled("root cannot be opened as a no-follow directory")
-    try:
-        info = os.fstat(descriptor)
-        if not stat.S_ISDIR(info.st_mode):
-            return Capabilities.disabled("root is not a directory")
-        source = f".exomem-held-probe-{secrets.token_hex(16)}"
-        linked = f"{source}-link"
-        renamed = f"{source}-renamed"
-        try:
-            leaf = os.open(
-                source,
-                os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
-                0o600,
-                dir_fd=descriptor,
-            )
-            try:
-                leaf_identity = os.fstat(leaf)
-                if not stat.S_ISREG(leaf_identity.st_mode):
-                    return Capabilities.disabled("stable final identity is unavailable")
-            finally:
-                os.close(leaf)
-            try:
-                os.link(source, linked, src_dir_fd=descriptor, dst_dir_fd=descriptor, follow_symlinks=False)
-                os.rename(linked, renamed, src_dir_fd=descriptor, dst_dir_fd=descriptor)
-                os.unlink(renamed, dir_fd=descriptor)
-                hard_link = True
-            except OSError:
-                hard_link = False
-            os.unlink(source, dir_fd=descriptor)
-        except OSError:
-            return Capabilities.disabled("relative filesystem operations are unavailable")
-        return Capabilities(
-            relative_operations=True,
-            no_follow=True,
-            stable_identity=True,
-            same_device_rename=True,
-            hard_link=hard_link,
-        )
-    finally:
-        for name in (locals().get("source"), locals().get("linked"), locals().get("renamed")):
-            if isinstance(name, str):
-                try:
-                    os.unlink(name, dir_fd=descriptor)
-                except OSError:
-                    pass
+def _linux_openat2(parent: int, name: str, flags: int, mode: int = 0) -> int:
+    how = _OpenHow(flags, mode, _OPENAT2_RESOLVE)
+    result = _LIBC.syscall(
+        c_long(_SYS_OPENAT2),
+        c_int(parent),
+        c_char_p(os.fsencode(name)),
+        byref(how),
+        c_size_t(ctypes.sizeof(how)),
+    )
+    if result < 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+    return int(result)
+
+
+def _open_relative(parent: int, name: str, flags: int, mode: int = 0o600) -> int:
+    if sys.platform.startswith("linux"):
+        return _linux_openat2(parent, name, flags, mode if flags & os.O_CREAT else 0)
+    descriptor = os.open(name, flags, mode, dir_fd=parent)
+    if os.fstat(descriptor).st_dev != os.fstat(parent).st_dev:
         os.close(descriptor)
-
-
-def probe(root: Path) -> Capabilities:
-    return _probe(root)
+        raise OSError(errno.EXDEV, "mount traversal is unavailable")
+    return descriptor
 
 
 class PosixHeldDirectory(HeldDirectory):
@@ -135,12 +134,58 @@ class PosixHeldDirectory(HeldDirectory):
         if self.closed:
             raise OSError(errno.ESTALE, "held directory is closed")
         current = _identity(os.fstat(self.descriptor))
-        if current != self.identity or current.kind != "directory":
+        if not _same_object(current, self.identity) or current.kind != "directory":
             raise OSError(errno.ESTALE, "held directory changed")
 
     def close(self) -> None:
         if not self.closed:
             os.close(self.descriptor)
+            self.closed = True
+
+
+class PosixHeldFile(HeldFile):
+    def __init__(
+        self,
+        filesystem: PosixHeldFilesystem,
+        parent_descriptor: int,
+        parent_identity: StableIdentity,
+        name: str,
+        descriptor: int,
+        access: str,
+    ) -> None:
+        self.filesystem = filesystem
+        self.parent_descriptor = parent_descriptor
+        self.parent_identity = parent_identity
+        self.name = name
+        self.descriptor = descriptor
+        self.access = access
+        self.identity = _identity(os.fstat(descriptor))
+        self.closed = False
+        self.named = True
+
+    def check(self) -> None:
+        if self.closed or self.filesystem.closed:
+            raise OSError(errno.ESTALE, "held file is closed")
+        current = _identity(os.fstat(self.descriptor))
+        if current != self.identity or current.kind != "file":
+            raise OSError(errno.ESTALE, "held file changed")
+        if not _same_object(_identity(os.fstat(self.parent_descriptor)), self.parent_identity):
+            raise OSError(errno.ESTALE, "held parent changed")
+
+    def check_name(self) -> None:
+        self.check()
+        if not self.named:
+            raise OSError(errno.ESTALE, "held name is no longer current")
+        current = _identity(
+            os.stat(self.name, dir_fd=self.parent_descriptor, follow_symlinks=False)
+        )
+        if current != self.identity:
+            raise OSError(errno.ESTALE, "held name identity changed")
+
+    def close(self) -> None:
+        if not self.closed:
+            os.close(self.descriptor)
+            os.close(self.parent_descriptor)
             self.closed = True
 
 
@@ -156,11 +201,21 @@ class PosixHeldFilesystem(HeldFilesystem):
             os.close(self.descriptor)
             self.closed = True
 
-    def _check(self, parent: HeldDirectory) -> PosixHeldDirectory:
-        if self.closed or not isinstance(parent, PosixHeldDirectory) or parent.filesystem is not self:
+    def _check_directory(self, parent: HeldDirectory) -> PosixHeldDirectory:
+        if (
+            self.closed
+            or not isinstance(parent, PosixHeldDirectory)
+            or parent.filesystem is not self
+        ):
             raise OSError(errno.ESTALE, "held filesystem is unavailable")
         parent.check()
         return parent
+
+    def _check_file(self, file: HeldFile) -> PosixHeldFile:
+        if not isinstance(file, PosixHeldFile) or file.filesystem is not self:
+            raise OSError(errno.ESTALE, "held file is unavailable")
+        file.check()
+        return file
 
     def parent(self, relative: str, *, create: bool = False) -> HeldResult[HeldDirectory]:
         parts = _parts(relative)
@@ -172,12 +227,12 @@ class PosixHeldFilesystem(HeldFilesystem):
         try:
             for part in parts:
                 try:
-                    child = os.open(part, _DIRECTORY_FLAGS, dir_fd=descriptor)
+                    child = _open_relative(descriptor, part, _DIRECTORY_FLAGS)
                 except FileNotFoundError:
                     if not create:
                         raise
                     os.mkdir(part, 0o700, dir_fd=descriptor)
-                    child = os.open(part, _DIRECTORY_FLAGS, dir_fd=descriptor)
+                    child = _open_relative(descriptor, part, _DIRECTORY_FLAGS)
                 os.close(descriptor)
                 descriptor = child
             return HeldResult(value=PosixHeldDirectory(self, descriptor))
@@ -185,144 +240,214 @@ class PosixHeldFilesystem(HeldFilesystem):
             os.close(descriptor)
             return HeldResult(error=_error(error))
 
-    def _open_leaf(self, parent: HeldDirectory, leaf: str, flags: int, mode: int = 0o600) -> int:
-        if not _leaf(leaf):
-            raise OSError(errno.ELOOP, "invalid relative leaf")
-        checked = self._check(parent)
-        descriptor = os.open(leaf, flags, mode, dir_fd=checked.descriptor)
-        info = os.fstat(descriptor)
-        if not stat.S_ISREG(info.st_mode):
-            os.close(descriptor)
-            raise OSError(errno.ELOOP, "leaf is not a regular file")
-        return descriptor
-
-    def identity(self, parent: HeldDirectory, leaf: str) -> HeldResult[StableIdentity]:
+    def file(
+        self,
+        parent: HeldDirectory,
+        leaf: str,
+        *,
+        access: str = "read",
+        create: bool = False,
+        exclusive: bool = False,
+    ) -> HeldResult[HeldFile]:
+        if not _leaf(leaf) or access not in {"read", "write", "mutate"}:
+            return HeldResult(error=_invalid())
+        if exclusive and not create:
+            return HeldResult(error=HeldFsError("INVALID_INPUT", "exclusive requires create"))
+        parent_descriptor: int | None = None
+        descriptor: int | None = None
         try:
-            descriptor = self._open_leaf(parent, leaf, _READ_FLAGS)
-            try:
-                return HeldResult(value=_identity(os.fstat(descriptor)))
-            finally:
+            checked = self._check_directory(parent)
+            parent_descriptor = os.dup(checked.descriptor)
+            flags = _READ_FLAGS if access in {"read", "mutate"} else _WRITE_FLAGS
+            if create:
+                flags |= os.O_CREAT
+            if exclusive:
+                flags |= os.O_EXCL
+            descriptor = _open_relative(parent_descriptor, leaf, flags)
+            identity = _identity(os.fstat(descriptor))
+            if identity.kind != "file":
+                raise OSError(errno.ELOOP, "leaf is not a regular file")
+            return HeldResult(
+                value=PosixHeldFile(
+                    self,
+                    parent_descriptor,
+                    checked.identity,
+                    leaf,
+                    descriptor,
+                    access,
+                )
+            )
+        except OSError as error:
+            if descriptor is not None:
                 os.close(descriptor)
+            if parent_descriptor is not None:
+                os.close(parent_descriptor)
+            return HeldResult(error=_error(error))
+
+    def read(self, file: HeldFile) -> HeldResult[bytes]:
+        try:
+            checked = self._check_file(file)
+            os.lseek(checked.descriptor, 0, os.SEEK_SET)
+            chunks = []
+            while chunk := os.read(checked.descriptor, 65536):
+                chunks.append(chunk)
+            return HeldResult(value=b"".join(chunks))
         except OSError as error:
             return HeldResult(error=_error(error))
 
-    def read(self, parent: HeldDirectory, leaf: str) -> HeldResult[bytes]:
-        try:
-            descriptor = self._open_leaf(parent, leaf, _READ_FLAGS)
-            try:
-                chunks = []
-                while chunk := os.read(descriptor, 65536):
-                    chunks.append(chunk)
-                return HeldResult(value=b"".join(chunks))
-            finally:
-                os.close(descriptor)
-        except OSError as error:
-            return HeldResult(error=_error(error))
-
-    def write(self, parent: HeldDirectory, leaf: str, data: bytes) -> HeldResult[None]:
+    def write(self, file: HeldFile, data: bytes) -> HeldResult[None]:
         if not isinstance(data, bytes):
             return HeldResult(error=HeldFsError("INVALID_INPUT", "data must be bytes"))
         try:
-            descriptor = self._open_leaf(parent, leaf, _WRITE_FLAGS)
-            try:
-                view = memoryview(data)
-                written = 0
-                while written < len(view):
-                    written += os.write(descriptor, view[written:])
-                os.fsync(descriptor)
-                return HeldResult(value=None)  # type: ignore[arg-type]
-            finally:
-                os.close(descriptor)
+            checked = self._check_file(file)
+            if checked.access != "write":
+                return HeldResult(error=HeldFsError("INVALID_ACCESS", "held file is not writable"))
+            os.ftruncate(checked.descriptor, 0)
+            os.lseek(checked.descriptor, 0, os.SEEK_SET)
+            view = memoryview(data)
+            written = 0
+            while written < len(view):
+                written += os.write(checked.descriptor, view[written:])
+            os.fsync(checked.descriptor)
+            checked.identity = _identity(os.fstat(checked.descriptor))
+            return HeldResult(value=None)
         except OSError as error:
             return HeldResult(error=_error(error))
 
-    def _paired(self, source: HeldDirectory, destination: HeldDirectory, source_leaf: str, destination_leaf: str) -> tuple[PosixHeldDirectory, PosixHeldDirectory]:
-        if not _leaf(source_leaf) or not _leaf(destination_leaf):
-            raise OSError(errno.ELOOP, "invalid relative leaf")
-        source_parent = self._check(source)
+    def _destination(
+        self, source: PosixHeldFile, destination: HeldDirectory, destination_leaf: str
+    ) -> PosixHeldDirectory:
+        if source.access != "mutate" or not _leaf(destination_leaf):
+            raise OSError(errno.ELOOP, "invalid held mutation")
+        source.check_name()
         if not isinstance(destination, PosixHeldDirectory):
             raise OSError(errno.ESTALE, "destination handle is unavailable")
         destination.check()
-        if source_parent.identity.device != destination.identity.device:
+        if source.identity.device != destination.identity.device:
             raise OSError(errno.EXDEV, "parents are on different devices")
-        return source_parent, destination
-
-    def rename(self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory, destination_leaf: str) -> HeldResult[None]:
+        if destination.filesystem is not self:
+            raise OSError(errno.ESTALE, "destination belongs to another root")
         try:
-            source, destination = self._paired(source_parent, destination_parent, source_leaf, destination_leaf)
-            os.rename(source_leaf, destination_leaf, src_dir_fd=source.descriptor, dst_dir_fd=destination.descriptor)
-            return HeldResult(value=None)  # type: ignore[arg-type]
+            os.stat(destination_leaf, dir_fd=destination.descriptor, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise OSError(errno.EEXIST, "destination exists")
+        return destination
+
+    def rename(
+        self, source: HeldFile, destination_parent: HeldDirectory, destination_leaf: str
+    ) -> HeldResult[None]:
+        try:
+            checked = self._check_file(source)
+            destination = self._destination(checked, destination_parent, destination_leaf)
+            os.rename(
+                checked.name,
+                destination_leaf,
+                src_dir_fd=checked.parent_descriptor,
+                dst_dir_fd=destination.descriptor,
+            )
+            checked.named = False
+            return HeldResult(value=None)
         except OSError as error:
             return HeldResult(error=_error(error))
 
-    def link(self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory, destination_leaf: str) -> HeldResult[None]:
+    def link(
+        self, source: HeldFile, destination_parent: HeldDirectory, destination_leaf: str
+    ) -> HeldResult[None]:
         if not self.capabilities.hard_link:
-            return HeldResult(error=HeldFsError("CAPABILITY_UNAVAILABLE", "hard links are unavailable"))
+            return HeldResult(
+                error=HeldFsError("CAPABILITY_UNAVAILABLE", "hard links are unavailable")
+            )
         try:
-            source, destination = self._paired(source_parent, destination_parent, source_leaf, destination_leaf)
-            source_descriptor = self._open_leaf(source, source_leaf, _READ_FLAGS)
-            os.close(source_descriptor)
-            os.link(source_leaf, destination_leaf, src_dir_fd=source.descriptor, dst_dir_fd=destination.descriptor, follow_symlinks=False)
-            return HeldResult(value=None)  # type: ignore[arg-type]
+            checked = self._check_file(source)
+            destination = self._destination(checked, destination_parent, destination_leaf)
+            os.link(
+                checked.name,
+                destination_leaf,
+                src_dir_fd=checked.parent_descriptor,
+                dst_dir_fd=destination.descriptor,
+                follow_symlinks=False,
+            )
+            checked.identity = _identity(os.fstat(checked.descriptor))
+            return HeldResult(value=None)
         except OSError as error:
             return HeldResult(error=_error(error))
 
-    def unlink(self, parent: HeldDirectory, leaf: str) -> HeldResult[None]:
+    def unlink(self, file: HeldFile) -> HeldResult[None]:
         try:
-            checked = self._check(parent)
-            descriptor = self._open_leaf(checked, leaf, _READ_FLAGS)
-            os.close(descriptor)
-            os.unlink(leaf, dir_fd=checked.descriptor)
-            return HeldResult(value=None)  # type: ignore[arg-type]
+            checked = self._check_file(file)
+            if checked.access != "mutate":
+                return HeldResult(error=HeldFsError("INVALID_ACCESS", "held file is not mutable"))
+            checked.check_name()
+            os.unlink(checked.name, dir_fd=checked.parent_descriptor)
+            checked.named = False
+            return HeldResult(value=None)
         except OSError as error:
             return HeldResult(error=_error(error))
 
-    def copy(self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory, destination_leaf: str) -> HeldResult[None]:
+    def copy(
+        self, source: HeldFile, destination_parent: HeldDirectory, destination_leaf: str
+    ) -> HeldResult[None]:
         temporary = f".exomem-held-{secrets.token_hex(16)}"
         temporary_descriptor: int | None = None
+        destination: PosixHeldDirectory | None = None
         try:
-            if not _leaf(source_leaf) or not _leaf(destination_leaf):
-                raise OSError(errno.ELOOP, "invalid relative leaf")
-            source = self._check(source_parent)
+            checked = self._check_file(source)
+            if not _leaf(destination_leaf):
+                raise OSError(errno.ELOOP, "invalid destination leaf")
             if not isinstance(destination_parent, PosixHeldDirectory):
                 raise OSError(errno.ESTALE, "destination handle is unavailable")
             destination_parent.check()
+            if destination_parent.filesystem.closed:
+                raise OSError(errno.ESTALE, "destination root is unavailable")
             destination = destination_parent
-            source_descriptor = self._open_leaf(source, source_leaf, _READ_FLAGS)
             try:
-                temporary_descriptor = os.open(
-                    temporary,
-                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
-                    0o600,
+                os.stat(
+                    destination_leaf,
                     dir_fd=destination.descriptor,
+                    follow_symlinks=False,
                 )
-                while chunk := os.read(source_descriptor, 65536):
-                    view = memoryview(chunk)
-                    written = 0
-                    while written < len(view):
-                        written += os.write(temporary_descriptor, view[written:])
-                os.fsync(temporary_descriptor)
-            finally:
-                os.close(source_descriptor)
-                if temporary_descriptor is not None:
-                    os.close(temporary_descriptor)
-                    temporary_descriptor = None
-            os.replace(temporary, destination_leaf, src_dir_fd=destination.descriptor, dst_dir_fd=destination.descriptor)
-            os.fsync(destination.descriptor)
-            return HeldResult(value=None)  # type: ignore[arg-type]
-        except OSError as error:
-            try:
-                if temporary_descriptor is not None:
-                    os.close(temporary_descriptor)
-                if isinstance(destination_parent, PosixHeldDirectory):
-                    os.unlink(temporary, dir_fd=destination_parent.descriptor)
-            except OSError:
+            except FileNotFoundError:
                 pass
+            else:
+                raise OSError(errno.EEXIST, "destination exists")
+
+            os.lseek(checked.descriptor, 0, os.SEEK_SET)
+            temporary_descriptor = _open_relative(
+                destination.descriptor,
+                temporary,
+                _WRITE_FLAGS | os.O_CREAT | os.O_EXCL,
+            )
+            while chunk := os.read(checked.descriptor, 65536):
+                view = memoryview(chunk)
+                written = 0
+                while written < len(view):
+                    written += os.write(temporary_descriptor, view[written:])
+            os.fsync(temporary_descriptor)
+            os.close(temporary_descriptor)
+            temporary_descriptor = None
+            os.rename(
+                temporary,
+                destination_leaf,
+                src_dir_fd=destination.descriptor,
+                dst_dir_fd=destination.descriptor,
+            )
+            os.fsync(destination.descriptor)
+            return HeldResult(value=None)
+        except OSError as error:
+            if temporary_descriptor is not None:
+                os.close(temporary_descriptor)
+            if destination is not None:
+                try:
+                    os.unlink(temporary, dir_fd=destination.descriptor)
+                except OSError:
+                    pass
             return HeldResult(error=_error(error))
 
     def enumerate(self, parent: HeldDirectory) -> HeldResult[tuple[SagaRecord, ...]]:
         try:
-            checked = self._check(parent)
+            checked = self._check_directory(parent)
             records: list[SagaRecord] = []
             self._enumerate(checked.descriptor, "", records)
             return HeldResult(value=tuple(records))
@@ -336,23 +461,116 @@ class PosixHeldFilesystem(HeldFilesystem):
             info = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
             if stat.S_ISLNK(info.st_mode):
                 raise OSError(errno.ELOOP, "unsafe recursive entry")
-            relative = f"{prefix}/{name}" if prefix else name
-            identity = _identity(info)
-            if identity.kind not in {"file", "directory"}:
-                raise OSError(errno.ELOOP, "unsafe recursive entry")
-            records.append(SagaRecord(relative, identity))
-            if identity.kind == "directory":
-                child = os.open(name, _DIRECTORY_FLAGS, dir_fd=descriptor)
-                try:
+            flags = _DIRECTORY_FLAGS if stat.S_ISDIR(info.st_mode) else _READ_FLAGS
+            child = _open_relative(descriptor, name, flags)
+            try:
+                identity = _identity(os.fstat(child))
+                if identity.kind not in {"file", "directory"} or identity != _identity(info):
+                    raise OSError(errno.ESTALE, "recursive entry changed")
+                relative = f"{prefix}/{name}" if prefix else name
+                records.append(SagaRecord(relative, identity))
+                if identity.kind == "directory":
                     self._enumerate(child, relative, records)
-                finally:
-                    os.close(child)
+            finally:
+                os.close(child)
+
+
+def _probe(root: Path) -> Capabilities:
+    if not sys.platform.startswith("linux"):
+        return Capabilities.disabled("mount-aware relative operations are unavailable")
+    if not all(
+        (
+            getattr(os, "O_NOFOLLOW", 0),
+            os.open in os.supports_dir_fd,
+            os.rename in os.supports_dir_fd,
+            os.unlink in os.supports_dir_fd,
+        )
+    ):
+        return Capabilities.disabled("descriptor-relative no-follow operations are unavailable")
+    try:
+        descriptor = os.open(os.fspath(root), _DIRECTORY_FLAGS)
+    except OSError:
+        return Capabilities.disabled("root cannot be opened as a no-follow directory")
+
+    provisional = Capabilities(True, True, True, True, True)
+    filesystem = PosixHeldFilesystem(descriptor, provisional)
+    token = secrets.token_hex(16)
+    source_name = f".exomem-held-probe-{token}"
+    renamed_name = f"{source_name}-renamed"
+    linked_name = f"{source_name}-link"
+    alias_name = f"{source_name}-alias"
+    directory_name = f"{source_name}-directory"
+    directory_alias_name = f"{directory_name}-alias"
+    try:
+        with filesystem.parent(".").require() as parent:
+            with filesystem.file(
+                parent, source_name, access="write", create=True, exclusive=True
+            ).require() as source:
+                if not filesystem.write(source, b"probe").ok:
+                    return Capabilities.disabled("relative create/write is unavailable")
+
+            os.symlink(source_name, alias_name, dir_fd=parent.descriptor)
+            alias = filesystem.file(parent, alias_name)
+            if alias.ok:
+                alias.require().close()
+                return Capabilities.disabled("final no-follow refusal is unavailable")
+            os.mkdir(directory_name, 0o700, dir_fd=parent.descriptor)
+            os.symlink(
+                directory_name,
+                directory_alias_name,
+                target_is_directory=True,
+                dir_fd=parent.descriptor,
+            )
+            alias_parent = filesystem.parent(directory_alias_name)
+            if alias_parent.ok:
+                alias_parent.require().close()
+                return Capabilities.disabled("parent no-follow refusal is unavailable")
+
+            with filesystem.file(parent, source_name, access="mutate").require() as source:
+                hard_link = filesystem.link(source, parent, linked_name).ok
+                renamed = filesystem.rename(source, parent, renamed_name)
+                if not renamed.ok:
+                    return Capabilities.disabled("same-device relative rename is unavailable")
+            with filesystem.file(parent, renamed_name, access="mutate").require() as renamed:
+                if not filesystem.unlink(renamed).ok:
+                    return Capabilities.disabled("relative unlink is unavailable")
+        return Capabilities(True, True, True, True, hard_link)
+    except (HeldFsError, OSError):
+        return Capabilities.disabled("actual-filesystem capability probe failed")
+    finally:
+        try:
+            root_descriptor = filesystem.descriptor
+            for name in (
+                source_name,
+                renamed_name,
+                linked_name,
+                alias_name,
+                directory_alias_name,
+            ):
+                try:
+                    os.unlink(name, dir_fd=root_descriptor)
+                except OSError:
+                    pass
+            try:
+                os.rmdir(directory_name, dir_fd=root_descriptor)
+            except OSError:
+                pass
+        finally:
+            filesystem.close()
+
+
+def probe(root: Path) -> Capabilities:
+    return _probe(root)
 
 
 def acquire(root: Path) -> HeldResult[HeldFilesystem]:
     capability = probe(root)
     if not capability.relative_operations:
-        return HeldResult(error=HeldFsError("CAPABILITY_UNAVAILABLE", "required filesystem primitives are unavailable"))
+        return HeldResult(
+            error=HeldFsError(
+                "CAPABILITY_UNAVAILABLE", "required filesystem primitives are unavailable"
+            )
+        )
     try:
         descriptor = os.open(os.fspath(root), _DIRECTORY_FLAGS)
         info = os.fstat(descriptor)

--- a/src/exomem/_held_fs_posix.py
+++ b/src/exomem/_held_fs_posix.py
@@ -1,0 +1,364 @@
+"""POSIX implementation of the held, no-follow filesystem primitive."""
+
+from __future__ import annotations
+
+import errno
+import os
+import secrets
+import stat
+from pathlib import Path
+
+from .held_fs import (
+    Capabilities,
+    HeldDirectory,
+    HeldFilesystem,
+    HeldFsError,
+    HeldResult,
+    SagaRecord,
+    StableIdentity,
+)
+
+_DIRECTORY_FLAGS = os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_CLOEXEC", 0) | getattr(
+    os, "O_NOFOLLOW", 0
+)
+_READ_FLAGS = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+_WRITE_FLAGS = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_CLOEXEC", 0) | getattr(
+    os, "O_NOFOLLOW", 0
+)
+
+
+def _identity(info: os.stat_result) -> StableIdentity:
+    if stat.S_ISDIR(info.st_mode):
+        kind = "directory"
+    elif stat.S_ISREG(info.st_mode):
+        kind = "file"
+    else:
+        kind = "other"
+    return StableIdentity(info.st_dev, info.st_ino, kind, info.st_nlink)
+
+
+def _error(error: OSError) -> HeldFsError:
+    if error.errno == errno.EXDEV:
+        return HeldFsError("CROSS_DEVICE", "operation requires one filesystem")
+    if error.errno in {errno.ELOOP, errno.ENOTDIR}:
+        return HeldFsError("UNSAFE_PATH", "unsafe filesystem object")
+    if error.errno in {errno.ENOENT, errno.ESTALE}:
+        return HeldFsError("MISSING", "filesystem object is unavailable")
+    return HeldFsError("IO_REFUSED", "held filesystem operation was refused")
+
+
+def _invalid() -> HeldFsError:
+    return HeldFsError("UNSAFE_PATH", "unsafe filesystem object")
+
+
+def _parts(relative: str) -> tuple[str, ...] | None:
+    if relative == ".":
+        return ()
+    if not isinstance(relative, str) or not relative or "\x00" in relative:
+        return None
+    parts = tuple(relative.split("/"))
+    if any(part in {"", ".", ".."} or "\\" in part for part in parts):
+        return None
+    return parts
+
+
+def _leaf(name: str) -> bool:
+    return isinstance(name, str) and name not in {"", ".", ".."} and "/" not in name and "\\" not in name and "\x00" not in name
+
+
+def _probe(root: Path) -> Capabilities:
+    if not all((getattr(os, "O_NOFOLLOW", 0), os.open in os.supports_dir_fd, os.rename in os.supports_dir_fd, os.unlink in os.supports_dir_fd)):
+        return Capabilities.disabled("descriptor-relative no-follow operations are unavailable")
+    try:
+        descriptor = os.open(os.fspath(root), _DIRECTORY_FLAGS)
+    except OSError:
+        return Capabilities.disabled("root cannot be opened as a no-follow directory")
+    try:
+        info = os.fstat(descriptor)
+        if not stat.S_ISDIR(info.st_mode):
+            return Capabilities.disabled("root is not a directory")
+        source = f".exomem-held-probe-{secrets.token_hex(16)}"
+        linked = f"{source}-link"
+        renamed = f"{source}-renamed"
+        try:
+            leaf = os.open(
+                source,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+                0o600,
+                dir_fd=descriptor,
+            )
+            try:
+                leaf_identity = os.fstat(leaf)
+                if not stat.S_ISREG(leaf_identity.st_mode):
+                    return Capabilities.disabled("stable final identity is unavailable")
+            finally:
+                os.close(leaf)
+            try:
+                os.link(source, linked, src_dir_fd=descriptor, dst_dir_fd=descriptor, follow_symlinks=False)
+                os.rename(linked, renamed, src_dir_fd=descriptor, dst_dir_fd=descriptor)
+                os.unlink(renamed, dir_fd=descriptor)
+                hard_link = True
+            except OSError:
+                hard_link = False
+            os.unlink(source, dir_fd=descriptor)
+        except OSError:
+            return Capabilities.disabled("relative filesystem operations are unavailable")
+        return Capabilities(
+            relative_operations=True,
+            no_follow=True,
+            stable_identity=True,
+            same_device_rename=True,
+            hard_link=hard_link,
+        )
+    finally:
+        for name in (locals().get("source"), locals().get("linked"), locals().get("renamed")):
+            if isinstance(name, str):
+                try:
+                    os.unlink(name, dir_fd=descriptor)
+                except OSError:
+                    pass
+        os.close(descriptor)
+
+
+def probe(root: Path) -> Capabilities:
+    return _probe(root)
+
+
+class PosixHeldDirectory(HeldDirectory):
+    def __init__(self, filesystem: PosixHeldFilesystem, descriptor: int) -> None:
+        self.filesystem = filesystem
+        self.descriptor = descriptor
+        self.identity = _identity(os.fstat(descriptor))
+        self.closed = False
+
+    def check(self) -> None:
+        if self.closed:
+            raise OSError(errno.ESTALE, "held directory is closed")
+        current = _identity(os.fstat(self.descriptor))
+        if current != self.identity or current.kind != "directory":
+            raise OSError(errno.ESTALE, "held directory changed")
+
+    def close(self) -> None:
+        if not self.closed:
+            os.close(self.descriptor)
+            self.closed = True
+
+
+class PosixHeldFilesystem(HeldFilesystem):
+    def __init__(self, descriptor: int, capabilities: Capabilities) -> None:
+        self.descriptor = descriptor
+        self.capabilities = capabilities
+        self.root_identity = _identity(os.fstat(descriptor))
+        self.closed = False
+
+    def close(self) -> None:
+        if not self.closed:
+            os.close(self.descriptor)
+            self.closed = True
+
+    def _check(self, parent: HeldDirectory) -> PosixHeldDirectory:
+        if self.closed or not isinstance(parent, PosixHeldDirectory) or parent.filesystem is not self:
+            raise OSError(errno.ESTALE, "held filesystem is unavailable")
+        parent.check()
+        return parent
+
+    def parent(self, relative: str, *, create: bool = False) -> HeldResult[HeldDirectory]:
+        parts = _parts(relative)
+        if parts is None:
+            return HeldResult(error=_invalid())
+        if self.closed:
+            return HeldResult(error=HeldFsError("IO_REFUSED", "held root is closed"))
+        descriptor = os.dup(self.descriptor)
+        try:
+            for part in parts:
+                try:
+                    child = os.open(part, _DIRECTORY_FLAGS, dir_fd=descriptor)
+                except FileNotFoundError:
+                    if not create:
+                        raise
+                    os.mkdir(part, 0o700, dir_fd=descriptor)
+                    child = os.open(part, _DIRECTORY_FLAGS, dir_fd=descriptor)
+                os.close(descriptor)
+                descriptor = child
+            return HeldResult(value=PosixHeldDirectory(self, descriptor))
+        except OSError as error:
+            os.close(descriptor)
+            return HeldResult(error=_error(error))
+
+    def _open_leaf(self, parent: HeldDirectory, leaf: str, flags: int, mode: int = 0o600) -> int:
+        if not _leaf(leaf):
+            raise OSError(errno.ELOOP, "invalid relative leaf")
+        checked = self._check(parent)
+        descriptor = os.open(leaf, flags, mode, dir_fd=checked.descriptor)
+        info = os.fstat(descriptor)
+        if not stat.S_ISREG(info.st_mode):
+            os.close(descriptor)
+            raise OSError(errno.ELOOP, "leaf is not a regular file")
+        return descriptor
+
+    def identity(self, parent: HeldDirectory, leaf: str) -> HeldResult[StableIdentity]:
+        try:
+            descriptor = self._open_leaf(parent, leaf, _READ_FLAGS)
+            try:
+                return HeldResult(value=_identity(os.fstat(descriptor)))
+            finally:
+                os.close(descriptor)
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def read(self, parent: HeldDirectory, leaf: str) -> HeldResult[bytes]:
+        try:
+            descriptor = self._open_leaf(parent, leaf, _READ_FLAGS)
+            try:
+                chunks = []
+                while chunk := os.read(descriptor, 65536):
+                    chunks.append(chunk)
+                return HeldResult(value=b"".join(chunks))
+            finally:
+                os.close(descriptor)
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def write(self, parent: HeldDirectory, leaf: str, data: bytes) -> HeldResult[None]:
+        if not isinstance(data, bytes):
+            return HeldResult(error=HeldFsError("INVALID_INPUT", "data must be bytes"))
+        try:
+            descriptor = self._open_leaf(parent, leaf, _WRITE_FLAGS)
+            try:
+                view = memoryview(data)
+                written = 0
+                while written < len(view):
+                    written += os.write(descriptor, view[written:])
+                os.fsync(descriptor)
+                return HeldResult(value=None)  # type: ignore[arg-type]
+            finally:
+                os.close(descriptor)
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def _paired(self, source: HeldDirectory, destination: HeldDirectory, source_leaf: str, destination_leaf: str) -> tuple[PosixHeldDirectory, PosixHeldDirectory]:
+        if not _leaf(source_leaf) or not _leaf(destination_leaf):
+            raise OSError(errno.ELOOP, "invalid relative leaf")
+        source_parent = self._check(source)
+        if not isinstance(destination, PosixHeldDirectory):
+            raise OSError(errno.ESTALE, "destination handle is unavailable")
+        destination.check()
+        if source_parent.identity.device != destination.identity.device:
+            raise OSError(errno.EXDEV, "parents are on different devices")
+        return source_parent, destination
+
+    def rename(self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory, destination_leaf: str) -> HeldResult[None]:
+        try:
+            source, destination = self._paired(source_parent, destination_parent, source_leaf, destination_leaf)
+            os.rename(source_leaf, destination_leaf, src_dir_fd=source.descriptor, dst_dir_fd=destination.descriptor)
+            return HeldResult(value=None)  # type: ignore[arg-type]
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def link(self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory, destination_leaf: str) -> HeldResult[None]:
+        if not self.capabilities.hard_link:
+            return HeldResult(error=HeldFsError("CAPABILITY_UNAVAILABLE", "hard links are unavailable"))
+        try:
+            source, destination = self._paired(source_parent, destination_parent, source_leaf, destination_leaf)
+            source_descriptor = self._open_leaf(source, source_leaf, _READ_FLAGS)
+            os.close(source_descriptor)
+            os.link(source_leaf, destination_leaf, src_dir_fd=source.descriptor, dst_dir_fd=destination.descriptor, follow_symlinks=False)
+            return HeldResult(value=None)  # type: ignore[arg-type]
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def unlink(self, parent: HeldDirectory, leaf: str) -> HeldResult[None]:
+        try:
+            checked = self._check(parent)
+            descriptor = self._open_leaf(checked, leaf, _READ_FLAGS)
+            os.close(descriptor)
+            os.unlink(leaf, dir_fd=checked.descriptor)
+            return HeldResult(value=None)  # type: ignore[arg-type]
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def copy(self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory, destination_leaf: str) -> HeldResult[None]:
+        temporary = f".exomem-held-{secrets.token_hex(16)}"
+        temporary_descriptor: int | None = None
+        try:
+            if not _leaf(source_leaf) or not _leaf(destination_leaf):
+                raise OSError(errno.ELOOP, "invalid relative leaf")
+            source = self._check(source_parent)
+            if not isinstance(destination_parent, PosixHeldDirectory):
+                raise OSError(errno.ESTALE, "destination handle is unavailable")
+            destination_parent.check()
+            destination = destination_parent
+            source_descriptor = self._open_leaf(source, source_leaf, _READ_FLAGS)
+            try:
+                temporary_descriptor = os.open(
+                    temporary,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+                    0o600,
+                    dir_fd=destination.descriptor,
+                )
+                while chunk := os.read(source_descriptor, 65536):
+                    view = memoryview(chunk)
+                    written = 0
+                    while written < len(view):
+                        written += os.write(temporary_descriptor, view[written:])
+                os.fsync(temporary_descriptor)
+            finally:
+                os.close(source_descriptor)
+                if temporary_descriptor is not None:
+                    os.close(temporary_descriptor)
+                    temporary_descriptor = None
+            os.replace(temporary, destination_leaf, src_dir_fd=destination.descriptor, dst_dir_fd=destination.descriptor)
+            os.fsync(destination.descriptor)
+            return HeldResult(value=None)  # type: ignore[arg-type]
+        except OSError as error:
+            try:
+                if temporary_descriptor is not None:
+                    os.close(temporary_descriptor)
+                if isinstance(destination_parent, PosixHeldDirectory):
+                    os.unlink(temporary, dir_fd=destination_parent.descriptor)
+            except OSError:
+                pass
+            return HeldResult(error=_error(error))
+
+    def enumerate(self, parent: HeldDirectory) -> HeldResult[tuple[SagaRecord, ...]]:
+        try:
+            checked = self._check(parent)
+            records: list[SagaRecord] = []
+            self._enumerate(checked.descriptor, "", records)
+            return HeldResult(value=tuple(records))
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def _enumerate(self, descriptor: int, prefix: str, records: list[SagaRecord]) -> None:
+        with os.scandir(os.dup(descriptor)) as children:
+            names = sorted(child.name for child in children)
+        for name in names:
+            info = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+            if stat.S_ISLNK(info.st_mode):
+                raise OSError(errno.ELOOP, "unsafe recursive entry")
+            relative = f"{prefix}/{name}" if prefix else name
+            identity = _identity(info)
+            if identity.kind not in {"file", "directory"}:
+                raise OSError(errno.ELOOP, "unsafe recursive entry")
+            records.append(SagaRecord(relative, identity))
+            if identity.kind == "directory":
+                child = os.open(name, _DIRECTORY_FLAGS, dir_fd=descriptor)
+                try:
+                    self._enumerate(child, relative, records)
+                finally:
+                    os.close(child)
+
+
+def acquire(root: Path) -> HeldResult[HeldFilesystem]:
+    capability = probe(root)
+    if not capability.relative_operations:
+        return HeldResult(error=HeldFsError("CAPABILITY_UNAVAILABLE", "required filesystem primitives are unavailable"))
+    try:
+        descriptor = os.open(os.fspath(root), _DIRECTORY_FLAGS)
+        info = os.fstat(descriptor)
+        if not stat.S_ISDIR(info.st_mode):
+            os.close(descriptor)
+            return HeldResult(error=_invalid())
+        return HeldResult(value=PosixHeldFilesystem(descriptor, capability))
+    except OSError as error:
+        return HeldResult(error=_error(error))

--- a/src/exomem/_held_fs_windows.py
+++ b/src/exomem/_held_fs_windows.py
@@ -1,8 +1,7 @@
 """Native Windows held-handle implementation.
 
-Descendants are always opened with ``NtCreateFile`` relative to a retained
-directory handle.  This deliberately has no ``CreateFileW(child_path)``
-fallback: an unavailable native primitive disables the route.
+Descendants are opened with ``NtCreateFile`` relative to a retained directory
+handle. There is deliberately no reconstructed-descendant-path fallback.
 """
 
 from __future__ import annotations
@@ -17,6 +16,7 @@ from ctypes import (
     byref,
     c_byte,
     c_long,
+    c_ubyte,
     c_ulong,
     c_ulonglong,
     c_ushort,
@@ -31,6 +31,7 @@ from pathlib import Path
 from .held_fs import (
     Capabilities,
     HeldDirectory,
+    HeldFile,
     HeldFilesystem,
     HeldFsError,
     HeldResult,
@@ -39,6 +40,7 @@ from .held_fs import (
 )
 
 FILE_OPEN = 1
+FILE_CREATE = 2
 FILE_OPEN_IF = 3
 FILE_DIRECTORY_FILE = 0x00000001
 FILE_NON_DIRECTORY_FILE = 0x00000040
@@ -47,6 +49,9 @@ FILE_OPEN_REPARSE_POINT = 0x00200000
 FILE_ATTRIBUTE_NORMAL = 0x00000080
 FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
 FILE_SHARE_READ = 0x00000001
+FILE_SHARE_WRITE = 0x00000002
+FILE_SHARE_DELETE = 0x00000004
+FILE_SHARE_ALL = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
 FILE_LIST_DIRECTORY = 0x00000001
 FILE_ADD_FILE = 0x00000002
 FILE_ADD_SUBDIRECTORY = 0x00000004
@@ -55,6 +60,7 @@ FILE_WRITE_DATA = 0x00000002
 FILE_READ_ATTRIBUTES = 0x00000080
 DELETE = 0x00010000
 SYNCHRONIZE = 0x00100000
+OBJ_CASE_INSENSITIVE = 0x00000040
 FILE_RENAME_INFORMATION = 10
 FILE_LINK_INFORMATION = 11
 FILE_DISPOSITION_INFORMATION = 4
@@ -110,15 +116,32 @@ class BY_HANDLE_FILE_INFORMATION(Structure):
     ]
 
 
+class FILE_NAME_INFORMATION(Structure):
+    """ABI-derived header shared by native rename and link information."""
+
+    _fields_ = [
+        ("ReplaceIfExists", c_ubyte),
+        ("RootDirectory", c_void_p),
+        ("FileNameLength", c_ulong),
+        ("FileName", c_ushort * 1),
+    ]
+
+
+class FILE_DISPOSITION_INFO(Structure):
+    _fields_ = [("DeleteFile", c_ubyte)]
+
+
 if os.name == "nt":  # pragma: no cover - executed by windows-latest
     NtCreateFile = ctypes.windll.ntdll.NtCreateFile
     NtSetInformationFile = ctypes.windll.ntdll.NtSetInformationFile
     NtQueryDirectoryFile = ctypes.windll.ntdll.NtQueryDirectoryFile
+    RtlNtStatusToDosError = ctypes.windll.ntdll.RtlNtStatusToDosError
     SetFileInformationByHandle = ctypes.windll.kernel32.SetFileInformationByHandle
     GetFileInformationByHandleEx = ctypes.windll.kernel32.GetFileInformationByHandleEx
     GetFileInformationByHandle = ctypes.windll.kernel32.GetFileInformationByHandle
     CreateFileW = ctypes.windll.kernel32.CreateFileW
     CloseHandle = ctypes.windll.kernel32.CloseHandle
+
     NtCreateFile.argtypes = [
         POINTER(c_void_p),
         c_ulong,
@@ -134,7 +157,11 @@ if os.name == "nt":  # pragma: no cover - executed by windows-latest
     ]
     NtCreateFile.restype = c_long
     NtSetInformationFile.argtypes = [
-        c_void_p, POINTER(IO_STATUS_BLOCK), c_void_p, c_ulong, c_ulong
+        c_void_p,
+        POINTER(IO_STATUS_BLOCK),
+        c_void_p,
+        c_ulong,
+        c_ulong,
     ]
     NtSetInformationFile.restype = c_long
     NtQueryDirectoryFile.argtypes = [
@@ -151,6 +178,8 @@ if os.name == "nt":  # pragma: no cover - executed by windows-latest
         wintypes.BOOL,
     ]
     NtQueryDirectoryFile.restype = c_long
+    RtlNtStatusToDosError.argtypes = [c_long]
+    RtlNtStatusToDosError.restype = c_ulong
     SetFileInformationByHandle.argtypes = [c_void_p, c_ulong, c_void_p, c_ulong]
     SetFileInformationByHandle.restype = wintypes.BOOL
     GetFileInformationByHandleEx.argtypes = [c_void_p, c_ulong, c_void_p, c_ulong]
@@ -173,6 +202,7 @@ else:  # pragma: no cover - keeps Linux imports syntactically safe
     NtCreateFile = None
     NtSetInformationFile = None
     NtQueryDirectoryFile = None
+    RtlNtStatusToDosError = None
     SetFileInformationByHandle = None
     GetFileInformationByHandleEx = None
     GetFileInformationByHandle = None
@@ -184,11 +214,17 @@ def _invalid() -> HeldFsError:
     return HeldFsError("UNSAFE_PATH", "unsafe filesystem object")
 
 
-def _error(_error: OSError | None = None) -> HeldFsError:
-    if _error is not None and _error.errno == errno.EXDEV:
+def _error(error: OSError | None = None) -> HeldFsError:
+    if error is not None and error.errno in {17, errno.EXDEV}:
         return HeldFsError("CROSS_DEVICE", "operation requires one filesystem")
-    if _error is not None and _error.errno in {errno.ELOOP, errno.ENOTDIR}:
+    if error is not None and error.errno in {errno.ELOOP, errno.ENOTDIR}:
         return _invalid()
+    if error is not None and error.errno == errno.ESTALE:
+        return HeldFsError("IDENTITY_CHANGED", "held filesystem identity changed")
+    if error is not None and error.errno in {2, 3, errno.ENOENT}:
+        return HeldFsError("MISSING", "filesystem object is unavailable")
+    if error is not None and error.errno in {80, 183, errno.EEXIST}:
+        return HeldFsError("DESTINATION_EXISTS", "destination already exists")
     return HeldFsError("IO_REFUSED", "held filesystem operation was refused")
 
 
@@ -204,8 +240,10 @@ def _parts(relative: str) -> tuple[str, ...] | None:
 
 
 def _leaf(name: str) -> bool:
-    return isinstance(name, str) and name not in {"", ".", ".."} and all(
-        marker not in name for marker in ("/", "\\", ":", "\x00")
+    return (
+        isinstance(name, str)
+        and name not in {"", ".", ".."}
+        and all(marker not in name for marker in ("/", "\\", ":", "\x00"))
     )
 
 
@@ -215,14 +253,27 @@ def _native(fd: int) -> int:
     return int(msvcrt.get_osfhandle(fd))
 
 
-def _fd(handle: int) -> int:
+def _fd(handle: int, access: str = "read") -> int:
     import msvcrt
 
-    return msvcrt.open_osfhandle(handle, os.O_BINARY)
+    flags = os.O_BINARY | (os.O_RDWR if access == "write" else os.O_RDONLY)
+    try:
+        return msvcrt.open_osfhandle(handle, flags)
+    except BaseException as error:
+        assert CloseHandle is not None
+        CloseHandle(c_void_p(handle))
+        if isinstance(error, (KeyboardInterrupt, SystemExit)):
+            raise
+        raise OSError("native handle could not become a CRT descriptor") from error
 
 
 def _nt_success(status: int) -> bool:
     return status >= 0
+
+
+def _raise_nt(status: int, message: str) -> None:
+    code = int(RtlNtStatusToDosError(status)) if RtlNtStatusToDosError is not None else 1
+    raise OSError(code, message)
 
 
 def _identity(handle: int) -> StableIdentity:
@@ -231,10 +282,15 @@ def _identity(handle: int) -> StableIdentity:
     file_id = FILE_ID_INFO()
     attributes = FILE_ATTRIBUTE_TAG_INFO()
     basic = BY_HANDLE_FILE_INFORMATION()
-    if not GetFileInformationByHandleEx(handle, FILE_ID_INFO_CLASS, byref(file_id), sizeof(file_id)):
+    if not GetFileInformationByHandleEx(
+        handle, FILE_ID_INFO_CLASS, byref(file_id), sizeof(file_id)
+    ):
         raise OSError("FileIdInfo is unavailable")
     if not GetFileInformationByHandleEx(
-        handle, FILE_ATTRIBUTE_TAG_INFO_CLASS, byref(attributes), sizeof(attributes)
+        handle,
+        FILE_ATTRIBUTE_TAG_INFO_CLASS,
+        byref(attributes),
+        sizeof(attributes),
     ):
         raise OSError("FileAttributeTagInfo is unavailable")
     if attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT:
@@ -250,21 +306,35 @@ def _identity(handle: int) -> StableIdentity:
     )
 
 
+def _same_object(left: StableIdentity, right: StableIdentity) -> bool:
+    return (left.device, left.inode, left.kind) == (right.device, right.inode, right.kind)
+
+
 def _unicode(name: str) -> tuple[UNICODE_STRING, object]:
     buffer = create_unicode_buffer(name)
-    value = UNICODE_STRING(len(name.encode("utf-16-le")), (len(name) + 1) * 2, buffer)
+    value = UNICODE_STRING(
+        len(name.encode("utf-16-le")),
+        (len(name) + 1) * 2,
+        ctypes.cast(buffer, wintypes.LPWSTR),
+    )
     return value, buffer
 
 
-def _open_relative(parent_handle: int, name: str, access: int, options: int, disposition: int) -> int:
+def _open_relative(
+    parent_handle: int,
+    name: str,
+    access: int,
+    options: int,
+    disposition: int,
+) -> int:
     """Open exactly one component under ``parent_handle`` through NtCreateFile."""
     assert NtCreateFile is not None
     string, _buffer = _unicode(name)
     attributes = OBJECT_ATTRIBUTES(
         sizeof(OBJECT_ATTRIBUTES),
         c_void_p(parent_handle),
-        byref(string),
-        0,
+        ctypes.pointer(string),
+        OBJ_CASE_INSENSITIVE,
         None,
         None,
     )
@@ -277,14 +347,14 @@ def _open_relative(parent_handle: int, name: str, access: int, options: int, dis
         byref(status),
         None,
         FILE_ATTRIBUTE_NORMAL,
-        FILE_SHARE_READ,
+        FILE_SHARE_ALL,
         disposition,
         options | FILE_OPEN_REPARSE_POINT,
         None,
         0,
     )
     if not _nt_success(result) or handle.value in {None, INVALID_HANDLE_VALUE}:
-        raise OSError("NtCreateFile refused relative handle operation")
+        _raise_nt(result, "NtCreateFile refused relative handle operation")
     try:
         _identity(int(handle.value))
         return int(handle.value)
@@ -294,41 +364,48 @@ def _open_relative(parent_handle: int, name: str, access: int, options: int, dis
         raise
 
 
-def _probe(root: Path) -> Capabilities:
-    if os.name != "nt" or any(
-        primitive is None
-        for primitive in (NtCreateFile, NtSetInformationFile, SetFileInformationByHandle, GetFileInformationByHandleEx)
+def _name_payload(replace: bool, destination_handle: int, leaf: str) -> ctypes.Array[ctypes.c_char]:
+    encoded = leaf.encode("utf-16-le")
+    offset = FILE_NAME_INFORMATION.FileName.offset
+    payload = create_string_buffer(sizeof(FILE_NAME_INFORMATION) + len(encoded))
+    information = FILE_NAME_INFORMATION.from_buffer(payload)
+    information.ReplaceIfExists = replace
+    information.RootDirectory = destination_handle
+    information.FileNameLength = len(encoded)
+    ctypes.memmove(ctypes.addressof(payload) + offset, encoded, len(encoded))
+    return payload
+
+
+def _set_name_information(
+    descriptor: int,
+    destination_handle: int,
+    leaf: str,
+    information_class: int,
+) -> None:
+    assert NtSetInformationFile is not None
+    payload = _name_payload(False, destination_handle, leaf)
+    status = IO_STATUS_BLOCK()
+    result = NtSetInformationFile(
+        _native(descriptor),
+        byref(status),
+        payload,
+        len(payload),
+        information_class,
+    )
+    if not _nt_success(result):
+        _raise_nt(result, "native relative name mutation was refused")
+
+
+def _delete_descriptor(descriptor: int) -> None:
+    assert SetFileInformationByHandle is not None
+    disposition = FILE_DISPOSITION_INFO(True)
+    if not SetFileInformationByHandle(
+        _native(descriptor),
+        FILE_DISPOSITION_INFORMATION,
+        byref(disposition),
+        sizeof(disposition),
     ):
-        return Capabilities.disabled("native Windows handle primitives are unavailable")
-    descriptor = _open_root(root)
-    if descriptor is None:
-        return Capabilities.disabled("root cannot be opened with stable identity")
-    filesystem = WindowsHeldFilesystem(descriptor)
-    source_name = f".exomem-held-probe-{secrets.token_hex(16)}"
-    linked_name = f"{source_name}-link"
-    renamed_name = f"{source_name}-renamed"
-    try:
-        with filesystem.parent(".").require() as parent:
-            if not filesystem.write(parent, source_name, b"probe").ok:
-                return Capabilities.disabled("relative create/write is unavailable")
-            source_identity = filesystem.identity(parent, source_name)
-            if not source_identity.ok or source_identity.require().kind != "file":
-                return Capabilities.disabled("stable final identity is unavailable")
-            if not filesystem.link(parent, source_name, parent, linked_name).ok:
-                return Capabilities.disabled("relative hard link is unavailable")
-            if not filesystem.rename(parent, linked_name, parent, renamed_name).ok:
-                return Capabilities.disabled("same-volume relative rename is unavailable")
-            if not filesystem.unlink(parent, renamed_name).ok:
-                return Capabilities.disabled("relative unlink is unavailable")
-            if not filesystem.unlink(parent, source_name).ok:
-                return Capabilities.disabled("relative cleanup is unavailable")
-    finally:
-        filesystem.close()
-    return Capabilities(True, True, True, True, True)
-
-
-def probe(root: Path) -> Capabilities:
-    return _probe(root)
+        raise OSError(ctypes.get_last_error(), "relative disposition was refused")
 
 
 def _open_root(root: Path) -> int | None:
@@ -336,7 +413,7 @@ def _open_root(root: Path) -> int | None:
     handle = CreateFileW(
         str(root),
         FILE_LIST_DIRECTORY | FILE_ADD_FILE | FILE_ADD_SUBDIRECTORY | FILE_READ_ATTRIBUTES,
-        FILE_SHARE_READ,
+        FILE_SHARE_ALL,
         None,
         3,
         0x02000000 | FILE_OPEN_REPARSE_POINT,
@@ -351,7 +428,7 @@ def _open_root(root: Path) -> int | None:
         return _fd(int(handle))
     except OSError:
         assert CloseHandle is not None
-        CloseHandle(handle)
+        CloseHandle(c_void_p(handle))
         return None
 
 
@@ -363,8 +440,8 @@ class WindowsHeldDirectory(HeldDirectory):
         self.closed = False
 
     def check(self) -> None:
-        if self.closed or _identity(_native(self.descriptor)) != self.identity:
-            raise OSError("held directory changed")
+        if self.closed or not _same_object(_identity(_native(self.descriptor)), self.identity):
+            raise OSError(errno.ESTALE, "held directory changed")
 
     def close(self) -> None:
         if not self.closed:
@@ -372,9 +449,45 @@ class WindowsHeldDirectory(HeldDirectory):
             self.closed = True
 
 
-class WindowsHeldFilesystem(HeldFilesystem):
-    def __init__(self, descriptor: int) -> None:
+class WindowsHeldFile(HeldFile):
+    def __init__(
+        self,
+        filesystem: WindowsHeldFilesystem,
+        parent_descriptor: int,
+        parent_identity: StableIdentity,
+        name: str,
+        descriptor: int,
+        access: str,
+    ) -> None:
+        self.filesystem = filesystem
+        self.parent_descriptor = parent_descriptor
+        self.parent_identity = parent_identity
+        self.name = name
         self.descriptor = descriptor
+        self.access = access
+        self.identity = _identity(_native(descriptor))
+        self.closed = False
+        self.named = True
+
+    def check(self) -> None:
+        if self.closed or self.filesystem.closed:
+            raise OSError(errno.ESTALE, "held file is closed")
+        if _identity(_native(self.descriptor)) != self.identity:
+            raise OSError(errno.ESTALE, "held file changed")
+        if not _same_object(_identity(_native(self.parent_descriptor)), self.parent_identity):
+            raise OSError(errno.ESTALE, "held parent changed")
+
+    def close(self) -> None:
+        if not self.closed:
+            os.close(self.descriptor)
+            os.close(self.parent_descriptor)
+            self.closed = True
+
+
+class WindowsHeldFilesystem(HeldFilesystem):
+    def __init__(self, descriptor: int, capabilities: Capabilities) -> None:
+        self.descriptor = descriptor
+        self.capabilities = capabilities
         self.root_identity = _identity(_native(descriptor))
         self.closed = False
 
@@ -383,193 +496,297 @@ class WindowsHeldFilesystem(HeldFilesystem):
             os.close(self.descriptor)
             self.closed = True
 
-    def _check(self, parent: HeldDirectory) -> WindowsHeldDirectory:
-        if self.closed or not isinstance(parent, WindowsHeldDirectory) or parent.filesystem is not self:
-            raise OSError("held directory is unavailable")
+    def _check_directory(self, parent: HeldDirectory) -> WindowsHeldDirectory:
+        if (
+            self.closed
+            or not isinstance(parent, WindowsHeldDirectory)
+            or parent.filesystem is not self
+        ):
+            raise OSError(errno.ESTALE, "held filesystem is unavailable")
         parent.check()
         return parent
+
+    def _check_file(self, file: HeldFile) -> WindowsHeldFile:
+        if not isinstance(file, WindowsHeldFile) or file.filesystem is not self:
+            raise OSError(errno.ESTALE, "held file is unavailable")
+        file.check()
+        return file
 
     def parent(self, relative: str, *, create: bool = False) -> HeldResult[HeldDirectory]:
         parts = _parts(relative)
         if parts is None:
             return HeldResult(error=_invalid())
+        if self.closed:
+            return HeldResult(error=HeldFsError("IO_REFUSED", "held root is closed"))
         descriptor = os.dup(self.descriptor)
         try:
             for part in parts:
                 handle = _open_relative(
                     _native(descriptor),
                     part,
-                    FILE_LIST_DIRECTORY | FILE_ADD_FILE | FILE_ADD_SUBDIRECTORY | FILE_READ_ATTRIBUTES,
+                    FILE_LIST_DIRECTORY
+                    | FILE_ADD_FILE
+                    | FILE_ADD_SUBDIRECTORY
+                    | FILE_READ_ATTRIBUTES,
                     FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT,
                     FILE_OPEN_IF if create else FILE_OPEN,
                 )
+                child = _fd(handle)
                 os.close(descriptor)
-                descriptor = _fd(handle)
+                descriptor = child
             return HeldResult(value=WindowsHeldDirectory(self, descriptor))
         except OSError as error:
             os.close(descriptor)
             return HeldResult(error=_error(error))
 
-    def _open_leaf(self, parent: HeldDirectory, leaf: str, write: bool = False, create: bool = False, delete: bool = False) -> int:
-        if not _leaf(leaf):
-            raise OSError(errno.ELOOP, "invalid relative leaf")
-        checked = self._check(parent)
-        access = FILE_READ_DATA | FILE_READ_ATTRIBUTES
-        if write:
-            access |= FILE_WRITE_DATA
-        if delete:
-            access |= DELETE
-        handle = _open_relative(
-            _native(checked.descriptor),
-            leaf,
-            access,
-            FILE_NON_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT,
-            FILE_OPEN_IF if create else FILE_OPEN,
-        )
-        return _fd(handle)
-
-    def identity(self, parent: HeldDirectory, leaf: str) -> HeldResult[StableIdentity]:
+    def file(
+        self,
+        parent: HeldDirectory,
+        leaf: str,
+        *,
+        access: str = "read",
+        create: bool = False,
+        exclusive: bool = False,
+    ) -> HeldResult[HeldFile]:
+        if not _leaf(leaf) or access not in {"read", "write", "mutate"}:
+            return HeldResult(error=_invalid())
+        if exclusive and not create:
+            return HeldResult(error=HeldFsError("INVALID_INPUT", "exclusive requires create"))
+        parent_descriptor: int | None = None
+        descriptor: int | None = None
         try:
-            descriptor = self._open_leaf(parent, leaf)
-            try:
-                return HeldResult(value=_identity(_native(descriptor)))
-            finally:
+            checked = self._check_directory(parent)
+            parent_descriptor = os.dup(checked.descriptor)
+            desired = FILE_READ_DATA | FILE_READ_ATTRIBUTES
+            descriptor_access = "read"
+            if access == "write":
+                desired |= FILE_WRITE_DATA
+                descriptor_access = "write"
+            if access == "mutate":
+                desired |= DELETE
+            disposition = FILE_CREATE if exclusive else FILE_OPEN_IF if create else FILE_OPEN
+            handle = _open_relative(
+                _native(parent_descriptor),
+                leaf,
+                desired,
+                FILE_NON_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT,
+                disposition,
+            )
+            descriptor = _fd(handle, descriptor_access)
+            return HeldResult(
+                value=WindowsHeldFile(
+                    self,
+                    parent_descriptor,
+                    checked.identity,
+                    leaf,
+                    descriptor,
+                    access,
+                )
+            )
+        except OSError as error:
+            if descriptor is not None:
                 os.close(descriptor)
+            if parent_descriptor is not None:
+                os.close(parent_descriptor)
+            return HeldResult(error=_error(error))
+
+    def read(self, file: HeldFile) -> HeldResult[bytes]:
+        try:
+            checked = self._check_file(file)
+            os.lseek(checked.descriptor, 0, os.SEEK_SET)
+            chunks = []
+            while chunk := os.read(checked.descriptor, 65536):
+                chunks.append(chunk)
+            return HeldResult(value=b"".join(chunks))
         except OSError as error:
             return HeldResult(error=_error(error))
 
-    def read(self, parent: HeldDirectory, leaf: str) -> HeldResult[bytes]:
-        try:
-            descriptor = self._open_leaf(parent, leaf)
-            try:
-                chunks = []
-                while chunk := os.read(descriptor, 65536):
-                    chunks.append(chunk)
-                return HeldResult(value=b"".join(chunks))
-            finally:
-                os.close(descriptor)
-        except OSError as error:
-            return HeldResult(error=_error(error))
-
-    def write(self, parent: HeldDirectory, leaf: str, data: bytes) -> HeldResult[None]:
+    def write(self, file: HeldFile, data: bytes) -> HeldResult[None]:
         if not isinstance(data, bytes):
             return HeldResult(error=HeldFsError("INVALID_INPUT", "data must be bytes"))
         try:
-            descriptor = self._open_leaf(parent, leaf, write=True, create=True)
+            checked = self._check_file(file)
+            if checked.access != "write":
+                return HeldResult(error=HeldFsError("INVALID_ACCESS", "held file is not writable"))
+            os.ftruncate(checked.descriptor, 0)
+            os.lseek(checked.descriptor, 0, os.SEEK_SET)
+            view = memoryview(data)
+            written = 0
+            while written < len(view):
+                written += os.write(checked.descriptor, view[written:])
+            os.fsync(checked.descriptor)
+            checked.identity = _identity(_native(checked.descriptor))
+            return HeldResult(value=None)
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def _destination(
+        self, source: WindowsHeldFile, destination: HeldDirectory, destination_leaf: str
+    ) -> WindowsHeldDirectory:
+        if source.access != "mutate" or not _leaf(destination_leaf):
+            raise OSError(errno.ELOOP, "invalid held mutation")
+        if not isinstance(destination, WindowsHeldDirectory):
+            raise OSError(errno.ESTALE, "destination handle is unavailable")
+        destination.check()
+        if source.identity.device != destination.identity.device:
+            raise OSError(errno.EXDEV, "cross-volume operation")
+        if destination.filesystem is not self:
+            raise OSError(errno.ESTALE, "destination belongs to another root")
+        try:
+            handle = _open_relative(
+                _native(destination.descriptor),
+                destination_leaf,
+                FILE_READ_ATTRIBUTES,
+                FILE_SYNCHRONOUS_IO_NONALERT,
+                FILE_OPEN,
+            )
+        except OSError as error:
+            if error.errno in {2, 3, errno.ENOENT}:
+                return destination
+            raise
+        else:
+            assert CloseHandle is not None
+            CloseHandle(c_void_p(handle))
+            raise OSError(errno.EEXIST, "destination exists")
+
+    def rename(
+        self, source: HeldFile, destination_parent: HeldDirectory, destination_leaf: str
+    ) -> HeldResult[None]:
+        try:
+            checked = self._check_file(source)
+            destination = self._destination(checked, destination_parent, destination_leaf)
+            _set_name_information(
+                checked.descriptor,
+                _native(destination.descriptor),
+                destination_leaf,
+                FILE_RENAME_INFORMATION,
+            )
+            checked.named = False
+            return HeldResult(value=None)
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def link(
+        self, source: HeldFile, destination_parent: HeldDirectory, destination_leaf: str
+    ) -> HeldResult[None]:
+        if not self.capabilities.hard_link:
+            return HeldResult(
+                error=HeldFsError("CAPABILITY_UNAVAILABLE", "hard links are unavailable")
+            )
+        try:
+            checked = self._check_file(source)
+            destination = self._destination(checked, destination_parent, destination_leaf)
+            _set_name_information(
+                checked.descriptor,
+                _native(destination.descriptor),
+                destination_leaf,
+                FILE_LINK_INFORMATION,
+            )
+            checked.identity = _identity(_native(checked.descriptor))
+            return HeldResult(value=None)
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def unlink(self, file: HeldFile) -> HeldResult[None]:
+        try:
+            checked = self._check_file(file)
+            if checked.access != "mutate":
+                return HeldResult(error=HeldFsError("INVALID_ACCESS", "held file is not mutable"))
+            _delete_descriptor(checked.descriptor)
+            checked.named = False
+            return HeldResult(value=None)
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def copy(
+        self, source: HeldFile, destination_parent: HeldDirectory, destination_leaf: str
+    ) -> HeldResult[None]:
+        temporary = f".exomem-held-{secrets.token_hex(16)}"
+        temporary_file: WindowsHeldFile | None = None
+        temporary_identity: StableIdentity | None = None
+        destination: WindowsHeldDirectory | None = None
+        destination_filesystem: WindowsHeldFilesystem | None = None
+        try:
+            checked = self._check_file(source)
+            if not _leaf(destination_leaf):
+                raise OSError(errno.ELOOP, "invalid destination leaf")
+            if not isinstance(destination_parent, WindowsHeldDirectory):
+                raise OSError(errno.ESTALE, "destination handle is unavailable")
+            destination_parent.check()
+            if destination_parent.filesystem.closed:
+                raise OSError(errno.ESTALE, "destination root is unavailable")
+            destination = destination_parent
+            destination_filesystem = destination.filesystem
             try:
-                os.lseek(descriptor, 0, os.SEEK_SET)
-                os.ftruncate(descriptor, 0)
-                view = memoryview(data)
+                existing = destination_filesystem.file(destination, destination_leaf)
+                if existing.ok:
+                    existing.require().close()
+                    raise OSError(errno.EEXIST, "destination exists")
+                if existing.error is not None and existing.error.code != "MISSING":
+                    raise OSError("destination could not be classified")
+            except HeldFsError as error:
+                raise OSError(str(error)) from error
+
+            created = destination_filesystem.file(
+                destination,
+                temporary,
+                access="write",
+                create=True,
+                exclusive=True,
+            )
+            if not created.ok:
+                raise OSError("destination temporary could not be acquired")
+            temporary_file = created.require()
+            temporary_identity = temporary_file.identity
+            os.lseek(checked.descriptor, 0, os.SEEK_SET)
+            while chunk := os.read(checked.descriptor, 65536):
+                view = memoryview(chunk)
                 written = 0
                 while written < len(view):
-                    written += os.write(descriptor, view[written:])
-                os.fsync(descriptor)
-                return HeldResult(value=None)  # type: ignore[arg-type]
-            finally:
-                os.close(descriptor)
+                    written += os.write(temporary_file.descriptor, view[written:])
+            os.fsync(temporary_file.descriptor)
+
+            # Reopen the exact temporary with DELETE authority, then rename by handle.
+            temporary_file.close()
+            temporary_file = None
+            mutable = destination_filesystem.file(destination, temporary, access="mutate")
+            if not mutable.ok:
+                raise OSError("destination temporary mutation handle was refused")
+            temporary_file = mutable.require()
+            if temporary_file.identity != temporary_identity:
+                raise OSError(errno.ESTALE, "destination temporary changed")
+            _set_name_information(
+                temporary_file.descriptor,
+                _native(destination.descriptor),
+                destination_leaf,
+                FILE_RENAME_INFORMATION,
+            )
+            temporary_file.named = False
+            temporary_file.close()
+            temporary_file = None
+            return HeldResult(value=None)
         except OSError as error:
-            return HeldResult(error=_error(error))
-
-    def _paired(self, source: HeldDirectory, destination: HeldDirectory, source_leaf: str, destination_leaf: str) -> tuple[WindowsHeldDirectory, WindowsHeldDirectory]:
-        if not _leaf(source_leaf) or not _leaf(destination_leaf):
-            raise OSError(errno.ELOOP, "invalid relative leaf")
-        source_parent = self._check(source)
-        if not isinstance(destination, WindowsHeldDirectory):
-            raise OSError("destination handle is unavailable")
-        destination.check()
-        if source_parent.identity.device != destination.identity.device:
-            raise OSError(errno.EXDEV, "cross-volume operation")
-        return source_parent, destination
-
-    def _rename_handle(self, descriptor: int, destination: WindowsHeldDirectory, leaf: str) -> None:
-        assert SetFileInformationByHandle is not None
-        encoded = leaf.encode("utf-16-le")
-        payload = create_string_buffer(20 + len(encoded))
-        payload[0] = 1
-        c_void_p.from_buffer(payload, 8).value = _native(destination.descriptor)
-        c_ulong.from_buffer(payload, 16).value = len(encoded)
-        payload[20 : 20 + len(encoded)] = encoded
-        if not SetFileInformationByHandle(_native(descriptor), FILE_RENAME_INFORMATION, payload, len(payload)):
-            raise OSError("relative rename was refused")
-
-    def rename(self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory, destination_leaf: str) -> HeldResult[None]:
-        try:
-            source, destination = self._paired(source_parent, destination_parent, source_leaf, destination_leaf)
-            descriptor = self._open_leaf(source, source_leaf, delete=True)
-            try:
-                self._rename_handle(descriptor, destination, destination_leaf)
-            finally:
-                os.close(descriptor)
-            return HeldResult(value=None)  # type: ignore[arg-type]
-        except OSError as error:
-            return HeldResult(error=_error(error))
-
-    def link(self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory, destination_leaf: str) -> HeldResult[None]:
-        try:
-            source, destination = self._paired(source_parent, destination_parent, source_leaf, destination_leaf)
-            descriptor = self._open_leaf(source, source_leaf, delete=True)
-            try:
-                assert NtSetInformationFile is not None
-                encoded = destination_leaf.encode("utf-16-le")
-                payload = create_string_buffer(20 + len(encoded))
-                payload[0] = 0
-                c_void_p.from_buffer(payload, 8).value = _native(destination.descriptor)
-                c_ulong.from_buffer(payload, 16).value = len(encoded)
-                payload[20 : 20 + len(encoded)] = encoded
-                status = IO_STATUS_BLOCK()
-                if not _nt_success(NtSetInformationFile(_native(descriptor), byref(status), payload, len(payload), FILE_LINK_INFORMATION)):
-                    raise OSError("relative hard link was refused")
-            finally:
-                os.close(descriptor)
-            return HeldResult(value=None)  # type: ignore[arg-type]
-        except OSError as error:
-            return HeldResult(error=_error(error))
-
-    def unlink(self, parent: HeldDirectory, leaf: str) -> HeldResult[None]:
-        try:
-            descriptor = self._open_leaf(parent, leaf, delete=True)
-            try:
-                assert SetFileInformationByHandle is not None
-                delete = wintypes.BOOL(True)
-                if not SetFileInformationByHandle(_native(descriptor), FILE_DISPOSITION_INFORMATION, byref(delete), sizeof(delete)):
-                    raise OSError("relative disposition was refused")
-            finally:
-                os.close(descriptor)
-            return HeldResult(value=None)  # type: ignore[arg-type]
-        except OSError as error:
-            return HeldResult(error=_error(error))
-
-    def copy(self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory, destination_leaf: str) -> HeldResult[None]:
-        temporary = f".exomem-held-{secrets.token_hex(16)}"
-        try:
-            if not _leaf(source_leaf) or not _leaf(destination_leaf):
-                raise OSError(errno.ELOOP, "invalid relative leaf")
-            source = self._check(source_parent)
-            if not isinstance(destination_parent, WindowsHeldDirectory):
-                raise OSError("destination handle is unavailable")
-            destination_parent.check()
-            destination = destination_parent
-            source_descriptor = self._open_leaf(source, source_leaf)
-            temporary_descriptor = self._open_leaf(destination, temporary, write=True, create=True)
-            try:
-                while chunk := os.read(source_descriptor, 65536):
-                    view = memoryview(chunk)
-                    written = 0
-                    while written < len(view):
-                        written += os.write(temporary_descriptor, view[written:])
-                os.fsync(temporary_descriptor)
-                self._rename_handle(temporary_descriptor, destination, destination_leaf)
-            finally:
-                os.close(source_descriptor)
-                os.close(temporary_descriptor)
-            return HeldResult(value=None)  # type: ignore[arg-type]
-        except OSError as error:
+            if temporary_file is not None:
+                try:
+                    if temporary_file.access == "mutate":
+                        _delete_descriptor(temporary_file.descriptor)
+                except OSError:
+                    pass
+                temporary_file.close()
+            if destination is not None and destination_filesystem is not None:
+                cleanup = destination_filesystem.file(destination, temporary, access="mutate")
+                if cleanup.ok:
+                    with cleanup.require() as file:
+                        if temporary_identity is not None and file.identity == temporary_identity:
+                            try:
+                                _delete_descriptor(file.descriptor)
+                            except OSError:
+                                pass
             return HeldResult(error=_error(error))
 
     def enumerate(self, parent: HeldDirectory) -> HeldResult[tuple[SagaRecord, ...]]:
-        """Enumerate via ``NtQueryDirectoryFile``; recursive records are name ordered."""
         try:
-            checked = self._check(parent)
+            checked = self._check_directory(parent)
             records: list[SagaRecord] = []
             self._enumerate(checked, "", records)
             return HeldResult(value=tuple(records))
@@ -583,12 +800,24 @@ class WindowsHeldFilesystem(HeldFilesystem):
         restart = True
         names: list[str] = []
         while True:
-            result = NtQueryDirectoryFile(_native(parent.descriptor), None, None, None, byref(status), buffer, len(buffer), FILE_BOTH_DIRECTORY_INFORMATION, False, None, restart)
+            result = NtQueryDirectoryFile(
+                _native(parent.descriptor),
+                None,
+                None,
+                None,
+                byref(status),
+                buffer,
+                len(buffer),
+                FILE_BOTH_DIRECTORY_INFORMATION,
+                False,
+                None,
+                restart,
+            )
             restart = False
             if (int(result) & 0xFFFFFFFF) == STATUS_NO_MORE_FILES:
                 return sorted(names)
             if not _nt_success(result):
-                raise OSError("directory enumeration was refused")
+                _raise_nt(result, "directory enumeration was refused")
             offset = 0
             while True:
                 next_offset = int.from_bytes(buffer.raw[offset : offset + 4], "little")
@@ -600,27 +829,119 @@ class WindowsHeldFilesystem(HeldFilesystem):
                     break
                 offset += next_offset
 
-    def _enumerate(self, parent: WindowsHeldDirectory, prefix: str, records: list[SagaRecord]) -> None:
+    def _enumerate(
+        self, parent: WindowsHeldDirectory, prefix: str, records: list[SagaRecord]
+    ) -> None:
         for name in self._entries(parent):
-            handle = _open_relative(_native(parent.descriptor), name, FILE_READ_ATTRIBUTES, FILE_SYNCHRONOUS_IO_NONALERT, FILE_OPEN)
+            handle = _open_relative(
+                _native(parent.descriptor),
+                name,
+                FILE_LIST_DIRECTORY | FILE_READ_DATA | FILE_READ_ATTRIBUTES,
+                FILE_SYNCHRONOUS_IO_NONALERT,
+                FILE_OPEN,
+            )
             descriptor = _fd(handle)
+            identity = _identity(_native(descriptor))
+            relative = f"{prefix}/{name}" if prefix else name
+            records.append(SagaRecord(relative, identity))
+            if identity.kind == "directory":
+                with WindowsHeldDirectory(self, descriptor) as child:
+                    self._enumerate(child, relative, records)
+            else:
+                os.close(descriptor)
+
+
+def _probe(root: Path) -> Capabilities:
+    if os.name != "nt" or any(
+        primitive is None
+        for primitive in (
+            NtCreateFile,
+            NtSetInformationFile,
+            SetFileInformationByHandle,
+            GetFileInformationByHandleEx,
+        )
+    ):
+        return Capabilities.disabled("native Windows handle primitives are unavailable")
+    descriptor = _open_root(root)
+    if descriptor is None:
+        return Capabilities.disabled("root cannot be opened with stable identity")
+
+    provisional = Capabilities(True, True, True, True, True)
+    filesystem = WindowsHeldFilesystem(descriptor, provisional)
+    token = secrets.token_hex(16)
+    source_name = f".exomem-held-probe-{token}"
+    renamed_name = f"{source_name}-renamed"
+    linked_name = f"{source_name}-link"
+    alias_name = f"{source_name}-alias"
+    directory_name = f"{source_name}-directory"
+    directory_alias_name = f"{directory_name}-alias"
+    try:
+        with filesystem.parent(".").require() as parent:
+            with filesystem.file(
+                parent, source_name, access="write", create=True, exclusive=True
+            ).require() as source:
+                if not filesystem.write(source, b"probe").ok:
+                    return Capabilities.disabled("relative create/write is unavailable")
+
+            os.symlink(root / source_name, root / alias_name)
+            alias = filesystem.file(parent, alias_name)
+            if alias.ok:
+                alias.require().close()
+                return Capabilities.disabled("final reparse refusal is unavailable")
+            (root / directory_name).mkdir()
+            os.symlink(
+                root / directory_name,
+                root / directory_alias_name,
+                target_is_directory=True,
+            )
+            alias_parent = filesystem.parent(directory_alias_name)
+            if alias_parent.ok:
+                alias_parent.require().close()
+                return Capabilities.disabled("parent reparse refusal is unavailable")
+
+            with filesystem.file(parent, source_name, access="mutate").require() as source:
+                hard_link = filesystem.link(source, parent, linked_name).ok
+                renamed = filesystem.rename(source, parent, renamed_name)
+                if not renamed.ok:
+                    return Capabilities.disabled("same-volume relative rename is unavailable")
+            with filesystem.file(parent, renamed_name, access="mutate").require() as renamed:
+                if not filesystem.unlink(renamed).ok:
+                    return Capabilities.disabled("relative unlink is unavailable")
+        return Capabilities(True, True, True, True, hard_link)
+    except (HeldFsError, OSError):
+        return Capabilities.disabled("actual-filesystem capability probe failed")
+    finally:
+        filesystem.close()
+        for name in (
+            source_name,
+            renamed_name,
+            linked_name,
+            alias_name,
+            directory_alias_name,
+        ):
             try:
-                identity = _identity(_native(descriptor))
-                relative = f"{prefix}/{name}" if prefix else name
-                records.append(SagaRecord(relative, identity))
-                if identity.kind == "directory":
-                    self._enumerate(WindowsHeldDirectory(self, descriptor), relative, records)
-                    descriptor = -1
-            finally:
-                if descriptor != -1:
-                    os.close(descriptor)
+                (root / name).unlink(missing_ok=True)
+            except OSError:
+                pass
+        try:
+            (root / directory_name).rmdir()
+        except OSError:
+            pass
+
+
+def probe(root: Path) -> Capabilities:
+    return _probe(root)
 
 
 def acquire(root: Path) -> HeldResult[HeldFilesystem]:
     capability = probe(root)
     if not capability.relative_operations:
-        return HeldResult(error=HeldFsError("CAPABILITY_UNAVAILABLE", "required filesystem primitives are unavailable"))
+        return HeldResult(
+            error=HeldFsError(
+                "CAPABILITY_UNAVAILABLE", "required filesystem primitives are unavailable"
+            )
+        )
     descriptor = _open_root(root)
     if descriptor is None:
         return HeldResult(error=HeldFsError("IO_REFUSED", "root anchor could not be acquired"))
-    return HeldResult(value=WindowsHeldFilesystem(descriptor))
+    return HeldResult(value=WindowsHeldFilesystem(descriptor, capability))

--- a/src/exomem/_held_fs_windows.py
+++ b/src/exomem/_held_fs_windows.py
@@ -1,0 +1,626 @@
+"""Native Windows held-handle implementation.
+
+Descendants are always opened with ``NtCreateFile`` relative to a retained
+directory handle.  This deliberately has no ``CreateFileW(child_path)``
+fallback: an unavailable native primitive disables the route.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import os
+import secrets
+from ctypes import (
+    POINTER,
+    Structure,
+    byref,
+    c_byte,
+    c_long,
+    c_ulong,
+    c_ulonglong,
+    c_ushort,
+    c_void_p,
+    create_string_buffer,
+    create_unicode_buffer,
+    sizeof,
+    wintypes,
+)
+from pathlib import Path
+
+from .held_fs import (
+    Capabilities,
+    HeldDirectory,
+    HeldFilesystem,
+    HeldFsError,
+    HeldResult,
+    SagaRecord,
+    StableIdentity,
+)
+
+FILE_OPEN = 1
+FILE_OPEN_IF = 3
+FILE_DIRECTORY_FILE = 0x00000001
+FILE_NON_DIRECTORY_FILE = 0x00000040
+FILE_SYNCHRONOUS_IO_NONALERT = 0x00000020
+FILE_OPEN_REPARSE_POINT = 0x00200000
+FILE_ATTRIBUTE_NORMAL = 0x00000080
+FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
+FILE_SHARE_READ = 0x00000001
+FILE_LIST_DIRECTORY = 0x00000001
+FILE_ADD_FILE = 0x00000002
+FILE_ADD_SUBDIRECTORY = 0x00000004
+FILE_READ_DATA = 0x00000001
+FILE_WRITE_DATA = 0x00000002
+FILE_READ_ATTRIBUTES = 0x00000080
+DELETE = 0x00010000
+SYNCHRONIZE = 0x00100000
+FILE_RENAME_INFORMATION = 10
+FILE_LINK_INFORMATION = 11
+FILE_DISPOSITION_INFORMATION = 4
+FILE_BOTH_DIRECTORY_INFORMATION = 3
+FILE_ATTRIBUTE_TAG_INFO_CLASS = 9
+FILE_ID_INFO_CLASS = 18
+INVALID_HANDLE_VALUE = c_void_p(-1).value
+STATUS_NO_MORE_FILES = 0x80000006
+
+
+class UNICODE_STRING(Structure):
+    _fields_ = [("Length", c_ushort), ("MaximumLength", c_ushort), ("Buffer", wintypes.LPWSTR)]
+
+
+class OBJECT_ATTRIBUTES(Structure):
+    _fields_ = [
+        ("Length", c_ulong),
+        ("RootDirectory", c_void_p),
+        ("ObjectName", POINTER(UNICODE_STRING)),
+        ("Attributes", c_ulong),
+        ("SecurityDescriptor", c_void_p),
+        ("SecurityQualityOfService", c_void_p),
+    ]
+
+
+class IO_STATUS_BLOCK(Structure):
+    _fields_ = [("Status", c_void_p), ("Information", c_void_p)]
+
+
+class FILE_ATTRIBUTE_TAG_INFO(Structure):
+    _fields_ = [("FileAttributes", c_ulong), ("ReparseTag", c_ulong)]
+
+
+class FILE_ID_INFO(Structure):
+    _fields_ = [("VolumeSerialNumber", c_ulonglong), ("FileId", c_byte * 16)]
+
+
+class BY_HANDLE_FILE_INFORMATION(Structure):
+    _fields_ = [
+        ("FileAttributes", c_ulong),
+        ("CreationTimeLow", c_ulong),
+        ("CreationTimeHigh", c_ulong),
+        ("LastAccessTimeLow", c_ulong),
+        ("LastAccessTimeHigh", c_ulong),
+        ("LastWriteTimeLow", c_ulong),
+        ("LastWriteTimeHigh", c_ulong),
+        ("VolumeSerialNumber", c_ulong),
+        ("FileSizeHigh", c_ulong),
+        ("FileSizeLow", c_ulong),
+        ("NumberOfLinks", c_ulong),
+        ("FileIndexHigh", c_ulong),
+        ("FileIndexLow", c_ulong),
+    ]
+
+
+if os.name == "nt":  # pragma: no cover - executed by windows-latest
+    NtCreateFile = ctypes.windll.ntdll.NtCreateFile
+    NtSetInformationFile = ctypes.windll.ntdll.NtSetInformationFile
+    NtQueryDirectoryFile = ctypes.windll.ntdll.NtQueryDirectoryFile
+    SetFileInformationByHandle = ctypes.windll.kernel32.SetFileInformationByHandle
+    GetFileInformationByHandleEx = ctypes.windll.kernel32.GetFileInformationByHandleEx
+    GetFileInformationByHandle = ctypes.windll.kernel32.GetFileInformationByHandle
+    CreateFileW = ctypes.windll.kernel32.CreateFileW
+    CloseHandle = ctypes.windll.kernel32.CloseHandle
+    NtCreateFile.argtypes = [
+        POINTER(c_void_p),
+        c_ulong,
+        POINTER(OBJECT_ATTRIBUTES),
+        POINTER(IO_STATUS_BLOCK),
+        c_void_p,
+        c_ulong,
+        c_ulong,
+        c_ulong,
+        c_ulong,
+        c_void_p,
+        c_ulong,
+    ]
+    NtCreateFile.restype = c_long
+    NtSetInformationFile.argtypes = [
+        c_void_p, POINTER(IO_STATUS_BLOCK), c_void_p, c_ulong, c_ulong
+    ]
+    NtSetInformationFile.restype = c_long
+    NtQueryDirectoryFile.argtypes = [
+        c_void_p,
+        c_void_p,
+        c_void_p,
+        c_void_p,
+        POINTER(IO_STATUS_BLOCK),
+        c_void_p,
+        c_ulong,
+        c_ulong,
+        wintypes.BOOL,
+        c_void_p,
+        wintypes.BOOL,
+    ]
+    NtQueryDirectoryFile.restype = c_long
+    SetFileInformationByHandle.argtypes = [c_void_p, c_ulong, c_void_p, c_ulong]
+    SetFileInformationByHandle.restype = wintypes.BOOL
+    GetFileInformationByHandleEx.argtypes = [c_void_p, c_ulong, c_void_p, c_ulong]
+    GetFileInformationByHandleEx.restype = wintypes.BOOL
+    GetFileInformationByHandle.argtypes = [c_void_p, POINTER(BY_HANDLE_FILE_INFORMATION)]
+    GetFileInformationByHandle.restype = wintypes.BOOL
+    CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        c_ulong,
+        c_ulong,
+        c_void_p,
+        c_ulong,
+        c_ulong,
+        c_void_p,
+    ]
+    CreateFileW.restype = c_void_p
+    CloseHandle.argtypes = [c_void_p]
+    CloseHandle.restype = wintypes.BOOL
+else:  # pragma: no cover - keeps Linux imports syntactically safe
+    NtCreateFile = None
+    NtSetInformationFile = None
+    NtQueryDirectoryFile = None
+    SetFileInformationByHandle = None
+    GetFileInformationByHandleEx = None
+    GetFileInformationByHandle = None
+    CreateFileW = None
+    CloseHandle = None
+
+
+def _invalid() -> HeldFsError:
+    return HeldFsError("UNSAFE_PATH", "unsafe filesystem object")
+
+
+def _error(_error: OSError | None = None) -> HeldFsError:
+    if _error is not None and _error.errno == errno.EXDEV:
+        return HeldFsError("CROSS_DEVICE", "operation requires one filesystem")
+    if _error is not None and _error.errno in {errno.ELOOP, errno.ENOTDIR}:
+        return _invalid()
+    return HeldFsError("IO_REFUSED", "held filesystem operation was refused")
+
+
+def _parts(relative: str) -> tuple[str, ...] | None:
+    if relative == ".":
+        return ()
+    if not isinstance(relative, str) or not relative or "\x00" in relative:
+        return None
+    parts = tuple(relative.split("/"))
+    if any(part in {"", ".", ".."} or "\\" in part or ":" in part for part in parts):
+        return None
+    return parts
+
+
+def _leaf(name: str) -> bool:
+    return isinstance(name, str) and name not in {"", ".", ".."} and all(
+        marker not in name for marker in ("/", "\\", ":", "\x00")
+    )
+
+
+def _native(fd: int) -> int:
+    import msvcrt
+
+    return int(msvcrt.get_osfhandle(fd))
+
+
+def _fd(handle: int) -> int:
+    import msvcrt
+
+    return msvcrt.open_osfhandle(handle, os.O_BINARY)
+
+
+def _nt_success(status: int) -> bool:
+    return status >= 0
+
+
+def _identity(handle: int) -> StableIdentity:
+    assert GetFileInformationByHandleEx is not None
+    assert GetFileInformationByHandle is not None
+    file_id = FILE_ID_INFO()
+    attributes = FILE_ATTRIBUTE_TAG_INFO()
+    basic = BY_HANDLE_FILE_INFORMATION()
+    if not GetFileInformationByHandleEx(handle, FILE_ID_INFO_CLASS, byref(file_id), sizeof(file_id)):
+        raise OSError("FileIdInfo is unavailable")
+    if not GetFileInformationByHandleEx(
+        handle, FILE_ATTRIBUTE_TAG_INFO_CLASS, byref(attributes), sizeof(attributes)
+    ):
+        raise OSError("FileAttributeTagInfo is unavailable")
+    if attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT:
+        raise OSError(errno.ELOOP, "reparse point")
+    if not GetFileInformationByHandle(handle, byref(basic)):
+        raise OSError("file identity is unavailable")
+    kind = "directory" if attributes.FileAttributes & 0x10 else "file"
+    return StableIdentity(
+        int(file_id.VolumeSerialNumber),
+        int.from_bytes(bytes(file_id.FileId), "little"),
+        kind,
+        int(basic.NumberOfLinks),
+    )
+
+
+def _unicode(name: str) -> tuple[UNICODE_STRING, object]:
+    buffer = create_unicode_buffer(name)
+    value = UNICODE_STRING(len(name.encode("utf-16-le")), (len(name) + 1) * 2, buffer)
+    return value, buffer
+
+
+def _open_relative(parent_handle: int, name: str, access: int, options: int, disposition: int) -> int:
+    """Open exactly one component under ``parent_handle`` through NtCreateFile."""
+    assert NtCreateFile is not None
+    string, _buffer = _unicode(name)
+    attributes = OBJECT_ATTRIBUTES(
+        sizeof(OBJECT_ATTRIBUTES),
+        c_void_p(parent_handle),
+        byref(string),
+        0,
+        None,
+        None,
+    )
+    status = IO_STATUS_BLOCK()
+    handle = c_void_p()
+    result = NtCreateFile(
+        byref(handle),
+        access | SYNCHRONIZE,
+        byref(attributes),
+        byref(status),
+        None,
+        FILE_ATTRIBUTE_NORMAL,
+        FILE_SHARE_READ,
+        disposition,
+        options | FILE_OPEN_REPARSE_POINT,
+        None,
+        0,
+    )
+    if not _nt_success(result) or handle.value in {None, INVALID_HANDLE_VALUE}:
+        raise OSError("NtCreateFile refused relative handle operation")
+    try:
+        _identity(int(handle.value))
+        return int(handle.value)
+    except OSError:
+        assert CloseHandle is not None
+        CloseHandle(handle)
+        raise
+
+
+def _probe(root: Path) -> Capabilities:
+    if os.name != "nt" or any(
+        primitive is None
+        for primitive in (NtCreateFile, NtSetInformationFile, SetFileInformationByHandle, GetFileInformationByHandleEx)
+    ):
+        return Capabilities.disabled("native Windows handle primitives are unavailable")
+    descriptor = _open_root(root)
+    if descriptor is None:
+        return Capabilities.disabled("root cannot be opened with stable identity")
+    filesystem = WindowsHeldFilesystem(descriptor)
+    source_name = f".exomem-held-probe-{secrets.token_hex(16)}"
+    linked_name = f"{source_name}-link"
+    renamed_name = f"{source_name}-renamed"
+    try:
+        with filesystem.parent(".").require() as parent:
+            if not filesystem.write(parent, source_name, b"probe").ok:
+                return Capabilities.disabled("relative create/write is unavailable")
+            source_identity = filesystem.identity(parent, source_name)
+            if not source_identity.ok or source_identity.require().kind != "file":
+                return Capabilities.disabled("stable final identity is unavailable")
+            if not filesystem.link(parent, source_name, parent, linked_name).ok:
+                return Capabilities.disabled("relative hard link is unavailable")
+            if not filesystem.rename(parent, linked_name, parent, renamed_name).ok:
+                return Capabilities.disabled("same-volume relative rename is unavailable")
+            if not filesystem.unlink(parent, renamed_name).ok:
+                return Capabilities.disabled("relative unlink is unavailable")
+            if not filesystem.unlink(parent, source_name).ok:
+                return Capabilities.disabled("relative cleanup is unavailable")
+    finally:
+        filesystem.close()
+    return Capabilities(True, True, True, True, True)
+
+
+def probe(root: Path) -> Capabilities:
+    return _probe(root)
+
+
+def _open_root(root: Path) -> int | None:
+    assert CreateFileW is not None
+    handle = CreateFileW(
+        str(root),
+        FILE_LIST_DIRECTORY | FILE_ADD_FILE | FILE_ADD_SUBDIRECTORY | FILE_READ_ATTRIBUTES,
+        FILE_SHARE_READ,
+        None,
+        3,
+        0x02000000 | FILE_OPEN_REPARSE_POINT,
+        None,
+    )
+    if handle in {None, INVALID_HANDLE_VALUE}:
+        return None
+    try:
+        identity = _identity(int(handle))
+        if identity.kind != "directory":
+            raise OSError("root is not a directory")
+        return _fd(int(handle))
+    except OSError:
+        assert CloseHandle is not None
+        CloseHandle(handle)
+        return None
+
+
+class WindowsHeldDirectory(HeldDirectory):
+    def __init__(self, filesystem: WindowsHeldFilesystem, descriptor: int) -> None:
+        self.filesystem = filesystem
+        self.descriptor = descriptor
+        self.identity = _identity(_native(descriptor))
+        self.closed = False
+
+    def check(self) -> None:
+        if self.closed or _identity(_native(self.descriptor)) != self.identity:
+            raise OSError("held directory changed")
+
+    def close(self) -> None:
+        if not self.closed:
+            os.close(self.descriptor)
+            self.closed = True
+
+
+class WindowsHeldFilesystem(HeldFilesystem):
+    def __init__(self, descriptor: int) -> None:
+        self.descriptor = descriptor
+        self.root_identity = _identity(_native(descriptor))
+        self.closed = False
+
+    def close(self) -> None:
+        if not self.closed:
+            os.close(self.descriptor)
+            self.closed = True
+
+    def _check(self, parent: HeldDirectory) -> WindowsHeldDirectory:
+        if self.closed or not isinstance(parent, WindowsHeldDirectory) or parent.filesystem is not self:
+            raise OSError("held directory is unavailable")
+        parent.check()
+        return parent
+
+    def parent(self, relative: str, *, create: bool = False) -> HeldResult[HeldDirectory]:
+        parts = _parts(relative)
+        if parts is None:
+            return HeldResult(error=_invalid())
+        descriptor = os.dup(self.descriptor)
+        try:
+            for part in parts:
+                handle = _open_relative(
+                    _native(descriptor),
+                    part,
+                    FILE_LIST_DIRECTORY | FILE_ADD_FILE | FILE_ADD_SUBDIRECTORY | FILE_READ_ATTRIBUTES,
+                    FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT,
+                    FILE_OPEN_IF if create else FILE_OPEN,
+                )
+                os.close(descriptor)
+                descriptor = _fd(handle)
+            return HeldResult(value=WindowsHeldDirectory(self, descriptor))
+        except OSError as error:
+            os.close(descriptor)
+            return HeldResult(error=_error(error))
+
+    def _open_leaf(self, parent: HeldDirectory, leaf: str, write: bool = False, create: bool = False, delete: bool = False) -> int:
+        if not _leaf(leaf):
+            raise OSError(errno.ELOOP, "invalid relative leaf")
+        checked = self._check(parent)
+        access = FILE_READ_DATA | FILE_READ_ATTRIBUTES
+        if write:
+            access |= FILE_WRITE_DATA
+        if delete:
+            access |= DELETE
+        handle = _open_relative(
+            _native(checked.descriptor),
+            leaf,
+            access,
+            FILE_NON_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT,
+            FILE_OPEN_IF if create else FILE_OPEN,
+        )
+        return _fd(handle)
+
+    def identity(self, parent: HeldDirectory, leaf: str) -> HeldResult[StableIdentity]:
+        try:
+            descriptor = self._open_leaf(parent, leaf)
+            try:
+                return HeldResult(value=_identity(_native(descriptor)))
+            finally:
+                os.close(descriptor)
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def read(self, parent: HeldDirectory, leaf: str) -> HeldResult[bytes]:
+        try:
+            descriptor = self._open_leaf(parent, leaf)
+            try:
+                chunks = []
+                while chunk := os.read(descriptor, 65536):
+                    chunks.append(chunk)
+                return HeldResult(value=b"".join(chunks))
+            finally:
+                os.close(descriptor)
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def write(self, parent: HeldDirectory, leaf: str, data: bytes) -> HeldResult[None]:
+        if not isinstance(data, bytes):
+            return HeldResult(error=HeldFsError("INVALID_INPUT", "data must be bytes"))
+        try:
+            descriptor = self._open_leaf(parent, leaf, write=True, create=True)
+            try:
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                os.ftruncate(descriptor, 0)
+                view = memoryview(data)
+                written = 0
+                while written < len(view):
+                    written += os.write(descriptor, view[written:])
+                os.fsync(descriptor)
+                return HeldResult(value=None)  # type: ignore[arg-type]
+            finally:
+                os.close(descriptor)
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def _paired(self, source: HeldDirectory, destination: HeldDirectory, source_leaf: str, destination_leaf: str) -> tuple[WindowsHeldDirectory, WindowsHeldDirectory]:
+        if not _leaf(source_leaf) or not _leaf(destination_leaf):
+            raise OSError(errno.ELOOP, "invalid relative leaf")
+        source_parent = self._check(source)
+        if not isinstance(destination, WindowsHeldDirectory):
+            raise OSError("destination handle is unavailable")
+        destination.check()
+        if source_parent.identity.device != destination.identity.device:
+            raise OSError(errno.EXDEV, "cross-volume operation")
+        return source_parent, destination
+
+    def _rename_handle(self, descriptor: int, destination: WindowsHeldDirectory, leaf: str) -> None:
+        assert SetFileInformationByHandle is not None
+        encoded = leaf.encode("utf-16-le")
+        payload = create_string_buffer(20 + len(encoded))
+        payload[0] = 1
+        c_void_p.from_buffer(payload, 8).value = _native(destination.descriptor)
+        c_ulong.from_buffer(payload, 16).value = len(encoded)
+        payload[20 : 20 + len(encoded)] = encoded
+        if not SetFileInformationByHandle(_native(descriptor), FILE_RENAME_INFORMATION, payload, len(payload)):
+            raise OSError("relative rename was refused")
+
+    def rename(self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory, destination_leaf: str) -> HeldResult[None]:
+        try:
+            source, destination = self._paired(source_parent, destination_parent, source_leaf, destination_leaf)
+            descriptor = self._open_leaf(source, source_leaf, delete=True)
+            try:
+                self._rename_handle(descriptor, destination, destination_leaf)
+            finally:
+                os.close(descriptor)
+            return HeldResult(value=None)  # type: ignore[arg-type]
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def link(self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory, destination_leaf: str) -> HeldResult[None]:
+        try:
+            source, destination = self._paired(source_parent, destination_parent, source_leaf, destination_leaf)
+            descriptor = self._open_leaf(source, source_leaf, delete=True)
+            try:
+                assert NtSetInformationFile is not None
+                encoded = destination_leaf.encode("utf-16-le")
+                payload = create_string_buffer(20 + len(encoded))
+                payload[0] = 0
+                c_void_p.from_buffer(payload, 8).value = _native(destination.descriptor)
+                c_ulong.from_buffer(payload, 16).value = len(encoded)
+                payload[20 : 20 + len(encoded)] = encoded
+                status = IO_STATUS_BLOCK()
+                if not _nt_success(NtSetInformationFile(_native(descriptor), byref(status), payload, len(payload), FILE_LINK_INFORMATION)):
+                    raise OSError("relative hard link was refused")
+            finally:
+                os.close(descriptor)
+            return HeldResult(value=None)  # type: ignore[arg-type]
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def unlink(self, parent: HeldDirectory, leaf: str) -> HeldResult[None]:
+        try:
+            descriptor = self._open_leaf(parent, leaf, delete=True)
+            try:
+                assert SetFileInformationByHandle is not None
+                delete = wintypes.BOOL(True)
+                if not SetFileInformationByHandle(_native(descriptor), FILE_DISPOSITION_INFORMATION, byref(delete), sizeof(delete)):
+                    raise OSError("relative disposition was refused")
+            finally:
+                os.close(descriptor)
+            return HeldResult(value=None)  # type: ignore[arg-type]
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def copy(self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory, destination_leaf: str) -> HeldResult[None]:
+        temporary = f".exomem-held-{secrets.token_hex(16)}"
+        try:
+            if not _leaf(source_leaf) or not _leaf(destination_leaf):
+                raise OSError(errno.ELOOP, "invalid relative leaf")
+            source = self._check(source_parent)
+            if not isinstance(destination_parent, WindowsHeldDirectory):
+                raise OSError("destination handle is unavailable")
+            destination_parent.check()
+            destination = destination_parent
+            source_descriptor = self._open_leaf(source, source_leaf)
+            temporary_descriptor = self._open_leaf(destination, temporary, write=True, create=True)
+            try:
+                while chunk := os.read(source_descriptor, 65536):
+                    view = memoryview(chunk)
+                    written = 0
+                    while written < len(view):
+                        written += os.write(temporary_descriptor, view[written:])
+                os.fsync(temporary_descriptor)
+                self._rename_handle(temporary_descriptor, destination, destination_leaf)
+            finally:
+                os.close(source_descriptor)
+                os.close(temporary_descriptor)
+            return HeldResult(value=None)  # type: ignore[arg-type]
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def enumerate(self, parent: HeldDirectory) -> HeldResult[tuple[SagaRecord, ...]]:
+        """Enumerate via ``NtQueryDirectoryFile``; recursive records are name ordered."""
+        try:
+            checked = self._check(parent)
+            records: list[SagaRecord] = []
+            self._enumerate(checked, "", records)
+            return HeldResult(value=tuple(records))
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def _entries(self, parent: WindowsHeldDirectory) -> list[str]:
+        assert NtQueryDirectoryFile is not None
+        buffer = create_string_buffer(65536)
+        status = IO_STATUS_BLOCK()
+        restart = True
+        names: list[str] = []
+        while True:
+            result = NtQueryDirectoryFile(_native(parent.descriptor), None, None, None, byref(status), buffer, len(buffer), FILE_BOTH_DIRECTORY_INFORMATION, False, None, restart)
+            restart = False
+            if (int(result) & 0xFFFFFFFF) == STATUS_NO_MORE_FILES:
+                return sorted(names)
+            if not _nt_success(result):
+                raise OSError("directory enumeration was refused")
+            offset = 0
+            while True:
+                next_offset = int.from_bytes(buffer.raw[offset : offset + 4], "little")
+                name_length = int.from_bytes(buffer.raw[offset + 60 : offset + 64], "little")
+                name = buffer.raw[offset + 94 : offset + 94 + name_length].decode("utf-16-le")
+                if name not in {".", ".."}:
+                    names.append(name)
+                if next_offset == 0:
+                    break
+                offset += next_offset
+
+    def _enumerate(self, parent: WindowsHeldDirectory, prefix: str, records: list[SagaRecord]) -> None:
+        for name in self._entries(parent):
+            handle = _open_relative(_native(parent.descriptor), name, FILE_READ_ATTRIBUTES, FILE_SYNCHRONOUS_IO_NONALERT, FILE_OPEN)
+            descriptor = _fd(handle)
+            try:
+                identity = _identity(_native(descriptor))
+                relative = f"{prefix}/{name}" if prefix else name
+                records.append(SagaRecord(relative, identity))
+                if identity.kind == "directory":
+                    self._enumerate(WindowsHeldDirectory(self, descriptor), relative, records)
+                    descriptor = -1
+            finally:
+                if descriptor != -1:
+                    os.close(descriptor)
+
+
+def acquire(root: Path) -> HeldResult[HeldFilesystem]:
+    capability = probe(root)
+    if not capability.relative_operations:
+        return HeldResult(error=HeldFsError("CAPABILITY_UNAVAILABLE", "required filesystem primitives are unavailable"))
+    descriptor = _open_root(root)
+    if descriptor is None:
+        return HeldResult(error=HeldFsError("IO_REFUSED", "root anchor could not be acquired"))
+    return HeldResult(value=WindowsHeldFilesystem(descriptor))

--- a/src/exomem/held_fs.py
+++ b/src/exomem/held_fs.py
@@ -16,7 +16,7 @@ T = TypeVar("T")
 _MISSING = object()
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class HeldFsError(Exception):
     """A typed, content-free refusal from a held filesystem operation."""
 
@@ -95,6 +95,21 @@ class HeldDirectory:
         raise NotImplementedError
 
 
+class HeldFile:
+    """A retained regular-file handle and the identity observed from that handle."""
+
+    identity: StableIdentity
+
+    def __enter__(self) -> HeldFile:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        raise NotImplementedError
+
+
 class HeldFilesystem:
     """A retained vault-root anchor with handle-relative leaf operations."""
 
@@ -110,32 +125,46 @@ class HeldFilesystem:
     def parent(self, relative: str, *, create: bool = False) -> HeldResult[HeldDirectory]:
         raise NotImplementedError
 
-    def identity(self, parent: HeldDirectory, leaf: str) -> HeldResult[StableIdentity]:
+    def file(
+        self,
+        parent: HeldDirectory,
+        leaf: str,
+        *,
+        access: str = "read",
+        create: bool = False,
+        exclusive: bool = False,
+    ) -> HeldResult[HeldFile]:
         raise NotImplementedError
 
-    def read(self, parent: HeldDirectory, leaf: str) -> HeldResult[bytes]:
+    def read(self, file: HeldFile) -> HeldResult[bytes]:
         raise NotImplementedError
 
-    def write(self, parent: HeldDirectory, leaf: str, data: bytes) -> HeldResult[None]:
+    def write(self, file: HeldFile, data: bytes) -> HeldResult[None]:
         raise NotImplementedError
 
     def rename(
-        self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory,
+        self,
+        source: HeldFile,
+        destination_parent: HeldDirectory,
         destination_leaf: str,
     ) -> HeldResult[None]:
         raise NotImplementedError
 
     def link(
-        self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory,
+        self,
+        source: HeldFile,
+        destination_parent: HeldDirectory,
         destination_leaf: str,
     ) -> HeldResult[None]:
         raise NotImplementedError
 
-    def unlink(self, parent: HeldDirectory, leaf: str) -> HeldResult[None]:
+    def unlink(self, file: HeldFile) -> HeldResult[None]:
         raise NotImplementedError
 
     def copy(
-        self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory,
+        self,
+        source: HeldFile,
+        destination_parent: HeldDirectory,
         destination_leaf: str,
     ) -> HeldResult[None]:
         raise NotImplementedError
@@ -178,10 +207,11 @@ def publish_sqlite_identities(
     names = (primary, f"{primary}-wal", f"{primary}-shm")
     identities: dict[str, StableIdentity] = {}
     for name in names:
-        result = filesystem.identity(parent, name)
+        result = filesystem.file(parent, name)
         if not result.ok:
             return HeldResult(error=result.error)
-        identities[name] = result.require()
+        with result.require() as file:
+            identities[name] = file.identity
     try:
         publish(identities)
     except Exception:  # noqa: BLE001 - caller publication must not escape the closed result.

--- a/src/exomem/held_fs.py
+++ b/src/exomem/held_fs.py
@@ -1,0 +1,189 @@
+"""Closed, handle-relative filesystem primitives for cooperating subsystems.
+
+This module deliberately exposes no path-based descendant operation.  A caller
+first acquires a root anchor, then works through retained parent handles.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+_MISSING = object()
+
+
+@dataclass(frozen=True, slots=True)
+class HeldFsError(Exception):
+    """A typed, content-free refusal from a held filesystem operation."""
+
+    code: str
+    detail: str
+
+    def __str__(self) -> str:
+        return f"{self.code}: {self.detail}"
+
+
+@dataclass(frozen=True, slots=True)
+class HeldResult(Generic[T]):
+    """The closed result shape used by every public primitive operation."""
+
+    value: T | object = _MISSING
+    error: HeldFsError | None = None
+
+    def __post_init__(self) -> None:
+        if (self.value is _MISSING) == (self.error is None):
+            raise ValueError("held result must contain exactly one outcome")
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+    def require(self) -> T:
+        if self.error is not None:
+            raise self.error
+        return self.value  # type: ignore[return-value]
+
+
+@dataclass(frozen=True, slots=True)
+class Capabilities:
+    """Capabilities proven against the requested filesystem, not the host alone."""
+
+    relative_operations: bool
+    no_follow: bool
+    stable_identity: bool
+    same_device_rename: bool
+    hard_link: bool
+    reason: str = ""
+
+    @classmethod
+    def disabled(cls, reason: str) -> Capabilities:
+        return cls(False, False, False, False, False, reason)
+
+
+@dataclass(frozen=True, slots=True)
+class StableIdentity:
+    """Stable identity derived from the handle already used for the operation."""
+
+    device: int
+    inode: int
+    kind: str
+    link_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class SagaRecord:
+    """One deterministic recursive enumeration effect/observation record."""
+
+    relative_path: str
+    identity: StableIdentity
+
+
+class HeldDirectory:
+    """A retained directory handle.  Instances are created by ``parent`` only."""
+
+    def __enter__(self) -> HeldDirectory:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        raise NotImplementedError
+
+
+class HeldFilesystem:
+    """A retained vault-root anchor with handle-relative leaf operations."""
+
+    def __enter__(self) -> HeldFilesystem:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        raise NotImplementedError
+
+    def parent(self, relative: str, *, create: bool = False) -> HeldResult[HeldDirectory]:
+        raise NotImplementedError
+
+    def identity(self, parent: HeldDirectory, leaf: str) -> HeldResult[StableIdentity]:
+        raise NotImplementedError
+
+    def read(self, parent: HeldDirectory, leaf: str) -> HeldResult[bytes]:
+        raise NotImplementedError
+
+    def write(self, parent: HeldDirectory, leaf: str, data: bytes) -> HeldResult[None]:
+        raise NotImplementedError
+
+    def rename(
+        self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory,
+        destination_leaf: str,
+    ) -> HeldResult[None]:
+        raise NotImplementedError
+
+    def link(
+        self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory,
+        destination_leaf: str,
+    ) -> HeldResult[None]:
+        raise NotImplementedError
+
+    def unlink(self, parent: HeldDirectory, leaf: str) -> HeldResult[None]:
+        raise NotImplementedError
+
+    def copy(
+        self, source_parent: HeldDirectory, source_leaf: str, destination_parent: HeldDirectory,
+        destination_leaf: str,
+    ) -> HeldResult[None]:
+        raise NotImplementedError
+
+    def enumerate(self, parent: HeldDirectory) -> HeldResult[tuple[SagaRecord, ...]]:
+        raise NotImplementedError
+
+
+def _backend():
+    if os.name == "nt":  # pragma: no cover - exercised by the Windows CI gate
+        from . import _held_fs_windows as backend
+    else:
+        from . import _held_fs_posix as backend
+    return backend
+
+
+def probe(root: Path) -> Capabilities:
+    """Probe the actual target filesystem; no failed probe gets a fallback."""
+    return _backend().probe(Path(root))
+
+
+def acquire(root: Path) -> HeldResult[HeldFilesystem]:
+    """Acquire a root anchor or return a content-free capability/IO refusal."""
+    return _backend().acquire(Path(root))
+
+
+def publish_sqlite_identities(
+    filesystem: HeldFilesystem,
+    parent: HeldDirectory,
+    primary: str,
+    publish: Callable[[dict[str, StableIdentity]], None],
+) -> HeldResult[None]:
+    """Publish reachable SQLite family identities while caller coordination is held.
+
+    The adapter does not acquire coordination or own a store.  It first reads every
+    handle-derived identity and invokes ``publish`` only after primary, WAL, and SHM
+    are all reachable, so a caller can publish the complete family before releasing
+    its existing cooperative fence.
+    """
+    names = (primary, f"{primary}-wal", f"{primary}-shm")
+    identities: dict[str, StableIdentity] = {}
+    for name in names:
+        result = filesystem.identity(parent, name)
+        if not result.ok:
+            return HeldResult(error=result.error)
+        identities[name] = result.require()
+    try:
+        publish(identities)
+    except Exception:  # noqa: BLE001 - caller publication must not escape the closed result.
+        return HeldResult(error=HeldFsError("PUBLISH_REFUSED", "identity publication was refused"))
+    return HeldResult(value=None)

--- a/tests/test_ci_reliability_contract.py
+++ b/tests/test_ci_reliability_contract.py
@@ -212,6 +212,31 @@ def test_superseded_pr_runs_cancel_and_one_stable_gate_requires_every_ci_job() -
     assert gate["steps"][0]["env"]["RESULTS"] == "${{ join(needs.*.result, ' ') }}"
 
 
+def test_native_held_filesystem_has_a_required_ntfs_gate() -> None:
+    workflow = _workflow()
+    job = workflow["jobs"]["windows-held-filesystem"]
+
+    assert job["runs-on"] == "windows-latest"
+    assert job["timeout-minutes"] == 12
+    preparation = next(
+        step for step in job["steps"] if step.get("name") == "Require NTFS and 8.3 aliases"
+    )["run"]
+    assert "Get-Volume" in preparation
+    assert 'FileSystem -ne "NTFS"' in preparation
+    assert "at least two writable NTFS volumes" in preparation
+    assert "fsutil.exe 8dot3name set" in preparation
+    assert "$LASTEXITCODE" in preparation
+
+    command = next(
+        step for step in job["steps"] if step.get("name") == "Native held-filesystem gate"
+    )["run"]
+    assert "--python 3.13" in command
+    assert "tests/test_held_fs_contract.py" in command
+    assert "tests/test_held_fs_windows.py" in command
+    assert "--session-timeout=600" in command
+    assert "windows-held-filesystem" in workflow["jobs"]["gate"]["needs"]
+
+
 def test_the_cross_platform_split_count_matches_its_shard_matrix() -> None:
     """A mismatch here loses coverage without losing green.
 

--- a/tests/test_held_fs_contract.py
+++ b/tests/test_held_fs_contract.py
@@ -1,0 +1,116 @@
+"""Public contract for the registry-independent held-filesystem primitive."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from pathlib import Path
+
+
+def _module():
+    assert importlib.util.find_spec("exomem.held_fs") is not None, (
+        "the held filesystem primitive must be available"
+    )
+    return importlib.import_module("exomem.held_fs")
+
+
+def test_public_contract_uses_closed_results_and_content_free_refusals(tmp_path: Path) -> None:
+    held_fs = _module()
+    capability = held_fs.probe(tmp_path)
+
+    assert isinstance(capability, held_fs.Capabilities)
+    assert capability.relative_operations is True
+    assert capability.no_follow is True
+    assert capability.stable_identity is True
+
+    acquired = held_fs.acquire(tmp_path)
+    assert isinstance(acquired, held_fs.HeldResult)
+    assert acquired.ok is True
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (tmp_path / "link").symlink_to(outside, target_is_directory=True)
+    with acquired.require() as filesystem:
+        unsafe = filesystem.parent("link/out")
+        assert unsafe.ok is False
+        assert unsafe.error is not None
+        assert unsafe.error.code == "UNSAFE_PATH"
+        assert "link/out" not in unsafe.error.detail
+
+
+def test_relative_leaf_operations_use_held_parents_only(tmp_path: Path) -> None:
+    held_fs = _module()
+    with held_fs.acquire(tmp_path).require() as filesystem:
+        with filesystem.parent("one/two", create=True).require() as source:
+            assert filesystem.write(source, "source.txt", b"source").ok
+            assert filesystem.read(source, "source.txt").require() == b"source"
+            source_identity = filesystem.identity(source, "source.txt").require()
+            assert source_identity.kind == "file"
+            assert source_identity.link_count == 1
+
+            with filesystem.parent("destination", create=True).require() as destination:
+                assert filesystem.rename(source, "source.txt", destination, "moved.txt").ok
+                assert filesystem.read(destination, "moved.txt").require() == b"source"
+                assert filesystem.link(destination, "moved.txt", destination, "linked.txt").ok
+                assert filesystem.identity(destination, "linked.txt").require() == filesystem.identity(
+                    destination, "moved.txt"
+                ).require()
+                assert filesystem.unlink(destination, "linked.txt").ok
+
+
+def test_copy_is_destination_atomic_and_recursive_enumeration_is_ordered(tmp_path: Path) -> None:
+    held_fs = _module()
+    with held_fs.acquire(tmp_path).require() as filesystem:
+        with filesystem.parent("source", create=True).require() as source:
+            assert filesystem.write(source, "payload.bin", b"payload").ok
+            with filesystem.parent("destination/tree", create=True).require() as destination:
+                assert filesystem.write(destination, "z.txt", b"z").ok
+                assert filesystem.write(destination, "a.txt", b"a").ok
+            with filesystem.parent("destination", create=False).require() as destination:
+                assert filesystem.copy(source, "payload.bin", destination, "copied.bin").ok
+                assert filesystem.read(destination, "copied.bin").require() == b"payload"
+                records = filesystem.enumerate(destination).require()
+
+    assert [record.relative_path for record in records] == sorted(
+        record.relative_path for record in records
+    )
+    assert [record.relative_path for record in records] == [
+        "copied.bin",
+        "tree",
+        "tree/a.txt",
+        "tree/z.txt",
+    ]
+
+
+def test_symlink_parent_and_final_leaf_refuse_without_destination_publication(tmp_path: Path) -> None:
+    held_fs = _module()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("secret", encoding="utf-8")
+    (tmp_path / "link").symlink_to(outside, target_is_directory=True)
+    (tmp_path / "final-link").symlink_to(outside / "secret.txt")
+
+    with held_fs.acquire(tmp_path).require() as filesystem:
+        parent = filesystem.parent("link")
+        assert parent.ok is False
+        assert parent.error is not None
+        assert parent.error.code == "UNSAFE_PATH"
+        with filesystem.parent(".").require() as root:
+            leaf = filesystem.read(root, "final-link")
+            assert leaf.ok is False
+            assert leaf.error is not None
+            assert leaf.error.code == "UNSAFE_PATH"
+
+
+def test_sqlite_identity_publication_waits_for_the_complete_reachable_family(tmp_path: Path) -> None:
+    held_fs = _module()
+    published: list[dict[str, object]] = []
+    with held_fs.acquire(tmp_path).require() as filesystem:
+        with filesystem.parent("sqlite", create=True).require() as parent:
+            for name in ("state.sqlite", "state.sqlite-wal", "state.sqlite-shm"):
+                assert filesystem.write(parent, name, b"sqlite").ok
+            result = held_fs.publish_sqlite_identities(
+                filesystem, parent, "state.sqlite", published.append
+            )
+
+    assert result.ok
+    assert list(published[0]) == ["state.sqlite", "state.sqlite-wal", "state.sqlite-shm"]

--- a/tests/test_held_fs_contract.py
+++ b/tests/test_held_fs_contract.py
@@ -163,6 +163,7 @@ def test_held_leaf_survives_name_exchange_and_name_mutation_refuses(tmp_path: Pa
                 ).require() as leaf:
                     assert filesystem.write(leaf, data).ok
 
+            removed_by_handle = False
             with filesystem.file(parent, "reviewed.txt", access="mutate").require() as reviewed:
                 (tmp_path / "retained" / "reviewed.txt").rename(
                     tmp_path / "retained" / "moved-reviewed.txt"
@@ -174,11 +175,15 @@ def test_held_leaf_survives_name_exchange_and_name_mutation_refuses(tmp_path: Pa
                 assert filesystem.read(reviewed).require() == b"reviewed"
                 refused = filesystem.unlink(reviewed)
                 if refused.ok:
-                    assert not (tmp_path / "retained" / "moved-reviewed.txt").exists()
+                    removed_by_handle = True
                 else:
                     assert refused.error is not None
                     assert refused.error.code == "IDENTITY_CHANGED"
 
+            if removed_by_handle:
+                assert not (tmp_path / "retained" / "moved-reviewed.txt").exists()
+            else:
+                assert (tmp_path / "retained" / "moved-reviewed.txt").read_bytes() == b"reviewed"
             assert (tmp_path / "retained" / "reviewed.txt").read_bytes() == b"reserved"
 
 

--- a/tests/test_held_fs_contract.py
+++ b/tests/test_held_fs_contract.py
@@ -4,7 +4,16 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import os
+import sys
 from pathlib import Path
+
+import pytest
+
+_requires_native_route = pytest.mark.skipif(
+    os.name != "nt" and not sys.platform.startswith("linux"),
+    reason="mount-aware held operations require Linux openat2 or native Windows handles",
+)
 
 
 def _module():
@@ -14,6 +23,26 @@ def _module():
     return importlib.import_module("exomem.held_fs")
 
 
+def test_windows_ffi_structures_construct_on_every_supported_interpreter() -> None:
+    backend = importlib.import_module("exomem._held_fs_windows")
+    string, buffer = backend._unicode("leaf.txt")
+    attributes = backend.OBJECT_ATTRIBUTES(
+        backend.ctypes.sizeof(backend.OBJECT_ATTRIBUTES),
+        backend.ctypes.c_void_p(1),
+        backend.ctypes.pointer(string),
+        backend.OBJ_CASE_INSENSITIVE,
+        None,
+        None,
+    )
+
+    assert buffer.value == "leaf.txt"
+    assert attributes.ObjectName.contents.Buffer == "leaf.txt"
+    assert len(backend._name_payload(False, 1, "x")) >= backend.ctypes.sizeof(
+        backend.FILE_NAME_INFORMATION
+    )
+
+
+@_requires_native_route
 def test_public_contract_uses_closed_results_and_content_free_refusals(tmp_path: Path) -> None:
     held_fs = _module()
     capability = held_fs.probe(tmp_path)
@@ -37,37 +66,56 @@ def test_public_contract_uses_closed_results_and_content_free_refusals(tmp_path:
         assert "link/out" not in unsafe.error.detail
 
 
+@_requires_native_route
 def test_relative_leaf_operations_use_held_parents_only(tmp_path: Path) -> None:
     held_fs = _module()
     with held_fs.acquire(tmp_path).require() as filesystem:
         with filesystem.parent("one/two", create=True).require() as source:
-            assert filesystem.write(source, "source.txt", b"source").ok
-            assert filesystem.read(source, "source.txt").require() == b"source"
-            source_identity = filesystem.identity(source, "source.txt").require()
-            assert source_identity.kind == "file"
-            assert source_identity.link_count == 1
+            with filesystem.file(
+                source, "source.txt", access="write", create=True, exclusive=True
+            ).require() as source_file:
+                assert filesystem.write(source_file, b"source").ok
+                assert source_file.identity.kind == "file"
+                assert source_file.identity.link_count == 1
 
-            with filesystem.parent("destination", create=True).require() as destination:
-                assert filesystem.rename(source, "source.txt", destination, "moved.txt").ok
-                assert filesystem.read(destination, "moved.txt").require() == b"source"
-                assert filesystem.link(destination, "moved.txt", destination, "linked.txt").ok
-                assert filesystem.identity(destination, "linked.txt").require() == filesystem.identity(
-                    destination, "moved.txt"
-                ).require()
-                assert filesystem.unlink(destination, "linked.txt").ok
+            with filesystem.file(source, "source.txt", access="mutate").require() as source_file:
+                assert filesystem.read(source_file).require() == b"source"
+
+                with filesystem.parent("destination", create=True).require() as destination:
+                    assert filesystem.rename(source_file, destination, "moved.txt").ok
+                    with filesystem.file(
+                        destination, "moved.txt", access="mutate"
+                    ).require() as moved:
+                        assert filesystem.read(moved).require() == b"source"
+                        assert filesystem.link(moved, destination, "linked.txt").ok
+                        with filesystem.file(destination, "linked.txt").require() as linked:
+                            assert linked.identity == moved.identity
+                        with filesystem.file(
+                            destination, "linked.txt", access="mutate"
+                        ).require() as linked:
+                            assert filesystem.unlink(linked).ok
 
 
+@_requires_native_route
 def test_copy_is_destination_atomic_and_recursive_enumeration_is_ordered(tmp_path: Path) -> None:
     held_fs = _module()
     with held_fs.acquire(tmp_path).require() as filesystem:
         with filesystem.parent("source", create=True).require() as source:
-            assert filesystem.write(source, "payload.bin", b"payload").ok
+            with filesystem.file(
+                source, "payload.bin", access="write", create=True, exclusive=True
+            ).require() as payload:
+                assert filesystem.write(payload, b"payload").ok
             with filesystem.parent("destination/tree", create=True).require() as destination:
-                assert filesystem.write(destination, "z.txt", b"z").ok
-                assert filesystem.write(destination, "a.txt", b"a").ok
+                for name, data in (("z.txt", b"z"), ("a.txt", b"a")):
+                    with filesystem.file(
+                        destination, name, access="write", create=True, exclusive=True
+                    ).require() as leaf:
+                        assert filesystem.write(leaf, data).ok
             with filesystem.parent("destination", create=False).require() as destination:
-                assert filesystem.copy(source, "payload.bin", destination, "copied.bin").ok
-                assert filesystem.read(destination, "copied.bin").require() == b"payload"
+                with filesystem.file(source, "payload.bin").require() as payload:
+                    assert filesystem.copy(payload, destination, "copied.bin").ok
+                with filesystem.file(destination, "copied.bin").require() as copied:
+                    assert filesystem.read(copied).require() == b"payload"
                 records = filesystem.enumerate(destination).require()
 
     assert [record.relative_path for record in records] == sorted(
@@ -81,7 +129,10 @@ def test_copy_is_destination_atomic_and_recursive_enumeration_is_ordered(tmp_pat
     ]
 
 
-def test_symlink_parent_and_final_leaf_refuse_without_destination_publication(tmp_path: Path) -> None:
+@_requires_native_route
+def test_symlink_parent_and_final_leaf_refuse_without_destination_publication(
+    tmp_path: Path,
+) -> None:
     held_fs = _module()
     outside = tmp_path / "outside"
     outside.mkdir()
@@ -95,22 +146,74 @@ def test_symlink_parent_and_final_leaf_refuse_without_destination_publication(tm
         assert parent.error is not None
         assert parent.error.code == "UNSAFE_PATH"
         with filesystem.parent(".").require() as root:
-            leaf = filesystem.read(root, "final-link")
+            leaf = filesystem.file(root, "final-link")
             assert leaf.ok is False
             assert leaf.error is not None
             assert leaf.error.code == "UNSAFE_PATH"
 
 
-def test_sqlite_identity_publication_waits_for_the_complete_reachable_family(tmp_path: Path) -> None:
+@_requires_native_route
+def test_held_leaf_survives_name_exchange_and_name_mutation_refuses(tmp_path: Path) -> None:
+    held_fs = _module()
+    with held_fs.acquire(tmp_path).require() as filesystem:
+        with filesystem.parent("retained", create=True).require() as parent:
+            for name, data in (("reviewed.txt", b"reviewed"), ("reserved.txt", b"reserved")):
+                with filesystem.file(
+                    parent, name, access="write", create=True, exclusive=True
+                ).require() as leaf:
+                    assert filesystem.write(leaf, data).ok
+
+            with filesystem.file(parent, "reviewed.txt", access="mutate").require() as reviewed:
+                (tmp_path / "retained" / "reviewed.txt").rename(
+                    tmp_path / "retained" / "moved-reviewed.txt"
+                )
+                (tmp_path / "retained" / "reserved.txt").rename(
+                    tmp_path / "retained" / "reviewed.txt"
+                )
+
+                assert filesystem.read(reviewed).require() == b"reviewed"
+                refused = filesystem.unlink(reviewed)
+                if refused.ok:
+                    assert not (tmp_path / "retained" / "moved-reviewed.txt").exists()
+                else:
+                    assert refused.error is not None
+                    assert refused.error.code == "IDENTITY_CHANGED"
+
+            assert (tmp_path / "retained" / "reviewed.txt").read_bytes() == b"reserved"
+
+
+@_requires_native_route
+def test_sqlite_identity_publication_waits_for_the_complete_reachable_family(
+    tmp_path: Path,
+) -> None:
     held_fs = _module()
     published: list[dict[str, object]] = []
     with held_fs.acquire(tmp_path).require() as filesystem:
         with filesystem.parent("sqlite", create=True).require() as parent:
             for name in ("state.sqlite", "state.sqlite-wal", "state.sqlite-shm"):
-                assert filesystem.write(parent, name, b"sqlite").ok
+                with filesystem.file(
+                    parent, name, access="write", create=True, exclusive=True
+                ).require() as leaf:
+                    assert filesystem.write(leaf, b"sqlite").ok
             result = held_fs.publish_sqlite_identities(
                 filesystem, parent, "state.sqlite", published.append
             )
 
     assert result.ok
     assert list(published[0]) == ["state.sqlite", "state.sqlite-wal", "state.sqlite-shm"]
+
+
+@pytest.mark.skipif(
+    os.name == "nt" or sys.platform.startswith("linux"),
+    reason="unsupported POSIX route only",
+)
+def test_posix_without_mount_aware_resolution_fails_closed(tmp_path: Path) -> None:
+    held_fs = _module()
+
+    capability = held_fs.probe(tmp_path)
+    assert capability.relative_operations is False
+    assert capability.no_follow is False
+    refused = held_fs.acquire(tmp_path)
+    assert refused.ok is False
+    assert refused.error is not None
+    assert refused.error.code == "CAPABILITY_UNAVAILABLE"

--- a/tests/test_held_fs_posix.py
+++ b/tests/test_held_fs_posix.py
@@ -1,0 +1,82 @@
+"""POSIX no-follow descriptor-relative held-filesystem coverage."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX descriptor primitives")
+
+
+def _held_fs():
+    assert importlib.util.find_spec("exomem.held_fs") is not None, (
+        "the held filesystem primitive must be available"
+    )
+    return importlib.import_module("exomem.held_fs")
+
+
+def test_posix_backend_never_authorizes_descendants_by_pathname_reopen(tmp_path: Path) -> None:
+    held_fs = _held_fs()
+    with held_fs.acquire(tmp_path).require() as filesystem:
+        with filesystem.parent("retained", create=True).require() as parent:
+            assert filesystem.write(parent, "note.txt", b"before").ok
+            moved = tmp_path / "moved"
+            (tmp_path / "retained").rename(moved)
+            (tmp_path / "retained").symlink_to(tmp_path / "outside", target_is_directory=True)
+
+            assert filesystem.write(parent, "note.txt", b"after").ok
+            assert (moved / "note.txt").read_bytes() == b"after"
+            assert not (tmp_path / "outside" / "note.txt").exists()
+
+
+def test_posix_capability_failure_disables_operations_without_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    held_fs = _held_fs()
+    posix = importlib.import_module("exomem._held_fs_posix")
+    monkeypatch.setattr(posix, "_probe", lambda _root: held_fs.Capabilities.disabled("probe failed"))
+
+    capability = held_fs.probe(tmp_path)
+    assert capability.relative_operations is False
+    refused = held_fs.acquire(tmp_path)
+    assert refused.ok is False
+    assert refused.error is not None
+    assert refused.error.code == "CAPABILITY_UNAVAILABLE"
+
+
+def test_posix_source_and_destination_must_be_on_the_same_filesystem(tmp_path: Path) -> None:
+    held_fs = _held_fs()
+    alternate = Path("/dev/shm") / f"exomem-held-fs-{os.getpid()}"
+    try:
+        alternate.mkdir()
+    except OSError:
+        pytest.skip("an alternate writable filesystem is unavailable")
+    try:
+        if tmp_path.stat().st_dev == alternate.stat().st_dev:
+            pytest.skip("the available temporary roots share one filesystem")
+        with held_fs.acquire(tmp_path).require() as source_filesystem:
+            with source_filesystem.parent("source", create=True).require() as source:
+                assert source_filesystem.write(source, "source.txt", b"source").ok
+                with held_fs.acquire(alternate).require() as destination_filesystem:
+                    with destination_filesystem.parent("destination", create=True).require() as destination:
+                        copied = source_filesystem.copy(
+                            source, "source.txt", destination, "copied.txt"
+                        )
+                        assert copied.ok
+                        assert destination_filesystem.read(destination, "copied.txt").require() == b"source"
+                        moved = source_filesystem.rename(
+                            source, "source.txt", destination, "moved.txt"
+                        )
+                        assert moved.ok is False
+                        assert moved.error is not None
+                        assert moved.error.code == "CROSS_DEVICE"
+                        assert source_filesystem.read(source, "source.txt").require() == b"source"
+    finally:
+        try:
+            alternate.rmdir()
+        except OSError:
+            pass

--- a/tests/test_held_fs_posix.py
+++ b/tests/test_held_fs_posix.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import importlib
 import importlib.util
 import os
+import sys
 from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX descriptor primitives")
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux openat2 mount confinement",
+)
 
 
 def _held_fs():
@@ -23,12 +27,16 @@ def test_posix_backend_never_authorizes_descendants_by_pathname_reopen(tmp_path:
     held_fs = _held_fs()
     with held_fs.acquire(tmp_path).require() as filesystem:
         with filesystem.parent("retained", create=True).require() as parent:
-            assert filesystem.write(parent, "note.txt", b"before").ok
+            with filesystem.file(
+                parent, "note.txt", access="write", create=True, exclusive=True
+            ).require() as note:
+                assert filesystem.write(note, b"before").ok
             moved = tmp_path / "moved"
             (tmp_path / "retained").rename(moved)
             (tmp_path / "retained").symlink_to(tmp_path / "outside", target_is_directory=True)
 
-            assert filesystem.write(parent, "note.txt", b"after").ok
+            with filesystem.file(parent, "note.txt", access="write").require() as note:
+                assert filesystem.write(note, b"after").ok
             assert (moved / "note.txt").read_bytes() == b"after"
             assert not (tmp_path / "outside" / "note.txt").exists()
 
@@ -38,7 +46,9 @@ def test_posix_capability_failure_disables_operations_without_fallback(
 ) -> None:
     held_fs = _held_fs()
     posix = importlib.import_module("exomem._held_fs_posix")
-    monkeypatch.setattr(posix, "_probe", lambda _root: held_fs.Capabilities.disabled("probe failed"))
+    monkeypatch.setattr(
+        posix, "_probe", lambda _root: held_fs.Capabilities.disabled("probe failed")
+    )
 
     capability = held_fs.probe(tmp_path)
     assert capability.relative_operations is False
@@ -60,23 +70,41 @@ def test_posix_source_and_destination_must_be_on_the_same_filesystem(tmp_path: P
             pytest.skip("the available temporary roots share one filesystem")
         with held_fs.acquire(tmp_path).require() as source_filesystem:
             with source_filesystem.parent("source", create=True).require() as source:
-                assert source_filesystem.write(source, "source.txt", b"source").ok
+                with source_filesystem.file(
+                    source, "source.txt", access="write", create=True, exclusive=True
+                ).require() as created:
+                    assert source_filesystem.write(created, b"source").ok
                 with held_fs.acquire(alternate).require() as destination_filesystem:
-                    with destination_filesystem.parent("destination", create=True).require() as destination:
-                        copied = source_filesystem.copy(
-                            source, "source.txt", destination, "copied.txt"
-                        )
-                        assert copied.ok
-                        assert destination_filesystem.read(destination, "copied.txt").require() == b"source"
-                        moved = source_filesystem.rename(
-                            source, "source.txt", destination, "moved.txt"
-                        )
-                        assert moved.ok is False
-                        assert moved.error is not None
-                        assert moved.error.code == "CROSS_DEVICE"
-                        assert source_filesystem.read(source, "source.txt").require() == b"source"
+                    with destination_filesystem.parent(
+                        "destination", create=True
+                    ).require() as destination:
+                        with source_filesystem.file(
+                            source, "source.txt", access="mutate"
+                        ).require() as source_file:
+                            copied = source_filesystem.copy(source_file, destination, "copied.txt")
+                            assert copied.ok
+                            moved = source_filesystem.rename(source_file, destination, "moved.txt")
+                            assert moved.ok is False
+                            assert moved.error is not None
+                            assert moved.error.code == "CROSS_DEVICE"
+                            assert source_filesystem.read(source_file).require() == b"source"
+                        with destination_filesystem.file(
+                            destination, "copied.txt"
+                        ).require() as copied_file:
+                            assert destination_filesystem.read(copied_file).require() == b"source"
     finally:
         try:
             alternate.rmdir()
         except OSError:
             pass
+
+
+def test_linux_parent_opens_require_no_cross_mount_resolution() -> None:
+    posix = importlib.import_module("exomem._held_fs_posix")
+    if not sys.platform.startswith("linux"):
+        pytest.skip("openat2 mount confinement is Linux-specific")
+
+    assert posix._OPENAT2_RESOLVE & posix.RESOLVE_BENEATH
+    assert posix._OPENAT2_RESOLVE & posix.RESOLVE_NO_SYMLINKS
+    assert posix._OPENAT2_RESOLVE & posix.RESOLVE_NO_MAGICLINKS
+    assert posix._OPENAT2_RESOLVE & posix.RESOLVE_NO_XDEV

--- a/tests/test_held_fs_windows.py
+++ b/tests/test_held_fs_windows.py
@@ -1,0 +1,150 @@
+"""Native Windows held-handle fixtures; executed by the NTFS CI gate."""
+
+from __future__ import annotations
+
+import ctypes
+import importlib
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="requires native Windows NTFS")
+
+
+def _held_fs():
+    return importlib.import_module("exomem.held_fs")
+
+
+def _short_path(path: Path) -> Path:
+    get_short = ctypes.windll.kernel32.GetShortPathNameW
+    result = ctypes.create_unicode_buffer(32768)
+    assert get_short(str(path), result, len(result)) > 0
+    assert result.value.casefold() != str(path).casefold()
+    return Path(result.value)
+
+
+def test_windows_probe_and_relative_leaf_round_trip(tmp_path: Path) -> None:
+    held_fs = _held_fs()
+    capability = held_fs.probe(tmp_path)
+    assert capability.relative_operations is True
+    assert capability.no_follow is True
+    assert capability.stable_identity is True
+
+    with held_fs.acquire(tmp_path).require() as filesystem:
+        with filesystem.parent("parent", create=True).require() as parent:
+            assert filesystem.write(parent, "one.txt", b"one").ok
+            assert filesystem.read(parent, "one.txt").require() == b"one"
+            assert filesystem.rename(parent, "one.txt", parent, "two.txt").ok
+            assert filesystem.link(parent, "two.txt", parent, "three.txt").ok
+            assert filesystem.unlink(parent, "three.txt").ok
+
+
+def test_windows_backend_declares_native_relative_ffi_contract() -> None:
+    backend = importlib.import_module("exomem._held_fs_windows")
+    assert backend.NtCreateFile is not None
+    assert backend.NtSetInformationFile is not None
+    assert backend.SetFileInformationByHandle is not None
+    assert backend.FILE_OPEN_REPARSE_POINT
+
+
+def test_windows_native_open_uses_a_root_handle_one_component_and_reparse_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    held_fs = _held_fs()
+    backend = importlib.import_module("exomem._held_fs_windows")
+    original = backend.NtCreateFile
+    calls: list[tuple[int, str, int]] = []
+
+    def observed(*args):
+        attributes = ctypes.cast(
+            args[2], ctypes.POINTER(backend.OBJECT_ATTRIBUTES)
+        ).contents
+        calls.append(
+            (int(attributes.RootDirectory), attributes.ObjectName.contents.Buffer, int(args[8]))
+        )
+        return original(*args)
+
+    monkeypatch.setattr(backend, "NtCreateFile", observed)
+    with held_fs.acquire(tmp_path).require() as filesystem:
+        with filesystem.parent("native", create=True).require() as parent:
+            assert filesystem.write(parent, "leaf.txt", b"native").ok
+
+    leaf_calls = [call for call in calls if call[1] == "leaf.txt"]
+    assert leaf_calls
+    assert all(root and "/" not in name and "\\" not in name for root, name, _ in leaf_calls)
+    assert all(options & backend.FILE_OPEN_REPARSE_POINT for _, _, options in leaf_calls)
+
+
+def test_windows_reparse_points_and_short_aliases_refuse(tmp_path: Path) -> None:
+    held_fs = _held_fs()
+    root = tmp_path / "Held Filesystem Eight Dot Three"
+    root.mkdir()
+    target = root / "target"
+    target.mkdir()
+    junction = root / "junction"
+    subprocess.run(["cmd", "/c", "mklink", "/J", str(junction), str(target)], check=True)
+    final = root / "final-link.txt"
+    os.symlink(target / "outside.txt", final)
+    short_root = _short_path(root)
+
+    with held_fs.acquire(short_root).require() as filesystem:
+        assert filesystem.parent("junction").error is not None
+        with filesystem.parent(".").require() as parent:
+            refused = filesystem.read(parent, "final-link.txt")
+            assert refused.error is not None
+            assert refused.error.code == "UNSAFE_PATH"
+
+
+def test_windows_parent_swap_race_cannot_redirect_a_retained_parent(tmp_path: Path) -> None:
+    held_fs = _held_fs()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    go = threading.Event()
+    finished = threading.Event()
+    outcome: list[OSError | None] = []
+
+    with held_fs.acquire(tmp_path).require() as filesystem:
+        with filesystem.parent("retained", create=True).require() as parent:
+            assert filesystem.write(parent, "note.txt", b"before").ok
+
+            def swap() -> None:
+                go.wait()
+                try:
+                    (tmp_path / "retained").rename(tmp_path / "moved")
+                    os.symlink(outside, tmp_path / "retained", target_is_directory=True)
+                    outcome.append(None)
+                except OSError as error:  # Windows sharing may stop the swap.
+                    outcome.append(error)
+                finally:
+                    finished.set()
+
+            worker = threading.Thread(target=swap)
+            worker.start()
+            go.set()
+            assert finished.wait(5)
+            result = filesystem.write(parent, "note.txt", b"after")
+            worker.join()
+
+    assert result.ok or (
+        result.error is not None and result.error.code in {"IO_REFUSED", "UNSAFE_PATH"}
+    )
+    assert not (outside / "note.txt").exists()
+    if outcome == [None] and result.ok:
+        assert (tmp_path / "moved" / "note.txt").read_bytes() == b"after"
+    assert outcome
+
+
+def test_windows_probe_failure_disables_acquisition_without_a_path_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    held_fs = _held_fs()
+    backend = importlib.import_module("exomem._held_fs_windows")
+    monkeypatch.setattr(backend, "_probe", lambda _root: held_fs.Capabilities.disabled("fixture"))
+
+    refused = held_fs.acquire(tmp_path)
+    assert refused.error is not None
+    assert refused.error.code == "CAPABILITY_UNAVAILABLE"

--- a/tests/test_held_fs_windows.py
+++ b/tests/test_held_fs_windows.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import ctypes
+import errno
+import gc
 import importlib
 import os
+import shutil
+import sqlite3
 import subprocess
 import sys
 import threading
+import uuid
 from pathlib import Path
 
 import pytest
@@ -27,6 +32,31 @@ def _short_path(path: Path) -> Path:
     return Path(result.value)
 
 
+def _alternate_volume_directory(tmp_path: Path) -> Path:
+    candidates: list[Path] = []
+    for variable in ("USERPROFILE", "RUNNER_TEMP", "TEMP"):
+        value = os.environ.get(variable)
+        if value:
+            candidates.append(Path(value))
+    candidates.extend(Path(f"{letter}:\\") for letter in "CDEFGHIJKLMNOPQRSTUVWXYZ")
+
+    failures: list[str] = []
+    for candidate in candidates:
+        if candidate.drive.casefold() == tmp_path.drive.casefold():
+            continue
+        directory = candidate / f"exomem-held-fs-{uuid.uuid4().hex}"
+        try:
+            directory.mkdir(parents=False)
+        except OSError as error:
+            failures.append(f"{candidate.drive or candidate}: {error.winerror or error.errno}")
+            continue
+        return directory
+    raise AssertionError(
+        "native cross-volume coverage requires a second writable Windows volume; "
+        + ", ".join(failures)
+    )
+
+
 def test_windows_probe_and_relative_leaf_round_trip(tmp_path: Path) -> None:
     held_fs = _held_fs()
     capability = held_fs.probe(tmp_path)
@@ -36,19 +66,26 @@ def test_windows_probe_and_relative_leaf_round_trip(tmp_path: Path) -> None:
 
     with held_fs.acquire(tmp_path).require() as filesystem:
         with filesystem.parent("parent", create=True).require() as parent:
-            assert filesystem.write(parent, "one.txt", b"one").ok
-            assert filesystem.read(parent, "one.txt").require() == b"one"
-            assert filesystem.rename(parent, "one.txt", parent, "two.txt").ok
-            assert filesystem.link(parent, "two.txt", parent, "three.txt").ok
-            assert filesystem.unlink(parent, "three.txt").ok
+            with filesystem.file(
+                parent, "one.txt", access="write", create=True, exclusive=True
+            ).require() as one:
+                assert filesystem.write(one, b"one").ok
+            with filesystem.file(parent, "one.txt", access="mutate").require() as one:
+                assert filesystem.read(one).require() == b"one"
+                assert filesystem.rename(one, parent, "two.txt").ok
+            with filesystem.file(parent, "two.txt", access="mutate").require() as two:
+                assert filesystem.link(two, parent, "three.txt").ok
+            with filesystem.file(parent, "three.txt", access="mutate").require() as three:
+                assert filesystem.unlink(three).ok
 
 
 def test_windows_backend_declares_native_relative_ffi_contract() -> None:
     backend = importlib.import_module("exomem._held_fs_windows")
     assert backend.NtCreateFile is not None
     assert backend.NtSetInformationFile is not None
-    assert backend.SetFileInformationByHandle is not None
     assert backend.FILE_OPEN_REPARSE_POINT
+    assert backend.FILE_RENAME_INFORMATION == 10
+    assert backend.FILE_DISPOSITION_INFORMATION == 4
 
 
 def test_windows_native_open_uses_a_root_handle_one_component_and_reparse_flag(
@@ -60,9 +97,7 @@ def test_windows_native_open_uses_a_root_handle_one_component_and_reparse_flag(
     calls: list[tuple[int, str, int]] = []
 
     def observed(*args):
-        attributes = ctypes.cast(
-            args[2], ctypes.POINTER(backend.OBJECT_ATTRIBUTES)
-        ).contents
+        attributes = ctypes.cast(args[2], ctypes.POINTER(backend.OBJECT_ATTRIBUTES)).contents
         calls.append(
             (int(attributes.RootDirectory), attributes.ObjectName.contents.Buffer, int(args[8]))
         )
@@ -71,12 +106,40 @@ def test_windows_native_open_uses_a_root_handle_one_component_and_reparse_flag(
     monkeypatch.setattr(backend, "NtCreateFile", observed)
     with held_fs.acquire(tmp_path).require() as filesystem:
         with filesystem.parent("native", create=True).require() as parent:
-            assert filesystem.write(parent, "leaf.txt", b"native").ok
+            with filesystem.file(
+                parent, "leaf.txt", access="write", create=True, exclusive=True
+            ).require() as leaf:
+                assert filesystem.write(leaf, b"native").ok
 
     leaf_calls = [call for call in calls if call[1] == "leaf.txt"]
     assert leaf_calls
     assert all(root and "/" not in name and "\\" not in name for root, name, _ in leaf_calls)
     assert all(options & backend.FILE_OPEN_REPARSE_POINT for _, _, options in leaf_calls)
+
+
+def test_windows_rename_uses_native_relative_information_class(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    held_fs = _held_fs()
+    backend = importlib.import_module("exomem._held_fs_windows")
+    with held_fs.acquire(tmp_path).require() as filesystem:
+        original = backend.NtSetInformationFile
+        information_classes: list[int] = []
+
+        def observed(*args):
+            information_classes.append(int(args[4]))
+            return original(*args)
+
+        monkeypatch.setattr(backend, "NtSetInformationFile", observed)
+        with filesystem.parent("native-rename", create=True).require() as parent:
+            with filesystem.file(
+                parent, "before.txt", access="write", create=True, exclusive=True
+            ).require() as before:
+                assert filesystem.write(before, b"rename").ok
+            with filesystem.file(parent, "before.txt", access="mutate").require() as before:
+                assert filesystem.rename(before, parent, "after.txt").ok
+
+    assert backend.FILE_RENAME_INFORMATION in information_classes
 
 
 def test_windows_reparse_points_and_short_aliases_refuse(tmp_path: Path) -> None:
@@ -94,9 +157,25 @@ def test_windows_reparse_points_and_short_aliases_refuse(tmp_path: Path) -> None
     with held_fs.acquire(short_root).require() as filesystem:
         assert filesystem.parent("junction").error is not None
         with filesystem.parent(".").require() as parent:
-            refused = filesystem.read(parent, "final-link.txt")
+            refused = filesystem.file(parent, "final-link.txt")
             assert refused.error is not None
             assert refused.error.code == "UNSAFE_PATH"
+
+
+def test_windows_descendant_short_alias_retains_file_identity(tmp_path: Path) -> None:
+    held_fs = _held_fs()
+    root = tmp_path / "Held Filesystem Descendant Alias"
+    root.mkdir()
+    long_leaf = root / "A Descendant With A Long Name.txt"
+    long_leaf.write_bytes(b"alias")
+    short_leaf = _short_path(long_leaf).name
+    assert short_leaf.casefold() != long_leaf.name.casefold()
+
+    with held_fs.acquire(root).require() as filesystem:
+        with filesystem.parent(".").require() as parent:
+            with filesystem.file(parent, long_leaf.name).require() as long_file:
+                with filesystem.file(parent, short_leaf).require() as short_file:
+                    assert short_file.identity == long_file.identity
 
 
 def test_windows_parent_swap_race_cannot_redirect_a_retained_parent(tmp_path: Path) -> None:
@@ -109,7 +188,10 @@ def test_windows_parent_swap_race_cannot_redirect_a_retained_parent(tmp_path: Pa
 
     with held_fs.acquire(tmp_path).require() as filesystem:
         with filesystem.parent("retained", create=True).require() as parent:
-            assert filesystem.write(parent, "note.txt", b"before").ok
+            with filesystem.file(
+                parent, "note.txt", access="write", create=True, exclusive=True
+            ).require() as note:
+                assert filesystem.write(note, b"before").ok
 
             def swap() -> None:
                 go.wait()
@@ -126,7 +208,8 @@ def test_windows_parent_swap_race_cannot_redirect_a_retained_parent(tmp_path: Pa
             worker.start()
             go.set()
             assert finished.wait(5)
-            result = filesystem.write(parent, "note.txt", b"after")
+            with filesystem.file(parent, "note.txt", access="write").require() as note:
+                result = filesystem.write(note, b"after")
             worker.join()
 
     assert result.ok or (
@@ -148,3 +231,165 @@ def test_windows_probe_failure_disables_acquisition_without_a_path_fallback(
     refused = held_fs.acquire(tmp_path)
     assert refused.error is not None
     assert refused.error.code == "CAPABILITY_UNAVAILABLE"
+
+
+def test_windows_copy_failure_removes_verified_temporary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    held_fs = _held_fs()
+    backend = importlib.import_module("exomem._held_fs_windows")
+    with held_fs.acquire(tmp_path).require() as filesystem:
+        with filesystem.parent("copy", create=True).require() as parent:
+            with filesystem.file(
+                parent, "source.txt", access="write", create=True, exclusive=True
+            ).require() as source:
+                assert filesystem.write(source, b"source").ok
+
+            original = backend._set_name_information
+
+            def refuse_copy(descriptor, destination_handle, leaf, information_class):
+                if leaf == "destination.txt":
+                    raise OSError("forced rename refusal")
+                return original(descriptor, destination_handle, leaf, information_class)
+
+            monkeypatch.setattr(backend, "_set_name_information", refuse_copy)
+            with filesystem.file(parent, "source.txt").require() as source:
+                refused = filesystem.copy(source, parent, "destination.txt")
+            assert refused.error is not None
+
+    assert not (tmp_path / "copy" / "destination.txt").exists()
+    assert list((tmp_path / "copy").glob(".exomem-held-*")) == []
+
+
+def test_windows_copy_write_failure_removes_early_verified_temporary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    held_fs = _held_fs()
+    backend = importlib.import_module("exomem._held_fs_windows")
+    with held_fs.acquire(tmp_path).require() as filesystem:
+        with filesystem.parent("copy-write-failure", create=True).require() as parent:
+            with filesystem.file(
+                parent, "source.txt", access="write", create=True, exclusive=True
+            ).require() as source:
+                assert filesystem.write(source, b"source").ok
+
+            def refuse_write(_descriptor, _data):
+                raise OSError(errno.ENOSPC, "forced write refusal")
+
+            monkeypatch.setattr(backend.os, "write", refuse_write)
+            with filesystem.file(parent, "source.txt").require() as source:
+                refused = filesystem.copy(source, parent, "destination.txt")
+            assert refused.error is not None
+
+    assert not (tmp_path / "copy-write-failure" / "destination.txt").exists()
+    assert list((tmp_path / "copy-write-failure").glob(".exomem-held-*")) == []
+
+
+def test_windows_copy_crosses_volumes_but_rename_refuses(tmp_path: Path) -> None:
+    held_fs = _held_fs()
+    alternate = _alternate_volume_directory(tmp_path)
+    try:
+        with held_fs.acquire(tmp_path).require() as source_filesystem:
+            with source_filesystem.parent("cross-volume", create=True).require() as source_parent:
+                with source_filesystem.file(
+                    source_parent,
+                    "source.txt",
+                    access="write",
+                    create=True,
+                    exclusive=True,
+                ).require() as source:
+                    assert source_filesystem.write(source, b"source").ok
+
+                with held_fs.acquire(alternate).require() as destination_filesystem:
+                    with destination_filesystem.parent(
+                        "destination", create=True
+                    ).require() as destination_parent:
+                        with source_filesystem.file(
+                            source_parent, "source.txt", access="mutate"
+                        ).require() as source:
+                            copied = source_filesystem.copy(
+                                source, destination_parent, "copied.txt"
+                            )
+                            assert copied.ok
+                            moved = source_filesystem.rename(
+                                source, destination_parent, "moved.txt"
+                            )
+                            assert moved.ok is False
+                            assert moved.error is not None
+                            assert moved.error.code == "CROSS_DEVICE"
+                            assert source_filesystem.read(source).require() == b"source"
+                        with destination_filesystem.file(
+                            destination_parent, "copied.txt"
+                        ).require() as copied_file:
+                            assert destination_filesystem.read(copied_file).require() == b"source"
+    finally:
+        shutil.rmtree(alternate, ignore_errors=True)
+
+
+def test_windows_recursive_enumeration_closes_every_child_handle(tmp_path: Path) -> None:
+    get_handle_count = ctypes.windll.kernel32.GetProcessHandleCount
+    get_handle_count.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_ulong)]
+    get_handle_count.restype = ctypes.c_int
+    get_current_process = ctypes.windll.kernel32.GetCurrentProcess
+    get_current_process.restype = ctypes.c_void_p
+
+    tree = tmp_path / "tree"
+    for index in range(12):
+        child = tree / f"level-{index}" / "nested"
+        child.mkdir(parents=True)
+        (child / "leaf.txt").write_text("held", encoding="utf-8")
+
+    def handle_count() -> int:
+        value = ctypes.c_ulong()
+        assert get_handle_count(get_current_process(), ctypes.byref(value))
+        return int(value.value)
+
+    held_fs = _held_fs()
+    gc.collect()
+    before = handle_count()
+    with held_fs.acquire(tmp_path).require() as filesystem:
+        with filesystem.parent("tree").require() as parent:
+            for _ in range(10):
+                assert len(filesystem.enumerate(parent).require()) == 36
+    gc.collect()
+    assert handle_count() <= before + 2
+
+
+def test_windows_live_wal_identity_publication_uses_compatible_share_modes(
+    tmp_path: Path,
+) -> None:
+    held_fs = _held_fs()
+    database = tmp_path / "state.sqlite"
+    connection = sqlite3.connect(database)
+    try:
+        assert connection.execute("PRAGMA journal_mode=WAL").fetchone() == ("wal",)
+        connection.execute("CREATE TABLE records (value TEXT)")
+        connection.execute("INSERT INTO records VALUES ('held')")
+        connection.commit()
+        connection.execute("BEGIN")
+        connection.execute("SELECT * FROM records").fetchall()
+
+        published: list[dict[str, object]] = []
+        with held_fs.acquire(tmp_path).require() as filesystem:
+            with filesystem.parent(".").require() as parent:
+                result = held_fs.publish_sqlite_identities(
+                    filesystem, parent, "state.sqlite", published.append
+                )
+        assert result.ok
+        assert set(published[0]) == {"state.sqlite", "state.sqlite-wal", "state.sqlite-shm"}
+    finally:
+        connection.close()
+
+
+def test_windows_native_information_buffers_use_abi_offsets() -> None:
+    backend = importlib.import_module("exomem._held_fs_windows")
+    assert backend.FILE_NAME_INFORMATION.FileName.offset > backend.ctypes.sizeof(
+        backend.ctypes.c_void_p
+    )
+    assert backend.FILE_NAME_INFORMATION.FileNameLength.offset < (
+        backend.FILE_NAME_INFORMATION.FileName.offset
+    )
+    assert backend.FILE_DISPOSITION_INFO.DeleteFile.size == 1
+    assert len(backend._name_payload(False, 1, "x")) >= backend.ctypes.sizeof(
+        backend.FILE_NAME_INFORMATION
+    )


### PR DESCRIPTION
## Why

Governed consolidation needs one trustworthy filesystem boundary before reserved administration paths can be enforced. Pathname rechecks are not enough against symlink, reparse, alias, and final-component races.

## What

- adds a closed held-file and held-directory API for no-follow traversal and stable identity
- uses Linux openat2 confinement and native Windows RootDirectory-relative NtCreateFile and NtSetInformationFile operations
- makes copies destination-atomic while refusing cross-device rename, and records ordered recursive saga identities
- publishes complete SQLite primary/WAL/SHM identities under caller-held coordination
- fails closed when the required native route is unavailable
- adds a required real Windows/NTFS job covering junctions, 8.3 aliases, native mutations, live WAL handles, cleanup, and two-volume behavior

## Verification

- Python 3.11 focused and adjacent: 36 passed, 18 platform skips
- Python 3.13 focused: 22 passed, 15 platform skips
- touched-file Ruff: passed
- OpenSpec strict validation: passed
- public artifact privacy gate: 2983 files and 3029 text payloads clean
- independent security review: GO, no remaining source-level findings

The PR must remain blocked until the native Windows job and aggregate required CI gate pass. This does not touch or consolidate any live vault.