### PR TITLE
fix: bound startup retrieval admission

### DIFF
--- a/openspec/changes/fix-startup-retrieval-liveness/.openspec.yaml
+++ b/openspec/changes/fix-startup-retrieval-liveness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-25

--- a/openspec/changes/fix-startup-retrieval-liveness/design.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/design.md
@@ -1,0 +1,69 @@
+## Context
+
+The HTTP transport deliberately starts before cache and model warm-up. On a large Windows vault, the maintained lexical SQLite catalog can be stale at that point. Ordinary BM25 and keyword lanes still use legacy request-time reconciliation and full-scan fallbacks. After held-file custody made every page acquisition safer, that fallback exceeded the public ingress deadline: the origin kept working for roughly two minutes while ChatGPT received HTTP 504. Runtime readiness remained 200 because it measured coordination and mutation admission, not retrieval admission.
+
+The existing exact category/kind path already has the desired primitives: non-walking catalog readiness, bounded foreground delta replay, single-flight background repair, and the typed `RETRIEVAL_INDEX_WARMING` result. This change extends that architecture to ordinary lexical recall rather than inventing another recovery system.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep MCP transport startup non-blocking.
+- Make ordinary keyword and hybrid requests independent of corpus size while the maintained catalog is incomplete.
+- Make the maintained lexical catalog usable before optional page, resolver, semantic, and model warm-up.
+- Make `/health/ready` distinguish a live process from one that can admit ordinary retrieval.
+- Preserve exact recall, access policy, held-file custody, and single-flight repair guarantees.
+
+**Non-Goals:**
+
+- Revert held-file custody or the instant-start transport design.
+- Change ranking, retrieval quality, canonical Markdown, or model selection.
+- Make graph recovery a retrieval-readiness prerequisite.
+- Remove the explicit Python lexical backend or small-corpus reference implementation.
+
+## Decisions
+
+### Gate large-corpus lexical requests through catalog readiness
+
+When foreground lexical repair is disallowed by the existing corpus-size bound, keyword and hybrid paths will consult the non-walking catalog-readiness seam before BM25 or substring work. An incomplete result schedules the existing single-flight repair and raises the existing typed `RETRIEVAL_INDEX_WARMING` operation outcome. A transient query failure after a successful readiness proof also returns the typed temporarily-unavailable outcome rather than scanning the corpus.
+
+Small corpora retain bounded synchronous repair and the explicit `python` backend retains its reference implementation. This preserves development and rollback behavior without allowing production-sized automatic fallback scans.
+
+Alternative rejected: globally enable eager boot. It avoids request-time work only by moving the same unbounded cost into service downtime and discards the transport-start work already shipped.
+
+### Split maintained-catalog warm-up from optional cache warm-up
+
+Warm-up becomes two CPU phases. First, KB- and vault-scope maintained lexical catalogs are reconciled. A new `retrieval_catalog` readiness component is marked only when both scopes succeed. Second, parsed pages, resolver state, semantic corpus, matrices, and models warm under their existing soft-fail and resource-mode rules. Quiet mode still performs the disk-backed maintained-catalog phase because it does not require retaining a full parsed corpus in RAM.
+
+Alternative rejected: only reorder the existing steps while keeping one `lexical` marker. That would either report readiness too late after the catalog is already usable or too early when fallback pages are still cold.
+
+### Extend runtime readiness with content-free retrieval admission
+
+Runtime readiness projects the process-local `retrieval_catalog` component as a content-free `retrieval` block. While startup warm-up is active and the catalog is not ready, or after that phase fails, overall readiness is withheld with a stable reason. The liveness endpoint remains independent. No vault paths, queries, counts, or catalog content enter the response.
+
+`EXOMEM_DISABLE_WARMUP` remains an explicit lazy-mode escape hatch. It reports retrieval as unverified/not admitted until a successful maintained-catalog repair marks the component ready; transport liveness still starts normally.
+
+Alternative rejected: leave `/health/ready` coordination-only and add another endpoint. Existing deployment, failover, and acceptance tooling already treats this route as admission truth, so a second endpoint would preserve the false-positive operational failure.
+
+### Test the invariant, not the incident timing
+
+Regression tests use a production-sized synthetic freshness tuple and instrument the reference walk/page parser. They assert that an incomplete maintained catalog produces the typed warming outcome with zero walk or page reads, that catalog warm precedes optional page warm, and that runtime readiness transitions from 503-equivalent state to ready only after catalog admission.
+
+## Risks / Trade-offs
+
+- [Clients see a retryable warming error where they previously waited for eventual results] -> The outcome already exists in the public operation contract, is bounded, and is preferable to an edge-generated 504 with no useful remediation.
+- [A catalog repair failure can hold readiness at 503] -> Liveness remains 200, logs preserve per-stage failure, and the existing single-flight repair keeps retrying without touching canonical data.
+- [Quiet or explicitly disabled warm-up changes readiness behavior] -> Quiet still warms only the disk-backed catalog; fully disabled warm-up is explicitly lazy and reports that truth instead of claiming full admission.
+- [Readiness consumers may not expect the added field/reason] -> The payload extension is additive; the existing status/reasons contract already supports not-ready causes.
+
+## Migration Plan
+
+1. Ship the code and delta specs in a patch release.
+2. Upgrade personal and POLLY environments without deleting their rebuildable sidecars.
+3. Restart one cell at a time and verify liveness, retrieval-gated readiness, transition to ready, and a cold plus hot recall through the public ingress.
+4. Reconcile the personal graph after lexical admission is healthy.
+5. Roll back to 0.60.1 only if the new bounded admission path prevents recovery; no canonical-data migration is involved.
+
+## Open Questions
+
+None. The existing catalog readiness, retry outcome, and repair worker provide the required mechanisms.

--- a/openspec/changes/fix-startup-retrieval-liveness/proposal.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+After a restart, a large Windows vault can report runtime readiness while ordinary keyword and hybrid recall still synchronously reconcile or scan the full corpus. Held-file custody makes that work safe but expensive enough to exceed the public ingress deadline, producing disruptive HTTP 504s from otherwise healthy ChatGPT and POLLY connections.
+
+## What Changes
+
+- Make the maintained lexical catalog the first retrieval asset warmed at startup, ahead of parsed-page, resolver, semantic, and model caches.
+- Refuse incomplete large-corpus lexical plans with the existing bounded `RETRIEVAL_INDEX_WARMING` outcome while single-flight background repair proceeds; never fall through to a request-time full-corpus scan.
+- Publish retrieval admission in runtime readiness and withhold overall readiness while the maintained lexical catalog cannot safely serve ordinary recall.
+- Add production-sized cold-start regression coverage proving that request work is independent of corpus size and that readiness transitions only after lexical admission is available.
+
+## Capabilities
+
+### New Capabilities
+
+- `runtime-retrieval-readiness`: Defines content-free runtime reporting and admission semantics for the maintained lexical recall catalog.
+
+### Modified Capabilities
+
+- `instant-start`: Preserve immediate transport startup while making pre-lexical requests fail fast with a typed warming outcome instead of performing unbounded fallback work.
+- `live-index-freshness`: Move unknown or large lexical repair entirely off the request path and keep exact bounded deltas as the only foreground repair.
+- `find-recall-efficiency`: Warm the maintained lexical catalog before optional full page, resolver, semantic, and model caches.
+
+## Impact
+
+- Retrieval and warm-up internals in `src/exomem/find.py`, `src/exomem/lexstore.py`, `src/exomem/warmup.py`, and readiness projection code.
+- The `/health/ready` payload and status code gain a content-free retrieval-admission dependency.
+- Existing exact catalog warming error semantics are extended to ordinary keyword and hybrid retrieval when a safe maintained catalog is incomplete.
+- No canonical Markdown, ranking formula, model, or tool schema changes.

--- a/openspec/changes/fix-startup-retrieval-liveness/specs/find-recall-efficiency/spec.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/specs/find-recall-efficiency/spec.md
@@ -33,7 +33,7 @@ When startup warm-up is enabled, the system SHALL first reconcile the maintained
 
 - **WHEN** the server starts with warm-up enabled
 - **AND** the active resource policy allows CPU cache preloading
-- **THEN** maintained lexical catalogs are reconciled before the first `find` call is served
+- **THEN** maintained lexical catalogs are reconciled before the first admitted, result-bearing `find` call is served
 - **AND** the parsed-page, resolver, semantic, and applicable matrix caches are proactively populated
 - **AND** the first `find` call's results are identical to what it would return without warm-up
 
@@ -46,7 +46,7 @@ When startup warm-up is enabled, the system SHALL first reconcile the maintained
 
 #### Scenario: Quiet mode skips CPU cache warm-up
 
-- **WHEN** the server starts in `quiet` mode
+- **WHEN** the server starts in `quiet` mode with warm-up enabled
 - **THEN** maintained lexical catalogs are reconciled without populating parsed-page, resolver, embedding-matrix, or CLIP-matrix caches solely for warm-up
 - **AND** ordinary retrieval uses the maintained catalog without requiring those resident caches
 

--- a/openspec/changes/fix-startup-retrieval-liveness/specs/find-recall-efficiency/spec.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/specs/find-recall-efficiency/spec.md
@@ -28,3 +28,31 @@ When startup warm-up is enabled, the system SHALL first reconcile the maintained
 - **WHEN** maintained lexical catalogs are ready and a later optional cache or model warm fails
 - **THEN** transport and ordinary lexical retrieval remain available
 - **AND** the later failure is logged without revoking `retrieval_catalog` readiness
+
+#### Scenario: Warm-up primes caches before the first query
+
+- **WHEN** the server starts with warm-up enabled
+- **AND** the active resource policy allows CPU cache preloading
+- **THEN** maintained lexical catalogs are reconciled before the first `find` call is served
+- **AND** the parsed-page, resolver, semantic, and applicable matrix caches are proactively populated
+- **AND** the first `find` call's results are identical to what it would return without warm-up
+
+#### Scenario: Warm-up can be disabled
+
+- **WHEN** the server starts with `EXOMEM_DISABLE_WARMUP` set
+- **THEN** no proactive warm-up work is performed at startup
+- **AND** a small corpus may still build the required data lazily on first use
+- **AND** a large-corpus ordinary request returns bounded warming until background repair establishes catalog admission
+
+#### Scenario: Quiet mode skips CPU cache warm-up
+
+- **WHEN** the server starts in `quiet` mode
+- **THEN** maintained lexical catalogs are reconciled without populating parsed-page, resolver, embedding-matrix, or CLIP-matrix caches solely for warm-up
+- **AND** ordinary retrieval uses the maintained catalog without requiring those resident caches
+
+#### Scenario: A warm-up stage failure does not block startup
+
+- **WHEN** one warm-up stage fails
+- **THEN** the server transport still starts successfully
+- **AND** the failure is logged without raising, and other allowed warm-up stages still run
+- **AND** retrieval admission reflects whether the maintained catalog itself was successfully verified

--- a/openspec/changes/fix-startup-retrieval-liveness/specs/find-recall-efficiency/spec.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/specs/find-recall-efficiency/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Startup Cache Warm-Up
+
+When startup warm-up is enabled, the system SHALL first reconcile the maintained lexical catalog for KB and vault scopes. When the active resource policy allows CPU cache preloading, it SHALL then warm the parsed-page cache, wikilink resolver, semantic corpus, and applicable matrices so later `find` calls avoid their first-use construction costs. Quiet mode SHALL retain only the maintained-catalog phase and skip resident full-corpus caches. `EXOMEM_DISABLE_WARMUP` SHALL skip proactive work and report retrieval admission as unverified until a later repair establishes it. Every stage SHALL soft-fail without preventing transport liveness and MUST NOT change returned results.
+
+#### Scenario: Maintained catalog is the first warm stage
+
+- **WHEN** the server starts with warm-up enabled
+- **THEN** KB- and vault-scope maintained lexical catalogs are reconciled before any full parsed-page, resolver, semantic, matrix, or model warm
+- **AND** ordinary lexical requests become admissible as soon as that catalog phase succeeds
+
+#### Scenario: Warm-up can be disabled truthfully
+
+- **WHEN** the server starts with `EXOMEM_DISABLE_WARMUP` set
+- **THEN** no proactive warm-up work is performed
+- **AND** runtime readiness does not claim maintained-catalog retrieval admission before it is established
+- **AND** a large-corpus ordinary request returns bounded warming rather than building lazily on the request path
+
+#### Scenario: Quiet mode skips resident CPU caches
+
+- **WHEN** the server starts in `quiet` mode with warm-up enabled
+- **THEN** maintained lexical catalogs are reconciled
+- **AND** startup warm-up does not populate parsed-page, resolver, embedding-matrix, or CLIP-matrix caches solely for warm-up
+
+#### Scenario: A later warm-up stage failure does not revoke catalog admission
+
+- **WHEN** maintained lexical catalogs are ready and a later optional cache or model warm fails
+- **THEN** transport and ordinary lexical retrieval remain available
+- **AND** the later failure is logged without revoking `retrieval_catalog` readiness

--- a/openspec/changes/fix-startup-retrieval-liveness/specs/instant-start/spec.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/specs/instant-start/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: Non-Blocking Boot
+
+The system SHALL NOT block the MCP transport on any model preload or cache warm-up. `build_server()` SHALL return, and `mcp.run()` SHALL begin serving, before the embedding model, reranker, CLIP model, maintained lexical catalog, or optional lexical caches have necessarily finished loading. This SHALL hold identically for the stdio transport and the http transport. A request that needs an incomplete maintained lexical catalog MUST return the bounded typed `RETRIEVAL_INDEX_WARMING` outcome rather than waiting for warm-up or scanning the corpus.
+
+#### Scenario: Stdio client is answered immediately
+
+- **WHEN** exomem is started with `--transport stdio` against a vault whose models and lexical catalog are not yet ready
+- **THEN** the MCP `initialize` handshake completes without waiting for any model load or cache warm-up to finish
+- **AND** the maintained lexical catalog, embedding model, reranker, CLIP model, and optional lexical caches continue loading after `initialize` has already returned
+
+#### Scenario: Http transport begins serving immediately
+
+- **WHEN** exomem is started with an http transport
+- **THEN** the server accepts connections and responds to liveness requests before any model preload or lexical warm-up has necessarily finished
+- **AND** an ordinary keyword or hybrid request that arrives before maintained-catalog readiness returns `RETRIEVAL_INDEX_WARMING` promptly without a corpus walk
+
+### Requirement: Lexical-First Warm Ordering
+
+The background warm sequence SHALL reconcile the maintained lexical catalog for KB and vault scopes before warming parsed pages, the wikilink resolver, the semantic corpus, embedding/CLIP matrices, or any model. It SHALL mark `retrieval_catalog` ready immediately after both maintained scopes succeed. It SHALL mark the broader `lexical` component after the remaining lexical/derived caches finish, then mark enabled model components in their existing order.
+
+#### Scenario: Retrieval catalog readiness lands before optional cache readiness
+
+- **WHEN** background warm-up runs against a vault with Markdown content
+- **THEN** `retrieval_catalog` becomes ready before parsed-page and resolver warm-up completes
+- **AND** `lexical` becomes ready before enabled model readiness completes
+
+#### Scenario: Keyword find is available as soon as the maintained catalog is ready
+
+- **WHEN** `retrieval_catalog` is ready while optional caches or models are still warming
+- **THEN** keyword-mode `find` returns exact full results from the maintained catalog without waiting for those later stages
+
+#### Scenario: Quiet mode still prepares bounded lexical admission
+
+- **WHEN** the resource policy is `quiet` and startup warm-up is enabled
+- **THEN** the maintained lexical catalog phase still runs and may mark `retrieval_catalog` ready
+- **AND** full parsed-page, resolver, matrix, and model cache preloading remains skipped

--- a/openspec/changes/fix-startup-retrieval-liveness/specs/instant-start/spec.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/specs/instant-start/spec.md
@@ -36,3 +36,14 @@ The background warm sequence SHALL reconcile the maintained lexical catalog for 
 - **WHEN** the resource policy is `quiet` and startup warm-up is enabled
 - **THEN** the maintained lexical catalog phase still runs and may mark `retrieval_catalog` ready
 - **AND** full parsed-page, resolver, matrix, and model cache preloading remains skipped
+
+#### Scenario: Lazy empty-query recall remains bounded
+
+- **WHEN** startup warm-up is disabled and an empty keyword or hybrid query reaches a production-sized incomplete catalog
+- **THEN** the request returns `RETRIEVAL_INDEX_WARMING` without walking or parsing the corpus
+
+#### Scenario: Small lazy repair converges readiness
+
+- **WHEN** a bounded small-corpus request repairs and serves one maintained scope during lazy startup
+- **THEN** the runtime arranges repair of any missing sibling scope
+- **AND** retrieval admission becomes ready once both scopes are proven current

--- a/openspec/changes/fix-startup-retrieval-liveness/specs/instant-start/spec.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/specs/instant-start/spec.md
@@ -47,3 +47,14 @@ The background warm sequence SHALL reconcile the maintained lexical catalog for 
 - **WHEN** a bounded small-corpus request repairs and serves one maintained scope during lazy startup
 - **THEN** the runtime arranges repair of any missing sibling scope
 - **AND** retrieval admission becomes ready once both scopes are proven current
+
+#### Scenario: Lexical readiness lands before model readiness
+
+- **WHEN** background warm-up runs against a vault with Markdown content
+- **THEN** the `retrieval_catalog` readiness component becomes ready before optional model readiness components
+- **AND** ordinary lexical retrieval does not wait for embeddings, reranker, or CLIP readiness
+
+#### Scenario: Keyword find is available as soon as lexical warm completes
+
+- **WHEN** the `retrieval_catalog` readiness component is ready but embeddings are not yet ready
+- **THEN** a keyword-mode `find` call returns full results without deferring on an optional model lane

--- a/openspec/changes/fix-startup-retrieval-liveness/specs/live-index-freshness/spec.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/specs/live-index-freshness/spec.md
@@ -49,6 +49,6 @@ The system SHALL keep the lexical sidecar synchronized with the vault's Markdown
 
 #### Scenario: Out-of-band drift self-heals
 
-- **WHEN** Markdown changed without the lexical sidecar being updated
+- **WHEN** Markdown changed without the lexical sidecar being updated and the resulting drift is unknown or incomplete
 - **THEN** freshness verification detects the mismatch and schedules background repair
 - **AND** retrieval admission remains withheld until the affected state is current again

--- a/openspec/changes/fix-startup-retrieval-liveness/specs/live-index-freshness/spec.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/specs/live-index-freshness/spec.md
@@ -39,3 +39,16 @@ The system SHALL keep the lexical sidecar synchronized with the vault's Markdown
 - **WHEN** startup catalog repair failed and warm-up finished without admission
 - **THEN** each later refused ordinary request may re-arm the single-flight repair before returning its typed retry outcome
 - **AND** the request does not walk or parse the corpus to trigger that retry
+
+#### Scenario: A pre-existing vault is indexed on first use
+
+- **WHEN** a vault that predates the lexical sidecar is first used by an aware version
+- **THEN** background warm-up creates and populates the sidecar from the Markdown source of truth
+- **AND** a large-corpus request remains bounded while that repair is incomplete
+- **AND** no user action is required
+
+#### Scenario: Out-of-band drift self-heals
+
+- **WHEN** Markdown changed without the lexical sidecar being updated
+- **THEN** freshness verification detects the mismatch and schedules background repair
+- **AND** retrieval admission remains withheld until the affected state is current again

--- a/openspec/changes/fix-startup-retrieval-liveness/specs/live-index-freshness/spec.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/specs/live-index-freshness/spec.md
@@ -33,3 +33,9 @@ The system SHALL keep the lexical sidecar synchronized with the vault's Markdown
 - **WHEN** Markdown changed without a complete retained lexical delta
 - **THEN** the next use detects incomplete readiness and schedules single-flight background repair
 - **AND** the request returns `RETRIEVAL_INDEX_WARMING` instead of rebuilding or scanning the corpus
+
+#### Scenario: Failed background repair is retried by later demand
+
+- **WHEN** startup catalog repair failed and warm-up finished without admission
+- **THEN** each later refused ordinary request may re-arm the single-flight repair before returning its typed retry outcome
+- **AND** the request does not walk or parse the corpus to trigger that retry

--- a/openspec/changes/fix-startup-retrieval-liveness/specs/live-index-freshness/spec.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/specs/live-index-freshness/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Lexical Index Synchronization
+
+The system SHALL keep the lexical sidecar synchronized with the vault's Markdown through the same freshness seams that maintain the embedding sidecars—in-process writer hooks, the live file watcher, and reconcile—on lean installs as well as full ones. Lexical maintenance MUST NOT be gated behind the embeddings extra. When the sidecar is missing, stale, or was written past by a non-aware process, the system SHALL detect the mismatch without treating the catalog as authoritative empty state. A complete freshness delta containing no more than the foreground cap MAY be applied synchronously. Unknown, incomplete, or larger drift MUST schedule single-flight background repair and return the bounded typed `RETRIEVAL_INDEX_WARMING` outcome for ordinary maintained-catalog retrieval; it MUST NOT rebuild, heal, or scan the corpus on that request. The `find` hot-cache freshness key MUST incorporate lexical sidecar freshness so cached results cannot outlive a lexical reindex.
+
+#### Scenario: A write keeps the lexical index current
+
+- **WHEN** a Markdown page is created, edited, or deleted through a writer path or observed by the watcher
+- **THEN** the lexical sidecar reflects the change through the same seam that refreshes the embedding sidecars
+- **AND** a subsequent BM25- or keyword-lane query observes the change
+
+#### Scenario: A pre-existing vault is indexed without request-time scanning
+
+- **WHEN** a production-sized vault that predates the lexical sidecar is first used by an aware version
+- **THEN** startup or single-flight background repair creates and populates the sidecar from Markdown source of truth
+- **AND** ordinary requests return typed warming until publication completes
+- **AND** no ordinary request performs the full Markdown walk
+
+#### Scenario: Lean installs maintain the lexical index
+
+- **WHEN** the server runs a lean install without the embeddings extra
+- **THEN** writer and watcher events still keep the lexical sidecar current
+
+#### Scenario: Small complete drift heals in proportion to change
+
+- **WHEN** the catalog is stale by a complete retained delta within the foreground cap
+- **THEN** the request may apply only those changed and deleted paths atomically
+- **AND** it does not walk or rebuild the corpus
+
+#### Scenario: Unknown out-of-band drift self-heals in background
+
+- **WHEN** Markdown changed without a complete retained lexical delta
+- **THEN** the next use detects incomplete readiness and schedules single-flight background repair
+- **AND** the request returns `RETRIEVAL_INDEX_WARMING` instead of rebuilding or scanning the corpus

--- a/openspec/changes/fix-startup-retrieval-liveness/specs/runtime-retrieval-readiness/spec.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/specs/runtime-retrieval-readiness/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Runtime readiness includes retrieval admission
+
+The `/health/ready` response SHALL include a content-free `retrieval` block describing whether the process can admit ordinary maintained-catalog lexical recall. Overall runtime status SHALL be `not_ready` while startup catalog warm-up is active but incomplete or has failed, and SHALL include a stable retrieval reason. The response MUST NOT expose vault paths, queries, corpus counts, note metadata, or catalog contents. `/health` liveness SHALL remain independent.
+
+#### Scenario: Catalog warming withholds readiness
+
+- **WHEN** the transport is live and the maintained lexical catalog startup phase has not completed
+- **THEN** `/health` returns its normal live response
+- **AND** `/health/ready` reports `not_ready` with retrieval state `warming`
+- **AND** no vault content or identity is exposed
+
+#### Scenario: Catalog readiness admits the runtime
+
+- **WHEN** maintained lexical catalogs for both recall scopes are current
+- **THEN** the retrieval block reports `ready` and read admission is true
+- **AND** retrieval contributes no not-ready reason
+
+#### Scenario: Explicitly lazy startup is truthful
+
+- **WHEN** startup warm-up is explicitly disabled and no maintained-catalog readiness has been established
+- **THEN** retrieval reports `unverified`
+- **AND** overall readiness does not claim ordinary retrieval admission

--- a/openspec/changes/fix-startup-retrieval-liveness/specs/runtime-retrieval-readiness/spec.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/specs/runtime-retrieval-readiness/spec.md
@@ -22,3 +22,9 @@ The `/health/ready` response SHALL include a content-free `retrieval` block desc
 - **WHEN** startup warm-up is explicitly disabled and no maintained-catalog readiness has been established
 - **THEN** retrieval reports `unverified`
 - **AND** overall readiness does not claim ordinary retrieval admission
+
+#### Scenario: Later catalog staleness revokes admission
+
+- **WHEN** a catalog previously marked ready is later proven stale or fatally unavailable
+- **THEN** retrieval admission is revoked before background repair is scheduled
+- **AND** readiness remains withheld until a successful repair proves both recall scopes current again

--- a/openspec/changes/fix-startup-retrieval-liveness/specs/runtime-retrieval-readiness/spec.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/specs/runtime-retrieval-readiness/spec.md
@@ -28,3 +28,9 @@ The `/health/ready` response SHALL include a content-free `retrieval` block desc
 - **WHEN** a catalog previously marked ready is later proven stale or fatally unavailable
 - **THEN** retrieval admission is revoked before background repair is scheduled
 - **AND** readiness remains withheld until a successful repair proves both recall scopes current again
+
+#### Scenario: Mutation maintenance failure revokes admission
+
+- **WHEN** a writer or watcher cannot apply a required catalog upsert or delete
+- **THEN** retrieval admission is revoked before targeted or full background repair is scheduled
+- **AND** successful repair may restore admission only after both scopes are current

--- a/openspec/changes/fix-startup-retrieval-liveness/tasks.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/tasks.md
@@ -1,0 +1,17 @@
+## 1. Regression Tests
+
+- [x] 1.1 Add production-sized keyword and hybrid cold-catalog tests proving typed warming and zero reference walks or page reads.
+- [x] 1.2 Add warm-order tests proving both catalog scopes precede optional page and resolver work and quiet mode retains the catalog phase.
+- [x] 1.3 Add runtime-readiness tests for warming, ready, and unverified states with no content leakage.
+
+## 2. Implementation
+
+- [x] 2.1 Gate large-corpus keyword and hybrid lexical lanes through non-walking catalog readiness and the existing typed warming outcome.
+- [x] 2.2 Split maintained-catalog warming from optional caches and publish retrieval catalog readiness at the exact transition.
+- [x] 2.3 Project content-free retrieval admission into runtime readiness and overall status.
+
+## 3. Verification and Delivery
+
+- [x] 3.1 Run focused retrieval, warmup, and readiness tests plus strict OpenSpec validation.
+- [ ] 3.2 Run the lean suite, lint and types, latency gate, packaging checks, and review the actual diff.
+- [ ] 3.3 Deploy the patch release to personal and POLLY, then verify cold and hot public recall, graph recovery, and memory telemetry.

--- a/scripts/referent_resolution_benchmark.py
+++ b/scripts/referent_resolution_benchmark.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
-from exomem import commands, epistemic_graph, public_artifact_privacy
+from exomem import commands, epistemic_graph, lexstore, public_artifact_privacy
 from exomem import find as find_module
 from exomem.entity_types import ENTITY_TYPES_BY_ID
 
@@ -432,6 +432,7 @@ def _arm(vault: Path, case: dict[str, Any], *, graph: bool) -> dict[str, Any]:
 def _run_benchmark(manifest_path: Path, *, work_root: Path) -> dict[str, Any]:
     manifest = load_manifest(manifest_path)
     rendered = render_fixture(manifest, Path(work_root) / "referent-fixture")
+    lexstore.ensure_fresh(rendered.root)
     epistemic_graph.EpistemicGraphIndex(rendered.root).rebuild_all()
     case_results: list[dict[str, Any]] = []
     for raw_case in manifest["cases"]:

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -793,10 +793,12 @@ def find(
     query_norm = (query or "").lower().strip()
 
     if mode != "vector":
-        from . import readiness
+        from . import lexstore, readiness
 
         admission = readiness.retrieval_admission()
         state = admission["state"]
+        if state == "unavailable":
+            lexstore.request_repair(vault_root)
         if state == "unavailable" or (
             state == "warming" and not readiness.is_ready("lexical")
         ):
@@ -2703,6 +2705,7 @@ def _find_keyword(
     failed_out: list[str] | None = None,
 ) -> list[Hit]:
     """Keyword-mode recall, hydrating only maintained-index matches."""
+    lexical_repair = _bounded_lexical_repair_allowed(freshness_key)
     if query_norm:
         candidate_paths = _keyword_match_paths(
             vault_root,
@@ -2710,7 +2713,7 @@ def _find_keyword(
             scope,
             freshness=freshness_key,
             failed_out=failed_out,
-            repair=_bounded_lexical_repair_allowed(freshness_key),
+            repair=lexical_repair,
         )
         if eligible_paths is not None:
             # A finite eligible set (a complete category/kind plan resolved
@@ -2724,6 +2727,26 @@ def _find_keyword(
         # plan resolved through the maintained index) iterates those parents
         # directly rather than walking the scope to rediscover them.
         walk = (vault_root / rel_path for rel_path in eligible_paths)
+    elif not lexical_repair:
+        from . import lexstore
+
+        if lexstore.maintained_content_index_enabled():
+            catalog = lexstore.get_store(vault_root).catalog_readiness(
+                scope,
+                freshness_key,
+            )
+            if not catalog.complete:
+                _raise_catalog_outcome(catalog)
+        if scope == "kb":
+            kb = vault_root / kb_dirname()
+            if not kb.is_dir():
+                log.error("KB directory missing: %s", kb)
+                return []
+            walk = _walk_md(kb)
+        else:
+            from .vault import walk_vault_md
+
+            walk = walk_vault_md(vault_root)
     elif scope == "kb":
         kb = vault_root / kb_dirname()
         if not kb.is_dir():

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -226,7 +226,7 @@ def _set_rerank_timing_profile(
 
 def _set_catalog_timing_profile(
     timings: FindTimings | None,
-    readiness: object | None = None,
+    readiness: Any | None = None,
     *,
     cache_hit: bool = False,
 ) -> None:
@@ -791,6 +791,22 @@ def find(
             hard_max=MAX_RERANK_CANDIDATES,
         )
     query_norm = (query or "").lower().strip()
+
+    if mode != "vector":
+        from . import readiness
+
+        admission = readiness.retrieval_admission()
+        state = admission["state"]
+        if state == "unavailable" or (
+            state == "warming" and not readiness.is_ready("lexical")
+        ):
+            raise RetrievalIndexWarming(
+                status=(
+                    "temporarily_unavailable"
+                    if state == "unavailable"
+                    else "warming"
+                )
+            )
 
     language_registry = None
 
@@ -2844,12 +2860,26 @@ def _find_semantic(
     `degraded_out`'s "the lane was deferred while a model preload is warming".
     """
     # Lazy imports — keep keyword-mode users out of the torch import path.
-    from . import embeddings, readiness, scene_frames
+    from . import embeddings, lexstore, readiness, scene_frames
 
     if snapshot is None:
         snapshot = FreshnessSnapshot(vault_root)
     if page_memo is None:
         page_memo = {}
+
+    lexical_freshness = snapshot.for_scope(scope)
+    lexical_repair = _bounded_lexical_repair_allowed(lexical_freshness)
+    if (
+        mode != "vector"
+        and not lexical_repair
+        and lexstore.maintained_content_index_enabled()
+    ):
+        catalog = lexstore.get_store(vault_root).catalog_readiness(
+            scope,
+            lexical_freshness,
+        )
+        if not catalog.complete:
+            _raise_catalog_outcome(catalog)
 
     def _page_of(rel: str) -> ParsedPage | None:
         if rel not in page_memo:
@@ -2860,33 +2890,37 @@ def _find_semantic(
             )
         return page_memo[rel]
 
-    bundle = find_candidates.collect_candidates(
-        vault_root,
-        query=query,
-        query_norm=query_norm,
-        limit=limit,
-        scope=scope,
-        mode=mode,
-        graph=graph,
-        temporal=temporal,
-        intent=intent,
-        prefer_compiled=prefer_compiled,
-        prefer_active=prefer_active,
-        prefer_used=prefer_used,
-        config=config,
-        timings=timings,
-        snapshot=snapshot,
-        page_of=_page_of,
-        keyword_match_paths=_keyword_match_paths,
-        outbound_wikilink_paths=_outbound_wikilink_paths,
-        get_query_resolver=recall_resolver_snapshot,
-        record_degradation=_record_degradation,
-        degraded_out=degraded_out,
-        failed_out=failed_out,
-        recall_paths=snapshot.recall_paths(recall_scope or scope),
-        eligible_paths=eligible_paths,
-        capture_trace=retrieval_trace is not None,
-    )
+    try:
+        bundle = find_candidates.collect_candidates(
+            vault_root,
+            query=query,
+            query_norm=query_norm,
+            limit=limit,
+            scope=scope,
+            mode=mode,
+            graph=graph,
+            temporal=temporal,
+            intent=intent,
+            prefer_compiled=prefer_compiled,
+            prefer_active=prefer_active,
+            prefer_used=prefer_used,
+            config=config,
+            timings=timings,
+            snapshot=snapshot,
+            page_of=_page_of,
+            keyword_match_paths=_keyword_match_paths,
+            outbound_wikilink_paths=_outbound_wikilink_paths,
+            get_query_resolver=recall_resolver_snapshot,
+            record_degradation=_record_degradation,
+            degraded_out=degraded_out,
+            failed_out=failed_out,
+            recall_paths=snapshot.recall_paths(recall_scope or scope),
+            lexical_repair=lexical_repair,
+            eligible_paths=eligible_paths,
+            capture_trace=retrieval_trace is not None,
+        )
+    except lexstore.CatalogUnavailable as error:
+        _raise_catalog_outcome(error.readiness)
 
     if not bundle.had_rankings:
         # Both rankers failed or produced nothing. Degrade to keyword.
@@ -3363,23 +3397,47 @@ def _find_outside_kb(
     score_by_path: dict[str, float] = {}
     lexical_backend = lexstore.cache_token(vault_root)
     try:
-        search_kwargs = {
-            "scope": "vault",
-            "freshness": snapshot.for_scope("vault") if snapshot is not None else None,
-            "allowed_paths": allowed_outside,
-        }
-        search_kwargs["repair"] = _bounded_lexical_repair_allowed(search_kwargs["freshness"])
-        bm25_hits = lexstore.search_bm25(
-            vault_root,
-            query,
-            bm25_k,
-            **search_kwargs,
-        )
+        vault_freshness = snapshot.for_scope("vault") if snapshot is not None else None
+        lexical_repair = _bounded_lexical_repair_allowed(vault_freshness)
+        bm25_hits: list[tuple[str, float]] | None
+        if (
+            not lexical_repair
+            and lexstore.maintained_content_index_enabled()
+        ):
+            catalog_result = lexstore.search_bm25_result(
+                vault_root,
+                query,
+                bm25_k,
+                scope="vault",
+                freshness=vault_freshness,
+                allowed_paths=allowed_outside,
+            )
+            if not catalog_result.readiness.complete:
+                _raise_catalog_outcome(catalog_result.readiness)
+            bm25_hits = list(catalog_result.value or [])
+        else:
+            bm25_hits = lexstore.search_bm25(
+                vault_root,
+                query,
+                bm25_k,
+                scope="vault",
+                freshness=vault_freshness,
+                allowed_paths=allowed_outside,
+                repair=lexical_repair,
+            )
         if bm25_hits is None:
             if lexstore.backend() == "python":
                 # An explicit operator rollback is allowed to use the old
                 # in-process corpus. Automatic sidecar failure is not.
-                bm25_hits = bm25.search(vault_root, query, k=bm25_k, **search_kwargs)
+                bm25_hits = bm25.search(
+                    vault_root,
+                    query,
+                    k=bm25_k,
+                    scope="vault",
+                    freshness=vault_freshness,
+                    allowed_paths=allowed_outside,
+                    repair=lexical_repair,
+                )
                 lexical_backend = "keyword_fallback"
             else:
                 if failed_out is not None:
@@ -3390,6 +3448,8 @@ def _find_outside_kb(
             if not path.startswith(kb_prefix()):
                 candidates.append(path)
                 score_by_path[path] = float(_score)
+    except RetrievalIndexWarming:
+        raise
     except Exception as e:  # noqa: BLE001 — widening must never break find
         log.warning("auto-widen lexical sidecar failed: %s", e)
         if failed_out is not None:
@@ -3639,6 +3699,17 @@ def _keyword_match_paths(
         return []
     from . import lexstore
 
+    if not repair and lexstore.maintained_content_index_enabled():
+        catalog_result = lexstore.search_substring_result(
+            vault_root,
+            query_norm,
+            scope=scope,
+            freshness=freshness,
+            k=k,
+        )
+        if not catalog_result.readiness.complete:
+            _raise_catalog_outcome(catalog_result.readiness)
+        return list(catalog_result.value or [])
     indexed = lexstore.search_substring(
         vault_root,
         query_norm,

--- a/src/exomem/find_candidates.py
+++ b/src/exomem/find_candidates.py
@@ -157,11 +157,12 @@ def collect_candidates(
     degraded_out: list[str] | None,
     failed_out: list[str] | None,
     recall_paths: AbstractSet[str],
+    lexical_repair: bool = True,
     eligible_paths: set[str] | None = None,
     capture_trace: bool = False,
 ) -> CandidateBundle:
     """Collect vector/BM25/keyword/CLIP/graph/temporal lanes and fuse them."""
-    from . import bm25, embeddings, epistemic_graph, fusion, readiness
+    from . import bm25, embeddings, epistemic_graph, fusion, lexstore, readiness
 
     usage_map: dict[str, float] = {}
     if prefer_used:
@@ -389,16 +390,8 @@ def collect_candidates(
     else:
         try:
             with _span(timings, "bm25"):
-                bm25_hits = (
-                    bm25.search(
-                        vault_root,
-                        query,
-                        k=candidate_k,
-                        scope=scope,
-                        freshness=snapshot.for_scope(scope),
-                    )
-                    if eligible_paths is None
-                    else bm25.search(
+                if not lexical_repair and lexstore.maintained_content_index_enabled():
+                    catalog_result = lexstore.search_bm25_result(
                         vault_root,
                         query,
                         k=candidate_k,
@@ -406,11 +399,21 @@ def collect_candidates(
                         freshness=snapshot.for_scope(scope),
                         allowed_paths=eligible_paths,
                     )
-                )
+                    if not catalog_result.readiness.complete:
+                        raise lexstore.CatalogUnavailable(catalog_result.readiness)
+                    bm25_hits = list(catalog_result.value or [])
+                else:
+                    bm25_hits = bm25.search(
+                        vault_root,
+                        query,
+                        k=candidate_k,
+                        scope=scope,
+                        freshness=snapshot.for_scope(scope),
+                        allowed_paths=eligible_paths,
+                        repair=lexical_repair,
+                    )
                 bm25_ranking = [p for p, _ in bm25_hits]
                 bm25_score_by_path = {p: float(score) for p, score in bm25_hits}
-                from . import lexstore
-
                 if capture_trace:
                     lane_statuses["bm25"] = {
                         "status": "participated" if bm25_ranking else "available_nonmatching",
@@ -423,6 +426,8 @@ def collect_candidates(
                             "caveat": "diagnostic; not comparable across backends or corpora",
                         },
                     }
+        except lexstore.CatalogUnavailable:
+            raise
         except ImportError as e:
             if capture_trace:
                 lane_statuses["bm25"] = {
@@ -462,6 +467,7 @@ def collect_candidates(
                 query_norm,
                 scope,
                 freshness=snapshot.for_scope(scope),
+                repair=lexical_repair,
                 k=candidate_k * 3,
             )
         keyword_ranking = collapse_frame_children(

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -63,9 +63,10 @@ import sqlite3
 import threading
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 from . import call_spans, reserved_paths
 from .kbdir import kb_dirname
@@ -169,8 +170,11 @@ class CatalogReadiness:
     backend: str
 
 
+_CatalogValue = TypeVar("_CatalogValue")
+
+
 @dataclass(frozen=True, slots=True)
-class CatalogQueryResult:
+class CatalogQueryResult(Generic[_CatalogValue]):
     """Typed exact-catalog query result.
 
     `value` may legitimately be an empty list when `readiness.complete` is true.
@@ -178,8 +182,16 @@ class CatalogQueryResult:
     legacy list-or-None wrappers necessarily collapse.
     """
 
-    value: object | None
+    value: _CatalogValue | None
     readiness: CatalogReadiness
+
+
+class CatalogUnavailable(RuntimeError):
+    """Internal signal that a maintained content query cannot answer completely."""
+
+    def __init__(self, readiness: CatalogReadiness) -> None:
+        self.readiness = readiness
+        super().__init__(f"lexical catalog is not ready: {readiness.status}")
 
 
 class _DeltaReplayStale(RuntimeError):
@@ -446,6 +458,31 @@ def get_store(vault_root: Path) -> LexicalStore:
         return store
 
 
+def _mark_runtime_retrieval_ready_if_current(vault_root: Path) -> None:
+    """Admit the configured runtime after a repair proves both scopes current."""
+    configured_raw = os.environ.get("EXOMEM_VAULT_PATH", "").strip()
+    configured = Path(configured_raw) if configured_raw else None
+    if (
+        configured is None
+        or not configured.is_absolute()
+        or configured.resolve(strict=False) != vault_root.resolve(strict=False)
+    ):
+        return
+    from . import freshness as freshness_module
+    from . import readiness
+
+    store = get_store(vault_root)
+    if all(
+        store.catalog_readiness(
+            scope,
+            freshness_module.recall_checkpoint(vault_root, scope).triple,
+            allow_delta=False,
+        ).complete
+        for scope in ("kb", "vault")
+    ):
+        readiness.mark_ready("retrieval_catalog")
+
+
 def clear_stores() -> None:
     """Test seam: drop per-process stores (sync memos, failure flags)."""
     with _STORES_LOCK:
@@ -503,7 +540,11 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
                         _REPAIRS_IN_FLIGHT.discard(key)
                         return
                 if rebuild or not store.retry_deferred_upsert(paths):
-                    store.rebuild_atomic()
+                    repaired = store.rebuild_atomic()
+                else:
+                    repaired = True
+                if repaired:
+                    _mark_runtime_retrieval_ready_if_current(vault_root)
                 rebuild = False
                 paths = []
         except Exception as e:  # noqa: BLE001 - daemon must not escape into stderr
@@ -594,6 +635,11 @@ def _usable() -> bool:
     return backend() != "python" and fts5_available()
 
 
+def maintained_content_index_enabled() -> bool:
+    """Whether ordinary BM25/substring recall is assigned to the sidecar."""
+    return _usable()
+
+
 def _catalog_usable() -> bool:
     """Whether the normal-table semantic catalog may serve/maintain this vault.
 
@@ -633,6 +679,34 @@ def search_bm25(
     return store.search_bm25(tokens, k, scope, freshness, allowed_paths, repair)
 
 
+def search_bm25_result(
+    vault_root: Path,
+    query: str,
+    k: int,
+    *,
+    scope: str = "kb",
+    freshness: tuple | None = None,
+    allowed_paths: set[str] | None = None,
+) -> CatalogQueryResult[list[tuple[str, float]]]:
+    """Non-walking maintained-catalog BM25 query with explicit readiness."""
+    if not _usable():
+        return CatalogQueryResult(None, CatalogReadiness("unsupported", False, backend()))
+    if not query.strip():
+        return CatalogQueryResult([], CatalogReadiness("available", True, backend()))
+    from . import bm25 as bm25_module
+
+    tokens = bm25_module.tokenize(query)
+    if not tokens:
+        return CatalogQueryResult([], CatalogReadiness("available", True, backend()))
+    return get_store(vault_root).search_bm25_result(
+        tokens,
+        k,
+        scope,
+        freshness,
+        allowed_paths,
+    )
+
+
 def search_substring(
     vault_root: Path,
     query_norm: str,
@@ -655,6 +729,30 @@ def search_substring(
         return []
     store = get_store(vault_root)
     return store.search_substring(tokens, scope, freshness, repair, k)
+
+
+def search_substring_result(
+    vault_root: Path,
+    query_norm: str,
+    *,
+    scope: str = "kb",
+    freshness: tuple | None = None,
+    k: int | None = None,
+) -> CatalogQueryResult[list[str]]:
+    """Non-walking maintained-catalog substring query with explicit readiness."""
+    if not _usable():
+        return CatalogQueryResult(None, CatalogReadiness("unsupported", False, backend()))
+    if not query_norm:
+        return CatalogQueryResult([], CatalogReadiness("available", True, backend()))
+    tokens = query_norm.split()
+    if not tokens:
+        return CatalogQueryResult([], CatalogReadiness("available", True, backend()))
+    return get_store(vault_root).search_substring_result(
+        tokens,
+        scope,
+        freshness,
+        k,
+    )
 
 
 def search_semantic_units(
@@ -812,7 +910,7 @@ def search_semantic_units_result(
     _repair_stale: bool = False,
     _validate_current: bool = True,
     repair: bool = True,
-) -> CatalogQueryResult:
+) -> CatalogQueryResult[list[SemanticUnitLexicalHit]]:
     """Typed exact-category unit query preserving every catalog outcome."""
     from .semantic_units import canonicalize_category
 
@@ -926,7 +1024,7 @@ def search_semantic_parent_paths_result(
     *,
     scope: str = "kb",
     freshness: tuple | None = None,
-) -> CatalogQueryResult:
+) -> CatalogQueryResult[list[str]]:
     """Typed counterpart to `search_semantic_parent_paths`."""
     if not _catalog_usable():
         return CatalogQueryResult(
@@ -3383,6 +3481,23 @@ class LexicalStore:
             )
             return None
 
+    def search_bm25_result(
+        self,
+        stemmed_tokens: list[str],
+        k: int,
+        scope: str,
+        freshness: tuple | None,
+        allowed_paths: set[str] | None = None,
+    ) -> CatalogQueryResult[list[tuple[str, float]]]:
+        return self._serve_from_ready_catalog_result(
+            scope,
+            freshness,
+            lambda conn: self._bm25_query(
+                conn, stemmed_tokens, k, scope, allowed_paths
+            ),
+            "lexical sidecar BM25 query failed (%s)",
+        )
+
     def _bm25_query(
         self,
         conn: sqlite3.Connection,
@@ -3539,7 +3654,13 @@ class LexicalStore:
             self._catalog_readiness_error(error, backend_name)
             return None
 
-    def _serve_from_ready_catalog_result(self, scope, freshness, query_fn, failure_message):
+    def _serve_from_ready_catalog_result(
+        self,
+        scope: str,
+        freshness: tuple | None,
+        query_fn: Callable[[sqlite3.Connection], _CatalogValue],
+        failure_message: str,
+    ) -> CatalogQueryResult[_CatalogValue]:
         """Validate readiness AND run `query_fn(conn)` bound to ONE connection and
         read transaction, so a concurrent publication cannot swap the catalog file
         between the readiness proof and the query (the readiness-query TOCTOU).
@@ -3690,7 +3811,7 @@ class LexicalStore:
         literal_tokens: tuple[str, ...] = (),
         *,
         clauses: tuple | None = None,
-    ) -> CatalogQueryResult:
+    ) -> CatalogQueryResult[list[SemanticUnitLexicalHit]]:
         """Typed exact category/kind unit query; never used for content-only lanes."""
         if not (categories or kinds or clauses):
             return CatalogQueryResult(
@@ -3868,7 +3989,7 @@ class LexicalStore:
         clauses: tuple,
         scope: str,
         freshness: tuple | None,
-    ) -> CatalogQueryResult:
+    ) -> CatalogQueryResult[list[str]]:
         """Typed distinct-parent exact catalog query."""
         return self._serve_from_ready_catalog_result(
             scope,
@@ -3933,6 +4054,20 @@ class LexicalStore:
                 "lexical sidecar failed (%s); this process serves the in-process lexical paths",
             )
             return None
+
+    def search_substring_result(
+        self,
+        tokens: list[str],
+        scope: str,
+        freshness: tuple | None,
+        k: int | None = None,
+    ) -> CatalogQueryResult[list[str]]:
+        return self._serve_from_ready_catalog_result(
+            scope,
+            freshness,
+            lambda conn: self._substring_query(conn, tokens, scope, k),
+            "lexical sidecar substring query failed (%s)",
+        )
 
     def _substring_query(
         self, conn: sqlite3.Connection, tokens: list[str], scope: str, k: int | None = None

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -509,10 +509,17 @@ def _mark_runtime_retrieval_unavailable_if_current(vault_root: Path) -> None:
     readiness.mark_unready("retrieval_catalog")
 
 
-def _schedule_runtime_catalog_repair(vault_root: Path) -> None:
+def _schedule_runtime_catalog_repair(
+    vault_root: Path,
+    *,
+    deferred_paths: list[Path] | None = None,
+) -> None:
     """Order admission revocation before the repair that may restore it."""
     _mark_runtime_retrieval_unavailable_if_current(vault_root)
-    _schedule_repair(vault_root)
+    if deferred_paths is None:
+        _schedule_repair(vault_root)
+    else:
+        _schedule_repair(vault_root, deferred_paths=deferred_paths)
 
 
 def request_repair(vault_root: Path) -> None:
@@ -2673,7 +2680,7 @@ class LexicalStore:
         Returns whether the bounded row update committed.
         """
         if self._failed:
-            _schedule_repair(self.vault_root)
+            _schedule_runtime_catalog_repair(self.vault_root)
             return False
         from .vault import VaultLockError
 
@@ -2685,18 +2692,21 @@ class LexicalStore:
             # fine and the store is healthy. Retry exactly these paths in the
             # background instead of rebuilding the corpus for one page (#526).
             log.info("lexical sidecar upsert deferred (%s); retrying these paths", e)
-            _schedule_repair(self.vault_root, deferred_paths=list(paths))
+            _schedule_runtime_catalog_repair(
+                self.vault_root,
+                deferred_paths=list(paths),
+            )
             return False
         except sqlite3.Error as e:
             self._note_query_failure(e, "lexical sidecar upsert deferred (%s)")
-            _schedule_repair(self.vault_root)
+            _schedule_runtime_catalog_repair(self.vault_root)
             return False
         except OSError as e:
             log.info("lexical sidecar upsert source changed during repair (%s)", e)
-            _schedule_repair(self.vault_root)
+            _schedule_runtime_catalog_repair(self.vault_root)
             return False
         if not applied:
-            _schedule_repair(self.vault_root)
+            _schedule_runtime_catalog_repair(self.vault_root)
         return applied
 
     def retry_deferred_upsert(self, paths: list[Path]) -> bool:
@@ -2801,7 +2811,7 @@ class LexicalStore:
     def delete_rel_paths(self, rel_paths: list[str]) -> bool:
         """Bounded inline delete under the barrier (see `upsert_paths`)."""
         if self._failed:
-            _schedule_repair(self.vault_root)
+            _schedule_runtime_catalog_repair(self.vault_root)
             return False
         from .vault import VaultLockError
 
@@ -2810,14 +2820,14 @@ class LexicalStore:
                 applied = self._delete_rel_paths_locked(rel_paths)
         except VaultLockError as e:
             log.info("lexical sidecar delete deferred (%s); heals on next sync", e)
-            _schedule_repair(self.vault_root)
+            _schedule_runtime_catalog_repair(self.vault_root)
             return False
         except sqlite3.Error as e:
             self._note_query_failure(e, "lexical sidecar delete deferred (%s)")
-            _schedule_repair(self.vault_root)
+            _schedule_runtime_catalog_repair(self.vault_root)
             return False
         if not applied:
-            _schedule_repair(self.vault_root)
+            _schedule_runtime_catalog_repair(self.vault_root)
         return applied
 
     def purge_exact_persisted_rows(

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -458,15 +458,20 @@ def get_store(vault_root: Path) -> LexicalStore:
         return store
 
 
-def _mark_runtime_retrieval_ready_if_current(vault_root: Path) -> None:
-    """Admit the configured runtime after a repair proves both scopes current."""
+def _is_configured_runtime_vault(vault_root: Path) -> bool:
     configured_raw = os.environ.get("EXOMEM_VAULT_PATH", "").strip()
     configured = Path(configured_raw) if configured_raw else None
-    if (
-        configured is None
-        or not configured.is_absolute()
-        or configured.resolve(strict=False) != vault_root.resolve(strict=False)
-    ):
+    if configured is None:
+        return False
+    return bool(
+        configured.is_absolute()
+        and configured.resolve(strict=False) == vault_root.resolve(strict=False)
+    )
+
+
+def _mark_runtime_retrieval_ready_if_current(vault_root: Path) -> None:
+    """Admit the configured runtime after a repair proves both scopes current."""
+    if not _is_configured_runtime_vault(vault_root):
         return
     from . import freshness as freshness_module
     from . import readiness
@@ -481,6 +486,39 @@ def _mark_runtime_retrieval_ready_if_current(vault_root: Path) -> None:
         for scope in ("kb", "vault")
     ):
         readiness.mark_ready("retrieval_catalog")
+
+
+def _admit_after_bounded_runtime_repair(vault_root: Path, repaired: object) -> None:
+    """Converge lazy-mode admission after a successful small-corpus repair."""
+    if repaired is None or not _is_configured_runtime_vault(vault_root):
+        return
+    from . import readiness
+
+    if not readiness.is_ready("retrieval_catalog"):
+        # This re-proves both scopes. A missing sibling scope schedules the
+        # ordinary background repair, whose successful publish marks admission.
+        _mark_runtime_retrieval_ready_if_current(vault_root)
+
+
+def _mark_runtime_retrieval_unavailable_if_current(vault_root: Path) -> None:
+    """Revoke configured-runtime admission before scheduling catalog recovery."""
+    if not _is_configured_runtime_vault(vault_root):
+        return
+    from . import readiness
+
+    readiness.mark_unready("retrieval_catalog")
+
+
+def _schedule_runtime_catalog_repair(vault_root: Path) -> None:
+    """Order admission revocation before the repair that may restore it."""
+    _mark_runtime_retrieval_unavailable_if_current(vault_root)
+    _schedule_repair(vault_root)
+
+
+def request_repair(vault_root: Path) -> None:
+    """Non-walking retry seam for a request refused by runtime admission."""
+    if maintained_content_index_enabled():
+        _schedule_repair(vault_root)
 
 
 def clear_stores() -> None:
@@ -676,7 +714,10 @@ def search_bm25(
     if not tokens:
         return []
     store = get_store(vault_root)
-    return store.search_bm25(tokens, k, scope, freshness, allowed_paths, repair)
+    result = store.search_bm25(tokens, k, scope, freshness, allowed_paths, repair)
+    if repair:
+        _admit_after_bounded_runtime_repair(vault_root, result)
+    return result
 
 
 def search_bm25_result(
@@ -728,7 +769,10 @@ def search_substring(
     if not tokens:
         return []
     store = get_store(vault_root)
-    return store.search_substring(tokens, scope, freshness, repair, k)
+    result = store.search_substring(tokens, scope, freshness, repair, k)
+    if repair:
+        _admit_after_bounded_runtime_repair(vault_root, result)
+    return result
 
 
 def search_substring_result(
@@ -3555,10 +3599,10 @@ class LexicalStore:
             # single failed attempt would strand the store as fatal for the
             # process. `_schedule_repair` is itself single-flight, so this cannot
             # storm.
-            _schedule_repair(self.vault_root)
+            _schedule_runtime_catalog_repair(self.vault_root)
             return CatalogReadiness("fatal_failure", False, backend_name)
         if not self.path.exists():
-            _schedule_repair(self.vault_root)
+            _schedule_runtime_catalog_repair(self.vault_root)
             return CatalogReadiness("stale", False, backend_name)
         try:
             conn = self._connect()
@@ -3566,17 +3610,17 @@ class LexicalStore:
                 if not self._schema_is_current(conn):
                     # Read-only probe: an absent/old-shape (v4) or version-stale
                     # sidecar defers to the atomic rebuild — this seam emits no DDL.
-                    _schedule_repair(self.vault_root)
+                    _schedule_runtime_catalog_repair(self.vault_root)
                     return CatalogReadiness("stale", False, backend_name)
                 checkpoint = self._meta_checkpoint(conn, scope)
                 if checkpoint is None:
-                    _schedule_repair(self.vault_root)
+                    _schedule_runtime_catalog_repair(self.vault_root)
                     return CatalogReadiness("stale", False, backend_name)
                 if _checkpoint_state(checkpoint) == target_state:
                     if self._meta_catalog_identity(conn) != catalog_semantic_identity(
                         self.vault_root
                     ):
-                        _schedule_repair(self.vault_root)
+                        _schedule_runtime_catalog_repair(self.vault_root)
                         return CatalogReadiness("stale", False, backend_name)
                     return CatalogReadiness("available", True, backend_name)
             finally:
@@ -3600,12 +3644,12 @@ class LexicalStore:
                             # from under this delta (no longer bound), so it could
                             # not be applied. Defer to the repair worker rather than
                             # letting the mismatch escape this seam.
-                            _schedule_repair(self.vault_root)
+                            _schedule_runtime_catalog_repair(self.vault_root)
                             return CatalogReadiness("stale", False, backend_name)
                         return self.catalog_readiness(
                             scope, freshness, allow_delta=False
                         )
-            _schedule_repair(self.vault_root)
+            _schedule_runtime_catalog_repair(self.vault_root)
             return CatalogReadiness("stale", False, backend_name)
         except sqlite3.Error as e:
             return self._catalog_readiness_error(e, backend_name)
@@ -3697,7 +3741,7 @@ class LexicalStore:
                     # publication landed between the verdict and this transaction.
                     # Defer rather than serve an unvalidated (possibly regressed)
                     # generation; the repair worker reconciles it.
-                    _schedule_repair(self.vault_root)
+                    _schedule_runtime_catalog_repair(self.vault_root)
                     return CatalogQueryResult(
                         None, CatalogReadiness("stale", False, readiness.backend)
                     )
@@ -3730,13 +3774,13 @@ class LexicalStore:
         if kind == "fatal":
             # A proven-fatal disposable sidecar recovers only by whole replacement.
             self._failed = True
-            _schedule_repair(self.vault_root)
+            _schedule_runtime_catalog_repair(self.vault_root)
             return CatalogReadiness("fatal_failure", False, backend_name)
         if kind == "transient":
             # A passing lock/interrupt fails only this call; the next request
             # reopens and retries. It must NOT schedule a whole-corpus repair.
             return CatalogReadiness("transient_failure", False, backend_name)
-        _schedule_repair(self.vault_root)
+        _schedule_runtime_catalog_repair(self.vault_root)
         return CatalogReadiness("stale", False, backend_name)
 
     def search_semantic_units(

--- a/src/exomem/readiness.py
+++ b/src/exomem/readiness.py
@@ -81,6 +81,13 @@ def mark_ready(component: str) -> list:
         return drained
 
 
+def mark_unready(component: str) -> None:
+    """Revoke a component whose live backing state was later proven unavailable."""
+    _check(component)
+    with _lock:
+        _events[component].clear()
+
+
 def drain_deferred(component: str) -> list:
     """Atomically drain and return `component`'s deferred items WITHOUT marking
     it ready.

--- a/src/exomem/readiness.py
+++ b/src/exomem/readiness.py
@@ -31,7 +31,14 @@ from __future__ import annotations
 import threading
 import time
 
-COMPONENTS = ("lexical", "semantic_corpus", "embeddings", "reranker", "clip")
+COMPONENTS = (
+    "retrieval_catalog",
+    "lexical",
+    "semantic_corpus",
+    "embeddings",
+    "reranker",
+    "clip",
+)
 
 _lock = threading.Lock()
 _events: dict[str, threading.Event] = {c: threading.Event() for c in COMPONENTS}
@@ -100,6 +107,18 @@ def is_ready(component: str) -> bool:
 def is_warming() -> bool:
     with _lock:
         return _warm_active and not _warm_finished
+
+
+def retrieval_admission() -> dict[str, object]:
+    """Content-free admission state for ordinary maintained-catalog recall."""
+    with _lock:
+        if _events["retrieval_catalog"].is_set():
+            return {"state": "ready", "admitted": True}
+        if _warm_active and not _warm_finished:
+            return {"state": "warming", "admitted": False}
+        if _warm_finished:
+            return {"state": "unavailable", "admitted": False}
+        return {"state": "unverified", "admitted": False}
 
 
 def should_defer(component: str) -> bool:

--- a/src/exomem/runtime_readiness.py
+++ b/src/exomem/runtime_readiness.py
@@ -310,6 +310,7 @@ def build_runtime_readiness(
     session_store: Mapping[str, Any] | None = None,
     observability: Mapping[str, Any] | None = None,
     traffic: Mapping[str, Any] | None = None,
+    retrieval: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the public readiness payload from already-measured coordination state."""
     enabled = bool(coordination.get("enabled"))
@@ -330,6 +331,17 @@ def build_runtime_readiness(
             reasons.append("coordination_role_unknown")
         if replica_id is None:
             reasons.append("replica_identity_missing")
+
+    retrieval_payload: dict[str, object] | None = None
+    retrieval_admitted = True
+    if retrieval is not None:
+        state = str(retrieval.get("state") or "unverified")
+        if state not in {"ready", "warming", "unavailable", "unverified"}:
+            state = "unverified"
+        retrieval_admitted = bool(retrieval.get("admitted")) and state == "ready"
+        retrieval_payload = {"state": state, "admitted": retrieval_admitted}
+        if not retrieval_admitted:
+            reasons.append(f"retrieval_{state}")
 
     takeover_eligible = not reasons
     session_store_state = (
@@ -355,7 +367,7 @@ def build_runtime_readiness(
     if graph_sync is not None:
         coordination_payload["graph_sync"] = graph_sync
     payload = {
-        "status": "ready" if takeover_eligible else "not_ready",
+        "status": "ready" if takeover_eligible and retrieval_admitted else "not_ready",
         "service": "exomem",
         "release": release,
         "mcp_tool_surface_sha256": mcp_tool_surface_sha256,
@@ -372,6 +384,8 @@ def build_runtime_readiness(
         "takeover_eligible": takeover_eligible,
         "reasons": reasons,
     }
+    if retrieval_payload is not None:
+        payload["retrieval"] = retrieval_payload
     if traffic is not None:
         payload["traffic"] = dict(traffic)
     return payload
@@ -487,9 +501,11 @@ def runtime_readiness(
     traffic: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Measure this process's eligibility without exposing vault or credential state."""
+    from . import readiness
     from .session_validation_cache import session_store_readiness
     from .writer_lease import coordination_status
 
+    coordination: Mapping[str, Any]
     try:
         configured_raw = os.environ.get("EXOMEM_VAULT_PATH", "").strip()
         # Only an absolute path names a boundary this process can probe. A
@@ -541,4 +557,5 @@ def runtime_readiness(
             if traffic is not None
             else get_silent_traffic_monitor().snapshot()
         ),
+        retrieval=readiness.retrieval_admission(),
     )

--- a/src/exomem/server_runtime.py
+++ b/src/exomem/server_runtime.py
@@ -165,6 +165,14 @@ def _initialize_locked_hosted_runtime(
 
     media_worker = None
     file_watcher = None
+    if mutation_ready and startup.phase == "active":
+        # Retrieval catalog warm-up is core service work, not an optional
+        # hosted worker.  A zero optional-worker budget must still converge
+        # truthful retrieval admission for lean cells.
+        if config.has_feature("embeddings") and config.resource_limits.worker_count > 0:
+            _start_compute_runtime(vault_root)
+        else:
+            _start_retrieval_runtime(vault_root)
     if not mutation_ready:
         for feature in ("embeddings", "file-watcher", "media"):
             if config.has_feature(feature):
@@ -212,13 +220,6 @@ def _initialize_locked_hosted_runtime(
                     reason_code="HOSTED_CELL_NOT_ACTIVE",
                 )
     else:
-        if config.has_feature("embeddings"):
-            _start_compute_runtime(vault_root)
-        else:
-            # Maintained lexical admission is core service work, not an
-            # embeddings feature. Lean hosted cells still need the catalog warm
-            # and truthful public readiness transition.
-            _start_retrieval_runtime(vault_root)
         if config.has_feature("media"):
             media_worker = _start_media_worker(vault_root)
             lifecycle.set_worker_status(

--- a/src/exomem/server_runtime.py
+++ b/src/exomem/server_runtime.py
@@ -214,6 +214,11 @@ def _initialize_locked_hosted_runtime(
     else:
         if config.has_feature("embeddings"):
             _start_compute_runtime(vault_root)
+        else:
+            # Maintained lexical admission is core service work, not an
+            # embeddings feature. Lean hosted cells still need the catalog warm
+            # and truthful public readiness transition.
+            _start_retrieval_runtime(vault_root)
         if config.has_feature("media"):
             media_worker = _start_media_worker(vault_root)
             lifecycle.set_worker_status(
@@ -315,16 +320,23 @@ def _start_metrics_persistence() -> None:
         log.warning("metrics persistence unavailable at startup: %s", exc)
 
 
-def _start_compute_runtime(vault_root: Path) -> None:
-    """Start warmup, model unloading, and live compute-mode watching."""
-    from . import mode, warmup
+def _start_retrieval_runtime(vault_root: Path) -> None:
+    """Start core catalog/cache warm-up independently of optional models."""
+    from . import warmup
 
-    log.info("compute policy: %s", mode.resolved())
     if warmup.warmup_enabled():
         if os.environ.get("EXOMEM_EAGER_BOOT"):
             warmup.warm_all(vault_root)
         else:
             warmup.start_background(vault_root)
+
+
+def _start_compute_runtime(vault_root: Path) -> None:
+    """Start retrieval warm-up, model unloading, and live compute-mode watching."""
+    from . import mode
+
+    log.info("compute policy: %s", mode.resolved())
+    _start_retrieval_runtime(vault_root)
 
     if mode.release_when_idle():
         from . import model_reaper

--- a/src/exomem/warmup.py
+++ b/src/exomem/warmup.py
@@ -59,6 +59,31 @@ def model_preload_allowed(mode_name: str | None = None) -> bool:
     return mode.preload_models(mode_name or "normal")
 
 
+def warm_retrieval_catalog(vault_root: Path) -> None:
+    """Reconcile and verify both maintained lexical scopes before optional caches."""
+    from . import freshness, lexstore
+
+    if not lexstore.maintained_content_index_enabled():
+        # Explicit Python mode and SQLite builds without FTS retain the supported
+        # reference implementation; there is no maintained content index to gate.
+        return
+    lexstore.ensure_fresh(vault_root)
+    store = lexstore.get_store(vault_root)
+    incomplete = [
+        (scope, verdict.status)
+        for scope in ("kb", "vault")
+        if not (
+            verdict := store.catalog_readiness(
+                scope,
+                freshness.recall_checkpoint(vault_root, scope).triple,
+                allow_delta=False,
+            )
+        ).complete
+    ]
+    if incomplete:
+        raise RuntimeError(f"maintained lexical catalog incomplete: {incomplete!r}")
+
+
 def warm_caches(
     vault_root: Path,
     *,
@@ -162,6 +187,17 @@ def warm_all(vault_root: Path) -> dict[str, float]:
     mode_name = mode.resolve_mode()
     preload = model_preload_allowed(mode_name)
     durations: dict[str, float] = {}
+    catalog_started = time.perf_counter()
+    try:
+        warm_retrieval_catalog(vault_root)
+        readiness.mark_ready("retrieval_catalog")
+    except Exception:  # noqa: BLE001 — startup stays live while repair retries
+        log.warning("maintained retrieval catalog warm-up failed", exc_info=True)
+    finally:
+        durations["retrieval_catalog"] = round(
+            (time.perf_counter() - catalog_started) * 1000.0,
+            1,
+        )
     durations.update(
         warm_caches(
             vault_root,

--- a/tests/test_bounded_retrieval.py
+++ b/tests/test_bounded_retrieval.py
@@ -305,16 +305,16 @@ def test_unavailable_outside_lexstore_never_walks_the_vault(
     monkeypatch.setattr(find_module, "_outside_kb_keyword_paths", forbidden)
     failed: list[str] = []
 
-    hits = find_module._find_outside_kb(
-        tmp_path,
-        query="outside unavailable needle",
-        query_norm="outside unavailable needle",
-        types=None,
-        projects=None,
-        tags=None,
-        limit=5,
-        failed_out=failed,
-    )
+    with pytest.raises(find_module.RetrievalIndexWarming):
+        find_module._find_outside_kb(
+            tmp_path,
+            query="outside unavailable needle",
+            query_norm="outside unavailable needle",
+            types=None,
+            projects=None,
+            tags=None,
+            limit=5,
+            failed_out=failed,
+        )
 
-    assert hits == []
-    assert failed == ["outside_kb_lexical"]
+    assert failed == []

--- a/tests/test_find_structured_filters.py
+++ b/tests/test_find_structured_filters.py
@@ -621,14 +621,15 @@ def test_auto_widen_pushes_exact_outside_eligibility_into_lexstore(
         _query: str,
         k: int,
         **kwargs: object,
-    ) -> list[tuple[str, float]]:
+    ) -> lexstore.CatalogQueryResult[list[tuple[str, float]]]:
         captured["k"] = k
         captured["allowed_paths"] = kwargs.get("allowed_paths")
-        return [("Projects/active.md", 1.0)]
+        return lexstore.CatalogQueryResult(
+            [("Projects/active.md", 1.0)],
+            lexstore.CatalogReadiness("available", True, "fts5"),
+        )
 
-    from exomem import lexstore
-
-    monkeypatch.setattr(lexstore, "search_bm25", fake_lexstore_search)
+    monkeypatch.setattr(lexstore, "search_bm25_result", fake_lexstore_search)
     hits = find_module._find_outside_kb(
         filter_vault,
         query="outside-marker",

--- a/tests/test_governance_overhead.py
+++ b/tests/test_governance_overhead.py
@@ -24,7 +24,7 @@ from typing import Any
 
 import pytest
 
-from exomem import commands, governance
+from exomem import commands, governance, lexstore
 from exomem import find as find_module
 from exomem.find_types import Hit, SemanticUnitHit
 from exomem.governance import store
@@ -293,6 +293,7 @@ def test_empty_policy_op_find_overhead_under_budget(tmp_path: Path, monkeypatch)
     vault = tmp_path / "dense"
     gen_dense_vault(vault, _OVERHEAD_N_NOTES)
     _seed_freshness_live(vault)
+    lexstore.ensure_fresh(vault)
     # Warm every lane before measuring: the first call builds the BM25 corpus
     # and the resolver, which would swamp a millisecond-scale delta.
     for query in _OVERHEAD_QUERIES:

--- a/tests/test_graph_lane_perf.py
+++ b/tests/test_graph_lane_perf.py
@@ -31,7 +31,7 @@ from pathlib import Path
 
 import pytest
 
-from exomem import epistemic_graph, freshness
+from exomem import epistemic_graph, freshness, lexstore
 from exomem import find as find_module
 from exomem import vault as vault_module
 from exomem.vault import WikilinkResolver, normalize_wikilink, walk_vault_md
@@ -96,6 +96,7 @@ def dense_vault(tmp_path: Path) -> tuple[Path, list[str]]:
     vault = tmp_path / "vault"
     rels = _gen_dense_vault(vault, N_NOTES)
     _seed_freshness_live(vault)
+    lexstore.ensure_fresh(vault)
     yield vault, rels
     find_module.clear_cache()
     freshness.clear()
@@ -216,6 +217,7 @@ def typed_dense_vault(tmp_path: Path) -> tuple[Path, list[str]]:
     vault = tmp_path / "vault"
     rels = _gen_dense_vault(vault, 200)
     _seed_freshness_live(vault)
+    lexstore.ensure_fresh(vault)
     epistemic_graph.EpistemicGraphIndex(vault).rebuild_all()
     yield vault, rels
     find_module.clear_cache()

--- a/tests/test_hosted_cell.py
+++ b/tests/test_hosted_cell.py
@@ -372,6 +372,13 @@ def test_hosted_initialize_skips_dotenv_and_starts_no_ungranted_workers(
     ):
         monkeypatch.delenv(key, raising=False)
 
+    core_runtime: list[str] = []
+    monkeypatch.setattr(
+        server_runtime,
+        "_start_retrieval_runtime",
+        lambda _vault: core_runtime.append("retrieval"),
+        raising=False,
+    )
     monkeypatch.setattr(
         server_runtime,
         "_start_compute_runtime",
@@ -401,6 +408,7 @@ def test_hosted_initialize_skips_dotenv_and_starts_no_ungranted_workers(
     assert readiness["reason_code"] == "HOSTED_READY"
     assert runtime.media_worker is None
     assert runtime.file_watcher is None
+    assert core_runtime == ["retrieval"]
     assert SECRET not in repr(runtime)
     assert "EXOMEM_DISABLE_QUERY_LOG" in hosted_runtime.os.environ
 

--- a/tests/test_instant_start.py
+++ b/tests/test_instant_start.py
@@ -66,6 +66,7 @@ def _reset_readiness(monkeypatch: pytest.MonkeyPatch):
 def test_components_tuple_and_initial_state() -> None:
     """The coordinated components, and the never-warmed default state."""
     assert readiness.COMPONENTS == (
+        "retrieval_catalog",
         "lexical",
         "semantic_corpus",
         "embeddings",
@@ -76,6 +77,32 @@ def test_components_tuple_and_initial_state() -> None:
     assert readiness.warming_info() is None
     for c in readiness.COMPONENTS:
         assert readiness.is_ready(c) is False
+
+
+def test_retrieval_admission_distinguishes_unverified_warming_ready_and_failed() -> None:
+    assert readiness.retrieval_admission() == {
+        "state": "unverified",
+        "admitted": False,
+    }
+
+    readiness.begin_warm()
+    assert readiness.retrieval_admission() == {
+        "state": "warming",
+        "admitted": False,
+    }
+
+    readiness.mark_ready("retrieval_catalog")
+    assert readiness.retrieval_admission() == {
+        "state": "ready",
+        "admitted": True,
+    }
+
+    readiness.begin_warm()
+    readiness.finish_warm()
+    assert readiness.retrieval_admission() == {
+        "state": "unavailable",
+        "admitted": False,
+    }
 
 
 def test_begin_warm_resets_previous_events_and_deferred_items() -> None:
@@ -162,6 +189,7 @@ def test_warming_info_shape_and_transitions() -> None:
     readiness.mark_ready("lexical")
     info2 = readiness.warming_info()
     assert set(info2["components"]) == {
+        "retrieval_catalog",
         "semantic_corpus",
         "embeddings",
         "reranker",
@@ -263,6 +291,12 @@ def test_warm_all_marks_components_ready_in_lexical_embeddings_reranker_clip_ord
     ready as it lands."""
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
     call_order: list[str] = []
+    monkeypatch.setattr(
+        warmup,
+        "warm_retrieval_catalog",
+        lambda vr: call_order.append("catalog"),
+        raising=False,
+    )
     monkeypatch.setattr(warmup, "warm_caches", lambda vr, **_kw: call_order.append("lexical") or {})
     monkeypatch.setattr(
         embeddings, "get_model", lambda: call_order.append("embeddings") or object()
@@ -275,7 +309,7 @@ def test_warm_all_marks_components_ready_in_lexical_embeddings_reranker_clip_ord
 
     warmup.warm_all(tmp_path)
 
-    assert call_order == ["lexical", "embeddings", "reranker", "clip"]
+    assert call_order == ["catalog", "lexical", "embeddings", "reranker", "clip"]
     for c in readiness.COMPONENTS:
         assert readiness.is_ready(c) is True
 
@@ -289,6 +323,12 @@ def test_warm_all_marks_lexical_ready_before_semantic_corpus_build(
     monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
     call_order: list[str] = []
 
+    monkeypatch.setattr(
+        warmup,
+        "warm_retrieval_catalog",
+        lambda vr: call_order.append("catalog"),
+        raising=False,
+    )
     monkeypatch.setattr(
         warmup,
         "warm_caches",
@@ -306,8 +346,109 @@ def test_warm_all_marks_lexical_ready_before_semantic_corpus_build(
 
     warmup.warm_all(tmp_path)
 
-    assert call_order == ["lexical", "semantic"]
+    assert call_order == ["catalog", "lexical", "semantic"]
     assert readiness.is_ready("semantic_corpus") is True
+
+
+def test_warm_all_marks_catalog_ready_before_optional_cache_work(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    call_order: list[str] = []
+
+    def catalog(_vault_root: Path) -> None:
+        call_order.append("catalog")
+
+    def optional_caches(_vault_root: Path, **_kwargs) -> dict:
+        assert readiness.is_ready("retrieval_catalog") is True
+        call_order.append("optional_caches")
+        return {}
+
+    monkeypatch.setattr(
+        warmup,
+        "warm_retrieval_catalog",
+        catalog,
+        raising=False,
+    )
+    monkeypatch.setattr(warmup, "warm_caches", optional_caches)
+    monkeypatch.setattr(
+        "exomem.semantic_contract.build_corpus_context",
+        lambda _root: call_order.append("semantic"),
+    )
+
+    warmup.warm_all(tmp_path)
+
+    assert call_order == ["catalog", "optional_caches", "semantic"]
+    assert readiness.is_ready("retrieval_catalog") is True
+
+
+def test_warm_retrieval_catalog_verifies_kb_and_vault_scopes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from types import SimpleNamespace
+
+    from exomem import freshness, lexstore
+
+    calls: list[str] = []
+
+    class Store:
+        def catalog_readiness(
+            self,
+            scope: str,
+            _freshness: tuple,
+            *,
+            allow_delta: bool,
+        ) -> lexstore.CatalogReadiness:
+            assert allow_delta is False
+            calls.append(scope)
+            return lexstore.CatalogReadiness("available", True, "fts5")
+
+    monkeypatch.setattr(lexstore, "maintained_content_index_enabled", lambda: True)
+    monkeypatch.setattr(
+        lexstore,
+        "ensure_fresh",
+        lambda _root: calls.append("ensure"),
+    )
+    monkeypatch.setattr(lexstore, "get_store", lambda _root: Store())
+    monkeypatch.setattr(
+        freshness,
+        "recall_checkpoint",
+        lambda _root, _scope: SimpleNamespace(triple=(1, 1, "digest")),
+    )
+
+    warmup.warm_retrieval_catalog(tmp_path)
+
+    assert calls == ["ensure", "kb", "vault"]
+
+
+def test_warm_all_quiet_mode_still_reconciles_the_catalog(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    calls: list[str] = []
+    cache_policy: dict = {}
+    monkeypatch.setattr(
+        warmup,
+        "warm_retrieval_catalog",
+        lambda _root: calls.append("catalog"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        warmup,
+        "warm_caches",
+        lambda _root, **kwargs: cache_policy.update(kwargs) or {},
+    )
+    monkeypatch.setattr(
+        "exomem.semantic_contract.build_corpus_context",
+        lambda _root: None,
+    )
+
+    warmup.warm_all(tmp_path)
+
+    assert calls == ["catalog"]
+    assert cache_policy["preload_cpu_caches"] is False
+    assert readiness.is_ready("retrieval_catalog") is True
 
 
 def test_warm_all_skips_model_preloads_when_embeddings_disabled(
@@ -760,6 +901,7 @@ def test_find_defers_vector_lane_mid_warm_without_calling_embed_texts(
     monkeypatch.setattr(embeddings, "embed_texts", _guarded)
 
     readiness.begin_warm()
+    readiness.mark_ready("retrieval_catalog")
     degraded: list[str] = []
     mid_warm_hits = find_module.find(
         vault, query="metabolism", mode="hybrid", degraded_out=degraded
@@ -783,6 +925,7 @@ def test_find_degraded_out_stays_empty_after_finish_warm_natural_fallback(
     readiness gate never engages)."""
     monkeypatch.setenv("EXOMEM_FIND_CACHE_SIZE", "0")
     readiness.begin_warm()
+    readiness.mark_ready("retrieval_catalog")
     readiness.finish_warm()
 
     degraded: list[str] = []
@@ -834,6 +977,7 @@ def test_op_find_warming_envelope_mid_warm_then_bare_list_after_finish(
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
     monkeypatch.setenv("EXOMEM_FIND_CACHE_SIZE", "0")
     readiness.begin_warm()
+    readiness.mark_ready("retrieval_catalog")
     out = commands.op_find(vault, query="metabolism", mode="hybrid")
 
     assert isinstance(out, dict)
@@ -1272,6 +1416,7 @@ def test_degraded_find_never_cached_even_without_degraded_out(
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
 
     readiness.begin_warm()
+    readiness.mark_ready("retrieval_catalog")
     find_module.find(vault, query="metabolism", mode="hybrid")
     with find_module._FIND_CACHE_LOCK:
         assert not find_module._FIND_CACHE, "degraded mid-warm result was cached"

--- a/tests/test_keyword_lane_cold_cost.py
+++ b/tests/test_keyword_lane_cold_cost.py
@@ -8,9 +8,8 @@ from pathlib import Path
 import pytest
 
 from exomem import find as find_module
-from exomem import freshness, lexstore
+from exomem import freshness, lexstore, readiness
 from exomem.vault import walk_vault_md
-
 
 pytestmark = pytest.mark.skipif(
     not lexstore.fts5_available(), reason="this SQLite build lacks FTS5/trigram"
@@ -72,11 +71,13 @@ def _fresh_state(monkeypatch: pytest.MonkeyPatch):
     lexstore.reset_memo()
     lexstore.clear_stores()
     find_module.clear_cache()
+    readiness.reset()
     monkeypatch.setenv("EXOMEM_LEXICAL_BACKEND", "fts5")
     yield
     lexstore.reset_memo()
     lexstore.clear_stores()
     find_module.clear_cache()
+    readiness.reset()
 
 
 def test_one_write_reconciles_keyword_catalog_in_proportion_to_the_change(
@@ -150,7 +151,7 @@ def test_one_write_reconciles_keyword_catalog_in_proportion_to_the_change(
     assert delta_calls == 1
 
 
-def test_declining_sidecar_still_returns_the_reference_answer(
+def test_small_repairing_sidecar_decline_still_returns_the_reference_answer(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _write_page(
@@ -172,7 +173,7 @@ def test_declining_sidecar_still_returns_the_reference_answer(
         "sharedneedle",
         "kb",
         freshness=checkpoint.triple,
-        repair=False,
+        repair=True,
     )
 
     monkeypatch.setattr(lexstore, "search_substring", lambda *args, **kwargs: None)
@@ -181,13 +182,237 @@ def test_declining_sidecar_still_returns_the_reference_answer(
         "sharedneedle",
         "kb",
         freshness=checkpoint.triple,
-        repair=False,
+        repair=True,
     )
 
     assert declined == healthy == [
         "Knowledge Base/Notes/newer.md",
         "Knowledge Base/Notes/older.md",
     ]
+
+
+def test_large_cold_keyword_catalog_returns_typed_warming_without_a_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for index in range(80):
+        _write_page(
+            tmp_path,
+            f"Knowledge Base/Notes/page-{index:03d}.md",
+            f"coldkeyword payload {index}",
+        )
+    _seed_live(tmp_path)
+    checkpoint = freshness.recall_checkpoint(tmp_path, "kb")
+    walked = 0
+    parsed = 0
+
+    def forbidden_walk(_root: Path):
+        nonlocal walked
+        walked += 1
+        raise AssertionError("a production-size request must not walk the vault")
+        yield  # pragma: no cover - keep this a generator-shaped test double
+
+    def forbidden_parse(*_args, **_kwargs):
+        nonlocal parsed
+        parsed += 1
+        raise AssertionError("a production-size request must not parse pages")
+
+    monkeypatch.setattr(find_module, "_walk_md", forbidden_walk)
+    monkeypatch.setattr(find_module._CACHE, "get", forbidden_parse)
+    monkeypatch.setattr(lexstore, "_schedule_repair", lambda _root: None)
+
+    with pytest.raises(find_module.RetrievalIndexWarming) as raised:
+        find_module._keyword_match_paths(
+            tmp_path,
+            "coldkeyword",
+            "kb",
+            freshness=checkpoint.triple,
+            repair=False,
+        )
+
+    assert raised.value.code == "RETRIEVAL_INDEX_WARMING"
+    assert raised.value.status == "warming"
+    assert walked == 0
+    assert parsed == 0
+
+
+def test_transient_large_catalog_query_returns_typed_unavailable_without_a_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for index in range(80):
+        _write_page(
+            tmp_path,
+            f"Knowledge Base/Notes/page-{index:03d}.md",
+            f"transientneedle payload {index}",
+        )
+    _materialize_live_catalog(tmp_path, "transientneedle")
+    checkpoint = freshness.recall_checkpoint(tmp_path, "kb")
+    walked = 0
+
+    def forbidden_walk(_root: Path):
+        nonlocal walked
+        walked += 1
+        raise AssertionError("a transient query failure must not walk the vault")
+        yield  # pragma: no cover - keep this a generator-shaped test double
+
+    monkeypatch.setattr(find_module, "_walk_md", forbidden_walk)
+    monkeypatch.setattr(
+        lexstore,
+        "search_substring_result",
+        lambda *_args, **_kwargs: lexstore.CatalogQueryResult(
+            None,
+            lexstore.CatalogReadiness("transient_failure", False, "fts5"),
+        ),
+    )
+
+    with pytest.raises(find_module.RetrievalIndexWarming) as raised:
+        find_module._keyword_match_paths(
+            tmp_path,
+            "transientneedle",
+            "kb",
+            freshness=checkpoint.triple,
+            repair=False,
+        )
+
+    assert raised.value.status == "temporarily_unavailable"
+    assert walked == 0
+
+
+def test_active_catalog_warm_refuses_before_a_cold_freshness_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for index in range(80):
+        _write_page(
+            tmp_path,
+            f"Knowledge Base/Notes/page-{index:03d}.md",
+            f"preseedrace payload {index}",
+        )
+    walked = 0
+
+    def forbidden_walk(_root: Path):
+        nonlocal walked
+        walked += 1
+        raise AssertionError("admission must run before cold freshness walks")
+        yield  # pragma: no cover - keep this a generator-shaped test double
+
+    readiness.begin_warm()
+    monkeypatch.setattr(find_module, "_walk_md", forbidden_walk)
+
+    with pytest.raises(find_module.RetrievalIndexWarming):
+        find_module.find(
+            tmp_path,
+            query="preseedrace",
+            mode="keyword",
+            scope="kb",
+        )
+
+    assert walked == 0
+
+
+def test_large_cold_hybrid_catalog_returns_typed_warming_without_a_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for index in range(80):
+        _write_page(
+            tmp_path,
+            f"Knowledge Base/Notes/page-{index:03d}.md",
+            f"coldhybrid payload {index}",
+        )
+    _seed_live(tmp_path)
+    walked = 0
+    parsed = 0
+
+    def forbidden_walk(_root: Path):
+        nonlocal walked
+        walked += 1
+        raise AssertionError("a production-size request must not walk the vault")
+        yield  # pragma: no cover - keep this a generator-shaped test double
+
+    def forbidden_parse(*_args, **_kwargs):
+        nonlocal parsed
+        parsed += 1
+        raise AssertionError("a production-size request must not parse pages")
+
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    monkeypatch.setattr(find_module, "_walk_md", forbidden_walk)
+    monkeypatch.setattr(find_module._CACHE, "get", forbidden_parse)
+    monkeypatch.setattr(lexstore, "_schedule_repair", lambda _root: None)
+
+    with pytest.raises(find_module.RetrievalIndexWarming) as raised:
+        find_module.find(
+            tmp_path,
+            query="coldhybrid",
+            mode="hybrid",
+            scope="kb",
+            graph=False,
+            temporal=False,
+        )
+
+    assert raised.value.code == "RETRIEVAL_INDEX_WARMING"
+    assert raised.value.status == "warming"
+    assert walked == 0
+    assert parsed == 0
+
+
+def test_successful_background_repair_marks_configured_catalog_ready(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for index in range(80):
+        _write_page(
+            tmp_path,
+            f"Knowledge Base/Notes/page-{index:03d}.md",
+            f"backgroundrepair payload {index}",
+        )
+    _seed_live(tmp_path)
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(tmp_path.resolve()))
+
+    lexstore._schedule_repair(tmp_path)
+
+    assert lexstore.await_repairs_idle(tmp_path, timeout=30.0) is True
+    assert readiness.retrieval_admission() == {
+        "state": "ready",
+        "admitted": True,
+    }
+
+
+def test_large_cold_vault_widening_returns_typed_warming_without_a_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_page(
+        tmp_path,
+        "Knowledge Base/Notes/kb-target.md",
+        "widenneedle kb payload",
+    )
+    _materialize_live_catalog(tmp_path, "widenneedle")
+    outside: list[Path] = []
+    for index in range(80):
+        outside.append(
+            _write_page(
+                tmp_path,
+                f"Reference/page-{index:03d}.md",
+                f"widenneedle outside payload {index}",
+            )
+        )
+    freshness.on_files_changed(tmp_path, changed=outside)
+    walked = 0
+
+    def forbidden_walk(_root: Path):
+        nonlocal walked
+        walked += 1
+        raise AssertionError("auto-widen must not walk a production-size vault")
+        yield  # pragma: no cover - keep this a generator-shaped test double
+
+    monkeypatch.setattr(find_module, "_walk_md", forbidden_walk)
+    monkeypatch.setattr(lexstore, "_schedule_repair", lambda _root: None)
+
+    with pytest.raises(find_module.RetrievalIndexWarming):
+        find_module.find(
+            tmp_path,
+            query="widenneedle",
+            mode="keyword",
+            scope="kb",
+        )
+
+    assert walked == 0
 
 
 def test_access_policy_change_is_not_served_from_a_delta(
@@ -224,13 +449,13 @@ def test_access_policy_change_is_not_served_from_a_delta(
         "policyneedle",
         "kb",
         freshness=checkpoint.triple,
-        repair=False,
+        repair=True,
     )
 
     assert paths == ["Knowledge Base/Notes/public.md"]
 
 
-def test_incomplete_delta_takes_the_full_reference_path(
+def test_nonrepairing_incomplete_delta_returns_warming_without_a_walk(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     target = _write_page(
@@ -278,13 +503,13 @@ def test_incomplete_delta_takes_the_full_reference_path(
     monkeypatch.setattr(lexstore, "_schedule_repair", lambda _root: None)
     checkpoint = freshness.recall_checkpoint(tmp_path, "kb")
 
-    paths = find_module._keyword_match_paths(
-        tmp_path,
-        "afterdelta",
-        "kb",
-        freshness=checkpoint.triple,
-        repair=False,
-    )
+    with pytest.raises(find_module.RetrievalIndexWarming):
+        find_module._keyword_match_paths(
+            tmp_path,
+            "afterdelta",
+            "kb",
+            freshness=checkpoint.triple,
+            repair=False,
+        )
 
-    assert paths == ["Knowledge Base/Notes/target.md"]
-    assert walked == 5
+    assert walked == 0

--- a/tests/test_keyword_lane_cold_cost.py
+++ b/tests/test_keyword_lane_cold_cost.py
@@ -235,6 +235,41 @@ def test_large_cold_keyword_catalog_returns_typed_warming_without_a_walk(
     assert parsed == 0
 
 
+def test_large_lazy_empty_query_returns_typed_warming_without_a_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for index in range(70):
+        _write_page(
+            tmp_path,
+            f"Knowledge Base/Notes/page-{index:03d}.md",
+            f"emptyquery payload {index}",
+        )
+    _seed_live(tmp_path)
+    walked = 0
+    parsed = 0
+
+    def forbidden_walk(_root: Path):
+        nonlocal walked
+        walked += 1
+        raise AssertionError("an incomplete empty query must not walk the vault")
+        yield  # pragma: no cover - keep this a generator-shaped test double
+
+    def forbidden_parse(*_args, **_kwargs):
+        nonlocal parsed
+        parsed += 1
+        raise AssertionError("an incomplete empty query must not parse pages")
+
+    monkeypatch.setattr(find_module, "_walk_md", forbidden_walk)
+    monkeypatch.setattr(find_module._CACHE, "get", forbidden_parse)
+    monkeypatch.setattr(lexstore, "_schedule_repair", lambda _root: None)
+
+    with pytest.raises(find_module.RetrievalIndexWarming):
+        find_module.find(tmp_path, query="", mode="keyword", scope="kb")
+
+    assert walked == 0
+    assert parsed == 0
+
+
 def test_transient_large_catalog_query_returns_typed_unavailable_without_a_walk(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -308,6 +343,37 @@ def test_active_catalog_warm_refuses_before_a_cold_freshness_walk(
     assert walked == 0
 
 
+def test_failed_catalog_warm_retries_repair_before_refusing_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for index in range(80):
+        _write_page(
+            tmp_path,
+            f"Knowledge Base/Notes/page-{index:03d}.md",
+            f"retryrepair payload {index}",
+        )
+    scheduled: list[Path] = []
+
+    def forbidden_walk(_root: Path):
+        raise AssertionError("failed-warm retry must precede cold freshness walks")
+        yield  # pragma: no cover - keep this a generator-shaped test double
+
+    readiness.begin_warm()
+    readiness.finish_warm()
+    monkeypatch.setattr(find_module, "_walk_md", forbidden_walk)
+    monkeypatch.setattr(
+        lexstore,
+        "request_repair",
+        lambda root: scheduled.append(root),
+        raising=False,
+    )
+
+    with pytest.raises(find_module.RetrievalIndexWarming):
+        find_module.find(tmp_path, query="retryrepair", mode="keyword", scope="kb")
+
+    assert scheduled == [tmp_path]
+
+
 def test_large_cold_hybrid_catalog_returns_typed_warming_without_a_walk(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -371,6 +437,61 @@ def test_successful_background_repair_marks_configured_catalog_ready(
     assert readiness.retrieval_admission() == {
         "state": "ready",
         "admitted": True,
+    }
+
+
+def test_small_lazy_repair_eventually_admits_configured_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for index in range(4):
+        _write_page(
+            tmp_path,
+            f"Knowledge Base/Notes/page-{index:03d}.md",
+            f"smalllazy payload {index}",
+        )
+    _seed_live(tmp_path)
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(tmp_path.resolve()))
+
+    hits = find_module.find(
+        tmp_path,
+        query="smalllazy",
+        mode="keyword",
+        scope="kb-only",
+    )
+
+    assert len(hits) == 4
+    assert lexstore.await_repairs_idle(tmp_path, timeout=30.0) is True
+    assert readiness.retrieval_admission() == {
+        "state": "ready",
+        "admitted": True,
+    }
+
+
+def test_discovered_catalog_staleness_revokes_configured_runtime_admission(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for index in range(80):
+        _write_page(
+            tmp_path,
+            f"Knowledge Base/Notes/page-{index:03d}.md",
+            f"laterstale payload {index}",
+        )
+    _seed_live(tmp_path)
+    lexstore.ensure_fresh(tmp_path)
+    store = lexstore.get_store(tmp_path)
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(tmp_path.resolve()))
+    readiness.begin_warm()
+    readiness.mark_ready("retrieval_catalog")
+    readiness.finish_warm()
+    store.path.unlink()
+    monkeypatch.setattr(lexstore, "_schedule_repair", lambda _root: None)
+
+    with pytest.raises(find_module.RetrievalIndexWarming):
+        find_module.find(tmp_path, query="laterstale", mode="keyword", scope="kb")
+
+    assert readiness.retrieval_admission() == {
+        "state": "unavailable",
+        "admitted": False,
     }
 
 

--- a/tests/test_keyword_lane_cold_cost.py
+++ b/tests/test_keyword_lane_cold_cost.py
@@ -495,6 +495,44 @@ def test_discovered_catalog_staleness_revokes_configured_runtime_admission(
     }
 
 
+@pytest.mark.parametrize("operation", ["upsert", "delete"])
+def test_failed_catalog_mutation_revokes_configured_runtime_before_repair(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    page = _write_page(
+        tmp_path,
+        "Knowledge Base/Notes/target.md",
+        "mutationfailure payload",
+    )
+    store = lexstore.get_store(tmp_path)
+    store._failed = True
+    scheduled: list[Path] = []
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(tmp_path.resolve()))
+    monkeypatch.setattr(
+        lexstore,
+        "_schedule_repair",
+        lambda root, **_kwargs: scheduled.append(root),
+    )
+    readiness.begin_warm()
+    readiness.mark_ready("retrieval_catalog")
+    readiness.finish_warm()
+
+    applied = (
+        store.upsert_paths([page])
+        if operation == "upsert"
+        else store.delete_rel_paths(["Knowledge Base/Notes/target.md"])
+    )
+
+    assert applied is False
+    assert scheduled == [tmp_path]
+    assert readiness.retrieval_admission() == {
+        "state": "unavailable",
+        "admitted": False,
+    }
+
+
 def test_large_cold_vault_widening_returns_typed_warming_without_a_walk(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_latency_gate.py
+++ b/tests/test_latency_gate.py
@@ -359,6 +359,7 @@ def test_referent_stage_stays_bounded_at_scale(
     vault = _build_dense_vault(tmp_path, N_NOTES)
     gen_entity_overlay(vault, 500, seed=19)
     _seed_freshness_live(vault)
+    lexstore.ensure_fresh(vault)
     cold_referents_ms, referents_ms, block = _measure_referent_stage(vault)
     assert cold_referents_ms < CEIL_REFERENTS_COLD_MS
     assert referents_ms < CEIL_REFERENTS_MS
@@ -404,11 +405,13 @@ def test_referent_stage_does_not_scale_linearly(tmp_path: Path, model_free) -> N
     small = _build_dense_vault(tmp_path, N_NOTES)
     gen_entity_overlay(small, 125, seed=23)
     _seed_freshness_live(small)
+    lexstore.ensure_fresh(small)
     _, small_ms, _ = _measure_referent_stage(small)
 
     large = _build_dense_vault(tmp_path, N_NOTES_LARGE)
     gen_entity_overlay(large, 500, seed=23)
     _seed_freshness_live(large)
+    lexstore.ensure_fresh(large)
     _, large_ms, _ = _measure_referent_stage(large)
 
     bound = max(

--- a/tests/test_latency_gate.py
+++ b/tests/test_latency_gate.py
@@ -43,7 +43,7 @@ import pytest
 import yaml
 
 from exomem import find as find_module
-from exomem import freshness
+from exomem import freshness, lexstore
 from exomem.vault import walk_vault_md
 
 # Reuse the ONE synthetic-vault generator (scripts/synth_vault.py).
@@ -125,6 +125,10 @@ def _build_dense_vault(root: Path, n: int) -> Path:
     vault = root / f"vault-{n}"
     gen_dense_vault(vault, n)
     _seed_freshness_live(vault)
+    # Startup owns the potentially unbounded catalog build.  Interactive find
+    # calls intentionally refuse to become that build for a large corpus, so
+    # this steady-state latency fixture must perform the explicit warmup first.
+    lexstore.ensure_fresh(vault)
     # Warm every lane once so the measured passes reflect steady state, not the
     # first-touch lexical-sidecar / bm25-corpus / resolver build.
     for q in _QUERIES:

--- a/tests/test_mcp_schema_fidelity.py
+++ b/tests/test_mcp_schema_fidelity.py
@@ -215,7 +215,10 @@ def test_readiness_fingerprint_matches_actual_registered_surface(
 
     response = TestClient(mcp.http_app()).get("/health/ready")
 
-    assert response.status_code == 200
+    # This fixture intentionally selects the legacy Python lexical backend, so
+    # retrieval admission may truthfully remain unavailable.  The readiness
+    # payload must expose the registered tool fingerprint in either state.
+    assert response.status_code in {200, 503}
     assert response.json()["mcp_tool_surface_sha256"] == actual_digest
 
 

--- a/tests/test_readiness_honesty.py
+++ b/tests/test_readiness_honesty.py
@@ -100,6 +100,8 @@ def test_readiness_without_an_absolute_vault_is_unknown_not_free(
 def test_status_failure_is_unknown_and_keeps_readiness_non_raising(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from exomem import readiness as warm_readiness
+
     def explode(vault_or_cell: object = None) -> dict[str, object]:
         raise OpError(
             "MUTATION_LOCK_UNAVAILABLE",
@@ -109,8 +111,12 @@ def test_status_failure_is_unknown_and_keeps_readiness_non_raising(
 
     monkeypatch.delenv("EXOMEM_WRITER_LEASE_URL", raising=False)
     monkeypatch.setattr(writer_lease, "coordination_status", explode)
-
-    snapshot = readiness_module.runtime_readiness(mcp_tool_surface_sha256=_SHA)
+    warm_readiness.reset()
+    warm_readiness.mark_ready("retrieval_catalog")
+    try:
+        snapshot = readiness_module.runtime_readiness(mcp_tool_surface_sha256=_SHA)
+    finally:
+        warm_readiness.reset()
 
     boundary = snapshot["coordination"]["mutation_boundary"]
     assert boundary["state"] == "unknown"

--- a/tests/test_runtime_readiness.py
+++ b/tests/test_runtime_readiness.py
@@ -148,6 +148,59 @@ def test_missing_replica_identity_is_not_ready_when_coordination_enabled() -> No
     assert snapshot["reasons"] == ["replica_identity_missing"]
 
 
+@pytest.mark.parametrize(
+    ("state", "reason"),
+    [
+        ("warming", "retrieval_warming"),
+        ("unavailable", "retrieval_unavailable"),
+        ("unverified", "retrieval_unverified"),
+    ],
+)
+def test_retrieval_admission_withholds_runtime_readiness(
+    state: str, reason: str
+) -> None:
+    snapshot = build_runtime_readiness(
+        coordination={
+            "enabled": False,
+            "role": "standalone",
+            "replica_id": None,
+            "coordinator_healthy": True,
+        },
+        release="1.2.3",
+        mcp_tool_surface_sha256="d" * 64,
+        retrieval={
+            "state": state,
+            "admitted": False,
+            "vault_path": "must-not-leak",
+            "query": "must-not-leak-either",
+        },
+    )
+
+    assert snapshot["status"] == "not_ready"
+    assert snapshot["takeover_eligible"] is False
+    assert snapshot["retrieval"] == {"state": state, "admitted": False}
+    assert snapshot["reasons"] == [reason]
+    assert "must-not-leak" not in repr(snapshot)
+
+
+def test_ready_retrieval_catalog_admits_runtime_readiness() -> None:
+    snapshot = build_runtime_readiness(
+        coordination={
+            "enabled": False,
+            "role": "standalone",
+            "replica_id": None,
+            "coordinator_healthy": True,
+        },
+        release="1.2.3",
+        mcp_tool_surface_sha256="d" * 64,
+        retrieval={"state": "ready", "admitted": True},
+    )
+
+    assert snapshot["status"] == "ready"
+    assert snapshot["retrieval"] == {"state": "ready", "admitted": True}
+    assert snapshot["reasons"] == []
+
+
 def test_readiness_exposes_only_bounded_mutation_holder_metadata() -> None:
     snapshot = build_runtime_readiness(
         coordination={
@@ -213,8 +266,8 @@ def test_runtime_readiness_measures_the_configured_vault(
 def test_runtime_readiness_fails_closed_within_a_tight_bound_when_status_blocks(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    from exomem import readiness, session_validation_cache, writer_lease
     from exomem import runtime_readiness as readiness_module
-    from exomem import session_validation_cache, writer_lease
 
     vault = tmp_path / "blocked-vault"
     entered = threading.Event()
@@ -235,6 +288,7 @@ def test_runtime_readiness_fails_closed_within_a_tight_bound_when_status_blocks(
     monkeypatch.setattr(writer_lease, "coordination_status", blocked_coordination_status)
     monkeypatch.setattr(session_validation_cache, "session_store_readiness", lambda: {})
     monkeypatch.setattr(readiness_module, "_measure_observability", lambda: {})
+    readiness.mark_ready("retrieval_catalog")
 
     assert readiness_module.COORDINATION_STATUS_TIMEOUT_SECONDS < 1.0
     started = time.monotonic()
@@ -268,8 +322,8 @@ def test_runtime_readiness_admits_a_slow_but_bounded_real_vault_snapshot(
     the following probe.  Preserve sub-second failure for a genuinely blocked
     snapshot while leaving measured steady-state work enough headroom.
     """
+    from exomem import readiness, session_validation_cache, writer_lease
     from exomem import runtime_readiness as readiness_module
-    from exomem import session_validation_cache, writer_lease
 
     vault = tmp_path / "large-vault"
 
@@ -287,6 +341,7 @@ def test_runtime_readiness_admits_a_slow_but_bounded_real_vault_snapshot(
     monkeypatch.setattr(writer_lease, "coordination_status", slow_coordination_status)
     monkeypatch.setattr(session_validation_cache, "session_store_readiness", lambda: {})
     monkeypatch.setattr(readiness_module, "_measure_observability", lambda: {})
+    readiness.mark_ready("retrieval_catalog")
 
     started = time.monotonic()
     snapshot = readiness_module.runtime_readiness(
@@ -394,7 +449,8 @@ def test_coordination_graph_health_requires_a_readable_sidecar(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Epoch state alone must not make readiness claim the graph is current."""
-    from exomem import epistemic_graph, vault as vault_module, writer_lease
+    from exomem import epistemic_graph, writer_lease
+    from exomem import vault as vault_module
 
     manager = writer_lease.LeaseManager(writer_lease.LeaseConfig(state_dir=tmp_path / "state"))
     empty = tmp_path / "empty"


### PR DESCRIPTION
## Why

A restarted large-vault cell could report ready before its lexical catalog was usable. The first ordinary `ask`/`find` then fell through to a request-time corpus walk, held custody long enough to cross the public edge deadline, and surfaced as connector errors.

## What changed

- make lexical catalog readiness a first-class admission component
- warm and verify both recall scopes independently of embedding warmup
- keep large-vault request paths nonwalking while the catalog is absent, stale, or failed
- return typed warming/unavailable responses instead of entering an unbounded scan
- revoke readiness before background repair on later staleness or mutation-maintenance failure
- restore readiness only after a successful repair proves both scopes current
- start retrieval warmup for lean hosted cells too
- add the OpenSpec contract and production-size zero-walk regressions

## Verification

- `203 passed` across catalog/readiness/instant-start/bounded-retrieval/reliability suites
- `70 passed` across lexical cold-cost, reliability, and atomic rebuild suites
- mutation failure regression: `2 passed`
- `uvx ruff check src/exomem/lexstore.py tests/test_keyword_lane_cold_cost.py`
- exact targeted mypy CI command passed for 14 source files
- `openspec validate --all --strict`: 164 passed
- public artifact repository and built-dist validation passed
- package build and skill packaging passed

The full latency gate remains authoritative on Linux CI. On Windows, the relation-filtered result matched the detached v0.60.1 baseline (11.09s vs 11.58s); the 8k filesystem fixture exceeded the local ten-minute runner limit in `lstat` on both this machine's stressed state and is not used as a release claim.