### PR TITLE
fix(hosted): fail closed on reviewer lock drift

### DIFF
--- a/scripts/reviewer_bootstrap.py
+++ b/scripts/reviewer_bootstrap.py
@@ -262,15 +262,14 @@ def attach_openai_locks(cp: ControlPlane, candidate_id: str, locks: dict) -> Non
     if attached.get("attached") is True:
         print("  openai locks attached")
         return
-    # The guard also requires `openai_package_lock IS NULL`, so a false here means
-    # the candidate already carries locks. Preflight has just proved its state and
-    # all three digests, which leaves nothing else the predicate could have
-    # rejected -- but locks attached from a different repo checkout would still
-    # break the sibling stage, and that cannot be read back through any endpoint.
-    print(
-        "  openai locks were already attached by an earlier prepare.\n"
-        "        If that run used a different checkout, `run` will fail at the\n"
-        "        OpenAI sibling stage and the candidate must be replaced."
+    # `attached: false` is deliberately not treated as idempotent success. The
+    # endpoint does not expose the stored lock bytes, so this process cannot prove
+    # that an earlier attachment used this exact release checkout. Continuing
+    # would defer the mismatch until after reviewer authority is spent.
+    raise SystemExit(
+        "attach-openai-locks returned attached=false; the harness could not prove "
+        "that the candidate carries these exact OpenAI locks. Refusing before "
+        "reviewer authority is created; verify or replace the pending candidate."
     )
 
 
@@ -901,6 +900,18 @@ def load_locks(repo: Path) -> dict:
     fixture = json.loads(
         (repo / "plugins" / "hosted" / "marketplace-review-fixture-v1.json").read_text()
     )
+    contract_fields = (
+        "command_surface_sha256",
+        "schema_contract_sha256",
+        "compatibility_sha256",
+    )
+    drift = [field for field in contract_fields if claude.get(field) != openai.get(field)]
+    if drift:
+        raise SystemExit(
+            "Claude and OpenAI release locks disagree on "
+            f"{', '.join(drift)}; regenerate the OpenAI bundle from this exact "
+            "release before promotion."
+        )
     return {
         "claude_package": claude["artifact_sha256"],
         "claude_archive": claude_zip["archive_sha256"],

--- a/tests/test_reviewer_bootstrap_cli.py
+++ b/tests/test_reviewer_bootstrap_cli.py
@@ -290,6 +290,47 @@ def test_attach_surfaces_a_rejected_attachment(monkeypatch) -> None:
         module.attach_openai_locks(cp, "cand-1", _locks())
 
 
+def test_attach_refuses_an_unproven_already_attached_response(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setenv("EXOMEM_HOSTED_CONTRACT_IMPORT_KEY_ID", "key-1")
+    monkeypatch.setenv("EXOMEM_HOSTED_CONTRACT_IMPORT_SECRET", "s3cret")
+    cp = _RecordingControlPlane({"prepare-attach-openai-locks": (200, {"attached": False})})
+
+    with pytest.raises(SystemExit) as raised:
+        module.attach_openai_locks(cp, "cand-1", _locks())
+
+    assert "could not prove" in str(raised.value)
+
+
+def test_load_locks_rejects_cross_platform_contract_drift(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    generated = tmp_path / "plugins" / "hosted" / "generated"
+    generated.mkdir(parents=True)
+    fixture = tmp_path / "plugins" / "hosted" / "marketplace-review-fixture-v1.json"
+
+    claude_lock = {
+        **OPENAI_PACKAGE_LOCK,
+        "platform": "claude",
+        "artifact_sha256": "9d" * 32,
+    }
+    openai_lock = {
+        **OPENAI_PACKAGE_LOCK,
+        "schema_contract_sha256": "aa" * 32,
+    }
+    (generated / "claude.lock.json").write_text(json.dumps(claude_lock))
+    (generated / "claude.zip.lock.json").write_text(
+        json.dumps({"platform": "claude", "archive_sha256": "0d" * 32})
+    )
+    (generated / "openai.lock.json").write_text(json.dumps(openai_lock))
+    (generated / "openai.zip.lock.json").write_text(json.dumps(OPENAI_ARCHIVE_LOCK))
+    fixture.write_text(json.dumps({"fixture_version": "v1", "payload_sha256": "ff" * 32}))
+
+    with pytest.raises(SystemExit) as raised:
+        module.load_locks(tmp_path)
+
+    assert "schema_contract_sha256" in str(raised.value)
+
+
 def test_prepare_attaches_the_openai_locks_before_anything_else(monkeypatch) -> None:
     """Ordering is the whole point: after `run` starts, this is unrecoverable."""
     module = _load_module()

--- a/tests/test_reviewer_bootstrap_cli.py
+++ b/tests/test_reviewer_bootstrap_cli.py
@@ -302,7 +302,13 @@ def test_attach_refuses_an_unproven_already_attached_response(monkeypatch) -> No
     assert "could not prove" in str(raised.value)
 
 
-def test_load_locks_rejects_cross_platform_contract_drift(tmp_path: pathlib.Path) -> None:
+@pytest.mark.parametrize(
+    "field",
+    ("command_surface_sha256", "schema_contract_sha256", "compatibility_sha256"),
+)
+def test_load_locks_rejects_cross_platform_contract_drift(
+    tmp_path: pathlib.Path, field: str
+) -> None:
     module = _load_module()
     generated = tmp_path / "plugins" / "hosted" / "generated"
     generated.mkdir(parents=True)
@@ -315,7 +321,7 @@ def test_load_locks_rejects_cross_platform_contract_drift(tmp_path: pathlib.Path
     }
     openai_lock = {
         **OPENAI_PACKAGE_LOCK,
-        "schema_contract_sha256": "aa" * 32,
+        field: "aa" * 32,
     }
     (generated / "claude.lock.json").write_text(json.dumps(claude_lock))
     (generated / "claude.zip.lock.json").write_text(
@@ -328,7 +334,7 @@ def test_load_locks_rejects_cross_platform_contract_drift(tmp_path: pathlib.Path
     with pytest.raises(SystemExit) as raised:
         module.load_locks(tmp_path)
 
-    assert "schema_contract_sha256" in str(raised.value)
+    assert field in str(raised.value)
 
 
 def test_prepare_attaches_the_openai_locks_before_anything_else(monkeypatch) -> None:


### PR DESCRIPTION
## Why

The 0.57.2 reviewer ceremony exposed two promotion-window hazards: cross-platform contract drift was not validated before control-plane work, and an ambiguous `attached: false` response was treated as if exact prior locks were proven. Both can defer failure until after one-shot reviewer authority is consumed.

## What changed

- reject Claude/OpenAI lock pairs whose command surface, schema contract, or compatibility identity differs
- fail closed when lock attachment returns `attached: false`, since the endpoint does not expose stored lock bytes
- add regression coverage for both cases

## Verification

- `uvx ruff check scripts/reviewer_bootstrap.py tests/test_reviewer_bootstrap_cli.py`
- `uvx ruff format --check scripts/reviewer_bootstrap.py tests/test_reviewer_bootstrap_cli.py`
- `uv run python scripts/validate-public-artifacts.py --repository`
- `uv run pytest -q tests/test_reviewer_bootstrap_cli.py tests/test_hosted_plugin_rendering.py` (49 passed)
- `git diff --check origin/main...HEAD`