### PR TITLE
chore(openspec): complete the funnel spec with startup, projection-lag, and access fail-closed requirements

### DIFF
--- a/openspec/changes/bound-graph-recovery-funnel/specs/live-index-freshness/spec.md
+++ b/openspec/changes/bound-graph-recovery-funnel/specs/live-index-freshness/spec.md
@@ -52,3 +52,18 @@ The out-of-process index drain SHALL detect that a live service owns graph work 
 - **WHEN** the out-of-process index drain is invoked for a vault whose running service currently performs graph work
 - **THEN** the drain exits without taking the graph claim
 - **AND** its message names the stop-window procedure as the remediation
+
+### Requirement: Graph startup validation is bounded
+
+A service restart that finds a coherent durable graph checkpoint SHALL admit graph reads without rebuilding the whole graph; the startup pass validates against durable state and reserves the whole-vault rebuild for genuine incoherence (missing or malformed checkpoint, digest mismatch, or a recorded crash marker). Read suspension during startup validation SHALL be bounded by the validation itself, not by a full rebuild.
+
+#### Scenario: Restart with a coherent graph admits without a full rebuild
+
+- **WHEN** the service restarts and the durable graph checkpoint matches the published sidecar's digest and generation
+- **THEN** graph reads are admitted after the O(1) validation
+- **AND** no whole-vault graph rebuild is scheduled by the startup pass
+
+#### Scenario: Genuine incoherence still rebuilds
+
+- **WHEN** the service restarts and the durable graph checkpoint is missing, malformed, or does not match the published sidecar
+- **THEN** the startup pass suspends reads and schedules the whole-vault rebuild

--- a/openspec/changes/bound-graph-recovery-funnel/specs/live-index-freshness/spec.md
+++ b/openspec/changes/bound-graph-recovery-funnel/specs/live-index-freshness/spec.md
@@ -67,3 +67,18 @@ A service restart that finds a coherent durable graph checkpoint SHALL admit gra
 
 - **WHEN** the service restarts and the durable graph checkpoint is missing, malformed, or does not match the published sidecar
 - **THEN** the startup pass suspends reads and schedules the whole-vault rebuild
+
+### Requirement: Semantic recall admission tolerates bounded projection lag
+
+Semantic recall SHALL NOT refuse solely because the maintained recall projection lags current content by in-flight writes; it SHALL serve from the last published projection while the projection refresh is pending, disclosing bounded staleness, and SHALL refuse only when no published projection exists or the projection's identity (policy, access fingerprint, catalog identity) no longer matches. The write path SHALL refresh the projection proportionally to the delta, never by whole-vault work.
+
+#### Scenario: A write does not interrupt semantic recall
+
+- **WHEN** semantic recall arrives while writes have advanced content past the last published recall projection
+- **THEN** the recall serves from the last published projection with a bounded-staleness disclosure
+- **AND** the projection refresh proceeds proportionally to the delta
+
+#### Scenario: Identity changes still refuse
+
+- **WHEN** the recall policy, access fingerprint, or catalog identity changes
+- **THEN** semantic recall refuses until a projection published under the new identity exists

--- a/openspec/changes/bound-graph-recovery-funnel/specs/recall-read-path/spec.md
+++ b/openspec/changes/bound-graph-recovery-funnel/specs/recall-read-path/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Access-policy loading fails closed on transient errors
+
+A transient failure to stat or read the access-policy file SHALL NOT install or cache a policy more permissive than the last successfully loaded one, and SHALL NOT change the access fingerprint used in recall identity. While the last successful load remains valid under an unchanged stat signature, transient errors reuse it; when no successful load exists, the system SHALL treat every path as excluded (fail closed) until a read succeeds. Recall identity SHALL only change when the policy content provably changed.
+
+#### Scenario: A transient read error cannot widen visibility
+
+- **WHEN** reading the access-policy file raises a transient error while a previously loaded policy exists
+- **THEN** the previously loaded policy and its fingerprint remain in effect
+- **AND** no cache entry is installed that outlives the error
+
+#### Scenario: No successful load yet fails closed
+
+- **WHEN** the access-policy file exists but has never been successfully read in this process
+- **AND** reading it raises a transient error
+- **THEN** access-gated serving treats all paths as excluded until a read succeeds
+
+#### Scenario: A transient blip does not flip recall identity
+
+- **WHEN** a stat or read blip occurs with the policy file's content unchanged
+- **THEN** the recall identity and its access fingerprint are unchanged
+- **AND** no recall generation advances and no admission refusal results

--- a/openspec/changes/bound-graph-recovery-funnel/tasks.md
+++ b/openspec/changes/bound-graph-recovery-funnel/tasks.md
@@ -23,8 +23,18 @@
       service owns graph work refuses with the documented remediation
       instead of taking the claim.
 
+- [ ] 1.6 Access fail-open pin (red first): a transient OSError reading the
+      access-policy file currently caches an EMPTY policy (nothing excluded)
+      under the unchanged stat signature and flips the access fingerprint,
+      widening visibility and flapping recall identity with zero writes.
+      After the fix: last-known-good policy retained, fingerprint stable,
+      no cache poisoning; with no prior successful load, everything is
+      excluded until a read succeeds.
+
 ## 2. Implementation
 
+- [ ] 2.0 Access-policy fail-closed loading per the recall-read-path delta
+      (precondition for trusting the projection-lag identity guard).
 - [ ] 2.1 Extend the `epistemic_graph` clause of `full_upsert_succeeded`
       with the durable-coverage carve-out (mirror of the embeddings
       warm-up carve-out from #850).

--- a/openspec/changes/bound-graph-recovery-funnel/tasks.md
+++ b/openspec/changes/bound-graph-recovery-funnel/tasks.md
@@ -14,7 +14,12 @@
       graph-disabled-while-recovery-checkpoint-exists combination FAILs
       immediately, including when the kill switch comes from an unowned
       site-packages `.pth`.
-- [ ] 1.4 Drain-refusal pin: `exomem index` against a vault whose live
+- [ ] 1.4 Startup-bound pin: a restart over a coherent durable graph
+      checkpoint currently schedules a whole-vault rebuild in the watcher
+      startup pass (measured: ~30 min of suspended reads per restart on a
+      3.3k-file vault); after the fix it admits after O(1) validation, and
+      only genuine incoherence rebuilds.
+- [ ] 1.5 Drain-refusal pin: `exomem index` against a vault whose live
       service owns graph work refuses with the documented remediation
       instead of taking the claim.
 
@@ -25,6 +30,8 @@
       warm-up carve-out from #850).
 - [ ] 2.2 Recovery-age telemetry + health surfacing + doctor FAIL findings.
 - [ ] 2.3 Live-service ownership probe and refusal in the CLI index path.
+- [ ] 2.4 Bounded startup validation: O(1) durable-checkpoint check in the
+      watcher startup pass; whole-vault rebuild only on incoherence.
 
 ## 3. Verification and delivery
 

--- a/openspec/changes/bound-graph-recovery-funnel/tasks.md
+++ b/openspec/changes/bound-graph-recovery-funnel/tasks.md
@@ -30,7 +30,12 @@
       warm-up carve-out from #850).
 - [ ] 2.2 Recovery-age telemetry + health surfacing + doctor FAIL findings.
 - [ ] 2.3 Live-service ownership probe and refusal in the CLI index path.
-- [ ] 2.4 Bounded startup validation: O(1) durable-checkpoint check in the
+- [ ] 2.4 Projection-lag tolerance: serve semantic recall from the last
+      published projection during refresh; refuse only on identity change or
+      absent projection (red-first pin: a single write currently flips
+      semantic recall to RETRIEVAL_INDEX_WARMING until the graph republishes
+      the projection - measured live as the flapping-admission duty cycle).
+- [ ] 2.5 Bounded startup validation: O(1) durable-checkpoint check in the
       watcher startup pass; whole-vault rebuild only on incoherence.
 
 ## 3. Verification and delivery


### PR DESCRIPTION
Restores the two requirements lost when #857's auto-merge fired before the amendment pushes (bounded graph startup validation; semantic recall projection-lag tolerance), and adds a third surfaced by the implementer lane's stop condition: access-policy loading currently caches an EMPTY policy on a transient read error (access.py:147-152) — a cached fail-open on the privacy boundary — and the same transient blip flips recall identity with zero writes, which is the measured serve/refuse admission flapping on the personal cell. The new recall-read-path delta makes transient errors fail closed and keeps recall identity stable unless policy content provably changed. Red-first task pins included; strict validation green.