### PR TITLE
feat(governance): certify CPU vector profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,45 @@ jobs:
           tests/test_governance_projection_wire_gate.py
           --session-timeout=360
 
+  governance-projection-wire-vector-cpu:
+    name: governance projected vector CPU wire (${{ matrix.route }})
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    strategy:
+      fail-fast: false
+      matrix:
+        route: [keyword, bm25, vector-live, rerank-hard-off, clip-hard-off, graph, graph-rerank-hard-off, max-query, max-limit, max-shape, hidden-index-missing, pagination]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Cache the certified BGE vector model
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-bge-base-en-v1.5-vector-cpu-v1
+      - name: Verify lockfile is current
+        run: uv lock --check
+      - name: Certify exact-capacity hidden-corpus vector CPU routes
+        env:
+          EXOMEM_GOVERNANCE_TIMING_PROFILE: vectors-cpu-torch-v1
+          EXOMEM_GOVERNANCE_TIMING_ROUTE: ${{ matrix.route }}
+          EXOMEM_DISABLE_MEDIA_EXTRACTION: "1"
+          EXOMEM_DISABLE_CLIP: "1"
+          EXOMEM_DISABLE_RANKING: "1"
+          EXOMEM_DEVICE: cpu
+          EXOMEM_EMBED_BACKEND: torch
+          OMP_NUM_THREADS: "1"
+          MKL_NUM_THREADS: "1"
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: >-
+          uv run --frozen --extra embeddings --python 3.13 python -m pytest -q
+          tests/test_governance_projection_wire_gate.py
+          --session-timeout=600
+
   semantic-write-latency:
     name: semantic write latency (2k and 8k)
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'release-please--branches--main') }}
@@ -518,6 +557,7 @@ jobs:
       - retrieval-quality
       - retrieval-latency
       - governance-projection-wire
+      - governance-projection-wire-vector-cpu
       - semantic-write-latency
       - graph-convergence
       - onboarding

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
 
   governance-projection-wire-vector-cpu:
     name: governance projected vector CPU wire (${{ matrix.route }})
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'release-please--branches--main') }}
     runs-on: ubuntu-latest
     timeout-minutes: 12
     strategy:

--- a/benchmarks/governance/projected-wire-vector-cpu-release-v1.json
+++ b/benchmarks/governance/projected-wire-vector-cpu-release-v1.json
@@ -1,0 +1,39 @@
+{
+  "schema": "exomem.governed-projection-timing-release/v1",
+  "hidden_corpus_wire_delta_ms": 25,
+  "sample_count_per_condition": 200,
+  "bootstrap_resamples": 2000,
+  "bootstrap_seed": 20260822,
+  "hardware_runtime_profile": "github-hosted-ubuntu-latest-x64-python3.13",
+  "model_runtime_profile": "vectors-cpu-torch-v1",
+  "request_classes": [
+    {
+      "name": "projected-find-vector-cpu-v1",
+      "padding_ms": 1000,
+      "deadline_ms": 1500,
+      "max_query_chars": 4096,
+      "max_limit": 100
+    }
+  ],
+  "routes": [
+    "keyword",
+    "bm25",
+    "vector-live",
+    "rerank-hard-off",
+    "clip-hard-off",
+    "graph",
+    "graph-rerank-hard-off",
+    "max-query",
+    "max-limit",
+    "max-shape",
+    "hidden-index-missing",
+    "pagination"
+  ],
+  "capacity": {
+    "catalog_items": 16384,
+    "searchable_bytes_per_item": 1048576,
+    "graph_edges": 262144
+  },
+  "scheduler_tolerance_subtracted": false,
+  "padding_selected_before_sampling": true
+}

--- a/openspec/changes/harden-governance-for-consolidation/design.md
+++ b/openspec/changes/harden-governance-for-consolidation/design.md
@@ -753,6 +753,21 @@ replicas, covers zero, one, and the exact maximum supported capacity across lexi
 vector, rerank, CLIP, graph, error, and pagination paths, and computes 99% bootstrap
 upper confidence bounds for absolute median and p95 completion-time differences.
 
+Model execution is released as a closed profile, not one ambient "models enabled"
+switch. A manifest, route set, completion class, exact device/backend/hard-off tuple, and
+required measurement families belong to exactly one profile and cannot certify another.
+The first live-model profile is `vectors-cpu-torch-v1`: text embeddings are enabled with
+`EXOMEM_DEVICE=cpu` and `EXOMEM_EMBED_BACKEND=torch`, the embedding and legacy device
+overrides are absent, and CLIP plus reranking remain hard-off. It requires an exact
+`projected-text-v1`/`BAAI/bge-base-en-v1.5` vector family before serving and uses the
+repository class `projected-find-vector-cpu-v1` (1,000 ms padding, 1,500 ms deadline).
+Only the vector-model input uses `" ".join(query.split())`, capped to the first 600
+Unicode code points and retreated to the preceding complete U+0020-delimited token when
+truncated. Lexical acquisition and the request/continuation digest retain the full
+validated public query. This bound is fixed before characterization and cannot be
+caller-, manifest-, or observation-selected. Reranker-, CLIP-, GPU-, ONNX-, mixed-, and
+override-bearing configurations remain non-serving until separately characterized.
+
 For each route and public request class, both upper bounds must be no greater than all
 three applicable ceilings: the manifest differential, 25 ms absolute, and 10% of the
 physically-absent replica's measured p95. The same fixed public deadline and padding are

--- a/openspec/changes/harden-governance-for-consolidation/design.md
+++ b/openspec/changes/harden-governance-for-consolidation/design.md
@@ -758,7 +758,8 @@ switch. A manifest, route set, completion class, exact device/backend/hard-off t
 required measurement families belong to exactly one profile and cannot certify another.
 The first live-model profile is `vectors-cpu-torch-v1`: text embeddings are enabled with
 `EXOMEM_DEVICE=cpu` and `EXOMEM_EMBED_BACKEND=torch`, the embedding and legacy device
-overrides are absent, and CLIP plus reranking remain hard-off. It requires an exact
+overrides are absent, `OMP_NUM_THREADS=1` and `MKL_NUM_THREADS=1`, and CLIP plus
+reranking remain hard-off. It requires an exact
 `projected-text-v1`/`BAAI/bge-base-en-v1.5` vector family before serving and uses the
 repository class `projected-find-vector-cpu-v1` (1,000 ms padding, 1,500 ms deadline).
 Only the vector-model input uses `" ".join(query.split())`, capped to the first 600

--- a/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
+++ b/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
@@ -224,6 +224,21 @@ replicas for zero, one, and the exact maximum capacity across lexical, vector, r
 CLIP, graph, error, and pagination routes. Scheduler tolerance MAY be reported but MUST
 NOT be subtracted from observations or added to a ceiling.
 
+Each model execution profile SHALL have a closed literal identity, exact device/backend/
+hard-off configuration, exact required measurement families, exact route set, and exactly
+one repository-owned completion class. Evidence or a manifest for one profile MUST NOT
+activate another profile. `vectors-cpu-torch-v1` SHALL mean text embeddings enabled,
+`EXOMEM_DEVICE=cpu`, `EXOMEM_EMBED_BACKEND=torch`, absent per-model and legacy device
+overrides for the embedding lane, CLIP hard-off, and reranking hard-off. It SHALL require
+the exact active
+`projected-text-v1`/`BAAI/bge-base-en-v1.5` vector family and SHALL use only
+`projected-find-vector-cpu-v1` with 1,000 ms padding and a 1,500 ms deadline. Its vector
+model input SHALL normalize whitespace with `" ".join(query.split())`, retain at most
+the first 600 Unicode code points, and, when truncated and a U+0020 exists, retreat to
+the preceding complete token. This model-only transform MUST NOT alter lexical input or
+the full-query request/continuation binding. Every unregistered, mixed, override-bearing,
+GPU, ONNX, reranker-active, or CLIP-active profile SHALL remain non-serving.
+
 For every route/public request class, the 99% bootstrap upper confidence bounds for
 absolute median and p95 completion-time differences SHALL each be no greater than the
 manifest differential, 25 ms, and 10% of the physically-absent p95. Both conditions
@@ -241,6 +256,19 @@ identity or authorization bearers.
   absent
 - **THEN** the serialized top-k permitted results, their order, ranks, and shown count
   are byte-identical
+
+#### Scenario: Vector evidence cannot be borrowed by another runtime
+
+- **WHEN** an operator relabels hard-off evidence, supplies a device override, omits the
+  exact vector family, or enables reranking or CLIP under the vector CPU profile
+- **THEN** projected serving refuses before model invocation or content disclosure
+
+#### Scenario: Maximum public query has a fixed vector cost
+
+- **WHEN** a valid 4,096-code-point query reaches `vectors-cpu-torch-v1`
+- **THEN** lexical lanes and request binding use that complete query while the vector
+  model receives only the fixed canonical at-most-600-code-point projection used by the
+  release gate
 
 #### Scenario: Projection-only lexical match is acquired
 

--- a/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
+++ b/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
@@ -229,8 +229,8 @@ hard-off configuration, exact required measurement families, exact route set, an
 one repository-owned completion class. Evidence or a manifest for one profile MUST NOT
 activate another profile. `vectors-cpu-torch-v1` SHALL mean text embeddings enabled,
 `EXOMEM_DEVICE=cpu`, `EXOMEM_EMBED_BACKEND=torch`, absent per-model and legacy device
-overrides for the embedding lane, CLIP hard-off, and reranking hard-off. It SHALL require
-the exact active
+overrides for the embedding lane, `OMP_NUM_THREADS=1`, `MKL_NUM_THREADS=1`, CLIP
+hard-off, and reranking hard-off. It SHALL require the exact active
 `projected-text-v1`/`BAAI/bge-base-en-v1.5` vector family and SHALL use only
 `projected-find-vector-cpu-v1` with 1,000 ms padding and a 1,500 ms deadline. Its vector
 model input SHALL normalize whitespace with `" ".join(query.split())`, retain at most

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -542,9 +542,17 @@ made before both PRs and their combined verification are complete.
   public-request deadline/padding classes; fail if either bound exceeds any ceiling or
   maximum capacity cannot complete. Do not claim cryptographic constant time or pass by
   deleting timing fields; keep server-only aggregates content- and bearer-free.
+- [x] 8.15a Register the exact `vectors-cpu-torch-v1` model/device/hard-off tuple and its
+  distinct 1,000/1,500 ms completion class; bind serving to the exact active vector
+  measurement family, refuse mixed/override configurations, and cap only vector-model
+  query input with the fixed 600-code-point whole-token projection.
 - [ ] 8.16 Run the full no-model counterfactual and exact-capacity actual-wire suites, then optional live
   embedding/reranker and CLIP lanes behind their existing soft-fail/marker gates; no
   optional-model absence may skip keyword/graph or the declared timing security oracle.
+- [ ] 8.16a Check in and pass the separate `vectors-cpu-torch-v1` 12-route actual-wire
+  manifest/matrix with 200 hidden-present and 200 physically-absent REST observations per
+  route at zero/one/exact capacity. Keep reranker, CLIP, GPU, ONNX, and mixed profiles
+  closed pending their own evidence.
 
 ## 9. Integration Migration And Regression Gates
 

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -543,7 +543,8 @@ made before both PRs and their combined verification are complete.
   maximum capacity cannot complete. Do not claim cryptographic constant time or pass by
   deleting timing fields; keep server-only aggregates content- and bearer-free.
 - [x] 8.15a Register the exact `vectors-cpu-torch-v1` model/device/hard-off tuple and its
-  distinct 1,000/1,500 ms completion class; bind serving to the exact active vector
+  distinct single-threaded 1,000/1,500 ms completion class; bind serving to the exact
+  active vector
   measurement family, refuse mixed/override configurations, and cap only vector-model
   query input with the fixed 600-code-point whole-token projection.
 - [ ] 8.16 Run the full no-model counterfactual and exact-capacity actual-wire suites, then optional live

--- a/src/exomem/governance/projection_runtime.py
+++ b/src/exomem/governance/projection_runtime.py
@@ -59,29 +59,49 @@ _PROJECTED_CONTINUATION_DOMAIN = b"exomem.projected-find-continuation.v1\0"
 _VISIBLE_SNAPSHOT_DOMAIN = b"exomem.projected-visible-snapshot.v1\0"
 _AUTHORIZATION_MAP_DOMAIN = b"exomem.projected-authorization-map.v1\0"
 _VISIBLE_AUTHORIZATION_DOMAIN = b"exomem.projected-visible-authorization.v1\0"
-# Repository-owned release fence. The checked release manifest and required
-# actual-wire CI matrix currently certify only the exact model-hard-off runtime
-# profile. Environment cannot opt an uncertified model-enabled profile into
-# serving; those configurations remain closed until their own evidence lands.
-# The model-hard-off implementation is accepted only with the repository-owned
-# actual-wire matrix, including hidden-only missing-index reduction and a real
-# second-page continuation. Model-enabled profiles remain closed.
+_PROJECTED_VECTOR_QUERY_MAX_CODEPOINTS = 600
+# Repository-owned release fence. Checked manifests and required actual-wire CI
+# matrices certify the exact hard-off and CPU/Torch-vector profiles. Environment
+# cannot opt any other model configuration into serving; reranker, CLIP, GPU,
+# ONNX, mixed, and device-override profiles remain closed until their own evidence
+# lands. Both accepted profiles include hidden-only missing-index reduction and a
+# real second-page continuation.
 _PROJECTED_SERVING_RELEASE_ACCEPTED = True
 
 
 def projected_serving_release_profile() -> str | None:
-    """Return the one repository-certified runtime profile, if exact."""
+    """Return a repository-certified runtime profile only when exact."""
 
-    if all(
-        os.environ.get(name) == "1"
-        for name in (
-            "EXOMEM_DISABLE_EMBEDDINGS",
-            "EXOMEM_DISABLE_CLIP",
-            "EXOMEM_DISABLE_RANKING",
-        )
-    ):
-        return projection_timing.MODEL_RUNTIME_PROFILE
-    return None
+    return projection_timing.model_runtime_profile_from_environment()
+
+
+def _runtime_supports_release_profile(
+    runtime: ActiveProjectionRuntime,
+    profile: str,
+) -> bool:
+    if profile == projection_timing.MODEL_RUNTIME_PROFILE:
+        return True
+    if profile != projection_timing.VECTOR_CPU_MODEL_RUNTIME_PROFILE:
+        return False
+    from .. import embeddings
+
+    return (
+        runtime.vector_index is not None
+        and runtime.vector_index.extractor_version == "projected-text-v1"
+        and runtime.vector_index.model_version == embeddings.MODEL_NAME
+    )
+
+
+def _projected_vector_query(query: str) -> str:
+    """Return the fixed, model-only query projection certified by release CI."""
+
+    normalized = " ".join(query.split())
+    if len(normalized) <= _PROJECTED_VECTOR_QUERY_MAX_CODEPOINTS:
+        return normalized
+    prefix = normalized[:_PROJECTED_VECTOR_QUERY_MAX_CODEPOINTS]
+    if " " in prefix:
+        prefix = prefix.rsplit(" ", 1)[0]
+    return prefix
 
 
 @dataclass(frozen=True, slots=True)
@@ -862,10 +882,14 @@ def load_active_projection_runtime(
     root = Path(vault_root)
     preactivated = _preactivated_runtime(root)
     if preactivated is not None:
+        release_profile = projected_serving_release_profile()
         if (
             not _PROJECTED_SERVING_RELEASE_ACCEPTED
-            or projected_serving_release_profile()
-            != projection_timing.MODEL_RUNTIME_PROFILE
+            or release_profile is None
+            or not _runtime_supports_release_profile(
+                preactivated,
+                release_profile,
+            )
         ):
             raise ProjectionRuntimeUnavailable(
                 "governed projected retrieval is unavailable"
@@ -1431,7 +1455,7 @@ def find_projected_hits(
                     query_vector = tuple(
                         float(value)
                         for value in embeddings_module.embed_texts(
-                            [query],
+                            [_projected_vector_query(query)],
                             is_query=True,
                         )[0]
                     )

--- a/src/exomem/governance/projection_timing.py
+++ b/src/exomem/governance/projection_timing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import os
 import random
 import statistics
 import time
@@ -62,9 +63,21 @@ _PROJECTED_FIND_V1 = PublicRequestClass(
     max_hidden_delta_ms=projections.MAX_HIDDEN_CORPUS_WIRE_DELTA_MS,
     max_hidden_delta_ratio=projections.MAX_HIDDEN_CORPUS_WIRE_DELTA_RATIO,
 )
+_PROJECTED_FIND_VECTOR_CPU_V1 = PublicRequestClass(
+    name="projected-find-vector-cpu-v1",
+    padding_ms=1_000,
+    deadline_ms=1_500,
+    max_query_chars=4_096,
+    max_limit=100,
+    max_hidden_delta_ms=projections.MAX_HIDDEN_CORPUS_WIRE_DELTA_MS,
+    max_hidden_delta_ratio=projections.MAX_HIDDEN_CORPUS_WIRE_DELTA_RATIO,
+)
 
 PUBLIC_REQUEST_CLASSES: Mapping[str, PublicRequestClass] = MappingProxyType(
-    {_PROJECTED_FIND_V1.name: _PROJECTED_FIND_V1}
+    {
+        _PROJECTED_FIND_V1.name: _PROJECTED_FIND_V1,
+        _PROJECTED_FIND_VECTOR_CPU_V1.name: _PROJECTED_FIND_VECTOR_CPU_V1,
+    }
 )
 
 _RELEASE_MANIFEST_SCHEMA = "exomem.governed-projection-timing-release/v1"
@@ -90,7 +103,7 @@ _REQUEST_CLASS_KEYS = frozenset(
 _CAPACITY_KEYS = frozenset(
     {"catalog_items", "searchable_bytes_per_item", "graph_edges"}
 )
-_REQUIRED_ROUTES = frozenset(
+_HARD_OFF_REQUIRED_ROUTES = frozenset(
     {
         "keyword",
         "bm25",
@@ -106,8 +119,38 @@ _REQUIRED_ROUTES = frozenset(
         "pagination",
     }
 )
+_VECTOR_CPU_REQUIRED_ROUTES = frozenset(
+    {
+        "keyword",
+        "bm25",
+        "vector-live",
+        "rerank-hard-off",
+        "clip-hard-off",
+        "graph",
+        "graph-rerank-hard-off",
+        "max-query",
+        "max-limit",
+        "max-shape",
+        "hidden-index-missing",
+        "pagination",
+    }
+)
+_ALL_REQUIRED_ROUTES = _HARD_OFF_REQUIRED_ROUTES | _VECTOR_CPU_REQUIRED_ROUTES
 _HARDWARE_RUNTIME_PROFILE = "github-hosted-ubuntu-latest-x64-python3.13"
 MODEL_RUNTIME_PROFILE = "models-hard-off-v1"
+VECTOR_CPU_MODEL_RUNTIME_PROFILE = "vectors-cpu-torch-v1"
+_PROFILE_REQUEST_CLASSES: Mapping[str, tuple[str, ...]] = MappingProxyType(
+    {
+        MODEL_RUNTIME_PROFILE: (_PROJECTED_FIND_V1.name,),
+        VECTOR_CPU_MODEL_RUNTIME_PROFILE: (_PROJECTED_FIND_VECTOR_CPU_V1.name,),
+    }
+)
+_PROFILE_REQUIRED_ROUTES: Mapping[str, frozenset[str]] = MappingProxyType(
+    {
+        MODEL_RUNTIME_PROFILE: _HARD_OFF_REQUIRED_ROUTES,
+        VECTOR_CPU_MODEL_RUNTIME_PROFILE: _VECTOR_CPU_REQUIRED_ROUTES,
+    }
+)
 _MIN_SAMPLE_COUNT_PER_CONDITION = 200
 _MIN_BOOTSTRAP_RESAMPLES = 2_000
 _TIMING_RELEASE_MANIFEST_PROOF = object()
@@ -200,7 +243,7 @@ class WireSample:
         if (
             type(self.pair_id) is not int
             or self.pair_id < 0
-            or self.route not in _REQUIRED_ROUTES
+            or self.route not in _ALL_REQUIRED_ROUTES
             or self.capacity not in {"zero", "one", "maximum"}
             or type(self.hidden_present) is not bool
         ):
@@ -300,7 +343,14 @@ def validate_release_manifest(value: object) -> TimingReleaseManifest:
         raise ProjectedRequestTimingUnavailable(
             "governed projected request timing is unavailable"
         )
-    if manifest["model_runtime_profile"] != MODEL_RUNTIME_PROFILE:
+    model_runtime_profile = manifest["model_runtime_profile"]
+    if not isinstance(model_runtime_profile, str):
+        raise ProjectedRequestTimingUnavailable(
+            "governed projected request timing is unavailable"
+        )
+    expected_class_names = _PROFILE_REQUEST_CLASSES.get(model_runtime_profile)
+    expected_routes = _PROFILE_REQUIRED_ROUTES.get(model_runtime_profile)
+    if expected_class_names is None or expected_routes is None:
         raise ProjectedRequestTimingUnavailable(
             "governed projected request timing is unavailable"
         )
@@ -338,7 +388,7 @@ def validate_release_manifest(value: object) -> TimingReleaseManifest:
                 "governed projected request timing is unavailable"
             )
         names.append(name)
-    if len(names) != len(set(names)) or set(names) != set(PUBLIC_REQUEST_CLASSES):
+    if len(names) != len(set(names)) or tuple(names) != expected_class_names:
         raise ProjectedRequestTimingUnavailable(
             "governed projected request timing is unavailable"
         )
@@ -351,7 +401,7 @@ def validate_release_manifest(value: object) -> TimingReleaseManifest:
     if (
         any(not isinstance(route, str) for route in routes)
         or len(routes) != len(set(routes))
-        or frozenset(routes) != _REQUIRED_ROUTES
+        or frozenset(routes) != expected_routes
     ):
         raise ProjectedRequestTimingUnavailable(
             "governed projected request timing is unavailable"
@@ -377,7 +427,7 @@ def validate_release_manifest(value: object) -> TimingReleaseManifest:
         bootstrap_resamples=bootstrap_resamples,
         bootstrap_seed=bootstrap_seed,
         hardware_runtime_profile=_HARDWARE_RUNTIME_PROFILE,
-        model_runtime_profile=MODEL_RUNTIME_PROFILE,
+        model_runtime_profile=model_runtime_profile,
         request_class_names=tuple(names),
         routes=frozenset(routes),
         catalog_items=expected_capacity["catalog_items"],
@@ -496,7 +546,7 @@ def release_sample_schedule(
     if (
         not isinstance(manifest, TimingReleaseManifest)
         or route not in manifest.routes
-        or route not in _REQUIRED_ROUTES
+        or route not in _ALL_REQUIRED_ROUTES
     ):
         raise ProjectedRequestTimingUnavailable(
             "governed projected request timing is unavailable"
@@ -592,7 +642,34 @@ def request_class_for_find(
         raise ProjectedRequestTimingUnavailable(
             "governed projected request timing is unavailable"
         )
+    if model_runtime_profile_from_environment() == VECTOR_CPU_MODEL_RUNTIME_PROFILE:
+        return _PROJECTED_FIND_VECTOR_CPU_V1
     return _PROJECTED_FIND_V1
+
+
+def model_runtime_profile_from_environment() -> str | None:
+    """Resolve only repository-certified, exact model execution profiles."""
+
+    if all(
+        os.environ.get(name) == "1"
+        for name in (
+            "EXOMEM_DISABLE_EMBEDDINGS",
+            "EXOMEM_DISABLE_CLIP",
+            "EXOMEM_DISABLE_RANKING",
+        )
+    ):
+        return MODEL_RUNTIME_PROFILE
+    if (
+        "EXOMEM_DISABLE_EMBEDDINGS" not in os.environ
+        and os.environ.get("EXOMEM_DISABLE_CLIP") == "1"
+        and os.environ.get("EXOMEM_DISABLE_RANKING") == "1"
+        and os.environ.get("EXOMEM_DEVICE") == "cpu"
+        and os.environ.get("EXOMEM_EMBED_BACKEND") == "torch"
+        and "EXOMEM_EMBED_DEVICE" not in os.environ
+        and "EXOMEM_TORCH_DEVICE" not in os.environ
+    ):
+        return VECTOR_CPU_MODEL_RUNTIME_PROFILE
+    return None
 
 
 def request_class_for_command(
@@ -613,6 +690,8 @@ def request_class_for_command(
     # The one class covers every registered shape up to its declared maxima,
     # plus normalized refusals. Shape-specific actual-wire routes enforce that
     # breadth; callers cannot select another padding or deadline.
+    if model_runtime_profile_from_environment() == VECTOR_CPU_MODEL_RUNTIME_PROFILE:
+        return _PROJECTED_FIND_VECTOR_CPU_V1
     return _PROJECTED_FIND_V1
 
 
@@ -692,8 +771,10 @@ __all__ = [
     "evaluate_wire_differential",
     "evaluate_wire_route",
     "fixed_public_completion",
+    "model_runtime_profile_from_environment",
     "request_class_for_command",
     "request_class_for_find",
     "release_sample_schedule",
     "validate_release_manifest",
+    "VECTOR_CPU_MODEL_RUNTIME_PROFILE",
 ]

--- a/src/exomem/governance/projection_timing.py
+++ b/src/exomem/governance/projection_timing.py
@@ -665,6 +665,8 @@ def model_runtime_profile_from_environment() -> str | None:
         and os.environ.get("EXOMEM_DISABLE_RANKING") == "1"
         and os.environ.get("EXOMEM_DEVICE") == "cpu"
         and os.environ.get("EXOMEM_EMBED_BACKEND") == "torch"
+        and os.environ.get("OMP_NUM_THREADS") == "1"
+        and os.environ.get("MKL_NUM_THREADS") == "1"
         and "EXOMEM_EMBED_DEVICE" not in os.environ
         and "EXOMEM_TORCH_DEVICE" not in os.environ
     ):

--- a/tests/test_ci_reliability_contract.py
+++ b/tests/test_ci_reliability_contract.py
@@ -11,6 +11,7 @@ FULL_CI_JOBS = {
     "retrieval-quality",
     "retrieval-latency",
     "governance-projection-wire",
+    "governance-projection-wire-vector-cpu",
     "semantic-write-latency",
     "graph-convergence",
     "docker",
@@ -249,6 +250,49 @@ def test_governance_wire_characterization_runs_every_registered_route() -> None:
     assert job["steps"][-1]["env"]["EXOMEM_DISABLE_CLIP"] == "1"
     assert job["steps"][-1]["env"]["EXOMEM_DISABLE_RANKING"] == "1"
     assert "governance-projection-wire" in workflow["jobs"]["gate"]["needs"]
+
+
+def test_governance_vector_cpu_wire_characterization_is_exact_and_required() -> None:
+    workflow = _workflow()
+    job = workflow["jobs"]["governance-projection-wire-vector-cpu"]
+
+    assert job["runs-on"] == "ubuntu-latest"
+    assert job["timeout-minutes"] == 12
+    assert job["strategy"]["fail-fast"] is False
+    assert set(job["strategy"]["matrix"]["route"]) == {
+        "keyword",
+        "bm25",
+        "vector-live",
+        "rerank-hard-off",
+        "clip-hard-off",
+        "graph",
+        "graph-rerank-hard-off",
+        "max-query",
+        "max-limit",
+        "max-shape",
+        "hidden-index-missing",
+        "pagination",
+    }
+    step = job["steps"][-1]
+    command = step["run"]
+    assert "--extra embeddings" in command
+    assert "--python 3.13" in command
+    assert "tests/test_governance_projection_wire_gate.py" in command
+    assert step["env"] == {
+        "EXOMEM_GOVERNANCE_TIMING_PROFILE": "vectors-cpu-torch-v1",
+        "EXOMEM_GOVERNANCE_TIMING_ROUTE": "${{ matrix.route }}",
+        "EXOMEM_DISABLE_MEDIA_EXTRACTION": "1",
+        "EXOMEM_DISABLE_CLIP": "1",
+        "EXOMEM_DISABLE_RANKING": "1",
+        "EXOMEM_DEVICE": "cpu",
+        "EXOMEM_EMBED_BACKEND": "torch",
+        "OMP_NUM_THREADS": "1",
+        "MKL_NUM_THREADS": "1",
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    assert "governance-projection-wire-vector-cpu" in workflow["jobs"]["gate"][
+        "needs"
+    ]
 
 
 def test_expensive_ci_runs_nightly_manually_and_for_release_prs_only() -> None:

--- a/tests/test_governance_projected_runtime_lanes.py
+++ b/tests/test_governance_projected_runtime_lanes.py
@@ -16,6 +16,7 @@ from exomem.governance import (
     projection_measurement_store,
     projection_runtime,
     projection_store,
+    projection_timing,
     projections,
     schema_v4,
 )
@@ -871,6 +872,63 @@ def test_vector_runtime_does_not_invent_a_lexical_rank(monkeypatch, tmp_path):
     assert result.hits[0].vector_rank == 1
     assert result.hits[0].bm25_rank is None
     assert result.hits[0].keyword_rank is None
+
+
+def test_vector_model_receives_the_fixed_bounded_query_projection(
+    monkeypatch,
+    tmp_path,
+):
+    alpha = _variant("Knowledge Base/alpha.md", "b" * 64, "semantic only")
+    runtime = _runtime(
+        (_item(alpha),),
+        vectors=(_vector(alpha, (1.0, 0.0)),),
+    )
+    observed: list[str] = []
+
+    def embed_texts(texts, *, is_query):
+        assert is_query is True
+        observed.extend(texts)
+        return [[1.0, 0.0]]
+
+    monkeypatch.setattr(embeddings, "embed_texts", embed_texts)
+    query = ("semantic    projection\n" * 80).strip()
+    normalized = " ".join(query.split())
+    expected = normalized[:600]
+    if len(normalized) > 600 and " " in expected:
+        expected = expected.rsplit(" ", 1)[0]
+
+    projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query=query,
+        limit=1,
+        mode="vector",
+        graph=False,
+        rerank=False,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert observed == [expected]
+    assert len(observed[0]) <= 600
+
+
+def test_vector_release_profile_requires_the_exact_measurement_family():
+    alpha = _variant("Knowledge Base/alpha.md", "b" * 64, "semantic only")
+    without_vectors = _runtime((_item(alpha),))
+    with_vectors = _runtime(
+        (_item(alpha),),
+        vectors=(_vector(alpha, (1.0, 0.0)),),
+    )
+
+    assert not projection_runtime._runtime_supports_release_profile(
+        without_vectors,
+        projection_timing.VECTOR_CPU_MODEL_RUNTIME_PROFILE,
+    )
+    assert projection_runtime._runtime_supports_release_profile(
+        with_vectors,
+        projection_timing.VECTOR_CPU_MODEL_RUNTIME_PROFILE,
+    )
 
 
 def test_keyword_runtime_does_not_admit_bm25_only_candidates(tmp_path):

--- a/tests/test_governance_projection_timing.py
+++ b/tests/test_governance_projection_timing.py
@@ -20,6 +20,12 @@ _CHECKED_RELEASE_MANIFEST = (
     / "governance"
     / "projected-wire-release-v1.json"
 )
+_CHECKED_VECTOR_RELEASE_MANIFEST = (
+    Path(__file__).parents[1]
+    / "benchmarks"
+    / "governance"
+    / "projected-wire-vector-cpu-release-v1.json"
+)
 
 
 def _timing_module():
@@ -73,6 +79,35 @@ def _release_manifest() -> dict[str, object]:
     }
 
 
+def _vector_release_manifest() -> dict[str, object]:
+    manifest = _release_manifest()
+    manifest["model_runtime_profile"] = "vectors-cpu-torch-v1"
+    manifest["request_classes"] = [
+        {
+            "name": "projected-find-vector-cpu-v1",
+            "padding_ms": 1_000,
+            "deadline_ms": 1_500,
+            "max_query_chars": 4_096,
+            "max_limit": 100,
+        }
+    ]
+    manifest["routes"] = [
+        "keyword",
+        "bm25",
+        "vector-live",
+        "rerank-hard-off",
+        "clip-hard-off",
+        "graph",
+        "graph-rerank-hard-off",
+        "max-query",
+        "max-limit",
+        "max-shape",
+        "hidden-index-missing",
+        "pagination",
+    ]
+    return manifest
+
+
 def test_checked_release_manifest_is_the_validated_nonwaivable_contract() -> None:
     timing = _timing_module()
 
@@ -95,6 +130,63 @@ def test_checked_release_manifest_is_the_validated_nonwaivable_contract() -> Non
             "pagination",
         }
     )
+
+
+def test_checked_vector_release_manifest_is_a_distinct_nonwaivable_contract() -> None:
+    timing = _timing_module()
+
+    checked = json.loads(
+        _CHECKED_VECTOR_RELEASE_MANIFEST.read_text(encoding="utf-8")
+    )
+
+    assert checked == _vector_release_manifest()
+    validated = timing.validate_release_manifest(checked)
+    assert validated.model_runtime_profile == "vectors-cpu-torch-v1"
+    assert validated.request_class_names == ("projected-find-vector-cpu-v1",)
+    assert "vector-live" in validated.routes
+    assert "vector-hard-off" not in validated.routes
+
+
+def test_hard_off_manifest_cannot_be_relabelled_as_vector_certification() -> None:
+    timing = _timing_module()
+    relabelled = _release_manifest()
+    relabelled["model_runtime_profile"] = "vectors-cpu-torch-v1"
+
+    with pytest.raises(timing.ProjectedRequestTimingUnavailable):
+        timing.validate_release_manifest(relabelled)
+
+
+def test_exact_vector_cpu_environment_selects_its_own_completion_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    timing = _timing_module()
+    for name in (
+        "EXOMEM_DISABLE_EMBEDDINGS",
+        "EXOMEM_EMBED_DEVICE",
+        "EXOMEM_TORCH_DEVICE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("EXOMEM_DISABLE_CLIP", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_RANKING", "1")
+    monkeypatch.setenv("EXOMEM_DEVICE", "cpu")
+    monkeypatch.setenv("EXOMEM_EMBED_BACKEND", "torch")
+
+    assert (
+        timing.model_runtime_profile_from_environment()
+        == "vectors-cpu-torch-v1"
+    )
+    request_class = timing.request_class_for_find(
+        mode="hybrid",
+        scope="vault",
+        graph=True,
+        rerank=True,
+    )
+    assert request_class.name == "projected-find-vector-cpu-v1"
+    assert request_class.padding_ms == 1_000
+    assert request_class.deadline_ms == 1_500
+
+    monkeypatch.setenv("EXOMEM_EMBED_DEVICE", "cuda")
+    assert timing.model_runtime_profile_from_environment() is None
 
 
 def test_keyword_request_class_is_closed_and_repository_owned() -> None:

--- a/tests/test_governance_projection_timing.py
+++ b/tests/test_governance_projection_timing.py
@@ -170,6 +170,8 @@ def test_exact_vector_cpu_environment_selects_its_own_completion_class(
     monkeypatch.setenv("EXOMEM_DISABLE_RANKING", "1")
     monkeypatch.setenv("EXOMEM_DEVICE", "cpu")
     monkeypatch.setenv("EXOMEM_EMBED_BACKEND", "torch")
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
+    monkeypatch.setenv("MKL_NUM_THREADS", "1")
 
     assert (
         timing.model_runtime_profile_from_environment()
@@ -186,6 +188,9 @@ def test_exact_vector_cpu_environment_selects_its_own_completion_class(
     assert request_class.deadline_ms == 1_500
 
     monkeypatch.setenv("EXOMEM_EMBED_DEVICE", "cuda")
+    assert timing.model_runtime_profile_from_environment() is None
+    monkeypatch.delenv("EXOMEM_EMBED_DEVICE")
+    monkeypatch.setenv("OMP_NUM_THREADS", "2")
     assert timing.model_runtime_profile_from_environment() is None
 
 

--- a/tests/test_governance_projection_wire_gate.py
+++ b/tests/test_governance_projection_wire_gate.py
@@ -388,8 +388,33 @@ def _client_for_root(
 
 
 def _canonical_response_digest(response) -> str:  # noqa: ANN001
-    value = {"status": response.status_code, "body": response.json()}
-    return hashlib.sha256(projections.canonical_jcs(value)).hexdigest()
+    """Hash the actual status/body bytes observed at the HTTP boundary."""
+
+    status = response.status_code
+    content = bytes(response.content)
+    framed = (
+        b"exomem.governed-wire-envelope.v1\0"
+        + status.to_bytes(2, "big")
+        + len(content).to_bytes(8, "big")
+        + content
+    )
+    return hashlib.sha256(framed).hexdigest()
+
+
+def test_wire_digest_uses_the_actual_serialized_model_score_envelope() -> None:
+    response = SimpleNamespace(
+        status_code=200,
+        content=b'{"data":{"hits":[{"vector_score":0.0498}]}}',
+        json=lambda: {"data": {"hits": [{"vector_score": 0.0498}]}},
+    )
+
+    expected = hashlib.sha256(
+        b"exomem.governed-wire-envelope.v1\0"
+        + (200).to_bytes(2, "big")
+        + len(response.content).to_bytes(8, "big")
+        + response.content
+    ).hexdigest()
+    assert _canonical_response_digest(response) == expected
 
 
 def _assert_route_response(response, route: str) -> None:  # noqa: ANN001

--- a/tests/test_governance_projection_wire_gate.py
+++ b/tests/test_governance_projection_wire_gate.py
@@ -997,6 +997,13 @@ def test_projected_hidden_corpus_actual_wire_characterization(
             ),
         ),
     }
+    assert all(
+        projection_runtime._runtime_supports_release_profile(
+            runtime,
+            selected_profile,
+        )
+        for runtime in runtimes.values()
+    )
     # Production settles one immutable runtime before publication. This wire
     # fixture holds three replica states in one process, so settle their
     # combined object graph before any client becomes observable.

--- a/tests/test_governance_projection_wire_gate.py
+++ b/tests/test_governance_projection_wire_gate.py
@@ -20,10 +20,11 @@ import pytest
 from governance_projection_support import verified_namespace
 from starlette.testclient import TestClient
 
-from exomem import server, writer_lease
+from exomem import embeddings, server, writer_lease
 from exomem.governance import (
     principal,
     projected_graph,
+    projected_retrieval,
     projection_runtime,
     projection_store,
     projection_timing,
@@ -39,8 +40,16 @@ _MANIFEST_PATH = (
     / "governance"
     / "projected-wire-release-v1.json"
 )
+_VECTOR_MANIFEST_PATH = (
+    Path(__file__).parents[1]
+    / "benchmarks"
+    / "governance"
+    / "projected-wire-vector-cpu-release-v1.json"
+)
 _ROUTE_ENV = "EXOMEM_GOVERNANCE_TIMING_ROUTE"
+_PROFILE_ENV = "EXOMEM_GOVERNANCE_TIMING_PROFILE"
 _REST_KEY = "governance-wire-release-key"
+_VECTOR_EXTRACTOR = "projected-text-v1"
 _GRAPH_EXTRACTOR = "projected-graph-v1"
 _GRAPH_MODEL = "projected-graph-v1"
 
@@ -135,6 +144,30 @@ def _graph_measurements(
     )
 
 
+def _vector_measurements(
+    items: tuple[projection_store.ProjectionItemVariants, ...],
+    *,
+    visible_count: int,
+) -> tuple[projected_retrieval.ProjectionVectorMeasurement, ...]:
+    measurements: list[projected_retrieval.ProjectionVectorMeasurement] = []
+    for index, item in enumerate(items[:visible_count]):
+        variant = _l6_variant(item)
+        vector = [0.0] * 768
+        vector[index % len(vector)] = 1.0
+        measurements.append(
+            projected_retrieval.ProjectionVectorMeasurement(
+                measurement_key=projections.MeasurementKey(
+                    projection_variant_id=variant.projection_variant_id,
+                    lane="vector",
+                    extractor_version=_VECTOR_EXTRACTOR,
+                    model_version=embeddings.MODEL_NAME,
+                ),
+                vector=tuple(vector),
+            )
+        )
+    return tuple(measurements)
+
+
 def _active_runtime(
     *,
     visible_count: int,
@@ -142,6 +175,7 @@ def _active_runtime(
     hidden_count: int,
     graph_edge_count: int,
     omit_last_hidden_graph_measurement: bool = False,
+    vector_enabled: bool = False,
     policy_fingerprint: str = "f" * 64,
 ) -> projection_runtime.ActiveProjectionRuntime:
     visible = Scope(id="wire-visible", source="scopes/wire-visible.yaml")
@@ -243,6 +277,35 @@ def _active_runtime(
         graph_edge_count=measured_graph_edge_count,
         rows_digest=_digest(f"graph:{hidden_count}:{graph_edge_count}"),
     )
+    vector_index = None
+    vector_root = None
+    if vector_enabled:
+        vector_measurements = _vector_measurements(
+            item_tuple,
+            visible_count=visible_count,
+        )
+        vector_index = projected_retrieval.ProjectedVectorIndex(
+            namespace,
+            vector_measurements,
+            extractor_version=_VECTOR_EXTRACTOR,
+            model_version=embeddings.MODEL_NAME,
+        )
+        vector_root = projection_store.ProjectionMeasurementRoot(
+            namespace_key=key,
+            family_id=projection_store.projection_measurement_family_id(
+                key,
+                lane="vector",
+                extractor_version=_VECTOR_EXTRACTOR,
+                model_version=embeddings.MODEL_NAME,
+            ),
+            lane="vector",
+            extractor_version=_VECTOR_EXTRACTOR,
+            model_version=embeddings.MODEL_NAME,
+            measurement_count=len(vector_measurements),
+            vector_dimension=768,
+            graph_edge_count=0,
+            rows_digest=_digest(f"vector-visible:{visible_count}"),
+        )
     snapshot = schema_v4.ActivePolicySnapshot(
         active=active,
         policy=policy,
@@ -253,7 +316,8 @@ def _active_runtime(
     return projection_runtime.ActiveProjectionRuntime(
         snapshot,
         namespace,
-        (graph_root,),
+        tuple(root for root in (vector_root, graph_root) if root is not None),
+        vector_index=vector_index,
         graph_index=graph_index,
     )
 
@@ -273,7 +337,7 @@ def _route_body(
     }
     if route == "keyword":
         body["mode"] = "keyword"
-    elif route == "vector-hard-off":
+    elif route in {"vector-hard-off", "vector-live"}:
         body["mode"] = "vector"
     elif route == "rerank-hard-off":
         body["rerank"] = True
@@ -817,7 +881,7 @@ def test_projected_hidden_missing_graph_measurement_is_absence_only(
 
 
 @pytest.mark.governance_timing_release
-@pytest.mark.timeout(240)
+@pytest.mark.timeout(540)
 def test_projected_hidden_corpus_actual_wire_characterization(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -827,17 +891,36 @@ def test_projected_hidden_corpus_actual_wire_characterization(
     route = os.environ.get(_ROUTE_ENV)
     if route is None:
         pytest.skip("dedicated governance actual-wire route job only")
-    manifest = projection_timing.validate_release_manifest(
-        json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    selected_profile = os.environ.get(
+        _PROFILE_ENV,
+        projection_timing.MODEL_RUNTIME_PROFILE,
     )
-    assert manifest.model_runtime_profile == "models-hard-off-v1"
+    manifest_path = (
+        _VECTOR_MANIFEST_PATH
+        if selected_profile == projection_timing.VECTOR_CPU_MODEL_RUNTIME_PROFILE
+        else _MANIFEST_PATH
+    )
+    manifest = projection_timing.validate_release_manifest(
+        json.loads(manifest_path.read_text(encoding="utf-8"))
+    )
+    assert manifest.model_runtime_profile == selected_profile
     if route not in manifest.routes:
         pytest.fail(f"unregistered governance timing route: {route!r}")
 
     monkeypatch.setenv("EXOMEM_REST_API_KEY", _REST_KEY)
-    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
-    monkeypatch.setenv("EXOMEM_DISABLE_CLIP", "1")
-    monkeypatch.setenv("EXOMEM_DISABLE_RANKING", "1")
+    if selected_profile == projection_timing.VECTOR_CPU_MODEL_RUNTIME_PROFILE:
+        monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+        monkeypatch.setenv("EXOMEM_DISABLE_CLIP", "1")
+        monkeypatch.setenv("EXOMEM_DISABLE_RANKING", "1")
+        monkeypatch.setenv("EXOMEM_DEVICE", "cpu")
+        monkeypatch.setenv("EXOMEM_EMBED_BACKEND", "torch")
+        monkeypatch.delenv("EXOMEM_EMBED_DEVICE", raising=False)
+        monkeypatch.delenv("EXOMEM_TORCH_DEVICE", raising=False)
+        embeddings.get_model()
+    else:
+        monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+        monkeypatch.setenv("EXOMEM_DISABLE_CLIP", "1")
+        monkeypatch.setenv("EXOMEM_DISABLE_RANKING", "1")
     assert (
         projection_runtime.projected_serving_release_profile()
         == manifest.model_runtime_profile
@@ -884,6 +967,10 @@ def test_projected_hidden_corpus_actual_wire_characterization(
             visible_body=visible_body,
             hidden_count=0,
             graph_edge_count=1,
+            vector_enabled=(
+                selected_profile
+                == projection_timing.VECTOR_CPU_MODEL_RUNTIME_PROFILE
+            ),
         ),
         roots["one"]: _active_runtime(
             visible_count=visible_count,
@@ -891,6 +978,10 @@ def test_projected_hidden_corpus_actual_wire_characterization(
             hidden_count=1,
             graph_edge_count=2,
             omit_last_hidden_graph_measurement=(route == "hidden-index-missing"),
+            vector_enabled=(
+                selected_profile
+                == projection_timing.VECTOR_CPU_MODEL_RUNTIME_PROFILE
+            ),
         ),
         roots["maximum"]: _active_runtime(
             visible_count=visible_count,
@@ -900,6 +991,10 @@ def test_projected_hidden_corpus_actual_wire_characterization(
             ),
             graph_edge_count=projections.MAX_GOVERNED_GRAPH_EDGES,
             omit_last_hidden_graph_measurement=(route == "hidden-index-missing"),
+            vector_enabled=(
+                selected_profile
+                == projection_timing.VECTOR_CPU_MODEL_RUNTIME_PROFILE
+            ),
         ),
     }
     # Production settles one immutable runtime before publication. This wire


### PR DESCRIPTION
## Summary

- add a distinct `vectors-cpu-torch-v1` governed retrieval profile with an exact CPU/Torch environment and fixed 1,000/1,500 ms completion class
- bind serving to the exact projected BGE vector measurement family and cap only vector-model query input to a deterministic 600-code-point whole-token projection
- add a separate non-waivable manifest and required 12-route actual-REST CI matrix; reranker, CLIP, GPU, ONNX, mixed, and override-bearing profiles remain closed
- update the active hardening OpenSpec without claiming the broader projected-retrieval task complete

## Verification

- 74 focused projected timing/runtime/wire/activation tests passed (timing-release marker excluded locally)
- exact-capacity warmed local max shape: 16,384 items, 262,144 graph edges, 100 results, 732.41 ms
- `openspec validate harden-governance-for-consolidation --strict`
- Ruff on touched Python files
- `git diff --check`
- `uv lock --check`
- `python3 scripts/validate-public-artifacts.py --repository`
- CI YAML parsed successfully

The authoritative 200+200-sample per-route wire distributions intentionally run in CI. No personal or delegated vault was touched.
