### PR TITLE
feat(governance): publish trash through v4 catalog

### DIFF
--- a/src/exomem/delete_file.py
+++ b/src/exomem/delete_file.py
@@ -21,21 +21,25 @@ this op (they're already trashed); use the filesystem.
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
 import json
 import logging
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
 from . import media_types, reserved_paths
-from .governance import lifecycle
+from .governance import catalog_publication, lifecycle
 from .kbdir import kb_dirname, kb_prefix
 from .vault import (
     VaultPathError,
+    batch_atomic_write,
     find_inbound_wikilinks,
     in_append_only_tree,
     in_curated_tree,
     kb_root,
     parse_frontmatter,
+    plan_log_entry,
     resolve_under_vault,
     write_log_entry,
 )
@@ -161,9 +165,11 @@ def delete_file(
     # Supersession history check.
     fm: dict = {}
     fm_warn: str | None = None
-    if rel_path.endswith(".md"):
+    catalog_before_hash: str | None = None
+    if rel_path.lower().endswith(".md"):
         try:
             snapshot = reserved_paths.read_generic_bytes(vault_root, rel_path)
+            catalog_before_hash = hashlib.sha256(snapshot.data).hexdigest()
             text = snapshot.data.decode("utf-8")
             fm, _, _ = parse_frontmatter(text)
             if fm.get("superseded_by") and not force_superseded:
@@ -320,6 +326,44 @@ def delete_file(
                 "DELETE_FAILED",
                 "trash metadata destination could not be acquired safely",
             ) from None
+
+    today_iso = today.isoformat()
+    rel_no_ext = rel_path.removesuffix(".md") if rel_path.endswith(".md") else rel_path
+    log_body = (
+        f"Trashed {rel_path!r} → {trash_rel!r} via exomem Tier 2. "
+        f"inbound_links_at_trash={len(inbound_all)} "
+        f"(ignored={len(inbound_ignored)}, remaining={len(inbound)})."
+    )
+    if force_orphan:
+        log_body += " force_orphan=true."
+    if force_superseded:
+        log_body += " force_superseded=true."
+    if curated and allow_curated:
+        log_body += f" allow_curated=true (target tree: {curated})."
+    log_plan = plan_log_entry(
+        vault_root,
+        date_iso=today_iso,
+        op="delete_file (trash)",
+        rel_path_no_ext=rel_no_ext,
+        body=log_body,
+    )
+    try:
+        catalog_target = catalog_publication.prepare_catalog_membership_batch(
+            vault_root,
+            writes=log_plan.writes,
+            removals=(
+                catalog_publication.CatalogRemoval(
+                    rel_path,
+                    catalog_before_hash,
+                ),
+            ),
+            now=int(time.time()),
+        )
+    except catalog_publication.CatalogPublicationError as error:
+        raise DeleteFileError(
+            code="GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
+            reason=str(error),
+        ) from error
     from . import graph_sync
 
     try:
@@ -484,26 +528,29 @@ def delete_file(
             "content remains tombstoned until reconcile"
         )
 
-    today_iso = today.isoformat()
-    rel_no_ext = rel_path.removesuffix(".md") if rel_path.endswith(".md") else rel_path
-    log_body = (
-        f"Trashed {rel_path!r} → {trash_rel!r} via exomem Tier 2. "
-        f"inbound_links_at_trash={len(inbound_all)} "
-        f"(ignored={len(inbound_ignored)}, remaining={len(inbound)})."
-    )
-    if force_orphan:
-        log_body += " force_orphan=true."
-    if force_superseded:
-        log_body += " force_superseded=true."
-    if curated and allow_curated:
-        log_body += f" allow_curated=true (target tree: {curated})."
-    log_warning = write_log_entry(
-        vault_root,
-        date_iso=today_iso,
-        op="delete_file (trash)",
-        rel_path_no_ext=rel_no_ext,
-        body=log_body,
-    )
+    if catalog_target is not None:
+        try:
+            if log_plan.writes:
+                batch_atomic_write(log_plan.writes, vault_root=vault_root)
+            catalog_publication.publish_markdown_batch(catalog_target)
+        except Exception as error:  # noqa: BLE001 - canonical removal already committed
+            raise DeleteFileError(
+                code="GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN",
+                reason=(
+                    "the file was trashed but its active catalog publication "
+                    "did not reach a verified terminal"
+                ),
+            ) from error
+
+    log_warning = log_plan.warning
+    if catalog_target is None:
+        log_warning = write_log_entry(
+            vault_root,
+            date_iso=today_iso,
+            op="delete_file (trash)",
+            rel_path_no_ext=rel_no_ext,
+            body=log_body,
+        )
     if log_warning:
         warnings.append(log_warning)
 

--- a/src/exomem/governance/catalog_publication.py
+++ b/src/exomem/governance/catalog_publication.py
@@ -42,6 +42,14 @@ class MarkdownCatalogMutation:
 
 
 @dataclass(frozen=True, slots=True)
+class CatalogRemoval:
+    """One intended catalog membership removal and its exact predecessor."""
+
+    path: str
+    expected_before_hash: str | None
+
+
+@dataclass(frozen=True, slots=True)
 class PreparedMarkdownCatalogPublication:
     """One complete lexical-only catalog successor awaiting canonical bytes."""
 
@@ -319,7 +327,7 @@ def _normalize_markdown_mutations(
     vault_root: Path,
     mutations: tuple[MarkdownCatalogMutation, ...],
 ) -> tuple[tuple[str, MarkdownCatalogMutation], ...]:
-    if type(mutations) is not tuple or not mutations:
+    if type(mutations) is not tuple:
         raise CatalogPublicationError(
             "catalog publication requires a finite Markdown mutation batch"
         )
@@ -343,11 +351,50 @@ def _normalize_markdown_mutations(
     return tuple(normalized)
 
 
+def _normalize_catalog_removals(
+    vault_root: Path,
+    removals: tuple[CatalogRemoval, ...],
+) -> tuple[tuple[str, CatalogRemoval], ...]:
+    if type(removals) is not tuple:
+        raise CatalogPublicationError(
+            "catalog publication requires a finite removal batch"
+        )
+    normalized: list[tuple[str, CatalogRemoval]] = []
+    aliases: set[str] = set()
+    for removal in removals:
+        if type(removal) is not CatalogRemoval:
+            raise CatalogPublicationError("catalog publication removal is invalid")
+        candidate = PurePosixPath(str(removal.path).replace("\\", "/"))
+        if candidate.suffix.casefold() != ".md":
+            raise CatalogPublicationError(
+                "non-Markdown content publication is not available"
+            )
+        relative = _relative_markdown_path(vault_root, removal.path)
+        if not _is_catalog_markdown_path(relative):
+            continue
+        expected = removal.expected_before_hash
+        if (
+            type(expected) is not str
+            or len(expected) != 64
+            or any(character not in "0123456789abcdef" for character in expected)
+        ):
+            raise CatalogPublicationError(
+                "catalog removal lacks an exact predecessor binding"
+            )
+        alias = unicodedata.normalize("NFC", relative).casefold()
+        if alias in aliases:
+            raise CatalogPublicationError("catalog publication removal targets collide")
+        aliases.add(alias)
+        normalized.append((relative, removal))
+    return tuple(normalized)
+
+
 def _prepare_markdown_batch(
     vault_root: Path,
     *,
     normalized: tuple[tuple[str, MarkdownCatalogMutation], ...] | None,
     planned_writes: tuple[vault.PlannedWrite, ...] | None,
+    removals: tuple[CatalogRemoval, ...] = (),
     now: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
     """Prepare one complete batch successor, or return ``None`` for v3/open.
@@ -459,9 +506,13 @@ def _prepare_markdown_batch(
 
     if normalized is None:
         assert planned_writes is not None
-        if type(planned_writes) is not tuple or not planned_writes:
+        if type(planned_writes) is not tuple:
             raise CatalogPublicationError(
                 "catalog publication requires a finite planned-write batch"
+            )
+        if not planned_writes and not removals:
+            raise CatalogPublicationError(
+                "catalog publication requires a non-empty planned-write batch"
             )
         mutations = tuple(
             mutation
@@ -469,6 +520,15 @@ def _prepare_markdown_batch(
             if (mutation := mutation_from_planned_write(root, write)) is not None
         )
         normalized = _normalize_markdown_mutations(root, mutations)
+    normalized_removals = _normalize_catalog_removals(root, removals)
+    membership_aliases = [
+        unicodedata.normalize("NFC", relative).casefold()
+        for relative, _mutation in (*normalized_removals, *normalized)
+    ]
+    if len(membership_aliases) != len(set(membership_aliases)):
+        raise CatalogPublicationError("catalog membership targets collide")
+    if not normalized and not normalized_removals:
+        return None
 
     by_identity = {item.item_identity: item for item in verified.items}
     target_key = projections.ProjectionNamespaceKey(
@@ -476,6 +536,16 @@ def _prepare_markdown_batch(
         projector_schema_version=snapshot.active.projector_schema_version,
         catalog_generation=snapshot.active.catalog_generation + 1,
     )
+    for relative, removal in normalized_removals:
+        predecessor = by_identity.get(relative)
+        if (
+            predecessor is None
+            or predecessor.content_hash != removal.expected_before_hash
+        ):
+            raise CatalogPublicationError(
+                "catalog removal no longer matches the reviewed predecessor"
+            )
+        del by_identity[relative]
     for relative, mutation in normalized:
         predecessor = by_identity.get(relative)
         if mutation.expected_before_hash is None:
@@ -512,7 +582,7 @@ def _prepare_markdown_batch(
         target_items=target_items,
         catalog_descriptor=descriptor,
         activated_at=activated_at,
-        mutation_count=len(normalized),
+        mutation_count=len(normalized) + len(normalized_removals),
     )
 
 
@@ -524,11 +594,16 @@ def prepare_markdown_batch(
 ) -> PreparedMarkdownCatalogPublication | None:
     """Prepare an explicit canonical Markdown mutation batch."""
 
+    if type(mutations) is not tuple or not mutations:
+        raise CatalogPublicationError(
+            "catalog publication requires a finite Markdown mutation batch"
+        )
     root = Path(vault_root)
     return _prepare_markdown_batch(
         root,
         normalized=_normalize_markdown_mutations(root, mutations),
         planned_writes=None,
+        removals=(),
         now=now,
     )
 
@@ -545,6 +620,30 @@ def prepare_planned_markdown_batch(
         vault_root,
         normalized=None,
         planned_writes=writes,
+        removals=(),
+        now=now,
+    )
+
+
+def prepare_catalog_membership_batch(
+    vault_root: Path,
+    *,
+    writes: tuple[vault.PlannedWrite, ...] = (),
+    removals: tuple[CatalogRemoval, ...] = (),
+    now: int | None = None,
+) -> PreparedMarkdownCatalogPublication | None:
+    """Prepare lazy write/removal membership changes for a product mutation.
+
+    Open and schema-v3 vaults retain their existing behavior. Exact-v4 vaults
+    validate every removal only after enrollment is established, so unsupported
+    content kinds fail before the caller mutates canonical bytes.
+    """
+
+    return _prepare_markdown_batch(
+        vault_root,
+        normalized=None,
+        planned_writes=writes,
+        removals=removals,
         now=now,
     )
 
@@ -697,10 +796,12 @@ def publish_markdown_upsert(
 
 __all__ = [
     "CatalogPublicationError",
+    "CatalogRemoval",
     "MarkdownCatalogMutation",
     "PreparedMarkdownCatalogPublication",
     "mutation_from_planned_write",
     "prepare_markdown_batch",
+    "prepare_catalog_membership_batch",
     "prepare_planned_markdown_batch",
     "prepare_markdown_upsert",
     "publish_markdown_batch",

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -6513,20 +6513,12 @@ def write_log_entry(
     Returns None on success; a warning string if log.md was missing (so the
     op can include it in its warnings list). Atomic via `replace`.
     """
-    operation_token = hashlib.sha256(
-        json.dumps(
-            [date_iso, op, rel_path_no_ext, body],
-            ensure_ascii=False,
-            separators=(",", ":"),
-        ).encode("utf-8")
-    ).hexdigest()
-    plan = plan_log_writes(
+    plan = plan_log_entry(
         vault_root,
         date_iso=date_iso,
         op=op,
         rel_path_no_ext=rel_path_no_ext,
         body=body,
-        operation_token="standalone-entry:" + operation_token,
     )
     if plan.warning is not None:
         return plan.warning
@@ -6536,6 +6528,33 @@ def write_log_entry(
     except Exception as error:  # noqa: BLE001 — standalone logging is best-effort
         log.warning("log write skipped (%s)", error)
         return f"log entry skipped: {error}"
+
+
+def plan_log_entry(
+    vault_root: Path,
+    *,
+    date_iso: str,
+    op: str,
+    rel_path_no_ext: str,
+    body: str,
+) -> LogWritePlan:
+    """Plan the exact writes used by :func:`write_log_entry`."""
+
+    operation_token = hashlib.sha256(
+        json.dumps(
+            [date_iso, op, rel_path_no_ext, body],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    return plan_log_writes(
+        vault_root,
+        date_iso=date_iso,
+        op=op,
+        rel_path_no_ext=rel_path_no_ext,
+        body=body,
+        operation_token="standalone-entry:" + operation_token,
+    )
 
 
 # Matches a single log.md entry header, at either recorded precision:

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -18,6 +18,9 @@ from exomem import (
     create_file as create_file_module,
 )
 from exomem import (
+    delete_file as delete_file_module,
+)
+from exomem import (
     find_corpus,
     reserved_paths,
     semantic_writes,
@@ -2334,6 +2337,118 @@ def test_semantic_creation_publishes_index_and_log_auxiliaries_in_one_generation
     assert active.active.catalog_generation == 2
     assert manifest.item_count == 3
     assert {item.item_identity: item.content_hash for item in items} == expected
+
+
+def test_markdown_removal_and_log_write_publish_one_v4_catalog_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    relative = "Knowledge Base/Notes/private.md"
+    log_relative = "Knowledge Base/log.md"
+    before = "---\ntitle: Private\nstatus: draft\n---\n\nbefore\n"
+    log_before = "# Log\n\n---\n"
+    for existing, source in ((relative, before), (log_relative, log_before)):
+        target = vault / existing
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((relative, before), (log_relative, log_before)),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    removed = delete_file_module.delete_file(
+        vault,
+        path=relative,
+        confirm=True,
+        today=dt.date(2026, 8, 25),
+        now=dt.datetime.fromtimestamp(now),
+    )
+
+    assert not (vault / relative).exists()
+    assert (vault / removed.trash_path).is_file()
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 2
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        active = schema_v4.load_active_policy(
+            connection,
+            expected_logical_vault_id=LOGICAL_VAULT_ID,
+            expected_activation_store_id=ACTIVATION_STORE_ID,
+            expected_activation_epoch=2,
+            expected_activation_state_digest=custody.control.activation_state_digest or "",
+        )
+    finally:
+        connection.close()
+    evidence = projection_store.namespace_evidence_from_snapshot(active)
+    manifest, items = projection_store.load_projection_catalog(
+        vault,
+        key=evidence.manifest.namespace_key,
+        expected_rows_digest=evidence.manifest.rows_digest,
+    )
+    assert active.active.catalog_generation == 2
+    assert manifest.item_count == 1
+    assert [(item.item_identity, item.content_hash) for item in items] == [
+        (
+            log_relative,
+            vault_module.content_hash((vault / log_relative).read_text(encoding="utf-8")),
+        )
+    ]
+
+
+def test_v4_trash_refuses_unsupported_non_markdown_before_moving_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    relative = "Knowledge Base/Notes/private.bin"
+    target = vault / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"private bytes")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    with pytest.raises(delete_file_module.DeleteFileError) as blocked:
+        delete_file_module.delete_file(
+            vault,
+            path=relative,
+            confirm=True,
+            today=dt.date(2026, 8, 25),
+            now=dt.datetime.fromtimestamp(now),
+        )
+
+    assert blocked.value.code == "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED"
+    assert blocked.value.reason == "non-Markdown content publication is not available"
+    assert target.read_bytes() == b"private bytes"
+    assert not (vault / "Knowledge Base/_trash").exists()
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 1
 
 
 def test_open_vault_skips_v4_only_auxiliary_predecessor_validation(


### PR DESCRIPTION
## Why

Exact-v4 semantic creates and edits already advance the immutable catalog tuple, but trash still removed canonical Markdown without retiring its active catalog row. That left a stale membership boundary and allowed unsupported binary deletion to bypass the content publisher.

## What changed

- add predecessor-bound catalog removals alongside planned Markdown writes
- publish a Markdown trash plus its deterministic log update in one catalog generation and active-tuple CAS
- refuse exact-v4 non-Markdown trash before canonical bytes move until companion publication is connected
- preserve open/schema-v3 behavior and standalone log semantics
- keep post-commit uncertainty recoverable through existing trash metadata and lifecycle tombstones

## Verification

- red first: 2 expected failures for stale Markdown membership and non-Markdown fail-open
- `tests/test_governance_active_tuple.py`: 49 passed
- `tests/test_tier2.py`: 68 passed
- `tests/test_graph_lifecycle_transition.py`: 26 passed
- focused receipt/semantic/media deletion suites: 37 passed
- `tests/test_log_rotation.py`: 12 passed
- Ruff on all touched Python files: clean
- strict OpenSpec validation: valid
- public artifact scan: 3300 files / 3368 text payloads clean
- sdist and wheel build: green

Broad suite is intentionally left to CI.