### PR TITLE
feat(governance): preserve projected video keyframes

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/design.md
+++ b/openspec/changes/harden-governance-for-consolidation/design.md
@@ -641,7 +641,12 @@ The search lanes consume that map directly:
    vector disables or warms that visible lane without falling back to a raw embedding;
 3. reranking receives only selected projected text and runs before final visible top-k;
 4. CLIP pixels/keyframes participate only for items selected at L6, with authorization
-   filtering inside the CLIP lane before its cap. At L1-L5 an image/video can match only
+   filtering inside the CLIP lane before its cap. One immutable measurement row binds
+   each media projection: an image has one untimestamped vector, while a video has one
+   through forty strictly timestamp-ordered vectors using the canonical bounded
+   `frame_timestamp_ms`. The fixed forty-sample ceiling is not configurable. Retrieval
+   scores every authorized sample, emits the parent media item once at its best score,
+   and carries the earliest best frame timestamp. At L1-L5 an image/video can match only
    through its authorized textual companion projection; if that record is unavailable,
    the binary CLIP lane is excluded rather than searched raw;
 5. graph vertices and edges are projection-indexed and admitted before expansion, so

--- a/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
+++ b/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
@@ -114,7 +114,12 @@ text embedding rows before its cap; a missing/stale selected embedding SHALL war
 disable that visible lane and MUST NOT fall back to a raw embedding. Reranking SHALL
 receive only selected projected fields and SHALL precede final top-k. CLIP pixels and
 keyframes SHALL participate only for artifacts selected at L6, with the authorization
-map applied inside the lane before its cap. Below L6, image/video recall SHALL use only
+map applied inside the lane before its cap. Each L6 media projection SHALL bind one
+immutable measurement row: exactly one untimestamped vector for an image, or one through
+forty vectors for a video in strict canonical `frame_timestamp_ms` order. The forty-sample
+ceiling SHALL NOT be configurable. The lane SHALL score every authorized sample, return
+the parent media item once at its best score, and bind the earliest best frame timestamp.
+Below L6, image/video recall SHALL use only
 an authorized textual companion projection, or exclude the binary lane when none is
 available. Graph vertices and edges SHALL be admitted before expansion and every graph
 reduction SHALL run over the selected projected graph.

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -485,7 +485,9 @@ made before both PRs and their combined verification are complete.
 - [ ] 8.3 Add red CLIP/non-text pairs where the highest hidden pixel/keyframe match would
   consume the cap. Assert authorization occurs inside CLIP before its cap, L6 visible
   visual top-k is exact, and L1-L5 media participates only through its authorized textual
-  companion projection or is excluded from the binary lane.
+  companion projection or is excluded from the binary lane. Bind each image to one
+  untimestamped sample and each video to one through forty strictly timestamp-ordered
+  samples, returning the parent once with its earliest best `frame_timestamp_ms`.
 - [ ] 8.4 Add red graph pairs where hidden vertices/edges change in-degree, out-degree,
   reachability, shortest paths, relation matches, seed expansion, graph-assisted fusion,
   and pagination; assert the visible graph/order is identical to physical absence.

--- a/src/exomem/governance/projected_retrieval.py
+++ b/src/exomem/governance/projected_retrieval.py
@@ -151,8 +151,16 @@ class ProjectedLexicalHit:
     score: float
     search_fields: Mapping[str, str]
     snippet: str
+    clip_frame_timestamp_ms: int | None = None
 
     def __post_init__(self) -> None:
+        if self.clip_frame_timestamp_ms is not None and (
+            type(self.clip_frame_timestamp_ms) is not int
+            or not 0 <= self.clip_frame_timestamp_ms <= 4_294_967_295
+        ):
+            raise projections.ProjectionCanonicalizationError(
+                "projected CLIP hit timestamp must be a bounded integer millisecond value"
+            )
         object.__setattr__(self, "search_fields", MappingProxyType(dict(self.search_fields)))
 
 
@@ -189,11 +197,62 @@ class ProjectionVectorMeasurement:
 
 
 @dataclass(frozen=True, slots=True)
+class ProjectionClipSample:
+    """One canonical pixel/keyframe vector within a projected media row."""
+
+    frame_timestamp_ms: int | None
+    vector: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        if self.frame_timestamp_ms is not None and (
+            type(self.frame_timestamp_ms) is not int
+            or not 0 <= self.frame_timestamp_ms <= 4_294_967_295
+        ):
+            raise projections.ProjectionCanonicalizationError(
+                "CLIP frame timestamp must be a bounded integer millisecond value"
+            )
+        vector = _vector(self.vector, "CLIP projection vector")
+        if math.sqrt(sum(value * value for value in vector)) == 0:
+            raise projections.ProjectionCanonicalizationError(
+                "CLIP projection vector must have non-zero magnitude"
+            )
+        object.__setattr__(self, "vector", vector)
+
+
+MAX_PROJECTED_CLIP_SAMPLES_PER_VARIANT = 40
+
+
+@dataclass(frozen=True, slots=True, init=False)
 class ProjectionClipMeasurement:
-    """One principal-free CLIP measurement beneath an L6 projection row."""
+    """One principal-free image or multi-keyframe video measurement row."""
 
     measurement_key: projections.MeasurementKey
-    vector: tuple[float, ...]
+    samples: tuple[ProjectionClipSample, ...]
+
+    def __init__(
+        self,
+        measurement_key: projections.MeasurementKey,
+        vector: tuple[float, ...] | None = None,
+        *,
+        samples: tuple[ProjectionClipSample, ...] | None = None,
+    ) -> None:
+        if (vector is None) == (samples is None):
+            raise projections.ProjectionCanonicalizationError(
+                "CLIP measurement requires either one image vector or canonical samples"
+            )
+        if vector is not None:
+            normalized = (
+                ProjectionClipSample(frame_timestamp_ms=None, vector=vector),
+            )
+        else:
+            if samples is None:
+                raise projections.ProjectionCanonicalizationError(
+                    "CLIP measurement samples are unavailable"
+                )
+            normalized = samples
+        object.__setattr__(self, "measurement_key", measurement_key)
+        object.__setattr__(self, "samples", normalized)
+        self.__post_init__()
 
     def __post_init__(self) -> None:
         if not isinstance(self.measurement_key, projections.MeasurementKey):
@@ -204,12 +263,44 @@ class ProjectionClipMeasurement:
             raise projections.ProjectionCanonicalizationError(
                 "CLIP measurement key has an invalid lane"
             )
-        vector = _vector(self.vector, "CLIP projection vector")
-        if math.sqrt(sum(value * value for value in vector)) == 0:
+        if not isinstance(self.samples, tuple) or not self.samples:
             raise projections.ProjectionCanonicalizationError(
-                "CLIP projection vector must have non-zero magnitude"
+                "CLIP measurement samples must be a non-empty immutable tuple"
             )
-        object.__setattr__(self, "vector", vector)
+        if len(self.samples) > MAX_PROJECTED_CLIP_SAMPLES_PER_VARIANT:
+            raise projections.ProjectionCapacityExceeded(
+                "projected CLIP samples exceed the fixed per-variant capacity"
+            )
+        if any(not isinstance(sample, ProjectionClipSample) for sample in self.samples):
+            raise projections.ProjectionCanonicalizationError(
+                "CLIP measurement sample has an invalid type"
+            )
+        if len({len(sample.vector) for sample in self.samples}) != 1:
+            raise projections.ProjectionCanonicalizationError(
+                "CLIP measurement samples have inconsistent dimensions"
+            )
+        timestamps = tuple(sample.frame_timestamp_ms for sample in self.samples)
+        if any(timestamp is None for timestamp in timestamps):
+            if timestamps != (None,):
+                raise projections.ProjectionCanonicalizationError(
+                    "CLIP image measurement must be one untimestamped sample"
+                )
+        elif tuple(sorted(timestamps)) != timestamps or len(set(timestamps)) != len(
+            timestamps
+        ):
+            raise projections.ProjectionCanonicalizationError(
+                "CLIP samples must use strict canonical timestamp order"
+            )
+
+    @property
+    def vector(self) -> tuple[float, ...]:
+        """Compatibility view for a legacy singleton image measurement."""
+
+        if len(self.samples) != 1:
+            raise projections.ProjectionCanonicalizationError(
+                "multi-sample CLIP measurements do not have one vector"
+            )
+        return self.samples[0].vector
 
 
 def _vector(value: object, name: str) -> tuple[float, ...]:
@@ -406,6 +497,8 @@ def clip_variant_applicable(variant: projections.ProjectionVariant) -> bool:
 def _projected_hit(
     variant: projections.ProjectionVariant,
     score: float,
+    *,
+    clip_frame_timestamp_ms: int | None = None,
 ) -> ProjectedLexicalHit:
     compact = " ".join(projection_text(variant).split())
     return ProjectedLexicalHit(
@@ -415,6 +508,7 @@ def _projected_hit(
         score=score,
         search_fields=variant.search_fields,
         snippet=compact[:_SNIPPET_CHARS].rstrip(),
+        clip_frame_timestamp_ms=clip_frame_timestamp_ms,
     )
 
 
@@ -734,8 +828,8 @@ class ProjectedClipIndex:
             "CLIP model version",
             maximum=256,
         )
-        clip_variant_ids = {
-            variant.projection_variant_id
+        clip_variants = {
+            variant.projection_variant_id: variant
             for item in self._items.values()
             for variant in item.variants
             if clip_variant_applicable(variant)
@@ -756,7 +850,7 @@ class ProjectedClipIndex:
                 raise projections.ProjectionCanonicalizationError(
                     "CLIP measurement model version does not match index"
                 )
-            if key.projection_variant_id not in clip_variant_ids:
+            if key.projection_variant_id not in clip_variants:
                 raise projections.ProjectionCanonicalizationError(
                     "CLIP measurement variant is not an applicable L6 pixel catalog projection"
                 )
@@ -764,9 +858,26 @@ class ProjectedClipIndex:
                 raise projections.ProjectionCanonicalizationError(
                     "projected CLIP index contains a duplicate variant measurement"
                 )
+            variant = clip_variants[key.projection_variant_id]
+            timestamps = tuple(
+                sample.frame_timestamp_ms for sample in measurement.samples
+            )
+            if variant.search_fields.get("media_type") == "image" and timestamps != (
+                None,
+            ):
+                raise projections.ProjectionCanonicalizationError(
+                    "projected image CLIP measurement must be one untimestamped sample"
+                )
+            if variant.search_fields.get("media_type") == "video" and any(
+                timestamp is None for timestamp in timestamps
+            ):
+                raise projections.ProjectionCanonicalizationError(
+                    "projected video CLIP measurements require frame timestamps"
+                )
+            row_dimension = len(measurement.samples[0].vector)
             if dimension is None:
-                dimension = len(measurement.vector)
-            elif len(measurement.vector) != dimension:
+                dimension = row_dimension
+            elif row_dimension != dimension:
                 raise projections.ProjectionCanonicalizationError(
                     "projected CLIP measurements have inconsistent dimensions"
                 )
@@ -808,21 +919,31 @@ class ProjectedClipIndex:
         if query_magnitude == 0:
             raise ProjectedLaneUnavailable("CLIP query vector has zero magnitude")
 
-        scored: list[tuple[projections.ProjectionVariant, float]] = []
+        scored: list[tuple[projections.ProjectionVariant, float, int | None]] = []
         for variant in selected:
             measurement = self._measurements.get(variant.projection_variant_id)
             if measurement is None:
                 raise ProjectedLaneUnavailable(
                     "selected projection CLIP measurement is unavailable"
                 )
-            measurement_magnitude = math.sqrt(
-                sum(value * value for value in measurement.vector)
+            sample_scores: list[tuple[float, int | None]] = []
+            for sample in measurement.samples:
+                measurement_magnitude = math.sqrt(
+                    sum(value * value for value in sample.vector)
+                )
+                score = sum(
+                    left * right
+                    for left, right in zip(query, sample.vector, strict=True)
+                ) / (query_magnitude * measurement_magnitude)
+                sample_scores.append((score, sample.frame_timestamp_ms))
+            score, timestamp_ms = min(
+                sample_scores,
+                key=lambda item: (
+                    -item[0],
+                    -1 if item[1] is None else item[1],
+                ),
             )
-            score = sum(
-                left * right
-                for left, right in zip(query, measurement.vector, strict=True)
-            ) / (query_magnitude * measurement_magnitude)
-            scored.append((variant, score))
+            scored.append((variant, score, timestamp_ms))
         scored.sort(
             key=lambda item: (
                 -item[1],
@@ -830,7 +951,14 @@ class ProjectedClipIndex:
                 item[0].projection_variant_id,
             )
         )
-        return tuple(_projected_hit(variant, score) for variant, score in scored[:limit])
+        return tuple(
+            _projected_hit(
+                variant,
+                score,
+                clip_frame_timestamp_ms=timestamp_ms,
+            )
+            for variant, score, timestamp_ms in scored[:limit]
+        )
 
 
 class ProjectedReranker:
@@ -978,6 +1106,7 @@ class ProjectedReranker:
 
 __all__ = [
     "AuthorizationProjectionMap",
+    "MAX_PROJECTED_CLIP_SAMPLES_PER_VARIANT",
     "ProjectedClipIndex",
     "ProjectedLaneUnavailable",
     "ProjectedLexicalHit",
@@ -985,6 +1114,7 @@ __all__ = [
     "ProjectedReranker",
     "ProjectedRetrievalUnavailable",
     "ProjectedVectorIndex",
+    "ProjectionClipSample",
     "ProjectionClipMeasurement",
     "ProjectionCatalog",
     "ProjectionVectorMeasurement",

--- a/src/exomem/governance/projection_measurement_store.py
+++ b/src/exomem/governance/projection_measurement_store.py
@@ -29,6 +29,7 @@ _STORE_FILENAME = "rows.sqlite"
 _STORE_STATUS = "measurement-rows-ready"
 _ROW_DOMAIN = b"exomem.authorization-projection-measurement-row.v1"
 _STORE_DOMAIN = b"exomem.authorization-projection-measurements.v1"
+_CLIP_PAYLOAD_PREFIX = b"exomem.projection-clip-samples.v1\x00"
 _LANES = frozenset({"vector", "clip", "graph"})
 _HEX = frozenset("0123456789abcdef")
 _TABLES = frozenset({"measurement_meta", "measurement_rows"})
@@ -266,6 +267,26 @@ def _vector_payload(vector: tuple[float, ...]) -> bytes:
     return struct.pack(f">{len(canonical)}d", *canonical)
 
 
+def _clip_payload(
+    measurement: projected_retrieval.ProjectionClipMeasurement,
+) -> bytes:
+    if (
+        len(measurement.samples) == 1
+        and measurement.samples[0].frame_timestamp_ms is None
+    ):
+        return _vector_payload(measurement.samples[0].vector)
+    output = bytearray(_CLIP_PAYLOAD_PREFIX)
+    output.extend(len(measurement.samples).to_bytes(4, "big"))
+    for sample in measurement.samples:
+        if sample.frame_timestamp_ms is None:
+            output.append(0)
+        else:
+            output.append(1)
+            output.extend(sample.frame_timestamp_ms.to_bytes(4, "big"))
+        output.extend(_vector_payload(sample.vector))
+    return bytes(output)
+
+
 def _graph_payload(measurement: projected_graph.ProjectionGraphMeasurement) -> bytes:
     return projections.canonical_jcs(
         {
@@ -282,14 +303,10 @@ def _graph_payload(measurement: projected_graph.ProjectionGraphMeasurement) -> b
 
 
 def _measurement_payload(measurement: ProjectionMeasurement) -> bytes:
-    if isinstance(
-        measurement,
-        (
-            projected_retrieval.ProjectionVectorMeasurement,
-            projected_retrieval.ProjectionClipMeasurement,
-        ),
-    ):
+    if isinstance(measurement, projected_retrieval.ProjectionVectorMeasurement):
         return _vector_payload(measurement.vector)
+    if isinstance(measurement, projected_retrieval.ProjectionClipMeasurement):
+        return _clip_payload(measurement)
     if isinstance(measurement, projected_graph.ProjectionGraphMeasurement):
         return _graph_payload(measurement)
     raise projections.ProjectionCanonicalizationError(
@@ -336,7 +353,11 @@ def _materialize(
                 projected_retrieval.ProjectionClipMeasurement,
             ),
         )
-        vector_dimension = len(first.vector)
+        vector_dimension = (
+            len(first.samples[0].vector)
+            if isinstance(first, projected_retrieval.ProjectionClipMeasurement)
+            else len(first.vector)
+        )
     if family.lane == "graph":
         graph_edge_count = sum(
             len(row.measurement.edges)
@@ -531,6 +552,58 @@ def _decode_vector(
         raise MeasurementStoreMismatch("measurement vector does not verify") from error
 
 
+def _decode_clip_samples(
+    payload: bytes,
+    *,
+    dimension: int,
+) -> tuple[projected_retrieval.ProjectionClipSample, ...]:
+    if len(payload) == dimension * 8:
+        return (
+            projected_retrieval.ProjectionClipSample(
+                frame_timestamp_ms=None,
+                vector=_decode_vector(payload, dimension=dimension),
+            ),
+        )
+    if not payload.startswith(_CLIP_PAYLOAD_PREFIX):
+        raise MeasurementStoreMismatch("CLIP measurement samples do not verify")
+    cursor = len(_CLIP_PAYLOAD_PREFIX)
+    if len(payload) < cursor + 4:
+        raise MeasurementStoreMismatch("CLIP measurement samples do not verify")
+    count = int.from_bytes(payload[cursor : cursor + 4], "big")
+    cursor += 4
+    if not 1 <= count <= projected_retrieval.MAX_PROJECTED_CLIP_SAMPLES_PER_VARIANT:
+        raise MeasurementStoreMismatch("CLIP measurement samples do not verify")
+    vector_bytes = dimension * 8
+    samples: list[projected_retrieval.ProjectionClipSample] = []
+    for _index in range(count):
+        if cursor >= len(payload):
+            raise MeasurementStoreMismatch("CLIP measurement samples do not verify")
+        tag = payload[cursor]
+        cursor += 1
+        if tag == 0:
+            timestamp_ms = None
+        elif tag == 1 and len(payload) >= cursor + 4:
+            timestamp_ms = int.from_bytes(payload[cursor : cursor + 4], "big")
+            cursor += 4
+        else:
+            raise MeasurementStoreMismatch("CLIP measurement samples do not verify")
+        if len(payload) < cursor + vector_bytes:
+            raise MeasurementStoreMismatch("CLIP measurement samples do not verify")
+        samples.append(
+            projected_retrieval.ProjectionClipSample(
+                frame_timestamp_ms=timestamp_ms,
+                vector=_decode_vector(
+                    payload[cursor : cursor + vector_bytes],
+                    dimension=dimension,
+                ),
+            )
+        )
+        cursor += vector_bytes
+    if cursor != len(payload):
+        raise MeasurementStoreMismatch("CLIP measurement samples do not verify")
+    return tuple(samples)
+
+
 def _decode_graph(payload: bytes) -> tuple[projected_graph.ProjectionGraphEdge, ...]:
     try:
         value = json.loads(payload)
@@ -589,7 +662,10 @@ def _decode_measurement(
             assert manifest.vector_dimension is not None
             return projected_retrieval.ProjectionClipMeasurement(
                 measurement_key=key,
-                vector=_decode_vector(payload, dimension=manifest.vector_dimension),
+                samples=_decode_clip_samples(
+                    payload,
+                    dimension=manifest.vector_dimension,
+                ),
             )
         edges = _decode_graph(payload)
         if len(edges) != len(json.loads(payload)["edges"]):

--- a/src/exomem/governance/projection_runtime.py
+++ b/src/exomem/governance/projection_runtime.py
@@ -1059,6 +1059,11 @@ def _wire_hit(
         vector_score=scores.get("vector"),
         clip_rank=ranks.get("clip"),
         clip_score=scores.get("clip"),
+        clip_frame_ts=(
+            None
+            if hit.clip_frame_timestamp_ms is None
+            else hit.clip_frame_timestamp_ms / 1000.0
+        ),
         graph_hop=graph_hop,
         graph_in_degree=graph_in_degree,
         graph_provenance=graph_provenance,

--- a/tests/test_governance_projected_clip_retrieval.py
+++ b/tests/test_governance_projected_clip_retrieval.py
@@ -97,6 +97,27 @@ def _measurement(
     )
 
 
+def _video_measurement(
+    variant: projections.ProjectionVariant,
+    *samples: tuple[int, tuple[float, ...]],
+) -> projected_retrieval.ProjectionClipMeasurement:
+    return projected_retrieval.ProjectionClipMeasurement(
+        measurement_key=projections.MeasurementKey(
+            projection_variant_id=variant.projection_variant_id,
+            lane="clip",
+            extractor_version="pixels-v1",
+            model_version="clip-test-v1",
+        ),
+        samples=tuple(
+            projected_retrieval.ProjectionClipSample(
+                frame_timestamp_ms=timestamp_ms,
+                vector=vector,
+            )
+            for timestamp_ms, vector in samples
+        ),
+    )
+
+
 def test_l0_pixel_match_is_equivalent_to_absence_before_clip_cap() -> None:
     visible = _variant("visible", "1" * 64, level=6, text="visible")
     hidden = _variant("hidden", "2" * 64, level=6, text="hidden")
@@ -194,4 +215,158 @@ def test_clip_measurement_lane_and_versions_are_closed_subkeys() -> None:
             (_measurement(full, (1.0, 0.0)),),
             extractor_version="pixels-v1",
             model_version="different-model",
+        )
+
+
+def test_video_scores_every_keyframe_but_returns_the_parent_once() -> None:
+    video = _variant(
+        "video",
+        "7" * 64,
+        level=6,
+        text="full video",
+        media_type="video",
+    )
+    item = _item(video)
+    index = projected_retrieval.ProjectedClipIndex(
+        _namespace(item),
+        (
+            _video_measurement(
+                video,
+                (1_000, (0.0, 1.0)),
+                (8_500, (1.0, 0.0)),
+                (19_000, (2.0, 0.0)),
+            ),
+        ),
+        extractor_version="pixels-v1",
+        model_version="clip-test-v1",
+    )
+
+    hits = index.search_clip(_map((item, video)), (1.0, 0.0), k=5)
+
+    assert len(hits) == 1
+    assert hits[0].item_identity == "video"
+    assert hits[0].clip_frame_timestamp_ms == 8_500
+    assert hits[0].score == pytest.approx(1.0)
+
+
+def test_hidden_video_keyframes_are_absent_before_parent_top_k() -> None:
+    visible = _variant(
+        "visible-video",
+        "c" * 64,
+        level=6,
+        text="visible video",
+        media_type="video",
+    )
+    hidden = _variant(
+        "hidden-video",
+        "d" * 64,
+        level=6,
+        text="hidden video",
+        media_type="video",
+    )
+    visible_item, hidden_item = _item(visible), _item(hidden)
+    visible_measurement = _video_measurement(
+        visible,
+        (1_000, (0.2, 0.8)),
+        (8_500, (0.6, 0.4)),
+    )
+    present = projected_retrieval.ProjectedClipIndex(
+        _namespace(visible_item, hidden_item),
+        (
+            visible_measurement,
+            _video_measurement(hidden, (2_000, (1.0, 0.0))),
+        ),
+        extractor_version="pixels-v1",
+        model_version="clip-test-v1",
+    )
+    absent = projected_retrieval.ProjectedClipIndex(
+        _namespace(visible_item),
+        (visible_measurement,),
+        extractor_version="pixels-v1",
+        model_version="clip-test-v1",
+    )
+
+    present_hits = present.search_clip(
+        _map((visible_item, visible), (hidden_item, None)),
+        (1.0, 0.0),
+        k=1,
+    )
+    absent_hits = absent.search_clip(
+        _map((visible_item, visible)),
+        (1.0, 0.0),
+        k=1,
+    )
+
+    assert present_hits == absent_hits
+    assert present_hits[0].clip_frame_timestamp_ms == 8_500
+
+
+def test_video_keyframes_require_a_strict_canonical_timestamp_order() -> None:
+    video = _variant(
+        "video",
+        "8" * 64,
+        level=6,
+        text="full video",
+        media_type="video",
+    )
+
+    with pytest.raises(
+        projections.ProjectionCanonicalizationError,
+        match="timestamp order",
+    ):
+        _video_measurement(
+            video,
+            (8_500, (1.0, 0.0)),
+            (1_000, (0.0, 1.0)),
+        )
+
+
+def test_projected_clip_keyframe_count_has_a_fixed_non_overridable_cap() -> None:
+    video = _variant(
+        "video",
+        "9" * 64,
+        level=6,
+        text="full video",
+        media_type="video",
+    )
+
+    with pytest.raises(
+        projections.ProjectionCapacityExceeded,
+        match="CLIP samples",
+    ):
+        _video_measurement(
+            video,
+            *((index, (1.0, 0.0)) for index in range(41)),
+        )
+
+
+def test_media_kind_and_clip_sample_shape_must_agree() -> None:
+    image = _variant("image", "a" * 64, level=6, text="image")
+    video = _variant(
+        "video",
+        "b" * 64,
+        level=6,
+        text="video",
+        media_type="video",
+    )
+
+    with pytest.raises(
+        projections.ProjectionCanonicalizationError,
+        match="image.*untimestamped",
+    ):
+        projected_retrieval.ProjectedClipIndex(
+            _namespace(_item(image)),
+            (_video_measurement(image, (1_000, (1.0, 0.0))),),
+            extractor_version="pixels-v1",
+            model_version="clip-test-v1",
+        )
+    with pytest.raises(
+        projections.ProjectionCanonicalizationError,
+        match="video.*timestamps",
+    ):
+        projected_retrieval.ProjectedClipIndex(
+            _namespace(_item(video)),
+            (_measurement(video, (1.0, 0.0)),),
+            extractor_version="pixels-v1",
+            model_version="clip-test-v1",
         )

--- a/tests/test_governance_projected_runtime_lanes.py
+++ b/tests/test_governance_projected_runtime_lanes.py
@@ -167,7 +167,7 @@ def _runtime(
                 extractor_version=_CLIP_EXTRACTOR,
                 model_version=embeddings.CLIP_MODEL_NAME,
                 measurement_count=len(clips),
-                vector_dimension=len(clips[0].vector),
+                vector_dimension=len(clips[0].samples[0].vector),
             )
         )
     if graphs:
@@ -219,6 +219,24 @@ def _clip(variant, value):
             model_version=embeddings.CLIP_MODEL_NAME,
         ),
         value,
+    )
+
+
+def _video_clip(variant, *samples):
+    return projected_retrieval.ProjectionClipMeasurement(
+        projections.MeasurementKey(
+            projection_variant_id=variant.projection_variant_id,
+            lane="clip",
+            extractor_version=_CLIP_EXTRACTOR,
+            model_version=embeddings.CLIP_MODEL_NAME,
+        ),
+        samples=tuple(
+            projected_retrieval.ProjectionClipSample(
+                frame_timestamp_ms=timestamp_ms,
+                vector=vector,
+            )
+            for timestamp_ms, vector in samples
+        ),
     )
 
 
@@ -308,6 +326,45 @@ def test_hybrid_runtime_fuses_complete_projected_lanes_and_graph(monkeypatch, tm
     assert result.hits[2].graph_in_degree == 2
     assert result.hits[2].graph_hop is False
     assert result.warming_components == ()
+
+
+def test_projected_video_clip_result_exposes_the_best_frame_timestamp(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    video = _variant(
+        "Knowledge Base/video.md",
+        "4" * 64,
+        "video",
+        fields={"media_type": "video"},
+    )
+    runtime = _runtime(
+        (_item(video),),
+        clips=(
+            _video_clip(
+                video,
+                (1_000, (0.0, 1.0)),
+                (8_500, (1.0, 0.0)),
+            ),
+        ),
+    )
+    monkeypatch.setattr(embeddings, "embed_clip_text", lambda query: [1.0, 0.0])
+
+    result = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        query="scene",
+        limit=1,
+        mode="hybrid",
+        graph=False,
+        rerank=False,
+        principal=principal.owner_principal(surface="library"),
+        purpose=None,
+    )
+
+    assert len(result.hits) == 1
+    assert result.hits[0].clip_frame_ts == 8.5
+    assert result.hits[0].as_dict()["clip_match_at"] == "0:08"
 
 
 def test_graph_lane_prefers_typed_edges_and_preserves_provenance(tmp_path):

--- a/tests/test_governance_projection_measurement_store.py
+++ b/tests/test_governance_projection_measurement_store.py
@@ -107,6 +107,27 @@ def _clip(
     )
 
 
+def _video_clip(
+    variant: projections.ProjectionVariant,
+    *samples: tuple[int, tuple[float, ...]],
+) -> projected_retrieval.ProjectionClipMeasurement:
+    return projected_retrieval.ProjectionClipMeasurement(
+        measurement_key=projections.MeasurementKey(
+            projection_variant_id=variant.projection_variant_id,
+            lane="clip",
+            extractor_version="extractor-v1",
+            model_version="model-v1",
+        ),
+        samples=tuple(
+            projected_retrieval.ProjectionClipSample(
+                frame_timestamp_ms=timestamp_ms,
+                vector=vector,
+            )
+            for timestamp_ms, vector in samples
+        ),
+    )
+
+
 def _graph(
     variant: projections.ProjectionVariant,
     *edges: projected_graph.ProjectionGraphEdge,
@@ -233,6 +254,55 @@ def test_clip_family_accepts_only_l6_projection_rows(tmp_path: Path) -> None:
         expected_rows_digest=manifest.rows_digest,
     )
     assert loaded == (_clip(full),)
+
+
+def test_clip_family_round_trips_every_timestamped_video_sample(
+    tmp_path: Path,
+) -> None:
+    namespace, _lower, full = _namespace()
+    video = projections.build_projection_variant(
+        item_identity=full.item_identity,
+        content_hash=full.content_hash,
+        decision=Decision(level=6, options={}),
+        projector_schema_version=1,
+        full_search_fields={"body": "full video", "media_type": "video"},
+    )
+    assert video is not None
+    namespace = verified_namespace(
+        _key(),
+        (
+            projection_store.ProjectionItemVariants(
+                item_identity=video.item_identity,
+                content_hash=video.content_hash,
+                variants=(video,),
+            ),
+        ),
+    )
+    family = _family("clip")
+    row = _video_clip(
+        video,
+        (1_000, (1.0, 0.0)),
+        (8_500, (0.0, 1.0)),
+        (19_000, (0.5, 0.5)),
+    )
+
+    manifest = projection_measurement_store.stage_measurement_store(
+        tmp_path,
+        namespace=namespace,
+        family=family,
+        measurements=(row,),
+    )
+    loaded_manifest, loaded = projection_measurement_store.load_measurement_store(
+        tmp_path,
+        namespace=namespace,
+        family=family,
+        expected_rows_digest=manifest.rows_digest,
+    )
+
+    assert loaded_manifest == manifest
+    assert loaded == (row,)
+    assert manifest.measurement_count == 1
+    assert manifest.vector_dimension == 2
 
 
 def test_graph_family_round_trips_canonical_edges(tmp_path: Path) -> None:


### PR DESCRIPTION
Adds the bounded multi-keyframe measurement model needed for governed visual retrieval.

- binds one immutable CLIP measurement row to each L6 media projection
- preserves one untimestamped image sample or 1-40 canonical video frame samples
- scores only request-authorized samples, returns the parent once, and exposes the earliest best frame timestamp
- persists the complete sample set under the existing namespace/family root while retaining singleton-image compatibility
- adds a hidden-video/physical-absence pair before parent top-k
- documents the non-configurable capacity and exact collapse semantics in the active OpenSpec

Verification:
- 203 passed, 1 dedicated-wire skip across governance projection/projected suites
- 47 passed in the final focused CLIP/store/runtime suite
- touched-file Ruff passed
- strict OpenSpec validation passed
- git diff --check passed

This intentionally does not mark OpenSpec 8.3 or 8.11 complete: live CLIP successor publication and the remaining paired oracle/release coverage follow in separate slices.
