### PR TITLE
feat(governance): bind standalone custody attachment

### DIFF
--- a/src/exomem/governance/authorization_custody.py
+++ b/src/exomem/governance/authorization_custody.py
@@ -191,6 +191,7 @@ def _path_is_within(candidate: Path, root: Path) -> bool:
 
 
 def _owner_identity(
+    root: Path,
     info: os.stat_result,
     filesystem: held_fs.HeldFilesystem,
 ) -> str:
@@ -201,9 +202,16 @@ def _owner_identity(
         if not isinstance(descriptor, int):
             raise AuthorizationCustodyUnavailable
         sid = mutation_lock._windows_current_user_sid()
-        sddl = mutation_lock._windows_dacl_sddl_for_handle(
-            msvcrt.get_osfhandle(descriptor)
-        )
+        retained_handle = msvcrt.get_osfhandle(descriptor)
+        security_handle = mutation_lock._windows_open_path(root, directory=True)
+        try:
+            if mutation_lock._windows_handle_identity(
+                security_handle
+            ) != mutation_lock._windows_handle_identity(retained_handle):
+                raise AuthorizationCustodyUnavailable
+            sddl = mutation_lock._windows_dacl_sddl_for_handle(security_handle)
+        finally:
+            mutation_lock._windows_close_handle(security_handle)
         if not mutation_lock._windows_owner_admits_current_user(
             mutation_lock._windows_sddl_owner(sddl),
             sid,
@@ -255,7 +263,7 @@ def standalone_attachment_id(vault_root: Path) -> str:
             ):
                 raise AuthorizationCustodyUnavailable
             canonical = os.path.normcase(str(root.resolve(strict=True))).encode("utf-8")
-            owner = _owner_identity(after, filesystem).encode("utf-8")
+            owner = _owner_identity(root, after, filesystem).encode("utf-8")
             digest = hashlib.sha256(
                 _framed(
                     _ATTACHMENT_DOMAIN,

--- a/src/exomem/governance/authorization_custody.py
+++ b/src/exomem/governance/authorization_custody.py
@@ -14,6 +14,7 @@ import hmac
 import json
 import os
 import re
+import secrets
 import stat
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -64,7 +65,18 @@ _CONTROL_FIELDS = frozenset(
     }
 )
 _CONTROL_MAC_DOMAIN = b"exomem.authorization-session.control/v1"
+_ATTACHMENT_DOMAIN = b"exomem.authorization-session.attachment/v1"
+_BOOTSTRAP_MEMBERSHIP_DOMAIN = b"exomem.authorization-session.membership-bootstrap/v1"
 _SHA256_HEX = re.compile(r"[0-9a-f]{64}\Z")
+_STANDALONE_ATTACHMENT = re.compile(r"attachment-v1-[0-9a-f]{64}\Z")
+_DEFAULT_CONTROL_TTL_SECONDS = 3_600
+_DEFAULT_KEY_TTL_SECONDS = 366 * 24 * 60 * 60
+_GOVERNANCE_AUTHORITY_NAMES = (
+    ".governance.sqlite",
+    ".governance.sqlite-wal",
+    ".governance.sqlite-shm",
+    ".governance.sqlite-journal",
+)
 
 
 class AuthorizationCustodyUnavailable(RuntimeError):
@@ -137,6 +149,19 @@ class AuthorizationCustody:
 
 
 @dataclass(frozen=True, slots=True)
+class StandaloneProvisioningResult:
+    """Non-secret identity returned by explicit standalone provisioning."""
+
+    keyring_path: Path
+    control_path: Path
+    keyring_id: str
+    cell_id: str
+    logical_vault_id: str
+    registry_attachment_id: str
+    attachment_epoch: int
+
+
+@dataclass(frozen=True, slots=True)
 class _LoadedCustodyFile:
     path: Path
     data: bytes = field(repr=False)
@@ -163,6 +188,106 @@ def _path_is_within(candidate: Path, root: Path) -> bool:
     except ValueError:
         return False
     return common == os.path.normcase(str(root))
+
+
+def _owner_identity(
+    info: os.stat_result,
+    filesystem: held_fs.HeldFilesystem,
+) -> str:
+    if os.name == "nt":  # pragma: no cover - exercised by Windows CI
+        import msvcrt
+
+        descriptor = getattr(filesystem, "descriptor", None)
+        if not isinstance(descriptor, int):
+            raise AuthorizationCustodyUnavailable
+        sid = mutation_lock._windows_current_user_sid()
+        sddl = mutation_lock._windows_dacl_sddl_for_handle(
+            msvcrt.get_osfhandle(descriptor)
+        )
+        if not mutation_lock._windows_owner_admits_current_user(
+            mutation_lock._windows_sddl_owner(sddl),
+            sid,
+        ):
+            raise AuthorizationCustodyUnavailable
+        return f"sid:{sid}"
+    owner = int(info.st_uid)
+    if owner != os.geteuid():
+        raise AuthorizationCustodyUnavailable
+    return f"uid:{owner}"
+
+
+def standalone_attachment_id(vault_root: Path) -> str:
+    """Bind one standalone registration to the held vault-root identity.
+
+    A copied vault and copied custody files therefore do not become a second
+    serving attachment merely because their logical ids still match.
+    """
+
+    root = Path(vault_root)
+    acquired: held_fs.HeldResult[held_fs.HeldFilesystem] | None = None
+    try:
+        before = os.lstat(root)
+        reparse = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+        if (
+            not stat.S_ISDIR(before.st_mode)
+            or stat.S_ISLNK(before.st_mode)
+            or getattr(before, "st_file_attributes", 0) & reparse
+        ):
+            raise AuthorizationCustodyUnavailable
+        acquired = held_fs.acquire(root)
+        if not acquired.ok:
+            raise AuthorizationCustodyUnavailable
+        with acquired.require() as filesystem:
+            identity = filesystem.root_identity
+            after = os.lstat(root)
+            if (
+                not stat.S_ISDIR(after.st_mode)
+                or stat.S_ISLNK(after.st_mode)
+                or getattr(after, "st_file_attributes", 0) & reparse
+                or identity.kind != "directory"
+                or (
+                    os.name != "nt"
+                    and (
+                        int(after.st_dev) != identity.device
+                        or int(after.st_ino) != identity.inode
+                    )
+                )
+            ):
+                raise AuthorizationCustodyUnavailable
+            canonical = os.path.normcase(str(root.resolve(strict=True))).encode("utf-8")
+            owner = _owner_identity(after, filesystem).encode("utf-8")
+            digest = hashlib.sha256(
+                _framed(
+                    _ATTACHMENT_DOMAIN,
+                    (
+                        canonical,
+                        str(identity.device).encode("ascii"),
+                        str(identity.inode).encode("ascii"),
+                        owner,
+                    ),
+                )
+            ).hexdigest()
+            return f"attachment-v1-{digest}"
+    except AuthorizationCustodyUnavailable:
+        raise
+    except (OSError, RuntimeError, UnicodeError, ValueError, held_fs.HeldFsError):
+        raise AuthorizationCustodyUnavailable from None
+
+
+def _verify_registered_attachment(vault_root: Path, attachment_id: str) -> None:
+    """Verify records minted by the standalone root-identity protocol.
+
+    Existing Hosted/control-plane records use their own opaque attachment
+    identifiers.  They remain the control plane's responsibility until that
+    protocol is integrated; the locally minted namespace is closed and always
+    verified here.
+    """
+
+    if attachment_id.startswith("attachment-v1-") and (
+        _STANDALONE_ATTACHMENT.fullmatch(attachment_id) is None
+        or attachment_id != standalone_attachment_id(vault_root)
+    ):
+        raise AuthorizationCustodyUnavailable
 
 
 def _configured_external_path(variable: str, vault_root: Path) -> Path:
@@ -538,6 +663,9 @@ def load_authorization_custody(
     external = load_external_custody(Path(vault_root))
     keyring = parse_keyring(external.keyring)
     control = parse_control_record(external.control, keyring=keyring, now=now)
+    _verify_registered_attachment(
+        Path(vault_root), control.registry_attachment_id
+    )
     return AuthorizationCustody(
         keyring_path=external.keyring_path,
         control_path=external.control_path,
@@ -591,7 +719,7 @@ def _signed_control_bytes(
     return encoded
 
 
-def _prepare_private_control_stage(control_path: Path, staged: held_fs.HeldFile) -> None:
+def _prepare_private_stage(target_path: Path, staged: held_fs.HeldFile) -> None:
     descriptor = getattr(staged, "descriptor", None)
     if not isinstance(descriptor, int):
         raise AuthorizationCustodyUnavailable
@@ -600,12 +728,89 @@ def _prepare_private_control_stage(control_path: Path, staged: held_fs.HeldFile)
         if not isinstance(name, str) or not name:
             raise AuthorizationCustodyUnavailable
         mutation_lock._windows_apply_private_dacl(
-            control_path.parent / name,
+            target_path.parent / name,
             mutation_lock._windows_current_user_sid(),
         )
+    else:
+        os.fchmod(descriptor, 0o600)
     info = os.fstat(descriptor)
     if not _file_is_owner_protected(descriptor, info):
         raise AuthorizationCustodyUnavailable
+
+
+def _private_parent_is_safe(path: Path) -> bool:
+    try:
+        info = os.lstat(path)
+        reparse = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+        if (
+            not stat.S_ISDIR(info.st_mode)
+            or stat.S_ISLNK(info.st_mode)
+            or getattr(info, "st_file_attributes", 0) & reparse
+        ):
+            return False
+        if os.name == "nt":  # pragma: no cover - exercised by Windows CI
+            sid = mutation_lock._windows_current_user_sid()
+            return (
+                mutation_lock._windows_private_dacl_verdict(
+                    mutation_lock._windows_dacl_sddl(path),
+                    sid,
+                    directory=True,
+                )
+                == "valid"
+            )
+        return int(info.st_uid) == os.geteuid() and not stat.S_IMODE(info.st_mode) & 0o077
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def _publish_private_file(path: Path, data: bytes) -> bytes:
+    """Create one exact private custody file, or adopt an exact concurrent retry."""
+
+    if not isinstance(data, bytes) or not 1 <= len(data) <= MAX_CUSTODY_FILE_BYTES:
+        raise AuthorizationCustodyUnavailable
+    parent_path = path.parent
+    anchor = parent_path.parent
+    if (
+        anchor == parent_path
+        or not parent_path.name
+        or not path.name
+        or not _private_parent_is_safe(parent_path)
+    ):
+        raise AuthorizationCustodyUnavailable
+    try:
+        acquired = held_fs.acquire(anchor)
+        if not acquired.ok:
+            raise AuthorizationCustodyUnavailable
+        with acquired.require() as filesystem:
+            parent_result = filesystem.parent(parent_path.name, access="flush")
+            if not parent_result.ok:
+                raise AuthorizationCustodyUnavailable
+            with parent_result.require() as parent:
+                published = held_fs.publish_bytes(
+                    filesystem,
+                    parent,
+                    path.name,
+                    data,
+                    prepare=lambda staged: _prepare_private_stage(path, staged),
+                )
+                if not published.ok:
+                    if published.error is None or published.error.code != "DESTINATION_EXISTS":
+                        raise AuthorizationCustodyUnavailable
+                    installed = _load_file(path)
+                    if not hmac.compare_digest(installed.data, data):
+                        raise AuthorizationCustodyUnavailable
+                    return installed.data
+                flushed = filesystem.flush_directory(parent)
+                if not flushed.ok:
+                    raise AuthorizationCustodyUnavailable
+        installed = _load_file(path)
+        if not hmac.compare_digest(installed.data, data):
+            raise AuthorizationCustodyUnavailable
+        return installed.data
+    except AuthorizationCustodyUnavailable:
+        raise
+    except (OSError, RuntimeError, TypeError, ValueError, held_fs.HeldFsError):
+        raise AuthorizationCustodyUnavailable from None
 
 
 def _replace_control_bytes(
@@ -646,7 +851,7 @@ def _replace_control_bytes(
                     target,
                     expected_identity=identity,
                     expected_sha256=hashlib.sha256(expected).hexdigest(),
-                    prepare=lambda staged: _prepare_private_control_stage(path, staged),
+                    prepare=lambda staged: _prepare_private_stage(path, staged),
                 )
                 if not published.ok:
                     raise AuthorizationCustodyUnavailable
@@ -660,6 +865,295 @@ def _replace_control_bytes(
         raise
     except (OSError, RuntimeError, TypeError, ValueError, held_fs.HeldFsError):
         raise AuthorizationCustodyUnavailable from None
+
+
+def _opaque_identifier(prefix: str) -> str:
+    return f"{prefix}-{secrets.token_hex(16)}"
+
+
+def _keyring_bytes(keyring: AuthorizationKeyring) -> bytes:
+    value = {
+        "version": keyring.version,
+        "keyring_id": keyring.keyring_id,
+        "cell_id": keyring.cell_id,
+        "logical_vault_id": keyring.logical_vault_id,
+        "active_key_id": keyring.active_key_id,
+        "accepted_keys": [
+            {
+                "key_id": item.key_id,
+                "key": base64.urlsafe_b64encode(item.key).rstrip(b"=").decode("ascii"),
+                "not_before": item.not_before,
+                "not_after": item.not_after,
+            }
+            for item in keyring.accepted_keys
+        ],
+    }
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    if not 1 <= len(encoded) <= MAX_CUSTODY_FILE_BYTES:
+        raise AuthorizationCustodyUnavailable
+    return encoded
+
+
+def _bootstrap_membership_digest(
+    *,
+    cell_id: str,
+    logical_vault_id: str,
+    attachment_id: str,
+    keyring_id: str,
+    active_key_id: str,
+) -> str:
+    return hashlib.sha256(
+        _framed(
+            _BOOTSTRAP_MEMBERSHIP_DOMAIN,
+            tuple(
+                value.encode("utf-8")
+                for value in (
+                    cell_id,
+                    logical_vault_id,
+                    attachment_id,
+                    keyring_id,
+                    active_key_id,
+                )
+            ),
+        )
+    ).hexdigest()
+
+
+def _governance_negative_scan(vault_root: Path) -> None:
+    try:
+        acquired = held_fs.acquire(vault_root)
+        if not acquired.ok:
+            raise AuthorizationCustodyUnavailable
+        with acquired.require() as filesystem:
+            kb_result = filesystem.parent("Knowledge Base")
+            if not kb_result.ok:
+                raise AuthorizationCustodyUnavailable
+            with kb_result.require() as knowledge_base:
+                governance = filesystem.parent("Knowledge Base/_Governance")
+                if governance.ok:
+                    governance.require().close()
+                    raise AuthorizationCustodyUnavailable
+                if governance.error is None or governance.error.code != "MISSING":
+                    raise AuthorizationCustodyUnavailable
+                for name in _GOVERNANCE_AUTHORITY_NAMES:
+                    candidate = filesystem.file(knowledge_base, name)
+                    if candidate.ok:
+                        candidate.require().close()
+                        raise AuthorizationCustodyUnavailable
+                    if candidate.error is None or candidate.error.code != "MISSING":
+                        raise AuthorizationCustodyUnavailable
+                if not filesystem.validate_directory(knowledge_base).ok:
+                    raise AuthorizationCustodyUnavailable
+    except AuthorizationCustodyUnavailable:
+        raise
+    except (OSError, RuntimeError, ValueError, held_fs.HeldFsError):
+        raise AuthorizationCustodyUnavailable from None
+
+
+def _provisioning_result(
+    custody: AuthorizationCustody,
+) -> StandaloneProvisioningResult:
+    return StandaloneProvisioningResult(
+        keyring_path=custody.keyring_path,
+        control_path=custody.control_path,
+        keyring_id=custody.keyring.keyring_id,
+        cell_id=custody.keyring.cell_id,
+        logical_vault_id=custody.keyring.logical_vault_id,
+        registry_attachment_id=custody.control.registry_attachment_id,
+        attachment_epoch=custody.control.attachment_epoch,
+    )
+
+
+def provision_standalone_custody(
+    vault_root: Path,
+    *,
+    now: int,
+) -> StandaloneProvisioningResult:
+    """Explicitly provision one never-enrolled standalone attachment.
+
+    This is never called from an ordinary loader.  It creates no vault state;
+    the externally authenticated control record is the final registration
+    point, and a keyring-only interruption can be retried without rotating the
+    generated identity.
+    """
+
+    root = Path(vault_root)
+    current_time = _bounded_time(now)
+    if current_time > _MAX_SIGNED_SQLITE_INTEGER - _DEFAULT_KEY_TTL_SECONDS:
+        raise AuthorizationCustodyUnavailable
+    attachment_id = standalone_attachment_id(root)
+    keyring_path = _configured_external_path(KEYRING_FILE_ENV, root)
+    control_path = _configured_external_path(CONTROL_FILE_ENV, root)
+    if keyring_path == control_path:
+        raise AuthorizationCustodyUnavailable
+
+    from .. import reserved_paths
+
+    # First attachment is the one operation that must prove the vault has no
+    # private owner state at all.  Take the registry-wide identity guard rather
+    # than pretending to hold dispatcher authority for two different owners.
+    with reserved_paths._identity_coordination_scope(root):
+        _governance_negative_scan(root)
+        keyring_loaded: _LoadedCustodyFile | None = None
+        control_loaded: _LoadedCustodyFile | None = None
+        try:
+            keyring_loaded = _load_file(keyring_path)
+        except AuthorizationCustodyUnavailable:
+            if keyring_path.exists():
+                raise
+        try:
+            control_loaded = _load_file(control_path)
+        except AuthorizationCustodyUnavailable:
+            if control_path.exists():
+                raise
+
+        if control_loaded is not None and keyring_loaded is None:
+            raise AuthorizationCustodyUnavailable
+        if keyring_loaded is not None:
+            keyring = parse_keyring(keyring_loaded.data)
+        else:
+            key = AuthorizationVerifierKey(
+                key_id=_opaque_identifier("auth-key"),
+                key=secrets.token_bytes(32),
+                not_before=current_time,
+                not_after=current_time + _DEFAULT_KEY_TTL_SECONDS,
+            )
+            keyring = AuthorizationKeyring(
+                version=1,
+                keyring_id=_opaque_identifier("keyring"),
+                cell_id=_opaque_identifier("cell"),
+                logical_vault_id=_opaque_identifier("vault"),
+                active_key_id=key.key_id,
+                accepted_keys=(key,),
+            )
+            encoded_keyring = _keyring_bytes(keyring)
+            _publish_private_file(keyring_path, encoded_keyring)
+
+        if not keyring.active_key.not_before <= current_time < keyring.active_key.not_after:
+            raise AuthorizationCustodyUnavailable
+        if control_loaded is None:
+            membership_digest = _bootstrap_membership_digest(
+                cell_id=keyring.cell_id,
+                logical_vault_id=keyring.logical_vault_id,
+                attachment_id=attachment_id,
+                keyring_id=keyring.keyring_id,
+                active_key_id=keyring.active_key_id,
+            )
+            control = AuthorizationControlRecord(
+                version=1,
+                keyring_id=keyring.keyring_id,
+                cell_id=keyring.cell_id,
+                logical_vault_id=keyring.logical_vault_id,
+                registry_attachment_id=attachment_id,
+                attachment_epoch=1,
+                governance_enrolled=False,
+                activation_store_id=None,
+                activation_epoch=None,
+                activation_state_digest=None,
+                serving_membership_epoch=1,
+                serving_membership_digest=membership_digest,
+                issued_at=current_time,
+                expires_at=min(
+                    current_time + _DEFAULT_CONTROL_TTL_SECONDS,
+                    keyring.active_key.not_after,
+                ),
+                signing_key_id=keyring.active_key_id,
+            )
+            encoded_control = _signed_control_bytes(
+                control,
+                signing_key=keyring.active_key.key,
+            )
+            _governance_negative_scan(root)
+            _publish_private_file(control_path, encoded_control)
+
+    return _provisioning_result(load_authorization_custody(root, now=current_time))
+
+
+def enroll_initial_activation_tuple(
+    vault_root: Path,
+    *,
+    expected_control: AuthorizationControlRecord,
+    target: VerifiedActiveGovernanceState,
+    now: int,
+) -> ActivationRegistryAcknowledgement:
+    """Irreversibly CAS never-enrolled custody to one exact initial tuple."""
+
+    from . import schema_v4
+
+    if (
+        not isinstance(expected_control, AuthorizationControlRecord)
+        or not isinstance(target, schema_v4.VerifiedActiveGovernanceState)
+        or expected_control.governance_enrolled
+        or expected_control.activation_store_id is not None
+        or expected_control.activation_epoch is not None
+        or expected_control.activation_state_digest is not None
+        or target.logical_vault_id != expected_control.logical_vault_id
+        or target.activation_epoch != 1
+    ):
+        raise AuthorizationCustodyUnavailable
+    _bounded_identifier(target.activation_store_id)
+    _sha256_hex(target.activation_state_digest)
+
+    root = Path(vault_root)
+    from .. import reserved_paths
+
+    with reserved_paths._identity_coordination_scope(root):
+        _governance_negative_scan(root)
+        external = load_external_custody(root)
+        keyring = parse_keyring(external.keyring)
+        current = parse_control_record(external.control, keyring=keyring, now=now)
+        _verify_registered_attachment(root, current.registry_attachment_id)
+        target_control = AuthorizationControlRecord(
+            version=expected_control.version,
+            keyring_id=expected_control.keyring_id,
+            cell_id=expected_control.cell_id,
+            logical_vault_id=expected_control.logical_vault_id,
+            registry_attachment_id=expected_control.registry_attachment_id,
+            attachment_epoch=expected_control.attachment_epoch,
+            governance_enrolled=True,
+            activation_store_id=target.activation_store_id,
+            activation_epoch=target.activation_epoch,
+            activation_state_digest=target.activation_state_digest,
+            serving_membership_epoch=expected_control.serving_membership_epoch,
+            serving_membership_digest=expected_control.serving_membership_digest,
+            issued_at=expected_control.issued_at,
+            expires_at=expected_control.expires_at,
+            signing_key_id=expected_control.signing_key_id,
+        )
+        acknowledgement = schema_v4.ActivationRegistryAcknowledgement(
+            activation_store_id=target.activation_store_id,
+            activation_epoch=target.activation_epoch,
+            activation_state_digest=target.activation_state_digest,
+        )
+        if current == target_control:
+            return acknowledgement
+        if current != expected_control:
+            raise AuthorizationCustodyUnavailable
+        signing_key = next(
+            (
+                item.key
+                for item in keyring.accepted_keys
+                if item.key_id == current.signing_key_id
+            ),
+            None,
+        )
+        if signing_key is None:
+            raise AuthorizationCustodyUnavailable
+        _replace_control_bytes(
+            external.control_path,
+            expected=external.control,
+            target=_signed_control_bytes(target_control, signing_key=signing_key),
+        )
+    verified = load_authorization_custody(root, now=now)
+    if verified.control != target_control:
+        raise AuthorizationCustodyUnavailable
+    return acknowledgement
 
 
 def acknowledge_activation_tuple(
@@ -686,9 +1180,11 @@ def acknowledge_activation_tuple(
     ):
         raise AuthorizationCustodyUnavailable
 
-    external = load_external_custody(Path(vault_root))
+    root = Path(vault_root)
+    external = load_external_custody(root)
     keyring = parse_keyring(external.keyring)
     current = parse_control_record(external.control, keyring=keyring, now=now)
+    _verify_registered_attachment(root, current.registry_attachment_id)
     target_control = AuthorizationControlRecord(
         version=expected_control.version,
         keyring_id=expected_control.keyring_id,
@@ -731,7 +1227,7 @@ def acknowledge_activation_tuple(
         expected=external.control,
         target=encoded,
     )
-    verified = load_authorization_custody(Path(vault_root), now=now)
+    verified = load_authorization_custody(root, now=now)
     if verified.control != target_control:
         raise AuthorizationCustodyUnavailable
     return acknowledgement

--- a/tests/test_authorization_standalone_provisioning.py
+++ b/tests/test_authorization_standalone_provisioning.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import os
+import stat
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from exomem import mutation_lock, writer_lease
+from exomem.governance import authorization_custody, policy, schema_v4
+
+
+@pytest.fixture(autouse=True)
+def _custody_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
+    external = tmp_path / "external"
+    external.mkdir(mode=0o700)
+    lease_state = tmp_path / "lease-state"
+    lease_state.mkdir(mode=0o700)
+    if os.name == "nt":  # pragma: no cover - exercised by Windows CI
+        sid = mutation_lock._windows_current_user_sid()
+        mutation_lock._windows_apply_private_dacl(external, sid)
+        mutation_lock._windows_apply_private_dacl(lease_state, sid)
+    monkeypatch.setenv(
+        authorization_custody.KEYRING_FILE_ENV,
+        str(external / "authorization-keyring.json"),
+    )
+    monkeypatch.setenv(
+        authorization_custody.CONTROL_FILE_ENV,
+        str(external / "authorization-control.json"),
+    )
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(lease_state))
+    writer_lease.reset_managers_for_tests()
+    yield
+    writer_lease.reset_managers_for_tests()
+
+
+def _vault(tmp_path: Path, name: str = "vault") -> Path:
+    vault = tmp_path / name
+    (vault / "Knowledge Base").mkdir(parents=True)
+    return vault
+
+
+def _target(
+    custody: authorization_custody.AuthorizationCustody,
+    *,
+    digest: str = "d" * 64,
+) -> schema_v4.VerifiedActiveGovernanceState:
+    return schema_v4.VerifiedActiveGovernanceState(
+        logical_vault_id=custody.control.logical_vault_id,
+        activation_store_id="activation-store-initial",
+        activation_epoch=1,
+        activation_state_digest=digest,
+        policy_generation_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        policy_fingerprint="a" * 64,
+        projector_schema_version=1,
+        catalog_generation=1,
+        projection_namespace_id="projection-namespace-initial",
+    )
+
+
+def test_attachment_identity_is_stable_for_one_root_and_changes_for_a_copy(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    copied = _vault(tmp_path, "copied-vault")
+
+    first = authorization_custody.standalone_attachment_id(vault)
+    second = authorization_custody.standalone_attachment_id(vault)
+
+    assert first == second
+    assert first.startswith("attachment-v1-")
+    assert authorization_custody.standalone_attachment_id(copied) != first
+
+
+def test_explicit_standalone_provisioning_is_private_idempotent_and_copy_bound(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = 1_800_000_000
+
+    first = authorization_custody.provision_standalone_custody(vault, now=now)
+    keyring_before = first.keyring_path.read_bytes()
+    control_before = first.control_path.read_bytes()
+    replay = authorization_custody.provision_standalone_custody(vault, now=now)
+    loaded = authorization_custody.load_authorization_custody(vault, now=now + 1)
+
+    assert replay == first
+    assert loaded.control.governance_enrolled is False
+    assert loaded.control.activation_store_id is None
+    assert loaded.control.registry_attachment_id == first.registry_attachment_id
+    assert first.keyring_path.read_bytes() == keyring_before
+    assert first.control_path.read_bytes() == control_before
+    assert first.cell_id == loaded.keyring.cell_id
+    assert first.logical_vault_id == loaded.keyring.logical_vault_id
+    assert first.keyring_id == loaded.keyring.keyring_id
+    active_secret = loaded.keyring.active_key.key.hex()
+    assert active_secret not in repr(first)
+    if os.name != "nt":
+        assert stat.S_IMODE(first.keyring_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(first.control_path.stat().st_mode) == 0o600
+
+    copied = _vault(tmp_path, "copied-vault")
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_authorization_custody(copied, now=now + 1)
+
+
+@pytest.mark.parametrize(
+    "relative",
+    (
+        "Knowledge Base/_Governance",
+        "Knowledge Base/.governance.sqlite",
+        "Knowledge Base/.governance.sqlite-wal",
+        "Knowledge Base/.governance.sqlite-shm",
+        "Knowledge Base/.governance.sqlite-journal",
+    ),
+)
+def test_never_enrolled_provisioning_refuses_existing_governance_authority(
+    tmp_path: Path,
+    relative: str,
+) -> None:
+    vault = _vault(tmp_path)
+    target = vault / relative
+    if target.suffix:
+        target.write_bytes(b"authority")
+    else:
+        target.mkdir()
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.provision_standalone_custody(
+            vault,
+            now=1_800_000_000,
+        )
+
+    assert not Path(os.environ[authorization_custody.KEYRING_FILE_ENV]).exists()
+    assert not Path(os.environ[authorization_custody.CONTROL_FILE_ENV]).exists()
+
+
+def test_initial_enrollment_is_irreversible_exact_and_idempotent(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = 1_800_000_000
+    authorization_custody.provision_standalone_custody(vault, now=now)
+    prior = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    target = _target(prior)
+
+    first = authorization_custody.enroll_initial_activation_tuple(
+        vault,
+        expected_control=prior.control,
+        target=target,
+        now=now + 1,
+    )
+    replay = authorization_custody.enroll_initial_activation_tuple(
+        vault,
+        expected_control=prior.control,
+        target=target,
+        now=now + 1,
+    )
+    enrolled = authorization_custody.load_authorization_custody(vault, now=now + 1)
+
+    assert first == replay == schema_v4.ActivationRegistryAcknowledgement(
+        activation_store_id=target.activation_store_id,
+        activation_epoch=1,
+        activation_state_digest=target.activation_state_digest,
+    )
+    assert enrolled.control.governance_enrolled is True
+    assert enrolled.control.activation_store_id == target.activation_store_id
+    assert enrolled.control.activation_epoch == 1
+    assert enrolled.control.activation_state_digest == target.activation_state_digest
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.enroll_initial_activation_tuple(
+            vault,
+            expected_control=prior.control,
+            target=_target(prior, digest="e" * 64),
+            now=now + 1,
+        )
+
+
+def test_bound_attachment_refuses_successor_cas_from_a_copied_root(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    copied = _vault(tmp_path, "copied-vault")
+    now = 1_800_000_000
+    authorization_custody.provision_standalone_custody(vault, now=now)
+    prior = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    authorization_custody.enroll_initial_activation_tuple(
+        vault,
+        expected_control=prior.control,
+        target=_target(prior),
+        now=now + 1,
+    )
+    enrolled = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    control_before = enrolled.control_path.read_bytes()
+    successor = schema_v4.VerifiedActiveGovernanceState(
+        logical_vault_id=enrolled.control.logical_vault_id,
+        activation_store_id="activation-store-initial",
+        activation_epoch=2,
+        activation_state_digest="e" * 64,
+        policy_generation_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        policy_fingerprint="b" * 64,
+        projector_schema_version=1,
+        catalog_generation=2,
+        projection_namespace_id="projection-namespace-successor",
+    )
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.acknowledge_activation_tuple(
+            copied,
+            expected_control=enrolled.control,
+            target=successor,
+            now=now + 1,
+        )
+
+    assert enrolled.control_path.read_bytes() == control_before
+
+
+def test_enrollment_before_store_creation_blocks_instead_of_reopening(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = 1_800_000_000
+    authorization_custody.provision_standalone_custody(vault, now=now)
+    prior = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    authorization_custody.enroll_initial_activation_tuple(
+        vault,
+        expected_control=prior.control,
+        target=_target(prior),
+        now=now + 1,
+    )
+
+    assert not (vault / "Knowledge Base" / ".governance.sqlite").exists()
+    loaded = policy.load(vault)
+    assert loaded.blocked
+    assert not loaded.empty
+
+
+def test_initial_enrollment_refuses_governance_state_created_after_registration(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = 1_800_000_000
+    authorization_custody.provision_standalone_custody(vault, now=now)
+    prior = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    control_before = prior.control_path.read_bytes()
+    (vault / "Knowledge Base" / "_Governance").mkdir()
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.enroll_initial_activation_tuple(
+            vault,
+            expected_control=prior.control,
+            target=_target(prior),
+            now=now + 1,
+        )
+
+    assert prior.control_path.read_bytes() == control_before
+
+
+def test_keyring_only_interruption_retries_without_rotating_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    now = 1_800_000_000
+    original = authorization_custody._publish_private_file
+    failed = False
+
+    def interrupt_control(path: Path, data: bytes) -> bytes:
+        nonlocal failed
+        if path.name == "authorization-control.json" and not failed:
+            failed = True
+            raise authorization_custody.AuthorizationCustodyUnavailable
+        return original(path, data)
+
+    monkeypatch.setattr(
+        authorization_custody,
+        "_publish_private_file",
+        interrupt_control,
+    )
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.provision_standalone_custody(vault, now=now)
+
+    keyring_path = Path(os.environ[authorization_custody.KEYRING_FILE_ENV])
+    control_path = Path(os.environ[authorization_custody.CONTROL_FILE_ENV])
+    assert keyring_path.exists()
+    assert not control_path.exists()
+    keyring_before = keyring_path.read_bytes()
+
+    monkeypatch.setattr(authorization_custody, "_publish_private_file", original)
+    result = authorization_custody.provision_standalone_custody(vault, now=now)
+
+    assert keyring_path.read_bytes() == keyring_before
+    assert result.control_path == control_path
+    assert authorization_custody.load_authorization_custody(
+        vault,
+        now=now + 1,
+    ).control.governance_enrolled is False


### PR DESCRIPTION
## Why

Governance schema v4 already authenticates external keyring/control records, but standalone records still carried an opaque attachment id with no local storage-identity binding and had no explicit never-enrolled provisioning/first-enrollment transition.

## What changed

- derive a closed standalone attachment id from the retained vault-root identity and OS owner
- explicitly provision owner-private external keyring/control files; ordinary loading still never mints identity
- serialize provisioning with the private-state registry and refuse any existing governance workspace or activation-store family
- add an exact, idempotent, irreversible false-to-true initial activation-tuple CAS before store creation
- preserve existing Hosted/control-plane opaque attachment ids while strictly verifying the new standalone namespace
- reject copied roots, interrupted partial provisioning, post-registration governance drift, and copied-root successor acknowledgements without mutating control state

This is a bounded custody foundation. It does not wire a public provisioning command, complete Hosted attachment transfer/restore, or claim the serving-membership epoch tasks complete. It touches no live vault.

## Verification

- 171 passed, 1 Windows-only skip across standalone provisioning, custody, schema-v4 store/active tuple, lifecycle, and authority tests
- changed-file Ruff: clean
- public artifact privacy gate: clean
- `openspec validate harden-governance-for-consolidation --strict`: valid
- `git diff --check`: clean
- wheel and sdist build: green
