### PR TITLE
fix(ops): stop the deploy floating every transitive to latest

### DIFF
--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -59,6 +59,48 @@ function Get-Provenance {
     try { return $raw | ConvertFrom-Json } catch { return $null }
 }
 
+# Name -> version for everything installed, so a deploy can SAY what it changed.
+# The torch gate below proves the general case matters: it exists because an
+# upgrade silently swapped an accelerated build for a CPU one, and torch is not
+# the only dependency that can move without anyone asking.
+function Get-PackageSnapshot {
+    param([string]$PythonPath)
+    $raw = & uv pip list --python $PythonPath --format json 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $raw) { return $null }
+    $map = @{}
+    try {
+        foreach ($pkg in ($raw | ConvertFrom-Json)) { $map[$pkg.name] = $pkg.version }
+    } catch { return $null }
+    return $map
+}
+
+# Report every version that moved, with `exomem` itself excluded: it is the
+# thing being deployed, so listing it as drift is noise.
+function Write-DependencyDrift {
+    param($Before, $After)
+    if (-not $Before -or -not $After) {
+        Write-Host "Dependency drift: unavailable (could not snapshot both sides)." -ForegroundColor Yellow
+        return
+    }
+    $moved = @()
+    foreach ($name in $After.Keys) {
+        if ($name -ieq "exomem") { continue }
+        $old = $Before[$name]
+        if ($null -eq $old) { $moved += "  + $name $($After[$name]) (new)" }
+        elseif ($old -ne $After[$name]) { $moved += "  ~ $name $old -> $($After[$name])" }
+    }
+    foreach ($name in $Before.Keys) {
+        if ($name -ieq "exomem") { continue }
+        if ($null -eq $After[$name]) { $moved += "  - $name $($Before[$name]) (removed)" }
+    }
+    if ($moved.Count -eq 0) {
+        Write-Host "Dependency drift: none (only exomem changed)." -ForegroundColor Green
+        return
+    }
+    Write-Host "Dependency drift ($($moved.Count) package(s) moved):" -ForegroundColor Yellow
+    $moved | Sort-Object | ForEach-Object { Write-Host $_ -ForegroundColor Yellow }
+}
+
 # The accelerator baseline comes from torch's own distribution metadata, not
 # from `install-info --json`. That payload has never carried `accelerated` or
 # `torch`: the property read $null, `[bool]$null` is $false, and so the gate at
@@ -80,9 +122,31 @@ if ($DryRun) {
 }
 
 # --- 2. Upgrade that environment ---------------------------------------------
+# Deliberately NOT `--upgrade`. `==$Version` pins exomem; `--upgrade` ADDITIONALLY
+# floats every transitive to its newest compatible release, which is not what a
+# version-pinned deploy is asking for. `sentence-transformers` is declared
+# `>=2.7` with no upper bound, so that flag walked it 5.7.0 -> 6.0.0 (a major
+# bump) on two separate deploys of unrelated patch releases, while the lockfile
+# CI tests against pins 5.5.1 -- meaning the combination running in production
+# was one nothing had ever validated.
+#
+# Without the flag uv still upgrades a dependency when the new exomem's own
+# constraints REQUIRE it, so a genuine floor bump is honoured; it just stops
+# rewriting the ML stack as a side effect. A patch release changes exomem.
+#
+# Deploying the lockfile instead would be worse, not better: it pins torch
+# 2.12.0, and this host runs an accelerated build the lock cannot express (see
+# the cu132 note in the gate below). Lock-exact would downgrade the GPU away.
+$packagesBefore = Get-PackageSnapshot -PythonPath $servicePython
 Write-Host "`nUpgrading to exomem[$Extras]==$Version ..." -ForegroundColor Cyan
-& uv pip install --python $servicePython --upgrade "exomem[$Extras]==$Version"
+& uv pip install --python $servicePython "exomem[$Extras]==$Version"
 if ($LASTEXITCODE -ne 0) { Fail "uv pip install returned $LASTEXITCODE." }
+
+# Whatever did move, say so. Silent drift is how both incidents stayed invisible
+# until a gate happened to trip on an unrelated check.
+$packagesAfter = Get-PackageSnapshot -PythonPath $servicePython
+Write-Host ""
+Write-DependencyDrift -Before $packagesBefore -After $packagesAfter
 
 # --- 3. Accelerator regression gate ------------------------------------------
 # The cu132 pin lives in the repo's [tool.uv.sources], which a PyPI-backed venv


### PR DESCRIPTION
## Summary

`deploy.ps1` ran `uv pip install --upgrade "exomem[extras]==<version>"`. The `==` pins exomem; `--upgrade` **additionally floats every transitive** to its newest compatible release — which is not what a version-pinned deploy is asking for.

`sentence-transformers` is declared `>=2.7` with no upper bound, so that flag walked it **5.7.0 → 6.0.0** (a major bump) during two separate deploys of unrelated *patch* releases:

| | uv.lock (what CI tests) | cells before | `--upgrade` pulled |
|---|---|---|---|
| sentence-transformers | 5.5.1 | 5.7.0 | **6.0.0** |
| torch | 2.12.0 | 2.13.0+cu132 | — |
| transformers | 5.9.0 | 5.15.1 | — |

The deployed combination was one nothing had ever validated, and it reached a live cell both times. The second was caught only because an unrelated doctor check happened to fail first — so the guard that stopped it was luck, not design.

## Why not just deploy the lockfile

That would be **worse**. The lock pins torch 2.12.0, while an accelerated host runs a cu132 build the lock cannot express (`[tool.uv.sources]` doesn't travel with a PyPI wheel — the script already documents this in its torch gate). Lock-exact would downgrade the GPU away. The lock is the CI contract, not the deploy target.

## Change

**Drop `--upgrade`.** uv still upgrades a dependency when the new exomem's own constraints *require* it, so a genuine floor bump is honoured — it just stops rewriting the ML stack as a side effect of shipping a patch release.

This generalises a guard the script already had. It carried a torch-specific accelerator check for precisely this failure class ("an upgrade silently resolves the default CPU wheel"); rather than add a second special case for `sentence-transformers`, remove the mechanism that causes both.

**Report what moved.** Both incidents stayed invisible because the deploy said nothing about transitives. `Get-PackageSnapshot` diffs the environment either side of the install and prints every version that changed, excluding exomem itself. A clean deploy now states `Dependency drift: none (only exomem changed)`.

## Verification

End-to-end against the live service, re-deploying the same version that had just floated ST to 6.0.0:

```
exomem                 0.57.2
sentence-transformers  5.7.0        <- was 6.0.0 under --upgrade
torch                  2.13.0+cu132 <- accelerator preserved
transformers           5.15.1
```

- `overall: PASS` on the doctor gate, clean restart, health endpoint confirms 0.57.2
- PowerShell AST parse check clean
- `Write-DependencyDrift` unit-tested over four cases — no-change, the actual incident (ST 5.7.0 → 6.0.0 + lxml), added/removed packages, and an unavailable snapshot — with the functions extracted from the shipped file via the AST rather than hand-copied

## Note

Nothing here claims 6.0.0 is broken; embeddings worked on it. The objection is that a patch deploy changed a major ML dependency **unrequested and untested**. Moving to 6.0.0 is a fine thing to do deliberately — bump the lock, let CI validate, then deploy.