### PR TITLE
docs: encode the live-cell incident guardrails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,3 +159,26 @@ pass: clean tree, diff within the brief's allowlist, guarded files untouched
 On failure: write `.task/FEEDBACK.md`, retry once, escalate Terra→Sol, then
 reassign to a Claude executor. Cap concurrent workers at 4–6; run benchmarks
 only on a quiesced machine.
+
+## Live-cell guardrails (2026-08 incident; standing until `bound-graph-recovery-funnel` lands in code)
+
+- **Never run an out-of-process drain (`exomem index --scope vault`) while the
+  service is running.** The CLI takes the graph claim, blocks at 0 CPU on the
+  live boundary, and the service mints full-index receipts on every write
+  meanwhile — a measured soft-deadlock (~2,100 receipts in 40 minutes).
+  Stop-window only: `Stop-Service exomem` → drain → `Start-Service exomem`.
+  Note: `exomem maintain --reconcile` does NOT drain the deferred queue;
+  `exomem index` does.
+- **Test kill-switch env INSIDE the venv python, never in the shell.** Unowned
+  site-packages `.pth` files inject `EXOMEM_*` flags at interpreter startup, so
+  shell/user/machine/NSSM scopes all show them unset while every venv process
+  has them. The 5-second test:
+  `<venv>\Scripts\python.exe -c "import os; print(os.environ.get('EXOMEM_DISABLE_GRAPH_SCHEDULING'))"`.
+  A cell whose graph work is disabled while a durable recovery checkpoint
+  exists can never converge, and every write mints a full-index receipt.
+- **Chained builds + "index upsert incomplete" warnings while `graph_sync` is
+  `recovery_required` are the graph accounting funnel** (openspec change
+  `bound-graph-recovery-funnel`), not a regression of the 0.63.x fixes. Read
+  `.deferred-index.sqlite` `full_upserts` and the graph state before
+  diagnosing anything else; the fixed-era signature is full receipts at 0 and
+  the graph converging within minutes of each write.


### PR DESCRIPTION
Encodes the three operational rules from the 2026-08 incident closeout that code cannot yet enforce (spec filed as `bound-graph-recovery-funnel`, #857): out-of-process drains run only in a service stop-window (measured soft-deadlock otherwise); kill-switch env is tested inside the venv python because unowned .pth injection makes every other scope lie; and the graph-funnel signature is read before diagnosing rebuild churn. Instructions-as-system per operator directive — these bind every future Claude/Codex session via CLAUDE.md/AGENTS.md.