### PR TITLE
feat(governance): publish recovery graph successors

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/design.md
+++ b/openspec/changes/harden-governance-for-consolidation/design.md
@@ -743,14 +743,16 @@ that edge payload and emits only the required empty lower-variant rows. A lower-
 policy projection therefore cannot turn an otherwise valid semantic write into a graph
 publication refusal or persist raw graph authority below L6.
 
-The existing-page semantic writer, semantic creation writers, and semantic move writer
+The existing-page semantic writer, semantic creation writers, semantic move writer, and
+semantic trash-recovery writer
 derive their graph replacements from the freshest validated detached before-corpus
 carried into the mutation boundary plus the exact guarded planned-write overlay. A move
-starts from its exact detached after-corpus, then overlays only its guarded auxiliary
-writes. These paths do not reopen the live graph or walk the vault again. The overlay
+or recovery starts from its exact detached after-corpus, then overlays only its guarded
+content and auxiliary writes. These paths do not reopen the live graph or walk the vault
+again. The overlay
 re-resolves title-dependent links and reverse relations, so the replacement set includes
-directly changed, created, or moved paths and otherwise-unchanged logical sources whose
-outgoing edge tuple changes. The provider is invoked lazily only when the active tuple
+directly changed, created, moved, or restored paths and otherwise-unchanged logical
+sources whose outgoing edge tuple changes. The provider is invoked lazily only when the active tuple
 contains a graph family; open and lexical-only writes do no graph-producer work. Other
 live writer families remain blocked until they supply the same target-bound replacement
 contract.

--- a/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
+++ b/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
@@ -227,16 +227,16 @@ required family SHALL remain blocked.
   targets, uniqueness, and aggregate capacity, discards the edge payload, and emits only
   empty lower-variant graph rows
 
-#### Scenario: Semantic writes, creations, and moves derive graph successors from retained state
+#### Scenario: Semantic writes, creations, moves, and recoveries derive graph successors from retained state
 
-- **WHEN** an existing-page semantic write, semantic creation, or semantic move changes a
-  direct edge, a path/title used by another page's link, or a reverse relation whose
-  logical source is another page
+- **WHEN** an existing-page semantic write, semantic creation, semantic move, or semantic
+  trash recovery changes a direct edge, a path/title used by another page's link, or a
+  reverse relation whose logical source is another page
 - **THEN** the writer derives target-bound replacements from the freshest validated
-  detached before-corpus carried into the mutation boundary, the move's exact detached
-  after-corpus when applicable, and exact guarded planned bytes; it includes every logical
-  source whose outgoing edge tuple changes and does not reopen the live graph or current
-  Markdown
+  detached before-corpus carried into the mutation boundary, the move or recovery's exact
+  detached after-corpus when applicable, and exact guarded planned bytes; it includes
+  every logical source whose outgoing edge tuple changes and does not reopen the live graph
+  or current Markdown
 - **AND** open and lexical-only writes do not invoke the graph producer
 
 When the projected source is exhausted, L1-and-above items SHALL still emit the

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -538,12 +538,12 @@ made before both PRs and their combined verification are complete.
   changed L6 sources, reject stale outside-catalog targets, and publish the complete graph
   root atomically. Validate conservative producer replacements for affected lower-only
   items, discard their edge payload, and emit only empty lower-variant rows. For
-  existing-page semantic writes, semantic creations, and semantic
-  moves, derive replacements from the freshest validated detached before-corpus carried
-  into the mutation boundary, the move's exact detached after-corpus when applicable,
-  and the exact guarded planned-write overlay; include indirect path/title-resolution and
-  reverse-relation source changes, and never reopen the live graph or walk the vault
-  again. Connect every other live graph producer to those replacements before checking
+  existing-page semantic writes, semantic creations, semantic moves, and semantic trash
+  recoveries, derive replacements from the freshest validated detached before-corpus
+  carried into the mutation boundary, the move or recovery's exact detached after-corpus
+  when applicable, and the exact guarded planned-write overlay; include indirect
+  path/title-resolution and reverse-relation source changes, and never reopen the live
+  graph or walk the vault again. Connect every other live graph producer to those replacements before checking
   this task; keep any unsupported required family blocked.
 - [x] 8.12 Implement BM25 posting intersection before cap, projected-corpus DF/IDF and
   exact top-k; exact filtered projected-vector top-k with visible-lane warming/disable;

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -3350,7 +3350,7 @@ def commit_recovery(
                 census_guard.recheck(root)
             if preflight.recovery_sidecar_guard is not None:
                 preflight.recovery_sidecar_guard.recheck(root)
-            from .governance import catalog_publication
+            from .governance import catalog_publication, graph_producer
 
             catalog_writes = [*lifecycle_writes, *preflight.catalog_auxiliary_writes]
             catalog_writes.extend(
@@ -3364,11 +3364,25 @@ def commit_recovery(
                     preflight.entries, destination_guards, strict=True
                 )
             )
+            semantic_states = {
+                item.after.path: item.after for item in preflight.evaluations
+            }
+
+            def graph_replacement_provider():
+                return graph_producer.replacements_for_semantic_transition(
+                    root,
+                    before_corpus=preflight.before_corpus,
+                    after_corpus=preflight.after_corpus,
+                    writes=tuple(catalog_writes),
+                    semantic_states=semantic_states,
+                )
+
             try:
                 catalog_target = catalog_publication.prepare_catalog_membership_batch(
                     root,
                     writes=tuple(catalog_writes),
                     content_paths=preflight.catalog_content_paths,
+                    graph_replacement_provider=graph_replacement_provider,
                     now=preflight.catalog_publication_now,
                 )
             except catalog_publication.CatalogPublicationError as error:

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -3340,6 +3340,106 @@ def test_v4_file_recovery_inserts_row_and_publishes_log_once(
     assert {item.item_identity: item.content_hash for item in items} == expected
 
 
+def test_v4_file_recovery_publishes_resolved_graph_successors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    restored_relative = "Knowledge Base/Notes/private.md"
+    referrer_relative = "Knowledge Base/Notes/referrer.md"
+    log_relative = "Knowledge Base/log.md"
+    trash_relative = "Knowledge Base/_trash/2026-08-25/120000-private.md"
+    restored_source = "---\ntitle: Private\nstatus: draft\n---\n\nRestored.\n"
+    referrer_source = (
+        "---\ntitle: Referrer\nstatus: draft\n---\n\n"
+        "See [[Knowledge Base/Notes/private]].\n"
+    )
+    log_before = "# Log\n\n---\n"
+    for path, source in (
+        (referrer_relative, referrer_source),
+        (log_relative, log_before),
+        (trash_relative, restored_source),
+    ):
+        target = vault / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+    trash = vault / trash_relative
+    trash.with_name(f"{trash.name}.meta.json").write_text(
+        json.dumps({"original_path": restored_relative}),
+        encoding="utf-8",
+    )
+    _write_workspace(vault, _documents(ceiling=6))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=(
+            (referrer_relative, referrer_source),
+            (log_relative, log_before),
+        ),
+        ceiling=6,
+        graph_edges=(),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    recovered = recover_module.recover_from_trash(
+        vault,
+        trash_path=trash_relative,
+        today=dt.date(2026, 8, 25),
+    )
+
+    assert recovered.restored_path == restored_relative
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    active, manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=2,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    evidence = projection_store.namespace_evidence_from_snapshot(active)
+    graph_root = next(
+        root for root in evidence.required_measurement_roots if root.lane == "graph"
+    )
+    family = projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=evidence.manifest.namespace_key,
+        lane=graph_root.lane,
+        extractor_version=graph_root.extractor_version,
+        model_version=graph_root.model_version,
+    )
+    namespace = projection_store.bind_active_projection_namespace(
+        active,
+        manifest=manifest,
+        items=items,
+    )
+    _graph_manifest, graph_rows = projection_measurement_store.load_measurement_store(
+        vault,
+        namespace=namespace,
+        family=family,
+        expected_rows_digest=graph_root.rows_digest,
+    )
+    assert tuple(
+        edge
+        for row in graph_rows
+        for edge in row.edges
+        if edge.source_item_identity == referrer_relative
+    ) == (
+        projected_graph.ProjectionGraphEdge(
+            referrer_relative,
+            restored_relative,
+            "links_to",
+        ),
+    )
+
+
 def test_v4_directory_recovery_inserts_every_row_in_one_generation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Why

Exact-v4 recovery must publish graph measurements from the same retained recovery preflight and guarded write overlay as the catalog successor. Otherwise restoring a page can activate while inbound or title-resolved graph edges remain stale.

## What changed

- derives lazy target-bound graph replacements inside the semantic recovery commit
- reuses the retained before/after corpora and exact catalog writes without reopening the live graph or walking the vault again
- proves a restored page and its referrer edge activate together in the exact-v4 successor
- keeps OpenSpec task 8.11 open until the remaining writer inventory is closed

## Verification

- 144 focused and semantic-lifecycle tests passed
- Ruff passed on touched Python files
- strict OpenSpec validation passed
- public-artifact validation passed
- git diff check passed
