### PR TITLE
feat(governance): publish media graph successors

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/design.md
+++ b/openspec/changes/harden-governance-for-consolidation/design.md
@@ -759,6 +759,12 @@ contains a graph family; open and lexical-only writes do no graph-producer work.
 live writer families remain blocked until they supply the same target-bound replacement
 contract.
 
+Machine-owned Evidence preservation, media-sidecar completion/failure updates, and
+scene-frame companion creation use the same lazy planned-Markdown provider. They build
+one detached before-corpus only when the active tuple contains a graph family, overlay the
+exact already-staged Markdown bytes, and publish graph/CLIP/catalog roots together before
+reporting success. Open and lexical-only paths do no graph-producer work.
+
 A policy
 fingerprint or projector-schema change builds a new namespace tuple and never relabels
 an old one. A model/extractor change writes or invalidates only the corresponding

--- a/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
+++ b/openspec/changes/harden-governance-for-consolidation/specs/release-gate/spec.md
@@ -243,6 +243,15 @@ required family SHALL remain blocked.
   removed targets
 - **AND** open and lexical-only writes do not invoke the graph producer
 
+#### Scenario: Machine-owned media Markdown uses the same graph successor
+
+- **WHEN** Evidence preservation, a media-sidecar state update, or scene-frame companion
+  creation changes Markdown while the active tuple contains a graph family
+- **THEN** the writer lazily derives replacements from one detached before-corpus and the
+  exact staged Markdown batch, and publishes graph, CLIP when applicable, catalog, and
+  active tuple together before reporting success
+- **AND** open and lexical-only writes do not invoke the graph producer
+
 When the projected source is exhausted, L1-and-above items SHALL still emit the
 projection their policy authorizes while L0 items SHALL produce a silently shorter list,
 identical to physical absence. The canonical governed envelope for the same input SHALL

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -546,6 +546,9 @@ made before both PRs and their combined verification are complete.
   path/title-resolution, removed-target, and reverse-relation source changes. Retained-
   corpus paths never walk the vault again; trash builds one lazy before-corpus only for an
   active graph family before canonical mutation. No producer reopens the live graph.
+  Apply the same lazy planned-Markdown contract to Evidence preservation, machine-owned
+  media-sidecar updates, and scene-frame companion creation, co-publishing CLIP when
+  applicable and doing no graph work for open or lexical-only tuples.
   Connect every other live graph producer to those replacements before checking
   this task; keep any unsupported required family blocked.
 - [x] 8.12 Implement BM25 posting intersection before cap, projected-corpus DF/IDF and

--- a/src/exomem/preserve.py
+++ b/src/exomem/preserve.py
@@ -36,7 +36,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import IO, BinaryIO
 
-from . import indexes, memory_refs, privacy_log, temporal
+from . import indexes, memory_refs, privacy_log, semantic_contract, temporal
 from .kbdir import kb_prefix
 from .vault import (
     MISSING_CONTENT_HASH,
@@ -416,12 +416,20 @@ def preserve(
         else:
             warnings.append(f"{kb_prefix()}log.md missing; skipped log entry")
 
-        from .governance import catalog_publication
+        from .governance import catalog_publication, graph_producer
+
+        def graph_replacement_provider():
+            return graph_producer.replacements_for_planned_markdown(
+                vault_root,
+                before_corpus=semantic_contract.build_corpus_context(vault_root),
+                writes=tuple(writes),
+            )
 
         try:
             prepared_catalog = catalog_publication.prepare_planned_markdown_batch(
                 vault_root,
                 writes=tuple(writes),
+                graph_replacement_provider=graph_replacement_provider,
             )
         except catalog_publication.CatalogPublicationError as error:
             raise catalog_publication.CatalogCommitError(
@@ -983,12 +991,20 @@ def commit_media_sidecar_writes(
 ) -> list[Path] | DeferredGraphCompletion:
     """Publish machine-owned Markdown through the active catalog tuple."""
 
-    from .governance import catalog_publication
+    from .governance import catalog_publication, graph_producer
+
+    def graph_replacement_provider():
+        return graph_producer.replacements_for_planned_markdown(
+            vault_root,
+            before_corpus=semantic_contract.build_corpus_context(vault_root),
+            writes=writes,
+        )
 
     try:
         prepared = catalog_publication.prepare_planned_markdown_batch(
             vault_root,
             writes=writes,
+            graph_replacement_provider=graph_replacement_provider,
         )
     except catalog_publication.CatalogPublicationError as error:
         raise catalog_publication.CatalogCommitError(

--- a/src/exomem/scene_frames.py
+++ b/src/exomem/scene_frames.py
@@ -26,7 +26,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO
 
-from . import embeddings, index_sync
+from . import embeddings, index_sync, semantic_contract
 from .governance import projected_retrieval
 from .preserve import _render_sidecar
 from .vault import (
@@ -390,7 +390,14 @@ def write_scene_frames(
         out.append((jpg, sidecar))
     if not writes:
         return []
-    from .governance import catalog_publication
+    from .governance import catalog_publication, graph_producer
+
+    def graph_replacement_provider():
+        return graph_producer.replacements_for_planned_markdown(
+            root,
+            before_corpus=semantic_contract.build_corpus_context(root),
+            writes=tuple(writes),
+        )
 
     try:
         try:
@@ -398,6 +405,7 @@ def write_scene_frames(
                 root,
                 writes=tuple(writes),
                 clip_replacements=clip_replacements,
+                graph_replacement_provider=graph_replacement_provider,
             )
         except catalog_publication.CatalogPublicationError as error:
             raise catalog_publication.CatalogCommitError(

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -4966,7 +4966,14 @@ def test_preserve_binary_v4_preflight_failure_leaves_no_canonical_bytes(
         now=now,
     )
 
-    def refuse(_vault_root: Path, *, writes, now=None):  # noqa: ANN001, ARG001
+    def refuse(
+        _vault_root: Path,
+        *,
+        writes,  # noqa: ANN001, ARG001
+        graph_replacement_provider,
+        now=None,  # noqa: ANN001, ARG001
+    ):
+        assert callable(graph_replacement_provider)
         raise catalog_publication.CatalogPublicationError("preflight refused")
 
     monkeypatch.setattr(

--- a/tests/test_governance_graph_producer.py
+++ b/tests/test_governance_graph_producer.py
@@ -263,6 +263,35 @@ def test_catalog_bridge_forwards_lazy_graph_replacement_provider(
     assert captured["graph_replacement_provider"] is provider
 
 
+def test_media_sidecar_writer_forwards_lazy_graph_replacement_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import preserve
+
+    sidecar = tmp_path / "Knowledge Base/Evidence/private.bin.md"
+    write = vault.PlannedWrite(sidecar, "---\ntitle: Private\n---\n")
+    captured: dict[str, object] = {}
+
+    def fake_prepare(vault_root, *, writes, graph_replacement_provider):
+        captured.update(
+            vault_root=vault_root,
+            writes=writes,
+            graph_replacement_provider=graph_replacement_provider,
+        )
+        return None
+
+    monkeypatch.setattr(catalog_publication, "prepare_planned_markdown_batch", fake_prepare)
+
+    assert preserve.commit_media_sidecar_writes(
+        tmp_path,
+        (write,),
+        batch_writer=lambda *_args, **_kwargs: [sidecar],
+    ) == [sidecar]
+    assert captured["writes"] == (write,)
+    assert callable(captured["graph_replacement_provider"])
+
+
 def test_creation_catalog_bridge_builds_provider_from_retained_preflight(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_scene_frames.py
+++ b/tests/test_scene_frames.py
@@ -227,6 +227,44 @@ def test_v4_preflight_refusal_does_not_create_frame_bytes(
     assert not scene_frames.frames_dir_for(video).exists()
 
 
+def test_scene_frame_writer_forwards_lazy_graph_replacement_provider(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    video = _video(vault)
+    captured: dict[str, object] = {}
+
+    def prepare(
+        vault_root,
+        *,
+        writes,
+        clip_replacements,
+        graph_replacement_provider,
+    ):
+        captured.update(
+            vault_root=vault_root,
+            writes=writes,
+            clip_replacements=clip_replacements,
+            graph_replacement_provider=graph_replacement_provider,
+        )
+        return None
+
+    monkeypatch.setattr(
+        catalog_publication,
+        "prepare_planned_markdown_batch",
+        prepare,
+    )
+
+    pairs = scene_frames.write_scene_frames(
+        vault,
+        video,
+        [(_scene(10.0), _FakeImg())],
+    )
+
+    assert len(pairs) == 1
+    assert callable(captured["graph_replacement_provider"])
+
+
 def test_rewrite_clears_stale_frames(vault: Path) -> None:
     video = _video(vault)
     scene_frames.write_scene_frames(


### PR DESCRIPTION
## Why

Exact-v4 media sidecar and scene-frame writers can change catalog-visible artifacts. When a graph family is active, those writes must publish a complete graph successor in the same activation rather than leave the graph root stale.

## What changed

- forwards lazy graph replacement providers through media sidecar publication
- forwards the already-validated scene-frame batch through the same exact-v4 graph successor
- preserves no-second-pass behavior and keeps the provider dormant when no graph family is active
- keeps OpenSpec task 8.11 open until the remaining writer inventory is closed

## Verification

- 29 focused graph/media/scene tests passed
- Ruff passed on touched Python files
- strict OpenSpec validation passed
- public-artifact validation passed
- git diff check passed
