### PR TITLE
test(governance): close projected retrieval evidence

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -479,12 +479,12 @@ made before both PRs and their combined verification are complete.
   governed envelope, not selected fields. Register one transport normalizer that may
   remove only echoed JSON-RPC id, HTTP Date/outer trace headers, and framing; application
   code/message/remediation/data, request ids, timings, warnings, and diagnostics remain.
-- [ ] 8.2 In that suite, cover high/middle/low hidden ranks, keyword/BM25 fusion,
+- [x] 8.2 In that suite, cover high/middle/low hidden ranks, keyword/BM25 fusion,
   raw-lane caps greater than visible top-k, projection-only query terms, projected-corpus
   DF/IDF, vector projection-only/raw-only relevance, reranking seams, top-k displacement,
   exhausted/non-exhausted sources, every pagination boundary, order, cursors, totals,
   facets, ambiguity counts, degraded diagnostics, and caller-visible candidate caps.
-- [ ] 8.3 Add red CLIP/non-text pairs where the highest hidden pixel/keyframe match would
+- [x] 8.3 Add red CLIP/non-text pairs where the highest hidden pixel/keyframe match would
   consume the cap. Assert authorization occurs inside CLIP before its cap, L6 visible
   visual top-k is exact, and L1-L5 media participates only through its authorized textual
   companion projection or is excluded from the binary lane. Bind each image to one
@@ -559,7 +559,7 @@ made before both PRs and their combined verification are complete.
 - [x] 8.13 Authorize graph vertices and edges before expansion and recompute all public
   graph reductions over the projected graph; absorb errors belonging only to L0 state as
   absence.
-- [ ] 8.14 Move fusion, final sort/top-k, pagination/cursor creation, counts/facets,
+- [x] 8.14 Move fusion, final sort/top-k, pagination/cursor creation, counts/facets,
   ambiguity, diagnostics, and error reduction after complete projected lane acquisition;
   add cross-principal hot-cache reuse tests proving decisions/order stay request-local.
   Governed find continuation SHALL use the exact bounded `pc1` visible-snapshot digest

--- a/tests/test_governance_oracle_closure.py
+++ b/tests/test_governance_oracle_closure.py
@@ -837,6 +837,65 @@ def test_projection_only_term_acquires_visible_rows_without_raw_text_or_l0_influ
     assert b"oracle-hidden" not in content
 
 
+def test_hot_runtime_reuse_keeps_principal_decisions_and_order_request_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_CLIP", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_RANKING", "1")
+    runtime = _projection_only_runtime(
+        ("projectivequartz hidden owner-only source",)
+    )
+    external = principal.RequestPrincipal(
+        audience_id="oracle-external",
+        surface="rest",
+        resolved=True,
+        issuer_family="oracle-test",
+    )
+    call = {
+        "query": "projectivequartz",
+        "limit": 2,
+        "scope": "vault",
+        "mode": "keyword",
+        "graph": False,
+        "rerank": False,
+        "purpose": None,
+    }
+
+    first_external = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        principal=external,
+        **call,
+    )
+    owner = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        principal=principal.owner_principal(surface="library"),
+        **call,
+    )
+    second_external = projection_runtime.find_projected_hits(
+        tmp_path,
+        runtime,
+        principal=external,
+        **call,
+    )
+
+    assert first_external == second_external
+    assert [hit.path for hit in first_external.hits] == [
+        "Knowledge Base/oracle-visible-000.md",
+        "Knowledge Base/oracle-visible-001.md",
+    ]
+    assert [hit.decision.level for hit in first_external.hits] == [3, 3]
+    assert [hit.path for hit in owner.hits] == [
+        "Knowledge Base/private/oracle-hidden-000.md"
+    ]
+    assert owner.hits[0].decision.level == 6
+    assert all("raw-source-only" not in hit.excerpt for hit in first_external.hits)
+    assert "hidden owner-only source" in owner.hits[0].excerpt
+
+
 def test_hidden_document_frequency_cannot_change_visible_bm25_order(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_rest_registry.py
+++ b/tests/test_rest_registry.py
@@ -94,6 +94,18 @@ def test_governed_continuation_is_shared_by_product_read_surfaces() -> None:
         assert continuation.type == "str"
         assert continuation.required is False
 
+    for profile in commands_module.PRODUCT_SURFACE_PROFILES:
+        command = next(
+            item
+            for item in commands_module.product_commands_for_profile(profile, "rest")
+            if item.name == "ask_memory"
+        )
+        continuation = next(
+            item for item in command.params if item.name == "continuation"
+        )
+        assert continuation.type == "str"
+        assert continuation.required is False
+
 
 def _client(vault, monkeypatch: pytest.MonkeyPatch, **env: str) -> TestClient:
     monkeypatch.setattr(server, "load_dotenv", lambda *a, **k: None)


### PR DESCRIPTION
## Summary

- prove one hot immutable projected runtime keeps decisions, content, and order request-local across external → owner → external reuse
- prove every hosted v1–v4 profile inherits the same governed continuation input as MCP, REST, and CLI
- reconcile completed OpenSpec retrieval evidence tasks 8.2, 8.3, and 8.14

Stacked after #861. This does not merge or touch any live vault.

## Verification

- focused projected retrieval/authorization/CLIP/graph/continuation/registry suites: 84 passed
- Ruff on both changed test modules
- `uv lock --check`
- `openspec validate harden-governance-for-consolidation --strict`
- public repository artifact validation
- `git diff --check`
