### PR TITLE
fix(governance): recover exact session grant scopes

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -8,7 +8,7 @@ this reconciliation is `origin/main` at `9dc37201` plus stacked evidence PR #832
 
 | Area | Merged implementation evidence | Remaining end-state obligation |
 | --- | --- | --- |
-| Per-scope disclosure | Conservative lattice, option meet, unconditional scrubber, and session-bound scope enforcement are merged. | Exact v3 grant migration/recovery closure in 1.7/1.10. |
+| Per-scope disclosure | Conservative lattice, option meet, unconditional scrubber, and session-bound scope enforcement are merged. | Exact v3 grant migration and receipt-first v4 scope-bound recovery are implemented and evidenced in this stacked change; no section 1 obligation remains. Merge stays behind the Personal stability hold. |
 | Non-Markdown membership | Descriptor binding, owner backfill, fail-closed propagation, structured-read preflight, and the combined regression matrix are complete through #723, #724, #727, and green PR #832 CI. | No section 2 obligation remains. |
 | Policy authority | Prospective snapshots, exact proposal authority binding, atomic policy publication, the held workspace mirror, and policy/content/companion/measurement/graph writer successors are merged through #729, #740, and #800-#830. | Remaining workspace-race, migration, recovery, suspend/resume/undo, and combined evidence closure in 3.4-3.7 and 3.12-3.13. |
 | Reserved state | Held filesystem substrate and the closed reserved-path monopoly are merged and complete. | Final whole-change review/verification only. |
@@ -59,7 +59,7 @@ this reconciliation is `origin/main` at `9dc37201` plus stacked evidence PR #832
   proving the shared terminal secret/bearer scrubber is non-disableable under active
   governance. Assert legacy scrubber-off policy blocks compilation and the exact typed
   open/rotate issuance occurrence remains the only terminal exception.
-- [ ] 1.7 Extend `tests/test_govern_memory_tool.py` and `tests/test_governance_store.py`
+- [x] 1.7 Extend `tests/test_govern_memory_tool.py` and `tests/test_governance_store.py`
   with red persistence/drift tests for exact session-grant scope bindings and a
   monotonic migration that expires legacy rows unable to prove them.
 - [x] 1.8 Implement the pure per-scope lattice and closed conservative option meet in
@@ -70,7 +70,7 @@ this reconciliation is `origin/main` at `9dc37201` plus stacked evidence PR #832
   migration finding for every legacy occurrence, and make terminal scrubber invocation
   unconditional across content/error/control dispatch; retain only the exact validated
   issuance exception.
-- [ ] 1.10 Persist the reviewed scope set with session grants, return it from active-grant
+- [x] 1.10 Persist the reviewed scope set with session grants, return it from active-grant
   lookup, include it in composite digests/recovery, and make membership or policy drift
   invalidate rather than broaden it.
 - [x] 1.11 Run the focused compiler/lattice/scrubber/store/tool tests and preserve the red-before-green

--- a/src/exomem/governance/authorization_session_authority.py
+++ b/src/exomem/governance/authorization_session_authority.py
@@ -463,7 +463,7 @@ def inspect_escalation_token(
     )
 
 
-def redeem_escalation_token(
+def review_escalation_redemption(
     connection: sqlite3.Connection,
     *,
     token: object,
@@ -476,7 +476,7 @@ def redeem_escalation_token(
     now: int,
     grant_expires_at: int | None = None,
 ) -> SessionGrant:
-    """Consume a token once and atomically create its exact session grant."""
+    """Return the exact grant a live token may create without changing state."""
 
     current = _active_context(connection, context, now=now)
     review = inspect_escalation_token(
@@ -508,7 +508,6 @@ def redeem_escalation_token(
         )
     ):
         raise _unavailable()
-    membership_json = _membership_json(canonical_membership)
     grant_id = hashlib.sha256(
         _GRANT_ID_DOMAIN + current.session_id.encode() + b"\0" + jti.encode("ascii")
     ).hexdigest()
@@ -535,25 +534,159 @@ def redeem_escalation_token(
             else _integer(grant_expires_at, minimum=_integer(now, minimum=1) + 1),
         ),
     )
+    return grant
+
+
+def _insert_session_grant(
+    connection: sqlite3.Connection,
+    grant: SessionGrant,
+    *,
+    status: str,
+    prepared_event_id: str | None,
+) -> None:
+    connection.execute(
+        "INSERT INTO governance_session_grants "
+        "(grant_id, authorization_session_id, principal_id, issuer_family, audience, "
+        "purpose, ceiling, paths, fingerprints, scope_ids, membership_manifest, "
+        "policy_fingerprint, token_jti, status, prepared_event_id, created_at, "
+        "expires_at, revoked_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
+        "?, ?, ?, NULL)",
+        (
+            grant.grant_id,
+            grant.authorization_session_id,
+            grant.principal_id,
+            grant.issuer_family,
+            grant.audience,
+            grant.purpose,
+            grant.ceiling,
+            _canonical_json(list(grant.paths)).decode(),
+            _canonical_json(list(grant.fingerprints)).decode(),
+            _canonical_json(list(grant.scope_ids)).decode(),
+            _membership_json(grant.membership),
+            grant.policy_fingerprint,
+            grant.token_jti,
+            status,
+            prepared_event_id,
+            grant.created_at,
+            grant.expires_at,
+        ),
+    )
+
+
+def prepare_escalation_redemption(
+    connection: sqlite3.Connection,
+    *,
+    token: object,
+    context: AuthorizationSessionContext,
+    signing_key: bytes,
+    audience: str,
+    purpose: str | None,
+    membership: tuple[SessionMembership, ...],
+    policy_fingerprint: str,
+    now: int,
+    grant_expires_at: int | None,
+    prepared_event_id: str,
+    expected_grant: SessionGrant,
+) -> SessionGrant:
+    """Atomically stage one receipt-bound token redemption and exact grant."""
+
+    event_id = _text(prepared_event_id)
+    if not isinstance(expected_grant, SessionGrant) or connection.in_transaction:
+        raise _unavailable()
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        reviewed = review_escalation_redemption(
+            connection,
+            token=token,
+            context=context,
+            signing_key=signing_key,
+            audience=audience,
+            purpose=purpose,
+            membership=membership,
+            policy_fingerprint=policy_fingerprint,
+            now=now,
+            grant_expires_at=grant_expires_at,
+        )
+        if reviewed != expected_grant:
+            raise _unavailable()
+        consumed = connection.execute(
+            "UPDATE withhold_tokens SET consumed_at=?, status='prepared', "
+            "prepared_event_id=? WHERE jti=? AND authorization_session_id=? "
+            "AND status='active' AND prepared_event_id IS NULL AND consumed_at IS NULL",
+            (
+                reviewed.created_at,
+                event_id,
+                reviewed.token_jti,
+                reviewed.authorization_session_id,
+            ),
+        )
+        if consumed.rowcount != 1:
+            raise _unavailable()
+        _insert_session_grant(
+            connection,
+            reviewed,
+            status="prepared",
+            prepared_event_id=event_id,
+        )
+        connection.commit()
+    except (sqlite3.Error, AuthorizationSessionUnavailable):
+        connection.rollback()
+        raise _unavailable() from None
+    except BaseException:
+        connection.rollback()
+        raise
+    return reviewed
+
+
+def redeem_escalation_token(
+    connection: sqlite3.Connection,
+    *,
+    token: object,
+    context: AuthorizationSessionContext,
+    signing_key: bytes,
+    audience: str,
+    purpose: str | None,
+    membership: tuple[SessionMembership, ...],
+    policy_fingerprint: str,
+    now: int,
+    grant_expires_at: int | None = None,
+) -> SessionGrant:
+    """Consume a token once and atomically create its exact session grant."""
+
+    grant = review_escalation_redemption(
+        connection,
+        token=token,
+        context=context,
+        signing_key=signing_key,
+        audience=audience,
+        purpose=purpose,
+        membership=membership,
+        policy_fingerprint=policy_fingerprint,
+        now=now,
+        grant_expires_at=grant_expires_at,
+    )
+    current = _active_context(connection, context, now=now)
+    canonical_policy = grant.policy_fingerprint
+    canonical_audience = grant.audience
+    canonical_purpose = grant.purpose
+    jti = grant.token_jti
     if connection.in_transaction:
         raise _unavailable()
     try:
         connection.execute("BEGIN IMMEDIATE")
         _active_context(connection, current, now=now)
-        if inspect_escalation_token(
+        if review_escalation_redemption(
             connection,
             token=token,
             context=current,
             signing_key=signing_key,
             audience=canonical_audience,
             purpose=canonical_purpose,
+            membership=membership,
+            policy_fingerprint=canonical_policy,
             now=now,
-        ) != review:
-            raise _unavailable()
-        active_policy = connection.execute(
-            "SELECT policy_fingerprint FROM active_governance_tuple WHERE singleton=1"
-        ).fetchone()
-        if active_policy != (canonical_policy,):
+            grant_expires_at=grant_expires_at,
+        ) != grant:
             raise _unavailable()
         consumed = connection.execute(
             "UPDATE withhold_tokens SET consumed_at=?, status='consumed' "
@@ -563,30 +696,11 @@ def redeem_escalation_token(
         )
         if consumed.rowcount != 1:
             raise _unavailable()
-        connection.execute(
-            "INSERT INTO governance_session_grants "
-            "(grant_id, authorization_session_id, principal_id, issuer_family, audience, "
-            "purpose, ceiling, paths, fingerprints, scope_ids, membership_manifest, "
-            "policy_fingerprint, token_jti, status, prepared_event_id, created_at, "
-            "expires_at, revoked_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
-            "'active', NULL, ?, ?, NULL)",
-            (
-                grant.grant_id,
-                grant.authorization_session_id,
-                grant.principal_id,
-                grant.issuer_family,
-                grant.audience,
-                grant.purpose,
-                grant.ceiling,
-                _canonical_json(list(grant.paths)).decode(),
-                _canonical_json(list(grant.fingerprints)).decode(),
-                _canonical_json(list(grant.scope_ids)).decode(),
-                membership_json,
-                grant.policy_fingerprint,
-                grant.token_jti,
-                grant.created_at,
-                grant.expires_at,
-            ),
+        _insert_session_grant(
+            connection,
+            grant,
+            status="active",
+            prepared_event_id=None,
         )
         connection.commit()
     except (sqlite3.Error, AuthorizationSessionUnavailable):

--- a/src/exomem/governance/recovery.py
+++ b/src/exomem/governance/recovery.py
@@ -373,6 +373,36 @@ def _actual_component_value(
             )
         )
     if kind == "token":
+        version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+        if version >= schema_v4.SCHEMA_USER_VERSION:
+            row = conn.execute(
+                "SELECT authorization_session_id, principal_id, issuer_family, audience, "
+                "max_level, fingerprints, paths, scope_ids, purpose, org_ceiling, status, "
+                "prepared_event_id, expires_at, minted_at, consumed_at "
+                "FROM withhold_tokens WHERE jti=?",
+                (key,),
+            ).fetchone()
+            return (
+                {"status": "absent"}
+                if row is None
+                else authorization_row(
+                    authorization_session_id=str(row[0]),
+                    principal_id=str(row[1]),
+                    issuer_family=str(row[2]),
+                    audience=str(row[3]),
+                    max_level=int(row[4]),
+                    fingerprints=str(row[5]),
+                    paths=str(row[6]),
+                    scope_ids=str(row[7]),
+                    purpose=row[8],
+                    org_ceiling=int(row[9]),
+                    status=str(row[10]),
+                    prepared_event_id=row[11],
+                    expires_at=int(row[12]),
+                    minted_at=int(row[13]),
+                    consumed_at=row[14],
+                )
+            )
         row = conn.execute(
             "SELECT audience, max_level, fingerprints, paths, expires_at, minted_at, consumed_at, "
             "authorization_session, purpose, org_ceiling, status, prepared_event_id "
@@ -392,6 +422,38 @@ def _actual_component_value(
             }
         )
     if kind in {"grant", "dependent_grant"}:
+        version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+        if version >= schema_v4.SCHEMA_USER_VERSION:
+            row = conn.execute(
+                "SELECT authorization_session_id, principal_id, issuer_family, audience, "
+                "purpose, ceiling, paths, fingerprints, scope_ids, membership_manifest, "
+                "policy_fingerprint, token_jti, status, prepared_event_id, created_at, "
+                "expires_at, revoked_at FROM governance_session_grants WHERE grant_id=?",
+                (key,),
+            ).fetchone()
+            return (
+                {"status": "absent"}
+                if row is None
+                else authorization_row(
+                    authorization_session_id=str(row[0]),
+                    principal_id=str(row[1]),
+                    issuer_family=str(row[2]),
+                    audience=str(row[3]),
+                    purpose=row[4],
+                    ceiling=int(row[5]),
+                    paths=str(row[6]),
+                    fingerprints=str(row[7]),
+                    scope_ids=str(row[8]),
+                    membership_manifest=str(row[9]),
+                    policy_fingerprint=str(row[10]),
+                    token_jti=str(row[11]),
+                    status=str(row[12]),
+                    prepared_event_id=row[13],
+                    created_at=int(row[14]),
+                    expires_at=int(row[15]),
+                    revoked_at=row[16],
+                )
+            )
         row = conn.execute(
             "SELECT authorization_session, audience, purpose, ceiling, paths, fingerprints, token_jti, "
             "status, prepared_event_id, created_at, expires_at, revoked_at, membership_manifest, "

--- a/src/exomem/governance/tool.py
+++ b/src/exomem/governance/tool.py
@@ -1694,7 +1694,74 @@ def _inspect_v4_token(
     raise GovernanceError("AUTHORIZATION_SESSION_UNAVAILABLE", "authorization session is unavailable")
 
 
+def _v4_token_projection(
+    row: tuple[Any, ...],
+    *,
+    status: str,
+    prepared_event_id: str | None,
+    consumed_at: int | None,
+) -> dict[str, Any]:
+    return authorization_row(
+        authorization_session_id=str(row[0]),
+        principal_id=str(row[1]),
+        issuer_family=str(row[2]),
+        audience=str(row[3]),
+        max_level=int(row[4]),
+        fingerprints=str(row[5]),
+        paths=str(row[6]),
+        scope_ids=str(row[7]),
+        purpose=row[8],
+        org_ceiling=int(row[9]),
+        status=status,
+        prepared_event_id=prepared_event_id,
+        expires_at=int(row[12]),
+        minted_at=int(row[13]),
+        consumed_at=consumed_at,
+    )
+
+
+def _v4_grant_projection(
+    grant: authorization_session_authority.SessionGrant,
+    *,
+    status: str,
+    prepared_event_id: str | None,
+) -> dict[str, Any]:
+    membership_manifest = _canonical_json(
+        [
+            {
+                "fingerprint": item.fingerprint,
+                "path": item.path,
+                "scope_ids": list(item.scope_ids),
+            }
+            for item in grant.membership
+        ]
+    )
+    return authorization_row(
+        authorization_session_id=grant.authorization_session_id,
+        principal_id=grant.principal_id,
+        issuer_family=grant.issuer_family,
+        audience=grant.audience,
+        purpose=grant.purpose,
+        ceiling=grant.ceiling,
+        paths=_canonical_json(list(grant.paths)),
+        fingerprints=_canonical_json(list(grant.fingerprints)),
+        scope_ids=_canonical_json(list(grant.scope_ids)),
+        membership_manifest=membership_manifest,
+        policy_fingerprint=grant.policy_fingerprint,
+        token_jti=grant.token_jti,
+        status=status,
+        prepared_event_id=prepared_event_id,
+        created_at=grant.created_at,
+        expires_at=grant.expires_at,
+        revoked_at=None,
+    )
+
+
 def _grant_v4(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
+    reconcile = reconcile_governance_operations(vault_root)
+    if reconcile["blocked"]:
+        raise GovernanceError("GOVERNANCE_BLOCKED", "pending operation needs manual repair")
+    selection = kwargs["_selection"]
     who, context, custody, connection, now = _v4_authority_inputs(vault_root, kwargs)
     try:
         purpose = kwargs.get("purpose")
@@ -1739,8 +1806,9 @@ def _grant_v4(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
         ):
             raise GovernanceError("AUTHORIZATION_SESSION_UNAVAILABLE", "authorization session is unavailable")
         duration = max(1, int(kwargs.get("duration_seconds", 3600)))
-        grant = authorization_session_authority.redeem_escalation_token(
-            connection=connection,
+        grant_expires_at = min(review.expires_at, now + duration)
+        grant = authorization_session_authority.review_escalation_redemption(
+            connection,
             token=kwargs.get("token"),
             context=context,
             signing_key=signing_key,
@@ -1749,9 +1817,159 @@ def _grant_v4(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
             membership=current_membership,
             policy_fingerprint=bound_policy.fingerprint,
             now=now,
-            grant_expires_at=min(review.expires_at, now + duration),
+            grant_expires_at=grant_expires_at,
         )
-        return {"status": "committed", "grant_id": grant.grant_id}
+        token_row = connection.execute(
+            "SELECT authorization_session_id, principal_id, issuer_family, audience, "
+            "max_level, fingerprints, paths, scope_ids, purpose, org_ceiling, status, "
+            "prepared_event_id, expires_at, minted_at, consumed_at FROM withhold_tokens "
+            "WHERE jti=?",
+            (grant.token_jti,),
+        ).fetchone()
+        if token_row is None:
+            raise GovernanceError(
+                "AUTHORIZATION_SESSION_UNAVAILABLE",
+                "authorization session is unavailable",
+            )
+        nonce = uuid.uuid4().hex
+        causation_id = receipts.critical_event_id(
+            {
+                "operation": "governance_session_grant",
+                "jti": grant.token_jti,
+                "authorization_session": context.session_id,
+                "nonce": nonce,
+            }
+        )
+        child_ids = [
+            receipts.critical_event_id(
+                {"causation_id": causation_id, "intent": f"child-{index}"}
+            )
+            for index, _receipt in enumerate(selection.child_receipts, start=1)
+        ]
+        prepared_grant = _v4_grant_projection(
+            grant,
+            status="prepared",
+            prepared_event_id=causation_id,
+        )
+        phases = {
+            "prior": [
+                _component(
+                    "token",
+                    grant.token_jti,
+                    _v4_token_projection(
+                        token_row,
+                        status="active",
+                        prepared_event_id=None,
+                        consumed_at=None,
+                    ),
+                    status="active",
+                ),
+                _component("grant", grant.grant_id, {"status": "absent"}, status="absent"),
+            ],
+            "prepared": [
+                _component(
+                    "token",
+                    grant.token_jti,
+                    _v4_token_projection(
+                        token_row,
+                        status="prepared",
+                        prepared_event_id=causation_id,
+                        consumed_at=now,
+                    ),
+                    status="prepared",
+                ),
+                _component("grant", grant.grant_id, prepared_grant, status="prepared"),
+            ],
+            "final": [
+                _component(
+                    "token",
+                    grant.token_jti,
+                    _v4_token_projection(
+                        token_row,
+                        status="consumed",
+                        prepared_event_id=None,
+                        consumed_at=now,
+                    ),
+                    status="consumed",
+                ),
+                _component(
+                    "grant",
+                    grant.grant_id,
+                    {**prepared_grant, "status": "active", "prepared_event_id": None},
+                    status="active",
+                ),
+            ],
+        }
+        digests = {phase: _composite(phase, rows) for phase, rows in phases.items()}
+        affected = sorted(
+            hashlib.sha256(
+                f"{component['component_kind']}:{component['component_key']}".encode()
+            ).hexdigest()
+            for component in phases["prepared"]
+        )
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            persisted = _create_journal(
+                connection,
+                event_id=causation_id,
+                operation=selection.journal_operation,
+                who=who,
+                authorization_session=context.session_id,
+                direction="widening",
+                phases=phases,
+                child_ids=child_ids,
+                phase="allocating",
+                now=now,
+            )
+            if persisted != digests:
+                raise GovernanceError("GOVERNANCE_BLOCKED", "transition digest changed")
+            connection.commit()
+        except BaseException:
+            connection.rollback()
+            raise
+        for index, (child_id, child_operation) in enumerate(
+            zip(child_ids, selection.child_receipts, strict=True), start=1
+        ):
+            receipts.begin_event(
+                vault_root,
+                operation=child_operation,
+                prior=digests["prior"],
+                prepared=digests["prepared"],
+                target=digests["final"],
+                affected_ids=affected,
+                event_id=child_id,
+                parent_causation_id=causation_id,
+                intent_id=f"child-{index}",
+            )
+            if kwargs.get("crash_at") == f"after_child_intent:{index}":
+                raise GovernanceCrash(f"after_child_intent:{index}")
+        _arm_journal(vault_root, causation_id, now=now)
+        authorization_session_authority.prepare_escalation_redemption(
+            connection,
+            token=kwargs.get("token"),
+            context=context,
+            signing_key=signing_key,
+            audience=who.audience_id,
+            purpose=purpose,
+            membership=current_membership,
+            policy_fingerprint=bound_policy.fingerprint,
+            now=now,
+            grant_expires_at=grant_expires_at,
+            prepared_event_id=causation_id,
+            expected_grant=grant,
+        )
+        if kwargs.get("crash_at") == "after_compound_state":
+            raise GovernanceCrash("after_compound_state")
+        for index, child_id in enumerate(child_ids, start=1):
+            receipts.commit_event(vault_root, child_id, outcome="prepared")
+            if kwargs.get("crash_at") == f"after_child_terminal:{index}":
+                raise GovernanceCrash(f"after_child_terminal:{index}")
+        _activate_event(vault_root, causation_id, remove_marker=False, now=now)
+        return {
+            "status": "committed",
+            "causation_id": causation_id,
+            "grant_id": grant.grant_id,
+        }
     except authorization_session_lifecycle.AuthorizationSessionUnavailable:
         raise GovernanceError(
             "AUTHORIZATION_SESSION_UNAVAILABLE",

--- a/tests/test_govern_memory_session_selector.py
+++ b/tests/test_govern_memory_session_selector.py
@@ -354,9 +354,49 @@ def test_verified_grant_binds_product_redemption_to_context_policy_and_membershi
 
     context = _context()
     principal = _principal(context)
+    token_jti = "7" * 32
+
+    class Cursor:
+        def __init__(self, row: tuple[object, ...] | None = None) -> None:
+            self.row = row
+
+        def fetchone(self) -> tuple[object, ...] | None:
+            return self.row
 
     class Connection:
         closed = False
+
+        def execute(
+            self, statement: str, _parameters: object = None
+        ) -> Cursor:
+            if "FROM withhold_tokens" in statement:
+                return Cursor(
+                    (
+                        context.session_id,
+                        context.principal_id,
+                        context.issuer_family,
+                        context.principal_id,
+                        5,
+                        '["' + "4" * 64 + '"]',
+                        '["Notes/shared.md"]',
+                        '["scope-a"]',
+                        "support",
+                        6,
+                        "active",
+                        None,
+                        NOW + 300,
+                        NOW - 1,
+                        None,
+                    )
+                )
+            assert statement == "BEGIN IMMEDIATE"
+            return Cursor()
+
+        def commit(self) -> None:
+            pass
+
+        def rollback(self) -> None:
+            pass
 
         def close(self) -> None:
             self.closed = True
@@ -378,7 +418,32 @@ def test_verified_grant_binds_product_redemption_to_context_policy_and_membershi
         expires_at=NOW + 300,
     )
     policy = SimpleNamespace(empty=False, blocked=False, fingerprint="3" * 64)
-    calls: list[dict[str, object]] = []
+    membership = (
+        authorization_session_authority.SessionMembership(
+            path="Notes/shared.md",
+            fingerprint="4" * 64,
+            scope_ids=("scope-a", "scope-b"),
+        ),
+    )
+    grant = authorization_session_authority.SessionGrant(
+        grant_id="8" * 64,
+        authorization_session_id=context.session_id,
+        principal_id=context.principal_id,
+        issuer_family=context.issuer_family,
+        audience=context.principal_id,
+        purpose="support",
+        ceiling=5,
+        paths=("Notes/shared.md",),
+        fingerprints=("4" * 64,),
+        scope_ids=("scope-a",),
+        membership=membership,
+        policy_fingerprint="3" * 64,
+        token_jti=token_jti,
+        created_at=NOW,
+        expires_at=NOW + 300,
+    )
+    review_calls: list[dict[str, object]] = []
+    prepare_calls: list[dict[str, object]] = []
 
     monkeypatch.setattr(
         governance_tool,
@@ -404,26 +469,49 @@ def test_verified_grant_binds_product_redemption_to_context_policy_and_membershi
         lambda _path: "4" * 64,
     )
 
-    def redeem_escalation_token(**kwargs: object):
-        calls.append(kwargs)
-        assert kwargs["connection"] is connection
+    def review_escalation_redemption(
+        active: object, **kwargs: object
+    ) -> authorization_session_authority.SessionGrant:
+        review_calls.append(kwargs)
+        assert active is connection
         assert kwargs["context"] is context
         assert kwargs["signing_key"] == key
         assert kwargs["policy_fingerprint"] == "3" * 64
-        assert kwargs["membership"] == (
-            authorization_session_authority.SessionMembership(
-                path="Notes/shared.md",
-                fingerprint="4" * 64,
-                scope_ids=("scope-a", "scope-b"),
-            ),
-        )
-        return SimpleNamespace(grant_id="8" * 64)
+        assert kwargs["membership"] == membership
+        return grant
+
+    def prepare_escalation_redemption(
+        active: object, **kwargs: object
+    ) -> authorization_session_authority.SessionGrant:
+        prepare_calls.append(kwargs)
+        assert active is connection
+        assert kwargs["expected_grant"] is grant
+        assert kwargs["context"] is context
+        assert kwargs["membership"] == membership
+        return grant
 
     monkeypatch.setattr(
         authorization_session_authority,
-        "redeem_escalation_token",
-        redeem_escalation_token,
+        "review_escalation_redemption",
+        review_escalation_redemption,
     )
+    monkeypatch.setattr(
+        authorization_session_authority,
+        "prepare_escalation_redemption",
+        prepare_escalation_redemption,
+    )
+    monkeypatch.setattr(
+        governance_tool,
+        "_create_journal",
+        lambda _connection, **kwargs: {
+            phase: governance_tool._composite(phase, rows)
+            for phase, rows in kwargs["phases"].items()
+        },
+    )
+    monkeypatch.setattr(governance_tool.receipts, "begin_event", lambda *_a, **_k: None)
+    monkeypatch.setattr(governance_tool.receipts, "commit_event", lambda *_a, **_k: None)
+    monkeypatch.setattr(governance_tool, "_arm_journal", lambda *_a, **_k: None)
+    monkeypatch.setattr(governance_tool, "_activate_event", lambda *_a, **_k: None)
 
     result = governance_tool.op_govern_memory(
         tmp_path / "vault",
@@ -434,6 +522,10 @@ def test_verified_grant_binds_product_redemption_to_context_policy_and_membershi
         now=NOW,
     )
 
-    assert result == {"status": "committed", "grant_id": "8" * 64}
-    assert len(calls) == 1
+    assert result["status"] == "committed"
+    assert result["grant_id"] == "8" * 64
+    assert result["causation_id"]
+    assert len(review_calls) == 1
+    assert len(prepare_calls) == 1
+    assert prepare_calls[0]["prepared_event_id"] == result["causation_id"]
     assert connection.closed

--- a/tests/test_govern_memory_tool.py
+++ b/tests/test_govern_memory_tool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import importlib
 import json
 import os
@@ -10,7 +11,7 @@ import sqlite3
 import subprocess
 import sys
 from pathlib import Path
-from types import MappingProxyType
+from types import MappingProxyType, SimpleNamespace
 
 import pytest
 
@@ -22,6 +23,7 @@ from exomem.governance.principal import RequestPrincipal, owner_principal
 SCOPE_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
 RULE_ID = "01ARZ3NDEKTSV4RRFFQ69G5FB0"
 PATTERN_GLOB = "Knowledge Base/Notes/Patterns/**"
+V4_NOW = 1_800_000_000
 
 
 @pytest.fixture(autouse=True)
@@ -677,6 +679,133 @@ def _committed_policy(vault: Path) -> None:
     )
 
 
+def _configure_v4_grant(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[RequestPrincipal, object, str, str, str]:
+    from exomem.governance import (
+        authorization_session_authority,
+        authorization_session_lifecycle,
+        policy,
+        schema_v4,
+    )
+    from exomem.governance import tool as governance_tool
+
+    _committed_policy(vault)
+    prospective = policy.compile_prospective(vault, {})
+    assert prospective is not None and not prospective.policy.blocked
+    compiled = prospective.policy
+    seed = schema_v4.MigrationSeed(
+        activation_store_id="activation-store-grant",
+        logical_vault_id="logical-vault-grant",
+        activation_epoch=1,
+        policy=schema_v4.PolicyGenerationSeed(
+            generation_id="01ARZ3NDEKTSV4RRFFQ69G5FAX",
+            source_documents=prospective.target_documents,
+            source_fingerprint=compiled.fingerprint,
+            conflict_digest=prospective.snapshot.conflict_set_digest,
+            compiled_policy=policy.canonical_compiled_bytes(compiled),
+            policy_fingerprint=compiled.fingerprint,
+            compiler_schema_version=1,
+            projector_schema_version=1,
+            predecessor_generation_id=None,
+            authoring_event_id="authoring-v4-grant",
+            receipt_event_id="receipt-v4-grant",
+            created_at=V4_NOW,
+        ),
+        catalog=schema_v4.CatalogGenerationSeed(
+            catalog_generation=1,
+            descriptor=b'{"artifacts":[]}',
+            artifact_count=0,
+            created_at=V4_NOW,
+        ),
+        namespace=schema_v4.ProjectionNamespaceSeed(
+            namespace_id="namespace-v4-grant",
+            evidence=b'{"ready":true}',
+            ready_at=V4_NOW,
+        ),
+        migrated_at=V4_NOW,
+    )
+    connection = store.open_connection(vault)
+    try:
+        schema_v4.migrate_v3_connection(connection, seed)
+        context = authorization_session_lifecycle.AuthorizationSessionContext(
+            session_id="authorization-session:grant-recovery",
+            principal_id="principal:external",
+            issuer_family="mcp-oauth",
+            cell_id="cell-grant",
+            logical_vault_id="logical-vault-grant",
+            keyring_id="keyring-grant",
+            credential_generation=1,
+            expires_at=V4_NOW + 600,
+        )
+        connection.execute(
+            "INSERT INTO governance_authorization_sessions "
+            "(session_id, locator_digest, verifier, verifier_key_id, "
+            "credential_generation, principal_id, issuer_family, cell_id, "
+            "logical_vault_id, keyring_id, status, created_at, rotated_at, "
+            "expires_at, closed_at) VALUES (?, ?, ?, 'key-grant', 1, ?, ?, ?, ?, "
+            "?, 'active', ?, NULL, ?, NULL)",
+            (
+                context.session_id,
+                b"l" * 32,
+                b"v" * 32,
+                context.principal_id,
+                context.issuer_family,
+                context.cell_id,
+                context.logical_vault_id,
+                context.keyring_id,
+                V4_NOW,
+                context.expires_at,
+            ),
+        )
+        connection.commit()
+        path = "Knowledge Base/Notes/Patterns/kill-switch-for-risky-releases.md"
+        fingerprint = hashlib.sha256((vault / path).read_bytes()).hexdigest()
+        signing_key = b"t" * 32
+        token = authorization_session_authority.mint_escalation_token(
+            connection,
+            context=context,
+            signing_key=signing_key,
+            audience=context.principal_id,
+            purpose=None,
+            max_level=5,
+            org_ceiling=6,
+            paths=(path,),
+            fingerprints=(fingerprint,),
+            scope_ids=(SCOPE_ID,),
+            now=V4_NOW + 1,
+            expires_at=V4_NOW + 300,
+        )
+    finally:
+        connection.close()
+
+    principal = RequestPrincipal(
+        audience_id=context.principal_id,
+        surface="mcp",
+        issuer_family=context.issuer_family,
+        verified_authorization_session=context,
+    )
+    custody = SimpleNamespace(
+        keyring=SimpleNamespace(
+            accepted_keys=(SimpleNamespace(key=signing_key),),
+        )
+    )
+
+    def authority_inputs(root: Path, _kwargs: object):
+        return (
+            principal,
+            context,
+            custody,
+            store.open_authorization_session_connection(root),
+            V4_NOW + 2,
+        )
+
+    monkeypatch.setattr(governance_tool, "_v4_authority_inputs", authority_inputs)
+    monkeypatch.setattr(governance_tool.policy_module, "load", lambda _root: compiled)
+    return principal, context, token, path, fingerprint
+
+
 def test_grant_compound_receipts_leave_schema_v3_session_grant_inert_until_v4(
     vault: Path,
 ) -> None:
@@ -753,6 +882,152 @@ def test_grant_compound_receipts_leave_schema_v3_session_grant_inert_until_v4(
             authorization_session="conversation-a",
             token=token,
         )
+
+
+def test_v4_grant_receipt_composite_persists_exact_reviewed_scope_ids(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import receipts
+    from exomem.governance.tool import op_govern_memory
+
+    principal, _context, token, _path, _fingerprint = _configure_v4_grant(
+        vault, monkeypatch
+    )
+
+    granted = op_govern_memory(
+        vault,
+        operation="grant",
+        principal=principal,
+        token=token,
+        duration_seconds=600,
+    )
+
+    assert granted["status"] == "committed"
+    assert granted["causation_id"]
+    records = receipts.event_records(vault)
+    assert {
+        record["operation"]
+        for record in records
+        if record.get("phase") == "intent"
+        and record.get("parent_causation_id") == granted["causation_id"]
+    } == {"governance_token_redemption", "governance_grant_creation"}
+    with sqlite3.connect(store.sidecar_path(vault)) as connection:
+        scope_ids, membership_manifest, status = connection.execute(
+            "SELECT scope_ids, membership_manifest, status "
+            "FROM governance_session_grants WHERE grant_id=?",
+            (granted["grant_id"],),
+        ).fetchone()
+        component = connection.execute(
+            "SELECT value_json FROM governance_operation_components "
+            "WHERE event_id=? AND phase='final' AND component_kind='grant'",
+            (granted["causation_id"],),
+        ).fetchone()
+    assert json.loads(scope_ids) == [SCOPE_ID]
+    assert json.loads(membership_manifest)[0]["scope_ids"] == [SCOPE_ID]
+    assert status == "active"
+    assert component is not None
+    projected = json.loads(component[0])
+    assert projected["scope_ids"] == json.dumps([SCOPE_ID], separators=(",", ":"))
+    assert json.loads(projected["membership_manifest"])[0]["scope_ids"] == [SCOPE_ID]
+
+
+def test_v4_grant_crash_recovers_only_the_exact_scope_bound_prepared_state(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import authorization_session_authority
+    from exomem.governance.tool import (
+        GovernanceCrash,
+        op_govern_memory,
+        reconcile_governance_operations,
+    )
+
+    principal, context, token, path, fingerprint = _configure_v4_grant(
+        vault, monkeypatch
+    )
+    with pytest.raises(GovernanceCrash, match="after_compound_state"):
+        op_govern_memory(
+            vault,
+            operation="grant",
+            principal=principal,
+            token=token,
+            crash_at="after_compound_state",
+        )
+
+    with sqlite3.connect(store.sidecar_path(vault)) as connection:
+        assert connection.execute(
+            "SELECT status, scope_ids FROM governance_session_grants"
+        ).fetchone() == ("prepared", json.dumps([SCOPE_ID], separators=(",", ":")))
+    recovered = reconcile_governance_operations(vault)
+    assert recovered["activated"] == 1 and recovered["blocked"] is False
+
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        active, _identity = authorization_session_authority.active_session_grants(
+            connection,
+            context=context,
+            audience=context.principal_id,
+            purpose=None,
+            path=path,
+            fingerprint=fingerprint,
+            scope_ids=(SCOPE_ID,),
+            policy_fingerprint=connection.execute(
+                "SELECT policy_fingerprint FROM active_governance_tuple WHERE singleton=1"
+            ).fetchone()[0],
+            now=V4_NOW + 3,
+        )
+        drifted, _identity = authorization_session_authority.active_session_grants(
+            connection,
+            context=context,
+            audience=context.principal_id,
+            purpose=None,
+            path=path,
+            fingerprint=fingerprint,
+            scope_ids=(SCOPE_ID, "scope-added-after-review"),
+            policy_fingerprint=connection.execute(
+                "SELECT policy_fingerprint FROM active_governance_tuple WHERE singleton=1"
+            ).fetchone()[0],
+            now=V4_NOW + 3,
+        )
+    finally:
+        connection.close()
+    assert tuple(grant.scope_ids for grant in active) == ((SCOPE_ID,),)
+    assert drifted == ()
+
+
+def test_v4_grant_scope_tamper_blocks_receipt_recovery(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.tool import (
+        GovernanceCrash,
+        op_govern_memory,
+        reconcile_governance_operations,
+    )
+
+    principal, _context, token, _path, _fingerprint = _configure_v4_grant(
+        vault, monkeypatch
+    )
+    with pytest.raises(GovernanceCrash, match="after_compound_state"):
+        op_govern_memory(
+            vault,
+            operation="grant",
+            principal=principal,
+            token=token,
+            crash_at="after_compound_state",
+        )
+    with sqlite3.connect(store.sidecar_path(vault)) as connection:
+        connection.execute(
+            "UPDATE governance_session_grants SET scope_ids=?",
+            (json.dumps([SCOPE_ID, "unreviewed-scope"], separators=(",", ":")),),
+        )
+        connection.commit()
+
+    recovered = reconcile_governance_operations(vault)
+
+    assert recovered["activated"] == 0
+    assert recovered["blocked"] is True
 
 
 def test_grant_explicit_session_scope_activates_like_the_omitted_scope(vault: Path) -> None:

--- a/tests/test_governance_store.py
+++ b/tests/test_governance_store.py
@@ -8,13 +8,58 @@ never the enforcement authority, never consulted by the live `policy.load`/
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 
 import pytest
 
 from exomem.governance import compile as governance_compile
-from exomem.governance import policy, store, tokens
+from exomem.governance import policy, schema_v4, store, tokens
+
+MIGRATION_NOW = 1_800_000_000
+
+
+def _legacy_expiry_migration_seed() -> schema_v4.MigrationSeed:
+    documents = (
+        (
+            "scopes/migration.yaml",
+            b"governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\npaths:\n  - Notes/**\n",
+        ),
+    )
+    compiled = policy.compile_documents(dict(documents))
+    assert not compiled.empty and not compiled.blocked
+    return schema_v4.MigrationSeed(
+        activation_store_id="activation-store-legacy-expiry",
+        logical_vault_id="logical-vault-legacy-expiry",
+        activation_epoch=1,
+        policy=schema_v4.PolicyGenerationSeed(
+            generation_id="01ARZ3NDEKTSV4RRFFQ69G5FAX",
+            source_documents=documents,
+            source_fingerprint=compiled.fingerprint,
+            conflict_digest="0" * 64,
+            compiled_policy=policy.canonical_compiled_bytes(compiled),
+            policy_fingerprint=compiled.fingerprint,
+            compiler_schema_version=1,
+            projector_schema_version=1,
+            predecessor_generation_id=None,
+            authoring_event_id="authoring-legacy-expiry",
+            receipt_event_id="receipt-legacy-expiry",
+            created_at=MIGRATION_NOW,
+        ),
+        catalog=schema_v4.CatalogGenerationSeed(
+            catalog_generation=1,
+            descriptor=b'{"artifacts":[]}',
+            artifact_count=0,
+            created_at=MIGRATION_NOW,
+        ),
+        namespace=schema_v4.ProjectionNamespaceSeed(
+            namespace_id="namespace-legacy-expiry",
+            evidence=b'{"ready":true}',
+            ready_at=MIGRATION_NOW,
+        ),
+        migrated_at=MIGRATION_NOW,
+    )
 
 
 def test_open_connection_creates_sidecar_with_pragmas_and_meta(vault: Path) -> None:
@@ -81,6 +126,54 @@ def test_v3_session_grant_rows_are_non_authoritative(vault: Path) -> None:
 
     assert active == []
     assert identity == "v3-session-grants-unscoped"
+
+
+def test_v3_to_v4_migration_monotonically_expires_manifest_only_session_grants(
+    vault: Path,
+) -> None:
+    connection = store.open_connection(vault)
+    connection.execute(
+        "INSERT INTO governance_session_grants "
+        "(grant_id, authorization_session, audience, purpose, ceiling, paths, "
+        "fingerprints, token_jti, status, created_at, expires_at, "
+        "membership_manifest, policy_fingerprint) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "legacy-grant",
+            "caller-chosen-session",
+            "external",
+            None,
+            6,
+            '["Notes/a.md"]',
+            '["hash"]',
+            "legacy-token",
+            "active",
+            0.0,
+            4_000_000_000.0,
+            '[{"path":"Notes/a.md","scope_ids":["scope-a"]}]',
+            "legacy-policy",
+        ),
+    )
+    connection.commit()
+
+    schema_v4.migrate_v3_connection(connection, _legacy_expiry_migration_seed())
+
+    assert connection.execute("PRAGMA user_version").fetchone() == (4,)
+    assert connection.execute(
+        "SELECT COUNT(*) FROM governance_session_grants"
+    ).fetchone() == (0,)
+    archived = connection.execute(
+        "SELECT row_json, reason, expired_at FROM governance_legacy_authority "
+        "WHERE source_table='governance_session_grants' AND source_key='legacy-grant'"
+    ).fetchone()
+    connection.close()
+    assert archived is not None
+    row = json.loads(archived[0])
+    assert "scope_ids" not in row
+    assert row["membership_manifest"] == (
+        '[{"path":"Notes/a.md","scope_ids":["scope-a"]}]'
+    )
+    assert archived[1:] == ("v3-unbound-authorization", MIGRATION_NOW)
 
 
 def test_existing_v3_sidecar_gets_purpose_staging_table_idempotently(vault: Path) -> None:


### PR DESCRIPTION
## Summary

- route verified schema-v4 session grants through the existing receipt-first compound journal instead of directly consuming the token
- persist exact reviewed scope, membership, policy, principal, and issuer bindings in prior/prepared/final recovery projections
- recover a crash only when the live v4 token and grant rows still match those projections; altered scopes fail closed
- preserve direct authority API atomicity and archive unprovable v3 grant authority during the v3-to-v4 migration
- close OpenSpec tasks 1.7 and 1.10, bringing the hardening ledger to 78/121 complete

## Stack and rollout safety

- stacked on #833, which is stacked on #832
- intentionally unmerged pending the separate Personal Exomem stability audit
- no service, deployment, Personal vault, or POLLY vault changes

## Verification

- red first: 2 expected product failures / 1 migration pass before implementation
- `42 passed, 154 deselected` across the focused grant/session/store/authority slice
- `13 passed, 156 deselected` across compound crash, tamper, and TTL recovery cases
- exact v4 receipt/recovery/tamper plus migration slice: `4 passed`
- `openspec validate harden-governance-for-consolidation --strict`
- Ruff on all touched Python files
- `git diff --check`
- `uv lock --check`
- `scripts/validate-public-artifacts.py --repository`
