### PR TITLE
perf(recall): stop loading the whole candidate set to rank ten results

### DIFF
--- a/src/exomem/find_candidates.py
+++ b/src/exomem/find_candidates.py
@@ -732,6 +732,13 @@ def collect_candidates(
             page_of=page_of,
             usage_map=usage_map,
             evidence_out=multiplier_chain_by_path,
+            # Bound the pass at the depth this system already says it needs.
+            # `candidate_k` is at least `limit * 5` and at least the 50-entry
+            # floor, while the consumer in `_find_semantic` stops building hits
+            # at `limit * 3` — so the exact prefix always covers what is read,
+            # with headroom for the candidates that loop skips. Without this the
+            # pass loads every fused page from disk purely to rank them (#283).
+            top_n=candidate_k,
         )
         adjusted_score_by_path = dict(fused) if capture_trace else {}
 

--- a/src/exomem/find_policy.py
+++ b/src/exomem/find_policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import heapq
 import math
 import re
 from collections.abc import Callable
@@ -103,6 +104,42 @@ def apply_status_demotion(
     return adjusted
 
 
+def multiplier_bounds(
+    config: RankingConfig,
+    *,
+    prefer_compiled: bool,
+    prefer_active: bool,
+    temporal_active: bool,
+    usage_active: bool,
+) -> tuple[float, float]:
+    """(min, max) of the product of every ACTIVE post-RRF multiplier.
+
+    Each factor is bounded by a declared config value, which is what makes the
+    bounded pass below exact rather than approximate:
+
+    * ``type_multiplier``   -> ``compiled_boost`` high, ``source_penalty`` low
+    * ``status_multiplier`` -> 1.0 high, ``superseded_penalty`` low (penalty only)
+    * ``recency_multiplier``-> ``temporal_boost`` at zero days, 1.0 at infinity
+    * ``usage_multiplier``  -> ``usage_boost`` high, 1.0 low (never a penalty)
+
+    An inactive factor contributes exactly 1.0 to both ends.
+    """
+    low = high = 1.0
+    if prefer_compiled:
+        low *= min(config.compiled_boost, config.source_penalty, 1.0)
+        high *= max(config.compiled_boost, config.source_penalty, 1.0)
+    if prefer_active:
+        low *= min(config.superseded_penalty, 1.0)
+        high *= max(config.superseded_penalty, 1.0)
+    if temporal_active:
+        low *= min(config.temporal_boost, 1.0)
+        high *= max(config.temporal_boost, 1.0)
+    if usage_active:
+        low *= min(config.usage_boost, 1.0)
+        high *= max(config.usage_boost, 1.0)
+    return low, high
+
+
 def apply_post_rrf_multipliers(
     fused: list[tuple[str, float]],
     query: str,
@@ -114,8 +151,27 @@ def apply_post_rrf_multipliers(
     page_of: PageOf,
     usage_map: dict[str, float] | None = None,
     evidence_out: dict[str, list[dict[str, float | str]]] | None = None,
+    top_n: int | None = None,
 ) -> list[tuple[str, float]]:
-    """All post-RRF multiplicative boosts in one pass with one final sort."""
+    """All post-RRF multiplicative boosts in one pass with one final sort.
+
+    Every factor needs the candidate's page, and `page_of` on a cold page is a
+    file read plus a policy admission check — so an unbounded pass loads the
+    whole fused set to rank it. On a 2.4k-page vault that measured ~500 pages
+    loaded to return 10 results, and was the single largest read-path term
+    (#283).
+
+    `top_n` bounds that work WITHOUT changing the answer. Candidates arrive in
+    descending RRF order, so once `top_n` results are in hand, a candidate whose
+    best possible adjusted score cannot reach the current `top_n`-th score can
+    be skipped — and so can every candidate after it, because their raw scores
+    are no lower. `multiplier_bounds` supplies "best possible" exactly.
+
+    The first `top_n` entries of the result are therefore byte-identical to an
+    unbounded pass. Entries beyond `top_n` keep raw RRF order and raw scores,
+    since by construction nothing there can enter the top. Pass `top_n=None`
+    (the default) for the full pass — every existing caller keeps its behaviour.
+    """
     temporal_active = temporal and config.temporal_boost != 1.0 and is_temporal_query(query)
     usage_active = bool(usage_map)
     if not (prefer_compiled or prefer_active or temporal_active or usage_active):
@@ -123,8 +179,33 @@ def apply_post_rrf_multipliers(
     if usage_active:
         from . import usage as usage_module
     today = date.today() if temporal_active else None
+    # Evidence must describe every candidate a trace will show, so an explain
+    # request takes the full pass. Bounding it would leave the tail with no
+    # multiplier chain and make the trace lie by omission.
+    bounded = top_n is not None and top_n > 0 and evidence_out is None
+    low_mult = high_mult = 1.0
+    if bounded:
+        low_mult, high_mult = multiplier_bounds(
+            config,
+            prefer_compiled=prefer_compiled,
+            prefer_active=prefer_active,
+            temporal_active=temporal_active,
+            usage_active=usage_active,
+        )
+    cutoff: list[float] = []  # min-heap of the best `top_n` adjusted scores
     adjusted: list[tuple[str, float]] = []
-    for path, score in fused:
+    for index, (path, score) in enumerate(fused):
+        if bounded and len(cutoff) >= top_n:
+            # Upper bound of `score * m` over m in [low, high]. Written as a max
+            # of both products rather than `score * high` so a negative raw
+            # score (a negative lane weight would produce one) bounds correctly
+            # instead of inverting.
+            reachable = max(score * low_mult, score * high_mult)
+            # Strict `<` only: on equality the loser could still win the
+            # `(-score, path)` tie-break, so an equal candidate must be scored.
+            if reachable < cutoff[0]:
+                adjusted.sort(key=lambda t: (-t[1], t[0]))
+                return adjusted + list(fused[index:])
         page = page_of(path)
         chain: list[dict[str, float | str]] | None = (
             [] if evidence_out is not None else None
@@ -205,6 +286,15 @@ def apply_post_rrf_multipliers(
             assert chain is not None
             evidence_out[path] = chain
         adjusted.append((path, score))
+        if bounded:
+            # `cutoff[0]` is the weakest of the best `top_n` adjusted scores
+            # seen so far. It only ever rises, which is what makes the early
+            # return above safe for every remaining candidate rather than only
+            # the next one.
+            if len(cutoff) < top_n:
+                heapq.heappush(cutoff, score)
+            elif score > cutoff[0]:
+                heapq.heapreplace(cutoff, score)
     adjusted.sort(key=lambda t: (-t[1], t[0]))
     return adjusted
 

--- a/tests/test_bounded_multiplier_pass.py
+++ b/tests/test_bounded_multiplier_pass.py
@@ -1,0 +1,266 @@
+"""The bounded post-RRF pass must be an optimisation, never a ranking change.
+
+`apply_post_rrf_multipliers` loads every fused candidate's page to score it, and
+`page_of` on a cold page is a file read plus a policy admission check. On a
+2.4k-page vault that measured ~500 pages loaded to return 10 results — the
+largest single read-path term in #283.
+
+The fix skips candidates that provably cannot reach the top `top_n`, using the
+config-declared ceiling on every multiplier. "Provably" is the whole claim, so
+these tests compare the bounded pass against the unbounded one over randomised
+inputs rather than a hand-picked case, and check the exact tuples — score and
+tie-break order — not just the path set.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import replace
+
+from exomem import find_policy
+from exomem.ranking_config import DEFAULT_RANKING
+
+COMPILED = "insight"  # gets compiled_boost
+SOURCE = "source"  # gets source_penalty
+
+
+class _Page:
+    """Minimal stand-in for ParsedPage: only the multiplier inputs matter."""
+
+    def __init__(self, page_type: str | None, status: str | None, updated: str | None):
+        self.page_type = page_type
+        self.status = status
+        self.updated = updated
+        self.media_type = None
+
+
+def _corpus(rng: random.Random, size: int) -> tuple[list[tuple[str, float]], dict[str, _Page]]:
+    """A descending-score fused list plus pages spanning every multiplier branch."""
+    pages: dict[str, _Page] = {}
+    for i in range(size):
+        path = f"Knowledge Base/Notes/page-{i:04d}.md"
+        pages[path] = _Page(
+            rng.choice([COMPILED, SOURCE, "note", None]),
+            rng.choice(["active", "superseded", None]),
+            rng.choice(["2026-08-20", "2020-01-01", None]),
+        )
+    scores = sorted((rng.random() * 10.0 for _ in range(size)), reverse=True)
+    fused = list(zip(sorted(pages), scores, strict=True))
+    fused.sort(key=lambda t: -t[1])
+    return fused, pages
+
+
+def _both_passes(
+    fused,
+    pages,
+    *,
+    top_n,
+    query="topic",
+    usage_map=None,
+    config=None,
+    prefer_compiled=True,
+    prefer_active=True,
+):
+    cfg = config or DEFAULT_RANKING
+    loaded: list[str] = []
+
+    def counting_page_of(path: str):
+        loaded.append(path)
+        return pages.get(path)
+
+    kwargs = dict(
+        prefer_compiled=prefer_compiled,
+        prefer_active=prefer_active,
+        temporal=True,
+        usage_map=usage_map,
+    )
+    full = find_policy.apply_post_rrf_multipliers(
+        list(fused), query, cfg, page_of=pages.get, **kwargs
+    )
+    bounded = find_policy.apply_post_rrf_multipliers(
+        list(fused), query, cfg, page_of=counting_page_of, top_n=top_n, **kwargs
+    )
+    return full, bounded, loaded
+
+
+def test_the_bounded_prefix_is_identical_over_many_random_corpora() -> None:
+    rng = random.Random(20260821)
+    for trial in range(40):
+        size = rng.choice([60, 200, 600])
+        top_n = rng.choice([10, 30, 50])
+        fused, pages = _corpus(rng, size)
+
+        full, bounded, _ = _both_passes(fused, pages, top_n=top_n)
+
+        # Exact tuples, not just paths: a wrong tie-break or a dropped
+        # multiplier would keep the path set and still be a ranking change.
+        assert bounded[:top_n] == full[:top_n], f"trial {trial} size={size} top_n={top_n}"
+
+
+def test_the_bounded_pass_returns_every_candidate() -> None:
+    """The tail is deprioritised, never dropped — callers may still walk past top_n."""
+    rng = random.Random(7)
+    fused, pages = _corpus(rng, 300)
+
+    full, bounded, _ = _both_passes(fused, pages, top_n=25)
+
+    assert len(bounded) == len(fused)
+    assert {p for p, _ in bounded} == {p for p, _ in full}
+
+
+def test_the_bounded_pass_actually_stops_early() -> None:
+    """A guard that never fires is not an optimisation."""
+    rng = random.Random(11)
+    fused, pages = _corpus(rng, 600)
+
+    _full, _bounded, loaded = _both_passes(fused, pages, top_n=50)
+
+    assert len(loaded) < 200, f"loaded {len(loaded)} of {len(fused)}"
+
+
+def test_a_superseded_tail_candidate_cannot_be_promoted_past_the_cutoff() -> None:
+    """The bound must hold in the direction that could hide a real winner.
+
+    Multipliers here are penalties as well as boosts, so the cutoff has to be
+    driven by the maximum reachable score. Give the tail the most favourable
+    page in the corpus and prove it still lands where a full pass puts it.
+    """
+    pages = {f"Knowledge Base/Notes/page-{i:03d}.md": _Page("note", None, None) for i in range(200)}
+    boosted = "Knowledge Base/Notes/page-199.md"
+    pages[boosted] = _Page(COMPILED, "active", "2026-08-20")
+    fused = [(f"Knowledge Base/Notes/page-{i:03d}.md", 100.0 - i) for i in range(200)]
+
+    full, bounded, _ = _both_passes(fused, pages, top_n=20)
+
+    assert bounded[:20] == full[:20]
+
+
+def test_a_tie_at_the_cutoff_is_scored_rather_than_skipped() -> None:
+    """The cutoff comparison must be strict `<`, not `<=`.
+
+    Random float corpora never tie, so they cannot catch this: with `<=`, a
+    candidate whose best reachable score EQUALS the current cutoff is skipped —
+    but an equal score is decided by the `(-score, path)` tie-break, which it
+    may well win. Here every page is neutral, so adjusted == raw and every
+    candidate ties; the full pass then orders purely by path. Input order is
+    deliberately the reverse of path order, so skipping on equality returns the
+    wrong set entirely.
+
+    `prefer_compiled` is off deliberately. With it on, the ceiling is
+    `compiled_boost` (1.15) and `reachable` is strictly ABOVE a tied cutoff, so
+    the comparison never reaches equality and the test proves nothing. Status is
+    penalty-only, so status-alone puts the ceiling at exactly 1.0 — which is
+    what makes `reachable == cutoff` reachable at all.
+    """
+    paths = [f"Knowledge Base/Notes/page-{i:03d}.md" for i in range(60)]
+    pages = {p: _Page("note", None, None) for p in paths}  # every multiplier 1.0
+    fused = [(p, 5.0) for p in reversed(paths)]  # tied scores, reversed order
+
+    full, bounded, _ = _both_passes(
+        fused, pages, top_n=20, prefer_compiled=False, prefer_active=True
+    )
+
+    assert bounded[:20] == full[:20]
+    # And the full pass really is path-ordered, so the assertion above has teeth.
+    assert [p for p, _ in full[:3]] == paths[:3]
+
+
+def test_a_negative_raw_score_bounds_upward_not_downward() -> None:
+    """A negative score inverts the multiplier bound, so the max must take both.
+
+    A negative lane weight yields negative fused scores. There, multiplying by
+    the HIGH multiplier gives the *smallest* value, not the largest — so a
+    cutoff computed as `score * high` understates what the candidate can reach
+    and would skip a genuine winner.
+    """
+    paths = [f"Knowledge Base/Notes/page-{i:03d}.md" for i in range(40)]
+    # Neutral pages keep their raw negative score. The late candidate is heavily
+    # penalised, and a penalty on a negative score moves it TOWARD zero — so it
+    # actually outranks everything above it. `score * high` would rate its
+    # ceiling far below the cutoff and skip the genuine winner.
+    pages = {p: _Page("note", None, None) for p in paths}
+    winner = paths[30]
+    pages[winner] = _Page(SOURCE, "superseded", None)
+    fused = [(p, -1.0 - i * 0.01) for i, p in enumerate(paths)]
+
+    full, bounded, _ = _both_passes(fused, pages, top_n=10)
+
+    assert full[0][0] == winner, "setup: the penalised late candidate must rank first"
+    assert bounded[:10] == full[:10]
+
+
+def test_the_ceiling_is_the_product_of_active_factors_only() -> None:
+    low, high = find_policy.multiplier_bounds(
+        DEFAULT_RANKING,
+        prefer_compiled=True,
+        prefer_active=True,
+        temporal_active=False,
+        usage_active=False,
+    )
+    assert high == DEFAULT_RANKING.compiled_boost  # status is penalty-only
+    assert low == DEFAULT_RANKING.source_penalty * DEFAULT_RANKING.superseded_penalty
+
+    none_active = find_policy.multiplier_bounds(
+        DEFAULT_RANKING,
+        prefer_compiled=False,
+        prefer_active=False,
+        temporal_active=False,
+        usage_active=False,
+    )
+    assert none_active == (1.0, 1.0)
+
+
+def test_a_wider_ceiling_still_produces_the_same_prefix() -> None:
+    """An aggressive config widens the bound; it must not break exactness."""
+    rng = random.Random(5)
+    fused, pages = _corpus(rng, 400)
+    wide = replace(DEFAULT_RANKING, compiled_boost=3.0, source_penalty=0.2, superseded_penalty=0.1)
+
+    full, bounded, _ = _both_passes(fused, pages, top_n=30, config=wide)
+
+    assert bounded[:30] == full[:30]
+
+
+def test_an_explain_request_takes_the_full_pass() -> None:
+    """Trace evidence must cover every candidate, so bounding is suppressed."""
+    rng = random.Random(3)
+    fused, pages = _corpus(rng, 150)
+    evidence: dict[str, list[dict[str, float | str]]] = {}
+    loaded: list[str] = []
+
+    def counting_page_of(path: str):
+        loaded.append(path)
+        return pages.get(path)
+
+    find_policy.apply_post_rrf_multipliers(
+        list(fused),
+        "topic",
+        DEFAULT_RANKING,
+        prefer_compiled=True,
+        prefer_active=True,
+        temporal=True,
+        page_of=counting_page_of,
+        evidence_out=evidence,
+        top_n=10,
+    )
+
+    assert len(loaded) == len(fused)
+    assert len(evidence) == len(fused)
+
+
+def test_top_n_none_is_byte_identical_to_the_old_behaviour() -> None:
+    rng = random.Random(99)
+    fused, pages = _corpus(rng, 250)
+
+    full, _bounded, _ = _both_passes(fused, pages, top_n=None)
+    again = find_policy.apply_post_rrf_multipliers(
+        list(fused),
+        "topic",
+        DEFAULT_RANKING,
+        prefer_compiled=True,
+        prefer_active=True,
+        temporal=True,
+        page_of=pages.get,
+    )
+
+    assert full == again


### PR DESCRIPTION
perf(recall): stop loading the whole candidate set to rank ten results

The post-RRF multiplier pass called `page_of` for every fused candidate, and
`page_of` on a cold page is a file read plus a policy admission check. Profiling
one query on a 2,000-note vault: 588 candidates fused, 588 pages loaded, to
return 10 hits. It was the largest single read-path term in #283.

Every multiplier has a config-declared ceiling, which makes an exact early exit
possible rather than an approximation:

    type    <= compiled_boost      status <= 1.0 (penalty only)
    recency <= temporal_boost      usage  <= usage_boost

`multiplier_bounds` returns the product of the active factors' extremes.
Candidates arrive in descending RRF order, so once `top_n` are scored, a
candidate whose best reachable score cannot beat the current `top_n`-th can be
skipped — and so can every candidate after it, since their raw scores are no
higher. The first `top_n` entries are therefore identical to an unbounded pass,
not merely similar; the tail keeps raw RRF order because nothing there can enter
the top.

Three details carry the correctness, and each was found by breaking it:

- The comparison is strictly `<`. On equality the candidate can still win the
  `(-score, path)` tie-break, so it must be scored.
- The bound is `max(score * low, score * high)`, not `score * high`. A negative
  fused score (a negative lane weight yields one) inverts which end is the
  maximum, and a penalty on a negative score moves it toward zero.
- An `explain` request takes the full pass. Bounding it would leave the tail
  with no multiplier chain and make the trace lie by omission.

The call site passes `candidate_k`, which is already `max(limit * 5, 50)` while
the consumer stops building hits at `limit * 3` — so the exact prefix always
covers what is read, with headroom for candidates that loop skips. `top_n=None`
stays the full pass, so every other caller is unchanged.

Measured on the same 2,000-note vault:

    pages loaded    588 -> 50       479 -> 50
    fusion span   376 ms -> 35 ms   406 ms -> 30 ms
    find() total  602 ms -> 296 ms  482 ms -> 128 ms

Four mutations, four caught — but only after two rounds. The first tie test
passed with `<` broken to `<=`, because `prefer_compiled` puts the ceiling at
1.15 so `reachable` is never equal to a tied cutoff; the equality boundary only
exists when the ceiling is exactly 1.0, which is status-only. The first negative
test asserted the wrong winner because I had the sign intuition backwards.

Refs #283

## Verification

- `tests/test_bounded_multiplier_pass.py` — 10 tests comparing the bounded pass against the unbounded one over 40 randomised corpora, asserting **exact tuples** (score and tie-break order), not just the path set.
- 108 passed across `test_find`, `test_find_candidates_architecture`, `test_find_results_architecture`, `test_find_structured_filters`, `test_find_typed_graph_lane`, `test_bounded_retrieval`, `test_find_hot_cache`, `test_find_degraded_retention`.
- Four mutations, four caught (details in the commit body — two needed a second round before they discriminated).
- CI's `retrieval quality (golden gate, embeddings)` is the cross-check I cannot run locally without the model extra; it is the job to watch on this PR.

Closes the last open item on #283 that was mine to fix. The remaining follow-up on that issue — caching `_safe_regular_file`'s directory prefix — is a symlink-escape decision and is deliberately still open.