### PR TITLE
chore(openspec): file the relation fragment-target follow-up

### DIFF
--- a/openspec/changes/resolve-relation-fragment-targets/.openspec.yaml
+++ b/openspec/changes/resolve-relation-fragment-targets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/resolve-relation-fragment-targets/design.md
+++ b/openspec/changes/resolve-relation-fragment-targets/design.md
@@ -1,0 +1,81 @@
+## Context
+
+Three pieces already exist and are not connected to each other.
+
+**The fragment survives resolution.** `vault.normalize_wikilink` returns
+`Knowledge Base/<rest>` with `.md` stripped and `#anchor` preserved — its
+docstring says so and its implementation splits the anchor off, canonicalizes the
+path, and re-appends it.
+
+**The fragment is then discarded.** `epistemic_graph._build_relation_edges`
+passes that canonical form to `_with_md`, whose second line is
+`cleaned.split("|", 1)[0].split("#", 1)[0]`. The page is what reaches `_file_key`.
+No warning is emitted, because from `_with_md`'s point of view nothing went
+wrong.
+
+**The destination it should have used is already indexed.** `graph_nodes` carries
+`unit_ref` with `idx_graph_nodes_unit_ref`, a unit node's key is
+`"unit:" + sha256(unit_ref)`, and `_current_unit_status(conn, vault_root, unit_ref)`
+resolves `parent#fragment` into `found` / `missing` / `ambiguous` / `stale` with
+parent paths and drift counts. That function exists for reference validation; it
+is the same question a fragment target asks.
+
+## Goals / Non-Goals
+
+**Goals.** A relation target may address a unit. An author who writes a precise
+target gets a precise edge or an explicit reason why not. `shared_open_question`
+proposes `duplicates` between the two units that actually share the question.
+
+**Non-Goals.** No new relation vocabulary. No change to the source side, which is
+already unit-precise. No fragment on a `links_to` edge from an ordinary inline
+wikilink — those are untyped by construction and a unit-level untyped edge would
+multiply the graph without adding a claim. No ranking or scoring.
+
+## Decisions
+
+**Degrade to the page, never drop the edge.** An unresolvable or ambiguous
+fragment produces the page-level edge today's code produces, plus a diagnostic.
+Refusing the edge would make a typo silently delete a relation, which is worse
+than the imprecision being fixed. This mirrors `normalize_wikilink(strict=False)`,
+which returns the cleaned input with a warning rather than raising.
+
+**`ambiguous` and `missing` are one outcome for the edge and two for the
+author.** The edge is page-level either way. The diagnostic distinguishes them,
+because the remedies differ: a missing fragment is a typo or a moved unit, an
+ambiguous one needs the target page to give its units distinct identity.
+
+**Reuse `_current_unit_status`, do not write a second resolver.** A relation
+target and a reference target ask the same question, and the failure mode of two
+resolvers is that they disagree on `ambiguous`. Its `work_exhausted` path already
+returns `stale`, which maps onto the page-level fallback.
+
+**The contract version bumps.** The relation grammar gains a documented target
+form, so `semantic_authoring`'s contract version and digest move, and with them
+the scaffold skill headers and the pinned tool schemas. This is the change that
+the archived design meant by "owns the schema bump" and it is not separable: an
+authoring form nobody is told about is not an authoring form.
+
+## Risks / Trade-offs
+
+**The plugin fingerprint moves while one is already pending.**
+`deploy/chatgpt/personal-plugin-contract.json` has held a
+`pending_tool_surface_sha256` different from `registered_tool_surface_sha256`
+since 0.45.0 (2026-08-11). This change makes that pending hash move again rather
+than resolve. It does not create the unverified state and cannot clear it —
+clearing it is an operator action against the live connector.
+
+**Write-path latency.** Every relation carrying a fragment costs one unit lookup
+against an indexed column. The bound has to be measured on the write path, not
+argued: `tests/test_latency_gate.py` at 2k and 8k, reported in this change.
+
+**A unit-level edge changes traversal fan-out.** Consumers that assume every
+edge endpoint is a page — traversal profiles, `graph-find-ranking`, the
+acceptance queue — need checking rather than assuming. The graph already holds
+unit *nodes*, so the shape is not new, but a unit appearing as a *destination*
+is.
+
+**`duplicates` between units is a stronger claim than `relates_to` between
+pages.** The existing `shared_open_question` candidate is deliberately weak
+because it can only say the pages are related. Making it unit-precise makes the
+proposal sharper and a false positive more costly; the acceptance queue stays the
+gate, and the candidate stays a proposal.

--- a/openspec/changes/resolve-relation-fragment-targets/proposal.md
+++ b/openspec/changes/resolve-relation-fragment-targets/proposal.md
@@ -1,0 +1,74 @@
+# Proposal: resolve-relation-fragment-targets
+
+## Why
+
+A relation is unit-precise on one end and page-only on the other. A
+`- relations: kind: [[Target]]` row on a rich `## Heading` unit produces an edge
+whose source is that unit's node; `markdown-relations` states this as
+"Block-level epistemic precision remains available". The destination has no
+equivalent. `epistemic_graph._with_md` strips everything from `#` onward before
+the target becomes a file key, so `[[Target#Some Unit]]` silently degrades to
+`[[Target]]` and the edge lands page-wide.
+
+The degradation is silent, which is the part that matters. `vault.normalize_wikilink`
+documents that it preserves `#anchor` across normalization, and it does — the
+fragment survives resolution and is then discarded one call later, with no
+warning, no diagnostic, and no authoring feedback. An author who writes the
+precise thing gets the imprecise edge and is never told.
+
+The node side is already built. `epistemic_graph` stores `unit_ref` on
+`graph_nodes` with its own index, keys a unit node as
+`"unit:" + sha256(unit_ref)`, and `_current_unit_status` already resolves a
+`parent#fragment` reference to its parent paths and reports `found`, `missing`,
+`ambiguous`, or `stale`. What is missing is an edge whose destination uses it.
+
+The concrete consumer is named in a shipped design.
+`suggest-epistemic-relations-from-structure` states that `shared_open_question`
+"should be revisited as a `duplicates` proposal once relation targets can
+address a unit", and its non-goals defer unit-level targets to
+"`resolve-relation-fragment-targets`, which owns the schema bump and the
+write-path latency evidence." That change was never filed, so the reference
+named nothing. This files it.
+
+`_shared_open_question_candidates` already carries `unit_ref` and `anchor` for
+both sides in its evidence, precisely so a dismissal expires when the other
+page's unit changes. It knows which two units share the question and can only
+propose an edge between the two pages.
+
+## What Changes
+
+- A relation target MAY carry a `#fragment`. When it resolves to exactly one
+  addressable unit on the target page, the edge's destination is that unit's
+  node rather than the page's.
+- Every other resolution outcome — no fragment, an unresolvable one, or one
+  matching more than one unit — keeps today's page-level edge. Nothing an author
+  writes today changes meaning.
+- An unresolvable or ambiguous fragment becomes authoring feedback rather than
+  silence, alongside the existing malformed-relation and unresolved-target
+  counts.
+- `shared_open_question` is revisited as a unit-level `duplicates` proposal, the
+  consumer this exists for.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `markdown-relations` — unit-level precision applies to a relation's
+  destination, not only to its source.
+
+## Impact
+
+- `src/exomem/epistemic_graph.py` — fragment-preserving target resolution and a
+  unit-destination edge; `_shared_open_question_candidates`.
+- `src/exomem/markdown_relations.py` — the fragment is already accepted by the
+  target pattern; the diagnostic for an unresolvable one is new.
+- The semantic-authoring contract version, because the relation grammar gains a
+  documented target form. That moves the contract digest embedded in the
+  scaffold skills and in `tests/fixtures/mcp_tool_schemas.json`, and therefore
+  the ChatGPT Personal Plugin fingerprint. `deploy/chatgpt/personal-plugin-contract.json`
+  has carried a `pending_tool_surface_sha256` distinct from its registered hash
+  since release 0.45.0 (2026-08-11); this change adds to that pending state and
+  does not clear it.
+- Write-path latency: resolving a fragment costs a unit lookup per relation with
+  one. The gate is `tests/test_latency_gate.py`; evidence belongs in this change,
+  not in a follow-up.

--- a/openspec/changes/resolve-relation-fragment-targets/specs/markdown-relations/spec.md
+++ b/openspec/changes/resolve-relation-fragment-targets/specs/markdown-relations/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Block-level epistemic precision remains available
+The existing semantic-block metadata syntax (`- relations: kind: [[Target]]`) SHALL continue to attach relations to claim/finding/evidence block nodes and SHALL use the same relation vocabulary as note-level relations. A relation target MAY address a unit by carrying a `#fragment`; when that fragment resolves to exactly one addressable unit on the target page the edge's destination SHALL be that unit, and in every other case the edge SHALL remain page-level and the unresolved fragment SHALL be reported to the author rather than discarded silently.
+
+#### Scenario: Note and block relations coexist
+- **WHEN** a note has a note-level `depends_on` relation and a Finding block with `evidenced_by` metadata
+- **THEN** the graph contains the note-to-note edge and the block-to-target edge with their distinct source anchors
+
+#### Scenario: A relation target addresses one unit
+- **WHEN** a relation target carries a `#fragment` that resolves to exactly one addressable unit on the target page
+- **THEN** the edge's destination is that unit's node rather than the target page's
+- **AND** the edge's source anchor is unchanged
+
+#### Scenario: A fragment that resolves to no unit or to several
+- **WHEN** a relation target's `#fragment` matches no addressable unit on the target page, or matches more than one
+- **THEN** the relation still produces the page-level edge it produces today
+- **AND** the write reports the unresolvable or ambiguous fragment to the author rather than discarding it silently
+
+#### Scenario: A target with no fragment is unaffected
+- **WHEN** a relation target carries no `#fragment`
+- **THEN** the resulting edge is identical to the one produced before unit-level destinations existed

--- a/openspec/changes/resolve-relation-fragment-targets/tasks.md
+++ b/openspec/changes/resolve-relation-fragment-targets/tasks.md
@@ -1,0 +1,42 @@
+## 1. Establish the current behaviour
+
+- [ ] 1.1 Assert that `[[Target#Some Unit]]` in a `- relations:` row today produces a page-level edge with no diagnostic, and that `normalize_wikilink` preserved the fragment before `_with_md` removed it.
+- [ ] 1.2 Assert the same for a canonical `## Relations` note-level bullet.
+
+## 2. Resolve the fragment
+
+- [ ] 2.1 Preserve the fragment through target resolution instead of splitting it off in `_with_md`, without changing `_with_md`'s other callers.
+- [ ] 2.2 Resolve a fragment through `_current_unit_status`, mapping `found` to a unit destination and `missing`, `ambiguous`, and `stale` to the page-level edge.
+- [ ] 2.3 Emit the unit-destination edge with the unit node key, and assert the source anchor is unchanged.
+- [ ] 2.4 Assert a target with no fragment is byte-identical to today.
+
+## 3. Tell the author
+
+- [ ] 3.1 Add an unresolvable-fragment and an ambiguous-fragment diagnostic beside the existing malformed-relation and unresolved-target counts.
+- [ ] 3.2 Assert a typo degrades to a page-level edge and reports, rather than deleting the relation.
+
+## 4. Revisit the consumer
+
+- [ ] 4.1 Propose `shared_open_question` as a unit-level `duplicates` candidate between the two question units, using the `unit_ref` pair its evidence already carries.
+- [ ] 4.2 Assert the dismissal fingerprint still expires when either unit is re-anchored.
+
+## 5. Check the consumers of an edge endpoint
+
+- [ ] 5.1 Traversal profiles, `graph-find-ranking`, and the acceptance queue over a graph containing a unit destination.
+- [ ] 5.2 Reconcile and rebuild converge on a graph containing unit destinations.
+
+## 6. Contract and surface
+
+- [ ] 6.1 Document the target form in the semantic-authoring contract and bump its version.
+- [ ] 6.2 Regenerate the scaffold skill headers, `docs/capabilities.md`, `tests/fixtures/mcp_tool_schemas.json`, and `src/exomem/tool_surface_contract.json`.
+- [ ] 6.3 Move `pending_tool_surface_sha256` in `deploy/chatgpt/personal-plugin-contract.json` and state in the PR that the connector remains unverified since 0.45.0 — this change adds to that state and does not clear it.
+
+## 7. Evidence
+
+- [ ] 7.1 `tests/test_latency_gate.py` at 2k and 8k, reported in the PR rather than deferred.
+- [ ] 7.2 `openspec validate resolve-relation-fragment-targets --strict` and `openspec validate --specs --strict`.
+- [ ] 7.3 The affected suites plus lint.
+
+## 8. Closure
+
+- [ ] 8.1 Once merged and therefore demonstrably shipped, sync the delta into `openspec/specs/` and archive with `openspec archive`, re-running `openspec validate --all --strict` before and after.


### PR DESCRIPTION
## Why

The archived design of `suggest-epistemic-relations-from-structure` says two things about unit-level relation targets:

> Unit-level (fragment) relation targets — deferred to `resolve-relation-fragment-targets`, which owns the schema bump and the write-path latency evidence.

> `shared_open_question` should be revisited as a `duplicates` proposal once relation targets can address a unit, tracked by the separately-filed `resolve-relation-fragment-targets`.

That change was never filed. A shipped design document has been pointing at nothing since it archived. This is the same failure mode as the boundary finding in #765: a deferral written as a cross-reference, with nothing on the other end.

## What is filed

Nothing is implemented here — this is the OpenSpec change, tasks unticked.

The proposal and design are written from evidence gathered against the current implementation rather than from the archived prose:

- **The fragment survives resolution and is then discarded.** `vault.normalize_wikilink` documents that it preserves `#anchor`, and it does. `epistemic_graph._build_relation_edges` hands the result to `_with_md`, whose second line is `cleaned.split("|", 1)[0].split("#", 1)[0]`. So `[[Target#Some Unit]]` degrades to `[[Target]]` with no warning and no diagnostic. An author who writes the precise thing gets the imprecise edge and is never told.
- **The destination it should use is already built.** `graph_nodes` carries `unit_ref` with `idx_graph_nodes_unit_ref`, a unit node's key is `"unit:" + sha256(unit_ref)`, and `_current_unit_status` already resolves a `parent#fragment` into `found` / `missing` / `ambiguous` / `stale`. The design reuses it rather than adding a second resolver, because two resolvers would eventually disagree on `ambiguous`.
- **The consumer already knows the answer.** `_shared_open_question_candidates` carries `unit_ref` and `anchor` for both sides in its evidence — it knows which two units share the question and can only propose an edge between the two pages.
- **The asymmetry, stated plainly.** `markdown-relations` already requires "Block-level epistemic precision remains available" for a relation's *source*. The delta widens that requirement to the destination.

## The cost this change carries, stated up front

The relation grammar gains a documented target form, so the semantic-authoring contract version and digest move — and with them the scaffold skill headers and the contract hash embedded ten times in `tests/fixtures/mcp_tool_schemas.json`, and therefore the ChatGPT Personal Plugin fingerprint.

`deploy/chatgpt/personal-plugin-contract.json` has carried a `pending_tool_surface_sha256` (`3d21bc4d…`) different from its `registered_tool_surface_sha256` (`81975043…`) since `last_verified_release: 0.45.0`, `last_verified_at: 2026-08-11`. Implementing this change moves that pending hash again rather than resolving it. It does not create the unverified state and cannot clear it — that is an operator action against the live connector. The design and task 6.3 both say so, so whoever picks it up does not discover it late.

## Verification

- `openspec validate resolve-relation-fragment-targets --strict` — valid.
- `openspec validate --specs --strict` — 104 passed.
- `check_openspec_archive_discipline.py` — OK, none task-complete.
