### PR TITLE
fix: bind transport before startup warm

### DIFF
--- a/openspec/changes/fix-startup-retrieval-liveness/design.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/design.md
@@ -33,7 +33,9 @@ Alternative rejected: globally enable eager boot. It avoids request-time work on
 
 ### Split maintained-catalog warm-up from optional cache warm-up
 
-Warm-up becomes two CPU phases. First, KB- and vault-scope maintained lexical catalogs are reconciled. A new `retrieval_catalog` readiness component is marked only when both scopes succeed. Second, parsed pages, resolver state, semantic corpus, matrices, and models warm under their existing soft-fail and resource-mode rules. Quiet mode still performs the disk-backed maintained-catalog phase because it does not require retaining a full parsed corpus in RAM.
+Warm-up becomes ordered admission and optimization phases. First, KB- and vault-scope maintained lexical catalogs are reconciled. A new `retrieval_catalog` readiness component is marked only when both scopes succeed. The semantic corpus required for mutation admission lands next. Only then do parsed pages, resolver state, matrices, and models warm under their existing soft-fail and resource-mode rules. Quiet mode still performs the disk-backed maintained-catalog and semantic-corpus phases because neither requires retaining all optional search caches in RAM.
+
+Local service composition also becomes transport-first. The HTTP server is built and allowed to answer liveness before local retrieval, watcher, graph-drain, or media startup work is activated. After activation, required catalog and semantic-corpus state gets exclusive startup priority: watcher reconciliation, graph recovery, and media discovery wait until retrieval and mutation admission are established, or warm-up reaches a terminal failed outcome. This prevents independent startup reconcilers from contending on the process-local mutation boundary while required state is being rebuilt.
 
 Alternative rejected: only reorder the existing steps while keeping one `lexical` marker. That would either report readiness too late after the catalog is already usable or too early when fallback pages are still cold.
 
@@ -53,6 +55,7 @@ Regression tests use a production-sized synthetic freshness tuple and instrument
 
 - [Clients see a retryable warming error where they previously waited for eventual results] -> The outcome already exists in the public operation contract, is bounded, and is preferable to an edge-generated 504 with no useful remediation.
 - [A catalog repair failure can hold readiness at 503] -> Liveness remains 200, logs preserve per-stage failure, and the existing single-flight repair keeps retrying without touching canonical data.
+- [Watcher, graph, and media reconciliation start later on a cold catalog] -> Their existing startup scans recover changes made while the service was stopped; deferring them avoids mutation contention without losing durable work.
 - [Quiet or explicitly disabled warm-up changes readiness behavior] -> Quiet still warms only the disk-backed catalog; fully disabled warm-up is explicitly lazy and reports that truth instead of claiming full admission.
 - [Readiness consumers may not expect the added field/reason] -> The payload extension is additive; the existing status/reasons contract already supports not-ready causes.
 

--- a/openspec/changes/fix-startup-retrieval-liveness/specs/find-recall-efficiency/spec.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/specs/find-recall-efficiency/spec.md
@@ -2,13 +2,19 @@
 
 ### Requirement: Startup Cache Warm-Up
 
-When startup warm-up is enabled, the system SHALL first reconcile the maintained lexical catalog for KB and vault scopes. When the active resource policy allows CPU cache preloading, it SHALL then warm the parsed-page cache, wikilink resolver, semantic corpus, and applicable matrices so later `find` calls avoid their first-use construction costs. Quiet mode SHALL retain only the maintained-catalog phase and skip resident full-corpus caches. `EXOMEM_DISABLE_WARMUP` SHALL skip proactive work and report retrieval admission as unverified until a later repair establishes it. Every stage SHALL soft-fail without preventing transport liveness and MUST NOT change returned results.
+When startup warm-up is enabled, the system SHALL first reconcile the maintained lexical catalog for KB and vault scopes, then establish the semantic corpus required for mutation admission. When the active resource policy allows CPU cache preloading, it SHALL then warm the parsed-page cache, wikilink resolver, and applicable matrices so later `find` calls avoid their first-use construction costs. Quiet mode SHALL retain the maintained-catalog and semantic-corpus phases while skipping resident optional full-corpus caches. `EXOMEM_DISABLE_WARMUP` SHALL skip proactive work and report retrieval admission as unverified until a later repair establishes it. Every stage SHALL soft-fail without preventing transport liveness and MUST NOT change returned results.
 
 #### Scenario: Maintained catalog is the first warm stage
 
 - **WHEN** the server starts with warm-up enabled
 - **THEN** KB- and vault-scope maintained lexical catalogs are reconciled before any full parsed-page, resolver, semantic, matrix, or model warm
 - **AND** ordinary lexical requests become admissible as soon as that catalog phase succeeds
+
+#### Scenario: Mutation admission precedes optional cache warm-up
+
+- **WHEN** maintained catalog admission succeeds during startup warm-up
+- **THEN** the semantic corpus is established and marked ready before parsed-page, resolver, matrix, or model cache preloading begins
+- **AND** mutations do not remain refused solely because optional performance caches are still warming
 
 #### Scenario: Warm-up can be disabled truthfully
 

--- a/openspec/changes/fix-startup-retrieval-liveness/specs/instant-start/spec.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/specs/instant-start/spec.md
@@ -16,9 +16,16 @@ The system SHALL NOT block the MCP transport on any model preload or cache warm-
 - **THEN** the server accepts connections and responds to liveness requests before any model preload or lexical warm-up has necessarily finished
 - **AND** an ordinary keyword or hybrid request that arrives before maintained-catalog readiness returns `RETRIEVAL_INDEX_WARMING` promptly without a corpus walk
 
+#### Scenario: Local reconcilers cannot delay or contend with catalog startup
+
+- **WHEN** a local HTTP service starts against an incomplete maintained lexical catalog
+- **THEN** liveness responds before retrieval, watcher, graph-drain, or media startup work is activated
+- **AND** watcher reconciliation, graph recovery, and media discovery wait until catalog and semantic-corpus admission are established or warm-up finishes unsuccessfully
+- **AND** those reconcilers cannot contend with required startup repair on the process-local mutation boundary during that phase
+
 ### Requirement: Lexical-First Warm Ordering
 
-The background warm sequence SHALL reconcile the maintained lexical catalog for KB and vault scopes before warming parsed pages, the wikilink resolver, the semantic corpus, embedding/CLIP matrices, or any model. It SHALL mark `retrieval_catalog` ready immediately after both maintained scopes succeed. It SHALL mark the broader `lexical` component after the remaining lexical/derived caches finish, then mark enabled model components in their existing order.
+The background warm sequence SHALL reconcile the maintained lexical catalog for KB and vault scopes before warming any other corpus or model state. It SHALL mark `retrieval_catalog` ready immediately after both maintained scopes succeed, establish and mark the semantic corpus next, then warm optional parsed pages, the wikilink resolver, embedding/CLIP matrices, and models. It SHALL mark the broader `lexical` component after the optional lexical/derived caches finish, then mark enabled model components in their existing order.
 
 #### Scenario: Retrieval catalog readiness lands before optional cache readiness
 

--- a/openspec/changes/fix-startup-retrieval-liveness/tasks.md
+++ b/openspec/changes/fix-startup-retrieval-liveness/tasks.md
@@ -3,12 +3,16 @@
 - [x] 1.1 Add production-sized keyword and hybrid cold-catalog tests proving typed warming and zero reference walks or page reads.
 - [x] 1.2 Add warm-order tests proving both catalog scopes precede optional page and resolver work and quiet mode retains the catalog phase.
 - [x] 1.3 Add runtime-readiness tests for warming, ready, and unverified states with no content leakage.
+- [x] 1.4 Add local activation regression coverage proving liveness-triggered startup and catalog-first reconciler ordering.
+- [x] 1.5 Add warm-order coverage proving semantic mutation admission precedes optional performance caches.
 
 ## 2. Implementation
 
 - [x] 2.1 Gate large-corpus keyword and hybrid lexical lanes through non-walking catalog readiness and the existing typed warming outcome.
 - [x] 2.2 Split maintained-catalog warming from optional caches and publish retrieval catalog readiness at the exact transition.
 - [x] 2.3 Project content-free retrieval admission into runtime readiness and overall status.
+- [x] 2.4 Activate local background workers only after transport liveness and keep non-retrieval reconcilers behind retrieval and mutation admission.
+- [x] 2.5 Establish semantic-corpus readiness immediately after catalog admission so optional cache warm-up cannot refuse mutations.
 
 ## 3. Verification and Delivery
 

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -36,7 +36,7 @@ from .server_auth import (  # noqa: F401 - re-exported for compatibility
 )
 from .server_hosted import register_hosted_routes
 from .server_rest import register_rest_facade
-from .server_runtime import initialize_runtime
+from .server_runtime import LocalRuntimeActivation, initialize_runtime
 from .server_transfer import register_transfer_routes
 from .server_transport import PrimeMcpSSEMiddleware
 
@@ -494,12 +494,19 @@ def build_server(*, require_auth: bool) -> FastMCP:
             transfer_security_authority=security_authority,
         )
     else:
+        runtime_activation = LocalRuntimeActivation(runtime.vault_root)
         auth = build_oauth(require_auth=require_auth, base_url=runtime.base_url)
-        mcp = ExomemFastMCP("exomem", auth=auth, icons=server_icons())
+        mcp = ExomemFastMCP(
+            "exomem",
+            auth=auth,
+            icons=server_icons(),
+            lifespan=runtime_activation.lifespan(),
+        )
         mcp.add_middleware(AuthorizationSessionMiddleware(runtime.vault_root))
         mcp.add_middleware(CallTraceMiddleware())
 
-        register_asset_routes(mcp)
+        register_asset_routes(mcp, on_liveness=runtime_activation.start)
+        mcp._exomem_local_runtime_activation = runtime_activation
         register_oauth_metadata_route(mcp, base_url=runtime.base_url, auth_enabled=auth is not None)
         transfer_config = register_transfer_routes(
             mcp, vault_root=runtime.vault_root, media_worker=runtime.media_worker

--- a/src/exomem/server_assets.py
+++ b/src/exomem/server_assets.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import base64
 import json
 import logging
+from collections.abc import Callable
 from pathlib import Path
 
 import mcp.types
 from fastmcp import FastMCP
+from starlette.background import BackgroundTask
 from starlette.requests import Request
 from starlette.responses import FileResponse, JSONResponse, RedirectResponse
 
@@ -87,7 +89,12 @@ def server_icons() -> list[mcp.types.Icon]:
     ]
 
 
-def register_asset_routes(mcp_app: FastMCP, *, traffic_monitor=None) -> None:
+def register_asset_routes(
+    mcp_app: FastMCP,
+    *,
+    traffic_monitor=None,
+    on_liveness: Callable[[], None] | None = None,
+) -> None:
     """Serve inert public assets outside MCP auth; vault data stays behind REST."""
     asset_dir = Path(__file__).parent
     if traffic_monitor is None:
@@ -119,7 +126,11 @@ def register_asset_routes(mcp_app: FastMCP, *, traffic_monitor=None) -> None:
             payload.update(deploy_provenance.provenance(include_local=False))
         except Exception:  # noqa: BLE001 — provenance must never fail the probe
             payload["version"] = "unknown"
-        return JSONResponse(payload, headers={"Cache-Control": "no-store"})
+        return JSONResponse(
+            payload,
+            headers={"Cache-Control": "no-store"},
+            background=(BackgroundTask(on_liveness) if on_liveness is not None else None),
+        )
 
     @mcp_app.custom_route("/health/ready", methods=["GET"])
     async def _runtime_ready(request: Request) -> JSONResponse:  # noqa: ARG001

--- a/src/exomem/server_runtime.py
+++ b/src/exomem/server_runtime.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+import threading
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
@@ -75,20 +76,99 @@ def initialize_runtime(*, load_dotenv_func: Callable[..., object]) -> ServerRunt
     project_keys_hint = project_keys.keys_hint(vault_root)
     projection_runtime.preactivate_projection_runtime(vault_root)
     _start_metrics_persistence()
-    _start_compute_runtime(vault_root)
-    media_worker = _start_media_worker(vault_root)
-    file_watcher = _start_file_watcher(vault_root)
-    _start_graph_drain(vault_root)
-
     base_url = os.environ.get("EXOMEM_BASE_URL", "").strip().rstrip("/")
     return ServerRuntime(
         vault_root=vault_root,
         source_schema=source_schema,
         project_keys_hint=project_keys_hint,
         base_url=base_url,
-        media_worker=media_worker,
-        file_watcher=file_watcher,
     )
+
+
+class LocalRuntimeActivation:
+    """Start local background workers after transport liveness is observable."""
+
+    def __init__(self, vault_root: Path, *, fallback_seconds: float = 5.0) -> None:
+        self.vault_root = vault_root
+        self.fallback_seconds = fallback_seconds
+        self._lock = threading.Lock()
+        self._started = False
+        self._timer: threading.Timer | None = None
+        self._thread: threading.Thread | None = None
+        self.media_worker: Any | None = None
+        self.file_watcher: Any | None = None
+
+    def start(self) -> None:
+        """Launch local workers once; safe from health and timer races."""
+        with self._lock:
+            if self._started:
+                return
+            self._started = True
+            timer = self._timer
+        if timer is not None:
+            timer.cancel()
+        thread = threading.Thread(
+            target=self._activate,
+            name="exomem-local-activation",
+            daemon=True,
+        )
+        with self._lock:
+            self._thread = thread
+        thread.start()
+
+    def _activate(self) -> None:
+        self._start_component("retrieval", _start_compute_runtime)
+        self._wait_for_required_admission()
+        starters = (
+            ("file watcher", self._start_file_watcher),
+            ("graph drain", _start_graph_drain),
+            ("media", self._start_media_worker),
+        )
+        for label, starter in starters:
+            self._start_component(label, starter)
+
+    def _wait_for_required_admission(self) -> None:
+        """Keep reconcilers out until retrieval and mutation state are admitted."""
+        from . import readiness
+
+        while readiness.is_warming():
+            if readiness.wait("semantic_corpus", timeout=1.0):
+                return
+
+    def _start_component(self, label: str, starter: Callable[[Path], Any]) -> None:
+        try:
+            starter(self.vault_root)
+        except Exception:  # noqa: BLE001 - workers cannot deny transport liveness
+            log.warning(
+                "%s runtime startup failed; transport continuing",
+                label,
+                exc_info=True,
+            )
+
+    def _start_media_worker(self, vault_root: Path) -> None:
+        self.media_worker = _start_media_worker(vault_root)
+
+    def _start_file_watcher(self, vault_root: Path) -> None:
+        self.file_watcher = _start_file_watcher(vault_root)
+
+    def lifespan(self):
+        """Arm a fallback for clients that never call the liveness endpoint."""
+        from fastmcp.server.lifespan import lifespan
+
+        @lifespan
+        async def _lifespan(_server):
+            timer = threading.Timer(self.fallback_seconds, self.start)
+            timer.daemon = True
+            with self._lock:
+                if not self._started:
+                    self._timer = timer
+                    timer.start()
+            try:
+                yield {}
+            finally:
+                timer.cancel()
+
+        return _lifespan
 
 
 def _initialize_hosted_runtime() -> ServerRuntime:
@@ -152,7 +232,9 @@ def _initialize_locked_hosted_runtime(
     startup = lifecycle.complete_startup(
         vault_ready=True,
         mutation_authority_ready=mutation_ready,
-        service_auth_ready=(security_authority is not None or config.service_credential is not None),
+        service_auth_ready=(
+            security_authority is not None or config.service_credential is not None
+        ),
     )
     if config.has_feature("diarization"):
         lifecycle.set_worker_status(

--- a/src/exomem/server_runtime.py
+++ b/src/exomem/server_runtime.py
@@ -132,8 +132,12 @@ class LocalRuntimeActivation:
         from . import readiness
 
         while readiness.is_warming():
-            if readiness.wait("semantic_corpus", timeout=1.0):
+            catalog_ready = readiness.is_ready("retrieval_catalog")
+            semantic_ready = readiness.is_ready("semantic_corpus")
+            if catalog_ready and semantic_ready:
                 return
+            missing = "retrieval_catalog" if not catalog_ready else "semantic_corpus"
+            readiness.wait(missing, timeout=0.1)
 
     def _start_component(self, label: str, starter: Callable[[Path], Any]) -> None:
         try:

--- a/src/exomem/warmup.py
+++ b/src/exomem/warmup.py
@@ -174,10 +174,11 @@ def warm_caches(
 
 
 def warm_all(vault_root: Path) -> dict[str, float]:
-    """Lexical caches, then model preloads, marking readiness as each lands.
+    """Required catalog/corpus state, then optional caches and model preloads.
 
-    Order is the product contract (lexical-first): a `find` is useful the
-    moment the BM25/page caches are hot, long before torch finishes loading.
+    Order is the product contract (catalog-first): retrieval admission lands
+    first, then semantic write admission, before optional full-corpus caches
+    and models can extend the warm window.
     Each stage soft-fails; a failed model preload leaves its component
     not-ready (never marked), so requests defer for the rest of the warm and
     then return to inline lazy-load semantics. Never raises.
@@ -198,14 +199,6 @@ def warm_all(vault_root: Path) -> dict[str, float]:
             (time.perf_counter() - catalog_started) * 1000.0,
             1,
         )
-    durations.update(
-        warm_caches(
-            vault_root,
-            preload_models=preload,
-            preload_cpu_caches=mode.preload_cpu_caches(),
-        )
-    )
-    readiness.mark_ready("lexical")
     semantic_started = time.perf_counter()
     try:
         from . import semantic_contract
@@ -219,6 +212,14 @@ def warm_all(vault_root: Path) -> dict[str, float]:
             (time.perf_counter() - semantic_started) * 1000.0,
             1,
         )
+    durations.update(
+        warm_caches(
+            vault_root,
+            preload_models=preload,
+            preload_cpu_caches=mode.preload_cpu_caches(),
+        )
+    )
+    readiness.mark_ready("lexical")
 
     def _model_step(name: str, fn) -> bool:
         t0 = time.perf_counter()

--- a/tests/test_event_indexes_wiring.py
+++ b/tests/test_event_indexes_wiring.py
@@ -137,14 +137,10 @@ def test_self_delete_updates_freshness_immediately(vault):
 
 
 def test_watcher_gate_decoupled_from_embeddings(vault, monkeypatch):
-    """The watcher now starts whenever EXOMEM_DISABLE_FILE_WATCHER is unset,
-    even with embeddings disabled (it maintains freshness/inbound); and it does
-    NOT start when EXOMEM_DISABLE_FILE_WATCHER is set."""
-    from exomem import server as server_module
+    """The deferred watcher remains independent from the embeddings gate."""
+    from exomem import server_runtime
 
-    monkeypatch.setattr(server_module, "load_dotenv", lambda *a, **k: None)
     monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
-    monkeypatch.setenv("EXOMEM_DISABLE_WARMUP", "1")
 
     started: list[str] = []
 
@@ -158,15 +154,15 @@ def test_watcher_gate_decoupled_from_embeddings(vault, monkeypatch):
 
     monkeypatch.setattr("exomem.file_watcher.FileWatcher", _FakeWatcher)
 
-    # Embeddings disabled but watcher NOT disabled → should start.
+    # Transport composition owns timing; this helper owns only watcher gating.
     monkeypatch.delenv("EXOMEM_DISABLE_FILE_WATCHER", raising=False)
-    server_module.build_server(require_auth=False)
+    server_runtime._start_file_watcher(vault)
     assert started, "watcher must start with embeddings disabled once decoupled"
 
     # Watcher explicitly disabled → must not start.
     started.clear()
     monkeypatch.setenv("EXOMEM_DISABLE_FILE_WATCHER", "1")
-    server_module.build_server(require_auth=False)
+    server_runtime._start_file_watcher(vault)
     assert not started, "EXOMEM_DISABLE_FILE_WATCHER must still suppress the watcher"
 
 

--- a/tests/test_hosted_cell.py
+++ b/tests/test_hosted_cell.py
@@ -138,7 +138,7 @@ def test_hosted_mode_is_explicit_and_local_mode_remains_ordinary(
     assert dotenv_calls == [
         {"dotenv_path": Path.cwd() / ".env", "override": True}
     ]
-    assert calls == ["compute", "media", "watcher"]
+    assert calls == []
     assert runtime.vault_root == tmp_path
     assert runtime.hosted_config is None
     assert runtime.hosted_lifecycle is None

--- a/tests/test_instant_start.py
+++ b/tests/test_instant_start.py
@@ -25,6 +25,7 @@ after), regardless of whether the test itself also calls finish_warm().
 
 from __future__ import annotations
 
+import asyncio
 import os
 import sys
 import threading
@@ -283,12 +284,10 @@ def test_model_preload_allowed_defaults_lazy_in_normal_mode(
     assert warmup.model_preload_allowed("normal") is True
 
 
-def test_warm_all_marks_components_ready_in_lexical_embeddings_reranker_clip_order(
+def test_warm_all_marks_components_ready_in_semantic_lexical_model_order(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """warm_all runs warm_caches (lexical) first, then bge, then the
-    reranker, then CLIP — in that exact order — marking each component
-    ready as it lands."""
+    """Required semantic write state lands before optional caches and models."""
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
     call_order: list[str] = []
     monkeypatch.setattr(
@@ -298,6 +297,10 @@ def test_warm_all_marks_components_ready_in_lexical_embeddings_reranker_clip_ord
         raising=False,
     )
     monkeypatch.setattr(warmup, "warm_caches", lambda vr, **_kw: call_order.append("lexical") or {})
+    monkeypatch.setattr(
+        "exomem.semantic_contract.build_corpus_context",
+        lambda _root: call_order.append("semantic"),
+    )
     monkeypatch.setattr(
         embeddings, "get_model", lambda: call_order.append("embeddings") or object()
     )
@@ -309,17 +312,22 @@ def test_warm_all_marks_components_ready_in_lexical_embeddings_reranker_clip_ord
 
     warmup.warm_all(tmp_path)
 
-    assert call_order == ["catalog", "lexical", "embeddings", "reranker", "clip"]
+    assert call_order == [
+        "catalog",
+        "semantic",
+        "lexical",
+        "embeddings",
+        "reranker",
+        "clip",
+    ]
     for c in readiness.COMPONENTS:
         assert readiness.is_ready(c) is True
 
 
-def test_warm_all_marks_lexical_ready_before_semantic_corpus_build(
+def test_warm_all_marks_semantic_corpus_ready_before_optional_cache_warm(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The rebuildable semantic corpus can be slow on a large vault, so it must
-    not sit in front of restart retrieval.  Lexical caches and their readiness
-    signal land first; semantic warming remains background follow-up work."""
+    """Mutation admission must not wait behind optional full-corpus caches."""
     monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
     call_order: list[str] = []
 
@@ -336,17 +344,23 @@ def test_warm_all_marks_lexical_ready_before_semantic_corpus_build(
     )
 
     def _semantic_warm(_vault_root: Path) -> None:
-        assert readiness.is_ready("lexical") is True
+        assert readiness.is_ready("retrieval_catalog") is True
         call_order.append("semantic")
+
+    def _optional_caches(_vault_root: Path, **_kwargs) -> dict:
+        assert readiness.is_ready("semantic_corpus") is True
+        call_order.append("lexical")
+        return {}
 
     monkeypatch.setattr(
         "exomem.semantic_contract.build_corpus_context",
         _semantic_warm,
     )
+    monkeypatch.setattr(warmup, "warm_caches", _optional_caches)
 
     warmup.warm_all(tmp_path)
 
-    assert call_order == ["catalog", "lexical", "semantic"]
+    assert call_order == ["catalog", "semantic", "lexical"]
     assert readiness.is_ready("semantic_corpus") is True
 
 
@@ -378,7 +392,7 @@ def test_warm_all_marks_catalog_ready_before_optional_cache_work(
 
     warmup.warm_all(tmp_path)
 
-    assert call_order == ["catalog", "optional_caches", "semantic"]
+    assert call_order == ["catalog", "semantic", "optional_caches"]
     assert readiness.is_ready("retrieval_catalog") is True
 
 
@@ -816,6 +830,17 @@ def test_start_background_runs_finish_warm_in_finally_even_on_crash(
 # ============================================================================
 
 
+def _enter_server_lifespan(mcp) -> None:
+    async def exercise() -> None:
+        async with mcp._lifespan_manager():
+            activation = mcp._exomem_local_runtime_activation
+            activation.start()
+            assert activation._thread is not None
+            activation._thread.join(timeout=1.0)
+
+    asyncio.run(exercise())
+
+
 def test_build_server_uses_background_warmup_by_default(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -833,8 +858,10 @@ def test_build_server_uses_background_warmup_by_default(
     monkeypatch.setattr(warmup, "start_background", lambda vr: calls.append("background"))
     monkeypatch.setattr(warmup, "warm_all", lambda vr: calls.append("eager"))
 
-    server.build_server(require_auth=False)
+    mcp = server.build_server(require_auth=False)
 
+    assert calls == []
+    _enter_server_lifespan(mcp)
     assert calls == ["background"]
 
 
@@ -850,8 +877,10 @@ def test_build_server_uses_eager_warmup_when_env_set(
     monkeypatch.setattr(warmup, "start_background", lambda vr: calls.append("background"))
     monkeypatch.setattr(warmup, "warm_all", lambda vr: calls.append("eager"))
 
-    server.build_server(require_auth=False)
+    mcp = server.build_server(require_auth=False)
 
+    assert calls == []
+    _enter_server_lifespan(mcp)
     assert calls == ["eager"]
 
 
@@ -867,8 +896,9 @@ def test_build_server_calls_neither_warmup_path_when_disabled(
     monkeypatch.setattr(warmup, "start_background", lambda vr: calls.append("background"))
     monkeypatch.setattr(warmup, "warm_all", lambda vr: calls.append("eager"))
 
-    server.build_server(require_auth=False)
+    mcp = server.build_server(require_auth=False)
 
+    _enter_server_lifespan(mcp)
     assert calls == []
 
 

--- a/tests/test_server_runtime.py
+++ b/tests/test_server_runtime.py
@@ -149,6 +149,43 @@ def test_local_runtime_activation_waits_for_liveness_and_starts_once(
         readiness.reset()
 
 
+def test_local_runtime_activation_waits_for_terminal_warm_after_catalog_failure(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    compute_started = threading.Event()
+    activated = threading.Event()
+
+    def start_compute(_root) -> None:
+        readiness.begin_warm()
+        compute_started.set()
+
+    monkeypatch.setattr(server_runtime, "_start_compute_runtime", start_compute)
+    monkeypatch.setattr(
+        server_runtime,
+        "_start_file_watcher",
+        lambda _root: activated.set(),
+    )
+    monkeypatch.setattr(server_runtime, "_start_graph_drain", lambda _root: None)
+    monkeypatch.setattr(server_runtime, "_start_media_worker", lambda _root: None)
+    activation = server_runtime.LocalRuntimeActivation(vault, fallback_seconds=60.0)
+
+    async def exercise() -> None:
+        async with activation.lifespan()(SimpleNamespace()):
+            activation.start()
+            assert compute_started.wait(timeout=1.0)
+            readiness.mark_ready("semantic_corpus")
+            assert not activated.wait(timeout=0.05)
+            readiness.finish_warm()
+            assert activated.wait(timeout=1.0)
+
+    try:
+        asyncio.run(exercise())
+    finally:
+        readiness.reset()
+
+
 def test_local_runtime_activation_falls_back_without_liveness_probe(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_server_runtime.py
+++ b/tests/test_server_runtime.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 import threading
 from types import SimpleNamespace
 
 import pytest
 
-from exomem import media_processing, server_runtime
+from exomem import media_processing, readiness, server_runtime
 from exomem.governance import projection_runtime
 
 
@@ -37,7 +38,7 @@ def test_initialize_runtime_loads_dotenv_from_service_working_directory(
     assert runtime.vault_root == vault
 
 
-def test_initialize_runtime_preactivates_governed_projection_before_workers(
+def test_initialize_runtime_does_not_start_workers_before_transport(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     vault = tmp_path / "vault"
@@ -72,16 +73,103 @@ def test_initialize_runtime_preactivates_governed_projection_before_workers(
         "_start_file_watcher",
         lambda root: events.append(f"watcher:{root}"),
     )
-    monkeypatch.setattr(server_runtime, "_start_graph_drain", lambda _root: None)
+    monkeypatch.setattr(
+        server_runtime,
+        "_start_graph_drain",
+        lambda root: events.append(f"graph:{root}"),
+    )
 
     server_runtime.initialize_runtime(load_dotenv_func=lambda **_kwargs: None)
 
-    assert events == [
-        f"projection:{vault}",
-        f"compute:{vault}",
-        f"media:{vault}",
-        f"watcher:{vault}",
-    ]
+    assert events == [f"projection:{vault}"]
+
+
+def test_local_runtime_activation_waits_for_liveness_and_starts_once(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    calls: list[str] = []
+    compute_started = threading.Event()
+    activated = threading.Event()
+
+    def start_compute(root) -> None:
+        calls.append(f"compute:{root}")
+        readiness.begin_warm()
+        compute_started.set()
+
+    monkeypatch.setattr(
+        server_runtime,
+        "_start_compute_runtime",
+        start_compute,
+    )
+    monkeypatch.setattr(
+        server_runtime,
+        "_start_file_watcher",
+        lambda root: calls.append(f"watcher:{root}"),
+    )
+    monkeypatch.setattr(
+        server_runtime,
+        "_start_graph_drain",
+        lambda root: calls.append(f"graph:{root}"),
+    )
+    monkeypatch.setattr(
+        server_runtime,
+        "_start_media_worker",
+        lambda root: (calls.append(f"media:{root}"), activated.set())[0],
+    )
+
+    activation = server_runtime.LocalRuntimeActivation(vault, fallback_seconds=60.0)
+
+    async def exercise() -> None:
+        assert calls == []
+        async with activation.lifespan()(SimpleNamespace()):
+            assert calls == []
+            activation.start()
+            assert compute_started.wait(timeout=1.0)
+            assert not activated.wait(timeout=0.05)
+            assert calls == [f"compute:{vault}"]
+            readiness.mark_ready("retrieval_catalog")
+            assert not activated.wait(timeout=0.05)
+            assert calls == [f"compute:{vault}"]
+            readiness.mark_ready("semantic_corpus")
+            assert activated.wait(timeout=1.0)
+            assert calls == [
+                f"compute:{vault}",
+                f"watcher:{vault}",
+                f"graph:{vault}",
+                f"media:{vault}",
+            ]
+            activation.start()
+            assert len(calls) == 4
+
+    try:
+        asyncio.run(exercise())
+    finally:
+        readiness.reset()
+
+
+def test_local_runtime_activation_falls_back_without_liveness_probe(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    activated = threading.Event()
+    monkeypatch.setattr(
+        server_runtime,
+        "_start_compute_runtime",
+        lambda root: activated.set() if root == vault else None,
+    )
+    monkeypatch.setattr(server_runtime, "_start_file_watcher", lambda _root: None)
+    monkeypatch.setattr(server_runtime, "_start_graph_drain", lambda _root: None)
+    monkeypatch.setattr(server_runtime, "_start_media_worker", lambda _root: None)
+    activation = server_runtime.LocalRuntimeActivation(vault, fallback_seconds=0.01)
+
+    async def exercise() -> None:
+        async with activation.lifespan()(SimpleNamespace()):
+            assert await asyncio.to_thread(activated.wait, 1.0)
+
+    asyncio.run(exercise())
 
 
 def test_media_worker_startup_reconciles_media_missed_while_service_was_stopped(


### PR DESCRIPTION
## Why

The 0.61.0 Windows service could spend minutes in local startup reconciliation before Uvicorn bound the port. Performance-mode retrieval, watcher, graph, and media work also raced for the process-local mutation boundary, producing connector timeouts and transient mutation failures.

## What changed

- expose transport liveness before starting local background workers
- activate exactly once after the first completed `/health` response, with a bounded fallback for transports that do not probe liveness
- serialize required catalog and semantic-corpus admission before watcher, graph, and media startup reconciliation
- establish semantic mutation admission before optional full-corpus caches and models
- extend the active startup-retrieval-liveness OpenSpec and regression coverage

## Verification

- `293 passed, 5 skipped, 1 deselected` across startup, readiness, health, traffic, and writer-lease coverage
- focused activation and warm-order red/green regressions
- `uvx ruff check . --select F`
- targeted Ruff `E,F,I,B,UP,BLE`
- public-artifact privacy validation
- strict OpenSpec validation
- `uv lock --check`, generated-capabilities check, and `uv build`
- personal Windows canary: `/health` at 10.6 s total including NSSM wait; repeated probes 15-45 ms during catalog rebuild
- public connector returned `RETRIEVAL_INDEX_WARMING` in 3.7 s during cold repair, then cold keyword recall in 15.3 s and hot recall in 2.6 s after readiness