### PR TITLE
fix(hosted): rotate provisioner database credential

### DIFF
--- a/infra/contracts/active-secret-selection-v1.json
+++ b/infra/contracts/active-secret-selection-v1.json
@@ -16,7 +16,7 @@
     "k3s.provisioner.database-backup-restore-key.active": "v1",
     "k3s.provisioner.database-backup-upload-key-id.active": "v1",
     "k3s.provisioner.database-backup-upload-key.active": "v1",
-    "k3s.provisioner.database-url.active": "v1",
+    "k3s.provisioner.database-url.active": "v2",
     "k3s.provisioner.hcloud-token.active": "v1",
     "k3s.provisioner.recovery-delete-key-id.active": "v1",
     "k3s.provisioner.recovery-delete-key.active": "v1",

--- a/infra/secrets/provisioner/database-url.v2.sops.json
+++ b/infra/secrets/provisioner/database-url.v2.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:6aQ=,iv:FImcHVumbhmKR7ugAFq6p5q936zAevSBO3ocMR3NW7A=,tag:M2UQKX86HTA6duBCy4p/+w==,type:str]",
+	"kind": "ENC[AES256_GCM,data:DIIf4wuX,iv:A2fyN2EWm2plVNs7dXaFSCZMEuDVoXnEID1KG12nV9o=,tag:70N1BO1SLeikjN0p0Incag==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:J+QhM8OjEuaBd1NWoK018pzTMnuj,iv:TVsHog+f5jhQ4rEGLkANFOVRbOpFfMH6dvh8RqKppcA=,tag:VTnqW2QQiS6V/Rd8zLoQ4A==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:xAI=,iv:eqOhTseqLx5io9xH/3jLIzDWoozLmi7d744X09/22Mg=,tag:dULr3wUyZS9ppP66j2HSIQ==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:hVR/EfzUPFB+9aDt8M1EwB8YTrJyWF3AFrYj,iv:MQ4Ay/P64xII9MOKAjzJDfQ6yVACeL1bd0MPCgXpMwE=,tag:exg/3mLyQnLUq4nJ9NNzXA==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:ow8rAEt5kvYXge97No5b,iv:RaQMQlhlwUMMRdYA7YU7F6RpyPI7grEOkRsAHFaSebY=,tag:ONnQWljEKfem1pVhfhnw3w==,type:str]"
+	},
+	"stringData": {
+		"url": "ENC[AES256_GCM,data:770+r05q21sYuvjt8ZbBBfA3KFQ8X2UfXSOi3tIkI+Ium7YyhT6SLgQm90PLfPOkc5SRwO4tJgoR1ge73MsIj2Q2XCTxZtvWDz59fvfyz3CGzxx59gVXk9tTFRORr/lpjttUIzbqZ+MIj6YEQJNXR5706ORoOrLAKVnlOBgW8Fl5Rdxmad385msoY6OsS4Xuu4vmj3nCEBt86MgpBaSdrdsTFWM9yyIrdB7MD14clc8WIPQxcHUT/yNO5w==,iv:4Zk6dCm7NCv4YPdn3OJPzUVFnXc+CHDHED9HJIOFtG4=,tag:TsKsq1K5f0ZHce2Lch/AvA==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:rrw4x9ZN,iv:tlptkqoZrYnuwMEhE5tmTJ57beNXAxo2oVJx3dP67AI=,tag:hx5cLIgts0RBqstVGnD/2w==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiRkxMQUpXV0R0RGExMXA2\nRGxXVE8zTHZYZGhyWW0wcnVJS2VVbGlRNlJ3CkZjYkcyZXk4MzVDWnROdzFKcVVs\nTG5MUDhkZkhKOW1KbmRIWmNjNmVZZTAKLS0tIE5OMWtJRmFyVG5EQVZqYWQzdUNm\nNFUxYVBRTTZEZkJISG1rSG5Mb0FubkUK8YGiVrlZNTu/FcGJT0qXlsoSoxoim6cX\n2+hCtQt/ZGb7t8tj/12xiW641isRoetM64PMbS4YN6gu/WaVa90KBQ==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-08-24T22:41:41Z",
+		"mac": "ENC[AES256_GCM,data:V0EJl2et9ZvAgiMehGIkNPrIn7QO4MeA6yShdv/kVTyDL2M41qeB3Xm2kq17BaPqd5Xjkq3LXSAzlEQBvKNnauk8oGRKUv2ia6vX/OLblzhRycGFTifngteF/ND649Dt0U+TtsO6PPgahxtkvpmBL93G20emhAd1NNMh2jFf7gc=,iv:StyZXZIo5FhrkLm29bAiVBKL3JfMr3UM51VBgFixEFs=,tag:DAvoACw++2oPnozK2tjk5A==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.3"
+	}
+}


### PR DESCRIPTION
## Why

Rotate the provisioner runtime database credential after it appeared in diagnostic command output. Select a new encrypted v2 Kubernetes Secret while retaining v1 for explicit post-cutover rejection proof and rollback.

## Verification

- SOPS ciphertext validation: passed
- Decrypt round-trip: same Secret identity and destination, v2 label, changed URL
- Hosted platform + secret-handoff suites: 80 passed, 1 real-SOPS opt-in skipped
- The actual handoff and decrypt used the pinned local SOPS/age tools successfully
- `git diff --check`: passed

No plaintext credential is committed.