### PR TITLE
fix(governance): add transactional v4 rollback

### DIFF
--- a/src/exomem/governance/schema_v4.py
+++ b/src/exomem/governance/schema_v4.py
@@ -179,6 +179,22 @@ class MigrationResult:
 
 
 @dataclass(frozen=True, slots=True)
+class DownmigrationResult:
+    schema_version: int
+    activation_store_id: str
+    activation_epoch: int
+    activation_state_digest: str
+    policy_generation_id: str
+    policy_fingerprint: str
+    source_documents: tuple[tuple[str, bytes], ...]
+    closed_sessions: int
+    expired_grants: int
+    expired_purposes: int
+    expired_tokens: int
+    expired_proposals: int
+
+
+@dataclass(frozen=True, slots=True)
 class VerifiedActiveGovernanceState:
     logical_vault_id: str
     activation_store_id: str
@@ -254,6 +270,28 @@ def _source_document_bytes(documents: tuple[tuple[str, bytes], ...]) -> bytes:
     if len(encoded) > _MAX_BLOB_BYTES:
         raise SchemaV4Error("source_documents exceeds the bounded byte map")
     return bytes(encoded)
+
+
+def source_documents_digest(documents: tuple[tuple[str, bytes], ...]) -> str:
+    """Bind one exact ordered policy-source byte map for an offline mirror proof."""
+
+    return hashlib.sha256(
+        _framed(
+            b"exomem.governance-v3-workspace-mirror.v1",
+            _source_document_bytes(documents),
+        )
+    ).hexdigest()
+
+
+def catalog_rebuild_digest(descriptor: bytes) -> str:
+    """Bind the exact active catalog descriptor rebuilt by an offline rollback."""
+
+    return hashlib.sha256(
+        _framed(
+            b"exomem.governance-v3-catalog-rebuild.v1",
+            _blob(descriptor, "catalog descriptor", allow_empty=True),
+        )
+    ).hexdigest()
 
 
 def _decode_source_document_bytes(value: object) -> tuple[tuple[str, bytes], ...]:
@@ -981,6 +1019,238 @@ def migrate_v3_connection(
         connection.rollback()
         raise
     return MigrationResult(4, seed.activation_store_id, material.activation_digest)
+
+
+_V4_ONLY_TABLES: Final = (
+    "governance_authorization_sessions",
+    "compiled_policy_generations",
+    "catalog_generation_descriptors",
+    "governance_projection_namespaces",
+    "active_governance_tuple",
+    "governance_activation_store",
+    "governance_tuple_publications",
+    "governance_schema_migrations",
+    "governance_legacy_authority",
+)
+_VERSIONED_AUTHORITY_TABLES: Final = (
+    "governance_session_grants",
+    "governance_session_purpose",
+    "governance_session_purpose_staging",
+    "withhold_tokens",
+)
+_V3_COMMON_TABLES: Final = (
+    "compiled_policy",
+    "governance_operation_components",
+    "governance_operation_journals",
+    "governance_policy_archives",
+    "governance_proposals",
+    "receipt_instance",
+    "receipt_secrets",
+    "receipts_head",
+)
+
+
+def _versioned_schema_signature(
+    connection: sqlite3.Connection,
+) -> tuple[tuple[object, ...], ...]:
+    tables = (*_VERSIONED_AUTHORITY_TABLES, *_V4_ONLY_TABLES)
+    placeholders = ",".join("?" for _ in tables)
+    return tuple(
+        tuple(row)
+        for row in connection.execute(
+            "SELECT type, name, tbl_name, sql FROM sqlite_master "
+            f"WHERE tbl_name IN ({placeholders}) "
+            "AND name NOT LIKE 'sqlite_autoindex_%' "
+            "ORDER BY type, name",
+            tables,
+        )
+    )
+
+
+def _expected_versioned_schema_signature() -> tuple[tuple[object, ...], ...]:
+    reference = sqlite3.connect(":memory:")
+    try:
+        _create_legacy_archive(reference)
+        _create_v4_schema(reference)
+        return _versioned_schema_signature(reference)
+    finally:
+        reference.close()
+
+
+def _require_downmigration_schema(connection: sqlite3.Connection) -> None:
+    tables = {
+        str(row[0])
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        )
+    }
+    required = (
+        set(_V4_ONLY_TABLES)
+        | set(_VERSIONED_AUTHORITY_TABLES)
+        | set(_V3_COMMON_TABLES)
+    )
+    if not required <= tables:
+        raise SchemaV4Error("schema v4 downmigration source is incomplete")
+    unexpected = tables - required - {"meta"}
+    if unexpected:
+        raise SchemaV4Error("schema v4 downmigration source has unknown state")
+    if _versioned_schema_signature(connection) != _expected_versioned_schema_signature():
+        raise SchemaV4Error("schema v4 downmigration source is not exact")
+
+
+def _close_downmigration_authority(
+    connection: sqlite3.Connection,
+    *,
+    downmigrated_at: int,
+) -> tuple[int, int, int, int, int]:
+    sessions = int(
+        connection.execute(
+            "UPDATE governance_authorization_sessions "
+            "SET status='closed', closed_at=? WHERE status='active'",
+            (downmigrated_at,),
+        ).rowcount
+        or 0
+    )
+    grants = int(
+        connection.execute(
+            "UPDATE governance_session_grants "
+            "SET status='revoked', revoked_at=? WHERE status<>'revoked'",
+            (downmigrated_at,),
+        ).rowcount
+        or 0
+    )
+    purposes = int(
+        connection.execute(
+            "UPDATE governance_session_purpose SET status='revoked' "
+            "WHERE status<>'revoked'"
+        ).rowcount
+        or 0
+    )
+    purposes += int(
+        connection.execute("DELETE FROM governance_session_purpose_staging").rowcount
+        or 0
+    )
+    tokens = int(
+        connection.execute(
+            "UPDATE withhold_tokens SET status='expired', "
+            "consumed_at=COALESCE(consumed_at, ?) WHERE status<>'expired'",
+            (downmigrated_at,),
+        ).rowcount
+        or 0
+    )
+    proposals = int(
+        connection.execute(
+            "UPDATE governance_proposals SET status='expired', "
+            "spent_at=COALESCE(spent_at, ?) WHERE status='pending'",
+            (downmigrated_at,),
+        ).rowcount
+        or 0
+    )
+    return sessions, grants, purposes, tokens, proposals
+
+
+def downmigrate_v4_connection(
+    connection: sqlite3.Connection,
+    *,
+    expected: VerifiedActiveGovernanceState,
+    expected_source_documents: tuple[tuple[str, bytes], ...],
+    expected_catalog_descriptor: bytes,
+    verified_workspace_digest: str,
+    verified_catalog_digest: str,
+    downmigrated_at: int,
+) -> DownmigrationResult:
+    """Atomically return a fully verified, quiesced v4 store to exact schema v3.
+
+    This is the database half of the offline rollback coordinator.  Its caller
+    must already hold the whole-tree/schema/replica fence and must supply the
+    digests produced after mirroring the pointed source bytes and rebuilding
+    the pointed catalog.  Ordinary openers never call this function.
+    """
+
+    version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+    if version != SCHEMA_USER_VERSION:
+        raise SchemaV4Error(
+            f"explicit governance downmigration requires exact schema v4, found v{version}"
+        )
+    if connection.in_transaction:
+        raise SchemaV4Error("schema v4 downmigration requires a clean transaction boundary")
+    if not isinstance(expected, VerifiedActiveGovernanceState):
+        raise SchemaV4Error("schema v4 downmigration expected tuple is invalid")
+    source_digest = source_documents_digest(expected_source_documents)
+    descriptor = _blob(
+        expected_catalog_descriptor,
+        "expected_catalog_descriptor",
+        allow_empty=True,
+    )
+    workspace_digest = _digest(
+        verified_workspace_digest,
+        "verified_workspace_digest",
+    )
+    rebuild_digest = _digest(
+        verified_catalog_digest,
+        "verified_catalog_digest",
+    )
+    completed_at = _integer(downmigrated_at, "downmigrated_at")
+    if not hmac.compare_digest(source_digest, workspace_digest):
+        raise SchemaV4Error("downmigration workspace parity does not verify")
+    if not hmac.compare_digest(catalog_rebuild_digest(descriptor), rebuild_digest):
+        raise SchemaV4Error("downmigration catalog parity does not verify")
+
+    connection.execute("BEGIN IMMEDIATE")
+    try:
+        _require_downmigration_schema(connection)
+        pending = connection.execute(
+            "SELECT event_id FROM governance_operation_journals "
+            "WHERE phase IN ('allocating','pending') ORDER BY event_id LIMIT 1"
+        ).fetchone()
+        if pending is not None:
+            raise SchemaV4Error("downmigration cannot discard an open recovery journal")
+        snapshot = load_active_policy(
+            connection,
+            expected_logical_vault_id=expected.logical_vault_id,
+            expected_activation_store_id=expected.activation_store_id,
+            expected_activation_epoch=expected.activation_epoch,
+            expected_activation_state_digest=expected.activation_state_digest,
+        )
+        if snapshot.active != expected:
+            raise SchemaV4Error("downmigration active tuple changed")
+        if snapshot.source_documents != expected_source_documents:
+            raise SchemaV4Error("downmigration workspace parity does not verify")
+        if not hmac.compare_digest(snapshot.catalog_descriptor, descriptor):
+            raise SchemaV4Error("downmigration catalog parity does not verify")
+        closed = _close_downmigration_authority(
+            connection,
+            downmigrated_at=completed_at,
+        )
+        _crash_point("downmigration-after-authority-close")
+        for table in (*_VERSIONED_AUTHORITY_TABLES, *_V4_ONLY_TABLES):
+            connection.execute(f"DROP TABLE {table}")
+        _crash_point("downmigration-after-v4-drop")
+        from . import store as store_module
+
+        store_module._migrate_v3(connection)
+        _crash_point("downmigration-after-v3-schema")
+        connection.execute("PRAGMA user_version=3")
+        _crash_point("downmigration-before-commit")
+        connection.commit()
+    except BaseException:
+        connection.rollback()
+        raise
+    return DownmigrationResult(
+        schema_version=3,
+        activation_store_id=expected.activation_store_id,
+        activation_epoch=expected.activation_epoch,
+        activation_state_digest=expected.activation_state_digest,
+        policy_generation_id=expected.policy_generation_id,
+        policy_fingerprint=expected.policy_fingerprint,
+        source_documents=expected_source_documents,
+        closed_sessions=closed[0],
+        expired_grants=closed[1],
+        expired_purposes=closed[2],
+        expired_tokens=closed[3],
+        expired_proposals=closed[4],
+    )
 
 
 def load_active_state(

--- a/tests/test_governance_store_v4.py
+++ b/tests/test_governance_store_v4.py
@@ -70,6 +70,60 @@ def _columns(connection: sqlite3.Connection, table: str) -> tuple[str, ...]:
     return tuple(str(row[1]) for row in connection.execute(f"PRAGMA table_info({table})"))
 
 
+def _schema_signature(connection: sqlite3.Connection) -> tuple[tuple[str, str, str], ...]:
+    return tuple(
+        (str(row[0]), str(row[1]), str(row[2]))
+        for row in connection.execute(
+            "SELECT type, name, sql FROM sqlite_master "
+            "WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name"
+        )
+    )
+
+
+def _migrated_v4() -> tuple[
+    sqlite3.Connection,
+    schema_v4.VerifiedActiveGovernanceState,
+]:
+    connection = _v3_connection()
+    migration = schema_v4.migrate_v3_connection(connection, _seed())
+    active = schema_v4.load_active_state(
+        connection,
+        expected_logical_vault_id="logical-vault-7",
+        expected_activation_store_id="activation-store-7",
+        expected_activation_epoch=1,
+        expected_activation_state_digest=migration.activation_state_digest,
+    )
+    return connection, active
+
+
+def _downmigrate(
+    connection: sqlite3.Connection,
+    active: schema_v4.VerifiedActiveGovernanceState,
+    *,
+    source_documents: tuple[tuple[str, bytes], ...] = POLICY_DOCUMENTS,
+    catalog_descriptor: bytes = b'{"artifacts":[]}',
+    workspace_digest: str | None = None,
+    catalog_digest: str | None = None,
+) -> schema_v4.DownmigrationResult:
+    return schema_v4.downmigrate_v4_connection(
+        connection,
+        expected=active,
+        expected_source_documents=source_documents,
+        expected_catalog_descriptor=catalog_descriptor,
+        verified_workspace_digest=(
+            schema_v4.source_documents_digest(source_documents)
+            if workspace_digest is None
+            else workspace_digest
+        ),
+        verified_catalog_digest=(
+            schema_v4.catalog_rebuild_digest(catalog_descriptor)
+            if catalog_digest is None
+            else catalog_digest
+        ),
+        downmigrated_at=1_800_000_100,
+    )
+
+
 def _insert_legacy_authority(connection: sqlite3.Connection) -> None:
     connection.execute(
         "INSERT INTO governance_session_grants "
@@ -501,6 +555,274 @@ def test_every_v4_migration_crash_barrier_restores_exact_v3(
         schema_v4.migrate_v3_connection(connection, _seed())
 
     assert connection.execute("PRAGMA user_version").fetchone()[0] == 3
+    assert tuple(connection.iterdump()) == before
+
+
+def test_v4_downmigration_restores_exact_v3_and_expires_session_authority() -> None:
+    expected_v3 = _v3_connection()
+    connection, active = _migrated_v4()
+    connection.execute(
+        "INSERT INTO governance_authorization_sessions "
+        "(session_id, locator_digest, verifier, verifier_key_id, credential_generation, "
+        "principal_id, issuer_family, cell_id, logical_vault_id, keyring_id, status, "
+        "created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)",
+        (
+            "session-v4",
+            b"l" * 32,
+            b"v" * 32,
+            "key-v4",
+            1,
+            "principal-v4",
+            "rest-oauth",
+            "cell-v4",
+            "logical-vault-7",
+            "keyring-v4",
+            1_800_000_000,
+            1_900_000_000,
+        ),
+    )
+    connection.execute(
+        "INSERT INTO governance_session_grants "
+        "(grant_id, authorization_session_id, principal_id, issuer_family, audience, "
+        "ceiling, paths, fingerprints, scope_ids, membership_manifest, "
+        "policy_fingerprint, token_jti, status, created_at, expires_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)",
+        (
+            "grant-v4",
+            "session-v4",
+            "principal-v4",
+            "rest-oauth",
+            "external",
+            4,
+            '["Notes/a.md"]',
+            '["4"]',
+            '["scope-a"]',
+            "[]",
+            POLICY_FINGERPRINT,
+            "token-v4",
+            1_800_000_000,
+            1_900_000_000,
+        ),
+    )
+    connection.execute(
+        "INSERT INTO governance_session_purpose "
+        "(authorization_session_id, principal_id, issuer_family, audience, purpose, "
+        "status, created_at, expires_at) VALUES (?, ?, ?, ?, ?, 'active', ?, ?)",
+        (
+            "session-v4",
+            "principal-v4",
+            "rest-oauth",
+            "external",
+            "support",
+            1_800_000_000,
+            1_900_000_000,
+        ),
+    )
+    connection.execute(
+        "INSERT INTO withhold_tokens "
+        "(jti, authorization_session_id, principal_id, issuer_family, audience, "
+        "max_level, fingerprints, paths, scope_ids, org_ceiling, status, expires_at, "
+        "minted_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)",
+        (
+            "token-v4",
+            "session-v4",
+            "principal-v4",
+            "rest-oauth",
+            "external",
+            4,
+            '["4"]',
+            '["Notes/a.md"]',
+            '["scope-a"]',
+            6,
+            1_900_000_000,
+            1_800_000_000,
+        ),
+    )
+    connection.execute(
+        "INSERT INTO governance_proposals "
+        "(proposal_id, created_at, expires_at, proposal_json, "
+        "fingerprint_at_propose, membership_manifest) VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            "proposal-v4",
+            1_800_000_000,
+            1_900_000_000,
+            "{}",
+            POLICY_FINGERPRINT,
+            "[]",
+        ),
+    )
+    connection.commit()
+
+    result = _downmigrate(connection, active)
+
+    assert result.schema_version == 3
+    assert result.activation_store_id == "activation-store-7"
+    assert result.activation_epoch == 1
+    assert result.closed_sessions == 1
+    assert result.expired_grants == 1
+    assert result.expired_purposes == 1
+    assert result.expired_tokens == 1
+    assert result.expired_proposals == 1
+    assert result.source_documents == POLICY_DOCUMENTS
+    assert connection.execute("PRAGMA user_version").fetchone()[0] == 3
+    assert _schema_signature(connection) == _schema_signature(expected_v3)
+    for table in (
+        "governance_session_grants",
+        "governance_session_purpose",
+        "governance_session_purpose_staging",
+        "withhold_tokens",
+    ):
+        assert connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] == 0
+    assert connection.execute(
+        "SELECT status, spent_at FROM governance_proposals WHERE proposal_id='proposal-v4'"
+    ).fetchone() == ("expired", 1_800_000_100)
+
+
+@pytest.mark.parametrize(
+    ("source_documents", "catalog_descriptor", "workspace_digest", "catalog_digest"),
+    (
+        (
+            (
+                ("scopes/migration.yaml", b"governance_version: 1\n"),
+            ),
+            b'{"artifacts":[]}',
+            schema_v4.source_documents_digest(
+                (("scopes/migration.yaml", b"governance_version: 1\n"),)
+            ),
+            schema_v4.catalog_rebuild_digest(b'{"artifacts":[]}'),
+        ),
+        (
+            POLICY_DOCUMENTS,
+            b'{"artifacts":["changed"]}',
+            schema_v4.source_documents_digest(POLICY_DOCUMENTS),
+            schema_v4.catalog_rebuild_digest(b'{"artifacts":["changed"]}'),
+        ),
+    ),
+)
+def test_v4_downmigration_refuses_unproved_workspace_or_catalog_parity(
+    source_documents: tuple[tuple[str, bytes], ...],
+    catalog_descriptor: bytes,
+    workspace_digest: str,
+    catalog_digest: str,
+) -> None:
+    connection, active = _migrated_v4()
+    before = tuple(connection.iterdump())
+
+    with pytest.raises(schema_v4.SchemaV4Error, match="parity"):
+        _downmigrate(
+            connection,
+            active,
+            source_documents=source_documents,
+            catalog_descriptor=catalog_descriptor,
+            workspace_digest=workspace_digest,
+            catalog_digest=catalog_digest,
+        )
+
+    assert tuple(connection.iterdump()) == before
+
+
+def test_v4_downmigration_refuses_open_recovery_journal_without_writes() -> None:
+    connection, active = _migrated_v4()
+    connection.execute(
+        "INSERT INTO governance_operation_journals "
+        "(event_id, operation, causation_id, principal_id, phase, direction, "
+        "prior_digest, prepared_digest, final_digest, affected_ids, "
+        "required_child_intents, required_child_terminals, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "journal-v4",
+            "commit",
+            "cause-v4",
+            "principal-v4",
+            "narrowing",
+            "1" * 64,
+            "2" * 64,
+            "3" * 64,
+            "[]",
+            "[]",
+            "[]",
+            1_800_000_000,
+            1_800_000_001,
+        ),
+    )
+    connection.commit()
+    before = tuple(connection.iterdump())
+
+    with pytest.raises(schema_v4.SchemaV4Error, match="recovery journal"):
+        _downmigrate(connection, active)
+
+    assert tuple(connection.iterdump()) == before
+
+
+def test_v4_downmigration_refuses_unknown_governance_state_without_writes() -> None:
+    connection, active = _migrated_v4()
+    connection.execute("CREATE TABLE future_state (id TEXT PRIMARY KEY)")
+    connection.commit()
+    before = tuple(connection.iterdump())
+
+    with pytest.raises(schema_v4.SchemaV4Error, match="unknown state"):
+        _downmigrate(connection, active)
+
+    assert tuple(connection.iterdump()) == before
+
+
+def test_v4_downmigration_refuses_future_v4_column_without_writes() -> None:
+    connection, active = _migrated_v4()
+    connection.execute(
+        "ALTER TABLE governance_authorization_sessions ADD COLUMN future_state TEXT"
+    )
+    connection.commit()
+    before = tuple(connection.iterdump())
+
+    with pytest.raises(schema_v4.SchemaV4Error, match="not exact"):
+        _downmigrate(connection, active)
+
+    assert tuple(connection.iterdump()) == before
+
+
+def test_v4_downmigration_refuses_non_v4_source_before_parsing_proofs() -> None:
+    connection = _v3_connection()
+    before = tuple(connection.iterdump())
+
+    with pytest.raises(schema_v4.SchemaV4Error, match="exact schema v4"):
+        schema_v4.downmigrate_v4_connection(
+            connection,
+            expected="not-an-active-tuple",  # type: ignore[arg-type]
+            expected_source_documents="not-documents",  # type: ignore[arg-type]
+            expected_catalog_descriptor="not-bytes",  # type: ignore[arg-type]
+            verified_workspace_digest="not-a-digest",
+            verified_catalog_digest="not-a-digest",
+            downmigrated_at=0,
+        )
+
+    assert tuple(connection.iterdump()) == before
+
+
+@pytest.mark.parametrize(
+    "crash_at",
+    (
+        "downmigration-after-authority-close",
+        "downmigration-after-v4-drop",
+        "downmigration-after-v3-schema",
+        "downmigration-before-commit",
+    ),
+)
+def test_every_v4_downmigration_crash_barrier_restores_exact_v4(
+    crash_at: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection, active = _migrated_v4()
+    before = tuple(connection.iterdump())
+
+    def crash(point: str) -> None:
+        if point == crash_at:
+            raise RuntimeError(f"injected {point}")
+
+    monkeypatch.setattr(schema_v4, "_crash_point", crash)
+    with pytest.raises(RuntimeError, match=f"injected {crash_at}"):
+        _downmigrate(connection, active)
+
+    assert connection.execute("PRAGMA user_version").fetchone()[0] == 4
     assert tuple(connection.iterdump()) == before
 
 


### PR DESCRIPTION
## Summary

- add the internal, offline exact-v4 to exact-v3 database reversal primitive
- verify the complete active tuple plus exact mirrored policy-source and rebuilt catalog proofs before mutation
- refuse open recovery journals, unknown/future schema state, and any non-v4 source
- make sessions, grants, purposes, tokens, and pending proposals inert before atomically restoring the v3 schema
- prove every injected crash barrier returns byte-for-byte to the predecessor v4 database

This is the database half of the OpenSpec rollback coordinator. It is deliberately not exposed as a public command, does not run at startup/request time, and does not mark the outer migration/downmigration tasks complete; the held-filesystem mirror and external registry/fleet transition remain the next layer.

No live vault is read or changed. This PR is stacked after #865 and is not a merge request yet.

## Red-first evidence

- initial focused collection failed because `source_documents_digest`, `catalog_rebuild_digest`, and `downmigrate_v4_connection` did not exist
- exact-schema extension tests then caught an incomplete canonical-schema reference before the legacy archive was included

## Verification

- `tests/test_governance_store_v4.py`: 38 passed
- focused store/session/active-tuple packet: 190 passed
- Ruff on both changed Python files
- `uv lock --check`
- public repository artifact validation
- `openspec validate harden-governance-for-consolidation --strict`
- `git diff --check`
