### PR TITLE
test(governance): prove workspace edits stay pending

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -10,7 +10,7 @@ this reconciliation is `origin/main` at `9dc37201` plus stacked evidence PR #832
 | --- | --- | --- |
 | Per-scope disclosure | Conservative lattice, option meet, unconditional scrubber, and session-bound scope enforcement are merged. | Exact v3 grant migration and receipt-first v4 scope-bound recovery are implemented and evidenced in this stacked change; no section 1 obligation remains. Merge stays behind the Personal stability hold. |
 | Non-Markdown membership | Descriptor binding, owner backfill, fail-closed propagation, structured-read preflight, and the combined regression matrix are complete through #723, #724, #727, and green PR #832 CI. | No section 2 obligation remains. |
-| Policy authority | Prospective snapshots, exact proposal authority binding, atomic policy publication, the held workspace mirror, and policy/content/companion/measurement/graph writer successors are merged through #729, #740, and #800-#830. | Remaining workspace-race, migration, recovery, suspend/resume/undo, and combined evidence closure in 3.4-3.7 and 3.12-3.13. |
+| Policy authority | Prospective snapshots, exact proposal authority binding, atomic policy publication, the held workspace mirror, and policy/content/companion/measurement/graph writer successors are merged through #729, #740, and #800-#830. | Direct workspace pending-vs-blocked authority evidence is complete in this stacked change. Remaining publication concurrency, migration, recovery, suspend/resume/undo, and combined evidence closure is in 3.5-3.7 and 3.12-3.13. |
 | Reserved state | Held filesystem substrate and the closed reserved-path monopoly are merged and complete. | Final whole-change review/verification only. |
 | Authorization sessions | Credential verification, external custody, schema-v4 authority, transport binding, standalone attachment, and serving-membership verification are merged in #728, #732, #734, #737, #741, #772, #775, and #778. | Hosted membership publisher, complete move/restore and v3 migration/downmigration, hygiene, and combined lifecycle evidence in the remaining section 5 tasks. |
 | Direct reads | Markdown and structured-direct gates are merged in #730/#731; the full L0-L6 and registry-proven never-enrolled matrix is complete in stacked PR #832. | No section 7 implementation obligation remains; merge stays behind the Personal stability hold. |
@@ -138,7 +138,7 @@ this reconciliation is `origin/main` at `9dc37201` plus stacked evidence PR #832
   exact workspace byte map/source/conflict/guard identities, reviewed active policy/
   projector/catalog tuple, canonical target compiled bytes/fingerprint/schema versions,
   exact membership, and ready projection namespace; reject any tuple mismatch at commit.
-- [ ] 3.4 Add red tests proving direct workspace create/edit/delete/conflict never changes
+- [x] 3.4 Add red tests proving direct workspace create/edit/delete/conflict never changes
   active authority. Prove valid edits/deletions remain pending and deletion does not
   revoke, while missing/corrupt/conflicted workspace blocks warm/restart content. Barrier
   every edit before/after snapshot and tuple commit; assert the cooperatively fenced

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -2256,6 +2256,126 @@ def test_v4_policy_load_uses_the_verified_immutable_generation_not_live_yaml(
     assert pending.rules[0].ceiling == 2
 
 
+@pytest.mark.parametrize("mutation", ("create", "edit", "delete"))
+def test_v4_valid_direct_workspace_mutation_is_pending_not_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutation: str,
+) -> None:
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _write_workspace(vault, _documents(ceiling=2))
+    result = _migrate(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=result.activation_state_digest,
+        now=now,
+    )
+    active_before = policy.load(vault)
+    rule = vault / "Knowledge Base" / "_Governance" / "rules" / "external.yaml"
+    if mutation == "create":
+        rule.with_name("pending.yaml").write_text(
+            "governance_version: 1\n"
+            "id: 01ARZ3NDEKTSV4RRFFQ69G5FB1\n"
+            "scope_ids:\n"
+            f"  - {SCOPE_ID}\n"
+            "audience: external\n"
+            "ceiling: 0\n",
+            encoding="utf-8",
+        )
+    elif mutation == "edit":
+        rule.write_bytes(dict(_documents(ceiling=0))["rules/external.yaml"])
+    else:
+        rule.unlink()
+
+    pending = policy.compile_prospective(vault, {})
+    served = policy.load(vault)
+    with sqlite3.connect(store.sidecar_path(vault)) as connection:
+        active_after = connection.execute(
+            "SELECT policy_generation_id, policy_fingerprint, projector_schema_version, "
+            "catalog_generation "
+            "FROM active_governance_tuple WHERE singleton=1"
+        ).fetchone()
+        activation_after = connection.execute(
+            "SELECT activation_epoch, activation_state_digest "
+            "FROM governance_activation_store WHERE singleton=1"
+        ).fetchone()
+        policy_publications = connection.execute(
+            "SELECT COUNT(*) FROM governance_tuple_publications "
+            "WHERE publication_kind='policy'"
+        ).fetchone()
+
+    assert pending is not None and not pending.policy.blocked
+    assert pending.policy.fingerprint != active_before.fingerprint
+    assert served == active_before
+    assert served.rules[0].ceiling == 2
+    assert active_after == (
+        FIRST_GENERATION_ID,
+        active_before.fingerprint,
+        1,
+        1,
+    )
+    assert activation_after == (1, result.activation_state_digest)
+    assert policy_publications == (0,)
+
+
+@pytest.mark.parametrize("mutation", ("conflict", "unparsable", "missing"))
+def test_v4_invalid_direct_workspace_blocks_warm_and_restart_without_tuple_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutation: str,
+) -> None:
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _write_workspace(vault, _documents(ceiling=2))
+    result = _migrate(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=result.activation_state_digest,
+        now=now,
+    )
+    assert policy.load(vault).rules[0].ceiling == 2
+    rule = vault / "Knowledge Base" / "_Governance" / "rules" / "external.yaml"
+    if mutation == "conflict":
+        rule.with_name(
+            "external.sync-conflict-20260826-120000-ABCDEFG.yaml"
+        ).write_bytes(rule.read_bytes())
+    elif mutation == "unparsable":
+        rule.write_text("governance_version: 1\nceiling: [\n", encoding="utf-8")
+    else:
+        root = vault / "Knowledge Base" / "_Governance"
+        for path in sorted(root.rglob("*"), reverse=True):
+            path.rmdir() if path.is_dir() else path.unlink()
+        root.rmdir()
+
+    warm = policy.load(vault)
+    policy._CACHE.clear()
+    policy._LAST_GOOD.clear()
+    policy._compile_pinned_documents.cache_clear()
+    restarted = policy.load(vault)
+    with sqlite3.connect(store.sidecar_path(vault)) as connection:
+        active_after = connection.execute(
+            "SELECT policy_generation_id, policy_fingerprint "
+            "FROM active_governance_tuple WHERE singleton=1"
+        ).fetchone()
+        activation_after = connection.execute(
+            "SELECT activation_epoch, activation_state_digest "
+            "FROM governance_activation_store WHERE singleton=1"
+        ).fetchone()
+
+    assert warm.blocked
+    assert restarted.blocked
+    assert active_after == (
+        FIRST_GENERATION_ID,
+        _compiled(_documents(ceiling=2)).fingerprint,
+    )
+    assert activation_after == (1, result.activation_state_digest)
+
+
 def test_v4_policy_load_blocks_registry_tuple_mismatch_and_workspace_loss(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- prove direct valid workspace create, edit, and delete remain reviewable pending input but never change the active policy generation
- prove deletion does not revoke the active rule and no policy publication row appears
- prove conflict copies, unparsable YAML, and a missing workspace block both warm and restart reads without mutating the active tuple
- combine that matrix with the existing snapshot and held-mirror barrier coverage to close OpenSpec task 3.4

## Stack and rollout safety

- stacked on #835, then #833 and #832
- test/OpenSpec-only; no production runtime behavior changes
- intentionally unmerged pending the separate Personal Exomem stability audit
- no service, deployment, Personal vault, or POLLY vault changes

## Verification

- direct pending-vs-blocked matrix: `6 passed, 92 deselected`
- combined direct workspace, prospective snapshot, and held-mirror barriers: `15 passed, 184 deselected`
- `openspec validate harden-governance-for-consolidation --strict`
- Ruff on the touched test module
- `git diff --check`
- `uv lock --check`
- `scripts/validate-public-artifacts.py --repository`
