### PR TITLE
fix(governance): bind non-markdown companions

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -62,11 +62,11 @@
 - [x] 2.1 Add red tests in `tests/test_governance_membership.py` for a missing companion
   under semantic-only project/tag/type/class scopes, proving the outcome is unresolved
   rather than the classified empty set.
-- [ ] 2.2 Add red tests for malformed, unreadable, stale, symlink-escaping, and
+- [x] 2.2 Add red tests for malformed, unreadable, stale, symlink-escaping, and
   artifact-mismatched companions; cover duplicate/relocated dataset cards and scene-frame
   parent/path/hash/timestamp mismatches, assert the same fail-closed outcome, and prove no
   cached open answer.
-- [ ] 2.3 Add red/passing distinction tests for path/ref-only policy, a path/ref exclusion
+- [x] 2.3 Add red/passing distinction tests for path/ref-only policy, a path/ref exclusion
   that proves a semantic scope excluded, a positive path match plus an unresolved
   semantic sibling, and a valid explicitly empty companion. The empty fixture must carry
   `state: classified`, all four explicit empty semantic lists, and the complete class-
@@ -85,7 +85,7 @@
 - [ ] 2.6 Add red integration coverage in `tests/test_governance_egress.py`,
   `tests/test_record_governance.py`, and media/dataset tests proving unresolved artifacts
   are L0/missing before counts, frames, rows, proposals, or grant-drift checks.
-- [ ] 2.7 Implement the closed companion locator/descriptor registry: sibling binary/media
+- [x] 2.7 Implement the closed companion locator/descriptor registry: sibling binary/media
   path/hash/size/class (+ media type/original name), unique dataset-card
   data-path/hash/size/format, and scene-frame frame/parent path+hash+size and canonical
   bounded `frame_timestamp_ms`, plus exact artifact
@@ -96,10 +96,10 @@
   context and receipt-first no-follow held-parent/descriptor-bound transaction. Validate
   the exact version-1 input, preserve all non-descriptor bytes, persist prior/target
   identities and owner/event evidence, and prohibit every metadata-inference path.
-- [ ] 2.9 Introduce the typed classified/unresolved membership result and update memo keys
+- [x] 2.9 Introduce the typed classified/unresolved membership result and update memo keys
   so companion and artifact immutable identities participate without adding index-time
   materialization.
-- [ ] 2.10 Wire direct media/frame/dataset reads, corpus walks, proposal membership, and
+- [x] 2.10 Wire direct media/frame/dataset reads, corpus walks, proposal membership, and
   active-session-grant revalidation to propagate unresolved membership; remove every
   fallback that converts it to `frozenset()`.
 - [ ] 2.11 Run the membership, preserve/media-processing, scene-frame, query-dataset,

--- a/src/exomem/governance/companions.py
+++ b/src/exomem/governance/companions.py
@@ -1,0 +1,337 @@
+"""Immutable governance-companion classification for non-Markdown artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, replace
+from pathlib import PurePosixPath
+from typing import Literal
+
+from .. import media_types, reserved_paths, vault
+from ..kbdir import kb_dirname
+
+SEMANTIC_KEYS = ("projects", "tags", "types", "classes")
+CompanionReason = Literal[
+    "artifact_unsafe",
+    "companion_unsafe",
+    "descriptor_missing",
+    "descriptor_invalid",
+    "artifact_mismatch",
+    "companion_ambiguous",
+]
+
+_DATASET_FORMATS = {".csv": "csv", ".tsv": "tsv", ".json": "json"}
+_FRAME_PATH_RE = re.compile(
+    r"^(?P<parent>.+)\.frames/(?P<leaf>scene-\d{3,}-t(?P<millis>\d+)ms\.jpg)$"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class BoundCompanion:
+    """Artifact semantics proven by one exact descriptor and byte snapshot."""
+
+    projects: tuple[str, ...]
+    tags: tuple[str, ...]
+    types: tuple[str, ...]
+    classes: tuple[str, ...]
+    identities: tuple[BoundSnapshot, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class BoundSnapshot:
+    """One exact held-file identity and byte digest in the classification."""
+
+    role: str
+    path: str
+    sha256: str
+    size: int
+    device: int
+    inode: int
+    kind: str
+    link_count: int
+
+
+@dataclass(slots=True)
+class CompanionClassificationError(Exception):
+    """Content-free reason a companion cannot classify its artifact."""
+
+    reason: CompanionReason
+
+
+def _canonical_relative_path(value: str) -> str:
+    normalized = value.replace("\\", "/")
+    path = PurePosixPath(normalized)
+    if (
+        not normalized
+        or normalized.startswith("/")
+        or normalized != path.as_posix()
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise CompanionClassificationError("descriptor_invalid")
+    return normalized
+
+
+def _read_artifact(vault_root, rel_path: str) -> reserved_paths.GenericFileSnapshot:
+    try:
+        return reserved_paths.read_generic_bytes(vault_root, rel_path)
+    except reserved_paths.ReservedPathLeafError as error:
+        raise CompanionClassificationError("artifact_unsafe") from error
+
+
+def _read_companion(vault_root, rel_path: str) -> reserved_paths.GenericFileSnapshot:
+    try:
+        return reserved_paths.read_generic_bytes(vault_root, rel_path)
+    except reserved_paths.ReservedPathLeafError as error:
+        reason: CompanionReason = (
+            "descriptor_missing" if error.code == "MISSING" else "companion_unsafe"
+        )
+        raise CompanionClassificationError(reason) from error
+
+
+def _semantics(value: object) -> dict[str, tuple[str, ...]]:
+    if not isinstance(value, dict) or set(value) != set(SEMANTIC_KEYS):
+        raise CompanionClassificationError("descriptor_invalid")
+    result: dict[str, tuple[str, ...]] = {}
+    for key in SEMANTIC_KEYS:
+        raw = value[key]
+        if not isinstance(raw, list) or any(
+            not isinstance(item, str) or not item for item in raw
+        ):
+            raise CompanionClassificationError("descriptor_invalid")
+        result[key] = tuple(raw)
+    return result
+
+
+def _descriptor(companion: reserved_paths.GenericFileSnapshot) -> dict[str, object]:
+    try:
+        text = companion.data.decode("utf-8")
+        frontmatter, _body, marker = vault.parse_frontmatter(text, strict=True)
+    except (UnicodeDecodeError, vault.FrontmatterError) as error:
+        raise CompanionClassificationError("descriptor_invalid") from error
+    descriptor = frontmatter.get("governance_companion")
+    if descriptor is None:
+        raise CompanionClassificationError("descriptor_missing")
+    if not isinstance(descriptor, dict) or marker is None:
+        raise CompanionClassificationError("descriptor_invalid")
+    return descriptor
+
+
+def _validate_common(
+    descriptor: dict[str, object],
+    *,
+    expected_keys: set[str],
+    expected_class: str,
+    artifact_path: str,
+    artifact: reserved_paths.GenericFileSnapshot,
+) -> BoundCompanion:
+    if set(descriptor) != {
+        "version",
+        "state",
+        "artifact_class",
+        "artifact_path",
+        "artifact_sha256",
+        "artifact_size",
+        "semantics",
+        *expected_keys,
+    }:
+        raise CompanionClassificationError("descriptor_invalid")
+    if (
+        descriptor.get("version") != 1
+        or isinstance(descriptor.get("version"), bool)
+        or descriptor.get("state") != "classified"
+    ):
+        raise CompanionClassificationError("descriptor_invalid")
+    if descriptor.get("artifact_class") != expected_class:
+        raise CompanionClassificationError("descriptor_invalid")
+    if descriptor.get("artifact_path") != artifact_path:
+        raise CompanionClassificationError("artifact_mismatch")
+    actual_hash = hashlib.sha256(artifact.data).hexdigest()
+    expected_hash = descriptor.get("artifact_sha256")
+    expected_size = descriptor.get("artifact_size")
+    if (
+        not isinstance(expected_hash, str)
+        or expected_hash != actual_hash
+        or not isinstance(expected_size, int)
+        or isinstance(expected_size, bool)
+        or expected_size != len(artifact.data)
+    ):
+        raise CompanionClassificationError("artifact_mismatch")
+    semantics = _semantics(descriptor.get("semantics"))
+    return BoundCompanion(**semantics)
+
+
+def _bind_snapshots(
+    companion: BoundCompanion,
+    *snapshots: tuple[str, str, reserved_paths.GenericFileSnapshot],
+) -> BoundCompanion:
+    identities = tuple(
+        BoundSnapshot(
+            role=role,
+            path=path,
+            sha256=hashlib.sha256(snapshot.data).hexdigest(),
+            size=len(snapshot.data),
+            device=snapshot.identity.device,
+            inode=snapshot.identity.inode,
+            kind=snapshot.identity.kind,
+            link_count=snapshot.identity.link_count,
+        )
+        for role, path, snapshot in snapshots
+    )
+    return replace(companion, identities=identities)
+
+
+def _classify_sibling(
+    vault_root,
+    artifact_path: str,
+    artifact: reserved_paths.GenericFileSnapshot,
+) -> BoundCompanion:
+    companion = _read_companion(vault_root, f"{artifact_path}.md")
+    descriptor = _descriptor(companion)
+    media_type = media_types.media_type_for(artifact_path)
+    if media_type is None:
+        result = _validate_common(
+            descriptor,
+            expected_keys=set(),
+            expected_class="binary",
+            artifact_path=artifact_path,
+            artifact=artifact,
+        )
+        return _bind_snapshots(
+            result,
+            ("artifact", artifact_path, artifact),
+            ("companion", f"{artifact_path}.md", companion),
+        )
+    result = _validate_common(
+        descriptor,
+        expected_keys={"media_type", "original_filename"},
+        expected_class="media",
+        artifact_path=artifact_path,
+        artifact=artifact,
+    )
+    if descriptor.get("media_type") != media_type or descriptor.get(
+        "original_filename"
+    ) != PurePosixPath(artifact_path).name:
+        raise CompanionClassificationError("artifact_mismatch")
+    return _bind_snapshots(
+        result,
+        ("artifact", artifact_path, artifact),
+        ("companion", f"{artifact_path}.md", companion),
+    )
+
+
+def _dataset_cards(vault_root, artifact_path: str):
+    try:
+        entries = reserved_paths.list_generic_tree(
+            vault_root, kb_dirname(), recursive=True
+        )
+    except reserved_paths.ReservedPathLeafError as error:
+        raise CompanionClassificationError("companion_unsafe") from error
+    cards: list[
+        tuple[str, dict[str, object], reserved_paths.GenericFileSnapshot]
+    ] = []
+    for entry in entries:
+        if entry.markdown is None:
+            continue
+        try:
+            text = entry.markdown.decode("utf-8")
+            frontmatter, _body, marker = vault.parse_frontmatter(text, strict=True)
+        except (UnicodeDecodeError, vault.FrontmatterError):
+            continue
+        if (
+            marker is not None
+            and frontmatter.get("type") == "dataset"
+            and frontmatter.get("data_file") == artifact_path
+        ):
+            cards.append(
+                (
+                    f"{kb_dirname()}/{entry.relative_path}",
+                    frontmatter,
+                    reserved_paths.GenericFileSnapshot(
+                        entry.markdown,
+                        entry.identity,
+                        entry.mtime or 0.0,
+                    ),
+                )
+            )
+    return cards
+
+
+def _classify_dataset(
+    vault_root,
+    artifact_path: str,
+    artifact: reserved_paths.GenericFileSnapshot,
+) -> BoundCompanion:
+    cards = _dataset_cards(vault_root, artifact_path)
+    if not cards:
+        raise CompanionClassificationError("descriptor_missing")
+    if len(cards) != 1:
+        raise CompanionClassificationError("companion_ambiguous")
+    companion_path, frontmatter, companion = cards[0]
+    descriptor = _descriptor(companion)
+    result = _validate_common(
+        descriptor,
+        expected_keys={"format"},
+        expected_class="dataset",
+        artifact_path=artifact_path,
+        artifact=artifact,
+    )
+    expected_format = _DATASET_FORMATS[PurePosixPath(artifact_path).suffix.casefold()]
+    if descriptor.get("format") != expected_format or frontmatter.get(
+        "format"
+    ) != expected_format:
+        raise CompanionClassificationError("artifact_mismatch")
+    return _bind_snapshots(
+        result,
+        ("artifact", artifact_path, artifact),
+        ("companion", companion_path, companion),
+    )
+
+
+def _classify_scene_frame(
+    vault_root,
+    artifact_path: str,
+    artifact: reserved_paths.GenericFileSnapshot,
+    match: re.Match[str],
+) -> BoundCompanion:
+    companion = _read_companion(vault_root, f"{artifact_path}.md")
+    descriptor = _descriptor(companion)
+    result = _validate_common(
+        descriptor,
+        expected_keys={"parent_path", "parent_sha256", "frame_timestamp_ms"},
+        expected_class="scene_frame",
+        artifact_path=artifact_path,
+        artifact=artifact,
+    )
+    parent_path = match.group("parent")
+    parent = _read_artifact(vault_root, parent_path)
+    timestamp = descriptor.get("frame_timestamp_ms")
+    if (
+        descriptor.get("parent_path") != parent_path
+        or descriptor.get("parent_sha256")
+        != hashlib.sha256(parent.data).hexdigest()
+        or not isinstance(timestamp, int)
+        or isinstance(timestamp, bool)
+        or not 0 <= timestamp <= 4_294_967_295
+        or timestamp != int(match.group("millis"))
+    ):
+        raise CompanionClassificationError("artifact_mismatch")
+    return _bind_snapshots(
+        result,
+        ("artifact", artifact_path, artifact),
+        ("companion", f"{artifact_path}.md", companion),
+        ("parent", parent_path, parent),
+    )
+
+
+def classify(vault_root, rel_path: str) -> BoundCompanion:
+    """Locate and validate the closed descriptor class for one artifact."""
+
+    artifact_path = _canonical_relative_path(rel_path)
+    artifact = _read_artifact(vault_root, artifact_path)
+    frame_match = _FRAME_PATH_RE.fullmatch(artifact_path)
+    if frame_match is not None:
+        return _classify_scene_frame(vault_root, artifact_path, artifact, frame_match)
+    if PurePosixPath(artifact_path).suffix.casefold() in _DATASET_FORMATS:
+        return _classify_dataset(vault_root, artifact_path, artifact)
+    return _classify_sibling(vault_root, artifact_path, artifact)

--- a/src/exomem/governance/membership.py
+++ b/src/exomem/governance/membership.py
@@ -20,11 +20,15 @@ from typing import Literal
 from .. import find_corpus
 from ..find_types import ParsedPage
 from ..kbdir import kb_dirname
+from . import companions
 from .policy import Policy, Scope
 
 _MEMO_MAX = 4096
 _MEMO: OrderedDict[tuple[str, str, int, int], frozenset[str]] = OrderedDict()
 _SNAPSHOT_MEMO: OrderedDict[tuple[str, str, str], frozenset[str]] = OrderedDict()
+_PATH_MEMO: OrderedDict[
+    tuple[str, str, tuple[companions.BoundSnapshot, ...]], MembershipOutcome
+] = OrderedDict()
 
 
 class MembershipUnresolved(Exception):
@@ -45,17 +49,28 @@ class MembershipOutcome:
 
     state: Literal["classified", "unresolved"]
     scope_ids: frozenset[str]
-    reason: Literal["companion_required"] | None = None
+    reason: Literal[
+        "companion_required",
+        "artifact_unsafe",
+        "companion_unsafe",
+        "descriptor_missing",
+        "descriptor_invalid",
+        "artifact_mismatch",
+        "companion_ambiguous",
+    ] | None = None
 
     def require_classified(self) -> frozenset[str]:
         if self.state == "classified":
             return self.scope_ids
-        raise MembershipUnresolved("non-Markdown membership requires a companion")
+        raise MembershipUnresolved(
+            f"non-Markdown membership is unresolved: {self.reason or 'unknown'}"
+        )
 
 
 def clear_memo() -> None:
     _MEMO.clear()
     _SNAPSHOT_MEMO.clear()
+    _PATH_MEMO.clear()
 
 
 def _kb_relative(rel_path: str) -> str:
@@ -144,6 +159,26 @@ def _needs_frontmatter(scope: Scope) -> bool:
     return bool(scope.projects or scope.tags or scope.types or scope.classes)
 
 
+def _semantic_scope_matches(scope: Scope, companion: companions.BoundCompanion) -> bool:
+    projects = {value.casefold() for value in companion.projects}
+    tags = {value.casefold() for value in companion.tags}
+    types = {value.casefold() for value in companion.types}
+    classes = {value.casefold() for value in companion.classes}
+    positive = (
+        any(value.casefold() in projects for value in scope.projects)
+        or any(value.casefold() in tags for value in scope.tags)
+        or any(value.casefold() in types for value in scope.types)
+        or any(value.casefold() in classes for value in scope.classes)
+    )
+    excluded = (
+        any(value.casefold() in projects for value in scope.exclude_projects)
+        or any(value.casefold() in tags for value in scope.exclude_tags)
+        or any(value.casefold() in types for value in scope.exclude_types)
+        or any(value.casefold() in classes for value in scope.exclude_classes)
+    )
+    return positive and not excluded
+
+
 def evaluate_path_only(
     vault_root: Path, rel_path: str, policy: Policy
 ) -> MembershipOutcome:
@@ -159,15 +194,15 @@ def evaluate_path_only(
     including the owner).
 
     A path/ref exclusion proves exclusion and a path/ref positive proves
-    membership.  A selector requiring artifact semantics cannot be decided in
-    this compatibility slice: descriptor-like legacy companions deliberately
-    stay unresolved until the closed companion registry lands.
+    membership. A still-undecided semantic selector is evaluated only from the
+    closed, byte-bound companion registry. Missing, stale, ambiguous, or unsafe
+    companion state remains unresolved instead of becoming an empty scope set.
     """
     if policy.empty or not policy.scopes:
         return MembershipOutcome("classified", frozenset())
 
     matched: set[str] = set()
-    unresolved = False
+    undecided: list[tuple[str, Scope]] = []
     for scope_id, scope in policy.scopes.items():
         if _path_ref_excludes(scope, rel_path):
             continue
@@ -175,9 +210,26 @@ def evaluate_path_only(
             matched.add(scope_id)
             continue
         if _needs_frontmatter(scope):
-            unresolved = True
-    if unresolved:
-        return MembershipOutcome("unresolved", frozenset(matched), "companion_required")
+            undecided.append((scope_id, scope))
+    if undecided:
+        try:
+            companion = companions.classify(vault_root, rel_path)
+        except companions.CompanionClassificationError as error:
+            return MembershipOutcome("unresolved", frozenset(matched), error.reason)
+        memo_key = (policy.fingerprint, rel_path, companion.identities)
+        cached = _PATH_MEMO.get(memo_key)
+        if cached is not None:
+            _PATH_MEMO.move_to_end(memo_key)
+            return cached
+        for scope_id, scope in undecided:
+            if _semantic_scope_matches(scope, companion):
+                matched.add(scope_id)
+        result = MembershipOutcome("classified", frozenset(matched))
+        _PATH_MEMO[memo_key] = result
+        _PATH_MEMO.move_to_end(memo_key)
+        while len(_PATH_MEMO) > _MEMO_MAX:
+            _PATH_MEMO.popitem(last=False)
+        return result
     return MembershipOutcome("classified", frozenset(matched))
 
 

--- a/tests/test_governance_membership.py
+++ b/tests/test_governance_membership.py
@@ -6,11 +6,13 @@ never an index-time table — and memoized per `(fingerprint, path, mtime_ns)`.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import time
 from pathlib import Path
 
 import pytest
+import yaml
 
 from exomem import find_corpus
 from exomem.governance import membership, policy
@@ -283,7 +285,7 @@ def test_missing_non_markdown_companion_is_unresolved_for_semantic_selectors(
     # explicit, non-iterable unresolved membership.
     assert type(outcome).__name__ == "MembershipOutcome"
     assert outcome.state == "unresolved"
-    assert outcome.reason == "companion_required"
+    assert outcome.reason == "descriptor_missing"
 
 
 def test_path_only_non_markdown_membership_is_classified_empty(vault: Path) -> None:
@@ -334,3 +336,627 @@ def test_path_match_does_not_erase_an_unresolved_semantic_sibling(vault: Path) -
     assert type(outcome).__name__ == "MembershipOutcome"
     assert outcome.state == "unresolved"
     assert outcome.scope_ids == frozenset({"01ARZ3NDEKTSV4RRFFQ69G5FAV"})
+
+
+def _write_binary_companion(
+    vault: Path,
+    *,
+    artifact_rel: str = "Knowledge Base/Notes/asset.bin",
+    semantics: str = (
+        "projects: [acmeco]\n"
+        "    tags: [confidential]\n"
+        "    types: [source]\n"
+        "    classes: [pii]"
+    ),
+    artifact_sha256: str | None = None,
+    artifact_size: int | None = None,
+    state: str = "classified",
+) -> Path:
+    artifact = vault / artifact_rel
+    raw = artifact.read_bytes()
+    companion = artifact.with_name(f"{artifact.name}.md")
+    companion.write_text(
+        "---\n"
+        "type: source\n"
+        "title: Bound binary companion\n"
+        "governance_companion:\n"
+        "  version: 1\n"
+        f"  state: {state}\n"
+        "  artifact_class: binary\n"
+        f"  artifact_path: {artifact_rel}\n"
+        f"  artifact_sha256: {artifact_sha256 or hashlib.sha256(raw).hexdigest()}\n"
+        f"  artifact_size: {len(raw) if artifact_size is None else artifact_size}\n"
+        "  semantics:\n"
+        f"    {semantics}\n"
+        "---\n"
+        "Companion page metadata is not artifact semantics.\n",
+        encoding="utf-8",
+    )
+    return companion
+
+
+def _write_descriptor_page(path: Path, descriptor: dict[str, object]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    document = {
+        "type": "source",
+        "title": "Bound artifact companion",
+        "governance_companion": descriptor,
+    }
+    path.write_text(
+        f"---\n{yaml.safe_dump(document, sort_keys=False)}---\nBound companion.\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _bound_descriptor(
+    artifact_rel: str,
+    data: bytes,
+    *,
+    artifact_class: str,
+    **fields: object,
+) -> dict[str, object]:
+    return {
+        "version": 1,
+        "state": "classified",
+        "artifact_class": artifact_class,
+        "artifact_path": artifact_rel,
+        "artifact_sha256": hashlib.sha256(data).hexdigest(),
+        "artifact_size": len(data),
+        **fields,
+        "semantics": {
+            "projects": [],
+            "tags": ["confidential"],
+            "types": ["source"],
+            "classes": [],
+        },
+    }
+
+
+def _write_four_semantic_scopes(vault: Path) -> policy.Policy:
+    selectors = (
+        ("projects", "acmeco", "01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+        ("tags", "confidential", "01ARZ3NDEKTSV4RRFFQ69G5FAW"),
+        ("types", "source", "01ARZ3NDEKTSV4RRFFQ69G5FAX"),
+        ("classes", "pii", "01ARZ3NDEKTSV4RRFFQ69G5FAY"),
+    )
+    for selector, value, scope_id in selectors:
+        _write_scope(
+            vault,
+            selector,
+            "governance_version: 1\n"
+            f"id: {scope_id}\n"
+            f'{selector}: ["{value}"]\n',
+        )
+    return policy.load(vault)
+
+
+def test_bound_binary_companion_classifies_all_explicit_semantics(vault: Path) -> None:
+    pol = _write_four_semantic_scopes(vault)
+    asset = vault / "Knowledge Base/Notes/asset.bin"
+    asset.parent.mkdir(parents=True, exist_ok=True)
+    asset.write_bytes(b"opaque binary")
+    _write_binary_companion(vault)
+
+    outcome = membership.evaluate_path_only(
+        vault, "Knowledge Base/Notes/asset.bin", pol
+    )
+
+    assert outcome.state == "classified"
+    assert outcome.scope_ids == frozenset(
+        {
+            "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            "01ARZ3NDEKTSV4RRFFQ69G5FAW",
+            "01ARZ3NDEKTSV4RRFFQ69G5FAX",
+            "01ARZ3NDEKTSV4RRFFQ69G5FAY",
+        }
+    )
+
+
+def test_explicitly_empty_bound_companion_is_classified_empty(vault: Path) -> None:
+    _write_scope(
+        vault,
+        "semantic",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntags: ["secret"]\n',
+    )
+    pol = policy.load(vault)
+    asset = vault / "Knowledge Base/Notes/asset.bin"
+    asset.parent.mkdir(parents=True, exist_ok=True)
+    asset.write_bytes(b"opaque binary")
+    _write_binary_companion(
+        vault,
+        semantics="projects: []\n    tags: []\n    types: []\n    classes: []",
+    )
+
+    outcome = membership.evaluate_path_only(
+        vault, "Knowledge Base/Notes/asset.bin", pol
+    )
+
+    assert outcome.state == "classified"
+    assert outcome.scope_ids == frozenset()
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_reason"),
+    [
+        ({"artifact_sha256": "0" * 64}, "artifact_mismatch"),
+        ({"artifact_size": 999}, "artifact_mismatch"),
+        ({"state": "pending"}, "descriptor_invalid"),
+    ],
+)
+def test_malformed_or_stale_binary_companion_is_unresolved(
+    vault: Path, overrides: dict[str, object], expected_reason: str
+) -> None:
+    _write_scope(
+        vault,
+        "semantic",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntags: ["confidential"]\n',
+    )
+    pol = policy.load(vault)
+    asset = vault / "Knowledge Base/Notes/asset.bin"
+    asset.parent.mkdir(parents=True, exist_ok=True)
+    asset.write_bytes(b"opaque binary")
+    _write_binary_companion(vault, **overrides)
+
+    outcome = membership.evaluate_path_only(
+        vault, "Knowledge Base/Notes/asset.bin", pol
+    )
+
+    assert outcome.state == "unresolved"
+    assert outcome.reason == expected_reason
+
+
+def test_binary_companion_for_a_different_artifact_path_is_unresolved(
+    vault: Path,
+) -> None:
+    _write_scope(
+        vault,
+        "semantic",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntags: ["confidential"]\n',
+    )
+    pol = policy.load(vault)
+    artifact_rel = "Knowledge Base/Notes/asset.bin"
+    data = b"opaque binary"
+    artifact = vault / artifact_rel
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_bytes(data)
+    _write_descriptor_page(
+        artifact.with_name("asset.bin.md"),
+        _bound_descriptor(
+            "Knowledge Base/Notes/other.bin",
+            data,
+            artifact_class="binary",
+        ),
+    )
+
+    outcome = membership.evaluate_path_only(vault, artifact_rel, pol)
+
+    assert outcome.state == "unresolved"
+    assert outcome.reason == "artifact_mismatch"
+
+
+def test_companion_page_metadata_is_not_silently_adopted(vault: Path) -> None:
+    _write_scope(
+        vault,
+        "semantic",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntags: ["confidential"]\n',
+    )
+    pol = policy.load(vault)
+    asset = vault / "Knowledge Base/Notes/asset.bin"
+    asset.parent.mkdir(parents=True, exist_ok=True)
+    asset.write_bytes(b"opaque binary")
+    companion = asset.with_name("asset.bin.md")
+    companion.write_text(
+        "---\ntype: source\ntags: [confidential]\n---\nLegacy page metadata only.\n",
+        encoding="utf-8",
+    )
+
+    outcome = membership.evaluate_path_only(
+        vault, "Knowledge Base/Notes/asset.bin", pol
+    )
+
+    assert outcome.state == "unresolved"
+    assert outcome.reason == "descriptor_missing"
+
+
+def test_symlinked_binary_companion_is_unresolved(vault: Path, tmp_path: Path) -> None:
+    _write_scope(
+        vault,
+        "semantic",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntags: ["confidential"]\n',
+    )
+    pol = policy.load(vault)
+    asset = vault / "Knowledge Base/Notes/asset.bin"
+    asset.parent.mkdir(parents=True, exist_ok=True)
+    asset.write_bytes(b"opaque binary")
+    external = tmp_path / "external.md"
+    external.write_text("---\ntype: source\n---\noutside\n", encoding="utf-8")
+    asset.with_name("asset.bin.md").symlink_to(external)
+
+    outcome = membership.evaluate_path_only(
+        vault, "Knowledge Base/Notes/asset.bin", pol
+    )
+
+    assert outcome.state == "unresolved"
+    assert outcome.reason == "companion_unsafe"
+
+
+def test_unreadable_binary_companion_is_unresolved(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_scope(
+        vault,
+        "semantic",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntags: ["confidential"]\n',
+    )
+    pol = policy.load(vault)
+    artifact_rel = "Knowledge Base/Notes/asset.bin"
+    asset = vault / artifact_rel
+    asset.parent.mkdir(parents=True, exist_ok=True)
+    asset.write_bytes(b"opaque binary")
+    _write_binary_companion(vault)
+    read = membership.companions.reserved_paths.read_generic_bytes
+
+    def _refuse_companion(root, value, **kwargs):
+        if str(value).endswith(".bin.md"):
+            raise membership.companions.reserved_paths.ReservedPathLeafError(
+                "IO_REFUSED"
+            )
+        return read(root, value, **kwargs)
+
+    monkeypatch.setattr(
+        membership.companions.reserved_paths,
+        "read_generic_bytes",
+        _refuse_companion,
+    )
+
+    outcome = membership.evaluate_path_only(vault, artifact_rel, pol)
+
+    assert outcome.state == "unresolved"
+    assert outcome.reason == "companion_unsafe"
+
+
+def test_artifact_drift_invalidates_a_previously_valid_companion(vault: Path) -> None:
+    _write_scope(
+        vault,
+        "semantic",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntags: ["confidential"]\n',
+    )
+    pol = policy.load(vault)
+    asset = vault / "Knowledge Base/Notes/asset.bin"
+    asset.parent.mkdir(parents=True, exist_ok=True)
+    asset.write_bytes(b"opaque binary")
+    _write_binary_companion(vault)
+    membership.clear_memo()
+
+    first = membership.evaluate_path_only(
+        vault, "Knowledge Base/Notes/asset.bin", pol
+    )
+    asset.write_bytes(b"changed binary")
+    second = membership.evaluate_path_only(
+        vault, "Knowledge Base/Notes/asset.bin", pol
+    )
+
+    assert first.state == "classified"
+    assert first.scope_ids == frozenset({"01ARZ3NDEKTSV4RRFFQ69G5FAV"})
+    assert second.state == "unresolved"
+    assert second.reason == "artifact_mismatch"
+
+
+def test_bound_media_companion_requires_media_identity(vault: Path) -> None:
+    _write_scope(
+        vault,
+        "semantic",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntags: ["confidential"]\n',
+    )
+    pol = policy.load(vault)
+    artifact_rel = "Knowledge Base/Evidence/client/call.mp4"
+    data = b"video bytes"
+    artifact = vault / artifact_rel
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_bytes(data)
+    _write_descriptor_page(
+        artifact.with_name("call.mp4.md"),
+        _bound_descriptor(
+            artifact_rel,
+            data,
+            artifact_class="media",
+            media_type="video",
+            original_filename="call.mp4",
+        ),
+    )
+
+    outcome = membership.evaluate_path_only(vault, artifact_rel, pol)
+
+    assert outcome.state == "classified"
+    assert outcome.scope_ids == frozenset({"01ARZ3NDEKTSV4RRFFQ69G5FAV"})
+
+
+def test_media_descriptor_without_original_filename_is_unresolved(vault: Path) -> None:
+    _write_scope(
+        vault,
+        "semantic",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntags: ["confidential"]\n',
+    )
+    pol = policy.load(vault)
+    artifact_rel = "Knowledge Base/Evidence/client/call.mp4"
+    data = b"video bytes"
+    artifact = vault / artifact_rel
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_bytes(data)
+    _write_descriptor_page(
+        artifact.with_name("call.mp4.md"),
+        _bound_descriptor(
+            artifact_rel,
+            data,
+            artifact_class="media",
+            media_type="video",
+        ),
+    )
+
+    outcome = membership.evaluate_path_only(vault, artifact_rel, pol)
+
+    assert outcome.state == "unresolved"
+    assert outcome.reason == "descriptor_invalid"
+
+
+def test_unique_bound_dataset_card_classifies_data_file(vault: Path) -> None:
+    _write_scope(
+        vault,
+        "semantic",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntags: ["confidential"]\n',
+    )
+    pol = policy.load(vault)
+    artifact_rel = "Knowledge Base/Data/ledger.csv"
+    data = b"amount\n42\n"
+    artifact = vault / artifact_rel
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_bytes(data)
+    descriptor = _bound_descriptor(
+        artifact_rel,
+        data,
+        artifact_class="dataset",
+        format="csv",
+    )
+    card = _write_descriptor_page(
+        vault / "Knowledge Base/Notes/ledger-dataset.md", descriptor
+    )
+    card_text = card.read_text(encoding="utf-8").replace(
+        "type: source\n", f"type: dataset\ndata_file: {artifact_rel}\nformat: csv\n", 1
+    )
+    card.write_text(card_text, encoding="utf-8")
+
+    outcome = membership.evaluate_path_only(vault, artifact_rel, pol)
+
+    assert outcome.state == "classified"
+    assert outcome.scope_ids == frozenset({"01ARZ3NDEKTSV4RRFFQ69G5FAV"})
+
+
+def test_duplicate_bound_dataset_cards_are_unresolved(vault: Path) -> None:
+    _write_scope(
+        vault,
+        "semantic",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntags: ["confidential"]\n',
+    )
+    pol = policy.load(vault)
+    artifact_rel = "Knowledge Base/Data/ledger.csv"
+    data = b"amount\n42\n"
+    artifact = vault / artifact_rel
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_bytes(data)
+    descriptor = _bound_descriptor(
+        artifact_rel,
+        data,
+        artifact_class="dataset",
+        format="csv",
+    )
+    for name in ("ledger-a.md", "ledger-b.md"):
+        card = _write_descriptor_page(vault / "Knowledge Base/Notes" / name, descriptor)
+        card.write_text(
+            card.read_text(encoding="utf-8").replace(
+                "type: source\n",
+                f"type: dataset\ndata_file: {artifact_rel}\nformat: csv\n",
+                1,
+            ),
+            encoding="utf-8",
+        )
+
+    outcome = membership.evaluate_path_only(vault, artifact_rel, pol)
+
+    assert outcome.state == "unresolved"
+    assert outcome.reason == "companion_ambiguous"
+
+
+def test_relocated_dataset_card_does_not_classify_the_new_artifact_path(
+    vault: Path,
+) -> None:
+    _write_scope(
+        vault,
+        "semantic",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntags: ["confidential"]\n',
+    )
+    pol = policy.load(vault)
+    artifact_rel = "Knowledge Base/Data/moved.csv"
+    old_rel = "Knowledge Base/Data/original.csv"
+    data = b"amount\n42\n"
+    artifact = vault / artifact_rel
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_bytes(data)
+    descriptor = _bound_descriptor(
+        artifact_rel,
+        data,
+        artifact_class="dataset",
+        format="csv",
+    )
+    card = _write_descriptor_page(
+        vault / "Knowledge Base/Notes/ledger-dataset.md", descriptor
+    )
+    card.write_text(
+        card.read_text(encoding="utf-8").replace(
+            "type: source\n",
+            f"type: dataset\ndata_file: {old_rel}\nformat: csv\n",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    outcome = membership.evaluate_path_only(vault, artifact_rel, pol)
+
+    assert outcome.state == "unresolved"
+    assert outcome.reason == "descriptor_missing"
+
+
+@pytest.mark.parametrize(
+    ("override", "expected_reason"),
+    [
+        ({"parent_sha256": "0" * 64}, "artifact_mismatch"),
+        ({"parent_path": "Knowledge Base/Evidence/client/other.mp4"}, "artifact_mismatch"),
+        ({"frame_timestamp_ms": 10001}, "artifact_mismatch"),
+    ],
+)
+def test_scene_frame_companion_binds_parent_and_timestamp(
+    vault: Path, override: dict[str, object], expected_reason: str
+) -> None:
+    _write_scope(
+        vault,
+        "semantic",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntags: ["confidential"]\n',
+    )
+    pol = policy.load(vault)
+    parent_rel = "Knowledge Base/Evidence/client/call.mp4"
+    parent_data = b"video bytes"
+    parent = vault / parent_rel
+    parent.parent.mkdir(parents=True, exist_ok=True)
+    parent.write_bytes(parent_data)
+    frame_rel = f"{parent_rel}.frames/scene-001-t10000ms.jpg"
+    frame_data = b"frame bytes"
+    frame = vault / frame_rel
+    frame.parent.mkdir(parents=True, exist_ok=True)
+    frame.write_bytes(frame_data)
+    descriptor = _bound_descriptor(
+        frame_rel,
+        frame_data,
+        artifact_class="scene_frame",
+        parent_path=parent_rel,
+        parent_sha256=hashlib.sha256(parent_data).hexdigest(),
+        frame_timestamp_ms=10000,
+    )
+    descriptor.update(override)
+    _write_descriptor_page(frame.with_name(f"{frame.name}.md"), descriptor)
+
+    outcome = membership.evaluate_path_only(vault, frame_rel, pol)
+
+    assert outcome.state == "unresolved"
+    assert outcome.reason == expected_reason
+
+
+def test_valid_scene_frame_companion_classifies(vault: Path) -> None:
+    _write_scope(
+        vault,
+        "semantic",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntags: ["confidential"]\n',
+    )
+    pol = policy.load(vault)
+    parent_rel = "Knowledge Base/Evidence/client/call.mp4"
+    parent_data = b"video bytes"
+    parent = vault / parent_rel
+    parent.parent.mkdir(parents=True, exist_ok=True)
+    parent.write_bytes(parent_data)
+    frame_rel = f"{parent_rel}.frames/scene-001-t10000ms.jpg"
+    frame_data = b"frame bytes"
+    frame = vault / frame_rel
+    frame.parent.mkdir(parents=True, exist_ok=True)
+    frame.write_bytes(frame_data)
+    _write_descriptor_page(
+        frame.with_name(f"{frame.name}.md"),
+        _bound_descriptor(
+            frame_rel,
+            frame_data,
+            artifact_class="scene_frame",
+            parent_path=parent_rel,
+            parent_sha256=hashlib.sha256(parent_data).hexdigest(),
+            frame_timestamp_ms=10000,
+        ),
+    )
+
+    outcome = membership.evaluate_path_only(vault, frame_rel, pol)
+
+    assert outcome.state == "classified"
+    assert outcome.scope_ids == frozenset({"01ARZ3NDEKTSV4RRFFQ69G5FAV"})
+
+
+def test_non_markdown_membership_memo_reuses_only_the_exact_bound_snapshots(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_scope(
+        vault,
+        "semantic",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntags: ["alpha"]\n',
+    )
+    pol = policy.load(vault)
+    asset = vault / "Knowledge Base/Notes/asset.bin"
+    asset.parent.mkdir(parents=True, exist_ok=True)
+    asset.write_bytes(b"opaque binary")
+    _write_binary_companion(
+        vault,
+        semantics="projects: []\n    tags: [alpha]\n    types: []\n    classes: []",
+    )
+    membership.clear_memo()
+    original = membership._semantic_scope_matches
+    calls = 0
+
+    def _counted(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(membership, "_semantic_scope_matches", _counted)
+    first = membership.evaluate_path_only(
+        vault, "Knowledge Base/Notes/asset.bin", pol
+    )
+    second = membership.evaluate_path_only(
+        vault, "Knowledge Base/Notes/asset.bin", pol
+    )
+
+    assert first == second
+    assert calls == 1
+
+
+def test_non_markdown_membership_memo_never_replays_changed_companion_bytes(
+    vault: Path,
+) -> None:
+    _write_scope(
+        vault,
+        "alpha",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntags: ["alpha"]\n',
+    )
+    _write_scope(
+        vault,
+        "bravo",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAW\ntags: ["bravo"]\n',
+    )
+    pol = policy.load(vault)
+    asset = vault / "Knowledge Base/Notes/asset.bin"
+    asset.parent.mkdir(parents=True, exist_ok=True)
+    asset.write_bytes(b"opaque binary")
+    companion = _write_binary_companion(
+        vault,
+        semantics="projects: []\n    tags: [alpha]\n    types: []\n    classes: []",
+    )
+    membership.clear_memo()
+
+    first = membership.evaluate_path_only(
+        vault, "Knowledge Base/Notes/asset.bin", pol
+    )
+    prior = companion.stat()
+    changed = companion.read_text(encoding="utf-8").replace(
+        "tags: [alpha]", "tags: [bravo]"
+    )
+    companion.write_text(changed, encoding="utf-8")
+    os.utime(companion, ns=(prior.st_atime_ns, prior.st_mtime_ns))
+    second = membership.evaluate_path_only(
+        vault, "Knowledge Base/Notes/asset.bin", pol
+    )
+
+    assert first.scope_ids == frozenset({"01ARZ3NDEKTSV4RRFFQ69G5FAV"})
+    assert second.scope_ids == frozenset({"01ARZ3NDEKTSV4RRFFQ69G5FAW"})

--- a/tests/test_narrow_boundary_leaf_guards.py
+++ b/tests/test_narrow_boundary_leaf_guards.py
@@ -21,6 +21,7 @@ from exomem import create_directory as create_directory_module
 from exomem import create_file as create_file_module
 from exomem import mutation_lock
 from exomem.append_to_file import append_to_file
+from exomem.cli_ops import OpError
 from exomem.create_directory import create_directory
 from exomem.create_file import CreateFileError, create_file
 
@@ -68,8 +69,9 @@ def test_concurrent_non_markdown_creates_do_not_clobber(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Two concurrent creates of the same non-``.md`` path: exactly one wins,
-    and the loser gets FILE_EXISTS from the under-boundary re-check instead of
-    silently clobbering the winner's bytes (the reproduced review defect)."""
+    and the loser gets an honest refusal instead of silently clobbering the
+    winner's bytes (the reproduced review defect). A saturated outer mutation
+    boundary may return retryable MUTATION_BUSY before the leaf re-check."""
     real_write = create_file_module.batch_atomic_write
     a_in_boundary = threading.Event()
     a_release = threading.Event()
@@ -94,7 +96,7 @@ def test_concurrent_non_markdown_creates_do_not_clobber(
                 content=f'{{"writer": "{name}"}}\n',
             )
             results[name] = "ok"
-        except CreateFileError as error:
+        except (CreateFileError, OpError) as error:
             results[name] = error.code
 
     thread_a = threading.Thread(target=writer, args=("A",))
@@ -112,6 +114,14 @@ def test_concurrent_non_markdown_creates_do_not_clobber(
     assert not thread_a.is_alive() and not thread_b.is_alive()
 
     assert results["A"] == "ok"
-    assert results["B"] == "FILE_EXISTS"
+    assert results["B"] in {"FILE_EXISTS", "MUTATION_BUSY"}
+    if results["B"] == "MUTATION_BUSY":
+        with pytest.raises(CreateFileError) as retry:
+            create_file(
+                vault,
+                path="Knowledge Base/race.json",
+                content='{"writer": "B"}\n',
+            )
+        assert retry.value.code == "FILE_EXISTS"
     content = (vault / "Knowledge Base" / "race.json").read_text(encoding="utf-8")
     assert content == '{"writer": "A"}\n'


### PR DESCRIPTION
## Why

Semantic governance cannot treat an opaque artifact with missing or stale metadata as belonging to no scopes. This adds the closed, immutable companion registry for ordinary binaries, media, datasets, and scene frames.

## What changed

- validate exact artifact-class descriptors and explicit four-list semantics
- bind artifact, companion, and parent snapshots by stable identity and SHA-256
- reject missing, malformed, unsafe, stale, relocated, ambiguous, or mismatched companions
- memoize only exact policy and bound snapshot identities
- preserve path/ref precedence and the explicit-empty distinction
- record completed OpenSpec tasks 2.2, 2.3, 2.7, 2.9, and 2.10

## Verification

- 77 focused governance membership/propagation tests passed
- Ruff passed on all touched Python files
- strict OpenSpec validation passed
- public artifact privacy validation passed
- git diff --check passed

No live vault was touched.