### PR TITLE
fix(governance): fail closed on malformed semantic metadata

### DIFF
--- a/src/exomem/find_corpus.py
+++ b/src/exomem/find_corpus.py
@@ -219,6 +219,7 @@ def parse_page(
     text = text.replace("\r\n", "\n").replace("\r", "\n")
 
     fm_match = FRONTMATTER_PATTERN.match(text)
+    frontmatter_valid = True
     if fm_match:
         try:
             # Hot path: every page-cache miss parses here (warm-up walks the
@@ -228,12 +229,14 @@ def parse_page(
             frontmatter = yaml_safe_load(fm_match.group(1)) or {}
             if not isinstance(frontmatter, dict):
                 frontmatter = {}
+                frontmatter_valid = False
         except yaml.YAMLError as e:
             if privacy_log.content_private_logging_enabled():
                 log.warning("hosted content parse failed code=HOSTED_CONTENT_PARSE_FAILED")
             else:
                 log.warning("YAML parse error in %s: %s", path, e)
             frontmatter = {}
+            frontmatter_valid = False
         body = fm_match.group(2)
         # The FRONTMATTER_PATTERN consumes the closing `\n---\n` but not the
         # blank line that conventionally follows. Strip a single leading `\n`
@@ -244,6 +247,10 @@ def parse_page(
     else:
         frontmatter = {}
         body = text
+        if text.startswith("---\n"):
+            # An opening fence without the complete frontmatter grammar is
+            # ambiguous metadata, not proof that the page has no metadata.
+            frontmatter_valid = False
 
     from .vault import resolve_display_title
 
@@ -265,6 +272,7 @@ def parse_page(
         title=title,
         mtime=mtime,
         snapshot_hash=hashlib.sha256(content).hexdigest(),
+        frontmatter_valid=frontmatter_valid,
     )
 
 

--- a/src/exomem/find_types.py
+++ b/src/exomem/find_types.py
@@ -41,6 +41,9 @@ class ParsedPage:
     # state: never serialized, but lets the post-cache release gate detect a
     # retrieval-to-projection swap even when size/mtime are preserved.
     snapshot_hash: str | None = None
+    # Whether an authored frontmatter block parsed as a YAML mapping. This is
+    # private classification state, not part of any public result shape.
+    frontmatter_valid: bool = True
 
     @property
     def page_type(self) -> str | None:

--- a/src/exomem/governance/egress.py
+++ b/src/exomem/governance/egress.py
@@ -2281,9 +2281,13 @@ def annotate_page(
         if "content" in page and page.get("content") != raw.decode("utf-8"):
             _record_blocked_outcome(who.audience_id)
             return None
-        scope_ids = membership_module.evaluate_snapshot(
-            parsed, policy, content_hash=snapshot_hash
-        )
+        try:
+            scope_ids = membership_module.evaluate_snapshot(
+                parsed, policy, content_hash=snapshot_hash
+            )
+        except membership_module.MembershipUnresolved:
+            _record_blocked_outcome(who.audience_id)
+            return None
         active_grants, _session_identity = _active_grants_for_snapshot(
             vault_root,
             policy=policy,

--- a/src/exomem/governance/membership.py
+++ b/src/exomem/governance/membership.py
@@ -24,7 +24,7 @@ from . import companions
 from .policy import Policy, Scope
 
 _MEMO_MAX = 4096
-_MEMO: OrderedDict[tuple[str, str, int, int], frozenset[str]] = OrderedDict()
+_MEMO: OrderedDict[tuple[str, str, int, int, bool], frozenset[str]] = OrderedDict()
 _SNAPSHOT_MEMO: OrderedDict[tuple[str, str, str], frozenset[str]] = OrderedDict()
 _PATH_MEMO: OrderedDict[
     tuple[str, str, tuple[companions.BoundSnapshot, ...]], MembershipOutcome
@@ -159,6 +159,29 @@ def _needs_frontmatter(scope: Scope) -> bool:
     return bool(scope.projects or scope.tags or scope.types or scope.classes)
 
 
+def _evaluate_markdown_scopes(page: ParsedPage, policy: Policy) -> frozenset[str]:
+    if page.frontmatter_valid:
+        return frozenset(
+            scope_id
+            for scope_id, scope in policy.scopes.items()
+            if _scope_matches(scope, page)
+        )
+
+    matched: set[str] = set()
+    for scope_id, scope in policy.scopes.items():
+        if _path_ref_excludes(scope, page.rel_path):
+            continue
+        if _path_ref_matches(scope, page.rel_path):
+            matched.add(scope_id)
+            continue
+        if _needs_frontmatter(scope):
+            raise MembershipUnresolved(
+                f"malformed frontmatter leaves scope membership unresolved for "
+                f"{page.rel_path!r}"
+            )
+    return frozenset(matched)
+
+
 def _semantic_scope_matches(scope: Scope, companion: companions.BoundCompanion) -> bool:
     projects = {value.casefold() for value in companion.projects}
     tags = {value.casefold() for value in companion.tags}
@@ -262,14 +285,12 @@ def evaluate(page: ParsedPage, policy: Policy) -> frozenset[str]:
         raise MembershipUnresolved(
             f"cannot stat {page.rel_path!r} to resolve scope membership: {exc}"
         ) from exc
-    key = (policy.fingerprint, page.rel_path, mtime_ns, size)
+    key = (policy.fingerprint, page.rel_path, mtime_ns, size, page.frontmatter_valid)
     cached = _MEMO.get(key)
     if cached is not None:
         _MEMO.move_to_end(key)
         return cached
-    result = frozenset(
-        scope_id for scope_id, scope in policy.scopes.items() if _scope_matches(scope, page)
-    )
+    result = _evaluate_markdown_scopes(page, policy)
     _MEMO[key] = result
     _MEMO.move_to_end(key)
     while len(_MEMO) > _MEMO_MAX:
@@ -295,9 +316,7 @@ def evaluate_snapshot(
     if cached is not None:
         _SNAPSHOT_MEMO.move_to_end(key)
         return cached
-    result = frozenset(
-        scope_id for scope_id, scope in policy.scopes.items() if _scope_matches(scope, page)
-    )
+    result = _evaluate_markdown_scopes(page, policy)
     _SNAPSHOT_MEMO[key] = result
     _SNAPSHOT_MEMO.move_to_end(key)
     while len(_SNAPSHOT_MEMO) > _MEMO_MAX:

--- a/tests/test_get_payload.py
+++ b/tests/test_get_payload.py
@@ -113,6 +113,43 @@ def test_include_raw_returns_disk_bytes(vault: Path) -> None:
     assert out["content_hash"] == content_hash(out["content"])
 
 
+def test_malformed_semantic_frontmatter_is_identical_to_physical_absence(
+    vault: Path,
+) -> None:
+    rel = "Knowledge Base/Notes/malformed-private.md"
+    target = vault / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        "---\ntype: insight\ntags: [private\n---\nprivate body\n",
+        encoding="utf-8",
+    )
+    governance = vault / "Knowledge Base" / "_Governance" / "scopes"
+    governance.mkdir(parents=True, exist_ok=True)
+    (governance / "private.yaml").write_text(
+        "governance_version: 1\n"
+        "id: 01ARZ3NDEKTSV4RRFFQ69G5FAV\n"
+        'tags: ["private"]\n'
+        "default_deny: true\n",
+        encoding="utf-8",
+    )
+    policy._CACHE.clear()
+    egress.clear_decision_memo()
+
+    def _error() -> ValueError:
+        with request_scope(_external()):
+            with pytest.raises(ValueError) as excinfo:
+                commands.op_get(vault, path=rel)
+        return excinfo.value
+
+    malformed_present = _error()
+    target.unlink()
+    physically_absent = _error()
+
+    assert type(malformed_present) is type(physically_absent)
+    assert malformed_present.args == physically_absent.args
+    assert "private body" not in str(malformed_present)
+
+
 def test_drift_guard_roundtrip_without_content(vault: Path) -> None:
     """edit(expected_hash=get().content_hash) still works — the hash is
     server-computed over raw bytes; callers never need `content`."""

--- a/tests/test_governance_membership.py
+++ b/tests/test_governance_membership.py
@@ -77,6 +77,80 @@ def test_tag_selector_resolves_membership(vault: Path) -> None:
     assert "01ARZ3NDEKTSV4RRFFQ69G5FB1" in membership.evaluate(parsed, pol)
 
 
+def test_malformed_markdown_frontmatter_is_unresolved_for_semantic_scope(
+    vault: Path,
+) -> None:
+    _write_scope(
+        vault,
+        "confidential",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FB1\ntags: ["confidential"]\n',
+    )
+    pol = policy.load(vault)
+    page = _write_page(
+        vault,
+        "Knowledge Base/Notes/malformed.md",
+        "type: insight\ntags: [confidential",
+        body="private body",
+    )
+    parsed = _parse(vault, "Knowledge Base/Notes/malformed.md")
+    assert parsed is not None
+
+    with pytest.raises(membership.MembershipUnresolved):
+        membership.evaluate_snapshot(
+            parsed,
+            pol,
+            content_hash=hashlib.sha256(page.read_bytes()).hexdigest(),
+        )
+
+
+def test_malformed_markdown_frontmatter_keeps_path_only_classification(
+    vault: Path,
+) -> None:
+    scope_id = "01ARZ3NDEKTSV4RRFFQ69G5FB1"
+    _write_scope(
+        vault,
+        "confidential",
+        f'governance_version: 1\nid: {scope_id}\npaths: ["Notes/**"]\n',
+    )
+    pol = policy.load(vault)
+    page = _write_page(
+        vault,
+        "Knowledge Base/Notes/malformed.md",
+        "type: insight\ntags: [confidential",
+    )
+    parsed = _parse(vault, "Knowledge Base/Notes/malformed.md")
+    assert parsed is not None
+
+    assert membership.evaluate_snapshot(
+        parsed,
+        pol,
+        content_hash=hashlib.sha256(page.read_bytes()).hexdigest(),
+    ) == frozenset({scope_id})
+
+
+def test_unterminated_frontmatter_is_unresolved_for_semantic_scope(
+    vault: Path,
+) -> None:
+    _write_scope(
+        vault,
+        "confidential",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FB1\ntags: ["confidential"]\n',
+    )
+    pol = policy.load(vault)
+    page = vault / "Knowledge Base" / "Notes" / "unterminated.md"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text("---\ntags: [confidential]\nprivate body\n", encoding="utf-8")
+    parsed = _parse(vault, "Knowledge Base/Notes/unterminated.md")
+    assert parsed is not None
+
+    with pytest.raises(membership.MembershipUnresolved):
+        membership.evaluate_snapshot(
+            parsed,
+            pol,
+            content_hash=hashlib.sha256(page.read_bytes()).hexdigest(),
+        )
+
+
 def test_type_selector_resolves_membership(vault: Path) -> None:
     _write_scope(
         vault,


### PR DESCRIPTION
## Summary

- preserve parser validity on immutable Markdown snapshots
- fail closed when malformed or unterminated frontmatter leaves semantic scope membership undecidable
- preserve conservative path/ref-only classification and make direct-read refusal identical to physical absence

Stacked after #855. This does not merge or touch any live vault.

## Verification

- red-first oracle: 2 expected failures and 1 path-only control pass before implementation
- exact regression: 4 passed
- focused governance/direct-read/parser suites: 476 passed
- find and line-ending parser suites: 49 passed
- Ruff on all six changed files
- uv lock --check
- openspec validate harden-governance-for-consolidation --strict
- public repository artifact validation
- git diff --check