### PR TITLE
feat(governance): load external authorization custody

### DIFF
--- a/src/exomem/governance/authorization_custody.py
+++ b/src/exomem/governance/authorization_custody.py
@@ -1,0 +1,539 @@
+"""Protected external custody inputs for authorization-session authority.
+
+The files are deliberately loaded before their record schemas are interpreted:
+path selection and filesystem custody are one trust boundary, while key/control
+record authentication is the next.  Callers cannot supply either path.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import os
+import re
+import stat
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from exomem import mutation_lock
+
+KEYRING_FILE_ENV = "EXOMEM_AUTH_SESSION_KEYRING_FILE"
+CONTROL_FILE_ENV = "EXOMEM_AUTH_SESSION_CONTROL_FILE"
+MAX_CUSTODY_FILE_BYTES = 64 * 1024
+_MAX_SIGNED_SQLITE_INTEGER = (1 << 63) - 1
+_MAX_ACCEPTED_KEYS = 32
+_KEYRING_FIELDS = frozenset(
+    {
+        "version",
+        "keyring_id",
+        "cell_id",
+        "logical_vault_id",
+        "active_key_id",
+        "accepted_keys",
+    }
+)
+_KEY_FIELDS = frozenset({"key_id", "key", "not_before", "not_after"})
+_CONTROL_FIELDS = frozenset(
+    {
+        "version",
+        "keyring_id",
+        "cell_id",
+        "logical_vault_id",
+        "registry_attachment_id",
+        "attachment_epoch",
+        "governance_enrolled",
+        "activation_store_id",
+        "activation_epoch",
+        "activation_state_digest",
+        "serving_membership_epoch",
+        "serving_membership_digest",
+        "issued_at",
+        "expires_at",
+        "signing_key_id",
+        "mac",
+    }
+)
+_CONTROL_MAC_DOMAIN = b"exomem.authorization-session.control/v1"
+_SHA256_HEX = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class AuthorizationCustodyUnavailable(RuntimeError):
+    """Content-free refusal for any unavailable or unsafe custody input."""
+
+    code = "AUTHORIZATION_SESSION_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__("authorization session custody is unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalAuthorizationCustody:
+    keyring_path: Path
+    control_path: Path
+    keyring: bytes = field(repr=False)
+    control: bytes = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationVerifierKey:
+    key_id: str
+    key: bytes = field(repr=False)
+    not_before: int
+    not_after: int
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationKeyring:
+    version: int
+    keyring_id: str
+    cell_id: str
+    logical_vault_id: str
+    active_key_id: str
+    accepted_keys: tuple[AuthorizationVerifierKey, ...]
+
+    @property
+    def active_key(self) -> AuthorizationVerifierKey:
+        for key in self.accepted_keys:
+            if key.key_id == self.active_key_id:
+                return key
+        raise AuthorizationCustodyUnavailable
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationControlRecord:
+    version: int
+    keyring_id: str
+    cell_id: str
+    logical_vault_id: str
+    registry_attachment_id: str
+    attachment_epoch: int
+    governance_enrolled: bool
+    activation_store_id: str | None
+    activation_epoch: int | None
+    activation_state_digest: str | None
+    serving_membership_epoch: int
+    serving_membership_digest: str
+    issued_at: int
+    expires_at: int
+    signing_key_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationCustody:
+    keyring_path: Path
+    control_path: Path
+    keyring: AuthorizationKeyring
+    control: AuthorizationControlRecord
+
+
+@dataclass(frozen=True, slots=True)
+class _LoadedCustodyFile:
+    path: Path
+    data: bytes = field(repr=False)
+    identity: tuple[int, ...]
+
+
+def _stat_identity(info: os.stat_result) -> tuple[int, ...]:
+    return (
+        int(info.st_dev),
+        int(info.st_ino),
+        int(info.st_mode),
+        int(info.st_nlink),
+        int(info.st_size),
+        int(info.st_mtime_ns),
+        int(info.st_ctime_ns),
+    )
+
+
+def _path_is_within(candidate: Path, root: Path) -> bool:
+    try:
+        common = os.path.commonpath(
+            (os.path.normcase(str(candidate)), os.path.normcase(str(root)))
+        )
+    except ValueError:
+        return False
+    return common == os.path.normcase(str(root))
+
+
+def _configured_external_path(variable: str, vault_root: Path) -> Path:
+    raw = os.environ.get(variable)
+    if raw is None or not raw or "\x00" in raw:
+        raise AuthorizationCustodyUnavailable
+    configured = Path(raw)
+    if not configured.is_absolute():
+        raise AuthorizationCustodyUnavailable
+    candidate = Path(os.path.abspath(configured))
+    vault = Path(os.path.abspath(vault_root))
+    if _path_is_within(candidate, vault):
+        raise AuthorizationCustodyUnavailable
+    return candidate
+
+
+def _windows_file_dacl_is_private(sddl: str, sid: str) -> bool:
+    if not mutation_lock._windows_private_dacl_is_valid(
+        sddl, sid, directory=False
+    ):
+        return False
+    return "D:" in sddl and sddl.split("D:", 1)[1].startswith("P")
+
+
+def _windows_file_is_private(descriptor: int) -> bool:
+    import msvcrt
+
+    handle = msvcrt.get_osfhandle(descriptor)
+    sddl = mutation_lock._windows_dacl_sddl_for_handle(handle)
+    sid = mutation_lock._windows_current_user_sid()
+    return _windows_file_dacl_is_private(
+        sddl, sid
+    )
+
+
+def _file_is_owner_protected(descriptor: int, info: os.stat_result) -> bool:
+    if os.name == "nt":
+        return _windows_file_is_private(descriptor)
+    return (
+        info.st_uid == os.geteuid()
+        and stat.S_IMODE(info.st_mode) in {0o400, 0o600}
+    )
+
+
+def _read_retained(descriptor: int, expected_size: int) -> bytes:
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    chunks: list[bytes] = []
+    remaining = MAX_CUSTODY_FILE_BYTES + 1
+    while remaining:
+        chunk = os.read(descriptor, min(remaining, 4096))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    data = b"".join(chunks)
+    if len(data) != expected_size or len(data) > MAX_CUSTODY_FILE_BYTES:
+        raise AuthorizationCustodyUnavailable
+    return data
+
+
+def _load_file(path: Path) -> _LoadedCustodyFile:
+    held: mutation_lock.RetainedRegularFile | None = None
+    try:
+        held = mutation_lock.retain_regular_file(path)
+        before = os.fstat(held.fd)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or not 1 <= before.st_size <= MAX_CUSTODY_FILE_BYTES
+            or not _file_is_owner_protected(held.fd, before)
+        ):
+            raise AuthorizationCustodyUnavailable
+        data = _read_retained(held.fd, before.st_size)
+        after = os.fstat(held.fd)
+        if (
+            _stat_identity(before) != _stat_identity(after)
+            or not mutation_lock._same_file_entry(
+                held.directory, held.path.name, held.fd
+            )
+        ):
+            raise AuthorizationCustodyUnavailable
+        return _LoadedCustodyFile(path, data, _stat_identity(after))
+    except AuthorizationCustodyUnavailable:
+        raise
+    except (OSError, ValueError, TypeError):
+        raise AuthorizationCustodyUnavailable from None
+    finally:
+        if held is not None:
+            held.close()
+
+
+def load_external_custody(vault_root: Path) -> ExternalAuthorizationCustody:
+    """Load both fixed env-selected custody files through retained handles."""
+
+    keyring_path = _configured_external_path(KEYRING_FILE_ENV, Path(vault_root))
+    control_path = _configured_external_path(CONTROL_FILE_ENV, Path(vault_root))
+    keyring = _load_file(keyring_path)
+    control = _load_file(control_path)
+    if keyring.identity[:2] == control.identity[:2]:
+        raise AuthorizationCustodyUnavailable
+    return ExternalAuthorizationCustody(
+        keyring_path=keyring.path,
+        control_path=control.path,
+        keyring=keyring.data,
+        control=control.data,
+    )
+
+
+def _closed_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for name, value in pairs:
+        if name in result:
+            raise AuthorizationCustodyUnavailable
+        result[name] = value
+    return result
+
+
+def _bounded_identifier(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or any(ord(character) < 0x20 for character in value)
+    ):
+        raise AuthorizationCustodyUnavailable
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError:
+        raise AuthorizationCustodyUnavailable from None
+    if len(encoded) > 512:
+        raise AuthorizationCustodyUnavailable
+    return value
+
+
+def _bounded_time(value: object) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 1 <= value <= _MAX_SIGNED_SQLITE_INTEGER
+    ):
+        raise AuthorizationCustodyUnavailable
+    return value
+
+
+def _decode_key(value: object) -> bytes:
+    if not isinstance(value, str) or len(value) != 43:
+        raise AuthorizationCustodyUnavailable
+    try:
+        encoded = value.encode("ascii")
+        decoded = base64.b64decode(encoded + b"=", altchars=b"-_", validate=True)
+    except (UnicodeEncodeError, binascii.Error, ValueError):
+        raise AuthorizationCustodyUnavailable from None
+    if (
+        len(decoded) != 32
+        or base64.urlsafe_b64encode(decoded).rstrip(b"=") != encoded
+    ):
+        raise AuthorizationCustodyUnavailable
+    return decoded
+
+
+def _sha256_hex(value: object) -> str:
+    if not isinstance(value, str) or _SHA256_HEX.fullmatch(value) is None:
+        raise AuthorizationCustodyUnavailable
+    return value
+
+
+def _framed(domain: bytes, fields: tuple[bytes, ...]) -> bytes:
+    output = bytearray(domain)
+    output.append(0)
+    for value in fields:
+        output.extend(len(value).to_bytes(4, "big"))
+        output.extend(value)
+    return bytes(output)
+
+
+def _control_mac_input(value: dict[str, object]) -> bytes:
+    activation_store = value["activation_store_id"]
+    activation_epoch = value["activation_epoch"]
+    activation_digest = value["activation_state_digest"]
+    return _framed(
+        _CONTROL_MAC_DOMAIN,
+        (
+            str(value["version"]).encode("ascii"),
+            str(value["keyring_id"]).encode("utf-8"),
+            str(value["cell_id"]).encode("utf-8"),
+            str(value["logical_vault_id"]).encode("utf-8"),
+            str(value["registry_attachment_id"]).encode("utf-8"),
+            str(value["attachment_epoch"]).encode("ascii"),
+            b"true" if value["governance_enrolled"] is True else b"false",
+            b"" if activation_store is None else str(activation_store).encode("utf-8"),
+            b"" if activation_epoch is None else str(activation_epoch).encode("ascii"),
+            b"" if activation_digest is None else str(activation_digest).encode("ascii"),
+            str(value["serving_membership_epoch"]).encode("ascii"),
+            str(value["serving_membership_digest"]).encode("ascii"),
+            str(value["issued_at"]).encode("ascii"),
+            str(value["expires_at"]).encode("ascii"),
+            str(value["signing_key_id"]).encode("utf-8"),
+        ),
+    )
+
+
+def _parse_key(value: object) -> AuthorizationVerifierKey:
+    if not isinstance(value, dict) or set(value) != _KEY_FIELDS:
+        raise AuthorizationCustodyUnavailable
+    key_id = _bounded_identifier(value["key_id"])
+    not_before = _bounded_time(value["not_before"])
+    not_after = _bounded_time(value["not_after"])
+    if not_before >= not_after:
+        raise AuthorizationCustodyUnavailable
+    return AuthorizationVerifierKey(
+        key_id=key_id,
+        key=_decode_key(value["key"]),
+        not_before=not_before,
+        not_after=not_after,
+    )
+
+
+def parse_keyring(raw: bytes) -> AuthorizationKeyring:
+    """Parse the exact version-1 verifier keyring without a permissive fallback."""
+
+    if not isinstance(raw, bytes) or not 1 <= len(raw) <= MAX_CUSTODY_FILE_BYTES:
+        raise AuthorizationCustodyUnavailable
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_closed_object)
+    except AuthorizationCustodyUnavailable:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError, TypeError):
+        raise AuthorizationCustodyUnavailable from None
+    if not isinstance(value, dict) or set(value) != _KEYRING_FIELDS:
+        raise AuthorizationCustodyUnavailable
+    version = value["version"]
+    if isinstance(version, bool) or version != 1:
+        raise AuthorizationCustodyUnavailable
+    entries = value["accepted_keys"]
+    if (
+        not isinstance(entries, list)
+        or not 1 <= len(entries) <= _MAX_ACCEPTED_KEYS
+    ):
+        raise AuthorizationCustodyUnavailable
+    accepted = tuple(_parse_key(entry) for entry in entries)
+    key_ids = tuple(key.key_id for key in accepted)
+    if len(set(key_ids)) != len(key_ids):
+        raise AuthorizationCustodyUnavailable
+    active_key_id = _bounded_identifier(value["active_key_id"])
+    if active_key_id not in key_ids:
+        raise AuthorizationCustodyUnavailable
+    return AuthorizationKeyring(
+        version=1,
+        keyring_id=_bounded_identifier(value["keyring_id"]),
+        cell_id=_bounded_identifier(value["cell_id"]),
+        logical_vault_id=_bounded_identifier(value["logical_vault_id"]),
+        active_key_id=active_key_id,
+        accepted_keys=accepted,
+    )
+
+
+def parse_control_record(
+    raw: bytes,
+    *,
+    keyring: AuthorizationKeyring,
+    now: int,
+) -> AuthorizationControlRecord:
+    """Authenticate the exact external control-plane record for one cell."""
+
+    if (
+        not isinstance(raw, bytes)
+        or not isinstance(keyring, AuthorizationKeyring)
+        or not 1 <= len(raw) <= MAX_CUSTODY_FILE_BYTES
+    ):
+        raise AuthorizationCustodyUnavailable
+    current_time = _bounded_time(now)
+    active_key = keyring.active_key
+    if not active_key.not_before <= current_time < active_key.not_after:
+        raise AuthorizationCustodyUnavailable
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_closed_object)
+    except AuthorizationCustodyUnavailable:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError, TypeError):
+        raise AuthorizationCustodyUnavailable from None
+    if not isinstance(value, dict) or set(value) != _CONTROL_FIELDS:
+        raise AuthorizationCustodyUnavailable
+    version = value["version"]
+    if isinstance(version, bool) or version != 1:
+        raise AuthorizationCustodyUnavailable
+
+    keyring_id = _bounded_identifier(value["keyring_id"])
+    cell_id = _bounded_identifier(value["cell_id"])
+    logical_vault_id = _bounded_identifier(value["logical_vault_id"])
+    if (
+        keyring_id != keyring.keyring_id
+        or cell_id != keyring.cell_id
+        or logical_vault_id != keyring.logical_vault_id
+    ):
+        raise AuthorizationCustodyUnavailable
+
+    registry_attachment_id = _bounded_identifier(value["registry_attachment_id"])
+    attachment_epoch = _bounded_time(value["attachment_epoch"])
+    serving_membership_epoch = _bounded_time(value["serving_membership_epoch"])
+    serving_membership_digest = _sha256_hex(value["serving_membership_digest"])
+    issued_at = _bounded_time(value["issued_at"])
+    expires_at = _bounded_time(value["expires_at"])
+    if not issued_at <= current_time < expires_at:
+        raise AuthorizationCustodyUnavailable
+
+    enrolled = value["governance_enrolled"]
+    if not isinstance(enrolled, bool):
+        raise AuthorizationCustodyUnavailable
+    if enrolled:
+        activation_store_id = _bounded_identifier(value["activation_store_id"])
+        activation_epoch = _bounded_time(value["activation_epoch"])
+        activation_state_digest = _sha256_hex(value["activation_state_digest"])
+    else:
+        if any(
+            value[name] is not None
+            for name in (
+                "activation_store_id",
+                "activation_epoch",
+                "activation_state_digest",
+            )
+        ):
+            raise AuthorizationCustodyUnavailable
+        activation_store_id = None
+        activation_epoch = None
+        activation_state_digest = None
+
+    signing_key_id = _bounded_identifier(value["signing_key_id"])
+    signing_key = next(
+        (key for key in keyring.accepted_keys if key.key_id == signing_key_id),
+        None,
+    )
+    if (
+        signing_key is None
+        or issued_at < signing_key.not_before
+        or expires_at > signing_key.not_after
+    ):
+        raise AuthorizationCustodyUnavailable
+    supplied_mac = _decode_key(value["mac"])
+    expected_mac = hmac.new(
+        signing_key.key,
+        _control_mac_input(value),
+        hashlib.sha256,
+    ).digest()
+    if not hmac.compare_digest(supplied_mac, expected_mac):
+        raise AuthorizationCustodyUnavailable
+
+    return AuthorizationControlRecord(
+        version=1,
+        keyring_id=keyring_id,
+        cell_id=cell_id,
+        logical_vault_id=logical_vault_id,
+        registry_attachment_id=registry_attachment_id,
+        attachment_epoch=attachment_epoch,
+        governance_enrolled=enrolled,
+        activation_store_id=activation_store_id,
+        activation_epoch=activation_epoch,
+        activation_state_digest=activation_state_digest,
+        serving_membership_epoch=serving_membership_epoch,
+        serving_membership_digest=serving_membership_digest,
+        issued_at=issued_at,
+        expires_at=expires_at,
+        signing_key_id=signing_key_id,
+    )
+
+
+def load_authorization_custody(
+    vault_root: Path,
+    *,
+    now: int,
+) -> AuthorizationCustody:
+    """Load and authenticate the complete external session-custody bundle."""
+
+    external = load_external_custody(Path(vault_root))
+    keyring = parse_keyring(external.keyring)
+    control = parse_control_record(external.control, keyring=keyring, now=now)
+    return AuthorizationCustody(
+        keyring_path=external.keyring_path,
+        control_path=external.control_path,
+        keyring=keyring,
+        control=control,
+    )

--- a/tests/test_authorization_session_custody.py
+++ b/tests/test_authorization_session_custody.py
@@ -1,0 +1,689 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from exomem.governance import authorization_custody
+
+
+@pytest.fixture(autouse=True)
+def _clear_custody_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(authorization_custody.KEYRING_FILE_ENV, raising=False)
+    monkeypatch.delenv(authorization_custody.CONTROL_FILE_ENV, raising=False)
+
+
+def _protected_file(path: Path, data: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    if os.name == "nt":
+        from exomem import mutation_lock
+
+        mutation_lock._windows_apply_private_dacl(
+            path, mutation_lock._windows_current_user_sid()
+        )
+    else:
+        path.chmod(0o600)
+    return path
+
+
+def _configure(
+    monkeypatch: pytest.MonkeyPatch,
+    root: Path,
+    *,
+    keyring: bytes = b'{"kind":"keyring-sentinel"}',
+    control: bytes = b'{"kind":"control-sentinel"}',
+) -> tuple[Path, Path]:
+    keyring_path = _protected_file(root / "authorization-keyring.json", keyring)
+    control_path = _protected_file(root / "authorization-control.json", control)
+    monkeypatch.setenv(authorization_custody.KEYRING_FILE_ENV, str(keyring_path))
+    monkeypatch.setenv(authorization_custody.CONTROL_FILE_ENV, str(control_path))
+    return keyring_path, control_path
+
+
+def _keyring_document(**changes: object) -> bytes:
+    document: dict[str, object] = {
+        "version": 1,
+        "keyring_id": "keyring-e7901e43",
+        "cell_id": "cell-7bd27031",
+        "logical_vault_id": "vault-a2699d30",
+        "active_key_id": "auth-key-2026-08",
+        "accepted_keys": [
+            {
+                "key_id": "auth-key-2026-08",
+                "key": base64.urlsafe_b64encode(b"k" * 32)
+                .rstrip(b"=")
+                .decode("ascii"),
+                "not_before": 1_800_000_000,
+                "not_after": 1_800_086_400,
+            }
+        ],
+    }
+    document.update(changes)
+    return json.dumps(document, separators=(",", ":")).encode()
+
+
+def _framed(domain: bytes, fields: list[bytes]) -> bytes:
+    output = bytearray(domain)
+    output.append(0)
+    for field in fields:
+        output.extend(len(field).to_bytes(4, "big"))
+        output.extend(field)
+    return bytes(output)
+
+
+def _control_document(*, signing_key: bytes = b"k" * 32, **changes: object) -> bytes:
+    document: dict[str, object] = {
+        "version": 1,
+        "keyring_id": "keyring-e7901e43",
+        "cell_id": "cell-7bd27031",
+        "logical_vault_id": "vault-a2699d30",
+        "registry_attachment_id": "attachment-5d998951",
+        "attachment_epoch": 7,
+        "governance_enrolled": False,
+        "activation_store_id": None,
+        "activation_epoch": None,
+        "activation_state_digest": None,
+        "serving_membership_epoch": 11,
+        "serving_membership_digest": "b" * 64,
+        "issued_at": 1_800_000_000,
+        "expires_at": 1_800_003_600,
+        "signing_key_id": "auth-key-2026-08",
+    }
+    document.update(changes)
+    fields = [
+        str(document["version"]).encode(),
+        str(document["keyring_id"]).encode(),
+        str(document["cell_id"]).encode(),
+        str(document["logical_vault_id"]).encode(),
+        str(document["registry_attachment_id"]).encode(),
+        str(document["attachment_epoch"]).encode(),
+        b"true" if document["governance_enrolled"] is True else b"false",
+        b"" if document["activation_store_id"] is None else str(document["activation_store_id"]).encode(),
+        b"" if document["activation_epoch"] is None else str(document["activation_epoch"]).encode(),
+        b"" if document["activation_state_digest"] is None else str(document["activation_state_digest"]).encode(),
+        str(document["serving_membership_epoch"]).encode(),
+        str(document["serving_membership_digest"]).encode(),
+        str(document["issued_at"]).encode(),
+        str(document["expires_at"]).encode(),
+        str(document["signing_key_id"]).encode(),
+    ]
+    mac = hmac.new(
+        signing_key,
+        _framed(b"exomem.authorization-session.control/v1", fields),
+        hashlib.sha256,
+    ).digest()
+    document["mac"] = base64.urlsafe_b64encode(mac).rstrip(b"=").decode()
+    return json.dumps(document, separators=(",", ":")).encode()
+
+
+@pytest.mark.parametrize(
+    "missing",
+    (
+        authorization_custody.KEYRING_FILE_ENV,
+        authorization_custody.CONTROL_FILE_ENV,
+    ),
+)
+def test_both_external_custody_paths_are_mandatory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, missing: str
+) -> None:
+    _configure(monkeypatch, tmp_path / "external")
+    monkeypatch.delenv(missing)
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable) as raised:
+        authorization_custody.load_external_custody(tmp_path / "vault")
+
+    assert raised.value.code == "AUTHORIZATION_SESSION_UNAVAILABLE"
+    assert missing not in str(raised.value)
+
+
+def test_custody_loader_never_generates_missing_first_use_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    external = tmp_path / "external"
+    keyring_path = external / "authorization-keyring.json"
+    control_path = external / "authorization-control.json"
+    monkeypatch.setenv(authorization_custody.KEYRING_FILE_ENV, str(keyring_path))
+    monkeypatch.setenv(authorization_custody.CONTROL_FILE_ENV, str(control_path))
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_external_custody(tmp_path / "vault")
+
+    assert not external.exists()
+    assert not keyring_path.exists()
+    assert not control_path.exists()
+
+
+def test_custody_read_is_bounded_stable_and_bearer_free_in_repr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    keyring = b'{"secret":"keyring-secret-sentinel"}'
+    control = b'{"signature":"control-signature-sentinel"}'
+    keyring_path, control_path = _configure(
+        monkeypatch, tmp_path / "external", keyring=keyring, control=control
+    )
+
+    loaded = authorization_custody.load_external_custody(tmp_path / "vault")
+
+    assert loaded.keyring == keyring
+    assert loaded.control == control
+    assert loaded.keyring_path == keyring_path
+    assert loaded.control_path == control_path
+    assert "keyring-secret-sentinel" not in repr(loaded)
+    assert "control-signature-sentinel" not in repr(loaded)
+
+
+def test_keyring_and_control_must_be_distinct_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    keyring_path, _control_path = _configure(monkeypatch, tmp_path / "external")
+    monkeypatch.setenv(authorization_custody.CONTROL_FILE_ENV, str(keyring_path))
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_external_custody(tmp_path / "vault")
+
+
+def test_custody_change_during_read_refuses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    keyring_path, _control_path = _configure(monkeypatch, tmp_path / "external")
+    original = authorization_custody._read_retained
+
+    def change_after_read(descriptor: int, expected_size: int) -> bytes:
+        data = original(descriptor, expected_size)
+        keyring_path.write_bytes(b"x" * expected_size)
+        return data
+
+    monkeypatch.setattr(authorization_custody, "_read_retained", change_after_read)
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_external_custody(tmp_path / "vault")
+
+
+def test_timestamp_preserving_custody_change_during_read_refuses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    keyring_path, _control_path = _configure(monkeypatch, tmp_path / "external")
+    original = authorization_custody._read_retained
+
+    def change_and_restore_mtime(descriptor: int, expected_size: int) -> bytes:
+        data = original(descriptor, expected_size)
+        before = keyring_path.stat()
+        keyring_path.write_bytes(b"x" * expected_size)
+        os.utime(
+            keyring_path,
+            ns=(before.st_atime_ns, before.st_mtime_ns),
+        )
+        return data
+
+    monkeypatch.setattr(
+        authorization_custody, "_read_retained", change_and_restore_mtime
+    )
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_external_custody(tmp_path / "vault")
+
+
+def test_keyring_parser_returns_exact_bearer_free_keys() -> None:
+    parsed = authorization_custody.parse_keyring(_keyring_document())
+
+    assert parsed.version == 1
+    assert parsed.keyring_id == "keyring-e7901e43"
+    assert parsed.cell_id == "cell-7bd27031"
+    assert parsed.logical_vault_id == "vault-a2699d30"
+    assert parsed.active_key.key_id == "auth-key-2026-08"
+    assert parsed.active_key.key == b"k" * 32
+    assert (b"k" * 32).hex() not in repr(parsed)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    (
+        b"",
+        b"[]",
+        b'{"version":1,"version":1}',
+        _keyring_document(version=2),
+        _keyring_document(extra="not-allowed"),
+        _keyring_document(keyring_id=""),
+        _keyring_document(cell_id="x" * 513),
+        _keyring_document(active_key_id="missing-key"),
+        _keyring_document(accepted_keys=[]),
+    ),
+)
+def test_keyring_parser_rejects_bad_shape_version_or_identity(raw: bytes) -> None:
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.parse_keyring(raw)
+
+
+def test_keyring_parser_maps_unencodable_identity_to_content_free_refusal() -> None:
+    raw = _keyring_document(keyring_id="\ud800")
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.parse_keyring(raw)
+
+
+@pytest.mark.parametrize(
+    "key_value",
+    (
+        "A" * 42,
+        "A" * 44,
+        "A" * 42 + "=",
+        "A" * 42 + "+",
+        "A" * 42 + "/",
+        "A" * 42 + "B",
+    ),
+)
+def test_keyring_parser_rejects_noncanonical_or_wrong_length_keys(
+    key_value: str,
+) -> None:
+    entry = json.loads(_keyring_document())["accepted_keys"][0]
+    entry["key"] = key_value
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.parse_keyring(
+            _keyring_document(accepted_keys=[entry])
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("not_before", True),
+        ("not_before", 0),
+        ("not_before", 2**63),
+        ("not_after", False),
+        ("not_after", 0),
+        ("not_after", 2**63),
+    ),
+)
+def test_keyring_parser_rejects_unbounded_key_times(field: str, value: object) -> None:
+    entry = json.loads(_keyring_document())["accepted_keys"][0]
+    entry[field] = value
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.parse_keyring(
+            _keyring_document(accepted_keys=[entry])
+        )
+
+
+def test_keyring_parser_rejects_reversed_time_or_duplicate_key_id() -> None:
+    entry = json.loads(_keyring_document())["accepted_keys"][0]
+    reversed_entry = {**entry, "not_before": 1_800_086_400}
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.parse_keyring(
+            _keyring_document(accepted_keys=[reversed_entry])
+        )
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.parse_keyring(
+            _keyring_document(accepted_keys=[entry, entry])
+        )
+
+
+def test_control_record_authenticates_external_identity_and_enrollment() -> None:
+    keyring = authorization_custody.parse_keyring(_keyring_document())
+
+    control = authorization_custody.parse_control_record(
+        _control_document(), keyring=keyring, now=1_800_000_100
+    )
+
+    assert control.cell_id == keyring.cell_id
+    assert control.logical_vault_id == keyring.logical_vault_id
+    assert control.keyring_id == keyring.keyring_id
+    assert control.registry_attachment_id == "attachment-5d998951"
+    assert control.attachment_epoch == 7
+    assert control.governance_enrolled is False
+    assert control.activation_store_id is None
+    assert control.serving_membership_epoch == 11
+    assert control.signing_key_id == "auth-key-2026-08"
+    assert "a2tra2" not in repr(control)
+
+
+def test_enrolled_control_requires_the_complete_activation_tuple() -> None:
+    keyring = authorization_custody.parse_keyring(_keyring_document())
+    raw = _control_document(
+        governance_enrolled=True,
+        activation_store_id="activation-3eb50845",
+        activation_epoch=4,
+        activation_state_digest="a" * 64,
+    )
+
+    control = authorization_custody.parse_control_record(
+        raw, keyring=keyring, now=1_800_000_100
+    )
+
+    assert control.governance_enrolled is True
+    assert control.activation_store_id == "activation-3eb50845"
+    assert control.activation_epoch == 4
+    assert control.activation_state_digest == "a" * 64
+
+
+@pytest.mark.parametrize(
+    "changes",
+    (
+        {"cell_id": "cell-other"},
+        {"logical_vault_id": "vault-other"},
+        {"keyring_id": "keyring-other"},
+        {"signing_key_id": "unknown-key"},
+        {"attachment_epoch": 0},
+        {"serving_membership_epoch": 0},
+        {"serving_membership_digest": "z" * 64},
+        {"governance_enrolled": True},
+        {"activation_store_id": "activation-unexpected"},
+        {"activation_epoch": 1},
+        {"activation_state_digest": "a" * 64},
+    ),
+)
+def test_control_record_rejects_identity_or_enrollment_mismatch(
+    changes: dict[str, object],
+) -> None:
+    keyring = authorization_custody.parse_keyring(_keyring_document())
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.parse_control_record(
+            _control_document(**changes), keyring=keyring, now=1_800_000_100
+        )
+
+
+@pytest.mark.parametrize("now", (1_799_999_999, 1_800_003_600, True))
+def test_control_record_rejects_outside_its_and_the_signing_keys_window(
+    now: object,
+) -> None:
+    keyring = authorization_custody.parse_keyring(_keyring_document())
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.parse_control_record(
+            _control_document(), keyring=keyring, now=now  # type: ignore[arg-type]
+        )
+
+
+def test_control_record_rejects_bad_mac_duplicate_or_extra_field() -> None:
+    keyring = authorization_custody.parse_keyring(_keyring_document())
+    document = json.loads(_control_document())
+    document["mac"] = "A" * 43
+    bad_mac = json.dumps(document, separators=(",", ":")).encode()
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.parse_control_record(
+            bad_mac, keyring=keyring, now=1_800_000_100
+        )
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.parse_control_record(
+            b'{"version":1,"version":1}',
+            keyring=keyring,
+            now=1_800_000_100,
+        )
+
+    document = json.loads(_control_document())
+    document["extra"] = "not-allowed"
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.parse_control_record(
+            json.dumps(document).encode(),
+            keyring=keyring,
+            now=1_800_000_100,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    (
+        ("version", 2),
+        ("keyring_id", "keyring-other"),
+        ("cell_id", "cell-other"),
+        ("logical_vault_id", "vault-other"),
+        ("registry_attachment_id", "attachment-other"),
+        ("attachment_epoch", 8),
+        ("governance_enrolled", False),
+        ("activation_store_id", "activation-other"),
+        ("activation_epoch", 5),
+        ("activation_state_digest", "b" * 64),
+        ("serving_membership_epoch", 12),
+        ("serving_membership_digest", "c" * 64),
+        ("issued_at", 1_800_000_001),
+        ("expires_at", 1_800_003_599),
+        ("signing_key_id", "unknown-key"),
+    ),
+)
+def test_control_mac_or_validation_binds_every_non_mac_field(
+    field: str,
+    replacement: object,
+) -> None:
+    keyring = authorization_custody.parse_keyring(_keyring_document())
+    document = json.loads(
+        _control_document(
+            governance_enrolled=True,
+            activation_store_id="activation-3eb50845",
+            activation_epoch=4,
+            activation_state_digest="a" * 64,
+        )
+    )
+    document[field] = replacement
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.parse_control_record(
+            json.dumps(document, separators=(",", ":")).encode(),
+            keyring=keyring,
+            now=1_800_000_100,
+        )
+
+
+def test_control_record_requires_the_active_issuance_key_to_be_current() -> None:
+    expired_active = json.loads(_keyring_document())["accepted_keys"][0]
+    expired_active["not_after"] = 1_800_000_050
+    control_signing = {
+        "key_id": "control-key-2026-08",
+        "key": base64.urlsafe_b64encode(b"s" * 32)
+        .rstrip(b"=")
+        .decode("ascii"),
+        "not_before": 1_800_000_000,
+        "not_after": 1_800_086_400,
+    }
+    keyring = authorization_custody.parse_keyring(
+        _keyring_document(accepted_keys=[expired_active, control_signing])
+    )
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.parse_control_record(
+            _control_document(
+                signing_key=b"s" * 32,
+                signing_key_id="control-key-2026-08",
+            ),
+            keyring=keyring,
+            now=1_800_000_100,
+        )
+
+
+def test_windows_custody_requires_a_protected_private_file_dacl() -> None:
+    from exomem import mutation_lock
+
+    sid = "S-1-5-21-9-9-9-1001"
+    protected = mutation_lock._windows_private_dacl_sddl(sid)
+    inherited = protected.replace("D:P", "D:", 1)
+
+    assert authorization_custody._windows_file_dacl_is_private(protected, sid)
+    assert not authorization_custody._windows_file_dacl_is_private(inherited, sid)
+
+
+def test_authenticated_custody_loader_returns_only_verified_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    keyring_path, control_path = _configure(
+        monkeypatch,
+        tmp_path / "external",
+        keyring=_keyring_document(),
+        control=_control_document(),
+    )
+
+    loaded = authorization_custody.load_authorization_custody(
+        tmp_path / "vault", now=1_800_000_100
+    )
+
+    assert loaded.keyring_path == keyring_path
+    assert loaded.control_path == control_path
+    assert loaded.keyring.active_key.key == b"k" * 32
+    assert loaded.control.registry_attachment_id == "attachment-5d998951"
+    assert (b"k" * 32).hex() not in repr(loaded)
+    assert "mac" not in repr(loaded)
+
+
+def test_authenticated_custody_loader_never_returns_unverified_control(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    control = json.loads(_control_document())
+    control["mac"] = "A" * 43
+    _configure(
+        monkeypatch,
+        tmp_path / "external",
+        keyring=_keyring_document(),
+        control=json.dumps(control, separators=(",", ":")).encode(),
+    )
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_authorization_custody(
+            tmp_path / "vault", now=1_800_000_100
+        )
+
+
+@pytest.mark.parametrize("configured_name", ("relative.json", ""))
+def test_relative_or_empty_custody_path_refuses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    configured_name: str,
+) -> None:
+    _configure(monkeypatch, tmp_path / "external")
+    monkeypatch.setenv(authorization_custody.KEYRING_FILE_ENV, configured_name)
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_external_custody(tmp_path / "vault")
+
+
+@pytest.mark.parametrize("kind", ("keyring", "control"))
+def test_custody_path_inside_the_vault_refuses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, kind: str
+) -> None:
+    vault = tmp_path / "vault"
+    keyring_path, control_path = _configure(monkeypatch, tmp_path / "external")
+    selected = _protected_file(vault / f"{kind}.json", b"{}")
+    monkeypatch.setenv(
+        authorization_custody.KEYRING_FILE_ENV
+        if kind == "keyring"
+        else authorization_custody.CONTROL_FILE_ENV,
+        str(selected),
+    )
+    assert keyring_path != selected and control_path != selected
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_external_custody(vault)
+
+
+@pytest.mark.parametrize("kind", ("keyring", "control"))
+def test_symlinked_custody_file_refuses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, kind: str
+) -> None:
+    keyring_path, control_path = _configure(monkeypatch, tmp_path / "external")
+    target = keyring_path if kind == "keyring" else control_path
+    link = target.with_name(f"{target.stem}-link.json")
+    try:
+        link.symlink_to(target)
+    except OSError as error:
+        pytest.skip(f"symlinks unavailable: {error}")
+    monkeypatch.setenv(
+        authorization_custody.KEYRING_FILE_ENV
+        if kind == "keyring"
+        else authorization_custody.CONTROL_FILE_ENV,
+        str(link),
+    )
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_external_custody(tmp_path / "vault")
+
+
+@pytest.mark.parametrize("kind", ("keyring", "control"))
+def test_directory_or_oversized_custody_file_refuses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    kind: str,
+) -> None:
+    keyring_path, control_path = _configure(monkeypatch, tmp_path / "external")
+    selected = keyring_path if kind == "keyring" else control_path
+    selected.unlink()
+    selected.mkdir()
+    monkeypatch.setenv(
+        authorization_custody.KEYRING_FILE_ENV
+        if kind == "keyring"
+        else authorization_custody.CONTROL_FILE_ENV,
+        str(selected),
+    )
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_external_custody(tmp_path / "vault")
+
+    selected.rmdir()
+    _protected_file(
+        selected,
+        b"x" * (authorization_custody.MAX_CUSTODY_FILE_BYTES + 1),
+    )
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_external_custody(tmp_path / "vault")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX owner/mode contract")
+@pytest.mark.parametrize("mode", (0o640, 0o604, 0o666, 0o000, 0o700))
+def test_posix_custody_requires_exact_owner_readable_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mode: int,
+) -> None:
+    keyring_path, _control_path = _configure(monkeypatch, tmp_path / "external")
+    keyring_path.chmod(mode)
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_external_custody(tmp_path / "vault")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX hard-link contract")
+def test_hard_linked_custody_file_refuses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    keyring_path, _control_path = _configure(monkeypatch, tmp_path / "external")
+    os.link(keyring_path, keyring_path.with_name("keyring-copy.json"))
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_external_custody(tmp_path / "vault")
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows DACL contract")
+def test_windows_custody_refuses_a_file_admitting_authenticated_users(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import mutation_lock
+
+    keyring_path, _control_path = _configure(monkeypatch, tmp_path / "external")
+    sid = mutation_lock._windows_current_user_sid()
+    unsafe = mutation_lock._windows_private_dacl_sddl(sid) + "(A;;FA;;;AU)"
+    mutation_lock._windows_apply_dacl_sddl(keyring_path, unsafe)
+    observed = mutation_lock._windows_dacl_sddl(keyring_path)
+    assert not mutation_lock._windows_private_dacl_is_valid(
+        observed, sid, directory=False
+    )
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_external_custody(tmp_path / "vault")
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX FIFO contract")
+def test_fifo_custody_file_refuses_without_blocking(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    keyring_path, _control_path = _configure(monkeypatch, tmp_path / "external")
+    keyring_path.unlink()
+    os.mkfifo(keyring_path, mode=0o600)
+    assert stat.S_ISFIFO(keyring_path.lstat().st_mode)
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_external_custody(tmp_path / "vault")


### PR DESCRIPTION
## Why

Authorization-session verifier keys and cell identity must come from protected external custody before schema-v4 sessions can be issued or resumed. This adds the fail-closed filesystem and record-authentication boundary without enabling session lifecycle or touching a vault.

## What changed

- load mandatory keyring and control files through retained no-follow handles outside the vault
- enforce exact POSIX modes or protected private Windows DACLs, single-link regular files, bounded stable reads, and no first-use generation
- parse a closed versioned keyring and MAC-authenticated control record bound to cell, logical vault, registry attachment, enrollment tuple, serving epoch, and key windows
- return one content-free refusal for malformed, unsafe, stale, mismatched, or unauthenticated custody

## Verification

- Python 3.11: 112 passed, 1 Windows-only skipped
- Python 3.13: 112 passed, 1 Windows-only skipped
- Ruff: clean
- OpenSpec strict validation: valid
- public artifact privacy validation: clean

The native Windows ACL refusal remains enabled for windows-latest CI. No live personal or delegated vault was accessed.