### PR TITLE
fix(runtime): bound startup graph coordination

### DIFF
--- a/src/exomem/claims.py
+++ b/src/exomem/claims.py
@@ -648,6 +648,7 @@ class ClaimIndex:
             with reserved_paths._identity_coordination_scope(
                 self.vault_root,
                 descriptor_ids=("claims-store",),
+                identity_may_change=False,
             ):
                 with reserved_paths._sqlite_owner_target_scope(
                     self.vault_root,

--- a/src/exomem/clip_index.py
+++ b/src/exomem/clip_index.py
@@ -228,6 +228,7 @@ class ClipIndex:
                 with reserved_paths._identity_coordination_scope(
                     self.vault_root,
                     descriptor_ids=("clip-store",),
+                    identity_may_change=False,
                 ):
                     with reserved_paths._sqlite_owner_target_scope(
                         self.vault_root,

--- a/src/exomem/deferred_index.py
+++ b/src/exomem/deferred_index.py
@@ -61,6 +61,7 @@ def _connect_readonly(vault_root: Path) -> sqlite3.Connection:
         with reserved_paths._identity_coordination_scope(
             vault_root,
             descriptor_ids=("deferred-index-store",),
+            identity_may_change=False,
         ):
             return _connect_readonly_owned(vault_root)
 
@@ -98,6 +99,7 @@ def _connect(
         with reserved_paths._identity_coordination_scope(
             vault_root,
             descriptor_ids=("deferred-index-store",),
+            identity_may_change=create,
         ):
             return _connect_owned(
                 vault_root,

--- a/src/exomem/deferred_index.py
+++ b/src/exomem/deferred_index.py
@@ -590,6 +590,40 @@ def mark_graph_full_rebuild(vault_root: Path, *, generation: int) -> None:
     _note_graph_debt()
 
 
+def advance_graph_full_rebuild(vault_root: Path, *, after_generation: int = 0) -> int:
+    """Atomically append whole-vault debt after every marker already observed.
+
+    A direct refresh has no canonical graph checkpoint generation to use. Read-
+    then-write arithmetic would let two writers choose the same next value, so
+    a drain that started between them could clear the later writer's debt. The
+    immediate transaction serializes the increment with the drain's marker
+    snapshot and returns the exact generation it persisted.
+    """
+    conn = _connect(vault_root, create=True)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = conn.execute(
+                "SELECT value FROM maintenance_state WHERE key = ?",
+                (_GRAPH_FULL_REBUILD_KEY,),
+            ).fetchone()
+            current = int(row[0]) if row is not None else 0
+            generation = max(current, int(after_generation)) + 1
+            conn.execute(
+                "INSERT INTO maintenance_state(key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (_GRAPH_FULL_REBUILD_KEY, str(generation)),
+            )
+        except Exception:
+            conn.rollback()
+            raise
+        conn.commit()
+    finally:
+        conn.close()
+    _note_graph_debt()
+    return generation
+
+
 def graph_full_rebuild_pending(vault_root: Path) -> int | None:
     """The generation a whole-vault rebuild is owed for, or None."""
     if not store_path(vault_root).exists():

--- a/src/exomem/deferred_index.py
+++ b/src/exomem/deferred_index.py
@@ -697,7 +697,28 @@ def clear_graph_full_rebuild(vault_root: Path, *, generation: int | None = None)
         return False
     conn = _connect(vault_root, create=True)
     try:
-        with conn:
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            rows = dict(
+                conn.execute(
+                    "SELECT key, value FROM maintenance_state WHERE key IN (?, ?)",
+                    (_GRAPH_FULL_REBUILD_KEY, _GRAPH_FULL_REBUILD_SEQUENCE_KEY),
+                ).fetchall()
+            )
+            if _GRAPH_FULL_REBUILD_KEY not in rows:
+                conn.commit()
+                return False
+            marker = int(rows[_GRAPH_FULL_REBUILD_KEY])
+            sequence = int(rows.get(_GRAPH_FULL_REBUILD_SEQUENCE_KEY, 0))
+            # Upgrade migration and steady-state safety share the same seam:
+            # persist the marker's generation before deleting it. A legacy
+            # sidecar has no sequence row, and a delayed second drain may still
+            # hold this marker value after the first one clears it.
+            conn.execute(
+                "INSERT INTO maintenance_state(key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (_GRAPH_FULL_REBUILD_SEQUENCE_KEY, str(max(sequence, marker))),
+            )
             if generation is None:
                 changed = conn.execute(
                     "DELETE FROM maintenance_state WHERE key = ?",
@@ -709,6 +730,10 @@ def clear_graph_full_rebuild(vault_root: Path, *, generation: int | None = None)
                     "AND CAST(value AS INTEGER) <= ?",
                     (_GRAPH_FULL_REBUILD_KEY, int(generation)),
                 ).rowcount
+        except Exception:
+            conn.rollback()
+            raise
+        conn.commit()
         return bool(changed)
     finally:
         conn.close()

--- a/src/exomem/deferred_index.py
+++ b/src/exomem/deferred_index.py
@@ -20,6 +20,7 @@ _SEMANTIC_ISOLATION_CURSOR_KEY = "semantic_isolation_cursors:v1"
 _SEMANTIC_UPSERTS_GENERATION_KEY = "semantic_upserts_generation"
 _GRAPH_UPSERTS_GENERATION_KEY = "graph_upserts_generation"
 _GRAPH_FULL_REBUILD_KEY = "graph_full_rebuild_generation"
+_GRAPH_FULL_REBUILD_SEQUENCE_KEY = "graph_full_rebuild_sequence"
 
 #: The queues this store carries, and the tables behind them.  The graph queue
 #: is the newest and the reason the mapping exists: it reuses the semantic
@@ -575,14 +576,44 @@ def mark_graph_full_rebuild(vault_root: Path, *, generation: int) -> None:
     """Record that a whole-vault rebuild is owed, at or after this generation."""
     conn = _connect(vault_root, create=True)
     try:
-        with conn:
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            rows = dict(
+                conn.execute(
+                    "SELECT key, value FROM maintenance_state WHERE key IN (?, ?)",
+                    (_GRAPH_FULL_REBUILD_KEY, _GRAPH_FULL_REBUILD_SEQUENCE_KEY),
+                ).fetchall()
+            )
+            current = (
+                int(rows[_GRAPH_FULL_REBUILD_KEY])
+                if _GRAPH_FULL_REBUILD_KEY in rows
+                else None
+            )
+            sequence = int(rows.get(_GRAPH_FULL_REBUILD_SEQUENCE_KEY, 0))
+            requested = int(generation)
+            # An absent marker means the previous debt was retired. New debt
+            # must advance past that retired generation so a delayed old drain
+            # cannot clear it. While debt remains, an equal checkpoint is an
+            # idempotent repeat and a newer checkpoint advances naturally.
+            recorded = (
+                max(sequence + 1, requested)
+                if current is None
+                else max(current, requested)
+            )
             conn.execute(
                 "INSERT INTO maintenance_state(key, value) VALUES (?, ?) "
-                "ON CONFLICT(key) DO UPDATE SET value = "
-                "CASE WHEN CAST(excluded.value AS INTEGER) > CAST(value AS INTEGER) "
-                "THEN excluded.value ELSE value END",
-                (_GRAPH_FULL_REBUILD_KEY, str(int(generation))),
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (_GRAPH_FULL_REBUILD_KEY, str(recorded)),
             )
+            conn.execute(
+                "INSERT INTO maintenance_state(key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (_GRAPH_FULL_REBUILD_SEQUENCE_KEY, str(max(sequence, recorded))),
+            )
+        except Exception:
+            conn.rollback()
+            raise
+        conn.commit()
     finally:
         conn.close()
     # A whole-vault marker is graph debt too, and the one the drain most needs
@@ -603,16 +634,24 @@ def advance_graph_full_rebuild(vault_root: Path, *, after_generation: int = 0) -
     try:
         conn.execute("BEGIN IMMEDIATE")
         try:
-            row = conn.execute(
-                "SELECT value FROM maintenance_state WHERE key = ?",
-                (_GRAPH_FULL_REBUILD_KEY,),
-            ).fetchone()
-            current = int(row[0]) if row is not None else 0
-            generation = max(current, int(after_generation)) + 1
+            rows = dict(
+                conn.execute(
+                    "SELECT key, value FROM maintenance_state WHERE key IN (?, ?)",
+                    (_GRAPH_FULL_REBUILD_KEY, _GRAPH_FULL_REBUILD_SEQUENCE_KEY),
+                ).fetchall()
+            )
+            current = int(rows.get(_GRAPH_FULL_REBUILD_KEY, 0))
+            sequence = int(rows.get(_GRAPH_FULL_REBUILD_SEQUENCE_KEY, 0))
+            generation = max(current, sequence, int(after_generation)) + 1
             conn.execute(
                 "INSERT INTO maintenance_state(key, value) VALUES (?, ?) "
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
                 (_GRAPH_FULL_REBUILD_KEY, str(generation)),
+            )
+            conn.execute(
+                "INSERT INTO maintenance_state(key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (_GRAPH_FULL_REBUILD_SEQUENCE_KEY, str(generation)),
             )
         except Exception:
             conn.rollback()

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -3188,7 +3188,7 @@ class EpistemicGraphIndex:
                 graph_checkpoint=graph_checkpoint,
             )
         if report.pop("_rebuild_after_release", False):
-            queued_before_rebuild = bool(report.pop("_queued_before_rebuild", False))
+            durable_before_rebuild = bool(report.pop("_durable_before_rebuild", False))
             try:
                 return self._rebuild_all_off_boundary(accept_stabilized_build=True)
             except graph_sync.GraphRebuildInProgress:
@@ -3197,7 +3197,7 @@ class EpistemicGraphIndex:
                 # cover a mutation that landed after its snapshot, so leave the
                 # receipt for the next drain instead of blocking this mutator or
                 # pretending an unqueued rebuild request was safely coalesced.
-                if not queued_before_rebuild:
+                if not durable_before_rebuild:
                     raise
                 return {
                     "indexed_files": 0,
@@ -3252,7 +3252,37 @@ class EpistemicGraphIndex:
             nothing.
             """
             try:
-                deferred_index.add_graph(self.vault_root, sorted(deferred_scope))
+                receipts = deferred_index.add_graph_receipts(
+                    self.vault_root, sorted(deferred_scope)
+                )
+                queued_scope = {receipt.rel_path for receipt in receipts}
+                if queued_scope != deferred_scope:
+                    # The path queue admits only canonical Knowledge Base
+                    # Markdown. A vault-wide resolver change can include a
+                    # supported recall path outside that root, and silently
+                    # dropping it would make a later coalesced response false.
+                    # Escalate incomplete path coverage to monotonic whole-vault
+                    # debt that an already-running drain cannot clear.
+                    pending_generation = deferred_index.graph_full_rebuild_pending(
+                        self.vault_root
+                    )
+                    graph_generation = int(
+                        graph_sync.status(self.vault_root).get("generation") or 0
+                    )
+                    checkpoint_generation = (
+                        int(graph_checkpoint.generation)
+                        if graph_checkpoint is not None
+                        else 0
+                    )
+                    deferred_index.mark_graph_full_rebuild(
+                        self.vault_root,
+                        generation=max(
+                            graph_generation,
+                            checkpoint_generation,
+                            int(pending_generation or 0),
+                        )
+                        + 1,
+                    )
             except Exception:  # noqa: BLE001 - a queue failure must not lose the rebuild
                 log.warning(
                     "graph deferral enqueue failed reason=%s; falling back to rebuild",
@@ -3266,7 +3296,7 @@ class EpistemicGraphIndex:
                     "nodes": 0,
                     "edges": 0,
                     "_rebuild_after_release": 1,
-                    "_queued_before_rebuild": 1,
+                    "_durable_before_rebuild": 1,
                 }
             self._mark_unavailable()
             # `queued` is what separates this from `fallback()`'s own deferral

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -3263,9 +3263,6 @@ class EpistemicGraphIndex:
                     # dropping it would make a later coalesced response false.
                     # Escalate incomplete path coverage to monotonic whole-vault
                     # debt that an already-running drain cannot clear.
-                    pending_generation = deferred_index.graph_full_rebuild_pending(
-                        self.vault_root
-                    )
                     graph_generation = int(
                         graph_sync.status(self.vault_root).get("generation") or 0
                     )
@@ -3274,14 +3271,12 @@ class EpistemicGraphIndex:
                         if graph_checkpoint is not None
                         else 0
                     )
-                    deferred_index.mark_graph_full_rebuild(
+                    deferred_index.advance_graph_full_rebuild(
                         self.vault_root,
-                        generation=max(
+                        after_generation=max(
                             graph_generation,
                             checkpoint_generation,
-                            int(pending_generation or 0),
-                        )
-                        + 1,
+                        ),
                     )
             except Exception:  # noqa: BLE001 - a queue failure must not lose the rebuild
                 log.warning(

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -3188,7 +3188,25 @@ class EpistemicGraphIndex:
                 graph_checkpoint=graph_checkpoint,
             )
         if report.pop("_rebuild_after_release", False):
-            return self._rebuild_all_off_boundary(accept_stabilized_build=True)
+            queued_before_rebuild = bool(report.pop("_queued_before_rebuild", False))
+            try:
+                return self._rebuild_all_off_boundary(accept_stabilized_build=True)
+            except graph_sync.GraphRebuildInProgress:
+                # A defer-disposition fallback has already persisted these exact
+                # paths and signalled the graph drain. The active owner cannot
+                # cover a mutation that landed after its snapshot, so leave the
+                # receipt for the next drain instead of blocking this mutator or
+                # pretending an unqueued rebuild request was safely coalesced.
+                if not queued_before_rebuild:
+                    raise
+                return {
+                    "indexed_files": 0,
+                    "nodes": 0,
+                    "edges": 0,
+                    "deferred": 1,
+                    "queued": 1,
+                    "coalesced": 1,
+                }
         # Standalone callers have already left the graph mutation hold. Command
         # callers retain their exact registration for writer_lease to start and
         # join only after canonical authority releases.
@@ -3243,7 +3261,13 @@ class EpistemicGraphIndex:
                 )
                 return None
             if graph_checkpoint is None:
-                return None
+                return {
+                    "indexed_files": 0,
+                    "nodes": 0,
+                    "edges": 0,
+                    "_rebuild_after_release": 1,
+                    "_queued_before_rebuild": 1,
+                }
             self._mark_unavailable()
             # `queued` is what separates this from `fallback()`'s own deferral
             # below, which registers a whole-vault rebuild and reports

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -3193,12 +3193,26 @@ class EpistemicGraphIndex:
                 return self._rebuild_all_off_boundary(accept_stabilized_build=True)
             except graph_sync.GraphRebuildInProgress:
                 # A defer-disposition fallback has already persisted these exact
-                # paths and signalled the graph drain. The active owner cannot
-                # cover a mutation that landed after its snapshot, so leave the
-                # receipt for the next drain instead of blocking this mutator or
-                # pretending an unqueued rebuild request was safely coalesced.
+                # paths. A rebuild-disposition fallback knows only that the
+                # affected scope is wider, so append whole-vault debt now. The
+                # active owner cannot cover a mutation that landed after its
+                # snapshot; only durable debt makes coalescing truthful.
                 if not durable_before_rebuild:
-                    raise
+                    graph_generation = int(
+                        graph_sync.status(self.vault_root).get("generation") or 0
+                    )
+                    checkpoint_generation = (
+                        int(graph_checkpoint.generation)
+                        if graph_checkpoint is not None
+                        else 0
+                    )
+                    deferred_index.advance_graph_full_rebuild(
+                        self.vault_root,
+                        after_generation=max(
+                            graph_generation,
+                            checkpoint_generation,
+                        ),
+                    )
                 return {
                     "indexed_files": 0,
                     "nodes": 0,

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -335,6 +335,7 @@ def _connect_existing_owner_target(
         with reserved_paths._identity_coordination_scope(
             root,
             descriptor_ids=(descriptor_id,),
+            identity_may_change=not readonly,
         ):
             with reserved_paths._sqlite_owner_target_scope(
                 root,
@@ -613,6 +614,8 @@ def is_publication_failure(error: BaseException) -> bool:
     registry-loss signals keep the pre-contract behaviour rather than being
     silently downgraded.
     """
+    if isinstance(error, graph_sync.GraphRebuildInProgress):
+        return False
     if isinstance(error, _PUBLICATION_FAILURE_TYPES):
         return True
     if isinstance(error, OpError):
@@ -633,7 +636,10 @@ def may_mark_external_pending(error: BaseException) -> bool:
     registry-loss signal keeps its pre-contract behaviour instead of being
     silently downgraded.
     """
-    return not (isinstance(error, GraphProjectionMoved) or is_publication_failure(error))
+    return not (
+        isinstance(error, (GraphProjectionMoved, graph_sync.GraphRebuildInProgress))
+        or is_publication_failure(error)
+    )
 
 
 # --- Class B recovery state and its bounded, single-flight retry (R2) ------
@@ -787,6 +793,12 @@ def recover_suspended_graph(vault_root: Path) -> bool:
             raise GraphPublicationUnavailable(
                 "recovered graph did not publish an available marker"
             )
+    except graph_sync.GraphRebuildInProgress:
+        # The kernel-backed owner is still responsible for the barrier and the
+        # publication.  Re-suspending here can race after that owner publishes
+        # and turn its fresh sidecar unavailable again.
+        log.info("persisted graph barrier recovery joined an active external owner")
+        return False
     except Exception:  # noqa: BLE001 - persisted barrier remains a retry signal
         try:
             graph.suspend_reads()
@@ -1970,23 +1982,13 @@ class EpistemicGraphIndex:
                     state_root=self._mutation_coordinator.state_root,
                 )
                 if not owner_claimed:
-                    if required is None and self._wait_for_legacy_rebuild():
-                        return {
-                            "indexed_files": 0,
-                            "nodes": 0,
-                            "edges": 0,
-                            "joined": 1,
-                        }
-                    if graph_sync.wait_for_current(
-                        self.vault_root, required, availability=self.available
-                    ):
-                        return {"indexed_files": 0, "nodes": 0, "edges": 0, "joined": 1}
-                    # Losing the rebuild owner is Class B by name in the
-                    # contract: the registry is intact, this projection simply
-                    # could not publish. Type it so callers can classify.
-                    raise GraphPublicationUnavailable(
-                        "another graph rebuild owner did not publish a current sidecar"
-                    )
+                    # A refused claim is already a kernel-backed proof that a
+                    # rebuild owner is live now.  Waiting 30 seconds and then
+                    # accusing that owner of non-publication is both false and
+                    # long enough to consume a request's edge budget.  Return a
+                    # typed warming state immediately; callers retain their
+                    # durable pending work and can retry after the owner exits.
+                    raise graph_sync.GraphRebuildInProgress()
                 temporary_index = EpistemicGraphIndex(
                     self.vault_root, mutation_coordinator=self._mutation_coordinator
                 )
@@ -2393,15 +2395,6 @@ class EpistemicGraphIndex:
         if not _reader_cycling_enabled():
             return None
         return _acquire_publication_hold(live)
-
-    def _wait_for_legacy_rebuild(self) -> bool:
-        """Wait for a competing legacy builder without requiring an epoch."""
-        deadline = time.monotonic() + 30.0
-        while time.monotonic() < deadline:
-            if self.available():
-                return True
-            time.sleep(0.025)
-        return False
 
     def _rebuild_all_locked(self) -> dict[str, int]:
         pass_started = False
@@ -5074,6 +5067,8 @@ def _join_registered_standalone(
             vault_root, state_root=mutation_coordinator.state_root
         )
     except graph_sync.GraphRebuildRegistrationError as error:
+        if isinstance(error, graph_sync.GraphRebuildInProgress):
+            return GraphDispatchResult("deferred", error.code, result.checkpoint)
         return GraphDispatchResult("failed", error.code, result.checkpoint)
     except Exception:  # noqa: BLE001 - canonical bytes remain durable
         log.warning("standalone graph rebuild failed", exc_info=True)
@@ -5098,6 +5093,8 @@ def _handle_graph_dispatch_failure(
     has already been marked exactly once by the proof that detected it. Only an
     exception this module cannot classify keeps the pre-contract marking.
     """
+    if isinstance(error, graph_sync.GraphRebuildInProgress):
+        return
     if may_mark_external_pending(error):
         freshness.mark_external_pending(vault_root)
         return
@@ -5140,6 +5137,11 @@ def schedule_background_rebuild(
             EpistemicGraphIndex(
                 vault_root, mutation_coordinator=mutation_coordinator
             ).rebuild_all()
+        except graph_sync.GraphRebuildInProgress:
+            # Another process owns the kernel-backed rebuild claim.  That is a
+            # healthy coalescing state, not a failed publication requiring a
+            # recovery memo or a warning traceback.
+            log.info("background graph rebuild joined an active external owner")
         except Exception as error:  # noqa: BLE001 - request path remains non-blocking
             _handle_graph_dispatch_failure(
                 vault_root, error, mutation_coordinator=mutation_coordinator

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -612,7 +612,7 @@ class FileWatcher:
         """
         if freshness.external_pending_epoch(self._vault_root) is None:
             return
-        from . import epistemic_graph
+        from . import epistemic_graph, graph_sync
         from . import find as find_module
         from . import vault as vault_module
 
@@ -643,6 +643,9 @@ class FileWatcher:
                     "rebuilt graph did not publish an available marker"
                 )
         except Exception as error:  # noqa: BLE001 - retain a retry signal and fail closed
+            if isinstance(error, graph_sync.GraphRebuildInProgress):
+                log.info("file watcher: graph recovery joined an active external owner")
+                return
             # A refused publication is Class B: the registry observed and
             # recorded every event, and only this projection failed to publish.
             # Re-marking here would allocate a fresh external-pending epoch on
@@ -676,7 +679,7 @@ class FileWatcher:
         the watcher's background startup pass is the only complete proof of
         source bytes and resolver topology across that crash boundary.
         """
-        from . import epistemic_graph
+        from . import epistemic_graph, graph_sync
         from . import find as find_module
         from . import vault as vault_module
 
@@ -695,6 +698,11 @@ class FileWatcher:
             if not graph.available():
                 raise RuntimeError("startup graph rebuild did not publish availability")
             return True
+        except graph_sync.GraphRebuildInProgress:
+            # The external owner will publish after the initial startup fence.
+            # A second suspension here could land after that publication.
+            log.info("file watcher: startup graph validation joined an active external owner")
+            return False
         except Exception:  # noqa: BLE001 - persisted barrier keeps reads fail-closed
             try:
                 graph.suspend_reads()

--- a/src/exomem/governance/projection_measurement_store.py
+++ b/src/exomem/governance/projection_measurement_store.py
@@ -800,6 +800,7 @@ def load_measurement_store(
         with reserved_paths._identity_coordination_scope(
             root,
             descriptor_ids=(_DESCRIPTOR_ID,),
+            identity_may_change=False,
         ):
             with reserved_paths._sqlite_owner_target_scope(
                 root,

--- a/src/exomem/governance/projection_store.py
+++ b/src/exomem/governance/projection_store.py
@@ -1073,6 +1073,7 @@ def verify_variant_store(
         with reserved_paths._identity_coordination_scope(
             root,
             descriptor_ids=(_DESCRIPTOR_ID,),
+            identity_may_change=False,
         ):
             with reserved_paths._sqlite_owner_target_scope(
                 root,
@@ -1121,6 +1122,7 @@ def load_projection_catalog(
         with reserved_paths._identity_coordination_scope(
             root,
             descriptor_ids=(_DESCRIPTOR_ID,),
+            identity_may_change=False,
         ):
             with reserved_paths._sqlite_owner_target_scope(
                 root,
@@ -1176,6 +1178,7 @@ def load_projection_variant(
         with reserved_paths._identity_coordination_scope(
             root,
             descriptor_ids=(_DESCRIPTOR_ID,),
+            identity_may_change=False,
         ):
             with reserved_paths._sqlite_owner_target_scope(
                 root,

--- a/src/exomem/governance/store.py
+++ b/src/exomem/governance/store.py
@@ -54,6 +54,7 @@ def open_readonly_connection(vault_root: Path) -> sqlite3.Connection | None:
         with reserved_paths._identity_coordination_scope(
             vault_root,
             descriptor_ids=("governance-store",),
+            identity_may_change=False,
         ):
             return _open_readonly_connection_owned(vault_root)
 
@@ -170,6 +171,7 @@ def open_active_governance_read_connection(vault_root: Path) -> sqlite3.Connecti
         with reserved_paths._identity_coordination_scope(
             vault_root,
             descriptor_ids=("governance-store",),
+            identity_may_change=False,
         ):
             path = sidecar_path(vault_root)
             try:
@@ -675,6 +677,7 @@ def guard_generation_probe(vault_root: Path) -> dict[str, object]:
             with reserved_paths._identity_coordination_scope(
                 vault_root,
                 descriptor_ids=("governance-store",),
+                identity_may_change=False,
             ):
                 with reserved_paths._sqlite_owner_target_scope(
                     vault_root,

--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -1797,6 +1797,16 @@ class GraphRebuildStopped(GraphRebuildRegistrationError):
         )
 
 
+class GraphRebuildInProgress(GraphRebuildRegistrationError):
+    """A verified rebuild owner is live, so this caller should retry later."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "GRAPH_SYNC_REBUILD_IN_PROGRESS",
+            "Retry after the active graph rebuild owner publishes or releases its claim.",
+        )
+
+
 class GraphSidecarReplaceUnavailable(GraphRebuildRegistrationError):
     """Windows has an open reader; retain the old sidecar and recover later."""
 
@@ -2507,6 +2517,18 @@ class GraphRebuildCoordinator:
             try:
                 outcome = builder(required)
             except BaseException as error:  # noqa: BLE001 - integration path
+                if isinstance(error, GraphRebuildInProgress):
+                    logger.info(
+                        "graph rebuild coalesced with active external owner "
+                        "checkpoint_sha256=%s generation=%s",
+                        required.checkpoint_sha256,
+                        required.generation,
+                    )
+                    with self._condition:
+                        self._error = error
+                        self._running = False
+                        self._condition.notify_all()
+                    return
                 if isinstance(error, GraphRebuildRegistrationError):
                     projection = self._advice_for(error)
                 else:

--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -775,7 +775,7 @@ def _drain_graph_work(
     `epoch_admits_incremental_repair`, which re-reads under the canonical
     boundary rather than condemning a lineage on one sample taken mid-batch.
     """
-    from . import epistemic_graph
+    from . import epistemic_graph, graph_sync
 
     pending_generation = deferred_index.graph_full_rebuild_pending(vault_root)
     receipts = deferred_index.snapshot_graph(
@@ -793,6 +793,9 @@ def _drain_graph_work(
     if pending_generation is not None:
         try:
             index.rebuild_all()
+        except graph_sync.GraphRebuildInProgress:
+            log.info("deferred graph rebuild joined an active external owner")
+            return 0
         except Exception:  # noqa: BLE001 - durable work must survive a failed rebuild
             log.warning("deferred graph rebuild failed; marker remains", exc_info=True)
             return 0

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -1211,6 +1211,7 @@ class LexicalStore:
             with reserved_paths._identity_coordination_scope(
                 self.vault_root,
                 descriptor_ids=("lexical-store",),
+                identity_may_change=False,
             ):
                 with reserved_paths._sqlite_owner_target_scope(
                     self.vault_root,

--- a/src/exomem/media_jobs.py
+++ b/src/exomem/media_jobs.py
@@ -334,6 +334,7 @@ class MediaJobStore:
             with reserved_paths._identity_coordination_scope(
                 self.vault_root,
                 descriptor_ids=("media-jobs-store",),
+                identity_may_change=not readonly,
             ):
                 return self._connect_owned(readonly=readonly)
 
@@ -1019,6 +1020,7 @@ def _diagnostic_snapshot_rows(
         with reserved_paths._identity_coordination_scope(
             vault_root,
             descriptor_ids=("media-jobs-store",),
+            identity_may_change=False,
         ):
             with reserved_paths._sqlite_owner_target_scope(
                 vault_root,

--- a/src/exomem/memory_refs.py
+++ b/src/exomem/memory_refs.py
@@ -173,6 +173,7 @@ class ReferenceIndex:
             with reserved_paths._identity_coordination_scope(
                 self.vault_root,
                 descriptor_ids=("refs-store",),
+                identity_may_change=False,
             ):
                 with reserved_paths._sqlite_owner_target_scope(
                     self.vault_root,

--- a/src/exomem/reserved_paths.py
+++ b/src/exomem/reserved_paths.py
@@ -250,7 +250,8 @@ def _identity_coordination_scope(
     vault_root: Path,
     *,
     descriptor_ids: Iterable[str] | None = None,
-) -> Iterator[None]:
+    identity_may_change: bool = True,
+) -> Iterator[str | None]:
     """Serialize private identity publication with generic held-leaf acquisition."""
 
     key = _vault_identity_key(vault_root)
@@ -265,7 +266,7 @@ def _identity_coordination_scope(
         for domain in active_set
     )
     if domains <= held_domains:
-        yield
+        yield None
         return
     if held_domains:
         raise RuntimeError("private identity coordination cannot widen while held")
@@ -276,12 +277,13 @@ def _identity_coordination_scope(
         vault_root,
         domains=domains,
         exclusive=exclusive,
+        advance_generation=identity_may_change,
         operation="reserved_identity",
         holder_kind="reserved-state",
-    ):
+    ) as generation:
         token = _ACTIVE_IDENTITY_COORDINATION.set((*active, (key, domains)))
         try:
-            yield
+            yield generation
         finally:
             _ACTIVE_IDENTITY_COORDINATION.reset(token)
 
@@ -1731,15 +1733,36 @@ def _baseline_identity_catalogue(vault_root: Path) -> IdentityCatalogue:
     if cached is not None:
         return cached
 
+    # Walking the whole KB can take tens of seconds on a mature vault. Take two
+    # short all-domain snapshots around the unlocked walk instead of holding
+    # every owner stopped for that duration. Exact owners advance the shared
+    # token before their domain is released from the gate, so equal snapshots
+    # prove that no cooperative private identity publication crossed the walk.
+    # A busy startup gets two optimistic attempts, then the old locked scan as a
+    # bounded fail-safe: safety and eventual progress both survive contention.
+    for _attempt in range(2):
+        with _identity_coordination_scope(vault_root) as before:
+            pass
+        candidate = IdentityCatalogue.from_vault(vault_root)
+        with _identity_coordination_scope(vault_root) as after:
+            with _PUBLISHED_IDENTITY_LOCK:
+                cached = _BASELINE_IDENTITY_CATALOGUES.get(vault_key)
+            if cached is not None:
+                return cached
+            if before == after:
+                with _PUBLISHED_IDENTITY_LOCK:
+                    _BASELINE_IDENTITY_CATALOGUES[vault_key] = candidate
+                return candidate
+
     with _identity_coordination_scope(vault_root):
         with _PUBLISHED_IDENTITY_LOCK:
             cached = _BASELINE_IDENTITY_CATALOGUES.get(vault_key)
         if cached is not None:
             return cached
-        catalogue = IdentityCatalogue.from_vault(vault_root)
+        candidate = IdentityCatalogue.from_vault(vault_root)
         with _PUBLISHED_IDENTITY_LOCK:
-            _BASELINE_IDENTITY_CATALOGUES[vault_key] = catalogue
-        return catalogue
+            _BASELINE_IDENTITY_CATALOGUES[vault_key] = candidate
+        return candidate
 
 
 def _publish_owner_identities(
@@ -2089,7 +2112,10 @@ def _publish_owner_bytes(
     except OSError as error:
         raise RuntimeError("private byte publication cannot create the vault") from error
 
-    with _identity_coordination_scope(root, descriptor_ids=(descriptor_id,)):
+    with _identity_coordination_scope(
+        root,
+        descriptor_ids=(descriptor_id,),
+    ):
         acquired = held_fs.acquire(root)
         if not acquired.ok:
             raise RuntimeError("private byte publication cannot acquire the vault")
@@ -2170,7 +2196,11 @@ def _read_owner_bytes(
     except OSError as error:
         raise OSError("private byte read cannot inspect the vault") from error
 
-    with _identity_coordination_scope(root, descriptor_ids=(descriptor_id,)):
+    with _identity_coordination_scope(
+        root,
+        descriptor_ids=(descriptor_id,),
+        identity_may_change=False,
+    ):
         acquired = held_fs.acquire(root)
         if not acquired.ok:
             raise OSError("private byte read cannot acquire the vault")

--- a/src/exomem/runtime_readiness.py
+++ b/src/exomem/runtime_readiness.py
@@ -23,6 +23,10 @@ log = logging.getLogger(__name__)
 # cadence of at least one probe per five minutes rather than one late burst.
 SILENT_TRAFFIC_WINDOW_SECONDS = 24 * 60 * 60
 SILENT_TRAFFIC_MINIMUM_HEALTH_PROBES = 288
+COORDINATION_STATUS_TIMEOUT_SECONDS = 0.25
+
+_COORDINATION_PROBES_LOCK = threading.Lock()
+_COORDINATION_PROBES: dict[str, tuple[threading.Event, dict[str, object]]] = {}
 
 
 class SilentTrafficMonitor:
@@ -226,6 +230,7 @@ def _public_mutation_boundary(value: object) -> dict[str, Any]:
       `reason` naming why (`process_local_only` when no vault identity was
       configured so only this process's own holds were visible,
       `status_error` when the coordination probe itself failed,
+      `status_timeout` when it did not complete inside the readiness budget,
       `unavailable` when no boundary block was reported at all).
 
     A missing or unrecognised block is `unknown`, never `free`.  "We did not
@@ -310,6 +315,8 @@ def build_runtime_readiness(
     reasons: list[str] = []
     if mcp_tool_surface_sha256 is None:
         reasons.append("mcp_tool_surface_unavailable")
+    if coordination.get("status_timed_out") is True:
+        reasons.append("coordination_status_timeout")
     if enabled:
         if not healthy:
             reasons.append("coordinator_unavailable")
@@ -413,6 +420,61 @@ def _measure_observability() -> dict[str, Any]:
     }
 
 
+def _bounded_coordination_status(
+    vault_root: Path | None,
+    probe: Callable[[Path | None], Mapping[str, Any]],
+    *,
+    timeout_seconds: float = COORDINATION_STATUS_TIMEOUT_SECONDS,
+) -> Mapping[str, Any] | None:
+    """Run at most one status probe per vault and fail closed on its deadline.
+
+    The underlying diagnostic traverses graph state and can encounter a live
+    publication hold.  Readiness cannot inherit that unbounded wait: the public
+    endpoint must answer within the edge budget, and repeated health polls must
+    not create an unbounded thread pile while the first probe is still blocked.
+    """
+    key = (
+        "<process-local>"
+        if vault_root is None
+        else os.path.normcase(str(vault_root.resolve(strict=False)))
+    )
+    with _COORDINATION_PROBES_LOCK:
+        current = _COORDINATION_PROBES.get(key)
+        if current is None:
+            completed = threading.Event()
+            result: dict[str, object] = {}
+            current = (completed, result)
+            _COORDINATION_PROBES[key] = current
+
+            def run_probe() -> None:
+                try:
+                    result["value"] = probe(vault_root)
+                except Exception as error:  # noqa: BLE001 - re-raised on request thread
+                    result["error"] = error
+                finally:
+                    completed.set()
+
+            threading.Thread(
+                target=run_probe,
+                name="exomem-readiness-coordination",
+                daemon=True,
+            ).start()
+
+    completed, result = current
+    if not completed.wait(timeout_seconds):
+        return None
+    with _COORDINATION_PROBES_LOCK:
+        if _COORDINATION_PROBES.get(key) is current:
+            _COORDINATION_PROBES.pop(key, None)
+    error = result.get("error")
+    if isinstance(error, Exception):
+        raise error
+    value = result.get("value")
+    if not isinstance(value, Mapping):
+        raise RuntimeError("coordination status returned an invalid payload")
+    return value
+
+
 def runtime_readiness(
     *,
     mcp_tool_surface_sha256: str | None,
@@ -434,7 +496,24 @@ def runtime_readiness(
             if configured_raw and Path(configured_raw).is_absolute()
             else None
         )
-        coordination = coordination_status(configured_vault)
+        measured = _bounded_coordination_status(
+            configured_vault,
+            coordination_status,
+        )
+        if measured is None:
+            coordination = {
+                "enabled": bool(os.environ.get("EXOMEM_WRITER_LEASE_URL", "").strip()),
+                "role": "unknown",
+                "replica_id": os.environ.get("EXOMEM_WRITER_LEASE_REPLICA_ID") or None,
+                "coordinator_healthy": False,
+                "status_timed_out": True,
+                "mutation_boundary": {
+                    "state": "unknown",
+                    "reason": "status_timeout",
+                },
+            }
+        else:
+            coordination = measured
     except Exception:  # noqa: BLE001 - readiness must return structured 503 state
         coordination = {
             "enabled": bool(os.environ.get("EXOMEM_WRITER_LEASE_URL", "").strip()),

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -2344,10 +2344,11 @@ class LeaseManager:
         *,
         domains: Iterable[str],
         exclusive: bool,
+        advance_generation: bool = True,
         request_id: str | None = None,
         operation: str | None = None,
         holder_kind: str = "reserved-state",
-    ) -> Iterator[None]:
+    ) -> Iterator[str]:
         """Coordinate one owner's identities without serializing other owners."""
 
         ordered_domains = tuple(sorted(set(domains)))
@@ -2392,15 +2393,26 @@ class LeaseManager:
                 enter(gate_stack, gate, operation_label=gate_label)
                 with ExitStack() as domains_stack:
                     enter_domains(domains_stack)
-                    yield
+                    yield _read_reserved_identity_generation(
+                        self.config.state_dir, vault_root
+                    )
             return
 
         with ExitStack() as domains_stack:
             with ExitStack() as gate_stack:
                 gate_label = f"{operation}:gate" if operation is not None else "gate"
                 enter(gate_stack, gate, operation_label=gate_label)
+                # Admission order matches the exclusive scanner: gate first,
+                # then domains.  The domain stack outlives the gate so exact
+                # owners still release admission before doing their work,
+                # without the gate/domain inversion that can deadlock a scan.
                 enter_domains(domains_stack)
-            yield
+                generation = (
+                    _bump_reserved_identity_generation(self.config.state_dir, vault_root)
+                    if advance_generation
+                    else _read_reserved_identity_generation(self.config.state_dir, vault_root)
+                )
+            yield generation
 
     @contextmanager
     def mutation_guard(
@@ -2662,6 +2674,8 @@ class LeaseManager:
         def graph_failure(checkpoint: Any, error: BaseException | None = None) -> dict[str, str]:
             from . import graph_sync
 
+            if isinstance(error, graph_sync.GraphRebuildInProgress):
+                return graph_sync.committed_graph_pending(checkpoint)
             if isinstance(error, graph_sync.GraphRebuildRegistrationError):
                 return graph_sync.committed_graph_failure(
                     checkpoint, code=error.code, remediation=error.remediation
@@ -3561,6 +3575,58 @@ def _commit_generation_path(
         canonical_mutation_identity(vault_or_cell).encode("utf-8")
     ).hexdigest()[:20]
     return Path(state_dir) / "commit-generations" / f"{digest}.txt"
+
+
+def _reserved_identity_generation_path(
+    state_dir: Path, vault_or_cell: os.PathLike[str] | str
+) -> Path:
+    digest = hashlib.sha256(
+        canonical_mutation_identity(vault_or_cell).encode("utf-8")
+    ).hexdigest()[:20]
+    return Path(state_dir) / "reserved-identity-generations" / f"{digest}.txt"
+
+
+def _read_reserved_identity_generation(
+    state_dir: Path, vault_or_cell: os.PathLike[str] | str
+) -> str:
+    """Read the cross-process private-identity seqlock token.
+
+    The caller holds the identity gate. Missing means no owner has entered yet;
+    malformed or unreadable state fails closed instead of blessing a stale
+    catalogue.
+    """
+
+    path = _reserved_identity_generation_path(state_dir, vault_or_cell)
+    try:
+        value = path.read_text(encoding="ascii").strip()
+    except FileNotFoundError:
+        return "0" * 32
+    except (OSError, UnicodeError) as error:
+        raise RuntimeError("reserved identity generation is unreadable") from error
+    if re.fullmatch(r"[0-9a-f]{32}", value) is None:
+        raise RuntimeError("reserved identity generation is malformed")
+    return value
+
+
+def _bump_reserved_identity_generation(
+    state_dir: Path, vault_or_cell: os.PathLike[str] | str
+) -> str:
+    """Advance the token before an exact owner may change private identities."""
+
+    path = _reserved_identity_generation_path(state_dir, vault_or_cell)
+    token = secrets.token_hex(16)
+    temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary.write_text(token, encoding="ascii")
+        os.replace(temporary, path)
+    except OSError as error:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise RuntimeError("reserved identity generation could not advance") from error
+    return token
 
 
 def read_commit_generation(vault_or_cell: os.PathLike[str] | str) -> int | None:

--- a/tests/test_bounded_graph_join.py
+++ b/tests/test_bounded_graph_join.py
@@ -303,6 +303,23 @@ def test_a_write_that_leaves_before_convergence_says_the_graph_is_catching_up(
     assert compact["graph_sync_remediation"]
 
 
+def test_a_registered_external_owner_is_reported_as_pending_not_failed(
+    vault: Path,
+) -> None:
+    required = _checkpoint(1)
+
+    def build(
+        _checkpoint: graph_sync.GraphSyncCheckpoint,
+    ) -> graph_sync.GraphBuildOutcome:
+        raise graph_sync.GraphRebuildInProgress()
+
+    compact = _invoke_with_registered_rebuild(vault, build, checkpoint=required)
+
+    assert compact["graph_sync"] == "pending"
+    assert compact["graph_sync_code"] == "GRAPH_SYNC_REBUILD_IN_PROGRESS"
+    assert compact["graph_sync_checkpoint"] == required.checkpoint_sha256
+
+
 def test_a_write_whose_repair_is_queued_says_the_graph_is_catching_up(
     vault: Path,
 ) -> None:

--- a/tests/test_epistemic_graph_freshness.py
+++ b/tests/test_epistemic_graph_freshness.py
@@ -10,7 +10,16 @@ from pathlib import Path
 
 import pytest
 
-from exomem import audit, epistemic_graph, freshness, graph_sync, index_sync, reconcile, semantic_index
+from exomem import (
+    audit,
+    deferred_index,
+    epistemic_graph,
+    freshness,
+    graph_sync,
+    index_sync,
+    reconcile,
+    semantic_index,
+)
 from exomem import find as find_module
 from exomem import vault as vault_module
 from exomem.cli_ops import OpError
@@ -235,6 +244,8 @@ def test_spawned_mutator_commits_while_full_rebuild_is_running(
         # 8.0s at which the held rebuild gives up -- and 0.5s was measuring
         # commit latency instead, which a loaded shared runner exceeds.
         assert completed.wait(_OBSERVE_SECONDS)
+        if operation == "refresh":
+            assert A in deferred_index.list_graph_paths(vault)
     finally:
         release_rebuild.set()
         rebuild_thread.join(timeout=_HOLD_SECONDS)

--- a/tests/test_epistemic_graph_freshness.py
+++ b/tests/test_epistemic_graph_freshness.py
@@ -258,7 +258,10 @@ def test_spawned_mutator_commits_while_full_rebuild_is_running(
         assert completed.wait(_OBSERVE_SECONDS)
         if operation == "refresh":
             if rel_path.startswith("Knowledge Base/"):
-                assert rel_path in deferred_index.list_graph_paths(vault)
+                assert (
+                    rel_path in deferred_index.list_graph_paths(vault)
+                    or deferred_index.graph_full_rebuild_pending(vault) is not None
+                )
             else:
                 assert deferred_index.graph_full_rebuild_pending(vault) is not None
     finally:

--- a/tests/test_epistemic_graph_freshness.py
+++ b/tests/test_epistemic_graph_freshness.py
@@ -193,13 +193,25 @@ def test_graph_dispatch_wrappers_propagate_structured_lock_errors(
         epistemic_graph.delete_after_remove(tmp_path, [A])
 
 
-@pytest.mark.parametrize("operation", ["refresh", "delete"])
+@pytest.mark.parametrize(
+    ("operation", "rel_path"),
+    [
+        ("refresh", A),
+        ("refresh", "Sources/raw.md"),
+        ("delete", A),
+    ],
+)
 def test_spawned_mutator_commits_while_full_rebuild_is_running(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, operation: str
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+    rel_path: str,
 ) -> None:
     context = multiprocessing.get_context("spawn")
     vault = tmp_path / "vault"
     _seed(vault)
+    if not rel_path.startswith("Knowledge Base/"):
+        _write(vault, rel_path, "# Raw\n\nVault-wide recall material.\n")
     index = epistemic_graph.EpistemicGraphIndex(vault)
     index.rebuild_all()
     real_index_path = index._index_path
@@ -229,7 +241,7 @@ def test_spawned_mutator_commits_while_full_rebuild_is_running(
     completed = context.Event()
     child = context.Process(
         target=_spawn_graph_mutation,
-        args=(str(vault), operation, A, attempting, completed),
+        args=(str(vault), operation, rel_path, attempting, completed),
     )
 
     rebuild_thread.start()
@@ -245,7 +257,10 @@ def test_spawned_mutator_commits_while_full_rebuild_is_running(
         # commit latency instead, which a loaded shared runner exceeds.
         assert completed.wait(_OBSERVE_SECONDS)
         if operation == "refresh":
-            assert A in deferred_index.list_graph_paths(vault)
+            if rel_path.startswith("Knowledge Base/"):
+                assert rel_path in deferred_index.list_graph_paths(vault)
+            else:
+                assert deferred_index.graph_full_rebuild_pending(vault) is not None
     finally:
         release_rebuild.set()
         rebuild_thread.join(timeout=_HOLD_SECONDS)

--- a/tests/test_freshness_liveness_contract.py
+++ b/tests/test_freshness_liveness_contract.py
@@ -729,9 +729,13 @@ def test_classification_covers_the_contract_named_class_b_members() -> None:
     assert epistemic_graph.is_publication_failure(OpError("MUTATION_BUSY", "busy"))
     assert not epistemic_graph.is_publication_failure(OpError("VAULT_UNREADABLE", "gone"))
     assert not epistemic_graph.is_publication_failure(ValueError("unclassified"))
+    assert not epistemic_graph.is_publication_failure(graph_sync.GraphRebuildInProgress())
     # Class C already marked exactly once; a caller may not mark again (R1).
     assert not epistemic_graph.may_mark_external_pending(
         epistemic_graph.GraphProjectionMoved("moved")
+    )
+    assert not epistemic_graph.may_mark_external_pending(
+        graph_sync.GraphRebuildInProgress()
     )
     assert epistemic_graph.may_mark_external_pending(ValueError("unclassified"))
 
@@ -763,6 +767,96 @@ def test_watcher_recovery_allocates_no_new_epoch_for_a_refused_publication(
     assert clock_after == clock_before + 1, (
         "each recovery cycle must not allocate a fresh external-pending epoch"
     )
+
+
+def test_watcher_external_owner_contention_adds_no_failure_recovery_state(
+    contract_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem.file_watcher import FileWatcher
+
+    root = contract_vault
+    watcher = FileWatcher(root)
+    pending_epoch = freshness.mark_external_pending(root)
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex,
+        "rebuild_all",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            graph_sync.GraphRebuildInProgress()
+        ),
+    )
+    monkeypatch.setattr(
+        epistemic_graph,
+        "record_publication_recovery_state",
+        lambda *_args, **_kwargs: pytest.fail(
+            "a verified external owner must not install failure recovery state"
+        ),
+    )
+
+    watcher._recover_external_pending(pending_epoch)
+
+    assert epistemic_graph.publication_refusal_active(root) is False
+
+
+def test_suspended_graph_recovery_does_not_resuspend_an_external_owner_publication(
+    contract_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = contract_vault
+    suspend_calls: list[str] = []
+    monkeypatch.setattr(epistemic_graph, "recovery_decline_reason", lambda _root: None)
+    monkeypatch.setattr(find_module, "evict_resolver_caches", lambda _root: None)
+    monkeypatch.setattr(vault_module, "evict_inbound_index", lambda _root: None)
+    monkeypatch.setattr(freshness, "external_pending", lambda _root: False)
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex,
+        "withdraw_availability",
+        lambda _self: None,
+    )
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex,
+        "rebuild_all",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            graph_sync.GraphRebuildInProgress()
+        ),
+    )
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex,
+        "suspend_reads",
+        lambda _self: suspend_calls.append("suspended"),
+    )
+
+    assert epistemic_graph.recover_suspended_graph(root) is False
+    assert suspend_calls == []
+
+
+def test_watcher_seed_validation_does_not_resuspend_an_external_owner_publication(
+    contract_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem.file_watcher import FileWatcher
+
+    root = contract_vault
+    sidecar = root / ".graph.sqlite"
+    sidecar.write_bytes(b"owner")
+    suspend_calls: list[str] = []
+    monkeypatch.setattr(epistemic_graph, "sidecar_path", lambda _root: sidecar)
+    monkeypatch.setattr(epistemic_graph, "graph_enabled", lambda: True)
+    monkeypatch.setattr(find_module, "evict_resolver_caches", lambda _root: None)
+    monkeypatch.setattr(vault_module, "evict_inbound_index", lambda _root: None)
+    monkeypatch.setattr(index_sync, "recover_full_receipt_graph_epoch", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex,
+        "suspend_reads",
+        lambda _self: suspend_calls.append("suspended"),
+    )
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex,
+        "rebuild_all",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            graph_sync.GraphRebuildInProgress()
+        ),
+    )
+
+    assert FileWatcher(root)._validate_existing_graph_on_seed() is False
+    assert suspend_calls == ["suspended"]
 
 
 @pytest.mark.parametrize("graph_scheduling", [True, False], ids=["scheduled", "disabled"])

--- a/tests/test_graph_deferred_queue.py
+++ b/tests/test_graph_deferred_queue.py
@@ -228,6 +228,7 @@ def test_direct_full_rebuild_debt_advances_atomically(vault: Path) -> None:
 
 def test_legacy_marker_clear_seeds_the_durable_generation_sequence(vault: Path) -> None:
     """The first post-upgrade drain cannot reset generation history to zero."""
+    deferred_index.mark_graph_full_rebuild(vault, generation=1)
     conn = sqlite3.connect(deferred_index.store_path(vault))
     try:
         with conn:

--- a/tests/test_graph_deferred_queue.py
+++ b/tests/test_graph_deferred_queue.py
@@ -210,16 +210,18 @@ def test_direct_full_rebuild_debt_advances_atomically(vault: Path) -> None:
     """A drain between direct writers must not clear the later writer's debt."""
     deferred_index.clear_graph_full_rebuild(vault)
     deferred_index.mark_graph_full_rebuild(vault, generation=7)
+    assert deferred_index.clear_graph_full_rebuild(vault, generation=7) is True
+    assert deferred_index.advance_graph_full_rebuild(vault) == 8
 
-    with ThreadPoolExecutor(max_workers=4) as pool:
+    with ThreadPoolExecutor(max_workers=3) as pool:
         generations = list(
             pool.map(
                 lambda _item: deferred_index.advance_graph_full_rebuild(vault),
-                range(4),
+                range(3),
             )
         )
 
-    assert sorted(generations) == [8, 9, 10, 11]
+    assert sorted(generations) == [9, 10, 11]
     assert deferred_index.clear_graph_full_rebuild(vault, generation=7) is False
     assert deferred_index.graph_full_rebuild_pending(vault) == 11
 

--- a/tests/test_graph_deferred_queue.py
+++ b/tests/test_graph_deferred_queue.py
@@ -209,6 +209,7 @@ def test_a_full_scope_batch_enqueues_a_marker_rather_than_a_path_list(vault: Pat
 def test_direct_full_rebuild_debt_advances_atomically(vault: Path) -> None:
     """A drain between direct writers must not clear the later writer's debt."""
     deferred_index.clear_graph_full_rebuild(vault)
+    deferred_index.mark_graph_full_rebuild(vault, generation=7)
 
     with ThreadPoolExecutor(max_workers=4) as pool:
         generations = list(
@@ -218,8 +219,9 @@ def test_direct_full_rebuild_debt_advances_atomically(vault: Path) -> None:
             )
         )
 
-    assert sorted(generations) == [1, 2, 3, 4]
-    assert deferred_index.graph_full_rebuild_pending(vault) == 4
+    assert sorted(generations) == [8, 9, 10, 11]
+    assert deferred_index.clear_graph_full_rebuild(vault, generation=7) is False
+    assert deferred_index.graph_full_rebuild_pending(vault) == 11
 
 
 def test_a_poisoned_path_is_rotated_behind_the_rest_of_the_queue(vault: Path) -> None:

--- a/tests/test_graph_deferred_queue.py
+++ b/tests/test_graph_deferred_queue.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import ast
 import sqlite3
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
@@ -203,6 +204,22 @@ def test_a_full_scope_batch_enqueues_a_marker_rather_than_a_path_list(vault: Pat
 
     assert deferred_index.list_graph_paths(vault) == []
     assert deferred_index.graph_full_rebuild_pending(vault) == 7
+
+
+def test_direct_full_rebuild_debt_advances_atomically(vault: Path) -> None:
+    """A drain between direct writers must not clear the later writer's debt."""
+    deferred_index.clear_graph_full_rebuild(vault)
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        generations = list(
+            pool.map(
+                lambda _item: deferred_index.advance_graph_full_rebuild(vault),
+                range(4),
+            )
+        )
+
+    assert sorted(generations) == [1, 2, 3, 4]
+    assert deferred_index.graph_full_rebuild_pending(vault) == 4
 
 
 def test_a_poisoned_path_is_rotated_behind_the_rest_of_the_queue(vault: Path) -> None:

--- a/tests/test_graph_deferred_queue.py
+++ b/tests/test_graph_deferred_queue.py
@@ -226,6 +226,28 @@ def test_direct_full_rebuild_debt_advances_atomically(vault: Path) -> None:
     assert deferred_index.graph_full_rebuild_pending(vault) == 11
 
 
+def test_legacy_marker_clear_seeds_the_durable_generation_sequence(vault: Path) -> None:
+    """The first post-upgrade drain cannot reset generation history to zero."""
+    conn = sqlite3.connect(deferred_index.store_path(vault))
+    try:
+        with conn:
+            conn.execute(
+                "DELETE FROM maintenance_state WHERE key IN (?, ?)",
+                ("graph_full_rebuild_generation", "graph_full_rebuild_sequence"),
+            )
+            conn.execute(
+                "INSERT INTO maintenance_state(key, value) VALUES (?, ?)",
+                ("graph_full_rebuild_generation", "7"),
+            )
+    finally:
+        conn.close()
+
+    assert deferred_index.clear_graph_full_rebuild(vault, generation=7) is True
+    assert deferred_index.advance_graph_full_rebuild(vault) == 8
+    assert deferred_index.clear_graph_full_rebuild(vault, generation=7) is False
+    assert deferred_index.graph_full_rebuild_pending(vault) == 8
+
+
 def test_a_poisoned_path_is_rotated_behind_the_rest_of_the_queue(vault: Path) -> None:
     """One unindexable page must not pin every later page in the sorted batch."""
     receipts = deferred_index.add_graph_receipts(vault, [PAGE_A, PAGE_B])

--- a/tests/test_graph_rebuild_availability.py
+++ b/tests/test_graph_rebuild_availability.py
@@ -1058,7 +1058,7 @@ def test_an_enqueue_that_failed_still_earns_a_whole_vault_rebuild(
     def refuse(*_args, **_kwargs):
         raise sqlite3.OperationalError("queue unavailable")
 
-    monkeypatch.setattr(deferred_index, "add_graph", refuse)
+    monkeypatch.setattr(deferred_index, "add_graph_receipts", refuse)
     monkeypatch.setattr(
         graph_sync,
         "register_rebuild",

--- a/tests/test_graph_rebuild_locking.py
+++ b/tests/test_graph_rebuild_locking.py
@@ -318,7 +318,7 @@ def test_background_rebuild_treats_verified_external_owner_as_coalescing(
         vault_root,
         mutation_coordinator=SimpleNamespace(state_root=tmp_path / "state"),
     )
-    assert finished.wait(2)
+    assert finished.wait(_OBSERVE_SECONDS)
     deadline = time.monotonic() + 2
     while epistemic_graph._REBUILDING and time.monotonic() < deadline:
         time.sleep(0.01)

--- a/tests/test_graph_rebuild_locking.py
+++ b/tests/test_graph_rebuild_locking.py
@@ -4,6 +4,7 @@ import multiprocessing
 import os
 import stat
 import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -231,7 +232,7 @@ def test_overlapping_custom_manager_registrations_do_not_cross_coalesce(tmp_path
     assert observed == [("a", 1), ("b", 2)]
 
 
-def test_joined_builder_requires_reader_valid_sidecar_before_claiming_success(
+def test_joined_builder_reports_verified_live_owner_without_waiting_or_false_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from exomem import epistemic_graph
@@ -256,18 +257,100 @@ def test_joined_builder_requires_reader_valid_sidecar_before_claiming_success(
         connection.commit()
     assert graph_sync.status(vault_root)["state"] == "current"
     assert index.available() is False
-    original_wait = graph_sync.wait_for_current
     monkeypatch.setattr(graph_sync, "claim_rebuild_owner", lambda *_args, **_kwargs: False)
     monkeypatch.setattr(
         graph_sync,
         "wait_for_current",
-        lambda root, required, **kwargs: original_wait(
-            root, required, timeout_seconds=0.01, **kwargs
+        lambda *_args, **_kwargs: pytest.fail(
+            "verified live owner contention must not enter the 30 second join loop"
         ),
     )
 
-    with pytest.raises(RuntimeError, match="did not publish a current sidecar"):
+    started = time.monotonic()
+    with pytest.raises(graph_sync.GraphRebuildInProgress) as raised:
         index._rebuild_all_off_boundary()
+    assert time.monotonic() - started < 1.0
+    assert raised.value.code == "GRAPH_SYNC_REBUILD_IN_PROGRESS"
+
+
+def test_legacy_builder_contention_also_returns_without_the_legacy_wait(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph
+
+    vault_root = tmp_path / "vault"
+    (vault_root / "Knowledge Base").mkdir(parents=True)
+    index = epistemic_graph.EpistemicGraphIndex(vault_root)
+    monkeypatch.setattr(graph_sync, "claim_rebuild_owner", lambda *_args, **_kwargs: False)
+
+    started = time.monotonic()
+    with pytest.raises(graph_sync.GraphRebuildInProgress):
+        index._rebuild_all_off_boundary()
+    assert time.monotonic() - started < 1.0
+
+
+def test_background_rebuild_treats_verified_external_owner_as_coalescing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph
+
+    vault_root = tmp_path / "vault"
+    finished = threading.Event()
+
+    def report_external_owner(_self) -> None:  # noqa: ANN001
+        finished.set()
+        raise graph_sync.GraphRebuildInProgress()
+
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex,
+        "rebuild_all",
+        report_external_owner,
+    )
+    monkeypatch.setattr(
+        epistemic_graph,
+        "_handle_graph_dispatch_failure",
+        lambda *_args, **_kwargs: pytest.fail(
+            "a live external rebuild owner is not a publication failure"
+        ),
+    )
+
+    assert epistemic_graph.schedule_background_rebuild(
+        vault_root,
+        mutation_coordinator=SimpleNamespace(state_root=tmp_path / "state"),
+    )
+    assert finished.wait(2)
+    deadline = time.monotonic() + 2
+    while epistemic_graph._REBUILDING and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert not epistemic_graph._REBUILDING
+
+
+def test_registered_external_owner_is_warming_and_the_next_registration_retries(
+    tmp_path: Path,
+) -> None:
+    coordinator = graph_sync.GraphRebuildCoordinator(tmp_path)
+    required = _checkpoint()
+    calls: list[str] = []
+
+    def externally_owned(
+        _checkpoint: graph_sync.GraphSyncCheckpoint,
+    ) -> graph_sync.GraphBuildOutcome:
+        calls.append("external")
+        raise graph_sync.GraphRebuildInProgress()
+
+    coordinator.ensure_started(required, externally_owned)
+    with pytest.raises(graph_sync.GraphRebuildInProgress):
+        coordinator.join(required).wait(_REGISTERED_REBUILD_WAIT_SECONDS)
+
+    def completed(
+        checkpoint: graph_sync.GraphSyncCheckpoint,
+    ) -> graph_sync.GraphBuildOutcome:
+        calls.append("completed")
+        return graph_sync.GraphBuildOutcome.covering(checkpoint)
+
+    coordinator.ensure_started(required, completed)
+    assert coordinator.join(required).wait(_REGISTERED_REBUILD_WAIT_SECONDS).covers(required)
+    assert calls == ["external", "completed"]
 
 
 def test_joined_builder_accepts_a_reader_valid_higher_generation_sidecar(tmp_path: Path) -> None:

--- a/tests/test_reserved_admin_paths.py
+++ b/tests/test_reserved_admin_paths.py
@@ -594,6 +594,70 @@ def test_owner_identity_domains_are_independent_but_generic_scope_covers_all(
     assert not worker.is_alive()
 
 
+def test_baseline_identity_scan_does_not_hold_every_owner_domain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault_root = tmp_path / "vault"
+    (vault_root / "Knowledge Base/Notes").mkdir(parents=True)
+    (vault_root / "Knowledge Base/Notes/note.md").write_text(
+        "# Note\n", encoding="utf-8"
+    )
+    manager = writer_lease.LeaseManager(
+        writer_lease.LeaseConfig(state_dir=tmp_path / "state"),
+        mutation_timeout_seconds=0.05,
+    )
+    monkeypatch.setattr(writer_lease, "active_manager", lambda: manager)
+    scan_entered = threading.Event()
+    release_scan = threading.Event()
+    scan_errors: list[BaseException] = []
+    scan_count = 0
+    original_from_vault = reserved_paths.IdentityCatalogue.from_vault.__func__
+
+    def blocked_from_vault(
+        cls: type[reserved_paths.IdentityCatalogue], root: Path
+    ) -> reserved_paths.IdentityCatalogue:
+        nonlocal scan_count
+        scan_count += 1
+        scan_entered.set()
+        assert release_scan.wait(5)
+        return original_from_vault(cls, root)
+
+    monkeypatch.setattr(
+        reserved_paths.IdentityCatalogue,
+        "from_vault",
+        classmethod(blocked_from_vault),
+    )
+
+    def build_baseline() -> None:
+        try:
+            reserved_paths._baseline_identity_catalogue(vault_root)
+        except BaseException as error:  # noqa: BLE001 - preserve worker failure
+            scan_errors.append(error)
+
+    worker = threading.Thread(target=build_baseline, daemon=True)
+    worker.start()
+    assert scan_entered.wait(2)
+
+    try:
+        with reserved_paths._subsystem_authority_scope("epistemic_graph"):
+            with reserved_paths._identity_coordination_scope(
+                vault_root,
+                descriptor_ids=("graph-store",),
+            ):
+                assert reserved_paths._identity_coordination_active(
+                    vault_root,
+                    "graph-store",
+                )
+    finally:
+        release_scan.set()
+        worker.join(5)
+
+    assert not worker.is_alive()
+    assert scan_errors == []
+    assert scan_count == 2
+
+
 def test_one_owner_coordinates_only_the_exact_descriptor_it_is_opening(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_runtime_readiness.py
+++ b/tests/test_runtime_readiness.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -206,6 +208,111 @@ def test_runtime_readiness_measures_the_configured_vault(
     readiness_module.runtime_readiness(mcp_tool_surface_sha256="f" * 64)
 
     assert observed == [vault]
+
+
+def test_runtime_readiness_fails_closed_within_a_tight_bound_when_status_blocks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import runtime_readiness as readiness_module
+    from exomem import session_validation_cache, writer_lease
+
+    vault = tmp_path / "blocked-vault"
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocked_coordination_status(_vault_root=None):  # noqa: ANN001
+        entered.set()
+        assert release.wait(5)
+        return {
+            "enabled": False,
+            "role": "standalone",
+            "replica_id": None,
+            "coordinator_healthy": True,
+            "mutation_boundary": {"state": "free"},
+        }
+
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(vault))
+    monkeypatch.setattr(writer_lease, "coordination_status", blocked_coordination_status)
+    monkeypatch.setattr(session_validation_cache, "session_store_readiness", lambda: {})
+    monkeypatch.setattr(readiness_module, "_measure_observability", lambda: {})
+
+    started = time.monotonic()
+    try:
+        snapshot = readiness_module.runtime_readiness(
+            mcp_tool_surface_sha256="a" * 64,
+            traffic={},
+        )
+    finally:
+        release.set()
+
+    assert entered.is_set()
+    assert time.monotonic() - started < 0.75
+    assert snapshot["status"] == "not_ready"
+    assert snapshot["takeover_eligible"] is False
+    assert snapshot["reasons"] == ["coordination_status_timeout"]
+    assert snapshot["coordination"]["mutation_boundary"] == {
+        "state": "unknown",
+        "reason": "status_timeout",
+    }
+
+
+def test_bounded_coordination_status_is_single_flight_and_reuses_late_result(
+    tmp_path: Path,
+) -> None:
+    from exomem import runtime_readiness as readiness_module
+
+    vault = tmp_path / "single-flight-vault"
+    entered = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    calls = 0
+    expected = {"enabled": False, "coordinator_healthy": True}
+
+    def blocked_probe(_vault_root: Path | None):
+        nonlocal calls
+        calls += 1
+        entered.set()
+        assert release.wait(5)
+        finished.set()
+        return expected
+
+    results: list[object] = []
+    workers = [
+        threading.Thread(
+            target=lambda: results.append(
+                readiness_module._bounded_coordination_status(
+                    vault,
+                    blocked_probe,
+                    timeout_seconds=0.05,
+                )
+            )
+        )
+        for _ in range(4)
+    ]
+    for worker in workers:
+        worker.start()
+    assert entered.wait(2)
+    for worker in workers:
+        worker.join(2)
+    assert all(not worker.is_alive() for worker in workers)
+    assert results == [None] * 4
+    assert calls == 1
+
+    release.set()
+    assert finished.wait(2)
+
+    assert readiness_module._bounded_coordination_status(
+        vault,
+        blocked_probe,
+        timeout_seconds=0.5,
+    ) == expected
+    assert calls == 1
+    assert readiness_module._bounded_coordination_status(
+        vault,
+        blocked_probe,
+        timeout_seconds=0.5,
+    ) == expected
+    assert calls == 2
 
 
 def test_runtime_readiness_uses_vault_path_identity_for_a_real_held_boundary(

--- a/tests/test_writer_lease.py
+++ b/tests/test_writer_lease.py
@@ -1177,8 +1177,69 @@ def test_reserved_identity_guard_does_not_fsync_diagnostic_holder_metadata(
         vault,
         domains={"graph-store"},
         exclusive=False,
-    ):
+    ) as first_generation:
         assert list((state_dir / "mutation-locks").glob("*.holder.json")) == []
+
+    with manager.reserved_identity_guard(
+        vault,
+        domains={"graph-store"},
+        exclusive=False,
+    ) as second_generation:
+        pass
+
+    with manager.reserved_identity_guard(
+        vault,
+        domains={"graph-store"},
+        exclusive=False,
+        advance_generation=False,
+    ) as read_generation:
+        pass
+
+    with manager.reserved_identity_guard(
+        vault,
+        domains={"graph-store"},
+        exclusive=True,
+    ) as observed_generation:
+        pass
+
+    assert first_generation != second_generation
+    assert read_generation == second_generation
+    assert observed_generation == second_generation
+
+
+def test_reserved_identity_owner_acquires_gate_before_its_domain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+    entered: list[str] = []
+
+    class RecordingCoordinator:
+        def __init__(self, identity: str) -> None:
+            self.identity = identity
+
+        @contextmanager
+        def hold(self, **_kwargs: object):
+            entered.append(self.identity)
+            yield self
+
+    monkeypatch.setattr(
+        manager,
+        "_mutation_coordinator_for",
+        lambda identity: RecordingCoordinator(str(identity)),
+    )
+
+    with manager.reserved_identity_guard(
+        vault,
+        domains={"graph-store"},
+        exclusive=False,
+    ):
+        pass
+
+    assert len(entered) == 2
+    assert ":gate:" in entered[0]
+    assert ":graph-store:" in entered[1]
 
 
 def test_direct_mutation_guard_threads_fence_to_atomic_commit(


### PR DESCRIPTION
## Why

The 0.58 startup path can hold every reserved-identity domain while scanning a mature vault, which starves media and graph startup. Competing graph rebuild callers then wait 30 seconds and misclassify a verified live owner as a failed publication. Readiness synchronously inherits the same waits and can exceed the public edge deadline.

## What changed

- snapshot the reserved-identity generation around the full catalogue scan, retry on a crossed owner publication, and retain the old fully locked scan as a bounded safety fallback
- classify a verified external graph rebuild owner as warming immediately across writer, watcher, recovery, drain, and background lanes
- bound readiness coordination probes to 250 ms with one in-flight probe per vault and structured not-ready status on timeout
- preserve generation advances on every writable/create/migrate owner scope; suppress them only for genuinely read-only existing-target opens

## Verification

- `git diff --check`
- `python -m compileall -q` over changed source and focused tests
- `ruff check --select F` over changed source and focused tests
- 462 focused tests collect successfully
- direct readiness single-flight smoke passed
- direct graph recovery contention smoke passed
- full local pytest execution is blocked by the current restricted Windows token when pytest hardens its temporary directory; CI is the execution authority
- independent adversarial review is in progress and will gate merge