### PR TITLE
feat(governance): publish CLIP measurement successors

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/design.md
+++ b/openspec/changes/harden-governance-for-consolidation/design.md
@@ -704,7 +704,16 @@ different visible order. Exhausting that bounded ranked window omits the continu
 Projection namespaces are built and validated before a governed compiled-policy
 generation is activated. An item write creates the next catalog generation, reuses only
 content-addressed unchanged rows, and publishes the complete catalog plus required
-projection/index rows atomically; it never mutates the prior namespace in place. A policy
+projection/index rows atomically; it never mutates the prior namespace in place. When
+the active tuple requires CLIP measurements, the successor builder verifies that the
+active image/video family is complete, carries only rows whose projection variant remains
+content-identical, and requires exact target-item/content-hash-bound replacement samples
+for changed visual media. Image rows remain one untimestamped sample; video rows remain
+one through forty canonical timestamped samples. Derived frame companions bind
+`parent_media` and are textual catalog artifacts, not duplicate CLIP measurement owners.
+The complete successor CLIP family binds the target namespace and activates in the same
+catalog publication transaction; missing, stale, mismatched, duplicate, or dimension-
+incompatible rows refuse before canonical bytes change. A policy
 fingerprint or projector-schema change builds a new namespace tuple and never relabels
 an old one. A model/extractor change writes or invalidates only the corresponding
 versioned measurement subkey. Initial migration builds the exact

--- a/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
+++ b/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
@@ -153,6 +153,34 @@ mismatch, per-item variant overflow, or namespace overflow SHALL block activatio
 or prior-policy index MUST NOT be used as fallback. Old namespaces MAY be collected only
 after no active request or cursor binds their exact tuple.
 
+When the active tuple requires a CLIP measurement family, a content or companion
+publication SHALL verify the complete active image/video family before canonical bytes
+change. The successor SHALL carry only content-identical image/video rows, require an
+exact target item identity and target content hash for each changed visual-media
+replacement, and bind the complete successor family to the target projection namespace.
+An image SHALL retain exactly one untimestamped sample and a video one through forty
+strictly timestamp-ordered canonical samples. A derived frame companion carrying
+`parent_media` SHALL remain a textual catalog artifact and SHALL NOT become an
+independent CLIP measurement owner. Missing, stale, duplicate, mismatched, or dimension-
+incompatible CLIP state SHALL refuse before canonical bytes change. The successor catalog,
+projection namespace, vector/CLIP measurement roots, receipt, and active tuple SHALL
+publish atomically; graph or another unsupported required family SHALL remain blocked.
+
+#### Scenario: Visual successor publication is complete and atomic
+
+- **WHEN** an exact-v4 catalog edit carries an unchanged image or video, replaces a
+  changed video's canonical samples, or adds a derived frame companion
+- **THEN** the next namespace carries or replaces only exact target-bound CLIP rows,
+  excludes the frame companion from binary ownership, and activates its complete vector
+  and CLIP roots in the same catalog transaction
+
+#### Scenario: Incomplete visual state refuses before bytes
+
+- **WHEN** the active CLIP family is incomplete or a replacement has a stale item,
+  content hash, sample shape, timestamp order, or vector dimension
+- **THEN** catalog preparation refuses before canonical content or the active tuple
+  changes and does not fall back to a raw or prior CLIP family
+
 When the projected source is exhausted, L1-and-above items SHALL still emit the
 projection their policy authorizes while L0 items SHALL produce a silently shorter list,
 identical to physical absence. The canonical governed envelope for the same input SHALL

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -526,7 +526,12 @@ made before both PRs and their combined verification are complete.
   finite reachable outputs, enforce 256, and keep principal, purpose, session, grant, and
   request decision out of persistent keys/hot caches. Publish policy/projector/catalog
   only through the one active-tuple CAS: policy commits expect catalog; content/companion
-  commits expect policy; readers never sample component pointers separately.
+  commits expect policy; readers never sample component pointers separately. For CLIP
+  successors, verify the complete active family, carry only content-identical image/video
+  rows, require target-item/content-hash-bound replacements for changed media, exclude
+  `parent_media` frame companions from duplicate binary ownership, and publish the target
+  namespace plus complete vector/CLIP roots atomically. Keep graph and any unsupported
+  required family blocked until its own complete successor builder lands.
 - [x] 8.12 Implement BM25 posting intersection before cap, projected-corpus DF/IDF and
   exact top-k; exact filtered projected-vector top-k with visible-lane warming/disable;
   projected-only reranking before final top-k; and L6-only pre-cap CLIP authorization.

--- a/src/exomem/governance/catalog_publication.py
+++ b/src/exomem/governance/catalog_publication.py
@@ -61,6 +61,15 @@ class CatalogRemoval:
 
 
 @dataclass(frozen=True, slots=True)
+class ClipMeasurementReplacement:
+    """Exact new pixel/keyframe samples for one target catalog item."""
+
+    item_identity: str
+    content_hash: str
+    samples: tuple[projected_retrieval.ProjectionClipSample, ...]
+
+
+@dataclass(frozen=True, slots=True)
 class PreparedMeasurementPublication:
     """One validated measurement family held until canonical bytes commit."""
 
@@ -291,6 +300,8 @@ def _search_fields(page: find_corpus.ParsedPage) -> dict[str, str]:
         ("status", page.frontmatter.get("status")),
         ("type", page.page_type),
         ("updated", page.updated),
+        ("media_type", page.frontmatter.get("media_type")),
+        ("parent_media", page.frontmatter.get("parent_media")),
     ):
         if value:
             fields[name] = str(value)
@@ -695,33 +706,209 @@ def _target_vector_measurements(
     )
 
 
+def _target_clip_measurements(
+    vault_root: Path,
+    *,
+    active_namespace: projection_store.VerifiedProjectionNamespace,
+    active_root: projection_store.ProjectionMeasurementRoot,
+    target_namespace: projection_store.PreparedProjectionNamespace,
+    replacements: tuple[ClipMeasurementReplacement, ...],
+) -> PreparedMeasurementPublication:
+    """Carry complete CLIP rows and replace only exact target media items."""
+
+    from .. import embeddings
+
+    if (
+        active_root.lane != "clip"
+        or active_root.extractor_version != "pixels-v1"
+        or active_root.model_version != embeddings.CLIP_MODEL_NAME
+    ):
+        raise CatalogPublicationError(
+            "content publication requires a supported CLIP measurement family"
+        )
+    active_family = projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=active_namespace.namespace_key,
+        lane=active_root.lane,
+        extractor_version=active_root.extractor_version,
+        model_version=active_root.model_version,
+    )
+    try:
+        _active_manifest, active_rows = (
+            projection_measurement_store.load_measurement_store(
+                vault_root,
+                namespace=active_namespace,
+                family=active_family,
+                expected_rows_digest=active_root.rows_digest,
+            )
+        )
+    except projection_measurement_store.MeasurementStoreError as error:
+        raise CatalogPublicationError(
+            "the active CLIP measurement family cannot be verified"
+        ) from error
+    active_expected = {
+        variant.projection_variant_id
+        for item in active_namespace.items
+        for variant in item.variants
+        if projected_retrieval.clip_variant_applicable(variant)
+    }
+    active_by_id: dict[str, projected_retrieval.ProjectionClipMeasurement] = {}
+    for row in active_rows:
+        if not isinstance(row, projected_retrieval.ProjectionClipMeasurement):
+            raise CatalogPublicationError(
+                "the active CLIP measurement family has an invalid row"
+            )
+        active_by_id[row.measurement_key.projection_variant_id] = row
+    if set(active_by_id) != active_expected:
+        raise CatalogPublicationError(
+            "the active CLIP measurement family is incomplete"
+        )
+
+    if type(replacements) is not tuple:
+        raise CatalogPublicationError(
+            "CLIP measurement replacements must be a finite immutable tuple"
+        )
+    target_items = {item.item_identity: item for item in target_namespace.items}
+    replacement_by_identity: dict[str, ClipMeasurementReplacement] = {}
+    for replacement in replacements:
+        if not isinstance(replacement, ClipMeasurementReplacement):
+            raise CatalogPublicationError("CLIP measurement replacement is invalid")
+        if replacement.item_identity in replacement_by_identity:
+            raise CatalogPublicationError("CLIP measurement replacements collide")
+        target_item = target_items.get(replacement.item_identity)
+        if (
+            target_item is None
+            or target_item.content_hash != replacement.content_hash
+            or not any(
+                projected_retrieval.clip_variant_applicable(variant)
+                for variant in target_item.variants
+            )
+        ):
+            raise CatalogPublicationError(
+                "CLIP measurement replacement does not match target content"
+            )
+        replacement_by_identity[replacement.item_identity] = replacement
+
+    target_family = projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=target_namespace.namespace_key,
+        lane=active_root.lane,
+        extractor_version=active_root.extractor_version,
+        model_version=active_root.model_version,
+    )
+    try:
+        target_rows: list[projected_retrieval.ProjectionClipMeasurement] = []
+        for item in target_namespace.items:
+            replacement = replacement_by_identity.get(item.item_identity)
+            for variant in item.variants:
+                if not projected_retrieval.clip_variant_applicable(variant):
+                    continue
+                active = active_by_id.get(variant.projection_variant_id)
+                if replacement is None and active is None:
+                    raise CatalogPublicationError(
+                        "the target CLIP measurement family is incomplete"
+                    )
+                target_rows.append(
+                    projected_retrieval.ProjectionClipMeasurement(
+                        measurement_key=projections.MeasurementKey(
+                            projection_variant_id=variant.projection_variant_id,
+                            lane=target_family.lane,
+                            extractor_version=target_family.extractor_version,
+                            model_version=target_family.model_version,
+                        ),
+                        samples=(
+                            replacement.samples
+                            if replacement is not None
+                            else active.samples
+                        ),
+                    )
+                )
+        dimensions = {len(row.samples[0].vector) for row in target_rows}
+        if (
+            len(dimensions) > 1
+            or (
+                active_root.vector_dimension is not None
+                and dimensions
+                and dimensions != {active_root.vector_dimension}
+            )
+        ):
+            raise CatalogPublicationError(
+                "the target CLIP measurement dimension changed"
+            )
+        target_manifest = projection_measurement_store.preview_measurement_store(
+            namespace=target_namespace,
+            family=target_family,
+            measurements=tuple(target_rows),
+        )
+    except CatalogPublicationError:
+        raise
+    except (
+        projection_measurement_store.MeasurementStoreError,
+        projections.ProjectionError,
+        OSError,
+        sqlite3.Error,
+        RuntimeError,
+        ValueError,
+    ) as error:
+        raise CatalogPublicationError(
+            "the target CLIP measurement family cannot be prepared"
+        ) from error
+    return PreparedMeasurementPublication(
+        family=target_family,
+        measurements=tuple(target_rows),
+        manifest=target_manifest,
+    )
+
+
 def _prepare_target_measurements(
     vault_root: Path,
     *,
     active_namespace: projection_store.VerifiedProjectionNamespace,
     active_roots: tuple[projection_store.ProjectionMeasurementRoot, ...],
     target_namespace: projection_store.PreparedProjectionNamespace,
+    clip_replacements: tuple[ClipMeasurementReplacement, ...] = (),
 ) -> tuple[PreparedMeasurementPublication, ...]:
     if not active_roots:
+        if clip_replacements:
+            raise CatalogPublicationError(
+                "CLIP measurement replacements require an active CLIP family"
+            )
         return ()
-    if (
-        len(active_roots) != 1
-        or not isinstance(
-            active_roots[0], projection_store.ProjectionMeasurementRoot
-        )
-        or active_roots[0].lane != "vector"
-    ):
+    if any(
+        not isinstance(root, projection_store.ProjectionMeasurementRoot)
+        for root in active_roots
+    ) or len({root.lane for root in active_roots}) != len(active_roots):
         raise CatalogPublicationError(
             "content publication requires rebuilt model and graph measurements"
         )
-    return (
-        _target_vector_measurements(
-            vault_root,
-            active_namespace=active_namespace,
-            active_root=active_roots[0],
-            target_namespace=target_namespace,
-        ),
-    )
+    if clip_replacements and not any(root.lane == "clip" for root in active_roots):
+        raise CatalogPublicationError(
+            "CLIP measurement replacements require an active CLIP family"
+        )
+    prepared: list[PreparedMeasurementPublication] = []
+    for active_root in active_roots:
+        if active_root.lane == "vector":
+            prepared.append(
+                _target_vector_measurements(
+                    vault_root,
+                    active_namespace=active_namespace,
+                    active_root=active_root,
+                    target_namespace=target_namespace,
+                )
+            )
+        elif active_root.lane == "clip":
+            prepared.append(
+                _target_clip_measurements(
+                    vault_root,
+                    active_namespace=active_namespace,
+                    active_root=active_root,
+                    target_namespace=target_namespace,
+                    replacements=clip_replacements,
+                )
+            )
+        else:
+            raise CatalogPublicationError(
+                "content publication requires rebuilt model and graph measurements"
+            )
+    return tuple(prepared)
 
 
 def _prepare_markdown_batch(
@@ -731,6 +918,7 @@ def _prepare_markdown_batch(
     planned_writes: tuple[vault.PlannedWrite, ...] | None,
     removals: tuple[CatalogRemoval, ...] = (),
     content_paths: tuple[str, ...] = (),
+    clip_replacements: tuple[ClipMeasurementReplacement, ...] = (),
     now: int | None = None,
     activated_at: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
@@ -738,8 +926,9 @@ def _prepare_markdown_batch(
 
     Lexical-only namespaces need no measurement work. The certified projected-
     text vector family reuses content-addressed unchanged rows and rebuilds new
-    variants before canonical bytes change. CLIP, graph, and unknown families
-    remain blocked until their exact publication builders are connected.
+    variants before canonical bytes change. The CLIP family carries complete
+    image/video rows and accepts only exact target-bound replacements. Graph and
+    unknown families remain blocked until their exact builders are connected.
     """
 
     root = Path(vault_root)
@@ -919,6 +1108,7 @@ def _prepare_markdown_batch(
             active_namespace=active_namespace,
             active_roots=evidence.required_measurement_roots,
             target_namespace=target_namespace,
+            clip_replacements=clip_replacements,
         )
         target_measurement_roots = tuple(
             projection_measurement_store.measurement_root(target.manifest)
@@ -985,6 +1175,7 @@ def prepare_markdown_batch(
     vault_root: Path,
     *,
     mutations: tuple[MarkdownCatalogMutation, ...],
+    clip_replacements: tuple[ClipMeasurementReplacement, ...] = (),
     now: int | None = None,
     activated_at: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
@@ -1000,6 +1191,7 @@ def prepare_markdown_batch(
         normalized=_normalize_markdown_mutations(root, mutations),
         planned_writes=None,
         removals=(),
+        clip_replacements=clip_replacements,
         now=now,
         activated_at=activated_at,
     )
@@ -1009,6 +1201,7 @@ def prepare_planned_markdown_batch(
     vault_root: Path,
     *,
     writes: tuple[vault.PlannedWrite, ...],
+    clip_replacements: tuple[ClipMeasurementReplacement, ...] = (),
     now: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
     """Prepare catalog rows lazily so v3/open planned writes remain unchanged."""
@@ -1018,6 +1211,7 @@ def prepare_planned_markdown_batch(
         normalized=None,
         planned_writes=writes,
         removals=(),
+        clip_replacements=clip_replacements,
         now=now,
     )
 
@@ -1028,6 +1222,7 @@ def prepare_catalog_membership_batch(
     writes: tuple[vault.PlannedWrite, ...] = (),
     removals: tuple[CatalogRemoval, ...] = (),
     content_paths: tuple[str, ...] = (),
+    clip_replacements: tuple[ClipMeasurementReplacement, ...] = (),
     now: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
     """Prepare lazy write/removal membership changes for a product mutation.
@@ -1043,6 +1238,7 @@ def prepare_catalog_membership_batch(
         planned_writes=writes,
         removals=removals,
         content_paths=content_paths,
+        clip_replacements=clip_replacements,
         now=now,
     )
 
@@ -1053,6 +1249,7 @@ def prepare_markdown_upsert(
     path: str,
     source: str,
     expected_before_hash: str | None,
+    clip_replacements: tuple[ClipMeasurementReplacement, ...] = (),
     now: int | None = None,
     activated_at: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
@@ -1061,6 +1258,7 @@ def prepare_markdown_upsert(
     return prepare_markdown_batch(
         vault_root,
         mutations=(MarkdownCatalogMutation(path, source, expected_before_hash),),
+        clip_replacements=clip_replacements,
         now=now,
         activated_at=activated_at,
     )
@@ -1205,6 +1403,7 @@ __all__ = [
     "CatalogCommitError",
     "CatalogPublicationError",
     "CatalogRemoval",
+    "ClipMeasurementReplacement",
     "MarkdownCatalogMutation",
     "PreparedMarkdownCatalogPublication",
     "catalog_component_values",

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -371,6 +371,8 @@ def _projection_item(
         ("status", parsed.frontmatter.get("status")),
         ("type", parsed.page_type),
         ("updated", parsed.updated),
+        ("media_type", parsed.frontmatter.get("media_type")),
+        ("parent_media", parsed.frontmatter.get("parent_media")),
     ):
         if value:
             search_fields[name] = str(value)
@@ -474,6 +476,11 @@ def _migrate_with_vector_projection_items(
     vault: Path,
     *,
     items: tuple[tuple[str, str], ...],
+    clip_samples_by_path: dict[
+        str,
+        tuple[projected_retrieval.ProjectionClipSample, ...],
+    ]
+    | None = None,
     now: int,
 ) -> tuple[
     schema_v4.MigrationResult,
@@ -534,6 +541,48 @@ def _migrate_with_vector_projection_items(
         family=family,
         measurements=measurements,
     )
+    measurement_roots = [
+        projection_measurement_store.measurement_root(measurement_manifest)
+    ]
+    if clip_samples_by_path is not None:
+        clip_family = projection_measurement_store.MeasurementFamilyKey(
+            namespace_key=key,
+            lane="clip",
+            extractor_version="pixels-v1",
+            model_version=embeddings.CLIP_MODEL_NAME,
+        )
+        clip_measurements = tuple(
+            projected_retrieval.ProjectionClipMeasurement(
+                measurement_key=projections.MeasurementKey(
+                    projection_variant_id=variant.projection_variant_id,
+                    lane=clip_family.lane,
+                    extractor_version=clip_family.extractor_version,
+                    model_version=clip_family.model_version,
+                ),
+                samples=clip_samples_by_path[item.item_identity],
+            )
+            for item in projected_items
+            for variant in item.variants
+            if projected_retrieval.clip_variant_applicable(variant)
+        )
+        expected_clip_items = {
+            item.item_identity
+            for item in projected_items
+            if any(
+                projected_retrieval.clip_variant_applicable(variant)
+                for variant in item.variants
+            )
+        }
+        assert set(clip_samples_by_path) == expected_clip_items
+        clip_manifest = projection_measurement_store.stage_measurement_store(
+            vault,
+            namespace=namespace,
+            family=clip_family,
+            measurements=clip_measurements,
+        )
+        measurement_roots.append(
+            projection_measurement_store.measurement_root(clip_manifest)
+        )
     connection = store.open_connection(vault)
     try:
         migration = schema_v4.migrate_v3_connection(
@@ -562,11 +611,7 @@ def _migrate_with_vector_projection_items(
                     namespace_id=key.namespace_id,
                     evidence=projection_store.projection_namespace_evidence_bytes(
                         manifest,
-                        required_measurement_roots=(
-                            projection_measurement_store.measurement_root(
-                                measurement_manifest
-                            ),
-                        ),
+                        required_measurement_roots=tuple(measurement_roots),
                     ),
                     ready_at=now,
                 ),
@@ -4675,6 +4720,201 @@ def test_semantic_edit_rebuilds_only_changed_vectors_before_v4_activation(
         for item in items
         for variant in item.variants
     }
+
+
+def test_semantic_edit_carries_complete_clip_family_into_the_same_v4_successor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    vault = tmp_path / "vault"
+    note_path = "Knowledge Base/Notes/changed.md"
+    video_path = "Knowledge Base/Evidence/Video/demo.mp4.md"
+    note_before = "---\ntitle: Changed\nstatus: draft\n---\n\nbefore\n"
+    note_after = note_before.replace("before", "after")
+    video_source = (
+        "---\ntitle: Demo video\ntype: source\nstatus: active\n"
+        "media_type: video\n---\n\nVideo evidence.\n"
+    )
+    for relative, source in (
+        (note_path, note_before),
+        (video_path, video_source),
+    ):
+        target = vault / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    samples = (
+        projected_retrieval.ProjectionClipSample(1_000, (1.0, 0.0)),
+        projected_retrieval.ProjectionClipSample(8_500, (0.0, 1.0)),
+    )
+    migration, _prior_vectors = _migrate_with_vector_projection_items(
+        vault,
+        items=((note_path, note_before), (video_path, video_source)),
+        clip_samples_by_path={video_path: samples},
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    monkeypatch.setattr(
+        embeddings,
+        "embed_texts",
+        lambda texts, *, is_query: [(9.0, 1.0) for _text in texts],
+    )
+    preflight = semantic_writes.preflight_existing(
+        vault,
+        path=note_path,
+        after_source=note_after,
+        operation="edit",
+        expected_before_hash=vault_module.content_hash(note_before),
+    )
+
+    committed = semantic_writes.commit_existing(vault, preflight=preflight)
+
+    assert committed.mutated is True
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    active, manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=2,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    evidence = projection_store.namespace_evidence_from_snapshot(active)
+    assert tuple(root.lane for root in evidence.required_measurement_roots) == (
+        "vector",
+        "clip",
+    )
+    namespace = projection_store.bind_active_projection_namespace(
+        active,
+        manifest=manifest,
+        items=items,
+    )
+    clip_root = next(
+        root for root in evidence.required_measurement_roots if root.lane == "clip"
+    )
+    family = projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=namespace.namespace_key,
+        lane=clip_root.lane,
+        extractor_version=clip_root.extractor_version,
+        model_version=clip_root.model_version,
+    )
+    _clip_manifest, rows = projection_measurement_store.load_measurement_store(
+        vault,
+        namespace=namespace,
+        family=family,
+        expected_rows_digest=clip_root.rows_digest,
+    )
+    assert len(rows) == 1
+    assert isinstance(rows[0], projected_retrieval.ProjectionClipMeasurement)
+    assert rows[0].samples == samples
+
+
+def test_video_edit_replaces_clip_samples_in_the_published_v4_successor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    video_path = "Knowledge Base/Evidence/Video/demo.mp4.md"
+    before = (
+        "---\ntitle: Demo video\ntype: source\nstatus: active\n"
+        "media_type: video\n---\n\nBefore.\n"
+    )
+    after = before.replace("Before.", "After.")
+    target = vault / video_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(before, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=2))
+    old_samples = (
+        projected_retrieval.ProjectionClipSample(1_000, (1.0, 0.0)),
+    )
+    new_samples = (
+        projected_retrieval.ProjectionClipSample(1_000, (0.0, 1.0)),
+        projected_retrieval.ProjectionClipSample(8_500, (1.0, 0.0)),
+    )
+    migration, _prior_vectors = _migrate_with_vector_projection_items(
+        vault,
+        items=((video_path, before),),
+        clip_samples_by_path={video_path: old_samples},
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setattr(
+        embeddings,
+        "embed_texts",
+        lambda texts, *, is_query: [(9.0, 1.0) for _text in texts],
+    )
+    prepared = catalog_publication.prepare_markdown_batch(
+        vault,
+        mutations=(
+            catalog_publication.MarkdownCatalogMutation(
+                video_path,
+                after,
+                vault_module.content_hash(before),
+            ),
+        ),
+        clip_replacements=(
+            catalog_publication.ClipMeasurementReplacement(
+                item_identity=video_path,
+                content_hash=vault_module.content_hash(after),
+                samples=new_samples,
+            ),
+        ),
+        now=now + 1,
+        activated_at=now + 1,
+    )
+    assert prepared is not None
+
+    target.write_text(after, encoding="utf-8")
+    published = catalog_publication.publish_markdown_batch(prepared)
+
+    assert published is not None
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    active, manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=2,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    evidence = projection_store.namespace_evidence_from_snapshot(active)
+    namespace = projection_store.bind_active_projection_namespace(
+        active,
+        manifest=manifest,
+        items=items,
+    )
+    clip_root = next(
+        root for root in evidence.required_measurement_roots if root.lane == "clip"
+    )
+    family = projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=namespace.namespace_key,
+        lane=clip_root.lane,
+        extractor_version=clip_root.extractor_version,
+        model_version=clip_root.model_version,
+    )
+    _clip_manifest, rows = projection_measurement_store.load_measurement_store(
+        vault,
+        namespace=namespace,
+        family=family,
+        expected_rows_digest=clip_root.rows_digest,
+    )
+    assert len(rows) == 1
+    assert isinstance(rows[0], projected_retrieval.ProjectionClipMeasurement)
+    assert rows[0].samples == new_samples
 
 
 def test_vector_catalog_preflight_refuses_unknown_measurement_family_before_bytes(

--- a/tests/test_governance_clip_successor_publication.py
+++ b/tests/test_governance_clip_successor_publication.py
@@ -1,0 +1,430 @@
+"""Exact catalog successors for projected image/video CLIP measurements."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from governance_projection_support import verified_namespace
+
+from exomem import embeddings, find_corpus
+from exomem.governance import (
+    catalog_publication,
+    projected_retrieval,
+    projection_measurement_store,
+    projection_store,
+    projections,
+)
+from exomem.governance.decisions import Decision
+
+
+def _key(generation: int) -> projections.ProjectionNamespaceKey:
+    return projections.ProjectionNamespaceKey(
+        policy_fingerprint="a" * 64,
+        projector_schema_version=1,
+        catalog_generation=generation,
+    )
+
+
+def _variant(
+    identity: str,
+    content_hash: str,
+    *,
+    media_type: str,
+    parent_media: str | None = None,
+) -> projections.ProjectionVariant:
+    variant = projections.build_projection_variant(
+        item_identity=identity,
+        content_hash=content_hash,
+        decision=Decision(level=6, options={}),
+        projector_schema_version=1,
+        full_search_fields={
+            "body": identity,
+            "media_type": media_type,
+            **({} if parent_media is None else {"parent_media": parent_media}),
+        },
+    )
+    assert variant is not None
+    return variant
+
+
+def _item(
+    variant: projections.ProjectionVariant,
+) -> projection_store.ProjectionItemVariants:
+    return projection_store.ProjectionItemVariants(
+        item_identity=variant.item_identity,
+        content_hash=variant.content_hash,
+        variants=(variant,),
+    )
+
+
+def _family(
+    key: projections.ProjectionNamespaceKey,
+) -> projection_measurement_store.MeasurementFamilyKey:
+    return projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=key,
+        lane="clip",
+        extractor_version="pixels-v1",
+        model_version="clip-ViT-B-32",
+    )
+
+
+def _vector_family(
+    key: projections.ProjectionNamespaceKey,
+) -> projection_measurement_store.MeasurementFamilyKey:
+    return projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=key,
+        lane="vector",
+        extractor_version="projected-text-v1",
+        model_version=embeddings.MODEL_NAME,
+    )
+
+
+def _vector_measurements(
+    family: projection_measurement_store.MeasurementFamilyKey,
+    *items: projection_store.ProjectionItemVariants,
+) -> tuple[projected_retrieval.ProjectionVectorMeasurement, ...]:
+    return tuple(
+        projected_retrieval.ProjectionVectorMeasurement(
+            projections.MeasurementKey(
+                projection_variant_id=variant.projection_variant_id,
+                lane=family.lane,
+                extractor_version=family.extractor_version,
+                model_version=family.model_version,
+            ),
+            (float(index + 1), 1.0),
+        )
+        for index, variant in enumerate(
+            variant for item in items for variant in item.variants
+        )
+    )
+
+
+def _image_measurement(
+    family: projection_measurement_store.MeasurementFamilyKey,
+    variant: projections.ProjectionVariant,
+) -> projected_retrieval.ProjectionClipMeasurement:
+    return projected_retrieval.ProjectionClipMeasurement(
+        projections.MeasurementKey(
+            projection_variant_id=variant.projection_variant_id,
+            lane=family.lane,
+            extractor_version=family.extractor_version,
+            model_version=family.model_version,
+        ),
+        (0.0, 1.0),
+    )
+
+
+def _video_measurement(
+    family: projection_measurement_store.MeasurementFamilyKey,
+    variant: projections.ProjectionVariant,
+    *samples: tuple[int, tuple[float, ...]],
+) -> projected_retrieval.ProjectionClipMeasurement:
+    return projected_retrieval.ProjectionClipMeasurement(
+        projections.MeasurementKey(
+            projection_variant_id=variant.projection_variant_id,
+            lane=family.lane,
+            extractor_version=family.extractor_version,
+            model_version=family.model_version,
+        ),
+        samples=tuple(
+            projected_retrieval.ProjectionClipSample(timestamp_ms, vector)
+            for timestamp_ms, vector in samples
+        ),
+    )
+
+
+def _prepared_namespace(
+    key: projections.ProjectionNamespaceKey,
+    items: tuple[projection_store.ProjectionItemVariants, ...],
+) -> projection_store.PreparedProjectionNamespace:
+    return projection_store.prepare_projection_namespace(
+        key=key,
+        manifest=projection_store.preview_variant_store(key=key, items=items),
+        items=items,
+    )
+
+
+def test_clip_successor_carries_images_and_replaces_one_video_row(
+    tmp_path: Path,
+) -> None:
+    active_key = _key(1)
+    video = _variant("Knowledge Base/video.mp4.md", "1" * 64, media_type="video")
+    image = _variant("Knowledge Base/image.jpg.md", "2" * 64, media_type="image")
+    active_items = (_item(video), _item(image))
+    active_namespace = verified_namespace(active_key, active_items)
+    active_family = _family(active_key)
+    active_manifest = projection_measurement_store.stage_measurement_store(
+        tmp_path,
+        namespace=active_namespace,
+        family=active_family,
+        measurements=(
+            _video_measurement(active_family, video, (1_000, (1.0, 0.0))),
+            _image_measurement(active_family, image),
+        ),
+    )
+    frame = _variant(
+        "Knowledge Base/video.mp4.frames/scene-000-t8500ms.jpg.md",
+        "3" * 64,
+        media_type="image",
+        parent_media="Knowledge Base/video.mp4",
+    )
+    target_namespace = _prepared_namespace(
+        _key(2),
+        (*active_items, _item(frame)),
+    )
+
+    prepared = catalog_publication._prepare_target_measurements(
+        tmp_path,
+        active_namespace=active_namespace,
+        active_roots=(
+            projection_measurement_store.measurement_root(active_manifest),
+        ),
+        target_namespace=target_namespace,
+        clip_replacements=(
+            catalog_publication.ClipMeasurementReplacement(
+                item_identity=video.item_identity,
+                content_hash=video.content_hash,
+                samples=(
+                    projected_retrieval.ProjectionClipSample(1_000, (0.0, 1.0)),
+                    projected_retrieval.ProjectionClipSample(8_500, (1.0, 0.0)),
+                ),
+            ),
+        ),
+    )
+
+    assert len(prepared) == 1
+    target = prepared[0]
+    assert target.family.namespace_key == target_namespace.namespace_key
+    assert target.manifest.measurement_count == 2
+    by_variant = {
+        row.measurement_key.projection_variant_id: row
+        for row in target.measurements
+    }
+    assert by_variant[video.projection_variant_id].samples[1].frame_timestamp_ms == 8_500
+    assert by_variant[image.projection_variant_id].samples[0].frame_timestamp_ms is None
+    assert frame.projection_variant_id not in by_variant
+
+
+def test_clip_successor_refuses_an_incomplete_active_family(tmp_path: Path) -> None:
+    active_key = _key(1)
+    video = _variant("Knowledge Base/video.mp4.md", "4" * 64, media_type="video")
+    image = _variant("Knowledge Base/image.jpg.md", "5" * 64, media_type="image")
+    active_items = (_item(video), _item(image))
+    active_namespace = verified_namespace(active_key, active_items)
+    active_family = _family(active_key)
+    active_manifest = projection_measurement_store.stage_measurement_store(
+        tmp_path,
+        namespace=active_namespace,
+        family=active_family,
+        measurements=(
+            _video_measurement(active_family, video, (1_000, (1.0, 0.0))),
+        ),
+    )
+
+    with pytest.raises(
+        catalog_publication.CatalogPublicationError,
+        match="CLIP measurement family is incomplete",
+    ):
+        catalog_publication._prepare_target_measurements(
+            tmp_path,
+            active_namespace=active_namespace,
+            active_roots=(
+                projection_measurement_store.measurement_root(active_manifest),
+            ),
+            target_namespace=_prepared_namespace(_key(2), active_items),
+            clip_replacements=(),
+        )
+
+
+def test_clip_successor_refuses_a_replacement_not_bound_to_target_content(
+    tmp_path: Path,
+) -> None:
+    active_key = _key(1)
+    image = _variant("Knowledge Base/image.jpg.md", "6" * 64, media_type="image")
+    active_items = (_item(image),)
+    active_namespace = verified_namespace(active_key, active_items)
+    active_family = _family(active_key)
+    active_manifest = projection_measurement_store.stage_measurement_store(
+        tmp_path,
+        namespace=active_namespace,
+        family=active_family,
+        measurements=(_image_measurement(active_family, image),),
+    )
+
+    with pytest.raises(
+        catalog_publication.CatalogPublicationError,
+        match="replacement does not match target content",
+    ):
+        catalog_publication._prepare_target_measurements(
+            tmp_path,
+            active_namespace=active_namespace,
+            active_roots=(
+                projection_measurement_store.measurement_root(active_manifest),
+            ),
+            target_namespace=_prepared_namespace(_key(2), active_items),
+            clip_replacements=(
+                catalog_publication.ClipMeasurementReplacement(
+                    item_identity=image.item_identity,
+                    content_hash="f" * 64,
+                    samples=(
+                        projected_retrieval.ProjectionClipSample(None, (1.0, 0.0)),
+                    ),
+                ),
+            ),
+        )
+
+
+def test_clip_successor_normalizes_invalid_media_samples_to_publication_refusal(
+    tmp_path: Path,
+) -> None:
+    active_key = _key(1)
+    image = _variant("Knowledge Base/image.jpg.md", "6" * 64, media_type="image")
+    active_items = (_item(image),)
+    active_namespace = verified_namespace(active_key, active_items)
+    active_family = _family(active_key)
+    active_manifest = projection_measurement_store.stage_measurement_store(
+        tmp_path,
+        namespace=active_namespace,
+        family=active_family,
+        measurements=(_image_measurement(active_family, image),),
+    )
+
+    with pytest.raises(
+        catalog_publication.CatalogPublicationError,
+        match="target CLIP measurement family cannot be prepared",
+    ):
+        catalog_publication._prepare_target_measurements(
+            tmp_path,
+            active_namespace=active_namespace,
+            active_roots=(
+                projection_measurement_store.measurement_root(active_manifest),
+            ),
+            target_namespace=_prepared_namespace(_key(2), active_items),
+            clip_replacements=(
+                catalog_publication.ClipMeasurementReplacement(
+                    item_identity=image.item_identity,
+                    content_hash=image.content_hash,
+                    samples=(
+                        projected_retrieval.ProjectionClipSample(
+                            1_000,
+                            (1.0, 0.0),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+
+def test_vector_and_clip_successors_share_one_target_namespace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    active_key = _key(1)
+    video = _variant("Knowledge Base/video.mp4.md", "7" * 64, media_type="video")
+    active_items = (_item(video),)
+    active_namespace = verified_namespace(active_key, active_items)
+    vector_family = _vector_family(active_key)
+    clip_family = _family(active_key)
+    vector_manifest = projection_measurement_store.stage_measurement_store(
+        tmp_path,
+        namespace=active_namespace,
+        family=vector_family,
+        measurements=_vector_measurements(vector_family, *active_items),
+    )
+    clip_manifest = projection_measurement_store.stage_measurement_store(
+        tmp_path,
+        namespace=active_namespace,
+        family=clip_family,
+        measurements=(
+            _video_measurement(clip_family, video, (1_000, (1.0, 0.0))),
+        ),
+    )
+    frame = _variant(
+        "Knowledge Base/video.mp4.frames/scene-000-t8500ms.jpg.md",
+        "8" * 64,
+        media_type="image",
+        parent_media="Knowledge Base/video.mp4",
+    )
+    target_namespace = _prepared_namespace(
+        _key(2),
+        (*active_items, _item(frame)),
+    )
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setattr(
+        embeddings,
+        "embed_texts",
+        lambda texts, *, is_query: [[1.0, 1.0] for _text in texts],
+    )
+
+    prepared = catalog_publication._prepare_target_measurements(
+        tmp_path,
+        active_namespace=active_namespace,
+        active_roots=(
+            projection_measurement_store.measurement_root(vector_manifest),
+            projection_measurement_store.measurement_root(clip_manifest),
+        ),
+        target_namespace=target_namespace,
+        clip_replacements=(
+            catalog_publication.ClipMeasurementReplacement(
+                item_identity=video.item_identity,
+                content_hash=video.content_hash,
+                samples=(
+                    projected_retrieval.ProjectionClipSample(1_000, (0.0, 1.0)),
+                    projected_retrieval.ProjectionClipSample(8_500, (1.0, 0.0)),
+                ),
+            ),
+        ),
+    )
+
+    assert [target.family.lane for target in prepared] == ["vector", "clip"]
+    assert all(
+        target.family.namespace_key == target_namespace.namespace_key
+        for target in prepared
+    )
+    vector_target, clip_target = prepared
+    assert vector_target.manifest.measurement_count == 2
+    assert clip_target.manifest.measurement_count == 1
+
+
+def test_catalog_projection_fields_distinguish_parent_media_from_frame_children(
+    tmp_path: Path,
+) -> None:
+    video_source = (
+        "---\ntitle: Demo\ntype: source\nmedia_type: video\n---\n\nVideo body.\n"
+    )
+    frame_source = (
+        "---\ntitle: Frame\ntype: evidence\nmedia_type: image\n"
+        "parent_media: Knowledge Base/demo.mp4\n---\n\nFrame body.\n"
+    )
+
+    def fields(path: str, source: str) -> dict[str, str]:
+        parsed = find_corpus.parse_page(
+            tmp_path / path,
+            0.0,
+            tmp_path,
+            content=source.encode(),
+            resolved_relative=path,
+        )
+        assert parsed is not None
+        return catalog_publication._search_fields(parsed)
+
+    video_fields = fields("Knowledge Base/demo.mp4.md", video_source)
+    frame_fields = fields(
+        "Knowledge Base/demo.mp4.frames/scene-000-t1000ms.jpg.md",
+        frame_source,
+    )
+    video = _variant(
+        "Knowledge Base/demo.mp4.md",
+        "9" * 64,
+        media_type=video_fields["media_type"],
+    )
+    frame = _variant(
+        "Knowledge Base/demo.mp4.frames/scene-000-t1000ms.jpg.md",
+        "0" * 64,
+        media_type=frame_fields["media_type"],
+        parent_media=frame_fields["parent_media"],
+    )
+
+    assert projected_retrieval.clip_variant_applicable(video)
+    assert not projected_retrieval.clip_variant_applicable(frame)


### PR DESCRIPTION
## Summary

- carry verified content-identical image/video CLIP rows into the next exact-v4 catalog generation
- require target-identity/content-hash-bound samples for changed visual media and reject incomplete or incompatible families before canonical bytes change
- publish vector and CLIP roots against one target namespace while keeping derived frame companions textual and graph successors fail-closed

## Verification

- `33 passed` across the focused CLIP successor, active-tuple, measurement-store, and measurement-activation tests
- `ruff check` on all changed Python files
- `openspec validate harden-governance-for-consolidation --strict`
- `python scripts/validate-public-artifacts.py --repository`
- `uv build`
- `git diff --check`