### PR TITLE
fix(runtime): allow real-vault readiness snapshots

### DIFF
--- a/src/exomem/runtime_readiness.py
+++ b/src/exomem/runtime_readiness.py
@@ -23,7 +23,13 @@ log = logging.getLogger(__name__)
 # cadence of at least one probe per five minutes rather than one late burst.
 SILENT_TRAFFIC_WINDOW_SECONDS = 24 * 60 * 60
 SILENT_TRAFFIC_MINIMUM_HEALTH_PROBES = 288
-COORDINATION_STATUS_TIMEOUT_SECONDS = 0.25
+# A 2.4k-note Windows vault needs about 0.27 seconds to read its mutation
+# boundary plus graph epoch under memory pressure.  The former 0.25-second
+# ceiling therefore rejected ordinary work and made successive readiness
+# probes alternate 503/200 as the second probe reused the first one's late
+# result.  Keep a hard sub-second bound, with enough headroom for the measured
+# steady state; genuinely blocked graph publication still fails closed.
+COORDINATION_STATUS_TIMEOUT_SECONDS = 0.75
 
 _COORDINATION_PROBES_LOCK = threading.Lock()
 _COORDINATION_PROBES: dict[str, tuple[threading.Event, dict[str, object]]] = {}

--- a/tests/test_runtime_readiness.py
+++ b/tests/test_runtime_readiness.py
@@ -236,6 +236,7 @@ def test_runtime_readiness_fails_closed_within_a_tight_bound_when_status_blocks(
     monkeypatch.setattr(session_validation_cache, "session_store_readiness", lambda: {})
     monkeypatch.setattr(readiness_module, "_measure_observability", lambda: {})
 
+    assert readiness_module.COORDINATION_STATUS_TIMEOUT_SECONDS < 1.0
     started = time.monotonic()
     try:
         snapshot = readiness_module.runtime_readiness(
@@ -246,7 +247,7 @@ def test_runtime_readiness_fails_closed_within_a_tight_bound_when_status_blocks(
         release.set()
 
     assert entered.is_set()
-    assert time.monotonic() - started < 0.75
+    assert time.monotonic() - started < 1.25
     assert snapshot["status"] == "not_ready"
     assert snapshot["takeover_eligible"] is False
     assert snapshot["reasons"] == ["coordination_status_timeout"]
@@ -254,6 +255,50 @@ def test_runtime_readiness_fails_closed_within_a_tight_bound_when_status_blocks(
         "state": "unknown",
         "reason": "status_timeout",
     }
+
+
+def test_runtime_readiness_admits_a_slow_but_bounded_real_vault_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A normal large-vault snapshot must not trip the fail-fast ceiling.
+
+    The 2.4k-note Windows service takes about 0.27 seconds to read the mutation
+    boundary and graph epoch under memory pressure.  The former 0.25-second
+    ceiling therefore alternated 503 and 200 as each late result was reused by
+    the following probe.  Preserve sub-second failure for a genuinely blocked
+    snapshot while leaving measured steady-state work enough headroom.
+    """
+    from exomem import runtime_readiness as readiness_module
+    from exomem import session_validation_cache, writer_lease
+
+    vault = tmp_path / "large-vault"
+
+    def slow_coordination_status(_vault_root=None):  # noqa: ANN001
+        time.sleep(0.35)
+        return {
+            "enabled": False,
+            "role": "standalone",
+            "replica_id": None,
+            "coordinator_healthy": True,
+            "mutation_boundary": {"state": "free"},
+        }
+
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(vault))
+    monkeypatch.setattr(writer_lease, "coordination_status", slow_coordination_status)
+    monkeypatch.setattr(session_validation_cache, "session_store_readiness", lambda: {})
+    monkeypatch.setattr(readiness_module, "_measure_observability", lambda: {})
+
+    started = time.monotonic()
+    snapshot = readiness_module.runtime_readiness(
+        mcp_tool_surface_sha256="a" * 64,
+        traffic={},
+    )
+
+    assert time.monotonic() - started < 1.25
+    assert snapshot["status"] == "ready"
+    assert snapshot["takeover_eligible"] is True
+    assert snapshot["reasons"] == []
+    assert snapshot["coordination"]["mutation_boundary"] == {"state": "free"}
 
 
 def test_bounded_coordination_status_is_single_flight_and_reuses_late_result(


### PR DESCRIPTION
## Why

The v0.60.0 readiness guard correctly prevents multi-minute hangs, but its 250 ms coordination-status budget is below the measured ~270 ms steady-state cost of the live 2.4k-note Windows vault. Fresh probes therefore alternated 503 and 200 as the following probe reused the first probe's late result.

## Change

- raise the hard coordination-status ceiling to 750 ms
- retain fail-closed, sub-second behavior for a genuinely blocked snapshot
- add a regression for a 350 ms legitimate snapshot
- pin the configured ceiling below one second

## Verification

- red reproduction: 350 ms snapshot returned `None` under the 250 ms budget
- green direct regression: 350 ms snapshot admitted under the 750 ms budget
- blocked snapshot still failed closed in ~0.76 s
- independent reviewer reproduced four 270-272 ms successful probes and the bounded failure; no findings remain
- Ruff correctness (`--select F`) passed for both changed files
- `git diff --check` passed
- public artifact privacy gate passed over 3,284 files / 3,353 text payloads

The normal pytest runner is blocked in this Codex restricted Windows token while cleaning its own temporary directory (`WinError 5`); the two regression functions were executed directly, and CI remains authoritative for the full suite.