### PR TITLE
feat(governance): mirror reviewed v4 policy workspace

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -175,7 +175,7 @@ this reconciliation is `origin/main` at `1a7f30e1` (merged PR #778).
   activation epoch/digest, and ready namespace. Make policy commits CAS expected catalog,
   content/companion writers CAS expected policy, and readers pin one tuple; remove direct
   workspace loading and independent policy/catalog pointer linearization.
-- [ ] 3.11 Implement the separate cooperatively fenced, handle-relative no-follow
+- [x] 3.11 Implement the separate cooperatively fenced, handle-relative no-follow
   workspace mirror with held-parent/descriptor-identity checks. Refuse observable drift,
   record exact mirror result and pending divergence, and allow an already-exact tuple
   transaction to stand; direct OS-owner mutation is outside the filesystem guarantee.

--- a/src/exomem/governance/policy.py
+++ b/src/exomem/governance/policy.py
@@ -378,6 +378,7 @@ class AuthoringSnapshot:
     conflict_set_digest: str
     guard_generation: str
     file_identities: tuple[AuthoringFileIdentity, ...]
+    directory_identities: tuple[tuple[str, held_fs.StableIdentity], ...]
     governance_root_identity: held_fs.StableIdentity | None
 
 
@@ -388,6 +389,41 @@ class ProspectiveCompile:
     snapshot: AuthoringSnapshot
     target_documents: tuple[tuple[str, bytes], ...]
     policy: Policy
+
+
+def observe_authoring_snapshot(vault_root: Path) -> AuthoringSnapshot | None:
+    """Acquire one stable no-follow workspace snapshot without selecting authority.
+
+    This is the mirror/recovery counterpart to ``compile_prospective``.  It does
+    not consult or advance the activation store: callers may compare the
+    mutable authoring workspace with already-reviewed immutable bytes, but may
+    never infer active policy from this observation.
+    """
+
+    before = _probe_authoring_tree(Path(vault_root))
+    read = _probe_authoring_tree(Path(vault_root))
+    after = _probe_authoring_tree(Path(vault_root))
+    if (
+        before is None
+        or read is None
+        or after is None
+        or before != read
+        or read != after
+        or read.conflict_paths
+    ):
+        return None
+    documents = dict(read.documents)
+    return AuthoringSnapshot(
+        documents=read.documents,
+        source_fingerprint=_document_fingerprint(documents),
+        conflict_set_digest=_path_set_digest(
+            b"exomem.governance-conflict-set.v1", read.conflict_paths
+        ),
+        guard_generation="",
+        file_identities=read.file_identities,
+        directory_identities=read.directory_identities,
+        governance_root_identity=read.root_identity,
+    )
 
 
 @dataclass(frozen=True)
@@ -1253,6 +1289,7 @@ def compile_prospective(
         ),
         guard_generation=guard_before,
         file_identities=read.file_identities,
+        directory_identities=read.directory_identities,
         governance_root_identity=read.root_identity,
     )
     target_documents = dict(current_documents)

--- a/src/exomem/governance/tool.py
+++ b/src/exomem/governance/tool.py
@@ -29,6 +29,7 @@ from .. import (
     epistemic_graph,
     find_corpus,
     graph_sync,
+    held_fs,
     index_paths,
     lexstore,
     media_jobs,
@@ -92,7 +93,10 @@ _LEXICAL_REBUILD_TEMP_RE = re.compile(
 _CROCKFORD32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 _ULID_RE = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
-_V4_POLICY_PROPOSAL_SCHEMA = "exomem.governance-policy-proposal/v2"
+_V4_POLICY_PROPOSAL_SCHEMA = "exomem.governance-policy-proposal/v3"
+_V4_POLICY_MIRROR_SCHEMA = "exomem.governance-policy-workspace-mirror/v1"
+_V4_POLICY_MIRROR_OPERATION = "governance_policy_workspace_mirror"
+_V4_POLICY_MIRROR_OUTCOMES = frozenset({"complete", "diverged"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -102,6 +106,7 @@ class _DecodedV4PolicyProposal:
     policy: schema_v4.PolicyGenerationSeed
     namespace: schema_v4.ProjectionNamespaceSeed
     direction: str
+    authoring_snapshot: policy_module.AuthoringSnapshot
 
 
 @dataclass(frozen=True, slots=True)
@@ -236,6 +241,13 @@ def _snapshot_value(snapshot: policy_module.AuthoringSnapshot) -> dict[str, Any]
                 "sha256": item.sha256,
             }
             for item in snapshot.file_identities
+        ],
+        "directory_identities": [
+            {
+                "path": relative,
+                "identity": _stable_identity_value(identity),
+            }
+            for relative, identity in snapshot.directory_identities
         ],
         "governance_root_identity": _stable_identity_value(
             snapshot.governance_root_identity
@@ -2732,6 +2744,196 @@ def _decoded_bound_documents(value: Any) -> tuple[tuple[str, bytes], ...]:
     return ordered
 
 
+def _v4_mirror_relative_path(relative: str) -> bool:
+    path = Path(relative)
+    return (
+        not path.is_absolute()
+        and len(path.parts) == 2
+        and path.parts[0] in {"scopes", "rules", "grants"}
+        and path.parts[1] not in {"", ".", ".."}
+        and path.parts[1].endswith(".yaml")
+        and relative == path.as_posix()
+    )
+
+
+def _decoded_stable_identity(value: object, *, kind: str) -> held_fs.StableIdentity:
+    if not isinstance(value, dict) or set(value) != {
+        "device",
+        "inode",
+        "kind",
+        "link_count",
+    }:
+        raise GovernanceError(
+            "INVALID_GOVERNANCE_PROPOSAL",
+            "stored governance authoring identity is invalid",
+        )
+    integer_fields = ("device", "inode", "link_count")
+    if (
+        any(
+            isinstance(value[field], bool)
+            or not isinstance(value[field], int)
+            or value[field] < 0
+            for field in integer_fields
+        )
+        or value["link_count"] < 1
+        or value["kind"] != kind
+        or (kind == "file" and value["link_count"] != 1)
+    ):
+        raise GovernanceError(
+            "INVALID_GOVERNANCE_PROPOSAL",
+            "stored governance authoring identity is invalid",
+        )
+    return held_fs.StableIdentity(
+        device=value["device"],
+        inode=value["inode"],
+        kind=value["kind"],
+        link_count=value["link_count"],
+    )
+
+
+def _decoded_v4_authoring_snapshot(value: object) -> policy_module.AuthoringSnapshot:
+    expected_fields = {
+        "documents",
+        "source_fingerprint",
+        "conflict_set_digest",
+        "guard_generation",
+        "file_identities",
+        "directory_identities",
+        "governance_root_identity",
+    }
+    if not isinstance(value, dict) or set(value) != expected_fields:
+        raise GovernanceError(
+            "INVALID_GOVERNANCE_PROPOSAL",
+            "stored governance authoring snapshot is invalid",
+        )
+    documents = _decoded_bound_documents(value["documents"])
+    document_map = dict(documents)
+    if any(not _v4_mirror_relative_path(relative) for relative in document_map):
+        raise GovernanceError(
+            "INVALID_GOVERNANCE_PROPOSAL",
+            "stored governance authoring path is invalid",
+        )
+    raw_identities = value["file_identities"]
+    if not isinstance(raw_identities, list):
+        raise GovernanceError(
+            "INVALID_GOVERNANCE_PROPOSAL",
+            "stored governance authoring identities are invalid",
+        )
+    identities: list[policy_module.AuthoringFileIdentity] = []
+    seen: set[str] = set()
+    for item in raw_identities:
+        if not isinstance(item, dict) or set(item) != {"path", "identity", "sha256"}:
+            raise GovernanceError(
+                "INVALID_GOVERNANCE_PROPOSAL",
+                "stored governance authoring identities are invalid",
+            )
+        relative = item["path"]
+        digest = item["sha256"]
+        if (
+            not isinstance(relative, str)
+            or relative in seen
+            or relative not in document_map
+            or not isinstance(digest, str)
+            or _SHA256_RE.fullmatch(digest) is None
+            or hashlib.sha256(document_map[relative]).hexdigest() != digest
+        ):
+            raise GovernanceError(
+                "INVALID_GOVERNANCE_PROPOSAL",
+                "stored governance authoring identities are invalid",
+            )
+        seen.add(relative)
+        identities.append(
+            policy_module.AuthoringFileIdentity(
+                path=relative,
+                identity=_decoded_stable_identity(item["identity"], kind="file"),
+                sha256=digest,
+            )
+        )
+    if tuple(item.path for item in identities) != tuple(sorted(document_map)):
+        raise GovernanceError(
+            "INVALID_GOVERNANCE_PROPOSAL",
+            "stored governance authoring identities are incomplete",
+        )
+    raw_directories = value["directory_identities"]
+    if not isinstance(raw_directories, list):
+        raise GovernanceError(
+            "INVALID_GOVERNANCE_PROPOSAL",
+            "stored governance authoring directories are invalid",
+        )
+    directories: list[tuple[str, held_fs.StableIdentity]] = []
+    seen_directories: set[str] = set()
+    for item in raw_directories:
+        if not isinstance(item, dict) or set(item) != {"path", "identity"}:
+            raise GovernanceError(
+                "INVALID_GOVERNANCE_PROPOSAL",
+                "stored governance authoring directories are invalid",
+            )
+        relative = item["path"]
+        path = Path(relative) if isinstance(relative, str) else None
+        if (
+            path is None
+            or path.is_absolute()
+            or relative != path.as_posix()
+            or any(part in {"", ".", ".."} for part in path.parts)
+            or relative in seen_directories
+        ):
+            raise GovernanceError(
+                "INVALID_GOVERNANCE_PROPOSAL",
+                "stored governance authoring directories are invalid",
+            )
+        seen_directories.add(relative)
+        directories.append(
+            (
+                relative,
+                _decoded_stable_identity(item["identity"], kind="directory"),
+            )
+        )
+    if tuple(relative for relative, _ in directories) != tuple(
+        sorted(seen_directories)
+    ):
+        raise GovernanceError(
+            "INVALID_GOVERNANCE_PROPOSAL",
+            "stored governance authoring directories are not ordered",
+        )
+    root_value = value["governance_root_identity"]
+    root_identity = (
+        None
+        if root_value is None
+        else _decoded_stable_identity(root_value, kind="directory")
+    )
+    if (root_identity is None) != (not documents):
+        raise GovernanceError(
+            "INVALID_GOVERNANCE_PROPOSAL",
+            "stored governance authoring root is invalid",
+        )
+    source_fingerprint = value["source_fingerprint"]
+    conflict_digest = value["conflict_set_digest"]
+    guard_generation = value["guard_generation"]
+    compiled = policy_module.compile_documents(document_map)
+    if (
+        not isinstance(source_fingerprint, str)
+        or _SHA256_RE.fullmatch(source_fingerprint) is None
+        or source_fingerprint != compiled.fingerprint
+        or not isinstance(conflict_digest, str)
+        or _SHA256_RE.fullmatch(conflict_digest) is None
+        or not isinstance(guard_generation, str)
+        or not guard_generation
+    ):
+        raise GovernanceError(
+            "INVALID_GOVERNANCE_PROPOSAL",
+            "stored governance authoring snapshot is invalid",
+        )
+    return policy_module.AuthoringSnapshot(
+        documents=documents,
+        source_fingerprint=source_fingerprint,
+        conflict_set_digest=conflict_digest,
+        guard_generation=guard_generation,
+        file_identities=tuple(identities),
+        directory_identities=tuple(directories),
+        governance_root_identity=root_identity,
+    )
+
+
 def _reviewed_active_state(value: object) -> schema_v4.VerifiedActiveGovernanceState:
     expected_keys = {
         "logical_vault_id",
@@ -2861,6 +3063,11 @@ def _decode_v4_proposal_binding(
             "stored governance target is invalid",
         )
     target_documents = _decoded_bound_documents(target["source_documents"])
+    if any(not _v4_mirror_relative_path(relative) for relative, _ in target_documents):
+        raise GovernanceError(
+            "INVALID_GOVERNANCE_PROPOSAL",
+            "stored governance target path is invalid",
+        )
     compiled = policy_module.compile_documents(dict(target_documents))
     try:
         compiled_bytes = base64.b64decode(target["compiled_policy"], validate=True)
@@ -2957,16 +3164,7 @@ def _decode_v4_proposal_binding(
             "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
             "the reviewed target projection namespace does not verify",
         )
-    snapshot = binding["authoring_snapshot"]
-    if (
-        not isinstance(snapshot, dict)
-        or not isinstance(snapshot.get("conflict_set_digest"), str)
-        or _SHA256_RE.fullmatch(snapshot["conflict_set_digest"]) is None
-    ):
-        raise GovernanceError(
-            "INVALID_GOVERNANCE_PROPOSAL",
-            "stored governance authoring snapshot is invalid",
-        )
+    snapshot = _decoded_v4_authoring_snapshot(binding["authoring_snapshot"])
     return _DecodedV4PolicyProposal(
         payload=payload,
         expected=expected,
@@ -2974,7 +3172,7 @@ def _decode_v4_proposal_binding(
             generation_id=target["generation_id"],
             source_documents=target_documents,
             source_fingerprint=target["source_fingerprint"],
-            conflict_digest=snapshot["conflict_set_digest"],
+            conflict_digest=snapshot.conflict_set_digest,
             compiled_policy=compiled_bytes,
             policy_fingerprint=target["policy_fingerprint"],
             compiler_schema_version=target["compiler_schema_version"],
@@ -2990,6 +3188,7 @@ def _decode_v4_proposal_binding(
             ready_at=namespace["ready_at"],
         ),
         direction=direction,
+        authoring_snapshot=snapshot,
     )
 
 
@@ -3237,20 +3436,417 @@ def _spend_v4_policy_proposal(
         connection.close()
 
 
+def _v4_workspace_mirror_barrier(_phase: str, _path: str | None = None) -> None:
+    """Deterministic test seam around the non-authoritative workspace mirror."""
+
+
+def _v4_workspace_mirror_event_id(decoded: _DecodedV4PolicyProposal) -> str:
+    return receipts.critical_event_id(
+        {
+            "schema": _V4_POLICY_MIRROR_SCHEMA,
+            "policy_receipt_event_id": decoded.policy.receipt_event_id,
+            "policy_generation_id": decoded.policy.generation_id,
+        }
+    )
+
+
+def _v4_workspace_mirror_terminal(
+    vault_root: Path,
+    decoded: _DecodedV4PolicyProposal,
+) -> str | None:
+    event_id = _v4_workspace_mirror_event_id(decoded)
+    prior, prepared, target, affected = _v4_workspace_mirror_receipt_digests(decoded)
+    try:
+        event_records = receipts.event_records(vault_root)
+        intents = [
+            record
+            for record in event_records
+            if record.get("event_id") == event_id and record.get("phase") == "intent"
+        ]
+        terminals = [
+            record
+            for record in event_records
+            if record.get("causation_id") == event_id
+            and record.get("phase") in {"committed", "aborted"}
+        ]
+    except receipts.ReceiptError:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy workspace mirror evidence cannot be verified",
+        ) from None
+    if not intents and not terminals:
+        return None
+    if len(intents) != 1 or any(
+        intents[0].get(field) != expected
+        for field, expected in {
+            "event_type": "critical",
+            "operation": _V4_POLICY_MIRROR_OPERATION,
+            "prior": prior,
+            "prepared": prepared,
+            "target": target,
+            "affected_ids": affected,
+            "parent_causation_id": decoded.policy.receipt_event_id,
+        }.items()
+    ):
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy workspace mirror intent evidence is contradictory",
+        )
+    if not terminals:
+        return None
+    if len(terminals) != 1 or terminals[0].get("phase") != "committed":
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy workspace mirror evidence is contradictory",
+        )
+    outcome = terminals[0].get("outcome")
+    if outcome not in _V4_POLICY_MIRROR_OUTCOMES:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy workspace mirror evidence has an unknown outcome",
+        )
+    return str(outcome)
+
+
+def _v4_workspace_mirror_receipt_digests(
+    decoded: _DecodedV4PolicyProposal,
+) -> tuple[str, str, str, list[str]]:
+    reviewed = decoded.authoring_snapshot
+    prior = _digest(
+        {
+            "schema": _V4_POLICY_MIRROR_SCHEMA,
+            "policy_generation_id": decoded.expected.policy_generation_id,
+            "source_fingerprint": reviewed.source_fingerprint,
+            "authoring_snapshot": _snapshot_value(reviewed),
+        }
+    )
+    prepared = _digest(
+        {
+            "schema": _V4_POLICY_MIRROR_SCHEMA,
+            "policy_generation_id": decoded.policy.generation_id,
+            "policy_receipt_event_id": decoded.policy.receipt_event_id,
+            "source_fingerprint": decoded.policy.source_fingerprint,
+        }
+    )
+    target = _digest(
+        {
+            "schema": _V4_POLICY_MIRROR_SCHEMA,
+            "policy_generation_id": decoded.policy.generation_id,
+            "source_fingerprint": decoded.policy.source_fingerprint,
+            "source_documents": [
+                {
+                    "path_digest": hashlib.sha256(relative.encode("utf-8")).hexdigest(),
+                    "sha256": hashlib.sha256(content).hexdigest(),
+                }
+                for relative, content in decoded.policy.source_documents
+            ],
+        }
+    )
+    affected = [
+        hashlib.sha256(
+            _canonical_json(
+                sorted(
+                    set(dict(reviewed.documents))
+                    | set(dict(decoded.policy.source_documents))
+                )
+            ).encode("utf-8")
+        ).hexdigest()
+    ]
+    return prior, prepared, target, affected
+
+
+def _same_v4_mirror_identity(
+    observed: held_fs.StableIdentity | None,
+    expected: held_fs.StableIdentity | None,
+) -> bool:
+    if observed is None or expected is None:
+        return observed is expected
+    return (
+        observed.device == expected.device
+        and observed.inode == expected.inode
+        and observed.kind == expected.kind
+        and (observed.kind != "file" or observed.link_count == expected.link_count == 1)
+    )
+
+
+def _v4_workspace_mirror_plan(
+    current: policy_module.AuthoringSnapshot,
+    reviewed: policy_module.AuthoringSnapshot,
+    target_documents: tuple[tuple[str, bytes], ...],
+) -> list[tuple[str, bytes | None, policy_module.AuthoringFileIdentity | None]] | None:
+    prior = dict(reviewed.documents)
+    target = dict(target_documents)
+    observed = dict(current.documents)
+    reviewed_identities = {item.path: item for item in reviewed.file_identities}
+    observed_identities = {item.path: item for item in current.file_identities}
+    reviewed_directories = dict(reviewed.directory_identities)
+    observed_directories = dict(current.directory_identities)
+    target_directories = {Path(relative).parent.as_posix() for relative in target}
+    if reviewed.governance_root_identity is not None and not _same_v4_mirror_identity(
+        current.governance_root_identity,
+        reviewed.governance_root_identity,
+    ):
+        return None
+    if set(observed) - (set(prior) | set(target)):
+        return None
+    if set(observed_directories) - (set(reviewed_directories) | target_directories):
+        return None
+    for relative, expected in reviewed_directories.items():
+        if not _same_v4_mirror_identity(observed_directories.get(relative), expected):
+            return None
+    effects: list[
+        tuple[str, bytes | None, policy_module.AuthoringFileIdentity | None]
+    ] = []
+    for relative in sorted(set(prior) | set(target)):
+        prior_bytes = prior.get(relative)
+        target_bytes = target.get(relative)
+        observed_bytes = observed.get(relative)
+        reviewed_identity = reviewed_identities.get(relative)
+        observed_identity = observed_identities.get(relative)
+        if prior_bytes == target_bytes:
+            if (
+                observed_bytes != prior_bytes
+                or reviewed_identity is None
+                or observed_identity != reviewed_identity
+            ):
+                return None
+            continue
+        if observed_bytes == target_bytes:
+            continue
+        if observed_bytes != prior_bytes:
+            return None
+        if prior_bytes is not None and (
+            reviewed_identity is None or observed_identity != reviewed_identity
+        ):
+            return None
+        effects.append((relative, target_bytes, observed_identity))
+    return effects
+
+
+def _v4_mirror_failure_status(error: held_fs.HeldFsError | None) -> str:
+    if error is not None and error.code in {
+        "DESTINATION_EXISTS",
+        "IDENTITY_CHANGED",
+        "MISSING",
+        "UNSAFE_PATH",
+    }:
+        return "diverged"
+    return "pending"
+
+
+def _apply_v4_workspace_mirror(
+    vault_root: Path,
+    decoded: _DecodedV4PolicyProposal,
+    *,
+    crash_at: object,
+) -> str:
+    base = f"{kb_dirname()}/{policy_module.GOVERNANCE_DIRNAME}"
+    reviewed = decoded.authoring_snapshot
+    target_documents = decoded.policy.source_documents
+    reviewed_directories = dict(reviewed.directory_identities)
+    with reserved_paths._identity_coordination_scope(
+        vault_root,
+        descriptor_ids=("governance-tree",),
+        identity_may_change=True,
+    ):
+        current = policy_module.observe_authoring_snapshot(vault_root)
+        if current is None:
+            return "diverged"
+        effects = _v4_workspace_mirror_plan(current, reviewed, target_documents)
+        if effects is None:
+            return "diverged"
+        acquired = held_fs.acquire(vault_root)
+        if not acquired.ok:
+            return _v4_mirror_failure_status(acquired.error)
+        publications = reserved_paths._reachable_owner_publications(
+            vault_root, "governance-tree"
+        )
+        with acquired.require() as filesystem:
+            root_result = filesystem.parent(
+                base,
+                create=reviewed.governance_root_identity is None,
+                access="flush",
+            )
+            if not root_result.ok:
+                return _v4_mirror_failure_status(root_result.error)
+            with root_result.require() as governance_root:
+                if reviewed.governance_root_identity is not None and not (
+                    _same_v4_mirror_identity(
+                        governance_root.identity,
+                        reviewed.governance_root_identity,
+                    )
+                ):
+                    return "diverged"
+                publications[base] = governance_root.identity
+                for index, (relative, target_bytes, current_identity) in enumerate(
+                    effects, start=1
+                ):
+                    _v4_workspace_mirror_barrier("before_write", relative)
+                    path = Path(relative)
+                    parent_relative = Path(base, path.parent).as_posix()
+                    parent_result = filesystem.parent(
+                        parent_relative,
+                        create=current_identity is None,
+                        access="flush",
+                    )
+                    if not parent_result.ok:
+                        return _v4_mirror_failure_status(parent_result.error)
+                    with parent_result.require() as parent:
+                        expected_parent = reviewed_directories.get(path.parent.as_posix())
+                        if expected_parent is not None and not _same_v4_mirror_identity(
+                            parent.identity,
+                            expected_parent,
+                        ):
+                            return "diverged"
+                        publications[parent_relative] = parent.identity
+                        if target_bytes is None:
+                            mutable = filesystem.file(parent, path.name, access="mutate")
+                            if not mutable.ok:
+                                return _v4_mirror_failure_status(mutable.error)
+                            with mutable.require() as existing:
+                                if current_identity is None or (
+                                    existing.identity != current_identity.identity
+                                ):
+                                    return "diverged"
+                                observed = filesystem.read(existing)
+                                if (
+                                    not observed.ok
+                                    or hashlib.sha256(observed.require()).hexdigest()
+                                    != current_identity.sha256
+                                ):
+                                    return "diverged"
+                                removed = filesystem.unlink(existing)
+                                if not removed.ok:
+                                    return _v4_mirror_failure_status(removed.error)
+                            flushed = filesystem.flush_directory(parent)
+                            if not flushed.ok:
+                                return _v4_mirror_failure_status(flushed.error)
+                            publications.pop(f"{base}/{relative}", None)
+                        else:
+                            published = held_fs.publish_bytes(
+                                filesystem,
+                                parent,
+                                path.name,
+                                target_bytes,
+                                expected_identity=(
+                                    None
+                                    if current_identity is None
+                                    else current_identity.identity
+                                ),
+                                expected_sha256=(
+                                    None
+                                    if current_identity is None
+                                    else current_identity.sha256
+                                ),
+                            )
+                            if not published.ok:
+                                return _v4_mirror_failure_status(published.error)
+                            flushed = filesystem.flush_directory(parent)
+                            if not flushed.ok:
+                                return _v4_mirror_failure_status(flushed.error)
+                            publications[f"{base}/{relative}"] = published.require()
+                        if (
+                            not filesystem.validate_directory(parent).ok
+                            or not filesystem.validate_directory(governance_root).ok
+                        ):
+                            return "diverged"
+                    _v4_workspace_mirror_barrier("after_write", relative)
+                    if crash_at in {
+                        "v4_after_mirror_write",
+                        f"v4_after_mirror_write:{index}",
+                    }:
+                        raise GovernanceCrash(str(crash_at))
+                if not filesystem.validate_directory(governance_root).ok:
+                    return "diverged"
+        final = policy_module.observe_authoring_snapshot(vault_root)
+        if (
+            final is None
+            or final.documents != target_documents
+            or (
+                reviewed.governance_root_identity is not None
+                and not _same_v4_mirror_identity(
+                    final.governance_root_identity,
+                    reviewed.governance_root_identity,
+                )
+            )
+        ):
+            return "diverged"
+        for item in final.file_identities:
+            publications[f"{base}/{item.path}"] = item.identity
+        for relative, identity in final.directory_identities:
+            publications[f"{base}/{relative}"] = identity
+        reserved_paths._publish_owner_identities(
+            vault_root, "governance-tree", publications
+        )
+    return "complete"
+
+
+def _mirror_v4_policy_workspace(
+    vault_root: Path,
+    decoded: _DecodedV4PolicyProposal,
+    *,
+    crash_at: object,
+) -> str:
+    event_id = _v4_workspace_mirror_event_id(decoded)
+    existing = _v4_workspace_mirror_terminal(vault_root, decoded)
+    if existing is not None:
+        return existing
+    prior, prepared, target, affected = _v4_workspace_mirror_receipt_digests(decoded)
+    try:
+        receipts.begin_event(
+            vault_root,
+            operation=_V4_POLICY_MIRROR_OPERATION,
+            prior=prior,
+            prepared=prepared,
+            target=target,
+            affected_ids=affected,
+            event_id=event_id,
+            parent_causation_id=decoded.policy.receipt_event_id,
+        )
+    except receipts.ReceiptError:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy workspace mirror intent could not be recorded",
+        ) from None
+    _v4_workspace_mirror_barrier("after_intent")
+    if crash_at == "v4_after_mirror_intent":
+        raise GovernanceCrash("v4_after_mirror_intent")
+    outcome = _apply_v4_workspace_mirror(
+        vault_root,
+        decoded,
+        crash_at=crash_at,
+    )
+    if crash_at == "v4_after_mirror_effect":
+        raise GovernanceCrash("v4_after_mirror_effect")
+    if outcome == "pending":
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "the committed policy tuple is active but its workspace mirror needs retry",
+        )
+    try:
+        receipts.commit_event(vault_root, event_id, outcome=outcome)
+    except receipts.ReceiptError:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy workspace mirror outcome could not be recorded",
+        ) from None
+    if crash_at == "v4_after_mirror_terminal":
+        raise GovernanceCrash("v4_after_mirror_terminal")
+    return outcome
+
+
 def _v4_commit_terminal(
     *,
     proposal_id: str,
     decoded: _DecodedV4PolicyProposal,
+    mirror_status: str,
 ) -> dict[str, Any]:
-    # Publication never treats mutable YAML as authority.  The held-handle
-    # workspace mirror is a separate protocol; until that lands, surface the
-    # divergence explicitly instead of falling back to pathname writes.
     return {
         "status": "committed",
         "event_id": decoded.policy.receipt_event_id,
         "proposal_id": proposal_id,
         "direction": decoded.direction,
-        "mirror_status": "pending",
+        "mirror_status": mirror_status,
     }
 
 
@@ -3270,9 +3866,8 @@ def _commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
             ).fetchone()
             if row is None:
                 raise GovernanceError("PROPOSAL_UNKNOWN", "no such proposal")
-            if str(row[2]) == "spent":
-                raise GovernanceError("PROPOSAL_SPENT", "proposal was already activated")
-            if str(row[2]) != "pending":
+            status = str(row[2])
+            if status not in {"pending", "spent"}:
                 raise GovernanceError("PROPOSAL_EXPIRED", "proposal is not active")
             proposal_json = str(row[0])
             manifest_json = str(row[1])
@@ -3292,6 +3887,22 @@ def _commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
             )
         finally:
             connection.close()
+        if status == "spent":
+            if recovered is None:
+                raise GovernanceError(
+                    "GOVERNANCE_BLOCKED",
+                    "spent policy proposal has no exact committed publication",
+                )
+            mirror_status = _mirror_v4_policy_workspace(
+                vault_root,
+                decoded,
+                crash_at=kwargs.get("crash_at"),
+            )
+            return _v4_commit_terminal(
+                proposal_id=proposal_id,
+                decoded=decoded,
+                mirror_status=mirror_status,
+            )
         if recovered is not None:
             _spend_v4_policy_proposal(
                 vault_root,
@@ -3300,9 +3911,15 @@ def _commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
                 membership_manifest=manifest_json,
                 spent_at=int(now),
             )
+            mirror_status = _mirror_v4_policy_workspace(
+                vault_root,
+                decoded,
+                crash_at=kwargs.get("crash_at"),
+            )
             return _v4_commit_terminal(
                 proposal_id=proposal_id,
                 decoded=decoded,
+                mirror_status=mirror_status,
             )
         if float(row[3]) < now:
             raise GovernanceError("PROPOSAL_EXPIRED", "proposal is not active")
@@ -3365,9 +3982,15 @@ def _commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
             membership_manifest=manifest_json,
             spent_at=int(now),
         )
+        mirror_status = _mirror_v4_policy_workspace(
+            vault_root,
+            validated.decoded,
+            crash_at=kwargs.get("crash_at"),
+        )
         return _v4_commit_terminal(
             proposal_id=proposal_id,
             decoded=validated.decoded,
+            mirror_status=mirror_status,
         )
     reconcile = reconcile_governance_operations(vault_root)
     if reconcile["blocked"]:

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -19,6 +19,7 @@ from exomem.governance import (
     policy,
     projection_store,
     projections,
+    receipts,
     schema_v4,
     store,
 )
@@ -352,7 +353,7 @@ def test_govern_memory_v4_proposal_persists_exact_authority_binding(
         catalog_generation=1,
     )
 
-    assert binding["schema"] == "exomem.governance-policy-proposal/v2"
+    assert binding["schema"] == "exomem.governance-policy-proposal/v3"
     assert reviewed == {
         "activation_epoch": 1,
         "activation_state_digest": migration.activation_state_digest,
@@ -375,6 +376,10 @@ def test_govern_memory_v4_proposal_persists_exact_authority_binding(
     assert snapshot["guard_generation"]
     assert len(snapshot["documents"]) == 2
     assert len(snapshot["file_identities"]) == 2
+    assert [item["path"] for item in snapshot["directory_identities"]] == [
+        "rules",
+        "scopes",
+    ]
     assert target["policy_fingerprint"] == target_policy.fingerprint
     assert target["source_fingerprint"] == target_policy.fingerprint
     assert re.fullmatch(r"[0-9A-HJKMNP-TV-Z]{26}", target["generation_id"])
@@ -502,7 +507,7 @@ def test_govern_memory_v4_commit_publishes_the_exact_reviewed_authority(
         "event_id": committed["event_id"],
         "proposal_id": proposed["proposal_id"],
         "direction": "narrowing",
-        "mirror_status": "pending",
+        "mirror_status": "complete",
     }
     assert re.fullmatch(r"[0-9a-f]{64}", committed["event_id"])
     assert served.fingerprint == _compiled(_documents(ceiling=1)).fingerprint
@@ -511,7 +516,19 @@ def test_govern_memory_v4_commit_publishes_the_exact_reviewed_authority(
     assert custody.control.activation_state_digest is not None
     assert (
         vault / "Knowledge Base" / "_Governance" / "rules" / "external.yaml"
-    ).read_bytes() == dict(_documents(ceiling=2))["rules/external.yaml"]
+    ).read_bytes() == dict(_documents(ceiling=1))["rules/external.yaml"]
+
+    mirror_records = [
+        record
+        for record in receipts.event_records(vault)
+        if record.get("operation") == "governance_policy_workspace_mirror"
+        or record.get("outcome") == "complete"
+    ]
+    assert [record["phase"] for record in mirror_records] == ["intent", "committed"]
+    assert mirror_records[0]["parent_causation_id"] == committed["event_id"]
+    assert re.fullmatch(r"[0-9a-f]{64}", mirror_records[0]["prior"])
+    assert re.fullmatch(r"[0-9a-f]{64}", mirror_records[0]["prepared"])
+    assert re.fullmatch(r"[0-9a-f]{64}", mirror_records[0]["target"])
 
     with sqlite3.connect(store.sidecar_path(vault)) as connection:
         assert connection.execute(
@@ -530,6 +547,433 @@ def test_govern_memory_v4_commit_publishes_the_exact_reviewed_authority(
             "SELECT COUNT(*) FROM governance_tuple_publications "
             "WHERE publication_kind='policy'"
         ).fetchone() == (1,)
+
+
+def test_govern_memory_v4_commit_recovers_mirror_after_lost_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.tool import GovernanceCrash, op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _write_workspace(vault, _documents(ceiling=2))
+    target_documents = dict(_documents(ceiling=1))
+    target_documents["scopes/private.yaml"] = target_documents[
+        "scopes/private.yaml"
+    ].replace(b"name: private\n", b"name: sensitive\n")
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        proposed = op_govern_memory(
+            vault,
+            operation="propose",
+            principal=owner_principal(),
+            intent="Lower the external ceiling",
+            documents={
+                relative: content.decode("utf-8")
+                for relative, content in target_documents.items()
+            },
+            target_ceiling=1,
+            now=now + 1,
+        )
+        with pytest.raises(GovernanceCrash, match="v4_after_mirror_write:1"):
+            op_govern_memory(
+                vault,
+                operation="commit",
+                principal=owner_principal(),
+                proposal_id=proposed["proposal_id"],
+                crash_at="v4_after_mirror_write:1",
+                now=now + 2,
+            )
+
+    assert (
+        vault / "Knowledge Base" / "_Governance" / "rules" / "external.yaml"
+    ).read_bytes() == target_documents["rules/external.yaml"]
+    assert (
+        vault / "Knowledge Base" / "_Governance" / "scopes" / "private.yaml"
+    ).read_bytes() == dict(_documents(ceiling=2))["scopes/private.yaml"]
+    with sqlite3.connect(store.sidecar_path(vault)) as connection:
+        assert connection.execute(
+            "SELECT status FROM governance_proposals WHERE proposal_id=?",
+            (proposed["proposal_id"],),
+        ).fetchone() == ("spent",)
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        recovered = op_govern_memory(
+            vault,
+            operation="commit",
+            principal=owner_principal(),
+            proposal_id=proposed["proposal_id"],
+            now=now + 3,
+        )
+
+    assert recovered["mirror_status"] == "complete"
+    assert (
+        vault / "Knowledge Base" / "_Governance" / "scopes" / "private.yaml"
+    ).read_bytes() == target_documents["scopes/private.yaml"]
+    records = receipts.event_records(vault)
+    intents = [
+        record
+        for record in records
+        if record.get("operation") == "governance_policy_workspace_mirror"
+    ]
+    terminals = [
+        record
+        for record in records
+        if record.get("causation_id") == intents[0]["event_id"]
+    ]
+    assert len(intents) == 1
+    assert [(record["phase"], record["outcome"]) for record in terminals] == [
+        ("committed", "complete")
+    ]
+    with sqlite3.connect(store.sidecar_path(vault)) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM governance_tuple_publications "
+            "WHERE publication_kind='policy'"
+        ).fetchone() == (1,)
+
+
+def test_govern_memory_v4_commit_retries_transient_mirror_refusal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import held_fs
+    from exomem.governance import tool
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    original_acquire = held_fs.acquire
+    armed = False
+    mirror_acquires = 0
+
+    def arm_after_intent(phase: str, _path: str | None = None) -> None:
+        nonlocal armed
+        if phase == "after_intent":
+            armed = True
+
+    def refuse_effect_acquire(root: Path):
+        nonlocal mirror_acquires
+        if armed:
+            mirror_acquires += 1
+            if mirror_acquires == 4:
+                return held_fs.HeldResult(
+                    error=held_fs.HeldFsError(
+                        "CAPABILITY_UNAVAILABLE",
+                        "test-only transient capability refusal",
+                    )
+                )
+        return original_acquire(root)
+
+    monkeypatch.setattr(tool, "_v4_workspace_mirror_barrier", arm_after_intent)
+    monkeypatch.setattr(held_fs, "acquire", refuse_effect_acquire)
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        proposed = tool.op_govern_memory(
+            vault,
+            operation="propose",
+            principal=owner_principal(),
+            intent="Lower the external ceiling",
+            documents={
+                relative: content.decode("utf-8")
+                for relative, content in _documents(ceiling=1)
+            },
+            target_ceiling=1,
+            now=now + 1,
+        )
+        with pytest.raises(tool.GovernanceError) as refused:
+            tool.op_govern_memory(
+                vault,
+                operation="commit",
+                principal=owner_principal(),
+                proposal_id=proposed["proposal_id"],
+                now=now + 2,
+            )
+
+    assert refused.value.code == "GOVERNANCE_BLOCKED"
+    assert policy.load(vault).rules[0].ceiling == 1
+    assert (
+        vault / "Knowledge Base" / "_Governance" / "rules" / "external.yaml"
+    ).read_bytes() == dict(_documents(ceiling=2))["rules/external.yaml"]
+
+    monkeypatch.setattr(held_fs, "acquire", original_acquire)
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        recovered = tool.op_govern_memory(
+            vault,
+            operation="commit",
+            principal=owner_principal(),
+            proposal_id=proposed["proposal_id"],
+            now=now + 3,
+        )
+
+    assert recovered["mirror_status"] == "complete"
+    assert (
+        vault / "Knowledge Base" / "_Governance" / "rules" / "external.yaml"
+    ).read_bytes() == dict(_documents(ceiling=1))["rules/external.yaml"]
+
+
+def test_govern_memory_v4_commit_replays_after_mirror_terminal_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.tool import GovernanceCrash, op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        proposed = op_govern_memory(
+            vault,
+            operation="propose",
+            principal=owner_principal(),
+            intent="Lower the external ceiling",
+            documents={
+                relative: content.decode("utf-8")
+                for relative, content in _documents(ceiling=1)
+            },
+            target_ceiling=1,
+            now=now + 1,
+        )
+        with pytest.raises(GovernanceCrash, match="v4_after_mirror_terminal"):
+            op_govern_memory(
+                vault,
+                operation="commit",
+                principal=owner_principal(),
+                proposal_id=proposed["proposal_id"],
+                crash_at="v4_after_mirror_terminal",
+                now=now + 2,
+            )
+        recovered = op_govern_memory(
+            vault,
+            operation="commit",
+            principal=owner_principal(),
+            proposal_id=proposed["proposal_id"],
+            now=now + 3,
+        )
+
+    assert recovered["mirror_status"] == "complete"
+    records = receipts.event_records(vault)
+    intents = [
+        record
+        for record in records
+        if record.get("operation") == "governance_policy_workspace_mirror"
+    ]
+    assert len(intents) == 1
+    assert sum(
+        record.get("causation_id") == intents[0]["event_id"] for record in records
+    ) == 1
+    with sqlite3.connect(store.sidecar_path(vault)) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM governance_tuple_publications "
+            "WHERE publication_kind='policy'"
+        ).fetchone() == (1,)
+
+
+def test_govern_memory_v4_commit_preserves_observed_workspace_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import tool
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    drift = dict(_documents(ceiling=3))["rules/external.yaml"]
+    changed = False
+
+    def mutate_after_intent(phase: str, _path: str | None = None) -> None:
+        nonlocal changed
+        if phase == "after_intent" and not changed:
+            changed = True
+            (
+                vault
+                / "Knowledge Base"
+                / "_Governance"
+                / "rules"
+                / "external.yaml"
+            ).write_bytes(drift)
+
+    monkeypatch.setattr(tool, "_v4_workspace_mirror_barrier", mutate_after_intent)
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        proposed = tool.op_govern_memory(
+            vault,
+            operation="propose",
+            principal=owner_principal(),
+            intent="Lower the external ceiling",
+            documents={
+                relative: content.decode("utf-8")
+                for relative, content in _documents(ceiling=1)
+            },
+            target_ceiling=1,
+            now=now + 1,
+        )
+        committed = tool.op_govern_memory(
+            vault,
+            operation="commit",
+            principal=owner_principal(),
+            proposal_id=proposed["proposal_id"],
+            now=now + 2,
+        )
+
+    assert committed["mirror_status"] == "diverged"
+    assert (
+        vault / "Knowledge Base" / "_Governance" / "rules" / "external.yaml"
+    ).read_bytes() == drift
+    assert policy.load(vault).rules[0].ceiling == 1
+    mirror_terminal = next(
+        record
+        for record in receipts.event_records(vault)
+        if record.get("outcome") == "diverged"
+    )
+    assert mirror_terminal["phase"] == "committed"
+
+
+def test_govern_memory_v4_commit_refuses_swapped_reviewed_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import tool
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    changed = False
+    rules = vault / "Knowledge Base" / "_Governance" / "rules"
+    displaced = tmp_path / "reviewed-rules"
+
+    def exchange_parent_after_intent(phase: str, _path: str | None = None) -> None:
+        nonlocal changed
+        if phase == "after_intent" and not changed:
+            changed = True
+            rules.rename(displaced)
+            rules.mkdir()
+            (displaced / "external.yaml").rename(rules / "external.yaml")
+            displaced.rmdir()
+
+    monkeypatch.setattr(
+        tool,
+        "_v4_workspace_mirror_barrier",
+        exchange_parent_after_intent,
+    )
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        proposed = tool.op_govern_memory(
+            vault,
+            operation="propose",
+            principal=owner_principal(),
+            intent="Lower the external ceiling",
+            documents={
+                relative: content.decode("utf-8")
+                for relative, content in _documents(ceiling=1)
+            },
+            target_ceiling=1,
+            now=now + 1,
+        )
+        committed = tool.op_govern_memory(
+            vault,
+            operation="commit",
+            principal=owner_principal(),
+            proposal_id=proposed["proposal_id"],
+            now=now + 2,
+        )
+
+    assert committed["mirror_status"] == "diverged"
+    assert (rules / "external.yaml").read_bytes() == dict(_documents(ceiling=2))[
+        "rules/external.yaml"
+    ]
+    assert policy.load(vault).rules[0].ceiling == 1
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink race fixture")
+def test_govern_memory_v4_commit_refuses_symlinked_mirror_leaf(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import tool
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    changed = False
+    leaf = vault / "Knowledge Base" / "_Governance" / "rules" / "external.yaml"
+
+    def alias_after_intent(phase: str, _path: str | None = None) -> None:
+        nonlocal changed
+        if phase == "after_intent" and not changed:
+            changed = True
+            leaf.unlink()
+            leaf.symlink_to("../scopes/private.yaml")
+
+    monkeypatch.setattr(tool, "_v4_workspace_mirror_barrier", alias_after_intent)
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        proposed = tool.op_govern_memory(
+            vault,
+            operation="propose",
+            principal=owner_principal(),
+            intent="Lower the external ceiling",
+            documents={
+                relative: content.decode("utf-8")
+                for relative, content in _documents(ceiling=1)
+            },
+            target_ceiling=1,
+            now=now + 1,
+        )
+        committed = tool.op_govern_memory(
+            vault,
+            operation="commit",
+            principal=owner_principal(),
+            proposal_id=proposed["proposal_id"],
+            now=now + 2,
+        )
+
+    assert committed["mirror_status"] == "diverged"
+    assert leaf.is_symlink()
+    assert policy.load(vault).blocked
 
 
 def test_govern_memory_v4_commit_recovers_lost_registry_ack_exactly_once(


### PR DESCRIPTION
## Summary

- mirror the receipt-proven v4 policy generation into the mutable governance workspace through the cooperative identity fence and held no-follow handles
- bind file, root, and intermediate directory identities; preserve observed drift instead of overwriting it
- add deterministic mirror intent/terminal evidence plus exact crash, partial-write, and transient-failure recovery without republishing the active tuple

## Verification

- 343 focused governance tests passed
- strict OpenSpec validation passed
- touched-file Ruff passed
- public artifact scan passed
- wheel and sdist build passed
- git diff check passed

No personal or POLLY vault was touched.