### PR TITLE
fix(governance): prevent bearer persistence

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -322,7 +322,7 @@ made before both PRs and their combined verification are complete.
   status, close, replay of the old bearer, restart/resume, and two v4 processes/replicas.
   Add malformed/extra-copy/raised issuance tests proving the terminal scrubber exception
   activates only after exact response validation and otherwise scrubs/refuses.
-- [ ] 5.5 Add red hygiene tests that scan request copies, sidecar rows, receipts, journals,
+- [x] 5.5 Add red hygiene tests that scan request copies, sidecar rows, receipts, journals,
   token claims, logs, metrics, traces, error/remediation strings, repr/debug output,
   idempotency/control-plane rows, and corpus projection for the exact raw bearer and find zero copies outside the
   exact typed successful issue field/protected request input; scan retry/validation/

--- a/src/exomem/governance/authorization_transport.py
+++ b/src/exomem/governance/authorization_transport.py
@@ -14,6 +14,7 @@ from functools import partial
 from io import TextIOWrapper
 from pathlib import Path
 from typing import Any, Final
+from urllib.parse import quote_plus, unquote_plus
 
 import anyio
 import mcp.types
@@ -37,6 +38,7 @@ from .authorization_request import (
 AUTHORIZATION_SESSION_HEADER_NAME: Final = "X-Exomem-Authorization-Session"
 AUTHORIZATION_SESSION_HEADER: Final = AUTHORIZATION_SESSION_HEADER_NAME.lower().encode()
 MCP_CREDENTIAL_PARAMETER: Final = "authorization_session_credential"
+_REDACTED_CREDENTIAL_VALUE: Final = "authorization-session-credential-removed"
 _MAX_MCP_JSON_BYTES: Final = 64 * 1024 * 1024
 _REQUEST_CARRIER: ContextVar[CredentialCarrier | None] = ContextVar(
     "exomem_authorization_credential_carrier", default=None
@@ -193,6 +195,42 @@ def _pairs_to_value(value: object) -> object:
     return value
 
 
+def _redact_canonical_bearer_text(value: str) -> tuple[str, bool]:
+    spans = tuple(authorization_sessions.iter_credential_spans(value))
+    if not spans:
+        return value, False
+    output: list[str] = []
+    cursor = 0
+    for start, end in spans:
+        output.extend((value[cursor:start], _REDACTED_CREDENTIAL_VALUE))
+        cursor = end
+    output.append(value[cursor:])
+    return "".join(output), True
+
+
+def _redact_canonical_bearers(value: object) -> tuple[object, bool]:
+    if isinstance(value, str):
+        return _redact_canonical_bearer_text(value)
+    if isinstance(value, dict):
+        output: dict[object, object] = {}
+        found = False
+        for key, item in value.items():
+            clean_key, key_found = _redact_canonical_bearers(key)
+            clean_item, item_found = _redact_canonical_bearers(item)
+            output[clean_key] = clean_item
+            found = found or key_found or item_found
+        return output, found
+    if isinstance(value, list):
+        output = []
+        found = False
+        for item in value:
+            clean_item, item_found = _redact_canonical_bearers(item)
+            output.append(clean_item)
+            found = found or item_found
+        return output, found
+    return value, False
+
+
 def _pair_value(pairs: _ObjectPairs, key: str) -> object:
     matches = [value for candidate, value in pairs if candidate == key]
     return matches[-1] if matches else None
@@ -245,6 +283,12 @@ def _sanitize_call(value: _ObjectPairs) -> tuple[object, CredentialCarrier, str 
             for key, item in arguments
             if key != MCP_CREDENTIAL_PARAMETER
         }
+    sanitized_arguments, misplaced_bearer = _redact_canonical_bearers(
+        sanitized_arguments
+    )
+    if misplaced_bearer:
+        carrier.discard()
+        carrier = CredentialCarrier.invalid()
 
     sanitized_params = {
         key: (
@@ -319,6 +363,103 @@ def sanitize_mcp_stdio_line(line: str) -> SessionMessage:
             request_context=_StdioAuthorizationRequest(sanitized.carrier)
         ),
     )
+
+
+def _is_http_command_path(path: str) -> bool:
+    parts = tuple(part for part in path.rstrip("/").split("/") if part)
+    return (
+        (len(parts) == 2 and parts[0] == "api")
+        or (
+            len(parts) == 5
+            and parts[:4] == ("private", "exomem", "v1", "command")
+        )
+        or (
+            len(parts) == 7
+            and parts[:4] == ("private", "exomem", "v1", "agent")
+            and parts[5] == "command"
+        )
+    )
+
+
+def _redact_forbidden_query_carrier(raw: object) -> bytes:
+    if raw is None:
+        return b""
+    if not isinstance(raw, bytes) or not raw:
+        return b""
+    changed = False
+    carrier_present = False
+    output: list[str] = []
+    try:
+        text = raw.decode("ascii")
+        for field in text.split("&"):
+            name, separator, value = field.partition("=")
+            decoded_name = unquote_plus(name)
+            decoded_value = unquote_plus(value)
+            cleaned_value, bearer_found = _redact_canonical_bearer_text(
+                decoded_value
+            )
+            if decoded_name == MCP_CREDENTIAL_PARAMETER:
+                cleaned_value = _REDACTED_CREDENTIAL_VALUE
+                separator = "="
+                carrier_present = True
+            if bearer_found or decoded_name == MCP_CREDENTIAL_PARAMETER:
+                value = quote_plus(cleaned_value)
+                changed = True
+            output.append(name + separator + value)
+    except (UnicodeDecodeError, ValueError):
+        scrubbed = _scrub_canonical_bearers_from_bytes(raw)
+        if scrubbed == raw:
+            return raw
+        return (
+            scrubbed
+            + b"&"
+            + MCP_CREDENTIAL_PARAMETER.encode()
+            + b"="
+            + _REDACTED_CREDENTIAL_VALUE.encode()
+        )
+    if changed and not carrier_present:
+        output.append(
+            MCP_CREDENTIAL_PARAMETER + "=" + quote_plus(_REDACTED_CREDENTIAL_VALUE)
+        )
+    return "&".join(output).encode("ascii") if changed else raw
+
+
+def _scrub_canonical_bearers_from_bytes(raw: bytes) -> bytes:
+    text = raw.decode("latin-1")
+    cleaned, found = _redact_canonical_bearer_text(text)
+    return cleaned.encode("latin-1") if found else raw
+
+
+def _redact_forbidden_http_body_carrier(raw: bytes) -> bytes:
+    try:
+        parsed = json.loads(raw, object_pairs_hook=_ObjectPairs)
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError):
+        return _scrub_canonical_bearers_from_bytes(raw)
+    if not isinstance(parsed, _ObjectPairs):
+        return raw
+    carrier_present = any(key == MCP_CREDENTIAL_PARAMETER for key, _value in parsed)
+    sanitized, bearer_found = _redact_canonical_bearers(_pairs_to_value(parsed))
+    if not carrier_present and not bearer_found:
+        return raw
+    assert isinstance(sanitized, dict)
+    sanitized[MCP_CREDENTIAL_PARAMETER] = _REDACTED_CREDENTIAL_VALUE
+    return json.dumps(sanitized, separators=(",", ":"), ensure_ascii=False).encode()
+
+
+def _redacting_http_receive(original_receive: Receive) -> Receive:
+    replay: Receive | None = None
+
+    async def receive() -> ASGIMessage:
+        nonlocal replay
+        if replay is None:
+            raw = await _read_asgi_body(original_receive)
+            replay = _replay_body(
+                _redact_forbidden_http_body_carrier(raw),
+                original_receive,
+            )
+        return await replay()
+
+    return receive
 
 
 @asynccontextmanager
@@ -507,6 +648,14 @@ class AuthorizationCarrierMiddleware:
         carrier = header_carrier
         request_receive = receive
         request_path = str(scope.get("path") or "").rstrip("/") or "/"
+        if scope.get("method") == "POST" and _is_http_command_path(request_path):
+            sanitized_scope = {
+                **sanitized_scope,
+                "query_string": _redact_forbidden_query_carrier(
+                    scope.get("query_string")
+                ),
+            }
+            request_receive = _redacting_http_receive(receive)
         if (
             self.mcp_path is not None
             and scope.get("method") == "POST"

--- a/src/exomem/governance/egress.py
+++ b/src/exomem/governance/egress.py
@@ -2604,6 +2604,20 @@ def postfilter(command_name: str, result: Any, vault_root: Path) -> Any:
     if result is None:
         return None
     issuance_context = scrubber._issuance_projection_context(result)
+    if issuance_context is not None:
+        # `rotate` has already invalidated the request's prior credential by
+        # the time terminal filtering runs. Re-entering the ordinary artifact
+        # gate would revalidate that stale context and swallow the one-time
+        # replacement. The sealed issuance projection was created only after
+        # exact lifecycle-shape validation and still runs the non-disableable
+        # terminal scrubber over every non-bearer field here.
+        cleaned, blocked = scrubber._scrub_issuance_projection(
+            result,
+            issuance_context,
+        )
+        if blocked:
+            _record_credential_block()
+        return cleaned
     vault_root = Path(vault_root)
     result = _withheld_cross_check(vault_root, result)
     # Free text and nested resource/prompt strings have no structural entry
@@ -2621,13 +2635,7 @@ def postfilter(command_name: str, result: Any, vault_root: Path) -> Any:
         if blocked:
             _record_credential_block()
         return cleaned
-    if issuance_context is not None:
-        cleaned, blocked = scrubber._scrub_issuance_projection(
-            result,
-            issuance_context,
-        )
-    else:
-        cleaned, blocked = scrubber.scrub_value(result)
+    cleaned, blocked = scrubber.scrub_value(result)
     if blocked:
         _record_credential_block()
     return cleaned

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -2563,6 +2563,19 @@ class LeaseManager:
         else:
             assert public_idempotency_key is None or isinstance(public_idempotency_key, str)
             effective_public_idempotency_key = public_idempotency_key
+        authorization_issuance = (
+            command.name == "govern_memory"
+            and kwargs.get("operation") == "session"
+            and kwargs.get("session_action") in {"open", "rotate"}
+        )
+        if authorization_issuance:
+            # The generic mutation store pickles its terminal for replay. An
+            # authorization-session issuance terminal contains the one raw
+            # bearer occurrence the product may return, so it must never enter
+            # that durable cache (or be emitted a second time by replay).
+            idempotency_key = None
+            implicit_idempotency_scope = None
+            effective_public_idempotency_key = None
         invocation_read_only = command.read_only if read_only is None else read_only
         if invocation_read_only:
             # Reads never take the mutation boundary, hosted or local: every

--- a/tests/test_authorization_carriers.py
+++ b/tests/test_authorization_carriers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from asyncio import run
 
 import pytest
 
@@ -233,3 +234,98 @@ def test_cli_fd_reader_marks_oversized_or_malformed_input_invalid(payload: bytes
         os.close(read_fd)
         if write_fd >= 0:
             os.close(write_fd)
+
+
+@pytest.mark.parametrize(
+    ("path", "query_string", "body"),
+    [
+        (
+            "/api/ask_memory",
+            f"authorization_session_credential={BEARER}".encode(),
+            b'{"query":"governance"}',
+        ),
+        (
+            "/private/exomem/v1/command/ask_memory",
+            b"",
+            json.dumps(
+                {
+                    "query": "governance",
+                    "authorization_session_credential": BEARER,
+                }
+            ).encode(),
+        ),
+        (
+            "/private/exomem/v1/agent/hosted-alpha-agent-v2/command/ask_memory",
+            b"",
+            json.dumps({"query": f"show inert text {BEARER}"}).encode(),
+        ),
+    ],
+)
+def test_forbidden_http_carrier_is_redacted_before_downstream_request_copies(
+    path: str,
+    query_string: bytes,
+    body: bytes,
+) -> None:
+    from exomem.governance.authorization_transport import AuthorizationCarrierMiddleware
+
+    downstream: list[object] = []
+    sent: list[dict[str, object]] = []
+
+    async def app(scope, receive, send) -> None:
+        downstream.append(scope)
+        downstream.append(await receive())
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    received = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal received
+        if received:
+            return {"type": "http.disconnect"}
+        received = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        sent.append(message)
+
+    run(
+        AuthorizationCarrierMiddleware(app)(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": path,
+                "query_string": query_string,
+                "headers": [(b"content-type", b"application/json")],
+            },
+            receive,
+            send,
+        )
+    )
+
+    rendered = repr((downstream, sent))
+    assert "authorization_session_credential" in rendered
+    assert BEARER not in rendered
+
+
+def test_mcp_bearer_outside_protected_placeholder_is_redacted_and_invalid() -> None:
+    from exomem.governance import authorization_request
+    from exomem.governance.authorization_transport import sanitize_mcp_http_body
+
+    raw = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "tools/call",
+            "params": {
+                "name": "ask_memory",
+                "arguments": {"query": f"retrieved text {BEARER}"},
+            },
+        }
+    ).encode()
+
+    sanitized = sanitize_mcp_http_body(raw)
+
+    assert sanitized.carrier.consume() is authorization_request.INVALID_CREDENTIAL
+    assert BEARER not in sanitized.body.decode()
+    assert BEARER not in repr(sanitized.arguments)

--- a/tests/test_authorization_session_wire_reconnect.py
+++ b/tests/test_authorization_session_wire_reconnect.py
@@ -14,7 +14,7 @@ import pytest
 from record_fixtures import copy_dataset_fixture
 from starlette.testclient import TestClient
 
-from exomem import commands, server, video_frames, writer_lease
+from exomem import commands, metrics, server, video_frames, writer_lease
 from exomem.governance import (
     authorization_custody,
     authorization_serving_membership,
@@ -112,6 +112,17 @@ def _private_file(path: Path, payload: bytes) -> None:
         )
     else:
         path.chmod(0o600)
+
+
+def _files_containing(root: Path, needle: str) -> tuple[str, ...]:
+    encoded = needle.encode()
+    return tuple(
+        sorted(
+            path.relative_to(root).as_posix()
+            for path in root.rglob("*")
+            if path.is_file() and encoded in path.read_bytes()
+        )
+    )
 
 
 def _framed(domain: bytes, fields: list[bytes]) -> bytes:
@@ -559,7 +570,7 @@ def test_stateless_mcp_session_resumes_on_another_replica(
     writer_lease.reset_managers_for_tests()
     replica_b = _build_replica(vault, monkeypatch)
     with TestClient(replica_b) as client:
-        replayed_open = _call(
+        second_open = _call(
             client,
             2,
             {
@@ -568,9 +579,11 @@ def test_stateless_mcp_session_resumes_on_another_replica(
                 "ttl_seconds": 600,
             },
         )
-        replayed_diagnostics = replayed_open["diagnostics"]
-        assert isinstance(replayed_diagnostics, dict)
-        assert replayed_diagnostics["issued_credential"]["bearer"] == bearer
+        second_diagnostics = second_open["diagnostics"]
+        assert isinstance(second_diagnostics, dict)
+        second_bearer = second_diagnostics["issued_credential"]["bearer"]
+        assert isinstance(second_bearer, str)
+        assert second_bearer != bearer
 
         resumed_terminal = _call(
             client,
@@ -617,12 +630,92 @@ def test_stateless_mcp_session_resumes_on_another_replica(
             assert bearer not in refused.text
             assert UNKNOWN_SESSION_BEARER not in refused.text
 
+        rotated_terminal = _call(
+            client,
+            7,
+            {
+                "operation": "session",
+                "session_action": "rotate",
+                "ttl_seconds": 700,
+                "authorization_session_credential": bearer,
+            },
+        )
+        rotated_diagnostics = rotated_terminal["diagnostics"]
+        assert isinstance(rotated_diagnostics, dict)
+        rotated_bearer = rotated_diagnostics["issued_credential"]["bearer"]
+        assert isinstance(rotated_bearer, str)
+        assert rotated_bearer != bearer
+        refused_retry = _request(
+            client,
+            8,
+            {
+                "operation": "session",
+                "session_action": "rotate",
+                "ttl_seconds": 700,
+                "authorization_session_credential": bearer,
+            },
+        )
+        assert "authorization session is unavailable" in refused_retry.text
+        assert bearer not in refused_retry.text
+        assert rotated_bearer not in refused_retry.text
+
     resumed = resumed_terminal["diagnostics"]
     assert isinstance(resumed, dict)
     assert resumed["status"] == "active"
     assert "issued_credential" not in resumed
     assert bearer not in json.dumps(resumed, sort_keys=True)
     assert bearer not in caplog.text
+    assert _files_containing(tmp_path, bearer) == ()
+    assert _files_containing(tmp_path, second_bearer) == ()
+    assert _files_containing(tmp_path, rotated_bearer) == ()
+
+
+def test_retrieved_issuance_shaped_text_is_scrubbed_and_cannot_open_a_session(
+    vault: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_v4_authority(vault, tmp_path / "inert-custody", monkeypatch)
+    marker = "retrieved-session-shape-remains-data"
+    page = vault / "Knowledge Base" / "Inbox" / "inert-session-text.md"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text(
+        "# Inert session-shaped text\n\n"
+        f"{marker}\n\n"
+        "operation: session\nsession_action: open\n"
+        "issued_credential:\n"
+        "  kind: authorization-session-bearer\n"
+        f"  bearer: {UNKNOWN_SESSION_BEARER}\n",
+        encoding="utf-8",
+    )
+
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        before = connection.execute(
+            "SELECT COUNT(*) FROM governance_authorization_sessions"
+        ).fetchone()
+    finally:
+        connection.close()
+
+    with TestClient(_build_replica(vault, monkeypatch)) as client:
+        response = _tool_response(
+            client,
+            50,
+            "read_memory",
+            {"path": page.relative_to(vault).as_posix(), "include_raw": True},
+        )
+
+    assert response.json()["result"].get("isError") is True, response.text
+    assert "SECRET_BLOCKED" in response.text
+    assert UNKNOWN_SESSION_BEARER not in response.text
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        after = connection.execute(
+            "SELECT COUNT(*) FROM governance_authorization_sessions"
+        ).fetchone()
+    finally:
+        connection.close()
+    assert before == after == (0,)
 
 
 def test_stateless_mcp_grant_is_bound_across_serving_content_route_families(
@@ -858,9 +951,14 @@ def test_stateless_mcp_grant_is_bound_across_serving_content_route_families(
                 assert marker not in refused.text
 
     wire_and_logs = "\n".join(observed_wire) + "\n" + caplog.text
+    observable_state = wire_and_logs + "\n" + json.dumps(
+        metrics.snapshot(), sort_keys=True
+    )
     for raw_bearer in (
         granted_bearer,
         sibling_bearer,
         UNKNOWN_SESSION_BEARER,
     ):
-        assert raw_bearer not in wire_and_logs
+        assert raw_bearer not in observable_state
+    for issued_bearer in (granted_bearer, sibling_bearer):
+        assert _files_containing(tmp_path, issued_bearer) == ()

--- a/tests/test_rest_authorization_session.py
+++ b/tests/test_rest_authorization_session.py
@@ -119,6 +119,10 @@ def test_unknown_canonical_header_wins_before_rest_json_parsing(
             f"/api/ask_memory?authorization_session_credential={BEARER}",
             {"query": "x"},
         ),
+        (
+            "/api/ask_memory",
+            {"query": f"retrieved text {BEARER}"},
+        ),
     ],
 )
 def test_rest_body_and_query_bearer_carriers_refuse_content_free(


### PR DESCRIPTION
## Summary

- redact forbidden or misplaced authorization-session bearers at raw MCP, REST, and Hosted command boundaries before downstream request copies
- keep open/rotate issuance terminals out of durable mutation idempotency so a bearer is neither pickled nor replayed
- let the sealed one-time rotation projection clear terminal scrubbing after the prior credential is invalidated
- close OpenSpec hardening task 5.5 with actual-wire scans across files, SQLite state, logs, metrics, errors, and inert retrieved issuance-shaped text

## Verification

- red-first boundary test: 2 expected failures before raw HTTP redaction
- focused authorization packet: 197 passed
- MCP/CLI/Hosted carrier slice: 23 passed
- `openspec validate harden-governance-for-consolidation --strict`
- `uv lock --check`
- touched-file Ruff: clean; whole `writer_lease.py` retains the same five pre-existing findings outside this diff
- `python scripts/validate-public-artifacts.py --repository`: 3335 files / 3403 text payloads clean
- `git diff --check`

## Stack

Depends on #837. Keep unmerged pending the separate Personal Exomem stability audit and final governance closeout.
