### PR TITLE
fix: bound background deferred index repair

### DIFF
--- a/openspec/changes/fix-deferred-work-drain/design.md
+++ b/openspec/changes/fix-deferred-work-drain/design.md
@@ -134,3 +134,28 @@ only while the service is stopped.
 - **Separate private roots also separate host-local mutation locks.** Operators must quiesce
   the service before direct CLI maintenance; supporting concurrent cross-principal local
   mutation would require a separate lock-root design outside this change.
+
+## Production follow-up: bound background publication, not only admission
+
+The first production backlog after deployment exposed two bounds that were individually
+finite but operationally unsafe together. Performance mode admitted 500 deferred files per
+reconcile pass, split them into a 250-file full-index batch, and an incomplete component then
+fell back to serial replay of every receipt. Against a large lexical catalog, one watcher
+pass could therefore keep derived retrieval warming for tens of minutes even though writes
+and the public transport stayed alive.
+
+Background repair now takes the smaller of the remaining reconcile budget and the live
+batch cap. This keeps performance mode's real-drift policy separate from the amount of old
+queued work it may publish at once. When a bounded batch is incomplete, only a small fixed
+prefix is isolated in that pass; attempted failures rotate behind untouched receipts and the
+next periodic pass continues fairly. An unbounded operator drain keeps the exhaustive
+isolation behavior because waiting for repair is the explicit purpose of that command.
+
+Alternatives rejected:
+
+- Reducing only the performance reconcile cap conflates real missed-event admission with
+  deferred backlog replay and leaves failure isolation unbounded.
+- Removing isolation entirely lets one poison receipt pin every later item forever.
+- Clearing a full receipt after only some component outcomes succeed loses durable repair
+  authority for the failed components; per-component receipt custody would be a larger
+  schema change.

--- a/openspec/changes/fix-deferred-work-drain/proposal.md
+++ b/openspec/changes/fix-deferred-work-drain/proposal.md
@@ -51,6 +51,9 @@ guards. **No caller passes it.** That queue grows monotonically for the life of 
 - Give the running server a bounded, mode-aware drain pass for both deferred queues, so
   queued work is retried by the system that queued it rather than by a human who happens to
   know `exomem index` exists.
+- Keep a background drain inside the mode's smaller live-publication batch even when the
+  performance reconcile budget is larger, and bound per-receipt isolation after an
+  incomplete batch so one pass cannot expand into hundreds of serial retries.
 - Redefine quiet-mode deferral as a **throttle, not a halt**: a small non-zero admission per
   reconcile pass, on CPU, so a quiet host still converges instead of accumulating forever.
   Quiet trades throughput for latency; it must not trade away correctness.

--- a/openspec/changes/fix-deferred-work-drain/specs/live-index-freshness/spec.md
+++ b/openspec/changes/fix-deferred-work-drain/specs/live-index-freshness/spec.md
@@ -8,6 +8,11 @@ unrelated operation running as a side effect, in order to be retried.
 
 The drain SHALL be bounded by the active compute mode's policy, and SHALL share the
 reconciliation pass budget rather than opening an independent write path.
+The periodic background drain SHALL also respect the mode's smaller live-batch cap;
+the larger reconcile cap MUST NOT turn queued repair into one vault-sized publication.
+If a bounded batch is incomplete, the drain SHALL isolate only a fixed small number of
+receipts in that pass. Unattempted and unsuccessful receipts remain durable for later
+passes, while an explicit unbounded operator drain may continue through the whole queue.
 
 #### Scenario: Queued semantic work drains without operator action
 
@@ -27,6 +32,26 @@ reconciliation pass budget rather than opening an independent write path.
 
 - **WHEN** a mutation is committed while entries are queued
 - **THEN** the mutation does not block on draining those entries
+
+#### Scenario: Performance mode does not create a vault-sized background batch
+
+- **WHEN** performance mode allows a reconcile admission larger than its live-batch cap
+- **AND** deferred work remains after drift admission
+- **THEN** the periodic drain admits no more than the live-batch cap
+- **AND** the remaining receipts stay queued for later passes
+
+#### Scenario: Incomplete background batch has bounded isolation
+
+- **WHEN** a bounded full or semantic batch reports incomplete work
+- **THEN** that pass retries only a fixed small number of individual receipts
+- **AND** it does not replay every admitted receipt serially in the same pass
+- **AND** unsuccessful and unattempted receipts remain durable and rotate across later passes
+
+#### Scenario: Explicit operator drain retains completion semantics
+
+- **WHEN** an operator invokes an unbounded drain explicitly
+- **THEN** incomplete batch isolation may continue through every admitted receipt
+- **AND** the background-only isolation bound does not silently weaken explicit repair
 
 ### Requirement: Deferral Throttles Rather Than Halts
 

--- a/openspec/changes/fix-deferred-work-drain/tasks.md
+++ b/openspec/changes/fix-deferred-work-drain/tasks.md
@@ -77,3 +77,15 @@ existing soft-fail seams; the lean suite runs with `EXOMEM_DISABLE_EMBEDDINGS=1`
 - [ ] 9.2 `PYTHONPATH=src EXOMEM_DISABLE_EMBEDDINGS=1 python -m pytest -q` green
 - [x] 9.3 `openspec validate fix-deferred-work-drain --strict`
 - [x] 9.4 Record before/after queue counts from a seeded backlog in the PR body.
+
+## 10. Bound production backlog repair
+
+- [x] 10.1 Add a failing watcher regression proving performance-mode deferred repair uses
+      the smaller live-batch cap rather than the 500-file reconcile cap.
+- [x] 10.2 Add failing full and semantic drain regressions proving a bounded incomplete
+      batch isolates only a small fixed prefix while retaining every other receipt.
+- [x] 10.3 Implement the background drain cap without changing real-drift admission or
+      explicit unbounded operator-drain semantics.
+- [x] 10.4 Bound per-receipt failure isolation for bounded drains and preserve fair rotation.
+- [ ] 10.5 Run focused watcher/deferred tests, Ruff, strict OpenSpec validation, privacy
+      validation, and the lean suite before delivery.

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -80,6 +80,26 @@ RECONCILE_INTERVAL_SECONDS = 300.0
 RECONCILE_MAX_EMBED_FILES = 500
 RECONCILE_MAX_MEDIA_FILES = media_processing.DEFAULT_RECONCILE_LIMIT
 
+
+def _background_deferred_limit(
+    policy: mode.WatcherPolicy, remaining: int | None
+) -> int | None:
+    """Keep old queued work inside the smaller live-publication envelope.
+
+    The reconcile cap governs real disk drift.  It is deliberately larger in
+    performance mode, but reusing it for deferred repair turned a 500-file
+    allowance into one 250-file full-index transaction.  A failed component
+    then expanded that transaction into serial replay.  Background queue work
+    has no freshness deadline, so it takes the smaller live cap and converges
+    over later passes instead.
+    """
+    caps = [
+        cap
+        for cap in (remaining, policy.max_embed_files_per_batch)
+        if cap is not None
+    ]
+    return min(caps) if caps else None
+
 # ---- Self-write suppression registry (module-level: available to writers even
 # when no FileWatcher is running; keyed by (resolved vault root, vault-rel path)) ----
 UPSERT_SUPPRESS_TTL_SECONDS = 30.0
@@ -545,7 +565,10 @@ class FileWatcher:
             if baselines_current and self._validate_existing_graph_on_seed():
                 from . import deferred_index
 
-                full_limit = self._watcher_policy().max_reconcile_embed_files
+                policy = self._watcher_policy()
+                full_limit = _background_deferred_limit(
+                    policy, policy.max_reconcile_embed_files
+                )
                 full_paths = [
                     self._vault_root / receipt.rel_path
                     for receipt in deferred_index.snapshot_full(
@@ -583,8 +606,9 @@ class FileWatcher:
             if policy.max_reconcile_embed_files is None
             else max(0, policy.max_reconcile_embed_files - drift_admission)
         )
+        drain_limit = _background_deferred_limit(policy, remaining)
         try:
-            index_sync.drain_deferred_work(self._vault_root, limit=remaining)
+            index_sync.drain_deferred_work(self._vault_root, limit=drain_limit)
         except Exception:  # noqa: BLE001 - queued work remains retryable
             log.exception("file watcher: deferred index drain failed")
         if not drifted:

--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -35,6 +35,9 @@ log = logging.getLogger(__name__)
 
 _REPORT_PATH_LIMIT = 256
 _REPORT_PATH_BYTE_LIMIT = 1024
+# A bounded daemon pass must not turn one failed batch into every receipt
+# replayed serially. Explicit unbounded maintenance retains exhaustive repair.
+_BOUNDED_FAILURE_ISOLATION_LIMIT = 4
 
 _FULL_UPSERT_COMPONENTS = frozenset(
     {
@@ -921,7 +924,12 @@ def drain_deferred_work(
                 processed += deferred_index.clear_full_receipts(vault_root, full_receipts)
             else:
                 log.warning("deferred full-index batch incomplete; isolating receipts")
-            for receipt in () if full_batch_completed else full_receipts:
+            isolation_receipts = () if full_batch_completed else full_receipts
+            if limit is not None:
+                isolation_receipts = isolation_receipts[
+                    :_BOUNDED_FAILURE_ISOLATION_LIMIT
+                ]
+            for receipt in isolation_receipts:
                 try:
                     dispatched = upsert_after_write(
                         vault_root, [vault_root / receipt.rel_path]
@@ -978,7 +986,10 @@ def drain_deferred_work(
     # A single malformed source must not pin every later receipt in the sorted
     # batch. The optimistic batch above is the fast path; only a failed batch
     # falls back to per-receipt replay so successful work can retire by CAS.
-    for receipt in semantic_receipts:
+    isolation_receipts = semantic_receipts
+    if limit is not None:
+        isolation_receipts = isolation_receipts[:_BOUNDED_FAILURE_ISOLATION_LIMIT]
+    for receipt in isolation_receipts:
         try:
             status = replay_deferred_embedding(
                 vault_root, [vault_root / receipt.rel_path], [receipt]

--- a/tests/test_deferred_work_drain.py
+++ b/tests/test_deferred_work_drain.py
@@ -411,8 +411,8 @@ def test_failed_full_prefix_rotates_so_later_work_is_not_starved(
 
     monkeypatch.setattr(index_sync, "upsert_after_write", dispatch)
 
-    assert index_sync.drain_deferred_work(vault, limit=12) == 0
-    assert index_sync.drain_deferred_work(vault, limit=12) == 1
+    outcomes = [index_sync.drain_deferred_work(vault, limit=12) for _ in range(4)]
+    assert outcomes == [0, 0, 0, 1]
     assert good_rel not in deferred_index.list_full_paths(vault)
 
 
@@ -479,8 +479,8 @@ def test_failed_semantic_prefix_rotates_so_later_work_is_not_starved(
 
     monkeypatch.setattr(index_sync, "replay_deferred_embedding", replay)
 
-    assert index_sync.drain_deferred_work(vault, limit=12) == 0
-    assert index_sync.drain_deferred_work(vault, limit=12) == 1
+    outcomes = [index_sync.drain_deferred_work(vault, limit=12) for _ in range(4)]
+    assert outcomes == [0, 0, 0, 1]
     assert good_rel not in deferred_index.list_paths(vault)
 
 
@@ -627,6 +627,94 @@ def test_reconcile_drift_spends_budget_before_deferred_drain(
     watcher._reconcile_once(seed=False)
 
     assert limits == [18]
+
+
+def test_performance_reconcile_backlog_uses_the_smaller_live_batch_cap(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    policy = mode.WatcherPolicy(0.5, 300.0, 32, 500, False)
+    watcher = file_watcher.FileWatcher(vault)
+    monkeypatch.setattr(watcher, "_watcher_policy", lambda: policy)
+    monkeypatch.setattr(file_watcher.freshness, "SCOPES", ())
+    monkeypatch.setattr(
+        file_watcher.media_processing, "reconcile_all_media", lambda *_a, **_kw: 0
+    )
+    monkeypatch.setattr(
+        file_watcher.freshness, "external_pending_epoch", lambda _root: None
+    )
+    monkeypatch.setattr(file_watcher.freshness, "external_pending", lambda _root: False)
+    monkeypatch.setattr(watcher, "_recover_suspended_graph", lambda: None)
+    limits: list[int | None] = []
+    monkeypatch.setattr(
+        index_sync,
+        "drain_deferred_work",
+        lambda _root, *, limit=None: limits.append(limit) or 0,
+    )
+
+    watcher._reconcile_once(seed=False)
+
+    assert limits == [32]
+
+
+def test_bounded_full_drain_limits_incomplete_batch_isolation(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    rels = [f"Knowledge Base/full-{index:02d}.md" for index in range(10)]
+    for rel in rels:
+        target = vault / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# queued\n", encoding="utf-8")
+    deferred_index.add_full(vault, rels)
+    monkeypatch.setattr(
+        index_sync, "recover_full_receipt_graph_epoch", lambda _root: True
+    )
+    attempts: list[list[str]] = []
+
+    def incomplete(_root: Path, paths: list[Path]):
+        attempts.append([path.relative_to(vault).as_posix() for path in paths])
+        return index_sync.IndexSyncReport(
+            "upsert",
+            tuple(attempts[-1]),
+            tuple(attempts[-1]),
+            (index_sync.IndexComponentOutcome("lexstore", "degraded", "failed"),),
+        )
+
+    monkeypatch.setattr(index_sync, "upsert_after_write", incomplete)
+
+    assert index_sync.drain_deferred_work(vault, limit=10) == 0
+    assert attempts[0] == rels
+    assert attempts[1:] == [[rel] for rel in rels[:4]]
+    assert set(deferred_index.list_full_paths(vault)) == set(rels)
+
+
+def test_bounded_semantic_drain_limits_incomplete_batch_isolation(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    rels = [f"Knowledge Base/semantic-{index:02d}.md" for index in range(10)]
+    for rel in rels:
+        target = vault / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# queued\n", encoding="utf-8")
+    deferred_index.add(vault, rels)
+    monkeypatch.setattr(
+        deferred_index,
+        "inspect_embedding_freshness",
+        lambda _root, paths, **_kwargs: {
+            rel: deferred_index.EmbeddingFreshness.STALE for rel in paths
+        },
+    )
+    attempts: list[list[str]] = []
+
+    def incomplete(_root: Path, _paths: list[Path], receipts):  # noqa: ANN001
+        attempts.append([receipt.rel_path for receipt in receipts])
+        return SimpleNamespace(status="degraded")
+
+    monkeypatch.setattr(index_sync, "replay_deferred_embedding", incomplete)
+
+    assert index_sync.drain_deferred_work(vault, limit=10) == 0
+    assert attempts[0] == rels
+    assert attempts[1:] == [[rel] for rel in rels[:4]]
+    assert set(deferred_index.list_paths(vault)) == set(rels)
 
 
 def test_doctor_warns_on_deferred_queue_fraction(


### PR DESCRIPTION
## Why

A performance-mode watcher was applying the 500-file reconcile allowance to old deferred work. With both queues populated, that admitted a 250-file full-index transaction; an incomplete component then expanded it into serial per-receipt replay. On a large lexical catalog a single background pass occupied the service for roughly 50 minutes and made retrieval latency unacceptable.

## What changed

- cap daemon deferred repair at the smaller of the remaining reconcile budget and the live publication batch cap
- bound failure isolation to four receipts for bounded drains
- preserve fair receipt rotation and exhaustive `limit=None` operator maintenance
- document the production regression and contract in the active OpenSpec change

## Verification

- red-first regressions failed before implementation: performance drain used 500; failed batches isolated all 10 receipts
- `tests/test_deferred_work_drain.py`: 29 passed
- startup/seed targeted regressions: 2 passed
- focused Ruff check for the changed Python files: passed
- `git diff --check`: passed
- `scripts/validate-public-artifacts.py --repository`: 3293 files / 3361 text payloads passed
- `openspec validate fix-deferred-work-drain --strict`: passed
- `openspec validate --all --strict`: 164 passed, 0 failed

The neighboring watcher/media-graph suite remains red on an unchanged Windows graph-WAL/temp-path failure that reproduces on exact `origin/main`; this PR does not claim that baseline issue as fixed. Required CI is the merge gate.