### PR TITLE
feat(governance): gate projected retrieval release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,35 @@ jobs:
         # home next to the golden quality gate.
         run: uv run --frozen python -m pytest tests/test_latency_gate.py -q
 
+  governance-projection-wire:
+    name: governance projected wire (${{ matrix.route }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    strategy:
+      fail-fast: false
+      matrix:
+        route: [keyword, bm25, vector-hard-off, rerank-hard-off, clip-hard-off, graph, graph-rerank-hard-off, max-query, max-limit, max-shape, error, pagination]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Verify lockfile is current
+        run: uv lock --check
+      - name: Exact-capacity hidden-corpus actual-wire gate
+        env:
+          EXOMEM_GOVERNANCE_TIMING_ROUTE: ${{ matrix.route }}
+          EXOMEM_DISABLE_EMBEDDINGS: "1"
+          EXOMEM_DISABLE_MEDIA_EXTRACTION: "1"
+          EXOMEM_DISABLE_CLIP: "1"
+          EXOMEM_DISABLE_RANKING: "1"
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: >-
+          uv run --frozen --python 3.13 python -m pytest -q
+          tests/test_governance_projection_wire_gate.py
+          --session-timeout=360
+
   semantic-write-latency:
     name: semantic write latency (2k and 8k)
     runs-on: ubuntu-latest
@@ -479,6 +508,7 @@ jobs:
       - product-e2e
       - retrieval-quality
       - retrieval-latency
+      - governance-projection-wire
       - semantic-write-latency
       - graph-convergence
       - onboarding

--- a/benchmarks/governance/projected-wire-release-v1.json
+++ b/benchmarks/governance/projected-wire-release-v1.json
@@ -1,0 +1,39 @@
+{
+  "schema": "exomem.governed-projection-timing-release/v1",
+  "hidden_corpus_wire_delta_ms": 25,
+  "sample_count_per_condition": 200,
+  "bootstrap_resamples": 2000,
+  "bootstrap_seed": 20260822,
+  "hardware_runtime_profile": "github-hosted-ubuntu-latest-x64-python3.13",
+  "model_runtime_profile": "models-hard-off-v1",
+  "request_classes": [
+    {
+      "name": "projected-find-v1",
+      "padding_ms": 250,
+      "deadline_ms": 300,
+      "max_query_chars": 4096,
+      "max_limit": 100
+    }
+  ],
+  "routes": [
+    "keyword",
+    "bm25",
+    "vector-hard-off",
+    "rerank-hard-off",
+    "clip-hard-off",
+    "graph",
+    "graph-rerank-hard-off",
+    "max-query",
+    "max-limit",
+    "max-shape",
+    "error",
+    "pagination"
+  ],
+  "capacity": {
+    "catalog_items": 16384,
+    "searchable_bytes_per_item": 1048576,
+    "graph_edges": 262144
+  },
+  "scheduler_tolerance_subtracted": false,
+  "padding_selected_before_sampling": true
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,6 +219,7 @@ markers = [
     # and the HF model cache). Excluded from the lean matrix; run in the dedicated
     # `retrieval-eval` CI job via `pytest -m embeddings`.
     "embeddings: loads live vector models; run only in the retrieval-eval job",
+    "governance_timing_release: exact-capacity actual-wire governance release gate",
 ]
 
 # Blackwell (RTX 50-series, sm_120 / compute capability 12.0) needs CUDA wheels.

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -1210,6 +1210,7 @@ def _require_supported_projected_find_request(
 ) -> None:
     """Refuse v4 features that do not yet have a projected implementation."""
 
+    del include_timings
     collections = (
         types,
         projects,
@@ -1239,7 +1240,6 @@ def _require_supported_projected_find_request(
         or prefer_used
         or pack
         or graph_enrich
-        or include_timings
         or explain
     ):
         raise projection_runtime_module.ProjectionRuntimeUnavailable(
@@ -1464,7 +1464,8 @@ def op_find(
         Right after a server start, while models are still warming in the
         background, semantic lanes are skipped rather than blocked on — the
         result is then the envelope {"hits": [...], "warming": {"components":
-        [...], "since_s": N}} and the hits are lexical-only ranking. If
+        [...]}} and the hits are lexical-only ranking. Legacy retrieval also
+        includes process age, while governed projection suppresses it. If
         recall quality matters for the query, retry once "warming" stops
         appearing (typically well under a minute).
     """
@@ -1534,7 +1535,20 @@ def op_find(
         if explain
         else None
     )
-    timings = find_module.FindTimings() if include_timings else None
+    timings = (
+        find_module.FindTimings()
+        if include_timings and projection_runtime is None
+        else None
+    )
+    timings_suppressed = (
+        {"status": "governed_projection"}
+        if projection_runtime is not None
+        else None
+    )
+    # Deliberately not declared in retrieval_models.FindEnvelope: its schema
+    # permits additive properties, while declaring this optional marker would
+    # rewrite the byte-frozen Hosted v1/v2 contracts. This is the same
+    # compatibility boundary used by the advisory due-state carrier below.
     if timings is not None:
         from . import mode as mode_module
 
@@ -1713,11 +1727,10 @@ def op_find(
     # (~30s per process start; minutes on a first-ever model download).
     warming: dict | None = None
     if degraded:
-        info = readiness_module.warming_info() or {}
-        warming = {
-            "components": sorted(set(degraded)),
-            "since_s": info.get("since_s", 0.0),
-        }
+        warming = {"components": sorted(set(degraded))}
+        if projection_runtime is None:
+            info = readiness_module.warming_info() or {}
+            warming["since_s"] = info.get("since_s", 0.0)
     # Degraded marker: a semantic lane FAILED post-warm (not merely deferred) so
     # the hits are a silently weaker ranking — vector→BM25, or every-lane-empty→
     # keyword. Distinct from `warming`: warming is the transient, expected boot
@@ -1726,6 +1739,7 @@ def op_find(
     degraded_marker: list[str] | None = sorted(set(failed)) if failed else None
     if (
         timings_dict is None
+        and timings_suppressed is None
         and warming is None
         and degraded_marker is None
         and retrieval_trace is None
@@ -1743,6 +1757,8 @@ def op_find(
         out["pack"] = pack_obj
     if timings_dict is not None:
         out["timings"] = timings_dict
+    if timings_suppressed is not None:
+        out["timings_suppressed"] = timings_suppressed
     if warming is not None:
         out["warming"] = warming
     if degraded_marker is not None:

--- a/src/exomem/governance/projected_graph.py
+++ b/src/exomem/governance/projected_graph.py
@@ -296,7 +296,7 @@ class ProjectedGraphIndex:
             for variant in item.variants
         }
         identities = frozenset(self.catalog.items)
-        by_variant: dict[str, ProjectionGraphMeasurement] = {}
+        by_variant: dict[str, tuple[tuple[str, str], ...]] = {}
         graph_edge_count = 0
         for measurement in measurements:
             if not isinstance(measurement, ProjectionGraphMeasurement):
@@ -336,7 +336,16 @@ class ProjectedGraphIndex:
                     raise projections.ProjectionCanonicalizationError(
                         "graph edge target is outside the projection catalog"
                     )
-            by_variant[key.projection_variant_id] = measurement
+            # Retain only atomic edge facts.  The typed ingest objects are
+            # useful for validation but keeping hundreds of thousands of them
+            # in the active runtime makes every full cyclic-GC traversal scale
+            # with hidden graph size.  Tuples of strings become untracked after
+            # the startup stabilization collection; admitted typed edges are
+            # reconstructed only for the caller-visible projection.
+            by_variant[key.projection_variant_id] = tuple(
+                (edge.target_item_identity, edge.relation_type)
+                for edge in measurement.edges
+            )
         self._measurements = MappingProxyType(by_variant)
 
     def authorize(
@@ -349,15 +358,19 @@ class ProjectedGraphIndex:
         selected_identities = frozenset(variant.item_identity for variant in selected)
         admitted_edges: list[ProjectionGraphEdge] = []
         for variant in selected:
-            measurement = self._measurements.get(variant.projection_variant_id)
-            if measurement is None:
+            variant_id = variant.projection_variant_id
+            if variant_id not in self._measurements:
                 raise projected_retrieval.ProjectedLaneUnavailable(
                     "selected projection graph measurement is unavailable"
                 )
             admitted_edges.extend(
-                edge
-                for edge in measurement.edges
-                if edge.target_item_identity in selected_identities
+                ProjectionGraphEdge(
+                    source_item_identity=variant.item_identity,
+                    target_item_identity=target,
+                    relation_type=relation,
+                )
+                for target, relation in self._measurements[variant_id]
+                if target in selected_identities
             )
         vertices = tuple(sorted(selected_identities, key=_sort_key))
         selected_variants = tuple(

--- a/src/exomem/governance/projected_retrieval.py
+++ b/src/exomem/governance/projected_retrieval.py
@@ -99,6 +99,7 @@ class AuthorizationProjectionMap:
 
     namespace_key: projections.ProjectionNamespaceKey
     selections: tuple[ProjectionSelection, ...]
+    withheld_identities: frozenset[str] = frozenset()
 
     def __post_init__(self) -> None:
         if not isinstance(self.namespace_key, projections.ProjectionNamespaceKey):
@@ -120,11 +121,24 @@ class AuthorizationProjectionMap:
                     "authorization map contains a duplicate item identity"
                 )
             by_identity[selection.item_identity] = selection
+        if not isinstance(self.withheld_identities, frozenset):
+            raise projections.ProjectionCanonicalizationError(
+                "authorization map withheld identities must be an immutable set"
+            )
+        withheld = frozenset(
+            _bounded_text(identity, "withheld item identity", maximum=4096)
+            for identity in self.withheld_identities
+        )
+        if withheld.intersection(by_identity):
+            raise projections.ProjectionCanonicalizationError(
+                "authorization map selects and withholds the same item"
+            )
         object.__setattr__(
             self,
             "selections",
             tuple(by_identity[key] for key in sorted(by_identity, key=_sort_key)),
         )
+        object.__setattr__(self, "withheld_identities", withheld)
 
 
 @dataclass(frozen=True, slots=True)
@@ -262,15 +276,27 @@ def _selected_variants(
     selections = {
         selection.item_identity: selection for selection in authorization.selections
     }
-    if frozenset(selections) != frozenset(items):
+    inline_withheld = frozenset(
+        identity
+        for identity, selection in selections.items()
+        if selection.projection_variant_id is None
+    )
+    explicit_withheld = authorization.withheld_identities
+    if (
+        inline_withheld.intersection(explicit_withheld)
+        or frozenset(selections).union(explicit_withheld) != frozenset(items)
+    ):
         raise ProjectedRetrievalUnavailable(
             "authorization map does not cover the exact projection catalog"
         )
 
     selected: list[projections.ProjectionVariant] = []
-    for identity in sorted(items, key=_sort_key):
-        item = items[identity]
-        selection = selections[identity]
+    for identity, selection in selections.items():
+        item = items.get(identity)
+        if item is None:
+            raise ProjectedRetrievalUnavailable(
+                "authorization map does not cover the exact projection catalog"
+            )
         if selection.content_hash != item.content_hash:
             raise ProjectedRetrievalUnavailable(
                 "authorization selection content hash does not match catalog"

--- a/src/exomem/governance/projected_retrieval.py
+++ b/src/exomem/governance/projected_retrieval.py
@@ -497,6 +497,14 @@ class ProjectedLexicalIndex:
             token: len(self._postings.get(token, frozenset()) & selected_ids)
             for token in frozenset(query_tokens)
         }
+        inverse_frequencies = {
+            token: math.log(
+                1
+                + (len(documents) - document_frequency + 0.5)
+                / (document_frequency + 0.5)
+            )
+            for token, document_frequency in frequencies.items()
+        }
         average_length = max(
             sum(len(document.tokens) for document in documents) / len(documents),
             1.0,
@@ -505,18 +513,12 @@ class ProjectedLexicalIndex:
         for document in candidates:
             term_counts = Counter(document.tokens)
             score = 0.0
+            length_normalization = 1 - _BM25_B + _BM25_B * (
+                len(document.tokens) / average_length
+            )
             for token in query_tokens:
                 frequency = term_counts[token]
-                document_frequency = frequencies[token]
-                inverse_document_frequency = math.log(
-                    1
-                    + (len(documents) - document_frequency + 0.5)
-                    / (document_frequency + 0.5)
-                )
-                length_normalization = 1 - _BM25_B + _BM25_B * (
-                    len(document.tokens) / average_length
-                )
-                score += inverse_document_frequency * (
+                score += inverse_frequencies[token] * (
                     frequency * (_BM25_K1 + 1)
                 ) / (frequency + _BM25_K1 * length_normalization)
             if score > 0:
@@ -548,11 +550,11 @@ class ProjectedLexicalIndex:
         )
         if not query_tokens:
             return ()
-        matches = [
-            document
-            for document in documents
-            if all(token in document.text.casefold() for token in query_tokens)
-        ]
+        matches: list[_SelectedDocument] = []
+        for document in documents:
+            folded_text = document.text.casefold()
+            if all(token in folded_text for token in query_tokens):
+                matches.append(document)
         matches.sort(
             key=lambda document: (
                 _sort_key(document.variant.item_identity),

--- a/src/exomem/governance/projection_authorization.py
+++ b/src/exomem/governance/projection_authorization.py
@@ -274,6 +274,7 @@ def build_authorization_map(
         grants_by_item.setdefault(grant.item_identity, []).append(grant)
 
     selections: list[projected_retrieval.ProjectionSelection] = []
+    withheld_identities: list[str] = []
     decision_cache: dict[
         tuple[tuple[str, ...], tuple[StandingGrant, ...]],
         Decision,
@@ -312,14 +313,7 @@ def build_authorization_map(
                     )
             decision_cache[decision_key] = decision
         if decision.level == 0:
-            selections.append(
-                projected_retrieval.ProjectionSelection(
-                    item_identity=request_item.item_identity,
-                    content_hash=request_item.content_hash,
-                    projection_variant_id=None,
-                    decision=decision,
-                )
-            )
+            withheld_identities.append(request_item.item_identity)
             continue
         candidate_descriptors = descriptor_cache.get(decision_key)
         if candidate_descriptors is None:
@@ -369,6 +363,7 @@ def build_authorization_map(
     return projected_retrieval.AuthorizationProjectionMap(
         namespace_key,
         tuple(selections),
+        frozenset(withheld_identities),
     )
 
 

--- a/src/exomem/governance/projection_runtime.py
+++ b/src/exomem/governance/projection_runtime.py
@@ -24,6 +24,7 @@ from . import (
     projection_authorization,
     projection_measurement_store,
     projection_store,
+    projection_timing,
     schema_v4,
     store,
 )
@@ -47,11 +48,26 @@ class _PreactivatedProjectionRuntime:
 
 _PREACTIVATED_RUNTIMES: dict[str, _PreactivatedProjectionRuntime] = {}
 _PREACTIVATED_RUNTIME_LOCK = threading.RLock()
-# Repository-owned release fence.  Preactivation proves startup readiness, but
-# public v4 serving stays closed until every required projected lane and the
-# exact-capacity actual-wire gate land together.  This is deliberately not an
-# environment or operator switch.
-_PROJECTED_SERVING_RELEASE_ACCEPTED = False
+# Repository-owned release fence. The checked release manifest and required
+# actual-wire CI matrix currently certify only the exact model-hard-off runtime
+# profile. Environment cannot opt an uncertified model-enabled profile into
+# serving; those configurations remain closed until their own evidence lands.
+_PROJECTED_SERVING_RELEASE_ACCEPTED = True
+
+
+def projected_serving_release_profile() -> str | None:
+    """Return the one repository-certified runtime profile, if exact."""
+
+    if all(
+        os.environ.get(name) == "1"
+        for name in (
+            "EXOMEM_DISABLE_EMBEDDINGS",
+            "EXOMEM_DISABLE_CLIP",
+            "EXOMEM_DISABLE_RANKING",
+        )
+    ):
+        return projection_timing.MODEL_RUNTIME_PROFILE
+    return None
 
 
 @dataclass(frozen=True, slots=True)
@@ -525,7 +541,11 @@ def load_active_projection_runtime(
     root = Path(vault_root)
     preactivated = _preactivated_runtime(root)
     if preactivated is not None:
-        if not _PROJECTED_SERVING_RELEASE_ACCEPTED:
+        if (
+            not _PROJECTED_SERVING_RELEASE_ACCEPTED
+            or projected_serving_release_profile()
+            != projection_timing.MODEL_RUNTIME_PROFILE
+        ):
             raise ProjectionRuntimeUnavailable(
                 "governed projected retrieval is unavailable"
             )
@@ -812,7 +832,13 @@ def find_projected_hits(
         )
     if type(limit) is not int or not 1 <= limit <= 100:
         raise ValueError("find: limit must be an integer from 1 through 100")
-    if not isinstance(query, str) or len(query) > 1_048_576:
+    if (
+        not isinstance(query, str)
+        or len(query)
+        > projection_timing.PUBLIC_REQUEST_CLASSES[
+            "projected-find-v1"
+        ].max_query_chars
+    ):
         raise ValueError("find: query must be bounded text")
     if (
         type(auto_rerank) is not bool
@@ -852,7 +878,7 @@ def find_projected_hits(
         verified_session_grants=verified_grants,
         catalog=runtime.catalog,
     )
-    withheld = frozenset(
+    withheld = authorization.withheld_identities.union(
         selection.item_identity
         for selection in authorization.selections
         if selection.projection_variant_id is None
@@ -860,11 +886,9 @@ def find_projected_hits(
     by_identity = {
         selection.item_identity: selection
         for selection in authorization.selections
+        if selection.projection_variant_id is not None
     }
-    selected_count = sum(
-        selection.projection_variant_id is not None
-        for selection in authorization.selections
-    )
+    selected_count = len(by_identity)
     selected_variants = {
         variant.item_identity: variant
         for variant in runtime.catalog.select(authorization)

--- a/src/exomem/governance/projection_runtime.py
+++ b/src/exomem/governance/projection_runtime.py
@@ -848,7 +848,7 @@ def find_projected_hits(
 ) -> ProjectedFindResult:
     """Acquire public candidates without opening a raw corpus/index lane."""
 
-    from .. import embeddings, readiness
+    from .. import readiness
 
     if not isinstance(runtime, ActiveProjectionRuntime):
         raise ProjectionRuntimeUnavailable(
@@ -902,10 +902,15 @@ def find_projected_hits(
         verified_session_grants=verified_grants,
         catalog=runtime.catalog,
     )
-    withheld = authorization.withheld_identities.union(
+    inline_withheld = frozenset(
         selection.item_identity
         for selection in authorization.selections
         if selection.projection_variant_id is None
+    )
+    withheld = (
+        authorization.withheld_identities
+        if not inline_withheld
+        else authorization.withheld_identities.union(inline_withheld)
     )
     by_identity = {
         selection.item_identity: selection
@@ -940,6 +945,7 @@ def find_projected_hits(
     )
     lane_hits: dict[str, tuple[projected_retrieval.ProjectedLexicalHit, ...]] = {}
     warming: set[str] = set()
+    embeddings_module = None
 
     if mode == "keyword":
         lane_hits["keyword"] = runtime.lexical_index.search_keyword(
@@ -965,67 +971,78 @@ def find_projected_hits(
             lane_hits["vector"] = ()
         elif readiness.should_defer("embeddings"):
             warming.add("vector")
-        elif (
-            vector_index is None
-            or vector_index.extractor_version != "projected-text-v1"
-            or vector_index.model_version != embeddings.MODEL_NAME
-        ):
-            warming.add("vector")
         else:
-            try:
-                query_vector = tuple(
-                    float(value)
-                    for value in embeddings.embed_texts([query], is_query=True)[0]
-                )
-            except Exception:  # noqa: BLE001 - optional query model soft-fails
+            from .. import embeddings as embeddings_module
+
+            if (
+                vector_index is None
+                or vector_index.extractor_version != "projected-text-v1"
+                or vector_index.model_version != embeddings_module.MODEL_NAME
+            ):
                 warming.add("vector")
             else:
                 try:
-                    lane_hits["vector"] = vector_index.search_vector(
-                        authorization,
-                        query_vector,
-                        k=lane_depth,
+                    query_vector = tuple(
+                        float(value)
+                        for value in embeddings_module.embed_texts(
+                            [query],
+                            is_query=True,
+                        )[0]
                     )
-                except projected_retrieval.ProjectedLaneUnavailable:
+                except Exception:  # noqa: BLE001 - optional query model soft-fails
                     warming.add("vector")
-                except projected_retrieval.ProjectedRetrievalUnavailable as error:
-                    raise ProjectionRuntimeUnavailable(
-                        "governed projected retrieval is unavailable"
-                    ) from error
+                else:
+                    try:
+                        lane_hits["vector"] = vector_index.search_vector(
+                            authorization,
+                            query_vector,
+                            k=lane_depth,
+                        )
+                    except projected_retrieval.ProjectedLaneUnavailable:
+                        warming.add("vector")
+                    except projected_retrieval.ProjectedRetrievalUnavailable as error:
+                        raise ProjectionRuntimeUnavailable(
+                            "governed projected retrieval is unavailable"
+                        ) from error
 
         clip_index = runtime.clip_index
-        if not has_selected_clip:
+        if not has_selected_clip or os.environ.get("EXOMEM_DISABLE_CLIP"):
             lane_hits["clip"] = ()
-        elif not embeddings.clip_enabled():
-            lane_hits["clip"] = ()
-        elif readiness.should_defer("clip"):
-            warming.add("clip")
-        elif (
-            clip_index is None
-            or clip_index.extractor_version != "pixels-v1"
-            or clip_index.model_version != embeddings.CLIP_MODEL_NAME
-        ):
-            warming.add("clip")
         else:
-            try:
-                clip_query = tuple(
-                    float(value) for value in embeddings.embed_clip_text(query)
-                )
-            except Exception:  # noqa: BLE001 - optional query model soft-fails
+            if embeddings_module is None:
+                from .. import embeddings as embeddings_module
+
+            if not embeddings_module.clip_enabled():
+                lane_hits["clip"] = ()
+            elif readiness.should_defer("clip"):
+                warming.add("clip")
+            elif (
+                clip_index is None
+                or clip_index.extractor_version != "pixels-v1"
+                or clip_index.model_version != embeddings_module.CLIP_MODEL_NAME
+            ):
                 warming.add("clip")
             else:
                 try:
-                    lane_hits["clip"] = clip_index.search_clip(
-                        authorization,
-                        clip_query,
-                        k=lane_depth,
+                    clip_query = tuple(
+                        float(value)
+                        for value in embeddings_module.embed_clip_text(query)
                     )
-                except projected_retrieval.ProjectedLaneUnavailable:
+                except Exception:  # noqa: BLE001 - optional query model soft-fails
                     warming.add("clip")
-                except projected_retrieval.ProjectedRetrievalUnavailable as error:
-                    raise ProjectionRuntimeUnavailable(
-                        "governed projected retrieval is unavailable"
-                    ) from error
+                else:
+                    try:
+                        lane_hits["clip"] = clip_index.search_clip(
+                            authorization,
+                            clip_query,
+                            k=lane_depth,
+                        )
+                    except projected_retrieval.ProjectedLaneUnavailable:
+                        warming.add("clip")
+                    except projected_retrieval.ProjectedRetrievalUnavailable as error:
+                        raise ProjectionRuntimeUnavailable(
+                            "governed projected retrieval is unavailable"
+                        ) from error
 
     raw_bm25_hits = lane_hits.get("bm25", ())
     if mode == "hybrid":
@@ -1171,7 +1188,11 @@ def find_projected_hits(
             and _should_auto_rerank(lane_hits, query)
         )
     )
-    if do_rerank and not embeddings.ranking_enabled():
+    if do_rerank and os.environ.get("EXOMEM_DISABLE_RANKING"):
+        do_rerank = False
+    if do_rerank and embeddings_module is None:
+        from .. import embeddings as embeddings_module
+    if do_rerank and not embeddings_module.ranking_enabled():
         do_rerank = False
     if do_rerank and readiness.should_defer("reranker"):
         warming.add("rerank")
@@ -1181,7 +1202,11 @@ def find_projected_hits(
             scorer_query: str,
             passages: list[str],
         ) -> list[float]:
-            raw_scores = tuple(embeddings.rerank_pairs(scorer_query, passages))
+            if embeddings_module is None:
+                raise ValueError("reranker runtime is unavailable")
+            raw_scores = tuple(
+                embeddings_module.rerank_pairs(scorer_query, passages)
+            )
             if len(raw_scores) != len(ordered_identities):
                 raise ValueError("reranker returned an invalid score count")
             pending_raw: dict[str, float] = {}

--- a/src/exomem/governance/projection_runtime.py
+++ b/src/exomem/governance/projection_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gc
 import math
 import os
 import sqlite3
@@ -216,6 +217,27 @@ class ProjectedFindResult:
     declared_purpose: str | None = None
 
 
+def _stabilize_projection_runtime(
+    runtime: ActiveProjectionRuntime,
+) -> ActiveProjectionRuntime:
+    """Finish tracing the immutable runtime before it becomes request-visible.
+
+    Exact-capacity catalogs and graph families contain hundreds of thousands of
+    long-lived immutable objects. Leaving their first full GC traversal to a
+    public request makes that request's completion depend on hidden corpus
+    size. Collect once at the startup publication boundary, before routing can
+    resolve this runtime; request-local allocations then stay in the young
+    generations covered by the fixed completion class.
+    """
+
+    if not isinstance(runtime, ActiveProjectionRuntime):
+        raise ProjectionRuntimeUnavailable(
+            "governed projected retrieval is unavailable"
+        )
+    gc.collect()
+    return runtime
+
+
 def _root_key(vault_root: Path) -> str:
     return os.path.normcase(os.path.abspath(os.fspath(Path(vault_root))))
 
@@ -363,13 +385,15 @@ def preactivate_projection_runtime(
                 raise ProjectionRuntimeUnavailable(
                     "governed projected retrieval is unavailable"
                 )
-        runtime = ActiveProjectionRuntime(
-            snapshot,
-            namespace,
-            evidence.required_measurement_roots,
-            vector_index=vector_index,
-            clip_index=clip_index,
-            graph_index=graph_index,
+        runtime = _stabilize_projection_runtime(
+            ActiveProjectionRuntime(
+                snapshot,
+                namespace,
+                evidence.required_measurement_roots,
+                vector_index=vector_index,
+                clip_index=clip_index,
+                graph_index=graph_index,
+            )
         )
         record = _PreactivatedProjectionRuntime(
             root_key=_root_key(root),

--- a/src/exomem/governance/projection_timing.py
+++ b/src/exomem/governance/projection_timing.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import inspect
 import math
 import random
 import statistics
@@ -10,6 +9,7 @@ import time
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
+from hashlib import sha256
 from types import MappingProxyType
 
 from . import projections
@@ -28,6 +28,8 @@ class PublicRequestClass:
     name: str
     padding_ms: int
     deadline_ms: int
+    max_query_chars: int
+    max_limit: int
     max_hidden_delta_ms: int
     max_hidden_delta_ratio: float
 
@@ -39,6 +41,8 @@ class PublicRequestClass:
             or type(self.deadline_ms) is not int
             or self.padding_ms <= 0
             or self.deadline_ms < self.padding_ms
+            or self.max_query_chars != 4_096
+            or self.max_limit != 100
             or self.max_hidden_delta_ms
             != projections.MAX_HIDDEN_CORPUS_WIRE_DELTA_MS
             or self.max_hidden_delta_ratio
@@ -49,16 +53,18 @@ class PublicRequestClass:
             )
 
 
-_PROJECTED_FIND_KEYWORD_V1 = PublicRequestClass(
-    name="projected-find-keyword-v1",
+_PROJECTED_FIND_V1 = PublicRequestClass(
+    name="projected-find-v1",
     padding_ms=250,
     deadline_ms=300,
+    max_query_chars=4_096,
+    max_limit=100,
     max_hidden_delta_ms=projections.MAX_HIDDEN_CORPUS_WIRE_DELTA_MS,
     max_hidden_delta_ratio=projections.MAX_HIDDEN_CORPUS_WIRE_DELTA_RATIO,
 )
 
 PUBLIC_REQUEST_CLASSES: Mapping[str, PublicRequestClass] = MappingProxyType(
-    {_PROJECTED_FIND_KEYWORD_V1.name: _PROJECTED_FIND_KEYWORD_V1}
+    {_PROJECTED_FIND_V1.name: _PROJECTED_FIND_V1}
 )
 
 _RELEASE_MANIFEST_SCHEMA = "exomem.governed-projection-timing-release/v1"
@@ -70,6 +76,7 @@ _RELEASE_MANIFEST_KEYS = frozenset(
         "bootstrap_resamples",
         "bootstrap_seed",
         "hardware_runtime_profile",
+        "model_runtime_profile",
         "request_classes",
         "routes",
         "capacity",
@@ -77,14 +84,30 @@ _RELEASE_MANIFEST_KEYS = frozenset(
         "padding_selected_before_sampling",
     }
 )
-_REQUEST_CLASS_KEYS = frozenset({"name", "padding_ms", "deadline_ms"})
+_REQUEST_CLASS_KEYS = frozenset(
+    {"name", "padding_ms", "deadline_ms", "max_query_chars", "max_limit"}
+)
 _CAPACITY_KEYS = frozenset(
     {"catalog_items", "searchable_bytes_per_item", "graph_edges"}
 )
 _REQUIRED_ROUTES = frozenset(
-    {"keyword", "bm25", "vector", "rerank", "clip", "graph", "error", "pagination"}
+    {
+        "keyword",
+        "bm25",
+        "vector-hard-off",
+        "rerank-hard-off",
+        "clip-hard-off",
+        "graph",
+        "graph-rerank-hard-off",
+        "max-query",
+        "max-limit",
+        "max-shape",
+        "error",
+        "pagination",
+    }
 )
 _HARDWARE_RUNTIME_PROFILE = "github-hosted-ubuntu-latest-x64-python3.13"
+MODEL_RUNTIME_PROFILE = "models-hard-off-v1"
 _MIN_SAMPLE_COUNT_PER_CONDITION = 200
 _MIN_BOOTSTRAP_RESAMPLES = 2_000
 _TIMING_RELEASE_MANIFEST_PROOF = object()
@@ -99,6 +122,7 @@ class TimingReleaseManifest:
     bootstrap_resamples: int
     bootstrap_seed: int
     hardware_runtime_profile: str
+    model_runtime_profile: str
     request_class_names: tuple[str, ...]
     routes: frozenset[str]
     catalog_items: int
@@ -113,6 +137,7 @@ class TimingReleaseManifest:
         bootstrap_resamples: int,
         bootstrap_seed: int,
         hardware_runtime_profile: str,
+        model_runtime_profile: str,
         request_class_names: tuple[str, ...],
         routes: frozenset[str],
         catalog_items: int,
@@ -130,6 +155,7 @@ class TimingReleaseManifest:
             "bootstrap_resamples": bootstrap_resamples,
             "bootstrap_seed": bootstrap_seed,
             "hardware_runtime_profile": hardware_runtime_profile,
+            "model_runtime_profile": model_runtime_profile,
             "request_class_names": request_class_names,
             "routes": routes,
             "catalog_items": catalog_items,
@@ -154,6 +180,71 @@ class WireDifferentialReport:
     p95_delta_upper_99_ms: float
     effective_delta_ceiling_ms: float
     deadline_misses: int
+    passed: bool
+
+
+@dataclass(frozen=True, slots=True)
+class WireSample:
+    """One predeclared member of a hidden-present/absent wire pair.
+
+    ``capacity`` is the actual hidden-corpus condition: absent samples are
+    always ``zero``; present samples alternate between ``one`` and ``maximum``.
+    """
+
+    pair_id: int
+    route: str
+    capacity: str
+    hidden_present: bool
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.pair_id) is not int
+            or self.pair_id < 0
+            or self.route not in _REQUIRED_ROUTES
+            or self.capacity not in {"zero", "one", "maximum"}
+            or type(self.hidden_present) is not bool
+        ):
+            raise ProjectedRequestTimingUnavailable(
+                "governed projected request timing is unavailable"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class WireObservation:
+    """Actual completion and canonical-envelope digest for one sample."""
+
+    sample: WireSample
+    elapsed_ms: float
+    canonical_envelope_sha256: str
+
+    def __post_init__(self) -> None:
+        try:
+            digest = bytes.fromhex(self.canonical_envelope_sha256)
+        except (TypeError, ValueError) as error:
+            raise ProjectedRequestTimingUnavailable(
+                "governed projected request timing is unavailable"
+            ) from error
+        if (
+            not isinstance(self.sample, WireSample)
+            or isinstance(self.elapsed_ms, bool)
+            or not isinstance(self.elapsed_ms, (int, float))
+            or not math.isfinite(float(self.elapsed_ms))
+            or float(self.elapsed_ms) < 0
+            or len(digest) != 32
+            or self.canonical_envelope_sha256 != digest.hex()
+        ):
+            raise ProjectedRequestTimingUnavailable(
+                "governed projected request timing is unavailable"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class WireRouteReport:
+    """Content and timing verdict for one mandatory actual-wire route."""
+
+    route: str
+    envelope_pairs_equal: bool
+    timing: WireDifferentialReport
     passed: bool
 
 
@@ -209,6 +300,10 @@ def validate_release_manifest(value: object) -> TimingReleaseManifest:
         raise ProjectedRequestTimingUnavailable(
             "governed projected request timing is unavailable"
         )
+    if manifest["model_runtime_profile"] != MODEL_RUNTIME_PROFILE:
+        raise ProjectedRequestTimingUnavailable(
+            "governed projected request timing is unavailable"
+        )
     if manifest["scheduler_tolerance_subtracted"] is not False or manifest[
         "padding_selected_before_sampling"
     ] is not True:
@@ -234,6 +329,10 @@ def validate_release_manifest(value: object) -> TimingReleaseManifest:
             or declared["padding_ms"] != registered.padding_ms
             or type(declared["deadline_ms"]) is not int
             or declared["deadline_ms"] != registered.deadline_ms
+            or type(declared["max_query_chars"]) is not int
+            or declared["max_query_chars"] != registered.max_query_chars
+            or type(declared["max_limit"]) is not int
+            or declared["max_limit"] != registered.max_limit
         ):
             raise ProjectedRequestTimingUnavailable(
                 "governed projected request timing is unavailable"
@@ -278,6 +377,7 @@ def validate_release_manifest(value: object) -> TimingReleaseManifest:
         bootstrap_resamples=bootstrap_resamples,
         bootstrap_seed=bootstrap_seed,
         hardware_runtime_profile=_HARDWARE_RUNTIME_PROFILE,
+        model_runtime_profile=MODEL_RUNTIME_PROFILE,
         request_class_names=tuple(names),
         routes=frozenset(routes),
         catalog_items=expected_capacity["catalog_items"],
@@ -386,6 +486,93 @@ def evaluate_wire_differential(
     )
 
 
+def release_sample_schedule(
+    manifest: TimingReleaseManifest,
+    *,
+    route: str,
+) -> tuple[WireSample, ...]:
+    """Return the immutable pre-observation paired schedule for one route."""
+
+    if (
+        not isinstance(manifest, TimingReleaseManifest)
+        or route not in manifest.routes
+        or route not in _REQUIRED_ROUTES
+    ):
+        raise ProjectedRequestTimingUnavailable(
+            "governed projected request timing is unavailable"
+        )
+    seed_material = f"{manifest.bootstrap_seed}\0{route}".encode("ascii")
+    rng = random.Random(int.from_bytes(sha256(seed_material).digest()[:8], "big"))
+    present_capacities = [
+        ("one", "maximum")[index % 2]
+        for index in range(manifest.sample_count_per_condition)
+    ]
+    rng.shuffle(present_capacities)
+    schedule: list[WireSample] = []
+    for pair_id, present_capacity in enumerate(present_capacities):
+        first_present = bool(rng.getrandbits(1))
+        for hidden_present in (first_present, not first_present):
+            schedule.append(
+                WireSample(
+                    pair_id=pair_id,
+                    route=route,
+                    capacity=present_capacity if hidden_present else "zero",
+                    hidden_present=hidden_present,
+                )
+            )
+    return tuple(schedule)
+
+
+def evaluate_wire_route(
+    manifest: TimingReleaseManifest,
+    *,
+    route: str,
+    observations: tuple[WireObservation, ...],
+) -> WireRouteReport:
+    """Evaluate one route only when it follows the predeclared paired schedule."""
+
+    if not isinstance(observations, tuple):
+        raise ProjectedRequestTimingUnavailable(
+            "governed projected request timing is unavailable"
+        )
+    schedule = release_sample_schedule(manifest, route=route)
+    if len(observations) != len(schedule) or any(
+        not isinstance(observation, WireObservation)
+        or observation.sample != expected
+        for observation, expected in zip(observations, schedule, strict=True)
+    ):
+        raise ProjectedRequestTimingUnavailable(
+            "governed projected request timing is unavailable"
+        )
+    present: list[float] = []
+    absent: list[float] = []
+    envelope_pairs_equal = True
+    for offset in range(0, len(observations), 2):
+        left, right = observations[offset : offset + 2]
+        envelope_pairs_equal = envelope_pairs_equal and (
+            left.canonical_envelope_sha256 == right.canonical_envelope_sha256
+        )
+    for observation in observations:
+        target = present if observation.sample.hidden_present else absent
+        target.append(float(observation.elapsed_ms))
+    if len(manifest.request_class_names) != 1:
+        raise ProjectedRequestTimingUnavailable(
+            "governed projected request timing is unavailable"
+        )
+    timing = evaluate_wire_differential(
+        manifest,
+        request_class_name=manifest.request_class_names[0],
+        hidden_present_ms=present,
+        physically_absent_ms=absent,
+    )
+    return WireRouteReport(
+        route=route,
+        envelope_pairs_equal=envelope_pairs_equal,
+        timing=timing,
+        passed=envelope_pairs_equal and timing.passed,
+    )
+
+
 def request_class_for_find(
     *,
     mode: str,
@@ -393,18 +580,19 @@ def request_class_for_find(
     graph: bool,
     rerank: bool | None,
 ) -> PublicRequestClass:
-    """Select only the one currently implemented public projected shape."""
+    """Select the fixed class shared by every implemented projected find lane."""
 
     if (
-        mode != "keyword"
+        mode not in {"keyword", "hybrid", "vector"}
         or scope != "vault"
-        or graph is not False
-        or rerank is not False
+        or type(graph) is not bool
+        or rerank not in {None, False, True}
+        or (mode == "keyword" and graph)
     ):
         raise ProjectedRequestTimingUnavailable(
             "governed projected request timing is unavailable"
         )
-    return _PROJECTED_FIND_KEYWORD_V1
+    return _PROJECTED_FIND_V1
 
 
 def request_class_for_command(
@@ -412,8 +600,9 @@ def request_class_for_command(
     injected: tuple[object, ...],
     kwargs: Mapping[str, object],
 ) -> PublicRequestClass | None:
-    """Resolve the fixed class from one shared-dispatch command invocation."""
+    """Resolve the class before semantic validation so errors are padded too."""
 
+    del injected, kwargs
     if getattr(command, "name", None) not in {"ask_memory", "find"}:
         return None
     leaf = getattr(command, "leaf", None)
@@ -421,19 +610,10 @@ def request_class_for_command(
         raise ProjectedRequestTimingUnavailable(
             "governed projected request timing is unavailable"
         )
-    try:
-        bound = inspect.signature(leaf).bind_partial(*injected, **kwargs)
-        bound.apply_defaults()
-        return request_class_for_find(
-            mode=bound.arguments["mode"],
-            scope=bound.arguments["scope"],
-            graph=bound.arguments["graph"],
-            rerank=bound.arguments["rerank"],
-        )
-    except (KeyError, TypeError, ValueError) as error:
-        raise ProjectedRequestTimingUnavailable(
-            "governed projected request timing is unavailable"
-        ) from error
+    # The one class covers every registered shape up to its declared maxima,
+    # plus normalized refusals. Shape-specific actual-wire routes enforce that
+    # breadth; callers cannot select another padding or deadline.
+    return _PROJECTED_FIND_V1
 
 
 def complete_public_request(
@@ -450,40 +630,37 @@ def complete_public_request(
         raise ProjectedRequestTimingUnavailable(
             "governed projected request timing is unavailable"
         )
-    finished_at = clock()
     if (
         isinstance(started_at, bool)
         or not isinstance(started_at, (int, float))
         or not math.isfinite(float(started_at))
-        or not math.isfinite(float(finished_at))
-        or finished_at < started_at
     ):
         raise ProjectedRequestTimingUnavailable(
             "governed projected request timing is unavailable"
         )
-    elapsed_ms = (finished_at - float(started_at)) * 1000.0
-    if elapsed_ms > request_class.deadline_ms:
-        raise ProjectedRequestDeadlineExceeded(
-            "governed projected request deadline was exceeded"
-        )
-    remaining = max(0.0, (request_class.padding_ms - elapsed_ms) / 1000.0)
-    if remaining:
-        sleeper(remaining)
-    completed_at = clock()
-    if (
-        isinstance(completed_at, bool)
-        or not isinstance(completed_at, (int, float))
-        or not math.isfinite(float(completed_at))
-        or completed_at < finished_at
-        or (
-        completed_at - float(started_at)
-        )
-        * 1000.0
-        > request_class.deadline_ms
-    ):
-        raise ProjectedRequestDeadlineExceeded(
-            "governed projected request deadline was exceeded"
-        )
+    started = float(started_at)
+    previous = started
+    while True:
+        reading = clock()
+        if (
+            isinstance(reading, bool)
+            or not isinstance(reading, (int, float))
+            or not math.isfinite(float(reading))
+            or float(reading) < previous
+        ):
+            raise ProjectedRequestTimingUnavailable(
+                "governed projected request timing is unavailable"
+            )
+        completed = float(reading)
+        elapsed_ms = (completed - started) * 1000.0
+        if elapsed_ms > request_class.deadline_ms:
+            raise ProjectedRequestDeadlineExceeded(
+                "governed projected request deadline was exceeded"
+            )
+        if elapsed_ms >= request_class.padding_ms:
+            return
+        sleeper((request_class.padding_ms - elapsed_ms) / 1000.0)
+        previous = completed
 
 
 @contextmanager
@@ -505,11 +682,16 @@ __all__ = [
     "ProjectedRequestTimingUnavailable",
     "PublicRequestClass",
     "TimingReleaseManifest",
+    "WireObservation",
     "WireDifferentialReport",
+    "WireRouteReport",
+    "WireSample",
     "complete_public_request",
     "evaluate_wire_differential",
+    "evaluate_wire_route",
     "fixed_public_completion",
     "request_class_for_command",
     "request_class_for_find",
+    "release_sample_schedule",
     "validate_release_manifest",
 ]

--- a/tests/test_ci_reliability_contract.py
+++ b/tests/test_ci_reliability_contract.py
@@ -197,6 +197,39 @@ def test_retrieval_gates_run_as_three_independent_jobs() -> None:
     assert "scripts/semantic_write_latency.py --check" in semantic_command
 
 
+def test_governance_wire_gate_runs_every_closed_route_on_the_registered_profile() -> None:
+    workflow = _workflow()
+    job = workflow["jobs"]["governance-projection-wire"]
+
+    assert job["runs-on"] == "ubuntu-latest"
+    assert job["timeout-minutes"] == 8
+    assert job["strategy"]["fail-fast"] is False
+    assert set(job["strategy"]["matrix"]["route"]) == {
+        "keyword",
+        "bm25",
+        "vector-hard-off",
+        "rerank-hard-off",
+        "clip-hard-off",
+        "graph",
+        "graph-rerank-hard-off",
+        "max-query",
+        "max-limit",
+        "max-shape",
+        "error",
+        "pagination",
+    }
+    command = job["steps"][-1]["run"]
+    assert "--python 3.13" in command
+    assert "tests/test_governance_projection_wire_gate.py" in command
+    assert job["steps"][-1]["env"]["EXOMEM_GOVERNANCE_TIMING_ROUTE"] == (
+        "${{ matrix.route }}"
+    )
+    assert job["steps"][-1]["env"]["EXOMEM_DISABLE_EMBEDDINGS"] == "1"
+    assert job["steps"][-1]["env"]["EXOMEM_DISABLE_CLIP"] == "1"
+    assert job["steps"][-1]["env"]["EXOMEM_DISABLE_RANKING"] == "1"
+    assert "governance-projection-wire" in workflow["jobs"]["gate"]["needs"]
+
+
 def test_superseded_pr_runs_cancel_and_one_stable_gate_requires_every_ci_job() -> None:
     workflow = _workflow()
 

--- a/tests/test_governance_projected_commands.py
+++ b/tests/test_governance_projected_commands.py
@@ -97,17 +97,111 @@ def test_v4_find_never_acquires_from_the_raw_corpus(monkeypatch, tmp_path) -> No
             rerank=False,
         )
 
-    assert response == [
-        {
-            "path": "Knowledge Base/visible.md",
-            "type": "note",
-            "scope": "kb",
-            "title": "Visible",
-            "updated": "",
-            "excerpt": "projection-only term",
-            "signals": {"bm25_rank": 1},
-        }
-    ]
+    assert response == {
+        "hits": [
+            {
+                "path": "Knowledge Base/visible.md",
+                "type": "note",
+                "scope": "kb",
+                "title": "Visible",
+                "updated": "",
+                "excerpt": "projection-only term",
+                "signals": {"bm25_rank": 1},
+            }
+        ],
+        "timings_suppressed": {"status": "governed_projection"},
+    }
+
+
+def test_projected_find_suppresses_application_timings_with_one_stable_shape(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    runtime = SimpleNamespace(
+        snapshot=SimpleNamespace(policy=Policy(fingerprint="f" * 64, scopes={}))
+    )
+    monkeypatch.setattr(
+        commands.projection_runtime_module,
+        "load_active_projection_runtime",
+        lambda _root: runtime,
+    )
+    monkeypatch.setattr(
+        commands.projection_runtime_module,
+        "find_projected_hits",
+        lambda *_args, **_kwargs: projection_runtime.ProjectedFindResult(
+            hits=(),
+            withheld_paths=frozenset(),
+        ),
+    )
+    monkeypatch.setattr(
+        commands.find_module,
+        "FindTimings",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("governed projected requests must not collect public timings")
+        ),
+    )
+
+    with principal.request_scope(principal.owner_principal(surface="library")):
+        response = commands.op_find(
+            tmp_path,
+            query="projection-only term",
+            scope="vault",
+            mode="keyword",
+            graph=False,
+            rerank=False,
+            include_timings=True,
+        )
+
+    assert response == {
+        "hits": [],
+        "timings_suppressed": {"status": "governed_projection"},
+    }
+
+
+def test_projected_warming_marker_omits_process_age(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    runtime = SimpleNamespace(
+        snapshot=SimpleNamespace(policy=Policy(fingerprint="f" * 64, scopes={}))
+    )
+    monkeypatch.setattr(
+        commands.projection_runtime_module,
+        "load_active_projection_runtime",
+        lambda _root: runtime,
+    )
+    monkeypatch.setattr(
+        commands.projection_runtime_module,
+        "find_projected_hits",
+        lambda *_args, **_kwargs: projection_runtime.ProjectedFindResult(
+            hits=(),
+            withheld_paths=frozenset(),
+            warming_components=("vector",),
+        ),
+    )
+    monkeypatch.setattr(
+        commands.readiness_module,
+        "warming_info",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("projected warming must not sample process age")
+        ),
+    )
+
+    with principal.request_scope(principal.owner_principal(surface="library")):
+        response = commands.op_find(
+            tmp_path,
+            query="projection-only term",
+            scope="vault",
+            mode="hybrid",
+            graph=False,
+            rerank=False,
+        )
+
+    assert response == {
+        "hits": [],
+        "timings_suppressed": {"status": "governed_projection"},
+        "warming": {"components": ["vector"]},
+    }
 
 
 def test_low_projection_never_enters_path_bearing_query_log(monkeypatch, tmp_path) -> None:
@@ -181,14 +275,17 @@ def test_low_projection_never_enters_path_bearing_query_log(monkeypatch, tmp_pat
             rerank=False,
         )
 
-    assert response == [
-        {
-            "withheld": True,
-            "level": 2,
-            "scope_label": "closed",
-            "constraint": "Approved readers only",
-        }
-    ]
+    assert response == {
+        "hits": [
+            {
+                "withheld": True,
+                "level": 2,
+                "scope_label": "closed",
+                "constraint": "Approved readers only",
+            }
+        ],
+        "timings_suppressed": {"status": "governed_projection"},
+    }
     assert logged == []
 
 

--- a/tests/test_governance_projected_graph.py
+++ b/tests/test_governance_projected_graph.py
@@ -172,6 +172,29 @@ def test_edges_to_hidden_targets_are_removed_before_relation_matching() -> None:
     assert graph.neighbors("source") == ("visible",)
 
 
+def test_index_compacts_measurements_before_runtime_publication() -> None:
+    source = _variant("source", "d" * 64)
+    target = _variant("target", "e" * 64)
+    source_item, target_item = _item(source), _item(target)
+    index = projected_graph.ProjectedGraphIndex(
+        _namespace(source_item, target_item),
+        (
+            _measurement(source, _edge("source", "target", "supports")),
+            _measurement(target),
+        ),
+        extractor_version="relations-v1",
+        model_version="graph-schema-v1",
+    )
+
+    assert all(
+        not isinstance(value, projected_graph.ProjectionGraphMeasurement)
+        for value in index._measurements.values()
+    )
+    assert index.authorize(_map((source_item, source), (target_item, target))).edges == (
+        _edge("source", "target", "supports"),
+    )
+
+
 def test_missing_selected_graph_measurement_disables_lane_without_raw_fallback() -> None:
     source = _variant("source", "a" * 64)
     source_item = _item(source)

--- a/tests/test_governance_projected_runtime_lanes.py
+++ b/tests/test_governance_projected_runtime_lanes.py
@@ -655,9 +655,13 @@ def test_projected_models_respect_hard_off_and_readiness(
     )
     def model_called(*_args, **_kwargs):
         raise AssertionError("disabled or warming model must not run")
+    clip_enabled = embeddings.clip_enabled
+    ranking_enabled = embeddings.ranking_enabled
     monkeypatch.setattr(embeddings, "embed_texts", model_called)
     monkeypatch.setattr(embeddings, "embed_clip_text", model_called)
     monkeypatch.setattr(embeddings, "rerank_pairs", model_called)
+    monkeypatch.setattr(embeddings, "clip_enabled", model_called)
+    monkeypatch.setattr(embeddings, "ranking_enabled", model_called)
     monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
     monkeypatch.setenv("EXOMEM_DISABLE_CLIP", "1")
     monkeypatch.setenv("EXOMEM_DISABLE_RANKING", "1")
@@ -675,6 +679,8 @@ def test_projected_models_respect_hard_off_and_readiness(
     )
     assert disabled.warming_components == ()
 
+    monkeypatch.setattr(embeddings, "clip_enabled", clip_enabled)
+    monkeypatch.setattr(embeddings, "ranking_enabled", ranking_enabled)
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS")
     monkeypatch.delenv("EXOMEM_DISABLE_CLIP")
     monkeypatch.delenv("EXOMEM_DISABLE_RANKING")

--- a/tests/test_governance_projection_activation.py
+++ b/tests/test_governance_projection_activation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -63,7 +64,7 @@ def _active_runtime():
     return runtime, items
 
 
-def test_startup_preactivates_one_digest_but_release_fence_stays_closed(
+def test_startup_preactivates_one_digest_and_serves_only_that_revalidated_runtime(
     monkeypatch,
     tmp_path,
 ) -> None:
@@ -107,6 +108,9 @@ def test_startup_preactivates_one_digest_but_release_fence_stays_closed(
 
     monkeypatch.setenv(authorization_custody.KEYRING_FILE_ENV, str(tmp_path / "keyring"))
     monkeypatch.setenv(authorization_custody.CONTROL_FILE_ENV, str(tmp_path / "control"))
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_CLIP", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_RANKING", "1")
     monkeypatch.setattr(
         authorization_custody,
         "load_authorization_custody",
@@ -165,17 +169,7 @@ def test_startup_preactivates_one_digest_but_release_fence_stays_closed(
             AssertionError("request reloaded projection catalog")
         ),
     )
-    with pytest.raises(
-        projection_runtime.ProjectionRuntimeUnavailable,
-        match="governed projected retrieval is unavailable",
-    ):
-        projection_runtime.load_active_projection_runtime(tmp_path)
-
-    monkeypatch.setattr(
-        projection_runtime,
-        "_PROJECTED_SERVING_RELEASE_ACCEPTED",
-        True,
-    )
+    assert projection_runtime._PROJECTED_SERVING_RELEASE_ACCEPTED is True
     assert projection_runtime.load_active_projection_runtime(tmp_path) is activated
 
     current_control[0] = replace(control, activation_epoch=control.activation_epoch + 1)
@@ -195,3 +189,36 @@ def test_startup_preactivates_one_digest_but_release_fence_stays_closed(
         match="governed projected retrieval is unavailable",
     ):
         projection_runtime.load_active_projection_runtime(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "enabled_model_variable",
+    [
+        "EXOMEM_DISABLE_EMBEDDINGS",
+        "EXOMEM_DISABLE_CLIP",
+        "EXOMEM_DISABLE_RANKING",
+    ],
+)
+def test_release_fence_refuses_every_uncertified_model_enabled_profile(
+    monkeypatch,
+    enabled_model_variable: str,
+) -> None:
+    runtime, _items = _active_runtime()
+    for name in (
+        "EXOMEM_DISABLE_EMBEDDINGS",
+        "EXOMEM_DISABLE_CLIP",
+        "EXOMEM_DISABLE_RANKING",
+    ):
+        monkeypatch.setenv(name, "1")
+    monkeypatch.delenv(enabled_model_variable)
+    monkeypatch.setattr(
+        projection_runtime,
+        "_preactivated_runtime",
+        lambda _root: runtime,
+    )
+
+    with pytest.raises(
+        projection_runtime.ProjectionRuntimeUnavailable,
+        match="governed projected retrieval is unavailable",
+    ):
+        projection_runtime.load_active_projection_runtime(Path("/fixture"))

--- a/tests/test_governance_projection_activation.py
+++ b/tests/test_governance_projection_activation.py
@@ -138,6 +138,12 @@ def test_startup_preactivates_one_digest_and_serves_only_that_revalidated_runtim
             items,
         )[1:],
     )
+    monkeypatch.setattr(
+        projection_runtime,
+        "_stabilize_projection_runtime",
+        lambda candidate: (events.append("stabilize"), candidate)[1],
+        raising=False,
+    )
     store_pointer = [runtime.snapshot.active]
     monkeypatch.setattr(
         schema_v4,
@@ -153,6 +159,7 @@ def test_startup_preactivates_one_digest_and_serves_only_that_revalidated_runtim
         "begin",
         f"policy:{control.activation_state_digest}",
         "catalog",
+        "stabilize",
     ]
 
     monkeypatch.setattr(
@@ -189,6 +196,21 @@ def test_startup_preactivates_one_digest_and_serves_only_that_revalidated_runtim
         match="governed projected retrieval is unavailable",
     ):
         projection_runtime.load_active_projection_runtime(tmp_path)
+
+
+def test_runtime_stabilization_finishes_collection_before_publication(
+    monkeypatch,
+) -> None:
+    runtime, _items = _active_runtime()
+    collections: list[int] = []
+    monkeypatch.setattr(
+        projection_runtime.gc,
+        "collect",
+        lambda: (collections.append(1), 0)[1],
+    )
+
+    assert projection_runtime._stabilize_projection_runtime(runtime) is runtime
+    assert collections == [1]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_governance_projection_authorization.py
+++ b/tests/test_governance_projection_authorization.py
@@ -137,7 +137,8 @@ def test_distinct_principals_select_variants_without_entering_persistent_rows() 
     assert reader_variant.search_fields == {
         "constraint": "Approved readers only"
     }
-    assert stranger.selections[0].projection_variant_id is None
+    assert stranger.selections == ()
+    assert stranger.withheld_identities == frozenset({"item"})
     assert not hasattr(reader, "audience")
     assert not hasattr(reader, "purpose")
     assert not hasattr(reader, "session")
@@ -187,7 +188,8 @@ def test_exact_scope_session_grant_does_not_cross_over_dual_membership() -> None
         verified_session_grants=(grant,),
     )
 
-    assert authorization.selections[0].projection_variant_id is None
+    assert authorization.selections == ()
+    assert authorization.withheld_identities == frozenset({"dual"})
 
 
 def test_exact_scope_session_grant_selects_prebuilt_variant() -> None:
@@ -247,7 +249,7 @@ def test_session_grant_is_bound_to_one_exact_projection_item() -> None:
         selection.item_identity: selection for selection in authorization.selections
     }
     assert by_identity["granted-item"].projection_variant_id is not None
-    assert by_identity["closed-sibling"].projection_variant_id is None
+    assert authorization.withheld_identities == frozenset({"closed-sibling"})
 
 
 def test_identical_scope_items_reuse_one_request_decision(
@@ -285,9 +287,9 @@ def test_identical_scope_items_reuse_one_request_decision(
     )
 
     assert calls == 1
-    assert all(
-        selection.projection_variant_id is None
-        for selection in authorization.selections
+    assert authorization.selections == ()
+    assert authorization.withheld_identities == frozenset(
+        {"closed-first", "closed-second"}
     )
 
 

--- a/tests/test_governance_projection_measurement_activation.py
+++ b/tests/test_governance_projection_measurement_activation.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from exomem import writer_lease
 from exomem.governance import (
     authorization_custody,
     projected_graph,
@@ -21,6 +22,16 @@ from exomem.governance import (
 )
 from exomem.governance.decisions import Decision
 from exomem.governance.policy import Policy, Scope
+
+
+@pytest.fixture(autouse=True)
+def _private_writer_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    state = tmp_path / "writer-state"
+    state.mkdir()
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(state))
+    writer_lease.reset_managers_for_tests()
+    yield
+    writer_lease.reset_managers_for_tests()
 
 
 def _fixture(tmp_path: Path):
@@ -236,6 +247,9 @@ def test_startup_preactivates_bound_vector_clip_and_graph_once(
 
     monkeypatch.setenv(authorization_custody.KEYRING_FILE_ENV, str(tmp_path / "keyring"))
     monkeypatch.setenv(authorization_custody.CONTROL_FILE_ENV, str(tmp_path / "control"))
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_CLIP", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_RANKING", "1")
     monkeypatch.setattr(
         authorization_custody,
         "load_authorization_custody",
@@ -279,7 +293,6 @@ def test_startup_preactivates_bound_vector_clip_and_graph_once(
                 AssertionError("request reloaded a projected measurement family")
             ),
         )
-    monkeypatch.setattr(projection_runtime, "_PROJECTED_SERVING_RELEASE_ACCEPTED", True)
     assert projection_runtime.load_active_projection_runtime(tmp_path) is runtime
 
 

--- a/tests/test_governance_projection_timing.py
+++ b/tests/test_governance_projection_timing.py
@@ -3,14 +3,23 @@
 from __future__ import annotations
 
 import importlib
+import json
 from contextlib import contextmanager
 from copy import deepcopy
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from exomem import writer_lease
 from exomem.governance import egress, projection_runtime, projections
+
+_CHECKED_RELEASE_MANIFEST = (
+    Path(__file__).parents[1]
+    / "benchmarks"
+    / "governance"
+    / "projected-wire-release-v1.json"
+)
 
 
 def _timing_module():
@@ -28,20 +37,27 @@ def _release_manifest() -> dict[str, object]:
         "bootstrap_resamples": 2_000,
         "bootstrap_seed": 20_260_822,
         "hardware_runtime_profile": "github-hosted-ubuntu-latest-x64-python3.13",
+        "model_runtime_profile": "models-hard-off-v1",
         "request_classes": [
             {
-                "name": "projected-find-keyword-v1",
+                "name": "projected-find-v1",
                 "padding_ms": 250,
                 "deadline_ms": 300,
+                "max_query_chars": 4_096,
+                "max_limit": 100,
             }
         ],
         "routes": [
             "keyword",
             "bm25",
-            "vector",
-            "rerank",
-            "clip",
+            "vector-hard-off",
+            "rerank-hard-off",
+            "clip-hard-off",
             "graph",
+            "graph-rerank-hard-off",
+            "max-query",
+            "max-limit",
+            "max-shape",
             "error",
             "pagination",
         ],
@@ -57,6 +73,30 @@ def _release_manifest() -> dict[str, object]:
     }
 
 
+def test_checked_release_manifest_is_the_validated_nonwaivable_contract() -> None:
+    timing = _timing_module()
+
+    checked = json.loads(_CHECKED_RELEASE_MANIFEST.read_text(encoding="utf-8"))
+
+    assert checked == _release_manifest()
+    assert timing.validate_release_manifest(checked).routes == frozenset(
+        {
+            "keyword",
+            "bm25",
+            "vector-hard-off",
+            "rerank-hard-off",
+            "clip-hard-off",
+            "graph",
+            "graph-rerank-hard-off",
+            "max-query",
+            "max-limit",
+            "max-shape",
+            "error",
+            "pagination",
+        }
+    )
+
+
 def test_keyword_request_class_is_closed_and_repository_owned() -> None:
     timing = _timing_module()
 
@@ -67,9 +107,11 @@ def test_keyword_request_class_is_closed_and_repository_owned() -> None:
         rerank=False,
     )
 
-    assert request_class.name == "projected-find-keyword-v1"
+    assert request_class.name == "projected-find-v1"
     assert request_class.padding_ms == 250
     assert request_class.deadline_ms == 300
+    assert request_class.max_query_chars == 4_096
+    assert request_class.max_limit == 100
     assert request_class.max_hidden_delta_ms == projections.MAX_HIDDEN_CORPUS_WIRE_DELTA_MS
     assert (
         request_class.max_hidden_delta_ratio
@@ -79,9 +121,36 @@ def test_keyword_request_class_is_closed_and_repository_owned() -> None:
         timing.PUBLIC_REQUEST_CLASSES["caller-selected"] = request_class
 
 
+@pytest.mark.parametrize(
+    ("mode", "graph", "rerank"),
+    [
+        ("keyword", False, False),
+        ("hybrid", False, False),
+        ("hybrid", True, False),
+        ("hybrid", False, True),
+        ("vector", False, False),
+    ],
+)
+def test_every_projected_find_lane_uses_the_same_fixed_completion_class(
+    mode: str,
+    graph: bool,
+    rerank: bool,
+) -> None:
+    timing = _timing_module()
+
+    request_class = timing.request_class_for_find(
+        mode=mode,
+        scope="vault",
+        graph=graph,
+        rerank=rerank,
+    )
+
+    assert request_class is timing.PUBLIC_REQUEST_CLASSES["projected-find-v1"]
+
+
 def test_completion_uses_the_fixed_target_without_observation_adaptation() -> None:
     timing = _timing_module()
-    request_class = timing.PUBLIC_REQUEST_CLASSES["projected-find-keyword-v1"]
+    request_class = timing.PUBLIC_REQUEST_CLASSES["projected-find-v1"]
     readings = iter((10.0, 10.1, 10.25))
     sleeps: list[float] = []
 
@@ -95,9 +164,25 @@ def test_completion_uses_the_fixed_target_without_observation_adaptation() -> No
     assert sleeps == [pytest.approx(0.15)]
 
 
+def test_completion_retries_an_early_padding_wake() -> None:
+    timing = _timing_module()
+    request_class = timing.PUBLIC_REQUEST_CLASSES["projected-find-v1"]
+    readings = iter((10.1, 10.2, 10.25))
+    sleeps: list[float] = []
+
+    timing.complete_public_request(
+        request_class,
+        started_at=10.0,
+        clock=lambda: next(readings),
+        sleeper=sleeps.append,
+    )
+
+    assert sleeps == [pytest.approx(0.15), pytest.approx(0.05)]
+
+
 def test_completion_refuses_a_missed_fixed_deadline() -> None:
     timing = _timing_module()
-    request_class = timing.PUBLIC_REQUEST_CLASSES["projected-find-keyword-v1"]
+    request_class = timing.PUBLIC_REQUEST_CLASSES["projected-find-v1"]
 
     with pytest.raises(timing.ProjectedRequestDeadlineExceeded):
         timing.complete_public_request(
@@ -110,7 +195,7 @@ def test_completion_refuses_a_missed_fixed_deadline() -> None:
 
 def test_completion_refuses_padding_sleep_that_misses_deadline() -> None:
     timing = _timing_module()
-    request_class = timing.PUBLIC_REQUEST_CLASSES["projected-find-keyword-v1"]
+    request_class = timing.PUBLIC_REQUEST_CLASSES["projected-find-v1"]
     readings = iter((30.240, 30.301))
 
     with pytest.raises(timing.ProjectedRequestDeadlineExceeded):
@@ -125,7 +210,7 @@ def test_completion_refuses_padding_sleep_that_misses_deadline() -> None:
 @pytest.mark.parametrize("reading", [float("nan"), float("inf"), float("-inf")])
 def test_completion_refuses_nonfinite_clock(reading: float) -> None:
     timing = _timing_module()
-    request_class = timing.PUBLIC_REQUEST_CLASSES["projected-find-keyword-v1"]
+    request_class = timing.PUBLIC_REQUEST_CLASSES["projected-find-v1"]
 
     with pytest.raises(timing.ProjectedRequestTimingUnavailable):
         timing.complete_public_request(
@@ -172,7 +257,7 @@ def test_shared_command_dispatch_owns_projected_completion_boundary(
 
     @contextmanager
     def fixed_completion(request_class):
-        assert request_class.name == "projected-find-keyword-v1"
+        assert request_class.name == "projected-find-v1"
         events.append("enter")
         try:
             yield
@@ -200,6 +285,63 @@ def test_shared_command_dispatch_owns_projected_completion_boundary(
     events.clear()
     with pytest.raises(RuntimeError, match="projected failure"):
         writer_lease.invoke_command(command, tmp_path, query="fail")
+    assert events == ["enter", "leaf", "complete"]
+
+
+def test_projected_completion_wraps_the_default_shape_and_its_error_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    timing = _timing_module()
+    events: list[str] = []
+
+    def leaf(
+        vault_root,
+        query: str = "",
+        *,
+        mode: str = "hybrid",
+        scope: str = "kb",
+        graph: bool = True,
+        rerank: bool | None = None,
+    ):
+        del vault_root, query, mode, scope, graph, rerank
+        events.append("leaf")
+        raise RuntimeError("projected failure")
+
+    command = SimpleNamespace(
+        name="ask_memory",
+        leaf=leaf,
+        read_only=True,
+        response_detail=None,
+        path_roles=(),
+    )
+
+    class Manager:
+        def invoke(self, current, injected, kwargs, **_metadata):
+            return current.leaf(*injected, **kwargs)
+
+    @contextmanager
+    def fixed_completion(request_class):
+        assert request_class is timing.PUBLIC_REQUEST_CLASSES[
+            "projected-find-v1"
+        ]
+        events.append("enter")
+        try:
+            yield
+        finally:
+            events.append("complete")
+
+    monkeypatch.setattr(writer_lease, "get_manager", lambda: Manager())
+    monkeypatch.setattr(egress, "is_vault_root", lambda _value: False)
+    monkeypatch.setattr(
+        projection_runtime,
+        "has_preactivated_projection_runtime",
+        lambda _root: True,
+    )
+    monkeypatch.setattr(timing, "fixed_public_completion", fixed_completion)
+
+    with pytest.raises(RuntimeError, match="projected failure"):
+        writer_lease.invoke_command(command, tmp_path, query="projection-only term")
     assert events == ["enter", "leaf", "complete"]
 
 
@@ -274,6 +416,15 @@ def test_unactivated_command_skips_projected_class_selection(
         lambda manifest: manifest["request_classes"][0].__setitem__(
             "deadline_ms", 301
         ),
+        lambda manifest: manifest.__setitem__(
+            "model_runtime_profile", "models-enabled"
+        ),
+        lambda manifest: manifest["request_classes"][0].__setitem__(
+            "max_query_chars", 4_097
+        ),
+        lambda manifest: manifest["request_classes"][0].__setitem__(
+            "max_limit", 101
+        ),
     ],
 )
 def test_release_manifest_cannot_self_waive_timing_contract(mutate) -> None:
@@ -294,13 +445,13 @@ def test_bootstrap_wire_oracle_enforces_absolute_and_relative_bounds() -> None:
 
     accepted = timing.evaluate_wire_differential(
         manifest,
-        request_class_name="projected-find-keyword-v1",
+        request_class_name="projected-find-v1",
         hidden_present_ms=equivalent,
         physically_absent_ms=absent,
     )
     refused = timing.evaluate_wire_differential(
         manifest,
-        request_class_name="projected-find-keyword-v1",
+        request_class_name="projected-find-v1",
         hidden_present_ms=displaced,
         physically_absent_ms=absent,
     )
@@ -318,7 +469,7 @@ def test_wire_oracle_derives_deadline_misses_from_actual_samples() -> None:
 
     report = timing.evaluate_wire_differential(
         manifest,
-        request_class_name="projected-find-keyword-v1",
+        request_class_name="projected-find-v1",
         hidden_present_ms=tuple(301.0 for _ in range(200)),
         physically_absent_ms=tuple(301.0 for _ in range(200)),
     )
@@ -337,7 +488,8 @@ def test_wire_oracle_rejects_directly_constructed_manifest() -> None:
             bootstrap_resamples=1,
             bootstrap_seed=0,
             hardware_runtime_profile="caller-selected",
-            request_class_names=("projected-find-keyword-v1",),
+            model_runtime_profile="models-enabled",
+            request_class_names=("projected-find-v1",),
             routes=frozenset(),
             catalog_items=0,
             searchable_bytes_per_item=0,
@@ -345,7 +497,107 @@ def test_wire_oracle_rejects_directly_constructed_manifest() -> None:
         )
         timing.evaluate_wire_differential(
             manifest,
-            request_class_name="projected-find-keyword-v1",
+            request_class_name="projected-find-v1",
             hidden_present_ms=(1.0,),
             physically_absent_ms=(1.0,),
         )
+
+
+def test_release_schedule_is_predeclared_paired_and_covers_every_capacity() -> None:
+    timing = _timing_module()
+    manifest = timing.validate_release_manifest(_release_manifest())
+
+    schedule = timing.release_sample_schedule(manifest, route="graph")
+
+    assert len(schedule) == 400
+    assert {sample.route for sample in schedule} == {"graph"}
+    assert {sample.capacity for sample in schedule} == {"zero", "one", "maximum"}
+    assert sum(sample.hidden_present for sample in schedule) == 200
+    assert sum(not sample.hidden_present for sample in schedule) == 200
+    assert sum(
+        sample.hidden_present and sample.capacity == "one" for sample in schedule
+    ) == 100
+    assert sum(
+        sample.hidden_present and sample.capacity == "maximum" for sample in schedule
+    ) == 100
+    for offset in range(0, len(schedule), 2):
+        left, right = schedule[offset : offset + 2]
+        assert left.pair_id == right.pair_id
+        assert left.hidden_present is not right.hidden_present
+        present = left if left.hidden_present else right
+        absent = right if left.hidden_present else left
+        assert present.capacity in {"one", "maximum"}
+        assert absent.capacity == "zero"
+
+
+def test_route_release_gate_requires_exact_schedule_and_byte_equal_pairs() -> None:
+    timing = _timing_module()
+    manifest = timing.validate_release_manifest(_release_manifest())
+    schedule = timing.release_sample_schedule(manifest, route="keyword")
+    observations = tuple(
+        timing.WireObservation(
+            sample=sample,
+            elapsed_ms=250.0,
+            canonical_envelope_sha256="a" * 64,
+        )
+        for sample in schedule
+    )
+
+    report = timing.evaluate_wire_route(
+        manifest,
+        route="keyword",
+        observations=observations,
+    )
+
+    assert report.route == "keyword"
+    assert report.envelope_pairs_equal is True
+    assert report.timing.passed is True
+
+    with pytest.raises(timing.ProjectedRequestTimingUnavailable):
+        timing.evaluate_wire_route(
+            manifest,
+            route="keyword",
+            observations=observations[:-1],
+        )
+
+    mismatched = list(observations)
+    mismatched[1] = timing.WireObservation(
+        sample=mismatched[1].sample,
+        elapsed_ms=mismatched[1].elapsed_ms,
+        canonical_envelope_sha256="b" * 64,
+    )
+    refused = timing.evaluate_wire_route(
+        manifest,
+        route="keyword",
+        observations=tuple(mismatched),
+    )
+    assert refused.envelope_pairs_equal is False
+    assert refused.passed is False
+
+
+def test_route_release_gate_derives_deadline_failure_from_wire_observation() -> None:
+    timing = _timing_module()
+    manifest = timing.validate_release_manifest(_release_manifest())
+    schedule = timing.release_sample_schedule(manifest, route="pagination")
+    observations = [
+        timing.WireObservation(
+            sample=sample,
+            elapsed_ms=250.0,
+            canonical_envelope_sha256="c" * 64,
+        )
+        for sample in schedule
+    ]
+    observations[0] = timing.WireObservation(
+        sample=observations[0].sample,
+        elapsed_ms=301.0,
+        canonical_envelope_sha256="c" * 64,
+    )
+
+    report = timing.evaluate_wire_route(
+        manifest,
+        route="pagination",
+        observations=tuple(observations),
+    )
+
+    assert report.timing.deadline_misses == 1
+    assert report.passed is False

--- a/tests/test_governance_projection_wire_gate.py
+++ b/tests/test_governance_projection_wire_gate.py
@@ -404,6 +404,10 @@ def test_projected_hidden_corpus_actual_wire_release_gate(
             graph_edge_count=projections.MAX_GOVERNED_GRAPH_EDGES,
         ),
     }
+    # Production settles one immutable runtime before publication. This wire
+    # fixture holds three replica states in one process, so settle their
+    # combined object graph before any client becomes observable.
+    projection_runtime._stabilize_projection_runtime(runtimes[roots["maximum"]])
     monkeypatch.setattr(
         projection_runtime,
         "has_preactivated_projection_runtime",

--- a/tests/test_governance_projection_wire_gate.py
+++ b/tests/test_governance_projection_wire_gate.py
@@ -1,0 +1,466 @@
+"""Actual-wire hidden-present/absent release gate for projected retrieval.
+
+The lean suite collects this module but does not execute the 200-pair timing run.
+CI selects exactly one mandatory route per matrix job through the closed route
+name.  Each job uses the checked manifest, fixed completion class, and all
+three predeclared corpus capacities; there is no sample-count or capacity knob.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from governance_projection_support import verified_namespace
+from starlette.testclient import TestClient
+
+from exomem import server, writer_lease
+from exomem.governance import (
+    principal,
+    projected_graph,
+    projection_runtime,
+    projection_store,
+    projection_timing,
+    projections,
+    schema_v4,
+)
+from exomem.governance.policy import Policy, Scope
+from exomem.server_runtime import ServerRuntime
+
+_MANIFEST_PATH = (
+    Path(__file__).parents[1]
+    / "benchmarks"
+    / "governance"
+    / "projected-wire-release-v1.json"
+)
+_ROUTE_ENV = "EXOMEM_GOVERNANCE_TIMING_ROUTE"
+_REST_KEY = "governance-wire-release-key"
+_GRAPH_EXTRACTOR = "projected-graph-v1"
+_GRAPH_MODEL = "projected-graph-v1"
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _maximum_query() -> str:
+    prefix = "wire-visible "
+    dense_unique_terms = "".join(f"q{index:04x} " for index in range(1_000))
+    query = (prefix + dense_unique_terms)[:4_096]
+    return query.ljust(4_096, " ")
+
+
+def _item(
+    policy: Policy,
+    *,
+    path: str,
+    scope_id: str,
+    body: str,
+    media_type: str | None = None,
+) -> projection_store.ProjectionItemVariants:
+    fields = {"body": body}
+    if media_type is not None:
+        fields["media_type"] = media_type
+    content_hash = _digest(body)
+    return projection_store.ProjectionItemVariants(
+        item_identity=path,
+        content_hash=content_hash,
+        scope_ids=(scope_id,),
+        variants=projections.enumerate_projection_variants(
+            item_identity=path,
+            content_hash=content_hash,
+            scope_ids=(scope_id,),
+            policy=policy,
+            projector_schema_version=projections.PROJECTOR_SCHEMA_VERSION,
+            full_search_fields=fields,
+        ),
+    )
+
+
+def _l6_variant(
+    item: projection_store.ProjectionItemVariants,
+) -> projections.ProjectionVariant:
+    return next(variant for variant in item.variants if variant.decision_level == 6)
+
+
+def _graph_measurements(
+    items: tuple[projection_store.ProjectionItemVariants, ...],
+    *,
+    visible_count: int,
+    graph_edge_count: int,
+) -> tuple[projected_graph.ProjectionGraphMeasurement, ...]:
+    variants = tuple(_l6_variant(item) for item in items)
+    visible_source, visible_target = variants[:2]
+    edges_by_source: dict[str, tuple[projected_graph.ProjectionGraphEdge, ...]] = {
+        visible_source.item_identity: (
+            projected_graph.ProjectionGraphEdge(
+                visible_source.item_identity,
+                visible_target.item_identity,
+                "supports",
+            ),
+        )
+    }
+    remaining = graph_edge_count - 1
+    if remaining > 0:
+        hidden_source = variants[visible_count]
+        targets = variants[visible_count:]
+        hidden_edges = tuple(
+            projected_graph.ProjectionGraphEdge(
+                hidden_source.item_identity,
+                targets[index % len(targets)].item_identity,
+                f"private-relation-{index // len(targets):05d}",
+            )
+            for index in range(remaining)
+        )
+        edges_by_source[hidden_source.item_identity] = hidden_edges
+    return tuple(
+        projected_graph.ProjectionGraphMeasurement(
+            measurement_key=projections.MeasurementKey(
+                projection_variant_id=variant.projection_variant_id,
+                lane="graph",
+                extractor_version=_GRAPH_EXTRACTOR,
+                model_version=_GRAPH_MODEL,
+            ),
+            edges=edges_by_source.get(variant.item_identity, ()),
+        )
+        for variant in variants
+    )
+
+
+def _active_runtime(
+    *,
+    visible_count: int,
+    visible_body: str,
+    hidden_count: int,
+    graph_edge_count: int,
+) -> projection_runtime.ActiveProjectionRuntime:
+    visible = Scope(id="wire-visible", source="scopes/wire-visible.yaml")
+    hidden = Scope(
+        id="wire-hidden",
+        source="scopes/wire-hidden.yaml",
+        default_deny=True,
+    )
+    policy = Policy(
+        fingerprint="f" * 64,
+        scopes={visible.id: visible, hidden.id: hidden},
+    )
+    if visible_count < 2:
+        raise ValueError("wire fixture requires at least two visible items")
+    items: list[projection_store.ProjectionItemVariants] = []
+    for index in range(visible_count):
+        items.append(
+            _item(
+                policy,
+                path=f"Knowledge Base/wire-visible-{index:03d}.md",
+                scope_id=visible.id,
+                body=f"{visible_body} item {index:03d}",
+                media_type="image" if index == 1 else None,
+            )
+        )
+    for index in range(hidden_count):
+        body = f"wire-visible private wire-hidden-body-{index:05d}"
+        if (
+            hidden_count + visible_count == projections.MAX_GOVERNED_CATALOG_ITEMS
+            and index == 0
+        ):
+            fragment = "wire-visible wire-hidden-body-maximum "
+            repeated = fragment * (
+                projections.MAX_GOVERNED_SEARCH_BYTES_PER_ITEM // len(fragment) + 1
+            )
+            body = repeated[: projections.MAX_GOVERNED_SEARCH_BYTES_PER_ITEM]
+            assert len(body.encode("utf-8")) == (
+                projections.MAX_GOVERNED_SEARCH_BYTES_PER_ITEM
+            )
+        items.append(
+            _item(
+                policy,
+                path=f"Knowledge Base/private/wire-hidden-{index:05d}.md",
+                scope_id=hidden.id,
+                body=body,
+            )
+        )
+    item_tuple = tuple(items)
+    projections.require_supported_capacity(catalog_items=len(item_tuple))
+    key = projections.ProjectionNamespaceKey(
+        policy.fingerprint,
+        projections.PROJECTOR_SCHEMA_VERSION,
+        max(1, hidden_count + visible_count),
+    )
+    namespace = verified_namespace(key, item_tuple)
+    active = schema_v4.VerifiedActiveGovernanceState(
+        logical_vault_id="wire-vault",
+        activation_store_id="wire-store",
+        activation_epoch=1,
+        activation_state_digest=namespace.active_state_digest,
+        policy_generation_id="wire-policy",
+        policy_fingerprint=key.policy_fingerprint,
+        projector_schema_version=key.projector_schema_version,
+        catalog_generation=key.catalog_generation,
+        projection_namespace_id=key.namespace_id,
+    )
+    measurements = _graph_measurements(
+        item_tuple,
+        visible_count=visible_count,
+        graph_edge_count=graph_edge_count,
+    )
+    graph_index = projected_graph.ProjectedGraphIndex(
+        namespace,
+        measurements,
+        extractor_version=_GRAPH_EXTRACTOR,
+        model_version=_GRAPH_MODEL,
+    )
+    graph_root = projection_store.ProjectionMeasurementRoot(
+        namespace_key=key,
+        family_id=projection_store.projection_measurement_family_id(
+            key,
+            lane="graph",
+            extractor_version=_GRAPH_EXTRACTOR,
+            model_version=_GRAPH_MODEL,
+        ),
+        lane="graph",
+        extractor_version=_GRAPH_EXTRACTOR,
+        model_version=_GRAPH_MODEL,
+        measurement_count=len(measurements),
+        vector_dimension=None,
+        graph_edge_count=graph_edge_count,
+        rows_digest=_digest(f"graph:{hidden_count}:{graph_edge_count}"),
+    )
+    snapshot = schema_v4.ActivePolicySnapshot(
+        active=active,
+        policy=policy,
+        source_documents=(),
+        catalog_descriptor=projection_store.catalog_descriptor_bytes(key, item_tuple),
+        projection_namespace_evidence=b"wire-release-fixture",
+    )
+    return projection_runtime.ActiveProjectionRuntime(
+        snapshot,
+        namespace,
+        (graph_root,),
+        graph_index=graph_index,
+    )
+
+
+def _route_body(route: str) -> dict[str, object]:
+    body: dict[str, object] = {
+        "query": "wire-visible",
+        "scope": "vault",
+        "mode": "hybrid",
+        "graph": False,
+        "rerank": False,
+        "include_timings": True,
+    }
+    if route == "keyword":
+        body["mode"] = "keyword"
+    elif route == "vector-hard-off":
+        body["mode"] = "vector"
+    elif route == "rerank-hard-off":
+        body["rerank"] = True
+    elif route == "clip-hard-off":
+        pass
+    elif route == "graph":
+        body["graph"] = True
+    elif route == "graph-rerank-hard-off":
+        body["graph"] = True
+        body["rerank"] = True
+    elif route == "max-query":
+        body["query"] = _maximum_query()
+    elif route == "max-limit":
+        body["limit"] = 100
+        body["detail"] = "full"
+    elif route == "max-shape":
+        body["query"] = _maximum_query()
+        body["limit"] = 100
+        body["detail"] = "full"
+        body["graph"] = True
+        body["rerank"] = True
+    elif route == "error":
+        body["limit"] = 101
+    elif route == "pagination":
+        body["limit"] = 1
+    return body
+
+
+def _client_for_root(
+    monkeypatch: pytest.MonkeyPatch,
+    root: Path,
+) -> TestClient:
+    runtime = ServerRuntime(
+        vault_root=root,
+        source_schema=SimpleNamespace(source_types={}),
+        project_keys_hint="",
+        base_url="",
+    )
+    monkeypatch.setattr(
+        server,
+        "initialize_runtime",
+        lambda **_kwargs: runtime,
+    )
+    return TestClient(server.build_server(require_auth=False).http_app())
+
+
+def _canonical_response_digest(response) -> str:  # noqa: ANN001
+    value = {"status": response.status_code, "body": response.json()}
+    return hashlib.sha256(projections.canonical_jcs(value)).hexdigest()
+
+
+def _assert_route_response(response, route: str) -> None:  # noqa: ANN001
+    expected_status = 400 if route == "error" else 200
+    assert response.status_code == expected_status, response.text
+    if response.status_code == 200:
+        data = response.json()["data"]
+        assert data["timings_suppressed"] == {
+            "status": "governed_projection"
+        }
+        if route in {"max-limit", "max-shape"}:
+            assert len(data["hits"]) == 100
+
+
+@pytest.mark.governance_timing_release
+@pytest.mark.timeout(240)
+def test_projected_hidden_corpus_actual_wire_release_gate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    route = os.environ.get(_ROUTE_ENV)
+    if route is None:
+        pytest.skip("dedicated governance actual-wire route job only")
+    manifest = projection_timing.validate_release_manifest(
+        json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    )
+    assert manifest.model_runtime_profile == "models-hard-off-v1"
+    if route not in manifest.routes:
+        pytest.fail(f"unregistered governance timing route: {route!r}")
+
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", _REST_KEY)
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_CLIP", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_RANKING", "1")
+    assert (
+        projection_runtime.projected_serving_release_profile()
+        == manifest.model_runtime_profile
+    )
+    writer_state = tmp_path / "writer-state"
+    writer_state.mkdir()
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(writer_state))
+    for name in (
+        "EXOMEM_AUTH_SESSION_KEYRING_FILE",
+        "EXOMEM_AUTH_SESSION_CONTROL_FILE",
+        "EXOMEM_CF_ACCESS_TEAM_DOMAIN",
+        "EXOMEM_CF_ACCESS_AUD",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(writer_lease, "start_server_lifecycle", lambda: None)
+    writer_lease.reset_managers_for_tests()
+    monkeypatch.setattr(
+        principal,
+        "resolve_rest_principal",
+        lambda _scope: principal.RequestPrincipal(
+            audience_id="wire-external-principal",
+            surface="rest",
+            resolved=True,
+            issuer_family="wire-release",
+        ),
+    )
+
+    roots = {
+        "absent": tmp_path / "absent",
+        "one": tmp_path / "one-hidden",
+        "maximum": tmp_path / "maximum-hidden",
+    }
+    for root in roots.values():
+        (root / "Knowledge Base").mkdir(parents=True)
+    visible_count = 100 if route in {"max-limit", "max-shape"} else 2
+    visible_body = (
+        _maximum_query()
+        if route in {"max-query", "max-shape"}
+        else "wire-visible projected retrieval"
+    )
+    runtimes = {
+        roots["absent"]: _active_runtime(
+            visible_count=visible_count,
+            visible_body=visible_body,
+            hidden_count=0,
+            graph_edge_count=1,
+        ),
+        roots["one"]: _active_runtime(
+            visible_count=visible_count,
+            visible_body=visible_body,
+            hidden_count=1,
+            graph_edge_count=2,
+        ),
+        roots["maximum"]: _active_runtime(
+            visible_count=visible_count,
+            visible_body=visible_body,
+            hidden_count=(
+                projections.MAX_GOVERNED_CATALOG_ITEMS - visible_count
+            ),
+            graph_edge_count=projections.MAX_GOVERNED_GRAPH_EDGES,
+        ),
+    }
+    monkeypatch.setattr(
+        projection_runtime,
+        "has_preactivated_projection_runtime",
+        lambda root: Path(root) in runtimes,
+    )
+    monkeypatch.setattr(
+        projection_runtime,
+        "load_active_projection_runtime",
+        lambda root: runtimes[Path(root)],
+    )
+
+    clients = {
+        name: _client_for_root(monkeypatch, root)
+        for name, root in roots.items()
+    }
+    schedule = projection_timing.release_sample_schedule(manifest, route=route)
+    observations: list[projection_timing.WireObservation] = []
+    caplog.set_level(logging.INFO)
+    try:
+        for client in clients.values():
+            warmup = client.post(
+                "/api/ask_memory",
+                json=_route_body(route),
+                headers={"Authorization": f"Bearer {_REST_KEY}"},
+            )
+            _assert_route_response(warmup, route)
+        for sample in schedule:
+            client_name = (
+                "absent"
+                if not sample.hidden_present or sample.capacity == "zero"
+                else sample.capacity
+            )
+            started = time.perf_counter()
+            response = clients[client_name].post(
+                "/api/ask_memory",
+                json=_route_body(route),
+                headers={"Authorization": f"Bearer {_REST_KEY}"},
+            )
+            elapsed_ms = (time.perf_counter() - started) * 1000.0
+            _assert_route_response(response, route)
+            observations.append(
+                projection_timing.WireObservation(
+                    sample=sample,
+                    elapsed_ms=elapsed_ms,
+                    canonical_envelope_sha256=_canonical_response_digest(response),
+                )
+            )
+    finally:
+        for client in clients.values():
+            client.close()
+        writer_lease.reset_managers_for_tests()
+
+    report = projection_timing.evaluate_wire_route(
+        manifest,
+        route=route,
+        observations=tuple(observations),
+    )
+    assert report.passed, report
+    assert "wire-hidden-" not in caplog.text
+    assert _REST_KEY not in caplog.text


### PR DESCRIPTION
## Why

Governed projected retrieval had the complete projected-corpus foundation but its public serving fence remained closed because the repository lacked a non-waivable actual-wire timing gate. Opening it globally would also have exposed model-enabled paths that CI did not certify.

## What changed

- adds a closed release manifest and fixed 250 ms / 300 ms public completion class
- emits stable `timings_suppressed` and warming envelopes without hidden-dependent process age
- enables serving only for the exact repository-certified `models-hard-off-v1` profile; model-enabled deployments remain fail-closed
- adds a required 12-route actual-wire CI matrix over zero, one, and exact maximum hidden-corpus capacity, including the combined 4,096-char / 100-hit / full-detail / graph shape
- compacts L0 authorization selections into an exact withheld identity set, removing corpus-sized per-request object churn while retaining total catalog coverage
- makes the governance wire matrix part of the aggregate required gate

## Verification

- `170 passed, 1 skipped` — complete focused projection packet; the skip is the dedicated CI-only wire test
- `106 passed` — MCP/schema/connector/startup compatibility packet
- exact local `max-query` wire route: `1 passed` in 139.50 s
- exact local combined `max-shape` wire route: `1 passed` in 141.86 s
- compact-map focused packet: `70 passed`
- independent verifier: `83 passed, 1 skipped`; all 162 OpenSpec changes strict-valid
- `openspec validate harden-governance-for-consolidation --strict`
- Ruff, `git diff --check`, `uv lock --check`, public artifact privacy scan, wheel and sdist build

## Deliberate boundary

This releases projected serving only when embeddings, CLIP, and reranking are all explicitly hard-off. It does not claim active-model timing acceptance, complete the broader governance OpenSpec, expose consolidation, or touch any personal/POLLY vault.
