### PR TITLE
fix(governance): bind prospective policy compilation

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -108,10 +108,10 @@
 
 ## 3. Conflict- And Fingerprint-Bound Prospective Compile
 
-- [ ] 3.1 Add red tests in `tests/test_governance_policy.py` for every supported conflict
+- [x] 3.1 Add red tests in `tests/test_governance_policy.py` for every supported conflict
   marker present before prospective compile and appearing/disappearing between its two
   probes; assert no reviewable target and no state creation.
-- [ ] 3.2 Add red tests for timestamp-preserving byte replacement, added/deleted policy
+- [x] 3.2 Add red tests for timestamp-preserving byte replacement, added/deleted policy
   files, pending-guard generation changes, symlink/non-regular policy paths, and mixed
   before/after document sets during prospective acquisition.
 - [ ] 3.3 Add red `tests/test_govern_memory_tool.py` coverage proving proposals persist
@@ -144,7 +144,7 @@
   preparation, receipt intent, narrowing overlay, tuple publication, external digest
   acknowledgement, response, and mirror. Assert predecessor-or-complete-target only,
   one tuple winner, no stale grant/catalog hybrid, and no semantic replay.
-- [ ] 3.8 Split the pure pinned-byte compiler from guarded live prospective acquisition;
+- [x] 3.8 Split the pure pinned-byte compiler from guarded live prospective acquisition;
   implement a before/read/after `AuthoringSnapshot` and return a bound
   `ProspectiveCompile` only for a stable conflict-free regular-file tree.
 - [ ] 3.9 Add append-only `compiled_policy_generations`, immutable catalog descriptors,

--- a/src/exomem/governance/policy.py
+++ b/src/exomem/governance/policy.py
@@ -24,16 +24,17 @@ from __future__ import annotations
 import dataclasses
 import datetime as dt
 import hashlib
+import json
 import re
 import stat
-import tempfile
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import yaml
 
-from .. import memory_refs
+from .. import held_fs, memory_refs
 from ..kbdir import kb_dirname
 from . import store as store_module
 
@@ -82,6 +83,10 @@ def is_valid_document_id(value: object) -> bool:
 # (`find_corpus`, `vault`, `lexstore`, `freshness`, `media_worker`); this is the
 # one place where missing it is a disclosure bug rather than a stale read.
 _CONFLICT_MARKERS = ("conflicted copy", ".sync-conflict-")
+_DOCUMENT_KINDS = ("scopes", "rules", "grants")
+_DOCUMENT_KIND_ORDER = {
+    kind: index for index, kind in enumerate(_DOCUMENT_KINDS)
+}
 
 
 def is_conflict_copy(name: str) -> bool:
@@ -340,9 +345,8 @@ class Policy:
         keep SERVING the last good policy — flooring every read to L0 because a
         sync tool dropped a sibling file would be worse than the defect. What it
         must not do is let policy be AUTHORED, because the author cannot see
-        which of the two documents will win, and `compile_prospective` filters
-        conflict copies out of its temp tree — so a mutation would be accepted
-        and receipted while the conflict silently decides the live outcome.
+        which of the two documents will win. The authoring gate and guarded
+        prospective snapshot both refuse every supported conflict-copy shape.
 
         Before conflict detection was widened, a conflict alongside its original
         produced a `duplicate_id` error that refused the mutation by accident.
@@ -350,6 +354,45 @@ class Policy:
         it deliberately and for the right reason.
         """
         return any(f.get("code") == "conflicted_copy" for f in self.findings)
+
+
+@dataclass(frozen=True)
+class AuthoringFileIdentity:
+    """One no-follow regular-file identity captured from the workspace."""
+
+    path: str
+    identity: held_fs.StableIdentity
+    sha256: str
+
+
+@dataclass(frozen=True)
+class AuthoringSnapshot:
+    """Stable source state that a prospective policy was compiled from."""
+
+    documents: tuple[tuple[str, bytes], ...]
+    source_fingerprint: str
+    conflict_set_digest: str
+    guard_generation: str
+    file_identities: tuple[AuthoringFileIdentity, ...]
+    governance_root_identity: held_fs.StableIdentity | None
+
+
+@dataclass(frozen=True)
+class ProspectiveCompile:
+    """A compiled target bound to the exact live authoring snapshot."""
+
+    snapshot: AuthoringSnapshot
+    target_documents: tuple[tuple[str, bytes], ...]
+    policy: Policy
+
+
+@dataclass(frozen=True)
+class _AuthoringTreeProbe:
+    root_identity: held_fs.StableIdentity | None
+    documents: tuple[tuple[str, bytes], ...]
+    file_identities: tuple[AuthoringFileIdentity, ...]
+    directory_identities: tuple[tuple[str, held_fs.StableIdentity], ...]
+    conflict_paths: tuple[str, ...]
 
 
 EMPTY_POLICY = Policy(fingerprint="missing")
@@ -402,19 +445,168 @@ def has_conflict_copy(vault_root: Path) -> bool:
 def _is_operational_state(root: Path, path: Path) -> bool:
     """Receipt evidence is governed state, never a policy input or warning."""
     try:
-        parts = path.relative_to(root).parts
+        relative = path.relative_to(root).as_posix()
     except ValueError:
         return False
+    return _is_operational_relative(relative)
+
+
+def _is_operational_relative(relative: str) -> bool:
+    parts = tuple(part for part in relative.replace("\\", "/").split("/") if part)
     return bool(parts) and (
         parts[0] in {"events", "deletion-tombstones", "archives"}
         or parts == (".policy-mutation.pending.json",)
     )
 
 
+def _document_kind(relative: str) -> str | None:
+    parts = relative.replace("\\", "/").split("/")
+    if (
+        len(parts) == 2
+        and parts[0] in _DOCUMENT_KIND_ORDER
+        and parts[1].endswith(".yaml")
+        and not is_conflict_copy(parts[1])
+    ):
+        return parts[0]
+    return None
+
+
+def _document_fingerprint(documents: Mapping[str, bytes]) -> str:
+    digest = hashlib.sha256()
+    recognized = [
+        (kind, relative, raw)
+        for relative, raw in documents.items()
+        if (kind := _document_kind(relative)) is not None
+    ]
+    for _kind, relative, raw in sorted(
+        recognized, key=lambda item: (_DOCUMENT_KIND_ORDER[item[0]], item[1])
+    ):
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(raw)
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _path_set_digest(domain: bytes, paths: tuple[str, ...]) -> str:
+    digest = hashlib.sha256(domain + b"\0")
+    for path in paths:
+        encoded = path.encode("utf-8")
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+    return digest.hexdigest()
+
+
+def _clear_guard_generation(
+    vault_root: Path,
+    *,
+    expected_pending_event_id: str | None = None,
+) -> str | None:
+    probe = store_module.guard_generation_probe(vault_root)
+    marker_generation, marker_present, marker_event_id = _marker_probe(vault_root)
+    event_ids = tuple(str(value) for value in probe.get("event_ids", ()))
+    if expected_pending_event_id is None:
+        if probe.get("state") != "clear" or marker_present:
+            return None
+    else:
+        if (
+            probe.get("state") != "pending"
+            or event_ids != (expected_pending_event_id,)
+        ):
+            return None
+        if marker_present and marker_event_id != expected_pending_event_id:
+            return None
+    generation = str(probe.get("generation", ""))
+    return _path_set_digest(
+        b"exomem.governance-authoring-guard.v1",
+        (str(probe.get("state")), generation, marker_generation, *event_ids),
+    )
+
+
+def _authoring_snapshot_barrier(_phase: str, _path: str | None = None) -> None:
+    """Deterministic test seam around the three live workspace probes."""
+
+
+def _probe_authoring_tree(vault_root: Path) -> _AuthoringTreeProbe | None:
+    base = f"{kb_dirname()}/{GOVERNANCE_DIRNAME}"
+    acquired = held_fs.acquire(vault_root)
+    if not acquired.ok:
+        return None
+    try:
+        with acquired.require() as filesystem:
+            root_result = filesystem.parent(base)
+            if not root_result.ok:
+                if root_result.error is not None and root_result.error.code == "MISSING":
+                    return _AuthoringTreeProbe(None, (), (), (), ())
+                return None
+            with root_result.require() as root:
+                records_result = filesystem.enumerate(root)
+                if not records_result.ok:
+                    return None
+                records = tuple(
+                    record
+                    for record in records_result.require()
+                    if not _is_operational_relative(record.relative_path)
+                )
+                directories = tuple(
+                    (record.relative_path, record.identity)
+                    for record in records
+                    if record.identity.kind == "directory"
+                )
+                documents: list[tuple[str, bytes]] = []
+                identities: list[AuthoringFileIdentity] = []
+                for record in records:
+                    if record.identity.kind == "directory":
+                        continue
+                    if record.identity.kind != "file" or record.identity.link_count != 1:
+                        return None
+                    relative = record.relative_path
+                    path = Path(relative)
+                    parent_relative = Path(base, path.parent).as_posix()
+                    parent_result = filesystem.parent(parent_relative)
+                    if not parent_result.ok:
+                        return None
+                    with parent_result.require() as parent:
+                        file_result = filesystem.file(parent, path.name)
+                        if not file_result.ok:
+                            return None
+                        with file_result.require() as file:
+                            if file.identity != record.identity:
+                                return None
+                            raw_result = filesystem.read(file)
+                            if not raw_result.ok:
+                                return None
+                            raw = raw_result.require()
+                        if not filesystem.validate_directory(parent).ok:
+                            return None
+                    documents.append((relative, raw))
+                    identities.append(
+                        AuthoringFileIdentity(
+                            path=relative,
+                            identity=record.identity,
+                            sha256=hashlib.sha256(raw).hexdigest(),
+                        )
+                    )
+                if not filesystem.validate_directory(root).ok:
+                    return None
+                conflicts = tuple(
+                    relative for relative, _raw in documents if is_conflict_copy(Path(relative).name)
+                )
+                return _AuthoringTreeProbe(
+                    root.identity,
+                    tuple(documents),
+                    tuple(identities),
+                    directories,
+                    conflicts,
+                )
+    except held_fs.HeldFsError:
+        return None
+
+
 def _iter_policy_files(root: Path) -> list[tuple[str, Path]]:
     """`(kind, path)` for every recognized `*.yaml` under scopes/rules/grants."""
     out: list[tuple[str, Path]] = []
-    for kind in ("scopes", "rules", "grants"):
+    for kind in _DOCUMENT_KINDS:
         sub = root / kind
         if not sub.is_dir():
             continue
@@ -539,19 +731,33 @@ def _load_unguarded(vault_root: Path) -> Policy:
     return compiled
 
 
-def _marker_generation(vault_root: Path) -> tuple[str, bool]:
+def _marker_probe(vault_root: Path) -> tuple[str, bool, str | None]:
     marker = governance_root(vault_root) / ".policy-mutation.pending.json"
     try:
         stat_result = marker.lstat()
         if not stat.S_ISREG(stat_result.st_mode):
-            return f"invalid:{stat_result.st_mode}", True
+            return f"invalid:{stat_result.st_mode}", True, None
         raw = marker.read_bytes()
     except FileNotFoundError:
-        return "absent", False
+        return "absent", False, None
     except OSError as exc:
-        return f"unreadable:{type(exc).__name__}", True
+        return f"unreadable:{type(exc).__name__}", True, None
     digest = hashlib.sha256(raw).hexdigest()
-    return f"{stat_result.st_ino}:{stat_result.st_size}:{digest}", True
+    try:
+        value = json.loads(raw)
+        event_id = value.get("event_id") if isinstance(value, dict) else None
+    except (UnicodeError, json.JSONDecodeError):
+        event_id = None
+    return (
+        f"{stat_result.st_ino}:{stat_result.st_size}:{digest}",
+        True,
+        event_id if isinstance(event_id, str) else None,
+    )
+
+
+def _marker_generation(vault_root: Path) -> tuple[str, bool]:
+    generation, present, _event_id = _marker_probe(vault_root)
+    return generation, present
 
 
 def _guarded_policy(vault_root: Path, code: str, detail: str) -> Policy:
@@ -636,7 +842,34 @@ def load(vault_root: Path) -> Policy:
 
 
 def _compile(
-    root: Path, files: list[tuple[str, Path]]
+    root: Path, _files: list[tuple[str, Path]]
+) -> tuple[
+    list[dict[str, str]],
+    dict[str, Scope],
+    tuple[Rule, ...],
+    tuple[StandingGrant, ...],
+    tuple[ReleaseGrant, ...],
+]:
+    documents: dict[str, bytes] = {}
+    findings: list[dict[str, str]] = []
+    for path in _iter_all_files(root):
+        relative = path.relative_to(root).as_posix()
+        try:
+            documents[relative] = path.read_bytes()
+        except OSError as error:
+            findings.append(_finding("read_error", relative, str(error)))
+    compiled = _compile_document_bytes(documents)
+    return (
+        [*findings, *compiled[0]],
+        compiled[1],
+        compiled[2],
+        compiled[3],
+        compiled[4],
+    )
+
+
+def _compile_document_bytes(
+    documents: Mapping[str, bytes],
 ) -> tuple[
     list[dict[str, str]],
     dict[str, Scope],
@@ -652,25 +885,30 @@ def _compile(
     rule_ids: set[str] = set()
     grant_ids: set[str] = set()
 
-    recognized = {path for _kind, path in files}
-    for p in _iter_all_files(root):
-        if p in recognized or is_conflict_copy(p.name):
+    recognized: list[tuple[str, str, bytes]] = []
+    for relative, raw in sorted(documents.items()):
+        kind = _document_kind(relative)
+        if kind is not None:
+            recognized.append((kind, relative, raw))
+            continue
+        if is_conflict_copy(Path(relative).name):
             continue
         findings.append(
             _finding(
                 "unknown_file",
-                p.relative_to(root).as_posix(),
+                relative,
                 "not a recognized governance document; ignored",
                 severity="warning",
             )
         )
 
-    for kind, path in files:
-        rel = path.relative_to(root).as_posix()
+    recognized.sort(key=lambda item: (_DOCUMENT_KIND_ORDER[item[0]], item[1]))
+
+    for kind, rel, encoded in recognized:
         try:
-            raw = path.read_text(encoding="utf-8")
-        except OSError as error:
-            findings.append(_finding("read_error", rel, str(error)))
+            raw = encoded.decode("utf-8")
+        except UnicodeError as error:
+            findings.append(_finding("invalid_yaml", rel, str(error)))
             continue
         try:
             data = yaml.safe_load(raw)
@@ -732,49 +970,92 @@ def _compile(
     return findings, scopes, tuple(rules), tuple(grants), tuple(release_grants)
 
 
-def compile_prospective(
-    vault_root: Path, documents: dict[str, str | None]
-) -> Policy:
-    """Compile the complete policy produced by overlaying proposed documents.
+def compile_documents(documents: Mapping[str, bytes]) -> Policy:
+    """Compile only the supplied immutable workspace bytes."""
 
-    This deliberately uses the same strict parser as the live loader.  The
-    temporary tree contains policy inputs only, so operational receipts and
-    mutation markers cannot accidentally become proposal warnings.
-    """
-    live_root = governance_root(Path(vault_root))
-    with tempfile.TemporaryDirectory(prefix="exomem-governance-") as temporary:
-        root = Path(temporary)
-        for _kind, source in _iter_policy_files(live_root):
-            rel = source.relative_to(live_root).as_posix()
-            if rel in documents:
-                continue
-            target = root / rel
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_bytes(source.read_bytes())
-        for rel, content in documents.items():
-            if content is None:
-                continue
-            target = root / rel
-            target.parent.mkdir(parents=True, exist_ok=True)
-            # `write_bytes`, matching the carried-over files six lines above
-            # and the live commit's `_durable_bytes(..., content.encode())`.
-            # This tree exists to predict the fingerprint the live tree will
-            # have after the commit, and `_content_fingerprint` hashes raw
-            # bytes -- so a text-mode write made the prediction wrong on
-            # Windows for exactly the documents being proposed.
-            target.write_bytes(content.encode("utf-8"))
-        files = _iter_policy_files(root)
-        findings, scopes, rules, grants, release_grants = _compile(root, files)
-        fingerprint = _content_fingerprint(root, files)
+    pinned: dict[str, bytes] = {}
+    for relative, raw in documents.items():
+        if not isinstance(relative, str) or not isinstance(raw, bytes):
+            raise TypeError("policy documents must map relative string paths to bytes")
+        pinned[relative.replace("\\", "/")] = raw
+    findings, scopes, rules, grants, release_grants = _compile_document_bytes(pinned)
     if any(finding["severity"] == "error" for finding in findings):
         return _blocked(tuple(findings))
     return Policy(
-        fingerprint=fingerprint,
+        fingerprint=_document_fingerprint(pinned),
         scopes=scopes,
         rules=rules,
         grants=grants,
         release_grants=release_grants,
         findings=tuple(findings),
+    )
+
+
+def compile_prospective(
+    vault_root: Path,
+    documents: dict[str, str | None],
+    *,
+    _expected_pending_event_id: str | None = None,
+) -> ProspectiveCompile | None:
+    """Compile an overlay only after a stable no-follow workspace acquisition."""
+
+    vault_root = Path(vault_root)
+    guard_before = _clear_guard_generation(
+        vault_root,
+        expected_pending_event_id=_expected_pending_event_id,
+    )
+    if guard_before is None:
+        return None
+    before = _probe_authoring_tree(vault_root)
+    if before is None:
+        return None
+
+    _authoring_snapshot_barrier("after_before")
+    read = _probe_authoring_tree(vault_root)
+    if read is None:
+        return None
+
+    _authoring_snapshot_barrier("after_read")
+    after = _probe_authoring_tree(vault_root)
+    guard_after = _clear_guard_generation(
+        vault_root,
+        expected_pending_event_id=_expected_pending_event_id,
+    )
+    if (
+        after is None
+        or before.conflict_paths
+        or read.conflict_paths
+        or after.conflict_paths
+        or guard_after is None
+        or guard_before != guard_after
+        or before != read
+        or read != after
+    ):
+        return None
+
+    current_documents = dict(read.documents)
+    snapshot = AuthoringSnapshot(
+        documents=read.documents,
+        source_fingerprint=_document_fingerprint(current_documents),
+        conflict_set_digest=_path_set_digest(
+            b"exomem.governance-conflict-set.v1", read.conflict_paths
+        ),
+        guard_generation=guard_before,
+        file_identities=read.file_identities,
+        governance_root_identity=read.root_identity,
+    )
+    target_documents = dict(current_documents)
+    for relative, content in documents.items():
+        normalized = relative.replace("\\", "/")
+        if content is None:
+            target_documents.pop(normalized, None)
+        else:
+            target_documents[normalized] = content.encode("utf-8")
+    target = tuple(sorted(target_documents.items()))
+    return ProspectiveCompile(
+        snapshot=snapshot,
+        target_documents=target,
+        policy=compile_documents(target_documents),
     )
 
 

--- a/src/exomem/governance/recovery.py
+++ b/src/exomem/governance/recovery.py
@@ -433,7 +433,10 @@ def _actual_component_value(
 
 
 def _proposal_guard_actual(
-    vault_root: Path, conn: sqlite3.Connection, proposal_id: str, event_id: str | None
+    vault_root: Path,
+    conn: sqlite3.Connection,
+    proposal_id: str,
+    event_id: str | None,
 ) -> dict[str, Any]:
     """Rebuild the proposal's pre-image before testing its live membership proof."""
     try:
@@ -470,8 +473,20 @@ def _proposal_guard_actual(
             prior_documents[path] = prior_bytes.decode("utf-8")
         if set(prior_documents) != set(documents):
             return {"status": "invalid"}
-        prior = policy_module.compile_prospective(vault_root, prior_documents)
-        prospective = policy_module.compile_prospective(vault_root, documents)
+        prior_compile = policy_module.compile_prospective(
+            vault_root,
+            prior_documents,
+            _expected_pending_event_id=event_id,
+        )
+        prospective_compile = policy_module.compile_prospective(
+            vault_root,
+            documents,
+            _expected_pending_event_id=event_id,
+        )
+        if prior_compile is None or prospective_compile is None:
+            return {"status": "invalid"}
+        prior = prior_compile.policy
+        prospective = prospective_compile.policy
         if prior.blocked or prospective.blocked:
             return {"status": "invalid"}
         if (

--- a/src/exomem/governance/tool.py
+++ b/src/exomem/governance/tool.py
@@ -94,6 +94,18 @@ def _require_owner(value: RequestPrincipal | None) -> RequestPrincipal:
     return who
 
 
+def _prospective_policy(
+    vault_root: Path, documents: Mapping[str, str | None]
+) -> policy_module.Policy:
+    prospective = policy_module.compile_prospective(vault_root, dict(documents))
+    if prospective is None:
+        raise GovernanceError(
+            "GOVERNANCE_AUTHORING_UNSTABLE",
+            "the policy workspace changed or could not be acquired safely",
+        )
+    return prospective.policy
+
+
 def _require_authorization_session(
     value: RequestPrincipal | None, supplied: Any
 ) -> tuple[RequestPrincipal, str]:
@@ -493,7 +505,7 @@ def _proposal(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
     current_policy = policy_module.load(vault_root)
     if current_policy.blocked:
         raise GovernanceError("GOVERNANCE_BLOCKED", "current policy cannot be evaluated")
-    prospective = policy_module.compile_prospective(vault_root, documents)
+    prospective = _prospective_policy(vault_root, documents)
     if prospective.blocked:
         raise GovernanceError(
             "INVALID_GOVERNANCE_POLICY",
@@ -844,7 +856,7 @@ def _standing_grant(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
         sort_keys=False,
         allow_unicode=True,
     )
-    prospective = policy_module.compile_prospective(vault_root, {rel: document})
+    prospective = _prospective_policy(vault_root, {rel: document})
     if prospective.blocked:
         raise GovernanceError(
             "INVALID_STANDING_GRANT", _canonical_json(list(prospective.findings))
@@ -1534,8 +1546,8 @@ def _effective_transition_direction(
     if current.blocked:
         return "widening"
     try:
-        prospective = policy_module.compile_prospective(vault_root, dict(documents))
-    except (OSError, TypeError, ValueError):
+        prospective = _prospective_policy(vault_root, documents)
+    except (GovernanceError, OSError, TypeError, ValueError):
         return "widening"
     if prospective.blocked or current.release_grants != prospective.release_grants:
         return "widening"
@@ -1959,7 +1971,7 @@ def _proposal_matches_exact_prior(
         current_policy = policy_module.load(vault_root)
         if current_policy.blocked:
             return False
-        prospective = policy_module.compile_prospective(vault_root, documents)
+        prospective = _prospective_policy(vault_root, documents)
         if prospective.blocked:
             return False
         current_manifest = _membership_manifest(
@@ -1992,7 +2004,15 @@ def _validate_proposal_values(
     if current_policy.blocked:
         raise GovernanceError("GOVERNANCE_BLOCKED", "current policy cannot be evaluated")
     documents = dict(payload["documents"])
-    prospective = policy_module.compile_prospective(vault_root, documents)
+    try:
+        prospective = _prospective_policy(vault_root, documents)
+    except GovernanceError as exc:
+        if exc.code != "GOVERNANCE_AUTHORING_UNSTABLE":
+            raise
+        raise GovernanceError(
+            "INVALID_GOVERNANCE_TARGET",
+            "the policy workspace cannot be acquired through stable regular-file identities",
+        ) from exc
     if prospective.blocked:
         raise GovernanceError(
             "INVALID_GOVERNANCE_POLICY", _canonical_json(list(prospective.findings))
@@ -2772,7 +2792,7 @@ def _undo(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
         str(path): (None if prior_bytes is None else bytes(prior_bytes).decode("utf-8"))
         for path, prior_bytes in archive_rows
     }
-    restored_policy = policy_module.compile_prospective(vault_root, documents)
+    restored_policy = _prospective_policy(vault_root, documents)
     if restored_policy.blocked:
         raise GovernanceError("ARCHIVE_INVALID", "the restored policy does not compile")
     dependent_targets: dict[str, str] = {}
@@ -2881,10 +2901,9 @@ def op_govern_memory(vault_root: Path, operation: str, **kwargs: Any) -> dict[st
     if not spec.read_only:
         _authorize_operation(selection, kwargs)
         # One registry-driven gate for every authoring operation, rather than
-        # thirteen `.blocked` sites. `compile_prospective` filters conflict
-        # copies out of the temp tree it compiles, so without this a mutation
-        # under a sync conflict is accepted, receipted, and silently overridden
-        # by whichever document the next real compile picks.
+        # thirteen `.blocked` sites. Prospective policy paths independently
+        # re-probe the conflict set around their held-handle byte acquisition;
+        # this fast gate also covers authoring variants that do not compile.
         if policy_module.has_conflict_copy(root):
             raise GovernanceError(
                 "GOVERNANCE_CONFLICTED",

--- a/tests/test_governance_policy.py
+++ b/tests/test_governance_policy.py
@@ -906,14 +906,14 @@ def test_compile_documents_matches_live_fingerprint_order_across_kinds(
 
 
 def test_compile_prospective_returns_a_bound_authoring_snapshot(vault: Path) -> None:
-    _write(vault, "scopes", "client", _SCOPE_A)
+    source = _write(vault, "scopes", "client", _SCOPE_A)
 
     prospective = policy.compile_prospective(vault, {})
 
     assert isinstance(prospective, policy.ProspectiveCompile)
     assert prospective.policy.scopes["01ARZ3NDEKTSV4RRFFQ69G5FAV"].name == "client-confidential"
     assert prospective.snapshot.source_fingerprint == prospective.policy.fingerprint
-    assert dict(prospective.snapshot.documents)["scopes/client.yaml"] == _SCOPE_A.encode()
+    assert dict(prospective.snapshot.documents)["scopes/client.yaml"] == source.read_bytes()
     assert prospective.snapshot.conflict_set_digest
     assert prospective.snapshot.guard_generation
     assert prospective.snapshot.file_identities[0].path == "scopes/client.yaml"

--- a/tests/test_governance_policy.py
+++ b/tests/test_governance_policy.py
@@ -785,15 +785,12 @@ def test_policy_document_without_either_conflict_marker_compiles_clean(
 
 
 def test_a_sync_conflict_copy_refuses_policy_AUTHORING_not_reading(vault: Path) -> None:
-    """The other half of conflict handling, and a regression this branch caused.
+    """The authoring half of conflict handling, kept separate from live reading.
 
-    Filtering conflict copies out of discovery also filtered them out of
-    `compile_prospective`, so a mutation compiled a CLEAN prospective tree while
-    the live compile still saw the conflict. Both gates passed, the mutation was
-    accepted and receipted, and whichever document the next real compile picked
-    silently decided the outcome. On main the copy reached the temp tree and a
-    `duplicate_id` error refused the mutation by accident; widening detection
-    removed that accident, so the refusal is now deliberate.
+    A conflict copy must remain visible to the guarded prospective snapshot even
+    though it is never a compilable policy document. Otherwise a mutation can be
+    accepted and receipted while the unresolved sibling still decides which
+    bytes a later live compile sees.
 
     Reads must NOT be refused: flooring a warm vault to L0 because a sync tool
     dropped a sibling file would be worse than the defect it prevents.
@@ -873,6 +870,195 @@ def test_the_authoring_gate_creates_no_state_when_it_refuses(vault: Path) -> Non
             duration="standing",
         )
     assert _snapshot() == before, "the refused authoring gate mutated the vault"
+
+
+def _workspace_files(vault: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(vault).as_posix(): path.read_bytes()
+        for path in sorted(vault.rglob("*"))
+        if path.is_file() and not path.is_symlink()
+    }
+
+
+def test_compile_documents_uses_only_the_supplied_pinned_bytes(vault: Path) -> None:
+    source = _write(vault, "scopes", "client", _SCOPE_A)
+    pinned = {"scopes/client.yaml": source.read_bytes()}
+    source.write_text(_SCOPE_A.replace("client-confidential", "changed-live"), encoding="utf-8")
+
+    compiled = policy.compile_documents(pinned)
+
+    assert compiled.scopes["01ARZ3NDEKTSV4RRFFQ69G5FAV"].name == "client-confidential"
+    assert compiled.fingerprint != policy.load(vault).fingerprint
+
+
+def test_compile_documents_matches_live_fingerprint_order_across_kinds(
+    vault: Path,
+) -> None:
+    _write(vault, "scopes", "client", _SCOPE_A)
+    _write(vault, "rules", "external", _RULE_A)
+    root = policy.governance_root(vault)
+    pinned = {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for _kind, path in policy._iter_policy_files(root)
+    }
+
+    assert policy.compile_documents(pinned).fingerprint == policy.load(vault).fingerprint
+
+
+def test_compile_prospective_returns_a_bound_authoring_snapshot(vault: Path) -> None:
+    _write(vault, "scopes", "client", _SCOPE_A)
+
+    prospective = policy.compile_prospective(vault, {})
+
+    assert isinstance(prospective, policy.ProspectiveCompile)
+    assert prospective.policy.scopes["01ARZ3NDEKTSV4RRFFQ69G5FAV"].name == "client-confidential"
+    assert prospective.snapshot.source_fingerprint == prospective.policy.fingerprint
+    assert dict(prospective.snapshot.documents)["scopes/client.yaml"] == _SCOPE_A.encode()
+    assert prospective.snapshot.conflict_set_digest
+    assert prospective.snapshot.guard_generation
+    assert prospective.snapshot.file_identities[0].path == "scopes/client.yaml"
+
+
+@pytest.mark.parametrize(
+    "name",
+    (
+        "client (conflicted copy 2026-08-21).yaml",
+        "client.sync-conflict-20260821-120000-ABCDEFG.yaml",
+    ),
+)
+def test_compile_prospective_refuses_every_supported_preexisting_conflict_without_state(
+    vault: Path,
+    name: str,
+) -> None:
+    _write(vault, "scopes", "client", _SCOPE_A)
+    conflict = vault / "Knowledge Base" / "_Governance" / "scopes" / name
+    conflict.write_text(_SCOPE_A, encoding="utf-8")
+    before = _workspace_files(vault)
+
+    assert policy.compile_prospective(vault, {}) is None
+    assert _workspace_files(vault) == before
+    assert not store.sidecar_path(vault).exists()
+
+
+@pytest.mark.parametrize("transition", ("appear", "disappear"))
+def test_compile_prospective_refuses_a_conflict_set_change_between_probes(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    transition: str,
+) -> None:
+    _write(vault, "scopes", "client", _SCOPE_A)
+    conflict = (
+        vault
+        / "Knowledge Base"
+        / "_Governance"
+        / "scopes"
+        / "client.sync-conflict-20260821-120000-ABCDEFG.yaml"
+    )
+    if transition == "disappear":
+        conflict.write_text(_SCOPE_A, encoding="utf-8")
+    changed = False
+
+    def barrier(phase: str, _path: str | None = None) -> None:
+        nonlocal changed
+        if phase != "after_before" or changed:
+            return
+        changed = True
+        if transition == "appear":
+            conflict.write_text(_SCOPE_A, encoding="utf-8")
+        else:
+            conflict.unlink()
+
+    monkeypatch.setattr(policy, "_authoring_snapshot_barrier", barrier, raising=False)
+
+    assert policy.compile_prospective(vault, {}) is None
+    assert changed
+    assert conflict.exists() is (transition == "appear")
+    assert not store.sidecar_path(vault).exists()
+
+
+@pytest.mark.parametrize("change", ("replace-bytes", "add-file", "delete-file"))
+def test_compile_prospective_refuses_policy_tree_changes_between_read_and_after_probe(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    change: str,
+) -> None:
+    source = _write(vault, "scopes", "client", _SCOPE_A)
+    changed = False
+
+    def barrier(phase: str, _path: str | None = None) -> None:
+        nonlocal changed
+        if phase != "after_read" or changed:
+            return
+        changed = True
+        if change == "replace-bytes":
+            before = source.stat()
+            source.write_text(
+                _SCOPE_A.replace("client-confidential", "client-classified"),
+                encoding="utf-8",
+            )
+            os.utime(source, ns=(before.st_atime_ns, before.st_mtime_ns))
+        elif change == "add-file":
+            _write(vault, "rules", "external", _RULE_A)
+        else:
+            source.unlink()
+
+    monkeypatch.setattr(policy, "_authoring_snapshot_barrier", barrier, raising=False)
+
+    assert policy.compile_prospective(vault, {}) is None
+    assert changed
+    assert not store.sidecar_path(vault).exists()
+
+
+def test_compile_prospective_refuses_pending_guard_generation_drift(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write(vault, "scopes", "client", _SCOPE_A)
+    probes = iter(
+        (
+            {"state": "clear", "generation": "guard-before", "event_ids": ()},
+            {"state": "clear", "generation": "guard-after", "event_ids": ()},
+        )
+    )
+    monkeypatch.setattr(store, "guard_generation_probe", lambda _vault: next(probes))
+
+    assert policy.compile_prospective(vault, {}) is None
+
+
+def test_compile_prospective_refuses_a_symlinked_policy_document(vault: Path) -> None:
+    outside = vault / "outside.yaml"
+    outside.write_text(_SCOPE_A, encoding="utf-8")
+    link = vault / "Knowledge Base" / "_Governance" / "scopes" / "client.yaml"
+    link.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        link.symlink_to(outside)
+    except OSError as exc:  # pragma: no cover - host capability dependent
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    assert policy.compile_prospective(vault, {}) is None
+    assert not store.sidecar_path(vault).exists()
+
+
+def test_compile_prospective_refuses_a_hard_linked_policy_document(vault: Path) -> None:
+    source = _write(vault, "scopes", "client", _SCOPE_A)
+    alias = source.with_name("client-alias.yaml")
+    try:
+        os.link(source, alias)
+    except OSError as exc:  # pragma: no cover - host capability dependent
+        pytest.skip(f"hard-link creation unavailable: {exc}")
+
+    assert policy.compile_prospective(vault, {}) is None
+    assert not store.sidecar_path(vault).exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX FIFO fixture")
+def test_compile_prospective_refuses_a_non_regular_policy_document(vault: Path) -> None:
+    fifo = vault / "Knowledge Base" / "_Governance" / "scopes" / "client.yaml"
+    fifo.parent.mkdir(parents=True, exist_ok=True)
+    os.mkfifo(fifo)
+
+    assert policy.compile_prospective(vault, {}) is None
+    assert not store.sidecar_path(vault).exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Governance authoring predicted policy outcomes from a temporary tree populated through pathname reads. That could accept a reviewable target while conflicts, byte-preserving swaps, link aliases, non-regular entries, or mutation-guard drift changed the live authoring workspace.

## What

- split pure pinned-byte policy compilation from guarded live acquisition
- acquire a before/read/after authoring snapshot through held no-follow filesystem handles
- bind the target to source bytes, file identities, conflict set, governance-root identity, and guard generation
- refuse conflict copies, symlinks, hard links, non-regular files, and any observed workspace or journal drift
- preserve prepared-recovery validation through an event-bound internal pending-journal seam
- update governance authoring callers to treat unstable acquisition as a content-free refusal
- mark OpenSpec tasks 3.1, 3.2, and 3.8 complete

## Verification

- `uv run --python 3.13 python -m pytest -q --tb=short tests/test_governance_policy.py tests/test_govern_memory_tool.py` — 267 passed
- adversarial prospective-compile slice — 13 passed after red-first failures
- `uvx ruff check` on all touched Python files — passed
- `openspec validate harden-governance-for-consolidation --strict` — valid
- `python scripts/validate-public-artifacts.py --repository` — 2990 files / 3036 text payloads clean
- `git diff --check` — clean
