### PR TITLE
fix(governance): hide ambiguous reference candidates

### DIFF
--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -1803,7 +1803,7 @@ def _citation_url(_path: str) -> str:
 
 def _resolve_memory_identifier(vault_root: Path, value: str) -> str:
     try:
-        resolved = memory_refs_module.resolve_identifier(vault_root, value)
+        resolved = egress_module.resolve_visible_identifier(vault_root, value)
     except memory_refs_module.ReferenceError as exc:
         raise ValueError(f"{exc.code}: {exc.reason}") from exc
     if reserved_paths_module.classify_logical(resolved).blocked:

--- a/src/exomem/governance/egress.py
+++ b/src/exomem/governance/egress.py
@@ -47,7 +47,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import unquote
 
-from .. import find_corpus, memory_refs
+from .. import find_corpus, memory_refs, reserved_paths
 from ..find_types import Hit, SemanticUnitHit
 from ..kbdir import kb_dirname
 from . import (
@@ -1445,6 +1445,79 @@ def _decide_path(
         policy=policy,
         audience=audience,
     )
+
+
+def resolve_visible_identifier(
+    vault_root: Path,
+    value: str,
+    *,
+    principal: RequestPrincipal | None = None,
+    purpose: str | None = None,
+) -> str:
+    """Resolve a memory ref after removing candidates invisible to the caller.
+
+    Raw reference resolution decides ambiguity from every matching page. That
+    leaks both the presence and count of L0 pages and lets one hidden duplicate
+    shadow an otherwise unique visible page. A governed content route must
+    instead behave as if those candidates were physically absent.
+    """
+
+    vault_root = Path(vault_root)
+    raw = str(value or "").strip()
+    memory_id = memory_refs.parse_memory_ref(raw)
+    if not raw.lower().startswith(memory_refs.REF_PREFIX):
+        return memory_refs.resolve_identifier(vault_root, raw)
+    if memory_id is None:
+        raise memory_refs.ReferenceError(
+            "INVALID_REFERENCE", f"invalid memory reference: {raw!r}"
+        )
+
+    candidates = tuple(
+        rel_path
+        for rel_path in memory_refs.paths_for_ids_read_only(
+            vault_root, (memory_id,)
+        ).get(memory_id, ())
+        if not reserved_paths.classify_logical(rel_path).blocked
+        if not lifecycle.is_tombstoned(vault_root, rel_path)
+    )
+    policy = policy_module.load(vault_root)
+    who = principal if principal is not None else effective_principal()
+    if policy.empty:
+        visible = candidates
+    elif policy.blocked or not who.resolved:
+        visible = ()
+    else:
+        declared_purpose = _declared_purpose(vault_root, who, purpose)
+        grants_hash = _grants_hash(policy)
+        visible = tuple(
+            rel_path
+            for rel_path in candidates
+            if (
+                decision := _decide_path(
+                    vault_root,
+                    rel_path,
+                    policy=policy,
+                    audience=who.audience_id,
+                    purpose=declared_purpose,
+                    grants_hash=grants_hash,
+                    authorization_session=who.authorization_session_id,
+                    authorization_context=who.verified_authorization_session,
+                )
+            )
+            is not None
+            and decision.level > LEVEL_NONE
+        )
+
+    if len(visible) > 1:
+        raise memory_refs.ReferenceError(
+            "AMBIGUOUS_REFERENCE",
+            f"memory id {memory_id} appears in {len(visible)} pages",
+        )
+    if not visible:
+        raise memory_refs.ReferenceError(
+            "REFERENCE_NOT_FOUND", f"memory id not found: {memory_id}"
+        )
+    return visible[0]
 
 
 def _scope_label(policy: Policy, decision: Decision) -> str | None:

--- a/tests/test_governance_postfilter.py
+++ b/tests/test_governance_postfilter.py
@@ -1803,17 +1803,19 @@ def test_a_raised_payload_naming_a_withheld_memory_ref_is_filtered(
     assert egress.WITHHELD_REFERENCE in text
 
 
-def test_an_identity_collision_does_not_name_the_colliding_pages(vault: Path) -> None:
-    """The reachable case, end to end. Duplicating an identity is an ordinary
-    consequence of a merge or a sync copy, so a caller can manufacture the
-    collision and then read the colliding vault paths out of the error."""
+def test_hidden_identity_collision_is_identical_to_physical_absence(
+    vault: Path,
+) -> None:
+    """Ambiguity is computed from caller-visible candidates, never raw rows."""
     from exomem import commands, memory_refs
     from exomem.writer_lease import invoke_command
 
     patterns = vault / "Knowledge Base" / "Notes" / "Patterns"
     identity = memory_refs.new_id()
+    pages = []
     for name in ("kill-switch-for-risky-releases.md", "kill-switch-copy.md"):
         page = patterns / name
+        pages.append(page)
         updated, _ = memory_refs.add_id_to_markdown(
             page.read_text(encoding="utf-8")
             if page.exists()
@@ -1824,15 +1826,87 @@ def test_an_identity_collision_does_not_name_the_colliding_pages(vault: Path) ->
     _govern_patterns_shut(vault)
 
     command = {c.name: c for c in commands.COMMANDS}["get"]
+
+    def _error() -> ValueError:
+        with _external_scope():
+            with pytest.raises(ValueError) as excinfo:
+                invoke_command(command, vault, path=memory_refs.memory_ref(identity))
+        return excinfo.value
+
+    hidden_present = _error()
+    memory_refs.ReferenceIndex(vault).delete_paths(
+        [page.relative_to(vault).as_posix() for page in pages]
+    )
+    for page in pages:
+        page.unlink()
+    physically_absent = _error()
+
+    assert type(hidden_present) is type(physically_absent)
+    assert hidden_present.args == physically_absent.args
+    text = str(hidden_present)
+    assert "REFERENCE_NOT_FOUND" in text
+    assert "AMBIGUOUS_REFERENCE" not in text
+    assert "2 pages" not in text
+    for leaked in ("kill-switch-for-risky-releases", "kill-switch-copy", "Patterns"):
+        assert leaked not in text, f"collision named {leaked!r}: {text!r}"
+
+
+def test_hidden_identity_collision_does_not_shadow_one_visible_page(
+    vault: Path,
+) -> None:
+    """One visible candidate resolves as though its hidden twin did not exist."""
+    from exomem import commands, memory_refs
+    from exomem.writer_lease import invoke_command
+
+    identity = memory_refs.new_id()
+    hidden = vault / ERROR_WITHHELD
+    visible = vault / "Knowledge Base" / "Notes" / "Insights" / "visible-twin.md"
+    visible.parent.mkdir(parents=True, exist_ok=True)
+    for page, body in ((hidden, "private"), (visible, "public")):
+        updated, _ = memory_refs.add_id_to_markdown(
+            page.read_text(encoding="utf-8")
+            if page.exists()
+            else f"---\ntype: insight\n---\n{body}\n",
+            identity,
+        )
+        page.write_text(updated, encoding="utf-8")
+    _govern_patterns_shut(vault)
+
+    command = {c.name: c for c in commands.COMMANDS}["get"]
     with _external_scope():
-        with pytest.raises(Exception) as excinfo:
+        result = invoke_command(command, vault, path=memory_refs.memory_ref(identity))
+
+    assert result["path"] == visible.relative_to(vault).as_posix()
+    assert result["body"].strip() == "public"
+    assert "kill-switch-for-risky-releases" not in json.dumps(result)
+
+
+def test_identity_collision_counts_only_visible_pages(vault: Path) -> None:
+    """A genuine ambiguity retains its stable code and visible-only count."""
+    from exomem import commands, memory_refs
+    from exomem.writer_lease import invoke_command
+
+    identity = memory_refs.new_id()
+    insights = vault / "Knowledge Base" / "Notes" / "Insights"
+    insights.mkdir(parents=True, exist_ok=True)
+    for name in ("visible-one.md", "visible-two.md"):
+        page = insights / name
+        updated, _ = memory_refs.add_id_to_markdown(
+            "---\ntype: insight\n---\npublic\n", identity
+        )
+        page.write_text(updated, encoding="utf-8")
+    _govern_patterns_shut(vault)
+
+    command = {c.name: c for c in commands.COMMANDS}["get"]
+    with _external_scope():
+        with pytest.raises(ValueError) as excinfo:
             invoke_command(command, vault, path=memory_refs.memory_ref(identity))
 
     text = str(excinfo.value)
-    assert "AMBIGUOUS_REFERENCE" in text, f"the stable code must survive: {text!r}"
-    assert "2" in text, "the match count is what an owner needs"
-    for leaked in ("kill-switch-for-risky-releases", "kill-switch-copy", "Patterns"):
-        assert leaked not in text, f"collision named {leaked!r}: {text!r}"
+    assert "AMBIGUOUS_REFERENCE" in text
+    assert "2 pages" in text
+    assert "visible-one" not in text
+    assert "visible-two" not in text
 
 
 def test_a_blocked_policy_fails_the_error_path_closed(vault: Path) -> None:

--- a/tests/test_reserved_admin_paths.py
+++ b/tests/test_reserved_admin_paths.py
@@ -4279,7 +4279,7 @@ def test_managed_alias_resolution_cannot_reintroduce_reserved_paths(
     assert error.value.args == ("NOT_FOUND: memory identifier is unavailable",)
 
 
-def test_canonical_reference_resolution_cannot_reintroduce_reserved_paths(
+def test_reserved_reference_index_row_is_identical_to_missing(
     tmp_path: Path,
 ) -> None:
     from exomem import memory_refs
@@ -4310,7 +4310,9 @@ def test_canonical_reference_resolution_cannot_reintroduce_reserved_paths(
     with pytest.raises(ValueError) as error:
         commands._resolve_memory_identifier(tmp_path, memory_refs.memory_ref(memory_id))
 
-    assert error.value.args == ("NOT_FOUND: memory identifier is unavailable",)
+    assert error.value.args == (
+        f"REFERENCE_NOT_FOUND: memory id not found: {memory_id}",
+    )
 
 
 def test_every_command_and_finite_selector_has_total_path_role_metadata() -> None:


### PR DESCRIPTION
## Summary

- resolve canonical memory references from the read-only current corpus before public ambiguity reduction
- remove reserved, tombstoned, blocked, unresolved-principal, and L0 candidates before deciding not-found, unique, or ambiguous
- keep a visible-only ambiguity count while making hidden duplicates and stale reserved index rows identical to physical absence

## Why

Raw reference resolution counted every colliding page. Two hidden pages therefore returned AMBIGUOUS_REFERENCE instead of the same REFERENCE_NOT_FOUND envelope as absence, and one hidden duplicate could shadow an otherwise unique visible page. This closes that error/count oracle at the shared command boundary.

This is a bounded part of OpenSpec task 8.5; the broad task remains open for the other malformed/stale/parser/candidate-safety cases.

## Verification

- red first: 2 failed, 1 passed for hidden-absent, hidden-plus-visible, and visible-only collision cases
- 449 passed, 1 dependency/platform skip: governance postfilter, direct get payload, egress, and memory-reference suites
- 194 passed, 93 deselected: reference/identifier/reserved-path regression slice
- Ruff on all four changed files
- uv lock --check
- strict OpenSpec validation
- public-artifact privacy validation
- git diff --check

## Stack

Stacked on #849. Keep unmerged until the Personal Exomem stability audit clears the governance stack.