### PR TITLE
feat(governance): publish semantic content batches

### DIFF
--- a/src/exomem/governance/catalog_publication.py
+++ b/src/exomem/governance/catalog_publication.py
@@ -12,10 +12,11 @@ import hashlib
 import os
 import sqlite3
 import time
+import unicodedata
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
-from .. import find_corpus
+from .. import find_corpus, reserved_paths, vault
 from . import (
     authorization_custody,
     membership,
@@ -32,6 +33,15 @@ class CatalogPublicationError(RuntimeError):
 
 
 @dataclass(frozen=True, slots=True)
+class MarkdownCatalogMutation:
+    """One intended canonical Markdown successor and its exact predecessor."""
+
+    path: str
+    source: str
+    expected_before_hash: str | None
+
+
+@dataclass(frozen=True, slots=True)
 class PreparedMarkdownCatalogPublication:
     """One complete lexical-only catalog successor awaiting canonical bytes."""
 
@@ -42,6 +52,7 @@ class PreparedMarkdownCatalogPublication:
     target_items: tuple[projection_store.ProjectionItemVariants, ...]
     catalog_descriptor: bytes
     activated_at: int
+    mutation_count: int
 
 
 def _custody_configured() -> bool:
@@ -69,6 +80,76 @@ def _relative_markdown_path(vault_root: Path, path: str) -> str:
     except (OSError, ValueError):
         raise CatalogPublicationError("catalog publication path is outside the vault") from None
     return value
+
+
+def _is_catalog_markdown_path(path: str) -> bool:
+    candidate = PurePosixPath(path)
+    if (
+        candidate.name.casefold().endswith(".md")
+        and ".sync-conflict-" not in candidate.name
+        and not any(
+            part in find_corpus.EXCLUDED_DIR_NAMES
+            or part.startswith(find_corpus.EXCLUDED_DIR_PREFIXES)
+            for part in candidate.parts[:-1]
+        )
+        and not reserved_paths.classify_logical(path).blocked
+    ):
+        return True
+    return False
+
+
+def mutation_from_planned_write(
+    vault_root: Path,
+    write: vault.PlannedWrite,
+) -> MarkdownCatalogMutation | None:
+    """Bind one canonical Markdown write to the same predecessor as its file CAS."""
+
+    root = Path(vault_root).absolute()
+    try:
+        relative = write.path.absolute().relative_to(root).as_posix()
+    except (AttributeError, ValueError):
+        raise CatalogPublicationError(
+            "catalog publication write is outside the vault"
+        ) from None
+    if PurePosixPath(relative).suffix.casefold() != ".md":
+        return None
+    relative = _relative_markdown_path(root, relative)
+    if not _is_catalog_markdown_path(relative):
+        return None
+
+    expected = write.expected_hash
+    if expected == vault.MISSING_CONTENT_HASH:
+        expected = None
+    guard = write.guard
+    if guard is not None:
+        if guard.target != relative:
+            raise CatalogPublicationError(
+                "catalog publication guard does not bind its Markdown target"
+            )
+        if guard.leaf_policy == "absent":
+            guarded_expected = None
+        elif guard.leaf_policy == "content":
+            guarded_expected = guard.expected_content_hash
+        else:
+            guarded_expected = expected
+        if expected is not None and guarded_expected != expected:
+            raise CatalogPublicationError(
+                "catalog publication predecessor bindings disagree"
+            )
+        expected = guarded_expected
+    elif expected is None and not write.create_only:
+        raise CatalogPublicationError(
+            "catalog Markdown mutation lacks an exact predecessor binding"
+        )
+    if expected is not None and (
+        type(expected) is not str
+        or len(expected) != 64
+        or any(character not in "0123456789abcdef" for character in expected)
+    ):
+        raise CatalogPublicationError(
+            "catalog publication predecessor hash is invalid"
+        )
+    return MarkdownCatalogMutation(relative, write.content, expected)
 
 
 def _search_fields(page: find_corpus.ParsedPage) -> dict[str, str]:
@@ -234,15 +315,13 @@ def _replacement_item(
         ) from error
 
 
-def prepare_markdown_upsert(
+def prepare_markdown_batch(
     vault_root: Path,
     *,
-    path: str,
-    source: str,
-    expected_before_hash: str | None,
+    mutations: tuple[MarkdownCatalogMutation, ...],
     now: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
-    """Prepare one complete catalog successor, or return ``None`` for v3/open.
+    """Prepare one complete batch successor, or return ``None`` for v3/open.
 
     The current slice intentionally supports lexical-only active namespaces.
     Model and graph measurement roots are content-bound, so reusing them after
@@ -251,7 +330,27 @@ def prepare_markdown_upsert(
     """
 
     root = Path(vault_root)
-    relative = _relative_markdown_path(root, path)
+    if type(mutations) is not tuple or not mutations:
+        raise CatalogPublicationError(
+            "catalog publication requires a finite Markdown mutation batch"
+        )
+    normalized: list[tuple[str, MarkdownCatalogMutation]] = []
+    aliases: set[str] = set()
+    for mutation in mutations:
+        if type(mutation) is not MarkdownCatalogMutation or type(mutation.source) is not str:
+            raise CatalogPublicationError("catalog publication mutation is invalid")
+        relative = _relative_markdown_path(root, mutation.path)
+        if not _is_catalog_markdown_path(relative):
+            raise CatalogPublicationError(
+                "catalog publication mutation is not canonical Markdown"
+            )
+        alias = unicodedata.normalize("NFC", relative).casefold()
+        if alias in aliases:
+            raise CatalogPublicationError(
+                "catalog publication Markdown targets collide"
+            )
+        aliases.add(alias)
+        normalized.append((relative, mutation))
     connection: sqlite3.Connection | None = None
     try:
         connection = store.open_active_governance_read_connection(root)
@@ -349,27 +448,30 @@ def prepare_markdown_upsert(
         connection.close()
 
     by_identity = {item.item_identity: item for item in verified.items}
-    predecessor = by_identity.get(relative)
-    if expected_before_hash is None:
-        if predecessor is not None:
-            raise CatalogPublicationError("catalog creation target already exists")
-    elif predecessor is None or predecessor.content_hash != expected_before_hash:
-        raise CatalogPublicationError(
-            "catalog content identity no longer matches the reviewed predecessor"
-        )
-
     target_key = projections.ProjectionNamespaceKey(
         policy_fingerprint=snapshot.active.policy_fingerprint,
         projector_schema_version=snapshot.active.projector_schema_version,
         catalog_generation=snapshot.active.catalog_generation + 1,
     )
-    by_identity[relative] = _replacement_item(
-        vault_root=root,
-        path=relative,
-        source=source,
-        snapshot=snapshot,
-        target_key=target_key,
-    )
+    for relative, mutation in normalized:
+        predecessor = by_identity.get(relative)
+        if mutation.expected_before_hash is None:
+            if predecessor is not None:
+                raise CatalogPublicationError("catalog creation target already exists")
+        elif (
+            predecessor is None
+            or predecessor.content_hash != mutation.expected_before_hash
+        ):
+            raise CatalogPublicationError(
+                "catalog content identity no longer matches the reviewed predecessor"
+            )
+        by_identity[relative] = _replacement_item(
+            vault_root=root,
+            path=relative,
+            source=mutation.source,
+            snapshot=snapshot,
+            target_key=target_key,
+        )
     target_items = tuple(by_identity.values())
     try:
         descriptor = projection_store.catalog_descriptor_bytes(
@@ -387,13 +489,31 @@ def prepare_markdown_upsert(
         target_items=target_items,
         catalog_descriptor=descriptor,
         activated_at=activated_at,
+        mutation_count=len(normalized),
     )
 
 
-def publish_markdown_upsert(
+def prepare_markdown_upsert(
+    vault_root: Path,
+    *,
+    path: str,
+    source: str,
+    expected_before_hash: str | None,
+    now: int | None = None,
+) -> PreparedMarkdownCatalogPublication | None:
+    """Compatibility wrapper for a one-item Markdown catalog batch."""
+
+    return prepare_markdown_batch(
+        vault_root,
+        mutations=(MarkdownCatalogMutation(path, source, expected_before_hash),),
+        now=now,
+    )
+
+
+def publish_markdown_batch(
     prepared: PreparedMarkdownCatalogPublication | None,
 ) -> schema_v4.TuplePublicationResult | None:
-    """Advance one prepared v4 catalog after canonical bytes have committed."""
+    """Advance one prepared v4 batch after canonical bytes have committed."""
 
     if prepared is None:
         return None
@@ -419,7 +539,7 @@ def publish_markdown_upsert(
         )
         receipt_event_id = receipts.critical_event_id(
             {
-                "operation": "governance_catalog_markdown_upsert",
+                "operation": "governance_catalog_markdown_batch",
                 "logical_vault_id": prepared.expected.logical_vault_id,
                 "predecessor_activation_state_digest": (
                     prepared.expected.activation_state_digest
@@ -430,6 +550,7 @@ def publish_markdown_upsert(
                 ).hexdigest(),
                 "namespace_id": prepared.target_key.namespace_id,
                 "projection_rows_digest": target_manifest.rows_digest,
+                "mutation_count": prepared.mutation_count,
             }
         )
         connection = store.open_authorization_session_connection(
@@ -510,9 +631,21 @@ def publish_markdown_upsert(
             connection.close()
 
 
+def publish_markdown_upsert(
+    prepared: PreparedMarkdownCatalogPublication | None,
+) -> schema_v4.TuplePublicationResult | None:
+    """Compatibility wrapper for publishing a one-item prepared batch."""
+
+    return publish_markdown_batch(prepared)
+
+
 __all__ = [
     "CatalogPublicationError",
+    "MarkdownCatalogMutation",
     "PreparedMarkdownCatalogPublication",
+    "mutation_from_planned_write",
+    "prepare_markdown_batch",
     "prepare_markdown_upsert",
+    "publish_markdown_batch",
     "publish_markdown_upsert",
 ]

--- a/src/exomem/governance/catalog_publication.py
+++ b/src/exomem/governance/catalog_publication.py
@@ -315,21 +315,10 @@ def _replacement_item(
         ) from error
 
 
-def prepare_markdown_batch(
+def _normalize_markdown_mutations(
     vault_root: Path,
-    *,
     mutations: tuple[MarkdownCatalogMutation, ...],
-    now: int | None = None,
-) -> PreparedMarkdownCatalogPublication | None:
-    """Prepare one complete batch successor, or return ``None`` for v3/open.
-
-    The current slice intentionally supports lexical-only active namespaces.
-    Model and graph measurement roots are content-bound, so reusing them after
-    an edit would be unsafe; those deployments refuse before canonical bytes
-    change until their rebuild publisher is connected.
-    """
-
-    root = Path(vault_root)
+) -> tuple[tuple[str, MarkdownCatalogMutation], ...]:
     if type(mutations) is not tuple or not mutations:
         raise CatalogPublicationError(
             "catalog publication requires a finite Markdown mutation batch"
@@ -339,7 +328,7 @@ def prepare_markdown_batch(
     for mutation in mutations:
         if type(mutation) is not MarkdownCatalogMutation or type(mutation.source) is not str:
             raise CatalogPublicationError("catalog publication mutation is invalid")
-        relative = _relative_markdown_path(root, mutation.path)
+        relative = _relative_markdown_path(vault_root, mutation.path)
         if not _is_catalog_markdown_path(relative):
             raise CatalogPublicationError(
                 "catalog publication mutation is not canonical Markdown"
@@ -351,6 +340,27 @@ def prepare_markdown_batch(
             )
         aliases.add(alias)
         normalized.append((relative, mutation))
+    return tuple(normalized)
+
+
+def _prepare_markdown_batch(
+    vault_root: Path,
+    *,
+    normalized: tuple[tuple[str, MarkdownCatalogMutation], ...] | None,
+    planned_writes: tuple[vault.PlannedWrite, ...] | None,
+    now: int | None = None,
+) -> PreparedMarkdownCatalogPublication | None:
+    """Prepare one complete batch successor, or return ``None`` for v3/open.
+
+    The current slice intentionally supports lexical-only active namespaces.
+    Model and graph measurement roots are content-bound, so reusing them after
+    an edit would be unsafe; those deployments refuse before canonical bytes
+    change until their rebuild publisher is connected.
+    """
+
+    root = Path(vault_root)
+    if (normalized is None) == (planned_writes is None):
+        raise CatalogPublicationError("catalog publication batch input is invalid")
     connection: sqlite3.Connection | None = None
     try:
         connection = store.open_active_governance_read_connection(root)
@@ -447,6 +457,19 @@ def prepare_markdown_batch(
     finally:
         connection.close()
 
+    if normalized is None:
+        assert planned_writes is not None
+        if type(planned_writes) is not tuple or not planned_writes:
+            raise CatalogPublicationError(
+                "catalog publication requires a finite planned-write batch"
+            )
+        mutations = tuple(
+            mutation
+            for write in planned_writes
+            if (mutation := mutation_from_planned_write(root, write)) is not None
+        )
+        normalized = _normalize_markdown_mutations(root, mutations)
+
     by_identity = {item.item_identity: item for item in verified.items}
     target_key = projections.ProjectionNamespaceKey(
         policy_fingerprint=snapshot.active.policy_fingerprint,
@@ -490,6 +513,39 @@ def prepare_markdown_batch(
         catalog_descriptor=descriptor,
         activated_at=activated_at,
         mutation_count=len(normalized),
+    )
+
+
+def prepare_markdown_batch(
+    vault_root: Path,
+    *,
+    mutations: tuple[MarkdownCatalogMutation, ...],
+    now: int | None = None,
+) -> PreparedMarkdownCatalogPublication | None:
+    """Prepare an explicit canonical Markdown mutation batch."""
+
+    root = Path(vault_root)
+    return _prepare_markdown_batch(
+        root,
+        normalized=_normalize_markdown_mutations(root, mutations),
+        planned_writes=None,
+        now=now,
+    )
+
+
+def prepare_planned_markdown_batch(
+    vault_root: Path,
+    *,
+    writes: tuple[vault.PlannedWrite, ...],
+    now: int | None = None,
+) -> PreparedMarkdownCatalogPublication | None:
+    """Prepare catalog rows lazily so v3/open planned writes remain unchanged."""
+
+    return _prepare_markdown_batch(
+        vault_root,
+        normalized=None,
+        planned_writes=writes,
+        now=now,
     )
 
 
@@ -645,6 +701,7 @@ __all__ = [
     "PreparedMarkdownCatalogPublication",
     "mutation_from_planned_write",
     "prepare_markdown_batch",
+    "prepare_planned_markdown_batch",
     "prepare_markdown_upsert",
     "publish_markdown_batch",
     "publish_markdown_upsert",

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -2145,20 +2145,9 @@ def _prepare_markdown_catalog_publication(
 
     from .governance import catalog_publication
 
-    mutations = tuple(
-        mutation
-        for write in writes
-        if (
-            mutation := catalog_publication.mutation_from_planned_write(
-                vault_root,
-                write,
-            )
-        )
-        is not None
-    )
-    return catalog_publication.prepare_markdown_batch(
+    return catalog_publication.prepare_planned_markdown_batch(
         vault_root,
-        mutations=mutations,
+        writes=tuple(writes),
     )
 
 

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -2066,22 +2066,12 @@ def _commit_existing_locked(
     from .governance import catalog_publication
 
     try:
-        catalog_target = catalog_publication.prepare_markdown_upsert(
-            root,
-            path=preflight.path,
-            source=preflight.after_source,
-            expected_before_hash=preflight.before.source_hash,
-        )
+        catalog_target = _prepare_markdown_catalog_publication(root, writes)
     except catalog_publication.CatalogPublicationError as error:
         raise SemanticWriteError(
             "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
             str(error),
         ) from error
-    if catalog_target is not None and (lifecycle_writes or auxiliaries):
-        raise SemanticWriteError(
-            "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
-            "v4 catalog publication does not yet admit auxiliary content writes",
-        )
     reports: list[Any] = []
     written = vault.batch_atomic_write(
         writes,
@@ -2091,7 +2081,7 @@ def _commit_existing_locked(
         semantic_states={preflight.path: semantic_index.from_semantic_page_state(preflight.after)},
     )
     try:
-        catalog_publication.publish_markdown_upsert(catalog_target)
+        catalog_publication.publish_markdown_batch(catalog_target)
     except catalog_publication.CatalogPublicationError as error:
         raise SemanticWriteError(
             "GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN",
@@ -2145,6 +2135,31 @@ def _revalidate_existing_preflight(
             relation_review_hash=relation_review_hash,
             relation_review_reason=relation_review_reason,
         )
+
+
+def _prepare_markdown_catalog_publication(
+    vault_root: Path,
+    writes: Sequence[vault.PlannedWrite],
+):  # noqa: ANN202 - private bridge returns the governance publication token
+    """Prepare one exact catalog successor for the canonical Markdown subset."""
+
+    from .governance import catalog_publication
+
+    mutations = tuple(
+        mutation
+        for write in writes
+        if (
+            mutation := catalog_publication.mutation_from_planned_write(
+                vault_root,
+                write,
+            )
+        )
+        is not None
+    )
+    return catalog_publication.prepare_markdown_batch(
+        vault_root,
+        mutations=mutations,
+    )
 
 
 def _structure_suggestion(
@@ -3645,22 +3660,23 @@ def _commit_creation(
             from .governance import catalog_publication
 
             try:
-                catalog_target = catalog_publication.prepare_markdown_upsert(
+                catalog_writes = [*prepared.auxiliaries]
+                catalog_writes.append(
+                    vault.PlannedWrite(
+                        root / preflight.destination,
+                        preflight.source,
+                        create_only=True,
+                    )
+                )
+                catalog_target = _prepare_markdown_catalog_publication(
                     root,
-                    path=preflight.destination,
-                    source=preflight.source,
-                    expected_before_hash=None,
+                    catalog_writes,
                 )
             except catalog_publication.CatalogPublicationError as error:
                 raise SemanticWriteError(
                     "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
                     str(error),
                 ) from error
-            if catalog_target is not None and auxiliary_writes:
-                raise SemanticWriteError(
-                    "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
-                    "v4 catalog publication does not yet admit auxiliary content writes",
-                )
             committed = relation_review.commit_prepared_creation_draft(
                 root,
                 prepared,
@@ -3674,7 +3690,7 @@ def _commit_creation(
                 semantic_state=semantic_index.from_semantic_page_state(preflight.semantic_state),
             )
             try:
-                catalog_publication.publish_markdown_upsert(catalog_target)
+                catalog_publication.publish_markdown_batch(catalog_target)
             except catalog_publication.CatalogPublicationError as error:
                 raise SemanticWriteError(
                     "GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN",
@@ -3713,32 +3729,26 @@ def _commit_creation(
             relation_review._record_prevalidated_commit_outcome("reused")
         from .governance import catalog_publication
 
-        try:
-            catalog_target = catalog_publication.prepare_markdown_upsert(
-                root,
-                path=preflight.destination,
-                source=preflight.source,
-                expected_before_hash=None,
-            )
-        except catalog_publication.CatalogPublicationError as error:
-            raise SemanticWriteError(
-                "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
-                str(error),
-            ) from error
-        if catalog_target is not None and auxiliary_writes:
-            raise SemanticWriteError(
-                "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
-                "v4 catalog publication does not yet admit auxiliary content writes",
-            )
         writes = [*auxiliary_writes]
         writes.append(
             vault.PlannedWrite(
                 root / preflight.destination,
                 preflight.source,
                 create_only=True,
-                guard=vault.PathGuard.capture(root, preflight.destination, leaf_policy="absent"),
+                guard=vault.PathGuard.capture(
+                    root,
+                    preflight.destination,
+                    leaf_policy="absent",
+                ),
             )
         )
+        try:
+            catalog_target = _prepare_markdown_catalog_publication(root, writes)
+        except catalog_publication.CatalogPublicationError as error:
+            raise SemanticWriteError(
+                "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
+                str(error),
+            ) from error
         token = semantic_index.set_parent_states(
             {preflight.destination: semantic_index.from_semantic_page_state(preflight.semantic_state)}
         )
@@ -3753,7 +3763,7 @@ def _commit_creation(
         finally:
             semantic_index.reset_parent_states(token)
         try:
-            catalog_publication.publish_markdown_upsert(catalog_target)
+            catalog_publication.publish_markdown_batch(catalog_target)
         except catalog_publication.CatalogPublicationError as error:
             raise SemanticWriteError(
                 "GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN",

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -2336,6 +2336,68 @@ def test_semantic_creation_publishes_index_and_log_auxiliaries_in_one_generation
     assert {item.item_identity: item.content_hash for item in items} == expected
 
 
+def test_open_vault_skips_v4_only_auxiliary_predecessor_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    relative = "Knowledge Base/Notes/legacy.md"
+    target = vault / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("legacy\n", encoding="utf-8")
+
+    prepared = catalog_publication.prepare_planned_markdown_batch(
+        vault,
+        writes=(vault_module.PlannedWrite(target, "updated\n"),),
+    )
+
+    assert prepared is None
+
+
+def test_v4_batch_refuses_existing_markdown_without_exact_predecessor_binding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    relative = "Knowledge Base/Notes/private.md"
+    before = "---\ntitle: Private\nstatus: draft\n---\n\nbefore\n"
+    target = vault / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(before, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_item(
+        vault,
+        path=relative,
+        source=before,
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    with pytest.raises(catalog_publication.CatalogPublicationError) as blocked:
+        catalog_publication.prepare_planned_markdown_batch(
+            vault,
+            writes=(vault_module.PlannedWrite(target, before.replace("before", "after")),),
+            now=now + 1,
+        )
+
+    assert "exact predecessor" in str(blocked.value)
+
+
 def test_semantic_edit_publishes_auxiliary_markdown_in_the_same_v4_generation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -376,6 +376,19 @@ def _migrate_with_projection_item(
     source: str,
     now: int,
 ) -> schema_v4.MigrationResult:
+    return _migrate_with_projection_items(
+        vault,
+        items=((path, source),),
+        now=now,
+    )
+
+
+def _migrate_with_projection_items(
+    vault: Path,
+    *,
+    items: tuple[tuple[str, str], ...],
+    now: int,
+) -> schema_v4.MigrationResult:
     documents = _documents(ceiling=2)
     compiled = _compiled(documents)
     key = projections.ProjectionNamespaceKey(
@@ -383,14 +396,21 @@ def _migrate_with_projection_item(
         projector_schema_version=1,
         catalog_generation=1,
     )
-    item = _projection_item(
-        vault=vault,
-        compiled=compiled,
-        path=path,
-        source=source,
-        catalog_generation=1,
+    projected_items = tuple(
+        _projection_item(
+            vault=vault,
+            compiled=compiled,
+            path=path,
+            source=source,
+            catalog_generation=1,
+        )
+        for path, source in items
     )
-    manifest = projection_store.stage_variant_store(vault, key=key, items=(item,))
+    manifest = projection_store.stage_variant_store(
+        vault,
+        key=key,
+        items=projected_items,
+    )
     connection = store.open_connection(vault)
     try:
         return schema_v4.migrate_v3_connection(
@@ -408,8 +428,11 @@ def _migrate_with_projection_item(
                 ),
                 catalog=schema_v4.CatalogGenerationSeed(
                     catalog_generation=1,
-                    descriptor=projection_store.catalog_descriptor_bytes(key, (item,)),
-                    artifact_count=1,
+                    descriptor=projection_store.catalog_descriptor_bytes(
+                        key,
+                        projected_items,
+                    ),
+                    artifact_count=len(projected_items),
                     created_at=now,
                 ),
                 namespace=schema_v4.ProjectionNamespaceSeed(
@@ -2238,6 +2261,250 @@ def test_semantic_creation_publishes_the_next_v4_catalog_before_returning(
     assert [(item.item_identity, item.content_hash) for item in items] == [
         (relative, vault_module.content_hash(source))
     ]
+
+
+def test_semantic_creation_publishes_index_and_log_auxiliaries_in_one_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    relative = "Knowledge Base/Notes/new.md"
+    index_relative = "Knowledge Base/index.md"
+    log_relative = "Knowledge Base/log.md"
+    index_before = "# Knowledge Base\n\n## Recent activity\n"
+    log_before = "# Log\n\n---\n"
+    for existing, source in (
+        (index_relative, index_before),
+        (log_relative, log_before),
+    ):
+        target = vault / existing
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((index_relative, index_before), (log_relative, log_before)),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    created = create_file_module.create_file(
+        vault,
+        path=relative,
+        content="New governed note.\n",
+        frontmatter={"title": "New", "status": "draft"},
+        today=dt.date(2026, 8, 25),
+    )
+
+    assert created.creation is not None
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 2
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        active = schema_v4.load_active_policy(
+            connection,
+            expected_logical_vault_id=LOGICAL_VAULT_ID,
+            expected_activation_store_id=ACTIVATION_STORE_ID,
+            expected_activation_epoch=2,
+            expected_activation_state_digest=custody.control.activation_state_digest or "",
+        )
+    finally:
+        connection.close()
+    evidence = projection_store.namespace_evidence_from_snapshot(active)
+    manifest, items = projection_store.load_projection_catalog(
+        vault,
+        key=evidence.manifest.namespace_key,
+        expected_rows_digest=evidence.manifest.rows_digest,
+    )
+    expected = {
+        path: vault_module.content_hash((vault / path).read_text(encoding="utf-8"))
+        for path in (relative, index_relative, log_relative)
+    }
+    assert active.active.catalog_generation == 2
+    assert manifest.item_count == 3
+    assert {item.item_identity: item.content_hash for item in items} == expected
+
+
+def test_semantic_edit_publishes_auxiliary_markdown_in_the_same_v4_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    primary_relative = "Knowledge Base/Notes/private.md"
+    auxiliary_relative = "Knowledge Base/Notes/backlinks.md"
+    primary_before = "---\ntitle: Private\nstatus: draft\n---\n\nbefore\n"
+    primary_after = primary_before.replace("before", "after")
+    auxiliary_before = "---\ntitle: Backlinks\nstatus: draft\n---\n\nold link\n"
+    auxiliary_after = auxiliary_before.replace("old link", "new link")
+    for relative, source in (
+        (primary_relative, primary_before),
+        (auxiliary_relative, auxiliary_before),
+    ):
+        target = vault / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=(
+            (primary_relative, primary_before),
+            (auxiliary_relative, auxiliary_before),
+        ),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    _auxiliary_source, auxiliary_guard = vault_module.read_guarded_text(
+        vault,
+        vault / auxiliary_relative,
+    )
+    preflight = semantic_writes.preflight_existing(
+        vault,
+        path=primary_relative,
+        after_source=primary_after,
+        operation="edit",
+        expected_before_hash=vault_module.content_hash(primary_before),
+    )
+
+    committed = semantic_writes.commit_existing(
+        vault,
+        preflight=preflight,
+        auxiliary_writes=(
+            vault_module.PlannedWrite(
+                vault / auxiliary_relative,
+                auxiliary_after,
+                guard=auxiliary_guard,
+            ),
+        ),
+    )
+
+    assert committed.mutated is True
+    assert (vault / primary_relative).read_text(encoding="utf-8") == primary_after
+    assert (vault / auxiliary_relative).read_text(encoding="utf-8") == auxiliary_after
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 2
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        active = schema_v4.load_active_policy(
+            connection,
+            expected_logical_vault_id=LOGICAL_VAULT_ID,
+            expected_activation_store_id=ACTIVATION_STORE_ID,
+            expected_activation_epoch=2,
+            expected_activation_state_digest=custody.control.activation_state_digest or "",
+        )
+    finally:
+        connection.close()
+    evidence = projection_store.namespace_evidence_from_snapshot(active)
+    manifest, items = projection_store.load_projection_catalog(
+        vault,
+        key=evidence.manifest.namespace_key,
+        expected_rows_digest=evidence.manifest.rows_digest,
+    )
+    assert active.active.catalog_generation == 2
+    assert manifest.item_count == 2
+    assert sorted(
+        (item.item_identity, item.content_hash) for item in items
+    ) == sorted(
+        (
+            (primary_relative, vault_module.content_hash(primary_after)),
+            (auxiliary_relative, vault_module.content_hash(auxiliary_after)),
+        )
+    )
+
+
+def test_semantic_edit_refuses_auxiliary_catalog_drift_before_changing_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    primary_relative = "Knowledge Base/Notes/private.md"
+    auxiliary_relative = "Knowledge Base/Notes/backlinks.md"
+    primary_before = "---\ntitle: Private\nstatus: draft\n---\n\nbefore\n"
+    primary_after = primary_before.replace("before", "after")
+    auxiliary_active = "---\ntitle: Backlinks\nstatus: draft\n---\n\nactive\n"
+    auxiliary_drifted = auxiliary_active.replace("active", "out-of-band")
+    auxiliary_requested = auxiliary_drifted.replace("out-of-band", "requested")
+    for relative, source in (
+        (primary_relative, primary_before),
+        (auxiliary_relative, auxiliary_active),
+    ):
+        target = vault / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=(
+            (primary_relative, primary_before),
+            (auxiliary_relative, auxiliary_active),
+        ),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    (vault / auxiliary_relative).write_text(auxiliary_drifted, encoding="utf-8")
+    _auxiliary_source, auxiliary_guard = vault_module.read_guarded_text(
+        vault,
+        vault / auxiliary_relative,
+    )
+    preflight = semantic_writes.preflight_existing(
+        vault,
+        path=primary_relative,
+        after_source=primary_after,
+        operation="edit",
+        expected_before_hash=vault_module.content_hash(primary_before),
+    )
+
+    with pytest.raises(semantic_writes.SemanticWriteError) as blocked:
+        semantic_writes.commit_existing(
+            vault,
+            preflight=preflight,
+            auxiliary_writes=(
+                vault_module.PlannedWrite(
+                    vault / auxiliary_relative,
+                    auxiliary_requested,
+                    guard=auxiliary_guard,
+                ),
+            ),
+        )
+
+    assert blocked.value.code == "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED"
+    assert "content identity" in blocked.value.reason
+    assert (vault / primary_relative).read_text(encoding="utf-8") == primary_before
+    assert (vault / auxiliary_relative).read_text(encoding="utf-8") == auxiliary_drifted
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 1
 
 
 def test_semantic_edit_refuses_catalog_drift_before_changing_bytes(


### PR DESCRIPTION
## What changed

- Generalizes v4 lexical catalog publication from one Markdown upsert to a closed batch of predecessor-bound Markdown mutations.
- Publishes a semantic primary plus canonical auxiliary Markdown (including index and log updates) under one next catalog generation and one active-tuple CAS.
- Reuses each file write guard as the catalog predecessor binding, rejects path aliases and unbound existing Markdown, and refuses catalog drift before canonical bytes change.
- Defers catalog-only predecessor validation until exact v4 authority is verified, preserving v3/open writer behavior.
- Keeps preparation side-effect-free.

## Verification

- `69 passed` — focused active-tuple, projection-store/activation, and semantic-writer packet
- Ruff: clean on all three changed files
- `openspec validate harden-governance-for-consolidation --strict`
- public artifact privacy scan: 3300 files / 3368 text payloads clean
- sdist and wheel build succeeded

## Deliberate boundary

This remains the lexical Markdown publication slice. Model/vector/CLIP/graph rebuilds, delete/move/recovery, non-Markdown companions, and general post-file/pre-tuple crash recovery remain fail-closed follow-up work; OpenSpec task 3.10 stays open.