### PR TITLE
fix(hosted): rotate database backup credential

### DIFF
--- a/infra/contracts/active-secret-selection-v1.json
+++ b/infra/contracts/active-secret-selection-v1.json
@@ -6,7 +6,7 @@
     "k3s.capacity-workers.capacity-receipt-verifier.active": "v1",
     "k3s.cloudflared.active": "v1",
     "k3s.database-backup.pg-service.active": "v1",
-    "k3s.database-backup.pgpass.active": "v1",
+    "k3s.database-backup.pgpass.active": "v2",
     "k3s.hcloud-capacity-reader.active": "v1",
     "k3s.hcloud-csi.active": "v1",
     "k3s.provider-recovery-signer.active": "v1",

--- a/infra/secrets/database-backup/pgpass.v2.sops.json
+++ b/infra/secrets/database-backup/pgpass.v2.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:eQY=,iv:nL8A9Lsubcf2uHs9Po9Tk2u5x5A72/TgbHUFTS+gX94=,tag:eo1efeZkPiKtG5JCxBmhcg==,type:str]",
+	"kind": "ENC[AES256_GCM,data:XL8ok9Jf,iv:EZuZqO+ecpWWkCnY6dHvtMUp7M2g5gE/G8pYh+GbkaA=,tag:y5y23hbHa669B8MwSstWww==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:zl5ySGyfWuK+V7crCRWNFLhmjKW8,iv:coZ61y9ywVW0/tyCaPi4XA0T/SgKFt41N1Ckn/zqZ0c=,tag:gCopKAEsWfxe5a8dc9NPpw==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:KZo=,iv:9+fq1Up4NYDQOORtd6CgSewJhtzc0qJ81IGS4sefwu8=,tag:Q2+IB/GdPYmYFqfcV66/vQ==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:PPELguk2n3N0l/+9ywcmeJWal9cQnafYdPnuZok=,iv:V20Ty8Fod4+sXx05H+VJAAziZKXtU+zQ6vCjSz5oVkY=,tag:EarVF6kWomyfdtH+gsoJrA==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:/2ZrFphgX7WkBDEm3BP8,iv:/JxS0D9a9wx0eDIuMDQCBmkJttOCRxYGqZEpcFuWUGg=,tag:xcL5ixs1fT9ReEAZTBnvqQ==,type:str]"
+	},
+	"stringData": {
+		"pgpass": "ENC[AES256_GCM,data:BHJnMx8qGoin8uS4NHAHw0/l/VA3MSpf8xCZe7YjE0+qhI0GMtnd+uvG1H+EFkO+2T5K9lhykHIvkmIfYtcQoANQqrbcEqw5CVsoFzR4WnYfe+wmoHQ4Yp54PaDEP/+V2BJKl4ZNixnvpzqrDIx17mAVD0och3303FRhSW8NpSMKuYBN3Idmwqxr0QOIOfbkO/NAeeO9BQ0EzNQe7jivdCBQrBAZjFAXV6jSleuKwULlQGlXfmlSGxbtnwBQOGY7B43GS6w8UX0GEb7EPW1xifKINcJO9t4GWNslBpEW69RBBLTE05xGpM1u49UcMCm80z00uneDvN34Q8542jkXEQQFsSCRxRwwx+W/4c8hCDaxkRHdoTq6GF3OflW2,iv:k+voBhexx2POFvK1cMF8S34gi9GI3J0OX+0wL1lyRkE=,tag:XpqgwYm5YwYQebiiwSwJdA==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:Q9EhcXyz,iv:auEQl3tdgYuXxQfphTwFGpPDYO2Ovq/grbQx9lO6aKU=,tag:bGiC/THwaytSfpeBVBAxSQ==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMdFFwdVc3NFJDZ3VKdXFw\ndTFVQ0Y3aG4vSXl6NWJCb1FDbFZmMG12RXk4CmFOYjhQSkJXK2VIQkRRWVRDdVM1\nVjNJck00b2l5bFl6enNIY0NpWWlzQVEKLS0tIHRudjc5VzVyblloSVlhVXNjeGtZ\nbjBEU1owVUNJOVVISGw1ZHhFUjRDN2cKky67kIAgJoVmiL4Y6KDnsbR+dmimrHzf\nK/41/+bV9GK66/aVHoopPWY02XnR1iX4uwzmHrvPy+bU9TW+bC1ywg==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-08-24T22:05:27Z",
+		"mac": "ENC[AES256_GCM,data:4TG3LPCUpID3a0uuVnuyIe9ny9vGtB60CMSc1hJMMA1SoAZEv02QMzLyDQghl9YEBOh6kp3skhjRRn9xZiPqF9hvFuC6Rudfy/XIJQd36TSCvCn+w8sAmlpKsO/M6EBZozyxVwGQmv64CNmvbxUayn6K4q6iZ0JYvvh/rF9cCwE=,iv:WIu86ZoZgSt4jqKJ/aBDZFzJQjqfLZcZpQh6mznoE7M=,tag:QorgzOX6jbySmOaT6PYH8w==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.3"
+	}
+}

--- a/tests/test_hosted_platform_operations.py
+++ b/tests/test_hosted_platform_operations.py
@@ -1355,11 +1355,21 @@ def test_active_secret_selection_is_complete_and_the_signer_publishes_a_verified
         if destination.get("kind") == "sops_k8s_secret" and destination.get("slot") == "active"
     }
     assert len(expected) == 34
-    assert selection == {"schema_version": 1, "destinations": {name: "v1" for name in expected}}
+    assert selection["schema_version"] == 1
+    assert set(selection["destinations"]) == expected
     assert all(
-        (ROOT / destination["target"].format(version="v1")).is_file()
+        re.fullmatch(r"v[1-9][0-9]*", version)
+        for version in selection["destinations"].values()
+    )
+    assert all(
+        (
+            ROOT
+            / destination["target"].format(
+                version=selection["destinations"][destination_id]
+            )
+        ).is_file()
         for secret in matrix["secrets"].values()
-        for destination in secret["destinations"].values()
+        for destination_id, destination in secret["destinations"].items()
         if destination.get("kind") == "sops_k8s_secret" and destination.get("slot") == "active"
     )
 


### PR DESCRIPTION
## Why

Rotate the hosted database-backup credential after the previous owner password stopped authenticating. Select the encrypted v2 artifact without changing the application database credential.

The active-selection contract test now remains fail-closed on the exact 34 governed destinations while permitting an immutable destination to select a version newer than v1. It also proves every selected encrypted artifact exists.

## Verification

- Secret/platform tests: 80 passed, 1 skipped (real SOPS environment opt-in)
- Focused selection/signing tests: 31 passed, 1 skipped, 49 deselected
- Ruff on changed test: passed
- Repository privacy gate: 3,283 files / 3,351 text payloads clean
- Signed 34-destination active registry: verify-only passed
- Encrypted v2 payload decrypts exactly to the rotated protected source

No plaintext credential is committed.