### PR TITLE
fix(governance): publish recovery catalog membership

### DIFF
--- a/src/exomem/governance/catalog_publication.py
+++ b/src/exomem/governance/catalog_publication.py
@@ -389,12 +389,33 @@ def _normalize_catalog_removals(
     return tuple(normalized)
 
 
+def _validate_catalog_content_paths(content_paths: tuple[str, ...]) -> None:
+    if type(content_paths) is not tuple:
+        raise CatalogPublicationError(
+            "catalog publication requires a finite content-path batch"
+        )
+    aliases: set[str] = set()
+    for path in content_paths:
+        if type(path) is not str:
+            raise CatalogPublicationError("catalog publication content path is invalid")
+        candidate = PurePosixPath(path.replace("\\", "/"))
+        if candidate.suffix.casefold() != ".md":
+            raise CatalogPublicationError(
+                "non-Markdown content publication is not available"
+            )
+        alias = unicodedata.normalize("NFC", candidate.as_posix()).casefold()
+        if alias in aliases:
+            raise CatalogPublicationError("catalog publication content paths collide")
+        aliases.add(alias)
+
+
 def _prepare_markdown_batch(
     vault_root: Path,
     *,
     normalized: tuple[tuple[str, MarkdownCatalogMutation], ...] | None,
     planned_writes: tuple[vault.PlannedWrite, ...] | None,
     removals: tuple[CatalogRemoval, ...] = (),
+    content_paths: tuple[str, ...] = (),
     now: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
     """Prepare one complete batch successor, or return ``None`` for v3/open.
@@ -504,6 +525,7 @@ def _prepare_markdown_batch(
     finally:
         connection.close()
 
+    _validate_catalog_content_paths(content_paths)
     if normalized is None:
         assert planned_writes is not None
         if type(planned_writes) is not tuple:
@@ -630,6 +652,7 @@ def prepare_catalog_membership_batch(
     *,
     writes: tuple[vault.PlannedWrite, ...] = (),
     removals: tuple[CatalogRemoval, ...] = (),
+    content_paths: tuple[str, ...] = (),
     now: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
     """Prepare lazy write/removal membership changes for a product mutation.
@@ -644,6 +667,7 @@ def prepare_catalog_membership_batch(
         normalized=None,
         planned_writes=writes,
         removals=removals,
+        content_paths=content_paths,
         now=now,
     )
 

--- a/src/exomem/recover_from_trash.py
+++ b/src/exomem/recover_from_trash.py
@@ -12,7 +12,9 @@ a different `restore_path` if the original location is now occupied.
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
 import logging
+import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -24,16 +26,18 @@ from . import (
     semantic_index,
     semantic_writes,
 )
-from .governance import lifecycle
+from .governance import catalog_publication, lifecycle
 from .kbdir import kb_dirname, kb_prefix
 from .vault import (
     DirectoryCensusGuard,
     PathGuard,
     PathGuardError,
     VaultPathError,
+    batch_atomic_write,
     content_hash,
     in_append_only_tree,
     in_curated_tree,
+    plan_log_entry,
     read_guarded_text,
     resolve_under_vault,
     write_log_entry,
@@ -107,11 +111,15 @@ def recover_from_trash(
     # Bind and classify the complete source before reading its sidecar, parsing
     # Markdown, counting children, or allocating lifecycle state. The later
     # lifecycle manifest performs the immediate pre-rename recheck.
+    trash_file_snapshot = None
+    trash_tree: tuple[reserved_paths.GenericTreeFile, ...] = ()
     try:
         if trash_abs.is_file():
-            reserved_paths.read_generic_bytes(vault_root, trash_rel)
+            trash_kind = "file"
+            trash_file_snapshot = reserved_paths.read_generic_bytes(vault_root, trash_rel)
         elif trash_abs.is_dir():
-            reserved_paths.read_generic_tree(vault_root, trash_rel)
+            trash_kind = "directory"
+            trash_tree = reserved_paths.read_generic_tree(vault_root, trash_rel)
         else:
             raise reserved_paths.ReservedPathLeafError("UNSAFE_PATH")
     except reserved_paths.ReservedPathLeafError as error:
@@ -266,6 +274,60 @@ def recover_from_trash(
             ),
         )
 
+    if trash_kind == "file":
+        assert trash_file_snapshot is not None
+        initial_restore_state = (
+            (restore_rel, hashlib.sha256(trash_file_snapshot.data).hexdigest()),
+        )
+    else:
+        initial_restore_state = tuple(
+            sorted(
+                (
+                    f"{restore_rel.rstrip('/')}/{item.relative_path}",
+                    hashlib.sha256(item.snapshot.data).hexdigest(),
+                )
+                for item in trash_tree
+            )
+        )
+    catalog_content_paths = tuple(path for path, _digest in initial_restore_state)
+
+    today = today or dt.date.today()
+    date_iso = today.isoformat()
+    restore_no_ext = (
+        restore_rel.removesuffix(".md") if restore_rel.endswith(".md") else restore_rel
+    )
+    log_body = (
+        f"Recovered {trash_rel!r} → {restore_rel!r} via exomem Tier 2. "
+        f"kind={trash_kind}."
+    )
+    if curated and allow_curated:
+        log_body += f" allow_curated=true (target tree: {curated})."
+    log_plan = plan_log_entry(
+        vault_root,
+        date_iso=date_iso,
+        op="recover_from_trash",
+        rel_path_no_ext=restore_no_ext,
+        body=log_body,
+    )
+    catalog_now = int(time.time())
+
+    # Open/schema-v3 restores keep their existing behavior. Exact-v4 restores
+    # must refuse every currently unsupported content kind before lifecycle
+    # state or canonical placement changes.
+    if any(not path.lower().endswith(".md") for path in catalog_content_paths):
+        try:
+            catalog_publication.prepare_catalog_membership_batch(
+                vault_root,
+                writes=log_plan.writes,
+                content_paths=catalog_content_paths,
+                now=catalog_now,
+            )
+        except catalog_publication.CatalogPublicationError as error:
+            raise RecoverError(
+                code="GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
+                reason=str(error),
+            ) from error
+
     semantic: dict | None = None
     lifecycle_operation: lifecycle.LifecycleOperation | None = None
     graph_transition: graph_sync.GraphLifecycleTransition | None = None
@@ -273,7 +335,8 @@ def recover_from_trash(
     recovery_entries: list[semantic_writes.RecoveryEntry] = []
     destination_root_guard: PathGuard | None = None
     trash_census_guards: tuple[DirectoryCensusGuard, ...] = ()
-    if trash_abs.is_file() and trash_rel.lower().endswith(".md"):
+    catalog_published = False
+    if trash_kind == "file" and trash_rel.lower().endswith(".md"):
         try:
             source, source_guard = read_guarded_text(vault_root, trash_abs)
             destination_guard = PathGuard.capture(
@@ -295,7 +358,7 @@ def recover_from_trash(
         except (OSError, UnicodeDecodeError, PathGuardError) as error:
             code = getattr(error, "code", "RECOVER_FAILED")
             raise RecoverError(code=code, reason=str(error)) from error
-    elif trash_abs.is_dir():
+    elif trash_kind == "directory":
         try:
             markdown = sorted(
                 trash_abs.rglob("*.md"), key=lambda item: item.as_posix()
@@ -358,6 +421,9 @@ def recover_from_trash(
                 destination_root_guard=destination_root_guard,
                 trash_census_guards=trash_census_guards,
                 recovery_sidecar_guard=sidecar_guard,
+                catalog_auxiliary_writes=log_plan.writes,
+                catalog_content_paths=catalog_content_paths,
+                catalog_publication_now=catalog_now,
                 relation_reviews=relation_reviews,
             )
             semantic_states = {
@@ -368,7 +434,7 @@ def recover_from_trash(
                 return RecoverResult(
                     trash_path=trash_rel,
                     restored_path=restore_rel,
-                    kind="directory" if trash_abs.is_dir() else "file",
+                    kind=trash_kind,
                     warnings=[],
                     semantic=preflight.as_dict(),
                 )
@@ -396,6 +462,17 @@ def recover_from_trash(
                     reason="the staged recovery transition could not be restored",
                 ) from error
             lifecycle_operation = graph_transition.operation
+            transition_restore_state = tuple(
+                sorted(
+                    (item.source_path, item.content_hash)
+                    for item in lifecycle_operation.manifest
+                )
+            )
+            if transition_restore_state != initial_restore_state:
+                raise RecoverError(
+                    code="PATH_GUARD_CHANGED",
+                    reason="trash contents changed before the recovery transition",
+                )
 
             def restore() -> None:
                 try:
@@ -413,16 +490,16 @@ def recover_from_trash(
                         code="GRAPH_SYNC_RECOVERY_CHECKPOINT_FAILED",
                         reason="graph checkpoint failed; recovery will be reversed",
                     ) from error
-                from .writer_lease import mark_active_mutation_committed
-
-                mark_active_mutation_committed()
-
             committed = semantic_writes.commit_recovery(
                 vault_root, preflight=preflight, mutate=restore
             )
+            catalog_published = committed.catalog_published
             semantic = committed.as_dict()
         except semantic_writes.SemanticWriteError as error:
-            if graph_transition is not None:
+            if (
+                graph_transition is not None
+                and error.code != "GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN"
+            ):
                 try:
                     graph_transition.abort()
                 except graph_sync.GraphLifecycleRollbackError as rollback_error:
@@ -461,9 +538,25 @@ def recover_from_trash(
             return RecoverResult(
                 trash_path=trash_rel,
                 restored_path=restore_rel,
-                kind="directory" if trash_abs.is_dir() else "file",
+                kind=trash_kind,
                 warnings=[],
             )
+        direct_catalog_target = None
+        if log_plan.writes:
+            try:
+                direct_catalog_target = (
+                    catalog_publication.prepare_catalog_membership_batch(
+                        vault_root,
+                        writes=log_plan.writes,
+                        content_paths=catalog_content_paths,
+                        now=catalog_now,
+                    )
+                )
+            except catalog_publication.CatalogPublicationError as error:
+                raise RecoverError(
+                    code="GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
+                    reason=str(error),
+                ) from error
         try:
             graph_transition = graph_sync.begin_recovery_transition(
                 vault_root,
@@ -484,9 +577,32 @@ def recover_from_trash(
                 reason="the staged recovery transition could not be restored",
             ) from error
         lifecycle_operation = graph_transition.operation
+        transition_restore_state = tuple(
+            sorted(
+                (item.source_path, item.content_hash)
+                for item in lifecycle_operation.manifest
+            )
+        )
+        if transition_restore_state != initial_restore_state:
+            try:
+                graph_transition.abort()
+            except graph_sync.GraphLifecycleRollbackError as rollback_error:
+                raise RecoverError(
+                    code="GRAPH_SYNC_RECOVERY_ROLLBACK_FAILED",
+                    reason="recovery could not be reversed; reconcile is required",
+                ) from rollback_error
+            raise RecoverError(
+                code="PATH_GUARD_CHANGED",
+                reason="trash contents changed before the recovery transition",
+            )
         try:
             graph_transition.rename()
             graph_transition.publish_checkpoint()
+            if direct_catalog_target is not None and log_plan.writes:
+                batch_atomic_write(log_plan.writes, vault_root=vault_root)
+            from .writer_lease import mark_active_mutation_committed
+
+            mark_active_mutation_committed()
         except lifecycle.LifecycleError as e:
             try:
                 graph_transition.abort()
@@ -499,6 +615,15 @@ def recover_from_trash(
                 code=e.code,
                 reason=e.reason,
             ) from e
+        except RecoverError:
+            try:
+                graph_transition.abort()
+            except graph_sync.GraphLifecycleRollbackError as rollback_error:
+                raise RecoverError(
+                    code="GRAPH_SYNC_RECOVERY_ROLLBACK_FAILED",
+                    reason="recovery could not be reversed; reconcile is required",
+                ) from rollback_error
+            raise
         except Exception as error:  # noqa: BLE001 - reverse a caught epoch failure
             try:
                 graph_transition.abort()
@@ -511,9 +636,15 @@ def recover_from_trash(
                 code="GRAPH_SYNC_RECOVERY_CHECKPOINT_FAILED",
                 reason="graph checkpoint failed; recovery was reversed",
             ) from error
-        from .writer_lease import mark_active_mutation_committed
-
-        mark_active_mutation_committed()
+        if direct_catalog_target is not None:
+            try:
+                catalog_publication.publish_markdown_batch(direct_catalog_target)
+            except catalog_publication.CatalogPublicationError as error:
+                raise RecoverError(
+                    code="GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN",
+                    reason=str(error),
+                ) from error
+            catalog_published = True
 
     warnings: list[str] = []
     if sidecar_guard.leaf_policy == "content":
@@ -626,25 +757,15 @@ def recover_from_trash(
             "content remains tombstoned until reconcile"
         )
 
-    today = today or dt.date.today()
-    date_iso = today.isoformat()
-    kind = "directory" if restore_abs.is_dir() else "file"
-    restore_no_ext = (
-        restore_rel.removesuffix(".md") if restore_rel.endswith(".md") else restore_rel
-    )
-    log_body = (
-        f"Recovered {trash_rel!r} → {restore_rel!r} via exomem Tier 2. "
-        f"kind={kind}."
-    )
-    if curated and allow_curated:
-        log_body += f" allow_curated=true (target tree: {curated})."
-    log_warning = write_log_entry(
-        vault_root,
-        date_iso=date_iso,
-        op="recover_from_trash",
-        rel_path_no_ext=restore_no_ext,
-        body=log_body,
-    )
+    log_warning = log_plan.warning
+    if not catalog_published:
+        log_warning = write_log_entry(
+            vault_root,
+            date_iso=date_iso,
+            op="recover_from_trash",
+            rel_path_no_ext=restore_no_ext,
+            body=log_body,
+        )
     if log_warning:
         warnings.append(log_warning)
 
@@ -661,7 +782,7 @@ def recover_from_trash(
     return RecoverResult(
         trash_path=trash_rel,
         restored_path=restore_rel,
-        kind=kind,
+        kind=trash_kind,
         warnings=warnings,
         semantic=semantic,
         index=index_feedback,

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -1128,6 +1128,9 @@ class RecoveryPreflight:
     destination_root_guard: vault.PathGuard
     trash_census_guards: tuple[vault.DirectoryCensusGuard, ...] = ()
     recovery_sidecar_guard: vault.PathGuard | None = None
+    catalog_auxiliary_writes: tuple[vault.PlannedWrite, ...] = ()
+    catalog_content_paths: tuple[str, ...] = ()
+    catalog_publication_now: int | None = None
     mutated: Literal[False] = False
 
     @property
@@ -1142,6 +1145,7 @@ class RecoveryPreflight:
 class RecoveryCommit:
     preflight: RecoveryPreflight
     lifecycle_states: tuple[tuple[str, str], ...]
+    catalog_published: bool = False
     mutated: Literal[True] = True
 
     def as_dict(self) -> dict[str, Any]:
@@ -2944,6 +2948,9 @@ def preflight_recovery(
     destination_root_guard: vault.PathGuard | None = None,
     trash_census_guards: tuple[vault.DirectoryCensusGuard, ...] = (),
     recovery_sidecar_guard: vault.PathGuard | None = None,
+    catalog_auxiliary_writes: tuple[vault.PlannedWrite, ...] = (),
+    catalog_content_paths: tuple[str, ...] = (),
+    catalog_publication_now: int | None = None,
     relation_reviews: Mapping[str, Mapping[str, str]] | None = None,
 ) -> RecoveryPreflight:
     """Evaluate exact trashed Markdown bytes at all final restore paths."""
@@ -3195,6 +3202,9 @@ def preflight_recovery(
         root_destination,
         tuple(trash_census_guards),
         recovery_sidecar_guard,
+        tuple(catalog_auxiliary_writes),
+        tuple(catalog_content_paths),
+        catalog_publication_now,
     )
     preflight.as_dict()
     return preflight
@@ -3323,6 +3333,32 @@ def commit_recovery(
                 census_guard.recheck(root)
             if preflight.recovery_sidecar_guard is not None:
                 preflight.recovery_sidecar_guard.recheck(root)
+            from .governance import catalog_publication
+
+            catalog_writes = [*lifecycle_writes, *preflight.catalog_auxiliary_writes]
+            catalog_writes.extend(
+                vault.PlannedWrite(
+                    root / item.restore_path,
+                    item.source,
+                    create_only=True,
+                    guard=destination_guard,
+                )
+                for item, destination_guard in zip(
+                    preflight.entries, destination_guards, strict=True
+                )
+            )
+            try:
+                catalog_target = catalog_publication.prepare_catalog_membership_batch(
+                    root,
+                    writes=tuple(catalog_writes),
+                    content_paths=preflight.catalog_content_paths,
+                    now=preflight.catalog_publication_now,
+                )
+            except catalog_publication.CatalogPublicationError as error:
+                raise SemanticWriteError(
+                    "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
+                    str(error),
+                ) from error
             if lifecycle_writes:
                 vault.batch_atomic_write(
                     lifecycle_writes,
@@ -3333,6 +3369,23 @@ def commit_recovery(
             for destination_guard in destination_guards:
                 destination_guard.recheck(root)
             mutate()
+            if catalog_target is not None:
+                if preflight.catalog_auxiliary_writes:
+                    vault.batch_atomic_write(
+                        preflight.catalog_auxiliary_writes,
+                        vault_root=root,
+                    )
+            from .writer_lease import mark_active_mutation_committed
+
+            mark_active_mutation_committed()
+            if catalog_target is not None:
+                try:
+                    catalog_publication.publish_markdown_batch(catalog_target)
+                except catalog_publication.CatalogPublicationError as error:
+                    raise SemanticWriteError(
+                        "GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN",
+                        str(error),
+                    ) from error
     except vault.VaultLockTimeout as error:
         raise SemanticWriteError(
             "SEMANTIC_CREATION_LOCK_TIMEOUT",
@@ -3340,7 +3393,11 @@ def commit_recovery(
         ) from error
     except vault.VaultLockError as error:
         raise SemanticWriteError(error.code, error.reason) from error
-    return RecoveryCommit(preflight, lifecycle_states)
+    return RecoveryCommit(
+        preflight,
+        lifecycle_states,
+        catalog_published=catalog_target is not None,
+    )
 
 
 def _evaluate_structural(

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -34,6 +34,9 @@ from exomem import (
     move_file as move_file_module,
 )
 from exomem import (
+    recover_from_trash as recover_module,
+)
+from exomem import (
     vault as vault_module,
 )
 from exomem.governance import (
@@ -457,6 +460,36 @@ def _migrate_with_projection_items(
         )
     finally:
         connection.close()
+
+
+def _load_active_projection_items(
+    vault: Path,
+    *,
+    activation_epoch: int,
+    activation_state_digest: str,
+) -> tuple[
+    schema_v4.VerifiedActiveGovernanceState,
+    projection_store.VariantStoreManifest,
+    tuple[projection_store.ProjectionItemVariants, ...],
+]:
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        active = schema_v4.load_active_policy(
+            connection,
+            expected_logical_vault_id=LOGICAL_VAULT_ID,
+            expected_activation_store_id=ACTIVATION_STORE_ID,
+            expected_activation_epoch=activation_epoch,
+            expected_activation_state_digest=activation_state_digest,
+        )
+    finally:
+        connection.close()
+    evidence = projection_store.namespace_evidence_from_snapshot(active)
+    manifest, items = projection_store.load_projection_catalog(
+        vault,
+        key=evidence.manifest.namespace_key,
+        expected_rows_digest=evidence.manifest.rows_digest,
+    )
+    return active, manifest, items
 
 
 def test_govern_memory_v4_proposal_persists_exact_authority_binding(
@@ -2693,6 +2726,313 @@ def test_v4_directory_trash_refuses_tree_drift_before_catalog_preparation(
     assert (vault / added_relative).read_text(encoding="utf-8") == "added concurrently\n"
     custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
     assert custody.control.activation_epoch == 1
+
+
+def test_v4_file_recovery_inserts_row_and_publishes_log_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    relative = "Knowledge Base/Notes/private.md"
+    log_relative = "Knowledge Base/log.md"
+    source = "---\ntitle: Private\nstatus: draft\n---\n\nPrivate.\n"
+    log_before = "# Log\n\n---\n"
+    for path, content in ((relative, source), (log_relative, log_before)):
+        target = vault / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((relative, source), (log_relative, log_before)),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    trashed = delete_file_module.delete_file(
+        vault,
+        path=relative,
+        confirm=True,
+        today=dt.date(2026, 8, 25),
+        now=dt.datetime.fromtimestamp(now),
+    )
+
+    recovered = recover_module.recover_from_trash(
+        vault,
+        trash_path=trashed.trash_path,
+        today=dt.date(2026, 8, 25),
+    )
+
+    assert recovered.restored_path == relative
+    assert (vault / relative).read_text(encoding="utf-8") == source
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 3
+    active, manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=3,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    expected = {
+        path: vault_module.content_hash((vault / path).read_text(encoding="utf-8"))
+        for path in (relative, log_relative)
+    }
+    assert active.active.catalog_generation == 3
+    assert manifest.item_count == 2
+    assert {item.item_identity: item.content_hash for item in items} == expected
+
+
+def test_v4_directory_recovery_inserts_every_row_in_one_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    directory = "Knowledge Base/Notes/private-tree"
+    first_relative = f"{directory}/first.md"
+    second_relative = f"{directory}/nested/second.md"
+    log_relative = "Knowledge Base/log.md"
+    first = "---\ntitle: First\nstatus: draft\n---\n\nFirst.\n"
+    second = "---\ntitle: Second\nstatus: draft\n---\n\nSecond.\n"
+    log_before = "# Log\n\n---\n"
+    for path, content in (
+        (first_relative, first),
+        (second_relative, second),
+        (log_relative, log_before),
+    ):
+        target = vault / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=(
+            (first_relative, first),
+            (second_relative, second),
+            (log_relative, log_before),
+        ),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    trashed = delete_directory_module.delete_directory(
+        vault,
+        path=directory,
+        confirm=True,
+        recursive=True,
+        today=dt.date(2026, 8, 25),
+        now=dt.datetime.fromtimestamp(now),
+    )
+
+    recovered = recover_module.recover_from_trash(
+        vault,
+        trash_path=trashed.trash_path,
+        today=dt.date(2026, 8, 25),
+    )
+
+    assert recovered.restored_path == directory
+    assert (vault / first_relative).read_text(encoding="utf-8") == first
+    assert (vault / second_relative).read_text(encoding="utf-8") == second
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 3
+    active, manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=3,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    expected = {
+        path: vault_module.content_hash((vault / path).read_text(encoding="utf-8"))
+        for path in (first_relative, second_relative, log_relative)
+    }
+    assert active.active.catalog_generation == 3
+    assert manifest.item_count == 3
+    assert {item.item_identity: item.content_hash for item in items} == expected
+
+
+def test_v4_recovery_refuses_non_markdown_before_moving_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    original = "Knowledge Base/Notes/private.bin"
+    trash_relative = "Knowledge Base/_trash/2026-08-25/120000-private.bin"
+    trash = vault / trash_relative
+    trash.parent.mkdir(parents=True, exist_ok=True)
+    trash.write_bytes(b"private bytes")
+    trash.with_name(f"{trash.name}.meta.json").write_text(
+        json.dumps({"original_path": original}),
+        encoding="utf-8",
+    )
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    with pytest.raises(recover_module.RecoverError) as blocked:
+        recover_module.recover_from_trash(
+            vault,
+            trash_path=trash_relative,
+            today=dt.date(2026, 8, 25),
+        )
+
+    assert blocked.value.code == "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED"
+    assert blocked.value.reason == "non-Markdown content publication is not available"
+    assert trash.read_bytes() == b"private bytes"
+    assert not (vault / original).exists()
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 1
+
+
+def test_v4_recovery_does_not_inverse_rename_after_publication_uncertainty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    relative = "Knowledge Base/Notes/private.md"
+    log_relative = "Knowledge Base/log.md"
+    source = "---\ntitle: Private\nstatus: draft\n---\n\nPrivate.\n"
+    log_before = "# Log\n\n---\n"
+    for path, content in ((relative, source), (log_relative, log_before)):
+        target = vault / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((relative, source), (log_relative, log_before)),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    trashed = delete_file_module.delete_file(
+        vault,
+        path=relative,
+        confirm=True,
+        today=dt.date(2026, 8, 25),
+        now=dt.datetime.fromtimestamp(now),
+    )
+
+    def lose_publication_terminal(_prepared) -> None:
+        raise catalog_publication.CatalogPublicationError("lost terminal")
+
+    monkeypatch.setattr(
+        catalog_publication,
+        "publish_markdown_batch",
+        lose_publication_terminal,
+    )
+
+    with pytest.raises(recover_module.RecoverError) as uncertain:
+        recover_module.recover_from_trash(
+            vault,
+            trash_path=trashed.trash_path,
+            today=dt.date(2026, 8, 25),
+        )
+
+    assert uncertain.value.code == "GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN"
+    assert (vault / relative).read_text(encoding="utf-8") == source
+    assert not (vault / trashed.trash_path).exists()
+
+
+def test_v4_directory_recovery_refuses_tree_drift_before_rename(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    directory = "Knowledge Base/Notes/private-tree"
+    relative = f"{directory}/private.md"
+    log_relative = "Knowledge Base/log.md"
+    source = "---\ntitle: Private\nstatus: draft\n---\n\nPrivate.\n"
+    log_before = "# Log\n\n---\n"
+    for path, content in ((relative, source), (log_relative, log_before)):
+        target = vault / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((relative, source), (log_relative, log_before)),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    trashed = delete_directory_module.delete_directory(
+        vault,
+        path=directory,
+        confirm=True,
+        recursive=True,
+        today=dt.date(2026, 8, 25),
+        now=dt.datetime.fromtimestamp(now),
+    )
+    real_begin = graph_sync.begin_recovery_transition
+    added = vault / trashed.trash_path / "added.md"
+
+    def drift_then_begin(*args, **kwargs):
+        added.write_text("added concurrently\n", encoding="utf-8")
+        return real_begin(*args, **kwargs)
+
+    monkeypatch.setattr(graph_sync, "begin_recovery_transition", drift_then_begin)
+
+    with pytest.raises(recover_module.RecoverError) as blocked:
+        recover_module.recover_from_trash(
+            vault,
+            trash_path=trashed.trash_path,
+            today=dt.date(2026, 8, 25),
+        )
+
+    assert blocked.value.code == "PATH_GUARD_CHANGED"
+    assert not (vault / directory).exists()
+    assert (vault / trashed.trash_path / "private.md").read_text(encoding="utf-8") == source
+    assert added.read_text(encoding="utf-8") == "added concurrently\n"
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 2
 
 
 def test_v4_move_replaces_membership_and_publishes_auxiliaries_once(


### PR DESCRIPTION
## Summary

- publish restored Markdown files, lifecycle auxiliaries, and the deterministic recovery log in one exact-v4 catalog successor
- refuse unsupported non-Markdown recovery before lifecycle state or canonical placement changes
- bind directory recovery to the complete held snapshot and keep restored bytes in place when catalog publication reaches an uncertain terminal
- preserve open/schema-v3 recovery behavior

## Verification

- `63 passed` — `tests/test_governance_active_tuple.py`
- `32 passed, 105 deselected` — recovery slice of `tests/test_semantic_lifecycle_writers.py`
- `59 passed` — graph lifecycle, recovery declines, media recovery, and trash exclusion
- Ruff on all changed Python files
- `git diff --check`
- `openspec validate harden-governance-for-consolidation --strict`
- `uv run python scripts/validate-public-artifacts.py --repository`
- `uv lock --check`
- `uv build`

No personal or POLLY vault was read or modified.