### PR TITLE
feat(governance): complete graph writer successors

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -520,7 +520,7 @@ made before both PRs and their combined verification are complete.
   capacity/lane reduction, scheduler-tolerance subtraction, post-observation padding,
   and missed fixed deadline. Require both bounds simultaneously within manifest, 25 ms,
   and 10% of physically-absent p95.
-- [ ] 8.11 Implement principal-free canonical fixed projection records and lexical/vector/CLIP/
+- [x] 8.11 Implement principal-free canonical fixed projection records and lexical/vector/CLIP/
   graph measurement rows plus a request-local membership/decision authorization map that
   selects exactly one hashed variant or L0 per catalog artifact. Enumerate/deduplicate
   finite reachable outputs, enforce 256, and keep principal, purpose, session, grant, and

--- a/src/exomem/governance/catalog_publication.py
+++ b/src/exomem/governance/catalog_publication.py
@@ -1394,6 +1394,10 @@ def prepare_markdown_batch(
     mutations: tuple[MarkdownCatalogMutation, ...],
     clip_replacements: tuple[ClipMeasurementReplacement, ...] = (),
     graph_replacements: tuple[GraphMeasurementReplacement, ...] = (),
+    graph_replacement_provider: Callable[
+        [], tuple[GraphMeasurementReplacement, ...]
+    ]
+    | None = None,
     now: int | None = None,
     activated_at: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
@@ -1411,6 +1415,7 @@ def prepare_markdown_batch(
         removals=(),
         clip_replacements=clip_replacements,
         graph_replacements=graph_replacements,
+        graph_replacement_provider=graph_replacement_provider,
         now=now,
         activated_at=activated_at,
     )
@@ -1484,6 +1489,10 @@ def prepare_markdown_upsert(
     expected_before_hash: str | None,
     clip_replacements: tuple[ClipMeasurementReplacement, ...] = (),
     graph_replacements: tuple[GraphMeasurementReplacement, ...] = (),
+    graph_replacement_provider: Callable[
+        [], tuple[GraphMeasurementReplacement, ...]
+    ]
+    | None = None,
     now: int | None = None,
     activated_at: int | None = None,
 ) -> PreparedMarkdownCatalogPublication | None:
@@ -1494,6 +1503,7 @@ def prepare_markdown_upsert(
         mutations=(MarkdownCatalogMutation(path, source, expected_before_hash),),
         clip_replacements=clip_replacements,
         graph_replacements=graph_replacements,
+        graph_replacement_provider=graph_replacement_provider,
         now=now,
         activated_at=activated_at,
     )

--- a/src/exomem/governance/graph_producer.py
+++ b/src/exomem/governance/graph_producer.py
@@ -196,6 +196,37 @@ def replacements_for_planned_markdown(
     return _replacements_between(before_corpus, after_corpus)
 
 
+def replacements_for_current_markdown(
+    vault_root: Path,
+    *,
+    current_corpus: semantic_contract.SemanticCorpusContext,
+    paths: tuple[str, ...],
+) -> tuple[catalog_publication.GraphMeasurementReplacement, ...]:
+    """Rebind already-committed Markdown to its exact recovery topology."""
+
+    root = Path(vault_root)
+    if current_corpus.vault_root != root:
+        raise GraphProducerError("graph producer corpus belongs to another vault")
+    if (
+        type(paths) is not tuple
+        or not paths
+        or len(set(paths)) != len(paths)
+        or any(type(path) is not str or path not in current_corpus.pages for path in paths)
+    ):
+        raise GraphProducerError(
+            "graph producer recovery paths do not bind the current corpus"
+        )
+    edges = _edges_by_source(current_corpus)
+    return tuple(
+        catalog_publication.GraphMeasurementReplacement(
+            item_identity=path,
+            content_hash=current_corpus.pages[path].source_hash,
+            edges=edges.get(path, ()),
+        )
+        for path in sorted(paths)
+    )
+
+
 def replacements_for_semantic_transition(
     vault_root: Path,
     *,
@@ -275,6 +306,7 @@ def replacements_for_removed_markdown(
 
 __all__ = [
     "GraphProducerError",
+    "replacements_for_current_markdown",
     "replacements_for_removed_markdown",
     "replacements_for_planned_markdown",
     "replacements_for_semantic_transition",

--- a/src/exomem/governance/recovery.py
+++ b/src/exomem/governance/recovery.py
@@ -15,8 +15,8 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import Any
 
-from .. import reserved_paths
-from . import catalog_publication
+from .. import reserved_paths, semantic_contract
+from . import catalog_publication, graph_producer
 from . import policy as policy_module
 from . import receipts, schema_v4, store
 from .operations import RECOVERY_STRATEGY_KEYS, journal_variant, recovery_strategy
@@ -945,11 +945,23 @@ def _recover_companion_catalog_publication(
         expected_before_hash = prior_companion[1].get("sha256")
         if not isinstance(expected_before_hash, str):
             return False
+
+        def graph_replacement_provider() -> tuple[
+            catalog_publication.GraphMeasurementReplacement, ...
+        ]:
+            current_corpus = semantic_contract.build_corpus_context(vault_root)
+            return graph_producer.replacements_for_current_markdown(
+                vault_root,
+                current_corpus=current_corpus,
+                paths=(prepared_companion[0],),
+            )
+
         prepared = catalog_publication.prepare_markdown_upsert(
             vault_root,
             path=prepared_companion[0],
             source=source,
             expected_before_hash=expected_before_hash,
+            graph_replacement_provider=graph_replacement_provider,
             now=int(time.time()),
             activated_at=int(float(journal["created_at"])),
         )

--- a/src/exomem/governance/tool.py
+++ b/src/exomem/governance/tool.py
@@ -36,6 +36,8 @@ from .. import (
     memory_refs,
     reserved_paths,
     review_state,
+    semantic_contract,
+    vault,
 )
 from ..kbdir import kb_dirname
 from . import (
@@ -45,6 +47,7 @@ from . import (
     catalog_publication,
     companion_backfill,
     decisions,
+    graph_producer,
     membership,
     projection_store,
     projections,
@@ -4250,11 +4253,30 @@ def _backfill_commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
             "STALE_COMPANION_BACKFILL", "reviewed companion snapshots changed"
         )
     try:
+        target_source = plan.target_bytes.decode("utf-8")
+        expected_before_hash = hashlib.sha256(plan.prior_bytes).hexdigest()
+
+        def graph_replacement_provider() -> tuple[
+            catalog_publication.GraphMeasurementReplacement, ...
+        ]:
+            before_corpus = semantic_contract.build_corpus_context(vault_root)
+            write = vault.PlannedWrite(
+                path=vault_root / plan.companion_path,
+                content=target_source,
+                expected_hash=expected_before_hash,
+            )
+            return graph_producer.replacements_for_planned_markdown(
+                vault_root,
+                before_corpus=before_corpus,
+                writes=(write,),
+            )
+
         catalog_target = catalog_publication.prepare_markdown_upsert(
             vault_root,
             path=plan.companion_path,
-            source=plan.target_bytes.decode("utf-8"),
-            expected_before_hash=hashlib.sha256(plan.prior_bytes).hexdigest(),
+            source=target_source,
+            expected_before_hash=expected_before_hash,
+            graph_replacement_provider=graph_replacement_provider,
             now=int(now),
         )
         catalog_values = (

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -700,6 +700,41 @@ def _load_active_projection_items(
     return active, manifest, items
 
 
+def _load_active_graph_rows(
+    vault: Path,
+    *,
+    active: schema_v4.VerifiedActiveGovernanceState,
+    manifest: projection_store.VariantStoreManifest,
+    items: tuple[projection_store.ProjectionItemVariants, ...],
+) -> tuple[projected_graph.ProjectionGraphMeasurement, ...]:
+    evidence = projection_store.namespace_evidence_from_snapshot(active)
+    graph_root = next(
+        root for root in evidence.required_measurement_roots if root.lane == "graph"
+    )
+    family = projection_measurement_store.MeasurementFamilyKey(
+        namespace_key=evidence.manifest.namespace_key,
+        lane=graph_root.lane,
+        extractor_version=graph_root.extractor_version,
+        model_version=graph_root.model_version,
+    )
+    namespace = projection_store.bind_active_projection_namespace(
+        active,
+        manifest=manifest,
+        items=items,
+    )
+    _graph_manifest, rows = projection_measurement_store.load_measurement_store(
+        vault,
+        namespace=namespace,
+        family=family,
+        expected_rows_digest=graph_root.rows_digest,
+    )
+    return tuple(
+        row
+        for row in rows
+        if isinstance(row, projected_graph.ProjectionGraphMeasurement)
+    )
+
+
 def _configure_media_v4(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -827,6 +862,8 @@ def test_v4_companion_backfill_publishes_catalog_successor(
     migration = _migrate_with_projection_items(
         vault,
         items=((companion_path, (vault / companion_path).read_text(encoding="utf-8")),),
+        ceiling=6,
+        graph_edges=(),
         now=now,
     )
     _configure_custody(
@@ -859,6 +896,20 @@ def test_v4_companion_backfill_publishes_catalog_successor(
     assert manifest.item_count == 1
     assert {item.item_identity: item.content_hash for item in items} == {
         companion_path: vault_module.content_hash(companion_after)
+    }
+    graph_rows = _load_active_graph_rows(
+        vault,
+        active=active,
+        manifest=manifest,
+        items=items,
+    )
+    assert {
+        (row.measurement_key.projection_variant_id, row.edges)
+        for row in graph_rows
+    } == {
+        (variant.projection_variant_id, ())
+        for item in items
+        for variant in item.variants
     }
     connection = store.open_connection(vault)
     try:
@@ -902,6 +953,8 @@ def test_v4_companion_backfill_recovers_after_catalog_publication(
     migration = _migrate_with_projection_items(
         vault,
         items=((companion_path, (vault / companion_path).read_text(encoding="utf-8")),),
+        ceiling=6,
+        graph_edges=(),
         now=now,
     )
     _configure_custody(
@@ -952,6 +1005,8 @@ def test_v4_companion_backfill_recovers_catalog_after_companion_publication(
     migration = _migrate_with_projection_items(
         vault,
         items=((companion_path, (vault / companion_path).read_text(encoding="utf-8")),),
+        ceiling=6,
+        graph_edges=(),
         now=now,
     )
     _configure_custody(
@@ -980,6 +1035,25 @@ def test_v4_companion_backfill_recovers_catalog_after_companion_publication(
     assert recovered["activated"] == 1
     custody = authorization_custody.load_authorization_custody(vault, now=now + 3)
     assert custody.control.activation_epoch == 2
+    active, manifest, items = _load_active_projection_items(
+        vault,
+        activation_epoch=2,
+        activation_state_digest=custody.control.activation_state_digest or "",
+    )
+    graph_rows = _load_active_graph_rows(
+        vault,
+        active=active,
+        manifest=manifest,
+        items=items,
+    )
+    assert {
+        (row.measurement_key.projection_variant_id, row.edges)
+        for row in graph_rows
+    } == {
+        (variant.projection_variant_id, ())
+        for item in items
+        for variant in item.variants
+    }
     replayed = _commit_companion_backfill(
         vault,
         payload,
@@ -3743,8 +3817,17 @@ def test_v4_recovery_refuses_non_markdown_before_moving_bytes(
         json.dumps({"original_path": original}),
         encoding="utf-8",
     )
-    _write_workspace(vault, _documents(ceiling=2))
-    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    log_relative = "Knowledge Base/log.md"
+    log_source = "# Log\n\n---\n"
+    (vault / log_relative).write_text(log_source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=6))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((log_relative, log_source),),
+        ceiling=6,
+        graph_edges=(),
+        now=now,
+    )
     _configure_custody(
         monkeypatch,
         tmp_path / "custody",
@@ -4047,8 +4130,17 @@ def test_v4_move_refuses_unsupported_non_markdown_before_moving_bytes(
     source = vault / old_relative
     source.parent.mkdir(parents=True, exist_ok=True)
     source.write_bytes(b"private bytes")
-    _write_workspace(vault, _documents(ceiling=2))
-    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    log_relative = "Knowledge Base/log.md"
+    log_source = "# Log\n\n---\n"
+    (vault / log_relative).write_text(log_source, encoding="utf-8")
+    _write_workspace(vault, _documents(ceiling=6))
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((log_relative, log_source),),
+        ceiling=6,
+        graph_edges=(),
+        now=now,
+    )
     _configure_custody(
         monkeypatch,
         tmp_path / "custody",

--- a/tests/test_governance_graph_producer.py
+++ b/tests/test_governance_graph_producer.py
@@ -132,6 +132,39 @@ def test_planned_source_replaces_its_exact_outgoing_edges(tmp_path: Path) -> Non
     )
 
 
+def test_current_source_rebinds_its_exact_recovery_edges(tmp_path: Path) -> None:
+    source_path = "Knowledge Base/Notes/Insights/source.md"
+    target_path = "Knowledge Base/Notes/Insights/target.md"
+    source = _source(
+        "Source",
+        "00000000-0000-0000-0000-000000000001",
+        body="## Observations\n\n- [decision] Keep the edge.\n\n[[Target]]\n",
+    )
+    current = _corpus(
+        tmp_path,
+        _state(tmp_path, source_path, source),
+        _state(
+            tmp_path,
+            target_path,
+            _source("Target", "00000000-0000-0000-0000-000000000002"),
+        ),
+    )
+
+    replacements = graph_producer.replacements_for_current_markdown(
+        tmp_path,
+        current_corpus=current,
+        paths=(source_path,),
+    )
+
+    assert replacements == (
+        catalog_publication.GraphMeasurementReplacement(
+            source_path,
+            vault.content_hash(source),
+            (_edge(source_path, target_path),),
+        ),
+    )
+
+
 def test_title_change_replaces_sources_whose_resolution_changed(tmp_path: Path) -> None:
     source_path = "Knowledge Base/Notes/Insights/source.md"
     target_path = "Knowledge Base/Notes/Insights/target.md"


### PR DESCRIPTION
## Summary

- publish target-bound graph successors for owner-reviewed companion backfill commits
- reconstruct the exact current graph row when recovering a backfill after canonical bytes committed
- keep unsupported non-Markdown move and recovery paths blocked with an active graph family
- close OpenSpec task 8.11 after auditing every live catalog producer

## Verification

- `49 passed, 80 deselected` across graph producer, companion backfill, and v4 move/recovery coverage
- touched-file Ruff: clean
- `openspec validate harden-governance-for-consolidation --strict`
- `python3 scripts/validate-public-artifacts.py --repository`
- `git diff --check`