### PR TITLE
feat(governance): publish move graph successors

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/design.md
+++ b/openspec/changes/harden-governance-for-consolidation/design.md
@@ -743,15 +743,17 @@ that edge payload and emits only the required empty lower-variant rows. A lower-
 policy projection therefore cannot turn an otherwise valid semantic write into a graph
 publication refusal or persist raw graph authority below L6.
 
-The existing-page semantic writer and semantic creation writers derive their graph
-replacements from the freshest validated detached before-corpus carried into the
-mutation boundary plus the exact guarded planned-write overlay. They do not reopen the
-live graph or walk the vault again. The overlay re-resolves title-dependent links and
-reverse relations, so the replacement set includes directly changed or created paths and
-otherwise-unchanged logical sources whose outgoing edge tuple changes. This producer is
-invoked lazily only when the active tuple contains a graph family; open and lexical-only
-writes do no graph-producer work. Other live writer families remain blocked until they
-supply the same target-bound replacement contract.
+The existing-page semantic writer, semantic creation writers, and semantic move writer
+derive their graph replacements from the freshest validated detached before-corpus
+carried into the mutation boundary plus the exact guarded planned-write overlay. A move
+starts from its exact detached after-corpus, then overlays only its guarded auxiliary
+writes. These paths do not reopen the live graph or walk the vault again. The overlay
+re-resolves title-dependent links and reverse relations, so the replacement set includes
+directly changed, created, or moved paths and otherwise-unchanged logical sources whose
+outgoing edge tuple changes. The provider is invoked lazily only when the active tuple
+contains a graph family; open and lexical-only writes do no graph-producer work. Other
+live writer families remain blocked until they supply the same target-bound replacement
+contract.
 
 A policy
 fingerprint or projector-schema change builds a new namespace tuple and never relabels

--- a/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
+++ b/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
@@ -227,15 +227,16 @@ required family SHALL remain blocked.
   targets, uniqueness, and aggregate capacity, discards the edge payload, and emits only
   empty lower-variant graph rows
 
-#### Scenario: Semantic writes and creations derive graph successors from retained state
+#### Scenario: Semantic writes, creations, and moves derive graph successors from retained state
 
-- **WHEN** an existing-page semantic write or semantic creation changes a direct edge, a
-  title used by another page's link, or a reverse relation whose logical source is
-  another page
+- **WHEN** an existing-page semantic write, semantic creation, or semantic move changes a
+  direct edge, a path/title used by another page's link, or a reverse relation whose
+  logical source is another page
 - **THEN** the writer derives target-bound replacements from the freshest validated
-  detached before-corpus carried into the mutation boundary and exact guarded planned
-  bytes, includes every logical source whose outgoing edge tuple changes, and does not
-  reopen the live graph or current Markdown
+  detached before-corpus carried into the mutation boundary, the move's exact detached
+  after-corpus when applicable, and exact guarded planned bytes; it includes every logical
+  source whose outgoing edge tuple changes and does not reopen the live graph or current
+  Markdown
 - **AND** open and lexical-only writes do not invoke the graph producer
 
 When the projected source is exhausted, L1-and-above items SHALL still emit the

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -538,12 +538,13 @@ made before both PRs and their combined verification are complete.
   changed L6 sources, reject stale outside-catalog targets, and publish the complete graph
   root atomically. Validate conservative producer replacements for affected lower-only
   items, discard their edge payload, and emit only empty lower-variant rows. For
-  existing-page semantic writes and semantic creations, derive
-  replacements from the freshest validated detached before-corpus carried into the
-  mutation boundary plus the exact guarded planned-write overlay, include indirect
-  title-resolution and reverse-relation source changes, and never reopen the live graph
-  or walk the vault again. Connect every other live graph producer to those replacements
-  before checking this task; keep any unsupported required family blocked.
+  existing-page semantic writes, semantic creations, and semantic
+  moves, derive replacements from the freshest validated detached before-corpus carried
+  into the mutation boundary, the move's exact detached after-corpus when applicable,
+  and the exact guarded planned-write overlay; include indirect path/title-resolution and
+  reverse-relation source changes, and never reopen the live graph or walk the vault
+  again. Connect every other live graph producer to those replacements before checking
+  this task; keep any unsupported required family blocked.
 - [x] 8.12 Implement BM25 posting intersection before cap, projected-corpus DF/IDF and
   exact top-k; exact filtered projected-vector top-k with visible-lane warming/disable;
   projected-only reranking before final top-k; and L6-only pre-cap CLIP authorization.

--- a/src/exomem/governance/catalog_publication.py
+++ b/src/exomem/governance/catalog_publication.py
@@ -1450,6 +1450,10 @@ def prepare_catalog_membership_batch(
     content_paths: tuple[str, ...] = (),
     clip_replacements: tuple[ClipMeasurementReplacement, ...] = (),
     graph_replacements: tuple[GraphMeasurementReplacement, ...] = (),
+    graph_replacement_provider: Callable[
+        [], tuple[GraphMeasurementReplacement, ...]
+    ]
+    | None = None,
     now: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
     """Prepare lazy write/removal membership changes for a product mutation.
@@ -1467,6 +1471,7 @@ def prepare_catalog_membership_batch(
         content_paths=content_paths,
         clip_replacements=clip_replacements,
         graph_replacements=graph_replacements,
+        graph_replacement_provider=graph_replacement_provider,
         now=now,
     )
 

--- a/src/exomem/governance/graph_producer.py
+++ b/src/exomem/governance/graph_producer.py
@@ -82,24 +82,16 @@ def _edges_by_source(
     }
 
 
-def replacements_for_planned_markdown(
+def _planned_overlay(
     vault_root: Path,
     *,
-    before_corpus: semantic_contract.SemanticCorpusContext,
+    base_corpus: semantic_contract.SemanticCorpusContext,
     writes: tuple[vault.PlannedWrite, ...],
     semantic_states: Mapping[str, semantic_contract.SemanticPageState] | None = None,
     language_registry: semantic_language_registry.SemanticLanguageRegistry | None = None,
-) -> tuple[catalog_publication.GraphMeasurementReplacement, ...]:
-    """Build complete replacements from one already-reviewed Markdown overlay.
-
-    The corpus is detached preflight evidence. Planned bytes are applied only to
-    that in-memory snapshot, so title resolution, reverse relations, and other
-    sources affected by a topology change are included without reopening the
-    live graph or walking the vault a second time.
-    """
-
+) -> semantic_contract.SemanticCorpusContext:
     root = Path(vault_root)
-    if before_corpus.vault_root != root:
+    if base_corpus.vault_root != root:
         raise GraphProducerError("graph producer corpus belongs to another vault")
     if type(writes) is not tuple or not writes:
         raise GraphProducerError("graph producer requires a finite planned-write batch")
@@ -116,63 +108,127 @@ def replacements_for_planned_markdown(
     except catalog_publication.CatalogPublicationError as error:
         raise GraphProducerError(str(error)) from error
     if not mutations:
-        return ()
+        return base_corpus
 
-    language = language_registry or semantic_language_registry.load_registry(root)
-    after_corpus = before_corpus
+    language = language_registry
+    target_corpus = base_corpus
     try:
         for path in sorted(mutations):
             mutation = mutations[path]
             state = prepared_states.get(path)
             if state is None:
-                state = semantic_contract.build_page_state(
-                    root,
-                    path,
-                    mutation.source,
-                    relation_registry=before_corpus.registry,
-                    language_registry=language,
-                )
+                existing = target_corpus.pages.get(path)
+                if existing is not None and existing.source_hash == vault.content_hash(
+                    mutation.source
+                ):
+                    state = existing
+                else:
+                    if language is None:
+                        language = semantic_language_registry.load_registry(root)
+                    state = semantic_contract.build_page_state(
+                        root,
+                        path,
+                        mutation.source,
+                        relation_registry=base_corpus.registry,
+                        language_registry=language,
+                    )
             if state.path != path or state.source_hash != vault.content_hash(
                 mutation.source
             ):
                 raise GraphProducerError(
                     "graph producer semantic state does not bind planned bytes"
                 )
-            after_corpus = after_corpus.with_candidate(state)
+            target_corpus = target_corpus.with_candidate(state)
     except GraphProducerError:
         raise
     except (OSError, RuntimeError, UnicodeError, ValueError) as error:
         raise GraphProducerError(
             "graph producer cannot derive the planned semantic topology"
         ) from error
+    return target_corpus
 
+
+def _replacements_between(
+    before_corpus: semantic_contract.SemanticCorpusContext,
+    after_corpus: semantic_contract.SemanticCorpusContext,
+) -> tuple[catalog_publication.GraphMeasurementReplacement, ...]:
     before_edges = _edges_by_source(before_corpus)
     after_edges = _edges_by_source(after_corpus)
-    affected = set(mutations)
+    affected = {
+        path
+        for path, state in after_corpus.pages.items()
+        if (before := before_corpus.pages.get(path)) is None
+        or before.source_hash != state.source_hash
+    }
     affected.update(
         source
         for source in set(before_edges) | set(after_edges)
         if before_edges.get(source, ()) != after_edges.get(source, ())
     )
-    replacements: list[catalog_publication.GraphMeasurementReplacement] = []
-    for source in sorted(affected):
-        state = after_corpus.pages.get(source)
-        if state is None:
-            continue
-        mutation = mutations.get(source)
-        content_hash = (
-            vault.content_hash(mutation.source)
-            if mutation is not None
-            else state.source_hash
+    return tuple(
+        catalog_publication.GraphMeasurementReplacement(
+            item_identity=source,
+            content_hash=after_corpus.pages[source].source_hash,
+            edges=after_edges.get(source, ()),
         )
-        replacements.append(
-            catalog_publication.GraphMeasurementReplacement(
-                item_identity=source,
-                content_hash=content_hash,
-                edges=after_edges.get(source, ()),
-            )
-        )
-    return tuple(replacements)
+        for source in sorted(affected)
+        if source in after_corpus.pages
+    )
 
 
-__all__ = ["GraphProducerError", "replacements_for_planned_markdown"]
+def replacements_for_planned_markdown(
+    vault_root: Path,
+    *,
+    before_corpus: semantic_contract.SemanticCorpusContext,
+    writes: tuple[vault.PlannedWrite, ...],
+    semantic_states: Mapping[str, semantic_contract.SemanticPageState] | None = None,
+    language_registry: semantic_language_registry.SemanticLanguageRegistry | None = None,
+) -> tuple[catalog_publication.GraphMeasurementReplacement, ...]:
+    """Build replacements from one already-reviewed Markdown overlay."""
+
+    after_corpus = _planned_overlay(
+        vault_root,
+        base_corpus=before_corpus,
+        writes=writes,
+        semantic_states=semantic_states,
+        language_registry=language_registry,
+    )
+    return _replacements_between(before_corpus, after_corpus)
+
+
+def replacements_for_semantic_transition(
+    vault_root: Path,
+    *,
+    before_corpus: semantic_contract.SemanticCorpusContext,
+    after_corpus: semantic_contract.SemanticCorpusContext,
+    writes: tuple[vault.PlannedWrite, ...],
+    semantic_states: Mapping[str, semantic_contract.SemanticPageState] | None = None,
+    language_registry: semantic_language_registry.SemanticLanguageRegistry | None = None,
+) -> tuple[catalog_publication.GraphMeasurementReplacement, ...]:
+    """Build replacements from exact detached before/after semantic corpora."""
+
+    root = Path(vault_root)
+    if before_corpus.vault_root != root or after_corpus.vault_root != root:
+        raise GraphProducerError("graph producer corpus belongs to another vault")
+    if (
+        before_corpus.registry.core_version,
+        before_corpus.registry.extension_hash,
+    ) != (
+        after_corpus.registry.core_version,
+        after_corpus.registry.extension_hash,
+    ):
+        raise GraphProducerError("graph producer semantic registries disagree")
+    target_corpus = _planned_overlay(
+        root,
+        base_corpus=after_corpus,
+        writes=writes,
+        semantic_states=semantic_states,
+        language_registry=language_registry,
+    )
+    return _replacements_between(before_corpus, target_corpus)
+
+__all__ = [
+    "GraphProducerError",
+    "replacements_for_planned_markdown",
+    "replacements_for_semantic_transition",
+]

--- a/src/exomem/move_file.py
+++ b/src/exomem/move_file.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from . import reserved_paths, semantic_index, semantic_writes
-from .governance import catalog_publication
+from .governance import catalog_publication, graph_producer
 from .kbdir import kb_dirname
 from .vault import (
     LogWritePlan,
@@ -540,11 +540,25 @@ def move_file(
                     *log_plan.writes,
                 ]
                 try:
+                    graph_states = {
+                        item.after.path: item.after for item in preflight.evaluations
+                    }
+
+                    def graph_replacement_provider():
+                        return graph_producer.replacements_for_semantic_transition(
+                            vault_root,
+                            before_corpus=preflight.before_corpus,
+                            after_corpus=preflight.after_corpus,
+                            writes=tuple(catalog_writes),
+                            semantic_states=graph_states,
+                        )
+
                     catalog_target = (
                         catalog_publication.prepare_catalog_membership_batch(
                             vault_root,
                             writes=tuple(catalog_writes),
                             removals=tuple(catalog_removals),
+                            graph_replacement_provider=graph_replacement_provider,
                             now=int(time.time()),
                         )
                     )

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -50,6 +50,7 @@ from exomem.governance import (
     companions,
     membership,
     policy,
+    projected_graph,
     projected_retrieval,
     projection_measurement_store,
     projection_store,
@@ -410,9 +411,11 @@ def _migrate_with_projection_items(
     vault: Path,
     *,
     items: tuple[tuple[str, str], ...],
+    ceiling: int = 2,
+    graph_edges: tuple[projected_graph.ProjectionGraphEdge, ...] | None = None,
     now: int,
 ) -> schema_v4.MigrationResult:
-    documents = _documents(ceiling=2)
+    documents = _documents(ceiling=ceiling)
     compiled = _compiled(documents)
     key = projections.ProjectionNamespaceKey(
         policy_fingerprint=compiled.fingerprint,
@@ -434,6 +437,48 @@ def _migrate_with_projection_items(
         key=key,
         items=projected_items,
     )
+    measurement_roots: tuple[projection_store.ProjectionMeasurementRoot, ...] = ()
+    if graph_edges is not None:
+        namespace = projection_store.prepare_projection_namespace(
+            key=key,
+            manifest=manifest,
+            items=projected_items,
+        )
+        family = projection_measurement_store.MeasurementFamilyKey(
+            namespace_key=key,
+            lane="graph",
+            extractor_version="projected-graph-v1",
+            model_version="graph-schema-v1",
+        )
+        graph_manifest = projection_measurement_store.stage_measurement_store(
+            vault,
+            namespace=namespace,
+            family=family,
+            measurements=tuple(
+                projected_graph.ProjectionGraphMeasurement(
+                    measurement_key=projections.MeasurementKey(
+                        projection_variant_id=variant.projection_variant_id,
+                        lane=family.lane,
+                        extractor_version=family.extractor_version,
+                        model_version=family.model_version,
+                    ),
+                    edges=(
+                        tuple(
+                            edge
+                            for edge in graph_edges
+                            if edge.source_item_identity == item.item_identity
+                        )
+                        if variant.decision_level == 6
+                        else ()
+                    ),
+                )
+                for item in projected_items
+                for variant in item.variants
+            ),
+        )
+        measurement_roots = (
+            projection_measurement_store.measurement_root(graph_manifest),
+        )
     connection = store.open_connection(vault)
     try:
         return schema_v4.migrate_v3_connection(
@@ -461,7 +506,8 @@ def _migrate_with_projection_items(
                 namespace=schema_v4.ProjectionNamespaceSeed(
                     namespace_id=key.namespace_id,
                     evidence=projection_store.projection_namespace_evidence_bytes(
-                        manifest
+                        manifest,
+                        required_measurement_roots=measurement_roots,
                     ),
                     ready_at=now,
                 ),
@@ -3566,13 +3612,21 @@ def test_v4_move_replaces_membership_and_publishes_auxiliaries_once(
         target = vault / existing
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(content, encoding="utf-8")
-    _write_workspace(vault, _documents(ceiling=2))
+    _write_workspace(vault, _documents(ceiling=6))
     migration = _migrate_with_projection_items(
         vault,
         items=(
             (old_relative, source),
             (inbound_relative, inbound_before),
             (log_relative, log_before),
+        ),
+        ceiling=6,
+        graph_edges=(
+            projected_graph.ProjectionGraphEdge(
+                inbound_relative,
+                old_relative,
+                "links_to",
+            ),
         ),
         now=now,
     )
@@ -3583,6 +3637,18 @@ def test_v4_move_replaces_membership_and_publishes_auxiliaries_once(
         activation_state_digest=migration.activation_state_digest,
         now=now,
     )
+    real_prepare_membership = catalog_publication.prepare_catalog_membership_batch
+    graph_providers: list[object] = []
+
+    def capture_graph_provider(*args, **kwargs):
+        graph_providers.append(kwargs.get("graph_replacement_provider"))
+        return real_prepare_membership(*args, **kwargs)
+
+    monkeypatch.setattr(
+        catalog_publication,
+        "prepare_catalog_membership_batch",
+        capture_graph_provider,
+    )
 
     moved = move_file_module.move_file(
         vault,
@@ -3592,6 +3658,7 @@ def test_v4_move_replaces_membership_and_publishes_auxiliaries_once(
     )
 
     assert moved.wikilinks_updated == 1
+    assert graph_providers and callable(graph_providers[-1])
     assert not (vault / old_relative).exists()
     assert (vault / new_relative).read_text(encoding="utf-8") == source
     assert "renamed-private" in (vault / inbound_relative).read_text(encoding="utf-8")
@@ -3622,6 +3689,39 @@ def test_v4_move_replaces_membership_and_publishes_auxiliaries_once(
     assert active.active.catalog_generation == 2
     assert manifest.item_count == len(expected_paths)
     assert {item.item_identity: item.content_hash for item in items} == expected
+    graph_root = next(
+        root for root in evidence.required_measurement_roots if root.lane == "graph"
+    )
+    graph_family = projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=evidence.manifest.namespace_key,
+        lane=graph_root.lane,
+        extractor_version=graph_root.extractor_version,
+        model_version=graph_root.model_version,
+    )
+    namespace = projection_store.bind_active_projection_namespace(
+        active,
+        manifest=manifest,
+        items=items,
+    )
+    _graph_manifest, graph_rows = projection_measurement_store.load_measurement_store(
+        vault,
+        namespace=namespace,
+        family=graph_family,
+        expected_rows_digest=graph_root.rows_digest,
+    )
+    referrer_edges = tuple(
+        edge
+        for row in graph_rows
+        for edge in row.edges
+        if edge.source_item_identity == inbound_relative
+    )
+    assert referrer_edges == (
+        projected_graph.ProjectionGraphEdge(
+            inbound_relative,
+            new_relative,
+            "links_to",
+        ),
+    )
 
 
 def test_v4_move_refuses_unsupported_non_markdown_before_moving_bytes(

--- a/tests/test_governance_graph_producer.py
+++ b/tests/test_governance_graph_producer.py
@@ -349,3 +349,59 @@ def test_creation_catalog_bridge_builds_provider_from_retained_preflight(
             (_edge(source_path, created_path),),
         ),
     )
+
+
+def test_semantic_transition_replaces_moved_target_and_its_referrers(
+    tmp_path: Path,
+) -> None:
+    source_path = "Knowledge Base/Notes/Insights/source.md"
+    old_path = "Knowledge Base/Notes/Insights/old.md"
+    new_path = "Knowledge Base/Notes/Insights/new.md"
+    source = _source(
+        "Source",
+        "00000000-0000-0000-0000-000000000001",
+        body="## Observations\n\n- [decision] Follow the move.\n\n[[Target]]\n",
+    )
+    target = _source(
+        "Target",
+        "00000000-0000-0000-0000-000000000002",
+    )
+    before = _corpus(
+        tmp_path,
+        _state(tmp_path, source_path, source),
+        _state(tmp_path, old_path, target),
+    )
+    moved_state = _state(tmp_path, new_path, target)
+    after = _corpus(
+        tmp_path,
+        _state(tmp_path, source_path, source),
+        moved_state,
+    )
+    writes = (
+        vault.PlannedWrite(
+            tmp_path / new_path,
+            target,
+            create_only=True,
+        ),
+    )
+
+    replacements = graph_producer.replacements_for_semantic_transition(
+        tmp_path,
+        before_corpus=before,
+        after_corpus=after,
+        writes=writes,
+        semantic_states={new_path: moved_state},
+    )
+
+    assert replacements == (
+        catalog_publication.GraphMeasurementReplacement(
+            new_path,
+            vault.content_hash(target),
+            (),
+        ),
+        catalog_publication.GraphMeasurementReplacement(
+            source_path,
+            vault.content_hash(source),
+            (_edge(source_path, new_path),),
+        ),
+    )

--- a/tests/test_governance_graph_successor_publication.py
+++ b/tests/test_governance_graph_successor_publication.py
@@ -373,6 +373,32 @@ def test_prepare_markdown_batch_forwards_graph_replacements(
     assert captured["graph_replacements"] == (replacement,)
 
 
+def test_prepare_membership_batch_forwards_lazy_graph_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def provider():
+        return ()
+
+    def fake_prepare(vault_root: Path, **kwargs: object) -> None:
+        captured["vault_root"] = vault_root
+        captured.update(kwargs)
+
+    monkeypatch.setattr(catalog_publication, "_prepare_markdown_batch", fake_prepare)
+
+    assert (
+        catalog_publication.prepare_catalog_membership_batch(
+            tmp_path,
+            writes=(),
+            graph_replacement_provider=provider,
+        )
+        is None
+    )
+    assert captured["graph_replacement_provider"] is provider
+
+
 def test_graph_successor_refuses_an_incomplete_active_family(tmp_path: Path) -> None:
     source = _variant("source", "5" * 64)
     target = _variant("target", "6" * 64)


### PR DESCRIPTION
## Why

Exact-v4 semantic moves must replace graph measurements for both the moved page and referrers whose typed links now resolve to the new identity. Otherwise the catalog/namespace transaction can activate with stale graph edges.

## What changed

- derives target-bound graph replacements from the validated before/after semantic corpora
- forwards the lazy graph provider through membership publication and keeps it dormant when no active graph family exists
- proves the public move path activates the renamed item and rewrites referrer edges in the same exact-v4 successor
- keeps OpenSpec task 8.11 open until the remaining writer inventory is closed

## Verification

- 20 focused tests passed
- Ruff passed on touched Python files
- strict OpenSpec validation passed
- public-artifact validation passed
- git diff check passed
