### PR TITLE
fix(governance): preflight structured reads

### DIFF
--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -3440,6 +3440,14 @@ def op_query_data(
             date_from=date_from,
             date_to=date_to,
             date_column=date_column,
+            authorize_path=lambda rel_path: (
+                egress_module.release_level_for_path_only(
+                    vault_root,
+                    rel_path,
+                    receipt_decision="released",
+                )
+                >= egress_module.LEVEL_FULL
+            ),
         )
     except query_data_module.QueryDataError as e:
         raise ValueError(f"{e.code}: {e.reason}") from e

--- a/src/exomem/governance/egress.py
+++ b/src/exomem/governance/egress.py
@@ -2841,6 +2841,16 @@ def release_level_for_path_only(
             vault_root, rel_path, policy
         ).require_classified()
     except membership_module.MembershipUnresolved:
+        if receipt_decision is not None:
+            _outcome_for_decision(
+                vault_root,
+                rel_path,
+                decision=None,
+                policy=policy,
+                audience=who.audience_id,
+                outcome="withheld",
+                purpose=purpose,
+            )
         return DISCLOSURE_MIN
     decision = decide(
         scope_ids,
@@ -3260,15 +3270,15 @@ def release_allows_frames(
     principal: RequestPrincipal | None = None,
     purpose: str | None = None,
 ) -> bool:
-    """True at the release floor and above.
+    """True only at full disclosure.
 
-    Sampled keyframes are a bounded excerpt of a video — the image-shaped
-    equivalent of the excerpt a hit already carries at L5 — so they ride the
-    same floor rather than requiring full disclosure. Below it there is no
-    'abstracted frame', so the answer is a refusal, not a degraded render.
+    Frames are a structured direct representation of the source video, not the
+    registered bounded Markdown excerpt projector. Until a typed image
+    projector exists, every level below L6 must refuse rather than decode or
+    return partial pixels.
     """
     return _binary_boundary(
-        vault_root, rel_path, boundary_name="video_frame", minimum_level=RELEASE_FLOOR,
+        vault_root, rel_path, boundary_name="video_frame", minimum_level=LEVEL_FULL,
         principal=principal, purpose=purpose,
     )
 

--- a/src/exomem/query_data.py
+++ b/src/exomem/query_data.py
@@ -31,6 +31,7 @@ import itertools
 import json
 import logging
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -630,6 +631,7 @@ def query_data(
     date_from: str | None = None,
     date_to: str | None = None,
     date_column: str | None = None,
+    authorize_path: Callable[[str], bool] | None = None,
 ) -> QueryDataResult:
     """Query a CSV/JSON data file under the vault. See module docstring."""
     try:
@@ -643,6 +645,8 @@ def query_data(
         raise QueryDataError("NOT_FOUND", f"path does not exist: {rel}")
     if abs_path.suffix.lower() not in ALLOWED_SUFFIXES:
         raise QueryDataError("UNSUPPORTED_FORMAT", f"only {list(ALLOWED_SUFFIXES)} supported")
+    if authorize_path is not None and not authorize_path(rel):
+        raise QueryDataError("NOT_FOUND", f"path does not exist: {rel}")
 
     fmt, rows, cols, warnings = load_generic_rows(
         vault_root, rel, abs_path.suffix, record_path

--- a/tests/test_governance_egress.py
+++ b/tests/test_governance_egress.py
@@ -19,6 +19,7 @@ import pytest
 
 from exomem import commands
 from exomem import find as find_module
+from exomem import query_data as query_data_module
 from exomem.find_types import GraphProvenance, Hit
 from exomem.governance import egress, receipts
 from exomem.governance.principal import RequestPrincipal, owner_principal, request_scope
@@ -1978,6 +1979,66 @@ def test_query_data_csv_rows_are_gated_and_receipted(vault: Path) -> None:
     assert "Alice" not in json.dumps(record)
 
 
+def test_unresolved_dataset_is_missing_before_rows_are_loaded(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dataset = "Knowledge Base/Data/private.csv"
+    target = vault / dataset
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("name,value\nAlice,42\n", encoding="utf-8")
+    card = vault / "Knowledge Base/Notes/Datasets/private.md"
+    card.parent.mkdir(parents=True, exist_ok=True)
+    card.write_text(
+        "---\n"
+        "type: dataset\n"
+        f"data_file: {dataset}\n"
+        "format: csv\n"
+        "tags: [confidential]\n"
+        "---\n\nLegacy dataset card without a governance companion descriptor.\n",
+        encoding="utf-8",
+    )
+    scope = _gov_dir(vault) / "scopes" / "patterns.yaml"
+    scope.parent.mkdir(parents=True, exist_ok=True)
+    scope.write_text(
+        f"governance_version: 1\nid: {SCOPE_ID}\nname: Confidential\n"
+        'tags: ["confidential"]\n',
+        encoding="utf-8",
+    )
+    write_rule(vault, ceiling=egress.LEVEL_FULL)
+    _reset_caches()
+
+    def forbidden_load(*_args: object, **_kwargs: object):
+        raise AssertionError("unresolved dataset reached the row parser")
+
+    monkeypatch.setattr(query_data_module, "load_generic_rows", forbidden_load)
+    with request_scope(_external()):
+        with egress.disclosure_boundary(vault, "query_data") as collector:
+            with pytest.raises(ValueError, match="NOT_FOUND"):
+                commands.op_query_data(vault, path=dataset)
+            egress.emit_boundary_receipt(collector)
+    assert _receipt_records(vault)[0]["outcomes"][0]["decision"] == "withheld"
+
+
+def test_l5_dataset_is_missing_before_rows_are_loaded(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dataset = "Knowledge Base/Data/private.csv"
+    target = vault / dataset
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("name,value\nAlice,42\n", encoding="utf-8")
+    write_scope(vault, paths="Data/**")
+    write_rule(vault, ceiling=egress.LEVEL_EXCERPT)
+    _reset_caches()
+
+    def forbidden_load(*_args: object, **_kwargs: object):
+        raise AssertionError("L5 dataset reached the row parser")
+
+    monkeypatch.setattr(query_data_module, "load_generic_rows", forbidden_load)
+    with request_scope(_external()):
+        with pytest.raises(ValueError, match="NOT_FOUND"):
+            commands.op_query_data(vault, path=dataset)
+
+
 def test_receipt_conflict_never_turns_a_committed_mutation_into_a_retry_error(vault: Path) -> None:
     write_scope(vault)
     write_rule(vault, ceiling=egress.LEVEL_FULL)
@@ -2736,6 +2797,16 @@ def test_withheld_media_download_is_still_denied(vault: Path) -> None:
 
     with request_scope(_external()):
         assert egress.release_allows_download(vault, rel) is False
+        assert egress.release_allows_frames(vault, rel) is False
+
+
+def test_excerpt_level_never_authorizes_raw_video_frames(vault: Path) -> None:
+    rel = _media(vault, "Knowledge Base/Notes/Patterns/recording.mp4")
+    write_scope(vault)
+    write_rule(vault, ceiling=egress.LEVEL_EXCERPT)
+    _reset_caches()
+
+    with request_scope(_external()):
         assert egress.release_allows_frames(vault, rel) is False
 
 

--- a/tests/test_record_governance.py
+++ b/tests/test_record_governance.py
@@ -145,6 +145,37 @@ def test_log_and_dataset_source_require_full_release_before_read(
     assert calls == []
 
 
+def test_unresolved_dataset_source_never_reaches_records_adapter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixture = copy_dataset_fixture(tmp_path)
+    manifest = collections.load_manifest(tmp_path, fixture / "_collection.md")
+    _write_l6_rule(tmp_path, ceiling=6, paths="Records/**")
+    semantic_scope = (
+        tmp_path
+        / "Knowledge Base"
+        / "_Governance"
+        / "scopes"
+        / "semantic-source.yaml"
+    )
+    semantic_scope.write_text(
+        "governance_version: 1\n"
+        "id: 01ARZ3NDEKTSV4RRFFQ69G5FZZ\n"
+        "name: Semantic sources\n"
+        'types: ["source"]\n',
+        encoding="utf-8",
+    )
+
+    def forbidden_read(_self: record_formats.DatasetAdapter):
+        raise AssertionError("unresolved dataset reached the Records adapter")
+
+    monkeypatch.setattr(record_formats.DatasetAdapter, "read", forbidden_read)
+    with request_scope(RequestPrincipal(audience_id=EXTERNAL, surface="mcp")):
+        with pytest.raises(collections.CollectionError) as raised:
+            record_governance.query_collection(tmp_path, manifest, aggregate="count")
+    assert raised.value.code == "COLLECTION_NOT_FOUND"
+
+
 @pytest.mark.parametrize(
     "aggregate",
     (

--- a/tests/test_video_frames.py
+++ b/tests/test_video_frames.py
@@ -18,6 +18,7 @@ import pytest
 from exomem import commands as commands_module
 from exomem import embeddings, video_frames
 from exomem import server as server_module
+from exomem.governance.principal import RequestPrincipal, request_scope
 
 VIDEO = "Knowledge Base/Sources/clip.mp4"
 
@@ -321,6 +322,35 @@ def test_mcp_tool_returns_metadata_then_images(video_vault, monkeypatch) -> None
     assert [b.mimeType for b in images] == ["image/jpeg", "image/jpeg"]
     assert base64.b64decode(images[0].data) == b"\xff\xd8AA"
     assert base64.b64decode(images[1].data) == b"\xff\xd8BB"
+
+
+def test_unresolved_video_is_missing_before_decoder_loads(video_vault, monkeypatch) -> None:
+    governance = video_vault / "Knowledge Base" / "_Governance"
+    (governance / "scopes").mkdir(parents=True, exist_ok=True)
+    (governance / "rules").mkdir(parents=True, exist_ok=True)
+    (governance / "scopes" / "semantic-source.yaml").write_text(
+        "governance_version: 1\n"
+        "id: 01ARZ3NDEKTSV4RRFFQ69G5FAV\n"
+        "name: Semantic sources\n"
+        'types: ["source"]\n',
+        encoding="utf-8",
+    )
+    (governance / "rules" / "external.yaml").write_text(
+        "governance_version: 1\n"
+        "id: 01ARZ3NDEKTSV4RRFFQ69G5FB0\n"
+        'scope_ids: ["01ARZ3NDEKTSV4RRFFQ69G5FAV"]\n'
+        "audience: external\n"
+        "ceiling: 6\n",
+        encoding="utf-8",
+    )
+
+    def forbidden_module():
+        raise AssertionError("unresolved video reached the decoder module")
+
+    monkeypatch.setattr(commands_module, "_video_frames_module", forbidden_module)
+    with request_scope(RequestPrincipal(audience_id="external", surface="mcp")):
+        with pytest.raises(ValueError, match="NOT_FOUND"):
+            commands_module.op_get_video_frames(video_vault, VIDEO)
 
 
 def test_mcp_tool_error_carries_code(video_vault, monkeypatch) -> None:


### PR DESCRIPTION
## Why

Governed structured reads must resolve membership and disclosure before loading dataset rows, Records adapters, or video decoders. Otherwise withheld or unclassifiable non-Markdown artifacts can still influence parsing work and error behavior.

## What

- authorize query_data before loading rows and return the missing-shaped refusal below L6
- emit a withheld receipt when non-Markdown membership is unresolved
- prevent unresolved Records dataset sources from reaching their adapter
- require L6 before decoding or returning raw video frames

## Verification

- focused governance/Records/dataset/video packet: **441 passed, 3 optional-dependency skips**
- Ruff on all six changed Python files: clean
- strict OpenSpec validation: valid
- public-artifact privacy gate: clean (2,990 files / 3,036 payloads)
- git diff --check: clean
- Conventional Commit title check: valid

No personal or POLLY vault was read or mutated.