### PR TITLE
fix(governance): publish companion backfill catalog

### DIFF
--- a/src/exomem/governance/catalog_publication.py
+++ b/src/exomem/governance/catalog_publication.py
@@ -58,9 +58,103 @@ class PreparedMarkdownCatalogPublication:
     expected_control: authorization_custody.AuthorizationControlRecord
     target_key: projections.ProjectionNamespaceKey
     target_items: tuple[projection_store.ProjectionItemVariants, ...]
+    target_manifest: projection_store.VariantStoreManifest
+    expected_catalog_descriptor: bytes
     catalog_descriptor: bytes
+    catalog_seed: schema_v4.CatalogGenerationSeed
+    namespace_seed: schema_v4.ProjectionNamespaceSeed
+    target_publication: schema_v4.TuplePublicationResult
     activated_at: int
     mutation_count: int
+
+
+def _catalog_component_value(
+    active: schema_v4.VerifiedActiveGovernanceState,
+    *,
+    catalog_descriptor: bytes,
+) -> dict[str, object]:
+    return {
+        "status": "active",
+        "logical_vault_id": active.logical_vault_id,
+        "activation_store_id": active.activation_store_id,
+        "activation_epoch": active.activation_epoch,
+        "activation_state_digest": active.activation_state_digest,
+        "policy_generation_id": active.policy_generation_id,
+        "policy_fingerprint": active.policy_fingerprint,
+        "projector_schema_version": active.projector_schema_version,
+        "catalog_generation": active.catalog_generation,
+        "projection_namespace_id": active.projection_namespace_id,
+        "catalog_descriptor_sha256": hashlib.sha256(catalog_descriptor).hexdigest(),
+    }
+
+
+def catalog_component_values(
+    prepared: PreparedMarkdownCatalogPublication,
+) -> tuple[dict[str, object], dict[str, object]]:
+    """Return the exact journal values before and after one catalog publication."""
+
+    if not isinstance(prepared, PreparedMarkdownCatalogPublication):
+        raise CatalogPublicationError("catalog publication target is invalid")
+    expected = _catalog_component_value(
+        prepared.expected,
+        catalog_descriptor=prepared.expected_catalog_descriptor,
+    )
+    target = _catalog_component_value(
+        prepared.target_publication.active,
+        catalog_descriptor=prepared.catalog_descriptor,
+    )
+    return expected, target
+
+
+def current_catalog_component_value(
+    vault_root: Path,
+    *,
+    now: int | None = None,
+) -> dict[str, object]:
+    """Load one externally acknowledged active catalog value for recovery."""
+
+    root = Path(vault_root)
+    moment = int(time.time()) if now is None else now
+    connection: sqlite3.Connection | None = None
+    try:
+        custody = authorization_custody.load_authorization_custody(root, now=moment)
+        control = custody.control
+        if (
+            not control.governance_enrolled
+            or control.activation_store_id is None
+            or control.activation_epoch is None
+            or control.activation_state_digest is None
+        ):
+            raise CatalogPublicationError("exact governance enrollment is unavailable")
+        connection = store.open_authorization_session_connection(root)
+        snapshot = schema_v4.load_active_policy(
+            connection,
+            expected_logical_vault_id=control.logical_vault_id,
+            expected_activation_store_id=control.activation_store_id,
+            expected_activation_epoch=control.activation_epoch,
+            expected_activation_state_digest=control.activation_state_digest,
+        )
+        return _catalog_component_value(
+            snapshot.active,
+            catalog_descriptor=snapshot.catalog_descriptor,
+        )
+    except CatalogPublicationError:
+        raise
+    except (
+        authorization_custody.AuthorizationCustodyUnavailable,
+        schema_v4.SchemaV4Error,
+        store.UnsupportedGovernanceSchema,
+        OSError,
+        sqlite3.Error,
+        RuntimeError,
+        ValueError,
+    ):
+        raise CatalogPublicationError(
+            "the active catalog component cannot be verified"
+        ) from None
+    finally:
+        if connection is not None:
+            connection.close()
 
 
 def _custody_configured() -> bool:
@@ -417,6 +511,7 @@ def _prepare_markdown_batch(
     removals: tuple[CatalogRemoval, ...] = (),
     content_paths: tuple[str, ...] = (),
     now: int | None = None,
+    activated_at: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
     """Prepare one complete batch successor, or return ``None`` for v3/open.
 
@@ -457,16 +552,17 @@ def _prepare_markdown_batch(
             "the governance activation store cannot be opened safely"
         ) from None
 
-    activated_at = int(time.time()) if now is None else now
+    moment = int(time.time()) if now is None else now
+    publication_time = moment if activated_at is None else activated_at
     try:
         custody = authorization_custody.load_authorization_custody(
-            root, now=activated_at
+            root, now=moment
         )
         custody = _recover_catalog_acknowledgement(
             root,
             connection,
             custody=custody,
-            now=activated_at,
+            now=moment,
         )
         control = custody.control
         if (
@@ -592,7 +688,44 @@ def _prepare_markdown_batch(
         descriptor = projection_store.catalog_descriptor_bytes(
             target_key, target_items
         )
-    except projections.ProjectionError:
+        target_manifest = projection_store.preview_variant_store(
+            key=target_key,
+            items=target_items,
+        )
+        namespace_seed = schema_v4.ProjectionNamespaceSeed(
+            namespace_id=target_key.namespace_id,
+            evidence=projection_store.projection_namespace_evidence_bytes(
+                target_manifest
+            ),
+            ready_at=publication_time,
+        )
+        catalog_seed = schema_v4.CatalogGenerationSeed(
+            catalog_generation=target_key.catalog_generation,
+            descriptor=descriptor,
+            artifact_count=len(target_items),
+            created_at=publication_time,
+        )
+        connection = store.open_authorization_session_connection(root)
+        try:
+            target_publication = schema_v4.preview_catalog_generation(
+                connection,
+                expected=snapshot.active,
+                catalog=catalog_seed,
+                namespace=namespace_seed,
+                activated_at=publication_time,
+            )
+        finally:
+            connection.close()
+    except (
+        projection_store.ProjectionStoreError,
+        projections.ProjectionError,
+        schema_v4.SchemaV4Error,
+        store.UnsupportedGovernanceSchema,
+        OSError,
+        sqlite3.Error,
+        RuntimeError,
+        ValueError,
+    ):
         raise CatalogPublicationError(
             "the target governance catalog cannot be prepared"
         ) from None
@@ -602,8 +735,13 @@ def _prepare_markdown_batch(
         expected_control=control,
         target_key=target_key,
         target_items=target_items,
+        target_manifest=target_manifest,
+        expected_catalog_descriptor=snapshot.catalog_descriptor,
         catalog_descriptor=descriptor,
-        activated_at=activated_at,
+        catalog_seed=catalog_seed,
+        namespace_seed=namespace_seed,
+        target_publication=target_publication,
+        activated_at=publication_time,
         mutation_count=len(normalized) + len(normalized_removals),
     )
 
@@ -613,6 +751,7 @@ def prepare_markdown_batch(
     *,
     mutations: tuple[MarkdownCatalogMutation, ...],
     now: int | None = None,
+    activated_at: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
     """Prepare an explicit canonical Markdown mutation batch."""
 
@@ -627,6 +766,7 @@ def prepare_markdown_batch(
         planned_writes=None,
         removals=(),
         now=now,
+        activated_at=activated_at,
     )
 
 
@@ -679,6 +819,7 @@ def prepare_markdown_upsert(
     source: str,
     expected_before_hash: str | None,
     now: int | None = None,
+    activated_at: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
     """Compatibility wrapper for a one-item Markdown catalog batch."""
 
@@ -686,6 +827,7 @@ def prepare_markdown_upsert(
         vault_root,
         mutations=(MarkdownCatalogMutation(path, source, expected_before_hash),),
         now=now,
+        activated_at=activated_at,
     )
 
 
@@ -703,19 +845,10 @@ def publish_markdown_batch(
             key=prepared.target_key,
             items=prepared.target_items,
         )
-        namespace = schema_v4.ProjectionNamespaceSeed(
-            namespace_id=prepared.target_key.namespace_id,
-            evidence=projection_store.projection_namespace_evidence_bytes(
-                target_manifest
-            ),
-            ready_at=prepared.activated_at,
-        )
-        catalog = schema_v4.CatalogGenerationSeed(
-            catalog_generation=prepared.target_key.catalog_generation,
-            descriptor=prepared.catalog_descriptor,
-            artifact_count=len(prepared.target_items),
-            created_at=prepared.activated_at,
-        )
+        if target_manifest != prepared.target_manifest:
+            raise CatalogPublicationError(
+                "the staged governance catalog does not match its reviewed target"
+            )
         receipt_event_id = receipts.critical_event_id(
             {
                 "operation": "governance_catalog_markdown_batch",
@@ -735,11 +868,11 @@ def publish_markdown_batch(
         connection = store.open_authorization_session_connection(
             prepared.vault_root
         )
-        return schema_v4.publish_catalog_generation(
+        result = schema_v4.publish_catalog_generation(
             connection,
             expected=prepared.expected,
-            catalog=catalog,
-            namespace=namespace,
+            catalog=prepared.catalog_seed,
+            namespace=prepared.namespace_seed,
             receipt_event_id=receipt_event_id,
             activated_at=prepared.activated_at,
             acknowledge_registry=lambda target: (
@@ -751,6 +884,11 @@ def publish_markdown_batch(
                 )
             ),
         )
+        if result != prepared.target_publication:
+            raise CatalogPublicationError(
+                "the committed governance catalog does not match its reviewed target"
+            )
+        return result
     except (
         authorization_custody.AuthorizationCustodyUnavailable,
         projection_store.ProjectionStoreError,
@@ -774,24 +912,8 @@ def publish_markdown_batch(
                     now=prepared.activated_at,
                 )
                 target = schema_v4.load_active_tuple_pointer(connection)
-                if (
-                    target.logical_vault_id == prepared.expected.logical_vault_id
-                    and target.activation_store_id
-                    == prepared.expected.activation_store_id
-                    and target.activation_epoch
-                    == prepared.expected.activation_epoch + 1
-                    and target.policy_generation_id
-                    == prepared.expected.policy_generation_id
-                    and target.policy_fingerprint
-                    == prepared.expected.policy_fingerprint
-                    and target.projector_schema_version
-                    == prepared.expected.projector_schema_version
-                    and target.catalog_generation
-                    == prepared.target_key.catalog_generation
-                    and target.projection_namespace_id
-                    == prepared.target_key.namespace_id
-                ):
-                    return None
+                if target == prepared.target_publication.active:
+                    return prepared.target_publication
             except (
                 authorization_custody.AuthorizationCustodyUnavailable,
                 CatalogPublicationError,
@@ -823,6 +945,8 @@ __all__ = [
     "CatalogRemoval",
     "MarkdownCatalogMutation",
     "PreparedMarkdownCatalogPublication",
+    "catalog_component_values",
+    "current_catalog_component_value",
     "mutation_from_planned_write",
     "prepare_markdown_batch",
     "prepare_catalog_membership_batch",

--- a/src/exomem/governance/operations.py
+++ b/src/exomem/governance/operations.py
@@ -27,7 +27,7 @@ _RECOVERY_STRATEGIES: Mapping[str, RecoveryStrategy] = MappingProxyType(
             "composite_sidecar", frozenset({"grant", "purpose"})
         ),
         "composite_companion": RecoveryStrategy(
-            "composite_companion", frozenset({"companion", "proposal"})
+            "composite_companion", frozenset({"catalog", "companion", "proposal"})
         ),
         "compound_grant": RecoveryStrategy(
             "compound_grant", frozenset({"grant", "token"})

--- a/src/exomem/governance/projection_store.py
+++ b/src/exomem/governance/projection_store.py
@@ -986,6 +986,17 @@ def _connect(
         raise
 
 
+def preview_variant_store(
+    *,
+    key: projections.ProjectionNamespaceKey,
+    items: Iterable[ProjectionItemVariants],
+) -> VariantStoreManifest:
+    """Derive the exact immutable store manifest without publishing files."""
+
+    _material, expected = _materialize(key, items)
+    return expected
+
+
 def stage_variant_store(
     vault_root: Path,
     *,

--- a/src/exomem/governance/recovery.py
+++ b/src/exomem/governance/recovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import re
 import sqlite3
 import stat
@@ -15,8 +16,9 @@ from types import MappingProxyType
 from typing import Any
 
 from .. import reserved_paths
+from . import catalog_publication
 from . import policy as policy_module
-from . import receipts, store
+from . import receipts, schema_v4, store
 from .operations import RECOVERY_STRATEGY_KEYS, journal_variant, recovery_strategy
 from .transaction import (
     GovernanceError,
@@ -224,10 +226,16 @@ def _journal_snapshot(conn: sqlite3.Connection, event_id: str) -> dict[str, Any]
     row = conn.execute(
         "SELECT event_id, operation, prior_digest, prepared_digest, final_digest, "
         "required_child_intents, required_child_terminals, proposal_id, marker_required, "
-        "affected_ids, phase FROM governance_operation_journals WHERE event_id=?",
+        "affected_ids, phase, created_at FROM governance_operation_journals WHERE event_id=?",
         (event_id,),
     ).fetchone()
-    if row is None or any(not isinstance(row[index], str) for index in (0, 1, 2, 3, 4, 5, 6, 9, 10)):
+    if (
+        row is None
+        or any(not isinstance(row[index], str) for index in (0, 1, 2, 3, 4, 5, 6, 9, 10))
+        or isinstance(row[11], bool)
+        or not isinstance(row[11], (int, float))
+        or not math.isfinite(float(row[11]))
+    ):
         return None
     return {
         "event_id": row[0],
@@ -241,6 +249,7 @@ def _journal_snapshot(conn: sqlite3.Connection, event_id: str) -> dict[str, Any]
         "marker_required": bool(row[8]),
         "affected_ids": row[9],
         "phase": row[10],
+        "created_at": float(row[11]),
     }
 
 
@@ -312,6 +321,11 @@ def _actual_component_value(
     expected: Mapping[str, Any] | None = None,
     event_id: str | None = None,
 ) -> dict[str, Any]:
+    if kind == "catalog":
+        try:
+            return catalog_publication.current_catalog_component_value(vault_root)
+        except catalog_publication.CatalogPublicationError:
+            return {"status": "unsafe"}
     if kind == "companion":
         try:
             snapshot = reserved_paths.read_generic_bytes(vault_root, key)
@@ -813,7 +827,155 @@ def _recovery_matches_components(
     kinds = {
         row["component_kind"] for row in _phase_rows(conn, event_id, "prepared")
     }
+    if policy == "composite_companion":
+        version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+        required = {"companion", "proposal"}
+        if version >= schema_v4.SCHEMA_USER_VERSION:
+            required.add("catalog")
+        return kinds == required
     return bool(kinds) and kinds <= strategy.component_kinds
+
+
+def _phase_component(
+    conn: sqlite3.Connection,
+    event_id: str,
+    phase: str,
+    kind: str,
+) -> tuple[str, dict[str, Any]] | None:
+    matches = [
+        row
+        for row in _phase_rows(conn, event_id, phase)
+        if row["component_kind"] == kind
+    ]
+    if len(matches) != 1:
+        return None
+    row = matches[0]
+    try:
+        value = json.loads(row["value_json"])
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(value, dict):
+        return None
+    return row["component_key"], value
+
+
+def _recover_companion_catalog_publication(
+    vault_root: Path,
+    journal: Mapping[str, Any],
+    terminals: set[str],
+) -> bool | None:
+    """Finish the exact catalog successor after companion bytes committed."""
+
+    if journal.get("operation") != "commit_backfill_companion":
+        return None
+    required_terminals = _string_list(journal.get("required_child_terminals"))
+    if required_terminals is None:
+        return False
+    event_id = str(journal["event_id"])
+    conn = store.open_connection(vault_root)
+    try:
+        if int(conn.execute("PRAGMA user_version").fetchone()[0]) < 4:
+            return None
+        prior_catalog = _phase_component(conn, event_id, "prior", "catalog")
+        prior_companion = _phase_component(conn, event_id, "prior", "companion")
+        prepared_catalog = _phase_component(conn, event_id, "prepared", "catalog")
+        prepared_companion = _phase_component(
+            conn, event_id, "prepared", "companion"
+        )
+        prepared_proposal = _phase_component(conn, event_id, "prepared", "proposal")
+        if any(
+            component is None
+            for component in (
+                prior_catalog,
+                prior_companion,
+                prepared_catalog,
+                prepared_companion,
+                prepared_proposal,
+            )
+        ):
+            return False
+        assert prior_catalog is not None
+        assert prior_companion is not None
+        assert prepared_catalog is not None
+        assert prepared_companion is not None
+        assert prepared_proposal is not None
+        if (
+            _actual_component_value(
+                vault_root,
+                conn,
+                "catalog",
+                prior_catalog[0],
+                phase="prior",
+                expected=prior_catalog[1],
+                event_id=event_id,
+            )
+            != prior_catalog[1]
+            or _actual_component_value(
+                vault_root,
+                conn,
+                "companion",
+                prepared_companion[0],
+                phase="prepared",
+                expected=prepared_companion[1],
+                event_id=event_id,
+            )
+            != prepared_companion[1]
+            or _actual_component_value(
+                vault_root,
+                conn,
+                "proposal",
+                prepared_proposal[0],
+                phase="prepared",
+                expected=prepared_proposal[1],
+                event_id=event_id,
+            )
+            != prepared_proposal[1]
+        ):
+            return None
+        if set(required_terminals) & terminals:
+            return False
+    finally:
+        conn.close()
+
+    try:
+        snapshot = reserved_paths.read_generic_bytes(
+            vault_root, prepared_companion[0]
+        )
+        source = snapshot.data.decode("utf-8")
+        expected_before_hash = prior_companion[1].get("sha256")
+        if not isinstance(expected_before_hash, str):
+            return False
+        prepared = catalog_publication.prepare_markdown_upsert(
+            vault_root,
+            path=prepared_companion[0],
+            source=source,
+            expected_before_hash=expected_before_hash,
+            now=int(time.time()),
+            activated_at=int(float(journal["created_at"])),
+        )
+        if prepared is None:
+            return False
+        catalog_prior, catalog_target = catalog_publication.catalog_component_values(
+            prepared
+        )
+        if (
+            catalog_prior != prior_catalog[1]
+            or catalog_target != prepared_catalog[1]
+        ):
+            return False
+        catalog_publication.publish_markdown_batch(prepared)
+        return True
+    except (
+        UnicodeDecodeError,
+        catalog_publication.CatalogPublicationError,
+        reserved_paths.ReservedPathLeafError,
+        KeyError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ):
+        return False
 
 
 def _activate_event(
@@ -1166,6 +1328,14 @@ def reconcile_governance_operations(vault_root: Path) -> dict[str, Any]:
             blocked = True
             continue
         if journal["marker_required"] and not _validated_marker(vault_root, journal):
+            blocked = True
+            continue
+        catalog_recovery = _recover_companion_catalog_publication(
+            vault_root,
+            journal,
+            terminals,
+        )
+        if catalog_recovery is False:
             blocked = True
             continue
         conn = store.open_connection(vault_root)

--- a/src/exomem/governance/schema_v4.py
+++ b/src/exomem/governance/schema_v4.py
@@ -1646,6 +1646,124 @@ def publish_policy_generation(
     return _publication_result(connection, active)
 
 
+def preview_catalog_generation(
+    connection: sqlite3.Connection,
+    *,
+    expected: VerifiedActiveGovernanceState,
+    catalog: CatalogGenerationSeed,
+    namespace: ProjectionNamespaceSeed,
+    activated_at: int,
+) -> TuplePublicationResult:
+    """Derive the exact catalog successor without changing the active tuple."""
+
+    if not isinstance(expected, VerifiedActiveGovernanceState):
+        raise SchemaV4Error("expected active tuple is invalid")
+    if not isinstance(catalog, CatalogGenerationSeed):
+        raise SchemaV4Error("catalog generation is invalid")
+    catalog_generation = _integer(
+        catalog.catalog_generation,
+        "catalog.catalog_generation",
+    )
+    if catalog_generation != expected.catalog_generation + 1:
+        raise ActiveTupleStale("catalog generation is not the reviewed successor")
+    descriptor = _blob(catalog.descriptor, "catalog.descriptor", allow_empty=True)
+    artifact_count = _integer(
+        catalog.artifact_count,
+        "catalog.artifact_count",
+        minimum=0,
+    )
+    catalog_created_at = _integer(catalog.created_at, "catalog.created_at")
+    activated = _integer(activated_at, "activated_at")
+    if not isinstance(namespace, ProjectionNamespaceSeed):
+        raise SchemaV4Error("projection namespace is invalid")
+    namespace_id = _text(namespace.namespace_id, "namespace.namespace_id")
+    namespace_evidence = _blob(
+        namespace.evidence,
+        "namespace.evidence",
+        allow_empty=True,
+    )
+    namespace_ready_at = _integer(namespace.ready_at, "namespace.ready_at")
+    if namespace_ready_at > activated:
+        raise SchemaV4Error("projection namespace is not ready at activation")
+    try:
+        current = load_active_state(
+            connection,
+            expected_logical_vault_id=expected.logical_vault_id,
+            expected_activation_store_id=expected.activation_store_id,
+            expected_activation_epoch=expected.activation_epoch,
+            expected_activation_state_digest=expected.activation_state_digest,
+        )
+    except SchemaV4Error as exc:
+        raise ActiveTupleStale(
+            "active tuple no longer matches the reviewed predecessor"
+        ) from exc
+    if current != expected:
+        raise ActiveTupleStale(
+            "active tuple no longer matches the reviewed predecessor"
+        )
+    policy_row = connection.execute(
+        "SELECT immutable_row_digest FROM compiled_policy_generations "
+        "WHERE generation_id=? AND policy_fingerprint=? "
+        "AND projector_schema_version=?",
+        (
+            expected.policy_generation_id,
+            expected.policy_fingerprint,
+            expected.projector_schema_version,
+        ),
+    ).fetchone()
+    if policy_row is None:
+        raise SchemaV4Error("reviewed policy generation is unavailable")
+    policy_row_digest = _digest(policy_row[0], "policy.immutable_row_digest")
+    catalog_descriptor_digest = _framed_digest(
+        b"exomem.catalog-generation-descriptor.v1",
+        _ascii_integer(catalog_generation),
+        descriptor,
+        _ascii_integer(artifact_count),
+        _ascii_integer(catalog_created_at),
+    )
+    namespace_digest = _framed_digest(
+        b"exomem.authorization-projection-namespace.v1",
+        expected.policy_fingerprint.encode("ascii"),
+        _ascii_integer(expected.projector_schema_version),
+        _ascii_integer(catalog_generation),
+        namespace_id.encode(),
+        namespace_evidence,
+        _ascii_integer(namespace_ready_at),
+    )
+    target_epoch = _integer(
+        expected.activation_epoch + 1,
+        "target_activation_epoch",
+    )
+    target_digest = activation_state_digest(
+        logical_vault_id=expected.logical_vault_id,
+        activation_store_id=expected.activation_store_id,
+        activation_epoch=target_epoch,
+        policy_generation_id=expected.policy_generation_id,
+        policy_fingerprint=expected.policy_fingerprint,
+        policy_row_digest=policy_row_digest,
+        projector_schema_version=expected.projector_schema_version,
+        catalog_generation=catalog_generation,
+        catalog_descriptor_digest=catalog_descriptor_digest,
+        projection_namespace_identity=namespace_digest,
+    )
+    return TuplePublicationResult(
+        active=VerifiedActiveGovernanceState(
+            logical_vault_id=expected.logical_vault_id,
+            activation_store_id=expected.activation_store_id,
+            activation_epoch=target_epoch,
+            activation_state_digest=target_digest,
+            policy_generation_id=expected.policy_generation_id,
+            policy_fingerprint=expected.policy_fingerprint,
+            projector_schema_version=expected.projector_schema_version,
+            catalog_generation=catalog_generation,
+            projection_namespace_id=namespace_id,
+        ),
+        policy_row_digest=policy_row_digest,
+        catalog_descriptor_digest=catalog_descriptor_digest,
+        projection_namespace_digest=namespace_digest,
+    )
+
+
 def publish_catalog_generation(
     connection: sqlite3.Connection,
     *,
@@ -1690,72 +1808,19 @@ def publish_catalog_generation(
     namespace_ready_at = _integer(namespace.ready_at, "namespace.ready_at")
     if namespace_ready_at > activated:
         raise SchemaV4Error("projection namespace is not ready at activation")
-    catalog_descriptor_digest = _framed_digest(
-        b"exomem.catalog-generation-descriptor.v1",
-        _ascii_integer(catalog_generation),
-        descriptor,
-        _ascii_integer(artifact_count),
-        _ascii_integer(catalog_created_at),
-    )
-    namespace_digest = _framed_digest(
-        b"exomem.authorization-projection-namespace.v1",
-        expected.policy_fingerprint.encode("ascii"),
-        _ascii_integer(expected.projector_schema_version),
-        _ascii_integer(catalog_generation),
-        namespace_id.encode(),
-        namespace_evidence,
-        _ascii_integer(namespace_ready_at),
-    )
-
     connection.execute("BEGIN IMMEDIATE")
     try:
-        try:
-            current = load_active_state(
-                connection,
-                expected_logical_vault_id=expected.logical_vault_id,
-                expected_activation_store_id=expected.activation_store_id,
-                expected_activation_epoch=expected.activation_epoch,
-                expected_activation_state_digest=expected.activation_state_digest,
-            )
-        except SchemaV4Error as exc:
-            raise ActiveTupleStale(
-                "active tuple no longer matches the reviewed predecessor"
-            ) from exc
-        if current != expected:
-            raise ActiveTupleStale(
-                "active tuple no longer matches the reviewed predecessor"
-            )
-        policy_row = connection.execute(
-            "SELECT immutable_row_digest FROM compiled_policy_generations "
-            "WHERE generation_id=? AND policy_fingerprint=? "
-            "AND projector_schema_version=?",
-            (
-                expected.policy_generation_id,
-                expected.policy_fingerprint,
-                expected.projector_schema_version,
-            ),
-        ).fetchone()
-        if policy_row is None:
-            raise SchemaV4Error("reviewed policy generation is unavailable")
-        policy_row_digest = _digest(
-            policy_row[0], "policy.immutable_row_digest"
+        preview = preview_catalog_generation(
+            connection,
+            expected=expected,
+            catalog=catalog,
+            namespace=namespace,
+            activated_at=activated,
         )
-        target_epoch = _integer(
-            expected.activation_epoch + 1,
-            "target_activation_epoch",
-        )
-        target_digest = activation_state_digest(
-            logical_vault_id=expected.logical_vault_id,
-            activation_store_id=expected.activation_store_id,
-            activation_epoch=target_epoch,
-            policy_generation_id=expected.policy_generation_id,
-            policy_fingerprint=expected.policy_fingerprint,
-            policy_row_digest=policy_row_digest,
-            projector_schema_version=expected.projector_schema_version,
-            catalog_generation=catalog_generation,
-            catalog_descriptor_digest=catalog_descriptor_digest,
-            projection_namespace_identity=namespace_digest,
-        )
+        target_epoch = preview.active.activation_epoch
+        target_digest = preview.active.activation_state_digest
+        catalog_descriptor_digest = preview.catalog_descriptor_digest
+        namespace_digest = preview.projection_namespace_digest
         connection.execute(
             "INSERT INTO catalog_generation_descriptors "
             "(catalog_generation, descriptor, descriptor_digest, artifact_count, "

--- a/src/exomem/governance/store.py
+++ b/src/exomem/governance/store.py
@@ -482,16 +482,27 @@ def _migrate_v3(conn: sqlite3.Connection) -> None:
     )
 
 
-def require_authoring_schema(vault_root: Path) -> None:
+def require_authoring_schema(
+    vault_root: Path,
+    *,
+    supported_versions: tuple[int, ...] = (SCHEMA_USER_VERSION,),
+) -> None:
     """Refuse authoring on a schema this release cannot interpret."""
+    if (
+        type(supported_versions) is not tuple
+        or not supported_versions
+        or any(type(version) is not int or version < 1 for version in supported_versions)
+    ):
+        raise ValueError("supported authoring schema versions are invalid")
     conn = open_connection(vault_root)
     try:
         version = int(conn.execute("PRAGMA user_version").fetchone()[0])
     finally:
         conn.close()
-    if version != SCHEMA_USER_VERSION:
+    if version not in supported_versions:
         raise UnsupportedGovernanceSchema(
-            f"governance authoring requires schema v{SCHEMA_USER_VERSION}, found v{version}"
+            "governance authoring requires schema "
+            f"{','.join(f'v{item}' for item in supported_versions)}, found v{version}"
         )
 
 

--- a/src/exomem/governance/tool.py
+++ b/src/exomem/governance/tool.py
@@ -42,6 +42,7 @@ from . import (
     authorization_custody,
     authorization_session_authority,
     authorization_session_lifecycle,
+    catalog_publication,
     companion_backfill,
     decisions,
     membership,
@@ -4087,7 +4088,10 @@ def _backfill_payload(
 
 def _backfill_preview(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
     _require_owner(kwargs.get("principal"))
-    store.require_authoring_schema(vault_root)
+    store.require_authoring_schema(
+        vault_root,
+        supported_versions=(store.SCHEMA_USER_VERSION, schema_v4.SCHEMA_USER_VERSION),
+    )
     plan = _backfill_plan(vault_root, kwargs.get("companion_input"))
     payload = _backfill_payload(plan)
     proposal_id = uuid.uuid4().hex
@@ -4226,7 +4230,10 @@ def _backfill_commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
     reconciliation = reconcile_governance_operations(vault_root)
     if reconciliation["blocked"]:
         raise GovernanceError("GOVERNANCE_BLOCKED", "pending operation needs repair")
-    store.require_authoring_schema(vault_root)
+    store.require_authoring_schema(
+        vault_root,
+        supported_versions=(store.SCHEMA_USER_VERSION, schema_v4.SCHEMA_USER_VERSION),
+    )
     now = float(kwargs.get("now", time.time()))
     row = _backfill_proposal(vault_root, proposal_id)
     payload = _validated_backfill_payload(row, kwargs.get("companion_input"))
@@ -4242,6 +4249,24 @@ def _backfill_commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
         raise GovernanceError(
             "STALE_COMPANION_BACKFILL", "reviewed companion snapshots changed"
         )
+    try:
+        catalog_target = catalog_publication.prepare_markdown_upsert(
+            vault_root,
+            path=plan.companion_path,
+            source=plan.target_bytes.decode("utf-8"),
+            expected_before_hash=hashlib.sha256(plan.prior_bytes).hexdigest(),
+            now=int(now),
+        )
+        catalog_values = (
+            None
+            if catalog_target is None
+            else catalog_publication.catalog_component_values(catalog_target)
+        )
+    except (UnicodeDecodeError, catalog_publication.CatalogPublicationError) as error:
+        raise GovernanceError(
+            "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
+            str(error),
+        ) from error
 
     prior_attempt = int(row[5])
     attempt_no = prior_attempt + 1
@@ -4280,6 +4305,17 @@ def _backfill_commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
             _component("proposal", proposal_id, final_proposal, status="spent"),
         ],
     }
+    if catalog_values is not None:
+        catalog_prior, catalog_final = catalog_values
+        phases["prior"].append(
+            _component("catalog", "active", catalog_prior, status="prior")
+        )
+        phases["prepared"].append(
+            _component("catalog", "active", catalog_final, status="prepared")
+        )
+        phases["final"].append(
+            _component("catalog", "active", catalog_final, status="active")
+        )
     digests = {phase: _composite(phase, values) for phase, values in phases.items()}
     event_id = receipts.critical_event_id(
         {
@@ -4389,6 +4425,16 @@ def _backfill_commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
         ) from error
     if kwargs.get("crash_at") == "after_publish":
         raise GovernanceCrash("after_publish")
+    if catalog_target is not None:
+        try:
+            catalog_publication.publish_markdown_batch(catalog_target)
+        except catalog_publication.CatalogPublicationError as error:
+            raise GovernanceError(
+                "GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN",
+                str(error),
+            ) from error
+        if kwargs.get("crash_at") == "after_catalog":
+            raise GovernanceCrash("after_catalog")
     receipts.commit_event(vault_root, event_id, outcome="prepared")
     if kwargs.get("crash_at") == "after_terminal":
         raise GovernanceCrash("after_terminal")

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -492,6 +492,312 @@ def _load_active_projection_items(
     return active, manifest, items
 
 
+def _legacy_companion_backfill_input(
+    vault: Path,
+) -> tuple[str, str, str, dict[str, object]]:
+    artifact_path = "Knowledge Base/Notes/private.bin"
+    companion_path = f"{artifact_path}.md"
+    artifact = b"\x00private-bytes\xff"
+    companion = (
+        "---\n"
+        "title: Private binary\n"
+        "type: source\n"
+        "status: draft\n"
+        "---\n\n"
+        "# Private binary\n\n"
+        "Legacy companion.\n"
+    )
+    artifact_target = vault / artifact_path
+    artifact_target.parent.mkdir(parents=True, exist_ok=True)
+    artifact_target.write_bytes(artifact)
+    (vault / companion_path).write_text(companion, encoding="utf-8")
+    payload: dict[str, object] = {
+        "version": 1,
+        "artifact_class": "binary",
+        "artifact_path": artifact_path,
+        "expected_artifact_sha256": hashlib.sha256(artifact).hexdigest(),
+        "expected_artifact_size": len(artifact),
+        "expected_companion_path": companion_path,
+        "expected_companion_sha256": hashlib.sha256(companion.encode()).hexdigest(),
+        "semantics": {
+            "projects": ["private"],
+            "tags": ["confidential"],
+            "types": ["source"],
+            "classes": ["pii"],
+        },
+    }
+    return artifact_path, companion_path, companion, payload
+
+
+def _preview_companion_backfill(
+    vault: Path,
+    payload: dict[str, object],
+    *,
+    now: int,
+) -> dict[str, object]:
+    from exomem.governance.tool import op_govern_memory
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        return op_govern_memory(
+            vault,
+            operation="backfill_companion",
+            backfill_action="preview",
+            companion_input=payload,
+            principal=owner_principal(),
+            now=now,
+        )
+
+
+def _commit_companion_backfill(
+    vault: Path,
+    payload: dict[str, object],
+    *,
+    proposal_id: str,
+    now: int,
+    crash_at: str | None = None,
+) -> dict[str, object]:
+    from exomem.governance.tool import op_govern_memory
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        return op_govern_memory(
+            vault,
+            operation="backfill_companion",
+            backfill_action="commit",
+            proposal_id=proposal_id,
+            companion_input=payload,
+            principal=owner_principal(),
+            now=now,
+            crash_at=crash_at,
+        )
+
+
+def test_v4_companion_backfill_publishes_catalog_successor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _artifact_path, companion_path, _companion, payload = (
+        _legacy_companion_backfill_input(vault)
+    )
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((companion_path, (vault / companion_path).read_text(encoding="utf-8")),),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    preview = _preview_companion_backfill(vault, payload, now=now + 1)
+
+    committed = _commit_companion_backfill(
+        vault,
+        payload,
+        proposal_id=str(preview["proposal_id"]),
+        now=now + 2,
+    )
+
+    assert committed["status"] == "committed"
+    companion_after = (vault / companion_path).read_text(encoding="utf-8")
+    assert "governance_companion:" in companion_after
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 3)
+    assert custody.control.activation_epoch == 2
+    active, manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=2,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    assert active.active.catalog_generation == 2
+    assert manifest.item_count == 1
+    assert {item.item_identity: item.content_hash for item in items} == {
+        companion_path: vault_module.content_hash(companion_after)
+    }
+    connection = store.open_connection(vault)
+    try:
+        component_kinds = {
+            str(row[0])
+            for row in connection.execute(
+                "SELECT component_kind FROM governance_operation_components "
+                "WHERE event_id=?",
+                (str(committed["event_id"]),),
+            ).fetchall()
+        }
+        catalog_target = connection.execute(
+            "SELECT value_json FROM governance_operation_components "
+            "WHERE event_id=? AND phase='final' AND component_kind='catalog'",
+            (str(committed["event_id"]),),
+        ).fetchone()
+    finally:
+        connection.close()
+    assert component_kinds == {"catalog", "companion", "proposal"}
+    assert catalog_target is not None
+    assert json.loads(str(catalog_target[0]))["activation_state_digest"] == (
+        custody.control.activation_state_digest
+    )
+
+
+@pytest.mark.parametrize("crash_at", ["after_catalog", "after_terminal"])
+def test_v4_companion_backfill_recovers_after_catalog_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    crash_at: str,
+) -> None:
+    from exomem.governance.recovery import reconcile_governance_operations
+    from exomem.governance.tool import GovernanceCrash
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _artifact_path, companion_path, _companion, payload = (
+        _legacy_companion_backfill_input(vault)
+    )
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((companion_path, (vault / companion_path).read_text(encoding="utf-8")),),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    preview = _preview_companion_backfill(vault, payload, now=now + 1)
+
+    with pytest.raises(GovernanceCrash, match=crash_at):
+        _commit_companion_backfill(
+            vault,
+            payload,
+            proposal_id=str(preview["proposal_id"]),
+            now=now + 2,
+            crash_at=crash_at,
+        )
+
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 3)
+    assert custody.control.activation_epoch == 2
+    recovered = reconcile_governance_operations(vault)
+    assert recovered["blocked"] is False
+    assert recovered["activated"] == 1
+    replayed = _commit_companion_backfill(
+        vault,
+        payload,
+        proposal_id=str(preview["proposal_id"]),
+        now=now + 4,
+    )
+    assert replayed["status"] == "committed"
+
+
+def test_v4_companion_backfill_recovers_catalog_after_companion_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.recovery import reconcile_governance_operations
+    from exomem.governance.tool import GovernanceCrash
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _artifact_path, companion_path, _companion, payload = (
+        _legacy_companion_backfill_input(vault)
+    )
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((companion_path, (vault / companion_path).read_text(encoding="utf-8")),),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    preview = _preview_companion_backfill(vault, payload, now=now + 1)
+
+    with pytest.raises(GovernanceCrash, match="after_publish"):
+        _commit_companion_backfill(
+            vault,
+            payload,
+            proposal_id=str(preview["proposal_id"]),
+            now=now + 2,
+            crash_at="after_publish",
+        )
+
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 3)
+    assert custody.control.activation_epoch == 1
+    assert "governance_companion:" in (vault / companion_path).read_text(encoding="utf-8")
+    recovered = reconcile_governance_operations(vault)
+    assert recovered["blocked"] is False
+    assert recovered["activated"] == 1
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 3)
+    assert custody.control.activation_epoch == 2
+    replayed = _commit_companion_backfill(
+        vault,
+        payload,
+        proposal_id=str(preview["proposal_id"]),
+        now=now + 4,
+    )
+    assert replayed["status"] == "committed"
+
+
+def test_v4_companion_backfill_publication_uncertainty_keeps_pending_journal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.recovery import reconcile_governance_operations
+    from exomem.governance.tool import GovernanceError
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _artifact_path, companion_path, _companion, payload = (
+        _legacy_companion_backfill_input(vault)
+    )
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((companion_path, (vault / companion_path).read_text(encoding="utf-8")),),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    preview = _preview_companion_backfill(vault, payload, now=now + 1)
+
+    def lose_catalog_terminal(_prepared) -> None:
+        raise catalog_publication.CatalogPublicationError("lost catalog terminal")
+
+    monkeypatch.setattr(
+        catalog_publication,
+        "publish_markdown_batch",
+        lose_catalog_terminal,
+    )
+    with pytest.raises(GovernanceError) as uncertain:
+        _commit_companion_backfill(
+            vault,
+            payload,
+            proposal_id=str(preview["proposal_id"]),
+            now=now + 2,
+        )
+
+    assert uncertain.value.code == "GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN"
+    assert "governance_companion:" in (vault / companion_path).read_text(encoding="utf-8")
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 3)
+    assert custody.control.activation_epoch == 1
+    recovered = reconcile_governance_operations(vault)
+    assert recovered["blocked"] is True
+    assert recovered["activated"] == 0
+
+
 def test_govern_memory_v4_proposal_persists_exact_authority_binding(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Why

Owner-reviewed companion backfill rewrites canonical Markdown. On exact-v4 vaults that rewrite must advance the active authorization-projection catalog, or the live tuple keeps serving the predecessor projection.

## What changed

- derive and journal the exact catalog successor, including its activation-state digest, before companion publication
- publish the companion replacement through the exact-v4 catalog CAS while preserving schema-v3 behavior
- recover forward from the crash window after companion bytes but before catalog activation
- preserve fail-closed pending state when the catalog outcome cannot be proven
- share pure catalog/variant preview helpers with the existing publication path so journal and committed bytes use identical digest material

## Verification

- 97 companion-backfill and active-tuple tests passed
- 38 focused recovery tests passed
- Ruff passed on all changed Python files
- strict OpenSpec validation passed
- lockfile check passed
- repository and built-artifact privacy validation passed
- package sdist and wheel build passed
