### PR TITLE
feat(governance): publish semantic graph successors

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/design.md
+++ b/openspec/changes/harden-governance-for-consolidation/design.md
@@ -736,6 +736,22 @@ roots, receipt, and active tuple. Live graph producers remain responsible for su
 the target-bound replacements for every affected changed L6 source; an unknown required
 measurement family remains blocked.
 
+A producer may conservatively return a target-bound replacement for an affected item
+whose target namespace has no L6 variant. The publisher still validates its item,
+content, edge sources, edge targets, uniqueness, and aggregate capacity, then discards
+that edge payload and emits only the required empty lower-variant rows. A lower-only
+policy projection therefore cannot turn an otherwise valid semantic write into a graph
+publication refusal or persist raw graph authority below L6.
+
+The existing-page semantic writer derives its graph replacements from the detached
+before-corpus retained by semantic preflight plus the exact guarded planned-write
+overlay. It does not reopen the live graph or walk the vault again. The overlay
+re-resolves title-dependent links and reverse relations, so the replacement set includes
+both directly changed paths and otherwise-unchanged logical sources whose outgoing edge
+tuple changes. This producer is invoked lazily only when the active tuple contains a
+graph family; open and lexical-only writes do no graph-producer work. Other live writer
+families remain blocked until they supply the same target-bound replacement contract.
+
 A policy
 fingerprint or projector-schema change builds a new namespace tuple and never relabels
 an old one. A model/extractor change writes or invalidates only the corresponding

--- a/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
+++ b/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
@@ -219,6 +219,23 @@ required family SHALL remain blocked.
 - **THEN** the complete target graph root advances with the target namespace, other
   required measurement roots, receipt, and active tuple in one catalog publication
 
+#### Scenario: Lower-only changed items retain empty graph rows
+
+- **WHEN** a live producer conservatively returns a target-bound replacement for an
+  affected item whose target namespace contains no L6 variant
+- **THEN** publication validates its exact item/content binding, edge sources, edge
+  targets, uniqueness, and aggregate capacity, discards the edge payload, and emits only
+  empty lower-variant graph rows
+
+#### Scenario: Semantic writes derive graph successors from retained preflight state
+
+- **WHEN** an existing-page semantic write changes a direct edge, a title used by
+  another page's link, or a reverse relation whose logical source is another page
+- **THEN** the writer derives target-bound replacements from the retained detached
+  before-corpus and exact guarded planned bytes, includes every logical source whose
+  outgoing edge tuple changes, and does not reopen the live graph or current Markdown
+- **AND** open and lexical-only writes do not invoke the graph producer
+
 When the projected source is exhausted, L1-and-above items SHALL still emit the
 projection their policy authorizes while L0 items SHALL produce a silently shorter list,
 identical to physical absence. The canonical governed envelope for the same input SHALL

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -536,8 +536,13 @@ made before both PRs and their combined verification are complete.
   verify exactly one active row per variant, emit empty lower-variant rows, carry only
   content-identical L6 rows, require target-item/content-hash-bound replacements for
   changed L6 sources, reject stale outside-catalog targets, and publish the complete graph
-  root atomically. Connect every live graph producer to those replacements before checking
-  this task; keep any other unsupported required family blocked.
+  root atomically. Validate conservative producer replacements for affected lower-only
+  items, discard their edge payload, and emit only empty lower-variant rows. For the
+  existing-page semantic writer, derive replacements from its
+  retained detached preflight corpus plus the exact guarded planned-write overlay, include
+  indirect title-resolution and reverse-relation source changes, and never reopen the live
+  graph or walk the vault again. Connect every other live graph producer to those
+  replacements before checking this task; keep any unsupported required family blocked.
 - [x] 8.12 Implement BM25 posting intersection before cap, projected-corpus DF/IDF and
   exact top-k; exact filtered projected-vector top-k with visible-lane warming/disable;
   projected-only reranking before final top-k; and L6-only pre-cap CLIP authorization.

--- a/src/exomem/governance/catalog_publication.py
+++ b/src/exomem/governance/catalog_publication.py
@@ -13,6 +13,7 @@ import os
 import sqlite3
 import time
 import unicodedata
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
@@ -921,19 +922,21 @@ def _target_graph_measurements(
     if type(replacements) is not tuple:
         raise CatalogPublicationError(
             "graph measurement replacements must be a finite immutable tuple"
-        )
+    )
     target_items = {item.item_identity: item for item in target_namespace.items}
     replacement_by_identity: dict[str, GraphMeasurementReplacement] = {}
+    seen_replacement_identities: set[str] = set()
+    replacement_edge_count = 0
     for replacement in replacements:
         if not isinstance(replacement, GraphMeasurementReplacement):
             raise CatalogPublicationError("graph measurement replacement is invalid")
-        if replacement.item_identity in replacement_by_identity:
+        if replacement.item_identity in seen_replacement_identities:
             raise CatalogPublicationError("graph measurement replacements collide")
+        seen_replacement_identities.add(replacement.item_identity)
         target_item = target_items.get(replacement.item_identity)
         if (
             target_item is None
             or target_item.content_hash != replacement.content_hash
-            or not any(variant.decision_level == 6 for variant in target_item.variants)
         ):
             raise CatalogPublicationError(
                 "graph measurement replacement does not match target content"
@@ -942,6 +945,27 @@ def _target_graph_measurements(
             raise CatalogPublicationError(
                 "graph measurement replacement edges must be immutable"
             )
+        replacement_edge_count += len(replacement.edges)
+        if replacement_edge_count > projections.MAX_GOVERNED_GRAPH_EDGES:
+            raise CatalogPublicationError(
+                "graph measurement replacement capacity is exceeded"
+            )
+        seen_edges: set[projected_graph.ProjectionGraphEdge] = set()
+        for edge in replacement.edges:
+            if (
+                not isinstance(edge, projected_graph.ProjectionGraphEdge)
+                or edge.source_item_identity != replacement.item_identity
+                or edge.target_item_identity not in target_items
+                or edge in seen_edges
+            ):
+                raise CatalogPublicationError(
+                    "graph measurement replacement edge is invalid"
+                )
+            seen_edges.add(edge)
+        if not any(
+            variant.decision_level == 6 for variant in target_item.variants
+        ):
+            continue
         replacement_by_identity[replacement.item_identity] = replacement
 
     target_family = projection_measurement_store.MeasurementFamilyKey(
@@ -1010,7 +1034,34 @@ def _prepare_target_measurements(
     target_namespace: projection_store.PreparedProjectionNamespace,
     clip_replacements: tuple[ClipMeasurementReplacement, ...] = (),
     graph_replacements: tuple[GraphMeasurementReplacement, ...] = (),
+    graph_replacement_provider: Callable[
+        [], tuple[GraphMeasurementReplacement, ...]
+    ]
+    | None = None,
 ) -> tuple[PreparedMeasurementPublication, ...]:
+    if graph_replacement_provider is not None and graph_replacements:
+        raise CatalogPublicationError(
+            "graph measurement replacements have multiple authorities"
+        )
+    if any(
+        not isinstance(root, projection_store.ProjectionMeasurementRoot)
+        for root in active_roots
+    ) or len({root.lane for root in active_roots}) != len(active_roots):
+        raise CatalogPublicationError(
+            "content publication requires rebuilt model and graph measurements"
+        )
+    has_graph_family = any(root.lane == "graph" for root in active_roots)
+    if graph_replacement_provider is not None and has_graph_family:
+        try:
+            graph_replacements = graph_replacement_provider()
+        except Exception as error:  # noqa: BLE001 - producer faults fail closed
+            raise CatalogPublicationError(
+                "the live graph producer cannot prepare target measurements"
+            ) from error
+        if type(graph_replacements) is not tuple:
+            raise CatalogPublicationError(
+                "the live graph producer returned an invalid replacement set"
+            )
     if not active_roots:
         if clip_replacements:
             raise CatalogPublicationError(
@@ -1021,13 +1072,6 @@ def _prepare_target_measurements(
                 "graph measurement replacements require an active graph family"
             )
         return ()
-    if any(
-        not isinstance(root, projection_store.ProjectionMeasurementRoot)
-        for root in active_roots
-    ) or len({root.lane for root in active_roots}) != len(active_roots):
-        raise CatalogPublicationError(
-            "content publication requires rebuilt model and graph measurements"
-        )
     if clip_replacements and not any(root.lane == "clip" for root in active_roots):
         raise CatalogPublicationError(
             "CLIP measurement replacements require an active CLIP family"
@@ -1085,6 +1129,10 @@ def _prepare_markdown_batch(
     content_paths: tuple[str, ...] = (),
     clip_replacements: tuple[ClipMeasurementReplacement, ...] = (),
     graph_replacements: tuple[GraphMeasurementReplacement, ...] = (),
+    graph_replacement_provider: Callable[
+        [], tuple[GraphMeasurementReplacement, ...]
+    ]
+    | None = None,
     now: int | None = None,
     activated_at: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
@@ -1277,6 +1325,7 @@ def _prepare_markdown_batch(
             target_namespace=target_namespace,
             clip_replacements=clip_replacements,
             graph_replacements=graph_replacements,
+            graph_replacement_provider=graph_replacement_provider,
         )
         target_measurement_roots = tuple(
             projection_measurement_store.measurement_root(target.manifest)
@@ -1373,6 +1422,10 @@ def prepare_planned_markdown_batch(
     writes: tuple[vault.PlannedWrite, ...],
     clip_replacements: tuple[ClipMeasurementReplacement, ...] = (),
     graph_replacements: tuple[GraphMeasurementReplacement, ...] = (),
+    graph_replacement_provider: Callable[
+        [], tuple[GraphMeasurementReplacement, ...]
+    ]
+    | None = None,
     now: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
     """Prepare catalog rows lazily so v3/open planned writes remain unchanged."""
@@ -1384,6 +1437,7 @@ def prepare_planned_markdown_batch(
         removals=(),
         clip_replacements=clip_replacements,
         graph_replacements=graph_replacements,
+        graph_replacement_provider=graph_replacement_provider,
         now=now,
     )
 

--- a/src/exomem/governance/graph_producer.py
+++ b/src/exomem/governance/graph_producer.py
@@ -1,0 +1,178 @@
+"""Translate exact semantic-write snapshots into projected graph successors."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+from .. import semantic_contract, semantic_language_registry, vault
+from . import catalog_publication, projected_graph
+
+
+class GraphProducerError(RuntimeError):
+    """A planned Markdown batch cannot produce an exact graph successor."""
+
+
+def _edge_key(
+    edge: projected_graph.ProjectionGraphEdge,
+) -> tuple[bytes, bytes, bytes]:
+    return (
+        edge.source_item_identity.encode("utf-8"),
+        edge.target_item_identity.encode("utf-8"),
+        edge.relation_type.encode("utf-8"),
+    )
+
+
+def _edges_by_source(
+    corpus: semantic_contract.SemanticCorpusContext,
+) -> dict[str, tuple[projected_graph.ProjectionGraphEdge, ...]]:
+    pages = frozenset(corpus.pages)
+    resolver = vault.WikilinkResolver.from_entries(
+        corpus.vault_root,
+        corpus.resolver_entries,
+    )
+    edges: dict[str, set[projected_graph.ProjectionGraphEdge]] = {
+        path: set() for path in pages
+    }
+    for fact in corpus.relation_facts:
+        source = fact.logical_source_path
+        target = fact.logical_target_path
+        relation = fact.canonical_relation
+        if (
+            source not in pages
+            or target not in pages
+            or fact.resolved_target_path is None
+            or not isinstance(relation, str)
+            or not relation
+        ):
+            continue
+        edges[source].add(
+            projected_graph.ProjectionGraphEdge(
+                source_item_identity=source,
+                target_item_identity=target,
+                relation_type=relation,
+            )
+        )
+    for source, state in corpus.pages.items():
+        for raw_target, _line in state.body_wikilinks:
+            try:
+                canonical, warning = vault.normalize_wikilink(
+                    raw_target,
+                    corpus.vault_root,
+                    resolver=resolver,
+                    strict=False,
+                )
+            except (OSError, RuntimeError, UnicodeError, ValueError):
+                continue
+            target = canonical.split("#", 1)[0]
+            if target and not target.casefold().endswith(".md"):
+                target += ".md"
+            if warning is not None or target not in pages:
+                continue
+            edges[source].add(
+                projected_graph.ProjectionGraphEdge(
+                    source_item_identity=source,
+                    target_item_identity=target,
+                    relation_type="links_to",
+                )
+            )
+    return {
+        source: tuple(sorted(values, key=_edge_key))
+        for source, values in edges.items()
+    }
+
+
+def replacements_for_planned_markdown(
+    vault_root: Path,
+    *,
+    before_corpus: semantic_contract.SemanticCorpusContext,
+    writes: tuple[vault.PlannedWrite, ...],
+    semantic_states: Mapping[str, semantic_contract.SemanticPageState] | None = None,
+    language_registry: semantic_language_registry.SemanticLanguageRegistry | None = None,
+) -> tuple[catalog_publication.GraphMeasurementReplacement, ...]:
+    """Build complete replacements from one already-reviewed Markdown overlay.
+
+    The corpus is detached preflight evidence. Planned bytes are applied only to
+    that in-memory snapshot, so title resolution, reverse relations, and other
+    sources affected by a topology change are included without reopening the
+    live graph or walking the vault a second time.
+    """
+
+    root = Path(vault_root)
+    if before_corpus.vault_root != root:
+        raise GraphProducerError("graph producer corpus belongs to another vault")
+    if type(writes) is not tuple or not writes:
+        raise GraphProducerError("graph producer requires a finite planned-write batch")
+    prepared_states = dict(semantic_states or {})
+    mutations: dict[str, catalog_publication.MarkdownCatalogMutation] = {}
+    try:
+        for write in writes:
+            mutation = catalog_publication.mutation_from_planned_write(root, write)
+            if mutation is None:
+                continue
+            if mutation.path in mutations:
+                raise GraphProducerError("graph producer Markdown targets collide")
+            mutations[mutation.path] = mutation
+    except catalog_publication.CatalogPublicationError as error:
+        raise GraphProducerError(str(error)) from error
+    if not mutations:
+        return ()
+
+    language = language_registry or semantic_language_registry.load_registry(root)
+    after_corpus = before_corpus
+    try:
+        for path in sorted(mutations):
+            mutation = mutations[path]
+            state = prepared_states.get(path)
+            if state is None:
+                state = semantic_contract.build_page_state(
+                    root,
+                    path,
+                    mutation.source,
+                    relation_registry=before_corpus.registry,
+                    language_registry=language,
+                )
+            if state.path != path or state.source_hash != vault.content_hash(
+                mutation.source
+            ):
+                raise GraphProducerError(
+                    "graph producer semantic state does not bind planned bytes"
+                )
+            after_corpus = after_corpus.with_candidate(state)
+    except GraphProducerError:
+        raise
+    except (OSError, RuntimeError, UnicodeError, ValueError) as error:
+        raise GraphProducerError(
+            "graph producer cannot derive the planned semantic topology"
+        ) from error
+
+    before_edges = _edges_by_source(before_corpus)
+    after_edges = _edges_by_source(after_corpus)
+    affected = set(mutations)
+    affected.update(
+        source
+        for source in set(before_edges) | set(after_edges)
+        if before_edges.get(source, ()) != after_edges.get(source, ())
+    )
+    replacements: list[catalog_publication.GraphMeasurementReplacement] = []
+    for source in sorted(affected):
+        state = after_corpus.pages.get(source)
+        if state is None:
+            continue
+        mutation = mutations.get(source)
+        content_hash = (
+            vault.content_hash(mutation.source)
+            if mutation is not None
+            else state.source_hash
+        )
+        replacements.append(
+            catalog_publication.GraphMeasurementReplacement(
+                item_identity=source,
+                content_hash=content_hash,
+                edges=after_edges.get(source, ()),
+            )
+        )
+    return tuple(replacements)
+
+
+__all__ = ["GraphProducerError", "replacements_for_planned_markdown"]

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -2067,10 +2067,24 @@ def _commit_existing_locked(
             guard=preflight.primary_guard,
         )
     )
-    from .governance import catalog_publication
+    from .governance import catalog_publication, graph_producer
+
+    planned_writes = tuple(writes)
+
+    def graph_replacement_provider():
+        return graph_producer.replacements_for_planned_markdown(
+            root,
+            before_corpus=preflight.before_corpus,
+            writes=planned_writes,
+            semantic_states={preflight.path: preflight.after},
+        )
 
     try:
-        catalog_target = _prepare_markdown_catalog_publication(root, writes)
+        catalog_target = _prepare_markdown_catalog_publication(
+            root,
+            planned_writes,
+            graph_replacement_provider=graph_replacement_provider,
+        )
     except catalog_publication.CatalogPublicationError as error:
         raise SemanticWriteError(
             "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
@@ -2144,6 +2158,8 @@ def _revalidate_existing_preflight(
 def _prepare_markdown_catalog_publication(
     vault_root: Path,
     writes: Sequence[vault.PlannedWrite],
+    *,
+    graph_replacement_provider: Callable[[], tuple[Any, ...]] | None = None,
 ):  # noqa: ANN202 - private bridge returns the governance publication token
     """Prepare one exact catalog successor for the canonical Markdown subset."""
 
@@ -2152,6 +2168,7 @@ def _prepare_markdown_catalog_publication(
     return catalog_publication.prepare_planned_markdown_batch(
         vault_root,
         writes=tuple(writes),
+        graph_replacement_provider=graph_replacement_provider,
     )
 
 

--- a/tests/test_governance_graph_producer.py
+++ b/tests/test_governance_graph_producer.py
@@ -1,0 +1,261 @@
+"""Target-bound graph replacements derived from semantic write preflight state."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from exomem import (
+    relation_registry,
+    semantic_contract,
+    semantic_language_registry,
+    vault,
+)
+from exomem.governance import catalog_publication, graph_producer, projected_graph
+
+
+def _source(
+    title: str,
+    identity: str,
+    *,
+    body: str = "## Observations\n\n- [decision] Keep the graph exact.\n",
+) -> str:
+    return (
+        "---\n"
+        f"title: {title}\n"
+        "type: insight\n"
+        "status: active\n"
+        "project: atlas\n"
+        f"exomem_id: {identity}\n"
+        "---\n\n"
+        f"{body}"
+    )
+
+
+def _state(
+    root: Path,
+    path: str,
+    source: str,
+) -> semantic_contract.SemanticPageState:
+    return semantic_contract.build_page_state(
+        root,
+        path,
+        source,
+        relation_registry=relation_registry.core_registry(),
+        language_registry=semantic_language_registry.core_registry(),
+        review_fingerprint="review-v1",
+    )
+
+
+def _corpus(
+    root: Path,
+    *states: semantic_contract.SemanticPageState,
+) -> semantic_contract.SemanticCorpusContext:
+    return semantic_contract.SemanticCorpusContext.from_states(
+        root,
+        states,
+        registry=relation_registry.core_registry(),
+        identity_census=semantic_contract.StableIdentityCensus(
+            tuple(
+                semantic_contract.StableIdentityEntry(state.path, state.identity)
+                for state in states
+            )
+        ),
+    )
+
+
+def _write(
+    root: Path,
+    path: str,
+    before: str,
+    after: str,
+) -> vault.PlannedWrite:
+    return vault.PlannedWrite(
+        root / path,
+        after,
+        expected_hash=vault.content_hash(before),
+    )
+
+
+def _edge(
+    source: str,
+    target: str,
+    relation: str = "links_to",
+) -> projected_graph.ProjectionGraphEdge:
+    return projected_graph.ProjectionGraphEdge(source, target, relation)
+
+
+def test_planned_source_replaces_its_exact_outgoing_edges(tmp_path: Path) -> None:
+    source_path = "Knowledge Base/Notes/Insights/source.md"
+    first_target = "Knowledge Base/Notes/Insights/first.md"
+    second_target = "Knowledge Base/Notes/Insights/second.md"
+    source_before = _source(
+        "Source",
+        "00000000-0000-0000-0000-000000000001",
+        body="## Observations\n\n- [decision] First edge.\n\n[[First]]\n",
+    )
+    source_after = _source(
+        "Source",
+        "00000000-0000-0000-0000-000000000001",
+        body="## Observations\n\n- [decision] Second edge.\n\n[[Second]]\n",
+    )
+    before = _corpus(
+        tmp_path,
+        _state(tmp_path, source_path, source_before),
+        _state(
+            tmp_path,
+            first_target,
+            _source("First", "00000000-0000-0000-0000-000000000002"),
+        ),
+        _state(
+            tmp_path,
+            second_target,
+            _source("Second", "00000000-0000-0000-0000-000000000003"),
+        ),
+    )
+
+    replacements = graph_producer.replacements_for_planned_markdown(
+        tmp_path,
+        before_corpus=before,
+        writes=(_write(tmp_path, source_path, source_before, source_after),),
+        semantic_states={source_path: _state(tmp_path, source_path, source_after)},
+        language_registry=semantic_language_registry.core_registry(),
+    )
+
+    assert replacements == (
+        catalog_publication.GraphMeasurementReplacement(
+            source_path,
+            vault.content_hash(source_after),
+            (_edge(source_path, second_target),),
+        ),
+    )
+
+
+def test_title_change_replaces_sources_whose_resolution_changed(tmp_path: Path) -> None:
+    source_path = "Knowledge Base/Notes/Insights/source.md"
+    target_path = "Knowledge Base/Notes/Insights/target.md"
+    source = _source(
+        "Source",
+        "00000000-0000-0000-0000-000000000001",
+        body=(
+            "## Observations\n\n"
+            "- [decision] Resolve the target by title.\n\n"
+            "[[Old target title]]\n"
+        ),
+    )
+    target_before = _source(
+        "Old target title",
+        "00000000-0000-0000-0000-000000000002",
+    )
+    target_after = _source(
+        "New target title",
+        "00000000-0000-0000-0000-000000000002",
+    )
+    before = _corpus(
+        tmp_path,
+        _state(tmp_path, source_path, source),
+        _state(tmp_path, target_path, target_before),
+    )
+
+    replacements = graph_producer.replacements_for_planned_markdown(
+        tmp_path,
+        before_corpus=before,
+        writes=(_write(tmp_path, target_path, target_before, target_after),),
+        semantic_states={target_path: _state(tmp_path, target_path, target_after)},
+        language_registry=semantic_language_registry.core_registry(),
+    )
+
+    assert replacements == (
+        catalog_publication.GraphMeasurementReplacement(
+            source_path,
+            vault.content_hash(source),
+            (),
+        ),
+        catalog_publication.GraphMeasurementReplacement(
+            target_path,
+            vault.content_hash(target_after),
+            (),
+        ),
+    )
+
+
+def test_reverse_supersession_replaces_the_logical_source_row(tmp_path: Path) -> None:
+    old_path = "Knowledge Base/Notes/Insights/old.md"
+    new_path = "Knowledge Base/Notes/Insights/new.md"
+    old_before = _source(
+        "Old",
+        "00000000-0000-0000-0000-000000000001",
+    )
+    old_after = _source(
+        "Old",
+        "00000000-0000-0000-0000-000000000001",
+        body="---\n",
+    ).replace("status: active", "status: superseded").replace(
+        "---\n\n---\n", "superseded_by: '[[New]]'\n---\n\n"
+    )
+    new_source = _source(
+        "New",
+        "00000000-0000-0000-0000-000000000002",
+    )
+    before = _corpus(
+        tmp_path,
+        _state(tmp_path, old_path, old_before),
+        _state(tmp_path, new_path, new_source),
+    )
+
+    replacements = graph_producer.replacements_for_planned_markdown(
+        tmp_path,
+        before_corpus=before,
+        writes=(_write(tmp_path, old_path, old_before, old_after),),
+        semantic_states={old_path: _state(tmp_path, old_path, old_after)},
+        language_registry=semantic_language_registry.core_registry(),
+    )
+
+    assert replacements == (
+        catalog_publication.GraphMeasurementReplacement(
+            new_path,
+            vault.content_hash(new_source),
+            (_edge(new_path, old_path, "supersedes"),),
+        ),
+        catalog_publication.GraphMeasurementReplacement(
+            old_path,
+            vault.content_hash(old_after),
+            (),
+        ),
+    )
+
+
+def test_catalog_bridge_forwards_lazy_graph_replacement_provider(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from exomem import semantic_writes
+
+    replacement = catalog_publication.GraphMeasurementReplacement(
+        "Knowledge Base/Notes/Insights/source.md",
+        "a" * 64,
+        (),
+    )
+    captured: dict[str, object] = {}
+
+    def provider():
+        return (replacement,)
+
+    def fake_prepare(vault_root, *, writes, graph_replacement_provider):
+        captured.update(
+            vault_root=vault_root,
+            writes=writes,
+            graph_replacement_provider=graph_replacement_provider,
+        )
+        return "prepared"
+
+    monkeypatch.setattr(catalog_publication, "prepare_planned_markdown_batch", fake_prepare)
+
+    assert (
+        semantic_writes._prepare_markdown_catalog_publication(
+            tmp_path,
+            (),
+            graph_replacement_provider=provider,
+        )
+        == "prepared"
+    )
+    assert captured["graph_replacement_provider"] is provider

--- a/tests/test_governance_graph_successor_publication.py
+++ b/tests/test_governance_graph_successor_publication.py
@@ -172,6 +172,170 @@ def test_graph_successor_carries_unchanged_rows_and_replaces_changed_source(
     assert by_variant[target.projection_variant_id].edges == ()
 
 
+def test_graph_successor_discards_edges_for_a_changed_lower_only_item(
+    tmp_path: Path,
+) -> None:
+    source = _variant("source", "1" * 64, level=3)
+    target = _variant("target", "2" * 64)
+    active_items = (
+        _item("source", "1" * 64, source),
+        _item("target", "2" * 64, target),
+    )
+    active_key = _key(18)
+    active_namespace = verified_namespace(active_key, active_items)
+    active_family = _family(active_key)
+    active_manifest = projection_measurement_store.stage_measurement_store(
+        tmp_path,
+        namespace=active_namespace,
+        family=active_family,
+        measurements=(
+            _measurement(active_family, source),
+            _measurement(active_family, target),
+        ),
+    )
+    changed_source = _variant("source", "3" * 64, level=3)
+    target_namespace = _prepared_namespace(
+        _key(19),
+        (
+            _item("source", "3" * 64, changed_source),
+            active_items[1],
+        ),
+    )
+
+    prepared = catalog_publication._prepare_target_measurements(
+        tmp_path,
+        active_namespace=active_namespace,
+        active_roots=(projection_measurement_store.measurement_root(active_manifest),),
+        target_namespace=target_namespace,
+        graph_replacements=(
+            catalog_publication.GraphMeasurementReplacement(
+                item_identity="source",
+                content_hash="3" * 64,
+                edges=(_edge("source", "target"),),
+            ),
+        ),
+    )
+
+    by_variant = {
+        row.measurement_key.projection_variant_id: row
+        for row in prepared[0].measurements
+    }
+    assert by_variant[changed_source.projection_variant_id].edges == ()
+
+    with pytest.raises(
+        catalog_publication.CatalogPublicationError,
+        match="replacement edge is invalid",
+    ):
+        catalog_publication._prepare_target_measurements(
+            tmp_path,
+            active_namespace=active_namespace,
+            active_roots=(
+                projection_measurement_store.measurement_root(active_manifest),
+            ),
+            target_namespace=target_namespace,
+            graph_replacements=(
+                catalog_publication.GraphMeasurementReplacement(
+                    item_identity="source",
+                    content_hash="3" * 64,
+                    edges=(_edge("source", "missing"),),
+                ),
+            ),
+        )
+
+
+def test_graph_successor_invokes_the_live_provider_only_for_a_graph_family(
+    tmp_path: Path,
+) -> None:
+    source = _variant("source", "4" * 64)
+    target = _variant("target", "5" * 64)
+    items = (
+        _item("source", "4" * 64, source),
+        _item("target", "5" * 64, target),
+    )
+    active_key = _key(20)
+    active_namespace = verified_namespace(active_key, items)
+    active_family = _family(active_key)
+    active_manifest = projection_measurement_store.stage_measurement_store(
+        tmp_path,
+        namespace=active_namespace,
+        family=active_family,
+        measurements=(
+            _measurement(active_family, source),
+            _measurement(active_family, target),
+        ),
+    )
+    called = 0
+
+    def replacements():
+        nonlocal called
+        called += 1
+        return (
+            catalog_publication.GraphMeasurementReplacement(
+                "source",
+                "4" * 64,
+                (_edge("source", "target"),),
+            ),
+        )
+
+    prepared = catalog_publication._prepare_target_measurements(
+        tmp_path,
+        active_namespace=active_namespace,
+        active_roots=(projection_measurement_store.measurement_root(active_manifest),),
+        target_namespace=_prepared_namespace(_key(21), items),
+        graph_replacement_provider=replacements,
+    )
+
+    assert called == 1
+    assert prepared[0].manifest.graph_edge_count == 1
+
+    def must_not_run():
+        raise AssertionError("lexical-only publication invoked the graph producer")
+
+    assert (
+        catalog_publication._prepare_target_measurements(
+            tmp_path,
+            active_namespace=active_namespace,
+            active_roots=(),
+            target_namespace=_prepared_namespace(_key(22), items),
+            graph_replacement_provider=must_not_run,
+        )
+        == ()
+    )
+
+    def broken_provider():
+        raise RuntimeError("private producer detail")
+
+    with pytest.raises(
+        catalog_publication.CatalogPublicationError,
+        match="live graph producer cannot prepare target measurements",
+    ) as caught:
+        catalog_publication._prepare_target_measurements(
+            tmp_path,
+            active_namespace=active_namespace,
+            active_roots=(
+                projection_measurement_store.measurement_root(active_manifest),
+            ),
+            target_namespace=_prepared_namespace(_key(23), items),
+            graph_replacement_provider=broken_provider,
+        )
+    assert "private producer detail" not in str(caught.value)
+
+    with pytest.raises(
+        catalog_publication.CatalogPublicationError,
+        match="multiple authorities",
+    ):
+        catalog_publication._prepare_target_measurements(
+            tmp_path,
+            active_namespace=active_namespace,
+            active_roots=(
+                projection_measurement_store.measurement_root(active_manifest),
+            ),
+            target_namespace=_prepared_namespace(_key(24), items),
+            graph_replacements=replacements(),
+            graph_replacement_provider=replacements,
+        )
+
+
 def test_prepare_markdown_batch_forwards_graph_replacements(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- derive target-bound projected graph replacements from the semantic writer’s retained detached preflight corpus and exact planned-write overlay
- include indirect title-resolution, body-link, and reverse-relation changes without reopening the live graph or walking the vault again
- invoke the producer only when the active tuple contains a graph family; keep other live writer families fail-closed and OpenSpec task 8.11 open

## Verification

- `16 passed, 210 deselected` — focused graph/catalog/semantic-context tests
- `130 passed` — semantic edit/observe regression slice
- touched-file Ruff: passed
- `openspec validate harden-governance-for-consolidation --strict`: passed
- public-artifact privacy validation: passed
- `git diff --check`: passed