### PR TITLE
feat(governance): integrate projected retrieval lanes

### DIFF
--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -1169,9 +1169,8 @@ def _require_supported_projected_find_request(
         or filters
         or result_level != "auto"
         or not query
-        or mode != "keyword"
-        or graph
-        or rerank is not False
+        or mode not in {"keyword", "hybrid", "vector"}
+        or (graph and mode == "keyword")
         or scope != "vault"
         or rerank_max_candidates is not None
         or not prefer_compiled
@@ -1508,6 +1507,10 @@ def op_find(
             mode=mode,
             graph=graph,
             rerank=rerank,
+            auto_rerank=auto_rerank,
+            prefer_compiled=prefer_compiled,
+            prefer_active=prefer_active,
+            rank_config=find_module._active_ranking(),
             principal=who,
             purpose=purpose,
         )

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -3468,40 +3468,6 @@ def _any_stem_present(page: ParsedPage, query_norm: str) -> bool:
     return any(qs in page.stem_set for qs in bm25_module.tokenize(query_norm))
 
 
-# Function words that must never, on their own, carry the degraded-retention
-# majority: articles/determiners, quantifiers, pronouns, wh-words,
-# prepositions/conjunctions, auxiliaries, negation. Surface forms; matched in
-# stem space via _function_word_stems() so classification consumes the same
-# tokenize() output presence checks use. (claims.py keeps a private
-# _STOPWORDS lexicon for contradiction topic-overlap, but it has no wh-words
-# and its own tokenizer — retention gating keeps an independent frozen set so
-# unrelated lexicon edits cannot reshape retrieval.)
-_FUNCTION_WORDS = frozenset(
-    """a an the this that these those all any some each no not
-    i we you he she it they me us them my our your their his her its
-    what which who whom whose when where why how
-    of in on at to for from by with about as into over under
-    and or but if then than so
-    is are was were be been being am
-    do does did done doing have has had having
-    can could will would shall should may might must""".split()
-)
-_FUNCTION_WORD_STEMS: frozenset[str] | None = None
-
-
-def _function_word_stems() -> frozenset[str]:
-    """Stem-space view of `_FUNCTION_WORDS`, built lazily (bm25 owns the
-    stemmer) and memoized — the set is tiny and the computation idempotent."""
-    global _FUNCTION_WORD_STEMS
-    if _FUNCTION_WORD_STEMS is None:
-        from . import bm25 as bm25_module
-
-        _FUNCTION_WORD_STEMS = frozenset(
-            bm25_module.stem_word(word) for word in _FUNCTION_WORDS
-        )
-    return _FUNCTION_WORD_STEMS
-
-
 def _query_word_stem_groups(query_norm: str) -> list[tuple[list[str], bool]]:
     """Per whitespace word: (BM25 subtoken stems, is_function_word).
 
@@ -3514,18 +3480,7 @@ def _query_word_stem_groups(query_norm: str) -> list[tuple[list[str], bool]]:
     (known limit: mixed-script queries are gated more permissively than
     v0.36.0's all-stems veto).
     """
-    from . import bm25 as bm25_module
-
-    function_stems = _function_word_stems()
-    groups: list[tuple[list[str], bool]] = []
-    for word in query_norm.split():
-        subtoken_stems = bm25_module.tokenize(word)
-        if not subtoken_stems:
-            continue
-        groups.append(
-            (subtoken_stems, all(s in function_stems for s in subtoken_stems))
-        )
-    return groups
+    return find_policy.query_word_stem_groups(query_norm)
 
 
 def _stem_word_coverage(
@@ -3546,15 +3501,7 @@ def _stem_word_coverage(
     `_any_stem_present` (>=1 stem anywhere) and `_stem_tokens_present` (ALL
     whitespace tokens, whole-token stems).
     """
-    text_stems = page.stem_set
-    present = 0
-    content_present = 0
-    for subtoken_stems, is_function in word_stem_groups:
-        if all(stem in text_stems for stem in subtoken_stems):
-            present += 1
-            if not is_function:
-                content_present += 1
-    return present, len(word_stem_groups), content_present
+    return find_policy.stem_word_coverage(page.stem_set, word_stem_groups)
 
 
 def _outside_kb_keyword_paths(vault_root: Path, query_norm: str) -> list[str]:

--- a/src/exomem/find_policy.py
+++ b/src/exomem/find_policy.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 import heapq
 import math
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Set
 from datetime import date, timedelta
 
 from .find_types import Hit
 from .ranking_config import DEFAULT_RANKING, RankingConfig
+
 # Names imported directly rather than the `temporal` module: this file already
 # has a parameter called `temporal` in `apply_post_rrf_multipliers`, and a
 # module of the same name would sit one refactor away from being shadowed.
-from .temporal import Moment, Order, compare as compare_moments, parse as parse_moment
+from .temporal import Moment, Order
+from .temporal import compare as compare_moments
+from .temporal import parse as parse_moment
 
 COMPILED_TYPES = frozenset(
     {
@@ -47,6 +50,68 @@ RELATIONSHIP_MARKERS = re.compile(
 EXACT_LEADING = re.compile(r"^(who|whose|what|which)\b", re.IGNORECASE)
 
 PageOf = Callable[[str], object | None]
+
+# Function words that cannot, by themselves, satisfy degraded BM25-only
+# retention.  Keep this policy next to the rank/retrieval policy rather than a
+# corpus reader so projected retrieval can apply the same rule without opening
+# a raw page.
+_FUNCTION_WORDS = frozenset(
+    """a an the this that these those all any some each no not
+    i we you he she it they me us them my our your their his her its
+    what which who whom whose when where why how
+    of in on at to for from by with about as into over under
+    and or but if then than so
+    is are was were be been being am
+    do does did done doing have has had having
+    can could will would shall should may might must""".split()
+)
+_FUNCTION_WORD_STEMS: frozenset[str] | None = None
+
+
+def _function_word_stems() -> frozenset[str]:
+    """Return the function-word lexicon in the canonical BM25 stem space."""
+
+    global _FUNCTION_WORD_STEMS
+    if _FUNCTION_WORD_STEMS is None:
+        from . import bm25
+
+        _FUNCTION_WORD_STEMS = frozenset(
+            bm25.stem_word(word) for word in _FUNCTION_WORDS
+        )
+    return _FUNCTION_WORD_STEMS
+
+
+def query_word_stem_groups(query: str) -> list[tuple[list[str], bool]]:
+    """Return BM25 subtoken stems and function-word status per query word."""
+
+    from . import bm25
+
+    function_stems = _function_word_stems()
+    groups: list[tuple[list[str], bool]] = []
+    for word in query.split():
+        subtoken_stems = bm25.tokenize(word)
+        if not subtoken_stems:
+            continue
+        groups.append(
+            (subtoken_stems, all(stem in function_stems for stem in subtoken_stems))
+        )
+    return groups
+
+
+def stem_word_coverage(
+    text_stems: Set[str],
+    word_stem_groups: list[tuple[list[str], bool]],
+) -> tuple[int, int, int]:
+    """Return present, total, and content-word coverage for stemmed text."""
+
+    present = 0
+    content_present = 0
+    for subtoken_stems, is_function in word_stem_groups:
+        if all(stem in text_stems for stem in subtoken_stems):
+            present += 1
+            if not is_function:
+                content_present += 1
+    return present, len(word_stem_groups), content_present
 
 
 def type_multiplier(

--- a/src/exomem/governance/projected_graph.py
+++ b/src/exomem/governance/projected_graph.py
@@ -15,7 +15,7 @@ from types import MappingProxyType
 
 from . import projected_retrieval, projection_store, projections
 
-_MAX_GRAPH_RESULTS = 1_000
+_MAX_GRAPH_RESULTS = projections.MAX_GOVERNED_CATALOG_ITEMS
 
 
 def _text(value: object, name: str, *, maximum: int = 4096) -> str:
@@ -107,6 +107,11 @@ class AuthorizedProjectedGraph:
         repr=False,
         compare=False,
     )
+    _edges_by_source: Mapping[str, tuple[ProjectionGraphEdge, ...]] = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
     _in_degrees: Mapping[str, int] = field(init=False, repr=False, compare=False)
     _out_degrees: Mapping[str, int] = field(init=False, repr=False, compare=False)
 
@@ -117,6 +122,9 @@ class AuthorizedProjectedGraph:
                 "authorized projected graph contains duplicate vertices"
             )
         neighbors: dict[str, set[str]] = {vertex: set() for vertex in self.vertices}
+        edges_by_source: dict[str, list[ProjectionGraphEdge]] = {
+            vertex: [] for vertex in self.vertices
+        }
         in_degrees = dict.fromkeys(self.vertices, 0)
         out_degrees = dict.fromkeys(self.vertices, 0)
         for edge in self.edges:
@@ -128,6 +136,7 @@ class AuthorizedProjectedGraph:
                     "authorized projected graph edge names an unavailable vertex"
                 )
             neighbors[edge.source_item_identity].add(edge.target_item_identity)
+            edges_by_source[edge.source_item_identity].append(edge)
             in_degrees[edge.target_item_identity] += 1
             out_degrees[edge.source_item_identity] += 1
         object.__setattr__(self, "_vertex_set", vertex_set)
@@ -143,6 +152,16 @@ class AuthorizedProjectedGraph:
         )
         object.__setattr__(self, "_in_degrees", MappingProxyType(in_degrees))
         object.__setattr__(self, "_out_degrees", MappingProxyType(out_degrees))
+        object.__setattr__(
+            self,
+            "_edges_by_source",
+            MappingProxyType(
+                {
+                    source: tuple(values)
+                    for source, values in edges_by_source.items()
+                }
+            ),
+        )
 
     def _require_vertex(self, item_identity: str) -> None:
         if item_identity not in self._vertex_set:
@@ -167,6 +186,15 @@ class AuthorizedProjectedGraph:
 
         self._require_vertex(item_identity)
         return self._neighbors[item_identity]
+
+    def outgoing_edges(
+        self,
+        item_identity: str,
+    ) -> tuple[ProjectionGraphEdge, ...]:
+        """Return admitted outbound edges without discarding relation semantics."""
+
+        self._require_vertex(item_identity)
+        return self._edges_by_source[item_identity]
 
     def relation_matches(self, relation_type: str) -> tuple[ProjectionGraphEdge, ...]:
         """Match one relation only after edge admission."""

--- a/src/exomem/governance/projected_retrieval.py
+++ b/src/exomem/governance/projected_retrieval.py
@@ -13,6 +13,7 @@ import math
 from collections import Counter
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
+from numbers import Real
 from types import MappingProxyType
 
 from .. import bm25
@@ -21,7 +22,7 @@ from . import projection_store, projections
 _HEX = frozenset("0123456789abcdef")
 _BM25_K1 = 1.5
 _BM25_B = 0.75
-_MAX_RESULTS = 1_000
+_MAX_RESULTS = projections.MAX_GOVERNED_CATALOG_ITEMS
 _SNIPPET_CHARS = 320
 
 
@@ -350,6 +351,16 @@ def _variant_text(variant: projections.ProjectionVariant) -> str:
     )
 
 
+def clip_variant_applicable(variant: projections.ProjectionVariant) -> bool:
+    """Whether one committed projection row owns a CLIP pixel measurement."""
+
+    return (
+        variant.decision_level == 6
+        and variant.search_fields.get("media_type") in {"image", "video"}
+        and not variant.search_fields.get("parent_media")
+    )
+
+
 def _projected_hit(
     variant: projections.ProjectionVariant,
     score: float,
@@ -667,11 +678,11 @@ class ProjectedClipIndex:
             "CLIP model version",
             maximum=256,
         )
-        l6_variant_ids = {
+        clip_variant_ids = {
             variant.projection_variant_id
             for item in self._items.values()
             for variant in item.variants
-            if variant.decision_level == 6
+            if clip_variant_applicable(variant)
         }
         by_variant: dict[str, ProjectionClipMeasurement] = {}
         dimension: int | None = None
@@ -689,9 +700,9 @@ class ProjectedClipIndex:
                 raise projections.ProjectionCanonicalizationError(
                     "CLIP measurement model version does not match index"
                 )
-            if key.projection_variant_id not in l6_variant_ids:
+            if key.projection_variant_id not in clip_variant_ids:
                 raise projections.ProjectionCanonicalizationError(
-                    "CLIP measurement variant is not an L6 catalog projection"
+                    "CLIP measurement variant is not an applicable L6 pixel catalog projection"
                 )
             if key.projection_variant_id in by_variant:
                 raise projections.ProjectionCanonicalizationError(
@@ -724,7 +735,7 @@ class ProjectedClipIndex:
                 self._items,
                 authorization,
             )
-            if variant.decision_level == 6
+            if clip_variant_applicable(variant)
         )
         if not selected:
             return ()
@@ -824,7 +835,7 @@ class ProjectedReranker:
                 raw_score = scorer(query, variant.search_fields)
             except Exception as error:
                 raise ProjectedLaneUnavailable("projected rerank scorer failed") from error
-            if isinstance(raw_score, bool) or not isinstance(raw_score, (int, float)):
+            if isinstance(raw_score, bool) or not isinstance(raw_score, Real):
                 raise ProjectedLaneUnavailable("projected rerank score must be finite")
             score = float(raw_score)
             if not math.isfinite(score):
@@ -834,6 +845,78 @@ class ProjectedReranker:
         return tuple(
             _projected_hit(variant, score)
             for _ordinal, variant, score in scored[:limit]
+        )
+
+    def rerank_batch(
+        self,
+        authorization: AuthorizationProjectionMap,
+        query: str,
+        candidates: tuple[str, ...],
+        *,
+        scorer: Callable[[str, list[str]], object],
+        k: int,
+    ) -> tuple[ProjectedLexicalHit, ...]:
+        """Batch-score every projected candidate before applying the final cap."""
+
+        limit = _result_limit(k)
+        if not isinstance(query, str) or len(query) > 1_048_576:
+            raise ValueError("query must be bounded text")
+        if (
+            not isinstance(candidates, tuple)
+            or len(candidates) > projections.MAX_GOVERNED_CATALOG_ITEMS
+        ):
+            raise ProjectedRetrievalUnavailable(
+                "rerank candidates must be one bounded immutable tuple"
+            )
+        if not callable(scorer):
+            raise ProjectedLaneUnavailable("projected rerank scorer is unavailable")
+        if len(frozenset(candidates)) != len(candidates):
+            raise ProjectedRetrievalUnavailable(
+                "rerank candidate set contains a duplicate"
+            )
+        for identity in candidates:
+            _bounded_text(identity, "rerank candidate identity", maximum=4096)
+
+        selected = _selected_variants(
+            self.namespace_key,
+            self._items,
+            authorization,
+        )
+        selected_by_identity = {variant.item_identity: variant for variant in selected}
+        if any(identity not in selected_by_identity for identity in candidates):
+            raise ProjectedRetrievalUnavailable(
+                "rerank candidate is outside the selected projected corpus"
+            )
+        variants = tuple(selected_by_identity[identity] for identity in candidates)
+        passages = [_variant_text(variant) for variant in variants]
+        try:
+            raw_scores = scorer(query, passages)
+            scores = tuple(raw_scores)  # type: ignore[arg-type]
+        except Exception as error:
+            raise ProjectedLaneUnavailable("projected rerank scorer failed") from error
+        if len(scores) != len(variants):
+            raise ProjectedLaneUnavailable(
+                "projected rerank score count does not match candidates"
+            )
+
+        ranked: list[tuple[int, projections.ProjectionVariant, float]] = []
+        for ordinal, (variant, raw_score) in enumerate(
+            zip(variants, scores, strict=True)
+        ):
+            if isinstance(raw_score, bool) or not isinstance(raw_score, Real):
+                raise ProjectedLaneUnavailable(
+                    "projected rerank score must be finite"
+                )
+            score = float(raw_score)
+            if not math.isfinite(score):
+                raise ProjectedLaneUnavailable(
+                    "projected rerank score must be finite"
+                )
+            ranked.append((ordinal, variant, score))
+        ranked.sort(key=lambda item: (-item[2], item[0]))
+        return tuple(
+            _projected_hit(variant, score)
+            for _ordinal, variant, score in ranked[:limit]
         )
 
 
@@ -850,4 +933,5 @@ __all__ = [
     "ProjectionCatalog",
     "ProjectionVectorMeasurement",
     "ProjectionSelection",
+    "clip_variant_applicable",
 ]

--- a/src/exomem/governance/projection_runtime.py
+++ b/src/exomem/governance/projection_runtime.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 from numbers import Real
 from pathlib import Path, PurePosixPath
 
-from .. import bm25, embeddings, find_policy, fusion, ranking_config, readiness
+from .. import bm25, find_policy, fusion, ranking_config
 from ..find_types import GraphProvenance, Hit
 from ..kbdir import kb_dirname
 from . import (
@@ -803,6 +803,8 @@ def find_projected_hits(
     purpose: str | None,
 ) -> ProjectedFindResult:
     """Acquire public candidates without opening a raw corpus/index lane."""
+
+    from .. import embeddings, readiness
 
     if not isinstance(runtime, ActiveProjectionRuntime):
         raise ProjectionRuntimeUnavailable(

--- a/src/exomem/governance/projection_runtime.py
+++ b/src/exomem/governance/projection_runtime.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import math
 import os
 import sqlite3
 import threading
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from numbers import Real
 from pathlib import Path, PurePosixPath
 
-from ..find_types import Hit
+from .. import bm25, embeddings, find_policy, fusion, ranking_config, readiness
+from ..find_types import GraphProvenance, Hit
 from ..kbdir import kb_dirname
 from . import (
     authorization_custody,
@@ -72,6 +76,10 @@ class ActiveProjectionRuntime:
         repr=False,
     )
     lexical_index: projected_retrieval.ProjectedLexicalIndex = field(
+        init=False,
+        repr=False,
+    )
+    reranker: projected_retrieval.ProjectedReranker = field(
         init=False,
         repr=False,
     )
@@ -167,6 +175,11 @@ class ActiveProjectionRuntime:
             self,
             "lexical_index",
             projected_retrieval.ProjectedLexicalIndex(catalog),
+        )
+        object.__setattr__(
+            self,
+            "reranker",
+            projected_retrieval.ProjectedReranker(self.namespace),
         )
 
     @property
@@ -643,6 +656,14 @@ def _wire_hit(
     rank: int,
     knowledge_base_name: str,
     keyword: bool,
+    lane_ranks: dict[str, int] | None = None,
+    lane_scores: dict[str, float] | None = None,
+    graph_in_degree: int = 0,
+    graph_hop: bool = False,
+    graph_provenance: GraphProvenance | None = None,
+    rerank_score: float | None = None,
+    rerank_raw_score: float | None = None,
+    rerank_input_rank: int | None = None,
 ) -> Hit:
     decision = selection.decision
     if decision is None or decision.level != hit.decision_level:
@@ -653,6 +674,13 @@ def _wire_hit(
     path = hit.item_identity
     path_parts = PurePosixPath(path).parts
     inside_kb = bool(path_parts and path_parts[0] == knowledge_base_name)
+    ranks = lane_ranks or {}
+    scores = lane_scores or {}
+    bm25_rank = ranks.get("bm25")
+    keyword_rank = ranks.get("keyword")
+    if lane_ranks is None:
+        bm25_rank = None if keyword else rank
+        keyword_rank = rank if keyword else None
     return Hit(
         path=path,
         type=fields.get("type"),
@@ -660,12 +688,102 @@ def _wire_hit(
         title=fields.get("title") or PurePosixPath(path).stem,
         updated=fields.get("updated", ""),
         excerpt=hit.snippet,
-        bm25_rank=None if keyword else rank,
-        keyword_rank=rank if keyword else None,
+        bm25_rank=bm25_rank,
+        keyword_rank=keyword_rank,
+        vector_rank=ranks.get("vector"),
+        vector_score=scores.get("vector"),
+        clip_rank=ranks.get("clip"),
+        clip_score=scores.get("clip"),
+        graph_hop=graph_hop,
+        graph_in_degree=graph_in_degree,
+        graph_provenance=graph_provenance,
+        rerank_score=rerank_score,
+        rerank_raw_score=rerank_raw_score,
+        rerank_input_rank=rerank_input_rank,
         outside_kb=not inside_kb,
+        media_type=fields.get("media_type"),
+        status=fields.get("status"),
         snapshot_hash=selection.content_hash,
         decision=decision,
     )
+
+
+def _projected_rank_multiplier(
+    fields: Mapping[str, str],
+    config: ranking_config.RankingConfig,
+    *,
+    prefer_compiled: bool,
+    prefer_active: bool,
+) -> float:
+    """Apply public type/status rank policy using projected fields only."""
+
+    multiplier = 1.0
+    if prefer_compiled and not fields.get("media_type"):
+        multiplier *= find_policy.type_multiplier(fields.get("type"), config)
+    if prefer_active:
+        multiplier *= find_policy.status_multiplier(fields.get("status"), config)
+    return multiplier
+
+
+def _retain_projected_bm25_hits(
+    lane_hits: Mapping[
+        str,
+        tuple[projected_retrieval.ProjectedLexicalHit, ...],
+    ],
+    query: str,
+) -> tuple[projected_retrieval.ProjectedLexicalHit, ...]:
+    """Apply the public BM25-only gate without reopening raw item bytes."""
+
+    bm25_hits = lane_hits.get("bm25", ())
+    corroborated = {
+        hit.item_identity
+        for lane in ("vector", "keyword", "clip")
+        for hit in lane_hits.get(lane, ())
+    }
+    semantic_lanes_absent = not lane_hits.get("vector") and not lane_hits.get("clip")
+    query_groups = find_policy.query_word_stem_groups(query)
+    retained: list[projected_retrieval.ProjectedLexicalHit] = []
+    for hit in bm25_hits:
+        if hit.item_identity in corroborated:
+            retained.append(hit)
+            continue
+        text = " ".join(
+            hit.search_fields[key]
+            for key in sorted(
+                hit.search_fields,
+                key=lambda value: value.encode("utf-16-be"),
+            )
+        )
+        present, total, content_present = find_policy.stem_word_coverage(
+            frozenset(bm25.tokenize(text)),
+            query_groups,
+        )
+        if semantic_lanes_absent:
+            keep = 2 * present > total and content_present > 0
+        else:
+            keep = total > 0 and present == total
+        if keep:
+            retained.append(hit)
+    return tuple(retained)
+
+
+def _should_auto_rerank(
+    lane_hits: Mapping[
+        str,
+        tuple[projected_retrieval.ProjectedLexicalHit, ...],
+    ],
+    query: str,
+) -> bool:
+    """Projected-input form of the public rerank policy."""
+
+    if len((query or "").split()) >= 5:
+        return True
+    vector = [hit.item_identity for hit in lane_hits.get("vector", ())[:3]]
+    lexical = [hit.item_identity for hit in lane_hits.get("bm25", ())[:3]]
+    if not vector or not lexical:
+        return False
+    overlap = len(set(vector) & set(lexical))
+    return 1.0 - overlap / max(len(vector), len(lexical)) > 0.5
 
 
 def find_projected_hits(
@@ -677,6 +795,10 @@ def find_projected_hits(
     mode: str,
     graph: bool,
     rerank: bool | None,
+    auto_rerank: bool = False,
+    prefer_compiled: bool = True,
+    prefer_active: bool = True,
+    rank_config: ranking_config.RankingConfig = ranking_config.DEFAULT_RANKING,
     principal: RequestPrincipal,
     purpose: str | None,
 ) -> ProjectedFindResult:
@@ -690,7 +812,19 @@ def find_projected_hits(
         raise ValueError("find: limit must be an integer from 1 through 100")
     if not isinstance(query, str) or len(query) > 1_048_576:
         raise ValueError("find: query must be bounded text")
-    if not query or mode != "keyword" or graph or rerank is not False:
+    if (
+        type(auto_rerank) is not bool
+        or type(prefer_compiled) is not bool
+        or type(prefer_active) is not bool
+        or not isinstance(rank_config, ranking_config.RankingConfig)
+    ):
+        raise ValueError("find: projected rank policy is invalid")
+    if (
+        not query
+        or mode not in {"keyword", "hybrid", "vector"}
+        or (graph and mode == "keyword")
+        or rerank not in {None, False, True}
+    ):
         raise ProjectionRuntimeUnavailable(
             "governed projected retrieval is unavailable"
         )
@@ -721,30 +855,390 @@ def find_projected_hits(
         for selection in authorization.selections
         if selection.projection_variant_id is None
     )
-    projected_hits = runtime.lexical_index.search_keyword(
-        authorization,
-        query,
-        k=limit,
-    )
-
     by_identity = {
         selection.item_identity: selection
         for selection in authorization.selections
     }
-    knowledge_base_name = kb_dirname()
-    hits = tuple(
-        _wire_hit(
-            hit,
-            selection=by_identity[hit.item_identity],
-            rank=rank,
-            knowledge_base_name=knowledge_base_name,
-            keyword=True,
-        )
-        for rank, hit in enumerate(projected_hits, 1)
+    selected_count = sum(
+        selection.projection_variant_id is not None
+        for selection in authorization.selections
     )
+    selected_variants = {
+        variant.item_identity: variant
+        for variant in runtime.catalog.select(authorization)
+    }
+    has_selected_l6 = any(
+        variant.decision_level == 6 for variant in selected_variants.values()
+    )
+    has_selected_clip = any(
+        projected_retrieval.clip_variant_applicable(variant)
+        for variant in selected_variants.values()
+    )
+    if selected_count == 0:
+        return ProjectedFindResult(
+            hits=(),
+            withheld_paths=withheld,
+            declared_purpose=declared_purpose,
+        )
+    lane_depth = selected_count
+    candidate_depth = min(
+        selected_count,
+        max(
+            limit * rank_config.candidate_multiplier,
+            rank_config.candidate_floor,
+        ),
+    )
+    lane_hits: dict[str, tuple[projected_retrieval.ProjectedLexicalHit, ...]] = {}
+    warming: set[str] = set()
+
+    if mode == "keyword":
+        lane_hits["keyword"] = runtime.lexical_index.search_keyword(
+            authorization,
+            query,
+            k=lane_depth,
+        )
+    elif mode == "hybrid":
+        lane_hits["bm25"] = runtime.lexical_index.search_bm25(
+            authorization,
+            query,
+            k=lane_depth,
+        )
+        lane_hits["keyword"] = runtime.lexical_index.search_keyword(
+            authorization,
+            query,
+            k=lane_depth,
+        )
+
+    if mode in {"hybrid", "vector"}:
+        vector_index = runtime.vector_index
+        if os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
+            lane_hits["vector"] = ()
+        elif readiness.should_defer("embeddings"):
+            warming.add("vector")
+        elif (
+            vector_index is None
+            or vector_index.extractor_version != "projected-text-v1"
+            or vector_index.model_version != embeddings.MODEL_NAME
+        ):
+            warming.add("vector")
+        else:
+            try:
+                query_vector = tuple(
+                    float(value)
+                    for value in embeddings.embed_texts([query], is_query=True)[0]
+                )
+            except Exception:  # noqa: BLE001 - optional query model soft-fails
+                warming.add("vector")
+            else:
+                try:
+                    lane_hits["vector"] = vector_index.search_vector(
+                        authorization,
+                        query_vector,
+                        k=lane_depth,
+                    )
+                except projected_retrieval.ProjectedLaneUnavailable:
+                    warming.add("vector")
+                except projected_retrieval.ProjectedRetrievalUnavailable as error:
+                    raise ProjectionRuntimeUnavailable(
+                        "governed projected retrieval is unavailable"
+                    ) from error
+
+        clip_index = runtime.clip_index
+        if not has_selected_clip:
+            lane_hits["clip"] = ()
+        elif not embeddings.clip_enabled():
+            lane_hits["clip"] = ()
+        elif readiness.should_defer("clip"):
+            warming.add("clip")
+        elif (
+            clip_index is None
+            or clip_index.extractor_version != "pixels-v1"
+            or clip_index.model_version != embeddings.CLIP_MODEL_NAME
+        ):
+            warming.add("clip")
+        else:
+            try:
+                clip_query = tuple(
+                    float(value) for value in embeddings.embed_clip_text(query)
+                )
+            except Exception:  # noqa: BLE001 - optional query model soft-fails
+                warming.add("clip")
+            else:
+                try:
+                    lane_hits["clip"] = clip_index.search_clip(
+                        authorization,
+                        clip_query,
+                        k=lane_depth,
+                    )
+                except projected_retrieval.ProjectedLaneUnavailable:
+                    warming.add("clip")
+                except projected_retrieval.ProjectedRetrievalUnavailable as error:
+                    raise ProjectionRuntimeUnavailable(
+                        "governed projected retrieval is unavailable"
+                    ) from error
+
+    raw_bm25_hits = lane_hits.get("bm25", ())
+    if mode == "hybrid":
+        lane_hits["bm25"] = _retain_projected_bm25_hits(lane_hits, query)
+
+    graph_degrees: dict[str, int] = {}
+    graph_hops: set[str] = set()
+    graph_provenance: dict[str, GraphProvenance] = {}
+    if graph:
+        if not has_selected_l6:
+            lane_hits["graph"] = ()
+        elif runtime.graph_index is None:
+            warming.add("graph")
+        else:
+            try:
+                admitted = runtime.graph_index.authorize(authorization)
+                seeds: list[str] = []
+                seen_seeds: set[str] = set()
+                graph_seed_cap = min(
+                    rank_config.graph_seed_cap,
+                    candidate_depth,
+                )
+                for lane in ("vector", "bm25"):
+                    for lane_hit in lane_hits.get(lane, ())[:graph_seed_cap]:
+                        if lane_hit.item_identity not in seen_seeds:
+                            seen_seeds.add(lane_hit.item_identity)
+                            seeds.append(lane_hit.item_identity)
+                primary_hits = {
+                    "vector": lane_hits.get("vector", ()),
+                    "bm25": raw_bm25_hits,
+                }
+                primary_set = {
+                    hit.item_identity
+                    for lane in ("vector", "bm25")
+                    for hit in primary_hits[lane][:candidate_depth]
+                }
+                best_tier: dict[str, int] = {}
+                first_seen: dict[str, int] = {}
+                position = 0
+                for seed in seeds:
+                    for edge in admitted.outgoing_edges(seed):
+                        target = edge.target_item_identity
+                        graph_degrees[target] = graph_degrees.get(target, 0) + 1
+                        if target in primary_set:
+                            position += 1
+                            continue
+                        tier = 1 if edge.relation_type == "links_to" else 0
+                        current_tier = best_tier.get(target)
+                        if current_tier is None or tier < current_tier:
+                            best_tier[target] = tier
+                            first_seen[target] = position
+                            graph_provenance[target] = GraphProvenance(
+                                relation_type=edge.relation_type,
+                                direction="outbound",
+                                seed=seed,
+                            )
+                        graph_hops.add(target)
+                        position += 1
+                graph_ranking = sorted(
+                    best_tier,
+                    key=lambda identity: (
+                        best_tier[identity],
+                        first_seen[identity],
+                        identity.encode("utf-16-be"),
+                    ),
+                )
+                lane_hits["graph"] = tuple(
+                    projected_retrieval.ProjectedLexicalHit(
+                        item_identity=identity,
+                        projection_variant_id=(
+                            selected_variants[identity].projection_variant_id
+                        ),
+                        decision_level=selected_variants[identity].decision_level,
+                        score=float(graph_degrees[identity]),
+                        search_fields=selected_variants[identity].search_fields,
+                        snippet=" ".join(
+                            selected_variants[identity].search_fields[key]
+                            for key in sorted(
+                                selected_variants[identity].search_fields,
+                                key=lambda value: value.encode("utf-16-be"),
+                            )
+                        )[:320].rstrip(),
+                    )
+                    for identity in graph_ranking
+                )
+            except projected_retrieval.ProjectedLaneUnavailable:
+                warming.add("graph")
+            except projected_retrieval.ProjectedRetrievalUnavailable as error:
+                raise ProjectionRuntimeUnavailable(
+                    "governed projected retrieval is unavailable"
+                ) from error
+
+    lane_order = ranking_config.LANE_ORDER[:5]
+    lane_hits = {
+        lane: hits[:candidate_depth]
+        for lane, hits in lane_hits.items()
+    }
+    active_lanes = [lane for lane in lane_order if lane_hits.get(lane)]
+    rankings = [
+        [hit.item_identity for hit in lane_hits[lane]] for lane in active_lanes
+    ]
+    if not rankings:
+        return ProjectedFindResult(
+            hits=(),
+            withheld_paths=withheld,
+            warming_components=tuple(
+                lane for lane in ("vector", "clip", "graph", "rerank") if lane in warming
+            ),
+            declared_purpose=declared_purpose,
+        )
+    intent_weights = rank_config.intent_weights(find_policy.classify_intent(query))
+    weights_by_lane = dict(zip(ranking_config.LANE_ORDER, intent_weights, strict=True))
+    fused = fusion.reciprocal_rank_fusion_weighted(
+        rankings,
+        [weights_by_lane[lane] for lane in active_lanes],
+        k=rank_config.rrf_k,
+    )
+    fused = [
+        (
+            identity,
+            score
+            * _projected_rank_multiplier(
+                selected_variants[identity].search_fields,
+                rank_config,
+                prefer_compiled=prefer_compiled,
+                prefer_active=prefer_active,
+            ),
+        )
+        for identity, score in fused
+    ]
+    fused.sort(key=lambda item: (-item[1], item[0]))
+    ordered_identities = tuple(identity for identity, _score in fused)
+    reranked: tuple[projected_retrieval.ProjectedLexicalHit, ...] | None = None
+    rerank_raw_scores: dict[str, float] = {}
+    rerank_inputs = {
+        identity: rank for rank, identity in enumerate(ordered_identities, 1)
+    }
+    do_rerank = mode != "keyword" and (
+        rerank is True
+        or (
+            rerank is None
+            and auto_rerank
+            and _should_auto_rerank(lane_hits, query)
+        )
+    )
+    if do_rerank and not embeddings.ranking_enabled():
+        do_rerank = False
+    if do_rerank and readiness.should_defer("reranker"):
+        warming.add("rerank")
+        do_rerank = False
+    if do_rerank:
+        def score_projected_passages(
+            scorer_query: str,
+            passages: list[str],
+        ) -> list[float]:
+            raw_scores = tuple(embeddings.rerank_pairs(scorer_query, passages))
+            if len(raw_scores) != len(ordered_identities):
+                raise ValueError("reranker returned an invalid score count")
+            pending_raw: dict[str, float] = {}
+            adjusted: list[float] = []
+            for identity, raw_score in zip(
+                ordered_identities,
+                raw_scores,
+                strict=True,
+            ):
+                if isinstance(raw_score, bool) or not isinstance(raw_score, Real):
+                    raise ValueError("reranker returned a non-finite score")
+                score = float(raw_score)
+                if not math.isfinite(score):
+                    raise ValueError("reranker returned a non-finite score")
+                pending_raw[identity] = score
+                adjusted.append(
+                    score
+                    * _projected_rank_multiplier(
+                        selected_variants[identity].search_fields,
+                        rank_config,
+                        prefer_compiled=prefer_compiled,
+                        prefer_active=prefer_active,
+                    )
+                )
+            rerank_raw_scores.update(pending_raw)
+            return adjusted
+
+        try:
+            reranked = runtime.reranker.rerank_batch(
+                authorization,
+                query,
+                ordered_identities,
+                scorer=score_projected_passages,
+                k=len(ordered_identities),
+            )
+            ordered_identities = tuple(hit.item_identity for hit in reranked)
+        except projected_retrieval.ProjectedLaneUnavailable:
+            warming.add("rerank")
+        except projected_retrieval.ProjectedRetrievalUnavailable as error:
+            raise ProjectionRuntimeUnavailable(
+                "governed projected retrieval is unavailable"
+            ) from error
+
+    hits_by_lane = {
+        lane: {hit.item_identity: hit for hit in hits}
+        for lane, hits in lane_hits.items()
+    }
+    ranks_by_lane = {
+        lane: {
+            hit.item_identity: rank for rank, hit in enumerate(lane_values, 1)
+        }
+        for lane, lane_values in lane_hits.items()
+    }
+    reranked_by_identity = (
+        {} if reranked is None else {hit.item_identity: hit for hit in reranked}
+    )
+    knowledge_base_name = kb_dirname()
+    hits: list[Hit] = []
+    for final_rank, identity in enumerate(ordered_identities[:limit], 1):
+        source_hit = reranked_by_identity.get(identity)
+        if source_hit is None:
+            source_hit = next(
+                hits_by_lane[lane][identity]
+                for lane in lane_order
+                if identity in hits_by_lane.get(lane, {})
+            )
+        lane_ranks = {
+            lane: ranks_for_lane[identity]
+            for lane, ranks_for_lane in ranks_by_lane.items()
+            if identity in ranks_for_lane
+        }
+        lane_scores = {
+            lane: lane_values[identity].score
+            for lane, lane_values in hits_by_lane.items()
+            if identity in lane_values and lane in {"vector", "clip"}
+        }
+        hits.append(
+            _wire_hit(
+                source_hit,
+                selection=by_identity[identity],
+                rank=final_rank,
+                knowledge_base_name=knowledge_base_name,
+                keyword=mode == "keyword",
+                lane_ranks=lane_ranks,
+                lane_scores=lane_scores,
+                graph_in_degree=graph_degrees.get(identity, 0),
+                graph_hop=identity in graph_hops,
+                graph_provenance=graph_provenance.get(identity),
+                rerank_score=(
+                    reranked_by_identity[identity].score
+                    if identity in reranked_by_identity
+                    else None
+                ),
+                rerank_raw_score=rerank_raw_scores.get(identity),
+                rerank_input_rank=(
+                    rerank_inputs[identity]
+                    if identity in reranked_by_identity
+                    else None
+                ),
+            )
+        )
     return ProjectedFindResult(
-        hits=hits,
+        hits=tuple(hits),
         withheld_paths=withheld,
+        warming_components=tuple(
+            lane for lane in ("vector", "clip", "graph", "rerank") if lane in warming
+        ),
         declared_purpose=declared_purpose,
     )
 

--- a/tests/test_governance_projected_clip_retrieval.py
+++ b/tests/test_governance_projected_clip_retrieval.py
@@ -23,6 +23,7 @@ def _variant(
     *,
     level: int,
     text: str,
+    media_type: str | None = "image",
 ) -> projections.ProjectionVariant:
     option_key = {1: "notice", 2: "constraint", 3: "abstract"}.get(level)
     variant = projections.build_projection_variant(
@@ -33,7 +34,11 @@ def _variant(
             options={} if option_key is None else {option_key: text},
         ),
         projector_schema_version=1,
-        full_search_fields={"body": text, "title": item_identity},
+        full_search_fields={
+            "body": text,
+            "title": item_identity,
+            **({} if media_type is None else {"media_type": media_type}),
+        },
     )
     assert variant is not None
     return variant
@@ -150,6 +155,32 @@ def test_missing_selected_l6_clip_measurement_disables_lane() -> None:
 
     with pytest.raises(projected_retrieval.ProjectedLaneUnavailable, match="selected"):
         index.search_clip(_map((item, full)), (1.0, 0.0), k=1)
+
+
+def test_l6_text_note_does_not_require_a_pixel_measurement() -> None:
+    image = _variant("image", "5" * 64, level=6, text="image")
+    note = _variant(
+        "note",
+        "6" * 64,
+        level=6,
+        text="ordinary note",
+        media_type=None,
+    )
+    image_item, note_item = _item(image), _item(note)
+    index = projected_retrieval.ProjectedClipIndex(
+        _namespace(image_item, note_item),
+        (_measurement(image, (1.0, 0.0)),),
+        extractor_version="pixels-v1",
+        model_version="clip-test-v1",
+    )
+
+    hits = index.search_clip(
+        _map((image_item, image), (note_item, note)),
+        (1.0, 0.0),
+        k=2,
+    )
+
+    assert [hit.item_identity for hit in hits] == [image.item_identity]
 
 
 def test_clip_measurement_lane_and_versions_are_closed_subkeys() -> None:

--- a/tests/test_governance_projected_commands.py
+++ b/tests/test_governance_projected_commands.py
@@ -444,14 +444,11 @@ def test_projected_wire_hit_never_emits_the_full_search_body() -> None:
 @pytest.mark.parametrize(
     ("query", "mode", "graph", "rerank"),
     [
-        ("term", "hybrid", False, False),
-        ("term", "vector", False, False),
         ("term", "keyword", True, False),
-        ("term", "keyword", False, True),
         ("", "keyword", False, False),
     ],
 )
-def test_projected_runtime_refuses_unimplemented_public_lanes(
+def test_projected_runtime_refuses_still_unsupported_public_lanes(
     tmp_path,
     query: str,
     mode: str,

--- a/tests/test_governance_projected_runtime_lanes.py
+++ b/tests/test_governance_projected_runtime_lanes.py
@@ -1,0 +1,858 @@
+"""Projected vector, CLIP, graph, fusion, and rerank runtime integration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import pytest
+from governance_projection_support import verified_namespace
+
+from exomem import embeddings, readiness
+from exomem.governance import (
+    principal,
+    projected_graph,
+    projected_retrieval,
+    projection_authorization,
+    projection_measurement_store,
+    projection_runtime,
+    projection_store,
+    projections,
+    schema_v4,
+)
+from exomem.governance.decisions import Decision
+from exomem.governance.policy import Policy
+
+_VECTOR_EXTRACTOR = "projected-text-v1"
+_CLIP_EXTRACTOR = "pixels-v1"
+_GRAPH_EXTRACTOR = "projected-graph-v1"
+_GRAPH_MODEL = "graph-schema-v1"
+
+
+@pytest.fixture(autouse=True)
+def _enable_projected_query_models(monkeypatch):
+    """Make model availability explicit; hard-off behavior has its own test."""
+
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_CLIP", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_RANKING", raising=False)
+
+
+def _variant(
+    identity: str,
+    content_hash: str,
+    text: str,
+    *,
+    level: int = 6,
+    fields: Mapping[str, str] | None = None,
+):
+    search_fields = {"title": identity.rsplit("/", 1)[-1], "body": text}
+    search_fields.update(fields or {})
+    variant = projections.build_projection_variant(
+        item_identity=identity,
+        content_hash=content_hash,
+        decision=Decision(
+            level=level,
+            options={"abstract": text} if level == 3 else {},
+        ),
+        projector_schema_version=projections.PROJECTOR_SCHEMA_VERSION,
+        full_search_fields=search_fields,
+    )
+    assert variant is not None
+    return variant
+
+
+def _item(variant):
+    return projection_store.ProjectionItemVariants(
+        item_identity=variant.item_identity,
+        content_hash=variant.content_hash,
+        variants=(variant,),
+    )
+
+
+def _measurement_root(
+    key,
+    *,
+    lane: str,
+    extractor_version: str,
+    model_version: str,
+    measurement_count: int,
+    vector_dimension: int | None,
+    graph_edge_count: int = 0,
+):
+    family = projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=key,
+        lane=lane,
+        extractor_version=extractor_version,
+        model_version=model_version,
+    )
+    return projection_store.ProjectionMeasurementRoot(
+        namespace_key=key,
+        family_id=family.family_id,
+        lane=lane,
+        extractor_version=extractor_version,
+        model_version=model_version,
+        measurement_count=measurement_count,
+        vector_dimension=vector_dimension,
+        graph_edge_count=graph_edge_count,
+        rows_digest={"vector": "a", "clip": "b", "graph": "c"}[lane] * 64,
+    )
+
+
+def _runtime(
+    items: Sequence[projection_store.ProjectionItemVariants],
+    *,
+    vectors: Sequence[projected_retrieval.ProjectionVectorMeasurement] = (),
+    clips: Sequence[projected_retrieval.ProjectionClipMeasurement] = (),
+    graphs: Sequence[projected_graph.ProjectionGraphMeasurement] = (),
+):
+    policy = Policy(fingerprint="f" * 64)
+    key = projections.ProjectionNamespaceKey(
+        policy.fingerprint,
+        projections.PROJECTOR_SCHEMA_VERSION,
+        1,
+    )
+    namespace = verified_namespace(key, tuple(items))
+    snapshot = schema_v4.ActivePolicySnapshot(
+        active=schema_v4.VerifiedActiveGovernanceState(
+            logical_vault_id="fixture-vault",
+            activation_store_id="fixture-store",
+            activation_epoch=1,
+            activation_state_digest=namespace.active_state_digest,
+            policy_generation_id="fixture-policy",
+            policy_fingerprint=key.policy_fingerprint,
+            projector_schema_version=key.projector_schema_version,
+            catalog_generation=key.catalog_generation,
+            projection_namespace_id=key.namespace_id,
+        ),
+        policy=policy,
+        source_documents=(),
+        catalog_descriptor=projection_store.catalog_descriptor_bytes(
+            key, tuple(items)
+        ),
+        projection_namespace_evidence=b"fixture",
+    )
+    roots = []
+    vector_index = None
+    clip_index = None
+    graph_index = None
+    if vectors:
+        vector_index = projected_retrieval.ProjectedVectorIndex(
+            namespace,
+            vectors,
+            extractor_version=_VECTOR_EXTRACTOR,
+            model_version=embeddings.MODEL_NAME,
+        )
+        roots.append(
+            _measurement_root(
+                key,
+                lane="vector",
+                extractor_version=_VECTOR_EXTRACTOR,
+                model_version=embeddings.MODEL_NAME,
+                measurement_count=len(vectors),
+                vector_dimension=len(vectors[0].vector),
+            )
+        )
+    if clips:
+        clip_index = projected_retrieval.ProjectedClipIndex(
+            namespace,
+            clips,
+            extractor_version=_CLIP_EXTRACTOR,
+            model_version=embeddings.CLIP_MODEL_NAME,
+        )
+        roots.append(
+            _measurement_root(
+                key,
+                lane="clip",
+                extractor_version=_CLIP_EXTRACTOR,
+                model_version=embeddings.CLIP_MODEL_NAME,
+                measurement_count=len(clips),
+                vector_dimension=len(clips[0].vector),
+            )
+        )
+    if graphs:
+        graph_index = projected_graph.ProjectedGraphIndex(
+            namespace,
+            tuple(graphs),
+            extractor_version=_GRAPH_EXTRACTOR,
+            model_version=_GRAPH_MODEL,
+        )
+        roots.append(
+            _measurement_root(
+                key,
+                lane="graph",
+                extractor_version=_GRAPH_EXTRACTOR,
+                model_version=_GRAPH_MODEL,
+                measurement_count=len(graphs),
+                vector_dimension=None,
+                graph_edge_count=sum(len(row.edges) for row in graphs),
+            )
+        )
+    return projection_runtime.ActiveProjectionRuntime(
+        snapshot,
+        namespace,
+        tuple(roots),
+        vector_index=vector_index,
+        clip_index=clip_index,
+        graph_index=graph_index,
+    )
+
+
+def _vector(variant, value):
+    return projected_retrieval.ProjectionVectorMeasurement(
+        projections.MeasurementKey(
+            projection_variant_id=variant.projection_variant_id,
+            lane="vector",
+            extractor_version=_VECTOR_EXTRACTOR,
+            model_version=embeddings.MODEL_NAME,
+        ),
+        value,
+    )
+
+
+def _clip(variant, value):
+    return projected_retrieval.ProjectionClipMeasurement(
+        projections.MeasurementKey(
+            projection_variant_id=variant.projection_variant_id,
+            lane="clip",
+            extractor_version=_CLIP_EXTRACTOR,
+            model_version=embeddings.CLIP_MODEL_NAME,
+        ),
+        value,
+    )
+
+
+def _graph(variant, *targets):
+    return projected_graph.ProjectionGraphMeasurement(
+        projections.MeasurementKey(
+            projection_variant_id=variant.projection_variant_id,
+            lane="graph",
+            extractor_version=_GRAPH_EXTRACTOR,
+            model_version=_GRAPH_MODEL,
+        ),
+        tuple(
+            projected_graph.ProjectionGraphEdge(
+                source_item_identity=variant.item_identity,
+                target_item_identity=target,
+                relation_type="links_to",
+            )
+            for target in targets
+        ),
+    )
+
+
+def test_hybrid_runtime_fuses_complete_projected_lanes_and_graph(monkeypatch, tmp_path):
+    alpha = _variant(
+        "Knowledge Base/alpha.md",
+        "1" * 64,
+        "alpha exact",
+        fields={"media_type": "image"},
+    )
+    beta = _variant(
+        "Knowledge Base/beta.md",
+        "2" * 64,
+        "alpha semantic",
+        fields={"media_type": "image"},
+    )
+    gamma = _variant(
+        "Knowledge Base/gamma.md",
+        "3" * 64,
+        "alpha graph",
+        fields={"media_type": "image"},
+    )
+    items = tuple(_item(variant) for variant in (alpha, beta, gamma))
+    runtime = _runtime(
+        items,
+        vectors=(
+            _vector(alpha, (0.0, 1.0)),
+            _vector(beta, (1.0, 0.0)),
+            _vector(gamma, (0.2, 0.8)),
+        ),
+        clips=(
+            _clip(alpha, (0.0, 1.0)),
+            _clip(beta, (1.0, 0.0)),
+            _clip(gamma, (0.2, 0.8)),
+        ),
+        graphs=(
+            _graph(alpha, gamma.item_identity),
+            _graph(beta, gamma.item_identity),
+            _graph(gamma),
+        ),
+    )
+    monkeypatch.setattr(
+        embeddings,
+        "embed_texts",
+        lambda texts, *, is_query: [[1.0, 0.0]],
+    )
+    monkeypatch.setattr(embeddings, "embed_clip_text", lambda query: [1.0, 0.0])
+
+    result = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="alpha",
+        limit=3,
+        mode="hybrid",
+        graph=True,
+        rerank=False,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert [hit.path for hit in result.hits] == [
+        beta.item_identity,
+        alpha.item_identity,
+        gamma.item_identity,
+    ]
+    assert result.hits[0].vector_rank == 1
+    assert result.hits[0].clip_rank == 1
+    assert result.hits[2].graph_in_degree == 2
+    assert result.hits[2].graph_hop is False
+    assert result.warming_components == ()
+
+
+def test_graph_lane_prefers_typed_edges_and_preserves_provenance(tmp_path):
+    seed = _variant("Knowledge Base/seed.md", "e" * 64, "seed match")
+    plain = _variant("Knowledge Base/a-plain.md", "f" * 64, "plain neighbor")
+    typed = _variant("Knowledge Base/z-typed.md", "0" * 64, "typed neighbor")
+    runtime = _runtime(
+        tuple(_item(variant) for variant in (seed, plain, typed)),
+        graphs=(
+            projected_graph.ProjectionGraphMeasurement(
+                projections.MeasurementKey(
+                    projection_variant_id=seed.projection_variant_id,
+                    lane="graph",
+                    extractor_version=_GRAPH_EXTRACTOR,
+                    model_version=_GRAPH_MODEL,
+                ),
+                (
+                    projected_graph.ProjectionGraphEdge(
+                        seed.item_identity,
+                        plain.item_identity,
+                        "links_to",
+                    ),
+                    projected_graph.ProjectionGraphEdge(
+                        seed.item_identity,
+                        typed.item_identity,
+                        "supports",
+                    ),
+                ),
+            ),
+            _graph(plain),
+            _graph(typed),
+        ),
+    )
+
+    result = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="seed",
+        limit=3,
+        mode="hybrid",
+        graph=True,
+        rerank=False,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert [hit.path for hit in result.hits] == [
+        seed.item_identity,
+        typed.item_identity,
+        plain.item_identity,
+    ]
+    assert result.hits[1].graph_provenance is not None
+    assert result.hits[1].graph_provenance.relation_type == "supports"
+    assert result.hits[1].graph_provenance.direction == "outbound"
+    assert result.hits[1].graph_provenance.seed == seed.item_identity
+    assert result.hits[2].graph_provenance is not None
+    assert result.hits[2].graph_provenance.relation_type == "links_to"
+
+
+def test_graph_promotes_a_target_below_the_complete_vector_candidate_prefix(
+    monkeypatch,
+    tmp_path,
+):
+    seed = _variant("Knowledge Base/seed.md", "1" * 64, "seed")
+    filler = _variant("Knowledge Base/filler.md", "2" * 64, "filler")
+    target = _variant("Knowledge Base/target.md", "3" * 64, "target")
+    runtime = _runtime(
+        tuple(_item(variant) for variant in (seed, filler, target)),
+        vectors=(
+            _vector(seed, (1.0, 0.0)),
+            _vector(filler, (0.5, 0.5)),
+            _vector(target, (-1.0, 0.0)),
+        ),
+        graphs=(
+            _graph(seed, target.item_identity),
+            _graph(filler),
+            _graph(target),
+        ),
+    )
+    monkeypatch.setattr(
+        embeddings,
+        "embed_texts",
+        lambda texts, *, is_query: [[1.0, 0.0]],
+    )
+
+    result = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="seed",
+        limit=2,
+        mode="hybrid",
+        graph=True,
+        rerank=False,
+        rank_config=projection_runtime.ranking_config.RankingConfig(
+            candidate_multiplier=1,
+            candidate_floor=2,
+            graph_seed_cap=1,
+        ),
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert [hit.path for hit in result.hits] == [
+        seed.item_identity,
+        target.item_identity,
+    ]
+    assert result.hits[1].graph_hop is True
+
+
+def test_graph_does_not_reintroduce_a_rejected_raw_bm25_candidate(tmp_path):
+    seed = _variant("Knowledge Base/seed.md", "4" * 64, "what alpha")
+    rejected = _variant("Knowledge Base/rejected.md", "5" * 64, "alpha only")
+    runtime = _runtime(
+        (_item(seed), _item(rejected)),
+        graphs=(
+            _graph(seed, rejected.item_identity),
+            _graph(rejected),
+        ),
+    )
+
+    result = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="what is alpha",
+        limit=2,
+        mode="hybrid",
+        graph=True,
+        rerank=False,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert [hit.path for hit in result.hits] == [seed.item_identity]
+
+
+def test_rerank_batches_every_projected_candidate_before_final_limit(
+    monkeypatch, tmp_path
+):
+    alpha = _variant("Knowledge Base/alpha.md", "4" * 64, "alpha first")
+    beta = _variant("Knowledge Base/beta.md", "5" * 64, "alpha second")
+    runtime = _runtime((_item(alpha), _item(beta)))
+    observed = []
+
+    def rerank_pairs(query: str, passages: list[str]):
+        observed.append((query, passages))
+        return [0.1, 0.9]
+
+    monkeypatch.setattr(embeddings, "rerank_pairs", rerank_pairs)
+
+    result = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="alpha",
+        limit=1,
+        mode="hybrid",
+        graph=False,
+        rerank=True,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert observed == [
+        (
+            "alpha",
+            [
+                "alpha first alpha.md",
+                "alpha second beta.md",
+            ],
+        )
+    ]
+    assert [hit.path for hit in result.hits] == [beta.item_identity]
+    assert result.hits[0].rerank_score == 0.9
+    assert result.hits[0].rerank_input_rank == 2
+    assert result.warming_components == ("vector",)
+
+
+def test_incomplete_selected_vector_warms_without_reopening_raw_lane(
+    monkeypatch, tmp_path
+):
+    alpha = _variant("Knowledge Base/alpha.md", "7" * 64, "alpha first")
+    beta = _variant("Knowledge Base/beta.md", "8" * 64, "alpha second")
+    runtime = _runtime(
+        (_item(alpha), _item(beta)),
+        vectors=(_vector(alpha, (1.0, 0.0)),),
+    )
+    monkeypatch.setattr(
+        embeddings,
+        "embed_texts",
+        lambda texts, *, is_query: [[1.0, 0.0]],
+    )
+
+    result = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="alpha",
+        limit=2,
+        mode="hybrid",
+        graph=False,
+        rerank=False,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert [hit.path for hit in result.hits] == [
+        alpha.item_identity,
+        beta.item_identity,
+    ]
+    assert all(hit.vector_rank is None for hit in result.hits)
+    assert result.warming_components == ("vector",)
+
+
+def test_hybrid_retention_drops_weak_bm25_only_projection(tmp_path):
+    weak = _variant("Knowledge Base/weak.md", "7" * 64, "alpha only")
+    strong = _variant("Knowledge Base/strong.md", "8" * 64, "what alpha")
+    runtime = _runtime((_item(weak), _item(strong)))
+
+    result = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="what is alpha",
+        limit=2,
+        mode="hybrid",
+        graph=False,
+        rerank=False,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert [hit.path for hit in result.hits] == [strong.item_identity]
+
+
+def test_projected_rank_policy_applies_type_and_status_multipliers(tmp_path):
+    stale_source = _variant(
+        "Knowledge Base/a-source.md",
+        "9" * 64,
+        "alpha",
+        fields={"type": "source", "status": "superseded"},
+    )
+    active_insight = _variant(
+        "Knowledge Base/z-insight.md",
+        "a" * 64,
+        "alpha",
+        fields={"type": "insight", "status": "active"},
+    )
+    runtime = _runtime((_item(stale_source), _item(active_insight)))
+
+    result = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="alpha",
+        limit=2,
+        mode="hybrid",
+        graph=False,
+        rerank=False,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert [hit.path for hit in result.hits] == [
+        active_insight.item_identity,
+        stale_source.item_identity,
+    ]
+
+
+def test_projected_rerank_applies_rank_policy_to_raw_scores(monkeypatch, tmp_path):
+    stale_source = _variant(
+        "Knowledge Base/a-source.md",
+        "b" * 64,
+        "alpha",
+        fields={"type": "source", "status": "superseded"},
+    )
+    active_insight = _variant(
+        "Knowledge Base/z-insight.md",
+        "c" * 64,
+        "alpha",
+        fields={"type": "insight", "status": "active"},
+    )
+    runtime = _runtime((_item(stale_source), _item(active_insight)))
+    monkeypatch.setattr(
+        embeddings,
+        "rerank_pairs",
+        lambda _query, _passages: [0.8, 1.0],
+    )
+
+    result = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="alpha",
+        limit=2,
+        mode="hybrid",
+        graph=False,
+        rerank=True,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert [hit.path for hit in result.hits] == [
+        active_insight.item_identity,
+        stale_source.item_identity,
+    ]
+    assert result.hits[0].rerank_raw_score == 0.8
+    assert result.hits[0].rerank_score == pytest.approx(0.92)
+
+
+def test_projected_auto_rerank_uses_public_policy(monkeypatch, tmp_path):
+    alpha = _variant("Knowledge Base/alpha.md", "d" * 64, "one two three four five")
+    runtime = _runtime((_item(alpha),))
+    observed = []
+
+    def rerank_pairs(query: str, passages: list[str]):
+        observed.append((query, passages))
+        return [1.0]
+
+    monkeypatch.setattr(embeddings, "rerank_pairs", rerank_pairs)
+
+    result = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="one two three four five",
+        limit=1,
+        mode="hybrid",
+        graph=False,
+        rerank=None,
+        auto_rerank=True,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert observed
+    assert result.hits[0].rerank_score == 1.0
+
+
+def test_projected_models_respect_hard_off_and_readiness(
+    monkeypatch, tmp_path
+):
+    alpha = _variant(
+        "Knowledge Base/alpha.md",
+        "e" * 64,
+        "alpha",
+        fields={"media_type": "image"},
+    )
+    runtime = _runtime(
+        (_item(alpha),),
+        vectors=(_vector(alpha, (1.0, 0.0)),),
+        clips=(_clip(alpha, (1.0, 0.0)),),
+    )
+    def model_called(*_args, **_kwargs):
+        raise AssertionError("disabled or warming model must not run")
+    monkeypatch.setattr(embeddings, "embed_texts", model_called)
+    monkeypatch.setattr(embeddings, "embed_clip_text", model_called)
+    monkeypatch.setattr(embeddings, "rerank_pairs", model_called)
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_CLIP", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_RANKING", "1")
+
+    disabled = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="alpha",
+        limit=1,
+        mode="hybrid",
+        graph=False,
+        rerank=True,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+    assert disabled.warming_components == ()
+
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS")
+    monkeypatch.delenv("EXOMEM_DISABLE_CLIP")
+    monkeypatch.delenv("EXOMEM_DISABLE_RANKING")
+    monkeypatch.setattr(readiness, "should_defer", lambda _component: True)
+    warming = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="alpha",
+        limit=1,
+        mode="hybrid",
+        graph=False,
+        rerank=True,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+    assert warming.warming_components == ("vector", "clip", "rerank")
+
+
+def test_clip_lane_is_non_applicable_without_a_selected_l6_variant(
+    monkeypatch, tmp_path
+):
+    alpha = _variant(
+        "Knowledge Base/alpha.md",
+        "d" * 64,
+        "approved abstraction",
+        level=3,
+    )
+    runtime = _runtime((_item(alpha),))
+    monkeypatch.setattr(
+        projection_authorization,
+        "build_authorization_map",
+        lambda *_args, **_kwargs: projected_retrieval.AuthorizationProjectionMap(
+            runtime.namespace.namespace_key,
+            (
+                projected_retrieval.ProjectionSelection(
+                    alpha.item_identity,
+                    alpha.content_hash,
+                    alpha.projection_variant_id,
+                    decision=Decision(
+                        level=3,
+                        options={"abstract": "approved abstraction"},
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    result = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="approved",
+        limit=1,
+        mode="hybrid",
+        graph=True,
+        rerank=False,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert [hit.path for hit in result.hits] == [alpha.item_identity]
+    assert result.hits[0].decision.level == 3
+    assert result.warming_components == ("vector",)
+
+
+def test_vector_runtime_does_not_invent_a_lexical_rank(monkeypatch, tmp_path):
+    alpha = _variant("Knowledge Base/alpha.md", "b" * 64, "semantic only")
+    runtime = _runtime(
+        (_item(alpha),),
+        vectors=(_vector(alpha, (1.0, 0.0)),),
+    )
+    monkeypatch.setattr(
+        embeddings,
+        "embed_texts",
+        lambda texts, *, is_query: [[1.0, 0.0]],
+    )
+
+    result = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="unmatched",
+        limit=1,
+        mode="vector",
+        graph=False,
+        rerank=False,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert len(result.hits) == 1
+    assert result.hits[0].vector_rank == 1
+    assert result.hits[0].bm25_rank is None
+    assert result.hits[0].keyword_rank is None
+
+
+def test_keyword_runtime_does_not_admit_bm25_only_candidates(tmp_path):
+    alpha = _variant("Knowledge Base/alpha.md", "9" * 64, "alpha only")
+    beta = _variant("Knowledge Base/beta.md", "a" * 64, "beta only")
+    runtime = _runtime((_item(alpha), _item(beta)))
+
+    result = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="alpha beta",
+        limit=2,
+        mode="keyword",
+        graph=False,
+        rerank=False,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert result.hits == ()
+
+
+def test_keyword_runtime_ignores_rerank_like_the_public_keyword_mode(
+    monkeypatch, tmp_path
+):
+    alpha = _variant("Knowledge Base/alpha.md", "c" * 64, "alpha only")
+    runtime = _runtime((_item(alpha),))
+    monkeypatch.setattr(
+        embeddings,
+        "rerank_pairs",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("keyword mode must not call the reranker")
+        ),
+    )
+
+    result = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="alpha",
+        limit=1,
+        mode="keyword",
+        graph=False,
+        rerank=True,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert [hit.path for hit in result.hits] == [alpha.item_identity]
+    assert result.warming_components == ()
+    assert result.hits[0].rerank_score is None
+
+
+def test_lane_result_caps_cover_the_repository_catalog_capacity():
+    variant = _variant("Knowledge Base/only.md", "6" * 64, "only")
+    item = _item(variant)
+    namespace = verified_namespace(
+        projections.ProjectionNamespaceKey(
+            "f" * 64,
+            projections.PROJECTOR_SCHEMA_VERSION,
+            1,
+        ),
+        (item,),
+    )
+    authorization = projected_retrieval.AuthorizationProjectionMap(
+        namespace.namespace_key,
+        (
+            projected_retrieval.ProjectionSelection(
+                variant.item_identity,
+                variant.content_hash,
+                variant.projection_variant_id,
+            ),
+        ),
+    )
+    lexical = projected_retrieval.ProjectedLexicalIndex(namespace)
+
+    assert lexical.search_bm25(
+        authorization,
+        "only",
+        k=projections.MAX_GOVERNED_CATALOG_ITEMS,
+    )
+    graph = projected_graph.ProjectedGraphIndex(
+        namespace,
+        (_graph(variant),),
+        extractor_version=_GRAPH_EXTRACTOR,
+        model_version=_GRAPH_MODEL,
+    ).authorize(authorization)
+    assert graph.rank_by_in_degree(
+        k=projections.MAX_GOVERNED_CATALOG_ITEMS
+    ) == (variant.item_identity,)

--- a/tests/test_governance_projection_measurement_activation.py
+++ b/tests/test_governance_projection_measurement_activation.py
@@ -32,7 +32,11 @@ def _fixture(tmp_path: Path):
         content_hash="1" * 64,
         decision=Decision(level=6, scope_ids=(scope.id,)),
         projector_schema_version=key.projector_schema_version,
-        full_search_fields={"title": "Visible", "body": "projected term"},
+        full_search_fields={
+            "title": "Visible",
+            "body": "projected term",
+            "media_type": "image",
+        },
     )
     assert variant is not None
     items = (

--- a/tests/test_governance_projection_measurement_store.py
+++ b/tests/test_governance_projection_measurement_store.py
@@ -34,7 +34,10 @@ def _variant(identity: str, level: int) -> projections.ProjectionVariant:
         content_hash=content_hash,
         decision=Decision(level=level, options=options),
         projector_schema_version=1,
-        full_search_fields={"body": f"private body for {identity}"},
+        full_search_fields={
+            "body": f"private body for {identity}",
+            **({"media_type": "image"} if level == 6 else {}),
+        },
     )
     assert variant is not None
     return variant


### PR DESCRIPTION
## Summary

- execute vector, CLIP, graph, weighted fusion, and reranking strictly over request-authorized projection variants
- preserve public BM25 retention, candidate-prefix, rank-weight, readiness, and hard-off behavior without reopening raw corpus state
- keep projected public serving behind the repository-owned release fence until the separate timing/release gates land

## Verification

- 89 focused projected/governance retrieval tests passed
- Ruff and `git diff --check` passed
- `openspec validate harden-governance-for-consolidation --strict` passed
- `uv lock --check` passed
- repository and built-artifact privacy validation passed
- wheel and sdist build passed
- independent adversarial review: GO, no P0/P1/P2 findings