### PR TITLE
chore(ci): move expensive gates off every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    - cron: "17 2 * * *"
+  workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && format('full-{0}', github.ref) || github.event.pull_request.number || github.ref }}
   # New pushes supersede PR feedback, but main/release evidence must finish.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
@@ -18,10 +21,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Compatibility boundaries are sufficient here: 3.11 is the minimum
-        # supported runtime and 3.13 is the newest. Testing the middle release
-        # duplicated the full lean suite without expanding the support range.
-        python-version: ["3.11", "3.13"]
+        # PRs and main pushes pay for the newest runtime only. The minimum
+        # supported runtime joins on nightly/manual runs and release PRs, where
+        # compatibility evidence is useful without doubling every feedback run.
+        python-version: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'release-please--branches--main')) && fromJSON('["3.11", "3.13"]') || fromJSON('["3.13"]') }}
         # Separate runners keep process, port, filesystem, and mutation-lock
         # state isolated while cutting the serial critical path by roughly 4x.
         shard: [1, 2, 3, 4]
@@ -215,6 +218,7 @@ jobs:
 
   retrieval-quality:
     name: retrieval quality (golden gate, embeddings)
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'release-please--branches--main') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -241,6 +245,7 @@ jobs:
 
   retrieval-latency:
     name: retrieval latency (2k synthetic vault)
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'release-please--branches--main') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -259,6 +264,7 @@ jobs:
 
   governance-projection-wire:
     name: governance projected wire characterization (${{ matrix.route }})
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'release-please--branches--main') }}
     runs-on: ubuntu-latest
     timeout-minutes: 8
     strategy:
@@ -288,6 +294,7 @@ jobs:
 
   semantic-write-latency:
     name: semantic write latency (2k and 8k)
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'release-please--branches--main') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -306,6 +313,7 @@ jobs:
 
   graph-convergence:
     name: graph convergence (concurrent writer)
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'release-please--branches--main') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -349,6 +357,7 @@ jobs:
 
   docker:
     name: docker (lean build + smoke)
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'release-please--branches--main') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -519,10 +528,18 @@ jobs:
       - lint
     runs-on: ubuntu-latest
     steps:
-      - name: Require every CI job to succeed
+      - name: Require the selected CI tier to succeed
         env:
           RESULTS: ${{ join(needs.*.result, ' ') }}
+          FULL_CI: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'release-please--branches--main') }}
         run: |
           for result in $RESULTS; do
-            test "$result" = success
+            if test "$result" = success; then
+              continue
+            fi
+            if test "$FULL_CI" != true && test "$result" = skipped; then
+              continue
+            fi
+            echo "unexpected CI result for full_ci=$FULL_CI: $result" >&2
+            exit 1
           done

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -15,13 +15,16 @@ name: cross-platform
 # with WinError 32 -- a failure mode Linux does not have. Four such defects were
 # found manually against this suite before this lane existed.
 #
-# Promote to a required gate once it is green across a few merges. An advisory
-# lane that stays advisory forever is just noise.
+# It is intentionally a full-confidence lane: nightly, manual, and release PRs
+# only. Ordinary PRs already exercise the focused native-NTFS contract in the
+# required workflow, so repeating four full Windows shards there spends the
+# whole repository runner allowance before Linux feedback can start.
 
 on:
-  push:
-    branches: [main]
   pull_request:
+  schedule:
+    - cron: "41 2 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: cross-platform-${{ github.event.pull_request.number || github.ref }}
@@ -30,48 +33,20 @@ concurrency:
 jobs:
   suite:
     name: tests (${{ matrix.os }}, py3.13, shard ${{ matrix.shard }}/4)
-    # Not for the release bot's version-bump PR. Its diff is a version string
-    # and a changelog; it carries no code this lane could say anything about,
-    # and `main` runs the lane on push immediately after it merges. The bot
-    # force-pushes that branch on every merge to main -- twenty times in one
-    # release cycle here -- and each force-push relaunched the whole matrix
-    # into a queue that real PRs were waiting in. macOS runners cap at five
-    # concurrent jobs for a public repo on the free tier, so those launches
-    # were not free capacity; they were the queue.
+    # A normal PR produces one cheap skipped check. The full matrix runs on the
+    # nightly/manual confidence lanes and once more for the exact release tree.
     if: >-
-      github.event_name != 'pull_request'
-      || !startsWith(github.head_ref, 'release-please--branches--')
+      github.event_name == 'schedule'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && github.head_ref == 'release-please--branches--main')
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        # macOS on merge; Windows on everything.
-        #
-        # These two runners are not equally scarce and do not buy equally much.
-        # A public repo on the free tier may run 20 jobs at once but only FIVE
-        # on macOS, so a four-shard macOS matrix cannot fit twice: two open PRs
-        # want eight macOS jobs, the second run's shards sit queued, and because
-        # a run's jobs are scheduled together the whole second run stalls behind
-        # the first. Going to four shards halved one run's wall clock and
-        # serialised the runs against each other -- with three PRs in flight the
-        # queue got longer, not shorter. Measured here: 16 runs queued behind 2
-        # in progress, both of them this lane.
-        #
-        # What macOS buys before a merge is also the smaller half. Everything
-        # this lane's header describes -- CPython opening files without
-        # FILE_SHARE_DELETE, WinError 32 refusing os.replace, backslash
-        # separators reaching a dict key -- is Windows behaviour, and Windows is
-        # where every defect this lane has actually caught has been. macOS
-        # shares POSIX file semantics and path separators with the ubuntu lane
-        # in ci.yml that already runs on every PR, so its marginal coverage
-        # pre-merge is thin. Paying the scarcest runner for the thinnest
-        # coverage is backwards.
-        #
-        # So PRs get Windows, where the defects are and where the cap is not,
-        # and pushes to main get both. No commit stops reaching macOS; it
-        # reaches it one merge later, on a lane that is advisory by design.
-        os: ${{ github.event_name == 'pull_request' && fromJSON('["windows-latest"]') || fromJSON('["windows-latest", "macos-latest"]') }}
+        os: [windows-latest, macos-latest]
         # Four shards, matching the Linux lane. This lane still exists to
         # expose platform behaviour rather than to be the fastest path to a
         # result -- but two shards made it the SLOWEST path by a wide margin: a

--- a/tests/test_ci_reliability_contract.py
+++ b/tests/test_ci_reliability_contract.py
@@ -7,6 +7,20 @@ import yaml
 
 ROOT = Path(__file__).parents[1]
 
+FULL_CI_JOBS = {
+    "retrieval-quality",
+    "retrieval-latency",
+    "governance-projection-wire",
+    "semantic-write-latency",
+    "graph-convergence",
+    "docker",
+}
+
+
+def _triggers(workflow: dict) -> dict:
+    # PyYAML 1.1 parses the unquoted workflow key `on` as boolean true.
+    return workflow.get("on") or workflow[True]
+
 
 def _workflow() -> dict:
     return yaml.safe_load((ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8"))
@@ -48,7 +62,14 @@ def test_lean_python_lanes_use_four_duration_balanced_isolated_shards() -> None:
     job = workflow["jobs"]["test"]
     matrix = job["strategy"]["matrix"]
 
-    assert matrix["python-version"] == ["3.11", "3.13"]
+    versions = " ".join(str(matrix["python-version"]).split())
+    assert "github.event_name == 'schedule'" in versions
+    assert "github.event_name == 'workflow_dispatch'" in versions
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in versions
+    assert "github.head_ref == 'release-please--branches--main'" in versions
+    assert "startsWith(github.head_ref" not in versions
+    assert '["3.11", "3.13"]' in versions
+    assert '["3.13"]' in versions
     assert matrix["shard"] == [1, 2, 3, 4]
     assert job["name"] == "tests (py${{ matrix.python-version }}, shard ${{ matrix.shard }}/4)"
 
@@ -230,11 +251,42 @@ def test_governance_wire_characterization_runs_every_registered_route() -> None:
     assert "governance-projection-wire" in workflow["jobs"]["gate"]["needs"]
 
 
-def test_superseded_pr_runs_cancel_and_one_stable_gate_requires_every_ci_job() -> None:
+def test_expensive_ci_runs_nightly_manually_and_for_release_prs_only() -> None:
+    workflow = _workflow()
+    triggers = _triggers(workflow)
+
+    assert triggers["schedule"] == [{"cron": "17 2 * * *"}]
+    assert "workflow_dispatch" in triggers
+
+    jobs = workflow["jobs"]
+    assert FULL_CI_JOBS < set(jobs)
+    conditions = {
+        " ".join(str(jobs[name].get("if", "")).split()) for name in FULL_CI_JOBS
+    }
+    assert len(conditions) == 1
+    condition = conditions.pop()
+    assert "github.event_name == 'schedule'" in condition
+    assert "github.event_name == 'workflow_dispatch'" in condition
+    assert "github.event_name == 'pull_request'" in condition
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in condition
+    assert "github.head_ref == 'release-please--branches--main'" in condition
+    assert "startsWith(github.head_ref" not in condition
+
+    fast_jobs = set(jobs) - FULL_CI_JOBS - {"gate"}
+    assert fast_jobs
+    assert all("if" not in jobs[name] for name in fast_jobs)
+
+
+def test_superseded_pr_runs_cancel_and_one_stable_gate_covers_both_tiers() -> None:
     workflow = _workflow()
 
     assert workflow["concurrency"] == {
-        "group": "ci-${{ github.event.pull_request.number || github.ref }}",
+        "group": (
+            "ci-${{ (github.event_name == 'schedule' || "
+            "github.event_name == 'workflow_dispatch') && "
+            "format('full-{0}', github.ref) || "
+            "github.event.pull_request.number || github.ref }}"
+        ),
         "cancel-in-progress": "${{ github.event_name == 'pull_request' }}",
     }
 
@@ -243,6 +295,11 @@ def test_superseded_pr_runs_cancel_and_one_stable_gate_requires_every_ci_job() -
     assert gate["if"] == "${{ !cancelled() }}"
     assert set(gate["needs"]) == set(workflow["jobs"]) - {"gate"}
     assert gate["steps"][0]["env"]["RESULTS"] == "${{ join(needs.*.result, ' ') }}"
+    assert "FULL_CI" in gate["steps"][0]["env"]
+    command = gate["steps"][0]["run"]
+    assert 'test "$result" = success' in command
+    assert 'test "$result" = skipped' in command
+    assert 'test "$FULL_CI" != true' in command
 
 
 def test_native_held_filesystem_has_a_required_ntfs_gate() -> None:
@@ -289,44 +346,24 @@ def test_the_cross_platform_split_count_matches_its_shard_matrix() -> None:
     assert job["name"].endswith(f"shard ${{{{ matrix.shard }}}}/{len(shards)})")
 
 
-def test_the_release_bot_branch_does_not_launch_the_cross_platform_matrix() -> None:
-    """Its diff is a version string; `main` runs this lane on push regardless.
+def test_cross_platform_matrix_runs_nightly_manually_and_for_releases() -> None:
+    workflow = _cross_platform_workflow()
+    triggers = _triggers(workflow)
 
-    The bot force-pushes that branch on every merge to main, and each push
-    relaunched the whole matrix into a queue real PRs were waiting in. macOS
-    runners cap at five concurrent jobs for a public repo on the free tier, so
-    those launches were not spare capacity -- they were the queue.
-    """
-    condition = " ".join(_cross_platform_workflow()["jobs"]["suite"]["if"].split())
+    assert "push" not in triggers
+    assert triggers["schedule"] == [{"cron": "41 2 * * *"}]
+    assert "workflow_dispatch" in triggers
+    assert "pull_request" in triggers
 
-    assert "release-please--branches--" in condition
-    # Skipped for that branch's PR, never for a push to main.
-    assert "github.event_name != 'pull_request'" in condition
-
-
-def test_the_capped_runner_is_paid_on_merge_not_on_every_pull_request() -> None:
-    """macOS caps at five concurrent jobs; a four-shard matrix cannot fit twice.
-
-    Two open PRs want eight macOS jobs against that cap, so the second run's
-    shards queue -- and a run's jobs are scheduled together, so the whole second
-    run stalls behind the first. That is a throughput cliff with no visible
-    symptom: every run still goes green, just later and later, and the obvious
-    reading is "CI is slow" rather than "these runs cannot overlap".
-
-    Asserted rather than reviewed because the tempting edit -- putting macOS
-    back on the pull_request arm "for parity" -- reintroduces the cliff while
-    looking like strictly more coverage.
-    """
-    matrix = _cross_platform_workflow()["jobs"]["suite"]["strategy"]["matrix"]
-    expression = " ".join(str(matrix["os"]).split())
-    pull_request_arm, _, push_arm = expression.partition("||")
-
-    assert "github.event_name == 'pull_request'" in pull_request_arm
-    assert "windows-latest" in pull_request_arm
-    assert "macos-latest" not in pull_request_arm, (
-        "the capped runner is back on every PR; two concurrent PRs will serialise"
-    )
-    # A push to main still runs both, so no commit stops reaching macOS -- it
-    # reaches it one merge later, on a lane that is advisory by design.
-    assert "macos-latest" in push_arm
-    assert "windows-latest" in push_arm
+    job = workflow["jobs"]["suite"]
+    condition = " ".join(job["if"].split())
+    assert "github.event_name == 'schedule'" in condition
+    assert "github.event_name == 'workflow_dispatch'" in condition
+    assert "github.event_name == 'pull_request'" in condition
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in condition
+    assert "github.head_ref == 'release-please--branches--main'" in condition
+    assert "startsWith(github.head_ref" not in condition
+    assert job["strategy"]["matrix"]["os"] == [
+        "windows-latest",
+        "macos-latest",
+    ]


### PR DESCRIPTION
## Why

Every ordinary pull request currently fans out the full 33-job confidence suite. With several merges in flight, obsolete Linux, Windows, and macOS matrices consume every runner and leave the actual release candidate queued.

## What changed

- Keep four Python 3.13 lean shards plus focused NTFS, TUI, product E2E, onboarding, OpenSpec, build, capabilities, and lint checks on ordinary PRs and main pushes.
- Run Python 3.11 compatibility, retrieval quality/latency, semantic latency, graph convergence, Docker, and the governance route matrix nightly, manually, and for the exact Release Please PR.
- Run the full Windows/macOS matrix nightly, manually, and for the exact Release Please PR instead of every PR/main push.
- Require same-repository provenance and the exact release branch before enabling expensive release lanes.
- Isolate nightly/manual concurrency from main-push concurrency so a normal push cannot replace pending full evidence.

## Verification

- All 12 CI reliability contract functions pass when invoked directly.
- Workflow YAML parsing and `git diff --check` pass.
- Independent adversarial review found and verified fixes for release-branch spoofing and full-run concurrency collision.
- Standard pytest execution is unavailable in this restricted Windows token because pytest cannot create its temp lock; this is the known host DACL boundary, not a test failure.