### PR TITLE
fix(hosted): reconcile terminal runtime history

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/fleet_observation.py
+++ b/infra/provisioner/src/exomem_provisioner/fleet_observation.py
@@ -181,8 +181,6 @@ def build_fleet_observation(
     resolved_desired: list[dict[str, Any]] = []
     for item in desired.values():
         runtime = _resolve_runtime(item["runtimeIdentity"], exact=exact, legacy=legacy)
-        if runtime is None:
-            _error("runtime-setting operation has no reviewed deployment identity")
         resolved_desired.append(
             {"cellId": item["cellId"], "runtime": runtime, "state": item["state"]}
         )

--- a/infra/provisioner/tests/test_fleet_observation.py
+++ b/infra/provisioner/tests/test_fleet_observation.py
@@ -200,7 +200,7 @@ def test_terminal_destroy_does_not_make_dead_runtime_history_a_catalog_dependenc
     assert observation["unfinishedOperations"] == []
 
 
-def test_live_desired_state_still_requires_a_reviewed_runtime() -> None:
+def test_unresolved_desired_history_is_redacted_for_cross_authority_reconciliation() -> None:
     operations = (
         _operation(
             operation_id="provision-alpha",
@@ -211,9 +211,32 @@ def test_live_desired_state_still_requires_a_reviewed_runtime() -> None:
         ),
     )
 
+    observation = build_fleet_observation(
+        operations,
+        lock=_lock(),
+        observed_at="2026-08-21T11:00:00Z",
+    )
+
+    assert observation["desiredCells"] == [
+        {"cellId": "cell-alpha", "runtime": None, "state": "ready"}
+    ]
+    assert observation["unfinishedOperations"] == []
+
+
+def test_unresolved_unfinished_runtime_still_fails_closed() -> None:
+    operations = (
+        _operation(
+            operation_id="provision-alpha",
+            action=OperationAction.PROVISION,
+            state=OperationState.PENDING,
+            runtime={"releaseVersion": "0.24.0", "protocolVersion": "1"},
+            offset=0,
+        ),
+    )
+
     with pytest.raises(
         FleetObservationError,
-        match="runtime-setting operation has no reviewed deployment identity",
+        match="unfinished operation has no reviewed deployment identity",
     ):
         build_fleet_observation(
             operations,

--- a/infra/scripts/hosted_fleet_inventory.py
+++ b/infra/scripts/hosted_fleet_inventory.py
@@ -1274,9 +1274,14 @@ def reconcile_inventory(
             cell=current,
             issues=issues,
         )
-        desired_runtime = _deployment_runtime(item["runtime"], label="desired runtime")
+        desired_runtime = (
+            None
+            if item["runtime"] is None
+            else _deployment_runtime(item["runtime"], label="desired runtime")
+        )
         current["desiredState"] = True
-        current["runtimeDeployments"].append(desired_runtime)
+        if desired_runtime is not None:
+            current["runtimeDeployments"].append(desired_runtime)
         current["desiredReady"] = _code(item["state"], label="desired state") == "ready"
 
     seen = set()

--- a/openspec/changes/standardize-hosted-runtime-upgrades/specs/hosted-runtime-upgrade/spec.md
+++ b/openspec/changes/standardize-hosted-runtime-upgrades/specs/hosted-runtime-upgrade/spec.md
@@ -93,8 +93,10 @@ Before expand deployment or any cell rollforward, the workflow SHALL reconcile S
 
 - **WHEN** Substrate marks a tenant binding destroyed, Kubernetes reports no namespace, Helm release, workload, or volume for that cell, and no route, assignment, unfinished operation, capacity claim, or reviewer authority remains
 - **AND** the provisioner operation ledger is the only authority that still projects desired state for the cell
-- **THEN** inventory retains that redacted desired-state surface as terminal evidence but excludes the cell and its runtime from live and legacy dependency counts
+- **THEN** the provisioner observer MAY redact an identity absent from the reviewed active and legacy catalogs to a null runtime solely for cross-authority reconciliation
+- **AND** inventory retains that redacted desired-state surface as terminal evidence but excludes the cell and its runtime from live and legacy dependency counts
 - **AND** any remaining control-plane, reviewer, operation, capacity, or Kubernetes surface keeps the cell inconsistent and blocks the upgrade
+- **AND** every unfinished operation or desired state with an independently live surface still requires an exact reviewed runtime identity or inventory fails closed
 
 ### Requirement: Expand adoption changes only the future-cell target
 

--- a/openspec/changes/standardize-hosted-runtime-upgrades/tasks.md
+++ b/openspec/changes/standardize-hosted-runtime-upgrades/tasks.md
@@ -17,6 +17,7 @@
 - [x] 2.7 Bootstrap the first pre-expand provisioner observation from one exact incoming image in a minimum-authority, tokenless, deadline-bounded Job when the installed legacy image lacks the collector
 - [x] 2.8 Keep terminal operation history observable without retaining dead runtime catalogs forever, while requiring every live desired or unfinished runtime to resolve exactly
 - [x] 2.9 Treat provisioner-only desired-state residue as terminal only when Substrate proves destruction and every independently live control-plane and Kubernetes surface is absent
+- [x] 2.10 Redact unresolved historical desired runtime identities only at the provisioner observation boundary, while requiring exact identity for unfinished or independently live state
 
 ## 3. Substrate per-cell rollforward companion
 

--- a/tests/test_hosted_fleet_inventory.py
+++ b/tests/test_hosted_fleet_inventory.py
@@ -910,6 +910,30 @@ def test_destroyed_binding_prunes_provisioner_only_desired_residue(
     assert facts["legacyCellCount"] == 0
 
 
+def test_destroyed_binding_prunes_unresolved_provisioner_only_residue() -> None:
+    module = _module()
+    target = _runtime("0.57.2", "a")
+    sources = _empty_sources()
+    sources["substrate"]["tenantBindings"].append(
+        {"cellId": "cell_destroyed", "status": "destroyed"}
+    )
+    sources["provisioner"]["desiredCells"].append(
+        {"cellId": "cell_destroyed", "runtime": None, "state": "ready"}
+    )
+
+    inventory = module.reconcile_inventory(sources, target=target)
+    facts = module.execution_inventory_facts(inventory)
+
+    assert inventory["status"] == "empty"
+    assert inventory["issues"] == []
+    assert inventory["counts"]["cells"] == 0
+    assert inventory["counts"]["legacyCells"] == 0
+    assert inventory["counts"]["terminalCells"] == 1
+    assert inventory["legacyRuntimes"] == []
+    assert inventory["cells"][0]["runtime"] is None
+    assert facts["cellCount"] == 0
+
+
 def test_provisioner_only_desired_state_without_a_destroyed_binding_stays_blocked() -> None:
     module = _module()
     target = _runtime("0.57.2", "a")
@@ -924,6 +948,23 @@ def test_provisioner_only_desired_state_without_a_destroyed_binding_stays_blocke
     assert inventory["counts"]["cells"] == 1
     assert inventory["counts"]["terminalCells"] == 0
     assert "missing_active_binding" in inventory["issues"]
+
+
+def test_unresolved_provisioner_desired_state_without_destruction_stays_blocked() -> None:
+    module = _module()
+    target = _runtime("0.57.2", "a")
+    sources = _empty_sources()
+    sources["provisioner"]["desiredCells"].append(
+        {"cellId": "cell_unbound", "runtime": None, "state": "ready"}
+    )
+
+    inventory = module.reconcile_inventory(sources, target=target)
+
+    assert inventory["status"] == "inconsistent"
+    assert inventory["counts"]["cells"] == 1
+    assert inventory["counts"]["terminalCells"] == 0
+    assert "missing_active_binding" in inventory["issues"]
+    assert "missing_runtime_identity" in inventory["issues"]
 
 
 def test_operator_cli_collects_three_authorities_and_writes_private_phase_facts(


### PR DESCRIPTION
## Summary

- let the provisioner redact unresolved historical desired-runtime identities at the observation boundary
- keep unfinished operations strict and fail closed for any independently live unresolved state
- reconcile destroyed provisioner-only residue as terminal evidence without restoring dead runtime catalogs
- update the Hosted runtime-upgrade OpenSpec contract and task ledger

## Verification

- `uv run --project infra/provisioner pytest -q infra/provisioner/tests` (508 passed, 17 skipped)
- `uv run pytest -q tests/test_hosted_fleet_inventory.py tests/test_hosted_runtime_upgrade.py tests/test_hosted_runtime_upgrade_orchestrator.py tests/test_hosted_composition_lock.py tests/test_hosted_deployment_lock_consumption.py tests/test_hosted_adoption_staging.py` (142 passed)
- Ruff on changed Python files
- `openspec validate standardize-hosted-runtime-upgrades --strict`
- `uv run python scripts/validate-public-artifacts.py --repository`
- `git diff --check origin/main...HEAD`

## Live context

The expand release is already safely installed with zero tenant resources. This change repairs the read-only post-expand observer boundary; it does not mutate tenant state.
