### PR TITLE
feat(governance): preactivate projected measurements

### DIFF
--- a/src/exomem/governance/projection_measurement_store.py
+++ b/src/exomem/governance/projection_measurement_store.py
@@ -27,7 +27,6 @@ _DESCRIPTOR_ID = "authorization-projections"
 _OWNER = "governance.projections"
 _STORE_FILENAME = "rows.sqlite"
 _STORE_STATUS = "measurement-rows-ready"
-_FAMILY_DOMAIN = b"exomem.authorization-projection-measurement-family.v1"
 _ROW_DOMAIN = b"exomem.authorization-projection-measurement-row.v1"
 _STORE_DOMAIN = b"exomem.authorization-projection-measurements.v1"
 _LANES = frozenset({"vector", "clip", "graph"})
@@ -133,17 +132,11 @@ class MeasurementFamilyKey:
 
     @property
     def family_id(self) -> str:
-        key = self.namespace_key
-        return _framed_digest(
-            _FAMILY_DOMAIN,
-            (
-                key.policy_fingerprint.encode("ascii"),
-                str(key.projector_schema_version).encode("ascii"),
-                str(key.catalog_generation).encode("ascii"),
-                self.lane.encode("ascii"),
-                self.extractor_version.encode("utf-8"),
-                self.model_version.encode("utf-8"),
-            ),
+        return projection_store.projection_measurement_family_id(
+            self.namespace_key,
+            lane=self.lane,
+            extractor_version=self.extractor_version,
+            model_version=self.model_version,
         )
 
 
@@ -163,6 +156,27 @@ class _StoredRow:
     measurement: ProjectionMeasurement
     payload: bytes
     row_digest: str
+
+
+def measurement_root(
+    manifest: MeasurementStoreManifest,
+) -> projection_store.ProjectionMeasurementRoot:
+    """Return the exact active-tuple commitment for one verified family."""
+
+    if not isinstance(manifest, MeasurementStoreManifest):
+        raise MeasurementStoreMismatch("measurement store manifest is unavailable")
+    family = manifest.family
+    return projection_store.ProjectionMeasurementRoot(
+        namespace_key=family.namespace_key,
+        family_id=family.family_id,
+        lane=family.lane,
+        extractor_version=family.extractor_version,
+        model_version=family.model_version,
+        measurement_count=manifest.measurement_count,
+        vector_dimension=manifest.vector_dimension,
+        graph_edge_count=manifest.graph_edge_count,
+        rows_digest=manifest.rows_digest,
+    )
 
 
 def measurement_store_path(vault_root: Path, family: MeasurementFamilyKey) -> Path:
@@ -917,6 +931,7 @@ __all__ = [
     "load_graph_index",
     "load_measurement_store",
     "load_vector_index",
+    "measurement_root",
     "measurement_store_path",
     "stage_measurement_store",
     "verify_measurement_store",

--- a/src/exomem/governance/projection_runtime.py
+++ b/src/exomem/governance/projection_runtime.py
@@ -15,8 +15,10 @@ from . import (
     authorization_custody,
     authorization_session_authority,
     authorization_session_lifecycle,
+    projected_graph,
     projected_retrieval,
     projection_authorization,
+    projection_measurement_store,
     projection_store,
     schema_v4,
     store,
@@ -52,6 +54,19 @@ _PROJECTED_SERVING_RELEASE_ACCEPTED = False
 class ActiveProjectionRuntime:
     snapshot: schema_v4.ActivePolicySnapshot
     namespace: projection_store.VerifiedProjectionNamespace
+    measurement_roots: tuple[projection_store.ProjectionMeasurementRoot, ...] = ()
+    vector_index: projected_retrieval.ProjectedVectorIndex | None = field(
+        default=None,
+        repr=False,
+    )
+    clip_index: projected_retrieval.ProjectedClipIndex | None = field(
+        default=None,
+        repr=False,
+    )
+    graph_index: projected_graph.ProjectedGraphIndex | None = field(
+        default=None,
+        repr=False,
+    )
     catalog: projected_retrieval.ProjectionCatalog = field(
         init=False,
         repr=False,
@@ -80,6 +95,72 @@ class ActiveProjectionRuntime:
             raise ProjectionRuntimeUnavailable(
                 "governed projected retrieval is unavailable"
             )
+        if not isinstance(self.measurement_roots, tuple):
+            raise ProjectionRuntimeUnavailable(
+                "governed projected retrieval is unavailable"
+            )
+        by_lane: dict[str, projection_store.ProjectionMeasurementRoot] = {}
+        for root_commitment in self.measurement_roots:
+            if (
+                not isinstance(
+                    root_commitment,
+                    projection_store.ProjectionMeasurementRoot,
+                )
+                or root_commitment.namespace_key != self.namespace.namespace_key
+                or root_commitment.lane in by_lane
+            ):
+                raise ProjectionRuntimeUnavailable(
+                    "governed projected retrieval is unavailable"
+                )
+            by_lane[root_commitment.lane] = root_commitment
+        ordered_roots = tuple(
+            by_lane[lane]
+            for lane in ("vector", "clip", "graph")
+            if lane in by_lane
+        )
+        if ordered_roots != self.measurement_roots:
+            raise ProjectionRuntimeUnavailable(
+                "governed projected retrieval is unavailable"
+            )
+        indexes = {
+            "vector": self.vector_index,
+            "clip": self.clip_index,
+            "graph": self.graph_index,
+        }
+        for lane, index in indexes.items():
+            root = by_lane.get(lane)
+            if (root is None) != (index is None):
+                raise ProjectionRuntimeUnavailable(
+                    "governed projected retrieval is unavailable"
+                )
+            if root is None or index is None:
+                continue
+            if lane == "vector":
+                if not isinstance(index, projected_retrieval.ProjectedVectorIndex):
+                    raise ProjectionRuntimeUnavailable(
+                        "governed projected retrieval is unavailable"
+                    )
+                index_key = index.namespace_key
+            elif lane == "clip":
+                if not isinstance(index, projected_retrieval.ProjectedClipIndex):
+                    raise ProjectionRuntimeUnavailable(
+                        "governed projected retrieval is unavailable"
+                    )
+                index_key = index.namespace_key
+            else:
+                if not isinstance(index, projected_graph.ProjectedGraphIndex):
+                    raise ProjectionRuntimeUnavailable(
+                        "governed projected retrieval is unavailable"
+                    )
+                index_key = index.catalog.namespace_key
+            if (
+                index_key != self.namespace.namespace_key
+                or index.extractor_version != root.extractor_version
+                or index.model_version != root.model_version
+            ):
+                raise ProjectionRuntimeUnavailable(
+                    "governed projected retrieval is unavailable"
+                )
         catalog = projected_retrieval.ProjectionCatalog(self.namespace)
         object.__setattr__(self, "catalog", catalog)
         object.__setattr__(
@@ -87,6 +168,13 @@ class ActiveProjectionRuntime:
             "lexical_index",
             projected_retrieval.ProjectedLexicalIndex(catalog),
         )
+
+    @property
+    def warming_components(self) -> tuple[str, ...]:
+        """Return model lanes absent from this immutable active tuple."""
+
+        ready = frozenset(root.lane for root in self.measurement_roots)
+        return tuple(lane for lane in ("vector", "clip", "graph") if lane not in ready)
 
 
 @dataclass(frozen=True, slots=True)
@@ -182,9 +270,8 @@ def preactivate_projection_runtime(
             expected_activation_epoch=epoch,
             expected_activation_state_digest=digest,
         )
-        expected_manifest = projection_store.manifest_from_namespace_evidence(
-            snapshot
-        )
+        evidence = projection_store.namespace_evidence_from_snapshot(snapshot)
+        expected_manifest = evidence.manifest
         manifest, items = projection_store.load_projection_catalog(
             root,
             key=expected_manifest.namespace_key,
@@ -199,7 +286,62 @@ def preactivate_projection_runtime(
             manifest=manifest,
             items=items,
         )
-        runtime = ActiveProjectionRuntime(snapshot, namespace)
+        vector_index: projected_retrieval.ProjectedVectorIndex | None = None
+        clip_index: projected_retrieval.ProjectedClipIndex | None = None
+        graph_index: projected_graph.ProjectedGraphIndex | None = None
+        for root_commitment in evidence.required_measurement_roots:
+            family = projection_measurement_store.MeasurementFamilyKey(
+                namespace_key=namespace.namespace_key,
+                lane=root_commitment.lane,
+                extractor_version=root_commitment.extractor_version,
+                model_version=root_commitment.model_version,
+            )
+            if family.family_id != root_commitment.family_id:
+                raise ProjectionRuntimeUnavailable(
+                    "governed projected retrieval is unavailable"
+                )
+            if root_commitment.lane == "vector":
+                loaded_manifest, vector_index = (
+                    projection_measurement_store.load_vector_index(
+                        root,
+                        namespace=namespace,
+                        family=family,
+                        expected_rows_digest=root_commitment.rows_digest,
+                    )
+                )
+            elif root_commitment.lane == "clip":
+                loaded_manifest, clip_index = (
+                    projection_measurement_store.load_clip_index(
+                        root,
+                        namespace=namespace,
+                        family=family,
+                        expected_rows_digest=root_commitment.rows_digest,
+                    )
+                )
+            else:
+                loaded_manifest, graph_index = (
+                    projection_measurement_store.load_graph_index(
+                        root,
+                        namespace=namespace,
+                        family=family,
+                        expected_rows_digest=root_commitment.rows_digest,
+                    )
+                )
+            if (
+                projection_measurement_store.measurement_root(loaded_manifest)
+                != root_commitment
+            ):
+                raise ProjectionRuntimeUnavailable(
+                    "governed projected retrieval is unavailable"
+                )
+        runtime = ActiveProjectionRuntime(
+            snapshot,
+            namespace,
+            evidence.required_measurement_roots,
+            vector_index=vector_index,
+            clip_index=clip_index,
+            graph_index=graph_index,
+        )
         record = _PreactivatedProjectionRuntime(
             root_key=_root_key(root),
             cell_id=cell_id,

--- a/src/exomem/governance/projection_store.py
+++ b/src/exomem/governance/projection_store.py
@@ -30,7 +30,10 @@ _ROW_DOMAIN = b"exomem.authorization-projection-row.v1"
 _ITEM_DOMAIN = b"exomem.authorization-projection-item.v1"
 _STORE_DOMAIN = b"exomem.authorization-projection-rows.v1"
 _CATALOG_SCHEMA = "exomem.authorization-projection-catalog/v1"
-_EVIDENCE_SCHEMA = "exomem.authorization-projection-namespace-evidence/v1"
+_EVIDENCE_SCHEMA_V1 = "exomem.authorization-projection-namespace-evidence/v1"
+_EVIDENCE_SCHEMA_V2 = "exomem.authorization-projection-namespace-evidence/v2"
+_MEASUREMENT_FAMILY_DOMAIN = b"exomem.authorization-projection-measurement-family.v1"
+_MEASUREMENT_LANES = frozenset({"vector", "clip", "graph"})
 _HEX = frozenset("0123456789abcdef")
 _TABLES = frozenset({"namespace_meta", "projection_items", "projection_variants"})
 _TRIGGERS = frozenset(
@@ -211,6 +214,111 @@ def _framed_digest(domain: bytes, fields: Sequence[bytes]) -> str:
     return hashlib.sha256(_framed(domain, fields)).hexdigest()
 
 
+def projection_measurement_family_id(
+    key: projections.ProjectionNamespaceKey,
+    *,
+    lane: str,
+    extractor_version: str,
+    model_version: str,
+) -> str:
+    """Return one canonical measurement-family identity beneath a namespace."""
+
+    if not isinstance(key, projections.ProjectionNamespaceKey):
+        raise projections.ProjectionCanonicalizationError(
+            "projection measurement namespace key is invalid"
+        )
+    if lane not in _MEASUREMENT_LANES:
+        raise projections.ProjectionCanonicalizationError(
+            "projection measurement lane is not registered"
+        )
+    extractor = _bounded_text(
+        extractor_version,
+        "projection measurement extractor version",
+        maximum=256,
+    )
+    model = _bounded_text(
+        model_version,
+        "projection measurement model version",
+        maximum=256,
+    )
+    return _framed_digest(
+        _MEASUREMENT_FAMILY_DOMAIN,
+        (
+            key.policy_fingerprint.encode("ascii"),
+            str(key.projector_schema_version).encode("ascii"),
+            str(key.catalog_generation).encode("ascii"),
+            lane.encode("ascii"),
+            extractor.encode("utf-8"),
+            model.encode("utf-8"),
+        ),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionMeasurementRoot:
+    """Active-tuple commitment to one complete immutable measurement family."""
+
+    namespace_key: projections.ProjectionNamespaceKey
+    family_id: str
+    lane: str
+    extractor_version: str
+    model_version: str
+    measurement_count: int
+    vector_dimension: int | None
+    graph_edge_count: int
+    rows_digest: str
+
+    def __post_init__(self) -> None:
+        expected_family_id = projection_measurement_family_id(
+            self.namespace_key,
+            lane=self.lane,
+            extractor_version=self.extractor_version,
+            model_version=self.model_version,
+        )
+        if _digest(self.family_id, "measurement family id") != expected_family_id:
+            raise projections.ProjectionCanonicalizationError(
+                "projection measurement family identity does not verify"
+            )
+        if type(self.measurement_count) is not int or self.measurement_count < 0:
+            raise projections.ProjectionCanonicalizationError(
+                "projection measurement count does not verify"
+            )
+        if type(self.graph_edge_count) is not int or self.graph_edge_count < 0:
+            raise projections.ProjectionCanonicalizationError(
+                "projection graph edge count does not verify"
+            )
+        if self.lane == "graph":
+            if self.vector_dimension is not None or (
+                self.measurement_count == 0 and self.graph_edge_count != 0
+            ):
+                raise projections.ProjectionCanonicalizationError(
+                    "projection graph measurement dimension does not verify"
+                )
+            projections.require_supported_capacity(graph_edges=self.graph_edge_count)
+        else:
+            if self.graph_edge_count != 0 or (
+                self.measurement_count == 0 and self.vector_dimension is not None
+            ) or (
+                self.measurement_count > 0
+                and (
+                    type(self.vector_dimension) is not int
+                    or not 1 <= self.vector_dimension <= 4096
+                )
+            ):
+                raise projections.ProjectionCanonicalizationError(
+                    "projection vector measurement shape does not verify"
+                )
+        _digest(self.rows_digest, "projection measurement rows digest")
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionNamespaceEvidence:
+    """Verified lexical manifest plus exact active measurement roots."""
+
+    manifest: VariantStoreManifest
+    required_measurement_roots: tuple[ProjectionMeasurementRoot, ...]
+
+
 def variant_store_path(
     vault_root: Path,
     key: projections.ProjectionNamespaceKey,
@@ -331,17 +439,54 @@ def catalog_descriptor_bytes(
     )
 
 
-def projection_namespace_evidence_bytes(manifest: VariantStoreManifest) -> bytes:
-    """Bind the ready lexical row root to one exact namespace tuple."""
-
+def _canonical_measurement_roots(
+    manifest: VariantStoreManifest,
+    roots: Iterable[ProjectionMeasurementRoot],
+) -> tuple[ProjectionMeasurementRoot, ...]:
     if not isinstance(manifest, VariantStoreManifest):
-        raise projections.ProjectionCanonicalizationError(
-            "projection namespace manifest is invalid"
-        )
+        raise ProjectionStoreMismatch("projection namespace manifest is invalid")
+    by_lane: dict[str, ProjectionMeasurementRoot] = {}
+    for root in roots:
+        if not isinstance(root, ProjectionMeasurementRoot):
+            raise ProjectionStoreMismatch(
+                "projection measurement root does not verify"
+            )
+        if root.namespace_key != manifest.namespace_key or root.lane in by_lane:
+            raise ProjectionStoreMismatch(
+                "projection measurement roots do not match the namespace"
+            )
+        by_lane[root.lane] = root
+    return tuple(by_lane[lane] for lane in ("vector", "clip", "graph") if lane in by_lane)
+
+
+def _measurement_root_value(root: ProjectionMeasurementRoot) -> dict[str, object]:
+    return {
+        "family_id": root.family_id,
+        "extractor_version": root.extractor_version,
+        "model_version": root.model_version,
+        "measurement_count": root.measurement_count,
+        "vector_dimension": root.vector_dimension,
+        "graph_edge_count": root.graph_edge_count,
+        "rows_digest": root.rows_digest,
+    }
+
+
+def projection_namespace_evidence_bytes(
+    manifest: VariantStoreManifest,
+    *,
+    required_measurement_roots: Iterable[ProjectionMeasurementRoot] = (),
+) -> bytes:
+    """Bind ready lexical and selected measurement roots to one namespace tuple."""
+
+    roots = _canonical_measurement_roots(manifest, required_measurement_roots)
     key = manifest.namespace_key
+    required_lane_roots: dict[str, object] = {"lexical": manifest.rows_digest}
+    required_lane_roots.update(
+        {root.lane: _measurement_root_value(root) for root in roots}
+    )
     return projections.canonical_jcs(
         {
-            "schema": _EVIDENCE_SCHEMA,
+            "schema": _EVIDENCE_SCHEMA_V2 if roots else _EVIDENCE_SCHEMA_V1,
             "policy_fingerprint": key.policy_fingerprint,
             "projector_schema_version": key.projector_schema_version,
             "catalog_generation": key.catalog_generation,
@@ -349,15 +494,15 @@ def projection_namespace_evidence_bytes(manifest: VariantStoreManifest) -> bytes
             "item_count": manifest.item_count,
             "variant_count": manifest.variant_count,
             "rows_digest": manifest.rows_digest,
-            "required_lane_roots": {"lexical": manifest.rows_digest},
+            "required_lane_roots": required_lane_roots,
         }
     )
 
 
-def manifest_from_namespace_evidence(
+def namespace_evidence_from_snapshot(
     snapshot: schema_v4.ActivePolicySnapshot,
-) -> VariantStoreManifest:
-    """Decode the exact active row-root commitment without sampling a store."""
+) -> ProjectionNamespaceEvidence:
+    """Decode the exact active lexical and measurement root commitments."""
 
     if not isinstance(snapshot, schema_v4.ActivePolicySnapshot):
         raise ProjectionStoreMismatch("active governance snapshot is unavailable")
@@ -409,6 +554,64 @@ def manifest_from_namespace_evidence(
         raise ProjectionStoreMismatch(
             "projection namespace evidence does not verify"
         ) from error
+    roots_value = value["required_lane_roots"]
+    if not isinstance(roots_value, dict) or "lexical" not in roots_value:
+        raise ProjectionStoreMismatch("projection namespace evidence does not verify")
+    measurement_roots: list[ProjectionMeasurementRoot] = []
+    if value["schema"] == _EVIDENCE_SCHEMA_V1:
+        if roots_value != {"lexical": manifest.rows_digest}:
+            raise ProjectionStoreMismatch(
+                "projection namespace evidence does not verify"
+            )
+    elif value["schema"] == _EVIDENCE_SCHEMA_V2:
+        if roots_value.get("lexical") != manifest.rows_digest or not set(
+            roots_value
+        ).issubset({"lexical", *_MEASUREMENT_LANES}):
+            raise ProjectionStoreMismatch(
+                "projection namespace evidence does not verify"
+            )
+        root_fields = {
+            "family_id",
+            "extractor_version",
+            "model_version",
+            "measurement_count",
+            "vector_dimension",
+            "graph_edge_count",
+            "rows_digest",
+        }
+        try:
+            for lane in ("vector", "clip", "graph"):
+                if lane not in roots_value:
+                    continue
+                root_value = roots_value[lane]
+                if not isinstance(root_value, dict) or set(root_value) != root_fields:
+                    raise ProjectionStoreMismatch(
+                        "projection measurement root does not verify"
+                    )
+                measurement_roots.append(
+                    ProjectionMeasurementRoot(
+                        namespace_key=key,
+                        family_id=root_value["family_id"],
+                        lane=lane,
+                        extractor_version=root_value["extractor_version"],
+                        model_version=root_value["model_version"],
+                        measurement_count=root_value["measurement_count"],
+                        vector_dimension=root_value["vector_dimension"],
+                        graph_edge_count=root_value["graph_edge_count"],
+                        rows_digest=root_value["rows_digest"],
+                    )
+                )
+        except (projections.ProjectionError, ProjectionStoreMismatch) as error:
+            raise ProjectionStoreMismatch(
+                "projection namespace evidence does not verify"
+            ) from error
+        if not measurement_roots:
+            raise ProjectionStoreMismatch(
+                "projection namespace evidence does not verify"
+            )
+    else:
+        raise ProjectionStoreMismatch("projection namespace evidence does not verify")
+    roots = tuple(measurement_roots)
     active = snapshot.active
     if (
         key.policy_fingerprint != active.policy_fingerprint
@@ -416,13 +619,26 @@ def manifest_from_namespace_evidence(
         or key.catalog_generation != active.catalog_generation
         or manifest.namespace_id != key.namespace_id
         or active.projection_namespace_id != key.namespace_id
-        or value["schema"] != _EVIDENCE_SCHEMA
-        or value["required_lane_roots"] != {"lexical": manifest.rows_digest}
         or projections.canonical_jcs(value) != raw
-        or projection_namespace_evidence_bytes(manifest) != raw
+        or projection_namespace_evidence_bytes(
+            manifest,
+            required_measurement_roots=roots,
+        )
+        != raw
     ):
         raise ProjectionStoreMismatch("projection namespace evidence does not verify")
-    return manifest
+    return ProjectionNamespaceEvidence(
+        manifest=manifest,
+        required_measurement_roots=roots,
+    )
+
+
+def manifest_from_namespace_evidence(
+    snapshot: schema_v4.ActivePolicySnapshot,
+) -> VariantStoreManifest:
+    """Decode the exact active lexical row-root commitment."""
+
+    return namespace_evidence_from_snapshot(snapshot).manifest
 
 
 def bind_active_projection_namespace(
@@ -456,15 +672,12 @@ def bind_active_projection_namespace(
             "projection namespace does not match the verified active tuple"
         )
     expected_catalog = catalog_descriptor_bytes(key, canonical_items)
-    expected_evidence = projection_namespace_evidence_bytes(manifest)
+    evidence = namespace_evidence_from_snapshot(snapshot)
     if not hmac.compare_digest(snapshot.catalog_descriptor, expected_catalog):
         raise ProjectionStoreMismatch(
             "projection catalog does not match the verified active tuple"
         )
-    if not hmac.compare_digest(
-        snapshot.projection_namespace_evidence,
-        expected_evidence,
-    ):
+    if evidence.manifest != manifest:
         raise ProjectionStoreMismatch(
             "projection evidence does not match the verified active tuple"
         )
@@ -1016,6 +1229,8 @@ def load_projection_variant(
 
 __all__ = [
     "ProjectionItemVariants",
+    "ProjectionMeasurementRoot",
+    "ProjectionNamespaceEvidence",
     "ProjectionStoreError",
     "ProjectionStoreMismatch",
     "VariantStoreManifest",
@@ -1024,6 +1239,8 @@ __all__ = [
     "catalog_descriptor_bytes",
     "load_projection_catalog",
     "load_projection_variant",
+    "namespace_evidence_from_snapshot",
+    "projection_measurement_family_id",
     "projection_namespace_evidence_bytes",
     "manifest_from_namespace_evidence",
     "stage_variant_store",

--- a/tests/test_governance_projection_measurement_activation.py
+++ b/tests/test_governance_projection_measurement_activation.py
@@ -1,0 +1,377 @@
+"""Active projection tuples bind and preactivate exact measurement families."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from exomem.governance import (
+    authorization_custody,
+    projected_graph,
+    projected_retrieval,
+    projection_measurement_store,
+    projection_runtime,
+    projection_store,
+    projections,
+    schema_v4,
+)
+from exomem.governance.decisions import Decision
+from exomem.governance.policy import Policy, Scope
+
+
+def _fixture(tmp_path: Path):
+    scope = Scope(id="visible", source="scopes/visible.yaml")
+    policy = Policy(fingerprint="f" * 64, scopes={scope.id: scope})
+    key = projections.ProjectionNamespaceKey(policy.fingerprint, 1, 7)
+    variant = projections.build_projection_variant(
+        item_identity="Knowledge Base/visible.md",
+        content_hash="1" * 64,
+        decision=Decision(level=6, scope_ids=(scope.id,)),
+        projector_schema_version=key.projector_schema_version,
+        full_search_fields={"title": "Visible", "body": "projected term"},
+    )
+    assert variant is not None
+    items = (
+        projection_store.ProjectionItemVariants(
+            item_identity=variant.item_identity,
+            content_hash=variant.content_hash,
+            scope_ids=(scope.id,),
+            variants=(variant,),
+        ),
+    )
+    catalog_manifest = projection_store.stage_variant_store(
+        tmp_path,
+        key=key,
+        items=items,
+    )
+    active = schema_v4.VerifiedActiveGovernanceState(
+        logical_vault_id="fixture-vault",
+        activation_store_id="fixture-store",
+        activation_epoch=3,
+        activation_state_digest="e" * 64,
+        policy_generation_id="fixture-policy",
+        policy_fingerprint=key.policy_fingerprint,
+        projector_schema_version=key.projector_schema_version,
+        catalog_generation=key.catalog_generation,
+        projection_namespace_id=key.namespace_id,
+    )
+    lexical_snapshot = schema_v4.ActivePolicySnapshot(
+        active=active,
+        policy=policy,
+        source_documents=(),
+        catalog_descriptor=projection_store.catalog_descriptor_bytes(key, items),
+        projection_namespace_evidence=(
+            projection_store.projection_namespace_evidence_bytes(catalog_manifest)
+        ),
+    )
+    namespace = projection_store.bind_active_projection_namespace(
+        lexical_snapshot,
+        manifest=catalog_manifest,
+        items=items,
+    )
+    families = {
+        lane: projection_measurement_store.MeasurementFamilyKey(
+            namespace_key=key,
+            lane=lane,
+            extractor_version="extractor-v1",
+            model_version="model-v1",
+        )
+        for lane in ("vector", "clip", "graph")
+    }
+    def measurement_key(lane: str) -> projections.MeasurementKey:
+        return projections.MeasurementKey(
+            projection_variant_id=variant.projection_variant_id,
+            lane=lane,
+            extractor_version="extractor-v1",
+            model_version="model-v1",
+        )
+    measurements = {
+        "vector": (
+            projected_retrieval.ProjectionVectorMeasurement(
+                measurement_key=measurement_key("vector"),
+                vector=(1.0, 0.0),
+            ),
+        ),
+        "clip": (
+            projected_retrieval.ProjectionClipMeasurement(
+                measurement_key=measurement_key("clip"),
+                vector=(0.0, 1.0),
+            ),
+        ),
+        "graph": (
+            projected_graph.ProjectionGraphMeasurement(
+                measurement_key=measurement_key("graph"),
+                edges=(),
+            ),
+        ),
+    }
+    manifests = {
+        lane: projection_measurement_store.stage_measurement_store(
+            tmp_path,
+            namespace=namespace,
+            family=families[lane],
+            measurements=measurements[lane],
+        )
+        for lane in families
+    }
+    roots = tuple(
+        projection_measurement_store.measurement_root(manifests[lane])
+        for lane in ("vector", "clip", "graph")
+    )
+    snapshot = replace(
+        lexical_snapshot,
+        projection_namespace_evidence=projection_store.projection_namespace_evidence_bytes(
+            catalog_manifest,
+            required_measurement_roots=roots,
+        ),
+    )
+    return snapshot, catalog_manifest, items, roots
+
+
+def test_v2_namespace_evidence_binds_exact_measurement_subkeys(tmp_path: Path) -> None:
+    snapshot, catalog_manifest, _items, roots = _fixture(tmp_path)
+
+    evidence = projection_store.namespace_evidence_from_snapshot(snapshot)
+    wire = json.loads(snapshot.projection_namespace_evidence)
+
+    assert evidence.manifest == catalog_manifest
+    assert evidence.required_measurement_roots == roots
+    assert wire["schema"] == "exomem.authorization-projection-namespace-evidence/v2"
+    assert wire["required_lane_roots"]["lexical"] == catalog_manifest.rows_digest
+    assert set(wire["required_lane_roots"]) == {
+        "lexical",
+        "vector",
+        "clip",
+        "graph",
+    }
+    assert all(root.namespace_key == catalog_manifest.namespace_key for root in roots)
+
+
+def test_evidence_refuses_duplicate_lane_or_family_namespace(tmp_path: Path) -> None:
+    snapshot, catalog_manifest, _items, roots = _fixture(tmp_path)
+    del snapshot
+
+    with pytest.raises(projection_store.ProjectionStoreMismatch):
+        projection_store.projection_namespace_evidence_bytes(
+            catalog_manifest,
+            required_measurement_roots=(roots[0], roots[0]),
+        )
+
+    with pytest.raises(projection_store.ProjectionStoreMismatch):
+        other_key = projections.ProjectionNamespaceKey(
+            "a" * 64,
+            catalog_manifest.namespace_key.projector_schema_version,
+            catalog_manifest.namespace_key.catalog_generation,
+        )
+        projection_store.projection_namespace_evidence_bytes(
+            catalog_manifest,
+            required_measurement_roots=(
+                replace(
+                    roots[0],
+                    namespace_key=other_key,
+                    family_id=projection_store.projection_measurement_family_id(
+                        other_key,
+                        lane=roots[0].lane,
+                        extractor_version=roots[0].extractor_version,
+                        model_version=roots[0].model_version,
+                    ),
+                ),
+            ),
+        )
+
+
+def test_v2_evidence_refuses_a_relabelled_measurement_family(tmp_path: Path) -> None:
+    snapshot, _catalog_manifest, _items, _roots = _fixture(tmp_path)
+    wire = json.loads(snapshot.projection_namespace_evidence)
+    wire["required_lane_roots"]["vector"]["model_version"] = "model-v2"
+    drifted = replace(
+        snapshot,
+        projection_namespace_evidence=projections.canonical_jcs(wire),
+    )
+
+    with pytest.raises(projection_store.ProjectionStoreMismatch):
+        projection_store.namespace_evidence_from_snapshot(drifted)
+
+
+def test_startup_preactivates_bound_vector_clip_and_graph_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot, _catalog_manifest, _items, roots = _fixture(tmp_path)
+    control = authorization_custody.AuthorizationControlRecord(
+        version=1,
+        keyring_id="keyring-1",
+        cell_id="cell-1",
+        logical_vault_id=snapshot.active.logical_vault_id,
+        registry_attachment_id="attachment-1",
+        attachment_epoch=1,
+        governance_enrolled=True,
+        activation_store_id=snapshot.active.activation_store_id,
+        activation_epoch=snapshot.active.activation_epoch,
+        activation_state_digest=snapshot.active.activation_state_digest,
+        serving_membership_epoch=1,
+        serving_membership_digest="2" * 64,
+        issued_at=1,
+        expires_at=2_000_000_000,
+        signing_key_id="key-1",
+    )
+
+    class Connection:
+        in_transaction = False
+
+        def execute(self, statement: str) -> None:
+            assert statement == "BEGIN"
+            self.in_transaction = True
+
+        def close(self) -> None:
+            self.in_transaction = False
+
+    monkeypatch.setenv(authorization_custody.KEYRING_FILE_ENV, str(tmp_path / "keyring"))
+    monkeypatch.setenv(authorization_custody.CONTROL_FILE_ENV, str(tmp_path / "control"))
+    monkeypatch.setattr(
+        authorization_custody,
+        "load_authorization_custody",
+        lambda *_args, **_kwargs: SimpleNamespace(control=control),
+    )
+    monkeypatch.setattr(
+        projection_runtime.store,
+        "open_active_governance_read_connection",
+        lambda _root: Connection(),
+    )
+    monkeypatch.setattr(
+        schema_v4,
+        "load_active_policy",
+        lambda *_args, **_kwargs: snapshot,
+    )
+    monkeypatch.setattr(
+        schema_v4,
+        "load_active_tuple_pointer",
+        lambda _connection: snapshot.active,
+    )
+
+    projection_runtime._clear_preactivated_runtimes_for_tests()
+    runtime = projection_runtime.preactivate_projection_runtime(tmp_path)
+
+    assert isinstance(runtime.vector_index, projected_retrieval.ProjectedVectorIndex)
+    assert isinstance(runtime.clip_index, projected_retrieval.ProjectedClipIndex)
+    assert isinstance(runtime.graph_index, projected_graph.ProjectedGraphIndex)
+    assert runtime.warming_components == ()
+    assert tuple(root.lane for root in runtime.measurement_roots) == (
+        "vector",
+        "clip",
+        "graph",
+    )
+    assert runtime.measurement_roots == roots
+
+    for name in ("load_vector_index", "load_clip_index", "load_graph_index"):
+        monkeypatch.setattr(
+            projection_measurement_store,
+            name,
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("request reloaded a projected measurement family")
+            ),
+        )
+    monkeypatch.setattr(projection_runtime, "_PROJECTED_SERVING_RELEASE_ACCEPTED", True)
+    assert projection_runtime.load_active_projection_runtime(tmp_path) is runtime
+
+
+def test_startup_refuses_a_wrong_required_measurement_root_digest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot, catalog_manifest, _items, roots = _fixture(tmp_path)
+    drifted = replace(roots[0], rows_digest="a" * 64)
+    snapshot = replace(
+        snapshot,
+        projection_namespace_evidence=projection_store.projection_namespace_evidence_bytes(
+            catalog_manifest,
+            required_measurement_roots=(drifted, *roots[1:]),
+        ),
+    )
+    control = SimpleNamespace(
+        governance_enrolled=True,
+        cell_id="cell-1",
+        logical_vault_id=snapshot.active.logical_vault_id,
+        activation_store_id=snapshot.active.activation_store_id,
+        activation_epoch=snapshot.active.activation_epoch,
+        activation_state_digest=snapshot.active.activation_state_digest,
+    )
+
+    class Connection:
+        def execute(self, _statement: str) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setenv(authorization_custody.KEYRING_FILE_ENV, str(tmp_path / "keyring"))
+    monkeypatch.setenv(authorization_custody.CONTROL_FILE_ENV, str(tmp_path / "control"))
+    monkeypatch.setattr(
+        authorization_custody,
+        "load_authorization_custody",
+        lambda *_args, **_kwargs: SimpleNamespace(control=control),
+    )
+    monkeypatch.setattr(
+        projection_runtime.store,
+        "open_active_governance_read_connection",
+        lambda _root: Connection(),
+    )
+    monkeypatch.setattr(
+        schema_v4,
+        "load_active_policy",
+        lambda *_args, **_kwargs: snapshot,
+    )
+
+    projection_runtime._clear_preactivated_runtimes_for_tests()
+    with pytest.raises(
+        projection_runtime.ProjectionRuntimeUnavailable,
+        match="governed projected retrieval is unavailable",
+    ):
+        projection_runtime.preactivate_projection_runtime(tmp_path)
+
+
+def test_v1_lexical_evidence_remains_loadable_but_model_lanes_are_warming(
+    tmp_path: Path,
+) -> None:
+    snapshot, catalog_manifest, items, _roots = _fixture(tmp_path)
+    legacy = replace(
+        snapshot,
+        projection_namespace_evidence=projection_store.projection_namespace_evidence_bytes(
+            catalog_manifest
+        ),
+    )
+    namespace = projection_store.bind_active_projection_namespace(
+        legacy,
+        manifest=catalog_manifest,
+        items=items,
+    )
+
+    runtime = projection_runtime.ActiveProjectionRuntime(legacy, namespace)
+
+    assert runtime.measurement_roots == ()
+    assert runtime.vector_index is None
+    assert runtime.clip_index is None
+    assert runtime.graph_index is None
+    assert runtime.warming_components == ("vector", "clip", "graph")
+
+
+def test_runtime_refuses_committed_roots_without_their_verified_indexes(
+    tmp_path: Path,
+) -> None:
+    snapshot, catalog_manifest, items, roots = _fixture(tmp_path)
+    namespace = projection_store.bind_active_projection_namespace(
+        snapshot,
+        manifest=catalog_manifest,
+        items=items,
+    )
+
+    with pytest.raises(projection_runtime.ProjectionRuntimeUnavailable):
+        projection_runtime.ActiveProjectionRuntime(
+            snapshot,
+            namespace,
+            measurement_roots=roots,
+        )


### PR DESCRIPTION
## Why

Governed retrieval cannot safely use vector, CLIP, or graph lanes until the active governance tuple commits to the exact immutable measurement families that startup will serve.

## What changed

- extend projection namespace evidence with a byte-compatible v2 shape that binds exact per-lane family roots
- verify and preload required vector, CLIP, and graph stores once during process preactivation
- retain v1 lexical-only evidence as warming-compatible
- fail content-free on missing, relabelled, mismatched, or unverified measurement families
- keep the repository-owned public serving release fence closed

## Verification

- 71 focused governance projection tests on Python 3.13
- 7 focused activation tests after the final edit
- strict OpenSpec validation
- Ruff on touched files
- repository public-artifact privacy scan
- wheel and sdist build
- git diff check