### PR TITLE
feat(graph): suggest epistemic relations from authored structure

### DIFF
--- a/openspec/changes/suggest-epistemic-relations-from-structure/.openspec.yaml
+++ b/openspec/changes/suggest-epistemic-relations-from-structure/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-22

--- a/openspec/changes/suggest-epistemic-relations-from-structure/design.md
+++ b/openspec/changes/suggest-epistemic-relations-from-structure/design.md
@@ -82,11 +82,22 @@ flood the queue. Adjacency is instead defined as: each page carries a
 complementary answers to one thing. That is a real shared observation and
 mirrors `shared_sources` directly.
 
-### The lift proposes the authored label, gated by family
+### The lift proposes the authored label, normalized, gated by family
 
-The proposed relation type is the `raw_relation` recorded on the unit edge —
-the label the author actually typed. The generator cannot manufacture a meaning,
-only fail to promote one.
+The proposed relation type is the `raw_relation` recorded on the unit edge — the
+label the author actually typed — put through `relation_registry.normalize_relation`.
+The generator cannot manufacture a meaning, only fail to promote one.
+
+Normalizing is not cosmetic. `- relations: Answers: [[T]]` parses with no
+diagnostic and resolves to `registry_status='core'`, but the canonical
+relation-bullet grammar in `markdown_relations` accepts only
+`[a-z][a-z0-9_.-]{1,80}`. Proposing the label verbatim therefore authors
+`- Answers [[T]]`, and the governed accept refuses it with
+`SEMANTIC_CONTRACT_BLOCKED: malformed_relation` — naming nothing the reader can
+act on, and leaving a queue item that is permanently unacceptable and reappears
+on every `build_queue`. The same holds for `EVIDENCED BY:` and `evidenced by:`.
+`normalize_relation` is the same function the registry used to resolve the edge
+in the first place, so the proposal is still the authored kind.
 
 The family allowlist (`answer`, `resolution`, `question`, `support`,
 `contradiction`, `refinement`, `evidence`, `duplication`) is resolved through
@@ -122,24 +133,64 @@ generator therefore aggregates to one candidate per `(target, relation type)`
 and folds all matches into a list inside `evidence`. The three method names are
 fresh, so they cannot collide with the existing four either.
 
-### Registration order is load-bearing
+### Registration order is load-bearing, and structural goes first
 
-`_wikilink_candidates` is unbounded and `suggest_relations` truncates at
-`limit`, so on a link-heavy page a structural candidate registered any later
-would never reach the acceptance queue. The three are registered after the
-deterministic generators (cheap, already relied upon) and before the optional
-embedding lane. The interaction is accepted deliberately and pinned by a test,
-so it is not incidental.
+`_wikilink_candidates` is unbounded and `suggest_relations` truncates at `limit`
+(10 by default in the acceptance queue), so ordering is a budget rather than a
+presentation choice.
+
+An earlier revision of this design placed the structural generators after the
+three deterministic ones, reasoning that the deterministic candidates were cheap
+and already relied upon. **That reasoning ran backwards and has been reversed.**
+A page with twelve body wikilinks and one typed unit relation yielded zero
+structural candidates — and a dense compiled note is exactly the page that
+carries typed unit relations, so the change would have been silent on its own
+motivating case. The interaction is worse than simple truncation: wikilink
+candidates are generated before `relation_queue._classify_candidate` drops the
+already-authored ones, so the budget can be spent on candidates that are then
+discarded.
+
+The ranking that follows: an author-written typed unit relation is the
+highest-evidence signal in the set, and a body wikilink is the lowest-cost to
+regenerate on the next read. Structural generators therefore run first, and the
+existing four keep their order relative to one another. Pinned in both
+directions, plus a dedicated link-heavy-page regression.
+
+The residual risk is the mirror of the one being fixed: the three structural
+generators are capped at three candidates each, so on a page rich in both
+semantic units and wikilinks they can occupy nine of ten slots. That is bounded
+by construction, it can only happen on a page whose author has written a great
+deal of structure, and the displaced `links_to` candidates are regenerated on
+the next read once these are accepted or dismissed.
 
 ### Bounds
 
 One SQL statement per generator, each with a row `LIMIT`; at most three
 candidates per generator per page; at most five folded matches inside one
-candidate's evidence. A test proves the query count is constant between a
-two-page corpus and a 201-page corpus.
+candidate's evidence, with the true total reported alongside. A test proves the
+query count is constant between a two-page corpus and a 201-page corpus.
+
+### The two co-participation generators suppress each other's duplicates
+
+Pages that share an open question very often also answer the same target, so
+`shared_open_question` and `shared_resolution_target` frequently find the same
+peer — and both propose `relates_to`, meaning the identical bullet. Since
+`_dedupe_candidates` keys on `method`, both would survive and spend two of ten
+slots on one edge that can be accepted only once (after which the second is
+filtered as an authored edge anyway). `_structural_candidates` therefore drops a
+later structural candidate whose `(target, relation type)` an earlier one has
+already claimed. The surviving candidate still carries the peer's unit identity,
+so dismissal semantics for the edge that is actually proposed are unaffected.
 
 ## Risks / Trade-offs
 
+- **The causality exclusion rests on a stated principle, not on a count.** The
+  allowlisted families express an epistemic stance between bodies of knowledge,
+  which a page can hold as a whole; causality asserts a mechanism between the
+  things described, which is a property of the referents, not the documents.
+  Broadening a stance yields a reviewable statement; broadening a mechanism
+  relocates it onto subjects that cannot bear it. Widening the allowlist to
+  causality would need a different argument, not one more entry.
 - **Page-level targets force `relates_to`.** "Both pages hold the same question"
   looks like it licenses `duplicates`, but the accepted bullet would read
   `- duplicates [[B]]` and assert that the *pages* duplicate. This is the

--- a/openspec/changes/suggest-epistemic-relations-from-structure/design.md
+++ b/openspec/changes/suggest-epistemic-relations-from-structure/design.md
@@ -110,6 +110,25 @@ between the *pages* that nobody wrote.
 the family gate, because a family can admit a deprecated, scope-violating or
 unregistered kind that the writer would reject on accept.
 
+### Registry standing is not bullet writability
+
+The status gate answers "does the registry admit this kind?", which is a weaker
+question than "can this label be written as a canonical relation bullet?".
+`relation_registry._KEY_RE` is length-unbounded while the grammar caps a label at
+81 characters; `_LABEL_RE` admits a one-character alias where the grammar needs
+two; neither constrains an alias to ASCII, and an alias that fails `_LABEL_RE` is
+recorded as a finding but registered anyway. All four shapes resolve with
+`extension` or `alias` standing and were verified to produce a bullet the
+governed write refuses as `malformed_relation`.
+
+The normalized label is therefore checked against the canonical grammar itself —
+by probing `markdown_relations._CANONICAL_RE` with the bullet the candidate would
+author, rather than restating the pattern, so the two cannot drift. The check
+runs per row, before grouping and before the per-generator cap, so an
+unproposable label cannot consume a slot a writable one would have taken; the
+cap was in fact masking two of the four shapes until the guard was moved ahead
+of it.
+
 ### Evidence is fingerprint-load-bearing
 
 `relation_queue._evidence_signal_version` hashes
@@ -156,12 +175,29 @@ regenerate on the next read. Structural generators therefore run first, and the
 existing four keep their order relative to one another. Pinned in both
 directions, plus a dedicated link-heavy-page regression.
 
-The residual risk is the mirror of the one being fixed: the three structural
-generators are capped at three candidates each, so on a page rich in both
-semantic units and wikilinks they can occupy nine of ten slots. That is bounded
-by construction, it can only happen on a page whose author has written a great
-deal of structure, and the displaced `links_to` candidates are regenerated on
-the next read once these are accepted or dismissed.
+The residual risk is the exact mirror of the one being fixed: the three
+structural generators are capped at three candidates each, so on a page rich in
+both semantic units and wikilinks they can occupy nine of ten slots.
+
+An earlier draft of this section claimed the displaced `links_to` candidates
+"are regenerated on the next read once these are accepted or dismissed." **That
+is false, and measurably so.** `suggest_relations` truncates at `limit` BEFORE
+`relation_queue._classify_candidate` applies the authored/decided filters, so a
+decided candidate keeps consuming its slot. Measured on a fixture with 24
+wikilink candidates plus three of each structural method: dismissing all ten
+shown items makes the page disappear from the next `build_queue` entirely — the
+remaining 23 wikilink candidates never surface, ever. Accepting one at a time,
+the lifts drain (their `NOT EXISTS` frees the slot at generation) but the six
+co-participation candidates keep consuming slots after acceptance.
+
+That truncation-before-classification behaviour is **pre-existing and
+mirror-symmetric**: under the previous order the wikilink generator starved the
+structural candidates in precisely the same way, which is what the link-heavy
+regression demonstrates. This change therefore amplifies the behaviour on one
+class of page rather than introducing it, and the ordering decision is a choice
+about which class gets starved — which is the honest reason the decision matters
+at all. Fixing the interaction properly means classifying before truncating, and
+that is filed as a follow-up below rather than smuggled in here.
 
 ### Bounds
 
@@ -181,6 +217,16 @@ filtered as an authored edge anyway). `_structural_candidates` therefore drops a
 later structural candidate whose `(target, relation type)` an earlier one has
 already claimed. The surviving candidate still carries the peer's unit identity,
 so dismissal semantics for the edge that is actually proposed are unaffected.
+
+Survivor selection is first-generator-wins, not strongest-evidence-wins, and
+that has a bounded consequence worth stating rather than leaving to be
+discovered: the suppressed candidate's genuinely different evidence — the shared
+resolution target and the relation kinds both sides used — becomes invisible and
+no longer feeds any fingerprint. So a change confined to the shared-resolution
+relationship will not resurface a dismissed `relates_to` between those two
+pages, even though a change to the shared question will. Both candidates propose
+the identical bullet, so nothing the reviewer can act on is lost; what is lost is
+one of two independent reasons for that bullet to come back.
 
 ## Risks / Trade-offs
 
@@ -211,8 +257,34 @@ None. No schema version change, no sidecar rebuild, no vault write, and no
 change to any persisted state. The generators are additive read-only paths
 inside an existing propose-only operation.
 
+## Follow-Ups Filed, Not Fixed Here
+
+- **`classify-relation-candidates-before-truncation`.** `suggest_relations`
+  truncates at `limit` before `relation_queue._classify_candidate` drops
+  authored and decided candidates, so a decided candidate keeps consuming its
+  slot and the surplus behind it can never surface: dismissing every shown item
+  on a page removes that page from the queue entirely rather than revealing the
+  next batch. Pre-existing and independent of this change, which only shifts
+  which class of candidate absorbs it. The fix belongs in the queue, not in a
+  generator.
+
+- **`relation-registry-registers-invalid-aliases`.** In
+  `relation_registry._parse_extension_data`, the alias loop records an
+  `invalid_alias` finding when a label fails `_LABEL_RE` but does not `continue`,
+  so the alias is still added to the alias map a few lines later and thereafter
+  resolves with `registry_status='alias'` — standing that every consumer of the
+  status gate treats as admitted. Reproduction: a vault
+  `_Schema/relation-registry.yaml` declaring `aliases: ['ré']` on an extension,
+  then a semantic unit authoring `- relations: ré: [[Target]]`; the edge is
+  indexed with `raw_relation='ré'` and `registry_status='alias'`. This is the
+  mechanism behind the non-ASCII case the writability guard above defends
+  against, but the defect is in the loader and well outside this change, so the
+  guard compensates rather than fixes.
+
+- **Fragment targets.** `shared_open_question` should be revisited as a
+  `duplicates` proposal once relation targets can address a unit, tracked by the
+  separately-filed `resolve-relation-fragment-targets`.
+
 ## Open Questions
 
-None blocking. `shared_open_question` should be revisited as a `duplicates`
-proposal once relation targets can address a unit, which is tracked by the
-separately-filed `resolve-relation-fragment-targets`.
+None blocking.

--- a/openspec/changes/suggest-epistemic-relations-from-structure/design.md
+++ b/openspec/changes/suggest-epistemic-relations-from-structure/design.md
@@ -1,0 +1,167 @@
+## Context
+
+`suggest_relations` composes four generators and truncates the deduplicated
+result at `limit` (default 10). Three are deterministic (`wikilink`,
+`frontmatter_sources`, `shared_sources`) and one is optional
+(`embedding_proximity`). `relation_queue._page_candidates` consumes
+`suggest_relations` directly, so anything added here reaches the acceptance
+queue with no queue changes at all.
+
+The graph sidecar already materializes everything the new generators need.
+`graph_nodes` carries `unit_ref`, `unit_category` and `unit_kind` for every
+addressable semantic unit; `graph_edges` carries `relation_type`,
+`raw_relation`, `registry_status`, `origin` and `source_path` for every edge,
+including block-level ones. No schema change, no `SCHEMA_VERSION` bump, and no
+rebuild is required.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make epistemic-family relation suggestions structurally possible without
+  inferring any meaning the author did not write.
+- Read the sidecar once per page across all three generators, and soft-fail to
+  no candidates when the snapshot is unavailable.
+- Keep every candidate's evidence sufficient to re-derive its identity, so a
+  dismissal expires when the evidence genuinely changes.
+- Leave the vault, the graph edges, the acceptance queue, the command registry
+  and the pinned tool surface untouched.
+
+**Non-Goals:**
+
+- Unit-level (fragment) relation targets — deferred to
+  `resolve-relation-fragment-targets`, which owns the schema bump and the
+  write-path latency evidence.
+- Ranking, scoring, confidence, or any ordering beyond deterministic sorting.
+- Any model-backed path.
+
+## Decisions
+
+### The seam: two authoring forms behave oppositely
+
+A `- relations: k: [[T]]` metadata row on a rich semantic block produces an edge
+whose `src_key` is the **block** key, with `origin = 'semantic_relation'`, and
+**no** page-level edge. A plain `- k [[T]]` bullet in the same block's body is
+parsed by the note-level relation scanner and produces a **page-level** edge
+whose `src_key` is the file key, and never appears in `unit.relations`.
+
+The lift therefore selects `origin = 'semantic_relation' AND src_key <> file_key`,
+which admits exactly the first form and excludes the second by construction. A
+`NOT EXISTS` against a page-level edge with the same `relation_type` and target
+drops any unit relation the author has already promoted by hand.
+
+This is the one seam the whole generator rests on, so a regression test asserts
+both directions rather than only the positive case.
+
+### Question units land on two indexed axes, so UNION rather than OR
+
+A rich `## Open Question` has `unit_kind = 'open_question'`, but a `- category:`
+metadata row overrides its category. A compact `- [question]` has
+`unit_kind = 'observation'` and `unit_category = 'question'`. A predicate on
+either column alone misses cases.
+
+The two columns are served by two separate indexes
+(`idx_graph_nodes_unit_kind`, `idx_graph_nodes_unit_category_kind`), and an `OR`
+across them defeats both — the same reasoning already recorded beside the
+relation-type indexes for relation-filtered recall. The query therefore UNIONs
+two indexed branches on each side of the join.
+
+### Question normalization lives in SQL, on both sides
+
+Normalization is `trim(rtrim(lower(trim(text)), '?'))`, applied in SQL on both
+sides of the join so no Python normalizer can drift from it. Two deliberate
+recall limits follow, and both are asserted rather than left implicit: SQLite's
+`lower()` is ASCII-only, so a non-ASCII case difference is not normalized away;
+and only trailing question marks are stripped.
+
+### Result-adjacency is defined over the resolution graph
+
+"Both pages hold a `result` unit" would fire on nearly every compiled note and
+flood the queue. Adjacency is instead defined as: each page carries a
+**unit-level** `answers` or `resolves` edge to the *same* target — competing or
+complementary answers to one thing. That is a real shared observation and
+mirrors `shared_sources` directly.
+
+### The lift proposes the authored label, gated by family
+
+The proposed relation type is the `raw_relation` recorded on the unit edge —
+the label the author actually typed. The generator cannot manufacture a meaning,
+only fail to promote one.
+
+The family allowlist (`answer`, `resolution`, `question`, `support`,
+`contradiction`, `refinement`, `evidence`, `duplication`) is resolved through
+the registry at call time, so a vault extension kind parented into an allowed
+family lifts without a code change. Causality is deliberately excluded:
+promoting one unit's `causes` claim to the whole page would assert a mechanism
+between the *pages* that nobody wrote.
+
+`registry_status` is filtered to `core`, `alias` and `extension` separately from
+the family gate, because a family can admit a deprecated, scope-violating or
+unregistered kind that the writer would reject on accept.
+
+### Evidence is fingerprint-load-bearing
+
+`relation_queue._evidence_signal_version` hashes
+`{page_signal_version, method, relation_type, to, evidence}`. A candidate driven
+by a *different* page whose evidence omitted that page's identity would keep the
+same fingerprint through any later edit to that page, so a dismissal would
+become permanent.
+
+Both co-participation generators are exactly that class, so their evidence
+carries the other side's `unit_ref`, anchor, and the relation kinds it used. A
+regression test dismisses a `shared_open_question` candidate, re-anchors the
+*other* page's question while this page stays byte-identical, and requires the
+candidate to reappear with a new fingerprint.
+
+### Aggregate within the generator, not only across generators
+
+`_dedupe_candidates` keys on `(from, to, relation_type, method)` and excludes
+`evidence`, so it collapses duplicates *within* a generator too. A naive
+one-row-per-match emitter would silently drop every match after the first. Each
+generator therefore aggregates to one candidate per `(target, relation type)`
+and folds all matches into a list inside `evidence`. The three method names are
+fresh, so they cannot collide with the existing four either.
+
+### Registration order is load-bearing
+
+`_wikilink_candidates` is unbounded and `suggest_relations` truncates at
+`limit`, so on a link-heavy page a structural candidate registered any later
+would never reach the acceptance queue. The three are registered after the
+deterministic generators (cheap, already relied upon) and before the optional
+embedding lane. The interaction is accepted deliberately and pinned by a test,
+so it is not incidental.
+
+### Bounds
+
+One SQL statement per generator, each with a row `LIMIT`; at most three
+candidates per generator per page; at most five folded matches inside one
+candidate's evidence. A test proves the query count is constant between a
+two-page corpus and a 201-page corpus.
+
+## Risks / Trade-offs
+
+- **Page-level targets force `relates_to`.** "Both pages hold the same question"
+  looks like it licenses `duplicates`, but the accepted bullet would read
+  `- duplicates [[B]]` and assert that the *pages* duplicate. This is the
+  concrete cost of deferring fragment targets; revisit `shared_open_question` as
+  a `duplicates` proposal once `to` can address a unit.
+- **One extra sidecar read per page.** `relation_queue.build_queue` runs
+  `suggest_relations` for up to 50 pages, each already opening one snapshot for
+  `shared_sources`. Sharing one snapshot across all three new generators holds
+  the increase to one additional validated open per page rather than three.
+- **Truncation interaction.** On a page with more than `limit` wikilinks, no
+  structural candidate is reached. Accepted; the alternative — registering
+  before the deterministic generators — would displace suggestions users already
+  depend on.
+
+## Migration Plan
+
+None. No schema version change, no sidecar rebuild, no vault write, and no
+change to any persisted state. The generators are additive read-only paths
+inside an existing propose-only operation.
+
+## Open Questions
+
+None blocking. `shared_open_question` should be revisited as a `duplicates`
+proposal once relation targets can address a unit, which is tracked by the
+separately-filed `resolve-relation-fragment-targets`.

--- a/openspec/changes/suggest-epistemic-relations-from-structure/proposal.md
+++ b/openspec/changes/suggest-epistemic-relations-from-structure/proposal.md
@@ -29,16 +29,20 @@ observations that mirror the existing `shared_sources` method.
   snapshot and soft-failing to no candidates when the sidecar is unavailable:
   - `unit_relation_lift` — promote a kind the author already typed on one of
     this page's own semantic units to a page-level proposal, when no page-level
-    edge of that kind to that target exists. Gated to an allowlist of relation
+    edge of that kind to that target exists. The proposal is the authored label
+    in the registry's normalized form, so the bullet it would author always
+    satisfies the canonical relation grammar. Gated to an allowlist of relation
     **families** resolved through the registry at call time, and to registry
     statuses `core`, `alias` and `extension`.
   - `shared_open_question` — two pages carrying the same normalized open
     question, proposed as `relates_to`.
   - `shared_resolution_target` — two pages whose semantic units each `answers`
     or `resolves` the same target, proposed as `relates_to`.
-- Register the three after the existing deterministic generators and before the
-  optional embedding lane, because `suggest_relations` truncates at `limit` and
-  the wikilink generator is unbounded.
+- Register the three ahead of the existing generators, because
+  `suggest_relations` truncates at `limit` and the unbounded wikilink generator
+  would otherwise consume the whole budget on exactly the dense pages that carry
+  typed unit relations. The existing four keep their order relative to one
+  another.
 - Carry the driving page's unit identity (`unit_ref`, anchor, relation kinds
   used) in each candidate's evidence, so a dismissed candidate resurfaces when
   the page that produced it changes.

--- a/openspec/changes/suggest-epistemic-relations-from-structure/proposal.md
+++ b/openspec/changes/suggest-epistemic-relations-from-structure/proposal.md
@@ -1,0 +1,57 @@
+# Suggest Epistemic Relations From Authored Structure
+
+## Why
+
+The four shipped relation-suggestion generators emit only `links_to`,
+`derived_from` and `relates_to`, so an epistemic-family suggestion is
+structurally impossible. The measured consequence in a real vault: 58% of
+registered relation uses are `relates_to`, 188 relation-debt findings, and 35%
+typed coverage.
+
+The gap is not a modelling problem — it is a visibility problem. A typed unit
+relation authored as `- relations: answers: [[Q]]` produces a **block-level**
+edge and no page-level edge at all, while a plain `- supports [[X]]` bullet
+inside the same block produces exactly the opposite. The scaffold documents the
+metadata form as *the* way to write typed unit relations, so every one of them
+is an author-written directional epistemic claim that the page-level graph,
+relation-filtered recall, and contract inference cannot see. Nothing proposes
+promoting it.
+
+Two further structural facts are already materialized in the graph sidecar and
+unused by any suggester: two pages can carry the same open question, and two
+pages can each answer or resolve the same target. Both are real shared
+observations that mirror the existing `shared_sources` method.
+
+## What Changes
+
+- Add three deterministic relation-suggestion generators to `suggest_relations`,
+  reading the typed graph sidecar through **one** shared validated read
+  snapshot and soft-failing to no candidates when the sidecar is unavailable:
+  - `unit_relation_lift` — promote a kind the author already typed on one of
+    this page's own semantic units to a page-level proposal, when no page-level
+    edge of that kind to that target exists. Gated to an allowlist of relation
+    **families** resolved through the registry at call time, and to registry
+    statuses `core`, `alias` and `extension`.
+  - `shared_open_question` — two pages carrying the same normalized open
+    question, proposed as `relates_to`.
+  - `shared_resolution_target` — two pages whose semantic units each `answers`
+    or `resolves` the same target, proposed as `relates_to`.
+- Register the three after the existing deterministic generators and before the
+  optional embedding lane, because `suggest_relations` truncates at `limit` and
+  the wikilink generator is unbounded.
+- Carry the driving page's unit identity (`unit_ref`, anchor, relation kinds
+  used) in each candidate's evidence, so a dismissed candidate resurfaces when
+  the page that produced it changes.
+- Aggregate to one candidate per `(target, relation type)` with all matches
+  folded into evidence, because candidate deduplication keys on
+  `(from, to, relation_type, method)` and excludes evidence.
+
+## Non-Goals
+
+- No fragment (unit-level) relation targets. Targets stay page-level, which is
+  why the two co-participation generators propose `relates_to` and nothing
+  narrower — with a page-level target, `- duplicates [[B]]` would assert that
+  the *pages* duplicate, which is false when only their question units do.
+- No sidecar schema change, no rebuild, no write-path work, and no change to
+  the acceptance queue, the command registry, or the pinned tool surface.
+- No model-backed suggestion path. `model_suggestions_available` stays `false`.

--- a/openspec/changes/suggest-epistemic-relations-from-structure/specs/epistemic-graph/spec.md
+++ b/openspec/changes/suggest-epistemic-relations-from-structure/specs/epistemic-graph/spec.md
@@ -1,0 +1,141 @@
+# epistemic-graph
+
+## ADDED Requirements
+
+### Requirement: Structural Relation Suggestions From Authored Semantic Units
+
+`suggest_relations` SHALL return deterministic structural candidates derived
+from authored semantic units held in the typed graph sidecar, in addition to the
+existing wikilink, frontmatter-source, shared-source and embedding-proximity
+candidates. The structural methods SHALL be `unit_relation_lift`,
+`shared_open_question`, and `shared_resolution_target`. Every structural
+candidate SHALL name a page-level target and SHALL carry a relation type, a
+method, and evidence. The operation MUST NOT write Markdown, mutate graph edges,
+change supersession fields, or change `find` ranking.
+
+#### Scenario: A typed unit relation is lifted to a page-level proposal
+
+- **WHEN** a page carries a semantic unit whose `relations` metadata names a registered relation kind and target, and the page holds no page-level edge of that kind to that target
+- **THEN** `suggest_relations` returns a `unit_relation_lift` candidate proposing that authored kind to that target
+- **AND** no file under the vault is created, modified, moved, or deleted
+
+#### Scenario: A plain relation bullet is not lifted
+
+- **WHEN** a page expresses a relation as a plain relation bullet inside a block body, which already produces a page-level edge
+- **THEN** `suggest_relations` returns no `unit_relation_lift` candidate for that relation
+
+#### Scenario: An already promoted unit relation is not lifted again
+
+- **WHEN** a page carries a typed unit relation and also a page-level edge of the same relation type to the same target
+- **THEN** `suggest_relations` returns no `unit_relation_lift` candidate for that relation type and target
+
+#### Scenario: Pages sharing an open question are proposed as related
+
+- **WHEN** two pages each carry a semantic unit that is an open question with the same normalized question text
+- **THEN** `suggest_relations` returns a `shared_open_question` candidate from each page to the other
+
+#### Scenario: Pages answering the same target are proposed as related
+
+- **WHEN** two pages each carry a unit-level `answers` or `resolves` edge to the same target
+- **THEN** `suggest_relations` returns a `shared_resolution_target` candidate from each page to the other
+
+### Requirement: Question Recall Spans Both Indexed Unit Axes
+
+Structural question matching SHALL select question units from both the unit-kind
+axis and the unit-category axis, so that a rich open-question block, a
+rich open-question block carrying a category override, and a compact question
+observation all participate. The selection SHALL use separately indexed branches
+rather than a disjunction across the two columns. Question text SHALL be
+normalized identically on both sides of the comparison; that normalization is
+ASCII-only case folding plus removal of trailing question marks, and those
+limits SHALL be treated as deterministic recall limits rather than defects.
+
+#### Scenario: All three question forms match one another
+
+- **WHEN** one page carries a rich open-question block, a second carries a rich open-question block with a category override, and a third carries a compact question observation, all with the same question text
+- **THEN** each page receives a `shared_open_question` candidate naming both of the others
+
+#### Scenario: Case and trailing question marks do not prevent a match
+
+- **WHEN** two pages carry the same ASCII question text differing only in letter case and a trailing question mark
+- **THEN** the two pages receive a `shared_open_question` candidate for each other
+
+#### Scenario: A non-ASCII case difference is not normalized away
+
+- **WHEN** two pages carry question text differing only in the case of a non-ASCII letter
+- **THEN** no `shared_open_question` candidate is returned for that pair
+
+### Requirement: Structural Suggestions Share One Snapshot And Soft-Fail
+
+All structural generators for one page SHALL read the typed graph sidecar
+through a single validated read snapshot. When that snapshot is unavailable,
+`suggest_relations` SHALL return zero structural candidates, SHALL still return
+its deterministic non-structural candidates, and MUST NOT raise. Each structural
+generator SHALL issue a bounded, constant number of sidecar queries independent
+of corpus size.
+
+#### Scenario: Unavailable sidecar still yields deterministic suggestions
+
+- **WHEN** the graph read snapshot is unavailable and `suggest_relations` is called for a page carrying wikilinks and typed unit relations
+- **THEN** the wikilink candidates are returned, no structural candidate is returned, and no error is raised
+
+#### Scenario: Query count does not grow with the corpus
+
+- **WHEN** `suggest_relations` runs against a two-page corpus and against a corpus of two hundred additional matching pages
+- **THEN** the number of sidecar queries issued is the same in both cases
+
+### Requirement: Structural Candidates Aggregate And Are Bounded
+
+Each structural generator SHALL emit at most one candidate per pair of proposed
+relation type and target, folding every contributing match into a list inside
+that candidate's evidence. Each generator SHALL emit a bounded number of
+candidates per page, and each candidate SHALL fold a bounded number of matches
+into its evidence. Repeated calls over an unchanged corpus SHALL return
+identical candidates.
+
+#### Scenario: Two matches between the same pair yield one candidate
+
+- **WHEN** two pages share two distinct open questions
+- **THEN** exactly one `shared_open_question` candidate is returned for that pair, and its evidence lists both questions
+
+#### Scenario: Two authoring units yield one lift candidate
+
+- **WHEN** two semantic units on one page each author the same relation kind to the same target, and no page-level edge of that kind exists
+- **THEN** exactly one `unit_relation_lift` candidate is returned, and its evidence lists both authoring units
+
+#### Scenario: A large matching corpus stays bounded
+
+- **WHEN** two hundred pages each carry the same open question as the requested page
+- **THEN** at most three `shared_open_question` candidates are returned
+
+### Requirement: Structural Evidence Identifies The Driving Unit
+
+A structural candidate whose evidence is derived from a page other than the
+candidate's source page SHALL include that other page's semantic unit identity —
+its unit reference, its anchor, and the relation kinds it used where applicable.
+A dismissed candidate SHALL therefore resurface with a different fingerprint
+when the page that produced its evidence changes, even while the source page
+remains byte-identical.
+
+#### Scenario: Dismissal expires when the other page changes
+
+- **WHEN** a `shared_open_question` candidate is dismissed and the other page's question unit is then re-anchored while the source page stays byte-identical
+- **THEN** the candidate reappears in the relation queue with a different fingerprint
+
+#### Scenario: Lift evidence names its authoring unit
+
+- **WHEN** a `unit_relation_lift` candidate is returned
+- **THEN** its evidence names the authoring unit's unit reference and anchor, the authored relation label, and the resolved relation family
+
+### Requirement: Structural Generators Run After Deterministic And Before Optional Generators
+
+Structural generators SHALL be invoked after the wikilink, frontmatter-source
+and shared-source generators and before the optional embedding-proximity
+generator, so that the deterministic candidates users already depend on are
+never displaced and structural candidates are never ranked behind an optional
+lane. This ordering interacts with the response truncation limit deliberately.
+
+#### Scenario: Candidate order places structural candidates between the two groups
+
+- **WHEN** `suggest_relations` returns candidates from every generator for one page
+- **THEN** the first structural candidate appears after the first shared-source candidate and before the first embedding-proximity candidate

--- a/openspec/changes/suggest-epistemic-relations-from-structure/specs/epistemic-graph/spec.md
+++ b/openspec/changes/suggest-epistemic-relations-from-structure/specs/epistemic-graph/spec.md
@@ -108,6 +108,16 @@ identical candidates.
 - **WHEN** two hundred pages each carry the same open question as the requested page
 - **THEN** at most three `shared_open_question` candidates are returned
 
+#### Scenario: Folded evidence is capped and the total stays honest
+
+- **WHEN** two pages share more open questions than one candidate's evidence may carry
+- **THEN** the candidate's evidence lists the capped number of matches and separately reports the true total
+
+#### Scenario: Two co-participation methods do not propose the same edge twice
+
+- **WHEN** two pages both share an open question and both answer the same target, so `shared_open_question` and `shared_resolution_target` would each propose `relates_to` to the same page
+- **THEN** exactly one structural candidate is returned for that relation type and target
+
 ### Requirement: Structural Evidence Identifies The Driving Unit
 
 A structural candidate whose evidence is derived from a page other than the
@@ -127,15 +137,23 @@ remains byte-identical.
 - **WHEN** a `unit_relation_lift` candidate is returned
 - **THEN** its evidence names the authoring unit's unit reference and anchor, the authored relation label, and the resolved relation family
 
-### Requirement: Structural Generators Run After Deterministic And Before Optional Generators
+### Requirement: Structural Generators Are Ordered Ahead Of Wikilink Suggestions
 
-Structural generators SHALL be invoked after the wikilink, frontmatter-source
-and shared-source generators and before the optional embedding-proximity
-generator, so that the deterministic candidates users already depend on are
-never displaced and structural candidates are never ranked behind an optional
-lane. This ordering interacts with the response truncation limit deliberately.
+Structural generators SHALL be invoked before the wikilink, frontmatter-source,
+shared-source and embedding-proximity generators, and those four SHALL retain
+their existing order relative to one another. Because the response is truncated
+at the requested limit, this ordering is a budget: an author-written typed
+relation is the highest-evidence signal available and SHALL NOT be displaced by
+unbounded body-wikilink candidates, which are the lowest-cost to regenerate on a
+later read.
 
-#### Scenario: Candidate order places structural candidates between the two groups
+#### Scenario: A link-heavy page still yields its structural candidates
+
+- **WHEN** a page carries more body wikilinks than the requested limit and also carries a typed unit relation with no page-level counterpart
+- **THEN** the response still contains the unit-relation-lift candidate
+
+#### Scenario: Candidate order places structural candidates first
 
 - **WHEN** `suggest_relations` returns candidates from every generator for one page
-- **THEN** the first structural candidate appears after the first shared-source candidate and before the first embedding-proximity candidate
+- **THEN** every first structural candidate appears before the first wikilink candidate
+- **AND** the first wikilink, frontmatter-source, shared-source and embedding-proximity candidates remain in that relative order

--- a/openspec/changes/suggest-epistemic-relations-from-structure/specs/graph-semantic-integrity/spec.md
+++ b/openspec/changes/suggest-epistemic-relations-from-structure/specs/graph-semantic-integrity/spec.md
@@ -27,14 +27,27 @@ units.
 A structural method that proposes a directional epistemic relation SHALL do so
 only by promoting a relation kind that is already present on a unit-level
 relation edge of that same source page. The proposed relation type SHALL be the
-label the author wrote on that unit edge. The method MUST NOT propose a relation
-kind absent from the source page's own unit-level edges, and MUST NOT derive a
-relation kind from similarity, proximity, or any other measurement.
+normalized form of the label the author wrote on that unit edge, using the
+relation registry's own label normalization, so that the proposed bullet always
+satisfies the canonical relation grammar and can therefore be accepted. The
+method MUST NOT propose a relation kind absent from the source page's own
+unit-level edges, and MUST NOT derive a relation kind from similarity,
+proximity, or any other measurement.
 
 #### Scenario: Only authored kinds are proposed
 
 - **WHEN** a unit-relation-lift candidate is returned for a page
-- **THEN** its proposed relation type appears verbatim as the authored relation label on a unit-level relation edge of that page
+- **THEN** its proposed relation type is the normalized form of an authored relation label on a unit-level relation edge of that page
+
+#### Scenario: A kind authored on another page is not proposed here
+
+- **WHEN** one page authors a unit-level relation of an allowed kind and a second page authors none of that kind
+- **THEN** no structural candidate proposing that kind is returned for the second page
+
+#### Scenario: A non-canonical authored label yields an acceptable proposal
+
+- **WHEN** a semantic unit authors a relation whose label differs from canonical form only in case or separators
+- **THEN** the proposed relation type is its normalized form, and accepting the candidate through the governed write path succeeds rather than being refused as a malformed relation
 
 #### Scenario: An unauthored kind is never proposed
 
@@ -45,9 +58,17 @@ relation kind from similarity, proximity, or any other measurement.
 
 No structural relation-suggestion method SHALL propose `causes`, `caused_by`, or
 any other relation in the causality family, even when the author has written
-such a relation on one of the page's semantic units. Promoting a unit's causal
-claim to a page-level proposal would assert a mechanism between the pages that
-the author did not write.
+such a relation on one of the page's semantic units.
+
+The allowlisted families each express an **epistemic stance between bodies of
+knowledge** — answering, resolving, questioning, supporting, contradicting,
+refining, evidencing, duplicating. A page can coherently hold such a stance as a
+whole, so broadening a unit's stance to its page yields a statement a reviewer
+can judge. Causality instead asserts a **mechanism between the things
+described**, which is a property of the referents rather than of the documents:
+broadening it does not weaken the claim, it relocates it onto subjects that
+cannot bear it. That is the distinction, and it is why widening the allowlist to
+causality would require a different justification rather than one more entry.
 
 #### Scenario: An authored causal unit relation is not lifted
 

--- a/openspec/changes/suggest-epistemic-relations-from-structure/specs/graph-semantic-integrity/spec.md
+++ b/openspec/changes/suggest-epistemic-relations-from-structure/specs/graph-semantic-integrity/spec.md
@@ -1,0 +1,87 @@
+# graph-semantic-integrity
+
+## ADDED Requirements
+
+### Requirement: Structural Co-Participation Suggestions Remain Semantically Neutral
+
+A structural suggestion method that observes only co-participation — two pages
+carrying the same open question, or two pages whose units answer or resolve the
+same target — SHALL propose the registered symmetric relation `relates_to` and
+nothing else. It MUST NOT propose `duplicates`, `refines`, `supports`,
+`contradicts`, or any other directional epistemic relation, because a
+page-level target cannot express a claim that holds only between two semantic
+units.
+
+#### Scenario: Shared open question does not assert duplication
+
+- **WHEN** two pages carry the same normalized open question and no directional relation between the pages is observed
+- **THEN** the shared-open-question candidate proposes `relates_to` and identifies the shared question and the other page's question unit in its evidence
+
+#### Scenario: Shared resolution target does not assert refinement
+
+- **WHEN** two pages each carry a unit-level `answers` or `resolves` edge to the same target
+- **THEN** the shared-resolution-target candidate proposes `relates_to` and identifies the shared target and both sides' relation kinds in its evidence
+
+### Requirement: A Lifted Relation Kind Must Already Be Authored On The Page
+
+A structural method that proposes a directional epistemic relation SHALL do so
+only by promoting a relation kind that is already present on a unit-level
+relation edge of that same source page. The proposed relation type SHALL be the
+label the author wrote on that unit edge. The method MUST NOT propose a relation
+kind absent from the source page's own unit-level edges, and MUST NOT derive a
+relation kind from similarity, proximity, or any other measurement.
+
+#### Scenario: Only authored kinds are proposed
+
+- **WHEN** a unit-relation-lift candidate is returned for a page
+- **THEN** its proposed relation type appears verbatim as the authored relation label on a unit-level relation edge of that page
+
+#### Scenario: An unauthored kind is never proposed
+
+- **WHEN** a page carries no unit-level relation edge of a given kind
+- **THEN** no structural method proposes that kind for that page
+
+### Requirement: No Structural Method Proposes Causality
+
+No structural relation-suggestion method SHALL propose `causes`, `caused_by`, or
+any other relation in the causality family, even when the author has written
+such a relation on one of the page's semantic units. Promoting a unit's causal
+claim to a page-level proposal would assert a mechanism between the pages that
+the author did not write.
+
+#### Scenario: An authored causal unit relation is not lifted
+
+- **WHEN** a page carries a unit-level `causes` or `caused_by` relation to a target
+- **THEN** no structural candidate proposing a causality-family relation is returned for that page
+
+### Requirement: Structural Lifts Respect Relation Registry Standing
+
+A structural lift SHALL propose only relation kinds that the registry resolves
+with standing `core`, `alias`, or `extension`, and whose resolved family is
+within the method's declared allowlist. It MUST NOT propose a kind that the
+registry reports as unregistered, deprecated, or in violation of its declared
+scope, and the family allowlist SHALL be resolved through the registry at call
+time so a vault relation extension participates without a code change.
+
+#### Scenario: An unregistered authored label is not lifted
+
+- **WHEN** a page carries a unit-level relation whose label the registry does not resolve
+- **THEN** no structural candidate proposing that label is returned
+
+#### Scenario: An out-of-family registered kind is not lifted
+
+- **WHEN** a page carries a unit-level relation whose resolved family is outside the lift allowlist
+- **THEN** no structural candidate proposing that kind is returned
+
+### Requirement: Structural Suggestions Remain Proposal-Only
+
+Adding structural suggestion methods SHALL NOT write Markdown, mutate accepted
+graph edges, change retrieval ranking, invoke a reasoning model, or require a
+sidecar schema change or rebuild. The response SHALL continue to report
+`mutated=false` and `model_suggestions_available=false`.
+
+#### Scenario: Structural suggestion call is non-mutating
+
+- **WHEN** `suggest_relations` returns structural candidates for a page
+- **THEN** the response reports `mutated=false` and `model_suggestions_available=false`
+- **AND** the vault Markdown bytes and the graph sidecar edges are unchanged

--- a/openspec/changes/suggest-epistemic-relations-from-structure/specs/graph-semantic-integrity/spec.md
+++ b/openspec/changes/suggest-epistemic-relations-from-structure/specs/graph-semantic-integrity/spec.md
@@ -84,6 +84,11 @@ registry reports as unregistered, deprecated, or in violation of its declared
 scope, and the family allowlist SHALL be resolved through the registry at call
 time so a vault relation extension participates without a code change.
 
+Registry standing SHALL NOT be treated as sufficient. A structural method MUST
+NOT propose a relation label that the canonical relation-bullet grammar cannot
+carry, even when the registry resolves it with admitted standing, because such a
+candidate can never be accepted and would recur on every read.
+
 #### Scenario: An unregistered authored label is not lifted
 
 - **WHEN** a page carries a unit-level relation whose label the registry does not resolve
@@ -93,6 +98,11 @@ time so a vault relation extension participates without a code change.
 
 - **WHEN** a page carries a unit-level relation whose resolved family is outside the lift allowlist
 - **THEN** no structural candidate proposing that kind is returned
+
+#### Scenario: A registered kind the bullet grammar cannot carry is not lifted
+
+- **WHEN** a vault relation extension resolves with admitted standing but its label exceeds the canonical grammar's length bound, is shorter than the grammar's minimum, or contains a non-ASCII character
+- **THEN** no structural candidate proposing that label is returned, and a writable kind on the same unit is still proposed
 
 ### Requirement: Structural Suggestions Remain Proposal-Only
 

--- a/openspec/changes/suggest-epistemic-relations-from-structure/tasks.md
+++ b/openspec/changes/suggest-epistemic-relations-from-structure/tasks.md
@@ -37,6 +37,20 @@
 - [x] 4.3 Run `ruff check` on every changed file.
 - [x] 4.4 Run `openspec validate suggest-epistemic-relations-from-structure --strict` and `openspec validate --specs --strict`.
 
-## 5. Orchestrator-owned (NOT for the implementation lane)
+## 5. Independent-Review Fixes
 
-- [ ] 5.1 After this change merges, sync both delta specs into `openspec/specs/` and archive it with `openspec archive`. It cannot be archived from the implementation lane: the change is not shipped until it is on the default branch, and a sibling lane is authoring specs concurrently, so an early sync would collide in `openspec/specs/`.
+- [x] 5.1 Normalize the lifted label through `relation_registry.normalize_relation`, so a non-canonical authored kind (`Answers:`, `EVIDENCED BY:`) cannot produce a bullet the governed write refuses as `malformed_relation`; add an end-to-end test through `op_connect_memory`.
+- [x] 5.2 Amend the `graph-semantic-integrity` delta, which mandated the verbatim label, to require the normalized authored label.
+- [x] 5.3 Add a foreign authoring page to the lift-honesty test so relaxing the `source_path` filter is caught; the previous expectation was derived from the same filter and could not fail.
+- [x] 5.4 Register the structural generators ahead of the unbounded wikilink generator, pin the new order in both directions, and add a link-heavy-page regression; record the reversal and its reason in `design.md`.
+- [x] 5.5 Switch the page-level-edge fixture to the block-body bullet form, so the `src_key <> file_key` guard is what the test actually exercises.
+- [x] 5.6 Replace the vacuous evidence-fold assertion with a fixture where the cap bites (eight shared questions, five folded matches, honest total).
+- [x] 5.7 Cover the registry-standing gate: a vault extension kind lifts without a code change, and deprecated or scope-violating kinds in the same allowed family do not.
+- [x] 5.8 Suppress a later co-participation candidate that duplicates an earlier one's `(target, relation type)`, and add the scenario and a test.
+- [x] 5.9 State the principle that distinguishes causality from the eight allowlisted families rather than asserting it.
+- [x] 5.10 Update `_scaffold/_Schema/references/operations.md` to list the structural generators.
+- [x] 5.11 Re-run the mutation battery: each of the eight behaviours above must fail its own test when reverted.
+
+## 6. Orchestrator-owned (NOT for the implementation lane)
+
+- [ ] 6.1 After this change merges, sync both delta specs into `openspec/specs/` and archive it with `openspec archive`. It cannot be archived from the implementation lane: the change is not shipped until it is on the default branch, and a sibling lane is authoring specs concurrently, so an early sync would collide in `openspec/specs/`.

--- a/openspec/changes/suggest-epistemic-relations-from-structure/tasks.md
+++ b/openspec/changes/suggest-epistemic-relations-from-structure/tasks.md
@@ -51,6 +51,15 @@
 - [x] 5.10 Update `_scaffold/_Schema/references/operations.md` to list the structural generators.
 - [x] 5.11 Re-run the mutation battery: each of the eight behaviours above must fail its own test when reverted.
 
-## 6. Orchestrator-owned (NOT for the implementation lane)
+## 6. Recheck Follow-Through
 
-- [ ] 6.1 After this change merges, sync both delta specs into `openspec/specs/` and archive it with `openspec archive`. It cannot be archived from the implementation lane: the change is not shipped until it is on the default branch, and a sibling lane is authoring specs concurrently, so an early sync would collide in `openspec/specs/`.
+- [x] 6.1 Guard the normalized label against the canonical relation-bullet grammar itself (probe `markdown_relations._CANONICAL_RE`, do not restate it), applied per row before grouping and before the per-generator cap; cover the over-length key, over-length alias, one-character alias, and non-ASCII alias.
+- [x] 6.2 Add the writability clause and scenario to the `graph-semantic-integrity` registry-standing requirement.
+- [x] 6.3 Correct the `design.md` residual-risk claim that displaced wikilink candidates are regenerated on the next read. They are not: truncation precedes classification. State what was measured, and that the behaviour is pre-existing and mirror-symmetric rather than introduced here.
+- [x] 6.4 File `classify-relation-candidates-before-truncation` as a named follow-up.
+- [x] 6.5 File `relation-registry-registers-invalid-aliases` as a named follow-up, with the reproduction: the alias loop records `invalid_alias` without `continue`, so the alias registers anyway and resolves with `alias` standing.
+- [x] 6.6 Record in `design.md` that suppression survivor selection is first-generator-wins, so the suppressed candidate's evidence stops feeding any fingerprint and a change confined to the shared-resolution relationship will not resurface a dismissed `relates_to`.
+
+## 7. Orchestrator-owned (NOT for the implementation lane)
+
+- [ ] 7.1 After this change merges, sync both delta specs into `openspec/specs/` and archive it with `openspec archive`. It cannot be archived from the implementation lane: the change is not shipped until it is on the default branch, and a sibling lane is authoring specs concurrently, so an early sync would collide in `openspec/specs/`.

--- a/openspec/changes/suggest-epistemic-relations-from-structure/tasks.md
+++ b/openspec/changes/suggest-epistemic-relations-from-structure/tasks.md
@@ -1,0 +1,42 @@
+## 1. Red-First Regressions
+
+- [x] 1.1 Add a failing test proving `- relations: k: [[T]]` yields a lift candidate while a plain `- k [[T]]` bullet inside a block does not.
+- [x] 1.2 Add a failing test proving a unit relation the page already promoted under `## Relations` yields no lift candidate, with an unpromoted sibling as the positive control.
+- [x] 1.3 Add a failing lift-honesty test proving every emitted relation type appears verbatim as a `raw_relation` on a unit-level edge of the source page.
+- [x] 1.4 Add a failing test proving causality, unregistered and out-of-family kinds are refused while an allowed kind on the same unit is taken.
+- [x] 1.5 Add a failing test proving lift evidence carries the authoring unit's `unit_ref`, anchor, authored label and resolved family.
+- [x] 1.6 Add failing intra-generator aggregation tests for the lift and for shared open questions, proving one candidate per `(target, relation type)` with all matches folded into evidence.
+- [x] 1.7 Add a failing test proving shared open questions match across a rich `## Open Question`, a `- category:` override, and a compact `- [question]`.
+- [x] 1.8 Add a failing test pinning the ASCII-only `lower()` and trailing-`?` normalization limits.
+- [x] 1.9 Add failing tests proving result-adjacency pairs pages whose units answer or resolve the same target, and ignores page-level resolution edges, with a unit-level positive control.
+- [x] 1.10 Add a failing test proving structural candidates are bounded and the query count is constant in corpus size.
+- [x] 1.11 Add a failing test pinning registration order after the deterministic generators and before the embedding lane.
+- [x] 1.12 Add a soft-fail test proving a forced-unavailable snapshot still yields the deterministic candidates, raises nothing, and emits no structural candidate.
+- [x] 1.13 Add propose-only and determinism tests proving the vault bytes and graph edges are unchanged and repeated calls agree.
+- [x] 1.14 Add a failing dismissal-resurfacing test in the relation-queue suite: dismiss a `shared_open_question` candidate, re-anchor the *other* page's question with this page byte-identical, and require a new fingerprint.
+- [x] 1.15 Add a failing test proving an accepted lift bullet re-enters as a page-level edge with `registry_status == "core"`.
+
+## 2. Implementation
+
+- [x] 2.1 Add the family allowlist, registry-status allowlist, resolution-relation set, bound constants and the shared SQL normalization fragment.
+- [x] 2.2 Add `_structural_candidates`, opening one validated read snapshot for all three generators and soft-failing to `[]`.
+- [x] 2.3 Add `_unit_relation_lift_candidates`: unit-level `semantic_relation` edges with no page-level counterpart, gated by registry status in SQL and by relation family through the registry at call time, aggregated per `(target, authored label)`.
+- [x] 2.4 Add `_shared_open_question_candidates`: two UNIONed indexed branches per side, SQL-side normalization, aggregated per target with the other page's unit identity in evidence.
+- [x] 2.5 Add `_shared_resolution_target_candidates`: unit-level `answers`/`resolves` edges to a shared target on both sides, aggregated per target with both sides' unit identity and relation kinds in evidence.
+- [x] 2.6 Register the shared entry point in `suggest_relations` after the deterministic generators and before the embedding lane, with the truncation interaction recorded in a comment.
+
+## 3. Specifications
+
+- [x] 3.1 Add an ADDED requirement set to `epistemic-graph` covering the three structural methods, the shared snapshot and soft-fail, evidence identity, intra-generator aggregation, bounds and registration order.
+- [x] 3.2 Add an ADDED requirement set to `graph-semantic-integrity` covering structural semantic neutrality: no causality, lift-only-what-was-authored, co-participation proposes `relates_to`, and propose-only.
+
+## 4. Verification
+
+- [x] 4.1 Run the new suite plus `tests/test_epistemic_graph.py`, `tests/test_relation_queue.py`, `tests/test_relation_queue_commands.py`, `tests/test_relation_registry.py`, `tests/test_relation_review.py`, `tests/test_markdown_relations.py`, `tests/test_semantic_blocks.py`, `tests/test_semantic_units.py`, `tests/test_semantic_unit_graph.py`, `tests/test_epistemic_graph_relation_filter.py`, `tests/test_epistemic_graph_neighbors.py` and `tests/test_audit_relation_debt.py`.
+- [x] 4.2 Confirm `tests/fixtures/mcp_tool_schemas.json` and `src/exomem/tool_surface_contract.json` are unchanged.
+- [x] 4.3 Run `ruff check` on every changed file.
+- [x] 4.4 Run `openspec validate suggest-epistemic-relations-from-structure --strict` and `openspec validate --specs --strict`.
+
+## 5. Orchestrator-owned (NOT for the implementation lane)
+
+- [ ] 5.1 After this change merges, sync both delta specs into `openspec/specs/` and archive it with `openspec archive`. It cannot be archived from the implementation lane: the change is not shipped until it is on the default branch, and a sibling lane is authoring specs concurrently, so an early sync would collide in `openspec/specs/`.

--- a/plugins/claude-code/skills/exomem/references/operations.md
+++ b/plugins/claude-code/skills/exomem/references/operations.md
@@ -644,8 +644,12 @@ are review-only and never write to the vault.
 ### Procedure
 1. Pass a `path` for an existing page, or `draft_title` / `draft_body` for an
    unwritten draft.
-2. Review deterministic candidates from wikilinks, frontmatter sources, shared
-   sources/entities, supersession, and optional embedding proximity.
+2. Review deterministic candidates. Structural ones come first: a relation kind
+   you already typed on one of the page's own semantic units and have not yet
+   promoted to a page-level relation, pages carrying the same open question, and
+   pages whose units answer or resolve the same target. Then wikilinks,
+   frontmatter sources, shared sources/entities, supersession, and optional
+   embedding proximity.
 3. Model-backed suggestions are default-off (`include_model_suggestions=false`),
    response-only, and soft-fail with warnings when optional extras are absent.
 4. Persist accepted relations through the normal Markdown write path (`note` or

--- a/src/exomem/_scaffold/_Schema/references/operations.md
+++ b/src/exomem/_scaffold/_Schema/references/operations.md
@@ -644,8 +644,12 @@ are review-only and never write to the vault.
 ### Procedure
 1. Pass a `path` for an existing page, or `draft_title` / `draft_body` for an
    unwritten draft.
-2. Review deterministic candidates from wikilinks, frontmatter sources, shared
-   sources/entities, supersession, and optional embedding proximity.
+2. Review deterministic candidates. Structural ones come first: a relation kind
+   you already typed on one of the page's own semantic units and have not yet
+   promoted to a page-level relation, pages carrying the same open question, and
+   pages whose units answer or resolve the same target. Then wikilinks,
+   frontmatter sources, shared sources/entities, supersession, and optional
+   embedding proximity.
 3. Model-backed suggestions are default-off (`include_model_suggestions=false`),
    response-only, and soft-fail with warnings when optional extras are absent.
 4. Persist accepted relations through the normal Markdown write path (`note` or

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -4862,6 +4862,13 @@ def suggest_relations(
             candidates.extend(_wikilink_candidates(vault_root, page.body, rel))
             candidates.extend(_frontmatter_source_candidates(page))
             candidates.extend(_shared_source_candidates(vault_root, rel))
+            # Deliberately here: `_wikilink_candidates` is unbounded and the
+            # truncation below is at `limit`, so on a link-heavy page a
+            # structural candidate registered any later would never reach the
+            # acceptance queue. After the three deterministic generators (which
+            # are cheap and already relied upon) and before the optional
+            # embedding lane. Pinned by the suggestion-order test.
+            candidates.extend(_structural_candidates(vault_root, rel))
             candidates.extend(_embedding_proximity_candidates(vault_root, page))
     elif draft_body:
         candidates.extend(
@@ -6482,6 +6489,364 @@ def _shared_source_candidates(vault_root: Path, rel_path: str) -> list[dict[str,
             }
         )
     return out
+
+
+#: Relation families the unit-relation lift may promote to a page-level
+#: proposal.  Causality is deliberately absent: `causes`/`caused_by` are the
+#: family where promoting one unit's claim to the whole page would assert a
+#: mechanism between the *pages* that the author never wrote.
+_LIFT_RELATION_FAMILIES: frozenset[str] = frozenset(
+    {
+        "answer",
+        "resolution",
+        "question",
+        "support",
+        "contradiction",
+        "refinement",
+        "evidence",
+        "duplication",
+    }
+)
+
+#: Registry statuses a lift may promote.  The allowlist above is by *family*,
+#: and a family can admit a deprecated (or scope-violating, or unregistered)
+#: extension kind — we must never propose a bullet the writer will reject.
+_LIFT_REGISTRY_STATUSES: tuple[str, ...] = ("core", "alias", "extension")
+
+#: The resolution graph: unit-level relation kinds that answer or close a
+#: question.  Result-adjacency is defined over these, NOT over a `result` block
+#: kind — "both pages hold a result unit" fires on nearly every compiled note.
+_RESOLUTION_RELATION_TYPES: tuple[str, ...] = ("answers", "resolves")
+
+#: Row cap per structural query.  The bound lives in the sidecar, not in
+#: Python, so a corpus with hundreds of matches never materializes more.
+_STRUCTURAL_ROW_LIMIT = 200
+#: Candidates emitted per structural generator, per page.
+_STRUCTURAL_CANDIDATE_LIMIT = 3
+#: Match entries folded into one candidate's evidence.
+_STRUCTURAL_EVIDENCE_MATCHES = 5
+
+#: Deterministic question normalization, expressed in SQL on BOTH sides of the
+#: join so no Python normalizer can drift from it.  Two deliberate recall
+#: limits, asserted by `tests/test_structural_relation_suggestions.py`: SQLite's
+#: `lower()` is ASCII-only, so `Élan` and `élan` stay distinct questions; and
+#: `rtrim(..., '?')` drops trailing question marks only.
+_NORMALIZED_QUESTION_SQL = "trim(rtrim(lower(trim({column})), '?'))"
+
+
+def _placeholders(values: tuple[str, ...]) -> str:
+    return ", ".join("?" * len(values))
+
+
+_UNIT_RELATION_LIFT_SQL = f"""
+    SELECT e.dst_key, e.raw_relation, e.relation_type, e.source_anchor, n.unit_ref
+    FROM graph_edges AS e
+    LEFT JOIN graph_nodes AS n ON n.node_key = e.src_key
+    WHERE e.source_path = ?
+      AND e.origin = 'semantic_relation'
+      AND e.src_key <> ?
+      AND e.dst_key <> ?
+      AND e.dst_key LIKE 'file:%'
+      AND e.relation_type IS NOT NULL
+      AND e.registry_status IN ({_placeholders(_LIFT_REGISTRY_STATUSES)})
+      AND NOT EXISTS (
+          SELECT 1 FROM graph_edges AS p
+          WHERE p.src_key = ? AND p.dst_key = e.dst_key
+            AND p.relation_type = e.relation_type
+      )
+    ORDER BY e.dst_key, e.raw_relation, e.source_anchor
+    LIMIT ?
+"""
+
+_SHARED_OPEN_QUESTION_SQL = """
+    WITH mine AS (
+        SELECT {norm} AS question, unit_ref AS unit_ref, anchor AS anchor
+        FROM graph_nodes
+        WHERE path = ? AND unit_kind = 'open_question'
+        UNION
+        SELECT {norm}, unit_ref, anchor
+        FROM graph_nodes
+        WHERE path = ? AND unit_category IN ('question', 'open_question')
+    ),
+    theirs AS (
+        SELECT {norm} AS question, path AS path, unit_ref AS unit_ref, anchor AS anchor
+        FROM graph_nodes
+        WHERE path <> ? AND unit_kind = 'open_question'
+        UNION
+        SELECT {norm}, path, unit_ref, anchor
+        FROM graph_nodes
+        WHERE path <> ? AND unit_category IN ('question', 'open_question')
+    )
+    SELECT theirs.path, mine.question, mine.unit_ref, mine.anchor,
+           theirs.unit_ref, theirs.anchor
+    FROM mine JOIN theirs ON theirs.question = mine.question
+    WHERE mine.question <> ''
+    ORDER BY theirs.path, mine.question, theirs.unit_ref
+    LIMIT ?
+""".format(norm=_NORMALIZED_QUESTION_SQL.format(column="text"))
+
+_SHARED_RESOLUTION_TARGET_SQL = f"""
+    SELECT e2.source_path, e1.dst_key,
+           e1.raw_relation, e1.source_anchor, n1.unit_ref,
+           e2.raw_relation, e2.source_anchor, n2.unit_ref
+    FROM graph_edges AS e1
+    JOIN graph_edges AS e2 ON e2.dst_key = e1.dst_key
+    LEFT JOIN graph_nodes AS n1 ON n1.node_key = e1.src_key
+    LEFT JOIN graph_nodes AS n2 ON n2.node_key = e2.src_key
+    WHERE e1.source_path = ?
+      AND e1.origin = 'semantic_relation'
+      AND e1.src_key <> ?
+      AND e1.relation_type IN ({_placeholders(_RESOLUTION_RELATION_TYPES)})
+      AND e2.origin = 'semantic_relation'
+      AND e2.relation_type IN ({_placeholders(_RESOLUTION_RELATION_TYPES)})
+      AND e2.source_path <> ?
+      AND e2.src_key <> ('file:' || e2.source_path)
+    ORDER BY e2.source_path, e1.dst_key, e2.source_anchor
+    LIMIT ?
+"""
+
+
+def _structural_candidates(vault_root: Path, rel_path: str) -> list[dict[str, Any]]:
+    """Three structural generators over ONE validated read snapshot.
+
+    `_open_read_snapshot` re-checks freshness, recall-policy identity and graph
+    status on every call, and `relation_queue.build_queue` runs
+    `suggest_relations` for up to 50 pages, so the three generators share a
+    single connection rather than opening three. Soft-fails to `[]` when the
+    snapshot is unavailable, exactly like `_shared_source_candidates`.
+
+    All three target PAGES. That is why the two co-participation generators
+    propose only `relates_to`: "both pages carry the same question" would look
+    like `duplicates`, but with a page-level target the accepted bullet would
+    read `- duplicates [[B]]` and assert that the *pages* duplicate, which is
+    false — only their question units do. Revisit once `to` can address a unit.
+    """
+    index = EpistemicGraphIndex(vault_root)
+    conn = index._open_read_snapshot()
+    if conn is None:
+        return []
+    try:
+        rel = _with_md(rel_path)
+        file_key = _file_key(rel)
+        return [
+            *_unit_relation_lift_candidates(conn, index.registry, rel, file_key),
+            *_shared_open_question_candidates(conn, rel),
+            *_shared_resolution_target_candidates(conn, rel, file_key),
+        ]
+    except sqlite3.Error:  # a structural suggestion must never break a read
+        return []
+    finally:
+        conn.close()
+
+
+def _unit_relation_lift_candidates(
+    conn: sqlite3.Connection,
+    registry: relation_registry.RelationRegistry,
+    rel_path: str,
+    file_key: str,
+) -> list[dict[str, Any]]:
+    """Propose the kinds the author already typed on this page's own units.
+
+    A typed unit relation (`- relations: answers: [[Q]]`) produces a
+    BLOCK-level edge and no page-level edge at all, while a plain
+    `- supports [[X]]` bullet inside a block produces the opposite. The scaffold
+    documents the metadata form as *the* way to write typed unit relations, so
+    every one of them is an author-written directional epistemic claim the
+    page-level graph, relation-filtered recall, and contract inference cannot
+    see. `src_key <> file_key` selects exactly the first form; the `NOT EXISTS`
+    drops any unit relation the page has already promoted by hand.
+
+    This infers nothing: the proposed kind is the authored label itself, taken
+    verbatim from `raw_relation` on that unit edge. The generator can only fail
+    to promote a meaning, never manufacture one.
+    """
+    rows = conn.execute(
+        _UNIT_RELATION_LIFT_SQL,
+        (
+            rel_path,
+            file_key,
+            file_key,
+            *_LIFT_REGISTRY_STATUSES,
+            file_key,
+            _STRUCTURAL_ROW_LIMIT,
+        ),
+    ).fetchall()
+    # `_dedupe_candidates` keys on (from, to, relation_type, method) and
+    # EXCLUDES evidence, so one row per match would silently drop every unit
+    # after the first. Aggregate to one candidate per (to, relation_type).
+    grouped: dict[tuple[str, str], dict[str, Any]] = {}
+    for dst_key, raw_relation, relation_type, source_anchor, unit_ref in rows:
+        definition = registry.definition(str(relation_type or ""))
+        if definition is None or definition.family not in _LIFT_RELATION_FAMILIES:
+            continue
+        authored = str(raw_relation or "").strip()
+        if not authored:
+            continue
+        target = _with_md(str(dst_key or "").removeprefix("file:"))
+        if not target or target == rel_path:
+            continue
+        entry = grouped.setdefault(
+            (target, authored), {"family": definition.family, "units": []}
+        )
+        entry["units"].append(
+            {
+                "unit_ref": unit_ref,
+                "anchor": source_anchor,
+                "raw_relation": authored,
+                "relation_type": str(relation_type),
+            }
+        )
+    out: list[dict[str, Any]] = []
+    for (target, authored), entry in sorted(grouped.items())[
+        :_STRUCTURAL_CANDIDATE_LIMIT
+    ]:
+        units = sorted(
+            entry["units"],
+            key=lambda unit: (str(unit["anchor"] or ""), str(unit["unit_ref"] or "")),
+        )
+        out.append(
+            {
+                "from": rel_path,
+                "to": target,
+                "relation_type": authored,
+                "method": "unit_relation_lift",
+                "evidence": {
+                    "source_path": rel_path,
+                    "relation_family": entry["family"],
+                    "authoring_units": len(units),
+                    "units": units[:_STRUCTURAL_EVIDENCE_MATCHES],
+                },
+            }
+        )
+    return out
+
+
+def _shared_open_question_candidates(
+    conn: sqlite3.Connection, rel_path: str
+) -> list[dict[str, Any]]:
+    """Pages carrying the same normalized open question.
+
+    Question units land on two different axes: a rich `## Open Question` has
+    `unit_kind = 'open_question'` but a `- category:` metadata row overrides its
+    category, while a compact `- [question]` has `unit_kind = 'observation'` and
+    `unit_category = 'question'`. A predicate on either column alone misses
+    cases, and an `OR` across them defeats both indexes — so the query UNIONs
+    two indexed branches, per the precedent in `_connect`'s index comments.
+
+    Evidence carries the OTHER page's unit identity (`unit_ref` and anchor)
+    because `relation_queue._evidence_signal_version` hashes the evidence: a
+    candidate driven by another page whose evidence omitted that page's identity
+    would never resurface after dismissal, no matter how that page later changed.
+    """
+    rows = conn.execute(
+        _SHARED_OPEN_QUESTION_SQL,
+        (rel_path, rel_path, rel_path, rel_path, _STRUCTURAL_ROW_LIMIT),
+    ).fetchall()
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for other_path, question, unit_ref, anchor, other_unit_ref, other_anchor in rows:
+        target = _with_md(str(other_path or ""))
+        if not target or target == rel_path:
+            continue
+        grouped.setdefault(target, []).append(
+            {
+                "question": question,
+                "unit_ref": unit_ref,
+                "anchor": anchor,
+                "other_unit_ref": other_unit_ref,
+                "other_anchor": other_anchor,
+            }
+        )
+    return [
+        {
+            "from": rel_path,
+            "to": target,
+            "relation_type": "relates_to",
+            "method": "shared_open_question",
+            "evidence": {
+                "shared_questions": len(matches),
+                "matches": _ordered_matches(
+                    matches, ("question", "other_unit_ref", "unit_ref")
+                ),
+            },
+        }
+        for target, matches in sorted(grouped.items())[:_STRUCTURAL_CANDIDATE_LIMIT]
+    ]
+
+
+def _shared_resolution_target_candidates(
+    conn: sqlite3.Connection, rel_path: str, file_key: str
+) -> list[dict[str, Any]]:
+    """Pages whose units answer or resolve the same target as this page's.
+
+    Adjacency is defined over the resolution graph, not over a `result` block
+    kind: two pages are adjacent when each carries a UNIT-level `answers` or
+    `resolves` edge to the same target — competing or complementary answers to
+    one thing. That mirrors `_shared_source_candidates` and, like it, observes
+    nothing directional, so the proposal is `relates_to`.
+
+    Evidence carries the other page's unit identity and the relation kinds both
+    sides used, for the same fingerprint reason as `shared_open_question`.
+    """
+    rows = conn.execute(
+        _SHARED_RESOLUTION_TARGET_SQL,
+        (
+            rel_path,
+            file_key,
+            *_RESOLUTION_RELATION_TYPES,
+            *_RESOLUTION_RELATION_TYPES,
+            rel_path,
+            _STRUCTURAL_ROW_LIMIT,
+        ),
+    ).fetchall()
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        (
+            other_path,
+            target_key,
+            relation,
+            anchor,
+            unit_ref,
+            other_relation,
+            other_anchor,
+            other_unit_ref,
+        ) = row
+        target = _with_md(str(other_path or ""))
+        if not target or target == rel_path:
+            continue
+        grouped.setdefault(target, []).append(
+            {
+                "target": _with_md(str(target_key or "").removeprefix("file:")),
+                "relation": relation,
+                "anchor": anchor,
+                "unit_ref": unit_ref,
+                "other_relation": other_relation,
+                "other_anchor": other_anchor,
+                "other_unit_ref": other_unit_ref,
+            }
+        )
+    return [
+        {
+            "from": rel_path,
+            "to": target,
+            "relation_type": "relates_to",
+            "method": "shared_resolution_target",
+            "evidence": {
+                "shared_targets": len(matches),
+                "matches": _ordered_matches(
+                    matches, ("target", "other_unit_ref", "unit_ref")
+                ),
+            },
+        }
+        for target, matches in sorted(grouped.items())[:_STRUCTURAL_CANDIDATE_LIMIT]
+    ]
+
+
+def _ordered_matches(
+    matches: list[dict[str, Any]], keys: tuple[str, ...]
+) -> list[dict[str, Any]]:
+    """Deterministically order and cap one candidate's folded evidence."""
+    ordered = sorted(matches, key=lambda match: tuple(str(match[key] or "") for key in keys))
+    return ordered[:_STRUCTURAL_EVIDENCE_MATCHES]
 
 
 def _embedding_proximity_candidates(vault_root: Path, page) -> list[dict[str, Any]]:

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -30,6 +30,7 @@ from . import (
     deferred_index,
     freshness,
     graph_sync,
+    markdown_relations,
     memory_refs,
     mutation_lock,
     recall_policy,
@@ -6546,8 +6547,39 @@ _STRUCTURAL_EVIDENCE_MATCHES = 5
 _NORMALIZED_QUESTION_SQL = "trim(rtrim(lower(trim({column})), '?'))"
 
 
+#: A label is only proposable if the canonical relation-bullet grammar can carry
+#: it. Derived from that grammar rather than restating it, so the two cannot
+#: drift.
+_CANONICAL_RELATION_PROBE = "- {label} [[probe]]"
+
+
 def _placeholders(values: tuple[str, ...]) -> str:
     return ", ".join("?" * len(values))
+
+
+def _is_writable_relation_label(label: str) -> bool:
+    """Would this label survive the canonical relation-bullet grammar?
+
+    Registry standing and bullet writability are separate questions, and the
+    registry is the weaker gate: `relation_registry._KEY_RE` is length-unbounded
+    while the grammar caps a label at 81 characters, `_LABEL_RE` admits a
+    one-character alias where the grammar needs two, and an alias that fails
+    `_LABEL_RE` is recorded as a finding but still registered (a loader defect
+    filed as a follow-up, not fixed here). So `extension` and `alias` standing
+    both admit labels `markdown_relations` cannot parse, and proposing one would
+    author a bullet the governed write refuses as `malformed_relation` — a queue
+    item that recurs on every read and names nothing the reader can act on. A
+    candidate that can never be accepted is worse than no candidate.
+
+    Applied per row, before grouping and before the per-generator cap, so an
+    unproposable label cannot consume a slot a writable one would have taken.
+    """
+    return (
+        markdown_relations._CANONICAL_RE.match(
+            _CANONICAL_RELATION_PROBE.format(label=label)
+        )
+        is not None
+    )
 
 
 _UNIT_RELATION_LIFT_SQL = f"""
@@ -6718,7 +6750,7 @@ def _unit_relation_lift_candidates(
         if definition is None or definition.family not in _LIFT_RELATION_FAMILIES:
             continue
         authored = relation_registry.normalize_relation(str(raw_relation or ""))
-        if not authored:
+        if not authored or not _is_writable_relation_label(authored):
             continue
         target = _with_md(str(dst_key or "").removeprefix("file:"))
         if not target or target == rel_path:

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -4859,16 +4859,28 @@ def suggest_relations(
             else None
         )
         if page is not None:
+            # Structural candidates go FIRST, ahead of the unbounded wikilink
+            # generator. The truncation below is at `limit` (10 by default in
+            # the acceptance queue), so ordering is a budget, not a cosmetic:
+            # a dense compiled note with a dozen body wikilinks would otherwise
+            # yield zero structural candidates -- and that is precisely the page
+            # that carries typed unit relations, so the change would be silent
+            # on its own motivating case. Worse, wikilink candidates are
+            # generated before `relation_queue._classify_candidate` drops the
+            # already-authored ones, so the budget can be spent on candidates
+            # that are then discarded.
+            #
+            # The ranking that follows from that: an author-written typed unit
+            # relation is the highest-evidence signal in the set, and a body
+            # wikilink is the lowest-cost to regenerate on the next read. The
+            # three structural generators are individually capped, so they can
+            # take at most nine of ten slots; the existing four keep their
+            # relative order among themselves. Pinned in both directions by the
+            # suggestion-order test.
+            candidates.extend(_structural_candidates(vault_root, rel))
             candidates.extend(_wikilink_candidates(vault_root, page.body, rel))
             candidates.extend(_frontmatter_source_candidates(page))
             candidates.extend(_shared_source_candidates(vault_root, rel))
-            # Deliberately here: `_wikilink_candidates` is unbounded and the
-            # truncation below is at `limit`, so on a link-heavy page a
-            # structural candidate registered any later would never reach the
-            # acceptance queue. After the three deterministic generators (which
-            # are cheap and already relied upon) and before the optional
-            # embedding lane. Pinned by the suggestion-order test.
-            candidates.extend(_structural_candidates(vault_root, rel))
             candidates.extend(_embedding_proximity_candidates(vault_root, page))
     elif draft_body:
         candidates.extend(
@@ -6628,7 +6640,7 @@ def _structural_candidates(vault_root: Path, rel_path: str) -> list[dict[str, An
     try:
         rel = _with_md(rel_path)
         file_key = _file_key(rel)
-        return [
+        produced = [
             *_unit_relation_lift_candidates(conn, index.registry, rel, file_key),
             *_shared_open_question_candidates(conn, rel),
             *_shared_resolution_target_candidates(conn, rel, file_key),
@@ -6637,6 +6649,22 @@ def _structural_candidates(vault_root: Path, rel_path: str) -> list[dict[str, An
         return []
     finally:
         conn.close()
+    # The two co-participation generators routinely find the SAME peer — pages
+    # that share a question usually also answer the same thing — and both
+    # propose `relates_to`, so they emit the identical bullet. `_dedupe_candidates`
+    # keys on `method` and would keep both, spending two of ten slots on one
+    # edge the reviewer can only accept once (after which the second is filtered
+    # as an authored edge anyway). Suppress the later duplicate here, where the
+    # collision is visible, rather than shipping the noise.
+    out: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for candidate in produced:
+        key = (str(candidate["to"]), str(candidate["relation_type"]))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(candidate)
+    return out
 
 
 def _unit_relation_lift_candidates(
@@ -6656,9 +6684,19 @@ def _unit_relation_lift_candidates(
     see. `src_key <> file_key` selects exactly the first form; the `NOT EXISTS`
     drops any unit relation the page has already promoted by hand.
 
-    This infers nothing: the proposed kind is the authored label itself, taken
-    verbatim from `raw_relation` on that unit edge. The generator can only fail
-    to promote a meaning, never manufacture one.
+    This infers nothing: the proposed kind is the author's own label from
+    `raw_relation` on that unit edge, put through the registry's own
+    `normalize_relation`. The generator can only fail to promote a meaning,
+    never manufacture one.
+
+    Normalizing is not cosmetic. `- relations: Answers: [[T]]` parses with no
+    diagnostic and resolves to core standing, but the canonical relation-bullet
+    grammar (`markdown_relations`) accepts only `[a-z][a-z0-9_.-]{1,80}`. Emitting
+    the label verbatim would therefore produce `- Answers [[T]]`, which
+    `relation_queue.accept` refuses with `SEMANTIC_CONTRACT_BLOCKED` — a queue
+    item that can never be accepted and recurs on every `build_queue`.
+    `normalize_relation` is the same function the registry used to resolve the
+    edge in the first place, so the proposal stays the authored kind.
     """
     rows = conn.execute(
         _UNIT_RELATION_LIFT_SQL,
@@ -6679,7 +6717,7 @@ def _unit_relation_lift_candidates(
         definition = registry.definition(str(relation_type or ""))
         if definition is None or definition.family not in _LIFT_RELATION_FAMILIES:
             continue
-        authored = str(raw_relation or "").strip()
+        authored = relation_registry.normalize_relation(str(raw_relation or ""))
         if not authored:
             continue
         target = _with_md(str(dst_key or "").removeprefix("file:"))

--- a/tests/test_relation_queue.py
+++ b/tests/test_relation_queue.py
@@ -284,3 +284,51 @@ def test_read_never_writes_to_the_vault(tmp_path: Path) -> None:
     before = _tree_hash(tmp_path)
     relation_queue.build_queue(tmp_path)
     assert _tree_hash(tmp_path) == before
+
+
+def test_dismissed_shared_open_question_resurfaces_when_the_other_page_changes(
+    tmp_path: Path,
+) -> None:
+    # `shared_open_question` is driven by the OTHER page's semantic unit, so its
+    # evidence must carry that unit's identity. If it did not, dismissing the
+    # candidate would be permanent through arbitrary later edits to the page
+    # that produced it — exactly the failure `_evidence_signal_version` exists
+    # to prevent, but here with a real graph-backed generator rather than a
+    # stubbed one.
+    from exomem import epistemic_graph
+
+    question = "Why is the tail latency spiky?"
+    _write_page(tmp_path, "alpha", f"## Open Question\n- id: q-alpha\n\n{question}")
+    beta = _write_page(tmp_path, "beta", f"## Open Question\n- id: q-beta\n\n{question}")
+    epistemic_graph.EpistemicGraphIndex(tmp_path).rebuild_all()
+    alpha_bytes = (
+        tmp_path / "Knowledge Base" / "Notes" / "Insights" / "alpha.md"
+    ).read_bytes()
+
+    first = relation_queue.build_queue(tmp_path)
+    item = next(
+        it
+        for it in _all_items(first)
+        if it["from"].endswith("alpha.md") and it["method"] == "shared_open_question"
+    )
+    relation_queue.triage(tmp_path, ref=item["ref"], action="dismiss")
+    assert item["ref"] not in {it["ref"] for it in _all_items(relation_queue.build_queue(tmp_path))}
+
+    # Re-anchor beta's question. alpha.md is untouched on disk, and the shared
+    # normalized question text is unchanged, so the candidate must come back.
+    beta.write_text(
+        beta.read_text(encoding="utf-8").replace("q-beta", "q-beta-renamed"),
+        encoding="utf-8",
+    )
+    epistemic_graph.EpistemicGraphIndex(tmp_path).rebuild_all()
+    assert (
+        tmp_path / "Knowledge Base" / "Notes" / "Insights" / "alpha.md"
+    ).read_bytes() == alpha_bytes
+
+    resurfaced = next(
+        it
+        for it in _all_items(relation_queue.build_queue(tmp_path))
+        if it["from"].endswith("alpha.md") and it["method"] == "shared_open_question"
+    )
+    assert resurfaced["ref"] == item["ref"]
+    assert resurfaced["fingerprint"] != item["fingerprint"]

--- a/tests/test_structural_relation_suggestions.py
+++ b/tests/test_structural_relation_suggestions.py
@@ -1,0 +1,691 @@
+"""Structural relation suggestions derived from authored semantic units.
+
+Three generators read the typed graph sidecar through one shared read snapshot
+and propose page-level relation candidates that the page-level graph cannot
+already see:
+
+* ``unit_relation_lift`` — a typed unit relation (``- relations: answers: [[Q]]``)
+  is a block-level edge with no page-level counterpart, so the authored kind is
+  lifted to a page-level proposal.
+* ``shared_open_question`` — two pages carrying the same normalized question.
+* ``shared_resolution_target`` — two pages each answering/resolving the same
+  target.
+
+Everything here is propose-only: nothing writes Markdown or graph edges.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from exomem import corpus_aware, epistemic_graph, relation_queue
+
+KB = "Knowledge Base/Notes/Insights"
+
+
+def _write(vault: Path, rel: str, body: str) -> Path:
+    path = vault / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _page(vault: Path, name: str, body: str) -> Path:
+    return _write(
+        vault,
+        f"{KB}/{name}.md",
+        # The H1 is deliberately NOT a bare `{name}`: an H1 whose normalized
+        # title matches a `semantic_blocks.BLOCK_TYPES` entry (`source`,
+        # `claim`, ...) becomes a rich unit that swallows the whole page.
+        f"---\ntype: insight\nstatus: active\n---\n# {name} note\n\n{body}\n",
+    )
+
+
+def _build(vault: Path) -> epistemic_graph.EpistemicGraphIndex:
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    return index
+
+
+def _candidates(vault: Path, rel_path: str, *, limit: int = 50) -> list[dict]:
+    return epistemic_graph.suggest_relations(vault, path=rel_path, limit=limit)[
+        "candidates"
+    ]
+
+
+def _by_method(candidates: list[dict], method: str) -> list[dict]:
+    return [c for c in candidates if c["method"] == method]
+
+
+# --------------------------------------------------------------------------
+# The seam the lift rests on: two authoring forms behave oppositely.
+# --------------------------------------------------------------------------
+
+
+def test_metadata_relation_lifts_and_plain_bullet_does_not(tmp_path: Path) -> None:
+    """`- relations: k: [[T]]` is block-level only; `- k [[T]]` is already page-level.
+
+    A metadata relation row produces an edge whose `src_key` is the BLOCK key
+    and no page-level edge at all, so the page-level graph, relation-filtered
+    recall, and contract inference cannot see the author's typed claim. A plain
+    relation bullet inside a block produces exactly the opposite — a page-level
+    edge that is absent from `unit.relations` — so lifting it would duplicate an
+    edge that already exists.
+    """
+    vault = tmp_path / "vault"
+    _page(vault, "target-answer", "The answer.")
+    _page(vault, "target-support", "The supported claim.")
+    _page(
+        vault,
+        "source",
+        "## Claim\n"
+        "- id: c-1\n"
+        f"- relations: answers: [[{KB}/target-answer]]\n"
+        "\n"
+        "A typed unit relation.\n"
+        "\n"
+        "## Finding\n"
+        "- id: f-1\n"
+        "\n"
+        f"- supports [[{KB}/target-support]]\n",
+    )
+    _build(vault)
+
+    lifted = _by_method(_candidates(vault, f"{KB}/source.md"), "unit_relation_lift")
+
+    assert [(c["relation_type"], c["to"]) for c in lifted] == [
+        ("answers", f"{KB}/target-answer.md")
+    ]
+    assert all(c["relation_type"] != "supports" for c in lifted)
+
+
+def test_lift_is_suppressed_when_the_page_already_authored_the_edge(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "target-answer", "The answer.")
+    _page(vault, "target-open", "The unpromoted answer.")
+    _page(
+        vault,
+        "source",
+        "## Claim\n"
+        "- id: c-1\n"
+        f"- relations: answers: [[{KB}/target-answer]], answers: [[{KB}/target-open]]\n"
+        "\n"
+        "One typed unit relation already promoted by hand, one not.\n"
+        "\n"
+        "## Relations\n"
+        "\n"
+        f"- answers [[{KB}/target-answer]]\n",
+    )
+    _build(vault)
+
+    lifted = _by_method(_candidates(vault, f"{KB}/source.md"), "unit_relation_lift")
+
+    assert [c["to"] for c in lifted] == [f"{KB}/target-open.md"]
+
+
+# --------------------------------------------------------------------------
+# Lift honesty: it may only promote a kind the author already typed.
+# --------------------------------------------------------------------------
+
+
+def test_lift_only_proposes_kinds_present_on_the_pages_own_unit_edges(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "target", "A target page.")
+    _page(
+        vault,
+        "source",
+        "## Claim\n"
+        "- id: c-1\n"
+        f"- relations: answers: [[{KB}/target]], refines: [[{KB}/target]]\n"
+        "\n"
+        "A claim with two typed unit relations.\n",
+    )
+    index = _build(vault)
+
+    lifted = _by_method(_candidates(vault, f"{KB}/source.md"), "unit_relation_lift")
+    assert lifted
+
+    authored_raw = {
+        edge["raw_relation"]
+        for edge in index.edges()
+        if edge["source_path"] == f"{KB}/source.md"
+        and edge["origin"] == "semantic_relation"
+        and edge["src_key"] != f"file:{KB}/source.md"
+    }
+    for candidate in lifted:
+        assert candidate["relation_type"] in authored_raw
+
+
+def test_lift_never_proposes_causality_or_unregistered_kinds(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "target", "A target page.")
+    _page(
+        vault,
+        "source",
+        "## Claim\n"
+        "- id: c-1\n"
+        f"- relations: causes: [[{KB}/target]], caused_by: [[{KB}/target]], "
+        f"made_up_relation: [[{KB}/target]], mentions: [[{KB}/target]], "
+        f"supports: [[{KB}/target]]\n"
+        "\n"
+        "A claim carrying four kinds the lift must refuse and one it must take.\n",
+    )
+    _build(vault)
+
+    lifted = _by_method(_candidates(vault, f"{KB}/source.md"), "unit_relation_lift")
+
+    # `supports` is the positive control: without it an empty result would pass
+    # for the wrong reason (a generator that emits nothing at all).
+    assert [c["relation_type"] for c in lifted] == ["supports"]
+
+
+def test_lift_carries_the_authoring_unit_identity_in_evidence(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "target", "A target page.")
+    _page(
+        vault,
+        "source",
+        "## Claim\n"
+        "- id: c-1\n"
+        f"- relations: answers: [[{KB}/target]]\n"
+        "\n"
+        "A typed unit relation.\n",
+    )
+    _build(vault)
+
+    candidate = _by_method(
+        _candidates(vault, f"{KB}/source.md"), "unit_relation_lift"
+    )[0]
+    evidence = candidate["evidence"]
+
+    assert evidence["relation_family"] == "answer"
+    assert [unit["anchor"] for unit in evidence["units"]] == ["c-1"]
+    assert evidence["units"][0]["unit_ref"].endswith("#c-1")
+    assert evidence["units"][0]["raw_relation"] == "answers"
+
+
+def test_lift_folds_several_authoring_units_into_one_candidate(
+    tmp_path: Path,
+) -> None:
+    """`_dedupe_candidates` excludes evidence, so a per-row emitter loses rows."""
+    vault = tmp_path / "vault"
+    _page(vault, "target", "A target page.")
+    _page(
+        vault,
+        "source",
+        "## Claim\n"
+        "- id: c-1\n"
+        f"- relations: answers: [[{KB}/target]]\n"
+        "\n"
+        "First claim.\n"
+        "\n"
+        "## Finding\n"
+        "- id: f-1\n"
+        f"- relations: answers: [[{KB}/target]]\n"
+        "\n"
+        "Second unit, same authored kind and target.\n",
+    )
+    _build(vault)
+
+    lifted = _by_method(_candidates(vault, f"{KB}/source.md"), "unit_relation_lift")
+
+    assert len(lifted) == 1
+    assert [unit["anchor"] for unit in lifted[0]["evidence"]["units"]] == ["c-1", "f-1"]
+
+
+# --------------------------------------------------------------------------
+# Shared open questions: two indexed axes, UNIONed.
+# --------------------------------------------------------------------------
+
+
+def test_shared_open_question_spans_both_question_axes(tmp_path: Path) -> None:
+    """A rich `## Open Question`, a `- category:` override, and a compact
+    `- [question]` land on different indexed columns; all three must match."""
+    vault = tmp_path / "vault"
+    question = "Why is the tail latency spiky?"
+    _page(vault, "rich", f"## Open Question\n- id: q-rich\n\n{question}\n")
+    _page(
+        vault,
+        "override",
+        f"## Open Question\n- id: q-over\n- category: risk\n\n{question}\n",
+    )
+    _page(vault, "compact", f"- [question] {question}\n")
+    _build(vault)
+
+    for name in ("rich", "override", "compact"):
+        candidates = _by_method(
+            _candidates(vault, f"{KB}/{name}.md"), "shared_open_question"
+        )
+        others = {c["to"] for c in candidates}
+        assert others == {
+            f"{KB}/{other}.md"
+            for other in ("rich", "override", "compact")
+            if other != name
+        }, name
+        assert all(c["relation_type"] == "relates_to" for c in candidates)
+
+
+def test_shared_open_question_evidence_carries_the_other_pages_unit_identity(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    question = "Why is the tail latency spiky?"
+    _page(vault, "alpha", f"## Open Question\n- id: q-alpha\n\n{question}\n")
+    _page(vault, "beta", f"## Open Question\n- id: q-beta\n\n{question}\n")
+    _build(vault)
+
+    candidate = _by_method(
+        _candidates(vault, f"{KB}/alpha.md"), "shared_open_question"
+    )[0]
+    match = candidate["evidence"]["matches"][0]
+
+    assert match["question"] == "why is the tail latency spiky"
+    assert match["anchor"] == "q-alpha"
+    assert match["other_anchor"] == "q-beta"
+    assert match["other_unit_ref"].endswith("#q-beta")
+
+
+def test_shared_open_question_folds_several_matches_into_one_candidate(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    _page(
+        vault,
+        "alpha",
+        "## Open Question\n- id: q-a1\n\nWhy is the tail latency spiky?\n\n"
+        "## Open Question\n- id: q-a2\n\nWhere does the retry storm start?\n",
+    )
+    _page(
+        vault,
+        "beta",
+        "## Open Question\n- id: q-b1\n\nWhy is the tail latency spiky?\n\n"
+        "## Open Question\n- id: q-b2\n\nWhere does the retry storm start?\n",
+    )
+    _build(vault)
+
+    candidates = _by_method(
+        _candidates(vault, f"{KB}/alpha.md"), "shared_open_question"
+    )
+
+    assert len(candidates) == 1
+    assert [m["question"] for m in candidates[0]["evidence"]["matches"]] == [
+        "where does the retry storm start",
+        "why is the tail latency spiky",
+    ]
+
+
+def test_shared_open_question_normalization_is_ascii_lower_and_trailing_question_mark(
+    tmp_path: Path,
+) -> None:
+    """Documented deterministic recall limits: SQLite's ASCII-only `lower()` and
+    trailing-`?` stripping. A non-ASCII case difference is NOT normalized away."""
+    vault = tmp_path / "vault"
+    _page(vault, "alpha", "## Open Question\n- id: q-a\n\nWhy Is The Tail Spiky?\n")
+    _page(vault, "beta", "## Open Question\n- id: q-b\n\nwhy is the tail spiky\n")
+    _page(vault, "gamma", "## Open Question\n- id: q-g\n\nÉlan vital ou éclat?\n")
+    _page(vault, "delta", "## Open Question\n- id: q-d\n\nélan vital ou éclat\n")
+    _build(vault)
+
+    alpha = _by_method(_candidates(vault, f"{KB}/alpha.md"), "shared_open_question")
+    gamma = _by_method(_candidates(vault, f"{KB}/gamma.md"), "shared_open_question")
+
+    assert [c["to"] for c in alpha] == [f"{KB}/beta.md"]
+    assert gamma == []
+
+
+# --------------------------------------------------------------------------
+# Shared resolution target: co-participation over the resolution graph.
+# --------------------------------------------------------------------------
+
+
+def test_shared_resolution_target_pairs_pages_answering_the_same_target(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "question", "The open question page.")
+    _page(
+        vault,
+        "alpha",
+        "## Claim\n- id: c-alpha\n"
+        f"- relations: answers: [[{KB}/question]]\n\nOne answer.\n",
+    )
+    _page(
+        vault,
+        "beta",
+        "## Claim\n- id: c-beta\n"
+        f"- relations: resolves: [[{KB}/question]]\n\nA competing answer.\n",
+    )
+    _build(vault)
+
+    candidates = _by_method(
+        _candidates(vault, f"{KB}/alpha.md"), "shared_resolution_target"
+    )
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate["to"] == f"{KB}/beta.md"
+    assert candidate["relation_type"] == "relates_to"
+    match = candidate["evidence"]["matches"][0]
+    assert match["target"] == f"{KB}/question.md"
+    assert match["relation"] == "answers"
+    assert match["other_relation"] == "resolves"
+    assert match["other_anchor"] == "c-beta"
+    assert match["other_unit_ref"].endswith("#c-beta")
+
+
+def test_shared_resolution_target_ignores_page_level_resolution_edges(
+    tmp_path: Path,
+) -> None:
+    """Adjacency is defined over UNIT-level resolution edges on both sides."""
+    vault = tmp_path / "vault"
+    _page(vault, "question", "The open question page.")
+    _page(
+        vault,
+        "alpha",
+        "## Claim\n- id: c-alpha\n"
+        f"- relations: answers: [[{KB}/question]]\n\nOne answer.\n",
+    )
+    _page(
+        vault,
+        "beta",
+        f"## Relations\n\n- answers [[{KB}/question]]\n",
+    )
+    _page(
+        vault,
+        "gamma",
+        "## Claim\n- id: c-gamma\n"
+        f"- relations: answers: [[{KB}/question]]\n\nA unit-level answer.\n",
+    )
+    _build(vault)
+
+    candidates = _by_method(
+        _candidates(vault, f"{KB}/alpha.md"), "shared_resolution_target"
+    )
+
+    # gamma is the positive control: beta's page-level edge must be the only
+    # thing missing, not the generator itself.
+    assert [c["to"] for c in candidates] == [f"{KB}/gamma.md"]
+
+
+# --------------------------------------------------------------------------
+# Bounds, ordering, soft-fail, purity.
+# --------------------------------------------------------------------------
+
+
+class _CountingConnection:
+    """Counts `execute` calls made by the structural generators."""
+
+    def __init__(self, inner, calls: list[str]) -> None:
+        self._inner = inner
+        self._calls = calls
+
+    def execute(self, sql, *args, **kwargs):
+        self._calls.append(sql)
+        return self._inner.execute(sql, *args, **kwargs)
+
+    def close(self) -> None:
+        self._inner.close()
+
+
+def _count_snapshot_queries(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    calls: list[str] = []
+    real = epistemic_graph.EpistemicGraphIndex._open_read_snapshot
+
+    def patched(self, **kwargs):
+        conn = real(self, **kwargs)
+        return None if conn is None else _CountingConnection(conn, calls)
+
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex, "_open_read_snapshot", patched
+    )
+    return calls
+
+
+def test_structural_candidates_are_bounded_and_query_count_is_constant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    question = "Why is the tail latency spiky?"
+    _page(vault, "alpha", f"## Open Question\n- id: q-alpha\n\n{question}\n")
+    for n in range(200):
+        _page(vault, f"other-{n:03d}", f"## Open Question\n- id: q-{n:03d}\n\n{question}\n")
+    _build(vault)
+    small = tmp_path / "small"
+    _page(small, "alpha", f"## Open Question\n- id: q-alpha\n\n{question}\n")
+    _page(small, "beta", f"## Open Question\n- id: q-beta\n\n{question}\n")
+    _build(small)
+
+    # Patched only after both sidecars exist: the proxy covers the read path,
+    # not the rebuild path.
+    calls = _count_snapshot_queries(monkeypatch)
+    candidates = _by_method(
+        _candidates(vault, f"{KB}/alpha.md", limit=500), "shared_open_question"
+    )
+    big_corpus_queries = len(calls)
+    calls.clear()
+    _candidates(small, f"{KB}/alpha.md", limit=500)
+
+    assert len(candidates) == 3
+    assert len(candidates[0]["evidence"]["matches"]) <= 5
+    assert big_corpus_queries == len(calls)
+
+
+def test_structural_generators_run_after_deterministic_and_before_embeddings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Registration order is deliberate: `_wikilink_candidates` is unbounded and
+    `suggest_relations` truncates at `limit`, so the position is load-bearing."""
+    vault = tmp_path / "vault"
+    _write(
+        vault,
+        "Knowledge Base/Sources/Articles/shared-source.md",
+        "---\ntype: source\nsource_type: article\ningested_into: []\n---\n"
+        "# Shared Source\n\n## Capture\n\nMaterial.\n",
+    )
+    question = "Why is the tail latency spiky?"
+    _write(
+        vault,
+        f"{KB}/neighbour.md",
+        "---\ntype: insight\nstatus: active\nsources:\n"
+        '  - "[[Knowledge Base/Sources/Articles/shared-source]]"\n---\n'
+        f"# neighbour note\n\n## Open Question\n- id: q-n\n\n{question}\n",
+    )
+    _page(vault, "target", "A target page.")
+    _write(
+        vault,
+        f"{KB}/source.md",
+        "---\ntype: insight\nstatus: active\nsources:\n"
+        '  - "[[Knowledge Base/Sources/Articles/shared-source]]"\n---\n'
+        f"# source note\n\nSee [[{KB}/target]].\n\n"
+        f"## Open Question\n- id: q-s\n- relations: answers: [[{KB}/target]]\n\n"
+        f"{question}\n\n"
+        "## Claim\n- id: c-s\n"
+        f"- relations: resolves: [[{KB}/target]]\n\nA claim.\n",
+    )
+    _write(
+        vault,
+        f"{KB}/rival.md",
+        "---\ntype: insight\nstatus: active\n---\n# rival\n\n"
+        "## Claim\n- id: c-r\n"
+        f"- relations: answers: [[{KB}/target]]\n\nA rival answer.\n",
+    )
+    _build(vault)
+    monkeypatch.setattr(
+        corpus_aware,
+        "_best_cosine_per_file",
+        lambda *_args, **_kwargs: {f"{KB}/target": 0.9},
+    )
+
+    methods = [c["method"] for c in _candidates(vault, f"{KB}/source.md", limit=500)]
+    first = {method: methods.index(method) for method in set(methods)}
+
+    for method in (
+        "wikilink",
+        "frontmatter_sources",
+        "shared_sources",
+        "unit_relation_lift",
+        "shared_open_question",
+        "shared_resolution_target",
+        "embedding_proximity",
+    ):
+        assert method in first, method
+    assert (
+        first["shared_sources"]
+        < first["unit_relation_lift"]
+        < first["shared_open_question"]
+        < first["shared_resolution_target"]
+        < first["embedding_proximity"]
+    )
+
+
+def test_structural_generators_soft_fail_when_the_snapshot_is_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "target", "A target page.")
+    _page(
+        vault,
+        "source",
+        f"See [[{KB}/target]].\n\n## Claim\n- id: c-1\n"
+        f"- relations: answers: [[{KB}/target]]\n\nA claim.\n",
+    )
+    _build(vault)
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex,
+        "_open_read_snapshot",
+        lambda self, **kwargs: None,
+    )
+
+    result = epistemic_graph.suggest_relations(vault, path=f"{KB}/source.md", limit=50)
+
+    assert result["warnings"] == []
+    assert any(c["method"] == "wikilink" for c in result["candidates"])
+    assert not [
+        c
+        for c in result["candidates"]
+        if c["method"]
+        in {"unit_relation_lift", "shared_open_question", "shared_resolution_target"}
+    ]
+
+
+def test_structural_suggestions_are_propose_only(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    question = "Why is the tail latency spiky?"
+    _page(vault, "target", "A target page.")
+    _page(vault, "beta", f"## Open Question\n- id: q-b\n\n{question}\n")
+    _page(
+        vault,
+        "source",
+        f"## Open Question\n- id: q-s\n- relations: answers: [[{KB}/target]]\n\n"
+        f"{question}\n",
+    )
+    index = _build(vault)
+    before_markdown = {
+        path.relative_to(vault).as_posix(): path.read_bytes()
+        for path in vault.rglob("*.md")
+    }
+    before_edges = index.edges()
+
+    result = epistemic_graph.suggest_relations(vault, path=f"{KB}/source.md", limit=50)
+
+    structural = {
+        c["method"]
+        for c in result["candidates"]
+        if c["method"]
+        in {"unit_relation_lift", "shared_open_question", "shared_resolution_target"}
+    }
+    assert structural == {"unit_relation_lift", "shared_open_question"}
+    assert result["mutated"] is False
+    assert result["model_suggestions_available"] is False
+    assert index.edges() == before_edges
+    assert {
+        path.relative_to(vault).as_posix(): path.read_bytes()
+        for path in vault.rglob("*.md")
+    } == before_markdown
+
+
+def test_structural_evidence_is_json_serializable_and_deterministic(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    question = "Why is the tail latency spiky?"
+    _page(vault, "target", "A target page.")
+    _page(vault, "beta", f"## Open Question\n- id: q-b\n\n{question}\n")
+    _page(
+        vault,
+        "source",
+        f"## Open Question\n- id: q-s\n- relations: answers: [[{KB}/target]]\n\n"
+        f"{question}\n",
+    )
+    _build(vault)
+
+    first = _candidates(vault, f"{KB}/source.md")
+    second = _candidates(vault, f"{KB}/source.md")
+    structural = [
+        c
+        for c in first
+        if c["method"]
+        in {"unit_relation_lift", "shared_open_question", "shared_resolution_target"}
+    ]
+
+    assert len(structural) == 2
+    assert first == second
+    assert json.dumps(structural, sort_keys=True)
+
+
+# --------------------------------------------------------------------------
+# The registry gate is a non-issue — proved empirically, not designed around.
+# --------------------------------------------------------------------------
+
+
+def test_accepted_lift_bullet_reenters_as_a_core_page_level_edge(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path
+    _page(vault, "target", "A target page.")
+    source = _page(
+        vault,
+        "source",
+        f"## Claim\n- id: c-1\n- relations: answers: [[{KB}/target]]\n\nA claim.\n",
+    )
+    _build(vault)
+
+    queue = relation_queue.build_queue(vault)
+    group = next(g for g in queue["groups"] if g["path"] == f"{KB}/source.md")
+    item = next(i for i in group["items"] if i["method"] == "unit_relation_lift")
+
+    def _append_bullet(vault_root, *, path, new_string, **_kwargs):
+        target = Path(vault_root) / path
+        target.write_text(
+            target.read_text(encoding="utf-8") + f"\n## Relations\n\n{new_string}\n",
+            encoding="utf-8",
+        )
+        return {"path": path}
+
+    relation_queue.accept(
+        vault,
+        ref=item["ref"],
+        expected_hash=group["content_hash"],
+        why="Accepted a lifted unit relation",
+        expected_fingerprint=item["fingerprint"],
+        edit_memory=_append_bullet,
+    )
+
+    assert f"- answers [[{KB}/target]]" in source.read_text(encoding="utf-8")
+    index = _build(vault)
+    page_level = [
+        edge
+        for edge in index.edges()
+        if edge["src_key"] == f"file:{KB}/source.md"
+        and edge["dst_key"] == f"file:{KB}/target.md"
+        and edge["relation_type"] == "answers"
+    ]
+    assert page_level
+    assert all(edge["registry_status"] == "core" for edge in page_level)

--- a/tests/test_structural_relation_suggestions.py
+++ b/tests/test_structural_relation_suggestions.py
@@ -21,7 +21,13 @@ from pathlib import Path
 
 import pytest
 
-from exomem import corpus_aware, epistemic_graph, relation_queue
+from exomem import (
+    commands,
+    corpus_aware,
+    epistemic_graph,
+    relation_queue,
+    relation_registry,
+)
 
 KB = "Knowledge Base/Notes/Insights"
 
@@ -136,6 +142,14 @@ def test_lift_is_suppressed_when_the_page_already_authored_the_edge(
 def test_lift_only_proposes_kinds_present_on_the_pages_own_unit_edges(
     tmp_path: Path,
 ) -> None:
+    """A kind authored on ANOTHER page must never surface here.
+
+    `foreign` is load-bearing. Deriving the expected set from the same
+    `source_path` filter the query uses proves nothing: relaxing that filter
+    (`e.source_path = ? OR 1=1`) would make every page's authored relations
+    liftable onto every page, and a fixture holding only one authoring page has
+    no foreign kind to catch it.
+    """
     vault = tmp_path / "vault"
     _page(vault, "target", "A target page.")
     _page(
@@ -147,20 +161,33 @@ def test_lift_only_proposes_kinds_present_on_the_pages_own_unit_edges(
         "\n"
         "A claim with two typed unit relations.\n",
     )
+    _page(
+        vault,
+        "foreign",
+        "## Claim\n"
+        "- id: c-f\n"
+        f"- relations: contradicts: [[{KB}/target]]\n"
+        "\n"
+        "A third in-allowlist kind, to the same target, on a different page.\n",
+    )
     index = _build(vault)
 
     lifted = _by_method(_candidates(vault, f"{KB}/source.md"), "unit_relation_lift")
-    assert lifted
+    foreign = _by_method(_candidates(vault, f"{KB}/foreign.md"), "unit_relation_lift")
 
-    authored_raw = {
-        edge["raw_relation"]
+    assert sorted(c["relation_type"] for c in lifted) == ["answers", "refines"]
+    assert [c["relation_type"] for c in foreign] == ["contradicts"]
+
+    authored = {
+        relation_registry.normalize_relation(edge["raw_relation"])
         for edge in index.edges()
         if edge["source_path"] == f"{KB}/source.md"
         and edge["origin"] == "semantic_relation"
         and edge["src_key"] != f"file:{KB}/source.md"
     }
+    assert "contradicts" not in authored
     for candidate in lifted:
-        assert candidate["relation_type"] in authored_raw
+        assert candidate["relation_type"] in authored
 
 
 def test_lift_never_proposes_causality_or_unregistered_kinds(tmp_path: Path) -> None:
@@ -238,6 +265,121 @@ def test_lift_folds_several_authoring_units_into_one_candidate(
 
     assert len(lifted) == 1
     assert [unit["anchor"] for unit in lifted[0]["evidence"]["units"]] == ["c-1", "f-1"]
+
+
+def test_lift_normalizes_the_authored_label_so_the_proposal_is_acceptable(
+    tmp_path: Path,
+) -> None:
+    """`- relations: Answers:` parses with no diagnostic and resolves to core
+    standing, but the canonical relation-bullet grammar accepts only
+    `[a-z][a-z0-9_.-]{1,80}`. A verbatim proposal would author `- Answers [[T]]`,
+    which the governed edit refuses as `malformed_relation` — leaving a queue
+    item that can never be accepted and recurs on every read. The normalized
+    label is still the authored kind."""
+    vault = tmp_path
+    source = _page(
+        vault,
+        "source",
+        f"## Claim\n- id: c-1\n- relations: Answers: [[{KB}/target]]\n\nA claim.\n",
+    )
+    _page(vault, "target", "A target page.")
+    _build(vault)
+
+    queue = relation_queue.build_queue(vault)
+    group = next(g for g in queue["groups"] if g["path"] == f"{KB}/source.md")
+    item = next(i for i in group["items"] if i["method"] == "unit_relation_lift")
+
+    assert item["relation_type"] == "answers"
+    assert item["bullet"] == f"- answers [[{KB}/target]]"
+
+    # The whole governed accept path, not an injected writer.
+    commands.op_connect_memory(
+        vault,
+        operation="accept-relation",
+        ref=item["ref"],
+        expected_hash=group["content_hash"],
+        why="Accepted a lifted unit relation",
+        expected_fingerprint=item["fingerprint"],
+    )
+
+    assert f"- answers [[{KB}/target]]" in source.read_text(encoding="utf-8")
+
+
+def _write_extension_registry(vault: Path) -> None:
+    path = vault / "Knowledge Base" / "_Schema" / "relation-registry.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "schema_version: 1\n"
+        "extensions:\n"
+        "  lab.answers_partially:\n"
+        "    parent: answers\n"
+        "    description: Partially answers\n"
+        "  lab.answers_retired:\n"
+        "    parent: answers\n"
+        "    description: Retired in favour of the parent\n"
+        "    status: deprecated\n"
+        "  lab.answers_sourceonly:\n"
+        "    parent: answers\n"
+        "    description: Only meaningful on source pages\n"
+        "    scope:\n"
+        "      page_types: [source]\n",
+        encoding="utf-8",
+    )
+
+
+def test_lift_takes_a_vault_extension_kind_without_a_code_change(
+    tmp_path: Path,
+) -> None:
+    """The family allowlist is resolved through the registry at call time, so an
+    extension parented into an allowed family lifts with no code change."""
+    vault = tmp_path / "vault"
+    _write_extension_registry(vault)
+    _page(vault, "target", "A target page.")
+    _page(
+        vault,
+        "source",
+        "## Claim\n- id: c-1\n"
+        f"- relations: lab.answers_partially: [[{KB}/target]]\n\nA claim.\n",
+    )
+    _build(vault)
+
+    lifted = _by_method(_candidates(vault, f"{KB}/source.md"), "unit_relation_lift")
+
+    assert [c["relation_type"] for c in lifted] == ["lab.answers_partially"]
+    assert lifted[0]["evidence"]["relation_family"] == "answer"
+
+
+def test_lift_refuses_deprecated_and_scope_violating_kinds_in_an_allowed_family(
+    tmp_path: Path,
+) -> None:
+    """The family allowlist and the registry-standing gate are independent: an
+    allowed family readily admits a deprecated or out-of-scope extension, and
+    proposing one would author a bullet the writer rejects."""
+    vault = tmp_path / "vault"
+    _write_extension_registry(vault)
+    _page(vault, "target", "A target page.")
+    _page(
+        vault,
+        "source",
+        "## Claim\n- id: c-1\n"
+        f"- relations: lab.answers_retired: [[{KB}/target]], "
+        f"lab.answers_sourceonly: [[{KB}/target]], "
+        f"lab.answers_partially: [[{KB}/target]]\n\nA claim.\n",
+    )
+    index = _build(vault)
+
+    statuses = {
+        edge["raw_relation"]: edge["registry_status"]
+        for edge in index.edges()
+        if edge["source_path"] == f"{KB}/source.md"
+        and edge["origin"] == "semantic_relation"
+    }
+    lifted = _by_method(_candidates(vault, f"{KB}/source.md"), "unit_relation_lift")
+
+    # All three are in family `answer`; only their standing differs.
+    assert statuses["lab.answers_retired"] == "deprecated"
+    assert statuses["lab.answers_sourceonly"] == "scope_violation"
+    assert [c["relation_type"] for c in lifted] == ["lab.answers_partially"]
 
 
 # --------------------------------------------------------------------------
@@ -340,6 +482,31 @@ def test_shared_open_question_normalization_is_ascii_lower_and_trailing_question
     assert gamma == []
 
 
+def test_shared_open_question_evidence_fold_is_capped(tmp_path: Path) -> None:
+    """Eight shared questions, five folded matches, and an honest total.
+
+    A fixture where every candidate carries one match cannot tell a cap of five
+    from a cap of a thousand.
+    """
+    questions = [f"Why does subsystem {n} stall?" for n in range(8)]
+    blocks = "\n\n".join(
+        f"## Open Question\n- id: q-{side}-{n}\n\n{question}"
+        for side in ("x",)
+        for n, question in enumerate(questions)
+    )
+    vault = tmp_path / "vault"
+    _page(vault, "alpha", blocks)
+    _page(vault, "beta", blocks.replace("q-x-", "q-y-"))
+    _build(vault)
+
+    candidate = _by_method(
+        _candidates(vault, f"{KB}/alpha.md"), "shared_open_question"
+    )[0]
+
+    assert candidate["evidence"]["shared_questions"] == 8
+    assert len(candidate["evidence"]["matches"]) == 5
+
+
 # --------------------------------------------------------------------------
 # Shared resolution target: co-participation over the resolution graph.
 # --------------------------------------------------------------------------
@@ -392,10 +559,14 @@ def test_shared_resolution_target_ignores_page_level_resolution_edges(
         "## Claim\n- id: c-alpha\n"
         f"- relations: answers: [[{KB}/question]]\n\nOne answer.\n",
     )
+    # A plain relation bullet INSIDE a block body, NOT under `## Relations`.
+    # That form keeps `origin = 'semantic_relation'` and is excluded only by the
+    # `src_key <> file_key` guard; the `## Relations` form would be excluded by
+    # the origin filter alone and would prove nothing about the guard.
     _page(
         vault,
         "beta",
-        f"## Relations\n\n- answers [[{KB}/question]]\n",
+        f"## Claim\n- id: c-beta\n\n- answers [[{KB}/question]]\n",
     )
     _page(
         vault,
@@ -412,6 +583,39 @@ def test_shared_resolution_target_ignores_page_level_resolution_edges(
     # gamma is the positive control: beta's page-level edge must be the only
     # thing missing, not the generator itself.
     assert [c["to"] for c in candidates] == [f"{KB}/gamma.md"]
+
+
+def test_co_participation_generators_do_not_propose_the_same_edge_twice(
+    tmp_path: Path,
+) -> None:
+    """Two pages that share a question usually also answer the same thing, and
+    both generators then propose the identical `relates_to` bullet. Keeping both
+    spends two scarce slots on one edge the reviewer can accept only once."""
+    vault = tmp_path / "vault"
+    question = "Why is the tail latency spiky?"
+    _page(vault, "topic", "The thing being answered.")
+    _page(
+        vault,
+        "alpha",
+        f"## Open Question\n- id: q-alpha\n\n{question}\n\n"
+        f"## Claim\n- id: c-alpha\n- relations: answers: [[{KB}/topic]]\n\nOne answer.\n",
+    )
+    _page(
+        vault,
+        "beta",
+        f"## Open Question\n- id: q-beta\n\n{question}\n\n"
+        f"## Claim\n- id: c-beta\n- relations: answers: [[{KB}/topic]]\n\nAnother answer.\n",
+    )
+    _build(vault)
+
+    candidates = _candidates(vault, f"{KB}/alpha.md")
+    to_beta = [
+        c
+        for c in candidates
+        if c["to"] == f"{KB}/beta.md" and c["relation_type"] == "relates_to"
+    ]
+
+    assert [c["method"] for c in to_beta] == ["shared_open_question"]
 
 
 # --------------------------------------------------------------------------
@@ -473,7 +677,6 @@ def test_structural_candidates_are_bounded_and_query_count_is_constant(
     _candidates(small, f"{KB}/alpha.md", limit=500)
 
     assert len(candidates) == 3
-    assert len(candidates[0]["evidence"]["matches"]) <= 5
     assert big_corpus_queries == len(calls)
 
 
@@ -536,13 +739,50 @@ def test_structural_generators_run_after_deterministic_and_before_embeddings(
         "embedding_proximity",
     ):
         assert method in first, method
+    # Structural first: an author-written typed relation outranks a body
+    # wikilink, and `limit` makes that a budget rather than a preference.
     assert (
-        first["shared_sources"]
-        < first["unit_relation_lift"]
+        first["unit_relation_lift"]
         < first["shared_open_question"]
         < first["shared_resolution_target"]
+        < first["wikilink"]
+    )
+    # ...and the pre-existing four keep their relative order among themselves.
+    assert (
+        first["wikilink"]
+        < first["frontmatter_sources"]
+        < first["shared_sources"]
         < first["embedding_proximity"]
     )
+
+
+def test_structural_candidates_survive_a_link_heavy_page(tmp_path: Path) -> None:
+    """The motivating case: a dense compiled note with more wikilinks than the
+    response limit. Registered after `_wikilink_candidates`, every structural
+    candidate would be truncated away and the change would be silent on exactly
+    the pages it exists to serve."""
+    vault = tmp_path / "vault"
+    _page(vault, "target", "A target page.")
+    for n in range(12):
+        _page(vault, f"link-{n:02d}", "A linked page.")
+    links = " ".join(f"[[{KB}/link-{n:02d}]]" for n in range(12))
+    _page(
+        vault,
+        "dense",
+        f"A dense compiled note citing {links}.\n\n"
+        f"## Claim\n- id: c-1\n- relations: answers: [[{KB}/target]]\n\nA claim.\n",
+    )
+    _build(vault)
+
+    # `relation_queue._DEFAULT_LIMIT_PER_PAGE` is 10; use it verbatim.
+    candidates = _candidates(
+        vault, f"{KB}/dense.md", limit=relation_queue._DEFAULT_LIMIT_PER_PAGE
+    )
+
+    assert len([c for c in candidates if c["method"] == "wikilink"]) >= 1
+    assert [c["relation_type"] for c in _by_method(candidates, "unit_relation_lift")] == [
+        "answers"
+    ]
 
 
 def test_structural_generators_soft_fail_when_the_snapshot_is_unavailable(

--- a/tests/test_structural_relation_suggestions.py
+++ b/tests/test_structural_relation_suggestions.py
@@ -25,6 +25,7 @@ from exomem import (
     commands,
     corpus_aware,
     epistemic_graph,
+    markdown_relations,
     relation_queue,
     relation_registry,
 )
@@ -380,6 +381,98 @@ def test_lift_refuses_deprecated_and_scope_violating_kinds_in_an_allowed_family(
     assert statuses["lab.answers_retired"] == "deprecated"
     assert statuses["lab.answers_sourceonly"] == "scope_violation"
     assert [c["relation_type"] for c in lifted] == ["lab.answers_partially"]
+
+
+#: `relation_registry._KEY_RE` is length-unbounded; the canonical relation
+#: grammar caps the label at 81 characters. 84 characters is a valid extension
+#: key that cannot be written as a bullet.
+_OVERLONG_KEY = "lab." + ("a" * 80)
+
+
+def test_lift_refuses_labels_the_canonical_relation_grammar_rejects(
+    tmp_path: Path,
+) -> None:
+    """Registry standing is not the same question as bullet writability.
+
+    Four vault-authored shapes resolve to `extension` or `alias` standing and
+    would still author a bullet the governed write refuses: a key longer than
+    the grammar's 81-character cap, a one-character alias (the grammar needs at
+    least two), an over-length alias, and a non-ASCII alias. A candidate that
+    can never be accepted is worse than no candidate, so the normalized label is
+    checked against the canonical grammar itself before emission.
+    """
+    vault = tmp_path / "vault"
+    path = vault / "Knowledge Base" / "_Schema" / "relation-registry.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "schema_version: 1\n"
+        "extensions:\n"
+        f"  {_OVERLONG_KEY}:\n"
+        "    parent: answers\n"
+        "    description: A key the bullet grammar cannot carry\n"
+        "  lab.answers_short:\n"
+        "    parent: answers\n"
+        "    description: One-character alias\n"
+        "    aliases: ['a']\n"
+        "  lab.answers_accented:\n"
+        "    parent: answers\n"
+        "    description: Non-ASCII alias\n"
+        "    aliases: ['ré']\n"
+        "  lab.answers_verbose:\n"
+        "    parent: answers\n"
+        "    description: Over-length alias\n"
+        f"    aliases: ['{'v' * 84}']\n"
+        # Three writable controls, all sorting AFTER the two unwritable labels
+        # that lead the ordering. If the guard ran after the per-generator cap
+        # instead of per row, `a` and the over-long key would consume two of the
+        # three slots and only one control would survive.
+        "  lab.answers_partially:\n"
+        "    parent: answers\n"
+        "    description: A writable extension, the positive control\n"
+        "  lab.answers_second:\n"
+        "    parent: answers\n"
+        "    description: A second writable extension\n"
+        "  lab.answers_third:\n"
+        "    parent: answers\n"
+        "    description: A third writable extension\n",
+        encoding="utf-8",
+    )
+    _page(vault, "target", "A target page.")
+    _page(
+        vault,
+        "source",
+        "## Claim\n- id: c-1\n"
+        f"- relations: {_OVERLONG_KEY}: [[{KB}/target]], a: [[{KB}/target]], "
+        f"ré: [[{KB}/target]], {'v' * 84}: [[{KB}/target]], "
+        f"lab.answers_partially: [[{KB}/target]], "
+        f"lab.answers_second: [[{KB}/target]], "
+        f"lab.answers_third: [[{KB}/target]]\n\nA claim.\n",
+    )
+    index = _build(vault)
+
+    standing = {
+        edge["raw_relation"]: edge["registry_status"]
+        for edge in index.edges()
+        if edge["source_path"] == f"{KB}/source.md"
+        and edge["origin"] == "semantic_relation"
+    }
+    lifted = _by_method(_candidates(vault, f"{KB}/source.md"), "unit_relation_lift")
+
+    # Every refused shape carries standing the status gate admits.
+    assert standing[_OVERLONG_KEY] == "extension"
+    assert standing["a"] == "alias"
+    assert standing["ré"] == "alias"
+    assert standing["v" * 84] == "alias"
+    assert [c["relation_type"] for c in lifted] == [
+        "lab.answers_partially",
+        "lab.answers_second",
+        "lab.answers_third",
+    ]
+
+    # And what survives is writable by construction.
+    for candidate in lifted:
+        bullet = relation_queue._bullet(candidate)
+        assert markdown_relations._CANONICAL_RE.match(bullet) is not None, bullet
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Implements `openspec/changes/suggest-epistemic-relations-from-structure`, Tier 3 change 10 of the loop-closure programme.

## Why

The three existing relation suggesters emit only `links_to`, `derived_from` and `relates_to`, so epistemic-family suggestions are structurally impossible. Measured consequence: 58% of registered relation uses are `relates_to`, 188 relation-debt findings, 35% typed coverage.

The seam that makes this fixable: a typed unit relation — `- relations: answers: [[Q]]` — produces a **block-level** edge and **no page-level edge at all**. The scaffold documents that metadata form as *the* way to write typed unit relations, so every one of them is an author-written directional epistemic claim that the page-level graph, relation-filtered recall, and contract inference cannot see.

## What changed

Three generators, sharing one graph snapshot, soft-failing to `[]` when it is unavailable. Targets stay page-level.

- **`unit_relation_lift`** → proposes the kind **already authored** on a unit of the page, where no page-level counterpart exists. Gated by relation *family* (answer, resolution, question, support, contradiction, refinement, evidence, duplication — never causality), resolved through the registry at call time so a vault extension kind lifts with no code change.
- **`shared_open_question`** → `relates_to` for two pages carrying the same normalized question text. Normalization happens in SQL on both sides so no Python normalizer can drift from it, and the corpus side UNIONs two indexed branches because a rich `## Open Question` and a compact `- [question]` land on different columns — an `OR` defeats both indexes.
- **`shared_resolution_target`** → `relates_to` when each page carries a unit-level `answers`/`resolves` edge to the same target.

No schema change, no rebuild, read-only, off the write path. `relation_queue` consumes `suggest_relations` directly, so candidates reach the acceptance queue with no queue changes.

## Semantic neutrality

The two co-participation generators observe nothing directional and emit `relates_to`. The lift satisfies the existing requirement rather than evading it: its evidence is that a human typed the kind and the parser registered it, and it proposes only a kind present on a unit-level edge of that page. It cannot manufacture a meaning, only fail to promote one. `model_suggestions_available` stays `False`.

Causality is excluded on a stated principle, not by taste: the eight allowlisted families express an epistemic stance between bodies of knowledge, which a page can coherently hold as a whole. Causality asserts a mechanism between the *things described* — a property of the referents, not the documents — so broadening it relocates the claim onto subjects that cannot bear it.

## Review findings fixed

Independently reviewed, then rechecked. Both rounds returned findings that mattered:

- **Proposals that could never be accepted.** The lift proposed the author's verbatim label, but canonical relation bullets require lowercase snake_case — so `- relations: Answers: [[T]]`, which parses with zero diagnostics, produced a queue item `accept` refuses with `SEMANTIC_CONTRACT_BLOCKED`, recurring forever. Now normalized through the registry's own function. Verified end-to-end through the governed accept path for `Answers:`, `EVIDENCED BY:`, `evidenced by:` and a mixed-case vault extension.
- **The property the change is named for had no test.** Replacing `WHERE e.source_path = ?` with `(e.source_path = ? OR 1=1)` — letting any page's relation lift onto any page — passed the entire suite, because the test derived its expected set from the same predicate. A third fixture page authoring a foreign kind breaks the circularity.
- **Registration order was backwards.** A page with 12 wikilinks and a typed unit relation yielded zero structural candidates. Structural now runs first. The displaced wikilink candidate only proposes canonicalising a `links_to` edge the graph already holds; the promoted class has no page-level counterpart at all.
- **A residual label class.** Over-length keys, one-character aliases and non-ASCII aliases still produced unwritable bullets. A guard probes the canonical grammar with the bullet the candidate would author — derived from the grammar rather than restating it. Placement is load-bearing: the per-generator cap was masking two of the four shapes until the guard moved ahead of it.
- Three vacuous assertions replaced with fixtures where the property actually bites (evidence-fold cap, registry-status gate, the block-body bullet form).

## Corrected rather than shipped

An earlier draft of `design.md` claimed displaced wikilink candidates "are regenerated on the next read once these are accepted or dismissed." Measured, that is false: `suggest_relations` truncates before `relation_queue` applies its authored/decided filters, so dismissing all ten visible items leaves the page with **no group at all** and the remaining candidates never surface. The behaviour is pre-existing and mirror-symmetric — the old order starved structural candidates identically — so this change amplifies rather than introduces it. The design note now carries the measurement instead of the claim.

## Follow-ups filed, not fixed here

- `classify-relation-candidates-before-truncation` — the truncation-before-filter behaviour above; belongs in the queue, not a generator.
- `relation-registry-registers-invalid-aliases` — `_parse_extension_data`'s alias loop records an `invalid_alias` finding without `continue`, so the alias is registered anyway and resolves with `alias` standing. The new guard compensates; it does not fix it.
- Suppression survivor selection is first-generator-wins, so a suppressed candidate's distinct evidence stops feeding any fingerprint. Both propose the identical bullet, so nothing actionable is lost — one of two independent reasons for it to resurface is.

## Verification

- Red-first throughout, with positive controls added after the first red run showed six of nineteen prohibition tests passing vacuously.
- 26 tests in the new suite; 87 passed after rebase across the suggestion, queue, graph, semantic-block and scaffold suites; wider sweeps during development covered 633.
- Ten mutations verified failing the right tests, including `OR 1=1`, the guard's placement, and stripping the other-page unit identity from evidence (which breaks dismissal-resurfacing).
- Query count constant between a 2-page and a 201-page corpus; `EXPLAIN QUERY PLAN` confirms every index the design claims.
- `openspec validate --all --strict` 161 passed, 0 failed. Pinned tool surface byte-identical.
