### PR TITLE
feat(governance): publish creation graph successors

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/design.md
+++ b/openspec/changes/harden-governance-for-consolidation/design.md
@@ -743,14 +743,15 @@ that edge payload and emits only the required empty lower-variant rows. A lower-
 policy projection therefore cannot turn an otherwise valid semantic write into a graph
 publication refusal or persist raw graph authority below L6.
 
-The existing-page semantic writer derives its graph replacements from the detached
-before-corpus retained by semantic preflight plus the exact guarded planned-write
-overlay. It does not reopen the live graph or walk the vault again. The overlay
-re-resolves title-dependent links and reverse relations, so the replacement set includes
-both directly changed paths and otherwise-unchanged logical sources whose outgoing edge
-tuple changes. This producer is invoked lazily only when the active tuple contains a
-graph family; open and lexical-only writes do no graph-producer work. Other live writer
-families remain blocked until they supply the same target-bound replacement contract.
+The existing-page semantic writer and semantic creation writers derive their graph
+replacements from the freshest validated detached before-corpus carried into the
+mutation boundary plus the exact guarded planned-write overlay. They do not reopen the
+live graph or walk the vault again. The overlay re-resolves title-dependent links and
+reverse relations, so the replacement set includes directly changed or created paths and
+otherwise-unchanged logical sources whose outgoing edge tuple changes. This producer is
+invoked lazily only when the active tuple contains a graph family; open and lexical-only
+writes do no graph-producer work. Other live writer families remain blocked until they
+supply the same target-bound replacement contract.
 
 A policy
 fingerprint or projector-schema change builds a new namespace tuple and never relabels

--- a/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
+++ b/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
@@ -227,13 +227,15 @@ required family SHALL remain blocked.
   targets, uniqueness, and aggregate capacity, discards the edge payload, and emits only
   empty lower-variant graph rows
 
-#### Scenario: Semantic writes derive graph successors from retained preflight state
+#### Scenario: Semantic writes and creations derive graph successors from retained state
 
-- **WHEN** an existing-page semantic write changes a direct edge, a title used by
-  another page's link, or a reverse relation whose logical source is another page
-- **THEN** the writer derives target-bound replacements from the retained detached
-  before-corpus and exact guarded planned bytes, includes every logical source whose
-  outgoing edge tuple changes, and does not reopen the live graph or current Markdown
+- **WHEN** an existing-page semantic write or semantic creation changes a direct edge, a
+  title used by another page's link, or a reverse relation whose logical source is
+  another page
+- **THEN** the writer derives target-bound replacements from the freshest validated
+  detached before-corpus carried into the mutation boundary and exact guarded planned
+  bytes, includes every logical source whose outgoing edge tuple changes, and does not
+  reopen the live graph or current Markdown
 - **AND** open and lexical-only writes do not invoke the graph producer
 
 When the projected source is exhausted, L1-and-above items SHALL still emit the

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -537,12 +537,13 @@ made before both PRs and their combined verification are complete.
   content-identical L6 rows, require target-item/content-hash-bound replacements for
   changed L6 sources, reject stale outside-catalog targets, and publish the complete graph
   root atomically. Validate conservative producer replacements for affected lower-only
-  items, discard their edge payload, and emit only empty lower-variant rows. For the
-  existing-page semantic writer, derive replacements from its
-  retained detached preflight corpus plus the exact guarded planned-write overlay, include
-  indirect title-resolution and reverse-relation source changes, and never reopen the live
-  graph or walk the vault again. Connect every other live graph producer to those
-  replacements before checking this task; keep any unsupported required family blocked.
+  items, discard their edge payload, and emit only empty lower-variant rows. For
+  existing-page semantic writes and semantic creations, derive
+  replacements from the freshest validated detached before-corpus carried into the
+  mutation boundary plus the exact guarded planned-write overlay, include indirect
+  title-resolution and reverse-relation source changes, and never reopen the live graph
+  or walk the vault again. Connect every other live graph producer to those replacements
+  before checking this task; keep any unsupported required family blocked.
 - [x] 8.12 Implement BM25 posting intersection before cap, projected-corpus DF/IDF and
   exact top-k; exact filtered projected-vector top-k with visible-lane warming/disable;
   projected-only reranking before final top-k; and L6-only pre-cap CLIP authorization.

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -3664,6 +3664,39 @@ def commit_creation(
     return replace(committed, structure_suggestion=suggestion, due_state=due)
 
 
+def _prepare_creation_catalog_publication(
+    vault_root: Path,
+    *,
+    destination: str,
+    before_corpus: semantic_contract.SemanticCorpusContext | None,
+    semantic_state: semantic_contract.SemanticPageState,
+    writes: Sequence[vault.PlannedWrite],
+):  # noqa: ANN202 - private bridge returns the governance publication token
+    """Prepare a creation successor from the retained semantic snapshot."""
+
+    from .governance import graph_producer
+
+    planned_writes = tuple(writes)
+
+    def graph_replacement_provider():
+        if before_corpus is None:
+            raise graph_producer.GraphProducerError(
+                "creation preflight did not retain its semantic corpus"
+            )
+        return graph_producer.replacements_for_planned_markdown(
+            vault_root,
+            before_corpus=before_corpus,
+            writes=planned_writes,
+            semantic_states={destination: semantic_state},
+        )
+
+    return _prepare_markdown_catalog_publication(
+        vault_root,
+        writes=planned_writes,
+        graph_replacement_provider=graph_replacement_provider,
+    )
+
+
 def _commit_creation(
     vault_root: Path,
     *,
@@ -3731,9 +3764,12 @@ def _commit_creation(
                         create_only=True,
                     )
                 )
-                catalog_target = _prepare_markdown_catalog_publication(
+                catalog_target = _prepare_creation_catalog_publication(
                     root,
-                    catalog_writes,
+                    destination=preflight.destination,
+                    before_corpus=prepared.preliminary.before_corpus,
+                    semantic_state=prepared.preliminary.candidate,
+                    writes=catalog_writes,
                 )
             except catalog_publication.CatalogPublicationError as error:
                 raise SemanticWriteError(
@@ -3770,13 +3806,15 @@ def _commit_creation(
         from .writer_lease import read_commit_generation
 
         contract_result = preflight.contract_result
+        catalog_corpus = preflight.corpus
+        catalog_state = preflight.semantic_state
         if not semantic_contract.validity_stamp_current(
             root,
             preflight.census_token,
             commit_generation=read_commit_generation(root),
         ):
             relation_review._record_prevalidated_commit_outcome("revalidated")
-            contract_result, _fresh_state, _fresh_census, _fresh_corpus = _evaluate_structural(
+            contract_result, catalog_state, _fresh_census, catalog_corpus = _evaluate_structural(
                 root,
                 destination=preflight.destination,
                 source=preflight.source,
@@ -3806,14 +3844,20 @@ def _commit_creation(
             )
         )
         try:
-            catalog_target = _prepare_markdown_catalog_publication(root, writes)
+            catalog_target = _prepare_creation_catalog_publication(
+                root,
+                destination=preflight.destination,
+                before_corpus=catalog_corpus,
+                semantic_state=catalog_state,
+                writes=writes,
+            )
         except catalog_publication.CatalogPublicationError as error:
             raise SemanticWriteError(
                 "GOVERNANCE_CATALOG_PUBLICATION_BLOCKED",
                 str(error),
             ) from error
         token = semantic_index.set_parent_states(
-            {preflight.destination: semantic_index.from_semantic_page_state(preflight.semantic_state)}
+            {preflight.destination: semantic_index.from_semantic_page_state(catalog_state)}
         )
         try:
             written = vault.batch_atomic_write(writes, vault_root=root)

--- a/tests/test_governance_graph_producer.py
+++ b/tests/test_governance_graph_producer.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from exomem import (
     relation_registry,
     semantic_contract,
@@ -259,3 +261,91 @@ def test_catalog_bridge_forwards_lazy_graph_replacement_provider(
         == "prepared"
     )
     assert captured["graph_replacement_provider"] is provider
+
+
+def test_creation_catalog_bridge_builds_provider_from_retained_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import semantic_writes
+
+    source_path = "Knowledge Base/Notes/Insights/source.md"
+    created_path = "Knowledge Base/Notes/Insights/created.md"
+    source = _source(
+        "Source",
+        "00000000-0000-0000-0000-000000000001",
+        body=(
+            "## Observations\n\n"
+            "- [decision] Resolve the future title.\n\n"
+            "[[Created]]\n"
+        ),
+    )
+    created = _source(
+        "Created",
+        "00000000-0000-0000-0000-000000000002",
+    )
+    created_state = _state(tmp_path, created_path, created)
+    preflight = semantic_writes.CreationPreflight(
+        applicability="full",
+        destination=created_path,
+        source=created,
+        draft_id="draft-1",
+        draft_token="token-1",
+        mutated=False,
+        contract_result=None,
+        creation_validation=None,
+        semantic_state=created_state,
+        corpus=_corpus(tmp_path, _state(tmp_path, source_path, source)),
+    )
+    writes = (
+        vault.PlannedWrite(
+            tmp_path / created_path,
+            created,
+            create_only=True,
+        ),
+    )
+    captured: dict[str, object] = {}
+
+    def fake_prepare(
+        vault_root,
+        *,
+        writes,
+        graph_replacement_provider,
+    ):
+        captured.update(
+            vault_root=vault_root,
+            writes=writes,
+            graph_replacement_provider=graph_replacement_provider,
+        )
+        return "prepared"
+
+    monkeypatch.setattr(
+        semantic_writes,
+        "_prepare_markdown_catalog_publication",
+        fake_prepare,
+    )
+
+    assert (
+        semantic_writes._prepare_creation_catalog_publication(
+            tmp_path,
+            destination=preflight.destination,
+            before_corpus=preflight.corpus,
+            semantic_state=preflight.semantic_state,
+            writes=writes,
+        )
+        == "prepared"
+    )
+    provider = captured["graph_replacement_provider"]
+    assert callable(provider)
+    assert provider() == (
+        catalog_publication.GraphMeasurementReplacement(
+            created_path,
+            vault.content_hash(created),
+            (),
+        ),
+        catalog_publication.GraphMeasurementReplacement(
+            source_path,
+            vault.content_hash(source),
+            (_edge(source_path, created_path),),
+        ),
+    )


### PR DESCRIPTION
## Why

Exact-v4 creation writers must publish graph measurements with the same catalog/namespace transaction. Otherwise a newly created Markdown page can activate with a stale graph family.

## What changed

- derives target-bound graph replacements for semantic page creation from the validated creation corpus
- uses the freshest guarded preflight candidate and keeps graph production lazy when no active graph family exists
- preserves the closed OpenSpec task 8.11 contract without marking the broader writer inventory complete

## Verification

- 71 focused tests passed (15 deselected)
- Ruff passed on touched Python files
- strict OpenSpec validation passed
- public-artifact validation passed
- git diff check passed