### PR TITLE
fix(retrieval): prevent rebuild publication starvation and persist reconcile freshness durably

### DIFF
--- a/openspec/changes/fix-rebuild-publication-starvation/.openspec.yaml
+++ b/openspec/changes/fix-rebuild-publication-starvation/.openspec.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven

--- a/openspec/changes/fix-rebuild-publication-starvation/design.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/design.md
@@ -73,6 +73,13 @@ of those paths may invoke an in-place whole-catalogue rebuild. Repeated demand i
 coalesced against the generation already being repaired; one worker does not
 chain whole-vault passes in a single flight.
 
+If a successfully published and promoted pass leaves an uncovered generation at
+its bounded idle handoff, the next flight first re-proves the persisted catalogue.
+A foreground delta may already have made that handoff current; in that case the
+worker acknowledges it without another full scan. Failed or unpromoted passes do
+not receive this shortcut, and a request arriving during the proof remains
+level-triggered and forces the normal repair path.
+
 Offline and deliberately unmanaged callers retain their synchronous correctness
 path because no long-lived repair owner exists there.
 

--- a/openspec/changes/fix-rebuild-publication-starvation/design.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/design.md
@@ -90,6 +90,12 @@ current live projection may promote retrieval. If the projection advances after
 publication but before promotion, the work remains pending and the next bounded
 delta catches up; readiness is never manufactured from a stale generation.
 
+The periodic safety-net walk is also an exact transition when it holds complete
+before and after recall maps. A missed filesystem event discovered there is
+retained as a bridgeable recall delta. Once its changed/deleted set is replayed,
+the lexical writer persists the resulting checkpoint so a process restart does
+not forget an exact-current catalogue and launch another full repair.
+
 ### 5. Report bounded, privacy-safe repair progress
 
 Repair telemetry will report phase, attempt age/duration, and a stable abort
@@ -102,6 +108,9 @@ reason such as `source_changed`, `delta_unavailable`, `identity_changed`, or
   exact published checkpoints again; a later generation stays pending.
 - **A retained delta can be incomplete.** Publication fails closed and preserves
   the current sidecar rather than guessing.
+- **A policy transition changes proof authority.** Reconcile history remains
+  discontinuous across policy identity changes; only same-policy complete map
+  diffs become bridgeable missed-event deltas.
 - **Replaying too much work can lengthen the publication barrier.** Final replay
   stays capped. A transient oversized suffix is caught up off-barrier and retried;
   repeated oversized suffixes exhaust the bounded retries, decline publication,

--- a/openspec/changes/fix-rebuild-publication-starvation/design.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/design.md
@@ -90,11 +90,21 @@ current live projection may promote retrieval. If the projection advances after
 publication but before promotion, the work remains pending and the next bounded
 delta catches up; readiness is never manufactured from a stale generation.
 
-The periodic safety-net walk is also an exact transition when it holds complete
-before and after recall maps. A missed filesystem event discovered there is
-retained as a bridgeable recall delta. Once its changed/deleted set is replayed,
-the lexical writer persists the resulting checkpoint so a process restart does
-not forget an exact-current catalogue and launch another full repair.
+The periodic safety-net walk holds complete before and after recall maps, so a
+missed filesystem event discovered there yields the exact changed/deleted set —
+but the walk runs off-lock and is not an atomic source snapshot, so that diff
+is retained as a bridgeable recall delta with explicit reconcile provenance,
+never as a trusted watcher transition. The lexical writer may replay it, and
+persists the resulting checkpoint only after an independent full-source
+re-proof executed off-barrier (at watcher-batch entry, before the publication
+barrier is taken) and validated under the barrier as an O(1) exact-checkpoint
+comparison. A scope whose proof is missing or superseded is refused alone;
+sibling scopes with exact observed witnesses still persist. The residual window
+— a source edit landing after the proof walk observed a path — is bounded by
+the next periodic reconcile, the same eventual-freshness bound
+`rebuild_atomic`'s existing off-barrier source proof already carries, so this
+weakens nothing relative to the status quo. Request and readiness paths refuse
+a reconcile-tainted delta outright rather than walking.
 
 ### 5. Report bounded, privacy-safe repair progress
 
@@ -110,7 +120,18 @@ reason such as `source_changed`, `delta_unavailable`, `identity_changed`, or
   the current sidecar rather than guessing.
 - **A policy transition changes proof authority.** Reconcile history remains
   discontinuous across policy identity changes; only same-policy complete map
-  diffs become bridgeable missed-event deltas.
+  diffs become bridgeable missed-event deltas, and even those carry reconcile
+  provenance requiring an independent source proof before any checkpoint
+  persists.
+- **The source-proof walk can itself be superseded.** The proof is prepared
+  off-barrier, so an edit after the walk observed a path is not seen by that
+  proof. The under-barrier validation compares the exact recall checkpoint, so
+  any observed event, reconcile, or policy change between the walk and the
+  barrier fails the proof closed (the scope is refused, rows still apply). An
+  edit that no event and no generation change ever observes within that window
+  is bounded by the next periodic reconcile, which re-detects the drift and
+  re-proves — bounded staleness, never a stale bless and never a starvation
+  loop.
 - **Replaying too much work can lengthen the publication barrier.** Final replay
   stays capped. A transient oversized suffix is caught up off-barrier and retried;
   repeated oversized suffixes exhaust the bounded retries, decline publication,

--- a/openspec/changes/fix-rebuild-publication-starvation/design.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/design.md
@@ -45,18 +45,22 @@ Alternative rejected: keep the exact SQLite token as a hard veto. That is the
 observed livelock because normal maintained-index traffic mutates the token during
 every long rebuild.
 
-### 2. Rebase the completed replacement under the publication barrier
+### 2. Rebase the completed replacement around a bounded publication barrier
 
 The detached worker records the recall checkpoints represented by its completed
-catalogue. Under the existing short publication barrier it compares those with
-the latest live projection. When the complete changed/deleted delta is retained
-and bounded, it applies that delta to the replacement, persists the exact new
-checkpoints, and revalidates before atomic replacement. If no logical generation
-changed, publication proceeds despite token-only churn.
+catalogue. It first replays the complete retained suffix off-barrier and proves
+the resulting source snapshot. It then waits on a background-only publication
+bound sized for a large foreground batch, compares its targets with the latest
+live projection, and applies only a small final suffix while holding the barrier.
+If a complete final suffix exceeds that cap, the worker preserves its completed
+temp catalogue, releases the barrier, catches up without the cap, re-proves the
+source, and retries. Retry count is bounded so sustained writes cannot turn one
+repair flight into an infinite owner.
 
-If the delta is missing, exceeds the bounded replay limit, fails validation, or
-the policy/semantic identity changes, the worker preserves the live catalogue and
-leaves repair pending for a later bounded flight.
+An incomplete delta, a suffix that remains oversized across the bounded retries,
+failed validation, or a policy/semantic identity change preserves the live
+catalogue and leaves repair pending for a later bounded flight. If no logical
+generation changed, publication proceeds despite token-only churn.
 
 Alternative rejected: hold the publication lock during the full scan. On the
 observed vault this would block normal work for ten to fifteen minutes.
@@ -91,9 +95,10 @@ reason such as `source_changed`, `delta_unavailable`, `identity_changed`, or
   exact published checkpoints again; a later generation stays pending.
 - **A retained delta can be incomplete.** Publication fails closed and preserves
   the current sidecar rather than guessing.
-- **Replaying too much work can lengthen the publication barrier.** Replay is
-  capped; an oversized delta declines publication and schedules a fresh bounded
-  flight.
+- **Replaying too much work can lengthen the publication barrier.** Final replay
+  stays capped. A transient oversized suffix is caught up off-barrier and retried;
+  repeated oversized suffixes exhaust the bounded retries, decline publication,
+  and leave repair pending.
 - **Another process can mutate the live sidecar.** Logical checkpoints and
   identity are re-read under the barrier; unexplained authoritative drift still
   aborts even though token-only churn does not.

--- a/openspec/changes/fix-rebuild-publication-starvation/design.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/design.md
@@ -1,0 +1,109 @@
+## Context
+
+Managed lexical recovery currently builds a replacement SQLite catalogue beside
+the live sidecar and publishes it only when `_live_publication_guard()` is byte
+for byte unchanged. Production evidence showed the live catalogue WAL and the
+detached rebuild WAL growing concurrently for more than ten minutes. Ordinary
+writer and watcher work therefore changes the disposable live SQLite set while
+the detached worker is scanning, causing an otherwise current replacement to be
+discarded. A later refused read schedules the next whole-vault pass, so normal
+traffic can starve readiness indefinitely.
+
+The Markdown vault, policy projection, semantic identity, and recall checkpoints
+are authoritative. SQLite main/WAL/SHM sizes and mtimes are useful observations,
+but they are not themselves source-of-truth state.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make managed full repair converge while ordinary writes and watcher events
+  continue.
+- Retain a single detached owner for full-catalogue work while retrieval is
+  unavailable.
+- Publish only a catalogue proven current for the authoritative source,
+  projection, policy, semantic identity, and complete retained delta.
+- Expose privacy-safe progress and decline reasons.
+
+**Non-Goals:**
+
+- Change the lexical sidecar schema or make it canonical state.
+- Block writers for the duration of a whole-vault rebuild.
+- Weaken path, access-policy, checkpoint, or semantic-identity validation.
+- Redesign pull-request CI; the heavyweight/nightly split remains separate.
+
+## Decisions
+
+### 1. Prove logical freshness, not disposable file stability
+
+Publication will distinguish authoritative guard changes from SQLite byte churn.
+A change to source/projection checkpoints, policy, or semantic identity remains a
+hard conflict until reconciled. A main/WAL/SHM token change alone will not veto a
+replacement whose logical proof still matches.
+
+Alternative rejected: keep the exact SQLite token as a hard veto. That is the
+observed livelock because normal maintained-index traffic mutates the token during
+every long rebuild.
+
+### 2. Rebase the completed replacement under the publication barrier
+
+The detached worker records the recall checkpoints represented by its completed
+catalogue. Under the existing short publication barrier it compares those with
+the latest live projection. When the complete changed/deleted delta is retained
+and bounded, it applies that delta to the replacement, persists the exact new
+checkpoints, and revalidates before atomic replacement. If no logical generation
+changed, publication proceeds despite token-only churn.
+
+If the delta is missing, exceeds the bounded replay limit, fails validation, or
+the policy/semantic identity changes, the worker preserves the live catalogue and
+leaves repair pending for a later bounded flight.
+
+Alternative rejected: hold the publication lock during the full scan. On the
+observed vault this would block normal work for ten to fifteen minutes.
+
+### 3. The detached worker is the sole managed full-rebuild owner
+
+Managed startup, refused reads, and watcher maintenance enqueue repair through
+the existing single-flight worker. While managed retrieval is unavailable, none
+of those paths may invoke an in-place whole-catalogue rebuild. Repeated demand is
+coalesced against the generation already being repaired; one worker does not
+chain whole-vault passes in a single flight.
+
+Offline and deliberately unmanaged callers retain their synchronous correctness
+path because no long-lived repair owner exists there.
+
+### 4. Readiness follows the exact published proof
+
+Only a successfully published catalogue whose persisted checkpoints match the
+current live projection may promote retrieval. If the projection advances after
+publication but before promotion, the work remains pending and the next bounded
+delta catches up; readiness is never manufactured from a stale generation.
+
+### 5. Report bounded, privacy-safe repair progress
+
+Repair telemetry will report phase, attempt age/duration, and a stable abort
+reason such as `source_changed`, `delta_unavailable`, `identity_changed`, or
+`publish_conflict`. It will not include vault paths, note names, or contents.
+
+## Risks / Trade-offs
+
+- **An event can arrive after the final proof.** Readiness promotion compares the
+  exact published checkpoints again; a later generation stays pending.
+- **A retained delta can be incomplete.** Publication fails closed and preserves
+  the current sidecar rather than guessing.
+- **Replaying too much work can lengthen the publication barrier.** Replay is
+  capped; an oversized delta declines publication and schedules a fresh bounded
+  flight.
+- **Another process can mutate the live sidecar.** Logical checkpoints and
+  identity are re-read under the barrier; unexplained authoritative drift still
+  aborts even though token-only churn does not.
+
+## Migration Plan
+
+No schema or canonical-data migration is required. Existing sidecars remain
+readable. Rollback reinstalls the previous package; any replacement database or
+temporary rebuild is disposable and can be regenerated from Markdown.
+
+## Open Questions
+
+None blocking implementation.

--- a/openspec/changes/fix-rebuild-publication-starvation/proposal.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+A managed Exomem cell can remain unavailable indefinitely when ordinary writer or
+watcher traffic changes the disposable live lexical SQLite set while a detached
+full rebuild is running. The completed rebuild then declines publication, later
+refused reads start another full pass, and concurrent work can repeat the cycle
+without any source or policy inconsistency.
+
+## What Changes
+
+- Make the detached background worker the only owner of a managed full-catalog
+  rebuild while retrieval is unavailable.
+- Reconcile a completed detached catalog against the latest authoritative
+  watcher checkpoints under the short publication barrier instead of treating
+  harmless live SQLite byte churn as a permanent veto.
+- Continue to fail closed when the source projection, access policy, semantic
+  identity, or retained delta cannot be proven current.
+- Expose bounded repair phase, duration, and abort-reason telemetry so an
+  operator can distinguish active progress, contention, and a declined publish.
+- Add concurrency regressions proving ordinary writes cannot create a competing
+  in-place full rebuild or starve eventual publication.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `live-index-freshness`: Managed lexical recovery must converge under ordinary
+  writer and watcher traffic while retaining exact source-of-truth freshness.
+- `instant-start`: Managed startup and late repair must retain one full-rebuild
+  owner and publish readiness after a current detached catalog lands.
+
+## Impact
+
+The change is confined to lexical catalog repair/publication, managed warmup
+coordination, privacy-safe repair telemetry, and their tests. It changes no MCP,
+REST, CLI, vault-content, or on-disk schema contract; the lexical sidecar remains
+disposable and rebuildable from Markdown.

--- a/openspec/changes/fix-rebuild-publication-starvation/specs/instant-start/spec.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/specs/instant-start/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Managed Full Rebuild Has One Owner
+
+While managed retrieval is unavailable, the detached single-flight repair worker
+SHALL be the only component allowed to perform a full lexical-catalogue rebuild.
+
+#### Scenario: Startup delegates incomplete catalogue repair
+
+- **WHEN** managed startup finds an incomplete or stale lexical catalogue
+- **THEN** it schedules the detached repair worker
+- **AND** does not start an in-place whole-vault rebuild beside it
+
+#### Scenario: Ordinary maintenance cannot start a competing full rebuild
+
+- **WHEN** a writer or watcher observes stale schema, identity, or checkpoints
+  during an active detached repair
+- **THEN** it records bounded repair demand for the single-flight owner
+- **AND** does not perform an in-place whole-catalogue rebuild
+
+#### Scenario: Refused reads coalesce behind the active generation
+
+- **WHEN** repeated managed reads are refused while the current generation is
+  already being repaired
+- **THEN** their repair requests coalesce behind that flight
+- **AND** one worker does not chain repeated whole-vault passes before yielding

--- a/openspec/changes/fix-rebuild-publication-starvation/specs/live-index-freshness/spec.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/specs/live-index-freshness/spec.md
@@ -38,6 +38,17 @@ validation.
 - **AND** a stale proof or a repair request arriving during the proof still
   follows the normal full-repair path
 
+#### Scenario: Safety-net reconcile proof survives restart
+
+- **WHEN** the periodic safety-net walk discovers a filesystem event the live
+  watcher missed
+- **AND** it holds complete before and after recall maps under one unchanged
+  policy identity
+- **THEN** the system retains their exact changed/deleted set as a bridgeable
+  recall delta
+- **AND** the lexical replay persists the resulting current checkpoint
+- **AND** a fresh process admits the current catalogue without a full rebuild
+
 #### Scenario: SQLite token-only churn does not veto a current replacement
 
 - **WHEN** the live SQLite main, WAL, or SHM token changes during a detached

--- a/openspec/changes/fix-rebuild-publication-starvation/specs/live-index-freshness/spec.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/specs/live-index-freshness/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Managed Lexical Repair Converges Under Live Traffic
+
+While managed retrieval is unavailable, the system SHALL allow a detached full
+lexical repair to publish under ordinary writer and watcher traffic without
+weakening authoritative source, projection, policy, or semantic-identity
+validation.
+
+#### Scenario: Concurrent live write is rebased before publication
+
+- **WHEN** a watcher generation changes or deletes Markdown paths while a
+  detached full repair is building
+- **AND** the complete bounded delta from the repair checkpoints to the current
+  live checkpoints is retained
+- **THEN** the system applies that delta to the completed replacement under the
+  publication barrier
+- **AND** publishes only after the replacement proves the current checkpoints
+- **AND** managed retrieval can become ready without a process restart
+
+#### Scenario: SQLite token-only churn does not veto a current replacement
+
+- **WHEN** the live SQLite main, WAL, or SHM token changes during a detached
+  repair
+- **AND** source/projection checkpoints, policy, and semantic identity still
+  match the replacement proof
+- **THEN** token-only churn SHALL NOT decline publication
+
+#### Scenario: Unprovable catch-up fails closed
+
+- **WHEN** the required delta is incomplete or oversized
+- **OR** source, policy, projection identity, or semantic identity cannot be
+  proven current
+- **THEN** the system preserves the live catalogue
+- **AND** leaves the repair request pending for a later bounded flight
+
+#### Scenario: Repair telemetry preserves vault privacy
+
+- **WHEN** a detached repair advances, publishes, or declines
+- **THEN** telemetry reports a bounded phase, duration, and stable result reason
+- **AND** contains no vault path, note name, or note content

--- a/openspec/changes/fix-rebuild-publication-starvation/specs/live-index-freshness/spec.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/specs/live-index-freshness/spec.md
@@ -45,9 +45,42 @@ validation.
 - **AND** it holds complete before and after recall maps under one unchanged
   policy identity
 - **THEN** the system retains their exact changed/deleted set as a bridgeable
-  recall delta
-- **AND** the lexical replay persists the resulting current checkpoint
+  recall delta carrying explicit reconcile provenance, never as a trusted
+  watcher transition
+- **AND** the lexical replay persists the resulting current checkpoint only
+  after an independent off-barrier source proof matches that exact checkpoint
 - **AND** a fresh process admits the current catalogue without a full rebuild
+
+#### Scenario: Mixed reconcile walk cannot bless a stale catalogue
+
+- **WHEN** the off-lock safety-net walk mixes pre- and post-change
+  observations because a source path changed after the walk observed it
+- **AND** the lexical replay applies the reconcile delta's changed/deleted set
+- **THEN** the independent source proof fails to match the reconcile-derived
+  checkpoint
+- **AND** the system refuses to persist that scope's checkpoint and preserves
+  the conservative repair path
+
+#### Scenario: Source proof never holds the publication barrier
+
+- **WHEN** a watcher batch must prove a reconcile-tainted checkpoint against
+  the complete current source
+- **THEN** the O(vault) proof walk executes before the publication barrier is
+  acquired, with no locks held
+- **AND** validation under the barrier is an O(1) exact-checkpoint comparison
+- **AND** request and readiness paths refuse a reconcile-tainted delta without
+  ever walking the vault
+
+#### Scenario: Invalidated source proof refuses only the affected scope and converges
+
+- **WHEN** an observed event, reconcile, or policy change lands between the
+  off-barrier source proof and the publication barrier
+- **THEN** the superseded proof fails closed and only the affected scope's
+  checkpoint is refused
+- **AND** sibling scopes with exact observed witnesses still persist
+- **AND** the batch's rows still apply, and a later batch covering the current
+  delta re-proves and persists the checkpoint without a full rebuild
+- **AND** proof outcomes are counted in stable, content-free telemetry
 
 #### Scenario: SQLite token-only churn does not veto a current replacement
 

--- a/openspec/changes/fix-rebuild-publication-starvation/specs/live-index-freshness/spec.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/specs/live-index-freshness/spec.md
@@ -18,6 +18,16 @@ validation.
 - **AND** publishes only after the replacement proves the current checkpoints
 - **AND** managed retrieval can become ready without a process restart
 
+#### Scenario: Large batch landing during publication wait catches up off-barrier
+
+- **WHEN** a foreground watcher batch holds the publication barrier while a
+  completed detached repair waits
+- **AND** the retained final suffix is complete but exceeds the barrier replay cap
+- **THEN** the system preserves the completed replacement and releases the barrier
+- **AND** replays that suffix off-barrier without the foreground cap
+- **AND** repeats the independent source proof before retrying publication
+- **AND** limits catch-up retries so sustained live churn cannot monopolize repair
+
 #### Scenario: SQLite token-only churn does not veto a current replacement
 
 - **WHEN** the live SQLite main, WAL, or SHM token changes during a detached
@@ -28,7 +38,8 @@ validation.
 
 #### Scenario: Unprovable catch-up fails closed
 
-- **WHEN** the required delta is incomplete or oversized
+- **WHEN** the required delta is incomplete
+- **OR** the final suffix remains oversized after the bounded catch-up retries
 - **OR** source, policy, projection identity, or semantic identity cannot be
   proven current
 - **THEN** the system preserves the live catalogue

--- a/openspec/changes/fix-rebuild-publication-starvation/specs/live-index-freshness/spec.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/specs/live-index-freshness/spec.md
@@ -28,6 +28,16 @@ validation.
 - **AND** repeats the independent source proof before retrying publication
 - **AND** limits catch-up retries so sustained live churn cannot monopolize repair
 
+#### Scenario: Published handoff does not repeat a current full scan
+
+- **WHEN** a successfully published and promoted repair leaves one generation
+  request pending at its bounded idle handoff
+- **AND** the next repair flight proves the persisted catalogue already covers
+  the current live projection
+- **THEN** the system acknowledges that handoff without another full-vault scan
+- **AND** a stale proof or a repair request arriving during the proof still
+  follows the normal full-repair path
+
 #### Scenario: SQLite token-only churn does not veto a current replacement
 
 - **WHEN** the live SQLite main, WAL, or SHM token changes during a detached

--- a/openspec/changes/fix-rebuild-publication-starvation/tasks.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/tasks.md
@@ -3,14 +3,14 @@
 - [x] 1.1 Replace the SQLite-token veto regression with coverage proving token-only live WAL churn cannot decline a logically current detached publication.
 - [x] 1.2 Add a concurrent watcher-delta regression proving a completed detached catalogue rebases changed and deleted paths to the latest exact checkpoints before publication.
 - [x] 1.3 Add coverage proving one oversized final suffix catches up off-barrier while incomplete, sustained-oversized, identity-shifted, and source-drifted catch-up preserves the live catalogue and pending repair demand.
-- [x] 1.4 Add managed-owner coverage proving startup, writers, watchers, and refused reads cannot start or chain a competing in-place full rebuild.
+- [x] 1.4 Add managed-owner coverage proving startup, writers, watchers, and refused reads cannot start or chain a competing in-place full rebuild, and a current published idle handoff does not launch a redundant scan.
 - [x] 1.5 Add privacy-safe repair progress and stable abort-reason telemetry coverage.
 
 ## 2. Convergent Repair
 
 - [x] 2.1 Split authoritative publication proof from disposable SQLite main/WAL/SHM observation.
 - [x] 2.2 Rebase a completed replacement off-barrier, keep the final barrier suffix capped, and retry a bounded number of off-barrier catch-ups before persisting and revalidating the exact current checkpoints.
-- [x] 2.3 Route every managed full-rebuild request through the existing detached single-flight owner and preserve uncovered demand across an idle handoff.
+- [x] 2.3 Route every managed full-rebuild request through the existing detached single-flight owner, preserve uncovered demand across an idle handoff, and re-prove a successful published handoff before repeating the scan.
 - [x] 2.4 Promote readiness only from the exact published checkpoint proof and retain later generations for bounded catch-up.
 - [x] 2.5 Emit privacy-safe repair phase, duration, and result-reason telemetry.
 

--- a/openspec/changes/fix-rebuild-publication-starvation/tasks.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/tasks.md
@@ -5,7 +5,8 @@
 - [x] 1.3 Add coverage proving one oversized final suffix catches up off-barrier while incomplete, sustained-oversized, identity-shifted, and source-drifted catch-up preserves the live catalogue and pending repair demand.
 - [x] 1.4 Add managed-owner coverage proving startup, writers, watchers, and refused reads cannot start or chain a competing in-place full rebuild, and a current published idle handoff does not launch a redundant scan.
 - [x] 1.5 Add privacy-safe repair progress and stable abort-reason telemetry coverage.
-- [x] 1.6 Add a restart regression proving a missed event discovered by the periodic reconcile persists the exact lexical checkpoint after replay.
+- [x] 1.6 Add a restart regression proving a missed event discovered by the periodic reconcile persists the exact lexical checkpoint after replay, after an independent off-barrier source proof.
+- [x] 1.7 Add coverage proving the reconcile source proof runs off-barrier (never while the publication barrier is held), a mixed or superseded walk refuses only the affected scope while sibling scopes bless, a proof invalidated between prepare and barrier refuses then converges on the next batch, a failing proof walk fails closed without losing the batch's rows or scheduling a rebuild, readiness over a tainted bridge never walks, and proof telemetry stays content-free.
 
 ## 2. Convergent Repair
 
@@ -14,12 +15,13 @@
 - [x] 2.3 Route every managed full-rebuild request through the existing detached single-flight owner, preserve uncovered demand across an idle handoff, and re-prove a successful published handoff before repeating the scan.
 - [x] 2.4 Promote readiness only from the exact published checkpoint proof and retain later generations for bounded catch-up.
 - [x] 2.5 Emit privacy-safe repair phase, duration, and result-reason telemetry.
-- [x] 2.6 Preserve same-policy reconcile map diffs as bridgeable recall history so bounded replay remains durable across process restart.
+- [x] 2.6 Preserve same-policy reconcile map diffs as bridgeable recall history with explicit reconcile provenance so bounded replay remains durable across process restart, persisting a checkpoint only after an independent off-barrier source proof.
+- [x] 2.7 Execute the reconcile source proof synchronously at watcher-batch entry with no locks held, validate it under the barrier as an O(1) exact-checkpoint comparison (single-use, per-scope, store-local), refuse tainted scopes on request paths and in the in-process witness map by proof absence, and count proof outcomes in stable content-free telemetry.
 
 ## 3. Verification and Delivery
 
 - [x] 3.1 Run focused repair/publication tests, lint, privacy validation, and strict OpenSpec validation.
 - [ ] 3.2 Run the proportional lean suite and latency/convergence gates.
-- [x] 3.3 Obtain independent adversarial review and resolve every attributable finding.
+- [ ] 3.3 Obtain independent adversarial review and resolve every attributable finding.
 - [ ] 3.4 Synchronize and archive the completed OpenSpec changes, then commit, push, and open the ready pull request.
 - [ ] 3.5 Merge through required checks, cut the release, deploy personal and POLLY candidates, and accept readiness plus distinct live retrieval queries.

--- a/openspec/changes/fix-rebuild-publication-starvation/tasks.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/tasks.md
@@ -1,0 +1,23 @@
+## 1. Regression Tests
+
+- [x] 1.1 Replace the SQLite-token veto regression with coverage proving token-only live WAL churn cannot decline a logically current detached publication.
+- [x] 1.2 Add a concurrent watcher-delta regression proving a completed detached catalogue rebases changed and deleted paths to the latest exact checkpoints before publication.
+- [x] 1.3 Add failure coverage proving incomplete, oversized, identity-shifted, and source-drifted catch-up preserves the live catalogue and pending repair demand.
+- [x] 1.4 Add managed-owner coverage proving startup, writers, watchers, and refused reads cannot start or chain a competing in-place full rebuild.
+- [x] 1.5 Add privacy-safe repair progress and stable abort-reason telemetry coverage.
+
+## 2. Convergent Repair
+
+- [x] 2.1 Split authoritative publication proof from disposable SQLite main/WAL/SHM observation.
+- [x] 2.2 Rebase a completed replacement through the complete bounded watcher delta under the publication barrier, then persist and revalidate the exact current checkpoints.
+- [x] 2.3 Route every managed full-rebuild request through the existing detached single-flight owner and preserve uncovered demand across an idle handoff.
+- [x] 2.4 Promote readiness only from the exact published checkpoint proof and retain later generations for bounded catch-up.
+- [x] 2.5 Emit privacy-safe repair phase, duration, and result-reason telemetry.
+
+## 3. Verification and Delivery
+
+- [x] 3.1 Run focused repair/publication tests, lint, privacy validation, and strict OpenSpec validation.
+- [ ] 3.2 Run the proportional lean suite and latency/convergence gates.
+- [x] 3.3 Obtain independent adversarial review and resolve every attributable finding.
+- [ ] 3.4 Synchronize and archive the completed OpenSpec changes, then commit, push, and open the ready pull request.
+- [ ] 3.5 Merge through required checks, cut the release, deploy personal and POLLY candidates, and accept readiness plus distinct live retrieval queries.

--- a/openspec/changes/fix-rebuild-publication-starvation/tasks.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/tasks.md
@@ -2,14 +2,14 @@
 
 - [x] 1.1 Replace the SQLite-token veto regression with coverage proving token-only live WAL churn cannot decline a logically current detached publication.
 - [x] 1.2 Add a concurrent watcher-delta regression proving a completed detached catalogue rebases changed and deleted paths to the latest exact checkpoints before publication.
-- [x] 1.3 Add failure coverage proving incomplete, oversized, identity-shifted, and source-drifted catch-up preserves the live catalogue and pending repair demand.
+- [x] 1.3 Add coverage proving one oversized final suffix catches up off-barrier while incomplete, sustained-oversized, identity-shifted, and source-drifted catch-up preserves the live catalogue and pending repair demand.
 - [x] 1.4 Add managed-owner coverage proving startup, writers, watchers, and refused reads cannot start or chain a competing in-place full rebuild.
 - [x] 1.5 Add privacy-safe repair progress and stable abort-reason telemetry coverage.
 
 ## 2. Convergent Repair
 
 - [x] 2.1 Split authoritative publication proof from disposable SQLite main/WAL/SHM observation.
-- [x] 2.2 Rebase a completed replacement through the complete bounded watcher delta under the publication barrier, then persist and revalidate the exact current checkpoints.
+- [x] 2.2 Rebase a completed replacement off-barrier, keep the final barrier suffix capped, and retry a bounded number of off-barrier catch-ups before persisting and revalidating the exact current checkpoints.
 - [x] 2.3 Route every managed full-rebuild request through the existing detached single-flight owner and preserve uncovered demand across an idle handoff.
 - [x] 2.4 Promote readiness only from the exact published checkpoint proof and retain later generations for bounded catch-up.
 - [x] 2.5 Emit privacy-safe repair phase, duration, and result-reason telemetry.

--- a/openspec/changes/fix-rebuild-publication-starvation/tasks.md
+++ b/openspec/changes/fix-rebuild-publication-starvation/tasks.md
@@ -5,6 +5,7 @@
 - [x] 1.3 Add coverage proving one oversized final suffix catches up off-barrier while incomplete, sustained-oversized, identity-shifted, and source-drifted catch-up preserves the live catalogue and pending repair demand.
 - [x] 1.4 Add managed-owner coverage proving startup, writers, watchers, and refused reads cannot start or chain a competing in-place full rebuild, and a current published idle handoff does not launch a redundant scan.
 - [x] 1.5 Add privacy-safe repair progress and stable abort-reason telemetry coverage.
+- [x] 1.6 Add a restart regression proving a missed event discovered by the periodic reconcile persists the exact lexical checkpoint after replay.
 
 ## 2. Convergent Repair
 
@@ -13,6 +14,7 @@
 - [x] 2.3 Route every managed full-rebuild request through the existing detached single-flight owner, preserve uncovered demand across an idle handoff, and re-prove a successful published handoff before repeating the scan.
 - [x] 2.4 Promote readiness only from the exact published checkpoint proof and retain later generations for bounded catch-up.
 - [x] 2.5 Emit privacy-safe repair phase, duration, and result-reason telemetry.
+- [x] 2.6 Preserve same-policy reconcile map diffs as bridgeable recall history so bounded replay remains durable across process restart.
 
 ## 3. Verification and Delivery
 

--- a/src/exomem/freshness.py
+++ b/src/exomem/freshness.py
@@ -1126,22 +1126,24 @@ def reconcile(
                 _recall_generations[key] = _next_gen()
                 _recall_history[key] = []
             elif old_recall != recall_fresh:
-                # The safety-net walk has both complete maps, so a missed
-                # filesystem event is still an exact, bridgeable recall delta.
-                # Retain it just like an observed watcher event.  Clearing the
-                # history here used to make the lexical watcher replay update
-                # every changed row but refuse to persist its checkpoint; the
-                # next process then launched a whole-vault rebuild despite an
-                # exact-current catalog.
+                # The safety-net walk holds both complete same-policy maps, so
+                # a missed filesystem event yields a BRIDGEABLE old/new map
+                # diff — but never a TRUSTED one: the walk ran off-lock and is
+                # not an atomic source snapshot, so a concurrent edit can leave
+                # it mixing pre- and post-change observations. The event is
+                # therefore recorded with ``requires_source_proof=True``: a
+                # consumer may replay the exact diff, but must independently
+                # re-prove the resulting target against the complete current
+                # source before persisting (blessing) that checkpoint, and
+                # request paths refuse it outright. Clearing the history here
+                # instead used to strand an exact-current catalog behind a
+                # stale persisted checkpoint and launch a whole-vault rebuild
+                # on the next restart.
                 recall_touched = {
                     path
                     for path in set(old_recall) | set(recall_fresh)
                     if old_recall.get(path) != recall_fresh.get(path)
                 }
-                # Unlike a watcher event, one off-lock walk is not an atomic
-                # source snapshot. Consumers may replay this exact old/new map
-                # diff only after independently proving its target against the
-                # complete current source.
                 _record_recall_event(
                     key,
                     recall_touched,

--- a/src/exomem/freshness.py
+++ b/src/exomem/freshness.py
@@ -149,6 +149,7 @@ class RecallDelta(NamedTuple):
     changed: frozenset[str]
     deleted: frozenset[str]
     target_signatures: tuple[tuple[str, FileSignature], ...] = ()
+    requires_source_proof: bool = False
 
 
 class ConsumerDelta(NamedTuple):
@@ -208,7 +209,9 @@ _recall_triples: dict[tuple[str, str], tuple[int, int, str] | None] = {}
 _recall_generations: dict[tuple[str, str], int] = {}
 _recall_identities: dict[tuple[str, str], tuple[str, str]] = {}
 _recall_live: set[tuple[str, str]] = set()
-_recall_history: dict[tuple[str, str], list[tuple[int, int, frozenset[str]]]] = {}
+_recall_history: dict[
+    tuple[str, str], list[tuple[int, int, frozenset[str], bool]]
+] = {}
 _recall_publications: dict[tuple[str, str], RecallPublicationState] = {}
 RECALL_PUBLICATION_PREPARE_ATTEMPTS = 4
 # Full replacement walks run without the registry lock.  While one is active,
@@ -256,12 +259,17 @@ def _record_event(key: tuple[str, str], paths: set[str]) -> None:
         del hist[:overflow]
 
 
-def _record_recall_event(key: tuple[str, str], paths: set[str]) -> None:
+def _record_recall_event(
+    key: tuple[str, str],
+    paths: set[str],
+    *,
+    requires_source_proof: bool = False,
+) -> None:
     previous = _recall_generations.get(key, 0)
     current = _next_gen()
     _recall_generations[key] = current
     history = _recall_history.setdefault(key, [])
-    history.append((previous, current, frozenset(paths)))
+    history.append((previous, current, frozenset(paths), requires_source_proof))
     overflow = len(history) - DELTA_HISTORY_LIMIT
     if overflow > 0:
         del history[:overflow]
@@ -948,9 +956,11 @@ def recall_delta_since(
             return RecallDelta(checkpoint, current, False, frozenset(), frozenset())
         changed: set[str] = set()
         deleted: set[str] = set()
-        for _before, _after, paths in history:
+        requires_source_proof = False
+        for _before, _after, paths, event_requires_source_proof in history:
             if _after <= checkpoint.generation:
                 continue
+            requires_source_proof |= event_requires_source_proof
             for path in paths:
                 if path in _recall_maps.get(key, {}):
                     changed.add(path)
@@ -966,6 +976,7 @@ def recall_delta_since(
             frozenset(changed),
             frozenset(deleted),
             tuple(sorted((path, signatures[path]) for path in changed if path in signatures)),
+            requires_source_proof,
         )
 
 
@@ -1108,9 +1119,34 @@ def reconcile(
             _recall_triples[key] = None
             _recall_identities[key] = recall_identity
             _recall_publications.pop(key, None)
-            if old_recall != recall_fresh or old_identity != recall_identity:
+            if old_recall is None or old_identity != recall_identity:
+                # Initialization and policy transitions change the proof
+                # authority.  No checkpoint from the prior projection may be
+                # resumed through the new one.
                 _recall_generations[key] = _next_gen()
                 _recall_history[key] = []
+            elif old_recall != recall_fresh:
+                # The safety-net walk has both complete maps, so a missed
+                # filesystem event is still an exact, bridgeable recall delta.
+                # Retain it just like an observed watcher event.  Clearing the
+                # history here used to make the lexical watcher replay update
+                # every changed row but refuse to persist its checkpoint; the
+                # next process then launched a whole-vault rebuild despite an
+                # exact-current catalog.
+                recall_touched = {
+                    path
+                    for path in set(old_recall) | set(recall_fresh)
+                    if old_recall.get(path) != recall_fresh.get(path)
+                }
+                # Unlike a watcher event, one off-lock walk is not an atomic
+                # source snapshot. Consumers may replay this exact old/new map
+                # diff only after independently proving its target against the
+                # complete current source.
+                _record_recall_event(
+                    key,
+                    recall_touched,
+                    requires_source_proof=True,
+                )
             _recall_live.add(key)
             if old is None:
                 # First initialization of this scope from a walk. Like `seed`, this is

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -133,6 +133,10 @@ _FULL_REBUILDS_IN_FLIGHT: set[Path] = set()
 #: by the explicit event-index rollback, where no live generation exists.
 _UNKNOWN_REPAIR_GENERATION = object()
 _FULL_REBUILD_REOBSERVED: dict[Path, set[object]] = {}
+# A successful publish+promotion may still preserve one uncovered generation at
+# the bounded idle handoff. The next flight may cheaply prove that a foreground
+# delta already covered it. Failed/unpromoted passes never enter this set.
+_PUBLISHED_HANDOFF_PENDING: set[Path] = set()
 #: One worker may scan the whole vault at most once. If that pass cannot cover a
 #: request observed during it, the request stays pending for a later caller to
 #: restart after an idle boundary instead of chaining full scans forever.
@@ -832,6 +836,7 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
             store = get_store(vault_root)
             while True:
                 with _REPAIRS_LOCK:
+                    published_handoff = False
                     full_requested = key in _FULL_REBUILD_REQUESTED
                     paths = sorted(_DEFERRED_UPSERTS.pop(key, set()))
                     if full_requested and full_passes >= _MAX_FULL_REBUILDS_PER_FLIGHT:
@@ -853,6 +858,8 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
                         rebuild = full_requested
                         if rebuild:
                             _FULL_REBUILD_REQUESTED.discard(key)
+                            published_handoff = key in _PUBLISHED_HANDOFF_PENDING
+                            _PUBLISHED_HANDOFF_PENDING.discard(key)
                     if not rebuild and not paths:
                         # Nothing left, and nothing can arrive between here and
                         # releasing the flight: a caller that takes this lock
@@ -866,6 +873,35 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
                             result=outcome or "targeted",
                         )
                         return
+                if rebuild and published_handoff:
+                    # A successful pass may leave one generation-tagged request
+                    # pending at its bounded idle handoff. Foreground delta work
+                    # can make that request current before the next caller starts
+                    # its flight. Re-prove the persisted catalogue before paying
+                    # for another whole-vault scan; a request arriving during the
+                    # proof sets the level-triggered bit again and is not cleared.
+                    from . import freshness as freshness_module
+
+                    if _is_configured_runtime_vault(vault_root):
+                        already_current = _mark_runtime_retrieval_ready_if_current(
+                            vault_root,
+                        )
+                    else:
+                        existing = runtime_retrieval_catalog_proof(
+                            vault_root,
+                            require_live_projection=(
+                                freshness_module.event_indexes_enabled()
+                            ),
+                            schedule_repair=False,
+                        )
+                        already_current = existing is not None
+                    with _REPAIRS_LOCK:
+                        requested_during_proof = key in _FULL_REBUILD_REQUESTED
+                    if already_current and not requested_during_proof:
+                        rebuild = False
+                        outcome = "published"
+                        if not paths:
+                            continue
                 full_pass = rebuild or not store.retry_deferred_upsert(paths)
                 if full_pass:
                     with _REPAIRS_LOCK:
@@ -963,6 +999,12 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
                                 _DEFERRED_UPSERTS.setdefault(key, set()).update(paths)
                         if uncovered:
                             _FULL_REBUILD_REQUESTED.add(key)
+                            if repaired and promoted:
+                                _PUBLISHED_HANDOFF_PENDING.add(key)
+                        else:
+                            _PUBLISHED_HANDOFF_PENDING.discard(key)
+                        if not (repaired and promoted):
+                            _PUBLISHED_HANDOFF_PENDING.discard(key)
                         _FULL_REBUILDS_IN_FLIGHT.discard(key)
                 rebuild = False
                 full_pass = False
@@ -983,6 +1025,7 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
                 if _FULL_REBUILD_REOBSERVED.get(key):
                     _FULL_REBUILD_REQUESTED.add(key)
                 _FULL_REBUILD_REOBSERVED.pop(key, None)
+                _PUBLISHED_HANDOFF_PENDING.discard(key)
                 _FULL_REBUILDS_IN_FLIGHT.discard(key)
                 _REPAIRS_IN_FLIGHT.discard(key)
                 _set_repair_progress(key, "idle", result="error")
@@ -1007,6 +1050,7 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
     except RuntimeError:
         with _REPAIRS_LOCK:
             _FULL_REBUILD_REOBSERVED.pop(key, None)
+            _PUBLISHED_HANDOFF_PENDING.discard(key)
             _FULL_REBUILDS_IN_FLIGHT.discard(key)
             _REPAIRS_IN_FLIGHT.discard(key)
             _set_repair_progress(key, "idle", result="error")

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -3689,6 +3689,7 @@ class LexicalStore:
             temp_path,
             scope_targets,
             start_identity,
+            max_paths=None,
         )
         if rebased_targets is None:
             return False
@@ -3792,13 +3793,17 @@ class LexicalStore:
         temp_path: Path,
         scope_targets: dict[str, tuple],
         expected_identity: str,
+        *,
+        max_paths: int | None = CATALOG_FOREGROUND_DELTA_CAP,
     ) -> dict[str, tuple] | None:
         """Replay one complete bounded live suffix onto a detached catalogue.
 
         Returns updated scope targets, the original targets when nothing moved,
         or ``None`` when the latest generation cannot be proven safely. The
         caller may hold the publication barrier; this helper touches only the
-        detached SQLite family and never walks the vault.
+        detached SQLite family and never walks the vault. ``max_paths=None`` is
+        reserved for the first off-barrier background catch-up; the final call
+        under the publication barrier retains the foreground cap.
         """
         from . import freshness as freshness_module
 
@@ -3839,7 +3844,7 @@ class LexicalStore:
                 return None
             touched.update(delta.changed)
             touched.update(delta.deleted)
-            if len(touched) > CATALOG_FOREGROUND_DELTA_CAP:
+            if max_paths is not None and len(touched) > max_paths:
                 self._last_rebuild_result = "delta_unavailable"
                 return None
             if not self._delta_target_still_current(scope, delta):

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -2753,6 +2753,7 @@ class LexicalStore:
         delta = freshness_module.recall_delta_since(self.vault_root, scope, stored)
         if (
             not delta.complete
+            or getattr(delta, "requires_source_proof", False)
             or delta.from_ != stored
             or delta.to != checkpoint
             or len({*delta.changed, *delta.deleted}) > CATALOG_FOREGROUND_DELTA_CAP
@@ -3212,7 +3213,11 @@ class LexicalStore:
 
         try:
             with self._publication_lock(timeout=_PUBLICATION_TIMEOUT_FOREGROUND):
-                applied = self._apply_paths_locked(paths, rel_paths)
+                applied = self._apply_paths_locked(
+                    paths,
+                    rel_paths,
+                    allow_reconciled_source_proof=True,
+                )
         except VaultLockError as e:
             log.info("lexical watcher batch deferred (%s); heals on next sync", e)
             _schedule_runtime_catalog_repair(self.vault_root)
@@ -3262,7 +3267,13 @@ class LexicalStore:
         """`upsert_paths` body with the publication barrier already held."""
         return self._apply_paths_locked(paths, [])
 
-    def _apply_paths_locked(self, paths: list[Path], rel_paths: list[str]) -> bool:
+    def _apply_paths_locked(
+        self,
+        paths: list[Path],
+        rel_paths: list[str],
+        *,
+        allow_reconciled_source_proof: bool = False,
+    ) -> bool:
         """Apply a changed/deleted union with the publication barrier held."""
         from . import freshness as freshness_module
         from . import recall_policy
@@ -3347,6 +3358,7 @@ class LexicalStore:
                 witness_targets,
                 requested_paths,
                 catalog_identity,
+                allow_reconciled_source_proof=allow_reconciled_source_proof,
             )
             return True
         finally:
@@ -3436,7 +3448,7 @@ class LexicalStore:
         self,
         targets: dict[str, tuple[object | None, object | None]],
         requested_paths: set[str],
-    ) -> dict[str, object]:
+    ) -> dict[str, tuple[object, bool]]:
         """Remember only the exact watcher-maintained corpus just applied.
 
         A bounded operation can attest a live checkpoint only when its requested
@@ -3446,7 +3458,7 @@ class LexicalStore:
         """
         from . import freshness as freshness_module
 
-        witnessed: dict[str, object] = {}
+        witnessed: dict[str, tuple[object, bool]] = {}
         for scope in ("kb", "vault"):
             checkpoint, stored = targets[scope]
             if checkpoint is None or freshness_module.recall_checkpoint(
@@ -3455,7 +3467,7 @@ class LexicalStore:
                 self._witnessed.pop(scope, None)
             elif stored == checkpoint:
                 self._witnessed[scope] = checkpoint
-                witnessed[scope] = checkpoint
+                witnessed[scope] = (checkpoint, False)
             elif stored is None:
                 self._witnessed.pop(scope, None)
             else:
@@ -3468,8 +3480,27 @@ class LexicalStore:
                     self._witnessed.pop(scope, None)
                 else:
                     self._witnessed[scope] = checkpoint
-                    witnessed[scope] = checkpoint
+                    witnessed[scope] = (
+                        checkpoint,
+                        bool(getattr(delta, "requires_source_proof", False)),
+                    )
         return witnessed
+
+    def _source_matches_recall_targets(self, targets: dict[str, object]) -> bool:
+        """Independently prove selected recall checkpoints against one full walk."""
+        from . import freshness as freshness_module
+
+        members, signatures = self._walk_entries()
+        for scope, checkpoint in targets.items():
+            idx = 1 if scope == "vault" else 0
+            entries = [
+                (str(path), signatures[path])
+                for path, flags in members.items()
+                if flags[idx]
+            ]
+            if freshness_module.triple_from_entries(entries) != checkpoint.triple:
+                return False
+        return True
 
     def _publish_live_witnesses(
         self,
@@ -3477,12 +3508,26 @@ class LexicalStore:
         targets: dict[str, tuple[object | None, object | None]],
         requested_paths: set[str],
         catalog_identity: str,
+        *,
+        allow_reconciled_source_proof: bool,
     ) -> None:
         """Persist exact watcher witnesses while the publication barrier is held."""
         from . import freshness as freshness_module
 
         witnessed = self._remember_live_witnesses(targets, requested_paths)
-        for scope, checkpoint in witnessed.items():
+        proof_targets = {
+            scope: checkpoint
+            for scope, (checkpoint, requires_source_proof) in witnessed.items()
+            if requires_source_proof
+        }
+        if proof_targets and (
+            not allow_reconciled_source_proof
+            or not self._source_matches_recall_targets(proof_targets)
+        ):
+            for scope in witnessed:
+                self._witnessed.pop(scope, None)
+            return
+        for scope, (checkpoint, _requires_source_proof) in witnessed.items():
             if (
                 freshness_module.recall_checkpoint(self.vault_root, scope) != checkpoint
                 or catalog_semantic_identity(self.vault_root) != catalog_identity
@@ -3921,6 +3966,10 @@ class LexicalStore:
             )
             if (
                 not delta.complete
+                or (
+                    getattr(delta, "requires_source_proof", False)
+                    and max_paths is not None
+                )
                 or delta.from_ != checkpoint
                 or (
                     delta.to.policy_version,
@@ -4027,6 +4076,8 @@ class LexicalStore:
             return
         if not getattr(delta, "complete", False):
             raise ValueError("apply_catalog_delta requires a complete delta")
+        if getattr(delta, "requires_source_proof", False):
+            raise ValueError("apply_catalog_delta requires an observed-event delta")
         if len({*delta.deleted, *delta.changed}) > CATALOG_FOREGROUND_DELTA_CAP:
             raise ValueError(
                 "apply_catalog_delta exceeds the foreground delta cap "
@@ -4384,6 +4435,7 @@ class LexicalStore:
                     )
                     if (
                         getattr(delta, "complete", False)
+                        and not getattr(delta, "requires_source_proof", False)
                         and len({*delta.changed, *delta.deleted})
                         <= CATALOG_FOREGROUND_DELTA_CAP
                     ):

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -158,6 +158,40 @@ _DEFERRED_UPSERTS: dict[Path, set[Path]] = {}
 _FULL_REBUILD_REQUESTED: set[Path] = set()
 _REPAIR_PROGRESS: dict[Path, dict[str, object]] = {}
 _REPAIRS_LOCK = threading.Lock()
+#: Reconcile source-proof outcomes — stable, content-free counters ONLY (no
+#: vault paths, note names, or content). ``prepared`` counts scopes an
+#: off-barrier walk proved; ``proof_mismatch`` counts scopes the walk refuted;
+#: ``walk_failed`` counts prepare passes that failed closed on OS/sqlite
+#: errors; ``ticket_stale`` counts proofs invalidated by an event between the
+#: prepare and the barrier; ``proof_missing`` counts tainted scopes that
+#: reached publication with no prepared proof; ``blessed`` counts tainted
+#: scopes actually persisted after their proof validated.
+_SOURCE_PROOF_TELEMETRY_KEYS = (
+    "prepared",
+    "proof_mismatch",
+    "walk_failed",
+    "ticket_stale",
+    "proof_missing",
+    "blessed",
+)
+_SOURCE_PROOF_TELEMETRY: dict[str, int] = dict.fromkeys(_SOURCE_PROOF_TELEMETRY_KEYS, 0)
+_SOURCE_PROOF_LOCK = threading.Lock()
+
+
+def _note_source_proof(reason: str) -> None:
+    """Count one stable reconcile source-proof outcome (never content).
+
+    Direct indexing on purpose: a typo'd reason raises KeyError instead of
+    silently minting a counter outside the stable key set.
+    """
+    with _SOURCE_PROOF_LOCK:
+        _SOURCE_PROOF_TELEMETRY[reason] += 1
+
+
+def source_proof_telemetry() -> dict[str, int]:
+    """Snapshot the stable, content-free reconcile source-proof counters."""
+    with _SOURCE_PROOF_LOCK:
+        return dict(_SOURCE_PROOF_TELEMETRY)
 
 
 @dataclass(frozen=True, slots=True)
@@ -779,6 +813,11 @@ def clear_stores() -> None:
     with _REPAIRS_LOCK:
         if not _REPAIRS_IN_FLIGHT:
             _REPAIR_PROGRESS.clear()
+    with _SOURCE_PROOF_LOCK:
+        _SOURCE_PROOF_TELEMETRY.clear()
+        _SOURCE_PROOF_TELEMETRY.update(
+            dict.fromkeys(_SOURCE_PROOF_TELEMETRY_KEYS, 0)
+        )
 
 
 def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = None) -> None:
@@ -1649,6 +1688,12 @@ class LexicalStore:
         # snapshot recomputes it so an ordinary-note edit is never missed.
         self._broad_seen: dict[str, tuple | None] = {}
         self._recall_seen: dict[str, object] = {}
+        # scope -> the exact RecallFreshnessCheckpoint one off-barrier source
+        # walk proved for a tainted (reconcile-derived) delta. Prepared at
+        # `apply_watcher_batch` entry with NO locks held, validated O(1) under
+        # the publication barrier by exact-checkpoint equality, and single-use:
+        # cleared when the batch finishes, whatever the outcome.
+        self._reconciled_source_proofs: dict[str, object] = {}
         self._failed = False  # runtime-retired for this process
         self._last_rebuild_result: str | None = None
         self._lock = threading.Lock()
@@ -3212,12 +3257,16 @@ class LexicalStore:
         from .vault import VaultLockError
 
         try:
+            # Prove any tainted reconcile-derived target against one source
+            # walk BEFORE taking the publication barrier: the walk is O(vault)
+            # and holds no locks here, while the validation under the barrier
+            # is an O(1) exact-checkpoint comparison. The proof is single-use
+            # per batch; running the prepare inside this try keeps it covered
+            # by the seam's deferred-heal handlers and the `finally` clear
+            # (the prepare's own internal catch remains primary).
+            self._prepare_reconcile_source_proof(paths, rel_paths)
             with self._publication_lock(timeout=_PUBLICATION_TIMEOUT_FOREGROUND):
-                applied = self._apply_paths_locked(
-                    paths,
-                    rel_paths,
-                    allow_reconciled_source_proof=True,
-                )
+                applied = self._apply_paths_locked(paths, rel_paths)
         except VaultLockError as e:
             log.info("lexical watcher batch deferred (%s); heals on next sync", e)
             _schedule_runtime_catalog_repair(self.vault_root)
@@ -3230,6 +3279,8 @@ class LexicalStore:
             log.info("lexical watcher source changed during repair (%s)", e)
             _schedule_runtime_catalog_repair(self.vault_root)
             return False
+        finally:
+            self._reconciled_source_proofs.clear()
         if not applied:
             _schedule_runtime_catalog_repair(self.vault_root)
         else:
@@ -3271,8 +3322,6 @@ class LexicalStore:
         self,
         paths: list[Path],
         rel_paths: list[str],
-        *,
-        allow_reconciled_source_proof: bool = False,
     ) -> bool:
         """Apply a changed/deleted union with the publication barrier held."""
         from . import freshness as freshness_module
@@ -3298,13 +3347,7 @@ class LexicalStore:
                 )
                 for scope in ("kb", "vault")
             }
-            requested_paths = {
-                key for path in paths if (key := self._live_event_path(path)) is not None
-            } | {
-                key
-                for rel in rel_paths
-                if (key := self._live_event_path(self.vault_root / rel)) is not None
-            }
+            requested_paths = self._requested_event_paths(paths, rel_paths)
             prepared: list[tuple[Path, str, tuple[int, int, int], bool, bool]] = []
             suppressed: list[str] = []
             for path in paths:
@@ -3358,7 +3401,6 @@ class LexicalStore:
                 witness_targets,
                 requested_paths,
                 catalog_identity,
-                allow_reconciled_source_proof=allow_reconciled_source_proof,
             )
             return True
         finally:
@@ -3444,6 +3486,23 @@ class LexicalStore:
         """`delete_rel_paths` body with the publication barrier already held."""
         return self._apply_paths_locked([], rel_paths)
 
+    def _requested_event_paths(
+        self, paths: list[Path], rel_paths: list[str]
+    ) -> set[str]:
+        """The live-registry path keys one bounded request names.
+
+        Shared by the under-barrier witness coverage check and the off-barrier
+        source-proof prepare so the two can never diverge on what "covered"
+        means.
+        """
+        return {
+            key for path in paths if (key := self._live_event_path(path)) is not None
+        } | {
+            key
+            for rel in rel_paths
+            if (key := self._live_event_path(self.vault_root / rel)) is not None
+        }
+
     def _remember_live_witnesses(
         self,
         targets: dict[str, tuple[object | None, object | None]],
@@ -3455,6 +3514,12 @@ class LexicalStore:
         paths cover every projected delta from the catalog's stored checkpoint.
         Without that proof (or without a live registry), the next read takes the
         conservative verify/rebuild path.
+
+        A reconcile-tainted checkpoint (``requires_source_proof``) is returned
+        for proof-gated publication but NEVER enters ``self._witnessed``: the
+        in-process witness map is consumed proof-free by ``_reconcile_live``,
+        so admitting a tainted checkpoint there would let a later request bless
+        a mixed-walk target without any source proof.
         """
         from . import freshness as freshness_module
 
@@ -3478,29 +3543,84 @@ class LexicalStore:
                     or not (set(delta.changed) | set(delta.deleted)) <= requested_paths
                 ):
                     self._witnessed.pop(scope, None)
+                elif getattr(delta, "requires_source_proof", False):
+                    self._witnessed.pop(scope, None)
+                    witnessed[scope] = (checkpoint, True)
                 else:
                     self._witnessed[scope] = checkpoint
-                    witnessed[scope] = (
-                        checkpoint,
-                        bool(getattr(delta, "requires_source_proof", False)),
-                    )
+                    witnessed[scope] = (checkpoint, False)
         return witnessed
 
-    def _source_matches_recall_targets(self, targets: dict[str, object]) -> bool:
-        """Independently prove selected recall checkpoints against one full walk."""
+    def _prepare_reconcile_source_proof(
+        self, paths: list[Path], rel_paths: list[str]
+    ) -> None:
+        """Prove tainted reconcile targets against one walk, with NO locks held.
+
+        Runs on the dispatching thread at ``apply_watcher_batch`` entry, before
+        the publication barrier: the O(vault) walk must never extend the
+        barrier hold (the design the uncommitted experiment got wrong). A scope
+        needs the proof only when a bless could actually result — its stored
+        checkpoint bridges to the current one through a complete, covered,
+        tainted delta. The proof is the exact current
+        ``RecallFreshnessCheckpoint``; any event, reconcile, or policy change
+        between this walk and the barrier advances the generation and fails the
+        under-barrier equality check closed (``ticket_stale``). Walk or sqlite
+        errors fail closed too: no proof is stored, the batch still applies its
+        rows, and the bless waits for a later batch (``walk_failed``).
+        """
         from . import freshness as freshness_module
 
-        members, signatures = self._walk_entries()
-        for scope, checkpoint in targets.items():
+        if not self.path.exists():
+            return
+        requested_paths = self._requested_event_paths(paths, rel_paths)
+        proof_targets: dict[str, object] = {}
+        try:
+            conn = self._connect()
+            try:
+                if not self._schema_is_current(conn):
+                    return
+                for scope in ("kb", "vault"):
+                    if not freshness_module.recall_is_live(self.vault_root, scope):
+                        continue
+                    current = freshness_module.recall_checkpoint(self.vault_root, scope)
+                    stored = self._meta_checkpoint(conn, scope)
+                    if stored is None or stored == current:
+                        continue
+                    delta = freshness_module.recall_delta_since(
+                        self.vault_root, scope, stored
+                    )
+                    if (
+                        delta.complete
+                        and getattr(delta, "requires_source_proof", False)
+                        and delta.to == current
+                        and (set(delta.changed) | set(delta.deleted)) <= requested_paths
+                    ):
+                        proof_targets[scope] = current
+            finally:
+                conn.close()
+            if not proof_targets:
+                return
+            members, signatures = self._walk_entries()
+        except (OSError, sqlite3.Error):
+            _note_source_proof("walk_failed")
+            return
+        for scope, checkpoint in proof_targets.items():
             idx = 1 if scope == "vault" else 0
             entries = [
                 (str(path), signatures[path])
                 for path, flags in members.items()
                 if flags[idx]
             ]
-            if freshness_module.triple_from_entries(entries) != checkpoint.triple:
-                return False
-        return True
+            if freshness_module.triple_from_entries(entries) == checkpoint.triple:
+                self._reconciled_source_proofs[scope] = checkpoint
+                _note_source_proof("prepared")
+            else:
+                # The refutation is authoritative: a walk that disproves this
+                # checkpoint must also EVICT any stale stored proof for the
+                # scope, or a proof prepared before an unobserved edit could be
+                # consumed after the newest walk refuted its exact target.
+                self._reconciled_source_proofs.pop(scope, None)
+                _note_source_proof("proof_mismatch")
 
     def _publish_live_witnesses(
         self,
@@ -3508,26 +3628,37 @@ class LexicalStore:
         targets: dict[str, tuple[object | None, object | None]],
         requested_paths: set[str],
         catalog_identity: str,
-        *,
-        allow_reconciled_source_proof: bool,
     ) -> None:
-        """Persist exact watcher witnesses while the publication barrier is held."""
+        """Persist exact watcher witnesses while the publication barrier is held.
+
+        Per-scope: an untainted witness blesses as before; a tainted witness
+        blesses only when the off-barrier prepare stored a proof for EXACTLY
+        this checkpoint. A missing or superseded proof refuses that one scope
+        (fail closed, O(1)) without touching the other scope's witness — no
+        walk is reachable while the barrier is held from any path into this
+        publication seam (the explicit repair seam, `ensure_fresh` →
+        `_reconcile_live` → `_rebuild`, walks under the barrier by design).
+        """
         from . import freshness as freshness_module
 
         witnessed = self._remember_live_witnesses(targets, requested_paths)
-        proof_targets = {
-            scope: checkpoint
-            for scope, (checkpoint, requires_source_proof) in witnessed.items()
-            if requires_source_proof
-        }
-        if proof_targets and (
-            not allow_reconciled_source_proof
-            or not self._source_matches_recall_targets(proof_targets)
-        ):
-            for scope in witnessed:
-                self._witnessed.pop(scope, None)
-            return
-        for scope, (checkpoint, _requires_source_proof) in witnessed.items():
+        for scope, (checkpoint, requires_source_proof) in witnessed.items():
+            if requires_source_proof:
+                proof = self._reconciled_source_proofs.pop(scope, None)
+                if proof is None:
+                    # No proof was prepared (non-batch path, coverage changed,
+                    # or the prepare failed closed). Refuse this scope only.
+                    _note_source_proof("proof_missing")
+                    continue
+                if proof != checkpoint:
+                    # An event landed between the prepare and the barrier; the
+                    # walk proved a superseded target. Refuse this scope only.
+                    # Exact-checkpoint equality is defense-in-depth here:
+                    # identity/policy divergence is closed upstream by delta
+                    # incompleteness, generation advance by this ticket
+                    # invalidation.
+                    _note_source_proof("ticket_stale")
+                    continue
             if (
                 freshness_module.recall_checkpoint(self.vault_root, scope) != checkpoint
                 or catalog_semantic_identity(self.vault_root) != catalog_identity
@@ -3544,6 +3675,8 @@ class LexicalStore:
                 checkpoint,
                 identity=catalog_identity,
             )
+            if requires_source_proof:
+                _note_source_proof("blessed")
             self._witnessed.pop(scope, None)
 
     def ensure_fresh(self) -> None:

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -98,7 +98,19 @@ CATALOG_FOREGROUND_DELTA_CAP = 32
 # non-reentrant per-thread across ALL namespaces, so a helper already under it
 # must be handed ownership, never re-acquire.
 _PUBLICATION_TIMEOUT_BACKGROUND = 30.0
+# A completed whole-vault replacement is far more valuable than an ordinary
+# background reconcile. Large watcher batches legitimately hold the same
+# publication barrier while applying hundreds of rows; on a memory-pressured
+# Windows host that exceeded the ordinary 30-second bound and discarded 21
+# minutes of completed work. Only the final background publish uses this longer
+# bound. Requests and writers retain their 50ms fail-fast path.
+_PUBLICATION_TIMEOUT_PUBLISH = 120.0
 _PUBLICATION_TIMEOUT_FOREGROUND = 0.05
+# A watcher may land another large batch while a completed build is waiting for
+# the publication barrier. Catch that generation up outside the barrier, prove
+# the source again, and retry; never turn sustained write traffic into an
+# unbounded repair worker.
+_PUBLICATION_CATCHUP_RETRIES = 2
 
 _PROBE_RESULT: bool | None = None
 _PROBE_LOCK = threading.Lock()
@@ -3526,12 +3538,14 @@ class LexicalStore:
         4. Persist each scope's exact target checkpoint/triple and the matching
            identity in the temp DB, then fold its WAL into a single self-contained
            main file — publication is refused unless that provably succeeds.
-        5. Rebase one bounded retained suffix, then re-walk the source and require
-           its exact triples to still match the temp targets. Under the publication
-           lock, rebase the final bounded suffix and reject only authoritative
-           guard conflicts; harmless live SQLite byte churn is not canonical state.
-           Fold the live WAL safely and publish with one `os.replace`. On any
-           failure/abort the live sidecar is preserved untouched.
+        5. Rebase one retained suffix off-barrier, then re-walk the source and
+           require its exact triples to still match the temp targets. Under the
+           publication lock, rebase the final bounded suffix. If a large writer
+           batch landed while publication waited, preserve the temp, catch up
+           off-barrier, re-prove the source, and retry a bounded number of times.
+           Reject only authoritative guard conflicts; harmless live SQLite byte
+           churn is not canonical state. Fold the live WAL safely and publish
+           with one `os.replace`. On any abort the live sidecar stays untouched.
 
         Returns True when it published, False when it declined (transient
         failure, incomplete/overflowed delta, identity change mid-build, a WAL
@@ -3696,43 +3710,121 @@ class LexicalStore:
         scope_targets = rebased_targets
         temp_targets = {scope: target[2] for scope, target in scope_targets.items()}
 
-        # A last identity re-check before publication: a shift after the scan
-        # means the built units reflect a superseded projection.
-        if catalog_semantic_identity(self.vault_root) != start_identity:
-            return self._decline_rebuild("identity_changed")
+        def source_matches_targets() -> bool:
+            # A shift after the scan means the built units reflect a superseded
+            # projection. The independent source snapshot also closes the gap
+            # where another process edits the shared corpus without this process
+            # observing a watcher event. This is background-only: no request path
+            # pays for the walk.
+            if catalog_semantic_identity(self.vault_root) != start_identity:
+                self._last_rebuild_result = "identity_changed"
+                return False
+            final_members, final_signatures = self._walk_entries()
+            for scope, idx in (("kb", 0), ("vault", 1)):
+                entries = [
+                    (str(path), final_signatures[path])
+                    for path, flags in final_members.items()
+                    if flags[idx]
+                ]
+                final_triple = freshness_module.triple_from_entries(entries)
+                if final_triple != scope_targets[scope][3]:
+                    log.info(
+                        "lexical atomic publish aborted: %s source changed after target capture",
+                        scope,
+                    )
+                    self._last_rebuild_result = "source_changed"
+                    return False
+            return True
 
-        # The replay target proves registry continuity, but another machine or
-        # process may edit the shared corpus without this process observing a
-        # watcher event. A final independent source snapshot closes that gap. It
-        # is deliberately background-only: no request path pays for this walk.
-        final_members, final_signatures = self._walk_entries()
-        for scope, idx in (("kb", 0), ("vault", 1)):
-            entries = [
-                (str(path), final_signatures[path])
-                for path, flags in final_members.items()
-                if flags[idx]
-            ]
-            final_triple = freshness_module.triple_from_entries(entries)
-            if final_triple != scope_targets[scope][3]:
-                log.info(
-                    "lexical atomic publish aborted: %s source changed after target capture",
-                    scope,
-                )
-                return self._decline_rebuild("source_changed")
+        if not source_matches_targets():
+            return False
 
         # Serialize the guard re-read + live-WAL fold + replace against any
         # concurrent publish (background rebuild or foreground delta) so a newer
         # live catalog is never overwritten and the replace is snapshot-consistent.
-        _mark_active_repair_phase(self.vault_root, "publishing")
-        with self._publication_lock():
-            # Close the final watcher race under the publication barrier. This is
-            # bounded to the foreground delta cap, so the barrier never grows into
-            # another whole-vault operation. An incomplete or oversized suffix
-            # declines safely and leaves the request pending for the next flight.
+        catchup_attempts = 0
+        while True:
+            _mark_active_repair_phase(self.vault_root, "publishing")
+            needs_off_barrier_catchup = False
+            with self._publication_lock(timeout=_PUBLICATION_TIMEOUT_PUBLISH):
+                # Close the final watcher race under the publication barrier. This
+                # is bounded to the foreground delta cap, so the barrier never
+                # grows into another whole-vault operation. If a large batch landed
+                # while this build waited, preserve the completed temp and catch it
+                # up outside the barrier instead of throwing the whole build away.
+                rebased_targets = self._rebase_detached_catalog(
+                    temp_path,
+                    scope_targets,
+                    start_identity,
+                )
+                if rebased_targets is None:
+                    needs_off_barrier_catchup = (
+                        self._last_rebuild_result == "delta_unavailable"
+                        and catchup_attempts < _PUBLICATION_CATCHUP_RETRIES
+                    )
+                    if not needs_off_barrier_catchup:
+                        return False
+                else:
+                    scope_targets = rebased_targets
+                    temp_targets = {
+                        scope: target[2] for scope, target in scope_targets.items()
+                    }
+                    now_guard = self._live_publication_guard()
+                    if self._publication_guard_changed(
+                        start_live_guard,
+                        now_guard,
+                        temp_targets,
+                    ):
+                        # Foreign-process/out-of-order checkpoints remain incomparable.
+                        # Same-process advances are safe only when the bounded rebase
+                        # above put their exact target into the replacement.
+                        log.info(
+                            "lexical atomic publish aborted: live catalog changed during build"
+                        )
+                        return self._decline_rebuild("publish_conflict")
+                    if self._live_regressed(now_guard, temp_targets, start_identity):
+                        # A foreground delta (or another rebuild) advanced the live
+                        # catalog past this build's target while we were building.
+                        # Abort rather than regress it.
+                        log.info(
+                            "lexical atomic publish aborted: live catalog advanced past build"
+                        )
+                        return self._decline_rebuild("publish_conflict")
+                    # The live main + `-wal` + `-shm` are one disposable set. A
+                    # missing main with orphan sidecars, or a proven-fatal main+WAL
+                    # that can never checkpoint itself, must move aside as a set.
+                    if self._live_set_disposition() == "quarantine":
+                        published = self._publish_over_quarantined_set(temp_path)
+                        if not published:
+                            self._last_rebuild_result = "publish_conflict"
+                        return published
+                    # Fold the healthy LIVE WAL before replacing its main file.
+                    if not self._quiesce_live_wal():
+                        log.info(
+                            "lexical atomic publish declined: live WAL not safely foldable"
+                        )
+                        return self._decline_rebuild("wal_busy")
+                    with reserved_paths._subsystem_authority_scope("lexstore"):
+                        reserved_paths._move_owner_file(
+                            self.vault_root,
+                            temp_path,
+                            "lexical-rebuild",
+                            self.path,
+                            "lexical-store",
+                            replace=True,
+                        )
+                    # Live `-wal`/`-shm` were folded away by `_quiesce_live_wal`.
+                    return True
+
+            # The capped suffix was complete but too large to replay while
+            # blocking writers. Rebase it without the barrier, then repeat the
+            # independent source proof before another short final suffix.
+            catchup_attempts += 1
             rebased_targets = self._rebase_detached_catalog(
                 temp_path,
                 scope_targets,
                 start_identity,
+                max_paths=None,
             )
             if rebased_targets is None:
                 return False
@@ -3740,53 +3832,8 @@ class LexicalStore:
             temp_targets = {
                 scope: target[2] for scope, target in scope_targets.items()
             }
-            now_guard = self._live_publication_guard()
-            if self._publication_guard_changed(
-                start_live_guard,
-                now_guard,
-                temp_targets,
-            ):
-                # Foreign-process/out-of-order checkpoints remain incomparable.
-                # Same-process advances are safe only when the bounded rebase
-                # above put their exact target into the replacement.
-                log.info("lexical atomic publish aborted: live catalog changed during build")
-                return self._decline_rebuild("publish_conflict")
-            if self._live_regressed(now_guard, temp_targets, start_identity):
-                # A foreground delta (or another rebuild) advanced the live catalog
-                # past this build's target while we were building. Abort rather
-                # than regress it; the later target stays in the registry history
-                # and a subsequent rebuild will capture it.
-                log.info("lexical atomic publish aborted: live catalog advanced past build")
-                return self._decline_rebuild("publish_conflict")
-            # The live main + `-wal` + `-shm` are one disposable set. A missing
-            # main with orphan sidecars, or a proven-fatal main+WAL that can never
-            # checkpoint itself, cannot be folded in place: recover by moving the
-            # WHOLE live-name set aside before installing the temp, so no stale WAL
-            # can share the freshly published main's name.
-            if self._live_set_disposition() == "quarantine":
-                published = self._publish_over_quarantined_set(temp_path)
-                if not published:
-                    self._last_rebuild_result = "publish_conflict"
-                return published
-            # Normal/healthy set: fold the LIVE `-wal`/`-shm` (content-preserving)
-            # so the single-file replace cannot strand a live WAL, and so we never
-            # blindly delete a live `-wal` a concurrent reader depends on. A busy/
-            # healthy WAL declines here rather than evicting a valid open DB.
-            if not self._quiesce_live_wal():
-                log.info("lexical atomic publish declined: live WAL not safely foldable")
-                return self._decline_rebuild("wal_busy")
-            with reserved_paths._subsystem_authority_scope("lexstore"):
-                reserved_paths._move_owner_file(
-                    self.vault_root,
-                    temp_path,
-                    "lexical-rebuild",
-                    self.path,
-                    "lexical-store",
-                    replace=True,
-                )
-            # Live `-wal`/`-shm` were folded away by `_quiesce_live_wal` before the
-            # replace; there is nothing to blindly unlink here.
-        return True
+            if not source_matches_targets():
+                return False
 
     def _rebase_detached_catalog(
         self,
@@ -3802,8 +3849,8 @@ class LexicalStore:
         or ``None`` when the latest generation cannot be proven safely. The
         caller may hold the publication barrier; this helper touches only the
         detached SQLite family and never walks the vault. ``max_paths=None`` is
-        reserved for the first off-barrier background catch-up; the final call
-        under the publication barrier retains the foreground cap.
+        reserved for off-barrier background catch-up; every final call under the
+        publication barrier retains the foreground cap.
         """
         from . import freshness as freshness_module
 

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -140,6 +140,7 @@ _DEFERRED_UPSERTS: dict[Path, set[Path]] = {}
 #: sqlite error, a noncurrent schema, a source that moved. These are NOT
 #: contention, and none of them is fixed by re-applying rows.
 _FULL_REBUILD_REQUESTED: set[Path] = set()
+_REPAIR_PROGRESS: dict[Path, dict[str, object]] = {}
 _REPAIRS_LOCK = threading.Lock()
 
 
@@ -699,10 +700,69 @@ def request_repair(vault_root: Path) -> None:
         _schedule_repair(vault_root)
 
 
+def repair_progress(vault_root: Path) -> dict[str, object] | None:
+    """Return fixed, content-free progress for one managed lexical repair."""
+    key = vault_root.resolve()
+    with _REPAIRS_LOCK:
+        progress = _REPAIR_PROGRESS.get(key)
+        if progress is None:
+            return None
+        started_at = progress.get("started_at")
+        age = (
+            max(0.0, time.monotonic() - float(started_at))
+            if isinstance(started_at, int | float)
+            and not isinstance(started_at, bool)
+            and progress.get("phase") != "idle"
+            else 0.0
+        )
+        return {
+            "phase": progress.get("phase", "idle"),
+            "age_seconds": round(age, 3),
+            "last_duration_seconds": progress.get("last_duration_seconds"),
+            "last_result": progress.get("last_result"),
+        }
+
+
+def _set_repair_progress(
+    key: Path,
+    phase: str,
+    *,
+    result: str | None = None,
+) -> None:
+    """Update process-local repair progress; caller holds `_REPAIRS_LOCK`."""
+    now = time.monotonic()
+    prior = _REPAIR_PROGRESS.get(key, {})
+    started_at = prior.get("started_at")
+    if phase == "queued" or not isinstance(started_at, int | float):
+        started_at = now
+    duration = prior.get("last_duration_seconds")
+    last_result = prior.get("last_result")
+    if phase == "idle":
+        duration = round(max(0.0, now - float(started_at)), 3)
+        last_result = result or last_result
+    _REPAIR_PROGRESS[key] = {
+        "phase": phase,
+        "started_at": started_at,
+        "last_duration_seconds": duration,
+        "last_result": last_result,
+    }
+
+
+def _mark_active_repair_phase(vault_root: Path, phase: str) -> None:
+    """Advance telemetry only when the managed scheduler owns this rebuild."""
+    key = vault_root.resolve()
+    with _REPAIRS_LOCK:
+        if key in _REPAIRS_IN_FLIGHT:
+            _set_repair_progress(key, phase)
+
+
 def clear_stores() -> None:
     """Test seam: drop per-process stores (sync memos, failure flags)."""
     with _STORES_LOCK:
         _STORES.clear()
+    with _REPAIRS_LOCK:
+        if not _REPAIRS_IN_FLIGHT:
+            _REPAIR_PROGRESS.clear()
 
 
 def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = None) -> None:
@@ -748,12 +808,14 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
             # request is picked up rather than dropped.
             return
         _REPAIRS_IN_FLIGHT.add(key)
+        _set_repair_progress(key, "queued")
 
     def _run() -> None:
         rebuild = False
         full_pass = False
         full_passes = 0
         paths: list[Path] = []
+        outcome: str | None = None
         try:
             store = get_store(vault_root)
             while True:
@@ -768,6 +830,11 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
                             _FULL_REBUILDS_IN_FLIGHT.discard(key)
                             _FULL_REBUILD_REOBSERVED.pop(key, None)
                             _REPAIRS_IN_FLIGHT.discard(key)
+                            _set_repair_progress(
+                                key,
+                                "idle",
+                                result=outcome or "delta_unavailable",
+                            )
                             return
                         rebuild = False
                     else:
@@ -781,6 +848,11 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
                         _FULL_REBUILDS_IN_FLIGHT.discard(key)
                         _FULL_REBUILD_REOBSERVED.pop(key, None)
                         _REPAIRS_IN_FLIGHT.discard(key)
+                        _set_repair_progress(
+                            key,
+                            "idle",
+                            result=outcome or "targeted",
+                        )
                         return
                 full_pass = rebuild or not store.retry_deferred_upsert(paths)
                 if full_pass:
@@ -794,6 +866,11 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
                                 _DEFERRED_UPSERTS.setdefault(key, set()).update(paths)
                             _FULL_REBUILD_REOBSERVED.pop(key, None)
                             _REPAIRS_IN_FLIGHT.discard(key)
+                            _set_repair_progress(
+                                key,
+                                "idle",
+                                result=outcome or "delta_unavailable",
+                            )
                             return
                         full_passes += 1
                         # A failed targeted retry escalates to the same full pass
@@ -802,13 +879,25 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
                         _FULL_REBUILD_REQUESTED.discard(key)
                         _FULL_REBUILD_REOBSERVED.pop(key, None)
                         _FULL_REBUILDS_IN_FLIGHT.add(key)
+                        _set_repair_progress(key, "building")
                     repaired = store.rebuild_atomic()
+                    # Telemetry is observational, never part of the scheduler's
+                    # store protocol. Minimal stores used by tests/integrations
+                    # may expose only `rebuild_atomic`.
+                    outcome = getattr(store, "_last_rebuild_result", None) or (
+                        "published" if repaired else "error"
+                    )
                 else:
+                    with _REPAIRS_LOCK:
+                        _set_repair_progress(key, "targeted")
                     repaired = True
+                    outcome = "targeted"
                 configured_runtime = _is_configured_runtime_vault(vault_root)
                 promoted = False
                 promotion_proof: dict[str, object] = {}
                 if repaired:
+                    with _REPAIRS_LOCK:
+                        _set_repair_progress(key, "promoting")
                     if configured_runtime:
                         promoted = _mark_runtime_retrieval_ready_if_current(
                             vault_root,
@@ -852,6 +941,12 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
                             )
                         }
                         if not (repaired and promoted):
+                            # A consumed full request is acknowledged only after
+                            # both publication and the exact-current promotion
+                            # proof succeed. Preserve a declined pass across the
+                            # bounded idle boundary even when nobody happened to
+                            # re-observe staleness while it was running.
+                            _FULL_REBUILD_REQUESTED.add(key)
                             if paths:
                                 _DEFERRED_UPSERTS.setdefault(key, set()).update(paths)
                         if uncovered:
@@ -878,6 +973,7 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
                 _FULL_REBUILD_REOBSERVED.pop(key, None)
                 _FULL_REBUILDS_IN_FLIGHT.discard(key)
                 _REPAIRS_IN_FLIGHT.discard(key)
+                _set_repair_progress(key, "idle", result="error")
 
     # Static name, deliberately — every other exomem thread name is a literal
     # too. Thread names now reach the log through `JsonLinesFormatter`'s
@@ -901,6 +997,7 @@ def _schedule_repair(vault_root: Path, *, deferred_paths: list[Path] | None = No
             _FULL_REBUILD_REOBSERVED.pop(key, None)
             _FULL_REBUILDS_IN_FLIGHT.discard(key)
             _REPAIRS_IN_FLIGHT.discard(key)
+            _set_repair_progress(key, "idle", result="error")
         log.warning("lexical background repair could not start for %s", key)
 
 
@@ -1497,7 +1594,13 @@ class LexicalStore:
         self._broad_seen: dict[str, tuple | None] = {}
         self._recall_seen: dict[str, object] = {}
         self._failed = False  # runtime-retired for this process
+        self._last_rebuild_result: str | None = None
         self._lock = threading.Lock()
+
+    def _decline_rebuild(self, reason: str) -> bool:
+        """Record one stable, content-free repair result and decline."""
+        self._last_rebuild_result = reason
+        return False
 
     # -------------------------------------------------------------- plumbing
 
@@ -1805,26 +1908,42 @@ class LexicalStore:
         )
 
     @staticmethod
-    def _publication_guard_changed(start_guard: dict, now_guard: dict) -> bool:
-        """Whether another process/writer changed the live DB set during build.
+    def _publication_guard_changed(
+        start_guard: dict,
+        now_guard: dict,
+        temp_targets: dict[str, object] | None = None,
+    ) -> bool:
+        """Whether live authoritative state conflicts with the replacement.
 
-        Exact equality is intentionally required. Checkpoint generations from
-        different process instances are incomparable, so ordering them is unsafe;
-        any changed currentness/identity/checkpoint/DB-set token aborts this stale
-        publish. Equivalent state compares equal and remains publishable.
+        SQLite main/WAL/SHM metadata is deliberately excluded: the lexical
+        sidecar is disposable derived state, and ordinary maintained-index work
+        changes those bytes throughout a long detached build. Treating that
+        observation as canonical made every healthy live write veto publication.
+
+        Schema/identity/existence changes still conflict. A checkpoint advance is
+        accepted only when it is the exact same-process target already replayed
+        into the temp catalogue; foreign or uncovered checkpoint changes remain
+        incomparable and fail closed.
         """
-        keys = (
-            "exists",
-            "schema_current",
-            "identity",
-            "checkpoints",
-            "db_set_token",
-        )
-        changed = tuple(
-            key for key in keys if start_guard.get(key) != now_guard.get(key)
-        )
+        changed = [
+            key
+            for key in ("exists", "schema_current", "identity")
+            if start_guard.get(key) != now_guard.get(key)
+        ]
+        start_checkpoints = start_guard.get("checkpoints", {})
+        now_checkpoints = now_guard.get("checkpoints", {})
+        if start_checkpoints != now_checkpoints:
+            targets = temp_targets or {}
+            for scope in set(start_checkpoints) | set(now_checkpoints):
+                before = start_checkpoints.get(scope)
+                after = now_checkpoints.get(scope)
+                if before == after:
+                    continue
+                target = targets.get(scope)
+                if after is None or target is None or after != target:
+                    changed.append(f"checkpoint:{scope}")
         if changed:
-            log.debug("lexical publication guard changed fields: %s", changed)
+            log.debug("lexical publication guard changed fields: %s", tuple(changed))
         return bool(changed)
 
     @staticmethod
@@ -2301,7 +2420,7 @@ class LexicalStore:
             return None
         try:
             val = ast.literal_eval(row[0])
-            return tuple(val) if isinstance(val, (list, tuple)) else None
+            return tuple(val) if isinstance(val, list | tuple) else None
         except (ValueError, SyntaxError):
             return None
 
@@ -2388,7 +2507,7 @@ class LexicalStore:
             val = ast.literal_eval(row[0])
         except (ValueError, SyntaxError):
             return None
-        if not isinstance(val, (list, tuple)) or len(val) != 5:
+        if not isinstance(val, list | tuple) or len(val) != 5:
             return None
         instance_id, generation, triple, policy_version, access_fingerprint = val
         if not isinstance(instance_id, str) or not instance_id:
@@ -2396,7 +2515,7 @@ class LexicalStore:
         if isinstance(generation, bool) or not isinstance(generation, int):
             return None
         if triple is not None:
-            if not isinstance(triple, (list, tuple)) or len(triple) != 3:
+            if not isinstance(triple, list | tuple) or len(triple) != 3:
                 return None
             count, mtime_ns, digest = triple
             if (
@@ -3392,10 +3511,10 @@ class LexicalStore:
 
         Sequence:
 
-        1. Under the cross-process publication lock, capture the live DB-set guard,
+        1. Under the cross-process publication lock, capture the live logical guard,
            each scope's start freshness checkpoint, and the semantic projection
            identity BEFORE the (potentially long) corpus scan. Any later live
-           publication changes that exact guard and makes this build ineligible.
+           publication establishes the baseline for later conflict detection.
         2. Build a fresh temp sidecar from the walk; if the projection identity
            shifted under the scan, discard it (the parsed units used the old
            projection).
@@ -3407,12 +3526,12 @@ class LexicalStore:
         4. Persist each scope's exact target checkpoint/triple and the matching
            identity in the temp DB, then fold its WAL into a single self-contained
            main file — publication is refused unless that provably succeeds.
-        5. Re-walk the source and require its exact triples to still match the temp
-           targets. Then, under the publication lock, require the live DB-set guard
-           to be equivalent to its start guard. This catches foreign-process
-           publications whose checkpoint generations cannot be ordered. Fold the
-           live WAL safely and publish with one `os.replace`. On any failure/abort
-           the live sidecar is preserved untouched.
+        5. Rebase one bounded retained suffix, then re-walk the source and require
+           its exact triples to still match the temp targets. Under the publication
+           lock, rebase the final bounded suffix and reject only authoritative
+           guard conflicts; harmless live SQLite byte churn is not canonical state.
+           Fold the live WAL safely and publish with one `os.replace`. On any
+           failure/abort the live sidecar is preserved untouched.
 
         Returns True when it published, False when it declined (transient
         failure, incomplete/overflowed delta, identity change mid-build, a WAL
@@ -3424,8 +3543,9 @@ class LexicalStore:
         from . import freshness as freshness_module
         from .vault import VaultLockError
 
+        self._last_rebuild_result = None
         if backend() == "python":
-            return False
+            return self._decline_rebuild("transient_failure")
 
         try:
             with self._publication_lock():
@@ -3439,7 +3559,7 @@ class LexicalStore:
             log.warning(
                 "lexical atomic rebuild baseline deferred (%s); live sidecar preserved", e
             )
-            return False
+            return self._decline_rebuild("transient_failure")
         temp_path = self.path.with_name(f"{self.path.name}.rebuild-{uuid.uuid4().hex}.tmp")
         try:
             try:
@@ -3453,22 +3573,23 @@ class LexicalStore:
                 if classify_sqlite_error(e) == "transient":
                     # A passing lock/interrupt fails only this attempt; the next
                     # request retries. Never escalate to a scheduled repair.
-                    return False
+                    return self._decline_rebuild("transient_failure")
                 raise
             except VaultLockError as e:
                 # Could not take (or timed out on) the publication lock, so this
                 # build cannot safely serialize its replace against a concurrent
                 # publish. Decline; the live sidecar is untouched.
                 log.warning("lexical atomic publish deferred (%s); live sidecar preserved", e)
-                return False
+                return self._decline_rebuild("publish_conflict")
             except OSError as e:
                 # A failed atomic publish leaves the live sidecar untouched.
                 log.warning("lexical atomic publish failed (%s); live sidecar preserved", e)
-                return False
+                return self._decline_rebuild("error")
         finally:
             self._cleanup_sidecar_files(temp_path)
 
         if published:
+            self._last_rebuild_result = "published"
             with self._lock:
                 # A published current catalog clears the disposable-failure flag
                 # and every stale attestation; the persisted meta triples let the
@@ -3490,7 +3611,7 @@ class LexicalStore:
         members, signatures = self._walk_entries()  # the corpus scan
         # The projection identity must not have shifted under the scan.
         if catalog_semantic_identity(self.vault_root) != start_identity:
-            return False
+            return self._decline_rebuild("identity_changed")
 
         # Deltas from each start checkpoint, captured (non-destructively) BEFORE
         # any temp write; an incomplete/overflowed span cannot prove the target.
@@ -3503,7 +3624,7 @@ class LexicalStore:
                     self.vault_root, scope, start_checkpoints[scope]
                 )
                 if not delta.complete:
-                    return False
+                    return self._decline_rebuild("delta_unavailable")
                 scope_targets[scope] = ("delta", delta, delta.to, delta.to.triple)
             else:
                 # No projected live registry: the policy-filtered walk is the
@@ -3558,12 +3679,26 @@ class LexicalStore:
             log.warning(
                 "lexical temp WAL fold incomplete; discarding build and preserving live"
             )
+            return self._decline_rebuild("fold_failed")
+
+        # Work observed while the temp rows were being materialized is not part
+        # of the earlier target capture. Replay that retained suffix now, before
+        # the independent source proof, so ordinary watcher traffic cannot force
+        # a whole-vault retry merely by arriving during a long build.
+        rebased_targets = self._rebase_detached_catalog(
+            temp_path,
+            scope_targets,
+            start_identity,
+        )
+        if rebased_targets is None:
             return False
+        scope_targets = rebased_targets
+        temp_targets = {scope: target[2] for scope, target in scope_targets.items()}
 
         # A last identity re-check before publication: a shift after the scan
         # means the built units reflect a superseded projection.
         if catalog_semantic_identity(self.vault_root) != start_identity:
-            return False
+            return self._decline_rebuild("identity_changed")
 
         # The replay target proves registry continuity, but another machine or
         # process may edit the shared corpus without this process observing a
@@ -3582,41 +3717,63 @@ class LexicalStore:
                     "lexical atomic publish aborted: %s source changed after target capture",
                     scope,
                 )
-                return False
+                return self._decline_rebuild("source_changed")
 
         # Serialize the guard re-read + live-WAL fold + replace against any
         # concurrent publish (background rebuild or foreground delta) so a newer
         # live catalog is never overwritten and the replace is snapshot-consistent.
+        _mark_active_repair_phase(self.vault_root, "publishing")
         with self._publication_lock():
-            now_guard = self._live_publication_guard()
-            if self._publication_guard_changed(start_live_guard, now_guard):
-                # Checkpoint generation ordering is meaningful only within one
-                # process instance. Exact guard equality also catches a foreign
-                # process/out-of-order publish and DB-set replacement that cannot
-                # be compared safely; a later rebuild can retry from that baseline.
-                log.info("lexical atomic publish aborted: live catalog changed during build")
+            # Close the final watcher race under the publication barrier. This is
+            # bounded to the foreground delta cap, so the barrier never grows into
+            # another whole-vault operation. An incomplete or oversized suffix
+            # declines safely and leaves the request pending for the next flight.
+            rebased_targets = self._rebase_detached_catalog(
+                temp_path,
+                scope_targets,
+                start_identity,
+            )
+            if rebased_targets is None:
                 return False
+            scope_targets = rebased_targets
+            temp_targets = {
+                scope: target[2] for scope, target in scope_targets.items()
+            }
+            now_guard = self._live_publication_guard()
+            if self._publication_guard_changed(
+                start_live_guard,
+                now_guard,
+                temp_targets,
+            ):
+                # Foreign-process/out-of-order checkpoints remain incomparable.
+                # Same-process advances are safe only when the bounded rebase
+                # above put their exact target into the replacement.
+                log.info("lexical atomic publish aborted: live catalog changed during build")
+                return self._decline_rebuild("publish_conflict")
             if self._live_regressed(now_guard, temp_targets, start_identity):
                 # A foreground delta (or another rebuild) advanced the live catalog
                 # past this build's target while we were building. Abort rather
                 # than regress it; the later target stays in the registry history
                 # and a subsequent rebuild will capture it.
                 log.info("lexical atomic publish aborted: live catalog advanced past build")
-                return False
+                return self._decline_rebuild("publish_conflict")
             # The live main + `-wal` + `-shm` are one disposable set. A missing
             # main with orphan sidecars, or a proven-fatal main+WAL that can never
             # checkpoint itself, cannot be folded in place: recover by moving the
             # WHOLE live-name set aside before installing the temp, so no stale WAL
             # can share the freshly published main's name.
             if self._live_set_disposition() == "quarantine":
-                return self._publish_over_quarantined_set(temp_path)
+                published = self._publish_over_quarantined_set(temp_path)
+                if not published:
+                    self._last_rebuild_result = "publish_conflict"
+                return published
             # Normal/healthy set: fold the LIVE `-wal`/`-shm` (content-preserving)
             # so the single-file replace cannot strand a live WAL, and so we never
             # blindly delete a live `-wal` a concurrent reader depends on. A busy/
             # healthy WAL declines here rather than evicting a valid open DB.
             if not self._quiesce_live_wal():
                 log.info("lexical atomic publish declined: live WAL not safely foldable")
-                return False
+                return self._decline_rebuild("wal_busy")
             with reserved_paths._subsystem_authority_scope("lexstore"):
                 reserved_paths._move_owner_file(
                     self.vault_root,
@@ -3629,6 +3786,110 @@ class LexicalStore:
             # Live `-wal`/`-shm` were folded away by `_quiesce_live_wal` before the
             # replace; there is nothing to blindly unlink here.
         return True
+
+    def _rebase_detached_catalog(
+        self,
+        temp_path: Path,
+        scope_targets: dict[str, tuple],
+        expected_identity: str,
+    ) -> dict[str, tuple] | None:
+        """Replay one complete bounded live suffix onto a detached catalogue.
+
+        Returns updated scope targets, the original targets when nothing moved,
+        or ``None`` when the latest generation cannot be proven safely. The
+        caller may hold the publication barrier; this helper touches only the
+        detached SQLite family and never walks the vault.
+        """
+        from . import freshness as freshness_module
+
+        if catalog_semantic_identity(self.vault_root) != expected_identity:
+            self._last_rebuild_result = "identity_changed"
+            return None
+
+        deltas: dict[str, object] = {}
+        touched: set[str] = set()
+        updated = dict(scope_targets)
+        for scope, (kind, _prior_delta, checkpoint, _triple) in scope_targets.items():
+            live_checkpoint = freshness_module.live_recall_checkpoint(
+                self.vault_root, scope
+            )
+            if kind != "delta" or live_checkpoint is None:
+                # Switching between walk-backed and live projection modes changes
+                # the proof model; a fresh flight must establish the new baseline.
+                if kind == "delta" or live_checkpoint is not None:
+                    self._last_rebuild_result = "delta_unavailable"
+                    return None
+                continue
+            delta = freshness_module.recall_delta_since(
+                self.vault_root, scope, checkpoint
+            )
+            if (
+                not delta.complete
+                or delta.from_ != checkpoint
+                or (
+                    delta.to.policy_version,
+                    delta.to.access_policy_fingerprint,
+                )
+                != (
+                    checkpoint.policy_version,
+                    checkpoint.access_policy_fingerprint,
+                )
+            ):
+                self._last_rebuild_result = "delta_unavailable"
+                return None
+            touched.update(delta.changed)
+            touched.update(delta.deleted)
+            if len(touched) > CATALOG_FOREGROUND_DELTA_CAP:
+                self._last_rebuild_result = "delta_unavailable"
+                return None
+            if not self._delta_target_still_current(scope, delta):
+                self._last_rebuild_result = "source_changed"
+                return None
+            if delta.to != checkpoint:
+                deltas[scope] = delta
+                updated[scope] = ("delta", delta, delta.to, delta.to.triple)
+
+        if not deltas:
+            return updated
+
+        conn = self._connect_setup(temp_path)
+        folded = False
+        try:
+            if (
+                not self._schema_is_current(conn)
+                or self._meta_catalog_identity(conn) != expected_identity
+            ):
+                self._last_rebuild_result = "identity_changed"
+                return None
+            try:
+                with conn:
+                    for delta in deltas.values():
+                        self._apply_delta_rows(conn, delta)
+                    if catalog_semantic_identity(self.vault_root) != expected_identity:
+                        raise _DeltaReplayStale
+                    for scope, delta in deltas.items():
+                        if not self._delta_target_still_current(scope, delta):
+                            raise _DeltaReplayStale
+                        if delta.to.triple is not None:
+                            conn.execute(
+                                "INSERT INTO meta(key, value) VALUES(?, ?) "
+                                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                                (f"triple:{scope}", repr(tuple(delta.to.triple))),
+                            )
+                        self._write_checkpoint(conn, scope, delta.to)
+                    self._write_catalog_identity(conn, expected_identity)
+            except _DeltaReplayStale:
+                self._last_rebuild_result = "source_changed"
+                return None
+            folded = self._fold_to_single_file(conn)
+        finally:
+            conn.close()
+
+        wal, shm = self._wal_shm_paths(temp_path)
+        if not folded or wal.exists() or shm.exists():
+            self._last_rebuild_result = "fold_failed"
+            return None
+        return updated
 
     # ---------------------------------------------------------- delta sidecar
 

--- a/src/exomem/runtime_readiness.py
+++ b/src/exomem/runtime_readiness.py
@@ -195,7 +195,7 @@ def _public_last_holder(value: object) -> dict[str, Any] | None:
             value.get("holder_kind"), fallback="unknown"
         ),
         "observed_at": float(observed_at)
-        if isinstance(observed_at, (int, float)) and not isinstance(observed_at, bool)
+        if isinstance(observed_at, int | float) and not isinstance(observed_at, bool)
         else 0.0,
         "source": source if source in {"refusal", "release"} else "unknown",
     }
@@ -216,7 +216,7 @@ def _public_contention(value: object) -> dict[str, Any] | None:
         "busy_refusals": _non_negative_int(value.get("busy_refusals")),
         "busy_refusals_recent": _non_negative_int(value.get("busy_refusals_recent")),
         "recent_window_seconds": float(window)
-        if isinstance(window, (int, float)) and not isinstance(window, bool)
+        if isinstance(window, int | float) and not isinstance(window, bool)
         else 0.0,
         # Stated, not implied: the counters describe this process only, so a
         # zero refusal count is not evidence that the boundary is uncontended.
@@ -301,6 +301,47 @@ _DEFAULT_OBSERVABILITY: dict[str, Any] = {
     "journal_ok": None,
 }
 
+_LEXICAL_REPAIR_PHASES = frozenset(
+    {"queued", "targeted", "building", "publishing", "promoting", "idle"}
+)
+_LEXICAL_REPAIR_RESULTS = frozenset(
+    {
+        "published",
+        "targeted",
+        "delta_unavailable",
+        "identity_changed",
+        "source_changed",
+        "publish_conflict",
+        "wal_busy",
+        "fold_failed",
+        "transient_failure",
+        "error",
+    }
+)
+
+
+def _public_lexical_repair(value: object) -> dict[str, object] | None:
+    """Project fixed, content-free repair progress into public readiness."""
+    if not isinstance(value, Mapping):
+        return None
+    raw_phase = value.get("phase")
+    phase = raw_phase if raw_phase in _LEXICAL_REPAIR_PHASES else "idle"
+    raw_result = value.get("last_result")
+    result = raw_result if raw_result in _LEXICAL_REPAIR_RESULTS else None
+
+    def duration(name: str) -> float | None:
+        raw = value.get(name)
+        if isinstance(raw, bool) or not isinstance(raw, int | float):
+            return None
+        return round(min(max(float(raw), 0.0), 604800.0), 3)
+
+    return {
+        "phase": phase,
+        "age_seconds": duration("age_seconds"),
+        "last_duration_seconds": duration("last_duration_seconds"),
+        "last_result": result,
+    }
+
 
 def build_runtime_readiness(
     *,
@@ -340,6 +381,9 @@ def build_runtime_readiness(
             state = "unverified"
         retrieval_admitted = bool(retrieval.get("admitted")) and state == "ready"
         retrieval_payload = {"state": state, "admitted": retrieval_admitted}
+        repair = _public_lexical_repair(retrieval.get("repair"))
+        if repair is not None:
+            retrieval_payload["repair"] = repair
         if not retrieval_admitted:
             reasons.append(f"retrieval_{state}")
 
@@ -547,6 +591,16 @@ def runtime_readiness(
             # here is what made MUTATION_LOCK_UNAVAILABLE read as healthy.
             "mutation_boundary": {"state": "unknown", "reason": "status_error"},
         }
+    retrieval = readiness.retrieval_admission(configured_vault)
+    if configured_vault is not None:
+        try:
+            from . import lexstore
+
+            progress = lexstore.repair_progress(configured_vault)
+        except Exception:  # noqa: BLE001 - diagnostics must not break readiness
+            progress = None
+        if progress is not None:
+            retrieval = {**retrieval, "repair": progress}
     return build_runtime_readiness(
         coordination=coordination,
         release=package_release(),
@@ -558,5 +612,5 @@ def runtime_readiness(
             if traffic is not None
             else get_silent_traffic_monitor().snapshot()
         ),
-        retrieval=readiness.retrieval_admission(configured_vault),
+        retrieval=retrieval,
     )

--- a/tests/test_freshness_registry.py
+++ b/tests/test_freshness_registry.py
@@ -302,6 +302,54 @@ def test_reconcile_detects_and_heals_a_missed_event(vault: Path) -> None:
     assert recall_delta.requires_source_proof is True
 
 
+def test_policy_identity_change_clears_reconcile_bridge(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A policy/access identity change is a hard proof boundary: even a
+    bridgeable tainted reconcile delta recorded before it can never resume
+    through the new projection (checkpoints read as incomplete, exposing no
+    partial suffix)."""
+    from exomem import recall_policy
+
+    state = {"fingerprint": "fingerprint-before"}
+    real_identity = recall_policy.recall_policy_identity
+    monkeypatch.setattr(
+        recall_policy,
+        "recall_policy_identity",
+        lambda root: (real_identity(root)[0], state["fingerprint"]),
+    )
+    _seed_both_scopes(vault)
+    before = freshness.recall_checkpoint(vault, "kb")
+
+    target = next(find_module._walk_md(vault / "Knowledge Base"))
+    future = time.time() + 10_000
+    os.utime(target, (future, future))
+    # No on_files_changed call here — simulates a missed watchdog event.
+    kb_dir = vault / "Knowledge Base"
+    drift = freshness.reconcile(
+        vault,
+        "kb",
+        ((str(p), freshness.stat_signature(p)) for p in find_module._walk_md(kb_dir)),
+    )
+    assert drift.changed == [str(target)]
+    tainted = freshness.recall_delta_since(vault, "kb", before)
+    assert tainted.complete is True
+    assert tainted.requires_source_proof is True
+
+    state["fingerprint"] = "fingerprint-after"
+    freshness.reconcile(
+        vault,
+        "kb",
+        ((str(p), freshness.stat_signature(p)) for p in find_module._walk_md(kb_dir)),
+    )
+
+    for checkpoint in (before, tainted.to):
+        bridged = freshness.recall_delta_since(vault, "kb", checkpoint)
+        assert bridged.complete is False
+        assert bridged.changed == frozenset()
+        assert bridged.deleted == frozenset()
+
+
 def test_reconcile_with_no_drift_returns_false(vault: Path) -> None:
     _seed_both_scopes(vault)
 

--- a/tests/test_freshness_registry.py
+++ b/tests/test_freshness_registry.py
@@ -275,6 +275,7 @@ def test_scope_boundary_schema_dir_updates_neither(vault: Path) -> None:
 def test_reconcile_detects_and_heals_a_missed_event(vault: Path) -> None:
     _seed_both_scopes(vault)
     stale_triple = freshness.triple(vault, "kb")
+    recall_before = freshness.recall_checkpoint(vault, "kb")
 
     target = next(find_module._walk_md(vault / "Knowledge Base"))
     future = time.time() + 10_000
@@ -294,6 +295,11 @@ def test_reconcile_detects_and_heals_a_missed_event(vault: Path) -> None:
     assert delta.changed == [str(target)]
     assert delta.deleted == []
     assert freshness.triple(vault, "kb") == fresh_truth
+    recall_delta = freshness.recall_delta_since(vault, "kb", recall_before)
+    assert recall_delta.complete is True
+    assert recall_delta.changed == frozenset({str(target)})
+    assert recall_delta.deleted == frozenset()
+    assert recall_delta.requires_source_proof is True
 
 
 def test_reconcile_with_no_drift_returns_false(vault: Path) -> None:

--- a/tests/test_lexical_deferred_upsert.py
+++ b/tests/test_lexical_deferred_upsert.py
@@ -205,6 +205,33 @@ def test_full_request_during_declined_rebuild_survives_a_bounded_idle_boundary(
     assert store.rebuilds == 2
 
 
+def test_declined_full_rebuild_preserves_demand_without_reobservation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed full pass must not rely on another probe to request repair."""
+
+    class _DecliningOnceStore(_FakeStore):
+        def rebuild_atomic(self) -> bool:
+            self.rebuilds += 1
+            return self.rebuilds > 1
+
+    store = _DecliningOnceStore()
+    _install(monkeypatch, store)
+    key = tmp_path.resolve()
+
+    lexstore._schedule_repair(tmp_path)
+    assert _wait_for_flight_end(tmp_path)
+
+    with lexstore._REPAIRS_LOCK:
+        assert key in lexstore._FULL_REBUILD_REQUESTED
+        assert key not in lexstore._FULL_REBUILDS_IN_FLIGHT
+    assert store.rebuilds == 1, "a declined pass retried without an idle boundary"
+
+    lexstore._schedule_repair(tmp_path)
+    assert _quiesce()
+    assert store.rebuilds == 2
+
+
 def test_newer_generation_observed_during_promotion_survives_for_next_flight(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_lexical_deferred_upsert.py
+++ b/tests/test_lexical_deferred_upsert.py
@@ -40,6 +40,7 @@ def _quiesce(timeout: float = 20.0) -> bool:
                 lexstore._FULL_REBUILD_REQUESTED.clear()
                 lexstore._FULL_REBUILDS_IN_FLIGHT.clear()
                 lexstore._FULL_REBUILD_REOBSERVED.clear()
+                lexstore._PUBLISHED_HANDOFF_PENDING.clear()
                 return not leaked_full_pass and not leaked_reobservation
         time.sleep(0.01)
     return False
@@ -172,6 +173,81 @@ def test_duplicate_full_request_during_full_rebuild_is_coalesced(
     assert _quiesce()
 
     assert store.rebuilds == 1, "an active full rebuild queued a duplicate pass"
+
+
+def test_pending_request_after_published_pass_skips_a_redundant_current_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An idle handoff must re-prove before repeating a successful full scan."""
+    store = _FakeStore()
+    _install(monkeypatch, store)
+    key = tmp_path.resolve()
+    with lexstore._REPAIRS_LOCK:
+        lexstore._set_repair_progress(key, "queued")
+        lexstore._set_repair_progress(key, "idle", result="published")
+        lexstore._FULL_REBUILD_REQUESTED.add(key)
+        lexstore._PUBLISHED_HANDOFF_PENDING.add(key)
+
+    lexstore._schedule_repair(tmp_path)
+    assert _quiesce()
+
+    assert store.rebuilds == 0, "a current published catalogue was scanned again"
+
+
+def test_pending_request_after_published_pass_rebuilds_when_proof_is_stale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cheap handoff proof may only suppress work it proves unnecessary."""
+    store = _FakeStore()
+    _install(monkeypatch, store)
+    monkeypatch.setattr(
+        lexstore,
+        "runtime_retrieval_catalog_proof",
+        lambda _root, **_kwargs: None,
+    )
+    key = tmp_path.resolve()
+    with lexstore._REPAIRS_LOCK:
+        lexstore._set_repair_progress(key, "queued")
+        lexstore._set_repair_progress(key, "idle", result="published")
+        lexstore._FULL_REBUILD_REQUESTED.add(key)
+        lexstore._PUBLISHED_HANDOFF_PENDING.add(key)
+
+    lexstore._schedule_repair(tmp_path)
+    assert _quiesce()
+
+    assert store.rebuilds == 1
+
+
+def test_request_arriving_during_current_handoff_proof_is_not_dropped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cheap proof cannot acknowledge a request that arrives after it starts."""
+    store = _FakeStore()
+    _install(monkeypatch, store)
+    current_proof = lexstore.runtime_retrieval_catalog_proof
+    fired = False
+
+    def prove_then_request(root: Path, **kwargs: object) -> dict[str, object] | None:
+        nonlocal fired
+        proof = current_proof(root, **kwargs)
+        if not fired:
+            fired = True
+            lexstore._schedule_repair(tmp_path)
+        return proof
+
+    monkeypatch.setattr(lexstore, "runtime_retrieval_catalog_proof", prove_then_request)
+    key = tmp_path.resolve()
+    with lexstore._REPAIRS_LOCK:
+        lexstore._set_repair_progress(key, "queued")
+        lexstore._set_repair_progress(key, "idle", result="published")
+        lexstore._FULL_REBUILD_REQUESTED.add(key)
+        lexstore._PUBLISHED_HANDOFF_PENDING.add(key)
+
+    lexstore._schedule_repair(tmp_path)
+    assert _quiesce()
+
+    assert fired
+    assert store.rebuilds == 1
 
 
 def test_full_request_during_declined_rebuild_survives_a_bounded_idle_boundary(

--- a/tests/test_lexstore.py
+++ b/tests/test_lexstore.py
@@ -378,6 +378,149 @@ def test_bounded_delete_witness_rejects_prior_uncovered_live_event(tmp_path):
         freshness.clear()
 
 
+def test_reconciled_missed_event_persists_catalog_proof_across_restart(
+    tmp_path, monkeypatch
+):
+    """A periodic-walk repair is an exact delta, not a reason to forget proof.
+
+    The watcher can miss a filesystem event and discover it in its safety-net
+    reconcile.  Once that exact changed/deleted set has been replayed into the
+    lexical catalog, a fresh process must be able to trust the persisted
+    checkpoint instead of launching a whole-vault rebuild.
+    """
+    from exomem import freshness
+    from exomem import vault as vault_module
+
+    freshness.clear()
+    monkeypatch.setattr(lexstore, "_admit_after_bounded_runtime_repair", lambda *_: None)
+    monkeypatch.setattr(lexstore, "_schedule_runtime_catalog_repair", lambda *_a, **_k: None)
+    try:
+        page = _write_page(tmp_path, "Knowledge Base/a.md", "beforemissedevent")
+        kb_dir = tmp_path / "Knowledge Base"
+
+        def _seed() -> None:
+            freshness.seed(
+                tmp_path,
+                "kb",
+                (
+                    (str(path), freshness.stat_signature(path))
+                    for path in find_module._walk_md(kb_dir)
+                ),
+            )
+            freshness.seed(
+                tmp_path,
+                "vault",
+                (
+                    (str(path), freshness.stat_signature(path))
+                    for path in vault_module.walk_vault_md(tmp_path)
+                ),
+            )
+
+        _seed()
+        assert lexstore.search_bm25(tmp_path, "beforemissedevent", k=3, scope="kb")
+
+        _write_page(tmp_path, "Knowledge Base/a.md", "aftermissedevent")
+        kb_drift = freshness.reconcile(
+            tmp_path,
+            "kb",
+            (
+                (str(path), freshness.stat_signature(path))
+                for path in find_module._walk_md(kb_dir)
+            ),
+        )
+        vault_drift = freshness.reconcile(
+            tmp_path,
+            "vault",
+            (
+                (str(path), freshness.stat_signature(path))
+                for path in vault_module.walk_vault_md(tmp_path)
+            ),
+        )
+        assert kb_drift.changed == [str(page)]
+        assert vault_drift.changed == [str(page)]
+
+        assert lexstore.get_store(tmp_path).apply_watcher_batch([page], [])
+
+        # Simulate a process restart: discard every in-memory witness and mint
+        # a fresh registry instance from disk.  Read-only admission must still
+        # accept the persisted catalog without scheduling or performing repair.
+        lexstore.clear_stores()
+        freshness.clear()
+        _seed()
+        assert (
+            lexstore.runtime_retrieval_catalog_proof(
+                tmp_path,
+                schedule_repair=False,
+            )
+            is not None
+        )
+        assert lexstore.search_bm25(tmp_path, "aftermissedevent", k=3, scope="kb")
+        assert lexstore.search_bm25(tmp_path, "beforemissedevent", k=3, scope="kb") == []
+    finally:
+        freshness.clear()
+
+
+def test_reconciled_mixed_walk_cannot_bless_stale_catalog(
+    tmp_path, monkeypatch
+):
+    """A reconcile delta needs a second source proof before it is authoritative."""
+    from exomem import freshness
+    from exomem import vault as vault_module
+
+    freshness.clear()
+    monkeypatch.setattr(lexstore, "_admit_after_bounded_runtime_repair", lambda *_: None)
+    monkeypatch.setattr(lexstore, "_schedule_runtime_catalog_repair", lambda *_a, **_k: None)
+    try:
+        a = _write_page(tmp_path, "Knowledge Base/a.md", "stalewalkalpha")
+        b = _write_page(tmp_path, "Knowledge Base/b.md", "stalewalkbeta")
+        kb_dir = tmp_path / "Knowledge Base"
+        freshness.seed(
+            tmp_path,
+            "kb",
+            (
+                (str(path), freshness.stat_signature(path))
+                for path in find_module._walk_md(kb_dir)
+            ),
+        )
+        freshness.seed(
+            tmp_path,
+            "vault",
+            (
+                (str(path), freshness.stat_signature(path))
+                for path in vault_module.walk_vault_md(tmp_path)
+            ),
+        )
+        assert lexstore.search_bm25(tmp_path, "stalewalkalpha", k=3, scope="kb")
+        store = lexstore.get_store(tmp_path)
+
+        # Model an off-lock walk that already statted A, then sees B's missed
+        # change, while a second missed change lands on A after its stat.
+        a_old = freshness.stat_signature(a)
+        _write_page(tmp_path, "Knowledge Base/b.md", "freshwalkbeta")
+        mixed = [
+            (str(a), a_old),
+            (str(b), freshness.stat_signature(b)),
+        ]
+        _write_page(tmp_path, "Knowledge Base/a.md", "freshwalkalpha")
+        assert freshness.reconcile(tmp_path, "kb", mixed).changed == [str(b)]
+        assert freshness.reconcile(tmp_path, "vault", mixed).changed == [str(b)]
+
+        assert store.apply_watcher_batch([b], [])
+
+        # The registry target itself is a mixed, superseded walk. Replaying B
+        # cannot make it an admissible catalogue: a fresh source proof sees A's
+        # later change and refuses the checkpoint.
+        assert (
+            lexstore.runtime_retrieval_catalog_proof(
+                tmp_path,
+                schedule_repair=False,
+            )
+            is None
+        )
+    finally:
+        freshness.clear()
+
+
 def test_restart_with_no_changes_skips_the_walk_verify(tmp_path):
     """Steady state across restarts: the meta-blessed triple lets a fresh
     store trust the sidecar without an exact verify (no rebuild)."""

--- a/tests/test_lexstore.py
+++ b/tests/test_lexstore.py
@@ -521,6 +521,534 @@ def test_reconciled_mixed_walk_cannot_bless_stale_catalog(
         freshness.clear()
 
 
+def _seed_live_scopes(vault_root: Path) -> None:
+    """Seed both live scopes exactly the way the watcher startup does."""
+    from exomem import freshness
+    from exomem import vault as vault_module
+
+    kb_dir = vault_root / "Knowledge Base"
+    freshness.seed(
+        vault_root,
+        "kb",
+        (
+            (str(path), freshness.stat_signature(path))
+            for path in find_module._walk_md(kb_dir)
+        ),
+    )
+    freshness.seed(
+        vault_root,
+        "vault",
+        (
+            (str(path), freshness.stat_signature(path))
+            for path in vault_module.walk_vault_md(vault_root)
+        ),
+    )
+
+
+def _reconcile_live_scopes(vault_root: Path) -> list:
+    """Run the safety-net reconcile over fresh walks for both live scopes."""
+    from exomem import freshness
+    from exomem import vault as vault_module
+
+    kb_dir = vault_root / "Knowledge Base"
+    return [
+        freshness.reconcile(
+            vault_root,
+            "kb",
+            (
+                (str(path), freshness.stat_signature(path))
+                for path in find_module._walk_md(kb_dir)
+            ),
+        ),
+        freshness.reconcile(
+            vault_root,
+            "vault",
+            (
+                (str(path), freshness.stat_signature(path))
+                for path in vault_module.walk_vault_md(vault_root)
+            ),
+        ),
+    ]
+
+
+def test_reconcile_source_proof_walk_never_holds_publication_barrier(
+    tmp_path, monkeypatch
+):
+    """The tainted-delta source proof is O(vault) work: it must run before the
+    publication barrier is taken, never while it is held, so a watcher batch
+    can never turn the barrier hold into a whole-vault scan."""
+    from exomem import freshness
+    from exomem.vault import VaultLockError, vault_creation_lock
+
+    freshness.clear()
+    monkeypatch.setattr(lexstore, "_admit_after_bounded_runtime_repair", lambda *_: None)
+    monkeypatch.setattr(lexstore, "_schedule_runtime_catalog_repair", lambda *_a, **_k: None)
+    try:
+        page = _write_page(tmp_path, "Knowledge Base/a.md", "barrierwalkbefore")
+        _seed_live_scopes(tmp_path)
+        assert lexstore.search_bm25(tmp_path, "barrierwalkbefore", k=3, scope="kb")
+        store = lexstore.get_store(tmp_path)
+
+        _write_page(tmp_path, "Knowledge Base/a.md", "barrierwalkafter")
+        for drift in _reconcile_live_scopes(tmp_path):
+            assert drift.changed == [str(page)]
+
+        real_walk = store._walk_entries
+        barrier_states: list[str] = []
+
+        def probing_walk():
+            # Same-thread probe: while THIS thread holds the publication
+            # barrier, a nested acquire raises; off-barrier it succeeds.
+            try:
+                with vault_creation_lock(
+                    tmp_path, "lexical-catalog-publication", timeout=0.2
+                ):
+                    barrier_states.append("free")
+            except VaultLockError:
+                barrier_states.append("held")
+            return real_walk()
+
+        monkeypatch.setattr(store, "_walk_entries", probing_walk)
+        assert store.apply_watcher_batch([page], [])
+        assert barrier_states, "replaying a tainted delta must prove the source"
+        assert barrier_states == ["free"] * len(barrier_states)
+    finally:
+        freshness.clear()
+
+
+def test_tainted_scope_refusal_still_blesses_untainted_scope(tmp_path, monkeypatch):
+    """Per-scope refusal: one unprovable tainted scope must not drop the other
+    scope's exact observed watcher witness."""
+    from exomem import freshness
+
+    freshness.clear()
+    monkeypatch.setattr(lexstore, "_admit_after_bounded_runtime_repair", lambda *_: None)
+    monkeypatch.setattr(lexstore, "_schedule_runtime_catalog_repair", lambda *_a, **_k: None)
+    try:
+        a = _write_page(tmp_path, "Knowledge Base/a.md", "scopedblessold")
+        v = _write_page(tmp_path, "Reference/v.md", "vaultonlybefore")
+        _seed_live_scopes(tmp_path)
+        assert lexstore.search_bm25(tmp_path, "scopedblessold", k=3, scope="kb")
+        store = lexstore.get_store(tmp_path)
+
+        # A vault-only missed event discovered by the safety net taints only
+        # the vault scope's bridge.
+        _write_page(tmp_path, "Reference/v.md", "vaultonlymissed")
+        kb_drift, vault_drift = _reconcile_live_scopes(tmp_path)
+        assert kb_drift.changed == []
+        assert vault_drift.changed == [str(v)]
+        # A second unobserved edit makes that tainted target unprovable: the
+        # registry retains the superseded signature, so no fresh source walk
+        # can ever match its triple.
+        _write_page(tmp_path, "Reference/v.md", "vaultonlynewer")
+
+        # An exact observed watcher event on the kb page.
+        _write_page(tmp_path, "Knowledge Base/a.md", "scopedblessnew")
+        freshness.on_files_changed(tmp_path, changed=[a])
+
+        assert store.apply_watcher_batch([a, v], [])
+
+        kb_ready = store.catalog_readiness(
+            "kb",
+            freshness.triple(tmp_path, "kb"),
+            allow_delta=False,
+            schedule_repair=False,
+        )
+        vault_ready = store.catalog_readiness(
+            "vault",
+            freshness.triple(tmp_path, "vault"),
+            allow_delta=False,
+            schedule_repair=False,
+        )
+        assert kb_ready.complete is True
+        assert vault_ready.complete is False
+    finally:
+        freshness.clear()
+
+
+def test_source_proof_invalidated_by_intervening_event_refuses_then_converges(
+    tmp_path, monkeypatch
+):
+    """An event landing between the off-barrier proof and the barrier fails the
+    proof closed: rows still apply, no request can sneak the bless in, and the
+    next watcher batch converges."""
+    from exomem import freshness
+
+    freshness.clear()
+    monkeypatch.setattr(lexstore, "_admit_after_bounded_runtime_repair", lambda *_: None)
+    monkeypatch.setattr(lexstore, "_schedule_runtime_catalog_repair", lambda *_a, **_k: None)
+    monkeypatch.setattr(lexstore, "_schedule_repair", lambda *_a, **_k: None)
+    try:
+        page = _write_page(tmp_path, "Knowledge Base/a.md", "intervenebefore")
+        _seed_live_scopes(tmp_path)
+        assert lexstore.search_bm25(tmp_path, "intervenebefore", k=3, scope="kb")
+        store = lexstore.get_store(tmp_path)
+
+        _write_page(tmp_path, "Knowledge Base/a.md", "intervenemissed")
+        for drift in _reconcile_live_scopes(tmp_path):
+            assert drift.changed == [str(page)]
+
+        real_apply = store._apply_paths_locked
+        fired = False
+
+        def _interleave_event(*args, **kwargs):
+            nonlocal fired
+            if not fired:
+                fired = True
+                _write_page(tmp_path, "Knowledge Base/a.md", "intervenenewest")
+                freshness.on_files_changed(tmp_path, changed=[page])
+            return real_apply(*args, **kwargs)
+
+        monkeypatch.setattr(store, "_apply_paths_locked", _interleave_event)
+        assert store.apply_watcher_batch([page], [])
+        assert fired
+
+        # The first attempt applied rows but must NOT have blessed: its proof
+        # was prepared against the pre-event registry state.
+        kb_after_first = store.catalog_readiness(
+            "kb",
+            freshness.triple(tmp_path, "kb"),
+            allow_delta=False,
+            schedule_repair=False,
+        )
+        assert kb_after_first.complete is False
+
+        # A read-only request cannot sneak the refused bless in either: a
+        # tainted checkpoint never enters the in-process witness map.
+        assert (
+            lexstore.search_bm25(
+                tmp_path, "intervenenewest", k=3, scope="kb", repair=False
+            )
+            is None
+        )
+        kb_after_probe = store.catalog_readiness(
+            "kb",
+            freshness.triple(tmp_path, "kb"),
+            allow_delta=False,
+            schedule_repair=False,
+        )
+        assert kb_after_probe.complete is False
+        assert lexstore.source_proof_telemetry()["ticket_stale"] >= 1
+
+        # The next watcher batch re-proves against the current registry state
+        # and converges without any rebuild.
+        monkeypatch.setattr(store, "_apply_paths_locked", real_apply)
+        assert store.apply_watcher_batch([page], [])
+        assert (
+            lexstore.runtime_retrieval_catalog_proof(tmp_path, schedule_repair=False)
+            is not None
+        )
+    finally:
+        freshness.clear()
+
+
+def test_source_proof_walk_failure_applies_rows_and_converges_without_rebuild(
+    tmp_path, monkeypatch
+):
+    """A failing proof walk fails closed on the bless ONLY: the batch's rows
+    still land durably, nothing schedules an O(vault) rebuild, and the next
+    batch converges once the walk works again."""
+    from exomem import freshness
+
+    freshness.clear()
+    monkeypatch.setattr(lexstore, "_admit_after_bounded_runtime_repair", lambda *_: None)
+    scheduled = {"n": 0}
+    monkeypatch.setattr(
+        lexstore,
+        "_schedule_runtime_catalog_repair",
+        lambda *_a, **_k: scheduled.__setitem__("n", scheduled["n"] + 1),
+    )
+    try:
+        page = _write_page(tmp_path, "Knowledge Base/a.md", "walkfailbefore")
+        _seed_live_scopes(tmp_path)
+        assert lexstore.search_bm25(tmp_path, "walkfailbefore", k=3, scope="kb")
+        store = lexstore.get_store(tmp_path)
+
+        rebuilds = {"n": 0}
+        real_rebuild = lexstore.LexicalStore._rebuild
+
+        def _counting_rebuild(self, conn):
+            rebuilds["n"] += 1
+            return real_rebuild(self, conn)
+
+        monkeypatch.setattr(lexstore.LexicalStore, "_rebuild", _counting_rebuild)
+
+        _write_page(tmp_path, "Knowledge Base/a.md", "walkfailafter")
+        for drift in _reconcile_live_scopes(tmp_path):
+            assert drift.changed == [str(page)]
+
+        real_walk = store._walk_entries
+        failures = {"n": 0}
+
+        def _failing_walk():
+            if failures["n"] == 0:
+                failures["n"] += 1
+                raise OSError("simulated stat failure during the proof walk")
+            return real_walk()
+
+        monkeypatch.setattr(store, "_walk_entries", _failing_walk)
+        scheduled["n"] = 0
+        assert store.apply_watcher_batch([page], []) is True
+        assert failures["n"] == 1
+        assert scheduled["n"] == 0
+
+        # Rows are durable even though the bless was refused.
+        conn = sqlite3.connect(lexstore.lexical_path(tmp_path))
+        try:
+            row = conn.execute(
+                "SELECT mtime_ns FROM pages WHERE path = ?", ("Knowledge Base/a.md",)
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert row[0] == page.stat().st_mtime_ns
+        assert lexstore.source_proof_telemetry()["walk_failed"] >= 1
+
+        assert store.apply_watcher_batch([page], []) is True
+        assert (
+            lexstore.runtime_retrieval_catalog_proof(tmp_path, schedule_repair=False)
+            is not None
+        )
+        assert rebuilds["n"] == 0
+    finally:
+        freshness.clear()
+
+
+def test_walk_refuted_stale_proof_cannot_bless(tmp_path, monkeypatch):
+    """A prepared proof must never outlive its refutation.
+
+    Two guards carry this: a walk that refutes a checkpoint EVICTS any stale
+    stored proof for that scope (the newest walk's verdict is authoritative),
+    and a proof never outlives its own batch (cleared on every exit path).
+    Act 1 pins the cross-batch leak: a batch fails transiently after its proof
+    was prepared, the source mutates unobserved (generation unchanged), and
+    the next batch's walk refutes that exact checkpoint — nothing may bless.
+    Act 2 pins the intra-batch leak: a concurrent prepare refutes the target
+    while the first batch already holds the barrier with its proof pending.
+    """
+    from exomem import freshness
+
+    freshness.clear()
+    monkeypatch.setattr(lexstore, "_admit_after_bounded_runtime_repair", lambda *_: None)
+    monkeypatch.setattr(lexstore, "_schedule_runtime_catalog_repair", lambda *_a, **_k: None)
+    try:
+        page = _write_page(tmp_path, "Knowledge Base/a.md", "staleproofbase")
+        _seed_live_scopes(tmp_path)
+        assert lexstore.search_bm25(tmp_path, "staleproofbase", k=3, scope="kb")
+        store = lexstore.get_store(tmp_path)
+
+        # --- Act 1 (cross-batch): batch N proves checkpoint C, then fails
+        # transiently AFTER the proof was prepared.
+        _write_page(tmp_path, "Knowledge Base/a.md", "staleproofmissed")
+        for drift in _reconcile_live_scopes(tmp_path):
+            assert drift.changed == [str(page)]
+
+        real_apply = store._apply_paths_locked
+        boom = {"armed": True}
+
+        def _failing_apply(*args, **kwargs):
+            if boom["armed"]:
+                boom["armed"] = False
+                raise sqlite3.OperationalError("simulated transient batch failure")
+            return real_apply(*args, **kwargs)
+
+        monkeypatch.setattr(store, "_apply_paths_locked", _failing_apply)
+        blessed_before = lexstore.source_proof_telemetry()["blessed"]
+        assert store.apply_watcher_batch([page], []) is False
+        leaked_after_failure = dict(store._reconciled_source_proofs)
+
+        # Unobserved edit: no event, no reconcile — the registry keeps the
+        # pre-edit signature, so the NEXT walk refutes checkpoint C.
+        _write_page(tmp_path, "Knowledge Base/a.md", "staleproofunobserved")
+
+        assert store.apply_watcher_batch([page], []) is True
+        assert lexstore.source_proof_telemetry()["blessed"] == blessed_before
+        for scope in ("kb", "vault"):
+            readiness = store.catalog_readiness(
+                scope,
+                freshness.triple(tmp_path, scope),
+                allow_delta=False,
+                schedule_repair=False,
+            )
+            assert readiness.complete is False
+
+        # --- Act 2 (intra-batch): while a batch holds the barrier with its
+        # own proof pending, a concurrent prepare observes newer truth and
+        # refutes that exact target. The refutation must evict the pending
+        # proof; the batch must refuse, never bless.
+        for drift in _reconcile_live_scopes(tmp_path):
+            assert drift.changed == [str(page)]
+        interleaved = {"fired": False}
+
+        def _interleave_refuting_prepare(*args, **kwargs):
+            if not interleaved["fired"]:
+                interleaved["fired"] = True
+                _write_page(tmp_path, "Knowledge Base/a.md", "staleproofnewest")
+                store._prepare_reconcile_source_proof([page], [])
+            return real_apply(*args, **kwargs)
+
+        monkeypatch.setattr(store, "_apply_paths_locked", _interleave_refuting_prepare)
+        blessed_before = lexstore.source_proof_telemetry()["blessed"]
+        assert store.apply_watcher_batch([page], []) is True
+        assert interleaved["fired"]
+        assert lexstore.source_proof_telemetry()["blessed"] == blessed_before
+        for scope in ("kb", "vault"):
+            readiness = store.catalog_readiness(
+                scope,
+                freshness.triple(tmp_path, scope),
+                allow_delta=False,
+                schedule_repair=False,
+            )
+            assert readiness.complete is False
+
+        # A proof never outlives its batch — success, refusal, or failure.
+        assert leaked_after_failure == {}
+        assert store._reconciled_source_proofs == {}
+    finally:
+        freshness.clear()
+
+
+def test_tainted_bridge_readiness_never_walks_and_schedules_repair(
+    tmp_path, monkeypatch
+):
+    """Property-7 pin: readiness over a pending tainted bridge stays a
+    read-only O(1) proof — stale plus a scheduled repair, never a vault walk."""
+    from exomem import freshness
+
+    freshness.clear()
+    monkeypatch.setattr(lexstore, "_admit_after_bounded_runtime_repair", lambda *_: None)
+    scheduled = {"n": 0}
+    monkeypatch.setattr(
+        lexstore,
+        "_schedule_runtime_catalog_repair",
+        lambda *_a, **_k: scheduled.__setitem__("n", scheduled["n"] + 1),
+    )
+    try:
+        page = _write_page(tmp_path, "Knowledge Base/a.md", "readinesswalkfree")
+        _seed_live_scopes(tmp_path)
+        assert lexstore.search_bm25(tmp_path, "readinesswalkfree", k=3, scope="kb")
+        store = lexstore.get_store(tmp_path)
+
+        _write_page(tmp_path, "Knowledge Base/a.md", "readinesswalkdrift")
+        for drift in _reconcile_live_scopes(tmp_path):
+            assert drift.changed == [str(page)]
+
+        def _forbidden_walk():
+            raise AssertionError("readiness must never walk the vault")
+
+        monkeypatch.setattr(store, "_walk_entries", _forbidden_walk)
+        scheduled["n"] = 0
+        for scope in ("kb", "vault"):
+            readiness = store.catalog_readiness(scope, freshness.triple(tmp_path, scope))
+            assert readiness.status == "stale"
+            assert readiness.complete is False
+        assert scheduled["n"] >= 1
+    finally:
+        freshness.clear()
+
+
+def test_uncovered_tainted_delta_does_not_pay_a_proof_walk(tmp_path, monkeypatch):
+    """Walk only when a bless could result: a batch that does not cover the
+    tainted delta cannot bless it, so it must not pay the O(vault) proof walk
+    either (ordinary watcher batches stay O(batch))."""
+    from exomem import freshness
+
+    freshness.clear()
+    monkeypatch.setattr(lexstore, "_admit_after_bounded_runtime_repair", lambda *_: None)
+    monkeypatch.setattr(lexstore, "_schedule_runtime_catalog_repair", lambda *_a, **_k: None)
+    try:
+        a = _write_page(tmp_path, "Knowledge Base/a.md", "uncoveredwalkold")
+        v = _write_page(tmp_path, "Reference/v.md", "uncoveredvaultonly")
+        _seed_live_scopes(tmp_path)
+        assert lexstore.search_bm25(tmp_path, "uncoveredwalkold", k=3, scope="kb")
+        store = lexstore.get_store(tmp_path)
+
+        # Vault-only missed event discovered by the safety net.
+        _write_page(tmp_path, "Reference/v.md", "uncoveredvaultmissed")
+        kb_drift, vault_drift = _reconcile_live_scopes(tmp_path)
+        assert kb_drift.changed == []
+        assert vault_drift.changed == [str(v)]
+
+        # An ordinary observed watcher event on the kb page only.
+        _write_page(tmp_path, "Knowledge Base/a.md", "uncoveredwalknew")
+        freshness.on_files_changed(tmp_path, changed=[a])
+
+        walks = {"n": 0}
+        real_walk = store._walk_entries
+
+        def _counting_walk():
+            walks["n"] += 1
+            return real_walk()
+
+        monkeypatch.setattr(store, "_walk_entries", _counting_walk)
+        # The batch names only `a`; the vault scope's tainted delta also
+        # carries `v`, so no bless can result there and no walk is owed.
+        assert store.apply_watcher_batch([a], [])
+        assert walks["n"] == 0
+
+        kb_ready = store.catalog_readiness(
+            "kb",
+            freshness.triple(tmp_path, "kb"),
+            allow_delta=False,
+            schedule_repair=False,
+        )
+        vault_ready = store.catalog_readiness(
+            "vault",
+            freshness.triple(tmp_path, "vault"),
+            allow_delta=False,
+            schedule_repair=False,
+        )
+        assert kb_ready.complete is True
+        assert vault_ready.complete is False
+    finally:
+        freshness.clear()
+
+
+def test_source_proof_telemetry_is_stable_and_content_free(tmp_path, monkeypatch):
+    """Source-proof telemetry is a stable counter set: ints only, no vault
+    paths or note content, reset by `clear_stores`."""
+    from exomem import freshness
+
+    freshness.clear()
+    monkeypatch.setattr(lexstore, "_admit_after_bounded_runtime_repair", lambda *_: None)
+    monkeypatch.setattr(lexstore, "_schedule_runtime_catalog_repair", lambda *_a, **_k: None)
+    try:
+        page = _write_page(tmp_path, "Knowledge Base/a.md", "telemetrybefore")
+        _seed_live_scopes(tmp_path)
+        assert lexstore.search_bm25(tmp_path, "telemetrybefore", k=3, scope="kb")
+        store = lexstore.get_store(tmp_path)
+
+        _write_page(tmp_path, "Knowledge Base/a.md", "telemetryafter")
+        for drift in _reconcile_live_scopes(tmp_path):
+            assert drift.changed == [str(page)]
+        assert store.apply_watcher_batch([page], [])
+
+        telemetry = lexstore.source_proof_telemetry()
+        assert set(telemetry) == {
+            "prepared",
+            "proof_mismatch",
+            "walk_failed",
+            "ticket_stale",
+            "proof_missing",
+            "blessed",
+        }
+        assert all(type(value) is int for value in telemetry.values())
+        assert telemetry["prepared"] >= 1
+        assert telemetry["blessed"] >= 1
+        rendered = repr(telemetry)
+        assert str(tmp_path) not in rendered
+        assert "Knowledge Base" not in rendered
+        # The accessor returns a copy; mutating it cannot poison the counters.
+        telemetry["blessed"] = 10_000
+        assert lexstore.source_proof_telemetry()["blessed"] != 10_000
+        lexstore.clear_stores()
+        assert all(
+            value == 0 for value in lexstore.source_proof_telemetry().values()
+        )
+    finally:
+        freshness.clear()
+
+
 def test_restart_with_no_changes_skips_the_walk_verify(tmp_path):
     """Steady state across restarts: the meta-blessed triple lets a fresh
     store trust the sidecar without an exact verify (no rebuild)."""

--- a/tests/test_lexstore_atomic_rebuild.py
+++ b/tests/test_lexstore_atomic_rebuild.py
@@ -24,8 +24,8 @@ parts of 1.4 — the exact contracts the atomic rebuild must uphold:
 Publication is serialized against foreground deltas and single-file-safe:
 
 * a foreground delta that advances the live catalog after this build captured
-  its temp target aborts the replace under the publication lock, leaving the
-  newer live rows and checkpoint intact rather than regressing them;
+  its temp target is replayed into the replacement under the publication lock,
+  so ordinary traffic cannot starve a logically current build;
 * a temp WAL that cannot be folded to a single self-contained file (the
   checkpoint/``journal_mode=DELETE`` proof fails, or a temp ``-wal`` survives)
   discards the temp and never publishes, preserving live;
@@ -407,12 +407,14 @@ def test_foreign_instance_publication_aborts_incomparable_older_build(
         live.close()
 
 
-def test_live_db_set_token_change_aborts_even_when_checkpoints_match(
+def test_live_db_set_token_churn_does_not_veto_current_replacement(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A foreign writer can change the live DB set without publishing a useful
-    comparable checkpoint. The private bounded DB token still makes the stale
-    temp ineligible, preserving the writer's committed marker."""
+    """The live SQLite set is disposable, not source-of-truth state.
+
+    WAL/main churn that leaves the authoritative checkpoints and identity
+    unchanged must not veto a logically current detached replacement.
+    """
     a = _kb_file(tmp_path, "a.md", "- [config] stablecontent ^u1")
     _seed(tmp_path, [a])
     lexstore.ensure_fresh(tmp_path)
@@ -438,14 +440,14 @@ def test_live_db_set_token_change_aborts_even_when_checkpoints_match(
         return folded
 
     monkeypatch.setattr(store, "_fold_to_single_file", fold_then_mutate_live_set)
-    assert store.rebuild_atomic() is False
+    assert store.rebuild_atomic() is True
 
     live = store._connect()
     try:
         assert store._meta_checkpoint(live, "kb") == before
         assert live.execute(
             "SELECT value FROM meta WHERE key = 'db_set_marker'"
-        ).fetchone() == ("committed",)
+        ).fetchone() is None
     finally:
         live.close()
 
@@ -798,15 +800,18 @@ def test_wal_mode_main_without_sidecars_is_persistently_switched_to_delete(
     assert not wal.exists() and not shm.exists()
 
 
-def test_foreground_delta_after_temp_target_aborts_replacement(
+def test_foreground_delta_after_temp_target_rebases_replacement(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A background rebuild must never overwrite a NEWER live catalog. If a
-    foreground delta advances the live sidecar past the temp build's captured
-    target while the build is finishing, publication aborts under the publication
-    lock and the newer live rows/checkpoint are preserved."""
+    """A normal live delta must not starve a completed detached rebuild.
+
+    If the watcher advances the live catalogue after the temp target was
+    captured, publication rebases the temp to that exact retained generation
+    under the barrier and publishes the current replacement.
+    """
     a = _kb_file(tmp_path, "a.md", "- [config] startcontent ^u1")
-    _seed(tmp_path, [a])
+    b = _kb_file(tmp_path, "b.md", "- [config] deletedcontent ^u2")
+    _seed(tmp_path, [a, b])
     lexstore.ensure_fresh(tmp_path)
     store = lexstore.get_store(tmp_path)
 
@@ -820,7 +825,8 @@ def test_foreground_delta_after_temp_target_aborts_replacement(
             state["injected"] = True
             a.write_text(_page_text("a", "- [config] newercontent ^u1"), encoding="utf-8")
             _touch_future(a)
-            freshness.on_files_changed(tmp_path, changed=[a])
+            b.unlink()
+            freshness.on_files_changed(tmp_path, changed=[a], deleted=[b])
             newer = freshness.recall_triple(tmp_path, "kb")
             state["newer"] = newer
             readiness = store.catalog_readiness("kb", newer)
@@ -831,12 +837,56 @@ def test_foreground_delta_after_temp_target_aborts_replacement(
     published = store.rebuild_atomic()
     monkeypatch.undo()
 
-    # The publish aborted rather than regress the newer live catalog.
-    assert published is False
+    assert published is True
+    assert store.catalog_checkpoint("kb") == freshness.recall_checkpoint(
+        tmp_path, "kb"
+    )
     assert store.catalog_checkpoint("kb").triple == state["newer"]
     contents = {hit.content.strip() for hit in _units_in_category(tmp_path, "config")}
     assert any("newercontent" in c for c in contents)
     assert not any("startcontent" in c for c in contents)
+    assert not any("deletedcontent" in c for c in contents)
+
+
+def test_oversized_late_rebase_declines_and_preserves_live_catalog(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    a = _kb_file(tmp_path, "a.md", "- [config] preservedtoken ^u1")
+    _seed(tmp_path, [a])
+    lexstore.ensure_fresh(tmp_path)
+    store = lexstore.get_store(tmp_path)
+    before = store.catalog_checkpoint("kb")
+    real_fold = store._fold_to_single_file
+    injected = False
+
+    def fold_then_overflow_delta(conn: sqlite3.Connection) -> bool:
+        nonlocal injected
+        folded = real_fold(conn)
+        if not injected:
+            injected = True
+            changed = [
+                _kb_file(
+                    tmp_path,
+                    f"late-{index}.md",
+                    f"- [config] late-{index} ^u{index + 2}",
+                )
+                for index in range(lexstore.CATALOG_FOREGROUND_DELTA_CAP + 1)
+            ]
+            freshness.on_files_changed(tmp_path, changed=changed)
+        return folded
+
+    monkeypatch.setattr(store, "_fold_to_single_file", fold_then_overflow_delta)
+    assert store.rebuild_atomic() is False
+    assert store._last_rebuild_result == "delta_unavailable"
+    assert store.catalog_checkpoint("kb") == before
+    assert not list(store.path.parent.glob("*rebuild*"))
+    live = store._connect()
+    try:
+        assert live.execute(
+            "SELECT 1 FROM semantic_units WHERE content LIKE '%preservedtoken%'"
+        ).fetchone() == (1,)
+    finally:
+        live.close()
 
 
 def test_readiness_and_query_stay_snapshot_consistent_across_replacement(
@@ -1044,6 +1094,48 @@ def test_await_repairs_idle_waits_for_an_in_flight_repair() -> None:
 
     # Idle on a key nobody ever registered.
     assert lexstore.await_repairs_idle(root, timeout=30.0) is True
+
+
+def test_repair_progress_reports_bounded_phase_duration_and_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    store = lexstore.get_store(tmp_path)
+
+    def rebuild() -> bool:
+        store._last_rebuild_result = "published"
+        entered.set()
+        assert release.wait(5)
+        return True
+
+    monkeypatch.setattr(store, "rebuild_atomic", rebuild)
+    monkeypatch.setattr(
+        lexstore,
+        "runtime_retrieval_catalog_proof",
+        lambda *_args, **_kwargs: {"kb": object(), "vault": object()},
+    )
+    lexstore._schedule_repair(tmp_path)
+    assert entered.wait(5)
+
+    active = lexstore.repair_progress(tmp_path)
+    assert active is not None
+    assert active["phase"] == "building"
+    assert isinstance(active["age_seconds"], float)
+    assert set(active) == {
+        "phase",
+        "age_seconds",
+        "last_duration_seconds",
+        "last_result",
+    }
+
+    release.set()
+    assert lexstore.await_repairs_idle(tmp_path, timeout=5)
+    finished = lexstore.repair_progress(tmp_path)
+    assert finished is not None
+    assert finished["phase"] == "idle"
+    assert finished["last_result"] == "published"
+    assert isinstance(finished["last_duration_seconds"], float)
 
 
 def test_await_repairs_idle_keys_on_the_resolved_path(tmp_path: Path) -> None:

--- a/tests/test_lexstore_atomic_rebuild.py
+++ b/tests/test_lexstore_atomic_rebuild.py
@@ -45,6 +45,7 @@ import sqlite3
 import threading
 import time
 import uuid
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -193,6 +194,89 @@ def test_edit_after_start_is_replayed_and_target_checkpoint_is_exact(
     stored = store.catalog_checkpoint("kb")
     assert stored == freshness.recall_checkpoint(tmp_path, "kb")
     assert stored.generation > pre_gen
+
+
+def test_final_publish_wait_catches_up_after_a_large_foreground_batch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A writer burst landing while publish waits must not waste the full build."""
+    a = _kb_file(tmp_path, "a.md", "- [config] stablecontent ^u1")
+    _seed(tmp_path, [a])
+    lexstore.ensure_fresh(tmp_path)
+    store = lexstore.get_store(tmp_path)
+    real_walk = store._walk_entries
+    real_lock = store._publication_lock
+    timeouts: list[float] = []
+    changed: list[Path] = []
+    writer_started = threading.Event()
+    release_writer = threading.Event()
+    writer_errors: list[Exception] = []
+    writer_thread: threading.Thread | None = None
+    walk_calls = 0
+
+    def blocking_writer_burst() -> None:
+        try:
+            with real_lock():
+                changed.extend(
+                    _kb_file(
+                        tmp_path,
+                        f"blocked-burst-{index}.md",
+                        f"- [config] blocked-burst-{index} ^u{index + 2}",
+                    )
+                    for index in range(lexstore.CATALOG_FOREGROUND_DELTA_CAP + 1)
+                )
+                freshness.on_files_changed(tmp_path, changed=changed)
+                writer_started.set()
+                assert release_writer.wait(timeout=2)
+                # Keep ownership long enough for the publisher to enter its wait.
+                time.sleep(0.05)
+        except Exception as exc:  # noqa: BLE001 - relayed to the parent test thread
+            writer_errors.append(exc)
+            writer_started.set()
+
+    def walk_then_start_blocking_writer() -> Any:
+        nonlocal walk_calls, writer_thread
+        walk_calls += 1
+        result = real_walk()
+        if walk_calls == 2:
+            writer_thread = threading.Thread(target=blocking_writer_burst)
+            writer_thread.start()
+            assert writer_started.wait(timeout=2)
+            assert not writer_errors
+        return result
+
+    @contextmanager
+    def traced_lock(timeout: float = lexstore._PUBLICATION_TIMEOUT_BACKGROUND):
+        timeouts.append(timeout)
+        if writer_started.is_set() and not release_writer.is_set():
+            release_writer.set()
+        with real_lock(timeout=timeout):
+            yield
+
+    monkeypatch.setattr(store, "_walk_entries", walk_then_start_blocking_writer)
+    monkeypatch.setattr(store, "_publication_lock", traced_lock)
+    try:
+        assert store.rebuild_atomic() is True
+    finally:
+        release_writer.set()
+        if writer_thread is not None:
+            writer_thread.join(timeout=2)
+
+    assert writer_thread is not None and not writer_thread.is_alive()
+    assert not writer_errors
+    assert timeouts == [
+        lexstore._PUBLICATION_TIMEOUT_BACKGROUND,
+        lexstore._PUBLICATION_TIMEOUT_PUBLISH,
+        lexstore._PUBLICATION_TIMEOUT_PUBLISH,
+    ]
+    assert store.catalog_checkpoint("kb") == freshness.recall_checkpoint(
+        tmp_path, "kb"
+    )
+    contents = {hit.content.strip() for hit in _units_in_category(tmp_path, "config")}
+    assert all(
+        any(f"blocked-burst-{index}" in content for content in contents)
+        for index in range(len(changed))
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -883,7 +967,7 @@ def test_large_off_barrier_rebase_converges_without_another_full_scan(
     assert all(any(f"burst-{index}" in content for content in contents) for index in range(len(changed)))
 
 
-def test_oversized_final_barrier_rebase_declines_and_preserves_live_catalog(
+def test_sustained_oversized_final_rebases_are_bounded_and_preserve_live_catalog(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     a = _kb_file(tmp_path, "a.md", "- [config] preservedtoken ^u1")
@@ -893,16 +977,19 @@ def test_oversized_final_barrier_rebase_declines_and_preserves_live_catalog(
     before = store.catalog_checkpoint("kb")
     real_rebase = store._rebase_detached_catalog
     rebase_calls = 0
+    final_rebase_calls = 0
 
     def rebase_then_overflow_delta(*args: Any, **kwargs: Any) -> Any:
-        nonlocal rebase_calls
+        nonlocal final_rebase_calls, rebase_calls
         rebase_calls += 1
-        if rebase_calls == 2:
+        if kwargs.get("max_paths", lexstore.CATALOG_FOREGROUND_DELTA_CAP) is not None:
+            final_rebase_calls += 1
             changed = [
                 _kb_file(
                     tmp_path,
-                    f"late-{index}.md",
-                    f"- [config] late-{index} ^u{index + 2}",
+                    f"late-{final_rebase_calls}-{index}.md",
+                    f"- [config] late-{final_rebase_calls}-{index} "
+                    f"^u{final_rebase_calls}-{index}",
                 )
                 for index in range(lexstore.CATALOG_FOREGROUND_DELTA_CAP + 1)
             ]
@@ -912,6 +999,8 @@ def test_oversized_final_barrier_rebase_declines_and_preserves_live_catalog(
     monkeypatch.setattr(store, "_rebase_detached_catalog", rebase_then_overflow_delta)
     assert store.rebuild_atomic() is False
     assert store._last_rebuild_result == "delta_unavailable"
+    assert final_rebase_calls == lexstore._PUBLICATION_CATCHUP_RETRIES + 1
+    assert rebase_calls == 1 + final_rebase_calls + lexstore._PUBLICATION_CATCHUP_RETRIES
     assert store.catalog_checkpoint("kb") == before
     assert not list(store.path.parent.glob("*rebuild*"))
     live = store._connect()

--- a/tests/test_lexstore_atomic_rebuild.py
+++ b/tests/test_lexstore_atomic_rebuild.py
@@ -848,7 +848,42 @@ def test_foreground_delta_after_temp_target_rebases_replacement(
     assert not any("deletedcontent" in c for c in contents)
 
 
-def test_oversized_late_rebase_declines_and_preserves_live_catalog(
+def test_large_off_barrier_rebase_converges_without_another_full_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The first catch-up is background work, so it must absorb a sync burst."""
+    a = _kb_file(tmp_path, "a.md", "- [config] preservedtoken ^u1")
+    _seed(tmp_path, [a])
+    lexstore.ensure_fresh(tmp_path)
+    store = lexstore.get_store(tmp_path)
+    real_fold = store._fold_to_single_file
+    changed: list[Path] = []
+
+    def fold_then_sync_burst(conn: sqlite3.Connection) -> bool:
+        folded = real_fold(conn)
+        if not changed:
+            changed.extend(
+                _kb_file(
+                    tmp_path,
+                    f"burst-{index}.md",
+                    f"- [config] burst-{index} ^u{index + 2}",
+                )
+                for index in range(lexstore.CATALOG_FOREGROUND_DELTA_CAP + 1)
+            )
+            freshness.on_files_changed(tmp_path, changed=changed)
+        return folded
+
+    monkeypatch.setattr(store, "_fold_to_single_file", fold_then_sync_burst)
+    assert store.rebuild_atomic() is True
+    assert store._last_rebuild_result == "published"
+    assert store.catalog_checkpoint("kb") == freshness.recall_checkpoint(
+        tmp_path, "kb"
+    )
+    contents = {hit.content.strip() for hit in _units_in_category(tmp_path, "config")}
+    assert all(any(f"burst-{index}" in content for content in contents) for index in range(len(changed)))
+
+
+def test_oversized_final_barrier_rebase_declines_and_preserves_live_catalog(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     a = _kb_file(tmp_path, "a.md", "- [config] preservedtoken ^u1")
@@ -856,14 +891,13 @@ def test_oversized_late_rebase_declines_and_preserves_live_catalog(
     lexstore.ensure_fresh(tmp_path)
     store = lexstore.get_store(tmp_path)
     before = store.catalog_checkpoint("kb")
-    real_fold = store._fold_to_single_file
-    injected = False
+    real_rebase = store._rebase_detached_catalog
+    rebase_calls = 0
 
-    def fold_then_overflow_delta(conn: sqlite3.Connection) -> bool:
-        nonlocal injected
-        folded = real_fold(conn)
-        if not injected:
-            injected = True
+    def rebase_then_overflow_delta(*args: Any, **kwargs: Any) -> Any:
+        nonlocal rebase_calls
+        rebase_calls += 1
+        if rebase_calls == 2:
             changed = [
                 _kb_file(
                     tmp_path,
@@ -873,9 +907,9 @@ def test_oversized_late_rebase_declines_and_preserves_live_catalog(
                 for index in range(lexstore.CATALOG_FOREGROUND_DELTA_CAP + 1)
             ]
             freshness.on_files_changed(tmp_path, changed=changed)
-        return folded
+        return real_rebase(*args, **kwargs)
 
-    monkeypatch.setattr(store, "_fold_to_single_file", fold_then_overflow_delta)
+    monkeypatch.setattr(store, "_rebase_detached_catalog", rebase_then_overflow_delta)
     assert store.rebuild_atomic() is False
     assert store._last_rebuild_result == "delta_unavailable"
     assert store.catalog_checkpoint("kb") == before

--- a/tests/test_lexstore_atomic_rebuild.py
+++ b/tests/test_lexstore_atomic_rebuild.py
@@ -227,7 +227,7 @@ def test_final_publish_wait_catches_up_after_a_large_foreground_batch(
                 )
                 freshness.on_files_changed(tmp_path, changed=changed)
                 writer_started.set()
-                assert release_writer.wait(timeout=2)
+                assert release_writer.wait(timeout=_HOLD_SECONDS)
                 # Keep ownership long enough for the publisher to enter its wait.
                 time.sleep(0.05)
         except Exception as exc:  # noqa: BLE001 - relayed to the parent test thread
@@ -241,7 +241,7 @@ def test_final_publish_wait_catches_up_after_a_large_foreground_batch(
         if walk_calls == 2:
             writer_thread = threading.Thread(target=blocking_writer_burst)
             writer_thread.start()
-            assert writer_started.wait(timeout=2)
+            assert writer_started.wait(timeout=_OBSERVE_SECONDS)
             assert not writer_errors
         return result
 
@@ -260,7 +260,7 @@ def test_final_publish_wait_catches_up_after_a_large_foreground_batch(
     finally:
         release_writer.set()
         if writer_thread is not None:
-            writer_thread.join(timeout=2)
+            writer_thread.join(timeout=_OBSERVE_SECONDS)
 
     assert writer_thread is not None and not writer_thread.is_alive()
     assert not writer_errors
@@ -1229,7 +1229,7 @@ def test_repair_progress_reports_bounded_phase_duration_and_result(
     def rebuild() -> bool:
         store._last_rebuild_result = "published"
         entered.set()
-        assert release.wait(5)
+        assert release.wait(_HOLD_SECONDS)
         return True
 
     monkeypatch.setattr(store, "rebuild_atomic", rebuild)
@@ -1239,7 +1239,7 @@ def test_repair_progress_reports_bounded_phase_duration_and_result(
         lambda *_args, **_kwargs: {"kb": object(), "vault": object()},
     )
     lexstore._schedule_repair(tmp_path)
-    assert entered.wait(5)
+    assert entered.wait(_OBSERVE_SECONDS)
 
     active = lexstore.repair_progress(tmp_path)
     assert active is not None

--- a/tests/test_runtime_readiness.py
+++ b/tests/test_runtime_readiness.py
@@ -201,6 +201,43 @@ def test_ready_retrieval_catalog_admits_runtime_readiness() -> None:
     assert snapshot["reasons"] == []
 
 
+def test_retrieval_repair_progress_is_bounded_and_privacy_safe() -> None:
+    snapshot = build_runtime_readiness(
+        coordination={
+            "enabled": False,
+            "role": "standalone",
+            "replica_id": None,
+            "coordinator_healthy": True,
+        },
+        release="1.2.3",
+        mcp_tool_surface_sha256="d" * 64,
+        retrieval={
+            "state": "unavailable",
+            "admitted": False,
+            "repair": {
+                "phase": "building",
+                "age_seconds": 12.3456,
+                "last_duration_seconds": 8.7654,
+                "last_result": "delta_unavailable",
+                "vault_path": "must-not-leak",
+                "note": "must-not-leak-either",
+            },
+        },
+    )
+
+    assert snapshot["retrieval"] == {
+        "state": "unavailable",
+        "admitted": False,
+        "repair": {
+            "phase": "building",
+            "age_seconds": 12.346,
+            "last_duration_seconds": 8.765,
+            "last_result": "delta_unavailable",
+        },
+    }
+    assert "must-not-leak" not in repr(snapshot)
+
+
 def test_readiness_exposes_only_bounded_mutation_holder_metadata() -> None:
     snapshot = build_runtime_readiness(
         coordination={
@@ -240,8 +277,8 @@ def test_readiness_exposes_only_bounded_mutation_holder_metadata() -> None:
 def test_runtime_readiness_measures_the_configured_vault(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    from exomem import lexstore, readiness, writer_lease
     from exomem import runtime_readiness as readiness_module
-    from exomem import writer_lease
 
     vault = tmp_path / "configured-vault"
     observed: list[Path | None] = []
@@ -258,9 +295,30 @@ def test_runtime_readiness_measures_the_configured_vault(
 
     monkeypatch.setenv("EXOMEM_VAULT_PATH", str(vault))
     monkeypatch.setattr(writer_lease, "coordination_status", fake_coordination_status)
-    readiness_module.runtime_readiness(mcp_tool_surface_sha256="f" * 64)
+    monkeypatch.setattr(
+        readiness,
+        "retrieval_admission",
+        lambda _vault_root=None: {"state": "unavailable", "admitted": False},
+    )
+    monkeypatch.setattr(
+        lexstore,
+        "repair_progress",
+        lambda _vault_root: {
+            "phase": "publishing",
+            "age_seconds": 4.2,
+            "last_duration_seconds": None,
+            "last_result": None,
+        },
+    )
+    snapshot = readiness_module.runtime_readiness(mcp_tool_surface_sha256="f" * 64)
 
     assert observed == [vault]
+    assert snapshot["retrieval"]["repair"] == {
+        "phase": "publishing",
+        "age_seconds": 4.2,
+        "last_duration_seconds": None,
+        "last_result": None,
+    }
 
 
 def test_runtime_readiness_fails_closed_within_a_tight_bound_when_status_blocks(


### PR DESCRIPTION
## Why

Two connected production defects made both Exomem cells repeatedly unusable (RETRIEVAL_INDEX_WARMING, 10–21 min full rebuilds, ready-then-demote loops):

1. **Publication starvation** (fixed by the first five commits): the exact live SQLite main/WAL/SHM token served as a publication veto, so ordinary read/write churn during a long detached rebuild discarded valid replacements and restarted whole-vault work, starving readiness.
2. **Durable-freshness loss** (fixed by the final commit): the 300 s safety-net `freshness.reconcile` cleared recall transition history on drift, so after the watcher applied the exact missed paths, `_remember_live_witnesses` could no longer bridge the stored catalog checkpoint to the live one and never persisted `recall_checkpoint:*`. In-process state masked it; the next restart/reseed demoted readiness and launched another 10–17 min full rebuild over an exact-current catalog.

## What

**Starvation half** (commits 1–5): one detached repair owner; source/checkpoint proof separated from disposable SQLite token churn; unbounded off-barrier retained-delta replay + capped final under-barrier suffix; bounded catch-up retries; declined-demand preservation; privacy-safe telemetry.

**Durable-freshness half** (final commit): a reconcile-discovered missed event becomes a bridgeable recall delta with explicit provenance (`RecallDelta.requires_source_proof`). Request/readiness paths refuse provisional deltas outright. The lexical writer blesses such a checkpoint only after one fresh full-source walk executed **before** the publication barrier is acquired; under the barrier only O(1) exact-checkpoint equality validates the proof (per scope, single-use, refutation evicts stale proofs). A mixed off-lock walk can never bless a stale catalog; the residual unobserved post-stat window is bounded by the next periodic reconcile — identical to the detached rebuild's existing off-barrier proof window. Ordinary writes never pay a walk. Content-free source-proof telemetry added.

## Verification

- Red-first evidence for every new behavior (5 predicted failure modes reproduced verbatim on the baseline before implementation).
- Independent adversarial review (zero-context reviewer, own scratch-copy gate re-runs + own mutations): **APPROVE** after one correction round. The correction closed a genuine defect the review surfaced — a concurrent-prepare refutation could previously bless a walk-refuted checkpoint; the fix (stale-proof eviction) is pinned by a test with three independent kill vectors, each mutation-proven.
- Gates (all serial, scratch-copy-verified by the reviewer independently): focused suites **218 passed**; watcher/recall/bm25 **78 passed**; `uvx ruff check . --select F` clean; privacy validator clean (3,319 files); `openspec validate fix-rebuild-publication-starvation --strict` valid.
- A real production-scale candidate previously published a 3,273-page catalog in 993.5 s and reached ready (starvation half).

OpenSpec change `fix-rebuild-publication-starvation` rides in this PR; delivery tasks (lean CI evidence, sync/archive, release/deploy acceptance) close with the 0.63.0 release.