### PR TITLE
fix(governance): guard projected serving release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,13 +258,13 @@ jobs:
         run: uv run --frozen python -m pytest tests/test_latency_gate.py -q
 
   governance-projection-wire:
-    name: governance projected wire (${{ matrix.route }})
+    name: governance projected wire characterization (${{ matrix.route }})
     runs-on: ubuntu-latest
     timeout-minutes: 8
     strategy:
       fail-fast: false
       matrix:
-        route: [keyword, bm25, vector-hard-off, rerank-hard-off, clip-hard-off, graph, graph-rerank-hard-off, max-query, max-limit, max-shape, error, pagination]
+        route: [keyword, bm25, vector-hard-off, rerank-hard-off, clip-hard-off, graph, graph-rerank-hard-off, max-query, max-limit, max-shape, invalid-limit, minimum-limit]
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
@@ -273,7 +273,7 @@ jobs:
           enable-cache: true
       - name: Verify lockfile is current
         run: uv lock --check
-      - name: Exact-capacity hidden-corpus actual-wire gate
+      - name: Characterize exact-capacity hidden-corpus actual-wire routes
         env:
           EXOMEM_GOVERNANCE_TIMING_ROUTE: ${{ matrix.route }}
           EXOMEM_DISABLE_EMBEDDINGS: "1"

--- a/benchmarks/governance/projected-wire-release-v1.json
+++ b/benchmarks/governance/projected-wire-release-v1.json
@@ -26,8 +26,8 @@
     "max-query",
     "max-limit",
     "max-shape",
-    "error",
-    "pagination"
+    "invalid-limit",
+    "minimum-limit"
   ],
   "capacity": {
     "catalog_items": 16384,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,7 +219,7 @@ markers = [
     # and the HF model cache). Excluded from the lean matrix; run in the dedicated
     # `retrieval-eval` CI job via `pytest -m embeddings`.
     "embeddings: loads live vector models; run only in the retrieval-eval job",
-    "governance_timing_release: exact-capacity actual-wire governance release gate",
+    "governance_timing_release: exact-capacity actual-wire governance timing characterization",
 ]
 
 # Blackwell (RTX 50-series, sm_120 / compute capability 12.0) needs CUDA wheels.

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -1233,7 +1233,7 @@ def _require_supported_projected_find_request(
         or not query
         or mode not in {"keyword", "hybrid", "vector"}
         or (graph and mode == "keyword")
-        or scope != "vault"
+        or scope not in {"kb", "vault"}
         or rerank_max_candidates is not None
         or not prefer_compiled
         or not prefer_active
@@ -1579,6 +1579,7 @@ def op_find(
             projection_runtime,
             query=query,
             limit=limit,
+            scope=scope,
             mode=mode,
             graph=graph,
             rerank=rerank,

--- a/src/exomem/governance/projection_runtime.py
+++ b/src/exomem/governance/projection_runtime.py
@@ -48,12 +48,17 @@ class _PreactivatedProjectionRuntime:
 
 
 _PREACTIVATED_RUNTIMES: dict[str, _PreactivatedProjectionRuntime] = {}
+_PROJECTED_COMPLETION_ROOTS: set[str] = set()
 _PREACTIVATED_RUNTIME_LOCK = threading.RLock()
 # Repository-owned release fence. The checked release manifest and required
 # actual-wire CI matrix currently certify only the exact model-hard-off runtime
 # profile. Environment cannot opt an uncertified model-enabled profile into
 # serving; those configurations remain closed until their own evidence lands.
-_PROJECTED_SERVING_RELEASE_ACCEPTED = True
+# The model-hard-off implementation remains installed but unavailable until the
+# actual-wire gate covers genuine hidden-state error reduction and real
+# pagination.  A malformed-argument response and ``limit=1`` are not evidence
+# for those two release claims.
+_PROJECTED_SERVING_RELEASE_ACCEPTED = False
 
 
 def projected_serving_release_profile() -> str | None:
@@ -280,6 +285,7 @@ def _clear_preactivated_runtimes_for_tests() -> None:
 
     with _PREACTIVATED_RUNTIME_LOCK:
         _PREACTIVATED_RUNTIMES.clear()
+        _PROJECTED_COMPLETION_ROOTS.clear()
 
 
 def has_preactivated_projection_runtime(vault_root: Path) -> bool:
@@ -287,6 +293,28 @@ def has_preactivated_projection_runtime(vault_root: Path) -> bool:
 
     with _PREACTIVATED_RUNTIME_LOCK:
         return _root_key(Path(vault_root)) in _PREACTIVATED_RUNTIMES
+
+
+def requires_fixed_projected_completion(vault_root: Path) -> bool:
+    """Return the process-classified timing boundary without request IO."""
+
+    with _PREACTIVATED_RUNTIME_LOCK:
+        return _root_key(Path(vault_root)) in _PROJECTED_COMPLETION_ROOTS
+
+
+def classify_projected_completion_boundary(vault_root: Path) -> bool:
+    """Observe and retain the irreversible projected timing boundary."""
+
+    root = Path(vault_root)
+    root_key = _root_key(root)
+    with _PREACTIVATED_RUNTIME_LOCK:
+        if root_key in _PROJECTED_COMPLETION_ROOTS:
+            return True
+    completion_required = requires_projected_read_boundary(root)
+    if completion_required:
+        with _PREACTIVATED_RUNTIME_LOCK:
+            _PROJECTED_COMPLETION_ROOTS.add(root_key)
+    return completion_required
 
 
 def preactivate_projection_runtime(
@@ -300,6 +328,8 @@ def preactivate_projection_runtime(
     """
 
     root = Path(vault_root)
+    root_key = _root_key(root)
+    classify_projected_completion_boundary(root)
     if not _configured_external_custody():
         return None
     connection: sqlite3.Connection | None = None
@@ -310,6 +340,8 @@ def preactivate_projection_runtime(
         )
         activation = _control_activation(custody)
         if activation is None:
+            with _PREACTIVATED_RUNTIME_LOCK:
+                _PROJECTED_COMPLETION_ROOTS.discard(root_key)
             return None
         cell_id, logical_vault_id, store_id, epoch, digest = activation
         connection = store.open_active_governance_read_connection(root)
@@ -769,6 +801,55 @@ def _projected_rank_multiplier(
     return multiplier
 
 
+def _order_projected_scope(
+    ordered_identities: tuple[str, ...],
+    *,
+    scope: str,
+    limit: int,
+    knowledge_base_name: str,
+) -> tuple[str, ...]:
+    """Apply the public KB-first reserve without reopening raw pages."""
+
+    if scope != "kb":
+        return ordered_identities
+    inside: list[str] = []
+    outside: list[str] = []
+    for identity in ordered_identities:
+        parts = PurePosixPath(identity).parts
+        target = inside if parts and parts[0] == knowledge_base_name else outside
+        target.append(identity)
+    if not outside:
+        return ordered_identities
+    reserve = min(len(outside), max(1, limit // 5), max(0, limit - 1))
+    kb_keep = limit - reserve
+    return tuple((inside[:kb_keep] + outside)[:limit])
+
+
+def _retain_projected_scope_lane(
+    hits: tuple[projected_retrieval.ProjectedLexicalHit, ...],
+    *,
+    scope: str,
+    candidate_depth: int,
+    outside_depth: int,
+    knowledge_base_name: str,
+) -> tuple[projected_retrieval.ProjectedLexicalHit, ...]:
+    """Keep a bounded outside-KB pool before per-lane truncation."""
+
+    head = hits[:candidate_depth]
+    if scope != "kb":
+        return head
+    outside = tuple(
+        hit
+        for hit in hits
+        if not (
+            (parts := PurePosixPath(hit.item_identity).parts)
+            and parts[0] == knowledge_base_name
+        )
+    )[:outside_depth]
+    retained = {hit.item_identity for hit in (*head, *outside)}
+    return tuple(hit for hit in hits if hit.item_identity in retained)
+
+
 def _retain_projected_bm25_hits(
     lane_hits: Mapping[
         str,
@@ -836,6 +917,7 @@ def find_projected_hits(
     *,
     query: str,
     limit: int,
+    scope: str = "vault",
     mode: str,
     graph: bool,
     rerank: bool | None,
@@ -874,6 +956,7 @@ def find_projected_hits(
     if (
         not query
         or mode not in {"keyword", "hybrid", "vector"}
+        or scope not in {"kb", "vault"}
         or (graph and mode == "keyword")
         or rerank not in {None, False, True}
     ):
@@ -1136,8 +1219,15 @@ def find_projected_hits(
                 ) from error
 
     lane_order = ranking_config.LANE_ORDER[:5]
+    knowledge_base_name = kb_dirname()
     lane_hits = {
-        lane: hits[:candidate_depth]
+        lane: _retain_projected_scope_lane(
+            hits,
+            scope=scope,
+            candidate_depth=candidate_depth,
+            outside_depth=limit,
+            knowledge_base_name=knowledge_base_name,
+        )
         for lane, hits in lane_hits.items()
     }
     active_lanes = [lane for lane in lane_order if lane_hits.get(lane)]
@@ -1250,6 +1340,13 @@ def find_projected_hits(
                 "governed projected retrieval is unavailable"
             ) from error
 
+    ordered_identities = _order_projected_scope(
+        ordered_identities,
+        scope=scope,
+        limit=limit,
+        knowledge_base_name=knowledge_base_name,
+    )
+
     hits_by_lane = {
         lane: {hit.item_identity: hit for hit in hits}
         for lane, hits in lane_hits.items()
@@ -1263,7 +1360,6 @@ def find_projected_hits(
     reranked_by_identity = (
         {} if reranked is None else {hit.item_identity: hit for hit in reranked}
     )
-    knowledge_base_name = kb_dirname()
     hits: list[Hit] = []
     for final_rank, identity in enumerate(ordered_identities[:limit], 1):
         source_hit = reranked_by_identity.get(identity)
@@ -1322,9 +1418,11 @@ __all__ = [
     "ActiveProjectionRuntime",
     "ProjectedFindResult",
     "ProjectionRuntimeUnavailable",
+    "classify_projected_completion_boundary",
     "find_projected_hits",
     "has_preactivated_projection_runtime",
     "load_active_projection_runtime",
     "preactivate_projection_runtime",
+    "requires_fixed_projected_completion",
     "requires_projected_read_boundary",
 ]

--- a/src/exomem/governance/projection_timing.py
+++ b/src/exomem/governance/projection_timing.py
@@ -102,8 +102,8 @@ _REQUIRED_ROUTES = frozenset(
         "max-query",
         "max-limit",
         "max-shape",
-        "error",
-        "pagination",
+        "invalid-limit",
+        "minimum-limit",
     }
 )
 _HARDWARE_RUNTIME_PROFILE = "github-hosted-ubuntu-latest-x64-python3.13"
@@ -584,7 +584,7 @@ def request_class_for_find(
 
     if (
         mode not in {"keyword", "hybrid", "vector"}
-        or scope != "vault"
+        or scope not in {"kb", "vault"}
         or type(graph) is not bool
         or rerank not in {None, False, True}
         or (mode == "keyword" and graph)
@@ -666,14 +666,16 @@ def complete_public_request(
 @contextmanager
 def fixed_public_completion(
     request_class: PublicRequestClass,
+    *,
+    started_at: float | None = None,
 ) -> Iterator[None]:
     """Apply one class to success and error completion paths alike."""
 
-    started_at = time.perf_counter()
+    started = time.perf_counter() if started_at is None else started_at
     try:
         yield
     finally:
-        complete_public_request(request_class, started_at=started_at)
+        complete_public_request(request_class, started_at=started)
 
 
 __all__ = [

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -3653,10 +3653,19 @@ def _fixed_projected_command_completion(
             getattr(command, "name", None) not in {"ask_memory", "find"}
             or not injected
             or not isinstance(injected[0], (str, os.PathLike))
-            or not projection_runtime.has_preactivated_projection_runtime(
-                Path(injected[0])
-            )
         ):
+            return invoke()
+        started_at = time.perf_counter()
+        vault_root = Path(injected[0])
+        preactivated = projection_runtime.has_preactivated_projection_runtime(
+            vault_root
+        )
+        completion_required = (
+            preactivated
+            or projection_runtime.requires_fixed_projected_completion(vault_root)
+            or projection_runtime.classify_projected_completion_boundary(vault_root)
+        )
+        if not completion_required:
             return invoke()
         request_class = projection_timing.request_class_for_command(
             command,
@@ -3665,7 +3674,15 @@ def _fixed_projected_command_completion(
         )
         if request_class is None:
             return invoke()
-        with projection_timing.fixed_public_completion(request_class):
+        completion = (
+            projection_timing.fixed_public_completion(request_class)
+            if preactivated
+            else projection_timing.fixed_public_completion(
+                request_class,
+                started_at=started_at,
+            )
+        )
+        with completion:
             return invoke()
 
     return wrapped

--- a/tests/test_ci_reliability_contract.py
+++ b/tests/test_ci_reliability_contract.py
@@ -197,7 +197,7 @@ def test_retrieval_gates_run_as_three_independent_jobs() -> None:
     assert "scripts/semantic_write_latency.py --check" in semantic_command
 
 
-def test_governance_wire_gate_runs_every_closed_route_on_the_registered_profile() -> None:
+def test_governance_wire_characterization_runs_every_registered_route() -> None:
     workflow = _workflow()
     job = workflow["jobs"]["governance-projection-wire"]
 
@@ -215,8 +215,8 @@ def test_governance_wire_gate_runs_every_closed_route_on_the_registered_profile(
         "max-query",
         "max-limit",
         "max-shape",
-        "error",
-        "pagination",
+        "invalid-limit",
+        "minimum-limit",
     }
     command = job["steps"][-1]["run"]
     assert "--python 3.13" in command

--- a/tests/test_governance_projected_commands.py
+++ b/tests/test_governance_projected_commands.py
@@ -158,6 +158,50 @@ def test_projected_find_suppresses_application_timings_with_one_stable_shape(
     }
 
 
+def test_projected_find_accepts_the_public_default_kb_scope(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    runtime = SimpleNamespace(
+        snapshot=SimpleNamespace(policy=Policy(fingerprint="f" * 64, scopes={}))
+    )
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        commands.projection_runtime_module,
+        "load_active_projection_runtime",
+        lambda _root: runtime,
+    )
+
+    def projected(*_args, **kwargs):
+        calls.append(kwargs)
+        return projection_runtime.ProjectedFindResult(
+            hits=(),
+            withheld_paths=frozenset(),
+        )
+
+    monkeypatch.setattr(
+        commands.projection_runtime_module,
+        "find_projected_hits",
+        projected,
+    )
+
+    with principal.request_scope(principal.owner_principal(surface="library")):
+        response = commands.op_find(
+            tmp_path,
+            query="projection-only term",
+            mode="keyword",
+            graph=False,
+            rerank=False,
+        )
+
+    assert response == {
+        "hits": [],
+        "timings_suppressed": {"status": "governed_projection"},
+    }
+    assert len(calls) == 1
+    assert calls[0]["scope"] == "kb"
+
+
 def test_projected_warming_marker_omits_process_age(
     monkeypatch,
     tmp_path,
@@ -462,7 +506,13 @@ def test_projected_find_uses_only_bound_variant_text(monkeypatch, tmp_path) -> N
         (visible.id,),
         "projection term",
     )
-    namespace = verified_namespace(key, (hidden, shown))
+    outside = item(
+        "Sources/outside.md",
+        "3" * 64,
+        (visible.id,),
+        "projection term projection term",
+    )
+    namespace = verified_namespace(key, (hidden, shown, outside))
     snapshot = schema_v4.ActivePolicySnapshot(
         active=schema_v4.VerifiedActiveGovernanceState(
             logical_vault_id="fixture-vault",
@@ -478,7 +528,7 @@ def test_projected_find_uses_only_bound_variant_text(monkeypatch, tmp_path) -> N
         policy=policy,
         source_documents=(),
         catalog_descriptor=projection_store.catalog_descriptor_bytes(
-            key, (hidden, shown)
+            key, (hidden, shown, outside)
         ),
         projection_namespace_evidence=b"fixture",
     )
@@ -495,7 +545,8 @@ def test_projected_find_uses_only_bound_variant_text(monkeypatch, tmp_path) -> N
         tmp_path,
         runtime,
         query="projection term",
-        limit=1,
+        limit=2,
+        scope="kb",
         mode="keyword",
         graph=False,
         rerank=False,
@@ -506,7 +557,10 @@ def test_projected_find_uses_only_bound_variant_text(monkeypatch, tmp_path) -> N
         purpose=None,
     )
 
-    assert [hit.path for hit in result.hits] == ["Knowledge Base/shown.md"]
+    assert [hit.path for hit in result.hits] == [
+        "Knowledge Base/shown.md",
+        "Sources/outside.md",
+    ]
     assert result.withheld_paths == frozenset({"Knowledge Base/hidden.md"})
 
 
@@ -536,6 +590,37 @@ def test_projected_wire_hit_never_emits_the_full_search_body() -> None:
     )
 
     assert wire.excerpt == "prefix bounded snippet"
+
+
+def test_projected_default_scope_reserves_outside_kb_slots() -> None:
+    ordered = (
+        "Knowledge Base/a.md",
+        "Knowledge Base/b.md",
+        "Knowledge Base/c.md",
+        "Knowledge Base/d.md",
+        "Knowledge Base/e.md",
+        "Sources/target.md",
+        "Sources/second.md",
+    )
+
+    assert projection_runtime._order_projected_scope(
+        ordered,
+        scope="kb",
+        limit=5,
+        knowledge_base_name="Knowledge Base",
+    ) == (
+        "Knowledge Base/a.md",
+        "Knowledge Base/b.md",
+        "Knowledge Base/c.md",
+        "Knowledge Base/d.md",
+        "Sources/target.md",
+    )
+    assert projection_runtime._order_projected_scope(
+        ordered,
+        scope="vault",
+        limit=5,
+        knowledge_base_name="Knowledge Base",
+    ) == ordered
 
 
 @pytest.mark.parametrize(

--- a/tests/test_governance_projected_runtime_lanes.py
+++ b/tests/test_governance_projected_runtime_lanes.py
@@ -416,6 +416,40 @@ def test_graph_promotes_a_target_below_the_complete_vector_candidate_prefix(
     assert result.hits[1].graph_hop is True
 
 
+def test_default_scope_retains_outside_target_beyond_the_lane_candidate_floor(
+    tmp_path,
+):
+    variants = (
+        _variant("Knowledge Base/a.md", "1" * 64, "needle"),
+        _variant("Knowledge Base/b.md", "2" * 64, "needle"),
+        _variant("Knowledge Base/c.md", "3" * 64, "needle"),
+        _variant("Sources/target.md", "4" * 64, "needle"),
+    )
+    runtime = _runtime(tuple(_item(variant) for variant in variants))
+
+    result = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="needle",
+        limit=2,
+        scope="kb",
+        mode="keyword",
+        graph=False,
+        rerank=False,
+        rank_config=projection_runtime.ranking_config.RankingConfig(
+            candidate_multiplier=1,
+            candidate_floor=2,
+        ),
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert [hit.path for hit in result.hits] == [
+        "Knowledge Base/a.md",
+        "Sources/target.md",
+    ]
+
+
 def test_graph_does_not_reintroduce_a_rejected_raw_bm25_candidate(tmp_path):
     seed = _variant("Knowledge Base/seed.md", "4" * 64, "what alpha")
     rejected = _variant("Knowledge Base/rejected.md", "5" * 64, "alpha only")

--- a/tests/test_governance_projection_activation.py
+++ b/tests/test_governance_projection_activation.py
@@ -161,6 +161,7 @@ def test_startup_preactivates_one_digest_and_serves_only_that_revalidated_runtim
         "catalog",
         "stabilize",
     ]
+    assert projection_runtime.requires_fixed_projected_completion(tmp_path) is True
 
     monkeypatch.setattr(
         schema_v4,
@@ -176,7 +177,18 @@ def test_startup_preactivates_one_digest_and_serves_only_that_revalidated_runtim
             AssertionError("request reloaded projection catalog")
         ),
     )
-    assert projection_runtime._PROJECTED_SERVING_RELEASE_ACCEPTED is True
+    assert projection_runtime._PROJECTED_SERVING_RELEASE_ACCEPTED is False
+    with pytest.raises(
+        projection_runtime.ProjectionRuntimeUnavailable,
+        match="governed projected retrieval is unavailable",
+    ):
+        projection_runtime.load_active_projection_runtime(tmp_path)
+
+    monkeypatch.setattr(
+        projection_runtime,
+        "_PROJECTED_SERVING_RELEASE_ACCEPTED",
+        True,
+    )
     assert projection_runtime.load_active_projection_runtime(tmp_path) is activated
 
     current_control[0] = replace(control, activation_epoch=control.activation_epoch + 1)
@@ -196,6 +208,63 @@ def test_startup_preactivates_one_digest_and_serves_only_that_revalidated_runtim
         match="governed projected retrieval is unavailable",
     ):
         projection_runtime.load_active_projection_runtime(tmp_path)
+
+
+def test_unavailable_projected_startup_keeps_the_fixed_completion_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv(
+        authorization_custody.KEYRING_FILE_ENV,
+        str(tmp_path / "keyring"),
+    )
+    monkeypatch.setattr(
+        projection_runtime.store,
+        "open_active_governance_read_connection",
+        lambda _root: (_ for _ in ()).throw(OSError("unavailable sidecar")),
+    )
+    monkeypatch.setattr(
+        authorization_custody,
+        "load_authorization_custody",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            authorization_custody.AuthorizationCustodyUnavailable(
+                "unavailable custody"
+            )
+        ),
+    )
+
+    projection_runtime._clear_preactivated_runtimes_for_tests()
+    with pytest.raises(
+        projection_runtime.ProjectionRuntimeUnavailable,
+        match="governed projected retrieval is unavailable",
+    ):
+        projection_runtime.preactivate_projection_runtime(tmp_path)
+
+    assert projection_runtime.requires_fixed_projected_completion(tmp_path) is True
+
+
+def test_completion_boundary_rechecks_legacy_until_governance_is_observed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    observations = iter((False, True))
+    calls: list[Path] = []
+
+    def observe(root: Path) -> bool:
+        calls.append(root)
+        return next(observations)
+
+    monkeypatch.setattr(
+        projection_runtime,
+        "requires_projected_read_boundary",
+        observe,
+    )
+    projection_runtime._clear_preactivated_runtimes_for_tests()
+
+    assert projection_runtime.classify_projected_completion_boundary(tmp_path) is False
+    assert projection_runtime.classify_projected_completion_boundary(tmp_path) is True
+    assert projection_runtime.classify_projected_completion_boundary(tmp_path) is True
+    assert calls == [tmp_path, tmp_path]
 
 
 def test_runtime_stabilization_finishes_collection_before_publication(

--- a/tests/test_governance_projection_measurement_activation.py
+++ b/tests/test_governance_projection_measurement_activation.py
@@ -293,6 +293,11 @@ def test_startup_preactivates_bound_vector_clip_and_graph_once(
                 AssertionError("request reloaded a projected measurement family")
             ),
         )
+    monkeypatch.setattr(
+        projection_runtime,
+        "_PROJECTED_SERVING_RELEASE_ACCEPTED",
+        True,
+    )
     assert projection_runtime.load_active_projection_runtime(tmp_path) is runtime
 
 

--- a/tests/test_governance_projection_timing.py
+++ b/tests/test_governance_projection_timing.py
@@ -58,8 +58,8 @@ def _release_manifest() -> dict[str, object]:
             "max-query",
             "max-limit",
             "max-shape",
-            "error",
-            "pagination",
+            "invalid-limit",
+            "minimum-limit",
         ],
         "capacity": {
             "catalog_items": projections.MAX_GOVERNED_CATALOG_ITEMS,
@@ -91,8 +91,8 @@ def test_checked_release_manifest_is_the_validated_nonwaivable_contract() -> Non
             "max-query",
             "max-limit",
             "max-shape",
-            "error",
-            "pagination",
+            "invalid-limit",
+            "minimum-limit",
         }
     )
 
@@ -119,6 +119,17 @@ def test_keyword_request_class_is_closed_and_repository_owned() -> None:
     )
     with pytest.raises(TypeError):
         timing.PUBLIC_REQUEST_CLASSES["caller-selected"] = request_class
+
+
+def test_public_default_kb_scope_uses_the_registered_completion_class() -> None:
+    timing = _timing_module()
+
+    assert timing.request_class_for_find(
+        mode="hybrid",
+        scope="kb",
+        graph=True,
+        rerank=None,
+    ) is timing.PUBLIC_REQUEST_CLASSES["projected-find-v1"]
 
 
 @pytest.mark.parametrize(
@@ -345,6 +356,78 @@ def test_projected_completion_wraps_the_default_shape_and_its_error_path(
     assert events == ["enter", "leaf", "complete"]
 
 
+def test_unavailable_projected_boundary_still_uses_fixed_completion(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    timing = _timing_module()
+    events: list[str] = []
+
+    def leaf(vault_root, query: str = ""):
+        assert vault_root == tmp_path
+        assert query == "projection-only term"
+        events.append("leaf")
+        raise projection_runtime.ProjectionRuntimeUnavailable(
+            "governed projected retrieval is unavailable"
+        )
+
+    command = SimpleNamespace(
+        name="ask_memory",
+        leaf=leaf,
+        read_only=True,
+        response_detail=None,
+        path_roles=(),
+    )
+
+    class Manager:
+        def invoke(self, current, injected, kwargs, **_metadata):
+            return current.leaf(*injected, **kwargs)
+
+    @contextmanager
+    def fixed_completion(request_class, *, started_at=None):
+        assert request_class.name == "projected-find-v1"
+        assert started_at is not None
+        events.append("enter")
+        try:
+            yield
+        finally:
+            events.append("complete")
+
+    monkeypatch.setattr(writer_lease, "get_manager", lambda: Manager())
+    monkeypatch.setattr(egress, "is_vault_root", lambda _value: False)
+    monkeypatch.setattr(
+        projection_runtime,
+        "has_preactivated_projection_runtime",
+        lambda _root: False,
+    )
+    monkeypatch.setattr(
+        projection_runtime,
+        "requires_fixed_projected_completion",
+        lambda _root: False,
+    )
+    monkeypatch.setattr(
+        projection_runtime,
+        "classify_projected_completion_boundary",
+        lambda _root: (events.append("classify"), True)[1],
+    )
+    monkeypatch.setattr(timing, "fixed_public_completion", fixed_completion)
+
+    with pytest.raises(
+        projection_runtime.ProjectionRuntimeUnavailable,
+        match="governed projected retrieval is unavailable",
+    ):
+        writer_lease.invoke_command(
+            command,
+            tmp_path,
+            query="projection-only term",
+        )
+    assert events == ["classify", "enter", "leaf", "complete"]
+
+
+def test_incomplete_error_and_pagination_evidence_keeps_serving_gate_closed() -> None:
+    assert projection_runtime._PROJECTED_SERVING_RELEASE_ACCEPTED is False
+
+
 def test_unactivated_command_skips_projected_class_selection(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
@@ -378,6 +461,16 @@ def test_unactivated_command_skips_projected_class_selection(
     monkeypatch.setattr(
         projection_runtime,
         "has_preactivated_projection_runtime",
+        lambda _root: False,
+    )
+    monkeypatch.setattr(
+        projection_runtime,
+        "requires_fixed_projected_completion",
+        lambda _root: False,
+    )
+    monkeypatch.setattr(
+        projection_runtime,
+        "classify_projected_completion_boundary",
         lambda _root: False,
     )
 
@@ -578,7 +671,7 @@ def test_route_release_gate_requires_exact_schedule_and_byte_equal_pairs() -> No
 def test_route_release_gate_derives_deadline_failure_from_wire_observation() -> None:
     timing = _timing_module()
     manifest = timing.validate_release_manifest(_release_manifest())
-    schedule = timing.release_sample_schedule(manifest, route="pagination")
+    schedule = timing.release_sample_schedule(manifest, route="minimum-limit")
     observations = [
         timing.WireObservation(
             sample=sample,
@@ -595,7 +688,7 @@ def test_route_release_gate_derives_deadline_failure_from_wire_observation() -> 
 
     report = timing.evaluate_wire_route(
         manifest,
-        route="pagination",
+        route="minimum-limit",
         observations=tuple(observations),
     )
 

--- a/tests/test_governance_projection_wire_gate.py
+++ b/tests/test_governance_projection_wire_gate.py
@@ -279,9 +279,9 @@ def _route_body(route: str) -> dict[str, object]:
         body["detail"] = "full"
         body["graph"] = True
         body["rerank"] = True
-    elif route == "error":
+    elif route == "invalid-limit":
         body["limit"] = 101
-    elif route == "pagination":
+    elif route == "minimum-limit":
         body["limit"] = 1
     return body
 
@@ -310,7 +310,7 @@ def _canonical_response_digest(response) -> str:  # noqa: ANN001
 
 
 def _assert_route_response(response, route: str) -> None:  # noqa: ANN001
-    expected_status = 400 if route == "error" else 200
+    expected_status = 400 if route == "invalid-limit" else 200
     assert response.status_code == expected_status, response.text
     if response.status_code == 200:
         data = response.json()["data"]
@@ -323,11 +323,16 @@ def _assert_route_response(response, route: str) -> None:  # noqa: ANN001
 
 @pytest.mark.governance_timing_release
 @pytest.mark.timeout(240)
-def test_projected_hidden_corpus_actual_wire_release_gate(
+def test_projected_hidden_corpus_actual_wire_characterization(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """Characterize implemented routes; release acceptance stays closed.
+
+    Invalid input and a minimum limit do not certify hidden-state failures or
+    real cursor pagination, so this harness must not be treated as that proof.
+    """
     route = os.environ.get(_ROUTE_ENV)
     if route is None:
         pytest.skip("dedicated governance actual-wire route job only")


### PR DESCRIPTION
## Why

PR #771 installed the projected-governance runtime, but its release fence opened before three claims were actually true: default recall rejected scope=kb, stale or unavailable activation could miss fixed completion, and the routes named error and pagination did not exercise those contracts.

This keeps the implementation and makes the rollout honest:

- supports default KB recall with the existing bounded outside-KB reserve, including candidates below the ordinary lane prefix
- classifies warm and cold governed transitions before public completion and retains that irreversible timing boundary
- keeps projected serving statically closed until genuine hidden-state error and real pagination evidence land
- renames the existing wire cases to invalid-limit and minimum-limit so CI no longer overclaims what they prove

## Verification

- independent security review: approved, no findings after one fix round
- 98 focused tests collect successfully
- direct execution smokes passed for default scope, candidate-floor reserve, warm transition, unavailable fixed completion, and release fence
- uvx ruff check . --select F
- git diff --check
- public artifact privacy gate: 3274 files / 3343 text payloads clean
- openspec validate --all --strict: 162 passed

The full local pytest execution is blocked before test bodies by the current Windows restricted-token tmp_path ACL. CI is the authoritative full-suite execution for this PR.