### PR TITLE
fix(governance): accept canonical private Windows custody DACL

### DIFF
--- a/src/exomem/governance/authorization_custody.py
+++ b/src/exomem/governance/authorization_custody.py
@@ -758,13 +758,10 @@ def _private_parent_is_safe(path: Path) -> bool:
             return False
         if os.name == "nt":  # pragma: no cover - exercised by Windows CI
             sid = mutation_lock._windows_current_user_sid()
-            return (
-                mutation_lock._windows_private_dacl_verdict(
-                    mutation_lock._windows_dacl_sddl(path),
-                    sid,
-                    directory=True,
-                )
-                == "valid"
+            return mutation_lock._windows_private_dacl_is_valid(
+                mutation_lock._windows_dacl_sddl(path),
+                sid,
+                directory=True,
             )
         return int(info.st_uid) == os.geteuid() and not stat.S_IMODE(info.st_mode) & 0o077
     except (OSError, RuntimeError, ValueError):


### PR DESCRIPTION
## Why

PR #772 exposed one additional Windows portability defect during a native normal-user-account probe: the custody parent guard compared the canonical DACL classifier result to the obsolete literal `valid`. The classifier now returns `private`, `inherited`, or `unsafe`, so a correctly protected standalone custody directory was refused outside the Administrator-shaped GitHub runner.

## Change

Use the canonical `_windows_private_dacl_is_valid(..., directory=True)` predicate for the external custody parent.

## Verification

- Native Windows 11 / normal user: `12 passed` in `tests/test_authorization_standalone_provisioning.py`
- Linux adjacent custody/activation packet: `118 passed, 1 skipped`
- Changed-file Ruff: passed
- `git diff --check`: passed

No live vault, keyring, or control record was touched.