### PR TITLE
fix(governance): collect unpinned projection namespaces

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -497,7 +497,7 @@ made before both PRs and their combined verification are complete.
   identifiers, ambiguous refs, parser failures, and candidate-safety boundaries; assert
   identical success/error code, text, shape, count, and remediation when hidden versus
   absent.
-- [ ] 8.6 Add red namespace tests proving its key is exactly `(policy_fingerprint,
+- [x] 8.6 Add red namespace tests proving its key is exactly `(policy_fingerprint,
   projector_schema_version, catalog_generation)`, immutable content identity is a row
   key, and extractor/model versions are measurement subkeys. Cover initial warming,
   complete build before active-tuple activation, atomic next-catalog generation, policy/

--- a/src/exomem/governance/projection_gc.py
+++ b/src/exomem/governance/projection_gc.py
@@ -1,0 +1,84 @@
+"""Owner-only exact-tuple garbage collection for projection namespaces."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable
+from pathlib import Path
+
+from . import projection_runtime, projection_store, schema_v4, store
+
+
+class ProjectionCollectionUnavailable(RuntimeError):
+    """The complete namespace retention snapshot cannot be proven."""
+
+
+def _namespace_ids(values: Iterable[str]) -> frozenset[str]:
+    normalized = frozenset(values)
+    if any(
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+        for value in normalized
+    ):
+        raise ProjectionCollectionUnavailable(
+            "projection namespace retention cannot be verified"
+        )
+    return normalized
+
+
+def _durable_namespace_snapshot(
+    vault_root: Path,
+) -> tuple[frozenset[str], frozenset[str]]:
+    connection: sqlite3.Connection | None = None
+    try:
+        connection = store.open_active_governance_read_connection(vault_root)
+        connection.execute("BEGIN")
+        registered = schema_v4.projection_namespace_ids(connection)
+        pinned = schema_v4.projection_namespace_pins(connection)
+        connection.commit()
+        return registered, pinned
+    except (
+        OSError,
+        RuntimeError,
+        sqlite3.Error,
+        schema_v4.SchemaV4Error,
+        store.UnsupportedGovernanceSchema,
+    ) as error:
+        if connection is not None and connection.in_transaction:
+            connection.rollback()
+        raise ProjectionCollectionUnavailable(
+            "projection namespace retention cannot be verified"
+        ) from error
+    finally:
+        if connection is not None:
+            connection.close()
+
+
+def collect_unpinned_projection_namespaces(
+    vault_root: Path,
+    *,
+    retained_namespace_ids: Iterable[str],
+) -> tuple[str, ...]:
+    """Collect registered history outside every durable and process-local pin.
+
+    The explicit retained set is the control-plane boundary for receipt, backup,
+    and rollback pins.  This module has no public command route and never runs on
+    a request thread.
+    """
+
+    root = Path(vault_root)
+    retained = _namespace_ids(retained_namespace_ids)
+    registered, durable = _durable_namespace_snapshot(root)
+    runtime = projection_runtime.projection_namespace_runtime_pins(root)
+    eligible = registered - durable - runtime - retained
+    return projection_store.collect_projection_namespaces(
+        root,
+        eligible_namespace_ids=eligible,
+    )
+
+
+__all__ = [
+    "ProjectionCollectionUnavailable",
+    "collect_unpinned_projection_namespaces",
+]

--- a/src/exomem/governance/projection_runtime.py
+++ b/src/exomem/governance/projection_runtime.py
@@ -9,7 +9,8 @@ import os
 import sqlite3
 import threading
 import time
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from numbers import Real
 from pathlib import Path, PurePosixPath
@@ -260,6 +261,7 @@ _PROJECTED_CONTINUATIONS: dict[
     tuple[str, str],
     _ProjectedContinuationRecord,
 ] = {}
+_ACTIVE_PROJECTED_REQUESTS: dict[tuple[str, str], int] = {}
 _PROJECTED_CONTINUATION_LOCK = threading.RLock()
 
 
@@ -416,6 +418,11 @@ def _clear_projected_continuations_for_tests() -> None:
         _PROJECTED_CONTINUATIONS.clear()
 
 
+def _clear_projection_request_pins_for_tests() -> None:
+    with _PROJECTED_CONTINUATION_LOCK:
+        _ACTIVE_PROJECTED_REQUESTS.clear()
+
+
 def _lookup_projected_continuation(
     vault_root: Path,
     continuation: object,
@@ -438,6 +445,64 @@ def _lookup_projected_continuation(
     if record is None:
         raise _invalid_continuation()
     return record
+
+
+@contextmanager
+def _projection_runtime_request_scope(
+    vault_root: Path,
+    runtime: ActiveProjectionRuntime,
+    *,
+    continuation: object,
+) -> Iterator[tuple[ActiveProjectionRuntime, _ProjectedContinuationRecord | None]]:
+    """Pin the exact current or continuation runtime for one complete request."""
+
+    if not isinstance(runtime, ActiveProjectionRuntime):
+        raise ProjectionRuntimeUnavailable(
+            "governed projected retrieval is unavailable"
+        )
+    root_key = _root_key(Path(vault_root))
+    with _PROJECTED_CONTINUATION_LOCK:
+        record = (
+            None
+            if continuation is None
+            else _lookup_projected_continuation(Path(vault_root), continuation)
+        )
+        selected = runtime if record is None else record.runtime
+        pin = (root_key, selected.namespace.namespace_key.namespace_id)
+        _ACTIVE_PROJECTED_REQUESTS[pin] = _ACTIVE_PROJECTED_REQUESTS.get(pin, 0) + 1
+    try:
+        yield selected, record
+    finally:
+        with _PROJECTED_CONTINUATION_LOCK:
+            remaining = _ACTIVE_PROJECTED_REQUESTS.get(pin, 0) - 1
+            if remaining > 0:
+                _ACTIVE_PROJECTED_REQUESTS[pin] = remaining
+            else:
+                _ACTIVE_PROJECTED_REQUESTS.pop(pin, None)
+
+
+def projection_namespace_runtime_pins(vault_root: Path) -> frozenset[str]:
+    """Snapshot exact process-local serving, request, and continuation pins."""
+
+    root_key = _root_key(Path(vault_root))
+    pins: set[str] = set()
+    with _PREACTIVATED_RUNTIME_LOCK:
+        current = _PREACTIVATED_RUNTIMES.get(root_key)
+        if current is not None:
+            pins.add(current.runtime.namespace.namespace_key.namespace_id)
+    with _PROJECTED_CONTINUATION_LOCK:
+        _purge_projected_continuations(time.monotonic())
+        pins.update(
+            record.runtime.namespace.namespace_key.namespace_id
+            for (record_root, _token), record in _PROJECTED_CONTINUATIONS.items()
+            if record_root == root_key
+        )
+        pins.update(
+            namespace_id
+            for (request_root, namespace_id), count in _ACTIVE_PROJECTED_REQUESTS.items()
+            if request_root == root_key and count > 0
+        )
+    return frozenset(pins)
 
 
 def _register_projected_continuation(
@@ -1227,10 +1292,12 @@ def _should_auto_rerank(
     return 1.0 - overlap / max(len(vector), len(lexical)) > 0.5
 
 
-def find_projected_hits(
+def _find_projected_hits_pinned(
     vault_root: Path,
     runtime: ActiveProjectionRuntime,
     *,
+    current_runtime: ActiveProjectionRuntime,
+    continuation_record: _ProjectedContinuationRecord | None,
     query: str,
     limit: int,
     scope: str = "vault",
@@ -1253,12 +1320,6 @@ def find_projected_hits(
         raise ProjectionRuntimeUnavailable(
             "governed projected retrieval is unavailable"
         )
-    current_runtime = runtime
-    continuation_record = (
-        None
-        if continuation is None
-        else _lookup_projected_continuation(Path(vault_root), continuation)
-    )
     if continuation_record is not None:
         if (
             continuation_record.runtime.snapshot.policy.fingerprint
@@ -1267,7 +1328,8 @@ def find_projected_hits(
             != current_runtime.namespace.namespace_key.projector_schema_version
         ):
             raise _invalid_continuation()
-        runtime = continuation_record.runtime
+        if runtime is not continuation_record.runtime:
+            raise _invalid_continuation()
     if type(limit) is not int or not 1 <= limit <= 100:
         raise ValueError("find: limit must be an integer from 1 through 100")
     if (
@@ -1849,6 +1911,52 @@ def find_projected_hits(
     )
 
 
+def find_projected_hits(
+    vault_root: Path,
+    runtime: ActiveProjectionRuntime,
+    *,
+    query: str,
+    limit: int,
+    scope: str = "vault",
+    mode: str,
+    graph: bool,
+    rerank: bool | None,
+    auto_rerank: bool = False,
+    prefer_compiled: bool = True,
+    prefer_active: bool = True,
+    rank_config: ranking_config.RankingConfig = ranking_config.DEFAULT_RANKING,
+    principal: RequestPrincipal,
+    purpose: str | None,
+    continuation: str | None = None,
+) -> ProjectedFindResult:
+    """Acquire one exact runtime pin before any projected request work."""
+
+    with _projection_runtime_request_scope(
+        Path(vault_root),
+        runtime,
+        continuation=continuation,
+    ) as (selected, continuation_record):
+        return _find_projected_hits_pinned(
+            Path(vault_root),
+            selected,
+            current_runtime=runtime,
+            continuation_record=continuation_record,
+            query=query,
+            limit=limit,
+            scope=scope,
+            mode=mode,
+            graph=graph,
+            rerank=rerank,
+            auto_rerank=auto_rerank,
+            prefer_compiled=prefer_compiled,
+            prefer_active=prefer_active,
+            rank_config=rank_config,
+            principal=principal,
+            purpose=purpose,
+            continuation=continuation,
+        )
+
+
 __all__ = [
     "ActiveProjectionRuntime",
     "ProjectedContinuationUnavailable",
@@ -1859,6 +1967,7 @@ __all__ = [
     "has_preactivated_projection_runtime",
     "load_active_projection_runtime",
     "preactivate_projection_runtime",
+    "projection_namespace_runtime_pins",
     "requires_fixed_projected_completion",
     "requires_projected_read_boundary",
 ]

--- a/src/exomem/governance/projection_store.py
+++ b/src/exomem/governance/projection_store.py
@@ -17,7 +17,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from .. import reserved_paths
+from .. import held_fs, reserved_paths
 from ..kbdir import kb_dirname
 from . import projections, schema_v4
 
@@ -1297,6 +1297,209 @@ def load_projection_variant(
                     connection.close()
 
 
+def _namespace_id(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in _HEX for character in value)
+    ):
+        raise ProjectionStoreMismatch("projection collection set is invalid")
+    return value
+
+
+def _collectable_namespace_path(record: held_fs.SagaRecord) -> bool:
+    """Closed topology for one immutable namespace and its measurement stores."""
+
+    parts = record.relative_path.split("/")
+    sqlite_names = {
+        _STORE_FILENAME,
+        f"{_STORE_FILENAME}-journal",
+        f"{_STORE_FILENAME}-wal",
+        f"{_STORE_FILENAME}-shm",
+    }
+    if record.identity.kind == "file":
+        return record.identity.link_count == 1 and (
+            (len(parts) == 1 and parts[0] in sqlite_names)
+            or (
+                len(parts) == 4
+                and parts[0] == "measurements"
+                and parts[1] in _MEASUREMENT_LANES
+                and len(parts[2]) == 64
+                and all(character in _HEX for character in parts[2])
+                and parts[3] in sqlite_names
+            )
+        )
+    if record.identity.kind != "directory":
+        return False
+    return (
+        parts == ["measurements"]
+        or (
+            len(parts) == 2
+            and parts[0] == "measurements"
+            and parts[1] in _MEASUREMENT_LANES
+        )
+        or (
+            len(parts) == 3
+            and parts[0] == "measurements"
+            and parts[1] in _MEASUREMENT_LANES
+            and len(parts[2]) == 64
+            and all(character in _HEX for character in parts[2])
+        )
+    )
+
+
+def _held_refusal(result: held_fs.HeldResult[object], detail: str) -> None:
+    if not result.ok:
+        raise ProjectionStoreMismatch(detail)
+
+
+def _same_collected_identity(
+    observed: held_fs.StableIdentity,
+    expected: held_fs.StableIdentity,
+) -> bool:
+    return (
+        observed.device == expected.device
+        and observed.inode == expected.inode
+        and observed.kind == expected.kind
+        and (observed.kind != "file" or observed.link_count == expected.link_count)
+    )
+
+
+def _remove_namespace_tree(
+    filesystem: held_fs.HeldFilesystem,
+    namespace_relative: str,
+    namespace_identity: held_fs.StableIdentity,
+    records: tuple[held_fs.SagaRecord, ...],
+) -> None:
+    expected = {record.relative_path: record.identity for record in records}
+    files = sorted(
+        (record for record in records if record.identity.kind == "file"),
+        key=lambda record: (-record.relative_path.count("/"), record.relative_path),
+    )
+    for record in files:
+        relative = f"{namespace_relative}/{record.relative_path}"
+        parent_text, _separator, leaf = relative.rpartition("/")
+        parent_result = filesystem.parent(parent_text, access="flush")
+        _held_refusal(parent_result, "projection collection parent changed")
+        with parent_result.require() as parent:
+            file_result = filesystem.file(parent, leaf, access="mutate")
+            _held_refusal(file_result, "projection collection file changed")
+            with file_result.require() as file:
+                if file.identity != record.identity or file.identity.link_count != 1:
+                    raise ProjectionStoreMismatch(
+                        "projection collection identity changed"
+                    )
+                removed = filesystem.unlink(file)
+                _held_refusal(removed, "projection collection file removal was refused")
+            flushed = filesystem.flush_directory(parent)
+            _held_refusal(flushed, "projection collection durability was refused")
+
+    directories = sorted(
+        (record for record in records if record.identity.kind == "directory"),
+        key=lambda record: (-record.relative_path.count("/"), record.relative_path),
+    )
+    for record in directories:
+        relative = f"{namespace_relative}/{record.relative_path}"
+        directory_result = filesystem.parent(relative, access="mutate")
+        _held_refusal(directory_result, "projection collection directory changed")
+        with directory_result.require() as directory:
+            if not _same_collected_identity(
+                directory.identity,
+                expected[record.relative_path],
+            ):
+                raise ProjectionStoreMismatch(
+                    "projection collection directory identity changed"
+                )
+            removed = filesystem.unlink_directory(directory)
+            _held_refusal(
+                removed,
+                "projection collection directory removal was refused",
+            )
+        parent_text = relative.rpartition("/")[0]
+        parent_result = filesystem.parent(parent_text, access="flush")
+        _held_refusal(parent_result, "projection collection parent changed")
+        with parent_result.require() as parent:
+            flushed = filesystem.flush_directory(parent)
+            _held_refusal(flushed, "projection collection durability was refused")
+
+    namespace_result = filesystem.parent(namespace_relative, access="mutate")
+    _held_refusal(namespace_result, "projection collection namespace changed")
+    with namespace_result.require() as namespace:
+        if not _same_collected_identity(namespace.identity, namespace_identity):
+            raise ProjectionStoreMismatch("projection collection namespace identity changed")
+        removed = filesystem.unlink_directory(namespace)
+        _held_refusal(removed, "projection collection namespace removal was refused")
+    root_relative = namespace_relative.rpartition("/")[0]
+    root_result = filesystem.parent(root_relative, access="flush")
+    _held_refusal(root_result, "projection collection root changed")
+    with root_result.require() as root:
+        flushed = filesystem.flush_directory(root)
+        _held_refusal(flushed, "projection collection durability was refused")
+
+
+def collect_projection_namespaces(
+    vault_root: Path,
+    *,
+    eligible_namespace_ids: Iterable[str],
+) -> tuple[str, ...]:
+    """Remove only registered exact namespaces already proven unpinned."""
+
+    eligible = tuple(sorted({_namespace_id(value) for value in eligible_namespace_ids}))
+    if not eligible:
+        return ()
+    root = Path(vault_root)
+    projection_root = f"{kb_dirname()}/.authorization-projections"
+    collected: list[str] = []
+    with reserved_paths._subsystem_authority_scope(_OWNER):
+        with reserved_paths._identity_coordination_scope(
+            root,
+            descriptor_ids=(_DESCRIPTOR_ID,),
+        ):
+            acquired = held_fs.acquire(root)
+            _held_refusal(acquired, "projection collection cannot acquire the vault")
+            with acquired.require() as filesystem:
+                for namespace_id in eligible:
+                    namespace_relative = f"{projection_root}/{namespace_id}"
+                    namespace_result = filesystem.parent(namespace_relative)
+                    if not namespace_result.ok:
+                        if (
+                            namespace_result.error is not None
+                            and namespace_result.error.code == "MISSING"
+                        ):
+                            continue
+                        raise ProjectionStoreMismatch(
+                            "projection collection namespace is unsafe"
+                        )
+                    with namespace_result.require() as namespace:
+                        namespace_identity = namespace.identity
+                        enumerated = filesystem.enumerate(namespace)
+                        _held_refusal(
+                            enumerated,
+                            "projection collection namespace cannot be enumerated",
+                        )
+                        records = enumerated.require()
+                        if any(
+                            not _collectable_namespace_path(record)
+                            for record in records
+                        ):
+                            raise ProjectionStoreMismatch(
+                                "projection collection namespace shape is unsafe"
+                            )
+                    _remove_namespace_tree(
+                        filesystem,
+                        namespace_relative,
+                        namespace_identity,
+                        records,
+                    )
+                    collected.append(namespace_id)
+            current = reserved_paths._reachable_owner_publications(
+                root,
+                _DESCRIPTOR_ID,
+            )
+            reserved_paths._publish_owner_identities(root, _DESCRIPTOR_ID, current)
+    return tuple(collected)
+
+
 __all__ = [
     "PreparedProjectionNamespace",
     "ProjectionItemVariants",
@@ -1308,6 +1511,7 @@ __all__ = [
     "VerifiedProjectionNamespace",
     "bind_active_projection_namespace",
     "catalog_descriptor_bytes",
+    "collect_projection_namespaces",
     "load_projection_catalog",
     "load_projection_variant",
     "namespace_evidence_from_snapshot",

--- a/src/exomem/governance/schema_v4.py
+++ b/src/exomem/governance/schema_v4.py
@@ -1339,6 +1339,89 @@ def load_active_policy(
     )
 
 
+def _projection_namespace_id(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in _HEX_DIGITS for character in value)
+    ):
+        raise SchemaV4Error("projection namespace pins cannot be verified")
+    return value
+
+
+def projection_namespace_ids(connection: sqlite3.Connection) -> frozenset[str]:
+    """Return every registered immutable namespace in one caller-held snapshot."""
+
+    try:
+        if int(connection.execute("PRAGMA user_version").fetchone()[0]) != 4:
+            raise SchemaV4Error("projection namespace inventory requires schema v4")
+        return frozenset(
+            _projection_namespace_id(row[0])
+            for row in connection.execute(
+                "SELECT namespace_id FROM governance_projection_namespaces"
+            )
+        )
+    except SchemaV4Error:
+        raise
+    except (IndexError, sqlite3.Error, TypeError) as error:
+        raise SchemaV4Error(
+            "projection namespace inventory cannot be verified"
+        ) from error
+
+
+def projection_namespace_pins(connection: sqlite3.Connection) -> frozenset[str]:
+    """Return active and recovery-bound namespaces in one caller-held snapshot."""
+
+    try:
+        if int(connection.execute("PRAGMA user_version").fetchone()[0]) != 4:
+            raise SchemaV4Error("projection namespace pins require schema v4")
+        active_rows = connection.execute(
+            "SELECT n.namespace_id FROM active_governance_tuple a "
+            "JOIN governance_projection_namespaces n "
+            "ON n.policy_fingerprint=a.policy_fingerprint "
+            "AND n.projector_schema_version=a.projector_schema_version "
+            "AND n.catalog_generation=a.catalog_generation "
+            "WHERE a.singleton=1"
+        ).fetchall()
+        if len(active_rows) != 1:
+            raise SchemaV4Error("projection namespace pins cannot be verified")
+        pins = {_projection_namespace_id(active_rows[0][0])}
+
+        for (proposal_json,) in connection.execute(
+            "SELECT proposal_json FROM governance_proposals WHERE status='pending'"
+        ):
+            try:
+                payload = json.loads(proposal_json)
+                binding = payload["authority_binding"]
+                reviewed = binding["reviewed_active_tuple"]
+                target = binding["target"]["projection_namespace"]
+                pins.add(_projection_namespace_id(reviewed["projection_namespace_id"]))
+                pins.add(_projection_namespace_id(target["namespace_id"]))
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+                raise SchemaV4Error(
+                    "projection namespace pins cannot be verified"
+                ) from error
+
+        for (value_json,) in connection.execute(
+            "SELECT c.value_json FROM governance_operation_components c "
+            "JOIN governance_operation_journals j ON j.event_id=c.event_id "
+            "WHERE j.phase IN ('allocating','pending') "
+            "AND c.component_kind='catalog'"
+        ):
+            try:
+                value = json.loads(value_json)
+                pins.add(_projection_namespace_id(value["projection_namespace_id"]))
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+                raise SchemaV4Error(
+                    "projection namespace pins cannot be verified"
+                ) from error
+        return frozenset(pins)
+    except SchemaV4Error:
+        raise
+    except (IndexError, sqlite3.Error, TypeError) as error:
+        raise SchemaV4Error("projection namespace pins cannot be verified") from error
+
+
 def _publication_result(
     connection: sqlite3.Connection,
     active: VerifiedActiveGovernanceState,

--- a/tests/test_governance_projection_gc.py
+++ b/tests/test_governance_projection_gc.py
@@ -1,0 +1,296 @@
+"""Exact-tuple retention and collection for authorization projections."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from governance_projection_support import verified_namespace
+
+from exomem.governance import (
+    projection_gc,
+    projection_runtime,
+    projection_store,
+    projections,
+    schema_v4,
+)
+from exomem.governance.decisions import Decision
+from exomem.governance.policy import Policy
+from exomem.governance.principal import RequestPrincipal
+
+
+def _key(generation: int) -> projections.ProjectionNamespaceKey:
+    return projections.ProjectionNamespaceKey("a" * 64, 1, generation)
+
+
+def _items(key: projections.ProjectionNamespaceKey):
+    variant = projections.build_projection_variant(
+        item_identity="Knowledge Base/visible.md",
+        content_hash=f"{key.catalog_generation:064x}",
+        decision=Decision(level=6),
+        projector_schema_version=key.projector_schema_version,
+        full_search_fields={"body": "visible projected text"},
+    )
+    assert variant is not None
+    return (
+        projection_store.ProjectionItemVariants(
+            item_identity=variant.item_identity,
+            content_hash=variant.content_hash,
+            variants=(variant,),
+        ),
+    )
+
+
+def _runtime(key: projections.ProjectionNamespaceKey):
+    items = _items(key)
+    namespace = verified_namespace(key, items)
+    snapshot = schema_v4.ActivePolicySnapshot(
+        active=schema_v4.VerifiedActiveGovernanceState(
+            logical_vault_id="fixture-vault",
+            activation_store_id="fixture-store",
+            activation_epoch=key.catalog_generation,
+            activation_state_digest=namespace.active_state_digest,
+            policy_generation_id="fixture-policy",
+            policy_fingerprint=key.policy_fingerprint,
+            projector_schema_version=key.projector_schema_version,
+            catalog_generation=key.catalog_generation,
+            projection_namespace_id=key.namespace_id,
+        ),
+        policy=Policy(fingerprint=key.policy_fingerprint),
+        source_documents=(),
+        catalog_descriptor=projection_store.catalog_descriptor_bytes(key, items),
+        projection_namespace_evidence=(
+            projection_store.projection_namespace_evidence_bytes(namespace.manifest)
+        ),
+    )
+    return projection_runtime.ActiveProjectionRuntime(snapshot, namespace)
+
+
+def _v4_connection() -> sqlite3.Connection:
+    connection = sqlite3.connect(":memory:")
+    schema_v4._create_v4_schema(connection)
+    connection.execute(
+        "CREATE TABLE governance_proposals ("
+        "proposal_id TEXT PRIMARY KEY, proposal_json TEXT NOT NULL, status TEXT NOT NULL)"
+    )
+    connection.execute(
+        "CREATE TABLE governance_operation_journals ("
+        "event_id TEXT PRIMARY KEY, phase TEXT NOT NULL)"
+    )
+    connection.execute(
+        "CREATE TABLE governance_operation_components ("
+        "event_id TEXT NOT NULL, component_kind TEXT NOT NULL, value_json TEXT NOT NULL)"
+    )
+    connection.execute("PRAGMA user_version=4")
+    return connection
+
+
+def _insert_active_namespace(
+    connection: sqlite3.Connection,
+    key: projections.ProjectionNamespaceKey,
+) -> None:
+    connection.execute(
+        "INSERT INTO governance_projection_namespaces "
+        "(policy_fingerprint, projector_schema_version, catalog_generation, "
+        "namespace_id, namespace_digest, evidence, ready_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            key.policy_fingerprint,
+            key.projector_schema_version,
+            key.catalog_generation,
+            key.namespace_id,
+            "b" * 64,
+            b"{}",
+            1,
+        ),
+    )
+    connection.execute(
+        "INSERT INTO active_governance_tuple "
+        "(singleton, policy_generation_id, policy_fingerprint, "
+        "projector_schema_version, catalog_generation) VALUES (1, ?, ?, ?, ?)",
+        ("policy-active", *key.as_tuple()),
+    )
+
+
+def test_durable_pins_cover_active_pending_policy_and_open_catalog_journal() -> None:
+    active = _key(7)
+    policy_target = _key(8)
+    catalog_target = _key(9)
+    connection = _v4_connection()
+    _insert_active_namespace(connection, active)
+    proposal = {
+        "authority_binding": {
+            "reviewed_active_tuple": {
+                "projection_namespace_id": active.namespace_id,
+            },
+            "target": {
+                "projection_namespace": {"namespace_id": policy_target.namespace_id},
+            },
+        }
+    }
+    connection.execute(
+        "INSERT INTO governance_proposals (proposal_id, proposal_json, status) "
+        "VALUES (?, ?, 'pending')",
+        ("proposal", json.dumps(proposal)),
+    )
+    connection.execute(
+        "INSERT INTO governance_operation_journals (event_id, phase) "
+        "VALUES (?, 'pending')",
+        ("event",),
+    )
+    connection.execute(
+        "INSERT INTO governance_operation_components "
+        "(event_id, component_kind, value_json) VALUES (?, 'catalog', ?)",
+        (
+            "event",
+            json.dumps({"projection_namespace_id": catalog_target.namespace_id}),
+        ),
+    )
+
+    assert schema_v4.projection_namespace_pins(connection) == frozenset(
+        {active.namespace_id, policy_target.namespace_id, catalog_target.namespace_id}
+    )
+
+
+def test_malformed_open_recovery_state_refuses_pin_snapshot() -> None:
+    connection = _v4_connection()
+    _insert_active_namespace(connection, _key(7))
+    connection.execute(
+        "INSERT INTO governance_proposals (proposal_id, proposal_json, status) "
+        "VALUES (?, ?, 'pending')",
+        ("proposal", "{}"),
+    )
+
+    with pytest.raises(schema_v4.SchemaV4Error, match="namespace pins"):
+        schema_v4.projection_namespace_pins(connection)
+
+
+def test_live_request_and_continuation_pin_their_exact_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _runtime(_key(7))
+    projection_runtime._clear_projected_continuations_for_tests()
+    projection_runtime._clear_projection_request_pins_for_tests()
+
+    with projection_runtime._projection_runtime_request_scope(
+        tmp_path,
+        runtime,
+        continuation=None,
+    ) as (selected, record):
+        assert selected is runtime
+        assert record is None
+        assert projection_runtime.projection_namespace_runtime_pins(tmp_path) == (
+            frozenset({runtime.namespace.namespace_key.namespace_id})
+        )
+
+    assert projection_runtime.projection_namespace_runtime_pins(tmp_path) == frozenset()
+
+    monkeypatch.setattr(projection_runtime.time, "monotonic", lambda: 100.0)
+    projection_runtime._register_projected_continuation(
+        tmp_path,
+        runtime=runtime,
+        principal_binding=("external", None),
+        declared_purpose=None,
+        request_digest="1" * 64,
+        authorization_digest="2" * 64,
+        visible_authorization_digest="3" * 64,
+        visible_snapshot_digest="4" * 64,
+        next_offset=1,
+        candidate_depth=1,
+        replace_existing=False,
+    )
+    assert projection_runtime.projection_namespace_runtime_pins(tmp_path) == frozenset(
+        {runtime.namespace.namespace_key.namespace_id}
+    )
+
+    monkeypatch.setattr(
+        projection_runtime.time,
+        "monotonic",
+        lambda: 100.0 + projection_runtime._PROJECTED_CONTINUATION_TTL_S,
+    )
+    assert projection_runtime.projection_namespace_runtime_pins(tmp_path) == frozenset()
+
+
+def test_public_projected_find_holds_and_releases_the_request_pin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _runtime(_key(7))
+    projection_runtime._clear_projected_continuations_for_tests()
+    projection_runtime._clear_projection_request_pins_for_tests()
+    observed: list[frozenset[str]] = []
+
+    def fail_while_pinned(*_args, **_kwargs):
+        observed.append(projection_runtime.projection_namespace_runtime_pins(tmp_path))
+        raise RuntimeError("injected projected request failure")
+
+    monkeypatch.setattr(
+        projection_runtime,
+        "_find_projected_hits_pinned",
+        fail_while_pinned,
+    )
+    with pytest.raises(RuntimeError, match="injected projected request failure"):
+        projection_runtime.find_projected_hits(
+            tmp_path,
+            runtime,
+            query="visible",
+            limit=10,
+            mode="keyword",
+            graph=False,
+            rerank=False,
+            principal=RequestPrincipal("external", resolved=True),
+            purpose=None,
+        )
+
+    assert observed == [frozenset({runtime.namespace.namespace_key.namespace_id})]
+    assert projection_runtime.projection_namespace_runtime_pins(tmp_path) == frozenset()
+
+
+def test_exact_tuple_collector_retains_every_authoritative_pin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    active = _key(7)
+    cursor = _key(8)
+    rollback = _key(9)
+    stale = _key(10)
+    staged = _key(11)
+    for key in (active, cursor, rollback, stale, staged):
+        projection_store.stage_variant_store(tmp_path, key=key, items=_items(key))
+    stale_measurement = (
+        projection_store.variant_store_path(tmp_path, stale).parent
+        / "measurements"
+        / "vector"
+        / ("c" * 64)
+        / "rows.sqlite"
+    )
+    stale_measurement.parent.mkdir(parents=True)
+    stale_measurement.write_bytes(b"closed fixture")
+
+    monkeypatch.setattr(
+        projection_gc,
+        "_durable_namespace_snapshot",
+        lambda _root: (
+            frozenset(key.namespace_id for key in (active, cursor, rollback, stale)),
+            frozenset({active.namespace_id}),
+        ),
+    )
+    monkeypatch.setattr(
+        projection_runtime,
+        "projection_namespace_runtime_pins",
+        lambda _root: frozenset({cursor.namespace_id}),
+    )
+
+    collected = projection_gc.collect_unpinned_projection_namespaces(
+        tmp_path,
+        retained_namespace_ids=frozenset({rollback.namespace_id}),
+    )
+
+    assert collected == (stale.namespace_id,)
+    for key in (active, cursor, rollback):
+        assert projection_store.variant_store_path(tmp_path, key).is_file()
+    assert projection_store.variant_store_path(tmp_path, staged).is_file()
+    assert not projection_store.variant_store_path(tmp_path, stale).exists()
+    assert not projection_store.variant_store_path(tmp_path, stale).parent.exists()


### PR DESCRIPTION
## Summary

- add an owner-only exact-tuple collector for registered authorization-projection namespaces
- retain the active tuple, pending policy targets, open catalog journals, preactivated runtimes, live requests, continuations, and explicit receipt/backup/rollback pins
- remove only closed, registered namespace trees through the held no-follow filesystem substrate; unregistered in-progress builds are never candidates
- close OpenSpec task 8.6 without scheduling cleanup on startup or any public request path

Stacked after #863. This does not merge or touch any live vault.

## Verification

- red-first: new GC suite initially failed on the missing module/API; nested measurement-tree coverage then reproduced directory link-count drift before the identity fix
- focused projection/schema/command suites: 150 passed, 1 dedicated actual-wire skip
- Ruff on all five changed Python files
- `uv lock --check`
- `python scripts/validate-public-artifacts.py --repository`
- `openspec validate harden-governance-for-consolidation --strict`
- `git diff --check`
