### PR TITLE
feat(governance): bind authorization credential verifiers

### DIFF
--- a/src/exomem/governance/authorization_sessions.py
+++ b/src/exomem/governance/authorization_sessions.py
@@ -1,0 +1,74 @@
+"""Pure authorization-session credential grammar.
+
+The parser is shared by capability verification and terminal scrubbing so an
+accepted credential can never fall outside the scrubber's canonical language.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+AUTHORIZATION_SESSION_CREDENTIAL_BYTES = 70
+_BASE64URL_ALPHABET = frozenset(
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationSessionCredential:
+    encoded: str
+    locator: bytes
+    secret: bytes
+
+
+def parse_credential(value: object) -> AuthorizationSessionCredential | None:
+    """Parse only canonical ``as1`` credentials with their exact bounded parts."""
+
+    if not isinstance(value, str):
+        return None
+    try:
+        encoded = value.encode("ascii")
+    except UnicodeEncodeError:
+        return None
+    if (
+        len(encoded) != AUTHORIZATION_SESSION_CREDENTIAL_BYTES
+        or encoded[:4] != b"as1."
+        or encoded[26:27] != b"."
+    ):
+        return None
+    locator = encoded[4:26]
+    secret = encoded[27:]
+    if not all(byte in _BASE64URL_ALPHABET for byte in (*locator, *secret)):
+        return None
+    try:
+        locator_bytes = base64.b64decode(locator + b"==", altchars=b"-_", validate=True)
+        secret_bytes = base64.b64decode(secret + b"=", altchars=b"-_", validate=True)
+    except (binascii.Error, ValueError):
+        return None
+    if len(locator_bytes) != 16 or len(secret_bytes) != 32:
+        return None
+    if (
+        base64.urlsafe_b64encode(locator_bytes).rstrip(b"=") != locator
+        or base64.urlsafe_b64encode(secret_bytes).rstrip(b"=") != secret
+    ):
+        return None
+    return AuthorizationSessionCredential(value, locator_bytes, secret_bytes)
+
+
+def iter_credential_spans(text: str) -> Iterator[tuple[int, int]]:
+    """Yield every canonical credential span using the shared bounded parser."""
+
+    search_from = 0
+    while True:
+        start = text.find("as1.", search_from)
+        if start < 0:
+            return
+        end = start + AUTHORIZATION_SESSION_CREDENTIAL_BYTES
+        if parse_credential(text[start:end]) is None:
+            search_from = start + 1
+            continue
+        yield start, end
+        search_from = end

--- a/src/exomem/governance/authorization_sessions.py
+++ b/src/exomem/governance/authorization_sessions.py
@@ -8,10 +8,17 @@ from __future__ import annotations
 
 import base64
 import binascii
+import hashlib
+import hmac
+import secrets
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Literal
 
 AUTHORIZATION_SESSION_CREDENTIAL_BYTES = 70
+_MAX_SIGNED_SQLITE_INTEGER = (1 << 63) - 1
+_LOCATOR_DIGEST_DOMAIN = b"exomem.authorization-session.locator/v1"
+_CREDENTIAL_VERIFIER_DOMAIN = b"exomem.authorization-session.verifier/v1"
 _BASE64URL_ALPHABET = frozenset(
     b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
 )
@@ -19,9 +26,219 @@ _BASE64URL_ALPHABET = frozenset(
 
 @dataclass(frozen=True, slots=True)
 class AuthorizationSessionCredential:
-    encoded: str
+    encoded: str = field(repr=False)
     locator: bytes
-    secret: bytes
+    secret: bytes = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationSessionBinding:
+    session_id: str
+    principal_id: str
+    issuer_family: str
+    cell_id: str
+    logical_vault_id: str
+    keyring_id: str
+    credential_generation: int
+    expires_at: int
+
+    def __post_init__(self) -> None:
+        for name in (
+            "session_id",
+            "principal_id",
+            "issuer_family",
+            "cell_id",
+            "logical_vault_id",
+            "keyring_id",
+        ):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value or len(value.encode("utf-8")) > 512:
+                raise ValueError(f"{name} must be non-empty bounded text")
+        if (
+            isinstance(self.credential_generation, bool)
+            or not 1
+            <= self.credential_generation
+            <= _MAX_SIGNED_SQLITE_INTEGER
+        ):
+            raise ValueError("credential_generation must be a positive integer")
+        if (
+            isinstance(self.expires_at, bool)
+            or not 1 <= self.expires_at <= _MAX_SIGNED_SQLITE_INTEGER
+        ):
+            raise ValueError("expires_at must be a positive integer")
+
+
+AuthorizationSessionStatus = Literal["active", "closed"]
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationSessionVerifierRecord:
+    binding: AuthorizationSessionBinding
+    verifier_key_id: str
+    locator_digest: bytes = field(repr=False)
+    verifier: bytes = field(repr=False)
+    status: AuthorizationSessionStatus = "active"
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.verifier_key_id, str)
+            or not self.verifier_key_id
+            or len(self.verifier_key_id.encode("utf-8")) > 512
+        ):
+            raise ValueError("verifier_key_id must be non-empty bounded text")
+        if (
+            not isinstance(self.locator_digest, bytes)
+            or len(self.locator_digest) != hashlib.sha256().digest_size
+        ):
+            raise ValueError("locator_digest must be one SHA-256 digest")
+        if (
+            not isinstance(self.verifier, bytes)
+            or len(self.verifier) != hashlib.sha256().digest_size
+        ):
+            raise ValueError("verifier must be one SHA-256 digest")
+        if self.status not in {"active", "closed"}:
+            raise ValueError("authorization session status is invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class IssuedAuthorizationSessionCredential:
+    bearer: str = field(repr=False)
+    record: AuthorizationSessionVerifierRecord
+
+
+def _frame(domain: bytes, fields: tuple[bytes, ...]) -> bytes:
+    framed = bytearray(domain)
+    framed.append(0)
+    for value in fields:
+        framed.extend(len(value).to_bytes(4, "big"))
+        framed.extend(value)
+    return bytes(framed)
+
+
+def _binding_fields(binding: AuthorizationSessionBinding) -> tuple[bytes, ...]:
+    return (
+        binding.session_id.encode("utf-8"),
+        binding.principal_id.encode("utf-8"),
+        binding.issuer_family.encode("utf-8"),
+        binding.cell_id.encode("utf-8"),
+        binding.logical_vault_id.encode("utf-8"),
+        binding.keyring_id.encode("utf-8"),
+        binding.credential_generation.to_bytes(8, "big"),
+        binding.expires_at.to_bytes(8, "big"),
+    )
+
+
+def _require_verifier_key(verifier_key: bytes) -> None:
+    if not isinstance(verifier_key, bytes) or len(verifier_key) != 32:
+        raise ValueError("authorization-session verifier key must contain exactly 256 bits")
+
+
+def _locator_digest(verifier_key: bytes, locator: bytes) -> bytes:
+    return hmac.new(
+        verifier_key,
+        _frame(_LOCATOR_DIGEST_DOMAIN, (locator,)),
+        hashlib.sha256,
+    ).digest()
+
+
+def _credential_verifier(
+    verifier_key: bytes,
+    *,
+    verifier_key_id: str,
+    locator: bytes,
+    secret: bytes,
+    binding: AuthorizationSessionBinding,
+) -> bytes:
+    return hmac.new(
+        verifier_key,
+        _frame(
+            _CREDENTIAL_VERIFIER_DOMAIN,
+            (
+                secret,
+                locator,
+                verifier_key_id.encode("utf-8"),
+                *_binding_fields(binding),
+            ),
+        ),
+        hashlib.sha256,
+    ).digest()
+
+
+def _encode_credential(locator: bytes, secret: bytes) -> str:
+    if len(locator) != 16 or len(secret) != 32:
+        raise ValueError("authorization-session credential parts have invalid lengths")
+    return (
+        "as1."
+        + base64.urlsafe_b64encode(locator).rstrip(b"=").decode("ascii")
+        + "."
+        + base64.urlsafe_b64encode(secret).rstrip(b"=").decode("ascii")
+    )
+
+
+def issue_credential(
+    *,
+    verifier_key: bytes,
+    verifier_key_id: str,
+    binding: AuthorizationSessionBinding,
+) -> IssuedAuthorizationSessionCredential:
+    """Issue one random credential and its bearer-free persisted verifier record."""
+
+    _require_verifier_key(verifier_key)
+    locator = secrets.token_bytes(16)
+    secret = secrets.token_bytes(32)
+    bearer = _encode_credential(locator, secret)
+    record = AuthorizationSessionVerifierRecord(
+        binding=binding,
+        verifier_key_id=verifier_key_id,
+        locator_digest=_locator_digest(verifier_key, locator),
+        verifier=_credential_verifier(
+            verifier_key,
+            verifier_key_id=verifier_key_id,
+            locator=locator,
+            secret=secret,
+            binding=binding,
+        ),
+    )
+    return IssuedAuthorizationSessionCredential(bearer=bearer, record=record)
+
+
+def verify_credential(
+    value: object,
+    *,
+    record: AuthorizationSessionVerifierRecord,
+    verifier_key: bytes,
+    verifier_key_id: str,
+    expected_binding: AuthorizationSessionBinding,
+    now: int,
+) -> bool:
+    """Verify a parsed credential against its row and trusted request binding."""
+
+    _require_verifier_key(verifier_key)
+    if isinstance(now, bool) or not isinstance(now, int):
+        return False
+    parsed = parse_credential(value)
+    if parsed is None:
+        return False
+    calculated_locator = _locator_digest(verifier_key, parsed.locator)
+    calculated_verifier = _credential_verifier(
+        verifier_key,
+        verifier_key_id=verifier_key_id,
+        locator=parsed.locator,
+        secret=parsed.secret,
+        binding=record.binding,
+    )
+    valid = hmac.compare_digest(calculated_locator, record.locator_digest)
+    valid &= hmac.compare_digest(calculated_verifier, record.verifier)
+    valid &= hmac.compare_digest(verifier_key_id, record.verifier_key_id)
+    for actual, expected in zip(
+        _binding_fields(record.binding),
+        _binding_fields(expected_binding),
+        strict=True,
+    ):
+        valid &= hmac.compare_digest(actual, expected)
+    valid &= record.status == "active"
+    valid &= now < record.binding.expires_at
+    return bool(valid)
 
 
 def parse_credential(value: object) -> AuthorizationSessionCredential | None:

--- a/src/exomem/governance/authorization_sessions.py
+++ b/src/exomem/governance/authorization_sessions.py
@@ -229,7 +229,10 @@ def verify_credential(
     )
     valid = hmac.compare_digest(calculated_locator, record.locator_digest)
     valid &= hmac.compare_digest(calculated_verifier, record.verifier)
-    valid &= hmac.compare_digest(verifier_key_id, record.verifier_key_id)
+    valid &= hmac.compare_digest(
+        verifier_key_id.encode("utf-8"),
+        record.verifier_key_id.encode("utf-8"),
+    )
     for actual, expected in zip(
         _binding_fields(record.binding),
         _binding_fields(expected_binding),

--- a/src/exomem/governance/scrubber.py
+++ b/src/exomem/governance/scrubber.py
@@ -24,8 +24,6 @@ Two properties make it safe to run on every result:
 
 from __future__ import annotations
 
-import base64
-import binascii
 import datetime as dt
 import functools
 import hmac
@@ -36,6 +34,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from . import authorization_sessions
 
 #: What replaces a blocked value. Deliberately fixed text: a per-credential
 #: description would itself carry information about what was found.
@@ -51,9 +51,6 @@ NOTICE = "[credential blocked by exomem egress policy]"
 _AUTHORIZATION_BEARER_CANDIDATE_RE = re.compile(
     r"(?<![A-Za-z0-9_-])as1\.[A-Za-z0-9_-]{1,256}\.[A-Za-z0-9_-]{1,256}(?![A-Za-z0-9_-])"
 )
-_BASE64URL_ALPHABET = frozenset(
-    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
-)
 _ISSUANCE_ACTIONS = frozenset({"open", "rotate"})
 _ISSUANCE_CONTEXT_SEAL = object()
 _RFC3339_RE = re.compile(
@@ -63,44 +60,10 @@ _RFC3339_RE = re.compile(
 
 
 def _parse_authorization_bearer(value: object) -> str | None:
-    """Return only the exact canonical 70-byte authorization bearer.
+    """Compatibility wrapper over the shared exact capability parser."""
 
-    Decode and byte-identical re-encoding are load-bearing: alphabet/length
-    checks alone accept final characters whose unused base64 bits are non-zero.
-    """
-    if not isinstance(value, str):
-        return None
-    try:
-        encoded = value.encode("ascii")
-    except UnicodeEncodeError:
-        return None
-    if (
-        len(encoded) != 70
-        or encoded[:4] != b"as1."
-        or encoded[26:27] != b"."
-    ):
-        return None
-    locator = encoded[4:26]
-    secret = encoded[27:]
-    if not all(byte in _BASE64URL_ALPHABET for byte in (*locator, *secret)):
-        return None
-    try:
-        locator_bytes = base64.b64decode(
-            locator + b"==", altchars=b"-_", validate=True
-        )
-        secret_bytes = base64.b64decode(
-            secret + b"=", altchars=b"-_", validate=True
-        )
-    except (binascii.Error, ValueError):
-        return None
-    if len(locator_bytes) != 16 or len(secret_bytes) != 32:
-        return None
-    if (
-        base64.urlsafe_b64encode(locator_bytes).rstrip(b"=") != locator
-        or base64.urlsafe_b64encode(secret_bytes).rstrip(b"=") != secret
-    ):
-        return None
-    return value
+    parsed = authorization_sessions.parse_credential(value)
+    return None if parsed is None else parsed.encoded
 
 
 @dataclass(frozen=True, slots=True)
@@ -522,20 +485,10 @@ def _scrub_canonical_authorization_bearers(text: str) -> tuple[str, int]:
     """
     parts: list[str] = []
     copied_through = 0
-    search_from = 0
     replacements = 0
-    while True:
-        start = text.find("as1.", search_from)
-        if start < 0:
-            break
-        end = start + 70
-        candidate = text[start:end]
-        if _parse_authorization_bearer(candidate) is None:
-            search_from = start + 1
-            continue
+    for start, end in authorization_sessions.iter_credential_spans(text):
         parts.extend((text[copied_through:start], NOTICE))
         copied_through = end
-        search_from = end
         replacements += 1
     if not replacements:
         return text, 0

--- a/tests/test_authorization_session_binding.py
+++ b/tests/test_authorization_session_binding.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from exomem.governance import authorization_sessions, scrubber
+
+
+def _credential(locator: bytes, secret: bytes) -> str:
+    return (
+        "as1."
+        + base64.urlsafe_b64encode(locator).rstrip(b"=").decode("ascii")
+        + "."
+        + base64.urlsafe_b64encode(secret).rstrip(b"=").decode("ascii")
+    )
+
+
+def test_shared_authorization_session_parser_returns_exact_bounded_parts() -> None:
+    bearer = _credential(bytes(range(16)), bytes(range(32)))
+
+    parsed = authorization_sessions.parse_credential(bearer)
+
+    assert parsed is not None
+    assert parsed.encoded == bearer
+    assert parsed.locator == bytes(range(16))
+    assert parsed.secret == bytes(range(32))
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        b"as1.not-a-string",
+        " as1." + "A" * 22 + "." + "A" * 43,
+        "as1." + "A" * 22 + "." + "A" * 43 + "\n",
+        "as1." + "A" * 21 + "=" + "." + "A" * 43,
+        "as1." + "A" * 21 + "+" + "." + "A" * 43,
+        "as1." + "A" * 21 + "/" + "." + "A" * 43,
+        "as1." + "A" * 21 + "B" + "." + "A" * 43,
+        "as1." + "A" * 22 + "." + "A" * 42 + "B",
+    ],
+)
+def test_shared_authorization_session_parser_rejects_noncanonical_values(
+    value: object,
+) -> None:
+    assert authorization_sessions.parse_credential(value) is None
+
+
+def test_shared_matcher_finds_adjacent_credentials_and_overlapping_starts() -> None:
+    first = _credential(bytes(range(16)), bytes(range(32)))
+    second = _credential(bytes(reversed(range(16))), bytes(reversed(range(32))))
+    text = f"as1.x{first}{second}y"
+
+    assert list(authorization_sessions.iter_credential_spans(text)) == [
+        (5, 75),
+        (75, 145),
+    ]
+
+
+def test_terminal_scrubber_uses_the_shared_authorization_session_parser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bearer = _credential(bytes(range(16)), bytes(range(32)))
+    calls: list[object] = []
+    real = authorization_sessions.parse_credential
+
+    def recording_parser(
+        value: object,
+    ) -> authorization_sessions.AuthorizationSessionCredential | None:
+        calls.append(value)
+        return real(value)
+
+    monkeypatch.setattr(authorization_sessions, "parse_credential", recording_parser)
+
+    cleaned, blocked = scrubber.scrub_text(f"prefix {bearer} suffix")
+
+    assert blocked is True
+    assert bearer not in cleaned
+    assert bearer in calls

--- a/tests/test_authorization_session_binding.py
+++ b/tests/test_authorization_session_binding.py
@@ -210,6 +210,24 @@ def test_verify_accepts_only_active_unexpired_record_and_matching_key() -> None:
     )
 
 
+def test_verify_accepts_a_matching_utf8_verifier_key_id() -> None:
+    key_id = "auth-key-å-2026"
+    issued = authorization_sessions.issue_credential(
+        verifier_key=b"k" * 32,
+        verifier_key_id=key_id,
+        binding=_binding(),
+    )
+
+    assert authorization_sessions.verify_credential(
+        issued.bearer,
+        record=issued.record,
+        verifier_key=b"k" * 32,
+        verifier_key_id=key_id,
+        expected_binding=_binding(),
+        now=1_800_000_000,
+    )
+
+
 def test_verify_compares_digest_before_rejecting_validly_parsed_credentials(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_authorization_session_binding.py
+++ b/tests/test_authorization_session_binding.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import base64
+import dataclasses
+import hmac
 
 import pytest
 
@@ -16,6 +18,23 @@ def _credential(locator: bytes, secret: bytes) -> str:
     )
 
 
+def _binding(
+    **changes: object,
+) -> authorization_sessions.AuthorizationSessionBinding:
+    values: dict[str, object] = {
+        "session_id": "session-018f621c",
+        "principal_id": "principal:local-owner:1000",
+        "issuer_family": "cli-local-owner",
+        "cell_id": "cell-7bd27031",
+        "logical_vault_id": "vault-a2699d30",
+        "keyring_id": "keyring-e7901e43",
+        "credential_generation": 3,
+        "expires_at": 1_800_003_600,
+    }
+    values.update(changes)
+    return authorization_sessions.AuthorizationSessionBinding(**values)  # type: ignore[arg-type]
+
+
 def test_shared_authorization_session_parser_returns_exact_bounded_parts() -> None:
     bearer = _credential(bytes(range(16)), bytes(range(32)))
 
@@ -25,6 +44,26 @@ def test_shared_authorization_session_parser_returns_exact_bounded_parts() -> No
     assert parsed.encoded == bearer
     assert parsed.locator == bytes(range(16))
     assert parsed.secret == bytes(range(32))
+    assert bearer not in repr(parsed)
+    assert bytes(range(32)).hex() not in repr(parsed)
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"session_id": ""}, "session_id"),
+        ({"principal_id": "x" * 513}, "principal_id"),
+        ({"credential_generation": 0}, "credential_generation"),
+        ({"credential_generation": 2**64}, "credential_generation"),
+        ({"expires_at": 0}, "expires_at"),
+        ({"expires_at": 2**64}, "expires_at"),
+    ],
+)
+def test_binding_rejects_empty_or_unframeable_values(
+    changes: dict[str, object], message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        _binding(**changes)
 
 
 @pytest.mark.parametrize(
@@ -56,6 +95,147 @@ def test_shared_matcher_finds_adjacent_credentials_and_overlapping_starts() -> N
         (5, 75),
         (75, 145),
     ]
+
+
+def test_issue_binds_credential_without_persisting_bearer_or_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    locator = bytes(range(16))
+    secret = bytes(range(32))
+
+    def deterministic_bytes(size: int) -> bytes:
+        return {16: locator, 32: secret}[size]
+
+    monkeypatch.setattr(authorization_sessions.secrets, "token_bytes", deterministic_bytes)
+
+    issued = authorization_sessions.issue_credential(
+        verifier_key=b"k" * 32,
+        verifier_key_id="auth-key-2026-08",
+        binding=_binding(),
+    )
+
+    assert issued.bearer == _credential(locator, secret)
+    assert issued.record.binding == _binding()
+    assert issued.record.status == "active"
+    assert issued.record.locator_digest.hex() == (
+        "67154d8db47a1c6438bd7625569028792d89fe273e235af70157fae09cbc6600"
+    )
+    assert issued.record.verifier.hex() == (
+        "723506256cf9c61c3257360099f2865cec9df4f743c1051cb6719d44513cbc48"
+    )
+    persisted = repr(dataclasses.asdict(issued.record))
+    assert issued.bearer not in persisted
+    assert secret.hex() not in persisted
+    assert issued.bearer not in repr(issued)
+
+
+@pytest.mark.parametrize("field_name", ["locator_digest", "verifier"])
+def test_verifier_record_rejects_text_disguised_as_digest(field_name: str) -> None:
+    issued = authorization_sessions.issue_credential(
+        verifier_key=b"k" * 32,
+        verifier_key_id="auth-key-2026-08",
+        binding=_binding(),
+    )
+
+    with pytest.raises(ValueError, match=field_name):
+        dataclasses.replace(issued.record, **{field_name: "x" * 32})
+
+
+@pytest.mark.parametrize(
+    "binding_change",
+    [
+        {"principal_id": "principal:local-owner:1001"},
+        {"issuer_family": "rest-api-key"},
+        {"cell_id": "cell-other"},
+        {"logical_vault_id": "vault-other"},
+        {"keyring_id": "keyring-other"},
+        {"credential_generation": 4},
+    ],
+)
+def test_verify_rejects_every_cross_binding(
+    binding_change: dict[str, object],
+) -> None:
+    issued = authorization_sessions.issue_credential(
+        verifier_key=b"k" * 32,
+        verifier_key_id="auth-key-2026-08",
+        binding=_binding(),
+    )
+
+    assert not authorization_sessions.verify_credential(
+        issued.bearer,
+        record=issued.record,
+        verifier_key=b"k" * 32,
+        verifier_key_id="auth-key-2026-08",
+        expected_binding=_binding(**binding_change),
+        now=1_800_000_000,
+    )
+
+
+def test_verify_accepts_only_active_unexpired_record_and_matching_key() -> None:
+    issued = authorization_sessions.issue_credential(
+        verifier_key=b"k" * 32,
+        verifier_key_id="auth-key-2026-08",
+        binding=_binding(),
+    )
+    common = {
+        "record": issued.record,
+        "verifier_key": b"k" * 32,
+        "verifier_key_id": "auth-key-2026-08",
+        "expected_binding": _binding(),
+    }
+
+    assert authorization_sessions.verify_credential(
+        issued.bearer, **common, now=1_800_000_000
+    )
+    assert not authorization_sessions.verify_credential(
+        issued.bearer, **common, now=1_800_003_600
+    )
+    assert not authorization_sessions.verify_credential(
+        issued.bearer,
+        **{**common, "record": dataclasses.replace(issued.record, status="closed")},
+        now=1_800_000_000,
+    )
+    assert not authorization_sessions.verify_credential(
+        issued.bearer,
+        **{**common, "verifier_key": b"z" * 32},
+        now=1_800_000_000,
+    )
+    assert not authorization_sessions.verify_credential(
+        issued.bearer,
+        **{**common, "verifier_key_id": "unknown-key"},
+        now=1_800_000_000,
+    )
+    assert not authorization_sessions.verify_credential(
+        issued.bearer, **common, now="not-a-clock"  # type: ignore[arg-type]
+    )
+
+
+def test_verify_compares_digest_before_rejecting_validly_parsed_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    issued = authorization_sessions.issue_credential(
+        verifier_key=b"k" * 32,
+        verifier_key_id="auth-key-2026-08",
+        binding=_binding(),
+    )
+    compared: list[tuple[bytes, bytes]] = []
+    real = hmac.compare_digest
+
+    def recording_compare(left: bytes, right: bytes) -> bool:
+        compared.append((left, right))
+        return real(left, right)
+
+    monkeypatch.setattr(authorization_sessions.hmac, "compare_digest", recording_compare)
+
+    assert not authorization_sessions.verify_credential(
+        issued.bearer,
+        record=issued.record,
+        verifier_key=b"z" * 32,
+        verifier_key_id="auth-key-2026-08",
+        expected_binding=_binding(principal_id="principal:other"),
+        now=1_800_000_000,
+    )
+    assert len(compared) >= 2
 
 
 def test_terminal_scrubber_uses_the_shared_authorization_session_parser(

--- a/tests/test_governance_postfilter.py
+++ b/tests/test_governance_postfilter.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import pytest
 
-from exomem.governance import egress, scrubber
+from exomem.governance import authorization_sessions, egress, scrubber
 
 
 class _FakeAlias:
@@ -399,13 +399,15 @@ def test_arbitrary_content_scanning_calls_the_canonical_as1_parser(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[object] = []
-    real = scrubber._parse_authorization_bearer
+    real = authorization_sessions.parse_credential
 
-    def recording_parser(value: object) -> str | None:
+    def recording_parser(
+        value: object,
+    ) -> authorization_sessions.AuthorizationSessionCredential | None:
         calls.append(value)
         return real(value)
 
-    monkeypatch.setattr(scrubber, "_parse_authorization_bearer", recording_parser)
+    monkeypatch.setattr(authorization_sessions, "parse_credential", recording_parser)
 
     cleaned, blocked = scrubber.scrub_text(f"prefix {AS1_VECTOR_BEARER} suffix")
 


### PR DESCRIPTION
## Why

Governed session authority needs one exact credential grammar shared by issuance, verification, and terminal scrubbing. Persisting bearer material or letting parser and scrubber languages drift would make later schema-v4 session work unsafe.

## What

- add the exact canonical 70-byte as1 credential parser and boundary-free scanner
- issue cryptographically random locator/secret pairs while persisting only keyed locator and verifier digests
- bind verifiers to session, principal, issuer family, cell, logical vault, keyring, generation, and expiry
- compare locator, verifier, key id, and every binding component without exposing bearer material
- make terminal scrubbing consume the same parser
- support bounded UTF-8 verifier key identifiers with byte-safe constant-time comparison

This is the pure credential/verifier foundation. External key custody, schema v4 persistence, lifecycle commands, and transport integration remain later hardening slices.

## Verification

- full authorization binding + governance postfilter packet: **137 passed**
- Unicode key-id regression: observed red TypeError, then green
- Ruff on all changed Python files: clean
- strict OpenSpec validation: valid
- public-artifact privacy gate: clean (2,992 files / 3,038 payloads)
- git diff --check: clean
- Conventional Commit title check: valid

No personal or POLLY vault was read or mutated.