### PR TITLE
fix: preserve low-cap deferred fairness

### DIFF
--- a/openspec/changes/fix-deferred-work-drain/design.md
+++ b/openspec/changes/fix-deferred-work-drain/design.md
@@ -156,6 +156,10 @@ reconcile budget remains: it may defer a live burst, but cannot turn durable rep
 a halt. With one shared slot and both queues populated, a durable turn marker alternates the
 slot between full and semantic work. Keeping the turn in the deferred-work sidecar preserves
 fairness across restarts and avoids permanently favoring whichever queue is checked first.
+The claim starts an immediate SQLite transaction before reading the turn, so concurrent
+drains serialize the read-and-flip rather than both observing the same queue. Startup uses
+the same unscoped allocator as periodic repair; targeting only full receipts there would
+bypass the turn marker and let repeated restarts starve semantic work.
 
 Alternatives rejected:
 

--- a/openspec/changes/fix-deferred-work-drain/design.md
+++ b/openspec/changes/fix-deferred-work-drain/design.md
@@ -151,6 +151,12 @@ prefix is isolated in that pass; attempted failures rotate behind untouched rece
 next periodic pass continues fairly. An unbounded operator drain keeps the exhaustive
 isolation behavior because waiting for repair is the explicit purpose of that command.
 
+The live cap can be overridden to zero or one. Zero still reserves one background slot when
+reconcile budget remains: it may defer a live burst, but cannot turn durable repair back into
+a halt. With one shared slot and both queues populated, a durable turn marker alternates the
+slot between full and semantic work. Keeping the turn in the deferred-work sidecar preserves
+fairness across restarts and avoids permanently favoring whichever queue is checked first.
+
 Alternatives rejected:
 
 - Reducing only the performance reconcile cap conflates real missed-event admission with

--- a/openspec/changes/fix-deferred-work-drain/specs/live-index-freshness/spec.md
+++ b/openspec/changes/fix-deferred-work-drain/specs/live-index-freshness/spec.md
@@ -13,6 +13,9 @@ the larger reconcile cap MUST NOT turn queued repair into one vault-sized public
 If a bounded batch is incomplete, the drain SHALL isolate only a fixed small number of
 receipts in that pass. Unattempted and unsuccessful receipts remain durable for later
 passes, while an explicit unbounded operator drain may continue through the whole queue.
+An operator-configured live-batch cap of zero SHALL still reserve one background
+convergence slot when reconcile budget remains. When that effective cap is one and both
+index queues contain work, repeated passes SHALL alternate durably between the queues.
 
 #### Scenario: Queued semantic work drains without operator action
 
@@ -46,6 +49,13 @@ passes, while an explicit unbounded operator drain may continue through the whol
 - **THEN** that pass retries only a fixed small number of individual receipts
 - **AND** it does not replay every admitted receipt serially in the same pass
 - **AND** unsuccessful and unattempted receipts remain durable and rotate across later passes
+
+#### Scenario: Minimum background cap preserves cross-queue convergence
+
+- **WHEN** the effective live-batch cap is zero or one
+- **AND** full and semantic work remain queued
+- **THEN** a background pass with remaining reconcile budget admits one receipt
+- **AND** repeated passes alternate between both queues so neither can starve the other
 
 #### Scenario: Explicit operator drain retains completion semantics
 

--- a/openspec/changes/fix-deferred-work-drain/specs/live-index-freshness/spec.md
+++ b/openspec/changes/fix-deferred-work-drain/specs/live-index-freshness/spec.md
@@ -15,7 +15,8 @@ receipts in that pass. Unattempted and unsuccessful receipts remain durable for 
 passes, while an explicit unbounded operator drain may continue through the whole queue.
 An operator-configured live-batch cap of zero SHALL still reserve one background
 convergence slot when reconcile budget remains. When that effective cap is one and both
-index queues contain work, repeated passes SHALL alternate durably between the queues.
+index queues contain work, repeated passes SHALL alternate durably between the queues,
+including startup passes and concurrent drain attempts.
 
 #### Scenario: Queued semantic work drains without operator action
 
@@ -55,7 +56,8 @@ index queues contain work, repeated passes SHALL alternate durably between the q
 - **WHEN** the effective live-batch cap is zero or one
 - **AND** full and semantic work remain queued
 - **THEN** a background pass with remaining reconcile budget admits one receipt
-- **AND** repeated passes alternate between both queues so neither can starve the other
+- **AND** repeated startup or periodic passes alternate between both queues
+- **AND** concurrent drain attempts cannot claim the same turn and starve the other queue
 
 #### Scenario: Explicit operator drain retains completion semantics
 

--- a/openspec/changes/fix-deferred-work-drain/tasks.md
+++ b/openspec/changes/fix-deferred-work-drain/tasks.md
@@ -93,3 +93,6 @@ existing soft-fail seams; the lean suite runs with `EXOMEM_DISABLE_EMBEDDINGS=1`
       reserve one background convergence slot and alternate it durably.
 - [x] 10.7 Prove an explicit unbounded operator drain still isolates more than the bounded
       four-receipt prefix for both full and semantic work.
+- [x] 10.8 Add adversarial regressions for zero-cap watcher wiring, restart fairness, and
+      concurrent turn claims; route startup through the shared allocator and serialize the
+      durable read-and-flip.

--- a/openspec/changes/fix-deferred-work-drain/tasks.md
+++ b/openspec/changes/fix-deferred-work-drain/tasks.md
@@ -89,3 +89,7 @@ existing soft-fail seams; the lean suite runs with `EXOMEM_DISABLE_EMBEDDINGS=1`
 - [x] 10.4 Bound per-receipt failure isolation for bounded drains and preserve fair rotation.
 - [ ] 10.5 Run focused watcher/deferred tests, Ruff, strict OpenSpec validation, privacy
       validation, and the lean suite before delivery.
+- [x] 10.6 Add red regressions for zero-cap progress and one-slot cross-queue fairness, then
+      reserve one background convergence slot and alternate it durably.
+- [x] 10.7 Prove an explicit unbounded operator drain still isolates more than the bounded
+      four-receipt prefix for both full and semantic work.

--- a/src/exomem/deferred_index.py
+++ b/src/exomem/deferred_index.py
@@ -17,6 +17,7 @@ from . import reserved_paths, sidecar_store
 from .kbdir import kb_dirname
 
 _SEMANTIC_ISOLATION_CURSOR_KEY = "semantic_isolation_cursors:v1"
+_MIXED_DRAIN_TURN_KEY = "mixed_drain_turn:v1"
 _SEMANTIC_UPSERTS_GENERATION_KEY = "semantic_upserts_generation"
 _GRAPH_UPSERTS_GENERATION_KEY = "graph_upserts_generation"
 _GRAPH_FULL_REBUILD_KEY = "graph_full_rebuild_generation"
@@ -332,6 +333,31 @@ def set_semantic_isolation_cursors(
     except (OSError, sqlite3.Error):
         return False
     return True
+
+
+def claim_mixed_drain_queue(vault_root: Path) -> str:
+    """Atomically alternate a one-slot drain between full and semantic work."""
+    conn = _connect(vault_root, create=True)
+    try:
+        with conn:
+            row = conn.execute(
+                "SELECT value FROM maintenance_state WHERE key = ?",
+                (_MIXED_DRAIN_TURN_KEY,),
+            ).fetchone()
+            current = (
+                str(row[0])
+                if row is not None and str(row[0]) in {"full", "semantic"}
+                else "full"
+            )
+            next_queue = "semantic" if current == "full" else "full"
+            conn.execute(
+                "INSERT INTO maintenance_state(key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (_MIXED_DRAIN_TURN_KEY, next_queue),
+            )
+        return current
+    finally:
+        conn.close()
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/exomem/deferred_index.py
+++ b/src/exomem/deferred_index.py
@@ -340,6 +340,10 @@ def claim_mixed_drain_queue(vault_root: Path) -> str:
     conn = _connect(vault_root, create=True)
     try:
         with conn:
+            # A deferred transaction would let concurrent claimants read the
+            # same turn before either writes it. Reserve the writer slot first
+            # so each claimant observes the prior claimant's committed flip.
+            conn.execute("BEGIN IMMEDIATE")
             row = conn.execute(
                 "SELECT value FROM maintenance_state WHERE key = ?",
                 (_MIXED_DRAIN_TURN_KEY,),

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -93,11 +93,13 @@ def _background_deferred_limit(
     has no freshness deadline, so it takes the smaller live cap and converges
     over later passes instead.
     """
-    caps = [
-        cap
-        for cap in (remaining, policy.max_embed_files_per_batch)
-        if cap is not None
-    ]
+    live_cap = policy.max_embed_files_per_batch
+    if live_cap is not None:
+        # Zero may defer a live burst, but background correctness still needs
+        # one convergence slot. A zero remaining reconcile budget continues to
+        # win below, so drift admission is never overspent.
+        live_cap = max(1, live_cap)
+    caps = [cap for cap in (remaining, live_cap) if cap is not None]
     return min(caps) if caps else None
 
 # ---- Self-write suppression registry (module-level: available to writers even

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -565,27 +565,17 @@ class FileWatcher:
                 log.exception("file watcher: periodic media reconciliation failed")
         if seed:
             if baselines_current and self._validate_existing_graph_on_seed():
-                from . import deferred_index
-
                 policy = self._watcher_policy()
                 full_limit = _background_deferred_limit(
                     policy, policy.max_reconcile_embed_files
                 )
-                full_paths = [
-                    self._vault_root / receipt.rel_path
-                    for receipt in deferred_index.snapshot_full(
-                        self._vault_root, limit=full_limit
+                try:
+                    index_sync.drain_deferred_work(
+                        self._vault_root,
+                        limit=full_limit,
                     )
-                ]
-                if full_paths:
-                    try:
-                        index_sync.drain_deferred_work(
-                            self._vault_root,
-                            paths=full_paths,
-                            limit=full_limit,
-                        )
-                    except Exception:  # noqa: BLE001 - queued work remains retryable
-                        log.exception("file watcher: startup deferred full-index drain failed")
+                except Exception:  # noqa: BLE001 - queued work remains retryable
+                    log.exception("file watcher: startup deferred index drain failed")
             return
         policy = self._watcher_policy()
         drift_admission = 0

--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -897,6 +897,10 @@ def drain_deferred_work(
         if full_receipts and semantic_receipts and budget > 1:
             full_budget = budget // 2
             semantic_budget = budget - full_budget
+        elif full_receipts and semantic_receipts and budget == 1:
+            turn = deferred_index.claim_mixed_drain_queue(vault_root)
+            full_budget = int(turn == "full")
+            semantic_budget = int(turn == "semantic")
         elif full_receipts:
             full_budget, semantic_budget = budget, 0
         else:

--- a/tests/test_deferred_work_drain.py
+++ b/tests/test_deferred_work_drain.py
@@ -501,6 +501,66 @@ def test_zero_live_cap_keeps_one_background_convergence_slot() -> None:
     assert file_watcher._background_deferred_limit(policy, 0) == 0
 
 
+def test_zero_live_cap_periodic_drain_progresses_without_overspending_drift(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    rel = "Knowledge Base/zero-cap.md"
+    target = vault / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# queued\n", encoding="utf-8")
+    monkeypatch.setenv("EXOMEM_MODE", "normal")
+    monkeypatch.setenv("EXOMEM_WATCHER_MAX_EMBED_FILES", "0")
+    assert mode.watcher_policy().max_embed_files_per_batch == 0
+    monkeypatch.setattr(file_watcher.freshness, "SCOPES", ())
+    monkeypatch.setattr(
+        file_watcher.media_processing, "reconcile_all_media", lambda *_a, **_kw: 0
+    )
+    monkeypatch.setattr(
+        file_watcher.freshness, "external_pending_epoch", lambda _root: None
+    )
+    monkeypatch.setattr(file_watcher.freshness, "external_pending", lambda _root: False)
+    monkeypatch.setattr(
+        file_watcher.FileWatcher, "_recover_suspended_graph", lambda _self: None
+    )
+    monkeypatch.setattr(
+        deferred_index,
+        "inspect_embedding_freshness",
+        lambda _root, paths, **_kwargs: {
+            queued: deferred_index.EmbeddingFreshness.STALE for queued in paths
+        },
+    )
+
+    def replay(root: Path, _paths: list[Path], receipts):  # noqa: ANN001
+        deferred_index.clear_receipts(root, list(receipts))
+        return SimpleNamespace(status="completed")
+
+    monkeypatch.setattr(index_sync, "replay_deferred_embedding", replay)
+    watcher = file_watcher.FileWatcher(vault)
+    deferred_index.add(vault, [rel])
+
+    watcher._reconcile_once(seed=False)
+
+    assert deferred_index.list_paths(vault) == []
+
+    deferred_index.add(vault, [rel])
+    monkeypatch.setattr(file_watcher.freshness, "SCOPES", ("kb",))
+    monkeypatch.setattr(
+        file_watcher.freshness,
+        "reconcile",
+        lambda *_a, **_kw: SimpleNamespace(drifted=True, changed=(), deleted=()),
+    )
+    monkeypatch.setattr(
+        watcher,
+        "_dispatch_reconcile_delta",
+        lambda *_a: mode.watcher_policy().max_reconcile_embed_files,
+    )
+    monkeypatch.setattr("exomem.bm25.warm", lambda *_a: None)
+
+    watcher._reconcile_once(seed=False)
+
+    assert deferred_index.list_paths(vault) == [rel]
+
+
 def test_quiet_watcher_sets_the_deferral_flag_it_logs(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -773,6 +833,113 @@ def test_single_slot_bounded_drain_alternates_between_full_and_semantic_queues(
     assert full_attempts == [[full_rel], [full_rel]]
     assert semantic_attempts == [[semantic_rel]]
     assert deferred_index.list_paths(vault) == []
+
+
+def test_single_slot_startup_drains_both_queues_across_restarts(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    full_rel = "Knowledge Base/startup-full.md"
+    semantic_rel = "Knowledge Base/startup-semantic.md"
+    for rel in (full_rel, semantic_rel):
+        target = vault / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# queued\n", encoding="utf-8")
+    deferred_index.add_full(vault, [full_rel])
+    deferred_index.add(vault, [semantic_rel])
+    policy = mode.WatcherPolicy(0.5, 300.0, 1, 500, False)
+    monkeypatch.setattr(file_watcher.freshness, "SCOPES", ())
+    monkeypatch.setattr(
+        file_watcher.FileWatcher, "_watcher_policy", lambda _self: policy
+    )
+    monkeypatch.setattr(
+        file_watcher.FileWatcher,
+        "_validate_existing_graph_on_seed",
+        lambda _self: True,
+    )
+    monkeypatch.setattr(
+        index_sync, "recover_full_receipt_graph_epoch", lambda _root: True
+    )
+
+    def incomplete_full(_root: Path, paths: list[Path]):
+        rels = tuple(path.relative_to(vault).as_posix() for path in paths)
+        return index_sync.IndexSyncReport(
+            "upsert",
+            rels,
+            rels,
+            (index_sync.IndexComponentOutcome("lexstore", "degraded", "failed"),),
+        )
+
+    semantic_attempts: list[str] = []
+
+    def complete_semantic(root: Path, _paths: list[Path], receipts):  # noqa: ANN001
+        semantic_attempts.extend(receipt.rel_path for receipt in receipts)
+        deferred_index.clear_receipts(root, list(receipts))
+        return SimpleNamespace(status="completed")
+
+    monkeypatch.setattr(index_sync, "upsert_after_write", incomplete_full)
+    monkeypatch.setattr(
+        deferred_index,
+        "inspect_embedding_freshness",
+        lambda _root, paths, **_kwargs: {
+            rel: deferred_index.EmbeddingFreshness.STALE for rel in paths
+        },
+    )
+    monkeypatch.setattr(index_sync, "replay_deferred_embedding", complete_semantic)
+
+    file_watcher.FileWatcher(vault)._reconcile_once(seed=True)
+    file_watcher.FileWatcher(vault)._reconcile_once(seed=True)
+
+    assert semantic_attempts == [semantic_rel]
+    assert deferred_index.list_paths(vault) == []
+
+
+def test_mixed_drain_turn_claim_serializes_concurrent_callers(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    deferred_index.add(vault, ["Knowledge Base/queued.md"])
+    real_connect = deferred_index._connect
+    simultaneous_select = threading.Barrier(2)
+
+    class ConnectionProxy:
+        def __init__(self, connection: sqlite3.Connection) -> None:
+            self._connection = connection
+
+        def __enter__(self):
+            self._connection.__enter__()
+            return self
+
+        def __exit__(self, *args):  # noqa: ANN002
+            return self._connection.__exit__(*args)
+
+        def execute(self, sql: str, *args, **kwargs):  # noqa: ANN002, ANN003
+            if sql.startswith("SELECT value") and not self._connection.in_transaction:
+                simultaneous_select.wait(timeout=5)
+            return self._connection.execute(sql, *args, **kwargs)
+
+        def __getattr__(self, name: str):
+            return getattr(self._connection, name)
+
+    monkeypatch.setattr(
+        deferred_index,
+        "_connect",
+        lambda *args, **kwargs: ConnectionProxy(real_connect(*args, **kwargs)),
+    )
+    start = threading.Barrier(3)
+    outcomes: list[str] = []
+
+    def claim() -> None:
+        start.wait(timeout=5)
+        outcomes.append(deferred_index.claim_mixed_drain_queue(vault))
+
+    threads = [threading.Thread(target=claim) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=5)
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert sorted(outcomes) == ["full", "semantic"]
 
 
 def test_unbounded_full_drain_isolates_every_incomplete_receipt(

--- a/tests/test_deferred_work_drain.py
+++ b/tests/test_deferred_work_drain.py
@@ -494,6 +494,13 @@ def test_quiet_policy_has_nonzero_bounded_deferred_admission(
     assert policy.max_reconcile_embed_files == policy.max_embed_files_per_batch
 
 
+def test_zero_live_cap_keeps_one_background_convergence_slot() -> None:
+    policy = mode.WatcherPolicy(0.5, 300.0, 0, 500, False)
+
+    assert file_watcher._background_deferred_limit(policy, 500) == 1
+    assert file_watcher._background_deferred_limit(policy, 0) == 0
+
+
 def test_quiet_watcher_sets_the_deferral_flag_it_logs(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -715,6 +722,115 @@ def test_bounded_semantic_drain_limits_incomplete_batch_isolation(
     assert attempts[0] == rels
     assert attempts[1:] == [[rel] for rel in rels[:4]]
     assert set(deferred_index.list_paths(vault)) == set(rels)
+
+
+def test_single_slot_bounded_drain_alternates_between_full_and_semantic_queues(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    full_rel = "Knowledge Base/full.md"
+    semantic_rel = "Knowledge Base/semantic.md"
+    for rel in (full_rel, semantic_rel):
+        target = vault / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# queued\n", encoding="utf-8")
+    deferred_index.add_full(vault, [full_rel])
+    deferred_index.add(vault, [semantic_rel])
+    monkeypatch.setattr(
+        index_sync, "recover_full_receipt_graph_epoch", lambda _root: True
+    )
+    full_attempts: list[list[str]] = []
+
+    def incomplete_full(_root: Path, paths: list[Path]):
+        rels = [path.relative_to(vault).as_posix() for path in paths]
+        full_attempts.append(rels)
+        return index_sync.IndexSyncReport(
+            "upsert",
+            tuple(rels),
+            tuple(rels),
+            (index_sync.IndexComponentOutcome("lexstore", "degraded", "failed"),),
+        )
+
+    semantic_attempts: list[list[str]] = []
+
+    def complete_semantic(root: Path, _paths: list[Path], receipts):  # noqa: ANN001
+        semantic_attempts.append([receipt.rel_path for receipt in receipts])
+        deferred_index.clear_receipts(root, list(receipts))
+        return SimpleNamespace(status="completed")
+
+    monkeypatch.setattr(index_sync, "upsert_after_write", incomplete_full)
+    monkeypatch.setattr(
+        deferred_index,
+        "inspect_embedding_freshness",
+        lambda _root, paths, **_kwargs: {
+            rel: deferred_index.EmbeddingFreshness.STALE for rel in paths
+        },
+    )
+    monkeypatch.setattr(index_sync, "replay_deferred_embedding", complete_semantic)
+
+    assert index_sync.drain_deferred_work(vault, limit=1) == 0
+    assert index_sync.drain_deferred_work(vault, limit=1) == 1
+
+    assert full_attempts == [[full_rel], [full_rel]]
+    assert semantic_attempts == [[semantic_rel]]
+    assert deferred_index.list_paths(vault) == []
+
+
+def test_unbounded_full_drain_isolates_every_incomplete_receipt(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    rels = [f"Knowledge Base/full-{index:02d}.md" for index in range(10)]
+    for rel in rels:
+        target = vault / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# queued\n", encoding="utf-8")
+    deferred_index.add_full(vault, rels)
+    monkeypatch.setattr(
+        index_sync, "recover_full_receipt_graph_epoch", lambda _root: True
+    )
+    attempts: list[list[str]] = []
+
+    def incomplete(_root: Path, paths: list[Path]):
+        rel_paths = [path.relative_to(vault).as_posix() for path in paths]
+        attempts.append(rel_paths)
+        return index_sync.IndexSyncReport(
+            "upsert",
+            tuple(rel_paths),
+            tuple(rel_paths),
+            (index_sync.IndexComponentOutcome("lexstore", "degraded", "failed"),),
+        )
+
+    monkeypatch.setattr(index_sync, "upsert_after_write", incomplete)
+
+    assert index_sync.drain_deferred_work(vault) == 0
+    assert attempts == [rels, *[[rel] for rel in rels]]
+
+
+def test_unbounded_semantic_drain_isolates_every_incomplete_receipt(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    rels = [f"Knowledge Base/semantic-{index:02d}.md" for index in range(10)]
+    for rel in rels:
+        target = vault / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# queued\n", encoding="utf-8")
+    deferred_index.add(vault, rels)
+    monkeypatch.setattr(
+        deferred_index,
+        "inspect_embedding_freshness",
+        lambda _root, paths, **_kwargs: {
+            rel: deferred_index.EmbeddingFreshness.STALE for rel in paths
+        },
+    )
+    attempts: list[list[str]] = []
+
+    def incomplete(_root: Path, _paths: list[Path], receipts):  # noqa: ANN001
+        attempts.append([receipt.rel_path for receipt in receipts])
+        return SimpleNamespace(status="degraded")
+
+    monkeypatch.setattr(index_sync, "replay_deferred_embedding", incomplete)
+
+    assert index_sync.drain_deferred_work(vault) == 0
+    assert attempts == [rels, *[[rel] for rel in rels]]
 
 
 def test_doctor_warns_on_deferred_queue_fraction(

--- a/tests/test_media_graph_recovery.py
+++ b/tests/test_media_graph_recovery.py
@@ -243,10 +243,10 @@ def test_watcher_seed_recovers_floor_ahead_receipt_before_rebuild_without_extrac
     assert sidecar.read_bytes() == committed_bytes
 
 
-def test_watcher_seed_caps_full_receipt_snapshot_before_targeted_drain(
+def test_watcher_seed_routes_configured_receipt_cap_through_fair_drain(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Startup replay admits only its configured receipt cap from a large backlog."""
+    """Startup replay gives its configured cap to the mixed-queue allocator."""
     rels = [f"Knowledge Base/Notes/backlog-{index:02d}.md" for index in range(24)]
     for rel in rels:
         path = vault / rel
@@ -254,14 +254,7 @@ def test_watcher_seed_caps_full_receipt_snapshot_before_targeted_drain(
         path.write_text("# queued\n", encoding="utf-8")
     deferred_index.add_full(vault, rels)
     watcher = file_watcher.FileWatcher(vault)
-    observed_limits: list[int | None] = []
-    real_snapshot_full = deferred_index.snapshot_full
-    drains: list[tuple[list[Path], int | None]] = []
-
-    def observe_snapshot_full(root: Path, *, limit=None, paths=None):  # noqa: ANN001
-        assert paths is None
-        observed_limits.append(limit)
-        return real_snapshot_full(root, limit=limit, paths=paths)
+    drains: list[int | None] = []
 
     monkeypatch.setattr(watcher, "_validate_existing_graph_on_seed", lambda: True)
     monkeypatch.setattr(
@@ -269,14 +262,12 @@ def test_watcher_seed_caps_full_receipt_snapshot_before_targeted_drain(
         "_watcher_policy",
         lambda: mode.WatcherPolicy(0.5, 300.0, 2, 2, False),
     )
-    monkeypatch.setattr(deferred_index, "snapshot_full", observe_snapshot_full)
     monkeypatch.setattr(
         index_sync,
         "drain_deferred_work",
-        lambda _root, *, paths, limit: drains.append((paths, limit)),
+        lambda _root, *, limit: drains.append(limit),
     )
 
     watcher._reconcile_once(seed=True)
 
-    assert observed_limits == [2]
-    assert drains == [([vault / rels[0], vault / rels[1]], 2)]
+    assert drains == [2]


### PR DESCRIPTION
## Why

The bounded background drain merged in #798 always assigned a one-item budget to the full-index queue and admitted nothing when the live cap was zero. Supported low-cap configurations could therefore strand semantic work or stop deferred convergence entirely. Adversarial review also found that startup bypassed the shared allocator and concurrent turn claims were not serialized.

## What changed

- reserve one background convergence slot for a zero live cap when reconcile budget remains
- persistently alternate a one-item shared budget between full and semantic queues
- route startup through the same unscoped allocator so restarts preserve fairness
- serialize the durable read-and-flip with an immediate SQLite transaction
- preserve bounded background failure isolation and exhaustive operator repair
- extend the active OpenSpec contract and regressions for zero-cap wiring, restart fairness, concurrent claims, and unbounded repair

## Verification

- 139 watcher, deferred-drain, and mode tests passed after the review fixes
- 36 deferred-drain tests passed again after integrating current main
- Ruff passed on all changed Python files
- OpenSpec strict validation passed
- public-artifact privacy validation passed
- independent adversarial re-review running against the final pushed diff