### PR TITLE
chore(openspec): file the contended-write index-refresh amplification

### DIFF
--- a/openspec/changes/bound-contended-write-index-refresh/.openspec.yaml
+++ b/openspec/changes/bound-contended-write-index-refresh/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-26

--- a/openspec/changes/bound-contended-write-index-refresh/proposal.md
+++ b/openspec/changes/bound-contended-write-index-refresh/proposal.md
@@ -1,0 +1,52 @@
+# Proposal: bound-contended-write-index-refresh
+
+## Why
+
+A canonical batch write whose lexical index upsert cannot complete records a
+**durable full-index refresh** demand (`vault.py`, WARNING "index upsert
+incomplete after batch_atomic_write; durable full-index refresh recorded").
+That fail-safe predates the bounded-delta machinery: it answers an O(1) cause —
+one contended batch, typically refused by the publication barrier's 50 ms
+foreground timeout while a rebuild holds it — with an O(vault) response.
+
+Measured on the personal cell, 2026-08-26, running 0.63.0 under live MCP
+traffic (54 client requests): a real 356-file semantic import burst started one
+legitimate full build; during that build, exactly **three** contended batch
+writes each recorded a full-index refresh demand, and each demand seeded
+another whole-vault build with its own retrieval-warming window
+(`RETRIEVAL_INDEX_WARMING`; one live client request observed a 25-minute
+warming stall). The 0.63.0 machinery made every episode converge — each build
+published through the writer burst and readiness returned — so this is
+bounded churn with a cause, not the starvation loop. But the amplification
+stands: heavy client write activity during any build costs whole-vault rebuild
+cycles and demotion windows that a targeted repair would avoid.
+
+This is the remaining instance of the pattern the 2026-08 latency incident
+established: unbounded O(vault) work from an O(1) cause.
+
+## What Changes
+
+- An incomplete index upsert after `batch_atomic_write` records a **targeted,
+  path-scoped** durable refresh demand (the exact paths of the batch), drained
+  through the existing bounded machinery (`retry_deferred_upsert`, the
+  single-flight repair owner's targeted mode) instead of a full-index refresh.
+- A full-index refresh remains the fail-safe only when the incomplete set
+  cannot be named exactly (fail closed, and count it in telemetry).
+- Stable, content-free telemetry distinguishes targeted-refresh demands from
+  full-refresh escalations so this amplification is observable in the health
+  decision trail.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `live-index-freshness` — contended canonical writes SHALL degrade to
+  bounded, path-scoped refresh demands; whole-vault work requires a cause that
+  names why path-scoped repair is impossible.
+
+## Impact
+
+- `src/exomem/vault.py` — the incomplete-upsert fail-safe.
+- `src/exomem/lexstore.py` — draining the path-scoped demand through the
+  bounded repair path.
+- Regression tests reproducing the contended-batch escalation red-first.

--- a/openspec/changes/bound-contended-write-index-refresh/specs/live-index-freshness/spec.md
+++ b/openspec/changes/bound-contended-write-index-refresh/specs/live-index-freshness/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: Bounded write-time index maintenance
+
+A canonical write whose lexical index upsert cannot complete SHALL record a durable refresh demand scoped to exactly the paths of that write, drained through the bounded deferred-upsert retry or the single-flight repair owner's targeted mode. The system SHALL demand a whole-vault index refresh from a write-time failure only when the incomplete path set cannot be named exactly, and SHALL count that escalation in stable content-free telemetry.
+
+#### Scenario: A contended batch write does not seed a whole-vault rebuild
+
+- **WHEN** a batch atomic write completes while the lexical publication barrier is held by an active rebuild and its foreground index upsert is refused
+- **THEN** the system records a durable refresh demand naming exactly that batch's changed and deleted paths
+- **AND** the bounded repair machinery drains it without a whole-vault walk or full rebuild
+- **AND** retrieval readiness windows remain bounded to the build that caused the contention

--- a/openspec/changes/bound-contended-write-index-refresh/tasks.md
+++ b/openspec/changes/bound-contended-write-index-refresh/tasks.md
@@ -1,0 +1,31 @@
+# Tasks
+
+## 1. Regression tests (red first)
+
+- [ ] 1.1 Reproduce the escalation: a batch write whose index upsert is
+      refused by a held publication barrier records a full-index refresh
+      demand today — pin the current behavior red-first against the fix.
+- [ ] 1.2 Assert the fixed path records a path-scoped demand naming exactly
+      the batch's changed/deleted paths, and that the bounded repair drains it
+      without an O(vault) walk or full rebuild.
+- [ ] 1.3 Assert the fail-closed branch: when the incomplete set cannot be
+      named, a full refresh is still demanded and counted in telemetry.
+
+## 2. Implementation
+
+- [ ] 2.1 Replace the full-index refresh recording in the
+      `batch_atomic_write` incomplete-upsert path with a path-scoped durable
+      demand.
+- [ ] 2.2 Drain path-scoped demands through `retry_deferred_upsert` /
+      the single-flight repair owner's targeted mode.
+- [ ] 2.3 Add stable content-free counters for targeted vs full-refresh
+      demands.
+
+## 3. Verification and delivery
+
+- [ ] 3.1 Focused suites, lint, privacy, strict OpenSpec validation.
+- [ ] 3.2 Independent adversarial review; resolve findings.
+- [ ] 3.3 Live acceptance: a client write burst during an active build no
+      longer seeds follow-on whole-vault builds; readiness windows stay
+      bounded to the causing build only.
+- [ ] 3.4 Sync and archive this change after delivery.


### PR DESCRIPTION
Files (does not fix) the one remaining O(vault)-from-O(1) edge, measured live during 0.63.0 acceptance: contended batch writes during an active rebuild record full-index refresh demands, each seeding another whole-vault build with a retrieval-warming window. Evidence, scope, and red-first task plan in the change; tasks deliberately unticked — this is the honest-debt filing pattern. `openspec validate bound-contended-write-index-refresh --strict` green; privacy gate clean.