### PR TITLE
fix(governance): publish directory trash membership

### DIFF
--- a/src/exomem/delete_directory.py
+++ b/src/exomem/delete_directory.py
@@ -16,20 +16,24 @@ directory tree; refuses if any exist unless `force_orphan=true`.
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
 import json
 import logging
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
 from . import media_types, reserved_paths
-from .governance import lifecycle
+from .governance import catalog_publication, lifecycle
 from .kbdir import kb_dirname, kb_prefix
 from .vault import (
     VaultPathError,
+    batch_atomic_write,
     find_inbound_wikilinks,
     in_append_only_tree,
     in_curated_tree,
     kb_root,
+    plan_log_entry,
     resolve_under_vault,
     write_log_entry,
 )
@@ -277,6 +281,56 @@ def delete_directory(
         except ValueError:
             continue
 
+    today_iso = today.isoformat()
+    log_body = (
+        f"Trashed directory {rel_path!r} → {trash_rel!r} via exomem Tier 2. "
+        f"files={len(files)}, md_files={len(md_files)}, "
+        f"inbound_links_at_trash={inbound_total}."
+    )
+    if recursive:
+        log_body += " recursive=true."
+    if force_orphan:
+        log_body += " force_orphan=true."
+    if curated and allow_curated:
+        log_body += f" allow_curated=true (target tree: {curated})."
+    log_plan = plan_log_entry(
+        vault_root,
+        date_iso=today_iso,
+        op="delete_directory (trash)",
+        rel_path_no_ext=rel_path,
+        body=log_body,
+    )
+    initial_tree_state = tuple(
+        sorted(
+            (
+                f"{rel_path.rstrip('/')}/{item.relative_path}",
+                hashlib.sha256(item.snapshot.data).hexdigest(),
+            )
+            for item in tree
+        )
+    )
+    catalog_removals = tuple(
+        catalog_publication.CatalogRemoval(
+            path,
+            digest if path.lower().endswith(".md") else None,
+        )
+        for path, digest in initial_tree_state
+    )
+    catalog_target: catalog_publication.PreparedMarkdownCatalogPublication | None = None
+    if log_plan.writes or catalog_removals:
+        try:
+            catalog_target = catalog_publication.prepare_catalog_membership_batch(
+                vault_root,
+                writes=log_plan.writes,
+                removals=catalog_removals,
+                now=int(time.time()),
+            )
+        except catalog_publication.CatalogPublicationError as error:
+            raise DeleteDirectoryError(
+                code="GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
+                reason=str(error),
+            ) from error
+
     from . import graph_sync
 
     try:
@@ -299,6 +353,28 @@ def delete_directory(
             reason="the staged trash transition could not be restored",
         ) from error
     lifecycle_operation = transition.operation
+    # The catalog successor was prepared from the first held tree. The
+    # lifecycle boundary independently recaptures that tree before staging its
+    # tombstone/graph epoch; require the two exact path/hash sets to agree so a
+    # concurrent child cannot be moved to trash while retaining an active row.
+    transition_tree_state = tuple(
+        sorted(
+            (item.source_path, item.content_hash)
+            for item in lifecycle_operation.manifest
+        )
+    )
+    if transition_tree_state != initial_tree_state:
+        try:
+            transition.abort()
+        except graph_sync.GraphLifecycleRollbackError as rollback_error:
+            raise DeleteDirectoryError(
+                code="GRAPH_SYNC_DELETION_ROLLBACK_FAILED",
+                reason="the changed directory transition could not be restored",
+            ) from rollback_error
+        raise DeleteDirectoryError(
+            code="PATH_GUARD_CHANGED",
+            reason="directory contents changed before the trash transition",
+        )
 
     # A doomed subtree may also contain CLIP-relevant media binaries (image/
     # video — the only kinds with derived-index residue: CLIP rows, and for a
@@ -447,25 +523,29 @@ def delete_directory(
             "content remains tombstoned until reconcile"
         )
 
-    today_iso = today.isoformat()
-    log_body = (
-        f"Trashed directory {rel_path!r} → {trash_rel!r} via exomem Tier 2. "
-        f"files={len(files)}, md_files={len(md_files)}, "
-        f"inbound_links_at_trash={inbound_total}."
-    )
-    if recursive:
-        log_body += " recursive=true."
-    if force_orphan:
-        log_body += " force_orphan=true."
-    if curated and allow_curated:
-        log_body += f" allow_curated=true (target tree: {curated})."
-    log_warning = write_log_entry(
-        vault_root,
-        date_iso=today_iso,
-        op="delete_directory (trash)",
-        rel_path_no_ext=rel_path,
-        body=log_body,
-    )
+    if catalog_target is not None:
+        try:
+            if log_plan.writes:
+                batch_atomic_write(log_plan.writes, vault_root=vault_root)
+            catalog_publication.publish_markdown_batch(catalog_target)
+        except Exception as error:  # noqa: BLE001 - canonical removal already committed
+            raise DeleteDirectoryError(
+                code="GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN",
+                reason=(
+                    "the directory was trashed but its active catalog publication "
+                    "did not reach a verified terminal"
+                ),
+            ) from error
+
+    log_warning = log_plan.warning
+    if catalog_target is None:
+        log_warning = write_log_entry(
+            vault_root,
+            date_iso=today_iso,
+            op="delete_directory (trash)",
+            rel_path_no_ext=rel_path,
+            body=log_body,
+        )
     if log_warning:
         warnings.append(log_warning)
 

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -18,10 +18,14 @@ from exomem import (
     create_file as create_file_module,
 )
 from exomem import (
+    delete_directory as delete_directory_module,
+)
+from exomem import (
     delete_file as delete_file_module,
 )
 from exomem import (
     find_corpus,
+    graph_sync,
     reserved_paths,
     semantic_writes,
     writer_lease,
@@ -2450,6 +2454,243 @@ def test_v4_trash_refuses_unsupported_non_markdown_before_moving_bytes(
     assert blocked.value.reason == "non-Markdown content publication is not available"
     assert target.read_bytes() == b"private bytes"
     assert not (vault / "Knowledge Base/_trash").exists()
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 1
+
+
+def test_v4_directory_trash_retires_all_rows_and_publishes_log_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    directory = "Knowledge Base/Notes/private-tree"
+    first_relative = f"{directory}/first.md"
+    second_relative = f"{directory}/nested/second.md"
+    log_relative = "Knowledge Base/log.md"
+    first = "---\ntitle: First\nstatus: draft\n---\n\nFirst.\n"
+    second = "---\ntitle: Second\nstatus: draft\n---\n\nSecond.\n"
+    log_before = "# Log\n\n---\n"
+    for relative, source in (
+        (first_relative, first),
+        (second_relative, second),
+        (log_relative, log_before),
+    ):
+        target = vault / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=(
+            (first_relative, first),
+            (second_relative, second),
+            (log_relative, log_before),
+        ),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    removed = delete_directory_module.delete_directory(
+        vault,
+        path=directory,
+        confirm=True,
+        recursive=True,
+        today=dt.date(2026, 8, 25),
+        now=dt.datetime.fromtimestamp(now),
+    )
+
+    assert not (vault / directory).exists()
+    assert (vault / removed.trash_path).is_dir()
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 2
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        active = schema_v4.load_active_policy(
+            connection,
+            expected_logical_vault_id=LOGICAL_VAULT_ID,
+            expected_activation_store_id=ACTIVATION_STORE_ID,
+            expected_activation_epoch=2,
+            expected_activation_state_digest=custody.control.activation_state_digest or "",
+        )
+    finally:
+        connection.close()
+    evidence = projection_store.namespace_evidence_from_snapshot(active)
+    manifest, items = projection_store.load_projection_catalog(
+        vault,
+        key=evidence.manifest.namespace_key,
+        expected_rows_digest=evidence.manifest.rows_digest,
+    )
+    assert active.active.catalog_generation == 2
+    assert manifest.item_count == 1
+    assert [(item.item_identity, item.content_hash) for item in items] == [
+        (
+            log_relative,
+            vault_module.content_hash((vault / log_relative).read_text(encoding="utf-8")),
+        )
+    ]
+
+
+def test_v4_directory_trash_refuses_non_markdown_child_before_moving_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    directory = "Knowledge Base/Notes/private-tree"
+    binary = vault / directory / "private.bin"
+    binary.parent.mkdir(parents=True, exist_ok=True)
+    binary.write_bytes(b"private bytes")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    with pytest.raises(delete_directory_module.DeleteDirectoryError) as blocked:
+        delete_directory_module.delete_directory(
+            vault,
+            path=directory,
+            confirm=True,
+            recursive=True,
+            today=dt.date(2026, 8, 25),
+            now=dt.datetime.fromtimestamp(now),
+        )
+
+    assert blocked.value.code == "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED"
+    assert blocked.value.reason == "non-Markdown content publication is not available"
+    assert binary.read_bytes() == b"private bytes"
+    assert not (vault / "Knowledge Base/_trash").exists()
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 1
+
+
+def test_v4_directory_trash_does_not_restore_tree_after_publication_uncertainty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    directory = "Knowledge Base/Notes/private-tree"
+    relative = f"{directory}/private.md"
+    source = "---\ntitle: Private\nstatus: draft\n---\n\nPrivate.\n"
+    target = vault / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_item(
+        vault,
+        path=relative,
+        source=source,
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    def lose_publication_terminal(_prepared) -> None:
+        raise catalog_publication.CatalogPublicationError("lost terminal")
+
+    monkeypatch.setattr(
+        catalog_publication,
+        "publish_markdown_batch",
+        lose_publication_terminal,
+    )
+
+    with pytest.raises(delete_directory_module.DeleteDirectoryError) as uncertain:
+        delete_directory_module.delete_directory(
+            vault,
+            path=directory,
+            confirm=True,
+            recursive=True,
+            today=dt.date(2026, 8, 25),
+            now=dt.datetime.fromtimestamp(now),
+        )
+
+    assert uncertain.value.code == "GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN"
+    assert not (vault / directory).exists()
+    trash_day = vault / "Knowledge Base/_trash/2026-08-25"
+    assert any(path.is_dir() for path in trash_day.iterdir())
+
+
+def test_v4_directory_trash_refuses_tree_drift_before_catalog_preparation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    directory = "Knowledge Base/Notes/private-tree"
+    relative = f"{directory}/private.md"
+    added_relative = f"{directory}/added.md"
+    source = "---\ntitle: Private\nstatus: draft\n---\n\nPrivate.\n"
+    target = vault / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_item(
+        vault,
+        path=relative,
+        source=source,
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    real_begin = graph_sync.begin_deletion_transition
+
+    def drift_then_begin(*args, **kwargs):
+        (vault / added_relative).write_text("added concurrently\n", encoding="utf-8")
+        return real_begin(*args, **kwargs)
+
+    monkeypatch.setattr(graph_sync, "begin_deletion_transition", drift_then_begin)
+
+    with pytest.raises(delete_directory_module.DeleteDirectoryError) as blocked:
+        delete_directory_module.delete_directory(
+            vault,
+            path=directory,
+            confirm=True,
+            recursive=True,
+            today=dt.date(2026, 8, 25),
+            now=dt.datetime.fromtimestamp(now),
+        )
+
+    assert blocked.value.code == "PATH_GUARD_CHANGED"
+    assert target.read_text(encoding="utf-8") == source
+    assert (vault / added_relative).read_text(encoding="utf-8") == "added concurrently\n"
     custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
     assert custody.control.activation_epoch == 1
 


### PR DESCRIPTION
## Why

Exact-v4 recursive directory trash moved canonical bytes but left every child row active in the governed projection catalog. That made the active tuple disagree with the vault after a successful trash operation.

## What changed

- prepare one exact catalog successor covering every removed Markdown row plus the deterministic audit-log write
- refuse exact-v4 trees containing unsupported non-Markdown children before moving any bytes
- compare two independently held path/hash snapshots before rename so a concurrent child cannot be trashed while retaining an active row
- publish the catalog only after lifecycle completion, and report an honest uncertain terminal without restoring bytes when tuple acknowledgement may have committed
- preserve the existing open/schema-v3 behavior

## Verification

- `uv run python -m pytest -q tests/test_governance_active_tuple.py -k 'v4_directory_trash'` — 4 passed
- focused active-tuple/tier-2/lifecycle regression — 11 passed
- full `tests/test_governance_active_tuple.py` — 58 passed
- Ruff on both changed Python files — passed
- `git diff --check` — passed
- `openspec validate harden-governance-for-consolidation --strict` — valid
- `uv run python scripts/validate-public-artifacts.py --repository` — 3300 files / 3368 text payloads clean
- source and wheel build — passed

No real personal or POLLY vault was touched.
