### PR TITLE
chore(ci): enforce release evidence in the gate instead of prose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,11 +643,53 @@ jobs:
           src/exomem/referent_runtime.py
           src/exomem/entity_types.py
 
+  release-evidence:
+    name: release evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Runs on the release PR (where it enforces) and on every non-PR event
+    # (where it is a trivial success, so the gate's skip-intolerant full-CI
+    # arm never sees a skip). Ordinary PRs skip it and the gate accepts the
+    # skip outside full CI. This is the ONLY permitted appearance of the
+    # release branch name in this workflow — a seconds-class API check, not
+    # the full-CI stampede the guard removal eliminated; the contract test
+    # pins the count.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.ref == 'release-please--branches--main' }}
+    steps:
+      - name: Require a green full run on main at the release base
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+        # Enforces docs/release.md's evidence step in CI instead of prose: a
+        # release PR merges only when a green dispatched (or scheduled) full
+        # run exists on main at the PR's recorded base revision. Known
+        # strictness bound: base.sha is captured at the PR's last synchronize
+        # event, so a main push AFTER the evidence run but WITHOUT a
+        # release-please resync is not caught here; release-please resyncs on
+        # every main push in practice, which re-points BASE_SHA and re-runs
+        # this job.
+        run: |
+          if test -z "$BASE_SHA"; then
+            echo "not a release pull request; nothing to verify"
+            exit 0
+          fi
+          count=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?branch=main&status=success&per_page=100" \
+            --jq "[.workflow_runs[] | select((.event == \"workflow_dispatch\" or .event == \"schedule\") and .head_sha == \"$BASE_SHA\")] | length")
+          if test "$count" -ge 1; then
+            echo "green full run found on main at $BASE_SHA"
+            exit 0
+          fi
+          echo "no green dispatched or scheduled full CI run exists on main at $BASE_SHA" >&2
+          echo "dispatch one and let it finish green first: gh workflow run ci.yml --ref main" >&2
+          echo "then re-run this job (docs/release.md, release flow)" >&2
+          exit 1
+
   gate:
     name: required CI gate
     # Surface dependency failures, but let superseded PR runs release the runner.
     if: ${{ !cancelled() }}
     needs:
+      - release-evidence
       - core-tests
       - harness-tests
       - windows-held-filesystem

--- a/tests/test_ci_reliability_contract.py
+++ b/tests/test_ci_reliability_contract.py
@@ -599,13 +599,57 @@ def test_expensive_ci_runs_nightly_and_manually_only() -> None:
     assert "head_ref" not in condition
     assert "release-please" not in condition
 
-    # The clause must not survive anywhere in the workflow — not in a job
-    # guard, not in the python matrix, not in the gate's FULL_CI expression.
-    assert "release-please--branches--main" not in _workflow_text()
+    # The clause must not creep back into the expensive tier: its only
+    # permitted appearance in the whole workflow is the release-evidence
+    # job's own guard (pinned exactly in
+    # test_release_evidence_is_enforced_on_the_release_pr) — a seconds-class
+    # API check, not a stampede.
+    assert _workflow_text().count("release-please--branches--main") == 1
 
-    fast_jobs = set(jobs) - FULL_CI_JOBS - {"gate"}
+    fast_jobs = set(jobs) - FULL_CI_JOBS - {"gate", "release-evidence"}
     assert fast_jobs
     assert all("if" not in jobs[name] for name in fast_jobs)
+
+
+def test_release_evidence_is_enforced_on_the_release_pr() -> None:
+    """The docs/release.md evidence step is CI-enforced, not prose.
+
+    Removing the full-CI stampede from the release PR moved release evidence
+    to one green dispatched (or scheduled) full run on main. A documented
+    procedure alone cannot bind a merge, so a seconds-class `release-evidence`
+    job runs on the release PR and fails unless such a run exists at the PR's
+    recorded base revision. Ordinary PRs skip it (the gate accepts skips
+    outside full CI); schedule/dispatch/push contexts run it as a trivial
+    success so the gate's skip-intolerant full-CI arm never sees a skip.
+    """
+    workflow = _workflow()
+    job = workflow["jobs"]["release-evidence"]
+
+    condition = " ".join(str(job["if"]).split())
+    assert condition == (
+        "${{ github.event_name != 'pull_request' || "
+        "github.event.pull_request.head.ref == 'release-please--branches--main' }}"
+    )
+
+    (step,) = job["steps"]
+    assert step["env"]["GH_TOKEN"] == "${{ github.token }}"
+    base = " ".join(str(step["env"]["BASE_SHA"]).split())
+    assert base == "${{ github.event.pull_request.base.sha || '' }}"
+
+    command = step["run"]
+    # Non-release contexts must succeed without querying anything.
+    assert 'test -z "$BASE_SHA"' in command
+    # The evidence query must demand a green full run at the exact base
+    # revision — event-filtered, status-filtered, sha-pinned.
+    assert "actions/workflows/ci.yml/runs" in command
+    assert "workflow_dispatch" in command
+    assert "schedule" in command
+    assert "status=success" in command
+    assert "head_sha" in command
+    # Failure must tell the operator the exact remediation.
+    assert "gh workflow run ci.yml --ref main" in command
+
+    assert "release-evidence" in set(workflow["jobs"]["gate"]["needs"])
 
 
 def test_superseded_pr_runs_cancel_and_one_stable_gate_covers_both_tiers() -> None:


### PR DESCRIPTION
## Why

Removing the full-CI stampede from the release PR (#831) moved release evidence to one green dispatched full run on main — but that requirement lived only in docs/release.md, honestly flagged as untestable prose in the #831 lane's mutation table. A documented procedure cannot bind a merge.

## What

A seconds-class `release-evidence` job: on the release PR it fails unless a green dispatched (or scheduled) full CI run exists on main at the PR's recorded base revision, with the exact remediation command in the failure output. Ordinary PRs skip it (the gate accepts skips outside full CI); schedule/dispatch/push contexts run it as a trivial success so the gate's skip-intolerant full-CI arm never sees a skip.

The contract test pins: the job's guard verbatim, BASE_SHA wiring, the evidence query's event/status/sha filters, gate-needs membership, and that the release branch name appears in ci.yml exactly once (this guard) — the prior raw-text absence sweep's intent was 'no stampede', and the pinned count preserves it.

Known strictness bound (commented in the job): BASE_SHA is captured at the PR's last synchronize event; release-please resyncs on every main push in practice, which re-points it and re-runs the job.

## Verification

- Red-first: both new/updated contract tests failed against the pre-change ci.yml (KeyError: 'release-evidence'; count 0 != 1).
- Green: full contract suite 23 passed; YAML parses; privacy validator clean.
- Mutation-proven: removing the job from gate needs → gate-needs equality + the new test red; loosening the guard's head-ref clause → the pinned-condition assertion red.