### PR TITLE
fix(governance): publish media sidecar catalog

### DIFF
--- a/src/exomem/governance/catalog_publication.py
+++ b/src/exomem/governance/catalog_publication.py
@@ -32,6 +32,15 @@ class CatalogPublicationError(RuntimeError):
     """A content change cannot safely advance the active v4 catalog."""
 
 
+class CatalogCommitError(CatalogPublicationError):
+    """A product write was blocked before bytes or became uncertain after them."""
+
+    def __init__(self, code: str, reason: str):
+        self.code = code
+        self.reason = reason
+        super().__init__(reason)
+
+
 @dataclass(frozen=True, slots=True)
 class MarkdownCatalogMutation:
     """One intended canonical Markdown successor and its exact predecessor."""
@@ -220,7 +229,8 @@ def mutation_from_planned_write(
         return None
 
     expected = write.expected_hash
-    if expected == vault.MISSING_CONTENT_HASH:
+    expected_missing = expected == vault.MISSING_CONTENT_HASH
+    if expected_missing:
         expected = None
     guard = write.guard
     if guard is not None:
@@ -239,7 +249,7 @@ def mutation_from_planned_write(
                 "catalog publication predecessor bindings disagree"
             )
         expected = guarded_expected
-    elif expected is None and not write.create_only:
+    elif expected is None and not write.create_only and not expected_missing:
         raise CatalogPublicationError(
             "catalog Markdown mutation lacks an exact predecessor binding"
         )
@@ -941,6 +951,7 @@ def publish_markdown_upsert(
 
 
 __all__ = [
+    "CatalogCommitError",
     "CatalogPublicationError",
     "CatalogRemoval",
     "MarkdownCatalogMutation",

--- a/src/exomem/media_processing.py
+++ b/src/exomem/media_processing.py
@@ -34,7 +34,6 @@ from .vault import (
     MISSING_CONTENT_HASH,
     VAULT_SCAN_SKIP_DIRS,
     PlannedWrite,
-    batch_atomic_write,
     content_hash,
     parse_frontmatter,
     post_commit_batch_fanout,
@@ -305,12 +304,18 @@ def reconcile_media(
     deferred_created: list[Path] = []
 
     def _write_sidecar(write: PlannedWrite) -> None:
-        written = batch_atomic_write(
-            [write],
-            vault_root=vault,
-            post_commit_fanout=commit_guard is None,
-        )
+        from .governance import catalog_publication
+
+        try:
+            written = _preserve_module().commit_media_sidecar_writes(
+                vault,
+                (write,),
+                post_commit_fanout=commit_guard is None,
+            )
+        except catalog_publication.CatalogCommitError as error:
+            raise MediaProcessingError(error.code, error.reason) from error
         if commit_guard is not None:
+            assert isinstance(written, list)
             deferred_fanout.extend(written)
             if write.create_only or write.expected_hash == MISSING_CONTENT_HASH:
                 deferred_created.extend(written)
@@ -1303,17 +1308,19 @@ def mark_processing_unavailable(
                         retryable=True,
                         next_action=next_action,
                     )
-                    written = batch_atomic_write(
-                        [
+                    written_result = preserve.commit_media_sidecar_writes(
+                        vault,
+                        (
                             PlannedWrite(
                                 path=job.sidecar_path,
                                 content=blocked,
                                 expected_hash=content_hash(content),
-                            )
-                        ],
-                        vault_root=vault,
+                            ),
+                        ),
                         post_commit_fanout=commit_guard is None,
                     )
+                    assert isinstance(written_result, list)
+                    written = written_result
                 store.mark(job.id, media_jobs.BLOCKED, reason)
                 changed += 1
         except Exception:  # noqa: BLE001 - one stale job must not abort startup

--- a/src/exomem/media_processing.py
+++ b/src/exomem/media_processing.py
@@ -34,6 +34,7 @@ from .vault import (
     MISSING_CONTENT_HASH,
     VAULT_SCAN_SKIP_DIRS,
     PlannedWrite,
+    batch_atomic_write,
     content_hash,
     parse_frontmatter,
     post_commit_batch_fanout,
@@ -311,6 +312,7 @@ def reconcile_media(
                 vault,
                 (write,),
                 post_commit_fanout=commit_guard is None,
+                batch_writer=batch_atomic_write,
             )
         except catalog_publication.CatalogCommitError as error:
             raise MediaProcessingError(error.code, error.reason) from error
@@ -1318,6 +1320,7 @@ def mark_processing_unavailable(
                             ),
                         ),
                         post_commit_fanout=commit_guard is None,
+                        batch_writer=batch_atomic_write,
                     )
                     assert isinstance(written_result, list)
                     written = written_result

--- a/src/exomem/preserve.py
+++ b/src/exomem/preserve.py
@@ -30,6 +30,7 @@ import logging
 import mimetypes
 import os
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import BinaryIO
@@ -854,6 +855,7 @@ def commit_media_sidecar_writes(
     *,
     post_commit_fanout: bool = True,
     defer_graph_completion: bool = False,
+    batch_writer: Callable[..., list[Path] | DeferredGraphCompletion] | None = None,
 ) -> list[Path] | DeferredGraphCompletion:
     """Publish machine-owned Markdown through the active catalog tuple."""
 
@@ -869,7 +871,8 @@ def commit_media_sidecar_writes(
             "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
             str(error),
         ) from error
-    written = batch_atomic_write(
+    writer = batch_atomic_write if batch_writer is None else batch_writer
+    written = writer(
         list(writes),
         vault_root=vault_root,
         post_commit_fanout=post_commit_fanout,

--- a/src/exomem/preserve.py
+++ b/src/exomem/preserve.py
@@ -37,10 +37,12 @@ from typing import BinaryIO
 from . import indexes, memory_refs, privacy_log, temporal
 from .kbdir import kb_prefix
 from .vault import (
+    MISSING_CONTENT_HASH,
     ContentHashMismatchError,
     DeferredGraphCompletion,
     PlannedWrite,
     batch_atomic_write,
+    content_hash,
     escape_wikilinks_for_log,
     kb_root,
     yaml_scalar,
@@ -709,7 +711,16 @@ def ensure_media_sidecar(
         extracted_by="none",  # not pending → the auto OCR scan ignores it; backfill OCRs it
         tree=tree,
     )
-    batch_atomic_write([PlannedWrite(path=sidecar, content=md)], vault_root=vault_root)
+    commit_media_sidecar_writes(
+        vault_root,
+        (
+            PlannedWrite(
+                path=sidecar,
+                content=md,
+                expected_hash=MISSING_CONTENT_HASH,
+            ),
+        ),
+    )
     return sidecar, True
 
 
@@ -761,7 +772,16 @@ def ensure_artifact_page(
         binary_size=size,
         tree=tree,
     )
-    batch_atomic_write([PlannedWrite(path=page, content=markdown)], vault_root=vault_root)
+    commit_media_sidecar_writes(
+        vault_root,
+        (
+            PlannedWrite(
+                path=page,
+                content=markdown,
+                expected_hash=MISSING_CONTENT_HASH,
+            ),
+        ),
+    )
     return page, True
 
 
@@ -790,8 +810,8 @@ def update_sidecar_extraction(
     structurally. Omitted (None/empty) leaves the frontmatter unchanged — every
     existing call site is unaffected.
     """
-    content = sidecar_path.read_text(encoding="utf-8")
-    content = _set_frontmatter_field(content, "extracted_by", engine)
+    before = sidecar_path.read_text(encoding="utf-8")
+    content = _set_frontmatter_field(before, "extracted_by", engine)
     content = _set_frontmatter_field(content, "processing_state", "completed")
     content = _set_frontmatter_field(content, "processing_error", "null")
     content = _set_frontmatter_field(content, "processing_retryable", "false")
@@ -814,12 +834,55 @@ def update_sidecar_extraction(
         if labels:
             content = _set_frontmatter_field(content, "speakers", f"[{', '.join(labels)}]")
     content = _set_extracted_text(content, _cap_extracted_text(text))
-    return batch_atomic_write(
-        [PlannedWrite(path=sidecar_path, content=content)],
-        vault_root=vault_root,
+    return commit_media_sidecar_writes(
+        vault_root,
+        (
+            PlannedWrite(
+                path=sidecar_path,
+                content=content,
+                expected_hash=content_hash(before),
+            ),
+        ),
         post_commit_fanout=not defer_index_fanout,
         defer_graph_completion=defer_graph_completion,
     )
+
+
+def commit_media_sidecar_writes(
+    vault_root: Path,
+    writes: tuple[PlannedWrite, ...],
+    *,
+    post_commit_fanout: bool = True,
+    defer_graph_completion: bool = False,
+) -> list[Path] | DeferredGraphCompletion:
+    """Publish machine-owned Markdown through the active catalog tuple."""
+
+    from .governance import catalog_publication
+
+    try:
+        prepared = catalog_publication.prepare_planned_markdown_batch(
+            vault_root,
+            writes=writes,
+        )
+    except catalog_publication.CatalogPublicationError as error:
+        raise catalog_publication.CatalogCommitError(
+            "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
+            str(error),
+        ) from error
+    written = batch_atomic_write(
+        list(writes),
+        vault_root=vault_root,
+        post_commit_fanout=post_commit_fanout,
+        defer_graph_completion=defer_graph_completion,
+    )
+    try:
+        catalog_publication.publish_markdown_batch(prepared)
+    except catalog_publication.CatalogPublicationError as error:
+        raise catalog_publication.CatalogCommitError(
+            "GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN",
+            str(error),
+        ) from error
+    return written
 
 
 def update_sidecar_processing_failure(
@@ -835,18 +898,24 @@ def update_sidecar_processing_failure(
     defer_graph_completion: bool = False,
 ) -> list[Path] | DeferredGraphCompletion:
     """Persist actionable worker state without replacing a pending transcript."""
-    content = sidecar_path.read_text(encoding="utf-8")
+    before = sidecar_path.read_text(encoding="utf-8")
     content = render_sidecar_processing_failure(
-        content,
+        before,
         state=state,
         attempts=attempts,
         error=error,
         retryable=retryable,
         next_action=next_action,
     )
-    return batch_atomic_write(
-        [PlannedWrite(path=sidecar_path, content=content)],
-        vault_root=vault_root,
+    return commit_media_sidecar_writes(
+        vault_root,
+        (
+            PlannedWrite(
+                path=sidecar_path,
+                content=content,
+                expected_hash=content_hash(before),
+            ),
+        ),
         post_commit_fanout=not defer_index_fanout,
         defer_graph_completion=defer_graph_completion,
     )
@@ -885,7 +954,8 @@ def update_sidecar_processing_pending(
     expected_hash: str | None = None,
 ) -> bool:
     """Keep changed-in-flight media automatic and actionable until reconciliation."""
-    content = sidecar_path.read_text(encoding="utf-8")
+    before = sidecar_path.read_text(encoding="utf-8")
+    content = before
     fields = (
         ("extracted_by", "pending"),
         ("processing_state", "pending"),
@@ -897,15 +967,15 @@ def update_sidecar_processing_pending(
     for field, value in fields:
         content = _set_frontmatter_field(content, field, value)
     try:
-        batch_atomic_write(
-            [
+        commit_media_sidecar_writes(
+            vault_root,
+            (
                 PlannedWrite(
                     path=sidecar_path,
                     content=content,
-                    expected_hash=expected_hash,
-                )
-            ],
-            vault_root=vault_root,
+                    expected_hash=expected_hash or content_hash(before),
+                ),
+            ),
         )
     except ContentHashMismatchError:
         return False

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -26,6 +26,9 @@ from exomem import (
 from exomem import (
     find_corpus,
     graph_sync,
+    media_jobs,
+    media_processing,
+    preserve,
     reserved_paths,
     semantic_writes,
     writer_lease,
@@ -490,6 +493,41 @@ def _load_active_projection_items(
         expected_rows_digest=evidence.manifest.rows_digest,
     )
     return active, manifest, items
+
+
+def _configure_media_v4(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    sidecar_source: str | None,
+    now: int,
+) -> tuple[Path, Path, schema_v4.MigrationResult]:
+    vault = tmp_path / "vault"
+    binary = vault / "Knowledge Base" / "Evidence" / "Audio" / "interview.m4a"
+    binary.parent.mkdir(parents=True, exist_ok=True)
+    binary.write_bytes(b"\x00\x00\x00\x18ftypM4A governed audio")
+    sidecar = binary.with_name(f"{binary.name}.md")
+    if sidecar_source is not None:
+        sidecar.write_text(sidecar_source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    if sidecar_source is None:
+        migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    else:
+        migration = _migrate_with_projection_item(
+            vault,
+            path=sidecar.relative_to(vault).as_posix(),
+            source=sidecar_source,
+            now=now,
+        )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    media_processing.set_media_runtime_available(vault)
+    return vault, sidecar, migration
 
 
 def _legacy_companion_backfill_input(
@@ -2927,6 +2965,7 @@ def test_v4_directory_trash_does_not_restore_tree_after_publication_uncertainty(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     now = int(time.time())
+    today = dt.datetime.fromtimestamp(now).date()
     monkeypatch.setenv(
         "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
     )
@@ -2968,13 +3007,13 @@ def test_v4_directory_trash_does_not_restore_tree_after_publication_uncertainty(
             path=directory,
             confirm=True,
             recursive=True,
-            today=dt.date(2026, 8, 25),
+            today=today,
             now=dt.datetime.fromtimestamp(now),
         )
 
     assert uncertain.value.code == "GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN"
     assert not (vault / directory).exists()
-    trash_day = vault / "Knowledge Base/_trash/2026-08-25"
+    trash_day = vault / f"Knowledge Base/_trash/{today.isoformat()}"
     assert any(path.is_dir() for path in trash_day.iterdir())
 
 
@@ -3683,6 +3722,294 @@ def test_v4_batch_refuses_existing_markdown_without_exact_predecessor_binding(
         )
 
     assert "exact predecessor" in str(blocked.value)
+
+
+def test_media_reconciliation_publishes_new_sidecar_in_next_v4_catalog(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    vault, sidecar, _migration = _configure_media_v4(
+        tmp_path,
+        monkeypatch,
+        sidecar_source=None,
+        now=now,
+    )
+
+    result = media_processing.reconcile_media(vault, sidecar.with_suffix(""))
+
+    assert result is not None
+    assert result.sidecar_path == sidecar
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 2
+    active, _manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=2,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    assert active.active.catalog_generation == 2
+    assert [(item.item_identity, item.content_hash) for item in items] == [
+        (
+            sidecar.relative_to(vault).as_posix(),
+            vault_module.content_hash(sidecar.read_text(encoding="utf-8")),
+        )
+    ]
+
+
+def test_media_extraction_update_publishes_exact_v4_catalog_successor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    pending = (
+        "---\ntitle: Interview\ntype: source\nstatus: draft\n"
+        "media_type: audio\nextracted_by: pending\n"
+        "processing_state: pending\n---\n\n## Extracted text\n\nPending.\n"
+    )
+    vault, sidecar, _migration = _configure_media_v4(
+        tmp_path,
+        monkeypatch,
+        sidecar_source=pending,
+        now=now,
+    )
+
+    preserve.update_sidecar_extraction(
+        vault,
+        sidecar,
+        text="Governed transcript.",
+        engine="test-engine",
+    )
+
+    after = sidecar.read_text(encoding="utf-8")
+    assert "Governed transcript." in after
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 2
+    active, _manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=2,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    assert active.active.catalog_generation == 2
+    assert [(item.item_identity, item.content_hash) for item in items] == [
+        (
+            sidecar.relative_to(vault).as_posix(),
+            vault_module.content_hash(after),
+        )
+    ]
+
+
+def test_media_reconciliation_refuses_model_bound_v4_before_sidecar_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    vault, sidecar, _migration = _configure_media_v4(
+        tmp_path,
+        monkeypatch,
+        sidecar_source=None,
+        now=now,
+    )
+    load_evidence = projection_store.namespace_evidence_from_snapshot
+
+    def model_bound(snapshot):
+        return dataclasses.replace(
+            load_evidence(snapshot),
+            required_measurement_roots=(object(),),
+        )
+
+    monkeypatch.setattr(
+        projection_store,
+        "namespace_evidence_from_snapshot",
+        model_bound,
+    )
+
+    with pytest.raises(media_processing.MediaProcessingError) as blocked:
+        media_processing.reconcile_media(vault, sidecar.with_suffix(""))
+
+    assert blocked.value.code == "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED"
+    assert not sidecar.exists()
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 1
+
+
+def test_media_catalog_uncertainty_keeps_committed_sidecar_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    pending = (
+        "---\ntitle: Interview\ntype: source\nstatus: draft\n"
+        "media_type: audio\nextracted_by: pending\n"
+        "processing_state: pending\n---\n\n## Extracted text\n\nPending.\n"
+    )
+    vault, sidecar, _migration = _configure_media_v4(
+        tmp_path,
+        monkeypatch,
+        sidecar_source=pending,
+        now=now,
+    )
+
+    def lose_publication_terminal(_prepared) -> None:
+        raise catalog_publication.CatalogPublicationError("lost terminal")
+
+    monkeypatch.setattr(
+        catalog_publication,
+        "publish_markdown_batch",
+        lose_publication_terminal,
+    )
+
+    with pytest.raises(catalog_publication.CatalogPublicationError, match="lost terminal"):
+        preserve.update_sidecar_extraction(
+            vault,
+            sidecar,
+            text="Committed before the terminal was lost.",
+            engine="test-engine",
+        )
+
+    assert "Committed before the terminal was lost." in sidecar.read_text(encoding="utf-8")
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 1
+
+
+def test_media_failure_and_pending_updates_each_publish_a_v4_successor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    pending = (
+        "---\ntitle: Interview\ntype: source\nstatus: draft\n"
+        "media_type: audio\nextracted_by: pending\n"
+        "processing_state: pending\n---\n\n## Extracted text\n\nPending.\n"
+    )
+    vault, sidecar, _migration = _configure_media_v4(
+        tmp_path,
+        monkeypatch,
+        sidecar_source=pending,
+        now=now,
+    )
+
+    preserve.update_sidecar_processing_failure(
+        vault,
+        sidecar,
+        state=media_jobs.BLOCKED,
+        attempts=1,
+        error="runtime unavailable",
+        retryable=True,
+        next_action="restore the runtime",
+    )
+    blocked = sidecar.read_text(encoding="utf-8")
+    first = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert first.control.activation_epoch == 2
+
+    assert preserve.update_sidecar_processing_pending(
+        vault,
+        sidecar,
+        attempts=2,
+        expected_hash=vault_module.content_hash(blocked),
+    )
+    after = sidecar.read_text(encoding="utf-8")
+    second = authorization_custody.load_authorization_custody(vault, now=now + 2)
+    assert second.control.activation_epoch == 3
+    active, _manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=3,
+        activation_state_digest=second.control.activation_state_digest or "",
+    )
+    assert active.active.catalog_generation == 3
+    assert items[0].content_hash == vault_module.content_hash(after)
+    assert "processing_attempts: 2" in after
+
+
+def test_mark_processing_unavailable_publishes_sidecar_before_job_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    pending = (
+        "---\ntitle: Interview\ntype: source\nstatus: draft\n"
+        "media_type: audio\nextracted_by: pending\n"
+        "processing_state: pending\n---\n\n## Extracted text\n\nPending.\n"
+    )
+    vault, sidecar, _migration = _configure_media_v4(
+        tmp_path,
+        monkeypatch,
+        sidecar_source=pending,
+        now=now,
+    )
+    binary = sidecar.with_suffix("")
+    store_instance = media_jobs.MediaJobStore(vault)
+    job_id = store_instance.enqueue(
+        media_jobs.MediaJob(
+            binary_path=binary,
+            sidecar_path=sidecar,
+            media_type="audio",
+        )
+    )
+
+    changed = media_processing.mark_processing_unavailable(
+        vault,
+        reason="runtime unavailable",
+        next_action="restore the runtime",
+    )
+
+    assert changed == 1
+    assert store_instance.get(job_id).state == media_jobs.BLOCKED
+    after = sidecar.read_text(encoding="utf-8")
+    assert "processing_state: blocked" in after
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 2
+    _active, _manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=2,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    assert items[0].content_hash == vault_module.content_hash(after)
+
+
+def test_existing_binary_backfill_pages_publish_v4_catalog_membership(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    vault, media_sidecar, _migration = _configure_media_v4(
+        tmp_path,
+        monkeypatch,
+        sidecar_source=None,
+        now=now,
+    )
+
+    created_media, media_created = preserve.ensure_media_sidecar(
+        vault,
+        media_sidecar.with_suffix(""),
+        today=dt.date(2026, 8, 25),
+    )
+
+    assert media_created and created_media == media_sidecar
+    first = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert first.control.activation_epoch == 2
+
+    artifact = vault / "Knowledge Base" / "Evidence" / "Files" / "sample.bin"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_bytes(b"existing artifact")
+    artifact_page, page_created = preserve.ensure_artifact_page(
+        vault,
+        artifact,
+        today=dt.date(2026, 8, 25),
+    )
+
+    assert page_created
+    second = authorization_custody.load_authorization_custody(vault, now=now + 2)
+    assert second.control.activation_epoch == 3
+    active, _manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=3,
+        activation_state_digest=second.control.activation_state_digest or "",
+    )
+    assert active.active.catalog_generation == 3
+    assert {item.item_identity for item in items} == {
+        media_sidecar.relative_to(vault).as_posix(),
+        artifact_page.relative_to(vault).as_posix(),
+    }
 
 
 def test_semantic_edit_publishes_auxiliary_markdown_in_the_same_v4_generation(


### PR DESCRIPTION
## Summary

- publish existing-binary media sidecar creation and worker transitions through the exact-v4 catalog tuple
- refuse model/graph-bound catalog mutations before canonical bytes and report post-byte publication uncertainty explicitly
- preserve the existing deferred graph/fanout and content-CAS boundaries for open/schema-v3 vaults
- make the directory-trash uncertainty fixture derive its expected day from the same clock

## Verification

- 8 exact-v4 media/catalog and boundary tests passed
- 149 media processing/worker tests passed
- 116 governance active-tuple/preserve/backfill tests passed after correcting the midnight fixture; the corrected fixture passes independently
- Ruff on touched files, git diff check, strict OpenSpec validation, uv lock check, public-artifact privacy, scaffold privacy, and uv build passed

This lane covers sidecar/page mutations for binaries that already exist. New binary publication and scene-frame bytes remain behind the measurement-aware catalog work; no real vault data is touched.