### PR TITLE
fix(hosted): use owned backup scratch directory

### DIFF
--- a/infra/helm/platform/templates/durability-workloads.yaml
+++ b/infra/helm/platform/templates/durability-workloads.yaml
@@ -750,7 +750,7 @@ spec:
                 - name: EXOMEM_DATABASE_BACKUP_VERIFICATION_SQL
                   value: {{ .Values.durability.databaseBackup.verificationSql | quote }}
                 - name: EXOMEM_DURABILITY_SCRATCH_ROOT
-                  value: /var/lib/exomem-scratch
+                  value: /var/lib/exomem-scratch/database-backup
                 - name: HOME
                   value: /tmp
               resources:

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -1168,6 +1168,9 @@ def test_platform_renders_disjoint_durability_workloads() -> None:
         "/run/secrets/exomem/database-backup/.pgpass"
     )
     assert database_env["EXOMEM_DATABASE_BACKUP_PG_DUMP"] == "/usr/bin/pg_dump"
+    assert database_env["EXOMEM_DURABILITY_SCRATCH_ROOT"] == (
+        "/var/lib/exomem-scratch/database-backup"
+    )
     assert database_env["EXOMEM_DATABASE_BACKUP_PROOF_TENANT_ID"] == "tenant-owner-proof"
     assert database_env["EXOMEM_DATABASE_BACKUP_PROOF_CELL_ID"] == "cell-owner-proof"
 


### PR DESCRIPTION
## Why

The hosted database-backup CronJob runs as non-root. It can write through the scratch volume group permissions, but it cannot chmod the Kubernetes-owned mount root, so every scheduled backup exits before producing a recovery artifact.

## What changed

- point the database-backup worker at an owned child directory beneath the mounted scratch volume
- pin the rendered Helm contract so the worker cannot regress to the mount root

## Verification

- hosted Helm contract test file: 56 passed
- strict platform Helm lint: passed
- platform Helm template render: passed
- git diff check: passed

The full local infrastructure validator could not run because this host lacks tflint, kubeconform, conftest, and trivy; CI remains the full gate.