### PR TITLE
feat(governance): publish vector measurement successors

### DIFF
--- a/src/exomem/governance/catalog_publication.py
+++ b/src/exomem/governance/catalog_publication.py
@@ -20,6 +20,8 @@ from .. import find_corpus, reserved_paths, vault
 from . import (
     authorization_custody,
     membership,
+    projected_retrieval,
+    projection_measurement_store,
     projection_store,
     projections,
     receipts,
@@ -59,6 +61,15 @@ class CatalogRemoval:
 
 
 @dataclass(frozen=True, slots=True)
+class PreparedMeasurementPublication:
+    """One validated measurement family held until canonical bytes commit."""
+
+    family: projection_measurement_store.MeasurementFamilyKey
+    measurements: tuple[projection_measurement_store.ProjectionMeasurement, ...]
+    manifest: projection_measurement_store.MeasurementStoreManifest
+
+
+@dataclass(frozen=True, slots=True)
 class PreparedMarkdownCatalogPublication:
     """One complete lexical-only catalog successor awaiting canonical bytes."""
 
@@ -68,6 +79,8 @@ class PreparedMarkdownCatalogPublication:
     target_key: projections.ProjectionNamespaceKey
     target_items: tuple[projection_store.ProjectionItemVariants, ...]
     target_manifest: projection_store.VariantStoreManifest
+    target_namespace: projection_store.PreparedProjectionNamespace
+    target_measurements: tuple[PreparedMeasurementPublication, ...]
     expected_catalog_descriptor: bytes
     catalog_descriptor: bytes
     catalog_seed: schema_v4.CatalogGenerationSeed
@@ -75,6 +88,9 @@ class PreparedMarkdownCatalogPublication:
     target_publication: schema_v4.TuplePublicationResult
     activated_at: int
     mutation_count: int
+
+
+_VECTOR_EXTRACTOR_VERSION = "projected-text-v1"
 
 
 def _catalog_component_value(
@@ -513,6 +529,197 @@ def _validate_catalog_content_paths(content_paths: tuple[str, ...]) -> None:
         aliases.add(alias)
 
 
+def _variant_ids(
+    items: tuple[projection_store.ProjectionItemVariants, ...],
+) -> frozenset[str]:
+    return frozenset(
+        variant.projection_variant_id
+        for item in items
+        for variant in item.variants
+    )
+
+
+def _target_vector_measurements(
+    vault_root: Path,
+    *,
+    active_namespace: projection_store.VerifiedProjectionNamespace,
+    active_root: projection_store.ProjectionMeasurementRoot,
+    target_namespace: projection_store.PreparedProjectionNamespace,
+) -> PreparedMeasurementPublication:
+    """Carry content-addressed vectors forward and rebuild only new variants."""
+
+    from .. import embeddings
+
+    if (
+        active_root.lane != "vector"
+        or active_root.extractor_version != _VECTOR_EXTRACTOR_VERSION
+        or active_root.model_version != embeddings.MODEL_NAME
+    ):
+        raise CatalogPublicationError(
+            "content publication requires a supported vector measurement family"
+        )
+    active_family = projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=active_namespace.namespace_key,
+        lane=active_root.lane,
+        extractor_version=active_root.extractor_version,
+        model_version=active_root.model_version,
+    )
+    try:
+        _active_manifest, active_rows = (
+            projection_measurement_store.load_measurement_store(
+                vault_root,
+                namespace=active_namespace,
+                family=active_family,
+                expected_rows_digest=active_root.rows_digest,
+            )
+        )
+    except projection_measurement_store.MeasurementStoreError as error:
+        raise CatalogPublicationError(
+            "the active vector measurement family cannot be verified"
+        ) from error
+    active_ids = _variant_ids(active_namespace.items)
+    active_by_id: dict[str, projected_retrieval.ProjectionVectorMeasurement] = {}
+    for row in active_rows:
+        if not isinstance(row, projected_retrieval.ProjectionVectorMeasurement):
+            raise CatalogPublicationError(
+                "the active vector measurement family has an invalid row"
+            )
+        active_by_id[row.measurement_key.projection_variant_id] = row
+    if frozenset(active_by_id) != active_ids:
+        raise CatalogPublicationError(
+            "the active vector measurement family is incomplete"
+        )
+
+    target_family = projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=target_namespace.namespace_key,
+        lane=active_root.lane,
+        extractor_version=active_root.extractor_version,
+        model_version=active_root.model_version,
+    )
+    target_variants = tuple(
+        variant
+        for item in target_namespace.items
+        for variant in item.variants
+    )
+    missing = tuple(
+        variant
+        for variant in target_variants
+        if variant.projection_variant_id not in active_by_id
+    )
+    rebuilt: dict[str, tuple[float, ...]] = {}
+    if missing:
+        if os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
+            raise CatalogPublicationError(
+                "the target vector measurement model is hard-disabled"
+            )
+        try:
+            vectors = tuple(
+                embeddings.embed_texts(
+                    [
+                        projected_retrieval.projection_text(variant)
+                        for variant in missing
+                    ],
+                    is_query=False,
+                )
+            )
+            if len(vectors) != len(missing):
+                raise ValueError("vector count does not match target variants")
+            rebuilt = {
+                variant.projection_variant_id: tuple(
+                    float(component) for component in vector
+                )
+                for variant, vector in zip(missing, vectors, strict=True)
+            }
+        except Exception as error:
+            raise CatalogPublicationError(
+                "the target vector measurements cannot be rebuilt"
+            ) from error
+
+    target_rows = tuple(
+        projected_retrieval.ProjectionVectorMeasurement(
+            measurement_key=projections.MeasurementKey(
+                projection_variant_id=variant.projection_variant_id,
+                lane=target_family.lane,
+                extractor_version=target_family.extractor_version,
+                model_version=target_family.model_version,
+            ),
+            vector=(
+                active_by_id[variant.projection_variant_id].vector
+                if variant.projection_variant_id in active_by_id
+                else rebuilt[variant.projection_variant_id]
+            ),
+        )
+        for variant in target_variants
+    )
+    target_dimensions = {len(row.vector) for row in target_rows}
+    expected_dimension = (
+        active_root.vector_dimension
+        if active_root.vector_dimension is not None
+        else embeddings.VECTOR_DIM
+    )
+    if (
+        len(target_dimensions) > 1
+        or (
+            target_dimensions
+            and target_dimensions != {expected_dimension}
+        )
+    ):
+        raise CatalogPublicationError(
+            "the target vector measurement dimension changed"
+        )
+    try:
+        target_manifest = projection_measurement_store.preview_measurement_store(
+            namespace=target_namespace,
+            family=target_family,
+            measurements=target_rows,
+        )
+    except (
+        projection_measurement_store.MeasurementStoreError,
+        projections.ProjectionError,
+        OSError,
+        sqlite3.Error,
+        RuntimeError,
+        ValueError,
+    ) as error:
+        raise CatalogPublicationError(
+            "the target vector measurement family cannot be prepared"
+        ) from error
+    return PreparedMeasurementPublication(
+        family=target_family,
+        measurements=target_rows,
+        manifest=target_manifest,
+    )
+
+
+def _prepare_target_measurements(
+    vault_root: Path,
+    *,
+    active_namespace: projection_store.VerifiedProjectionNamespace,
+    active_roots: tuple[projection_store.ProjectionMeasurementRoot, ...],
+    target_namespace: projection_store.PreparedProjectionNamespace,
+) -> tuple[PreparedMeasurementPublication, ...]:
+    if not active_roots:
+        return ()
+    if (
+        len(active_roots) != 1
+        or not isinstance(
+            active_roots[0], projection_store.ProjectionMeasurementRoot
+        )
+        or active_roots[0].lane != "vector"
+    ):
+        raise CatalogPublicationError(
+            "content publication requires rebuilt model and graph measurements"
+        )
+    return (
+        _target_vector_measurements(
+            vault_root,
+            active_namespace=active_namespace,
+            active_root=active_roots[0],
+            target_namespace=target_namespace,
+        ),
+    )
+
+
 def _prepare_markdown_batch(
     vault_root: Path,
     *,
@@ -525,10 +732,10 @@ def _prepare_markdown_batch(
 ) -> PreparedMarkdownCatalogPublication | None:
     """Prepare one complete batch successor, or return ``None`` for v3/open.
 
-    The current slice intentionally supports lexical-only active namespaces.
-    Model and graph measurement roots are content-bound, so reusing them after
-    an edit would be unsafe; those deployments refuse before canonical bytes
-    change until their rebuild publisher is connected.
+    Lexical-only namespaces need no measurement work. The certified projected-
+    text vector family reuses content-addressed unchanged rows and rebuilds new
+    variants before canonical bytes change. CLIP, graph, and unknown families
+    remain blocked until their exact publication builders are connected.
     """
 
     root = Path(vault_root)
@@ -594,16 +801,12 @@ def _prepare_markdown_batch(
         )
         connection.commit()
         evidence = projection_store.namespace_evidence_from_snapshot(snapshot)
-        if evidence.required_measurement_roots:
-            raise CatalogPublicationError(
-                "content publication requires rebuilt model and graph measurements"
-            )
         manifest, active_items = projection_store.load_projection_catalog(
             root,
             key=evidence.manifest.namespace_key,
             expected_rows_digest=evidence.manifest.rows_digest,
         )
-        verified = projection_store.bind_active_projection_namespace(
+        active_namespace = projection_store.bind_active_projection_namespace(
             snapshot,
             manifest=manifest,
             items=active_items,
@@ -658,7 +861,7 @@ def _prepare_markdown_batch(
     if not normalized and not normalized_removals:
         return None
 
-    by_identity = {item.item_identity: item for item in verified.items}
+    by_identity = {item.item_identity: item for item in active_namespace.items}
     target_key = projections.ProjectionNamespaceKey(
         policy_fingerprint=snapshot.active.policy_fingerprint,
         projector_schema_version=snapshot.active.projector_schema_version,
@@ -702,10 +905,26 @@ def _prepare_markdown_batch(
             key=target_key,
             items=target_items,
         )
+        target_namespace = projection_store.prepare_projection_namespace(
+            key=target_key,
+            manifest=target_manifest,
+            items=target_items,
+        )
+        target_measurements = _prepare_target_measurements(
+            root,
+            active_namespace=active_namespace,
+            active_roots=evidence.required_measurement_roots,
+            target_namespace=target_namespace,
+        )
+        target_measurement_roots = tuple(
+            projection_measurement_store.measurement_root(target.manifest)
+            for target in target_measurements
+        )
         namespace_seed = schema_v4.ProjectionNamespaceSeed(
             namespace_id=target_key.namespace_id,
             evidence=projection_store.projection_namespace_evidence_bytes(
-                target_manifest
+                target_manifest,
+                required_measurement_roots=target_measurement_roots,
             ),
             ready_at=publication_time,
         )
@@ -746,6 +965,8 @@ def _prepare_markdown_batch(
         target_key=target_key,
         target_items=target_items,
         target_manifest=target_manifest,
+        target_namespace=target_namespace,
+        target_measurements=target_measurements,
         expected_catalog_descriptor=snapshot.catalog_descriptor,
         catalog_descriptor=descriptor,
         catalog_seed=catalog_seed,
@@ -859,6 +1080,23 @@ def publish_markdown_batch(
             raise CatalogPublicationError(
                 "the staged governance catalog does not match its reviewed target"
             )
+        target_measurement_roots: list[
+            projection_store.ProjectionMeasurementRoot
+        ] = []
+        for target_measurement in prepared.target_measurements:
+            staged_measurement = projection_measurement_store.stage_measurement_store(
+                prepared.vault_root,
+                namespace=prepared.target_namespace,
+                family=target_measurement.family,
+                measurements=target_measurement.measurements,
+            )
+            if staged_measurement != target_measurement.manifest:
+                raise CatalogPublicationError(
+                    "the staged governance measurements do not match their reviewed target"
+                )
+            target_measurement_roots.append(
+                projection_measurement_store.measurement_root(staged_measurement)
+            )
         receipt_event_id = receipts.critical_event_id(
             {
                 "operation": "governance_catalog_markdown_batch",
@@ -872,6 +1110,14 @@ def publish_markdown_batch(
                 ).hexdigest(),
                 "namespace_id": prepared.target_key.namespace_id,
                 "projection_rows_digest": target_manifest.rows_digest,
+                "measurement_roots": [
+                    {
+                        "lane": root.lane,
+                        "family_id": root.family_id,
+                        "rows_digest": root.rows_digest,
+                    }
+                    for root in target_measurement_roots
+                ],
                 "mutation_count": prepared.mutation_count,
             }
         )
@@ -901,6 +1147,7 @@ def publish_markdown_batch(
         return result
     except (
         authorization_custody.AuthorizationCustodyUnavailable,
+        projection_measurement_store.MeasurementStoreError,
         projection_store.ProjectionStoreError,
         schema_v4.SchemaV4Error,
         store.UnsupportedGovernanceSchema,

--- a/src/exomem/governance/projected_retrieval.py
+++ b/src/exomem/governance/projected_retrieval.py
@@ -323,11 +323,20 @@ class ProjectionCatalog:
 
     def __init__(
         self,
-        namespace: projection_store.VerifiedProjectionNamespace,
+        namespace: (
+            projection_store.VerifiedProjectionNamespace
+            | projection_store.PreparedProjectionNamespace
+        ),
     ) -> None:
-        if not isinstance(namespace, projection_store.VerifiedProjectionNamespace):
+        if not isinstance(
+            namespace,
+            (
+                projection_store.VerifiedProjectionNamespace,
+                projection_store.PreparedProjectionNamespace,
+            ),
+        ):
             raise ProjectedRetrievalUnavailable(
-                "projected retrieval requires a verified active namespace"
+                "projected retrieval requires a verified namespace"
             )
         self.namespace = namespace
         self.namespace_key = namespace.namespace_key
@@ -371,7 +380,13 @@ class ProjectionCatalog:
         return variants.get(descriptor)
 
 
-def _variant_text(variant: projections.ProjectionVariant) -> str:
+def projection_text(variant: projections.ProjectionVariant) -> str:
+    """Return the canonical text measured for one immutable projection row."""
+
+    if not isinstance(variant, projections.ProjectionVariant):
+        raise projections.ProjectionCanonicalizationError(
+            "projection text requires one immutable variant"
+        )
     return " ".join(
         variant.search_fields[key]
         for key in sorted(variant.search_fields, key=_sort_key)
@@ -392,7 +407,7 @@ def _projected_hit(
     variant: projections.ProjectionVariant,
     score: float,
 ) -> ProjectedLexicalHit:
-    compact = " ".join(_variant_text(variant).split())
+    compact = " ".join(projection_text(variant).split())
     return ProjectedLexicalHit(
         item_identity=variant.item_identity,
         projection_variant_id=variant.projection_variant_id,
@@ -422,7 +437,7 @@ class ProjectedLexicalIndex:
         postings: dict[str, set[str]] = {}
         for item in self._items.values():
             for variant in item.variants:
-                text = _variant_text(variant)
+                text = projection_text(variant)
                 tokens = tuple(bm25.tokenize(text))
                 document = _SelectedDocument(
                     variant,
@@ -929,7 +944,7 @@ class ProjectedReranker:
                 "rerank candidate is outside the selected projected corpus"
             )
         variants = tuple(selected_by_identity[identity] for identity in candidates)
-        passages = [_variant_text(variant) for variant in variants]
+        passages = [projection_text(variant) for variant in variants]
         try:
             raw_scores = scorer(query, passages)
             scores = tuple(raw_scores)  # type: ignore[arg-type]
@@ -975,4 +990,5 @@ __all__ = [
     "ProjectionVectorMeasurement",
     "ProjectionSelection",
     "clip_variant_applicable",
+    "projection_text",
 ]

--- a/src/exomem/governance/projection_measurement_store.py
+++ b/src/exomem/governance/projection_measurement_store.py
@@ -52,6 +52,10 @@ ProjectionMeasurement: TypeAlias = (
     | projected_retrieval.ProjectionClipMeasurement
     | projected_graph.ProjectionGraphMeasurement
 )
+ProjectionNamespace: TypeAlias = (
+    projection_store.VerifiedProjectionNamespace
+    | projection_store.PreparedProjectionNamespace
+)
 
 
 def _bounded_text(value: object, name: str, *, maximum: int) -> str:
@@ -208,11 +212,17 @@ def _measurement_key(measurement: ProjectionMeasurement) -> projections.Measurem
 
 
 def _validate_measurements(
-    namespace: projection_store.VerifiedProjectionNamespace,
+    namespace: ProjectionNamespace,
     family: MeasurementFamilyKey,
     measurements: Iterable[ProjectionMeasurement],
 ) -> tuple[ProjectionMeasurement, ...]:
-    if not isinstance(namespace, projection_store.VerifiedProjectionNamespace):
+    if not isinstance(
+        namespace,
+        (
+            projection_store.VerifiedProjectionNamespace,
+            projection_store.PreparedProjectionNamespace,
+        ),
+    ):
         raise MeasurementStoreMismatch("verified projection namespace is unavailable")
     if family.namespace_key != namespace.namespace_key:
         raise MeasurementStoreMismatch(
@@ -307,7 +317,7 @@ def _stored_row(measurement: ProjectionMeasurement) -> _StoredRow:
 
 
 def _materialize(
-    namespace: projection_store.VerifiedProjectionNamespace,
+    namespace: ProjectionNamespace,
     family: MeasurementFamilyKey,
     measurements: Iterable[ProjectionMeasurement],
 ) -> tuple[tuple[_StoredRow, ...], MeasurementStoreManifest]:
@@ -626,7 +636,7 @@ def _verified_measurements(
 def _verify_connection(
     connection: sqlite3.Connection,
     *,
-    namespace: projection_store.VerifiedProjectionNamespace,
+    namespace: ProjectionNamespace,
     family: MeasurementFamilyKey,
     expected_rows_digest: str,
 ) -> tuple[MeasurementStoreManifest, tuple[ProjectionMeasurement, ...]]:
@@ -688,7 +698,7 @@ def _connect(
 def stage_measurement_store(
     vault_root: Path,
     *,
-    namespace: projection_store.VerifiedProjectionNamespace,
+    namespace: ProjectionNamespace,
     family: MeasurementFamilyKey,
     measurements: Iterable[ProjectionMeasurement],
 ) -> MeasurementStoreManifest:
@@ -763,10 +773,22 @@ def stage_measurement_store(
                     connection.close()
 
 
+def preview_measurement_store(
+    *,
+    namespace: ProjectionNamespace,
+    family: MeasurementFamilyKey,
+    measurements: Iterable[ProjectionMeasurement],
+) -> MeasurementStoreManifest:
+    """Validate and commit to one measurement family without writing its store."""
+
+    _material, manifest = _materialize(namespace, family, measurements)
+    return manifest
+
+
 def verify_measurement_store(
     vault_root: Path,
     *,
-    namespace: projection_store.VerifiedProjectionNamespace,
+    namespace: ProjectionNamespace,
     family: MeasurementFamilyKey,
     expected_rows_digest: str,
 ) -> MeasurementStoreManifest:
@@ -784,7 +806,7 @@ def verify_measurement_store(
 def load_measurement_store(
     vault_root: Path,
     *,
-    namespace: projection_store.VerifiedProjectionNamespace,
+    namespace: ProjectionNamespace,
     family: MeasurementFamilyKey,
     expected_rows_digest: str,
 ) -> tuple[MeasurementStoreManifest, tuple[ProjectionMeasurement, ...]]:
@@ -934,6 +956,7 @@ __all__ = [
     "load_vector_index",
     "measurement_root",
     "measurement_store_path",
+    "preview_measurement_store",
     "stage_measurement_store",
     "verify_measurement_store",
 ]

--- a/src/exomem/governance/projection_store.py
+++ b/src/exomem/governance/projection_store.py
@@ -126,6 +126,7 @@ class VariantStoreManifest:
 
 
 _VERIFIED_NAMESPACE_PROOF = object()
+_PREPARED_NAMESPACE_PROOF = object()
 
 
 @dataclass(frozen=True, slots=True, init=False)
@@ -152,6 +153,31 @@ class VerifiedProjectionNamespace:
             )
         object.__setattr__(self, "namespace_key", namespace_key)
         object.__setattr__(self, "active_state_digest", active_state_digest)
+        object.__setattr__(self, "manifest", manifest)
+        object.__setattr__(self, "items", items)
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class PreparedProjectionNamespace:
+    """One complete immutable namespace prepared for a future tuple activation."""
+
+    namespace_key: projections.ProjectionNamespaceKey
+    manifest: VariantStoreManifest
+    items: tuple[ProjectionItemVariants, ...]
+
+    def __init__(
+        self,
+        namespace_key: projections.ProjectionNamespaceKey,
+        manifest: VariantStoreManifest,
+        items: tuple[ProjectionItemVariants, ...],
+        *,
+        _proof: object,
+    ) -> None:
+        if _proof is not _PREPARED_NAMESPACE_PROOF:
+            raise ProjectionStoreMismatch(
+                "prepared projection namespace requires verified target rows"
+            )
+        object.__setattr__(self, "namespace_key", namespace_key)
         object.__setattr__(self, "manifest", manifest)
         object.__setattr__(self, "items", items)
 
@@ -690,6 +716,36 @@ def bind_active_projection_namespace(
         manifest=manifest,
         items=canonical_items,
         _proof=_VERIFIED_NAMESPACE_PROOF,
+    )
+
+
+def prepare_projection_namespace(
+    *,
+    key: projections.ProjectionNamespaceKey,
+    manifest: VariantStoreManifest,
+    items: Iterable[ProjectionItemVariants],
+) -> PreparedProjectionNamespace:
+    """Verify one complete immutable namespace before its tuple activates."""
+
+    if not isinstance(key, projections.ProjectionNamespaceKey):
+        raise ProjectionStoreMismatch("prepared projection key is unavailable")
+    if not isinstance(manifest, VariantStoreManifest):
+        raise ProjectionStoreMismatch("prepared projection manifest is unavailable")
+    material, recomputed = _materialize(key, items)
+    canonical_items = tuple(entry.item for entry in material)
+    if (
+        manifest.namespace_key != key
+        or manifest.namespace_id != key.namespace_id
+        or recomputed != manifest
+    ):
+        raise ProjectionStoreMismatch(
+            "prepared projection namespace does not match its immutable rows"
+        )
+    return PreparedProjectionNamespace(
+        namespace_key=key,
+        manifest=manifest,
+        items=canonical_items,
+        _proof=_PREPARED_NAMESPACE_PROOF,
     )
 
 
@@ -1242,6 +1298,7 @@ def load_projection_variant(
 
 
 __all__ = [
+    "PreparedProjectionNamespace",
     "ProjectionItemVariants",
     "ProjectionMeasurementRoot",
     "ProjectionNamespaceEvidence",
@@ -1256,6 +1313,7 @@ __all__ = [
     "namespace_evidence_from_snapshot",
     "projection_measurement_family_id",
     "projection_namespace_evidence_bytes",
+    "prepare_projection_namespace",
     "manifest_from_namespace_evidence",
     "stage_variant_store",
     "variant_store_path",

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -24,6 +24,7 @@ from exomem import (
     delete_file as delete_file_module,
 )
 from exomem import (
+    embeddings,
     find_corpus,
     graph_sync,
     media_jobs,
@@ -47,6 +48,8 @@ from exomem.governance import (
     catalog_publication,
     membership,
     policy,
+    projected_retrieval,
+    projection_measurement_store,
     projection_store,
     projections,
     receipts,
@@ -463,6 +466,114 @@ def _migrate_with_projection_items(
         )
     finally:
         connection.close()
+
+
+def _migrate_with_vector_projection_items(
+    vault: Path,
+    *,
+    items: tuple[tuple[str, str], ...],
+    now: int,
+) -> tuple[
+    schema_v4.MigrationResult,
+    tuple[projected_retrieval.ProjectionVectorMeasurement, ...],
+]:
+    documents = _documents(ceiling=2)
+    compiled = _compiled(documents)
+    key = projections.ProjectionNamespaceKey(
+        policy_fingerprint=compiled.fingerprint,
+        projector_schema_version=1,
+        catalog_generation=1,
+    )
+    projected_items = tuple(
+        _projection_item(
+            vault=vault,
+            compiled=compiled,
+            path=path,
+            source=source,
+            catalog_generation=1,
+        )
+        for path, source in items
+    )
+    manifest = projection_store.stage_variant_store(
+        vault,
+        key=key,
+        items=projected_items,
+    )
+    namespace = projection_store.prepare_projection_namespace(
+        key=key,
+        manifest=manifest,
+        items=projected_items,
+    )
+    family = projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=key,
+        lane="vector",
+        extractor_version="projected-text-v1",
+        model_version=embeddings.MODEL_NAME,
+    )
+    measurements = tuple(
+        projected_retrieval.ProjectionVectorMeasurement(
+            measurement_key=projections.MeasurementKey(
+                projection_variant_id=variant.projection_variant_id,
+                lane="vector",
+                extractor_version=family.extractor_version,
+                model_version=family.model_version,
+            ),
+            vector=(float(index + 1), 1.0),
+        )
+        for index, variant in enumerate(
+            variant
+            for item in projected_items
+            for variant in item.variants
+        )
+    )
+    measurement_manifest = projection_measurement_store.stage_measurement_store(
+        vault,
+        namespace=namespace,
+        family=family,
+        measurements=measurements,
+    )
+    connection = store.open_connection(vault)
+    try:
+        migration = schema_v4.migrate_v3_connection(
+            connection,
+            schema_v4.MigrationSeed(
+                activation_store_id=ACTIVATION_STORE_ID,
+                logical_vault_id=LOGICAL_VAULT_ID,
+                activation_epoch=1,
+                policy=_policy_seed(
+                    generation_id=FIRST_GENERATION_ID,
+                    documents=documents,
+                    predecessor_generation_id=None,
+                    event_suffix="first",
+                    now=now,
+                ),
+                catalog=schema_v4.CatalogGenerationSeed(
+                    catalog_generation=1,
+                    descriptor=projection_store.catalog_descriptor_bytes(
+                        key,
+                        projected_items,
+                    ),
+                    artifact_count=len(projected_items),
+                    created_at=now,
+                ),
+                namespace=schema_v4.ProjectionNamespaceSeed(
+                    namespace_id=key.namespace_id,
+                    evidence=projection_store.projection_namespace_evidence_bytes(
+                        manifest,
+                        required_measurement_roots=(
+                            projection_measurement_store.measurement_root(
+                                measurement_manifest
+                            ),
+                        ),
+                    ),
+                    ready_at=now,
+                ),
+                migrated_at=now,
+            ),
+        )
+    finally:
+        connection.close()
+    return migration, measurements
 
 
 def _load_active_projection_items(
@@ -4107,6 +4218,294 @@ def test_semantic_edit_publishes_auxiliary_markdown_in_the_same_v4_generation(
             (auxiliary_relative, vault_module.content_hash(auxiliary_after)),
         )
     )
+
+
+def test_semantic_edit_rebuilds_only_changed_vectors_before_v4_activation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    vault = tmp_path / "vault"
+    changed_path = "Knowledge Base/Notes/changed.md"
+    stable_path = "Knowledge Base/Notes/stable.md"
+    changed_before = "---\ntitle: Changed\nstatus: draft\n---\n\nbefore\n"
+    changed_after = changed_before.replace("before", "after")
+    stable_source = "---\ntitle: Stable\nstatus: draft\n---\n\nstable\n"
+    for relative, source in (
+        (changed_path, changed_before),
+        (stable_path, stable_source),
+    ):
+        target = vault / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration, prior_measurements = _migrate_with_vector_projection_items(
+        vault,
+        items=((changed_path, changed_before), (stable_path, stable_source)),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    embedded: list[list[str]] = []
+
+    def embed_target(texts: list[str], *, is_query: bool = False):
+        assert is_query is False
+        embedded.append(list(texts))
+        return tuple((9.0, float(index + 1)) for index, _text in enumerate(texts))
+
+    monkeypatch.setattr(embeddings, "embed_texts", embed_target)
+    preflight = semantic_writes.preflight_existing(
+        vault,
+        path=changed_path,
+        after_source=changed_after,
+        operation="edit",
+        expected_before_hash=vault_module.content_hash(changed_before),
+    )
+
+    committed = semantic_writes.commit_existing(vault, preflight=preflight)
+
+    assert committed.mutated is True
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    active, manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=2,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    evidence = projection_store.namespace_evidence_from_snapshot(active)
+    assert tuple(root.lane for root in evidence.required_measurement_roots) == (
+        "vector",
+    )
+    namespace = projection_store.bind_active_projection_namespace(
+        active,
+        manifest=manifest,
+        items=items,
+    )
+    root = evidence.required_measurement_roots[0]
+    family = projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=namespace.namespace_key,
+        lane=root.lane,
+        extractor_version=root.extractor_version,
+        model_version=root.model_version,
+    )
+    _measurement_manifest, target_measurements = (
+        projection_measurement_store.load_measurement_store(
+            vault,
+            namespace=namespace,
+            family=family,
+            expected_rows_digest=root.rows_digest,
+        )
+    )
+    stable_variant_ids = {
+        variant.projection_variant_id
+        for item in items
+        if item.item_identity == stable_path
+        for variant in item.variants
+    }
+    prior_by_id = {
+        row.measurement_key.projection_variant_id: row.vector
+        for row in prior_measurements
+    }
+    target_by_id = {
+        row.measurement_key.projection_variant_id: row.vector
+        for row in target_measurements
+    }
+    assert embedded and sum(len(batch) for batch in embedded) == (
+        len(target_measurements) - len(stable_variant_ids)
+    )
+    assert {
+        variant_id: target_by_id[variant_id] for variant_id in stable_variant_ids
+    } == {
+        variant_id: prior_by_id[variant_id] for variant_id in stable_variant_ids
+    }
+    assert set(target_by_id) == {
+        variant.projection_variant_id
+        for item in items
+        for variant in item.variants
+    }
+
+
+def test_vector_catalog_preflight_refuses_unknown_measurement_family_before_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    relative = "Knowledge Base/Notes/private.md"
+    before = "---\ntitle: Private\nstatus: draft\n---\n\nbefore\n"
+    after = before.replace("before", "after")
+    target = vault / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(before, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration, _measurements = _migrate_with_vector_projection_items(
+        vault,
+        items=((relative, before),),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    original = projection_store.namespace_evidence_from_snapshot
+
+    def unsupported(snapshot: schema_v4.ActivePolicySnapshot):
+        evidence = original(snapshot)
+        root = evidence.required_measurement_roots[0]
+        return projection_store.ProjectionNamespaceEvidence(
+            manifest=evidence.manifest,
+            required_measurement_roots=(
+                dataclasses.replace(root, model_version="unsupported-model"),
+            ),
+        )
+
+    monkeypatch.setattr(
+        projection_store,
+        "namespace_evidence_from_snapshot",
+        unsupported,
+    )
+
+    with pytest.raises(semantic_writes.SemanticWriteError) as blocked:
+        semantic_writes.commit_existing(
+            vault,
+            preflight=semantic_writes.preflight_existing(
+                vault,
+                path=relative,
+                after_source=after,
+                operation="edit",
+                expected_before_hash=vault_module.content_hash(before),
+            ),
+        )
+
+    assert blocked.value.code == "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED"
+    assert target.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.parametrize("failure_mode", ["hard-off", "model-error"])
+def test_vector_rebuild_failure_refuses_catalog_mutation_before_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_mode: str,
+) -> None:
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    relative = "Knowledge Base/Notes/private.md"
+    before = "---\ntitle: Private\nstatus: draft\n---\n\nbefore\n"
+    after = before.replace("before", "after")
+    target = vault / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(before, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration, _measurements = _migrate_with_vector_projection_items(
+        vault,
+        items=((relative, before),),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    def fail_rebuild(_texts: list[str], *, is_query: bool = False):
+        assert is_query is False
+        raise RuntimeError("model unavailable")
+
+    if failure_mode == "model-error":
+        monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+        monkeypatch.setattr(embeddings, "embed_texts", fail_rebuild)
+    else:
+        monkeypatch.setattr(
+            embeddings,
+            "embed_texts",
+            lambda *_args, **_kwargs: pytest.fail(
+                "hard-off publication must not call the vector model"
+            ),
+        )
+
+    with pytest.raises(semantic_writes.SemanticWriteError) as blocked:
+        semantic_writes.commit_existing(
+            vault,
+            preflight=semantic_writes.preflight_existing(
+                vault,
+                path=relative,
+                after_source=after,
+                operation="edit",
+                expected_before_hash=vault_module.content_hash(before),
+            ),
+        )
+
+    assert blocked.value.code == "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED"
+    assert target.read_text(encoding="utf-8") == before
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 1
+    assert custody.control.activation_state_digest == migration.activation_state_digest
+
+
+def test_vector_catalog_preparation_does_not_publish_an_abandoned_family(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    vault = tmp_path / "vault"
+    relative = "Knowledge Base/Notes/private.md"
+    before = "---\ntitle: Private\nstatus: draft\n---\n\nbefore\n"
+    after = before.replace("before", "after")
+    target = vault / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(before, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration, _measurements = _migrate_with_vector_projection_items(
+        vault,
+        items=((relative, before),),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    monkeypatch.setattr(
+        embeddings,
+        "embed_texts",
+        lambda texts, *, is_query=False: tuple(
+            (9.0, float(index + 1)) for index, _text in enumerate(texts)
+        ),
+    )
+
+    prepared = catalog_publication.prepare_markdown_upsert(
+        vault,
+        path=relative,
+        source=after,
+        expected_before_hash=vault_module.content_hash(before),
+        now=now + 1,
+    )
+
+    assert prepared is not None
+    assert len(prepared.target_measurements) == 1
+    family = prepared.target_measurements[0].family
+    assert not projection_measurement_store.measurement_store_path(
+        vault,
+        family,
+    ).exists()
+    assert target.read_text(encoding="utf-8") == before
 
 
 def test_semantic_edit_refuses_auxiliary_catalog_drift_before_changing_bytes(


### PR DESCRIPTION
## Summary

- let exact-v4 content and companion mutations advance certified projected-text vector namespaces
- reuse unchanged content-addressed vectors and rebuild only newly introduced projection variants before canonical bytes change
- keep CLIP, graph, unknown, hard-disabled, incomplete, and failed measurement families fail-closed
- separate prepared target namespaces and measurement previews from post-byte immutable store publication so abandoned preflights cannot poison a catalog generation

## Verification

- `uv run python -m pytest -q tests/test_governance_active_tuple.py tests/test_governance_projection_measurement_store.py tests/test_governance_projection_measurement_activation.py tests/test_governance_projected_vector_retrieval.py tests/test_governance_projected_runtime_lanes.py` (128 passed)
- `uvx ruff check` on all five touched files
- `openspec validate harden-governance-for-consolidation --strict`
- `uv run python scripts/validate-public-artifacts.py --repository`
- `uv build`
- `git diff --check`