### PR TITLE
fix(governance): publish move catalog membership

### DIFF
--- a/src/exomem/move_file.py
+++ b/src/exomem/move_file.py
@@ -17,21 +17,26 @@ from __future__ import annotations
 import datetime as dt
 import logging
 import re
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
 from . import reserved_paths, semantic_index, semantic_writes
+from .governance import catalog_publication
 from .kbdir import kb_dirname
 from .vault import (
+    LogWritePlan,
     PathGuard,
     PathGuardError,
     PlannedWrite,
     VaultPathError,
     batch_atomic_write,
+    content_hash,
     find_inbound_wikilinks,
     in_append_only_tree,
     in_curated_tree,
+    plan_log_entry,
     read_guarded_text,
     resolve_under_vault,
     walk_vault_md,
@@ -426,8 +431,40 @@ def move_file(
                 files_touched.append(rel)
                 wikilinks_updated += n_changed
 
+    today = today or dt.date.today()
+
+    def plan_activity_log() -> tuple[str, str, LogWritePlan]:
+        date_iso = today.isoformat()
+        new_rel_no_ext = (
+            new_rel.removesuffix(".md") if new_rel.endswith(".md") else new_rel
+        )
+        body = (
+            f"Moved {old_rel!r} → {new_rel!r} via exomem Tier 2. "
+            f"wikilinks_updated={wikilinks_updated} across "
+            f"{len(files_touched)} file(s)."
+        )
+        if src_curated or dst_curated:
+            body += f" allow_curated=true (tree: {src_curated or dst_curated})."
+        if promotion:
+            body += f" Promoted Sources → Evidence: {promotion_reason.strip()}"
+        return (
+            new_rel_no_ext,
+            body,
+            plan_log_entry(
+                vault_root,
+                date_iso=date_iso,
+                op="move_file",
+                rel_path_no_ext=new_rel_no_ext,
+                body=body,
+            ),
+        )
+
     semantic: dict | None = None
     semantic_states: dict[str, semantic_index.SemanticParentIndexState] = {}
+    catalog_target: catalog_publication.PreparedMarkdownCatalogPublication | None = None
+    log_rel_no_ext: str
+    log_body: str
+    log_plan: LogWritePlan
     if old_rel.lower().endswith(".md") and new_rel.lower().endswith(".md"):
         try:
             source, source_guard = read_guarded_text(vault_root, old_abs)
@@ -451,6 +488,7 @@ def move_file(
                     wikilinks_updated += source_changes
             if content_transform is not None:
                 moved_source = content_transform(moved_source)
+            log_rel_no_ext, log_body, log_plan = plan_activity_log()
             destination_guard = PathGuard.capture(
                 vault_root, new_rel, leaf_policy="absent"
             )
@@ -475,7 +513,46 @@ def move_file(
                 required_guards,
                 bound_destination: PathGuard,
             ) -> None:
+                nonlocal catalog_target
                 bound_destination.recheck(vault_root)
+                catalog_removals = [
+                    catalog_publication.CatalogRemoval(
+                        old_rel,
+                        content_hash(source),
+                    )
+                ]
+                if paired_binary is not None:
+                    catalog_removals.append(
+                        catalog_publication.CatalogRemoval(
+                            paired_binary[0],
+                            None,
+                        )
+                    )
+                catalog_writes = [
+                    *lifecycle_writes,
+                    PlannedWrite(
+                        path=new_abs,
+                        content=moved_source,
+                        create_only=True,
+                    ),
+                    *writes,
+                    *extra_writes,
+                    *log_plan.writes,
+                ]
+                try:
+                    catalog_target = (
+                        catalog_publication.prepare_catalog_membership_batch(
+                            vault_root,
+                            writes=tuple(catalog_writes),
+                            removals=tuple(catalog_removals),
+                            now=int(time.time()),
+                        )
+                    )
+                except catalog_publication.CatalogPublicationError as error:
+                    raise MoveFileError(
+                        code="GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
+                        reason=str(error),
+                    ) from error
                 _held_rename(vault_root, old_rel, new_rel)
                 # The bytes follow the page inside the same transaction. A
                 # rollback below undoes both, so a failure can never leave an
@@ -498,6 +575,8 @@ def move_file(
                         *writes,
                         *extra_writes,
                     ]
+                    if catalog_target is not None:
+                        combined.extend(log_plan.writes)
                     if combined:
                         batch_fanout_paths[:] = [write.path for write in combined]
                         batch_atomic_write(
@@ -539,7 +618,39 @@ def move_file(
             raise MoveFileError(code=error.code, reason=error.reason) from error
         except PathGuardError as error:
             raise MoveFileError(code=error.code, reason=error.reason) from error
+        if catalog_target is not None:
+            try:
+                catalog_publication.publish_markdown_batch(catalog_target)
+            except catalog_publication.CatalogPublicationError as error:
+                raise MoveFileError(
+                    code="GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN",
+                    reason=(
+                        "the file move committed but its active catalog publication "
+                        "did not reach a verified terminal"
+                    ),
+                ) from error
     else:
+        log_rel_no_ext, log_body, log_plan = plan_activity_log()
+        unsupported_rel = (
+            old_rel if not old_rel.lower().endswith(".md") else new_rel
+        )
+        try:
+            catalog_target = catalog_publication.prepare_catalog_membership_batch(
+                vault_root,
+                writes=log_plan.writes,
+                removals=(
+                    catalog_publication.CatalogRemoval(
+                        unsupported_rel,
+                        None,
+                    ),
+                ),
+                now=int(time.time()),
+            )
+        except catalog_publication.CatalogPublicationError as error:
+            raise MoveFileError(
+                code="GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
+                reason=str(error),
+            ) from error
         _held_rename(vault_root, old_rel, new_rel)
         try:
             if writes:
@@ -644,27 +755,15 @@ def move_file(
         ),
     }
 
-    today = today or dt.date.today()
-    date_iso = today.isoformat()
-    new_rel_no_ext = new_rel.removesuffix(".md") if new_rel.endswith(".md") else new_rel
-    log_body = (
-        f"Moved {old_rel!r} → {new_rel!r} via exomem Tier 2. "
-        f"wikilinks_updated={wikilinks_updated} across {len(files_touched)} file(s)."
-    )
-    if src_curated or dst_curated:
-        log_body += f" allow_curated=true (tree: {src_curated or dst_curated})."
-    if promotion:
-        # The reason is the whole audit trail for a reclassification: it records
-        # which claim or case made this raw item proof-bearing, at the moment
-        # someone judged that it had.
-        log_body += f" Promoted Sources → Evidence: {promotion_reason.strip()}"
-    log_warning = write_log_entry(
-        vault_root,
-        date_iso=date_iso,
-        op="move_file",
-        rel_path_no_ext=new_rel_no_ext,
-        body=log_body,
-    )
+    log_warning = log_plan.warning
+    if catalog_target is None:
+        log_warning = write_log_entry(
+            vault_root,
+            date_iso=today.isoformat(),
+            op="move_file",
+            rel_path_no_ext=log_rel_no_ext,
+            body=log_body,
+        )
     if log_warning:
         warnings.append(log_warning)
 

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -27,6 +27,9 @@ from exomem import (
     writer_lease,
 )
 from exomem import (
+    move_file as move_file_module,
+)
+from exomem import (
     vault as vault_module,
 )
 from exomem.governance import (
@@ -2449,6 +2452,288 @@ def test_v4_trash_refuses_unsupported_non_markdown_before_moving_bytes(
     assert not (vault / "Knowledge Base/_trash").exists()
     custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
     assert custody.control.activation_epoch == 1
+
+
+def test_v4_move_replaces_membership_and_publishes_auxiliaries_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    old_relative = "Knowledge Base/Notes/private.md"
+    new_relative = "Knowledge Base/Notes/renamed-private.md"
+    inbound_relative = "Knowledge Base/Notes/referrer.md"
+    log_relative = "Knowledge Base/log.md"
+    source = "---\ntitle: Private\nstatus: draft\n---\n\nMove me.\n"
+    inbound_before = (
+        "---\ntitle: Referrer\nstatus: draft\n---\n\n"
+        "See [[Knowledge Base/Notes/private]].\n"
+    )
+    log_before = "# Log\n\n---\n"
+    for existing, content in (
+        (old_relative, source),
+        (inbound_relative, inbound_before),
+        (log_relative, log_before),
+    ):
+        target = vault / existing
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=(
+            (old_relative, source),
+            (inbound_relative, inbound_before),
+            (log_relative, log_before),
+        ),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    moved = move_file_module.move_file(
+        vault,
+        old_path=old_relative,
+        new_path=new_relative,
+        today=dt.date(2026, 8, 25),
+    )
+
+    assert moved.wikilinks_updated == 1
+    assert not (vault / old_relative).exists()
+    assert (vault / new_relative).read_text(encoding="utf-8") == source
+    assert "renamed-private" in (vault / inbound_relative).read_text(encoding="utf-8")
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 2
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        active = schema_v4.load_active_policy(
+            connection,
+            expected_logical_vault_id=LOGICAL_VAULT_ID,
+            expected_activation_store_id=ACTIVATION_STORE_ID,
+            expected_activation_epoch=2,
+            expected_activation_state_digest=custody.control.activation_state_digest or "",
+        )
+    finally:
+        connection.close()
+    evidence = projection_store.namespace_evidence_from_snapshot(active)
+    manifest, items = projection_store.load_projection_catalog(
+        vault,
+        key=evidence.manifest.namespace_key,
+        expected_rows_digest=evidence.manifest.rows_digest,
+    )
+    expected_paths = (new_relative, inbound_relative, log_relative)
+    expected = {
+        path: vault_module.content_hash((vault / path).read_text(encoding="utf-8"))
+        for path in expected_paths
+    }
+    assert active.active.catalog_generation == 2
+    assert manifest.item_count == len(expected_paths)
+    assert {item.item_identity: item.content_hash for item in items} == expected
+
+
+def test_v4_move_refuses_unsupported_non_markdown_before_moving_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    old_relative = "Knowledge Base/Notes/private.bin"
+    new_relative = "Knowledge Base/Notes/renamed-private.bin"
+    source = vault / old_relative
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_bytes(b"private bytes")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    with pytest.raises(move_file_module.MoveFileError) as blocked:
+        move_file_module.move_file(
+            vault,
+            old_path=old_relative,
+            new_path=new_relative,
+            today=dt.date(2026, 8, 25),
+        )
+
+    assert blocked.value.code == "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED"
+    assert blocked.value.reason == "non-Markdown content publication is not available"
+    assert source.read_bytes() == b"private bytes"
+    assert not (vault / new_relative).exists()
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 1
+
+
+def test_v4_move_refuses_markdown_to_non_markdown_before_moving_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    old_relative = "Knowledge Base/Notes/private.md"
+    new_relative = "Knowledge Base/Notes/private.txt"
+    source = "---\ntitle: Private\nstatus: draft\n---\n\nPrivate bytes.\n"
+    target = vault / old_relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_item(
+        vault,
+        path=old_relative,
+        source=source,
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    with pytest.raises(move_file_module.MoveFileError) as blocked:
+        move_file_module.move_file(
+            vault,
+            old_path=old_relative,
+            new_path=new_relative,
+            today=dt.date(2026, 8, 25),
+        )
+
+    assert blocked.value.code == "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED"
+    assert blocked.value.reason == "non-Markdown content publication is not available"
+    assert target.read_text(encoding="utf-8") == source
+    assert not (vault / new_relative).exists()
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 1
+
+
+def test_v4_move_refuses_paired_artifact_until_companion_publication_exists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    old_binary = "Knowledge Base/Notes/private.bin"
+    old_page = f"{old_binary}.md"
+    new_binary = "Knowledge Base/Notes/renamed-private.bin"
+    new_page = f"{new_binary}.md"
+    page_source = (
+        "---\ntitle: Private artifact\nstatus: draft\n"
+        f"evidence_file: {old_binary}\n---\n\nPrivate artifact.\n"
+    )
+    binary = vault / old_binary
+    binary.parent.mkdir(parents=True, exist_ok=True)
+    binary.write_bytes(b"private bytes")
+    (vault / old_page).write_text(page_source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_item(
+        vault,
+        path=old_page,
+        source=page_source,
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    with pytest.raises(move_file_module.MoveFileError) as blocked:
+        move_file_module.move_file(
+            vault,
+            old_path=old_page,
+            new_path=new_page,
+            today=dt.date(2026, 8, 25),
+        )
+
+    assert blocked.value.code == "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED"
+    assert blocked.value.reason == "non-Markdown content publication is not available"
+    assert binary.read_bytes() == b"private bytes"
+    assert (vault / old_page).read_text(encoding="utf-8") == page_source
+    assert not (vault / new_binary).exists()
+    assert not (vault / new_page).exists()
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 1
+
+
+def test_v4_move_does_not_undo_bytes_after_catalog_outcome_becomes_uncertain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    old_relative = "Knowledge Base/Notes/private.md"
+    new_relative = "Knowledge Base/Notes/renamed-private.md"
+    source = "---\ntitle: Private\nstatus: draft\n---\n\nMove me.\n"
+    target = vault / old_relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_item(
+        vault,
+        path=old_relative,
+        source=source,
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    def lose_publication_terminal(_prepared) -> None:
+        raise catalog_publication.CatalogPublicationError("lost terminal")
+
+    monkeypatch.setattr(
+        catalog_publication,
+        "publish_markdown_batch",
+        lose_publication_terminal,
+    )
+
+    with pytest.raises(move_file_module.MoveFileError) as uncertain:
+        move_file_module.move_file(
+            vault,
+            old_path=old_relative,
+            new_path=new_relative,
+            today=dt.date(2026, 8, 25),
+        )
+
+    assert uncertain.value.code == "GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN"
+    assert not (vault / old_relative).exists()
+    assert (vault / new_relative).read_text(encoding="utf-8") == source
 
 
 def test_open_vault_skips_v4_only_auxiliary_predecessor_validation(


### PR DESCRIPTION
## Why

Exact-v4 governed moves changed canonical paths and auxiliary Markdown without advancing the active catalog tuple. That left the old identity reachable and the destination or rewritten links absent from the authorized projection.

## What

- retire the exact predecessor row and insert the moved destination in one catalog generation
- include inbound-link, lifecycle, extra Markdown, and deterministic log writes in the same successor
- refuse ordinary non-Markdown, extension-changing, and paired-artifact moves before mutation until companion publication exists
- report publication uncertainty without undoing canonical bytes after a possibly committed tuple
- preserve open and schema-v3 behavior

## Verification

- red first: 2 expected exact-v4 route failures
- `tests/test_governance_active_tuple.py`: 54 passed
- focused move and held-path regressions: 48 passed, 1 platform skip
- Ruff and `git diff --check`: clean
- `openspec validate harden-governance-for-consolidation --strict`: valid
- public artifact repository scan: clean
- source distribution and wheel build: green

No real personal or engagement vault was touched.