### PR TITLE
fix(governance): project direct reads at release level

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -422,7 +422,7 @@ made before both PRs and their combined verification are complete.
 
 ## 7. Governed Raw Direct-Read Projection
 
-- [x] 7.1 Add red `tests/test_get_payload.py` cases at L0-L6 for default,
+- [ ] 7.1 Add red `tests/test_get_payload.py` cases at L0-L6 for default,
   `frontmatter_only`, `include_raw=false`, and `include_raw=true`; assert exact bytes/hash
   only at L6, identical true/false projection at L1-L5, and same-input present-L0 versus
   absent byte equality. Add secret-free and secret/canonical-bearer L6 fixtures in both

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -422,7 +422,7 @@ made before both PRs and their combined verification are complete.
 
 ## 7. Governed Raw Direct-Read Projection
 
-- [ ] 7.1 Add red `tests/test_get_payload.py` cases at L0-L6 for default,
+- [x] 7.1 Add red `tests/test_get_payload.py` cases at L0-L6 for default,
   `frontmatter_only`, `include_raw=false`, and `include_raw=true`; assert exact bytes/hash
   only at L6, identical true/false projection at L1-L5, and same-input present-L0 versus
   absent byte equality. Add secret-free and secret/canonical-bearer L6 fixtures in both

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -429,7 +429,7 @@ made before both PRs and their combined verification are complete.
   governed and registry-proven never-enrolled modes: exact raw only when scrub-safe;
   otherwise deterministic content-free `SECRET_BLOCKED`, never redacted-as-raw, while
   full-raw hash and stale-edit semantics remain unchanged.
-- [ ] 7.2 Add red provenance fixtures covering forward/reverse citations, sources,
+- [x] 7.2 Add red provenance fixtures covering forward/reverse citations, sources,
   history, links, relation/supersession, and parent-media fields; prove no raw option or
   direct-read variant restores them below L6.
 - [ ] 7.3 Add red Tier-2 direct-content coverage for dataset rows, media bytes,

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -2562,7 +2562,8 @@ def op_get(
 
     Errors:
         INVALID_PATH (path escapes vault root or empty);
-        NOT_FOUND (no such file); UNREADABLE (parse failure).
+        NOT_FOUND (no such file); UNREADABLE (parse failure);
+        SECRET_BLOCKED (opt-in raw content contains protected material).
     """
     path = _resolve_memory_identifier(vault_root, path)
     try:
@@ -2586,7 +2587,7 @@ def op_get(
             "has_frontmatter": vault.parse_frontmatter(result.content)[2] is not None,
         }
     else:
-        out = result.as_dict(include_raw=include_raw)
+        out = result.as_dict(include_raw=False)
     if max_body_chars is not None and max_body_chars < 0:
         raise ValueError("get: max_body_chars must be non-negative")
     query_log.log_get_call(
@@ -2609,6 +2610,7 @@ def op_get(
         out,
         snapshot_content=result.content,
         stable_ref=snapshot_ref,
+        include_raw=include_raw,
     )
     if released is None:
         # `result.missing_path` — the EXACT value the genuinely-absent branch

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -2545,6 +2545,9 @@ def op_get(
             read) and nothing in the normal workflow needs it: edits
             round-trip `body`, and the drift guard uses `content_hash`,
             which the server always computes over the raw bytes for you.
+            Raw text is returned only at governance release level L6 and only
+            when the mandatory secret parser accepts the exact snapshot. At
+            L1-L5 this flag is identical to false; at L0 the read is missing.
         max_body_chars: Optional cap for the returned `body`. Use this when a
             client wants bounded content instead of an arbitrary full-page read.
             Values above 12000 are capped server-side; negative values are rejected.
@@ -2556,7 +2559,9 @@ def op_get(
         file text; echo it to `edit`/`multi_edit` via `expected_hash` to
         refuse a write if the file changed on disk since this read
         (two-writer drift guard); `mtime` is advisory.
-        Adds `content` (raw file text) when `include_raw=true`.
+        Adds `content` (raw file text) when `include_raw=true` at scrub-safe
+        L6. Lower levels retain their registered Markdown projection and never
+        expose exact hashes, frontmatter, history, links, or raw content.
         Adds `body_truncated` and `body_chars` when `max_body_chars` is supplied.
         Adds `history` when `include_history=true`.
 

--- a/src/exomem/governance/bridges.py
+++ b/src/exomem/governance/bridges.py
@@ -119,6 +119,18 @@ class BridgeAdmission:
 
 
 @dataclass(frozen=True)
+class BridgeProjection:
+    """Projection material derived from one exact current release grant."""
+
+    allowed: bool
+    reason: str | None
+    abstraction: str | None = None
+    grant: ReleaseGrant | None = None
+    strip_identities: tuple[StripIdentity, ...] = ()
+    dependency_digest: str | None = None
+
+
+@dataclass(frozen=True)
 class BridgeReviewSignal:
     cause: str
     bridge_hash: str
@@ -886,6 +898,78 @@ def admit(
         grant=grant,
         strip_identities=identities,
         dependency_digest=dependency_digest,
+    )
+
+
+def resolve_approved_abstraction(
+    vault_root: Path,
+    bridge_id: str,
+    *,
+    policy: Policy,
+    audience: str,
+) -> BridgeProjection:
+    """Resolve an opaque policy option to exact approved bridge content.
+
+    The authored option names a release-grant id; it is never response text.
+    Resolution rereads the grant-bound bridge bytes and delegates all path,
+    ref, audience, byte-hash, dependency, restriction-signature, and
+    provenance checks to :func:`admit`.  Only the approved bridge body after
+    release-bound provenance stripping is returned to the caller.
+    """
+    candidates = [
+        grant
+        for grant in policy.release_grants
+        if grant.id == bridge_id and grant.to_audience == audience
+    ]
+    if not candidates:
+        return BridgeProjection(False, RELEASE_UNAPPROVED)
+    if len(candidates) != 1:
+        return BridgeProjection(False, RELEASE_STALE)
+    grant = candidates[0]
+    try:
+        target, canonical = resolve_under_vault(
+            Path(vault_root),
+            grant.path,
+            must_exist=True,
+            must_be_file=True,
+        )
+        if canonical != grant.path:
+            return BridgeProjection(False, RELEASE_STALE)
+        raw = target.read_bytes()
+    except (VaultPathError, OSError):
+        return BridgeProjection(False, RELEASE_STALE)
+
+    admission = admit(
+        Path(vault_root),
+        canonical,
+        raw,
+        policy=policy,
+        audience=audience,
+    )
+    if (
+        not admission.allowed
+        or admission.grant is None
+        or admission.grant.id != bridge_id
+    ):
+        return BridgeProjection(False, admission.reason or RELEASE_STALE)
+    parsed = _parse_exact(Path(vault_root), canonical, raw)
+    if parsed is None:
+        return BridgeProjection(False, RELEASE_STALE)
+    projected = strip_provenance(
+        {"body": parsed.body},
+        admission.strip_identities,
+        direct_page=True,
+    )
+    abstraction = projected.get("body") if isinstance(projected, Mapping) else None
+    if not isinstance(abstraction, str) or not abstraction.strip():
+        return BridgeProjection(False, RELEASE_STALE)
+    return BridgeProjection(
+        True,
+        None,
+        abstraction=abstraction,
+        grant=admission.grant,
+        strip_identities=admission.strip_identities,
+        dependency_digest=admission.dependency_digest,
     )
 
 

--- a/src/exomem/governance/decisions.py
+++ b/src/exomem/governance/decisions.py
@@ -58,6 +58,10 @@ class Decision:
     default_deny_scope_ids: tuple[str, ...] = ()
     options: dict[str, Any] = field(default_factory=dict)
     notice: str | None = None
+    #: Trusted rendered content from an exact current bridge approval.  The
+    #: authored ``bridge`` option above remains an opaque approval id and is
+    #: never itself suitable for a wire response.
+    bridge_abstraction: str | None = None
     bridge: str | None = None
     release_reason: str | None = None
     release_grant_id: str | None = None

--- a/src/exomem/governance/egress.py
+++ b/src/exomem/governance/egress.py
@@ -766,6 +766,7 @@ def _notice(
     rule_ids: Sequence[str] = (),
     scope_label: str | None = None,
     options: Mapping[str, Any] | None = None,
+    bridge_abstraction: str | None = None,
 ) -> dict[str, Any]:
     """L1–L4 rendering: low-level notices or one approved L4 abstraction.
 
@@ -774,11 +775,11 @@ def _notice(
     oracles" scenario.
     """
     options = options or {}
-    if level == LEVEL_EXCERPT_REDACTED and options.get("bridge"):
+    if level == LEVEL_EXCERPT_REDACTED and bridge_abstraction:
         return {
             "withheld": True,
             "level": LEVEL_EXCERPT_REDACTED,
-            "bridge": str(options["bridge"]),
+            "bridge": bridge_abstraction,
         }
     out: dict[str, Any] = {"withheld": True, "level": level}
     if level == LEVEL_CONSTRAINT and options.get("constraint_source") == "scope":
@@ -825,15 +826,22 @@ def project(
     if decision is not None:
         rule_ids = rule_ids or decision.rule_ids
         options = options if options is not None else decision.options
+    bridge_abstraction = decision.bridge_abstraction if decision is not None else None
 
     if level <= LEVEL_NONE:
         return None
-    if level == LEVEL_EXCERPT_REDACTED and not (options or {}).get("bridge"):
+    if level == LEVEL_EXCERPT_REDACTED and not bridge_abstraction:
         # L4 without exact approved bridge content lowers to L3 rather than
         # borrowing any source text or reviving the retired redaction lane.
         level = LEVEL_ABSTRACT
     if level < RELEASE_FLOOR:
-        return _notice(level, rule_ids=rule_ids, scope_label=scope_label, options=options)
+        return _notice(
+            level,
+            rule_ids=rule_ids,
+            scope_label=scope_label,
+            options=options,
+            bridge_abstraction=bridge_abstraction,
+        )
 
     resolved_kind = kind or _kind_for(payload)
     if resolved_kind in _FULL_ONLY_PROJECTORS and level < LEVEL_FULL:
@@ -1016,6 +1024,61 @@ def _declared_purpose(
     )
 
 
+def _resolve_l4_bridge(
+    vault_root: Path,
+    decision: Decision,
+    *,
+    policy: Policy,
+    audience: str,
+) -> Decision:
+    """Bind an L4 decision to live approved content, never to its opaque id.
+
+    The pure policy meet deliberately carries only a release-grant id.  Bridge
+    bytes and dependency state are mutable inputs, so this resolution happens
+    after (and outside) the decision memo on every request.  A missing or stale
+    approval lowers to the already-authorized L3 abstract without borrowing
+    source text.
+    """
+    if decision.level != LEVEL_EXCERPT_REDACTED:
+        return decision
+    bridge_id = decision.bridge
+    projection = (
+        bridges.resolve_approved_abstraction(
+            vault_root,
+            bridge_id,
+            policy=policy,
+            audience=audience,
+        )
+        if bridge_id
+        else None
+    )
+    if projection is None or not projection.allowed:
+        return replace(
+            decision,
+            level=LEVEL_ABSTRACT,
+            options={
+                key: value
+                for key, value in decision.options.items()
+                if key != "bridge"
+            },
+            bridge=None,
+            bridge_abstraction=None,
+            release_reason=(
+                projection.reason if projection is not None else bridges.RELEASE_UNAPPROVED
+            ),
+            release_grant_id=None,
+            release_strip=(),
+            release_dependency_digest=None,
+        )
+    return replace(
+        decision,
+        bridge_abstraction=projection.abstraction,
+        release_grant_id=projection.grant.id if projection.grant else None,
+        release_strip=projection.strip_identities,
+        release_dependency_digest=projection.dependency_digest,
+    )
+
+
 def _applicable_org_ceiling(policy: Policy, decision: Decision) -> int:
     participating = set(decision.rule_ids)
     return min(
@@ -1096,7 +1159,12 @@ def _decide_path(
     cached = _DECISION_MEMO.get(key)
     if cached is not None and (raw is None or not bridges.maybe_bridge(raw)):
         _DECISION_MEMO.move_to_end(key)
-        return cached
+        return _resolve_l4_bridge(
+            vault_root,
+            cached,
+            policy=policy,
+            audience=audience,
+        )
 
     mtime = st.st_mtime
     if not rel_path.lower().endswith(".md"):
@@ -1168,7 +1236,12 @@ def _decide_path(
     _DECISION_MEMO.move_to_end(key)
     while len(_DECISION_MEMO) > _DECISION_MEMO_MAX:
         _DECISION_MEMO.popitem(last=False)
-    return decision
+    return _resolve_l4_bridge(
+        vault_root,
+        decision,
+        policy=policy,
+        audience=audience,
+    )
 
 
 def _scope_label(policy: Policy, decision: Decision) -> str | None:
@@ -1732,6 +1805,12 @@ def annotate_page(
                     release_strip=admission.strip_identities,
                     release_dependency_digest=admission.dependency_digest,
                 )
+        decision = _resolve_l4_bridge(
+            vault_root,
+            decision,
+            policy=policy,
+            audience=who.audience_id,
+        )
     else:
         # Compatibility for internal/synthetic callers. Production direct-read
         # leaves always supply ``snapshot_content``.
@@ -1763,7 +1842,7 @@ def annotate_page(
     )
 
     level = decision.level
-    if level == LEVEL_EXCERPT_REDACTED and not decision.bridge:
+    if level == LEVEL_EXCERPT_REDACTED and not decision.bridge_abstraction:
         level = LEVEL_ABSTRACT
     if level < RELEASE_FLOOR:
         # No path on a sub-floor notice. `op_get`/`op_read_memory` accept a
@@ -1776,6 +1855,7 @@ def annotate_page(
             rule_ids=decision.rule_ids,
             scope_label=_scope_label(policy, decision),
             options=decision.options,
+            bridge_abstraction=decision.bridge_abstraction,
         )
 
     # L5/L6: the page is released. Its own provenance must still not name a

--- a/src/exomem/governance/egress.py
+++ b/src/exomem/governance/egress.py
@@ -1588,6 +1588,29 @@ def _excerpt_of(body: str, limit: int = 600) -> str:
     return text[:limit].rsplit(" ", 1)[0] + " …"
 
 
+def _attach_raw_content(
+    page: Mapping[str, Any], snapshot_content: str | bytes | None
+) -> dict[str, Any]:
+    """Attach exact raw text only when the terminal parser finds no secret."""
+    if snapshot_content is None:
+        raise ValueError("SECRET_BLOCKED: raw content is unavailable")
+    try:
+        raw_text = (
+            snapshot_content
+            if isinstance(snapshot_content, str)
+            else bytes(snapshot_content).decode("utf-8")
+        )
+    except UnicodeDecodeError as error:
+        raise ValueError("SECRET_BLOCKED: raw content is unavailable") from error
+    _cleaned, blocked = scrubber.scrub_text(raw_text)
+    if blocked:
+        _record_credential_block()
+        raise ValueError("SECRET_BLOCKED: raw content contains protected material")
+    out = dict(page)
+    out["content"] = raw_text
+    return out
+
+
 def annotate_page(
     vault_root: Path,
     page: dict[str, Any],
@@ -1596,12 +1619,14 @@ def annotate_page(
     purpose: str | None = None,
     snapshot_content: str | bytes | None = None,
     stable_ref: str | None = None,
+    include_raw: bool = False,
 ) -> dict[str, Any] | None:
     """Render one page at its release decision's level, or `None` below notice.
 
     `None` is the caller's signal to answer byte-identically to a missing
     path — an item released below notice must be indistinguishable from one
-    that never existed.
+    that never existed. Raw text is assembled only after an L6 decision and
+    only when the terminal secret parser accepts the exact snapshot.
     """
     vault_root = Path(vault_root)
     rel_path = str(page.get("path") or stable_ref or "")
@@ -1611,7 +1636,7 @@ def annotate_page(
     who = principal if principal is not None else effective_principal()
 
     if policy.empty:
-        return page
+        return _attach_raw_content(page, snapshot_content) if include_raw else page
     if policy.blocked or not who.resolved:
         _record_blocked_outcome(who.audience_id)
         return None
@@ -1795,6 +1820,22 @@ def annotate_page(
             or ref_decision.level < RELEASE_FLOOR
         )
     )
+    if level == LEVEL_EXCERPT:
+        body = parsed.body if snapshot_content is not None else str(page.get("body") or "")
+        excerpt = {
+            "path": rel_path,
+            "body": _excerpt_of(body),
+            "body_truncated": True,
+            "release_level": level,
+        }
+        if decision.release_strip:
+            excerpt = bridges.strip_provenance(
+                excerpt,
+                decision.release_strip,
+                direct_page=True,
+            )
+        return excerpt
+
     out = _strip_page_provenance(dict(page), withheld)
     if decision.release_strip:
         out = bridges.strip_provenance(
@@ -1802,14 +1843,7 @@ def annotate_page(
             decision.release_strip,
             direct_page=True,
         )
-    if level == LEVEL_EXCERPT and isinstance(out.get("body"), str):
-        out["body"] = _excerpt_of(out["body"])
-        out["body_truncated"] = True
-        # Marked only BELOW full disclosure. A page released at L6 must be
-        # byte-identical to its ungoverned response — a `release_level: 6`
-        # marker would itself tell an audience that governance is in effect.
-        out["release_level"] = level
-    return out
+    return _attach_raw_content(out, snapshot_content) if include_raw else out
 
 
 

--- a/src/exomem/governance/egress.py
+++ b/src/exomem/governance/egress.py
@@ -406,7 +406,7 @@ LEVEL_NONE = 0  # L0 nothing — the item is omitted, silently
 LEVEL_NOTICE = 1  # L1 rule id + scope label
 LEVEL_CONSTRAINT = 2  # L2 + the constraint string
 LEVEL_ABSTRACT = 3  # L3 + an approved abstraction
-LEVEL_EXCERPT_REDACTED = 4  # L4 — renders as L3 until `add-redaction-levels`
+LEVEL_EXCERPT_REDACTED = 4  # L4 — exact approved bridge abstraction only
 LEVEL_EXCERPT = 5  # L5 bounded excerpt + ranking signals
 LEVEL_FULL = 6  # L6 full disclosure
 
@@ -767,13 +767,19 @@ def _notice(
     scope_label: str | None = None,
     options: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """L1–L4 rendering: rule id + scope label, then constraint, then abstract.
+    """L1–L4 rendering: low-level notices or one approved L4 abstraction.
 
     Deliberately carries no path, title, excerpt, score, or provenance at any
     of these levels — see the `release-gate` spec's "Low levels strip metadata
     oracles" scenario.
     """
     options = options or {}
+    if level == LEVEL_EXCERPT_REDACTED and options.get("bridge"):
+        return {
+            "withheld": True,
+            "level": LEVEL_EXCERPT_REDACTED,
+            "bridge": str(options["bridge"]),
+        }
     out: dict[str, Any] = {"withheld": True, "level": level}
     if level == LEVEL_CONSTRAINT and options.get("constraint_source") == "scope":
         constraint = options.get("constraint")
@@ -822,10 +828,9 @@ def project(
 
     if level <= LEVEL_NONE:
         return None
-    if level == LEVEL_EXCERPT_REDACTED:
-        # L4 needs redaction span maps, which `add-redaction-levels` ships.
-        # Until then it renders exactly as L3 — an approved abstraction —
-        # rather than releasing an unredacted excerpt.
+    if level == LEVEL_EXCERPT_REDACTED and not (options or {}).get("bridge"):
+        # L4 without exact approved bridge content lowers to L3 rather than
+        # borrowing any source text or reviving the retired redaction lane.
         level = LEVEL_ABSTRACT
     if level < RELEASE_FLOOR:
         return _notice(level, rule_ids=rule_ids, scope_label=scope_label, options=options)
@@ -1757,7 +1762,9 @@ def annotate_page(
         ref=stable_ref,
     )
 
-    level = LEVEL_ABSTRACT if decision.level == LEVEL_EXCERPT_REDACTED else decision.level
+    level = decision.level
+    if level == LEVEL_EXCERPT_REDACTED and not decision.bridge:
+        level = LEVEL_ABSTRACT
     if level < RELEASE_FLOOR:
         # No path on a sub-floor notice. `op_get`/`op_read_memory` accept a
         # fuzzy identifier and `_resolve_memory_identifier` canonicalizes it

--- a/src/exomem/governance/egress.py
+++ b/src/exomem/governance/egress.py
@@ -1829,6 +1829,12 @@ def annotate_page(
     )
     if level == LEVEL_EXCERPT:
         body = parsed.body if snapshot_content is not None else str(page.get("body") or "")
+        body = redact_withheld_references(
+            vault_root,
+            body,
+            principal=who,
+            purpose=declared_purpose,
+        )
         excerpt = {
             "path": rel_path,
             "body": _excerpt_of(body),

--- a/tests/test_get_payload.py
+++ b/tests/test_get_payload.py
@@ -331,10 +331,11 @@ def test_below_l6_projection_redacts_forward_reverse_and_wire_provenance(
     assert "private-source" not in str(result).casefold()
 
 
-def test_l4_direct_read_returns_only_the_approved_bridge_abstraction(
+def test_l4_direct_read_without_exact_bridge_approval_lowers_to_l3(
     vault: Path,
 ) -> None:
     rel = _page(vault)
+    opaque_bridge_id = "01ARZ3NDEKTSV4RRFFQ69G5FB1"
     _govern(
         vault,
         ceiling=egress.LEVEL_EXCERPT_REDACTED,
@@ -342,8 +343,8 @@ def test_l4_direct_read_returns_only_the_approved_bridge_abstraction(
             "options:\n"
             "  notice: must not appear\n"
             "  constraint: must not appear\n"
-            "  abstract: must not appear\n"
-            "  bridge: approved cross-domain abstraction\n"
+            "  abstract: safe fallback abstraction\n"
+            f"  bridge: {opaque_bridge_id}\n"
         ),
     )
 
@@ -356,8 +357,9 @@ def test_l4_direct_read_returns_only_the_approved_bridge_abstraction(
             links=True,
         )
 
-    assert result == {
-        "withheld": True,
-        "level": egress.LEVEL_EXCERPT_REDACTED,
-        "bridge": "approved cross-domain abstraction",
-    }
+    assert result["withheld"] is True
+    assert result["level"] == egress.LEVEL_ABSTRACT
+    assert result["abstract"] == "safe fallback abstraction"
+    assert opaque_bridge_id not in str(result)
+    assert "body text here" not in str(result)
+    assert not {"path", "body", "content", "content_hash"}.intersection(result)

--- a/tests/test_get_payload.py
+++ b/tests/test_get_payload.py
@@ -25,7 +25,7 @@ def _page(vault: Path) -> str:
     return "Knowledge Base/Notes/get-payload-probe.md"
 
 
-def _govern(vault: Path, *, ceiling: int) -> None:
+def _govern(vault: Path, *, ceiling: int, options: str = "") -> None:
     governance = vault / "Knowledge Base" / "_Governance"
     (governance / "scopes").mkdir(parents=True, exist_ok=True)
     (governance / "rules").mkdir(parents=True, exist_ok=True)
@@ -41,7 +41,8 @@ def _govern(vault: Path, *, ceiling: int) -> None:
         "id: 01ARZ3NDEKTSV4RRFFQ69G5FB0\n"
         'scope_ids: ["01ARZ3NDEKTSV4RRFFQ69G5FAV"]\n'
         "audience: external\n"
-        f"ceiling: {ceiling}\n",
+        f"ceiling: {ceiling}\n"
+        f"{options}",
         encoding="utf-8",
     )
     from exomem.governance import membership, policy
@@ -171,9 +172,20 @@ def test_l6_raw_is_exact_and_default_remains_raw_free(vault: Path) -> None:
 
     with request_scope(_external()):
         ordinary = commands.op_get(vault, path=rel)
+        explicit_false = commands.op_get(vault, path=rel, include_raw=False)
+        frontmatter_only = commands.op_get(vault, path=rel, frontmatter_only=True)
         raw = commands.op_get(vault, path=rel, include_raw=True)
 
+    assert explicit_false == ordinary
     assert "content" not in ordinary
+    assert frontmatter_only == {
+        "path": rel,
+        "frontmatter": {
+            "type": "research-note",
+            "project": "project-alpha",
+        },
+        "has_frontmatter": True,
+    }
     assert raw["content"] == (vault / rel).read_bytes().decode("utf-8")
     assert raw["content_hash"] == ordinary["content_hash"]
 
@@ -238,3 +250,35 @@ def test_l5_projection_omits_every_exact_provenance_channel(vault: Path) -> None
 
     assert set(result) == {"path", "body", "body_truncated", "release_level"}
     assert "private" not in str(result)
+
+
+def test_l4_direct_read_returns_only_the_approved_bridge_abstraction(
+    vault: Path,
+) -> None:
+    rel = _page(vault)
+    _govern(
+        vault,
+        ceiling=egress.LEVEL_EXCERPT_REDACTED,
+        options=(
+            "options:\n"
+            "  notice: must not appear\n"
+            "  constraint: must not appear\n"
+            "  abstract: must not appear\n"
+            "  bridge: approved cross-domain abstraction\n"
+        ),
+    )
+
+    with request_scope(_external()):
+        result = commands.op_get(
+            vault,
+            path=rel,
+            include_raw=True,
+            include_history=True,
+            links=True,
+        )
+
+    assert result == {
+        "withheld": True,
+        "level": egress.LEVEL_EXCERPT_REDACTED,
+        "bridge": "approved cross-domain abstraction",
+    }

--- a/tests/test_get_payload.py
+++ b/tests/test_get_payload.py
@@ -6,7 +6,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from exomem import commands
+from exomem.governance import egress
+from exomem.governance.principal import RequestPrincipal, request_scope
 from exomem.vault import content_hash
 
 
@@ -19,6 +23,36 @@ def _page(vault: Path) -> str:
         encoding="utf-8",
     )
     return "Knowledge Base/Notes/get-payload-probe.md"
+
+
+def _govern(vault: Path, *, ceiling: int) -> None:
+    governance = vault / "Knowledge Base" / "_Governance"
+    (governance / "scopes").mkdir(parents=True, exist_ok=True)
+    (governance / "rules").mkdir(parents=True, exist_ok=True)
+    (governance / "scopes" / "notes.yaml").write_text(
+        "governance_version: 1\n"
+        "id: 01ARZ3NDEKTSV4RRFFQ69G5FAV\n"
+        "name: Notes\n"
+        'paths: ["Notes/**"]\n',
+        encoding="utf-8",
+    )
+    (governance / "rules" / "external.yaml").write_text(
+        "governance_version: 1\n"
+        "id: 01ARZ3NDEKTSV4RRFFQ69G5FB0\n"
+        'scope_ids: ["01ARZ3NDEKTSV4RRFFQ69G5FAV"]\n'
+        "audience: external\n"
+        f"ceiling: {ceiling}\n",
+        encoding="utf-8",
+    )
+    from exomem.governance import membership, policy
+
+    policy._CACHE.clear()
+    membership.clear_memo()
+    egress.clear_decision_memo()
+
+
+def _external() -> RequestPrincipal:
+    return RequestPrincipal(audience_id="external", surface="mcp")
 
 
 def test_default_get_has_no_content_key(vault: Path) -> None:
@@ -64,3 +98,143 @@ def test_history_and_links_compose(vault: Path) -> None:
     out = commands.op_get(vault, path=rel, include_history=True, links=True)
     assert "content" not in out
     assert "history" in out and "links" in out
+
+
+@pytest.mark.parametrize("ceiling", range(1, 6))
+def test_include_raw_is_identical_to_default_below_l6(
+    vault: Path, ceiling: int
+) -> None:
+    rel = _page(vault)
+    _govern(vault, ceiling=ceiling)
+
+    with request_scope(_external()):
+        ordinary = commands.op_get(
+            vault,
+            path=rel,
+            include_history=True,
+            links=True,
+            include_raw=False,
+        )
+        raw_requested = commands.op_get(
+            vault,
+            path=rel,
+            include_history=True,
+            links=True,
+            include_raw=True,
+        )
+        frontmatter_only = commands.op_get(
+            vault,
+            path=rel,
+            frontmatter_only=True,
+            include_raw=True,
+        )
+
+    assert raw_requested == ordinary
+    assert frontmatter_only == ordinary
+    assert "content" not in ordinary
+    assert "content_hash" not in ordinary
+    assert "frontmatter" not in ordinary
+    assert "history" not in ordinary
+    assert "links" not in ordinary
+    if ceiling == egress.LEVEL_EXCERPT:
+        assert ordinary["body"] == "# Get payload probe body text here"
+        assert ordinary["body_truncated"] is True
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {},
+        {"include_raw": False},
+        {"include_raw": True},
+        {"frontmatter_only": True},
+    ],
+)
+def test_l0_read_is_byte_identical_to_same_input_missing(
+    vault: Path, options: dict[str, bool]
+) -> None:
+    rel = _page(vault)
+    _govern(vault, ceiling=egress.LEVEL_NONE)
+
+    with request_scope(_external()), pytest.raises(ValueError) as present:
+        commands.op_get(vault, path=rel, **options)
+    (vault / rel).unlink()
+    with request_scope(_external()), pytest.raises(ValueError) as absent:
+        commands.op_get(vault, path=rel, **options)
+
+    assert str(present.value) == str(absent.value)
+
+
+def test_l6_raw_is_exact_and_default_remains_raw_free(vault: Path) -> None:
+    rel = _page(vault)
+    _govern(vault, ceiling=egress.LEVEL_FULL)
+
+    with request_scope(_external()):
+        ordinary = commands.op_get(vault, path=rel)
+        raw = commands.op_get(vault, path=rel, include_raw=True)
+
+    assert "content" not in ordinary
+    assert raw["content"] == (vault / rel).read_bytes().decode("utf-8")
+    assert raw["content_hash"] == ordinary["content_hash"]
+
+
+@pytest.mark.parametrize("governed", [False, True])
+@pytest.mark.parametrize(
+    "secret",
+    [
+        "AKIA" + "IOSFODNN7EXAMPLE",
+        (
+            "as1."
+            + "AAECAwQFBgcICQoLDA0ODw"
+            + "."
+            + "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8"
+        ),
+    ],
+)
+def test_include_raw_secret_is_content_free_and_hash_semantics_survive(
+    vault: Path, governed: bool, secret: str
+) -> None:
+    rel = _page(vault)
+    target = vault / rel
+    target.write_text(target.read_text(encoding="utf-8") + f"\n{secret}\n", encoding="utf-8")
+    if governed:
+        _govern(vault, ceiling=egress.LEVEL_FULL)
+
+    scope = request_scope(_external()) if governed else request_scope(
+        RequestPrincipal(audience_id="owner", surface="cli")
+    )
+    with scope:
+        ordinary = commands.op_get(vault, path=rel)
+        with pytest.raises(ValueError, match="^SECRET_BLOCKED:") as blocked:
+            commands.op_get(vault, path=rel, include_raw=True)
+
+    assert secret not in str(blocked.value)
+    assert ordinary["content_hash"] == content_hash(target.read_bytes().decode("utf-8"))
+
+
+def test_l5_projection_omits_every_exact_provenance_channel(vault: Path) -> None:
+    rel = _page(vault)
+    target = vault / rel
+    target.write_text(
+        "---\n"
+        "type: research-note\n"
+        "sources: ['[[Knowledge Base/Sources/private]]']\n"
+        "superseded_by: ['[[Knowledge Base/Notes/private]]']\n"
+        "parent_media: Knowledge Base/Evidence/private.mp4\n"
+        "---\n\n"
+        "# Public-shaped excerpt\n\nBounded body only.\n",
+        encoding="utf-8",
+    )
+    _govern(vault, ceiling=egress.LEVEL_EXCERPT)
+
+    with request_scope(_external()):
+        result = commands.op_get(
+            vault,
+            path=rel,
+            include_raw=True,
+            include_history=True,
+            links=True,
+        )
+
+    assert set(result) == {"path", "body", "body_truncated", "release_level"}
+    assert "private" not in str(result)

--- a/tests/test_get_payload.py
+++ b/tests/test_get_payload.py
@@ -252,6 +252,85 @@ def test_l5_projection_omits_every_exact_provenance_channel(vault: Path) -> None
     assert "private" not in str(result)
 
 
+@pytest.mark.parametrize("ceiling", range(1, 6))
+def test_below_l6_projection_redacts_forward_reverse_and_wire_provenance(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, ceiling: int
+) -> None:
+    rel = _page(vault)
+    private_rel = "Knowledge Base/Private/private-source.md"
+    private = vault / private_rel
+    private.parent.mkdir(parents=True, exist_ok=True)
+    private.write_text("# Private source\n", encoding="utf-8")
+    (vault / rel).write_text(
+        "---\n"
+        "type: research-note\n"
+        f'sources: ["[[{private_rel.removesuffix(".md")}]]"]\n'
+        f'ingested_into: ["[[{private_rel.removesuffix(".md")}]]"]\n'
+        f'supersedes: ["[[{private_rel.removesuffix(".md")}]]"]\n'
+        f'superseded_by: ["[[{private_rel.removesuffix(".md")}]]"]\n'
+        f"parent_media: {private_rel}\n"
+        "---\n\n"
+        f"Public sentence citing [[{private_rel.removesuffix('.md')}]].\n",
+        encoding="utf-8",
+    )
+    scopes = vault / "Knowledge Base" / "_Governance" / "scopes"
+    scopes.mkdir(parents=True, exist_ok=True)
+    (scopes / "private.yaml").write_text(
+        "governance_version: 1\n"
+        "id: 01ARZ3NDEKTSV4RRFFQ69G5FC2\n"
+        'paths: ["Private/**"]\n'
+        "default_deny: true\n",
+        encoding="utf-8",
+    )
+    _govern(
+        vault,
+        ceiling=ceiling,
+        options=(
+            "options:\n"
+            "  notice: approved notice\n"
+            "  constraint: approved constraint\n"
+            "  abstract: approved abstract\n"
+            "  bridge: approved bridge abstraction\n"
+        ),
+    )
+    monkeypatch.setattr(
+        commands.vault,
+        "read_log_entries",
+        lambda *_args, **_kwargs: [{"path": private_rel, "reason": "private"}],
+    )
+    monkeypatch.setattr(
+        commands,
+        "_link_summary",
+        lambda *_args, **_kwargs: {
+            "inbound": [{"path": private_rel}],
+            "outbound": [private_rel],
+        },
+    )
+
+    with request_scope(_external()):
+        result = commands.op_get(
+            vault,
+            path=rel,
+            include_raw=True,
+            include_history=True,
+            links=True,
+        )
+
+    if ceiling == egress.LEVEL_EXCERPT:
+        assert set(result) == {"path", "body", "body_truncated", "release_level"}
+    else:
+        assert not {
+            "path",
+            "content",
+            "content_hash",
+            "frontmatter",
+            "history",
+            "links",
+        }.intersection(result)
+    assert private_rel.casefold() not in str(result).casefold()
+    assert "private-source" not in str(result).casefold()
+
+
 def test_l4_direct_read_returns_only_the_approved_bridge_abstraction(
     vault: Path,
 ) -> None:

--- a/tests/test_govern_memory_tool.py
+++ b/tests/test_govern_memory_tool.py
@@ -3830,7 +3830,7 @@ def test_non_owner_inspection_remains_available_when_a_grant_raises_the_default(
     grants.mkdir(parents=True, exist_ok=True)
     (grants / "external.yaml").write_text(
         "governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FB1\nkind: standing\n"
-        f'scope_ids: ["{SCOPE_ID}"]\naudience: external\nceiling: 4\n',
+        f'scope_ids: ["{SCOPE_ID}"]\naudience: external\nceiling: 3\n',
         encoding="utf-8",
     )
 
@@ -3849,5 +3849,5 @@ def test_non_owner_inspection_remains_available_when_a_grant_raises_the_default(
         paths=[DECLARED_RESTRICTED],
     )
 
-    assert explained["effective_ceiling"] == 4
+    assert explained["effective_ceiling"] == 3
     assert simulated["evaluated_count"] == 1

--- a/tests/test_governance_bridges.py
+++ b/tests/test_governance_bridges.py
@@ -34,6 +34,12 @@ BRIDGE_PATH = "Knowledge Base/Notes/Insights/workload-constraint.md"
 SOURCE_PATH = "Knowledge Base/Notes/Research/Health/private-source.md"
 SHA_A = "a" * 64
 SHA_B = "b" * 64
+APPROVED_BRIDGE_ABSTRACTION = (
+    "# Workload constraint\n\n"
+    "## Observations\n"
+    "- [constraint] Do not assume unlimited evening capacity #planning ^capacity\n\n"
+    "## Relations\n"
+)
 
 
 @pytest.fixture(autouse=True)
@@ -192,6 +198,8 @@ def _write_bridge_fixture(
     approval: bool,
     review: str = "2026-12-01",
     source_title: str = "Private source title",
+    source_ceiling: int = 0,
+    source_rule_extra: str = "",
 ) -> tuple[Path, Path]:
     source = vault / SOURCE_PATH
     bridge = vault / BRIDGE_PATH
@@ -200,7 +208,16 @@ def _write_bridge_fixture(
     source.write_text(_bridge_source_text(title=source_title), encoding="utf-8")
     bridge.write_text(_bridge_text(review=review), encoding="utf-8")
     _write_policy(vault, "scopes", "private", _scope_document(SCOPE_A))
-    _write_policy(vault, "rules", "private", _rule_document(scope_ids=(SCOPE_A,), ceiling=0))
+    _write_policy(
+        vault,
+        "rules",
+        "private",
+        _rule_document(
+            scope_ids=(SCOPE_A,),
+            ceiling=source_ceiling,
+            extra=source_rule_extra,
+        ),
+    )
     if approval:
         release = _release_document()
         release = release.replace(SHA_A, hashlib.sha256(bridge.read_bytes()).hexdigest(), 1)
@@ -523,6 +540,70 @@ def test_exact_approved_unchanged_bridge_releases_but_source_stays_withheld(
 
     assert "unlimited evening capacity" in page["body"]
     assert BRIDGE_PATH in [hit.get("path") for hit in hits]
+
+
+def test_l4_source_renders_only_the_exact_approved_bridge_abstraction(
+    vault: Path,
+) -> None:
+    _write_bridge_fixture(
+        vault,
+        approval=True,
+        source_ceiling=egress.LEVEL_EXCERPT_REDACTED,
+        source_rule_extra=(
+            "options:\n"
+            f"  bridge: {RELEASE_ID}\n"
+            "  abstract: safe fallback abstraction\n"
+        ),
+    )
+
+    with request_scope(_external()):
+        page = commands.op_get(vault, path=SOURCE_PATH, include_raw=True)
+
+    assert page == {
+        "withheld": True,
+        "level": egress.LEVEL_EXCERPT_REDACTED,
+        "bridge": APPROVED_BRIDGE_ABSTRACTION,
+    }
+    assert RELEASE_ID not in str(page)
+    assert SOURCE_PATH not in str(page)
+    assert SOURCE_REF not in str(page)
+
+
+def test_l4_source_bridge_edit_lowers_without_reusing_cached_approval(
+    vault: Path,
+) -> None:
+    bridge, _source = _write_bridge_fixture(
+        vault,
+        approval=True,
+        source_ceiling=egress.LEVEL_EXCERPT_REDACTED,
+        source_rule_extra=(
+            "options:\n"
+            f"  bridge: {RELEASE_ID}\n"
+            "  abstract: safe fallback abstraction\n"
+        ),
+    )
+    with request_scope(_external()):
+        approved = commands.op_get(vault, path=SOURCE_PATH, include_raw=True)
+    assert approved["bridge"] == APPROVED_BRIDGE_ABSTRACTION
+
+    bridge.write_text(
+        _bridge_text().replace("unlimited evening capacity", "changed private bridge"),
+        encoding="utf-8",
+    )
+    find_module.clear_cache()
+
+    with request_scope(_external()):
+        page = commands.op_get(vault, path=SOURCE_PATH, include_raw=True)
+
+    assert page == {
+        "withheld": True,
+        "level": egress.LEVEL_ABSTRACT,
+        "rule_ids": [RULE_ID],
+        "scope_label": SCOPE_A,
+        "abstract": "safe fallback abstraction",
+    }
+    assert RELEASE_ID not in str(page)
+    assert "changed private bridge" not in str(page)
 
 
 def test_empty_policy_bridge_fast_path_never_parses_or_creates_governance_state(

--- a/tests/test_governance_egress.py
+++ b/tests/test_governance_egress.py
@@ -228,6 +228,27 @@ def test_project_l4_falls_back_to_l3_abstract() -> None:
     assert l4 is not None and "excerpt" not in l4
 
 
+def test_project_l4_emits_only_the_approved_bridge_abstraction() -> None:
+    out = egress.project(
+        _hit(RESTRICTED_PATH, title="must not appear"),
+        egress.LEVEL_EXCERPT_REDACTED,
+        rule_ids=(RULE_ID,),
+        scope_label="must not appear",
+        options={
+            "notice": "must not appear",
+            "constraint": "must not appear",
+            "abstract": "must not appear",
+            "bridge": "approved cross-domain abstraction",
+        },
+    )
+
+    assert out == {
+        "withheld": True,
+        "level": egress.LEVEL_EXCERPT_REDACTED,
+        "bridge": "approved cross-domain abstraction",
+    }
+
+
 def test_project_l5_carries_path_title_and_excerpt() -> None:
     out = egress.project(_hit(RESTRICTED_PATH, title="Kill switch"), egress.LEVEL_EXCERPT)
     assert out is not None

--- a/tests/test_governance_egress.py
+++ b/tests/test_governance_egress.py
@@ -22,6 +22,7 @@ from exomem import find as find_module
 from exomem import query_data as query_data_module
 from exomem.find_types import GraphProvenance, Hit
 from exomem.governance import egress, receipts
+from exomem.governance.decisions import Decision
 from exomem.governance.principal import RequestPrincipal, owner_principal, request_scope
 
 # --------------------------------------------------------------------------
@@ -229,17 +230,23 @@ def test_project_l4_falls_back_to_l3_abstract() -> None:
 
 
 def test_project_l4_emits_only_the_approved_bridge_abstraction() -> None:
-    out = egress.project(
-        _hit(RESTRICTED_PATH, title="must not appear"),
-        egress.LEVEL_EXCERPT_REDACTED,
+    decision = Decision(
+        level=egress.LEVEL_EXCERPT_REDACTED,
         rule_ids=(RULE_ID,),
-        scope_label="must not appear",
         options={
             "notice": "must not appear",
             "constraint": "must not appear",
             "abstract": "must not appear",
-            "bridge": "approved cross-domain abstraction",
+            "bridge": "01ARZ3NDEKTSV4RRFFQ69G5FB1",
         },
+        bridge="01ARZ3NDEKTSV4RRFFQ69G5FB1",
+        bridge_abstraction="approved cross-domain abstraction",
+    )
+    out = egress.project(
+        _hit(RESTRICTED_PATH, title="must not appear"),
+        egress.LEVEL_EXCERPT_REDACTED,
+        decision=decision,
+        scope_label="must not appear",
     )
 
     assert out == {
@@ -247,6 +254,26 @@ def test_project_l4_emits_only_the_approved_bridge_abstraction() -> None:
         "level": egress.LEVEL_EXCERPT_REDACTED,
         "bridge": "approved cross-domain abstraction",
     }
+
+
+def test_project_l4_never_treats_the_opaque_bridge_id_as_abstraction() -> None:
+    opaque_bridge_id = "01ARZ3NDEKTSV4RRFFQ69G5FB1"
+
+    out = egress.project(
+        _hit(RESTRICTED_PATH, title="must not appear"),
+        egress.LEVEL_EXCERPT_REDACTED,
+        options={
+            "abstract": "safe fallback abstraction",
+            "bridge": opaque_bridge_id,
+        },
+    )
+
+    assert out == {
+        "withheld": True,
+        "level": egress.LEVEL_ABSTRACT,
+        "abstract": "safe fallback abstraction",
+    }
+    assert opaque_bridge_id not in str(out)
 
 
 def test_project_l5_carries_path_title_and_excerpt() -> None:


### PR DESCRIPTION
## Summary

- decide and project one immutable Markdown snapshot before optional raw assembly
- make L0 direct reads indistinguishable from missing, keep L1-L4 metadata-free, and emit only the fixed bounded L5 excerpt
- return exact raw text only at scrub-safe L6; protected secrets and authorization bearers fail with content-free `SECRET_BLOCKED`
- resolve an L4 policy bridge id through one exact current release grant, revalidate its bytes/dependencies on every request, strip bound provenance, and lower stale authority to the authorized abstract

## Verification

- `385 passed` — `tests/test_get_payload.py`, `tests/test_governance_egress.py`, `tests/test_governance_bridges.py`
- touched-file Ruff: passed
- `git diff origin/main --check`: passed
- `openspec validate harden-governance-for-consolidation --strict`: valid
- public-artifact privacy validation: 2994 files / 3040 text payloads clean

## OpenSpec boundary

This marks only task 7.2 complete. The remaining L0-L6 matrix, structured dataset/Records/media/frame routes, companion-only reachability, registry-enrollment semantics, and their combined gates remain open in tasks 7.1 and 7.3-7.6.

No live personal or client vault was read or modified.
