### PR TITLE
fix(ci): floor the O(N) scaling bounds so a faster small corpus cannot fail the build

### DIFF
--- a/scripts/semantic_write_latency.py
+++ b/scripts/semantic_write_latency.py
@@ -100,6 +100,44 @@ READ_AFTER_WRITE_P95_MS = 75_000.0
 READ_AFTER_WRITE_SCALING_RATIO = 8.0
 READ_AFTER_WRITE_SCALING_SLACK_MS = 2_000.0
 
+# --- Scaling-bound floors for the three O(N) rows.
+#
+# SCALING_BOUND_CEILING_FRACTION above floors validate and commit and is
+# explicitly withheld here: "only the two operations expected to stay FLAT with
+# corpus size get this; the read/cold rows are deliberately O(N) and carry their
+# own ratios."  That reasoning covers ratio MAGNITUDE.  It does not cover
+# baseline NOISE, and noise is what fails the build -- the bound is anchored to
+# the small sample either way, so a lucky-fast or a genuinely-improved 2k
+# measurement drags it down exactly as it did for commit.
+#
+# MEASURED BASIS (nine consecutive Linux CI runs on main, 2026-08-21 -- the
+# authoritative platform this lane actually gates on, not the contended Windows
+# box the ceilings above were calibrated from):
+#   read_after_write_median_ms  2k  671.8-2736.0 (4.1x spread)  8k  6578.7-19305.3
+#   cold_read_after_write_ms    2k 1633.8-3398.2               8k  5427.9-11614.9
+#   cold_preflight_ms           2k 2669.3-7540.7               8k  8630.8-22738.5
+# The read row's 2k baseline alone moves its bound by 16.5s across those runs,
+# while the 8k value it bounds spans 12.7s: the ruler is noisier than the thing
+# it measures, which is the commit-row finding restated one row down.
+#
+# The ratio itself is the runner-invariant statistic and stayed 6.6-8.3x across
+# seven of the nine -- a slow runner inflates both ends together.  It then read
+# 12.3-12.5x on the two most recent, because #715 and #718 made the SMALL corpus
+# disproportionately faster (#718's post-RRF early exit fires hard at 2k and
+# barely at 8k, since candidate_k grows with the eligible set).  Both 8k numbers
+# were at or below the running median.  Nothing regressed; the denominator
+# shrank, and a ratio rule cannot tell those apart.
+#
+# So floor each bound just clear of the worst UNREGRESSED large-corpus figure
+# observed on this runner, and keep every floor strictly below its own absolute
+# ceiling so the scaling rule still fails a real super-linear regression before
+# the ceiling does.  Runner spread is ~3x in absolute terms, so a floor that
+# clears the slow-runner normal cannot also be tight -- that is a real limit of
+# same-run anchoring, not a slack choice.  Re-measure rather than hand-tune.
+READ_AFTER_WRITE_SCALING_BOUND_FLOOR_MS = 22_000.0
+COLD_READ_AFTER_WRITE_SCALING_BOUND_FLOOR_MS = 14_000.0
+COLD_PREFLIGHT_SCALING_BOUND_FLOOR_MS = 26_000.0
+
 # --- Cold/evicted scenario (the row the upcoming #510 fix must move a cost
 # onto). `reset_corpus_context_cache()` drops the semantic-contract
 # corpus-context cache; `freshness.clear()` drops freshness liveness (only
@@ -402,9 +440,10 @@ def check(results: list[dict[str, float | int]]) -> None:
                     f"({small['pages']} -> {large['pages']} pages)"
                 )
         read_key = "read_after_write_median_ms"
-        read_bound = (
+        read_bound = max(
             float(small[read_key]) * READ_AFTER_WRITE_SCALING_RATIO
-            + READ_AFTER_WRITE_SCALING_SLACK_MS
+            + READ_AFTER_WRITE_SCALING_SLACK_MS,
+            READ_AFTER_WRITE_SCALING_BOUND_FLOOR_MS,
         )
         if float(large[read_key]) >= read_bound:
             failures.append(
@@ -415,9 +454,10 @@ def check(results: list[dict[str, float | int]]) -> None:
         # faster than headroom allows means the "next caller" bill is
         # scaling with corpus size, not staying flat.
         cold_key = "cold_read_after_write_ms"
-        cold_bound = (
+        cold_bound = max(
             float(small[cold_key]) * COLD_READ_AFTER_WRITE_SCALING_RATIO
-            + COLD_READ_AFTER_WRITE_SCALING_SLACK_MS
+            + COLD_READ_AFTER_WRITE_SCALING_SLACK_MS,
+            COLD_READ_AFTER_WRITE_SCALING_BOUND_FLOOR_MS,
         )
         if float(large[cold_key]) >= cold_bound:
             failures.append(
@@ -428,9 +468,10 @@ def check(results: list[dict[str, float | int]]) -> None:
         # relocated corpus rebuild lands, so this is the row that would
         # actually catch the ~70s walk moving back in.
         cold_preflight_key = "cold_preflight_ms"
-        cold_preflight_bound = (
+        cold_preflight_bound = max(
             float(small[cold_preflight_key]) * COLD_PREFLIGHT_SCALING_RATIO
-            + COLD_PREFLIGHT_SCALING_SLACK_MS
+            + COLD_PREFLIGHT_SCALING_SLACK_MS,
+            COLD_PREFLIGHT_SCALING_BOUND_FLOOR_MS,
         )
         if float(large[cold_preflight_key]) >= cold_preflight_bound:
             failures.append(

--- a/tests/test_semantic_write_latency_gate.py
+++ b/tests/test_semantic_write_latency_gate.py
@@ -30,9 +30,26 @@ for commit -- and the absolute ceilings are the primary bound below that.
 Claiming finer resolution than the measurement supports is what produced two
 false failures.
 
-These tests pin the floor, pin that both historical false-failure sample sets
-now pass, and pin that genuine super-linear growth still fails before the
-absolute ceiling catches it.
+On 2026-08-21 it recurred a third time, in the rows the floor was withheld from.
+`read_after_write` failed both attempts on main at 2a749c84 -- and its 8k figure,
+the quantity the rule bounds, was at or below the running median across nine
+consecutive runs. What moved was the 2k baseline it divides by: #718's post-RRF
+early exit fires hard on a small corpus and barely on a large one, so the small
+end improved roughly three times as much as the large end and the ratio rose
+from a stable 6.6-8.3x to 12.3x. Nothing regressed. The gate cannot tell an
+improved denominator from a regressed numerator, so it failed the build for
+being faster.
+
+The withheld reasoning was that the read/cold rows are "deliberately O(N) and
+carry their own ratios". That is about ratio MAGNITUDE. The defect is baseline
+NOISE -- the read row's own 2k sample spans 4.1x across those nine runs, moving
+its bound by 16.5s while the value it bounds spans 12.7s. Being O(N) does not
+exempt a row from having a noisy ruler, so all three now carry the same floor.
+
+These tests pin the floor, pin that every historical false-failure sample set
+now passes, pin that each floor is load-bearing rather than decorative, and pin
+that genuine super-linear growth still fails before the absolute ceiling catches
+it.
 """
 
 from __future__ import annotations
@@ -97,6 +114,77 @@ VALIDATE_MARGIN = [
 # ceiling, so only the scaling rule can catch it.
 SUPERLINEAR = [result(2_000, commit=130.0), result(8_000, commit=700.0)]
 
+# The 2026-08-21 recurrence, one row down. Both attempts of the run that failed
+# main at 2a749c84, plus attempt 1 at 2d40a8b2 -- all three verbatim from CI.
+# Every 8k figure here is at or below the nine-run running median; what moved
+# was the 2k baseline, because #718's post-RRF early exit fires hard on a small
+# corpus and barely on a large one. The gate read the improvement as a
+# regression in the row it divides by.
+READ_ROW_RECURRENCE = [
+    [
+        result(
+            2_000,
+            commit=149.5,
+            validate=20.9,
+            read_after_write=671.8,
+            cold_read_after_write=1_633.8,
+            cold_preflight=2_669.3,
+        ),
+        result(
+            8_000,
+            commit=393.0,
+            validate=86.8,
+            read_after_write=8_291.7,
+            cold_read_after_write=7_930.5,
+            cold_preflight=11_885.0,
+        ),
+    ],
+    [
+        result(
+            2_000,
+            commit=258.9,
+            validate=23.8,
+            read_after_write=746.6,
+            cold_read_after_write=1_845.3,
+            cold_preflight=2_647.1,
+        ),
+        result(
+            8_000,
+            commit=413.7,
+            validate=81.4,
+            read_after_write=8_824.8,
+            cold_read_after_write=8_369.3,
+            cold_preflight=10_689.1,
+        ),
+    ],
+    [
+        result(
+            2_000,
+            commit=279.2,
+            validate=29.2,
+            read_after_write=778.7,
+            cold_read_after_write=2_061.5,
+            cold_preflight=4_634.6,
+        ),
+        result(
+            8_000,
+            commit=477.9,
+            validate=161.5,
+            read_after_write=9_710.0,
+            cold_read_after_write=8_843.1,
+            cold_preflight=15_930.7,
+        ),
+    ],
+]
+
+# The worst UNREGRESSED large-corpus figure seen across the same nine runs. Each
+# floor has to clear its own entry here, or the gate is still inside its noise.
+WORST_OBSERVED_8K = {
+    "read_after_write_median_ms": 19_305.3,
+    "cold_read_after_write_ms": 11_614.9,
+    "cold_preflight_ms": 22_738.5,
+}
+
 
 def test_healthy_scaling_passes() -> None:
     load_module().check(HEALTHY)
@@ -139,7 +227,7 @@ def test_superlinear_scaling_fails() -> None:
         load_module().check(SUPERLINEAR)
 
 
-@pytest.mark.parametrize("sample", [NOISY, *RECURRENCE, VALIDATE_MARGIN])
+@pytest.mark.parametrize("sample", [NOISY, *RECURRENCE, VALIDATE_MARGIN, *READ_ROW_RECURRENCE])
 def test_measured_false_failures_pass(sample: list[dict[str, float | int]]) -> None:
     """Every sample set that has ever failed this gate falsely now passes.
 
@@ -186,6 +274,109 @@ def test_a_fast_baseline_cannot_tighten_the_bound_below_the_floor() -> None:
         module.VALIDATE_MEDIAN_MS * module.SCALING_BOUND_CEILING_FRACTION
         < module.VALIDATE_MEDIAN_MS
     )
+
+
+# (floor constant, ratio, slack, absolute ceiling) per O(N) row.
+ON_ROWS = [
+    (
+        "read_after_write_median_ms",
+        "READ_AFTER_WRITE_SCALING_BOUND_FLOOR_MS",
+        "READ_AFTER_WRITE_SCALING_RATIO",
+        "READ_AFTER_WRITE_SCALING_SLACK_MS",
+        "READ_AFTER_WRITE_MEDIAN_MS",
+    ),
+    (
+        "cold_read_after_write_ms",
+        "COLD_READ_AFTER_WRITE_SCALING_BOUND_FLOOR_MS",
+        "COLD_READ_AFTER_WRITE_SCALING_RATIO",
+        "COLD_READ_AFTER_WRITE_SCALING_SLACK_MS",
+        "COLD_READ_AFTER_WRITE_MS",
+    ),
+    (
+        "cold_preflight_ms",
+        "COLD_PREFLIGHT_SCALING_BOUND_FLOOR_MS",
+        "COLD_PREFLIGHT_SCALING_RATIO",
+        "COLD_PREFLIGHT_SCALING_SLACK_MS",
+        "COLD_PREFLIGHT_MS",
+    ),
+]
+
+
+@pytest.mark.parametrize("key,floor_name,ratio_name,slack_name,ceiling_name", ON_ROWS)
+def test_each_on_row_floor_clears_its_worst_unregressed_sample(
+    key: str, floor_name: str, ratio_name: str, slack_name: str, ceiling_name: str
+) -> None:
+    """The O(N) rows get the same floor, for the same reason as commit.
+
+    Being O(N) justifies a larger RATIO. It does nothing about baseline noise,
+    which is what actually fails the build -- the bound is anchored to the small
+    sample either way. So each floor must clear the worst large-corpus figure an
+    unregressed tree has produced on this runner, and must stay strictly under
+    its own absolute ceiling so the scaling rule still fires first.
+    """
+    module = load_module()
+    floor = getattr(module, floor_name)
+
+    assert floor > WORST_OBSERVED_8K[key]
+    assert floor < getattr(module, ceiling_name)
+
+    # The ratio term still moves with the baseline -- unchanged arithmetic --
+    # but it can no longer drag the applied bound below the floor.
+    ratio, slack = getattr(module, ratio_name), getattr(module, slack_name)
+    fast, slow = 100.0, 5_000.0
+    assert fast * ratio + slack < floor  # a fast baseline is floored
+    assert max(fast * ratio + slack, floor) == floor
+    assert max(slow * ratio + slack, floor) == slow * ratio + slack  # slow still rules
+
+
+@pytest.mark.parametrize("key,floor_name,ratio_name,slack_name,ceiling_name", ON_ROWS)
+def test_the_floor_is_load_bearing_on_every_on_row(
+    key: str, floor_name: str, ratio_name: str, slack_name: str, ceiling_name: str
+) -> None:
+    """Remove any one floor and this must go red.
+
+    The read row is covered by READ_ROW_RECURRENCE, which is measured. The two
+    cold rows have not landed on the wrong side of their bound in CI yet -- they
+    are nearer than they look (cold_preflight's bare bound clears its worst
+    observed 8k figure by 16%), and they read the same candidate path #718 just
+    made faster, so they move next. Rather than ship two floors no test
+    exercises, construct the case per row: a baseline fast enough that the bare
+    ratio term fails a large figure the floor and the ceiling both accept.
+    """
+    module = load_module()
+    ratio, slack = getattr(module, ratio_name), getattr(module, slack_name)
+    floor, ceiling = getattr(module, floor_name), getattr(module, ceiling_name)
+
+    fast_small = (floor - slack) / ratio * 0.55
+    big_large = (fast_small * ratio + slack + floor) / 2.0
+
+    # The case is only meaningful if the bare term fails where the floor saves.
+    assert fast_small * ratio + slack <= big_large, "bare bound must fail this sample"
+    assert big_large < floor < ceiling, "floor must save it, ceiling must allow it"
+
+    small, large = result(2_000, commit=130.0), result(8_000, commit=200.0)
+    small[key], large[key] = fast_small, big_large
+    module.check([small, large])  # passes only because the row is floored
+
+
+@pytest.mark.parametrize("key,floor_name,_r,_s,ceiling_name", ON_ROWS)
+def test_a_real_regression_on_an_on_row_still_fails(
+    key: str, floor_name: str, _r: str, _s: str, ceiling_name: str
+) -> None:
+    """The floor must not neuter the row it protects.
+
+    Growth past the floor but under the absolute ceiling can only be caught by
+    the scaling rule -- if this passes, flooring turned the check off.
+    """
+    module = load_module()
+    floor = getattr(module, floor_name)
+    assert floor + 1.0 < getattr(module, ceiling_name), "sample must clear the ceiling test"
+
+    small = result(2_000, commit=130.0)
+    large = result(8_000, commit=200.0)
+    large[key] = floor + 1.0
+    with pytest.raises(SystemExit, match=f"{key.removesuffix('_median_ms').removesuffix('_ms')} scaling"):
+        module.check([small, large])
 
 
 def test_check_failure_is_confirmed_by_a_second_measurement(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

`main` failed both attempts at `2a749c84` on `read_after_write scaling`. Nothing regressed — the gate failed the build for being **faster**.

The gate bounds each 8k figure by `ratio × (the same run's 2k median) + slack`. `validate` and `commit` have been floored since 2026-08-20 because that bound sat inside the natural spread of what it bounds. The read/cold rows were excluded as "deliberately O(N) and carry their own ratios" — which addresses ratio *magnitude*, not baseline *noise*. The bound is anchored to the small sample either way.

## Evidence (nine consecutive Linux CI runs on main)

| | 2k base | bound | 8k actual | ratio | |
|---|---|---|---|---|---|
| `74ae2153` | 1255.2 | 12041.6 | 8630.5 | 6.9× | pass |
| `2d40a8b2` | 778.7 | 8229.6 | 9710.0 | 12.5× | fail → retry passed |
| `2a749c84` | 671.8 | **7374.4** | 8291.7 | 12.3× | **fail both attempts** |

The 2k baseline spans 671.8–2736.0 (4.1×) across those runs, swinging the bound by **16.5 s** while the 8k value it bounds spans 12.7 s — the ruler is noisier than the measurement. The ratio was a stable 6.6–8.3× in seven of nine; it rose only because #718's post-RRF early exit fires hard at 2k and barely at 8k (`candidate_k` grows with the eligible set). The 8k figure at the failing commit was at or below the running median.

## Change

Each O(N) row now floors its bound just clear of the worst unregressed 8k figure observed on this runner, staying strictly under its own absolute ceiling so the scaling rule still fires first:

| row | floor | worst observed | ceiling |
|---|---|---|---|
| `read_after_write` | 22 000 ms | 19 305.3 | 60 000 |
| `cold_read_after_write` | 14 000 ms | 11 614.9 | 100 000 |
| `cold_preflight` | 26 000 ms | 22 738.5 | 80 000 |

Runner spread is ~3× in absolute terms, so a floor clearing the slow-runner normal cannot also be tight — a real limit of same-run anchoring, not a slack choice. The absolute ceilings remain the backstop for gross regressions.

The cold rows had not landed on the wrong side yet (`cold_preflight`'s bare bound clears its worst observed figure by only 16%) but read the same candidate path #718 just made faster, so they move next.

## Verification

- `39 passed` — `test_semantic_write_latency_gate.py` + `test_ci_reliability_contract.py`
- All three real failing sample sets from CI added verbatim as regression samples
- **Mutation-tested: 10 mutations, 10 caught, 0 survivors** — including one per row that removes only that row's floor, so no floor is decorative. An initial run had 3 mutations that only produced `TypeError` rather than an unfloored bound; those were rewritten and re-run.
- `uvx ruff check` and `ruff check --select F,E9,I` clean on both files

## Not addressed here

`read_after_write` at 8k is ~8–10 s on Linux CI against a 4× corpus — genuinely superlinear, pre-existing, and unrelated to this gate's correctness. Worth its own issue rather than hiding behind a noisy gate.