### PR TITLE
feat(governance): publish governed binary capture

### DIFF
--- a/src/exomem/governance/catalog_publication.py
+++ b/src/exomem/governance/catalog_publication.py
@@ -240,6 +240,10 @@ def mutation_from_planned_write(
         ) from None
     if PurePosixPath(relative).suffix.casefold() != ".md":
         return None
+    if not isinstance(write.content, str):
+        raise CatalogPublicationError(
+            "catalog Markdown publication requires textual source"
+        )
     relative = _relative_markdown_path(root, relative)
     if not _is_catalog_markdown_path(relative):
         return None

--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -1388,6 +1388,10 @@ def _epoch_writes_with_predecessor(
             or recall_policy.is_structured_only_path(root, relative)
         ):
             continue
+        if not isinstance(write.content, str):
+            raise GraphEpochIncoherent(
+                "graph-relevant batch content is not Markdown text"
+            )
         paths.append((relative, content_hash(write.content)))
         if not write.path.exists():
             created_paths.append(relative)

--- a/src/exomem/preserve.py
+++ b/src/exomem/preserve.py
@@ -30,10 +30,11 @@ import logging
 import mimetypes
 import os
 import re
+import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import BinaryIO
+from typing import IO, BinaryIO
 
 from . import indexes, memory_refs, privacy_log, temporal
 from .kbdir import kb_prefix
@@ -42,6 +43,7 @@ from .vault import (
     ContentHashMismatchError,
     DeferredGraphCompletion,
     PlannedWrite,
+    PreparedBinaryContent,
     batch_atomic_write,
     content_hash,
     escape_wikilinks_for_log,
@@ -213,16 +215,14 @@ def preserve(
         artifact_bytes = decoded
         artifact_text = None
     elif content_stream is not None:
-        # Large binary: streamed straight to disk in the write block below, so the
-        # file never materializes fully in RAM. Size is enforced during the copy.
+        # Large binary: copied into a bounded private spool below, so no canonical
+        # path becomes visible before governance preflight and held publication.
         artifact_bytes = None
         artifact_text = None
     else:
         # content is UTF-8 text; write as-is.
         artifact_bytes = None
         artifact_text = content
-
-    folder.mkdir(parents=True, exist_ok=True)
 
     warnings: list[str] = []
     written_artifact = False
@@ -236,30 +236,47 @@ def preserve(
         else mimetypes.guess_type(filename_safe)[0]
     )
 
+    artifact_stage = tempfile.SpooledTemporaryFile(
+        max_size=min(max(max_decoded_bytes, 1), 8 * 1024 * 1024),
+        mode="w+b",
+    )
     try:
         if content_stream is not None:
-            # Stream the upload to disk in chunks — peak memory is one chunk, not
-            # the whole file. Enforces the byte cap mid-copy (defense in depth; the
-            # HTTP layer's max_part_size already bounds the part during parsing).
-            artifact_size, artifact_hash = _copy_stream_to_file(
-                content_stream, artifact_path, limit=max_stream_bytes
+            # Stream into a process-private spool first. It spills to disk above
+            # 8 MiB, so large uploads stay bounded in RAM while no canonical path
+            # becomes visible before governance preflight succeeds.
+            artifact_size, artifact_hash = _copy_stream(
+                content_stream, artifact_stage, limit=max_stream_bytes
             )
-            written_artifact = True
         elif artifact_bytes is not None:
-            # Binary: write directly, no atomic batch (batch_atomic_write is text-only).
-            artifact_path.write_bytes(artifact_bytes)
+            artifact_stage.write(artifact_bytes)
             artifact_size = len(artifact_bytes)
             artifact_hash = hashlib.sha256(artifact_bytes).hexdigest()
-            written_artifact = True
         else:
             artifact_text_bytes = (artifact_text or "").encode("utf-8")
-            artifact_path.write_text(artifact_text or "", encoding="utf-8", newline="\n")
+            artifact_stage.write(artifact_text_bytes)
             artifact_size = len(artifact_text_bytes)
             artifact_hash = hashlib.sha256(artifact_text_bytes).hexdigest()
-            written_artifact = True
+        artifact_stage.seek(0)
 
-        writes: list[PlannedWrite] = []
         rel_artifact = artifact_path.relative_to(vault_root).as_posix()
+        staged_content: str | PreparedBinaryContent
+        if artifact_text is not None and filename_safe.lower().endswith(".md"):
+            staged_content = artifact_text
+        else:
+            staged_content = PreparedBinaryContent(
+                artifact_stage,
+                artifact_size,
+                artifact_hash,
+            )
+        writes: list[PlannedWrite] = [
+            PlannedWrite(
+                path=artifact_path,
+                content=staged_content,
+                create_only=True,
+                expected_hash=MISSING_CONTENT_HASH,
+            )
+        ]
 
         # Optional sidecar. Written when there's a short `description` caption
         # and/or full extracted `text` (the OCR companion that makes a binary
@@ -287,8 +304,13 @@ def preserve(
         else:
             sidecar_path = folder / f"{filename_safe}.md"
         if sidecar_path.exists():
-            warnings.append(
-                f"sidecar {sidecar_path.name!r} already exists; skipped."
+            return _raise(
+                "COMPANION_EXISTS",
+                ["filename"],
+                (
+                    f"{sidecar_path.relative_to(vault_root).as_posix()!r} already "
+                    "exists. Evidence capture cannot adopt or overwrite a companion."
+                ),
             )
         else:
             if text_clean:
@@ -315,10 +337,20 @@ def preserve(
                 extracted_by=extracted_by,
                 binary_sha256=artifact_hash if describes_artifact else None,
                 binary_size=artifact_size if describes_artifact else None,
+                governance_artifact_path=rel_artifact,
+                governance_artifact_sha256=artifact_hash,
+                governance_artifact_size=artifact_size,
                 tree="Evidence",
             )
             sidecar_ref = memory_refs.ref_from_markdown(sidecar_md)
-            writes.append(PlannedWrite(path=sidecar_path, content=sidecar_md))
+            writes.append(
+                PlannedWrite(
+                    path=sidecar_path,
+                    content=sidecar_md,
+                    create_only=True,
+                    expected_hash=MISSING_CONTENT_HASH,
+                )
+            )
             sidecar_rel = sidecar_path.relative_to(vault_root).as_posix()
 
         # Index + log updates.
@@ -339,8 +371,9 @@ def preserve(
 
         top_index = kb / "index.md"
         if top_index.exists():
+            current_top = top_index.read_text(encoding="utf-8")
             new_top, _trim_note = indexes._prepend_recent_activity(
-                top_index.read_text(encoding="utf-8"),
+                current_top,
                 date_iso=date_iso,
                 summary=activity_summary,
             )
@@ -353,28 +386,61 @@ def preserve(
             if new_top_with_counts is not None:
                 new_top = new_top_with_counts
             # Cap-50 trim is recorded in log.md; no per-write warning needed.
-            writes.append(PlannedWrite(path=top_index, content=new_top))
+            writes.append(
+                PlannedWrite(
+                    path=top_index,
+                    content=new_top,
+                    expected_hash=content_hash(current_top),
+                )
+            )
             writes.extend(sub_writes)
         else:
             warnings.append(f"{kb_prefix()}index.md missing; skipped Recent activity bump")
 
         log_file = kb / "log.md"
         if log_file.exists():
+            current_log = log_file.read_text(encoding="utf-8")
             new_log = _prepend_log_entry(
-                log_file.read_text(encoding="utf-8"),
+                current_log,
                 date_iso=stamp_iso,
                 rel_path=rel_artifact,
                 body=log_body,
             )
-            writes.append(PlannedWrite(path=log_file, content=new_log))
+            writes.append(
+                PlannedWrite(
+                    path=log_file,
+                    content=new_log,
+                    expected_hash=content_hash(current_log),
+                )
+            )
         else:
             warnings.append(f"{kb_prefix()}log.md missing; skipped log entry")
 
-        if writes:
-            # Pass vault_root so the sidecar (a real `.md`) is embedded on write
-            # — that's what makes the binary's extracted text immediately
-            # findable. index.md / log.md in the batch are skipped by name.
-            batch_atomic_write(writes, vault_root=vault_root)
+        from .governance import catalog_publication
+
+        try:
+            prepared_catalog = catalog_publication.prepare_planned_markdown_batch(
+                vault_root,
+                writes=tuple(writes),
+            )
+        except catalog_publication.CatalogPublicationError as error:
+            raise catalog_publication.CatalogCommitError(
+                "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
+                str(error),
+            ) from error
+
+        # The held batch owns the artifact, companion, index, and log as one
+        # caught-failure rollback set. The binary stage is copied without ever
+        # materializing a large upload fully in memory.
+        batch_atomic_write(writes, vault_root=vault_root)
+        written_artifact = True
+        try:
+            catalog_publication.publish_markdown_batch(prepared_catalog)
+        except catalog_publication.CatalogPublicationError as error:
+            raise catalog_publication.CatalogCommitError(
+                "GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN",
+                str(error),
+            ) from error
 
     except Exception as e:
         if privacy_log.content_private_logging_enabled():
@@ -386,6 +452,8 @@ def preserve(
             log.exception("preserve() failed mid-write; artifact_written=%s", written_artifact)
         warnings.append(f"partial write — reconcile on desktop: {e}")
         raise
+    finally:
+        artifact_stage.close()
 
     return PreserveResult(
         path=artifact_path.relative_to(vault_root).as_posix(),
@@ -477,33 +545,29 @@ def preserve_bytes(
 _STREAM_CHUNK = 1024 * 1024  # 1 MiB copy buffer
 
 
-def _copy_stream_to_file(stream: BinaryIO, dest: Path, *, limit: int) -> tuple[int, str]:
-    """Copy a binary file-like to `dest` in chunks, enforcing `limit` bytes.
+def _copy_stream(
+    stream: BinaryIO,
+    destination: IO[bytes],
+    *,
+    limit: int,
+) -> tuple[int, str]:
+    """Copy a binary stream into a private destination under an exact cap."""
 
-    Peak memory is one chunk regardless of file size. On overflow the partial
-    file is removed and TOO_LARGE is raised. Returns bytes written and SHA-256.
-    """
     try:
         stream.seek(0)
     except (OSError, AttributeError, ValueError):
         pass  # non-seekable stream: copy from the current position
     written = 0
     digest = hashlib.sha256()
-    overflow = False
-    with dest.open("wb") as out:
-        while True:
-            buf = stream.read(_STREAM_CHUNK)
-            if not buf:
-                break
-            written += len(buf)
-            if written > limit:
-                overflow = True
-                break
-            digest.update(buf)
-            out.write(buf)
-    if overflow:
-        dest.unlink(missing_ok=True)
-        _raise("TOO_LARGE", ["file"], f"upload exceeds the {limit:,}-byte limit")
+    while True:
+        buf = stream.read(_STREAM_CHUNK)
+        if not buf:
+            break
+        written += len(buf)
+        if written > limit:
+            _raise("TOO_LARGE", ["file"], f"upload exceeds the {limit:,}-byte limit")
+        digest.update(buf)
+        destination.write(buf)
     return written, digest.hexdigest()
 
 
@@ -587,6 +651,9 @@ def _render_sidecar(
     frame_ts: float | None = None,
     binary_sha256: str | None = None,
     binary_size: int | None = None,
+    governance_artifact_path: str | None = None,
+    governance_artifact_sha256: str | None = None,
+    governance_artifact_size: int | None = None,
     tree: str = "Evidence",
 ) -> str:
     """Sidecar .md describing a preserved binary artifact.
@@ -625,6 +692,33 @@ def _render_sidecar(
         lines.append(f"evidence_file: {evidence_file}")
     if extracted_by:
         lines.append(f"extracted_by: {extracted_by}")
+    if governance_artifact_path is not None:
+        if governance_artifact_sha256 is None or governance_artifact_size is None:
+            raise ValueError("governance companion requires an exact artifact identity")
+        artifact_class = "media" if media_type else "binary"
+        lines.extend(
+            (
+                "governance_companion:",
+                "  version: 1",
+                "  state: classified",
+                f"  artifact_class: {artifact_class}",
+                f"  artifact_path: {yaml_scalar(governance_artifact_path)}",
+                f"  artifact_sha256: {governance_artifact_sha256}",
+                f"  artifact_size: {governance_artifact_size}",
+            )
+        )
+        if media_type:
+            lines.append(f"  media_type: {media_type}")
+            lines.append(f"  original_filename: {yaml_scalar(artifact_name)}")
+        lines.extend(
+            (
+                "  semantics:",
+                "    projects: []",
+                "    tags: []",
+                "    types: []",
+                "    classes: []",
+            )
+        )
     # Same field names the media pipeline already writes and checks, so a page
     # written here and one re-rendered by reconciliation describe an artifact
     # in one vocabulary rather than two.

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -1261,6 +1261,10 @@ def _descriptor_hash(descriptor: int, expected: PathIdentity) -> str:
 def _write_all(descriptor: int, content: bytes) -> None:
     os.lseek(descriptor, 0, os.SEEK_SET)
     os.ftruncate(descriptor, 0)
+    _append_all(descriptor, content)
+
+
+def _append_all(descriptor: int, content: bytes) -> None:
     view = memoryview(content)
     written = 0
     while written < len(view):
@@ -2036,6 +2040,8 @@ class _BatchWorkspace:
             self.artifacts[name] = artifact
             digest = hashlib.sha256()
             written = 0
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            os.ftruncate(descriptor, 0)
             while True:
                 chunk = stream.read(1024 * 1024)
                 if not chunk:
@@ -2050,13 +2056,13 @@ class _BatchWorkspace:
                         "PATH_GUARD_CONTENT", "binary batch size changed"
                     )
                 digest.update(chunk)
-                _write_all(descriptor, chunk)
+                _append_all(descriptor, chunk)
             if written != expected_size or digest.hexdigest() != expected_hash:
                 raise PathGuardError(
                     "PATH_GUARD_CONTENT", "binary batch content changed"
                 )
-            artifact.content_bound = True
             artifact.recheck()
+            artifact.content_bound = True
             self.recheck()
             return artifact
         except Exception:

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -25,7 +25,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, BinaryIO, Literal
+from typing import IO, TYPE_CHECKING, Any, BinaryIO, Literal
 
 import yaml
 from slugify import slugify as _slugify
@@ -1957,6 +1957,116 @@ class _BatchWorkspace:
                     os.close(descriptor)
             raise
 
+    def create_stream_artifact(
+        self,
+        name: str,
+        stream: IO[bytes],
+        *,
+        expected_size: int,
+        expected_hash: str,
+    ) -> _WorkspaceArtifact:
+        """Copy a reviewed seekable stream into one held private stage."""
+
+        if (
+            not isinstance(expected_size, int)
+            or isinstance(expected_size, bool)
+            or expected_size < 0
+            or not isinstance(expected_hash, str)
+            or len(expected_hash) != 64
+            or any(character not in "0123456789abcdef" for character in expected_hash)
+        ):
+            raise PathGuardError(
+                "PATH_GUARD_INVALID", "binary batch identity is invalid"
+            )
+        try:
+            stream.seek(0)
+        except (AttributeError, OSError, ValueError) as error:
+            raise PathGuardError(
+                "PATH_GUARD_INVALID", "binary batch stream is not seekable"
+            ) from error
+
+        self.recheck()
+        held_file: held_fs.HeldFile | None = None
+        if self.held_filesystem is not None and self.held_directory is not None:
+            opened = self.held_filesystem.file(
+                self.held_directory,
+                name,
+                access="write",
+                create=True,
+                exclusive=True,
+            )
+            if not opened.ok:
+                raise PathGuardError(
+                    "PATH_GUARD_UNSAFE", "batch stage create was refused"
+                )
+            held_file = opened.require()
+            descriptor = getattr(held_file, "descriptor", None)
+            if not isinstance(descriptor, int):
+                held_file.close()
+                raise PathGuardError(
+                    "PATH_GUARD_UNSAFE", "batch stage is unavailable"
+                )
+        else:
+            flags = (
+                os.O_RDWR
+                | os.O_CREAT
+                | os.O_EXCL
+                | getattr(os, "O_BINARY", 0)
+                | getattr(os, "O_NOFOLLOW", 0)
+            )
+            if os.open in getattr(os, "supports_dir_fd", set()):
+                descriptor = os.open(name, flags, 0o600, dir_fd=self.descriptor)
+            else:  # pragma: no cover - legacy rootless Windows route
+                descriptor = os.open(self.path / name, flags, 0o600)
+        artifact: _WorkspaceArtifact | None = None
+        try:
+            self.recheck_identity()
+            info = os.fstat(descriptor)
+            if not stat.S_ISREG(info.st_mode) or _is_reparse(info):
+                raise PathGuardError("PATH_GUARD_UNSAFE", "batch stage is unsafe")
+            identity = _identity(name, info)
+            artifact = _WorkspaceArtifact(
+                self,
+                name,
+                descriptor,
+                identity,
+                expected_hash,
+                held_file=held_file,
+            )
+            self.artifacts[name] = artifact
+            digest = hashlib.sha256()
+            written = 0
+            while True:
+                chunk = stream.read(1024 * 1024)
+                if not chunk:
+                    break
+                if not isinstance(chunk, bytes):
+                    raise PathGuardError(
+                        "PATH_GUARD_INVALID", "binary batch stream returned non-bytes"
+                    )
+                written += len(chunk)
+                if written > expected_size:
+                    raise PathGuardError(
+                        "PATH_GUARD_CONTENT", "binary batch size changed"
+                    )
+                digest.update(chunk)
+                _write_all(descriptor, chunk)
+            if written != expected_size or digest.hexdigest() != expected_hash:
+                raise PathGuardError(
+                    "PATH_GUARD_CONTENT", "binary batch content changed"
+                )
+            artifact.content_bound = True
+            artifact.recheck()
+            self.recheck()
+            return artifact
+        except Exception:
+            if artifact is None:
+                if held_file is not None:
+                    held_file.close()
+                else:
+                    os.close(descriptor)
+            raise
+
     def _replace_once(self, artifact: _WorkspaceArtifact, final: Path) -> None:
         if os.replace in getattr(os, "supports_dir_fd", set()):
             os.replace(
@@ -3628,11 +3738,20 @@ def read_guarded_text(vault_root: Path, path: Path) -> tuple[str, PathGuard]:
 
 
 @dataclass
+class PreparedBinaryContent:
+    """One seekable binary payload with its exact precomputed identity."""
+
+    stream: IO[bytes]
+    size: int
+    sha256: str
+
+
+@dataclass
 class PlannedWrite:
     """One target file in a batch write, with an optional commit-time CAS guard."""
 
     path: Path
-    content: str
+    content: str | PreparedBinaryContent
     create_only: bool = False
     guard: PathGuard | None = None
     expected_hash: str | None = None
@@ -4254,6 +4373,10 @@ def _enqueue_graph_debt(vault_root: Path, checkpoint_write: PlannedWrite) -> Non
     """
     from . import deferred_index, graph_sync
 
+    if not isinstance(checkpoint_write.content, str):
+        raise PathGuardError(
+            "PATH_GUARD_INVALID", "graph checkpoint content is not textual"
+        )
     checkpoint = graph_sync.GraphSyncCheckpoint.parse(checkpoint_write.content)
     if checkpoint is None:  # pragma: no cover - graph_sync renders its own token
         return
@@ -4349,7 +4472,13 @@ def _batch_atomic_write_locked(
         if epoch_writes is not None:
             floor_write, checkpoint_write = epoch_writes
             if defer_graph_completion:
-                deferred_checkpoint = graph_sync.GraphSyncCheckpoint.parse(checkpoint_write.content)
+                if not isinstance(checkpoint_write.content, str):
+                    raise PathGuardError(
+                        "PATH_GUARD_INVALID", "graph checkpoint content is not textual"
+                    )
+                deferred_checkpoint = graph_sync.GraphSyncCheckpoint.parse(
+                    checkpoint_write.content
+                )
                 if deferred_checkpoint is None:  # pragma: no cover - graph_sync renders its own token
                     raise ValueError("deferred graph completion checkpoint is invalid")
                 writes = [floor_write, *writes]
@@ -4374,6 +4503,15 @@ def _batch_atomic_write_locked(
         absolute_parts = Path(os.path.abspath(write.path)).parts
         if any(part.startswith(_BATCH_RESIDUE_PREFIX) for part in absolute_parts):
             raise _batch_residue_error("BATCH_RESIDUE_UNSAFE")
+        if isinstance(write.content, PreparedBinaryContent):
+            if not write.create_only or write.expected_hash != MISSING_CONTENT_HASH:
+                raise PathGuardError(
+                    "PATH_GUARD_INVALID",
+                    "binary batch content requires an exact missing destination",
+                )
+            if os.path.lexists(write.path):
+                raise CreateOnlyConflict(_safe_write_target(write.path, vault_root))
+            continue
         if write.expected_hash is not None:
             try:
                 current = write.path.read_text(encoding="utf-8")
@@ -4492,9 +4630,26 @@ def _batch_atomic_write_locked(
                 )
         for index, write in enumerate(writes):
             workspace = workspace_by_parent[Path(os.path.abspath(write.path.parent))]
-            artifact = workspace.create_artifact(
-                f"stage-{index}.tmp", write.content.encode("utf-8")
-            )
+            if isinstance(write.content, str):
+                artifact = workspace.create_artifact(
+                    f"stage-{index}.tmp", write.content.encode("utf-8")
+                )
+            elif isinstance(write.content, PreparedBinaryContent):
+                if not write.create_only or write.expected_hash != MISSING_CONTENT_HASH:
+                    raise PathGuardError(
+                        "PATH_GUARD_INVALID",
+                        "binary batch content requires an exact missing destination",
+                    )
+                artifact = workspace.create_stream_artifact(
+                    f"stage-{index}.tmp",
+                    write.content.stream,
+                    expected_size=write.content.size,
+                    expected_hash=write.content.sha256,
+                )
+            else:  # pragma: no cover - the public union is closed
+                raise PathGuardError(
+                    "PATH_GUARD_INVALID", "batch content type is unsupported"
+                )
             staged.append((write.path, workspace, artifact))
         for final, _workspace, _artifact in staged:
             if not os.path.lexists(final):

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -46,6 +46,7 @@ from exomem import (
 from exomem.governance import (
     authorization_custody,
     catalog_publication,
+    companions,
     membership,
     policy,
     projected_retrieval,
@@ -4121,6 +4122,257 @@ def test_existing_binary_backfill_pages_publish_v4_catalog_membership(
         media_sidecar.relative_to(vault).as_posix(),
         artifact_page.relative_to(vault).as_posix(),
     }
+
+
+def test_preserve_binary_publishes_bound_companion_and_v4_catalog_successor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    result = preserve.preserve_bytes(
+        vault,
+        scope="Private",
+        category="files",
+        filename="payload.bin",
+        data=b"governed binary payload",
+        today=dt.date(2026, 8, 26),
+    )
+
+    bound = companions.classify(vault, result.path)
+    assert bound.projects == ()
+    assert bound.tags == ()
+    assert bound.types == ()
+    assert bound.classes == ()
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 2
+    active, manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=2,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    assert active.active.catalog_generation == 2
+    assert manifest.item_count == 1
+    assert {item.item_identity for item in items} == {result.sidecar_path}
+
+
+def test_preserve_v4_updates_navigation_in_the_same_projection_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    kb = vault / "Knowledge Base"
+    kb.mkdir(parents=True)
+    index = kb / "index.md"
+    log = kb / "log.md"
+    index.write_text("# Knowledge Base\n\n## Recent activity\n\n", encoding="utf-8")
+    log.write_text("# Activity log\n\n---\n", encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=(
+            ("Knowledge Base/index.md", index.read_text(encoding="utf-8")),
+            ("Knowledge Base/log.md", log.read_text(encoding="utf-8")),
+        ),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    result = preserve.preserve_bytes(
+        vault,
+        scope="Private",
+        category="files",
+        filename="with-navigation.bin",
+        data=b"governed payload",
+        today=dt.date(2026, 8, 26),
+    )
+
+    assert "with-navigation.bin" in index.read_text(encoding="utf-8")
+    assert "with-navigation.bin" in log.read_text(encoding="utf-8")
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    _active, _manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=2,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    assert {item.item_identity for item in items} == {
+        result.sidecar_path,
+        "Knowledge Base/index.md",
+        "Knowledge Base/log.md",
+    }
+
+
+def test_preserve_binary_rebuilds_vector_measurements_before_v4_activation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    vault = tmp_path / "vault"
+    _write_workspace(vault, _documents(ceiling=2))
+    migration, _prior = _migrate_with_vector_projection_items(
+        vault,
+        items=(),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    embedded: list[str] = []
+
+    def embed_target(texts: list[str], *, is_query: bool = False):
+        assert is_query is False
+        embedded.extend(texts)
+        return tuple(
+            tuple(float(index + 1) for _component in range(embeddings.VECTOR_DIM))
+            for index, _text in enumerate(texts)
+        )
+
+    monkeypatch.setattr(embeddings, "embed_texts", embed_target)
+
+    result = preserve.preserve_bytes(
+        vault,
+        scope="Private",
+        category="files",
+        filename="vector.bin",
+        data=b"vector-backed payload",
+        text="projection-only searchable text",
+        today=dt.date(2026, 8, 26),
+    )
+
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    active, manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=2,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    evidence = projection_store.namespace_evidence_from_snapshot(active)
+    namespace = projection_store.bind_active_projection_namespace(
+        active,
+        manifest=manifest,
+        items=items,
+    )
+    root = evidence.required_measurement_roots[0]
+    family = projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=namespace.namespace_key,
+        lane=root.lane,
+        extractor_version=root.extractor_version,
+        model_version=root.model_version,
+    )
+    _measurement_manifest, measurements = (
+        projection_measurement_store.load_measurement_store(
+            vault,
+            namespace=namespace,
+            family=family,
+            expected_rows_digest=root.rows_digest,
+        )
+    )
+    assert {item.item_identity for item in items} == {result.sidecar_path}
+    assert len(measurements) == sum(len(item.variants) for item in items)
+    assert len(embedded) == len(measurements)
+
+
+def test_preserve_binary_v4_preflight_failure_leaves_no_canonical_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    def refuse(_vault_root: Path, *, writes, now=None):  # noqa: ANN001, ARG001
+        raise catalog_publication.CatalogPublicationError("preflight refused")
+
+    monkeypatch.setattr(
+        catalog_publication,
+        "prepare_planned_markdown_batch",
+        refuse,
+    )
+    with pytest.raises(catalog_publication.CatalogCommitError) as blocked:
+        preserve.preserve_bytes(
+            vault,
+            scope="Private",
+            category="files",
+            filename="blocked.bin",
+            data=b"must not commit",
+            today=dt.date(2026, 8, 26),
+        )
+
+    assert blocked.value.code == "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED"
+    folder = vault / "Knowledge Base" / "Evidence" / "Private" / "files"
+    assert not (folder / "blocked.bin").exists()
+    assert not (folder / "blocked.bin.md").exists()
+
+
+def test_preserve_binary_v4_catalog_terminal_loss_is_explicitly_uncertain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    def lose_terminal(_prepared) -> None:  # noqa: ANN001
+        raise catalog_publication.CatalogPublicationError("lost catalog terminal")
+
+    monkeypatch.setattr(
+        catalog_publication,
+        "publish_markdown_batch",
+        lose_terminal,
+    )
+    with pytest.raises(catalog_publication.CatalogCommitError) as uncertain:
+        preserve.preserve_bytes(
+            vault,
+            scope="Private",
+            category="files",
+            filename="uncertain.bin",
+            data=b"canonical bytes committed",
+            today=dt.date(2026, 8, 26),
+        )
+
+    assert uncertain.value.code == "GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN"
+    folder = vault / "Knowledge Base" / "Evidence" / "Private" / "files"
+    assert (folder / "uncertain.bin").read_bytes() == b"canonical bytes committed"
+    assert (folder / "uncertain.bin.md").exists()
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 1
 
 
 def test_semantic_edit_publishes_auxiliary_markdown_in_the_same_v4_generation(

--- a/tests/test_preserve.py
+++ b/tests/test_preserve.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import base64
 import datetime as dt
+import io
 from pathlib import Path
 
 import pytest
 
 from exomem import preserve as preserve_module
+from exomem import vault as vault_module
+from exomem.governance import companions
 
 TODAY = dt.date(2026, 5, 25)
 
@@ -54,6 +57,26 @@ def test_preserve_text_artifact_writes_file(vault: Path) -> None:
     assert "## Artifact" in page
     # The artifact's own bytes are pointed at, never copied into the page.
     assert "cease and desist" not in page
+    descriptor = vault_module.parse_frontmatter(page, strict=True)[0][
+        "governance_companion"
+    ]
+    assert descriptor == {
+        "version": 1,
+        "state": "classified",
+        "artifact_class": "media",
+        "artifact_path": result.path,
+        "artifact_sha256": result.hash,
+        "artifact_size": result.size,
+        "media_type": "text",
+        "original_filename": "2026-05-25-warning-letter.txt",
+        "semantics": {
+            "projects": [],
+            "tags": [],
+            "types": [],
+            "classes": [],
+        },
+    }
+    assert companions.classify(vault, result.path).projects == ()
 
 
 def test_cap_extracted_text_passthrough_under_limit() -> None:
@@ -76,11 +99,17 @@ def test_capped_sidecar_keeps_corpus_small(vault: Path, monkeypatch: pytest.Monk
         vault, scope="Test", category="docs", filename="huge.docx", data=b"BINARY"
     )
     sidecar = vault / res.sidecar_path
+    descriptor_before = vault_module.parse_frontmatter(
+        sidecar.read_text(encoding="utf-8"), strict=True
+    )[0]["governance_companion"]
     preserve_module.update_sidecar_extraction(vault, sidecar, text="Z" * 20000, engine="markitdown")
     body = _read(sidecar)
     assert "truncated" in body
     assert body.count("Z") < 20000           # capped, not the full 20k chars
     assert len(body.encode("utf-8")) < 5000  # sidecar stays small → corpus protected
+    assert vault_module.parse_frontmatter(body, strict=True)[0][
+        "governance_companion"
+    ] == descriptor_before
 
 
 def test_preserve_binary_artifact_decodes_base64(vault: Path) -> None:
@@ -96,6 +125,22 @@ def test_preserve_binary_artifact_decodes_base64(vault: Path) -> None:
     written = vault / result.path
     assert written.exists()
     assert written.read_bytes() == payload
+    sidecar = vault / (result.sidecar_path or "")
+    descriptor = vault_module.parse_frontmatter(
+        sidecar.read_text(encoding="utf-8"), strict=True
+    )[0]["governance_companion"]
+    assert descriptor["artifact_class"] == "media"
+    assert descriptor["media_type"] == "image"
+    assert descriptor["original_filename"] == "2026-04-15-mri.png"
+    assert descriptor["artifact_path"] == result.path
+    assert descriptor["artifact_sha256"] == result.hash
+    assert descriptor["artifact_size"] == result.size
+    assert descriptor["semantics"] == {
+        "projects": [],
+        "tags": [],
+        "types": [],
+        "classes": [],
+    }
 
 
 def test_preserve_with_description_writes_sidecar(vault: Path) -> None:
@@ -217,6 +262,27 @@ def test_preserve_refuses_oversized_base64(vault: Path) -> None:
     assert exc.value.code == "TOO_LARGE"
 
 
+def test_preserve_refuses_oversized_stream_without_canonical_residue(
+    vault: Path,
+) -> None:
+    folder = vault / "Knowledge Base" / "Evidence" / "Private" / "files"
+
+    with pytest.raises(preserve_module.PreserveError) as exc:
+        preserve_module.preserve_stream(
+            vault,
+            scope="Private",
+            category="files",
+            filename="too-large.bin",
+            stream=io.BytesIO(b"five!"),
+            max_bytes=4,
+            today=TODAY,
+        )
+
+    assert exc.value.code == "TOO_LARGE"
+    assert not (folder / "too-large.bin").exists()
+    assert not (folder / "too-large.bin.md").exists()
+
+
 def test_preserve_auto_creates_scope_and_category_dirs(vault: Path) -> None:
     """Evidence/<scope>/<category>/ folders materialize on first write."""
     folder = vault / "Knowledge Base" / "Evidence" / "NewScope" / "NewCat"
@@ -230,6 +296,29 @@ def test_preserve_auto_creates_scope_and_category_dirs(vault: Path) -> None:
         today=TODAY,
     )
     assert folder.is_dir()
+
+
+def test_preserve_refuses_preexisting_companion_without_writing_artifact(
+    vault: Path,
+) -> None:
+    folder = vault / "Knowledge Base" / "Evidence" / "Private" / "files"
+    folder.mkdir(parents=True)
+    companion = folder / "collision.bin.md"
+    companion.write_text("existing companion", encoding="utf-8")
+
+    with pytest.raises(preserve_module.PreserveError) as exc:
+        preserve_module.preserve_bytes(
+            vault,
+            scope="Private",
+            category="files",
+            filename="collision.bin",
+            data=b"new artifact",
+            today=TODAY,
+        )
+
+    assert exc.value.code == "COMPANION_EXISTS"
+    assert not (folder / "collision.bin").exists()
+    assert companion.read_text(encoding="utf-8") == "existing companion"
 
 
 def test_preserve_with_text_writes_searchable_sidecar(vault: Path) -> None:

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -154,6 +154,29 @@ def test_batch_write_streams_binary_and_markdown_in_one_rollback_set(
     assert companion.read_text(encoding="utf-8").endswith("Bound companion.\n")
 
 
+def test_batch_write_streams_binary_larger_than_copy_chunk(tmp_path: Path) -> None:
+    payload = b"a" * (1024 * 1024) + b"b" * 17
+    binary = tmp_path / "Evidence" / "large.bin"
+
+    vault.batch_atomic_write(
+        [
+            vault.PlannedWrite(
+                binary,
+                vault.PreparedBinaryContent(
+                    io.BytesIO(payload),
+                    len(payload),
+                    hashlib.sha256(payload).hexdigest(),
+                ),
+                create_only=True,
+                expected_hash=vault.MISSING_CONTENT_HASH,
+            )
+        ],
+        vault_root=tmp_path,
+    )
+
+    assert binary.read_bytes() == payload
+
+
 def test_batch_binary_create_only_refuses_existing_non_utf8_leaf(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import io
 import os
 import threading
 from pathlib import Path
@@ -116,6 +118,147 @@ def test_path_guards_allow_fresh_multiwrite_without_self_invalidation(
         "content-1",
         "content-2",
     ]
+
+
+def test_batch_write_streams_binary_and_markdown_in_one_rollback_set(
+    tmp_path: Path,
+) -> None:
+    payload = b"\x00binary payload\xff"
+    binary = tmp_path / "Evidence" / "artifact.bin"
+    companion = tmp_path / "Evidence" / "artifact.bin.md"
+
+    written = vault.batch_atomic_write(
+        [
+            vault.PlannedWrite(
+                binary,
+                vault.PreparedBinaryContent(
+                    io.BytesIO(payload),
+                    len(payload),
+                    hashlib.sha256(payload).hexdigest(),
+                ),
+                create_only=True,
+                expected_hash=vault.MISSING_CONTENT_HASH,
+            ),
+            vault.PlannedWrite(
+                companion,
+                "---\ntitle: Artifact\n---\n\nBound companion.\n",
+                create_only=True,
+                expected_hash=vault.MISSING_CONTENT_HASH,
+            ),
+        ],
+        vault_root=tmp_path,
+    )
+
+    assert written == [binary, companion]
+    assert binary.read_bytes() == payload
+    assert companion.read_text(encoding="utf-8").endswith("Bound companion.\n")
+
+
+def test_batch_binary_create_only_refuses_existing_non_utf8_leaf(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "Evidence" / "artifact.bin"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"\xffexisting")
+    payload = b"replacement"
+
+    with pytest.raises(vault.CreateOnlyConflict) as conflict:
+        vault.batch_atomic_write(
+            [
+                vault.PlannedWrite(
+                    target,
+                    vault.PreparedBinaryContent(
+                        io.BytesIO(payload),
+                        len(payload),
+                        hashlib.sha256(payload).hexdigest(),
+                    ),
+                    create_only=True,
+                    expected_hash=vault.MISSING_CONTENT_HASH,
+                )
+            ],
+            vault_root=tmp_path,
+        )
+
+    assert conflict.value.code == "CREATE_ONLY_CONFLICT"
+    assert target.read_bytes() == b"\xffexisting"
+
+
+def test_batch_write_rejects_changed_binary_stream_before_publication(
+    tmp_path: Path,
+) -> None:
+    binary = tmp_path / "Evidence" / "artifact.bin"
+    companion = tmp_path / "Evidence" / "artifact.bin.md"
+    reviewed = b"reviewed"
+
+    with pytest.raises(vault.PathGuardError) as changed:
+        vault.batch_atomic_write(
+            [
+                vault.PlannedWrite(
+                    binary,
+                    vault.PreparedBinaryContent(
+                        io.BytesIO(b"changed!"),
+                        len(reviewed),
+                        hashlib.sha256(reviewed).hexdigest(),
+                    ),
+                    create_only=True,
+                    expected_hash=vault.MISSING_CONTENT_HASH,
+                ),
+                vault.PlannedWrite(
+                    companion,
+                    "companion",
+                    create_only=True,
+                    expected_hash=vault.MISSING_CONTENT_HASH,
+                ),
+            ],
+            vault_root=tmp_path,
+        )
+
+    assert changed.value.code == "PATH_GUARD_CONTENT"
+    assert not binary.exists()
+    assert not companion.exists()
+
+
+def test_batch_write_rolls_back_binary_when_later_publication_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = b"rollback payload"
+    binary = tmp_path / "Evidence" / "artifact.bin"
+    companion = tmp_path / "Evidence" / "artifact.bin.md"
+    real_hook = vault._after_batch_destination_published
+
+    def fail_after_companion(path: Path) -> None:
+        real_hook(path)
+        if path == companion:
+            raise RuntimeError("injected publication failure")
+
+    monkeypatch.setattr(vault, "_after_batch_destination_published", fail_after_companion)
+
+    with pytest.raises(RuntimeError, match="injected publication failure"):
+        vault.batch_atomic_write(
+            [
+                vault.PlannedWrite(
+                    binary,
+                    vault.PreparedBinaryContent(
+                        io.BytesIO(payload),
+                        len(payload),
+                        hashlib.sha256(payload).hexdigest(),
+                    ),
+                    create_only=True,
+                    expected_hash=vault.MISSING_CONTENT_HASH,
+                ),
+                vault.PlannedWrite(
+                    companion,
+                    "companion",
+                    create_only=True,
+                    expected_hash=vault.MISSING_CONTENT_HASH,
+                ),
+            ],
+            vault_root=tmp_path,
+        )
+
+    assert not binary.exists()
+    assert not companion.exists()
 
 
 def test_path_guards_share_new_parent_chain_safely(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- stage binary preserve payloads in a private bounded spool and publish them with their Markdown companion in one held rollback set
- emit exact classified companion descriptors for new captures, while leaving legacy artifacts on the existing owner-reviewed backfill path
- prepare vector/catalog successors before canonical publication and return explicit blocked or uncertain outcomes around the tuple commit
- fail closed on companion collisions, changed streams, and existing non-UTF-8 create-only destinations

## Verification

- 206 passed, 3 expected Windows-only skips across preserve, held batch, active tuple, and media regression tests
- final focused gate: 41 passed, 3 expected Windows-only skips; 5 active-tuple capture tests passed
- touched-file Ruff clean
- public artifact privacy validator clean
- Change 'harden-governance-for-consolidation' is valid
- 