### PR TITLE
chore(openspec): sync planned-versus-recorded review deltas into main specs

### DIFF
--- a/openspec/specs/attention-queue/spec.md
+++ b/openspec/specs/attention-queue/spec.md
@@ -671,3 +671,23 @@ Attention SHALL compute deterministic base scores before applying review state. 
 - **WHEN** the highest-ranked item is dismissed and attention is requested with `state="open"` and `limit=5`
 - **THEN** the next five open items are returned in their original relative order
 - **AND** the report counts the dismissed item separately
+
+### Requirement: Plan-progress review is a standalone mode outside the Epistemic Inbox
+
+Planned-versus-recorded review SHALL be a standalone read-only `review_memory` mode and SHALL NOT be an attention category. It SHALL NOT contribute items to the default `attention` union or to any registered typed semantic category, SHALL NOT participate in Reciprocal Rank Fusion or any other cross-queue ranking, SHALL NOT mint `exomem://review/<id>` references or signal fingerprints, and SHALL NOT be reachable by `review_item_context`, `triage_memory`, snooze, dismiss, or any other disposition.
+
+The reason is the adjudication boundary the attention queue already draws. Inbox items exist so a reviewer can dispose of a proposed finding; plan-progress divergence is a measured fact about authored intent and recorded observation that the human interprets directly. Enrolling it would also require a rank, and ranking plans by divergence would be exactly the derived judgment the review refuses to make. The existing attention categories, ordering, fusion, dedup, and truncation behaviour SHALL remain unchanged by this mode.
+
+#### Scenario: Default attention union is unchanged
+- **WHEN** `review_memory(mode="attention")` runs over a vault whose Planning items diverge from their recorded evidence
+- **THEN** the composed queue union, its default category order, and its counts are exactly what they were before plan-progress review existed
+- **AND** no plan, evidence binding, or divergence count appears as an attention item
+
+#### Scenario: Plan-progress produces no triageable reference
+- **WHEN** a plan-progress review returns items with unresolved bindings and zero completion observations
+- **THEN** the response carries plan references rather than review references
+- **AND** no returned identifier can be snoozed, dismissed, or otherwise triaged
+
+#### Scenario: Review state store is untouched
+- **WHEN** a plan-progress review runs
+- **THEN** no review-state entry, fingerprint, or disposition is read for adjudication or written

--- a/openspec/specs/planning/spec.md
+++ b/openspec/specs/planning/spec.md
@@ -354,3 +354,84 @@ plans back through this field.
 - **THEN** the item remains excluded from ordinary semantic recall and from
   the relation graph exactly as every other raw Planning item is, and no new
   graph edge is created toward the referenced memory
+
+### Requirement: Planned-versus-recorded review over shipped primitives
+
+Exomem SHALL expose a read-only planned-versus-recorded review as `review_memory(mode="plan-progress")`, reaching MCP, REST, and CLI through the existing generated command without a signature change. The review SHALL select Planning items that are `lifecycle: active`, `status: active`, `commitment: committed`, and carry at least one `progress_evidence` descriptor. Status and commitment SHALL be selected through the shipped bounded Planning query grammar; the presence of `progress_evidence` SHALL be tested on the returned item, because an otherwise valid Planning manifest need not declare that optional field.
+
+For each selected item the review SHALL execute every authored `progress_evidence` descriptor as the named Records saved view over the referenced Records collection, using only shipped primitives: released-manifest resolution, the governed Records query path, and the default-deny query envelope. The review SHALL NOT define a new query grammar, filter operator, saved-view feature, storage adapter, index, cache, or persisted artifact, and SHALL NOT traverse a Records manifest `links.plans` descriptor in the opposite direction.
+
+An optional `collection` selector MAY restrict the review to one Planning collection. Absent a selector, the review SHALL scan authorized Planning collections. A Planning collection that cannot be resolved or queried SHALL increment a bounded unavailable counter and SHALL disclose no path, title, identity, or existence.
+
+#### Scenario: Committed active item with evidence is reviewed
+- **WHEN** an active committed Planning item names a Records collection saved view as progress evidence and that collection holds matching records
+- **THEN** the review presents the item's authored intent together with the exact number of records the bound saved view matched
+- **AND** it names the collection, the role, and the view for every executed binding
+
+#### Scenario: Items outside the reviewed selection are absent
+- **WHEN** a Planning collection also contains candidate, planned, blocked, uncommitted, archived, or evidence-free items
+- **THEN** those items do not appear in the review and no placeholder, stub, or inferred entry is produced for them
+
+#### Scenario: Undeclared evidence field does not refuse the collection
+- **WHEN** a Planning manifest does not declare the optional `progress_evidence` field
+- **THEN** the review returns zero reviewed items for that collection instead of refusing it
+
+### Requirement: Bound evidence executes under authorization-precedes-resolution
+
+Every cross-profile evidence hop SHALL authorize before it resolves and SHALL resolve before any canonical Records source is parsed. The review SHALL resolve an evidence target only as a fully released Records manifest, SHALL authorize the named saved view before the query runs, and SHALL read observed numbers only from a non-withheld default-deny query envelope.
+
+An evidence binding that cannot be executed SHALL be reported with exactly one bounded reason from `collection_unavailable`, `profile_mismatch`, `view_unavailable`, `query_unavailable`, `result_withheld`, or `budget_exhausted`. A missing collection and a withheld collection SHALL both report `collection_unavailable`, so the review cannot be used to probe for hidden collections. An unresolved binding SHALL contribute no observed numbers and SHALL NOT remove the item from the review.
+
+The review SHALL be bounded independently of vault size. It SHALL cap the number of reviewed items, cap the number of distinct evidence-query executions per call, execute each distinct `(collection, view)` pair at most once per call and reuse the result, and report truncation explicitly rather than returning a silently partial answer.
+
+#### Scenario: Withheld evidence target matches an absent one
+- **WHEN** one item's evidence names a governance-withheld Records collection and another item's evidence names a collection that does not exist
+- **THEN** both bindings report `collection_unavailable` with no path, title, identity, snapshot, or count
+- **AND** both items remain in the review with the rest of their bindings intact
+
+#### Scenario: Unknown saved view is a bounded reason, not a failure
+- **WHEN** an evidence descriptor names a view the Records manifest does not declare
+- **THEN** that binding reports `view_unavailable` and the review still returns every other binding and item
+
+#### Scenario: Execution budget truncates explicitly
+- **WHEN** the selected items together bind more distinct collection-and-view pairs than the per-call execution budget allows
+- **THEN** the unexecuted bindings report `budget_exhausted`, the response reports binding truncation as true, and no binding is silently dropped
+
+#### Scenario: Repeated binding executes once
+- **WHEN** several reviewed items bind the same Records collection and the same saved view
+- **THEN** that query executes once per call, every item reports the same exact numbers, and the shared execution counts once against the budget
+
+### Requirement: Plan-progress review presents divergence without adjudicating it
+
+The review SHALL present authored intent next to observed numbers and SHALL leave every judgment to the human or calling agent. For each reviewed item it SHALL return the canonical `exomem://plan/<collection-uuid>/<plan-uuid>` reference, the authored intent fields it echoes unchanged, the ordered evidence bindings with their role, view, opaque collection reference, and either observed numbers or an unavailable reason, and a divergence block of non-negative integers containing `evidence_bindings`, `resolved_bindings`, `unresolved_bindings`, `progress_bindings`, `completion_bindings`, `progress_observations`, and `completion_observations`.
+
+Observed numbers per executed binding SHALL be exactly the matched count, the returned count, the truncation flag, and the canonical collection and snapshot identifiers. The review SHALL NOT return Records rows, bodies, or item identities.
+
+A bound saved view's own declared aggregate SHALL NOT be passed through, whatever its shape. The aggregate grammar admits a latest-row selector that carries a complete record including its identity and version, distinct-value and grouped-value shapes that carry record values, and mean/sum/min/max shapes that carry a derived statistic — rows, identities, and a score-shaped value respectively, all three of which this review refuses. The matched count is computed identically under every aggregate shape, so refusing the aggregate withholds no count from the reader.
+
+The response SHALL be marked derived and read-only, SHALL carry a generation timestamp, and SHALL report the number of Planning collections scanned, the number of items matched, the number of items presented, item truncation, binding truncation, and a bounded tally of unavailable reasons.
+
+Items SHALL be ordered deterministically by collection identity then plan identity, and evidence SHALL keep its authored descriptor order. Ordering SHALL carry no ranking meaning.
+
+#### Scenario: Divergence is exact integers
+- **WHEN** a committed active item binds two progress views and one completion view, and the completion view matches nothing
+- **THEN** the divergence block reports three bindings, two progress bindings, one completion binding, the exact progress match counts, and `completion_observations: 0`
+- **AND** the response contains no percentage, ratio, score, estimate, verdict, or severity
+
+#### Scenario: Aggregate-declaring evidence view leaks nothing
+- **WHEN** a bound saved view declares a latest-row, distinct-value, grouped-value, or mean aggregate
+- **THEN** the binding still resolves and reports its exact matched count
+- **AND** no record row, record identity, item version, record value, or derived statistic from that aggregate appears anywhere in the response
+
+#### Scenario: Authored health is echoed, never written
+- **WHEN** a reviewed item declares `health: unknown` while its completion evidence matches nothing
+- **THEN** the review echoes `unknown` unchanged, proposes no other health value, and the canonical item file is byte-identical afterwards
+
+#### Scenario: Review changes nothing it reads
+- **WHEN** the review runs over a vault containing Planning collections, Records collections, and evidence bindings
+- **THEN** no plan, record, manifest, audit head, activity event, review state, index, or cache is created, modified, moved, or deleted
+- **AND** the only writes a review may produce are the governance kernel's own disclosure receipts for the reads it performed, exactly as any ordinary governed read produces them
+
+#### Scenario: Ordering implies no priority
+- **WHEN** the review returns several items with very different observation counts
+- **THEN** the items are ordered by collection and plan identity rather than by any measure of divergence

--- a/openspec/specs/records/spec.md
+++ b/openspec/specs/records/spec.md
@@ -142,7 +142,7 @@ A Record collection manifest MAY store one or more opaque Planning references pa
 - **THEN** Records may preserve the observed outcome and Planning may preserve intent, while repository/OpenSpec artifacts remain execution truth
 
 ### Requirement: Neutral observed-state query views
-Records query views SHALL display bounded observed values and provenance. Domain-specific interpretation SHALL require an explicit analysis or protocol layer and SHALL NOT be embedded in generic Records machinery. Planned-versus-recorded comparison is outside this delivery.
+Records query views SHALL display bounded observed values and provenance. Domain-specific interpretation SHALL require an explicit analysis or protocol layer and SHALL NOT be embedded in generic Records machinery. Planned-versus-recorded comparison SHALL live in the read-only plan-progress review rather than in Records machinery: a Records view SHALL remain the same neutral observed-state rendering whether it is read directly or read as bound Planning evidence, and Records SHALL NOT gain a comparison, progress, completion, or success semantic of its own.
 
 #### Scenario: Three-month X3 view remains neutral
 - **WHEN** a user asks for X3 progression over three months
@@ -151,6 +151,11 @@ Records query views SHALL display bounded observed values and provenance. Domain
 #### Scenario: Vehicle latest-state view cites events
 - **WHEN** a user asks for current mileage or next due maintenance
 - **THEN** the result identifies the governing collection/query and the record item from which the latest value was derived
+
+#### Scenario: A view read as plan evidence is the same view
+- **WHEN** the same saved view is read directly through the Records command and read again as a Planning item's bound progress evidence
+- **THEN** both reads run the same declared view over the same canonical snapshot and produce the same observed numbers
+- **AND** the Records view definition, response shape, and neutrality are unchanged by having been used as evidence
 
 ### Requirement: Records authoring is self-describing and safely preflightable
 The Records product command SHALL expose content-free `describe` and `validate` actions in addition to collection inspection and mutation. `describe` SHALL return the complete supported manifest contract, all closed enum values, exact open constraints, and generic minimal and nested-measurement examples. `validate` SHALL run the binding parser, Records-profile rule, safe-path rules, create-only checks, and scaffold checks without requiring a mutation reason, acquiring writer authority, writing an audit event, or changing the vault.
@@ -273,3 +278,27 @@ When exactly one existing collection is compatible and the observation is suffic
 #### Scenario: Interpretation remains outside Records
 - **WHEN** a Records query supplies values that support a possible conclusion
 - **THEN** the Records response remains neutral observed state and any durable conclusion is compiled explicitly into a linked Note
+
+### Requirement: Records serves cross-profile review as an ordinary governed reader
+
+A planned-versus-recorded reviewer SHALL reach Records only through the existing governed read path: resolution of a fully released manifest, authorization of the named saved view, authorization of the canonical source before it is parsed, and the default-deny query envelope. Records SHALL NOT gain a review-specific query surface, filter operator, saved-view feature, bulk export, or relaxed authorization path, and SHALL NOT resolve Planning, compare intent with observation, copy plan state, or mutate either side.
+
+A reviewer SHALL take only bounded provenance and counts from the envelope — the matched count, the returned count, the truncation flag, and the collection and snapshot identifiers — and SHALL NOT receive record rows, bodies, item identities, record values, or a view's declared aggregate through the review. A withheld envelope SHALL yield no numbers at all rather than partial ones.
+
+#### Scenario: Review cannot widen Records authorization
+- **WHEN** governance withholds a Records collection, its canonical source, or the named saved view
+- **THEN** the cross-profile review receives the same refusal an ordinary Records reader receives and obtains no rows, counts, snapshot, or existence signal
+
+#### Scenario: Review reads counts, not records
+- **WHEN** a bound saved view matches many records
+- **THEN** the review reports the exact matched and returned counts, the truncation flag, and the snapshot identifier
+- **AND** no record row, body, or item identity appears in the review response
+
+#### Scenario: An aggregating view discloses no more than a plain one
+- **WHEN** a bound view declares an aggregate that would return a full record row, distinct record values, grouped values, or a mean
+- **THEN** the review discloses exactly the same fields it discloses for a view with no aggregate
+- **AND** the aggregate's row, values, and statistic are withheld entirely rather than partially projected
+
+#### Scenario: Records keeps no review state
+- **WHEN** a plan-progress review executes bound Records views repeatedly
+- **THEN** no Records manifest, canonical source, audit head, mutation receipt, or query cache is written, and the collection's next ordinary query is unaffected


### PR DESCRIPTION
`add-planned-vs-recorded-review` shipped in #525, but its delta specs were never synced into `openspec/specs/`, so the main specs did not describe plan-progress review at all.

That gap has already cost this programme twice: it hid a live least-privilege requirement from `openspec validate --strict` (how the hosted `_Schema` hole reached review), and it let two sessions independently specify the same `attention-queue` categories. A change now landing on top of plan-progress needs its MODIFIED blocks to quote requirements that actually exist.

## What this applies

- **attention-queue** — ADDED *Plan-progress review is a standalone mode outside the Epistemic Inbox*
- **planning** — ADDED *Planned-versus-recorded review over shipped primitives*, *Bound evidence executes under authorization-precedes-resolution*, *Plan-progress review presents divergence without adjudicating it*
- **records** — MODIFIED *Neutral observed-state query views* (drops "Planned-versus-recorded comparison is outside this delivery", gains the read-as-plan-evidence scenario), and ADDED *Records serves cross-profile review as an ordinary governed reader*

Specs only. No source, no tests, no behaviour change — the code shipped months ago; this is the written record catching up.

## Verification

`openspec validate --specs --strict` → 103 passed, 0 failed.