### PR TITLE
fix(governance): harden standalone custody bootstrap

### DIFF
--- a/src/exomem/governance/authorization_custody.py
+++ b/src/exomem/governance/authorization_custody.py
@@ -67,9 +67,9 @@ _CONTROL_FIELDS = frozenset(
 _CONTROL_MAC_DOMAIN = b"exomem.authorization-session.control/v1"
 _ATTACHMENT_DOMAIN = b"exomem.authorization-session.attachment/v1"
 _BOOTSTRAP_MEMBERSHIP_DOMAIN = b"exomem.authorization-session.membership-bootstrap/v1"
+_STANDALONE_STAGING_DOMAIN = b"exomem.authorization-session.standalone-staging/v1"
 _SHA256_HEX = re.compile(r"[0-9a-f]{64}\Z")
 _STANDALONE_ATTACHMENT = re.compile(r"attachment-v1-[0-9a-f]{64}\Z")
-_DEFAULT_CONTROL_TTL_SECONDS = 3_600
 _DEFAULT_KEY_TTL_SECONDS = 366 * 24 * 60 * 60
 _GOVERNANCE_AUTHORITY_NAMES = (
     ".governance.sqlite",
@@ -875,8 +875,65 @@ def _replace_control_bytes(
         raise AuthorizationCustodyUnavailable from None
 
 
-def _opaque_identifier(prefix: str) -> str:
-    return f"{prefix}-{secrets.token_hex(16)}"
+def _standalone_staging_identifier(
+    prefix: str,
+    *,
+    attachment_id: str,
+    key: bytes,
+) -> str:
+    digest = hmac.new(
+        key,
+        _framed(
+            _STANDALONE_STAGING_DOMAIN,
+            (prefix.encode("ascii"), attachment_id.encode("ascii")),
+        ),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{prefix}-{digest}"
+
+
+def _verify_standalone_staging_keyring(
+    keyring: AuthorizationKeyring,
+    *,
+    attachment_id: str,
+) -> None:
+    if keyring.version != 1 or len(keyring.accepted_keys) != 1:
+        raise AuthorizationCustodyUnavailable
+    active_key = keyring.active_key
+    expected = (
+        _standalone_staging_identifier(
+            "auth-key",
+            attachment_id=attachment_id,
+            key=active_key.key,
+        ),
+        _standalone_staging_identifier(
+            "keyring",
+            attachment_id=attachment_id,
+            key=active_key.key,
+        ),
+        _standalone_staging_identifier(
+            "cell",
+            attachment_id=attachment_id,
+            key=active_key.key,
+        ),
+        _standalone_staging_identifier(
+            "vault",
+            attachment_id=attachment_id,
+            key=active_key.key,
+        ),
+    )
+    observed = (
+        active_key.key_id,
+        keyring.keyring_id,
+        keyring.cell_id,
+        keyring.logical_vault_id,
+    )
+    matches = tuple(
+        hmac.compare_digest(actual, required)
+        for actual, required in zip(observed, expected, strict=True)
+    )
+    if not all(matches):
+        raise AuthorizationCustodyUnavailable
 
 
 def _keyring_bytes(keyring: AuthorizationKeyring) -> bytes:
@@ -1026,17 +1083,34 @@ def provision_standalone_custody(
         if keyring_loaded is not None:
             keyring = parse_keyring(keyring_loaded.data)
         else:
+            key_bytes = secrets.token_bytes(32)
             key = AuthorizationVerifierKey(
-                key_id=_opaque_identifier("auth-key"),
-                key=secrets.token_bytes(32),
+                key_id=_standalone_staging_identifier(
+                    "auth-key",
+                    attachment_id=attachment_id,
+                    key=key_bytes,
+                ),
+                key=key_bytes,
                 not_before=current_time,
                 not_after=current_time + _DEFAULT_KEY_TTL_SECONDS,
             )
             keyring = AuthorizationKeyring(
                 version=1,
-                keyring_id=_opaque_identifier("keyring"),
-                cell_id=_opaque_identifier("cell"),
-                logical_vault_id=_opaque_identifier("vault"),
+                keyring_id=_standalone_staging_identifier(
+                    "keyring",
+                    attachment_id=attachment_id,
+                    key=key_bytes,
+                ),
+                cell_id=_standalone_staging_identifier(
+                    "cell",
+                    attachment_id=attachment_id,
+                    key=key_bytes,
+                ),
+                logical_vault_id=_standalone_staging_identifier(
+                    "vault",
+                    attachment_id=attachment_id,
+                    key=key_bytes,
+                ),
                 active_key_id=key.key_id,
                 accepted_keys=(key,),
             )
@@ -1045,7 +1119,19 @@ def provision_standalone_custody(
 
         if not keyring.active_key.not_before <= current_time < keyring.active_key.not_after:
             raise AuthorizationCustodyUnavailable
+        if control_loaded is not None:
+            existing_control = parse_control_record(
+                control_loaded.data,
+                keyring=keyring,
+                now=current_time,
+            )
+            if existing_control.registry_attachment_id != attachment_id:
+                raise AuthorizationCustodyUnavailable
         if control_loaded is None:
+            _verify_standalone_staging_keyring(
+                keyring,
+                attachment_id=attachment_id,
+            )
             membership_digest = _bootstrap_membership_digest(
                 cell_id=keyring.cell_id,
                 logical_vault_id=keyring.logical_vault_id,
@@ -1067,10 +1153,7 @@ def provision_standalone_custody(
                 serving_membership_epoch=1,
                 serving_membership_digest=membership_digest,
                 issued_at=current_time,
-                expires_at=min(
-                    current_time + _DEFAULT_CONTROL_TTL_SECONDS,
-                    keyring.active_key.not_after,
-                ),
+                expires_at=keyring.active_key.not_after,
                 signing_key_id=keyring.active_key_id,
             )
             encoded_control = _signed_control_bytes(
@@ -1112,7 +1195,6 @@ def enroll_initial_activation_tuple(
     from .. import reserved_paths
 
     with reserved_paths._identity_coordination_scope(root):
-        _governance_negative_scan(root)
         external = load_external_custody(root)
         keyring = parse_keyring(external.keyring)
         current = parse_control_record(external.control, keyring=keyring, now=now)
@@ -1143,6 +1225,7 @@ def enroll_initial_activation_tuple(
             return acknowledgement
         if current != expected_control:
             raise AuthorizationCustodyUnavailable
+        _governance_negative_scan(root)
         signing_key = next(
             (
                 item.key

--- a/tests/test_authorization_standalone_provisioning.py
+++ b/tests/test_authorization_standalone_provisioning.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import stat
 from collections.abc import Iterator
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -108,6 +109,43 @@ def test_explicit_standalone_provisioning_is_private_idempotent_and_copy_bound(
         authorization_custody.load_authorization_custody(copied, now=now + 1)
 
 
+def test_standalone_provisioning_refuses_opaque_hosted_attachment(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = 1_800_000_000
+    provisioned = authorization_custody.provision_standalone_custody(vault, now=now)
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    opaque_control = replace(
+        custody.control,
+        registry_attachment_id="hosted-opaque-attachment",
+    )
+    provisioned.control_path.write_bytes(
+        authorization_custody._signed_control_bytes(
+            opaque_control,
+            signing_key=custody.keyring.active_key.key,
+        )
+    )
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.provision_standalone_custody(vault, now=now + 1)
+
+
+def test_standalone_control_remains_valid_past_bootstrap_hour(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    now = 1_800_000_000
+    authorization_custody.provision_standalone_custody(vault, now=now)
+    initial = authorization_custody.load_authorization_custody(vault, now=now + 1)
+
+    loaded = authorization_custody.load_authorization_custody(
+        vault,
+        now=now + 24 * 60 * 60,
+    )
+
+    assert initial.control.expires_at == initial.keyring.active_key.not_after
+    assert loaded.control == initial.control
+
+
 @pytest.mark.parametrize(
     "relative",
     (
@@ -179,6 +217,34 @@ def test_initial_enrollment_is_irreversible_exact_and_idempotent(
             target=_target(prior, digest="e" * 64),
             now=now + 1,
         )
+
+
+def test_initial_enrollment_exact_retry_survives_store_creation(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = 1_800_000_000
+    authorization_custody.provision_standalone_custody(vault, now=now)
+    prior = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    target = _target(prior)
+    first = authorization_custody.enroll_initial_activation_tuple(
+        vault,
+        expected_control=prior.control,
+        target=target,
+        now=now + 1,
+    )
+    control_before = prior.control_path.read_bytes()
+    (vault / "Knowledge Base" / ".governance.sqlite").write_bytes(b"authority")
+
+    replay = authorization_custody.enroll_initial_activation_tuple(
+        vault,
+        expected_control=prior.control,
+        target=target,
+        now=now + 1,
+    )
+
+    assert replay == first
+    assert prior.control_path.read_bytes() == control_before
 
 
 def test_bound_attachment_refuses_successor_cas_from_a_copied_root(
@@ -292,6 +358,12 @@ def test_keyring_only_interruption_retries_without_rotating_identity(
     keyring_before = keyring_path.read_bytes()
 
     monkeypatch.setattr(authorization_custody, "_publish_private_file", original)
+    copied = _vault(tmp_path, "copied-vault")
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.provision_standalone_custody(copied, now=now)
+    assert not control_path.exists()
+    assert keyring_path.read_bytes() == keyring_before
+
     result = authorization_custody.provision_standalone_custody(vault, now=now)
 
     assert keyring_path.read_bytes() == keyring_before


### PR DESCRIPTION
## Why

PR #772 introduced the standalone custody bootstrap needed by the governance upgrade, but three release-blocking boundaries remained: foreign custody adoption, a one-hour control expiry, and a lost-ack retry failure after governance-store creation.

## What

- bind interrupted standalone keyring staging to the physical vault attachment with domain-separated HMAC identifiers
- reject opaque or foreign control records during standalone provisioning
- keep bootstrap control valid through the active signing-key lifetime
- recognize the exact committed initial-enrollment target before scanning for the subsequently-created governance store
- add regressions for copied/opaque custody, past-one-hour validity, and post-store exact retry

## Verification

- independent security re-review: approved, no remaining findings
- `uvx ruff check` on both changed files
- `python -m compileall` on both changed files
- 15 focused tests collected successfully; full execution delegated to CI because this restricted Windows token loses access when the fixture applies the real-user private DACL
- direct staging-binding and control-lifetime smokes passed
- `openspec validate --all --strict`: 162 passed, 0 failed
- `git diff --check`

The broader `bind-hosted-candidate-runtime-identity` OpenSpec change remains active; this repair does not mark its unfinished tasks complete or archive it.