### PR TITLE
feat(governance): verify serving membership epochs

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/design.md
+++ b/openspec/changes/harden-governance-for-consolidation/design.md
@@ -794,6 +794,24 @@ intersection. A stopped or unreachable member remains included and blocks issuan
 A rejoin must attest the current epoch and accepted intersection before becoming
 `SERVING`; a stale-epoch process cannot issue or resume credentials.
 
+The version-1 wire record is a closed, canonical UTF-8 JSON object bounded to 64 KiB and
+64 admitted replicas. It carries `{version, epoch, cell_id, logical_vault_id,
+previous_epoch_digest, issued_at, expires_at, replicas, signing_key_id, mac}`; each
+replica entry carries `{version, epoch, replica_id, state, software_version,
+schema_version, cell_id, active_key_id, accepted_key_ids, control_digest,
+keyring_digest, attested_at, expires_at, issuance_stopped, no_in_flight,
+signing_key_id, mac}`. Identifiers are bounded opaque ASCII, keys and replicas are
+sorted/unique, numbers are bounded integers, duplicate/extra keys and noncanonical bytes
+are rejected, and epoch/attestation freshness is bounded to the maximum session TTL plus
+30 seconds of skew. The membership digest is SHA-256 over the complete canonical signed
+record. To avoid a circular commitment, replica `control_digest` is domain-separated over
+the immutable control identity/attachment basis only; the signed control record separately
+binds the complete membership digest and the mutable enrollment/activation tuple on every
+request. An epoch successor binds the exact predecessor digest. Removal is legal only from
+an already committed `DRAINING` predecessor with issuance stopped and no in-flight work;
+the current runtime additionally refuses any accepted-key intersection that omits a key
+named by a live unexpired session row.
+
 Startup/readiness fails session capability service when either external key/control file
 is missing/unsafe, identity binding differs, an admitted attestation is missing/stale, an
 active key falls outside the epoch intersection, or a live row names an unavailable key.

--- a/openspec/changes/harden-governance-for-consolidation/specs/authorization-session-binding/spec.md
+++ b/openspec/changes/harden-governance-for-consolidation/specs/authorization-session-binding/spec.md
@@ -273,6 +273,22 @@ advance; an unreachable member remains included and blocks issuance. A rejoin SH
 attest the current epoch before `SERVING`. Stale/missing attestations, epoch mismatch, or
 active-key union outside the intersection SHALL fail readiness/issuance closed.
 
+The version-1 membership record SHALL be closed canonical UTF-8 JSON bounded to 64 KiB
+and 64 admitted replicas. Its exact fields SHALL be `{version, epoch, cell_id,
+logical_vault_id, previous_epoch_digest, issued_at, expires_at, replicas,
+signing_key_id, mac}` and each exact replica attestation SHALL contain `{version, epoch,
+replica_id, state, software_version, schema_version, cell_id, active_key_id,
+accepted_key_ids, control_digest, keyring_digest, attested_at, expires_at,
+issuance_stopped, no_in_flight, signing_key_id, mac}`. Identifiers SHALL be bounded opaque
+ASCII, lists SHALL be sorted and unique, numbers SHALL be bounded integers, and duplicate,
+extra, noncanonical, over-capacity, or older-than-maximum-TTL-plus-30-seconds records SHALL
+fail closed. The signed control record SHALL bind SHA-256 of the complete canonical signed
+membership record. Replica `control_digest` SHALL use the domain-separated immutable
+control identity/attachment basis so it does not circularly include that membership
+digest; mutable enrollment and activation fields remain independently authenticated and
+rechecked on every request. An epoch successor SHALL bind its exact predecessor digest,
+and no member or live verifier key may disappear merely because it is silent or omitted.
+
 #### Scenario: Cross-principal capability is rejected
 
 - **WHEN** principal B presents a valid bearer issued to principal A

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -318,7 +318,7 @@ made before both PRs and their combined verification are complete.
   path does not self-refuse. Restore the v3 snapshot and test offline v4→v3 closure/
   expiry/schema plus exact pointed-source workspace parity before booting v3. Do not
   permit or claim mixed v3/v4 service.
-- [ ] 5.8 Add red authoritative serving-membership-epoch tests with two+ replicas:
+- [x] 5.8 Add red authoritative serving-membership-epoch tests with two+ replicas:
   authenticated current/stale attestations, active/accepted intersections, unreachable
   member blocking, old/new key overlap, issuance switch, max-TTL+skew/live-row drain,
   explicit `SERVING -> DRAINING`, no-in-flight acknowledgement, epoch advance/removal,

--- a/src/exomem/governance/authorization_custody.py
+++ b/src/exomem/governance/authorization_custody.py
@@ -16,11 +16,14 @@ import os
 import re
 import secrets
 import stat
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from exomem import held_fs, mutation_lock
+from exomem import __version__, held_fs, mutation_lock
+
+from . import authorization_serving_membership
+from .authorization_serving_membership import ServingMembershipEpoch
 
 if TYPE_CHECKING:
     from .schema_v4 import (
@@ -30,6 +33,8 @@ if TYPE_CHECKING:
 
 KEYRING_FILE_ENV = "EXOMEM_AUTH_SESSION_KEYRING_FILE"
 CONTROL_FILE_ENV = "EXOMEM_AUTH_SESSION_CONTROL_FILE"
+MEMBERSHIP_FILE_ENV = "EXOMEM_AUTH_SESSION_MEMBERSHIP_FILE"
+REPLICA_ID_ENV = "EXOMEM_AUTH_SESSION_REPLICA_ID"
 MAX_CUSTODY_FILE_BYTES = 64 * 1024
 _MAX_SIGNED_SQLITE_INTEGER = (1 << 63) - 1
 _MAX_ACCEPTED_KEYS = 32
@@ -66,7 +71,6 @@ _CONTROL_FIELDS = frozenset(
 )
 _CONTROL_MAC_DOMAIN = b"exomem.authorization-session.control/v1"
 _ATTACHMENT_DOMAIN = b"exomem.authorization-session.attachment/v1"
-_BOOTSTRAP_MEMBERSHIP_DOMAIN = b"exomem.authorization-session.membership-bootstrap/v1"
 _STANDALONE_STAGING_DOMAIN = b"exomem.authorization-session.standalone-staging/v1"
 _SHA256_HEX = re.compile(r"[0-9a-f]{64}\Z")
 _STANDALONE_ATTACHMENT = re.compile(r"attachment-v1-[0-9a-f]{64}\Z")
@@ -146,6 +150,9 @@ class AuthorizationCustody:
     control_path: Path
     keyring: AuthorizationKeyring
     control: AuthorizationControlRecord
+    serving_membership: ServingMembershipEpoch | None = None
+    local_replica_id: str | None = None
+    membership_path: Path | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -154,11 +161,13 @@ class StandaloneProvisioningResult:
 
     keyring_path: Path
     control_path: Path
+    membership_path: Path
     keyring_id: str
     cell_id: str
     logical_vault_id: str
     registry_attachment_id: str
     attachment_epoch: int
+    replica_id: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -471,6 +480,47 @@ def _framed(domain: bytes, fields: tuple[bytes, ...]) -> bytes:
     return bytes(output)
 
 
+def runtime_software_version() -> str:
+    """Return the release identity bound by the local replica attestation."""
+
+    return __version__
+
+
+def keyring_attestation_digest(keyring: AuthorizationKeyring) -> str:
+    """Digest the canonical semantic keyring bound by readiness attestations."""
+
+    if not isinstance(keyring, AuthorizationKeyring):
+        raise AuthorizationCustodyUnavailable
+    return hashlib.sha256(_keyring_bytes(keyring)).hexdigest()
+
+
+def control_attestation_digest(record: AuthorizationControlRecord) -> str:
+    """Digest the stable control identity without creating a membership cycle.
+
+    The signed control record binds the complete membership-record digest.  A
+    replica attestation therefore binds the immutable identity and attachment
+    basis.  Mutable enrollment/activation/lifetime fields are independently
+    authenticated and checked on every request; including them here would make
+    an unrelated policy publication rewrite an otherwise unchanged fleet epoch.
+    """
+
+    if not isinstance(record, AuthorizationControlRecord):
+        raise AuthorizationCustodyUnavailable
+    return hashlib.sha256(
+        _framed(
+            b"exomem.authorization-session.control-attestation-basis/v1",
+            (
+                str(record.version).encode("ascii"),
+                record.keyring_id.encode("utf-8"),
+                record.cell_id.encode("utf-8"),
+                record.logical_vault_id.encode("utf-8"),
+                record.registry_attachment_id.encode("utf-8"),
+                str(record.attachment_epoch).encode("ascii"),
+            ),
+        )
+    ).hexdigest()
+
+
 def _control_mac_input(value: dict[str, object]) -> bytes:
     activation_store = value["activation_store_id"]
     activation_epoch = value["activation_epoch"]
@@ -674,12 +724,73 @@ def load_authorization_custody(
     _verify_registered_attachment(
         Path(vault_root), control.registry_attachment_id
     )
+    serving_membership, local_replica_id, membership_path = (
+        _load_optional_serving_membership(
+            Path(vault_root),
+            external=external,
+            keyring=keyring,
+            control=control,
+            now=now,
+        )
+    )
     return AuthorizationCustody(
         keyring_path=external.keyring_path,
         control_path=external.control_path,
         keyring=keyring,
         control=control,
+        serving_membership=serving_membership,
+        local_replica_id=local_replica_id,
+        membership_path=membership_path,
     )
+
+
+def _load_optional_serving_membership(
+    vault_root: Path,
+    *,
+    external: ExternalAuthorizationCustody,
+    keyring: AuthorizationKeyring,
+    control: AuthorizationControlRecord,
+    now: int,
+) -> tuple[ServingMembershipEpoch | None, str | None, Path | None]:
+    """Load session-only fleet state without blocking standing-policy content.
+
+    Enrollment/activation custody remains mandatory for governed content.  Fleet
+    membership is a narrower authority used only for session issuance and
+    resumption, so an absent or bad record disables that capability rather than
+    turning a healthy standing-policy read into a content outage.
+    """
+
+    configured_path = os.environ.get(MEMBERSHIP_FILE_ENV, "").strip()
+    configured_replica = os.environ.get(REPLICA_ID_ENV, "").strip()
+    if not configured_path or not configured_replica:
+        return None, None, None
+    try:
+        membership_path = _configured_external_path(MEMBERSHIP_FILE_ENV, vault_root)
+        if membership_path in {external.keyring_path, external.control_path}:
+            raise AuthorizationCustodyUnavailable
+        loaded = _load_file(membership_path)
+        record = authorization_serving_membership.parse_serving_membership(
+            loaded.data,
+            verifier_keys={item.key_id: item.key for item in keyring.accepted_keys},
+            now=now,
+            expected_cell_id=control.cell_id,
+            expected_logical_vault_id=control.logical_vault_id,
+            expected_epoch=control.serving_membership_epoch,
+            expected_digest=control.serving_membership_digest,
+        )
+        replica_id = _bounded_identifier(configured_replica)
+        if not any(item.replica_id == replica_id for item in record.replicas):
+            raise AuthorizationCustodyUnavailable
+        return record, replica_id, membership_path
+    except (
+        AuthorizationCustodyUnavailable,
+        authorization_serving_membership.ServingMembershipUnavailable,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ):
+        return None, None, None
 
 
 def _control_value(record: AuthorizationControlRecord) -> dict[str, object]:
@@ -962,29 +1073,58 @@ def _keyring_bytes(keyring: AuthorizationKeyring) -> bytes:
     return encoded
 
 
-def _bootstrap_membership_digest(
+def _standalone_membership_bytes(
     *,
-    cell_id: str,
-    logical_vault_id: str,
-    attachment_id: str,
-    keyring_id: str,
-    active_key_id: str,
-) -> str:
-    return hashlib.sha256(
-        _framed(
-            _BOOTSTRAP_MEMBERSHIP_DOMAIN,
-            tuple(
-                value.encode("utf-8")
-                for value in (
-                    cell_id,
-                    logical_vault_id,
-                    attachment_id,
-                    keyring_id,
-                    active_key_id,
-                )
-            ),
-        )
-    ).hexdigest()
+    keyring: AuthorizationKeyring,
+    control: AuthorizationControlRecord,
+    replica_id: str,
+) -> bytes:
+    """Build the authenticated singleton form of the fleet record."""
+
+    if control.serving_membership_epoch != 1:
+        raise AuthorizationCustodyUnavailable
+    accepted_key_ids = tuple(sorted(key.key_id for key in keyring.accepted_keys))
+    attestation = authorization_serving_membership.ReplicaReadinessAttestation(
+        version=1,
+        epoch=control.serving_membership_epoch,
+        replica_id=_bounded_identifier(replica_id),
+        state="SERVING",
+        software_version=runtime_software_version(),
+        schema_version=4,
+        cell_id=control.cell_id,
+        active_key_id=keyring.active_key_id,
+        accepted_key_ids=accepted_key_ids,
+        control_digest=control_attestation_digest(control),
+        keyring_digest=keyring_attestation_digest(keyring),
+        attested_at=control.issued_at,
+        expires_at=min(
+            control.expires_at,
+            control.issued_at
+            + authorization_serving_membership.MAX_ATTESTATION_TTL_SECONDS,
+        ),
+        issuance_stopped=False,
+        no_in_flight=False,
+        signing_key_id=keyring.active_key_id,
+    )
+    record = authorization_serving_membership.ServingMembershipEpoch(
+        version=1,
+        epoch=control.serving_membership_epoch,
+        cell_id=control.cell_id,
+        logical_vault_id=control.logical_vault_id,
+        previous_epoch_digest=None,
+        issued_at=control.issued_at,
+        expires_at=min(
+            control.expires_at,
+            control.issued_at
+            + authorization_serving_membership.MAX_ATTESTATION_TTL_SECONDS,
+        ),
+        replicas=(attestation,),
+        signing_key_id=keyring.active_key_id,
+    )
+    return authorization_serving_membership.encode_serving_membership(
+        record,
+        verifier_keys={item.key_id: item.key for item in keyring.accepted_keys},
+    )
 
 
 def _governance_negative_scan(vault_root: Path) -> None:
@@ -1021,14 +1161,22 @@ def _governance_negative_scan(vault_root: Path) -> None:
 def _provisioning_result(
     custody: AuthorizationCustody,
 ) -> StandaloneProvisioningResult:
+    if (
+        custody.local_replica_id is None
+        or custody.serving_membership is None
+        or custody.membership_path is None
+    ):
+        raise AuthorizationCustodyUnavailable
     return StandaloneProvisioningResult(
         keyring_path=custody.keyring_path,
         control_path=custody.control_path,
+        membership_path=custody.membership_path,
         keyring_id=custody.keyring.keyring_id,
         cell_id=custody.keyring.cell_id,
         logical_vault_id=custody.keyring.logical_vault_id,
         registry_attachment_id=custody.control.registry_attachment_id,
         attachment_epoch=custody.control.attachment_epoch,
+        replica_id=custody.local_replica_id,
     )
 
 
@@ -1040,9 +1188,9 @@ def provision_standalone_custody(
     """Explicitly provision one never-enrolled standalone attachment.
 
     This is never called from an ordinary loader.  It creates no vault state;
-    the externally authenticated control record is the final registration
-    point, and a keyring-only interruption can be retried without rotating the
-    generated identity.
+    the externally authenticated control and serving-membership records are
+    the final registration points, and an interrupted publication can be
+    retried without rotating the generated identity.
     """
 
     root = Path(vault_root)
@@ -1052,7 +1200,9 @@ def provision_standalone_custody(
     attachment_id = standalone_attachment_id(root)
     keyring_path = _configured_external_path(KEYRING_FILE_ENV, root)
     control_path = _configured_external_path(CONTROL_FILE_ENV, root)
-    if keyring_path == control_path:
+    membership_path = _configured_external_path(MEMBERSHIP_FILE_ENV, root)
+    replica_id = _bounded_identifier(os.environ.get(REPLICA_ID_ENV, ""))
+    if len({keyring_path, control_path, membership_path}) != 3:
         raise AuthorizationCustodyUnavailable
 
     from .. import reserved_paths
@@ -1064,6 +1214,7 @@ def provision_standalone_custody(
         _governance_negative_scan(root)
         keyring_loaded: _LoadedCustodyFile | None = None
         control_loaded: _LoadedCustodyFile | None = None
+        membership_loaded: _LoadedCustodyFile | None = None
         try:
             keyring_loaded = _load_file(keyring_path)
         except AuthorizationCustodyUnavailable:
@@ -1074,8 +1225,16 @@ def provision_standalone_custody(
         except AuthorizationCustodyUnavailable:
             if control_path.exists():
                 raise
+        try:
+            membership_loaded = _load_file(membership_path)
+        except AuthorizationCustodyUnavailable:
+            if membership_path.exists():
+                raise
 
-        if control_loaded is not None and keyring_loaded is None:
+        if (
+            (control_loaded is not None and keyring_loaded is None)
+            or (membership_loaded is not None and control_loaded is None)
+        ):
             raise AuthorizationCustodyUnavailable
         if keyring_loaded is not None:
             keyring = parse_keyring(keyring_loaded.data)
@@ -1129,14 +1288,7 @@ def provision_standalone_custody(
                 keyring,
                 attachment_id=attachment_id,
             )
-            membership_digest = _bootstrap_membership_digest(
-                cell_id=keyring.cell_id,
-                logical_vault_id=keyring.logical_vault_id,
-                attachment_id=attachment_id,
-                keyring_id=keyring.keyring_id,
-                active_key_id=keyring.active_key_id,
-            )
-            control = AuthorizationControlRecord(
+            provisional_control = AuthorizationControlRecord(
                 version=1,
                 keyring_id=keyring.keyring_id,
                 cell_id=keyring.cell_id,
@@ -1148,10 +1300,23 @@ def provision_standalone_custody(
                 activation_epoch=None,
                 activation_state_digest=None,
                 serving_membership_epoch=1,
-                serving_membership_digest=membership_digest,
+                serving_membership_digest="0" * 64,
                 issued_at=current_time,
                 expires_at=keyring.active_key.not_after,
                 signing_key_id=keyring.active_key_id,
+            )
+            encoded_membership = _standalone_membership_bytes(
+                keyring=keyring,
+                control=provisional_control,
+                replica_id=replica_id,
+            )
+            control = replace(
+                provisional_control,
+                serving_membership_digest=(
+                    authorization_serving_membership.serving_membership_digest(
+                        encoded_membership
+                    )
+                ),
             )
             encoded_control = _signed_control_bytes(
                 control,
@@ -1159,6 +1324,31 @@ def provision_standalone_custody(
             )
             _governance_negative_scan(root)
             _publish_private_file(control_path, encoded_control)
+            _publish_private_file(membership_path, encoded_membership)
+        else:
+            control = parse_control_record(
+                control_loaded.data,
+                keyring=keyring,
+                now=current_time,
+            )
+            if control.serving_membership_epoch != 1:
+                raise AuthorizationCustodyUnavailable
+            encoded_membership = _standalone_membership_bytes(
+                keyring=keyring,
+                control=control,
+                replica_id=replica_id,
+            )
+            if (
+                authorization_serving_membership.serving_membership_digest(
+                    encoded_membership
+                )
+                != control.serving_membership_digest
+            ):
+                raise AuthorizationCustodyUnavailable
+            if membership_loaded is None:
+                _publish_private_file(membership_path, encoded_membership)
+            elif not hmac.compare_digest(membership_loaded.data, encoded_membership):
+                raise AuthorizationCustodyUnavailable
 
     return _provisioning_result(load_authorization_custody(root, now=current_time))
 

--- a/src/exomem/governance/authorization_serving_membership.py
+++ b/src/exomem/governance/authorization_serving_membership.py
@@ -1,0 +1,743 @@
+"""Authoritative serving-membership epochs for authorization sessions.
+
+The record is external control-plane state, not a view inferred from process
+liveness.  Every admitted replica signs its own current readiness statement and
+the control-plane signer authenticates the complete epoch.  Runtime evaluation
+is deliberately content-free: it yields only readiness, epoch, and counts.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+MAX_MEMBERSHIP_BYTES = 64 * 1024
+MAX_SERVING_REPLICAS = 64
+MAX_ATTESTATION_TTL_SECONDS = 3_630
+_MAX_SIGNED_INTEGER = (1 << 63) - 1
+_SHA256_HEX = re.compile(r"[0-9a-f]{64}\Z")
+_IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:+/-]{0,511}\Z")
+_STATES = frozenset({"SERVING", "DRAINING"})
+_RECORD_FIELDS = frozenset(
+    {
+        "version",
+        "epoch",
+        "cell_id",
+        "logical_vault_id",
+        "previous_epoch_digest",
+        "issued_at",
+        "expires_at",
+        "replicas",
+        "signing_key_id",
+        "mac",
+    }
+)
+_ATTESTATION_FIELDS = frozenset(
+    {
+        "version",
+        "epoch",
+        "replica_id",
+        "state",
+        "software_version",
+        "schema_version",
+        "cell_id",
+        "active_key_id",
+        "accepted_key_ids",
+        "control_digest",
+        "keyring_digest",
+        "attested_at",
+        "expires_at",
+        "issuance_stopped",
+        "no_in_flight",
+        "signing_key_id",
+        "mac",
+    }
+)
+_ATTESTATION_MAC_DOMAIN = b"exomem.authorization-session.replica-readiness/v1"
+_RECORD_MAC_DOMAIN = b"exomem.authorization-session.serving-membership/v1"
+
+
+class ServingMembershipUnavailable(RuntimeError):
+    """Content-free refusal for malformed, stale, or contradictory membership."""
+
+    code = "AUTHORIZATION_MEMBERSHIP_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__("authorization serving membership is unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class ReplicaReadinessAttestation:
+    version: int
+    epoch: int
+    replica_id: str
+    state: str
+    software_version: str
+    schema_version: int
+    cell_id: str
+    active_key_id: str
+    accepted_key_ids: tuple[str, ...]
+    control_digest: str
+    keyring_digest: str
+    attested_at: int
+    expires_at: int
+    issuance_stopped: bool
+    no_in_flight: bool
+    signing_key_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ServingMembershipEpoch:
+    version: int
+    epoch: int
+    cell_id: str
+    logical_vault_id: str
+    previous_epoch_digest: str | None
+    issued_at: int
+    expires_at: int
+    replicas: tuple[ReplicaReadinessAttestation, ...]
+    signing_key_id: str
+    record_digest: str = field(default="", compare=False, repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ServingMembershipReadiness:
+    ready: bool
+    code: str
+    epoch: int | None
+    serving_replicas: int
+    draining_replicas: int
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.ready, bool)
+            or self.code
+            not in {
+                "AUTHORIZATION_MEMBERSHIP_READY",
+                "AUTHORIZATION_MEMBERSHIP_UNAVAILABLE",
+            }
+            or (self.ready and self.code != "AUTHORIZATION_MEMBERSHIP_READY")
+            or (not self.ready and self.code != "AUTHORIZATION_MEMBERSHIP_UNAVAILABLE")
+            or (
+                self.epoch is not None
+                and (
+                    isinstance(self.epoch, bool)
+                    or not isinstance(self.epoch, int)
+                    or self.epoch < 1
+                )
+            )
+            or isinstance(self.serving_replicas, bool)
+            or not isinstance(self.serving_replicas, int)
+            or not 0 <= self.serving_replicas <= MAX_SERVING_REPLICAS
+            or isinstance(self.draining_replicas, bool)
+            or not isinstance(self.draining_replicas, int)
+            or not 0 <= self.draining_replicas <= MAX_SERVING_REPLICAS
+            or self.serving_replicas + self.draining_replicas > MAX_SERVING_REPLICAS
+        ):
+            raise ServingMembershipUnavailable
+
+    def as_public_dict(self) -> dict[str, object]:
+        return {
+            "ready": self.ready,
+            "code": self.code,
+            "servingMembershipEpoch": self.epoch,
+            "servingReplicaCount": self.serving_replicas,
+            "drainingReplicaCount": self.draining_replicas,
+        }
+
+
+def unavailable_readiness() -> ServingMembershipReadiness:
+    return ServingMembershipReadiness(
+        ready=False,
+        code="AUTHORIZATION_MEMBERSHIP_UNAVAILABLE",
+        epoch=None,
+        serving_replicas=0,
+        draining_replicas=0,
+    )
+
+
+def _closed_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for name, value in pairs:
+        if name in result:
+            raise ServingMembershipUnavailable
+        result[name] = value
+    return result
+
+
+def _identifier(value: object) -> str:
+    if not isinstance(value, str) or _IDENTIFIER.fullmatch(value) is None:
+        raise ServingMembershipUnavailable
+    return value
+
+
+def _integer(value: object, *, minimum: int = 1) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not minimum <= value <= _MAX_SIGNED_INTEGER
+    ):
+        raise ServingMembershipUnavailable
+    return value
+
+
+def _digest(value: object) -> str:
+    if not isinstance(value, str) or _SHA256_HEX.fullmatch(value) is None:
+        raise ServingMembershipUnavailable
+    return value
+
+
+def _key_ids(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list) or not 1 <= len(value) <= 32:
+        raise ServingMembershipUnavailable
+    result = tuple(_identifier(item) for item in value)
+    if result != tuple(sorted(set(result))):
+        raise ServingMembershipUnavailable
+    return result
+
+
+def _decode_mac(value: object) -> bytes:
+    if not isinstance(value, str) or len(value) != 43:
+        raise ServingMembershipUnavailable
+    try:
+        encoded = value.encode("ascii")
+        decoded = base64.b64decode(encoded + b"=", altchars=b"-_", validate=True)
+    except (UnicodeEncodeError, binascii.Error, ValueError):
+        raise ServingMembershipUnavailable from None
+    if (
+        len(decoded) != 32
+        or base64.urlsafe_b64encode(decoded).rstrip(b"=") != encoded
+    ):
+        raise ServingMembershipUnavailable
+    return decoded
+
+
+def _framed(domain: bytes, fields: tuple[bytes, ...]) -> bytes:
+    output = bytearray(domain)
+    output.append(0)
+    for value in fields:
+        output.extend(len(value).to_bytes(4, "big"))
+        output.extend(value)
+    return bytes(output)
+
+
+def _attestation_value(
+    attestation: ReplicaReadinessAttestation,
+) -> dict[str, object]:
+    return {
+        "version": attestation.version,
+        "epoch": attestation.epoch,
+        "replica_id": attestation.replica_id,
+        "state": attestation.state,
+        "software_version": attestation.software_version,
+        "schema_version": attestation.schema_version,
+        "cell_id": attestation.cell_id,
+        "active_key_id": attestation.active_key_id,
+        "accepted_key_ids": list(attestation.accepted_key_ids),
+        "control_digest": attestation.control_digest,
+        "keyring_digest": attestation.keyring_digest,
+        "attested_at": attestation.attested_at,
+        "expires_at": attestation.expires_at,
+        "issuance_stopped": attestation.issuance_stopped,
+        "no_in_flight": attestation.no_in_flight,
+        "signing_key_id": attestation.signing_key_id,
+    }
+
+
+def _attestation_mac_input(value: Mapping[str, object]) -> bytes:
+    accepted = value["accepted_key_ids"]
+    if not isinstance(accepted, list):
+        raise ServingMembershipUnavailable
+    return _framed(
+        _ATTESTATION_MAC_DOMAIN,
+        (
+            str(value["version"]).encode("ascii"),
+            str(value["epoch"]).encode("ascii"),
+            str(value["replica_id"]).encode("utf-8"),
+            str(value["state"]).encode("ascii"),
+            str(value["software_version"]).encode("utf-8"),
+            str(value["schema_version"]).encode("ascii"),
+            str(value["cell_id"]).encode("utf-8"),
+            str(value["active_key_id"]).encode("utf-8"),
+            json.dumps(accepted, ensure_ascii=False, separators=(",", ":")).encode(
+                "utf-8"
+            ),
+            str(value["control_digest"]).encode("ascii"),
+            str(value["keyring_digest"]).encode("ascii"),
+            str(value["attested_at"]).encode("ascii"),
+            str(value["expires_at"]).encode("ascii"),
+            b"true" if value["issuance_stopped"] is True else b"false",
+            b"true" if value["no_in_flight"] is True else b"false",
+            str(value["signing_key_id"]).encode("utf-8"),
+        ),
+    )
+
+
+def _signed_attestation_value(
+    attestation: ReplicaReadinessAttestation,
+    *,
+    verifier_keys: Mapping[str, bytes],
+) -> dict[str, object]:
+    value = _attestation_value(attestation)
+    key = verifier_keys.get(attestation.signing_key_id)
+    if not isinstance(key, bytes) or len(key) != 32:
+        raise ServingMembershipUnavailable
+    value["mac"] = (
+        base64.urlsafe_b64encode(
+            hmac.new(key, _attestation_mac_input(value), hashlib.sha256).digest()
+        )
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    return value
+
+
+def _record_value(
+    record: ServingMembershipEpoch,
+    *,
+    verifier_keys: Mapping[str, bytes],
+) -> dict[str, object]:
+    return {
+        "version": record.version,
+        "epoch": record.epoch,
+        "cell_id": record.cell_id,
+        "logical_vault_id": record.logical_vault_id,
+        "previous_epoch_digest": record.previous_epoch_digest,
+        "issued_at": record.issued_at,
+        "expires_at": record.expires_at,
+        "replicas": [
+            _signed_attestation_value(item, verifier_keys=verifier_keys)
+            for item in record.replicas
+        ],
+        "signing_key_id": record.signing_key_id,
+    }
+
+
+def _record_mac_input(value: Mapping[str, object]) -> bytes:
+    replicas = value["replicas"]
+    previous = value["previous_epoch_digest"]
+    return _framed(
+        _RECORD_MAC_DOMAIN,
+        (
+            str(value["version"]).encode("ascii"),
+            str(value["epoch"]).encode("ascii"),
+            str(value["cell_id"]).encode("utf-8"),
+            str(value["logical_vault_id"]).encode("utf-8"),
+            b"" if previous is None else str(previous).encode("ascii"),
+            str(value["issued_at"]).encode("ascii"),
+            str(value["expires_at"]).encode("ascii"),
+            json.dumps(
+                replicas,
+                ensure_ascii=False,
+                allow_nan=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8"),
+            str(value["signing_key_id"]).encode("utf-8"),
+        ),
+    )
+
+
+def encode_serving_membership(
+    record: ServingMembershipEpoch,
+    *,
+    verifier_keys: Mapping[str, bytes],
+) -> bytes:
+    """Return canonical authenticated bytes for one control-plane epoch."""
+
+    _validate_record_shape(record, now=None)
+    value = _record_value(record, verifier_keys=verifier_keys)
+    key = verifier_keys.get(record.signing_key_id)
+    if not isinstance(key, bytes) or len(key) != 32:
+        raise ServingMembershipUnavailable
+    value["mac"] = (
+        base64.urlsafe_b64encode(
+            hmac.new(key, _record_mac_input(value), hashlib.sha256).digest()
+        )
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    if not 1 <= len(encoded) <= MAX_MEMBERSHIP_BYTES:
+        raise ServingMembershipUnavailable
+    return encoded
+
+
+def serving_membership_digest(raw: bytes) -> str:
+    if not isinstance(raw, bytes) or not 1 <= len(raw) <= MAX_MEMBERSHIP_BYTES:
+        raise ServingMembershipUnavailable
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _parse_attestation(
+    value: object,
+    *,
+    verifier_keys: Mapping[str, bytes],
+    now: int,
+    expected_epoch: int,
+    expected_cell_id: str,
+) -> ReplicaReadinessAttestation:
+    if not isinstance(value, dict) or set(value) != _ATTESTATION_FIELDS:
+        raise ServingMembershipUnavailable
+    version = value["version"]
+    if isinstance(version, bool) or version != 1:
+        raise ServingMembershipUnavailable
+    epoch = _integer(value["epoch"])
+    state = value["state"]
+    if not isinstance(state, str) or state not in _STATES:
+        raise ServingMembershipUnavailable
+    attested_at = _integer(value["attested_at"])
+    expires_at = _integer(value["expires_at"])
+    if (
+        epoch != expected_epoch
+        or _identifier(value["cell_id"]) != expected_cell_id
+        or not attested_at <= now < expires_at
+        or expires_at - attested_at > MAX_ATTESTATION_TTL_SECONDS
+    ):
+        raise ServingMembershipUnavailable
+    issuance_stopped = value["issuance_stopped"]
+    no_in_flight = value["no_in_flight"]
+    if not isinstance(issuance_stopped, bool) or not isinstance(no_in_flight, bool):
+        raise ServingMembershipUnavailable
+    if (state == "SERVING" and (issuance_stopped or no_in_flight)) or (
+        state == "DRAINING" and not issuance_stopped
+    ):
+        raise ServingMembershipUnavailable
+    active_key_id = _identifier(value["active_key_id"])
+    accepted_key_ids = _key_ids(value["accepted_key_ids"])
+    signing_key_id = _identifier(value["signing_key_id"])
+    if active_key_id not in accepted_key_ids or signing_key_id != active_key_id:
+        raise ServingMembershipUnavailable
+    key = verifier_keys.get(signing_key_id)
+    if not isinstance(key, bytes) or len(key) != 32:
+        raise ServingMembershipUnavailable
+    supplied = _decode_mac(value["mac"])
+    if not hmac.compare_digest(
+        supplied,
+        hmac.new(key, _attestation_mac_input(value), hashlib.sha256).digest(),
+    ):
+        raise ServingMembershipUnavailable
+    return ReplicaReadinessAttestation(
+        version=1,
+        epoch=epoch,
+        replica_id=_identifier(value["replica_id"]),
+        state=state,
+        software_version=_identifier(value["software_version"]),
+        schema_version=_integer(value["schema_version"]),
+        cell_id=expected_cell_id,
+        active_key_id=active_key_id,
+        accepted_key_ids=accepted_key_ids,
+        control_digest=_digest(value["control_digest"]),
+        keyring_digest=_digest(value["keyring_digest"]),
+        attested_at=attested_at,
+        expires_at=expires_at,
+        issuance_stopped=issuance_stopped,
+        no_in_flight=no_in_flight,
+        signing_key_id=signing_key_id,
+    )
+
+
+def parse_serving_membership(
+    raw: bytes,
+    *,
+    verifier_keys: Mapping[str, bytes],
+    now: int,
+    expected_cell_id: str,
+    expected_logical_vault_id: str,
+    expected_epoch: int,
+    expected_digest: str,
+) -> ServingMembershipEpoch:
+    """Authenticate one exact, current serving-membership epoch."""
+
+    try:
+        current = _integer(now)
+        digest = serving_membership_digest(raw)
+        if digest != _digest(expected_digest):
+            raise ServingMembershipUnavailable
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_closed_object)
+        if not isinstance(value, dict) or set(value) != _RECORD_FIELDS:
+            raise ServingMembershipUnavailable
+        if value["version"] != 1 or isinstance(value["version"], bool):
+            raise ServingMembershipUnavailable
+        epoch = _integer(value["epoch"])
+        cell_id = _identifier(value["cell_id"])
+        logical_vault_id = _identifier(value["logical_vault_id"])
+        if (
+            epoch != _integer(expected_epoch)
+            or cell_id != _identifier(expected_cell_id)
+            or logical_vault_id != _identifier(expected_logical_vault_id)
+        ):
+            raise ServingMembershipUnavailable
+        previous = value["previous_epoch_digest"]
+        if epoch == 1:
+            if previous is not None:
+                raise ServingMembershipUnavailable
+        else:
+            previous = _digest(previous)
+        issued_at = _integer(value["issued_at"])
+        expires_at = _integer(value["expires_at"])
+        if (
+            not issued_at <= current < expires_at
+            or expires_at - issued_at > MAX_ATTESTATION_TTL_SECONDS
+        ):
+            raise ServingMembershipUnavailable
+        raw_replicas = value["replicas"]
+        if (
+            not isinstance(raw_replicas, list)
+            or not 1 <= len(raw_replicas) <= MAX_SERVING_REPLICAS
+        ):
+            raise ServingMembershipUnavailable
+        replicas = tuple(
+            _parse_attestation(
+                item,
+                verifier_keys=verifier_keys,
+                now=current,
+                expected_epoch=epoch,
+                expected_cell_id=cell_id,
+            )
+            for item in raw_replicas
+        )
+        replica_ids = tuple(item.replica_id for item in replicas)
+        if replica_ids != tuple(sorted(set(replica_ids))):
+            raise ServingMembershipUnavailable
+        signing_key_id = _identifier(value["signing_key_id"])
+        signing_key = verifier_keys.get(signing_key_id)
+        if not isinstance(signing_key, bytes) or len(signing_key) != 32:
+            raise ServingMembershipUnavailable
+        if not hmac.compare_digest(
+            _decode_mac(value["mac"]),
+            hmac.new(
+                signing_key,
+                _record_mac_input(value),
+                hashlib.sha256,
+            ).digest(),
+        ):
+            raise ServingMembershipUnavailable
+        record = ServingMembershipEpoch(
+            version=1,
+            epoch=epoch,
+            cell_id=cell_id,
+            logical_vault_id=logical_vault_id,
+            previous_epoch_digest=previous,
+            issued_at=issued_at,
+            expires_at=expires_at,
+            replicas=replicas,
+            signing_key_id=signing_key_id,
+            record_digest=digest,
+        )
+        _validate_record_shape(record, now=current)
+        if encode_serving_membership(record, verifier_keys=verifier_keys) != raw:
+            raise ServingMembershipUnavailable
+        return record
+    except ServingMembershipUnavailable:
+        raise
+    except (
+        AttributeError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        TypeError,
+        ValueError,
+    ):
+        raise ServingMembershipUnavailable from None
+
+
+def _validate_record_shape(
+    record: ServingMembershipEpoch,
+    *,
+    now: int | None,
+) -> None:
+    if not isinstance(record, ServingMembershipEpoch) or record.version != 1:
+        raise ServingMembershipUnavailable
+    epoch = _integer(record.epoch)
+    _identifier(record.cell_id)
+    _identifier(record.logical_vault_id)
+    if epoch == 1:
+        if record.previous_epoch_digest is not None:
+            raise ServingMembershipUnavailable
+    else:
+        _digest(record.previous_epoch_digest)
+    issued_at = _integer(record.issued_at)
+    expires_at = _integer(record.expires_at)
+    if (
+        issued_at >= expires_at
+        or expires_at - issued_at > MAX_ATTESTATION_TTL_SECONDS
+        or (now is not None and not issued_at <= now < expires_at)
+        or not 1 <= len(record.replicas) <= MAX_SERVING_REPLICAS
+    ):
+        raise ServingMembershipUnavailable
+    identifiers = tuple(item.replica_id for item in record.replicas)
+    if identifiers != tuple(sorted(set(identifiers))):
+        raise ServingMembershipUnavailable
+    _identifier(record.signing_key_id)
+    for item in record.replicas:
+        if (
+            not isinstance(item, ReplicaReadinessAttestation)
+            or item.version != 1
+            or item.epoch != epoch
+            or item.cell_id != record.cell_id
+            or item.state not in _STATES
+            or item.active_key_id not in item.accepted_key_ids
+            or item.signing_key_id != item.active_key_id
+            or tuple(item.accepted_key_ids)
+            != tuple(sorted(set(item.accepted_key_ids)))
+            or item.attested_at > issued_at
+            or item.expires_at < expires_at
+            or item.expires_at - item.attested_at > MAX_ATTESTATION_TTL_SECONDS
+            or (item.state == "SERVING" and (item.issuance_stopped or item.no_in_flight))
+            or (item.state == "DRAINING" and not item.issuance_stopped)
+        ):
+            raise ServingMembershipUnavailable
+        _identifier(item.replica_id)
+        _identifier(item.software_version)
+        _integer(item.schema_version)
+        _digest(item.control_digest)
+        _digest(item.keyring_digest)
+
+
+def evaluate_serving_membership(
+    record: ServingMembershipEpoch,
+    *,
+    now: int,
+    local_replica_id: str,
+    local_software_version: str,
+    local_schema_version: int,
+    expected_cell_id: str,
+    expected_control_digest: str,
+    expected_keyring_digest: str,
+    local_active_key_id: str,
+    local_accepted_key_ids: tuple[str, ...],
+    valid_verifier_key_ids: tuple[str, ...],
+    live_verifier_key_ids: tuple[str, ...],
+) -> ServingMembershipReadiness:
+    """Evaluate issuance/resumption readiness without exposing member details."""
+
+    serving = sum(item.state == "SERVING" for item in record.replicas)
+    draining = len(record.replicas) - serving
+    unavailable = ServingMembershipReadiness(
+        ready=False,
+        code="AUTHORIZATION_MEMBERSHIP_UNAVAILABLE",
+        epoch=record.epoch if isinstance(record.epoch, int) else None,
+        serving_replicas=serving,
+        draining_replicas=draining,
+    )
+    try:
+        current = _integer(now)
+        _validate_record_shape(record, now=current)
+        local_id = _identifier(local_replica_id)
+        cell_id = _identifier(expected_cell_id)
+        control_digest = _digest(expected_control_digest)
+        keyring_digest = _digest(expected_keyring_digest)
+        active_key = _identifier(local_active_key_id)
+        accepted_keys = tuple(_identifier(item) for item in local_accepted_key_ids)
+        valid_keys = tuple(_identifier(item) for item in valid_verifier_key_ids)
+        live_keys = tuple(_identifier(item) for item in live_verifier_key_ids)
+        if (
+            accepted_keys != tuple(sorted(set(accepted_keys)))
+            or valid_keys != tuple(sorted(set(valid_keys)))
+        ):
+            return unavailable
+        local = next((item for item in record.replicas if item.replica_id == local_id), None)
+        if (
+            record.cell_id != cell_id
+            or local is None
+            or local.state != "SERVING"
+            or local.software_version != _identifier(local_software_version)
+            or local.schema_version != _integer(local_schema_version)
+            or local.active_key_id != active_key
+            or local.accepted_key_ids != accepted_keys
+        ):
+            return unavailable
+        serving_members = tuple(item for item in record.replicas if item.state == "SERVING")
+        if not serving_members:
+            return unavailable
+        for item in record.replicas:
+            if (
+                item.epoch != record.epoch
+                or item.cell_id != cell_id
+                or not item.attested_at <= current < item.expires_at
+                or item.control_digest != control_digest
+                or item.keyring_digest != keyring_digest
+            ):
+                return unavailable
+        intersection = set(serving_members[0].accepted_key_ids)
+        for item in serving_members[1:]:
+            intersection.intersection_update(item.accepted_key_ids)
+        active_keys = {item.active_key_id for item in serving_members}
+        if (
+            not active_keys.issubset(intersection)
+            or not intersection.issubset(set(accepted_keys))
+            or not set(live_keys).issubset(intersection)
+            or not active_keys.issubset(set(valid_keys))
+            or record.signing_key_id not in valid_keys
+            or not set(live_keys).issubset(set(valid_keys))
+        ):
+            return unavailable
+        return ServingMembershipReadiness(
+            ready=True,
+            code="AUTHORIZATION_MEMBERSHIP_READY",
+            epoch=record.epoch,
+            serving_replicas=serving,
+            draining_replicas=draining,
+        )
+    except (AttributeError, TypeError, ValueError, ServingMembershipUnavailable):
+        return unavailable
+
+
+def validate_membership_successor(
+    previous: ServingMembershipEpoch,
+    current: ServingMembershipEpoch,
+    *,
+    now: int,
+) -> None:
+    """Enforce explicit epoch transitions; silence can never remove a replica."""
+
+    try:
+        _validate_record_shape(previous, now=None)
+        _validate_record_shape(current, now=now)
+        if (
+            not previous.record_digest
+            or current.epoch != previous.epoch + 1
+            or current.previous_epoch_digest != previous.record_digest
+            or current.cell_id != previous.cell_id
+            or current.logical_vault_id != previous.logical_vault_id
+            or current.issued_at < previous.issued_at
+        ):
+            raise ServingMembershipUnavailable
+        before = {item.replica_id: item for item in previous.replicas}
+        after = {item.replica_id: item for item in current.replicas}
+        for replica_id, prior in before.items():
+            successor = after.get(replica_id)
+            if successor is None:
+                if not (
+                    prior.state == "DRAINING"
+                    and prior.issuance_stopped
+                    and prior.no_in_flight
+                ):
+                    raise ServingMembershipUnavailable
+                continue
+            if prior.state == "SERVING" and successor.state == "DRAINING":
+                if not successor.issuance_stopped:
+                    raise ServingMembershipUnavailable
+            elif prior.state == "DRAINING" and successor.state == "SERVING":
+                if successor.epoch != current.epoch:
+                    raise ServingMembershipUnavailable
+            elif prior.state != successor.state:
+                raise ServingMembershipUnavailable
+            if prior.no_in_flight and successor.state == "DRAINING" and not successor.no_in_flight:
+                raise ServingMembershipUnavailable
+    except ServingMembershipUnavailable:
+        raise
+    except (AttributeError, TypeError, ValueError):
+        raise ServingMembershipUnavailable from None

--- a/src/exomem/governance/authorization_session_lifecycle.py
+++ b/src/exomem/governance/authorization_session_lifecycle.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 import secrets
 import sqlite3
+import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Final
 
-from . import authorization_custody, authorization_sessions, schema_v4
+from . import (
+    authorization_custody,
+    authorization_serving_membership,
+    authorization_sessions,
+    schema_v4,
+)
 
 MAX_SESSION_TTL_SECONDS: Final = 3_600
 _MAX_SQLITE_INTEGER: Final = (1 << 63) - 1
@@ -140,6 +147,47 @@ def _ready_custody(
             expected_activation_epoch=control.activation_epoch,
             expected_activation_state_digest=control.activation_state_digest,
         )
+        membership = custody.serving_membership
+        local_replica_id = custody.local_replica_id
+        if membership is None or local_replica_id is None:
+            raise AuthorizationSessionUnavailable
+        if membership.record_digest and (
+            membership.record_digest != control.serving_membership_digest
+        ):
+            raise AuthorizationSessionUnavailable
+        live_key_rows = connection.execute(
+            "SELECT DISTINCT verifier_key_id FROM governance_authorization_sessions "
+            "WHERE status='active' AND expires_at>?",
+            (current,),
+        ).fetchall()
+        readiness = authorization_serving_membership.evaluate_serving_membership(
+            membership,
+            now=current,
+            local_replica_id=local_replica_id,
+            local_software_version=authorization_custody.runtime_software_version(),
+            local_schema_version=schema_v4.SCHEMA_USER_VERSION,
+            expected_cell_id=control.cell_id,
+            expected_control_digest=authorization_custody.control_attestation_digest(
+                control
+            ),
+            expected_keyring_digest=authorization_custody.keyring_attestation_digest(
+                keyring
+            ),
+            local_active_key_id=keyring.active_key_id,
+            local_accepted_key_ids=tuple(
+                sorted(key.key_id for key in keyring.accepted_keys)
+            ),
+            valid_verifier_key_ids=tuple(
+                sorted(
+                    key.key_id
+                    for key in keyring.accepted_keys
+                    if key.not_before <= current < key.not_after
+                )
+            ),
+            live_verifier_key_ids=tuple(sorted(str(row[0]) for row in live_key_rows)),
+        )
+        if not readiness.ready:
+            raise AuthorizationSessionUnavailable
         return active_key
     except (
         AttributeError,
@@ -148,9 +196,57 @@ def _ready_custody(
         sqlite3.Error,
         schema_v4.SchemaV4Error,
         authorization_custody.AuthorizationCustodyUnavailable,
+        authorization_serving_membership.ServingMembershipUnavailable,
         AuthorizationSessionUnavailable,
     ):
         raise AuthorizationSessionUnavailable from None
+
+
+def serving_membership_readiness(
+    vault_root: Path,
+    *,
+    now: int | None = None,
+) -> authorization_serving_membership.ServingMembershipReadiness:
+    """Recheck exact-v4 fleet readiness for a content-free control surface."""
+
+    connection: sqlite3.Connection | None = None
+    try:
+        current = int(time.time()) if now is None else _bounded_time(now)
+        custody = authorization_custody.load_authorization_custody(
+            Path(vault_root),
+            now=current,
+        )
+        from . import store
+
+        connection = store.open_authorization_session_connection(Path(vault_root))
+        _ready_custody(connection, custody, now=current)
+        membership = custody.serving_membership
+        if membership is None:
+            raise AuthorizationSessionUnavailable
+        return authorization_serving_membership.ServingMembershipReadiness(
+            ready=True,
+            code="AUTHORIZATION_MEMBERSHIP_READY",
+            epoch=membership.epoch,
+            serving_replicas=sum(
+                item.state == "SERVING" for item in membership.replicas
+            ),
+            draining_replicas=sum(
+                item.state == "DRAINING" for item in membership.replicas
+            ),
+        )
+    except (
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+        sqlite3.Error,
+        AuthorizationSessionUnavailable,
+        authorization_custody.AuthorizationCustodyUnavailable,
+    ):
+        return authorization_serving_membership.unavailable_readiness()
+    finally:
+        if connection is not None:
+            connection.close()
 
 
 def _expiry(

--- a/src/exomem/hosted_runtime.py
+++ b/src/exomem/hosted_runtime.py
@@ -25,6 +25,10 @@ from typing import Any
 
 from . import __version__
 from . import init as init_module
+from .governance.authorization_serving_membership import (
+    ServingMembershipReadiness,
+    unavailable_readiness,
+)
 from .kbdir import kb_dirname
 
 HOSTED_PROTOCOL_VERSION = "1"
@@ -572,7 +576,14 @@ class HostedLifecycleSnapshot:
 class HostedCellLifecycle:
     """Thread-safe admission and lifecycle state for one immutable cell."""
 
-    def __init__(self, config: HostedCellConfig) -> None:
+    def __init__(
+        self,
+        config: HostedCellConfig,
+        *,
+        authorization_session_readiness_provider: (
+            Callable[[], ServingMembershipReadiness] | None
+        ) = None,
+    ) -> None:
         self.config = config
         self._condition = threading.Condition(threading.RLock())
         self._phase = self._load_durable_phase()
@@ -584,6 +595,9 @@ class HostedCellLifecycle:
         self._active_mutations = 0
         self._active_transfers = 0
         self._worker_status: dict[str, tuple[bool, str]] = {}
+        self._authorization_session_readiness_provider = (
+            authorization_session_readiness_provider
+        )
         self._background_workers: list[tuple[Callable[[], Any], Callable[[], Any] | None]] = []
 
     def _load_durable_phase(self) -> str:
@@ -707,6 +721,15 @@ class HostedCellLifecycle:
         single coarse ``ready`` boolean.
         """
 
+        session_readiness = unavailable_readiness()
+        provider = self._authorization_session_readiness_provider
+        if provider is not None:
+            try:
+                candidate = provider()
+                if isinstance(candidate, ServingMembershipReadiness):
+                    session_readiness = candidate
+            except Exception:  # noqa: BLE001 - readiness must remain content-free
+                session_readiness = unavailable_readiness()
         with self._condition:
             readiness = self.readiness()
             workers_enabled = self.config.resource_limits.worker_count > 0
@@ -725,6 +748,7 @@ class HostedCellLifecycle:
                     "semantic": workers_enabled and "embeddings" in self.config.feature_grants,
                     "media": workers_enabled and "media" in self.config.feature_grants,
                 },
+                "authorizationSession": session_readiness.as_public_dict(),
                 "code": "CELL_READY" if readiness.ready else readiness.reason_code,
             }
 

--- a/src/exomem/server_hosted.py
+++ b/src/exomem/server_hosted.py
@@ -1010,6 +1010,7 @@ def register_hosted_routes(
         except gateway.HostedGatewayError as exc:
             return _error_response(exc.code, config=config, operation="ready", started=started)
         readiness = lifecycle.readiness()
+        control_plane = lifecycle.control_plane_readiness()
         if private_authenticator is not None:
             assert config.vault_id is not None
             assert config.worker_policy_digest is not None
@@ -1023,14 +1024,15 @@ def register_hosted_routes(
                 "authenticated_credential_version": (context.authenticated_credential_version),
                 "security_revision": context.security_revision,
                 "service_authenticated": True,
-                "mutation_authority": lifecycle.control_plane_readiness()["mutationAuthority"],
+                "mutation_authority": control_plane["mutationAuthority"],
+                "authorization_session": control_plane["authorizationSession"],
                 "admission_phase": readiness.phase,
                 "read_admission": readiness.read_admitted,
                 "write_admission": readiness.write_admitted,
                 "worker_policy_digest": config.worker_policy_digest,
             }
         else:
-            data = {**readiness.as_dict(), **lifecycle.control_plane_readiness()}
+            data = {**readiness.as_dict(), **control_plane}
         return _success_response(
             data,
             config=config,

--- a/src/exomem/server_runtime.py
+++ b/src/exomem/server_runtime.py
@@ -26,7 +26,7 @@ from . import (
     project_keys,
     schema,
 )
-from .governance import projection_runtime
+from .governance import authorization_session_lifecycle, projection_runtime
 from .hosted_runtime import (
     HostedBindingV2,
     HostedCellConfig,
@@ -127,7 +127,14 @@ def _initialize_locked_hosted_runtime(
 
     config.apply_process_environment()
     _start_metrics_persistence()
-    lifecycle = HostedCellLifecycle(config)
+    lifecycle = HostedCellLifecycle(
+        config,
+        authorization_session_readiness_provider=lambda: (
+            authorization_session_lifecycle.serving_membership_readiness(
+                config.vault_root
+            )
+        ),
+    )
     security_authority = _initialize_hosted_security(config)
     vault_root = config.vault_root
 

--- a/tests/test_authorization_serving_membership.py
+++ b/tests/test_authorization_serving_membership.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from exomem.governance import authorization_serving_membership as membership
+
+NOW = 1_800_000_000
+CONTROL_DIGEST = "c" * 64
+KEYRING_DIGEST = "d" * 64
+OLD_KEY = b"o" * 32
+NEW_KEY = b"n" * 32
+KEYS = {"auth-key-old": OLD_KEY, "auth-key-new": NEW_KEY}
+
+
+def _replica(
+    replica_id: str,
+    *,
+    epoch: int = 7,
+    state: str = "SERVING",
+    active_key_id: str = "auth-key-old",
+    accepted_key_ids: tuple[str, ...] = ("auth-key-new", "auth-key-old"),
+    attested_at: int = NOW - 10,
+    expires_at: int = NOW + 60,
+    issuance_stopped: bool = False,
+    no_in_flight: bool = False,
+) -> membership.ReplicaReadinessAttestation:
+    return membership.ReplicaReadinessAttestation(
+        version=1,
+        epoch=epoch,
+        replica_id=replica_id,
+        state=state,
+        software_version="0.48.0",
+        schema_version=4,
+        cell_id="cell-7",
+        active_key_id=active_key_id,
+        accepted_key_ids=accepted_key_ids,
+        control_digest=CONTROL_DIGEST,
+        keyring_digest=KEYRING_DIGEST,
+        attested_at=attested_at,
+        expires_at=expires_at,
+        issuance_stopped=issuance_stopped,
+        no_in_flight=no_in_flight,
+        signing_key_id=active_key_id,
+    )
+
+
+def _record(
+    *replicas: membership.ReplicaReadinessAttestation,
+    epoch: int = 7,
+    previous_epoch_digest: str | None = "a" * 64,
+) -> membership.ServingMembershipEpoch:
+    return membership.ServingMembershipEpoch(
+        version=1,
+        epoch=epoch,
+        cell_id="cell-7",
+        logical_vault_id="logical-vault-7",
+        previous_epoch_digest=previous_epoch_digest,
+        issued_at=NOW - 10,
+        expires_at=NOW + 60,
+        replicas=tuple(replicas),
+        signing_key_id="auth-key-old",
+    )
+
+
+def _round_trip(
+    record: membership.ServingMembershipEpoch,
+) -> membership.ServingMembershipEpoch:
+    raw = membership.encode_serving_membership(record, verifier_keys=KEYS)
+    return membership.parse_serving_membership(
+        raw,
+        verifier_keys=KEYS,
+        now=NOW,
+        expected_cell_id="cell-7",
+        expected_logical_vault_id="logical-vault-7",
+        expected_epoch=record.epoch,
+        expected_digest=membership.serving_membership_digest(raw),
+    )
+
+
+def _readiness(
+    record: membership.ServingMembershipEpoch,
+    *,
+    local_replica_id: str = "replica-a",
+    live_verifier_key_ids: tuple[str, ...] = (),
+) -> membership.ServingMembershipReadiness:
+    return membership.evaluate_serving_membership(
+        record,
+        now=NOW,
+        local_replica_id=local_replica_id,
+        local_software_version="0.48.0",
+        local_schema_version=4,
+        expected_cell_id="cell-7",
+        expected_control_digest=CONTROL_DIGEST,
+        expected_keyring_digest=KEYRING_DIGEST,
+        local_active_key_id="auth-key-old",
+        local_accepted_key_ids=("auth-key-new", "auth-key-old"),
+        valid_verifier_key_ids=("auth-key-new", "auth-key-old"),
+        live_verifier_key_ids=live_verifier_key_ids,
+    )
+
+
+def test_two_current_replicas_with_mixed_active_keys_are_ready() -> None:
+    record = _round_trip(
+        _record(
+            _replica("replica-a"),
+            _replica("replica-b", active_key_id="auth-key-new"),
+        )
+    )
+
+    readiness = _readiness(record)
+
+    assert readiness.ready is True
+    assert readiness.code == "AUTHORIZATION_MEMBERSHIP_READY"
+    assert readiness.epoch == 7
+    assert readiness.serving_replicas == 2
+    assert readiness.draining_replicas == 0
+    assert readiness.as_public_dict() == {
+        "ready": True,
+        "code": "AUTHORIZATION_MEMBERSHIP_READY",
+        "servingMembershipEpoch": 7,
+        "servingReplicaCount": 2,
+        "drainingReplicaCount": 0,
+    }
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        _record(
+            _replica("replica-a"),
+            _replica("replica-b", expires_at=NOW),
+        ),
+        _record(
+            _replica("replica-a"),
+            _replica("replica-b", epoch=6),
+        ),
+        _record(
+            _replica("replica-a"),
+            _replica(
+                "replica-b",
+                active_key_id="auth-key-new",
+                accepted_key_ids=("auth-key-new",),
+            ),
+        ),
+    ],
+)
+def test_stale_epoch_silent_member_or_broken_intersection_blocks(
+    record: membership.ServingMembershipEpoch,
+) -> None:
+    try:
+        verified = _round_trip(record)
+    except membership.ServingMembershipUnavailable:
+        return
+
+    assert _readiness(verified).ready is False
+
+
+def test_membership_authentication_and_control_binding_are_not_optional() -> None:
+    raw = membership.encode_serving_membership(
+        _record(_replica("replica-a"), _replica("replica-b")),
+        verifier_keys=KEYS,
+    )
+    tampered = raw.replace(b'"replica-b"', b'"replica-x"')
+
+    with pytest.raises(membership.ServingMembershipUnavailable):
+        membership.parse_serving_membership(
+            tampered,
+            verifier_keys=KEYS,
+            now=NOW,
+            expected_cell_id="cell-7",
+            expected_logical_vault_id="logical-vault-7",
+            expected_epoch=7,
+            expected_digest=membership.serving_membership_digest(tampered),
+        )
+
+    verified = _round_trip(_record(_replica("replica-a"), _replica("replica-b")))
+    assert replace(
+        _readiness(verified),
+        ready=False,
+        code="AUTHORIZATION_MEMBERSHIP_UNAVAILABLE",
+    ).ready is False
+    assert membership.evaluate_serving_membership(
+        verified,
+        now=NOW,
+        local_replica_id="replica-a",
+        local_software_version="0.48.0",
+        local_schema_version=4,
+        expected_cell_id="cell-7",
+        expected_control_digest="e" * 64,
+        expected_keyring_digest=KEYRING_DIGEST,
+        local_active_key_id="auth-key-old",
+        local_accepted_key_ids=("auth-key-new", "auth-key-old"),
+        valid_verifier_key_ids=("auth-key-new", "auth-key-old"),
+        live_verifier_key_ids=(),
+    ).ready is False
+
+
+def test_live_old_key_row_blocks_key_removal_even_after_issuance_switch() -> None:
+    record = _round_trip(
+        _record(
+            _replica(
+                "replica-a",
+                active_key_id="auth-key-new",
+                accepted_key_ids=("auth-key-new",),
+            ),
+            _replica(
+                "replica-b",
+                active_key_id="auth-key-new",
+                accepted_key_ids=("auth-key-new",),
+            ),
+        )
+    )
+
+    readiness = membership.evaluate_serving_membership(
+        record,
+        now=NOW,
+        local_replica_id="replica-a",
+        local_software_version="0.48.0",
+        local_schema_version=4,
+        expected_cell_id="cell-7",
+        expected_control_digest=CONTROL_DIGEST,
+        expected_keyring_digest=KEYRING_DIGEST,
+        local_active_key_id="auth-key-new",
+        local_accepted_key_ids=("auth-key-new",),
+        valid_verifier_key_ids=("auth-key-new",),
+        live_verifier_key_ids=("auth-key-old",),
+    )
+
+    assert readiness.ready is False
+    assert readiness.code == "AUTHORIZATION_MEMBERSHIP_UNAVAILABLE"
+
+
+def test_expired_active_key_cannot_be_self_waived_by_an_attestation() -> None:
+    record = _round_trip(
+        _record(_replica("replica-a"), _replica("replica-b"))
+    )
+
+    readiness = membership.evaluate_serving_membership(
+        record,
+        now=NOW,
+        local_replica_id="replica-a",
+        local_software_version="0.48.0",
+        local_schema_version=4,
+        expected_cell_id="cell-7",
+        expected_control_digest=CONTROL_DIGEST,
+        expected_keyring_digest=KEYRING_DIGEST,
+        local_active_key_id="auth-key-old",
+        local_accepted_key_ids=("auth-key-new", "auth-key-old"),
+        valid_verifier_key_ids=("auth-key-new",),
+        live_verifier_key_ids=(),
+    )
+
+    assert readiness.ready is False
+    assert readiness.code == "AUTHORIZATION_MEMBERSHIP_UNAVAILABLE"
+
+
+def test_maximum_session_ttl_plus_skew_boundary_is_exact() -> None:
+    exact_expiry = NOW - 10 + membership.MAX_ATTESTATION_TTL_SECONDS
+    exact = _round_trip(
+        replace(
+            _record(
+                _replica("replica-a", expires_at=exact_expiry),
+                _replica("replica-b", expires_at=exact_expiry),
+            ),
+            expires_at=exact_expiry,
+        )
+    )
+
+    assert _readiness(exact).ready is True
+
+    overlong_expiry = exact_expiry + 1
+    overlong = replace(
+        _record(
+            _replica("replica-a", expires_at=overlong_expiry),
+            _replica("replica-b", expires_at=overlong_expiry),
+        ),
+        expires_at=overlong_expiry,
+    )
+    with pytest.raises(membership.ServingMembershipUnavailable):
+        membership.encode_serving_membership(overlong, verifier_keys=KEYS)
+
+
+def test_replica_removal_requires_drain_stop_ack_and_committed_successors() -> None:
+    epoch_7 = _round_trip(
+        _record(_replica("replica-a"), _replica("replica-b"))
+    )
+    illegal_epoch_8 = _round_trip(
+        _record(
+            _replica("replica-a", epoch=8),
+            epoch=8,
+            previous_epoch_digest=membership.serving_membership_digest(
+                membership.encode_serving_membership(epoch_7, verifier_keys=KEYS)
+            ),
+        )
+    )
+    with pytest.raises(membership.ServingMembershipUnavailable):
+        membership.validate_membership_successor(epoch_7, illegal_epoch_8, now=NOW)
+
+    draining_epoch_8 = _round_trip(
+        _record(
+            _replica("replica-a", epoch=8),
+            _replica(
+                "replica-b",
+                epoch=8,
+                state="DRAINING",
+                issuance_stopped=True,
+            ),
+            epoch=8,
+            previous_epoch_digest=membership.serving_membership_digest(
+                membership.encode_serving_membership(epoch_7, verifier_keys=KEYS)
+            ),
+        )
+    )
+    membership.validate_membership_successor(epoch_7, draining_epoch_8, now=NOW)
+
+    acknowledged_epoch_9 = _round_trip(
+        _record(
+            _replica("replica-a", epoch=9),
+            _replica(
+                "replica-b",
+                epoch=9,
+                state="DRAINING",
+                issuance_stopped=True,
+                no_in_flight=True,
+            ),
+            epoch=9,
+            previous_epoch_digest=membership.serving_membership_digest(
+                membership.encode_serving_membership(draining_epoch_8, verifier_keys=KEYS)
+            ),
+        )
+    )
+    membership.validate_membership_successor(draining_epoch_8, acknowledged_epoch_9, now=NOW)
+
+    removed_epoch_10 = _round_trip(
+        _record(
+            _replica("replica-a", epoch=10),
+            epoch=10,
+            previous_epoch_digest=membership.serving_membership_digest(
+                membership.encode_serving_membership(acknowledged_epoch_9, verifier_keys=KEYS)
+            ),
+        )
+    )
+    membership.validate_membership_successor(acknowledged_epoch_9, removed_epoch_10, now=NOW)
+
+
+def test_rejoin_must_attest_the_current_epoch_before_serving() -> None:
+    current = _round_trip(
+        _record(
+            _replica("replica-a"),
+            _replica(
+                "replica-b",
+                state="DRAINING",
+                issuance_stopped=True,
+                no_in_flight=True,
+            ),
+        )
+    )
+    stale_rejoin = _record(
+        _replica("replica-a", epoch=8),
+        _replica("replica-b", epoch=7),
+        epoch=8,
+        previous_epoch_digest=membership.serving_membership_digest(
+            membership.encode_serving_membership(current, verifier_keys=KEYS)
+        ),
+    )
+
+    with pytest.raises(membership.ServingMembershipUnavailable):
+        _round_trip(stale_rejoin)
+
+    current_rejoin = _round_trip(
+        _record(
+            _replica("replica-a", epoch=8),
+            _replica("replica-b", epoch=8),
+            epoch=8,
+            previous_epoch_digest=membership.serving_membership_digest(
+                membership.encode_serving_membership(current, verifier_keys=KEYS)
+            ),
+        )
+    )
+    membership.validate_membership_successor(current, current_rejoin, now=NOW)

--- a/tests/test_authorization_session_authority.py
+++ b/tests/test_authorization_session_authority.py
@@ -9,6 +9,7 @@ import pytest
 
 from exomem.governance import (
     authorization_custody,
+    authorization_serving_membership,
     authorization_session_lifecycle,
     policy,
     schema_v4,
@@ -102,11 +103,43 @@ def _custody(activation_digest: str) -> authorization_custody.AuthorizationCusto
         expires_at=NOW + 86_400,
         signing_key_id=key.key_id,
     )
+    membership = authorization_serving_membership.ServingMembershipEpoch(
+        version=1,
+        epoch=1,
+        cell_id=control.cell_id,
+        logical_vault_id=control.logical_vault_id,
+        previous_epoch_digest=None,
+        issued_at=NOW - 1,
+        expires_at=NOW + 299,
+        replicas=(
+            authorization_serving_membership.ReplicaReadinessAttestation(
+                version=1,
+                epoch=1,
+                replica_id="replica-7",
+                state="SERVING",
+                software_version=authorization_custody.runtime_software_version(),
+                schema_version=4,
+                cell_id=control.cell_id,
+                active_key_id=key.key_id,
+                accepted_key_ids=(key.key_id,),
+                control_digest=authorization_custody.control_attestation_digest(control),
+                keyring_digest=authorization_custody.keyring_attestation_digest(keyring),
+                attested_at=NOW - 1,
+                expires_at=NOW + 299,
+                issuance_stopped=False,
+                no_in_flight=False,
+                signing_key_id=key.key_id,
+            ),
+        ),
+        signing_key_id=key.key_id,
+    )
     return authorization_custody.AuthorizationCustody(
         keyring_path=Path("/external/keyring.json"),
         control_path=Path("/external/control.json"),
         keyring=keyring,
         control=control,
+        serving_membership=membership,
+        local_replica_id="replica-7",
     )
 
 

--- a/tests/test_authorization_session_custody.py
+++ b/tests/test_authorization_session_custody.py
@@ -10,13 +10,19 @@ from pathlib import Path
 
 import pytest
 
-from exomem.governance import authorization_custody, schema_v4
+from exomem.governance import (
+    authorization_custody,
+    authorization_serving_membership,
+    schema_v4,
+)
 
 
 @pytest.fixture(autouse=True)
 def _clear_custody_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(authorization_custody.KEYRING_FILE_ENV, raising=False)
     monkeypatch.delenv(authorization_custody.CONTROL_FILE_ENV, raising=False)
+    monkeypatch.delenv(authorization_custody.MEMBERSHIP_FILE_ENV, raising=False)
+    monkeypatch.delenv(authorization_custody.REPLICA_ID_ENV, raising=False)
 
 
 def _protected_file(path: Path, data: bytes) -> Path:
@@ -121,6 +127,41 @@ def _control_document(*, signing_key: bytes = b"k" * 32, **changes: object) -> b
     ).digest()
     document["mac"] = base64.urlsafe_b64encode(mac).rstrip(b"=").decode()
     return json.dumps(document, separators=(",", ":")).encode()
+
+
+def _membership_document(*, control_digest: str, keyring_digest: str) -> bytes:
+    attestation = authorization_serving_membership.ReplicaReadinessAttestation(
+        version=1,
+        epoch=11,
+        replica_id="replica-a",
+        state="SERVING",
+        software_version=authorization_custody.runtime_software_version(),
+        schema_version=4,
+        cell_id="cell-7bd27031",
+        active_key_id="auth-key-2026-08",
+        accepted_key_ids=("auth-key-2026-08",),
+        control_digest=control_digest,
+        keyring_digest=keyring_digest,
+        attested_at=1_800_000_099,
+        expires_at=1_800_000_399,
+        issuance_stopped=False,
+        no_in_flight=False,
+        signing_key_id="auth-key-2026-08",
+    )
+    return authorization_serving_membership.encode_serving_membership(
+        authorization_serving_membership.ServingMembershipEpoch(
+            version=1,
+            epoch=11,
+            cell_id="cell-7bd27031",
+            logical_vault_id="vault-a2699d30",
+            previous_epoch_digest="a" * 64,
+            issued_at=1_800_000_099,
+            expires_at=1_800_000_399,
+            replicas=(attestation,),
+            signing_key_id="auth-key-2026-08",
+        ),
+        verifier_keys={"auth-key-2026-08": b"k" * 32},
+    )
 
 
 def test_activation_registry_acknowledgement_is_exact_atomic_and_idempotent(
@@ -611,6 +652,76 @@ def test_authenticated_custody_loader_returns_only_verified_records(
     assert loaded.control.registry_attachment_id == "attachment-5d998951"
     assert (b"k" * 32).hex() not in repr(loaded)
     assert "mac" not in repr(loaded)
+
+
+def test_authenticated_custody_loader_attaches_exact_serving_membership(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    now = 1_800_000_100
+    keyring_raw = _keyring_document()
+    keyring = authorization_custody.parse_keyring(keyring_raw)
+    basis_control = authorization_custody.parse_control_record(
+        _control_document(), keyring=keyring, now=now
+    )
+    membership_raw = _membership_document(
+        control_digest=authorization_custody.control_attestation_digest(basis_control),
+        keyring_digest=authorization_custody.keyring_attestation_digest(keyring),
+    )
+    control_raw = _control_document(
+        serving_membership_digest=(
+            authorization_serving_membership.serving_membership_digest(membership_raw)
+        )
+    )
+    external = tmp_path / "external"
+    _configure(
+        monkeypatch,
+        external,
+        keyring=keyring_raw,
+        control=control_raw,
+    )
+    membership_path = _protected_file(
+        external / "authorization-serving-membership.json", membership_raw
+    )
+    monkeypatch.setenv(
+        authorization_custody.MEMBERSHIP_FILE_ENV, str(membership_path)
+    )
+    monkeypatch.setenv(authorization_custody.REPLICA_ID_ENV, "replica-a")
+
+    loaded = authorization_custody.load_authorization_custody(
+        tmp_path / "vault", now=now
+    )
+
+    assert loaded.local_replica_id == "replica-a"
+    assert loaded.serving_membership is not None
+    assert loaded.serving_membership.epoch == 11
+    assert loaded.serving_membership.record_digest == loaded.control.serving_membership_digest
+
+
+def test_bad_optional_membership_disables_sessions_without_blocking_standing_custody(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure(
+        monkeypatch,
+        tmp_path / "external",
+        keyring=_keyring_document(),
+        control=_control_document(),
+    )
+    membership_path = _protected_file(
+        tmp_path / "external" / "authorization-serving-membership.json",
+        b'{"invalid":true}',
+    )
+    monkeypatch.setenv(
+        authorization_custody.MEMBERSHIP_FILE_ENV, str(membership_path)
+    )
+    monkeypatch.setenv(authorization_custody.REPLICA_ID_ENV, "replica-a")
+
+    loaded = authorization_custody.load_authorization_custody(
+        tmp_path / "vault", now=1_800_000_100
+    )
+
+    assert loaded.serving_membership is None
+    assert loaded.local_replica_id is None
+    assert loaded.control.registry_attachment_id == "attachment-5d998951"
 
 
 def test_authenticated_custody_loader_never_returns_unverified_control(

--- a/tests/test_authorization_session_lifecycle.py
+++ b/tests/test_authorization_session_lifecycle.py
@@ -7,6 +7,7 @@ import sys
 import textwrap
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -14,6 +15,7 @@ import pytest
 
 from exomem.governance import (
     authorization_custody,
+    authorization_serving_membership,
     authorization_session_lifecycle,
     authorization_sessions,
     policy,
@@ -100,7 +102,11 @@ def _resume_in_fresh_process(
         from dataclasses import asdict
         from pathlib import Path
 
-        from exomem.governance import authorization_custody, authorization_session_lifecycle
+        from exomem.governance import (
+            authorization_custody,
+            authorization_session_lifecycle,
+            authorization_serving_membership,
+        )
 
         value = json.loads(sys.stdin.read())
         key = authorization_custody.AuthorizationVerifierKey(
@@ -109,34 +115,66 @@ def _resume_in_fresh_process(
             not_before=value["now"] - 60,
             not_after=value["now"] + 86_400,
         )
+        keyring = authorization_custody.AuthorizationKeyring(
+            version=1,
+            keyring_id="keyring-7",
+            cell_id="cell-7",
+            logical_vault_id="logical-vault-7",
+            active_key_id=key.key_id,
+            accepted_keys=(key,),
+        )
+        control = authorization_custody.AuthorizationControlRecord(
+            version=1,
+            keyring_id="keyring-7",
+            cell_id="cell-7",
+            logical_vault_id="logical-vault-7",
+            registry_attachment_id="attachment-7",
+            attachment_epoch=1,
+            governance_enrolled=True,
+            activation_store_id="activation-store-7",
+            activation_epoch=1,
+            activation_state_digest=value["activation_state_digest"],
+            serving_membership_epoch=1,
+            serving_membership_digest="a" * 64,
+            issued_at=value["now"] - 60,
+            expires_at=value["now"] + 86_400,
+            signing_key_id=key.key_id,
+        )
+        attestation = authorization_serving_membership.ReplicaReadinessAttestation(
+            version=1,
+            epoch=1,
+            replica_id="replica-7",
+            state="SERVING",
+            software_version=authorization_custody.runtime_software_version(),
+            schema_version=4,
+            cell_id="cell-7",
+            active_key_id=key.key_id,
+            accepted_key_ids=(key.key_id,),
+            control_digest=authorization_custody.control_attestation_digest(control),
+            keyring_digest=authorization_custody.keyring_attestation_digest(keyring),
+            attested_at=value["now"] - 1,
+            expires_at=value["now"] + 299,
+            issuance_stopped=False,
+            no_in_flight=False,
+            signing_key_id=key.key_id,
+        )
         custody = authorization_custody.AuthorizationCustody(
             keyring_path=Path("/external/keyring.json"),
             control_path=Path("/external/control.json"),
-            keyring=authorization_custody.AuthorizationKeyring(
+            keyring=keyring,
+            control=control,
+            serving_membership=authorization_serving_membership.ServingMembershipEpoch(
                 version=1,
-                keyring_id="keyring-7",
+                epoch=1,
                 cell_id="cell-7",
                 logical_vault_id="logical-vault-7",
-                active_key_id=key.key_id,
-                accepted_keys=(key,),
-            ),
-            control=authorization_custody.AuthorizationControlRecord(
-                version=1,
-                keyring_id="keyring-7",
-                cell_id="cell-7",
-                logical_vault_id="logical-vault-7",
-                registry_attachment_id="attachment-7",
-                attachment_epoch=1,
-                governance_enrolled=True,
-                activation_store_id="activation-store-7",
-                activation_epoch=1,
-                activation_state_digest=value["activation_state_digest"],
-                serving_membership_epoch=1,
-                serving_membership_digest="a" * 64,
-                issued_at=value["now"] - 60,
-                expires_at=value["now"] + 86_400,
+                previous_epoch_digest=None,
+                issued_at=value["now"] - 1,
+                expires_at=value["now"] + 299,
+                replicas=(attestation,),
                 signing_key_id=key.key_id,
             ),
+            local_replica_id="replica-7",
         )
         with sqlite3.connect(value["database_path"]) as connection:
             context = authorization_session_lifecycle.resume_session(
@@ -188,6 +226,7 @@ def _custody(
     *,
     active_key_id: str = "auth-key-old",
     keys: tuple[authorization_custody.AuthorizationVerifierKey, ...] | None = None,
+    membership_expires_at: int = NOW + 299,
 ) -> authorization_custody.AuthorizationCustody:
     accepted = keys or (_key("auth-key-old", b"o" * 32),)
     keyring = authorization_custody.AuthorizationKeyring(
@@ -215,11 +254,44 @@ def _custody(
         expires_at=NOW + 86_400,
         signing_key_id=active_key_id,
     )
+    key_ids = tuple(sorted(key.key_id for key in accepted))
+    serving_membership = authorization_serving_membership.ServingMembershipEpoch(
+        version=1,
+        epoch=control.serving_membership_epoch,
+        cell_id=control.cell_id,
+        logical_vault_id=control.logical_vault_id,
+        previous_epoch_digest=None,
+        issued_at=NOW - 1,
+        expires_at=membership_expires_at,
+        replicas=(
+            authorization_serving_membership.ReplicaReadinessAttestation(
+                version=1,
+                epoch=control.serving_membership_epoch,
+                replica_id="replica-7",
+                state="SERVING",
+                software_version=authorization_custody.runtime_software_version(),
+                schema_version=4,
+                cell_id=control.cell_id,
+                active_key_id=active_key_id,
+                accepted_key_ids=key_ids,
+                control_digest=authorization_custody.control_attestation_digest(control),
+                keyring_digest=authorization_custody.keyring_attestation_digest(keyring),
+                attested_at=NOW - 1,
+                expires_at=membership_expires_at,
+                issuance_stopped=False,
+                no_in_flight=False,
+                signing_key_id=active_key_id,
+            ),
+        ),
+        signing_key_id=active_key_id,
+    )
     return authorization_custody.AuthorizationCustody(
         keyring_path=Path("/external/keyring.json"),
         control_path=Path("/external/control.json"),
         keyring=keyring,
         control=control,
+        serving_membership=serving_membership,
+        local_replica_id="replica-7",
     )
 
 
@@ -266,6 +338,69 @@ def test_open_persists_only_a_bound_verifier_and_resume_returns_context() -> Non
     )
     assert issued.bearer not in "\n".join(connection.iterdump())
     assert issued.bearer not in repr(issued)
+
+
+@pytest.mark.parametrize("missing", [True, False])
+def test_open_fails_closed_before_writing_when_membership_is_missing_or_stale(
+    missing: bool,
+) -> None:
+    connection, migration = _connection()
+    custody = _custody(
+        migration.activation_state_digest,
+        membership_expires_at=NOW if not missing else NOW + 299,
+    )
+    if missing:
+        custody = replace(custody, serving_membership=None)
+
+    with pytest.raises(
+        authorization_session_lifecycle.AuthorizationSessionUnavailable
+    ) as raised:
+        authorization_session_lifecycle.open_session(
+            connection,
+            custody=custody,
+            principal_id="principal:owner:1000",
+            issuer_family="cli-local-owner",
+            now=NOW,
+            ttl_seconds=600,
+        )
+
+    assert raised.value.code == "AUTHORIZATION_SESSION_UNAVAILABLE"
+    assert connection.execute(
+        "SELECT COUNT(*) FROM governance_authorization_sessions"
+    ).fetchone() == (0,)
+
+
+def test_resume_fails_when_a_live_row_key_drops_from_the_serving_intersection() -> None:
+    connection, migration = _connection()
+    old_key = _key("auth-key-old", b"o" * 32)
+    new_key = _key("auth-key-new", b"n" * 32)
+    initial = _custody(
+        migration.activation_state_digest,
+        keys=(old_key, new_key),
+    )
+    issued = authorization_session_lifecycle.open_session(
+        connection,
+        custody=initial,
+        principal_id="principal:owner:1000",
+        issuer_family="cli-local-owner",
+        now=NOW,
+        ttl_seconds=600,
+    )
+    switched = _custody(
+        migration.activation_state_digest,
+        active_key_id="auth-key-new",
+        keys=(new_key,),
+    )
+
+    with pytest.raises(authorization_session_lifecycle.AuthorizationSessionUnavailable):
+        authorization_session_lifecycle.resume_session(
+            connection,
+            custody=switched,
+            bearer=issued.bearer,
+            principal_id="principal:owner:1000",
+            issuer_family="cli-local-owner",
+            now=NOW + 1,
+        )
 
 
 def test_open_builds_the_exact_typed_issuance_terminal() -> None:

--- a/tests/test_authorization_session_wire_reconnect.py
+++ b/tests/test_authorization_session_wire_reconnect.py
@@ -17,6 +17,7 @@ from starlette.testclient import TestClient
 from exomem import commands, server, video_frames, writer_lease
 from exomem.governance import (
     authorization_custody,
+    authorization_serving_membership,
     authorization_session_authority,
     authorization_session_lifecycle,
     membership,
@@ -219,6 +220,61 @@ def _configure_v4_authority(
         "expires_at": expires_at,
         "signing_key_id": key_id,
     }
+    keyring_record = authorization_custody.parse_keyring(
+        json.dumps(keyring, separators=(",", ":")).encode()
+    )
+    basis_control = authorization_custody.AuthorizationControlRecord(
+        version=1,
+        keyring_id=keyring_id,
+        cell_id=cell_id,
+        logical_vault_id=logical_vault_id,
+        registry_attachment_id="attachment-wire",
+        attachment_epoch=1,
+        governance_enrolled=True,
+        activation_store_id=migration.activation_store_id,
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        serving_membership_epoch=1,
+        serving_membership_digest="4" * 64,
+        issued_at=issued_at,
+        expires_at=expires_at,
+        signing_key_id=key_id,
+    )
+    attestation = authorization_serving_membership.ReplicaReadinessAttestation(
+        version=1,
+        epoch=1,
+        replica_id="replica-wire",
+        state="SERVING",
+        software_version=authorization_custody.runtime_software_version(),
+        schema_version=4,
+        cell_id=cell_id,
+        active_key_id=key_id,
+        accepted_key_ids=(key_id,),
+        control_digest=authorization_custody.control_attestation_digest(basis_control),
+        keyring_digest=authorization_custody.keyring_attestation_digest(keyring_record),
+        attested_at=issued_at,
+        expires_at=expires_at,
+        issuance_stopped=False,
+        no_in_flight=False,
+        signing_key_id=key_id,
+    )
+    membership_raw = authorization_serving_membership.encode_serving_membership(
+        authorization_serving_membership.ServingMembershipEpoch(
+            version=1,
+            epoch=1,
+            cell_id=cell_id,
+            logical_vault_id=logical_vault_id,
+            previous_epoch_digest=None,
+            issued_at=issued_at,
+            expires_at=expires_at,
+            replicas=(attestation,),
+            signing_key_id=key_id,
+        ),
+        verifier_keys={key_id: key},
+    )
+    control["serving_membership_digest"] = (
+        authorization_serving_membership.serving_membership_digest(membership_raw)
+    )
     fields = [
         str(control["version"]).encode(),
         str(control["keyring_id"]).encode(),
@@ -250,10 +306,16 @@ def _configure_v4_authority(
 
     keyring_path = custody_root / "authorization-keyring.json"
     control_path = custody_root / "authorization-control.json"
+    membership_path = custody_root / "authorization-serving-membership.json"
     _private_file(keyring_path, json.dumps(keyring, separators=(",", ":")).encode())
     _private_file(control_path, json.dumps(control, separators=(",", ":")).encode())
+    _private_file(membership_path, membership_raw)
     monkeypatch.setenv(authorization_custody.KEYRING_FILE_ENV, str(keyring_path))
     monkeypatch.setenv(authorization_custody.CONTROL_FILE_ENV, str(control_path))
+    monkeypatch.setenv(
+        authorization_custody.MEMBERSHIP_FILE_ENV, str(membership_path)
+    )
+    monkeypatch.setenv(authorization_custody.REPLICA_ID_ENV, "replica-wire")
 
 
 def _build_replica(vault: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_authorization_standalone_provisioning.py
+++ b/tests/test_authorization_standalone_provisioning.py
@@ -33,6 +33,11 @@ def _custody_paths(
         authorization_custody.CONTROL_FILE_ENV,
         str(external / "authorization-control.json"),
     )
+    monkeypatch.setenv(
+        authorization_custody.MEMBERSHIP_FILE_ENV,
+        str(external / "authorization-serving-membership.json"),
+    )
+    monkeypatch.setenv(authorization_custody.REPLICA_ID_ENV, "standalone")
     monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(lease_state))
     writer_lease.reset_managers_for_tests()
     yield
@@ -86,6 +91,7 @@ def test_explicit_standalone_provisioning_is_private_idempotent_and_copy_bound(
     first = authorization_custody.provision_standalone_custody(vault, now=now)
     keyring_before = first.keyring_path.read_bytes()
     control_before = first.control_path.read_bytes()
+    membership_before = first.membership_path.read_bytes()
     replay = authorization_custody.provision_standalone_custody(vault, now=now)
     loaded = authorization_custody.load_authorization_custody(vault, now=now + 1)
 
@@ -95,6 +101,10 @@ def test_explicit_standalone_provisioning_is_private_idempotent_and_copy_bound(
     assert loaded.control.registry_attachment_id == first.registry_attachment_id
     assert first.keyring_path.read_bytes() == keyring_before
     assert first.control_path.read_bytes() == control_before
+    assert first.membership_path.read_bytes() == membership_before
+    assert loaded.serving_membership is not None
+    assert loaded.serving_membership.epoch == 1
+    assert loaded.local_replica_id == "standalone"
     assert first.cell_id == loaded.keyring.cell_id
     assert first.logical_vault_id == loaded.keyring.logical_vault_id
     assert first.keyring_id == loaded.keyring.keyring_id
@@ -103,6 +113,7 @@ def test_explicit_standalone_provisioning_is_private_idempotent_and_copy_bound(
     if os.name != "nt":
         assert stat.S_IMODE(first.keyring_path.stat().st_mode) == 0o600
         assert stat.S_IMODE(first.control_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(first.membership_path.stat().st_mode) == 0o600
 
     copied = _vault(tmp_path, "copied-vault")
     with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
@@ -372,3 +383,48 @@ def test_keyring_only_interruption_retries_without_rotating_identity(
         vault,
         now=now + 1,
     ).control.governance_enrolled is False
+
+
+def test_control_before_membership_interruption_retries_without_session_fail_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    now = 1_800_000_000
+    original = authorization_custody._publish_private_file
+    failed = False
+
+    def interrupt_membership(path: Path, data: bytes) -> bytes:
+        nonlocal failed
+        if path.name == "authorization-serving-membership.json" and not failed:
+            failed = True
+            raise authorization_custody.AuthorizationCustodyUnavailable
+        return original(path, data)
+
+    monkeypatch.setattr(
+        authorization_custody,
+        "_publish_private_file",
+        interrupt_membership,
+    )
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.provision_standalone_custody(vault, now=now)
+
+    control_path = Path(os.environ[authorization_custody.CONTROL_FILE_ENV])
+    membership_path = Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV])
+    control_before = control_path.read_bytes()
+    assert not membership_path.exists()
+    interrupted = authorization_custody.load_authorization_custody(
+        vault,
+        now=now + 1,
+    )
+    assert interrupted.serving_membership is None
+
+    monkeypatch.setattr(authorization_custody, "_publish_private_file", original)
+    result = authorization_custody.provision_standalone_custody(vault, now=now)
+
+    assert control_path.read_bytes() == control_before
+    assert result.membership_path == membership_path
+    assert authorization_custody.load_authorization_custody(
+        vault,
+        now=now + 1,
+    ).serving_membership is not None

--- a/tests/test_hosted_cell.py
+++ b/tests/test_hosted_cell.py
@@ -12,6 +12,9 @@ from pathlib import Path
 import pytest
 
 from exomem import get_page, hosted_runtime, list_directory, server_runtime, vault
+from exomem.governance.authorization_serving_membership import (
+    ServingMembershipReadiness,
+)
 from exomem.hosted_runtime import (
     HostedCellConfig,
     HostedCellLifecycle,
@@ -649,6 +652,52 @@ def test_lifecycle_reports_content_free_readiness_and_degradation(
     readiness = lifecycle.readiness()
     assert readiness.ready is False
     assert readiness.reason_code == "HOSTED_MUTATION_LOCK_UNAVAILABLE"
+
+
+def test_control_plane_readiness_rechecks_content_free_session_membership(
+    tmp_path: Path,
+) -> None:
+    _values, config = _provisioned(tmp_path)
+    states = [
+        ServingMembershipReadiness(
+            ready=True,
+            code="AUTHORIZATION_MEMBERSHIP_READY",
+            epoch=17,
+            serving_replicas=2,
+            draining_replicas=0,
+        ),
+        ServingMembershipReadiness(
+            ready=False,
+            code="AUTHORIZATION_MEMBERSHIP_UNAVAILABLE",
+            epoch=17,
+            serving_replicas=2,
+            draining_replicas=0,
+        ),
+    ]
+    lifecycle = HostedCellLifecycle(
+        config,
+        authorization_session_readiness_provider=lambda: states.pop(0),
+    )
+    lifecycle.complete_startup(
+        vault_ready=True,
+        mutation_authority_ready=True,
+        service_auth_ready=True,
+    )
+
+    first = lifecycle.control_plane_readiness()["authorizationSession"]
+    second = lifecycle.control_plane_readiness()["authorizationSession"]
+
+    assert first == {
+        "ready": True,
+        "code": "AUTHORIZATION_MEMBERSHIP_READY",
+        "servingMembershipEpoch": 17,
+        "servingReplicaCount": 2,
+        "drainingReplicaCount": 0,
+    }
+    assert second == {**first, "ready": False, "code": "AUTHORIZATION_MEMBERSHIP_UNAVAILABLE"}
+    assert "replica-a" not in repr(first)
+    assert "auth-key" not in repr(first)
+    assert "digest" not in repr(first).lower()
 
 
 def test_quiesce_and_deletion_sealing_wait_for_an_admitted_download(tmp_path: Path) -> None:

--- a/tests/test_hosted_private_routes.py
+++ b/tests/test_hosted_private_routes.py
@@ -340,6 +340,13 @@ def test_private_routes_use_the_injected_dynamic_authority_for_every_request(
         "security_revision": 1,
         "service_authenticated": True,
         "mutation_authority": True,
+        "authorization_session": {
+            "ready": False,
+            "code": "AUTHORIZATION_MEMBERSHIP_UNAVAILABLE",
+            "servingMembershipEpoch": None,
+            "servingReplicaCount": 0,
+            "drainingReplicaCount": 0,
+        },
         "admission_phase": "active",
         "read_admission": True,
         "write_admission": True,
@@ -1055,6 +1062,13 @@ def test_private_readiness_is_a_complete_control_plane_binding_proof(tmp_path: P
         "readAdmission": True,
         "writeAdmission": True,
         "workerPolicy": {"workerCount": 0, "semantic": False, "media": False},
+        "authorizationSession": {
+            "ready": False,
+            "code": "AUTHORIZATION_MEMBERSHIP_UNAVAILABLE",
+            "servingMembershipEpoch": None,
+            "servingReplicaCount": 0,
+            "drainingReplicaCount": 0,
+        },
         "code": "CELL_READY",
     }
 


### PR DESCRIPTION
## Why

Authorization sessions need an authoritative fleet view before personal and organizational memory can safely share one governed substrate. Process liveness or a locally selected replica cannot decide which verifier keys and session generations remain valid.

## What changed

- add a closed, authenticated serving-membership epoch and per-replica readiness schema
- require current cell/schema/control/keyring parity, serving-key intersection, and live-session verifier retention before session issuance or resumption
- enforce explicit serving → draining → acknowledged removal and current-epoch rejoin
- provision the same protected singleton record for standalone custody, with crash-safe repair
- expose content-free dynamic authorization-session readiness on Hosted surfaces
- record the exact v1 contract and complete OpenSpec task 5.8; the Hosted control-plane publisher/operational transition remains tracked in task 5.12

## Verification

- `151 passed, 1 skipped, 60 deselected` across membership, custody, lifecycle, reconnect, Hosted readiness, and standalone focused suites
- actual stateless MCP reconnect exercised across fresh processes
- `openspec validate harden-governance-for-consolidation --strict`
- touched-file Ruff clean
- public-artifact privacy scan clean
- `git diff --check` clean