### PR TITLE
feat(governance): publish deletion graph successors

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/design.md
+++ b/openspec/changes/harden-governance-for-consolidation/design.md
@@ -743,15 +743,17 @@ that edge payload and emits only the required empty lower-variant rows. A lower-
 policy projection therefore cannot turn an otherwise valid semantic write into a graph
 publication refusal or persist raw graph authority below L6.
 
-The existing-page semantic writer, semantic creation writers, semantic move writer, and
-semantic trash-recovery writer
+The existing-page semantic writer, semantic creation writers, semantic move writer,
+semantic trash-recovery writer, and semantic file/directory trash writers
 derive their graph replacements from the freshest validated detached before-corpus
 carried into the mutation boundary plus the exact guarded planned-write overlay. A move
-or recovery starts from its exact detached after-corpus, then overlays only its guarded
-content and auxiliary writes. These paths do not reopen the live graph or walk the vault
-again. The overlay
+or recovery starts from its exact detached after-corpus, while trash removes its exact
+held Markdown identity set; each then overlays only its guarded
+content and auxiliary writes. The retained-corpus paths do not walk the vault again;
+trash builds one lazy detached before-corpus only after an active graph family is verified
+and before canonical bytes change. None of these paths reopens the live graph. The overlay
 re-resolves title-dependent links and reverse relations, so the replacement set includes
-directly changed, created, moved, or restored paths and otherwise-unchanged logical
+directly changed, created, moved, restored, or removed paths and otherwise-unchanged logical
 sources whose outgoing edge tuple changes. The provider is invoked lazily only when the active tuple
 contains a graph family; open and lexical-only writes do no graph-producer work. Other
 live writer families remain blocked until they supply the same target-bound replacement

--- a/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
+++ b/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
@@ -227,16 +227,20 @@ required family SHALL remain blocked.
   targets, uniqueness, and aggregate capacity, discards the edge payload, and emits only
   empty lower-variant graph rows
 
-#### Scenario: Semantic writes, creations, moves, and recoveries derive graph successors from retained state
+#### Scenario: Semantic writes, creations, moves, recoveries, and trash derive graph successors from retained state
 
 - **WHEN** an existing-page semantic write, semantic creation, semantic move, or semantic
-  trash recovery changes a direct edge, a path/title used by another page's link, or a
-  reverse relation whose logical source is another page
-- **THEN** the writer derives target-bound replacements from the freshest validated
-  detached before-corpus carried into the mutation boundary, the move or recovery's exact
-  detached after-corpus when applicable, and exact guarded planned bytes; it includes
-  every logical source whose outgoing edge tuple changes and does not reopen the live graph
-  or current Markdown
+  trash recovery or file/directory trash changes a direct edge, a path/title used by
+  another page's link, or a reverse relation whose logical source is another page
+- **THEN** the existing/edit/create/move/recovery writer derives target-bound replacements
+  from the freshest validated detached before-corpus carried into the mutation boundary,
+  the move or recovery's exact detached after-corpus when applicable, and exact guarded
+  planned bytes; it includes every logical source whose outgoing edge tuple changes and
+  does not reopen the live graph or current Markdown
+- **AND** trash removes the exact held Markdown identity set before applying its guarded
+  log overlay from one lazy detached before-corpus built only for an active graph family
+  before canonical bytes change, so otherwise-unchanged inbound sources lose edges to
+  removed targets
 - **AND** open and lexical-only writes do not invoke the graph producer
 
 When the projected source is exhausted, L1-and-above items SHALL still emit the

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -538,12 +538,15 @@ made before both PRs and their combined verification are complete.
   changed L6 sources, reject stale outside-catalog targets, and publish the complete graph
   root atomically. Validate conservative producer replacements for affected lower-only
   items, discard their edge payload, and emit only empty lower-variant rows. For
-  existing-page semantic writes, semantic creations, semantic moves, and semantic trash
-  recoveries, derive replacements from the freshest validated detached before-corpus
+  existing-page semantic writes, semantic creations, semantic moves, semantic trash
+  recoveries, and semantic file/directory trash, derive replacements from the freshest
+  validated detached before-corpus
   carried into the mutation boundary, the move or recovery's exact detached after-corpus
   when applicable, and the exact guarded planned-write overlay; include indirect
-  path/title-resolution and reverse-relation source changes, and never reopen the live
-  graph or walk the vault again. Connect every other live graph producer to those replacements before checking
+  path/title-resolution, removed-target, and reverse-relation source changes. Retained-
+  corpus paths never walk the vault again; trash builds one lazy before-corpus only for an
+  active graph family before canonical mutation. No producer reopens the live graph.
+  Connect every other live graph producer to those replacements before checking
   this task; keep any unsupported required family blocked.
 - [x] 8.12 Implement BM25 posting intersection before cap, projected-corpus DF/IDF and
   exact top-k; exact filtered projected-vector top-k with visible-lane warming/disable;

--- a/src/exomem/delete_directory.py
+++ b/src/exomem/delete_directory.py
@@ -23,8 +23,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import media_types, reserved_paths
-from .governance import catalog_publication, lifecycle
+from . import media_types, reserved_paths, semantic_contract
+from .governance import catalog_publication, graph_producer, lifecycle
 from .kbdir import kb_dirname, kb_prefix
 from .vault import (
     VaultPathError,
@@ -318,11 +318,22 @@ def delete_directory(
     )
     catalog_target: catalog_publication.PreparedMarkdownCatalogPublication | None = None
     if log_plan.writes or catalog_removals:
+        def graph_replacement_provider():
+            return graph_producer.replacements_for_removed_markdown(
+                vault_root,
+                before_corpus=semantic_contract.build_corpus_context(vault_root),
+                removed_paths=tuple(md_rels_to_unindex),
+                writes=log_plan.writes,
+            )
+
         try:
             catalog_target = catalog_publication.prepare_catalog_membership_batch(
                 vault_root,
                 writes=log_plan.writes,
                 removals=catalog_removals,
+                graph_replacement_provider=(
+                    graph_replacement_provider if md_rels_to_unindex else None
+                ),
                 now=int(time.time()),
             )
         except catalog_publication.CatalogPublicationError as error:

--- a/src/exomem/delete_file.py
+++ b/src/exomem/delete_file.py
@@ -28,8 +28,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import media_types, reserved_paths
-from .governance import catalog_publication, lifecycle
+from . import media_types, reserved_paths, semantic_contract
+from .governance import catalog_publication, graph_producer, lifecycle
 from .kbdir import kb_dirname, kb_prefix
 from .vault import (
     VaultPathError,
@@ -347,6 +347,15 @@ def delete_file(
         rel_path_no_ext=rel_no_ext,
         body=log_body,
     )
+    def graph_replacement_provider():
+        graph_before_corpus = semantic_contract.build_corpus_context(vault_root)
+        return graph_producer.replacements_for_removed_markdown(
+            vault_root,
+            before_corpus=graph_before_corpus,
+            removed_paths=(rel_path,),
+            writes=log_plan.writes,
+        )
+
     try:
         catalog_target = catalog_publication.prepare_catalog_membership_batch(
             vault_root,
@@ -356,6 +365,11 @@ def delete_file(
                     rel_path,
                     catalog_before_hash,
                 ),
+            ),
+            graph_replacement_provider=(
+                graph_replacement_provider
+                if rel_path.lower().endswith(".md")
+                else None
             ),
             now=int(time.time()),
         )

--- a/src/exomem/governance/graph_producer.py
+++ b/src/exomem/governance/graph_producer.py
@@ -227,8 +227,55 @@ def replacements_for_semantic_transition(
     )
     return _replacements_between(before_corpus, target_corpus)
 
+
+def replacements_for_removed_markdown(
+    vault_root: Path,
+    *,
+    before_corpus: semantic_contract.SemanticCorpusContext,
+    removed_paths: tuple[str, ...],
+    writes: tuple[vault.PlannedWrite, ...],
+    language_registry: semantic_language_registry.SemanticLanguageRegistry | None = None,
+) -> tuple[catalog_publication.GraphMeasurementReplacement, ...]:
+    """Build replacements after removing an exact Markdown identity set."""
+
+    root = Path(vault_root)
+    if before_corpus.vault_root != root:
+        raise GraphProducerError("graph producer corpus belongs to another vault")
+    if (
+        type(removed_paths) is not tuple
+        or not removed_paths
+        or any(type(path) is not str or path not in before_corpus.pages for path in removed_paths)
+        or len(set(removed_paths)) != len(removed_paths)
+    ):
+        raise GraphProducerError("graph producer removals do not bind the source corpus")
+    removed = frozenset(removed_paths)
+    after_corpus = semantic_contract.SemanticCorpusContext.from_states(
+        root,
+        (
+            state
+            for path, state in before_corpus.pages.items()
+            if path not in removed
+        ),
+        registry=before_corpus.registry,
+        identity_census=semantic_contract.StableIdentityCensus(
+            tuple(
+                entry
+                for entry in before_corpus.identity_census.entries
+                if entry.path not in removed
+            )
+        ),
+    )
+    target_corpus = _planned_overlay(
+        root,
+        base_corpus=after_corpus,
+        writes=writes,
+        language_registry=language_registry,
+    )
+    return _replacements_between(before_corpus, target_corpus)
+
 __all__ = [
     "GraphProducerError",
+    "replacements_for_removed_markdown",
     "replacements_for_planned_markdown",
     "replacements_for_semantic_transition",
 ]

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -32,6 +32,7 @@ from exomem import (
     preserve,
     reserved_paths,
     scene_frames,
+    semantic_contract,
     semantic_writes,
     writer_lease,
 )
@@ -2959,6 +2960,15 @@ def test_markdown_removal_and_log_write_publish_one_v4_catalog_generation(
         now=now,
     )
 
+    def reject_graph_corpus(*_args, **_kwargs):
+        raise AssertionError("lexical-only trash must not invoke the graph producer")
+
+    monkeypatch.setattr(
+        semantic_contract,
+        "build_corpus_context",
+        reject_graph_corpus,
+    )
+
     removed = delete_file_module.delete_file(
         vault,
         path=relative,
@@ -2996,6 +3006,104 @@ def test_markdown_removal_and_log_write_publish_one_v4_catalog_generation(
             vault_module.content_hash((vault / log_relative).read_text(encoding="utf-8")),
         )
     ]
+
+
+def test_v4_file_trash_removes_inbound_graph_edge_in_one_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    removed_relative = "Knowledge Base/Notes/private.md"
+    referrer_relative = "Knowledge Base/Notes/referrer.md"
+    log_relative = "Knowledge Base/log.md"
+    removed_source = "---\ntitle: Private\nstatus: draft\n---\n\nPrivate.\n"
+    referrer_source = (
+        "---\ntitle: Referrer\nstatus: draft\n---\n\n"
+        "See [[Knowledge Base/Notes/private]].\n"
+    )
+    log_before = "# Log\n\n---\n"
+    for path, source in (
+        (removed_relative, removed_source),
+        (referrer_relative, referrer_source),
+        (log_relative, log_before),
+    ):
+        target = vault / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=6))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=(
+            (removed_relative, removed_source),
+            (referrer_relative, referrer_source),
+            (log_relative, log_before),
+        ),
+        ceiling=6,
+        graph_edges=(
+            projected_graph.ProjectionGraphEdge(
+                referrer_relative,
+                removed_relative,
+                "links_to",
+            ),
+        ),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    removed = delete_file_module.delete_file(
+        vault,
+        path=removed_relative,
+        confirm=True,
+        force_orphan=True,
+        today=dt.date(2026, 8, 25),
+        now=dt.datetime.fromtimestamp(now),
+    )
+
+    assert not (vault / removed_relative).exists()
+    assert (vault / removed.trash_path).is_file()
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    active, manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=2,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    evidence = projection_store.namespace_evidence_from_snapshot(active)
+    graph_root = next(
+        root for root in evidence.required_measurement_roots if root.lane == "graph"
+    )
+    family = projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=evidence.manifest.namespace_key,
+        lane=graph_root.lane,
+        extractor_version=graph_root.extractor_version,
+        model_version=graph_root.model_version,
+    )
+    namespace = projection_store.bind_active_projection_namespace(
+        active,
+        manifest=manifest,
+        items=items,
+    )
+    _graph_manifest, graph_rows = projection_measurement_store.load_measurement_store(
+        vault,
+        namespace=namespace,
+        family=family,
+        expected_rows_digest=graph_root.rows_digest,
+    )
+    assert all(
+        edge.target_item_identity != removed_relative
+        for row in graph_rows
+        for edge in row.edges
+    )
 
 
 def test_v4_trash_refuses_unsupported_non_markdown_before_moving_bytes(
@@ -3120,6 +3228,106 @@ def test_v4_directory_trash_retires_all_rows_and_publishes_log_once(
             vault_module.content_hash((vault / log_relative).read_text(encoding="utf-8")),
         )
     ]
+
+
+def test_v4_directory_trash_removes_inbound_graph_edge_in_one_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-state")
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    directory = "Knowledge Base/Notes/private-tree"
+    removed_relative = f"{directory}/private.md"
+    referrer_relative = "Knowledge Base/Notes/referrer.md"
+    log_relative = "Knowledge Base/log.md"
+    removed_source = "---\ntitle: Private\nstatus: draft\n---\n\nPrivate.\n"
+    referrer_source = (
+        "---\ntitle: Referrer\nstatus: draft\n---\n\n"
+        "See [[Knowledge Base/Notes/private-tree/private]].\n"
+    )
+    log_before = "# Log\n\n---\n"
+    for path, source in (
+        (removed_relative, removed_source),
+        (referrer_relative, referrer_source),
+        (log_relative, log_before),
+    ):
+        target = vault / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=6))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=(
+            (removed_relative, removed_source),
+            (referrer_relative, referrer_source),
+            (log_relative, log_before),
+        ),
+        ceiling=6,
+        graph_edges=(
+            projected_graph.ProjectionGraphEdge(
+                referrer_relative,
+                removed_relative,
+                "links_to",
+            ),
+        ),
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    removed = delete_directory_module.delete_directory(
+        vault,
+        path=directory,
+        confirm=True,
+        recursive=True,
+        force_orphan=True,
+        today=dt.date(2026, 8, 25),
+        now=dt.datetime.fromtimestamp(now),
+    )
+
+    assert not (vault / directory).exists()
+    assert (vault / removed.trash_path).is_dir()
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    active, manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=2,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    evidence = projection_store.namespace_evidence_from_snapshot(active)
+    graph_root = next(
+        root for root in evidence.required_measurement_roots if root.lane == "graph"
+    )
+    family = projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=evidence.manifest.namespace_key,
+        lane=graph_root.lane,
+        extractor_version=graph_root.extractor_version,
+        model_version=graph_root.model_version,
+    )
+    namespace = projection_store.bind_active_projection_namespace(
+        active,
+        manifest=manifest,
+        items=items,
+    )
+    _graph_manifest, graph_rows = projection_measurement_store.load_measurement_store(
+        vault,
+        namespace=namespace,
+        family=family,
+        expected_rows_digest=graph_root.rows_digest,
+    )
+    assert all(
+        edge.target_item_identity != removed_relative
+        for row in graph_rows
+        for edge in row.edges
+    )
 
 
 def test_v4_directory_trash_refuses_non_markdown_child_before_moving_tree(


### PR DESCRIPTION
## Why

Exact-v4 file and directory trash operations must retire graph measurements in the same catalog successor. Otherwise an inbound graph edge can survive after its target leaves the active knowledge corpus.

## What changed

- derives graph replacements for affected referrers when files or directory trees are removed
- wires both file and directory deletion writers into the lazy exact-v4 graph successor
- proves inbound edges disappear in the same activation generation as the catalog removal
- keeps OpenSpec task 8.11 open until the remaining writer inventory is closed

## Verification

- 38 focused graph/deletion lifecycle tests passed
- Ruff passed on touched Python files
- strict OpenSpec validation passed
- public-artifact validation passed
- git diff check passed
