### PR TITLE
fix(index): accept durably covered warm-up deferrals in batch reports

### DIFF
--- a/openspec/changes/bound-contended-write-index-refresh/proposal.md
+++ b/openspec/changes/bound-contended-write-index-refresh/proposal.md
@@ -2,51 +2,68 @@
 
 ## Why
 
-A canonical batch write whose lexical index upsert cannot complete records a
-**durable full-index refresh** demand (`vault.py`, WARNING "index upsert
-incomplete after batch_atomic_write; durable full-index refresh recorded").
-That fail-safe predates the bounded-delta machinery: it answers an O(1) cause —
-one contended batch, typically refused by the publication barrier's 50 ms
-foreground timeout while a rebuild holds it — with an O(vault) response.
+During the 2026-08-26 0.63.0 acceptance, a 356-file semantic import burst on
+the personal cell chained follow-on whole-vault builds with retrieval-warming
+windows (one live client request stalled 25 minutes). Tracing the recording
+site (`vault.py` "index upsert incomplete after batch_atomic_write; durable
+full-index refresh recorded") against the code established the real trigger:
 
-Measured on the personal cell, 2026-08-26, running 0.63.0 under live MCP
-traffic (54 client requests): a real 356-file semantic import burst started one
-legitimate full build; during that build, exactly **three** contended batch
-writes each recorded a full-index refresh demand, and each demand seeded
-another whole-vault build with its own retrieval-warming window
-(`RETRIEVAL_INDEX_WARMING`; one live client request observed a 25-minute
-warming stall). The 0.63.0 machinery made every episode converge — each build
-published through the writer burst and readiness returned — so this is
-bounded churn with a cause, not the starvation loop. But the amplification
-stands: heavy client write activity during any build costs whole-vault rebuild
-cycles and demotion windows that a targeted repair would avoid.
+**A batch write during an embedding warm-up window is double-accounted.** The
+embeddings component defers with `("embeddings", "deferred",
+"deferred_warmup")` after ALREADY recording durable, path-exact semantic
+receipts for the batch (`embeddings.py` warm-up path). But
+`index_sync.full_upsert_succeeded` carves out only the code
+`"deferred_durable"`, so the warm-up deferral fails the batch report and
+`record_failed_refresh` mints a durable FULL-component receipt for paths whose
+semantic replay is already durably queued. Draining each full receipt runs
+`recover_full_receipt_graph_epoch(build=True)` — a whole-vault graph rebuild —
+and re-dispatches the entire component fan-out. Three contended-era batch
+writes during the burst window produced exactly the three measured demands,
+the chained builds, and hours of graph `recovery_required` churn.
 
-This is the remaining instance of the pattern the 2026-08 latency incident
-established: unbounded O(vault) work from an O(1) cause.
+O(vault) response to an O(1) cause, at the accounting layer: the deferral was
+already bounded and durable; declaring it failed is what escalates.
 
 ## What Changes
 
-- An incomplete index upsert after `batch_atomic_write` records a **targeted,
-  path-scoped** durable refresh demand (the exact paths of the batch), drained
-  through the existing bounded machinery (`retry_deferred_upsert`, the
-  single-flight repair owner's targeted mode) instead of a full-index refresh.
-- A full-index refresh remains the fail-safe only when the incomplete set
-  cannot be named exactly (fail closed, and count it in telemetry).
-- Stable, content-free telemetry distinguishes targeted-refresh demands from
-  full-refresh escalations so this amplification is observable in the health
-  decision trail.
+- `full_upsert_succeeded` accepts an embeddings `deferred_warmup` outcome as
+  success **when and only when** the deferral durably covers the batch's
+  semantic paths (the warm-up path's receipts), so no full-component refresh
+  demand is minted for work that is already durably queued path-by-path.
+- A warm-up deferral that did NOT record covering receipts still fails the
+  report and mints the full-component demand — fail closed, and the
+  escalation is counted in stable content-free telemetry alongside a counter
+  for the accepted-covered case.
+
+## Related debt discovered by the same trace (explicitly OUT of scope here)
+
+A lexical batch upsert refused by the publication barrier's 50 ms foreground
+timeout is swallowed at module-level `lexstore.upsert_after_write` (the
+`upsert_paths` return value is discarded; same for deletes): the batch report
+never learns of it, and the only recovery is the process-local, non-durable
+`_DEFERRED_UPSERTS` registry until the periodic reconcile heals it (durably,
+post-0.63.0). Making that refusal observable changes
+`post_commit_batch_fanout` semantics consumed by media completion and client
+degradation envelopes — a deliberate follow-up change, not a rider here. This
+change pins the current swallow behavior in a test so the debt is measured,
+not silent. A mixed batch — recall-candidate and non-candidate markdown in
+one write — still fails the coverage check and mints the full-component
+receipt, exactly as the pre-existing `deferred_durable` carve-out always has:
+that is spec-conformant fail-closed residual, and live acceptance (task 3.3)
+must not read those receipts as this fix failing.
 
 ## Capabilities
 
 ### Modified Capabilities
 
-- `live-index-freshness` — contended canonical writes SHALL degrade to
-  bounded, path-scoped refresh demands; whole-vault work requires a cause that
-  names why path-scoped repair is impossible.
+- `live-index-freshness` — a component deferral that is already durably
+  path-covered SHALL NOT fail the batch report nor seed a full-component
+  refresh demand; whole-vault work requires a component whose incomplete work
+  has no durable path coverage.
 
 ## Impact
 
-- `src/exomem/vault.py` — the incomplete-upsert fail-safe.
-- `src/exomem/lexstore.py` — draining the path-scoped demand through the
-  bounded repair path.
-- Regression tests reproducing the contended-batch escalation red-first.
+- `src/exomem/index_sync.py` — `full_upsert_succeeded`'s deferral carve-out;
+  telemetry counters.
+- Regression tests reproducing the warm-up double-accounting red-first, plus
+  the lexical-swallow baseline pin.

--- a/openspec/changes/bound-contended-write-index-refresh/specs/live-index-freshness/spec.md
+++ b/openspec/changes/bound-contended-write-index-refresh/specs/live-index-freshness/spec.md
@@ -2,11 +2,18 @@
 
 ### Requirement: Bounded write-time index maintenance
 
-A canonical write whose lexical index upsert cannot complete SHALL record a durable refresh demand scoped to exactly the paths of that write, drained through the bounded deferred-upsert retry or the single-flight repair owner's targeted mode. The system SHALL demand a whole-vault index refresh from a write-time failure only when the incomplete path set cannot be named exactly, and SHALL count that escalation in stable content-free telemetry.
+A component deferral that has already durably recorded path-exact receipts covering the batch SHALL count as batch-report success and SHALL NOT seed a full-component refresh demand. The system SHALL mint a durable full-component refresh demand from a write-time outcome only for a component whose incomplete work has no durable path coverage, and SHALL count both outcomes — covered deferrals accepted and uncovered deferrals escalated — in stable content-free telemetry.
 
-#### Scenario: A contended batch write does not seed a whole-vault rebuild
+#### Scenario: A warm-up-deferred embedding batch does not seed a whole-vault rebuild
 
-- **WHEN** a batch atomic write completes while the lexical publication barrier is held by an active rebuild and its foreground index upsert is refused
-- **THEN** the system records a durable refresh demand naming exactly that batch's changed and deleted paths
-- **AND** the bounded repair machinery drains it without a whole-vault walk or full rebuild
-- **AND** retrieval readiness windows remain bounded to the build that caused the contention
+- **WHEN** a batch atomic write's embeddings component defers because the embedding model is warming
+- **AND** the warm-up deferral has already recorded durable semantic receipts naming exactly that batch's paths
+- **THEN** the batch report treats the embeddings component as succeeded-deferred
+- **AND** no full-component refresh receipt is minted for the batch
+- **AND** the already-queued semantic replay remains the sole durable demand for those paths
+
+#### Scenario: An uncovered deferral still fails closed
+
+- **WHEN** a component defers without durable path-exact coverage of the batch
+- **THEN** the batch report fails and a durable full-component refresh demand is minted
+- **AND** the escalation increments its telemetry counter

--- a/openspec/changes/bound-contended-write-index-refresh/tasks.md
+++ b/openspec/changes/bound-contended-write-index-refresh/tasks.md
@@ -2,30 +2,35 @@
 
 ## 1. Regression tests (red first)
 
-- [ ] 1.1 Reproduce the escalation: a batch write whose index upsert is
-      refused by a held publication barrier records a full-index refresh
-      demand today — pin the current behavior red-first against the fix.
-- [ ] 1.2 Assert the fixed path records a path-scoped demand naming exactly
-      the batch's changed/deleted paths, and that the bounded repair drains it
-      without an O(vault) walk or full rebuild.
-- [ ] 1.3 Assert the fail-closed branch: when the incomplete set cannot be
-      named, a full refresh is still demanded and counted in telemetry.
+- [x] 1.1 Pin the measured escalation red-first: a batch write whose
+      embeddings component defers with `deferred_warmup` AND durable covering
+      receipts currently fails `full_upsert_succeeded` and mints a durable
+      full-component receipt (`.deferred-index.sqlite` `full_upserts` rows).
+      After the fix this pin inverts: report succeeds, no full receipt.
+- [x] 1.2 Fail-closed pin: a warm-up deferral WITHOUT covering durable
+      receipts still fails the report, still mints the full-component demand,
+      and increments the escalation counter.
+- [x] 1.3 Baseline debt pin (current behavior, kept green before AND after):
+      a lexical batch upsert refused under a held publication barrier is
+      swallowed — `full_upsert_succeeded` stays True, no durable demand of
+      any kind is recorded, recovery is the process-local deferred registry.
+      This measures the out-of-scope debt named in the proposal so it cannot
+      drift silently.
 
 ## 2. Implementation
 
-- [ ] 2.1 Replace the full-index refresh recording in the
-      `batch_atomic_write` incomplete-upsert path with a path-scoped durable
-      demand.
-- [ ] 2.2 Drain path-scoped demands through `retry_deferred_upsert` /
-      the single-flight repair owner's targeted mode.
-- [ ] 2.3 Add stable content-free counters for targeted vs full-refresh
-      demands.
+- [x] 2.1 Extend `full_upsert_succeeded`'s deferral carve-out: accept
+      embeddings `deferred_warmup` when and only when the deferral durably
+      covers the batch's semantic paths.
+- [x] 2.2 Stable content-free telemetry: covered-deferral-accepted and
+      uncovered-deferral-escalated counters with a public accessor, reset
+      with the module's test-reset seam.
 
 ## 3. Verification and delivery
 
 - [ ] 3.1 Focused suites, lint, privacy, strict OpenSpec validation.
 - [ ] 3.2 Independent adversarial review; resolve findings.
-- [ ] 3.3 Live acceptance: a client write burst during an active build no
-      longer seeds follow-on whole-vault builds; readiness windows stay
-      bounded to the causing build only.
+- [ ] 3.3 Live acceptance: a client write burst during an embedding warm-up
+      window no longer seeds follow-on whole-vault builds or graph epoch
+      rebuilds; readiness windows stay bounded to the causing build only.
 - [ ] 3.4 Sync and archive this change after delivery.

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -1132,7 +1132,13 @@ def upsert_after_write_status(
                     len(md_paths),
                 )
                 return EmbeddingSyncStatus(
-                    "deferred", "deferred_warmup", eligible_count
+                    "deferred",
+                    # The durable receipts above are the coverage evidence the
+                    # batch report trusts.  When recording them failed, say so
+                    # in the code so a stale queue entry for the same path can
+                    # never bless this batch as durably covered.
+                    "deferred_warmup" if race_receipts else "deferred_warmup_volatile",
+                    eligible_count,
                 )
 
     def finish(status: EmbeddingSyncStatus) -> EmbeddingSyncStatus:

--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import gc
 import logging
+import threading
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
@@ -49,6 +50,44 @@ _FULL_UPSERT_COMPONENTS = frozenset(
         "embeddings",
     }
 )
+
+#: Write-time deferral accounting — stable, content-free counters ONLY (no
+#: vault paths, note names, or content).  ``covered_deferral_accepted`` counts
+#: batch-report judgements where an embeddings deferral was accepted because
+#: durable path-exact receipts already covered the batch;
+#: ``uncovered_deferral_escalated`` counts embeddings deferrals that failed
+#: the report — at the write-time call site that minting judgement is what
+#: records the durable full-component refresh demand — because no such
+#: coverage could be proven.  Drain-time re-judgements of a still-deferred
+#: batch count too: the counters observe report decisions, not receipts.
+_DEFERRAL_TELEMETRY_KEYS = (
+    "covered_deferral_accepted",
+    "uncovered_deferral_escalated",
+)
+_DEFERRAL_TELEMETRY: dict[str, int] = dict.fromkeys(_DEFERRAL_TELEMETRY_KEYS, 0)
+_DEFERRAL_TELEMETRY_LOCK = threading.Lock()
+
+
+def _note_deferral(reason: str) -> None:
+    """Count one stable deferral-accounting outcome (never content).
+
+    Direct indexing on purpose: a typo'd reason raises KeyError instead of
+    silently minting a counter outside the stable key set.
+    """
+    with _DEFERRAL_TELEMETRY_LOCK:
+        _DEFERRAL_TELEMETRY[reason] += 1
+
+
+def deferral_telemetry() -> dict[str, int]:
+    """Snapshot the stable, content-free deferral-accounting counters."""
+    with _DEFERRAL_TELEMETRY_LOCK:
+        return dict(_DEFERRAL_TELEMETRY)
+
+
+def reset_deferral_telemetry() -> None:
+    """Test seam: zero the deferral-accounting counters."""
+    with _DEFERRAL_TELEMETRY_LOCK:
+        _DEFERRAL_TELEMETRY.update(dict.fromkeys(_DEFERRAL_TELEMETRY_KEYS, 0))
 
 
 def _evict_corpus_projection_consumers(vault_root: Path) -> None:
@@ -620,18 +659,29 @@ def full_upsert_succeeded(vault_root: Path, replaced: list[Path], report: object
                 and graph_sync.registered_checkpoint(vault_root) == checkpoint
             ):
                 continue
-        if (
-            component.component == "embeddings"
-            and component.outcome == "deferred"
-            and component.code == "deferred_durable"
-            and replaced_rels
-        ):
-            if receipt_rels is None:
-                receipt_rels = {
-                    receipt.rel_path for receipt in deferred_index.snapshot(vault_root)
-                }
-            if replaced_rels <= receipt_rels:
-                continue
+        if component.component == "embeddings" and component.outcome == "deferred":
+            # A deferral that is already durably queued path-by-path is not a
+            # batch failure — declaring it one is what escalated an O(1) cause
+            # into whole-vault work (bound-contended-write-index-refresh).
+            # Only a deferral whose durable recording succeeded names a
+            # coverage-claiming code (`deferred_durable` from the durable-defer
+            # branch, `deferred_warmup` from the warm-up branch); anything
+            # else — `deferred_warmup_volatile` included — carries no claim,
+            # so a stale queue entry can never bless it.
+            if (
+                component.code in {"deferred_durable", "deferred_warmup"}
+                and replaced_rels
+            ):
+                if receipt_rels is None:
+                    receipt_rels = {
+                        receipt.rel_path
+                        for receipt in deferred_index.snapshot(vault_root)
+                    }
+                if replaced_rels <= receipt_rels:
+                    _note_deferral("covered_deferral_accepted")
+                    continue
+            _note_deferral("uncovered_deferral_escalated")
+            return False
         return False
     return True
 

--- a/tests/test_index_sync.py
+++ b/tests/test_index_sync.py
@@ -715,3 +715,271 @@ def test_delete_report_continues_after_observable_component_failure(
     assert _outcome(report, "embeddings").outcome == "accepted"
     assert _outcome(report, "embeddings").code == "embeddings_disabled"
     assert report.reconcile_required is True
+
+
+# ---------------------------------------------------------------------------
+# bound-contended-write-index-refresh: warm-up deferral accounting.
+#
+# A batch write during an embedding warm-up window defers with durable,
+# path-exact semantic receipts already recorded.  Declaring that deferral a
+# batch failure is what escalated an O(1) cause into whole-vault work: the
+# minted full-component receipt re-runs the entire fan-out and a graph epoch
+# recovery build on every drain pass.
+# ---------------------------------------------------------------------------
+
+
+def _warm_deferred_note(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A real KB note plus a genuinely warming embedding component."""
+    target = tmp_path / "Knowledge Base" / "Notes" / "warm-accounting.md"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        "# Warm accounting\n\nwarm deferral accounting probe\n", encoding="utf-8"
+    )
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("EXOMEM_MODE", "normal")
+    monkeypatch.setattr(embeddings, "_IMPORT_FAILED", False)
+    readiness.reset()
+    readiness.begin_warm()
+    deferred_index.clear(tmp_path)
+    deferred_index.clear_full(tmp_path)
+    return target
+
+
+def _clean_warm_deferred_note(tmp_path: Path) -> None:
+    readiness.reset()
+    deferred_index.clear(tmp_path)
+    deferred_index.clear_full(tmp_path)
+
+
+def test_warm_covered_deferral_is_batch_success_and_mints_no_full_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Task 1.1: a warm-up deferral that durably covered the batch is success.
+
+    Red-first pin of the measured 2026-08-26 escalation: today the
+    `deferred_warmup` outcome fails `full_upsert_succeeded` and mints a durable
+    full-component receipt for paths whose semantic replay is already durably
+    queued path-by-path.
+    """
+    target = _warm_deferred_note(tmp_path, monkeypatch)
+    rel = "Knowledge Base/Notes/warm-accounting.md"
+    try:
+        report = index_sync.upsert_after_write(tmp_path, [target])
+        outcome = _outcome(report, "embeddings")
+        assert outcome.outcome == "deferred"
+        assert outcome.code == "deferred_warmup"
+        # The deferral durably covered the batch before the report is judged.
+        assert deferred_index.status(tmp_path)["paths"] == [rel]
+        # The covered deferral is batch-report success, not an escalation.
+        assert index_sync.full_upsert_succeeded(tmp_path, [target], report) is True
+        # A batch with no nameable rel paths can never be blessed by coverage:
+        # the empty set is a subset of every queue, so without the guard the
+        # acceptance would be vacuous.
+        assert index_sync.full_upsert_succeeded(tmp_path, [], report) is False
+
+        completed = vault_module.post_commit_batch_fanout(tmp_path, [target], None, None)
+        assert completed is True
+        # No durable full-component refresh receipt is minted for the batch;
+        # the already-queued semantic replay stays the sole durable demand.
+        assert deferred_index.snapshot_full(tmp_path) == []
+        assert deferred_index.status(tmp_path)["paths"] == [rel]
+    finally:
+        _clean_warm_deferred_note(tmp_path)
+
+
+def test_warm_deferral_accounting_telemetry_counts_both_outcomes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Task 2.2: stable content-free counters behind the module's reset seam."""
+    target = _warm_deferred_note(tmp_path, monkeypatch)
+    try:
+        index_sync.reset_deferral_telemetry()
+        report = index_sync.upsert_after_write(tmp_path, [target])
+        assert index_sync.full_upsert_succeeded(tmp_path, [target], report) is True
+        assert index_sync.deferral_telemetry() == {
+            "covered_deferral_accepted": 1,
+            "uncovered_deferral_escalated": 0,
+        }
+        # Judging the same deferred batch against an emptied queue is the
+        # uncovered case: fail closed, and count the escalation.
+        deferred_index.clear(tmp_path)
+        assert index_sync.full_upsert_succeeded(tmp_path, [target], report) is False
+        assert index_sync.deferral_telemetry() == {
+            "covered_deferral_accepted": 1,
+            "uncovered_deferral_escalated": 1,
+        }
+        index_sync.reset_deferral_telemetry()
+        assert all(
+            value == 0 for value in index_sync.deferral_telemetry().values()
+        )
+    finally:
+        _clean_warm_deferred_note(tmp_path)
+
+
+def test_volatile_warm_deferral_still_fails_closed_and_mints_the_demand(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Task 1.2: a warm-up deferral without durable coverage fails closed.
+
+    The durable store refuses both recording seams, so nothing covers the
+    batch: the component itself must name the missing coverage, the report
+    must fail, the full-component demand must still be minted, and the
+    escalation must be counted.
+    """
+    target = _warm_deferred_note(tmp_path, monkeypatch)
+    rel = "Knowledge Base/Notes/warm-accounting.md"
+
+    def refuse(_vault_root, _rels):
+        raise OSError("durable defer store unavailable")
+
+    monkeypatch.setattr(deferred_index, "add_receipts", refuse)
+    monkeypatch.setattr(deferred_index, "add", refuse)
+    try:
+        index_sync.reset_deferral_telemetry()
+        report = index_sync.upsert_after_write(tmp_path, [target])
+        outcome = _outcome(report, "embeddings")
+        assert outcome.outcome == "deferred"
+        # The component names the missing durable coverage itself, so a stale
+        # queue entry for the same path can never bless this deferral.
+        assert outcome.code == "deferred_warmup_volatile"
+        assert deferred_index.snapshot(tmp_path) == []
+        assert index_sync.full_upsert_succeeded(tmp_path, [target], report) is False
+        assert index_sync.deferral_telemetry()["uncovered_deferral_escalated"] == 1
+
+        completed = vault_module.post_commit_batch_fanout(tmp_path, [target], None, None)
+        assert completed is False
+        assert [
+            receipt.rel_path for receipt in deferred_index.snapshot_full(tmp_path)
+        ] == [rel]
+    finally:
+        _clean_warm_deferred_note(tmp_path)
+
+
+def test_stale_receipt_cannot_bless_a_volatile_warm_deferral(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A receipt from an earlier write is not this deferral's coverage.
+
+    The semantic queue retires receipts by per-revision CAS, so only the
+    revision bump THIS deferral performed guarantees a replay of the current
+    bytes; a stale entry for the same path proves nothing.  The component
+    code is therefore the gate: volatile means uncovered, even when the
+    queue happens to hold the rel — the tripwire for a mutant that folds
+    `deferred_warmup_volatile` into the accepted code set.
+    """
+    target = _warm_deferred_note(tmp_path, monkeypatch)
+    rel = "Knowledge Base/Notes/warm-accounting.md"
+    # A durable receipt from an EARLIER write is already queued for the path.
+    [stale] = deferred_index.add_receipts(tmp_path, [rel])
+
+    def refuse(_vault_root, _rels):
+        raise OSError("durable defer store unavailable")
+
+    monkeypatch.setattr(deferred_index, "add_receipts", refuse)
+    monkeypatch.setattr(deferred_index, "add", refuse)
+    try:
+        report = index_sync.upsert_after_write(tmp_path, [target])
+        outcome = _outcome(report, "embeddings")
+        assert outcome.code == "deferred_warmup_volatile"
+        # The stale receipt is still there — and must not bless the batch.
+        assert deferred_index.snapshot(tmp_path) == [stale]
+        assert index_sync.full_upsert_succeeded(tmp_path, [target], report) is False
+    finally:
+        _clean_warm_deferred_note(tmp_path)
+
+
+def test_warm_deferral_code_alone_cannot_bless_an_uncovered_batch(
+    tmp_path: Path,
+) -> None:
+    """The carve-out must verify durable coverage, never trust the code string.
+
+    Green before and after the fix; the tripwire for a mutant that accepts
+    every `deferred_warmup` outcome without proving queue coverage.
+    """
+    target = tmp_path / "Knowledge Base" / "Notes" / "uncovered.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("# Uncovered\n", encoding="utf-8")
+    rel = "Knowledge Base/Notes/uncovered.md"
+    report = index_sync.IndexSyncReport(
+        "upsert",
+        (rel,),
+        (rel,),
+        (
+            index_sync.IndexComponentOutcome(
+                "memory_refs", "completed", "dispatch_completed"
+            ),
+            index_sync.IndexComponentOutcome(
+                "resolver", "completed", "dispatch_completed"
+            ),
+            index_sync.IndexComponentOutcome(
+                "semantic_purge", "completed", "purge_completed"
+            ),
+            index_sync.IndexComponentOutcome(
+                "lexstore", "completed", "dispatch_completed"
+            ),
+            index_sync.IndexComponentOutcome(
+                "epistemic_graph", "completed", "incremental_completed"
+            ),
+            index_sync.IndexComponentOutcome(
+                "embeddings", "deferred", "deferred_warmup"
+            ),
+        ),
+    )
+    assert deferred_index.snapshot(tmp_path) == []
+    assert index_sync.full_upsert_succeeded(tmp_path, [target], report) is False
+
+
+def test_contended_lexical_upsert_stays_swallowed_from_the_batch_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Task 1.3 baseline debt pin — deliberately green before AND after.
+
+    A lexical batch upsert refused under a held publication barrier never
+    reaches the batch report: the module-level wrapper discards the refusal,
+    `full_upsert_succeeded` stays True, the refusal records no durable demand,
+    and recovery is only the process-local deferred registry.  Making the
+    refusal observable is the follow-up debt named in the proposal; this pin
+    measures it so it cannot drift silently.
+    """
+    from exomem import lexstore
+    from exomem.vault import vault_creation_lock
+
+    if not lexstore.fts5_available():
+        pytest.skip("this SQLite build lacks FTS5/trigram")
+    monkeypatch.setenv("EXOMEM_MODE", "normal")
+    page = tmp_path / "Knowledge Base" / "Notes" / "swallowed.md"
+    page.parent.mkdir(parents=True)
+    page.write_text(
+        "---\ntype: insight\ntitle: swallowed\nupdated: 2026-01-01\n---\n"
+        "# swallowed\n\nswallowprobe original\n",
+        encoding="utf-8",
+    )
+    # The first search builds the lexical sidecar whole; without it the module
+    # wrapper no-ops before ever reaching the publication barrier.
+    assert lexstore.search_bm25(tmp_path, "swallowprobe", k=3, scope="kb")
+    page.write_text(
+        "---\ntype: insight\ntitle: swallowed\nupdated: 2026-01-02\n---\n"
+        "# swallowed\n\nswallowprobe revised\n",
+        encoding="utf-8",
+    )
+    scheduled: list[dict] = []
+    monkeypatch.setattr(
+        lexstore,
+        "_schedule_repair",
+        lambda root, **kwargs: scheduled.append({"root": root, **kwargs}),
+    )
+
+    with vault_creation_lock(tmp_path, "lexical-catalog-publication", timeout=5):
+        report = index_sync.upsert_after_write(tmp_path, [page])
+
+    lexical = _outcome(report, "lexstore")
+    assert (lexical.outcome, lexical.code) == ("completed", "dispatch_completed")
+    assert index_sync.full_upsert_succeeded(tmp_path, [page], report) is True
+    assert deferred_index.snapshot_full(tmp_path) == []
+    # The semantic queue holds only the ordinary embeddings-disabled heal
+    # receipt every write records; the lexical refusal contributed nothing.
+    assert [receipt.rel_path for receipt in deferred_index.snapshot(tmp_path)] == [
+        "Knowledge Base/Notes/swallowed.md"
+    ]
+    # The only recovery for the refused rows is the process-local registry.
+    assert scheduled == [{"root": tmp_path, "deferred_paths": [page]}]

--- a/tests/test_instant_start.py
+++ b/tests/test_instant_start.py
@@ -1462,7 +1462,10 @@ def test_warm_defer_stays_in_memory_when_durable_receipt_creation_fails(
 
     status = embeddings.upsert_after_write_status(tmp_path, [path])
 
-    assert status.code == "deferred_warmup"
+    # The deferral still parks in memory, but the code names the missing
+    # durable coverage so the batch report cannot treat it as covered
+    # (bound-contended-write-index-refresh).
+    assert status.code == "deferred_warmup_volatile"
     [(item_vault, item_paths, receipts)] = readiness.mark_ready("embeddings")
     assert item_vault == tmp_path
     assert list(item_paths) == [path]


### PR DESCRIPTION
## Why

During 0.63.0 live acceptance, a 356-file semantic import burst chained three follow-on **whole-vault** builds with retrieval-warming windows (one live client request stalled 25 minutes). The trigger: a batch write during an embedding warm-up window is **double-accounted**. The embeddings component defers with `deferred_warmup` *after already recording durable, path-exact semantic receipts*, but `index_sync.full_upsert_succeeded` accepted only `deferred_durable` — so the report failed and a durable FULL-component receipt was minted for work already durably queued path-by-path. Draining each full receipt runs `recover_full_receipt_graph_epoch(build=True)`: a whole-vault graph rebuild per contended write. O(vault) response to an O(1) cause, at the accounting layer.

## What

- `embeddings.py`: the warm-up path returns `deferred_warmup` **only when covering receipts were durably recorded**; otherwise the new `deferred_warmup_volatile` code, which is never accepted.
- `index_sync.full_upsert_succeeded`: accepts `deferred_warmup` iff the durable queue covers the batch's replaced rels (`replaced_rels <= receipt_rels and replaced_rels`) — empty batches and uncovered deferrals still fail closed and escalate.
- Stable content-free telemetry: `covered_deferral_accepted` / `uncovered_deferral_escalated`.

## Verification

- **Red-first**: the covered warm-up deferral was pinned failing (full receipt minted) before the fix; the pin inverts after.
- Six regression additions in `tests/test_index_sync.py` (+ pin update in `test_instant_start.py`), including a **stale-receipt tripwire** (a pre-existing durable receipt for the same rel cannot bless a volatile deferral — pins that the code string, not queue presence, is the gate) and a `replaced=[]` vacuous-coverage guard. Every guard mutation-proven in a scratch copy (import path verified): each targeted mutant → exactly the named test red.
- Independent adversarial review: REQUEST_CHANGES (two surviving mutants) → correction round → targeted recheck **APPROVE**; the reviewer re-ran gates and reproduced both mutation kills on the actual bytes.
- Gates: focused suites 177 passed; `uvx ruff check` clean; `validate-public-artifacts.py --repository` clean; `openspec validate bound-contended-write-index-refresh --strict` valid.

## OpenSpec

`bound-contended-write-index-refresh` (filed in #840): tasks 1.x/2.x complete; 3.3 live acceptance and 3.4 archive follow post-deploy. The proposal names the mixed-batch fail-closed residual explicitly so live acceptance is not misread.
