### PR TITLE
feat(governance): publish classified scene frames

### DIFF
--- a/src/exomem/preserve.py
+++ b/src/exomem/preserve.py
@@ -654,6 +654,9 @@ def _render_sidecar(
     governance_artifact_path: str | None = None,
     governance_artifact_sha256: str | None = None,
     governance_artifact_size: int | None = None,
+    governance_parent_path: str | None = None,
+    governance_parent_sha256: str | None = None,
+    governance_frame_timestamp_ms: int | None = None,
     tree: str = "Evidence",
 ) -> str:
     """Sidecar .md describing a preserved binary artifact.
@@ -695,7 +698,26 @@ def _render_sidecar(
     if governance_artifact_path is not None:
         if governance_artifact_sha256 is None or governance_artifact_size is None:
             raise ValueError("governance companion requires an exact artifact identity")
-        artifact_class = "media" if media_type else "binary"
+        scene_binding = any(
+            value is not None
+            for value in (
+                governance_parent_path,
+                governance_parent_sha256,
+                governance_frame_timestamp_ms,
+            )
+        )
+        if scene_binding and (
+            governance_parent_path is None
+            or governance_parent_sha256 is None
+            or type(governance_frame_timestamp_ms) is not int
+            or not 0 <= governance_frame_timestamp_ms <= 4_294_967_295
+            or parent_media != governance_parent_path
+            or media_type != "image"
+        ):
+            raise ValueError("scene-frame companion requires an exact parent binding")
+        artifact_class = (
+            "scene_frame" if scene_binding else ("media" if media_type else "binary")
+        )
         lines.extend(
             (
                 "governance_companion:",
@@ -707,7 +729,15 @@ def _render_sidecar(
                 f"  artifact_size: {governance_artifact_size}",
             )
         )
-        if media_type:
+        if scene_binding:
+            lines.extend(
+                (
+                    f"  parent_path: {yaml_scalar(governance_parent_path)}",
+                    f"  parent_sha256: {governance_parent_sha256}",
+                    f"  frame_timestamp_ms: {governance_frame_timestamp_ms}",
+                )
+            )
+        elif media_type:
             lines.append(f"  media_type: {media_type}")
             lines.append(f"  original_filename: {yaml_scalar(artifact_name)}")
         lines.extend(

--- a/src/exomem/scene_frames.py
+++ b/src/exomem/scene_frames.py
@@ -9,20 +9,32 @@ need no extra index. Frames ride the existing image OCR path via
 per-scene vectors own visual search (the worker scan and backfill skip
 `parent_media` children at every CLIP-enqueue point).
 
-Everything here soft-fails: a frame that can't be encoded or written is logged
-and skipped; the caller's CLIP vectors are never blocked on frame persistence.
+Encoding and ordinary batch failures soft-fail without blocking the caller's
+CLIP vectors. Exact-v4 catalog refusal/uncertainty reaches the surrounding media
+boundary so governed publication is never reported as an ordinary skipped frame.
 """
 
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
 import logging
+import math
+import os
 import re
+import tempfile
 from pathlib import Path
+from typing import BinaryIO
 
 from . import embeddings, index_sync
 from .preserve import _render_sidecar
-from .vault import PlannedWrite, batch_atomic_write
+from .vault import (
+    MISSING_CONTENT_HASH,
+    PathGuard,
+    PlannedWrite,
+    PreparedBinaryContent,
+    batch_atomic_write,
+)
 
 log = logging.getLogger(__name__)
 
@@ -31,6 +43,8 @@ JPEG_MAX_SIDE = 1280  # downscale bound — keeps slide/terminal text legible fo
 JPEG_QUALITY = 80
 
 _FRAME_NAME_RE = re.compile(r"^scene-(\d{3,})-t(\d+)ms\.jpe?g$", re.IGNORECASE)
+_MAX_FRAME_TIMESTAMP_MS = 4_294_967_295
+_JPEG_SPOOL_MEMORY_BYTES = 4 * 1024 * 1024
 
 
 def scene_frames_enabled() -> bool:
@@ -43,9 +57,27 @@ def frames_dir_for(video_path: Path) -> Path:
     return video_path.with_name(video_path.name + FRAMES_DIR_SUFFIX)
 
 
+def frame_timestamp_ms(ts: float) -> int:
+    """Canonical bounded milliseconds for one binary64 scene timestamp."""
+    if type(ts) not in {int, float} or isinstance(ts, bool):
+        raise ValueError("scene-frame timestamp must be a finite number")
+    seconds = float(ts)
+    milliseconds = seconds * 1000.0
+    if not math.isfinite(seconds) or not math.isfinite(milliseconds) or seconds < 0:
+        raise ValueError("scene-frame timestamp must be finite and nonnegative")
+    value = int(round(milliseconds))
+    if not 0 <= value <= _MAX_FRAME_TIMESTAMP_MS:
+        raise ValueError("scene-frame timestamp is outside the supported range")
+    return value
+
+
+def _frame_filename_ms(index: int, milliseconds: int) -> str:
+    return f"scene-{index:03d}-t{milliseconds}ms.jpg"
+
+
 def frame_filename(index: int, ts: float) -> str:
     """`scene-<NNN>-t<ms>ms.jpg` — sorts chronologically, timestamp parseable back out."""
-    return f"scene-{index:03d}-t{int(round(ts * 1000))}ms.jpg"
+    return _frame_filename_ms(index, frame_timestamp_ms(ts))
 
 
 def parse_frame_ts(name: str) -> float | None:
@@ -117,18 +149,95 @@ def list_scene_frame_children(vault_root: Path, video_path: Path) -> list[str]:
     return out
 
 
-def _save_jpeg(img, path: Path) -> None:
+def _save_jpeg(img, target: BinaryIO) -> None:
     """Downscale (longest side ≤ JPEG_MAX_SIDE) and save as JPEG."""
     w, h = img.size
     scale = JPEG_MAX_SIDE / max(w, h)
     if scale < 1.0:
         img = img.resize((max(1, int(w * scale)), max(1, int(h * scale))))
-    img.convert("RGB").save(str(path), format="JPEG", quality=JPEG_QUALITY)
+    converted = img.convert("RGB")
+    try:
+        converted.save(target, format="JPEG", quality=JPEG_QUALITY)
+        return
+    except TypeError:
+        # Pillow accepts a binary file object. A few compatible encoders and
+        # lightweight test doubles accept only a pathname, so give them a
+        # private non-canonical path and copy those reviewed bytes into the
+        # spool. Nothing under the vault is visible before the held batch.
+        target.seek(0)
+        target.truncate()
+    with tempfile.TemporaryDirectory(prefix="exomem-scene-frame-") as directory:
+        stage = Path(directory) / "frame.jpg"
+        converted.save(str(stage), format="JPEG", quality=JPEG_QUALITY)
+        with stage.open("rb") as source:
+            while chunk := source.read(1024 * 1024):
+                target.write(chunk)
 
 
 def _format_mmss(ts: float) -> str:
     total = int(ts)
     return f"{total // 60:02d}:{total % 60:02d}"
+
+
+def _content_guard(
+    vault_root: Path,
+    relative: str,
+) -> tuple[str, PathGuard, PathGuard]:
+    """Hash one parent and return cheap identity plus completion guards."""
+    stable = PathGuard.capture(vault_root, relative, leaf_policy="stable")
+    digest = hashlib.sha256()
+    size = 0
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(vault_root / relative, flags)
+    try:
+        while chunk := os.read(descriptor, 1024 * 1024):
+            digest.update(chunk)
+            size += len(chunk)
+    finally:
+        os.close(descriptor)
+    stable.recheck(vault_root)
+    value = digest.hexdigest()
+    return (
+        value,
+        stable,
+        PathGuard.capture(
+            vault_root,
+            relative,
+            leaf_policy="content",
+            expected_content_hash=value,
+            expected_content_size=size,
+        ),
+    )
+
+
+def _spooled_jpeg(img) -> tuple[tempfile.SpooledTemporaryFile[bytes], int, str]:
+    stream = tempfile.SpooledTemporaryFile(max_size=_JPEG_SPOOL_MEMORY_BYTES, mode="w+b")
+    try:
+        _save_jpeg(img, stream)
+        size = stream.tell()
+        stream.seek(0)
+        digest = hashlib.sha256()
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+        stream.seek(0)
+        return stream, size, digest.hexdigest()
+    except BaseException:
+        stream.close()
+        raise
+
+
+def _has_owned_scene_frames(video_path: Path) -> bool:
+    directory = frames_dir_for(video_path)
+    try:
+        return directory.is_dir() and any(
+            parse_frame_ts(
+                child.name[:-3] if child.name.casefold().endswith(".md") else child.name
+            )
+            is not None
+            for child in directory.iterdir()
+        )
+    except OSError:
+        return True
 
 
 def write_scene_frames(
@@ -140,17 +249,23 @@ def write_scene_frames(
 ) -> list[tuple[Path, Path]]:
     """Persist one JPEG + pending sidecar per scene → `[(jpg_path, sidecar_path)]`.
 
-    Clears previously-owned frames first (delete-then-insert). Soft-fails per
-    frame: an unencodable/unwritable frame is logged and skipped; a sidecar batch
-    failure logs and returns [] (orphan JPEGs are healed by reconcile/backfill).
+    Fresh JPEG bytes and their classified sidecars share one held rollback set.
+    Open/schema-v3 vaults retain legacy delete-then-insert reprocessing. Exact-v4
+    refuses an existing frame set before deletion until removal publication has
+    its own atomic successor protocol. Encoding failures remain per-frame soft
+    failures; exact-v4 catalog refusal/uncertainty is surfaced to its caller.
     """
+    root = Path(os.path.abspath(vault_root))
     try:
-        video_rel = video_path.resolve().relative_to(vault_root.resolve()).as_posix()
+        canonical_video = Path(os.path.abspath(video_path))
+        video_rel = canonical_video.relative_to(root).as_posix()
+        parent_sha256, parent_identity_guard, parent_content_guard = _content_guard(
+            root, video_rel
+        )
     except (ValueError, OSError) as e:
         log.warning("scene frames skipped for %s: %s", video_path.name, e)
         return []
-    clear_scene_frames(vault_root, video_path)
-    d = frames_dir_for(video_path)
+    d = frames_dir_for(canonical_video)
     # Tag context from Knowledge Base/Evidence/<scope>/<category>/… (same derivation
     # as preserve.ensure_media_sidecar).
     parts = video_rel.split("/")
@@ -159,40 +274,108 @@ def write_scene_frames(
     date_iso = (today or dt.date.today()).isoformat()
     writes: list[PlannedWrite] = []
     out: list[tuple[Path, Path]] = []
+    streams: list[tempfile.SpooledTemporaryFile[bytes]] = []
     for i, (scene, img) in enumerate(scenes_with_images):
-        name = frame_filename(i, scene.rep_ts)
-        jpg = d / name
         try:
-            d.mkdir(parents=True, exist_ok=True)
-            _save_jpeg(img, jpg)
+            timestamp_ms = frame_timestamp_ms(scene.rep_ts)
+            name = _frame_filename_ms(i, timestamp_ms)
+            stream, artifact_size, artifact_sha256 = _spooled_jpeg(img)
         except Exception as e:  # noqa: BLE001 — one bad frame must not block the rest
-            log.warning("scene frame write failed for %s: %s", name, e)
+            log.warning("scene frame preparation failed for scene %d: %s", i, e)
             continue
+        jpg = d / name
         sidecar = jpg.with_name(name + ".md")
-        md = _render_sidecar(
-            artifact_name=name,
-            scope=scope,
-            category=category,
-            date_iso=date_iso,
-            description=(
-                f"Scene frame of `{video_path.name}` at {_format_mmss(scene.rep_ts)} "
-                f"(parent: {video_rel})."
-            ),
-            media_type="image",
-            evidence_file=f"{video_rel}{FRAMES_DIR_SUFFIX}/{name}",
-            extracted_by="pending",
-            parent_media=video_rel,
-            frame_ts=scene.rep_ts,
+        artifact_rel = jpg.relative_to(root).as_posix()
+        try:
+            md = _render_sidecar(
+                artifact_name=name,
+                scope=scope,
+                category=category,
+                date_iso=date_iso,
+                description=(
+                    f"Scene frame of `{canonical_video.name}` at "
+                    f"{_format_mmss(timestamp_ms / 1000.0)} "
+                    f"(parent: {video_rel})."
+                ),
+                media_type="image",
+                evidence_file=artifact_rel,
+                extracted_by="pending",
+                parent_media=video_rel,
+                frame_ts=timestamp_ms / 1000.0,
+                binary_sha256=artifact_sha256,
+                binary_size=artifact_size,
+                governance_artifact_path=artifact_rel,
+                governance_artifact_sha256=artifact_sha256,
+                governance_artifact_size=artifact_size,
+                governance_parent_path=video_rel,
+                governance_parent_sha256=parent_sha256,
+                governance_frame_timestamp_ms=timestamp_ms,
+            )
+        except Exception as error:  # noqa: BLE001 - keep per-frame isolation
+            stream.close()
+            log.warning("scene frame companion failed for %s: %s", name, error)
+            continue
+        streams.append(stream)
+        writes.append(
+            PlannedWrite(
+                path=jpg,
+                content=PreparedBinaryContent(stream, artifact_size, artifact_sha256),
+                create_only=True,
+                expected_hash=MISSING_CONTENT_HASH,
+            )
         )
-        writes.append(PlannedWrite(path=sidecar, content=md))
+        writes.append(
+            PlannedWrite(
+                path=sidecar,
+                content=md,
+                create_only=True,
+                expected_hash=MISSING_CONTENT_HASH,
+            )
+        )
         out.append((jpg, sidecar))
     if not writes:
         return []
+    from .governance import catalog_publication
+
     try:
-        batch_atomic_write(writes, vault_root=vault_root)
+        try:
+            prepared_catalog = catalog_publication.prepare_planned_markdown_batch(
+                root,
+                writes=tuple(writes),
+            )
+        except catalog_publication.CatalogPublicationError as error:
+            raise catalog_publication.CatalogCommitError(
+                "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
+                str(error),
+            ) from error
+        if prepared_catalog is not None and _has_owned_scene_frames(canonical_video):
+            raise catalog_publication.CatalogCommitError(
+                "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
+                "exact-v4 scene-frame replacement requires a removal successor",
+            )
+        if prepared_catalog is None:
+            clear_scene_frames(root, canonical_video)
+        batch_atomic_write(
+            writes,
+            vault_root=root,
+            required_guards=(parent_identity_guard,),
+            completion_guards=(parent_content_guard,),
+        )
+        try:
+            catalog_publication.publish_markdown_batch(prepared_catalog)
+        except catalog_publication.CatalogPublicationError as error:
+            raise catalog_publication.CatalogCommitError(
+                "GOVERNANCE_CATALOG_PUBLICATION_UNCERTAIN",
+                str(error),
+            ) from error
+    except catalog_publication.CatalogCommitError:
+        raise
     except Exception as e:  # noqa: BLE001 — sidecars are the findability layer, not the vectors
-        log.warning("scene frame sidecar write failed for %s: %s", video_path.name, e)
+        log.warning("scene frame batch write failed for %s: %s", canonical_video.name, e)
         return []
+    finally:
+        for stream in streams:
+            stream.close()
     return out
 
 

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -4397,6 +4397,7 @@ def batch_atomic_write(
     *,
     vault_root: Path | None = None,
     required_guards: Iterable[PathGuard | DirectoryCensusGuard] = (),
+    completion_guards: Iterable[PathGuard] = (),
     index_reports: list[Any] | None = None,
     semantic_states: Mapping[str, Any] | None = None,
     post_commit_fanout: bool = True,
@@ -4408,7 +4409,9 @@ def batch_atomic_write(
     A process-shared lock closes the gap between validating any ``expected_hash``
     guards and replacing destinations. The locked implementation uses private
     descriptor-owned staging, exact rollback snapshots, and one post-commit
-    index fan-out.
+    index fan-out. ``completion_guards`` bind large read-only inputs once before
+    publication and once at the rollback-capable completion point, avoiding a
+    full content rehash before every destination flip.
     """
     with _BATCH_COMMIT_LOCK:
         if defer_graph_completion and (post_commit_fanout or vault_root is None):
@@ -4419,6 +4422,7 @@ def batch_atomic_write(
             writes,
             vault_root=vault_root,
             required_guards=required_guards,
+            completion_guards=completion_guards,
             index_reports=index_reports,
             semantic_states=semantic_states,
             post_commit_fanout=post_commit_fanout,
@@ -4432,6 +4436,7 @@ def _batch_atomic_write_locked(
     *,
     vault_root: Path | None = None,
     required_guards: Iterable[PathGuard | DirectoryCensusGuard] = (),
+    completion_guards: Iterable[PathGuard] = (),
     index_reports: list[Any] | None = None,
     semantic_states: Mapping[str, Any] | None = None,
     post_commit_fanout: bool = True,
@@ -4540,6 +4545,14 @@ def _batch_atomic_write_locked(
     directory_guards = tuple(
         guard for guard in all_required_guards if isinstance(guard, DirectoryCensusGuard)
     )
+    all_completion_guards = tuple(completion_guards)
+    if any(
+        not isinstance(guard, PathGuard) or guard.leaf_policy != "content"
+        for guard in all_completion_guards
+    ):
+        raise PathGuardError(
+            "PATH_GUARD_INVALID", "completion guards must bind exact content"
+        )
     # Access-tier backstop: check before staging and again immediately before
     # every destination replace so a live `_access.yaml` change cannot race a
     # long staging interval.
@@ -4547,7 +4560,10 @@ def _batch_atomic_write_locked(
         _validate_batch_write_access(Path(vault_root), writes)
     target_summary = _summarize_batch_targets(writes, vault_root)
     if (
-        read_only_guards or directory_guards or any(write.guard is not None for write in writes)
+        read_only_guards
+        or directory_guards
+        or all_completion_guards
+        or any(write.guard is not None for write in writes)
     ) and vault_root is None:
         raise PathGuardError("PATH_GUARD_ROOT", "guarded writes require vault_root")
     created_dirs: list[Path | _CreatedDirectory] = []
@@ -4579,6 +4595,7 @@ def _batch_atomic_write_locked(
             for guard in (
                 *read_only_guards,
                 *(item for item in bound_guards if item is not None),
+                *all_completion_guards,
             ):
                 guard.recheck(root)
             for guard in directory_guards:
@@ -4780,6 +4797,8 @@ def _batch_atomic_write_locked(
             _after_batch_destination_published(final)
             workspace.recheck()
         for guard in read_only_guards:
+            guard.recheck(Path(vault_root))
+        for guard in all_completion_guards:
             guard.recheck(Path(vault_root))
         for workspace in workspace_by_parent.values():
             workspace.recheck()

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -31,6 +31,7 @@ from exomem import (
     media_processing,
     preserve,
     reserved_paths,
+    scene_frames,
     semantic_writes,
     writer_lease,
 )
@@ -3866,6 +3867,96 @@ def test_media_reconciliation_publishes_new_sidecar_in_next_v4_catalog(
             vault_module.content_hash(sidecar.read_text(encoding="utf-8")),
         )
     ]
+
+
+def test_scene_frame_bytes_and_companion_publish_one_v4_catalog_successor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Image:
+        size = (1920, 1080)
+
+        def resize(self, _size):
+            return self
+
+        def convert(self, _mode):
+            return self
+
+        def save(self, target, **_kwargs) -> None:
+            target.write(b"\xff\xd8governed-scene")
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    video = vault / "Knowledge Base/Evidence/Video/demo.mp4"
+    video.parent.mkdir(parents=True, exist_ok=True)
+    video.write_bytes(b"governed video")
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    pairs = scene_frames.write_scene_frames(
+        vault,
+        video,
+        [
+            (
+                embeddings.Scene(
+                    start_ts=8.0,
+                    end_ts=12.0,
+                    rep_ts=10.0,
+                    boundary_score=0.5,
+                ),
+                Image(),
+            )
+        ],
+    )
+
+    assert len(pairs) == 1
+    jpg, sidecar = pairs[0]
+    assert jpg.read_bytes() == b"\xff\xd8governed-scene"
+    companions.classify(vault, jpg.relative_to(vault).as_posix())
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    active, _manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=2,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    assert active.active.catalog_generation == 2
+    assert [(item.item_identity, item.content_hash) for item in items] == [
+        (
+            sidecar.relative_to(vault).as_posix(),
+            vault_module.content_hash(sidecar.read_text(encoding="utf-8")),
+        )
+    ]
+
+    before = {path: path.read_bytes() for path in (jpg, sidecar)}
+    with pytest.raises(catalog_publication.CatalogCommitError) as blocked:
+        scene_frames.write_scene_frames(
+            vault,
+            video,
+            [
+                (
+                    embeddings.Scene(
+                        start_ts=38.0,
+                        end_ts=42.0,
+                        rep_ts=40.0,
+                        boundary_score=0.5,
+                    ),
+                    Image(),
+                )
+            ],
+        )
+
+    assert blocked.value.code == "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED"
+    assert {path: path.read_bytes() for path in (jpg, sidecar)} == before
+    assert not list(jpg.parent.glob("*t40000ms.jpg"))
+    custody_after = authorization_custody.load_authorization_custody(vault, now=now + 2)
+    assert custody_after.control.activation_epoch == 2
 
 
 def test_media_extraction_update_publishes_exact_v4_catalog_successor(

--- a/tests/test_scene_frames.py
+++ b/tests/test_scene_frames.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import hashlib
+import math
 from pathlib import Path
 
+import pytest
+
 from exomem import scene_frames
+from exomem import vault as vault_module
 from exomem.embeddings import Scene
+from exomem.governance import catalog_publication, companions
 
 
 class _FakeImg:
@@ -23,10 +29,14 @@ class _FakeImg:
     def convert(self, mode: str) -> _FakeImg:
         return self
 
-    def save(self, path: str, format: str | None = None, quality: int | None = None) -> None:
+    def save(self, target, format: str | None = None, quality: int | None = None) -> None:
         if self._fail_save:
             raise OSError("disk full")
-        Path(path).write_bytes(b"\xff\xd8fakejpg")
+        payload = b"\xff\xd8fakejpg"
+        if hasattr(target, "write"):
+            target.write(payload)
+        else:
+            Path(target).write_bytes(payload)
 
 
 def _scene(rep: float) -> Scene:
@@ -48,6 +58,21 @@ def test_frame_filename_roundtrip() -> None:
     assert scene_frames.parse_frame_ts("scene-003-t734500ms.jpg.md") is None
 
 
+def test_frame_timestamp_ms_is_derived_once_with_bounded_ties_to_even() -> None:
+    assert scene_frames.frame_timestamp_ms(0.0005) == 0
+    assert scene_frames.frame_timestamp_ms(0.0015) == 2
+    assert scene_frames.frame_filename(1, 0.0015) == "scene-001-t2ms.jpg"
+    for invalid in (
+        -0.001,
+        math.inf,
+        -math.inf,
+        math.nan,
+        4_294_967.296,
+    ):
+        with pytest.raises(ValueError, match="timestamp"):
+            scene_frames.frame_timestamp_ms(invalid)
+
+
 def test_write_creates_jpeg_and_sidecar(vault: Path) -> None:
     video = _video(vault)
     pairs = scene_frames.write_scene_frames(
@@ -65,6 +90,101 @@ def test_write_creates_jpeg_and_sidecar(vault: Path) -> None:
     assert "scene-frame" in content  # tag
     assert "evidence_file: Knowledge Base/Evidence/Test/clips/demo.mp4.frames/" in content
     assert "01:15" in pairs[1][1].read_text(encoding="utf-8")  # mm:ss caption for 75s
+
+
+def test_write_creates_exact_classified_scene_frame_companion(vault: Path) -> None:
+    video = _video(vault)
+
+    pairs = scene_frames.write_scene_frames(vault, video, [(_scene(10.0), _FakeImg())])
+
+    assert len(pairs) == 1
+    jpg, sidecar = pairs[0]
+    jpg_rel = jpg.relative_to(vault).as_posix()
+    classified = companions.classify(vault, jpg_rel)
+    assert classified.projects == ()
+    assert classified.tags == ()
+    assert classified.types == ()
+    assert classified.classes == ()
+    assert {snapshot.role for snapshot in classified.identities} == {
+        "artifact",
+        "companion",
+        "parent",
+    }
+    content = sidecar.read_text(encoding="utf-8")
+    assert "artifact_class: scene_frame" in content
+    assert f"artifact_sha256: {hashlib.sha256(jpg.read_bytes()).hexdigest()}" in content
+    assert "parent_path: Knowledge Base/Evidence/Test/clips/demo.mp4" in content
+    assert f"parent_sha256: {hashlib.sha256(video.read_bytes()).hexdigest()}" in content
+    assert "frame_timestamp_ms: 10000" in content
+
+
+def test_write_rolls_back_jpeg_when_sidecar_publication_fails(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    video = _video(vault)
+    real_hook = vault_module._after_batch_destination_published
+
+    def fail_after_sidecar(path: Path) -> None:
+        real_hook(path)
+        if path.name.endswith(".jpg.md"):
+            raise RuntimeError("injected scene sidecar failure")
+
+    monkeypatch.setattr(
+        vault_module,
+        "_after_batch_destination_published",
+        fail_after_sidecar,
+    )
+
+    assert scene_frames.write_scene_frames(
+        vault, video, [(_scene(10.0), _FakeImg())]
+    ) == []
+    frame_dir = scene_frames.frames_dir_for(video)
+    assert not list(frame_dir.glob("scene-*.jpg"))
+    assert not list(frame_dir.glob("scene-*.jpg.md"))
+
+
+def test_write_refuses_parent_drift_before_any_frame_is_visible(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    video = _video(vault)
+    real_batch = scene_frames.batch_atomic_write
+
+    def drift_then_write(*args, **kwargs):
+        video.write_bytes(b"changed video")
+        return real_batch(*args, **kwargs)
+
+    monkeypatch.setattr(scene_frames, "batch_atomic_write", drift_then_write)
+
+    assert scene_frames.write_scene_frames(
+        vault, video, [(_scene(10.0), _FakeImg())]
+    ) == []
+    frame_dir = scene_frames.frames_dir_for(video)
+    assert not list(frame_dir.glob("scene-*.jpg"))
+    assert not list(frame_dir.glob("scene-*.jpg.md"))
+
+
+def test_v4_preflight_refusal_does_not_create_frame_bytes(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    video = _video(vault)
+
+    def refuse(*_args, **_kwargs):
+        raise catalog_publication.CatalogPublicationError("model family unavailable")
+
+    monkeypatch.setattr(
+        catalog_publication,
+        "prepare_planned_markdown_batch",
+        refuse,
+    )
+
+    with pytest.raises(catalog_publication.CatalogCommitError) as blocked:
+        scene_frames.write_scene_frames(vault, video, [(_scene(10.0), _FakeImg())])
+
+    assert blocked.value.code == "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED"
+    assert not scene_frames.frames_dir_for(video).exists()
 
 
 def test_rewrite_clears_stale_frames(vault: Path) -> None:

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -284,6 +284,109 @@ def test_batch_write_rolls_back_binary_when_later_publication_fails(
     assert not companion.exists()
 
 
+def test_batch_completion_guard_rolls_back_when_source_changes_after_last_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "Evidence" / "parent.bin"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"reviewed parent")
+    _data, completion_guard = vault.read_bounded_guarded_bytes(
+        tmp_path,
+        "Evidence/parent.bin",
+        limit=len(b"reviewed parent"),
+    )
+    stable_guard = vault.PathGuard.capture(
+        tmp_path,
+        "Evidence/parent.bin",
+        leaf_policy="stable",
+    )
+    binary = tmp_path / "Evidence" / "frame.jpg"
+    companion = tmp_path / "Evidence" / "frame.jpg.md"
+    real_hook = vault._after_batch_destination_published
+
+    def change_source_after_companion(path: Path) -> None:
+        real_hook(path)
+        if path == companion:
+            source.write_bytes(b"changed parent!")
+
+    monkeypatch.setattr(
+        vault,
+        "_after_batch_destination_published",
+        change_source_after_companion,
+    )
+
+    with pytest.raises(vault.PathGuardError) as changed:
+        vault.batch_atomic_write(
+            [
+                vault.PlannedWrite(
+                    binary,
+                    vault.PreparedBinaryContent(
+                        io.BytesIO(b"frame"),
+                        len(b"frame"),
+                        hashlib.sha256(b"frame").hexdigest(),
+                    ),
+                    create_only=True,
+                    expected_hash=vault.MISSING_CONTENT_HASH,
+                ),
+                vault.PlannedWrite(
+                    companion,
+                    "companion",
+                    create_only=True,
+                    expected_hash=vault.MISSING_CONTENT_HASH,
+                ),
+            ],
+            vault_root=tmp_path,
+            required_guards=(stable_guard,),
+            completion_guards=(completion_guard,),
+        )
+
+    assert changed.value.code == "PATH_GUARD_CONTENT"
+    assert not binary.exists()
+    assert not companion.exists()
+
+
+def test_batch_completion_guard_hash_work_is_independent_of_write_count(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "Evidence" / "parent.bin"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"reviewed parent")
+    _data, completion_guard = vault.read_bounded_guarded_bytes(
+        tmp_path,
+        "Evidence/parent.bin",
+        limit=len(b"reviewed parent"),
+    )
+    real_snapshot = vault._read_bounded_guarded_snapshot
+    reads = 0
+
+    def count_snapshot(*args, **kwargs):
+        nonlocal reads
+        target = args[1] if len(args) > 1 else kwargs.get("target")
+        if target == "Evidence/parent.bin":
+            reads += 1
+        return real_snapshot(*args, **kwargs)
+
+    monkeypatch.setattr(vault, "_read_bounded_guarded_snapshot", count_snapshot)
+
+    vault.batch_atomic_write(
+        [
+            vault.PlannedWrite(
+                tmp_path / "Evidence" / f"frame-{index}.md",
+                f"frame {index}",
+                create_only=True,
+                expected_hash=vault.MISSING_CONTENT_HASH,
+            )
+            for index in range(12)
+        ],
+        vault_root=tmp_path,
+        completion_guards=(completion_guard,),
+    )
+
+    assert reads == 2
+
+
 def test_path_guards_share_new_parent_chain_safely(tmp_path: Path) -> None:
     paths = [tmp_path / "new/nested/one.md", tmp_path / "new/nested/two.md"]
     writes = [


### PR DESCRIPTION
## Why

Persisted video scene frames previously wrote canonical JPEG bytes before their Markdown sidecars and before exact-v4 catalog preflight. That left orphan windows, legacy-unclassified companions, and unsafe delete-then-reinsert behavior for governed reprocessing.

## What changed

- spool scene JPEGs privately and publish each JPEG plus its sidecar in one held rollback set
- emit exact `scene_frame` governance descriptors bound to the JPEG, parent video hash, and canonical ties-to-even millisecond timestamp
- advance one exact-v4 catalog generation for fresh sidecars; refuse governed replacement before deleting an existing frame set
- add rollback-capable completion guards so large parent media is content-checked at batch entry/exit rather than rehashed for every destination
- retain existing open/schema-v3 replacement behavior

Projected multi-keyframe CLIP measurements remain deliberately non-serving and are the next schema slice; this PR does not flatten them into a single vector.

## Verification

- `93 passed, 3 skipped` across scene frames, find grouping, video visual pipeline, media deletion, semantic segments, and vault batch tests (Windows-native cases skipped locally)
- exact-v4 scene-frame catalog integration: `1 passed`
- companion/membership/preserve/media focused checks: `33 passed`
- Ruff on all touched Python files
- `git diff --check`
- `openspec validate harden-governance-for-consolidation --strict`
- public-artifact privacy validation
- package build