### PR TITLE
chore(openspec): file the graph recovery funnel bound

### DIFF
--- a/openspec/changes/bound-graph-recovery-funnel/proposal.md
+++ b/openspec/changes/bound-graph-recovery-funnel/proposal.md
@@ -1,0 +1,48 @@
+# Proposal: bound-graph-recovery-funnel
+
+## Why
+
+The 2026-08 incident's deepest layer was not a code defect but an interaction:
+`full_upsert_succeeded` accepts an `epistemic_graph` deferral only while the
+registered graph checkpoint equals the live one, so whenever `graph_sync`
+sits in `recovery_required`, EVERY batch write fails accounting and mints a
+durable full-index receipt for its paths — regardless of the durable
+per-path graph receipts the deferral already recorded. That funnel is
+correct when recovery completes in minutes. When something makes recovery
+impossible — a stale venv `.pth` force-disabling the graph subsystem
+(measured: 2,551 receipts, days of churn), or an out-of-process drain
+soft-deadlocked against the live service (measured: ~2,143 receipts in
+40 minutes) — the funnel self-sustains: backlog → recovery_required →
+every write mints → backlog. Draining the accumulated backlog re-embedded
+exactly 3 files; the rest was double-accounting. The system had no alarm
+for "recovery has been required for hours", no refusal for the concurrent
+drain, and only a WARN for the kill-switch that made recovery impossible.
+
+## What Changes
+
+- `full_upsert_succeeded` accepts an `epistemic_graph` deferral during
+  `recovery_required` **when and only when** the deferral durably covers the
+  batch's graph-input paths with per-path receipts (`graph_upserts`) — the
+  receipts ARE the exact durable demand; minting a full receipt on top is
+  the same double-accounting shape the warm-up fix (#850) removed for
+  embeddings. Uncovered graph deferrals still fail closed.
+- Persistent recovery becomes an alarmed, bounded condition: stable
+  content-free telemetry for time-in-recovery, surfaced in `/health/ready`,
+  and a doctor FAIL (not WARN) when `recovery_required` exceeds a bound or
+  when graph work is disabled while a recovery checkpoint exists (the
+  provably-unrecoverable combination, including kill-switch env injected by
+  unowned site-packages `.pth` files).
+- The out-of-process drain (`exomem index`) refuses to start, with a clear
+  remediation message, when a live service owns graph work for the same
+  vault — the soft-deadlock (CLI holds the graph claim at 0 CPU while the
+  service mints receipts) becomes unrepresentable.
+
+## Impact
+
+- `src/exomem/index_sync.py` — the graph clause of `full_upsert_succeeded`;
+  deferral telemetry.
+- `src/exomem/graph_sync.py` / doctor — recovery-age telemetry, the
+  unrecoverable-combination FAIL, `.pth` kill-switch detection.
+- `src/exomem/` CLI index path — live-service ownership probe and refusal.
+- Regression tests red-first for each: covered-deferral acceptance during
+  recovery, funnel alarm, drain refusal.

--- a/openspec/changes/bound-graph-recovery-funnel/specs/live-index-freshness/spec.md
+++ b/openspec/changes/bound-graph-recovery-funnel/specs/live-index-freshness/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: Bounded write-time index maintenance
+
+A component deferral that has already durably recorded path-exact receipts covering the batch SHALL count as batch-report success and SHALL NOT seed a full-component refresh demand — for the embeddings component (semantic receipts) AND for the epistemic-graph component (per-path graph receipts), including while graph synchronization is in recovery. The system SHALL mint a durable full-component refresh demand from a write-time outcome only for a component whose incomplete work has no durable path coverage, and SHALL count both outcomes — covered deferrals accepted and uncovered deferrals escalated — in stable content-free telemetry.
+
+#### Scenario: A warm-up-deferred embedding batch does not seed a whole-vault rebuild
+
+- **WHEN** a batch atomic write's embeddings component defers because the embedding model is warming
+- **AND** the warm-up deferral has already recorded durable semantic receipts naming exactly that batch's paths
+- **THEN** the batch report treats the embeddings component as succeeded-deferred
+- **AND** no full-component refresh receipt is minted for the batch
+- **AND** the already-queued semantic replay remains the sole durable demand for those paths
+
+#### Scenario: A durably covered graph deferral during recovery does not mint
+
+- **WHEN** graph synchronization is in a recovery-required state
+- **AND** a batch atomic write's graph component defers after durably recording per-path graph receipts covering the batch's graph-input paths
+- **THEN** the batch report treats the graph component as succeeded-deferred
+- **AND** no full-component refresh receipt is minted for the batch
+- **AND** the queued graph replay remains the sole durable demand for those paths
+
+#### Scenario: An uncovered deferral still fails closed
+
+- **WHEN** a component defers without durable path-exact coverage of the batch
+- **THEN** the batch report fails and a durable full-component refresh demand is minted
+- **AND** the escalation increments its telemetry counter
+
+## ADDED Requirements
+
+### Requirement: Persistent graph recovery is an alarmed, bounded condition
+
+The system SHALL measure how long graph synchronization has continuously required recovery and surface it as stable content-free telemetry in the readiness payload. Diagnostics SHALL fail — not merely warn — when recovery has been required beyond a configured bound, and SHALL fail immediately when graph work is disabled while a durable recovery checkpoint exists, including when the disabling kill switch is injected by an interpreter startup file rather than the process environment.
+
+#### Scenario: Recovery outlasting its bound raises a diagnostic failure
+
+- **WHEN** graph synchronization has continuously required recovery for longer than the configured bound
+- **THEN** the readiness payload exposes the recovery age
+- **AND** the doctor reports a failing finding naming the age and the remediation
+
+#### Scenario: An unrecoverable configuration fails diagnostics immediately
+
+- **WHEN** graph scheduling or the graph index is disabled while a durable graph recovery checkpoint exists
+- **THEN** the doctor reports a failing finding identifying the disabling source, including a site-packages startup file that injects the kill switch
+
+### Requirement: The out-of-process index drain refuses contended graph ownership
+
+The out-of-process index drain SHALL detect that a live service owns graph work for the target vault before taking any graph claim, and SHALL refuse to start with a remediation naming the stop-window procedure instead of contending for the claim.
+
+#### Scenario: Drain against a live graph-active service refuses
+
+- **WHEN** the out-of-process index drain is invoked for a vault whose running service currently performs graph work
+- **THEN** the drain exits without taking the graph claim
+- **AND** its message names the stop-window procedure as the remediation

--- a/openspec/changes/bound-graph-recovery-funnel/tasks.md
+++ b/openspec/changes/bound-graph-recovery-funnel/tasks.md
@@ -1,0 +1,36 @@
+# Tasks
+
+## 1. Regression tests (red first)
+
+- [ ] 1.1 Pin the funnel: during `recovery_required`, a batch write whose
+      graph deferral durably covers its graph-input paths currently fails
+      `full_upsert_succeeded` and mints a full receipt. After the fix the
+      pin inverts: report succeeds, no full receipt, telemetry counts the
+      covered acceptance.
+- [ ] 1.2 Fail-closed pin: a graph deferral WITHOUT covering per-path
+      receipts still fails the report and mints the demand.
+- [ ] 1.3 Alarm pin: recovery_required persisting beyond the bound surfaces
+      in health telemetry and turns the doctor finding into a FAIL; the
+      graph-disabled-while-recovery-checkpoint-exists combination FAILs
+      immediately, including when the kill switch comes from an unowned
+      site-packages `.pth`.
+- [ ] 1.4 Drain-refusal pin: `exomem index` against a vault whose live
+      service owns graph work refuses with the documented remediation
+      instead of taking the claim.
+
+## 2. Implementation
+
+- [ ] 2.1 Extend the `epistemic_graph` clause of `full_upsert_succeeded`
+      with the durable-coverage carve-out (mirror of the embeddings
+      warm-up carve-out from #850).
+- [ ] 2.2 Recovery-age telemetry + health surfacing + doctor FAIL findings.
+- [ ] 2.3 Live-service ownership probe and refusal in the CLI index path.
+
+## 3. Verification and delivery
+
+- [ ] 3.1 Focused suites, lint, privacy, strict OpenSpec validation.
+- [ ] 3.2 Independent adversarial review; resolve findings.
+- [ ] 3.3 Live acceptance: induce recovery_required on a test vault, write
+      through it, verify zero minting with covered deferrals and a firing
+      alarm; verify the drain refusal against a running service.
+- [ ] 3.4 Sync and archive this change after delivery.


### PR DESCRIPTION
Postmortem filing from the incident's deepest layer (see #854's closeout): while `graph_sync` requires recovery, every batch write fails `full_upsert_succeeded`'s graph clause and mints full-index receipts even when the deferral durably covers its paths — self-sustaining whenever recovery cannot complete (measured twice live). Files three requirements: the durable-coverage carve-out for graph deferrals (mirror of #850's embeddings fix), persistent-recovery alarm with doctor FAIL findings (including .pth-injected kill switches), and the out-of-process drain refusing contended graph ownership. Spec-only; red-first implementation plan in tasks.md; strict validation green.