### PR TITLE
test(governance): prove hidden continuation stability

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -493,7 +493,7 @@ made before both PRs and their combined verification are complete.
 - [ ] 8.4 Add red graph pairs where hidden vertices/edges change in-degree, out-degree,
   reachability, shortest paths, relation matches, seed expansion, graph-assisted fusion,
   and pagination; assert the visible graph/order is identical to physical absence.
-- [ ] 8.5 Add red error pairs for hidden malformed/stale/index-missing items, duplicate
+- [x] 8.5 Add red error pairs for hidden malformed/stale/index-missing items, duplicate
   identifiers, ambiguous refs, parser failures, and candidate-safety boundaries; assert
   identical success/error code, text, shape, count, and remediation when hidden versus
   absent.

--- a/tests/test_governance_oracle_closure.py
+++ b/tests/test_governance_oracle_closure.py
@@ -430,6 +430,10 @@ def _wire_pages(
         [tuple[str, ...]], projection_runtime.ActiveProjectionRuntime
     ]
     | None = None,
+    runtime_after_first_page_factory: Callable[
+        [tuple[str, ...]], projection_runtime.ActiveProjectionRuntime
+    ]
+    | None = None,
 ) -> tuple[
     dict[str, projection_runtime.ActiveProjectionRuntime],
     dict[str, tuple[httpx.Response, ...]],
@@ -537,6 +541,15 @@ def _wire_pages(
                     headers={"Authorization": f"Bearer {_REST_KEY}"},
                 )
                 pages.append(response)
+                if (
+                    _page_number == 0
+                    and runtime_after_first_page_factory is not None
+                ):
+                    runtimes_by_root[roots[name]] = (
+                        runtime_after_first_page_factory(
+                            () if name == "absent" else hidden_bodies
+                        )
+                    )
                 if response.status_code != 200:
                     break
                 continuation = response.json()["data"].get("continuation")
@@ -928,6 +941,67 @@ def test_hidden_rows_cannot_change_any_pagination_boundary_cursor_or_order(
     ]
     assert [data.get("continuation") for data in present_data] == [
         data.get("continuation") for data in absent_data
+    ]
+
+
+def test_hidden_only_catalog_change_preserves_the_live_wire_continuation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    visible_bodies = tuple(
+        "continuationchangequartz visible page row" for _ in range(5)
+    )
+
+    def current_runtime(
+        hidden_bodies: tuple[str, ...],
+    ) -> projection_runtime.ActiveProjectionRuntime:
+        changed_hidden = (
+            ()
+            if not hidden_bodies
+            else (
+                "continuationchangequartz changed hidden row",
+                "continuationchangequartz added hidden row",
+            )
+        )
+        return _counterfactual_runtime(
+            hidden_bodies=changed_hidden,
+            visible_bodies=visible_bodies,
+        )
+
+    runtimes, pages = _wire_pages(
+        monkeypatch,
+        tmp_path,
+        hidden_bodies=("continuationchangequartz original hidden row",),
+        visible_bodies=visible_bodies,
+        request=_request(query="continuationchangequartz", limit=2),
+        max_pages=4,
+        runtime_after_first_page_factory=current_runtime,
+    )
+
+    assert runtimes["absent"].namespace.namespace_key.catalog_generation == 5
+    assert runtimes["present"].namespace.namespace_key.catalog_generation == 7
+    assert len(pages["absent"]) == 3
+    assert len(pages["present"]) == 3
+    for absent, present in zip(pages["absent"], pages["present"], strict=True):
+        assert absent.status_code == 200, absent.text
+        assert present.status_code == 200, present.text
+        assert _canonical_transport_envelope(
+            present, transport="http"
+        ) == _canonical_transport_envelope(absent, transport="http")
+
+    assert [
+        [hit["path"] for hit in response.json()["data"]["hits"]]
+        for response in pages["present"]
+    ] == [
+        [
+            "Knowledge Base/oracle-visible-000.md",
+            "Knowledge Base/oracle-visible-001.md",
+        ],
+        [
+            "Knowledge Base/oracle-visible-002.md",
+            "Knowledge Base/oracle-visible-003.md",
+        ],
+        ["Knowledge Base/oracle-visible-004.md"],
     ]
 
 


### PR DESCRIPTION
## Summary

- prove a live governed REST continuation survives a catalog update that changes only default-denied L0 items
- compare the complete application wire envelope against the physical-absence control across every page
- close OpenSpec task 8.5 after the stacked malformed, stale/index-missing, duplicate/ambiguous, parser, and candidate-boundary oracle coverage

Stacked after #856. This does not merge or touch any live vault.

## Verification

- focused continuation/error oracle: 10 passed
- Ruff on the changed test module
- `uv lock --check`
- `openspec validate harden-governance-for-consolidation --strict`
- public repository artifact validation
- `git diff --check`
