### PR TITLE
fix(governance): stage existing v3 custody

### DIFF
--- a/src/exomem/governance/authorization_custody.py
+++ b/src/exomem/governance/authorization_custody.py
@@ -171,6 +171,18 @@ class StandaloneProvisioningResult:
 
 
 @dataclass(frozen=True, slots=True)
+class StandaloneV3StagingResult:
+    """Non-secret identity staged for one explicit offline v3 migration."""
+
+    keyring_path: Path
+    keyring_id: str
+    cell_id: str
+    logical_vault_id: str
+    registry_attachment_id: str
+    attachment_epoch: int
+
+
+@dataclass(frozen=True, slots=True)
 class _LoadedCustodyFile:
     path: Path
     data: bytes = field(repr=False)
@@ -1044,6 +1056,44 @@ def _verify_standalone_staging_keyring(
         raise AuthorizationCustodyUnavailable
 
 
+def _new_standalone_staging_keyring(
+    *,
+    attachment_id: str,
+    current_time: int,
+) -> AuthorizationKeyring:
+    key_bytes = secrets.token_bytes(32)
+    key = AuthorizationVerifierKey(
+        key_id=_standalone_staging_identifier(
+            "auth-key",
+            attachment_id=attachment_id,
+            key=key_bytes,
+        ),
+        key=key_bytes,
+        not_before=current_time,
+        not_after=current_time + _DEFAULT_KEY_TTL_SECONDS,
+    )
+    return AuthorizationKeyring(
+        version=1,
+        keyring_id=_standalone_staging_identifier(
+            "keyring",
+            attachment_id=attachment_id,
+            key=key_bytes,
+        ),
+        cell_id=_standalone_staging_identifier(
+            "cell",
+            attachment_id=attachment_id,
+            key=key_bytes,
+        ),
+        logical_vault_id=_standalone_staging_identifier(
+            "vault",
+            attachment_id=attachment_id,
+            key=key_bytes,
+        ),
+        active_key_id=key.key_id,
+        accepted_keys=(key,),
+    )
+
+
 def _keyring_bytes(keyring: AuthorizationKeyring) -> bytes:
     value = {
         "version": keyring.version,
@@ -1158,6 +1208,20 @@ def _governance_negative_scan(vault_root: Path) -> None:
         raise AuthorizationCustodyUnavailable from None
 
 
+def _require_exact_v3_authority(vault_root: Path) -> None:
+    from . import schema_v4, store
+
+    connection = store.open_readonly_connection(vault_root)
+    if connection is None:
+        raise AuthorizationCustodyUnavailable
+    try:
+        schema_v4.require_exact_v3_connection(connection)
+    except (schema_v4.SchemaV4Error, OSError, RuntimeError):
+        raise AuthorizationCustodyUnavailable from None
+    finally:
+        connection.close()
+
+
 def _provisioning_result(
     custody: AuthorizationCustody,
 ) -> StandaloneProvisioningResult:
@@ -1177,6 +1241,78 @@ def _provisioning_result(
         registry_attachment_id=custody.control.registry_attachment_id,
         attachment_epoch=custody.control.attachment_epoch,
         replica_id=custody.local_replica_id,
+    )
+
+
+def stage_standalone_v3_custody(
+    vault_root: Path,
+    *,
+    now: int,
+) -> StandaloneV3StagingResult:
+    """Stage inert external identity for an exact-v3 offline migration.
+
+    This explicit owner operation publishes only the keyring.  It does not
+    create a control or membership record, does not enrol governance, and
+    cannot make authorization-session service ready.  A later coordinator
+    must bind this identity to one exact initial v4 tuple under the full
+    schema/replica fence before it may migrate the sidecar.
+    """
+
+    root = Path(vault_root)
+    current_time = _bounded_time(now)
+    if current_time > _MAX_SIGNED_SQLITE_INTEGER - _DEFAULT_KEY_TTL_SECONDS:
+        raise AuthorizationCustodyUnavailable
+    attachment_id = standalone_attachment_id(root)
+    keyring_path = _configured_external_path(KEYRING_FILE_ENV, root)
+    control_path = _configured_external_path(CONTROL_FILE_ENV, root)
+    membership_path = _configured_external_path(MEMBERSHIP_FILE_ENV, root)
+    if len({keyring_path, control_path, membership_path}) != 3:
+        raise AuthorizationCustodyUnavailable
+
+    from .. import reserved_paths
+
+    with reserved_paths._identity_coordination_scope(root):
+        _require_exact_v3_authority(root)
+        for registered_path in (control_path, membership_path):
+            try:
+                registered = _load_file(registered_path)
+            except AuthorizationCustodyUnavailable:
+                if os.path.lexists(registered_path):
+                    raise
+            else:
+                if registered is not None:
+                    raise AuthorizationCustodyUnavailable
+
+        try:
+            loaded = _load_file(keyring_path)
+        except AuthorizationCustodyUnavailable:
+            if os.path.lexists(keyring_path):
+                raise
+            loaded = None
+        if loaded is None:
+            keyring = _new_standalone_staging_keyring(
+                attachment_id=attachment_id,
+                current_time=current_time,
+            )
+            _publish_private_file(keyring_path, _keyring_bytes(keyring))
+        else:
+            keyring = parse_keyring(loaded.data)
+
+        _verify_standalone_staging_keyring(
+            keyring,
+            attachment_id=attachment_id,
+        )
+        if not keyring.active_key.not_before <= current_time < keyring.active_key.not_after:
+            raise AuthorizationCustodyUnavailable
+        _require_exact_v3_authority(root)
+
+    return StandaloneV3StagingResult(
+        keyring_path=keyring_path,
+        keyring_id=keyring.keyring_id,
+        cell_id=keyring.cell_id,
+        logical_vault_id=keyring.logical_vault_id,
+        registry_attachment_id=attachment_id,
+        attachment_epoch=1,
     )
 
 
@@ -1239,36 +1375,9 @@ def provision_standalone_custody(
         if keyring_loaded is not None:
             keyring = parse_keyring(keyring_loaded.data)
         else:
-            key_bytes = secrets.token_bytes(32)
-            key = AuthorizationVerifierKey(
-                key_id=_standalone_staging_identifier(
-                    "auth-key",
-                    attachment_id=attachment_id,
-                    key=key_bytes,
-                ),
-                key=key_bytes,
-                not_before=current_time,
-                not_after=current_time + _DEFAULT_KEY_TTL_SECONDS,
-            )
-            keyring = AuthorizationKeyring(
-                version=1,
-                keyring_id=_standalone_staging_identifier(
-                    "keyring",
-                    attachment_id=attachment_id,
-                    key=key_bytes,
-                ),
-                cell_id=_standalone_staging_identifier(
-                    "cell",
-                    attachment_id=attachment_id,
-                    key=key_bytes,
-                ),
-                logical_vault_id=_standalone_staging_identifier(
-                    "vault",
-                    attachment_id=attachment_id,
-                    key=key_bytes,
-                ),
-                active_key_id=key.key_id,
-                accepted_keys=(key,),
+            keyring = _new_standalone_staging_keyring(
+                attachment_id=attachment_id,
+                current_time=current_time,
             )
             encoded_keyring = _keyring_bytes(keyring)
             _publish_private_file(keyring_path, encoded_keyring)

--- a/src/exomem/governance/schema_v4.py
+++ b/src/exomem/governance/schema_v4.py
@@ -9,6 +9,7 @@ policy/projector/catalog tuple in one transaction.
 from __future__ import annotations
 
 import base64
+import functools
 import hashlib
 import hmac
 import json
@@ -192,6 +193,54 @@ class DownmigrationResult:
     expired_purposes: int
     expired_tokens: int
     expired_proposals: int
+
+
+def _complete_schema_signature(
+    connection: sqlite3.Connection,
+) -> tuple[tuple[object, ...], ...]:
+    return tuple(
+        tuple(row)
+        for row in connection.execute(
+            "SELECT type, name, tbl_name, sql FROM sqlite_master "
+            "WHERE name NOT LIKE 'sqlite_autoindex_%' "
+            "ORDER BY type, name"
+        )
+    )
+
+
+@functools.cache
+def _expected_v3_schema_signature() -> tuple[tuple[object, ...], ...]:
+    from .. import sidecar_store
+    from . import store
+
+    reference = sqlite3.connect(":memory:")
+    try:
+        store._migrate(reference)
+        sidecar_store.ensure_meta_table(
+            reference,
+            store.DATA_TABLE,
+            "governance-v3-reference",
+        )
+        return _complete_schema_signature(reference)
+    finally:
+        reference.close()
+
+
+def require_exact_v3_connection(connection: sqlite3.Connection) -> None:
+    """Refuse any database that is not the frozen current schema-v3 authority."""
+
+    try:
+        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        quick_check = tuple(connection.execute("PRAGMA quick_check(1)"))
+        signature = _complete_schema_signature(connection)
+    except (AttributeError, TypeError, ValueError, sqlite3.Error) as exc:
+        raise SchemaV4Error("schema v3 migration source is unavailable") from exc
+    if version != 3:
+        raise SchemaV4Error(
+            f"schema v3 migration source requires exact schema v3, found v{version}"
+        )
+    if quick_check != (("ok",),) or signature != _expected_v3_schema_signature():
+        raise SchemaV4Error("schema v3 migration source is not exact")
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_authorization_standalone_provisioning.py
+++ b/tests/test_authorization_standalone_provisioning.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import stat
 from collections.abc import Iterator
 from dataclasses import replace
@@ -9,7 +10,7 @@ from pathlib import Path
 import pytest
 
 from exomem import mutation_lock, writer_lease
-from exomem.governance import authorization_custody, policy, schema_v4
+from exomem.governance import authorization_custody, policy, schema_v4, store
 
 
 @pytest.fixture(autouse=True)
@@ -66,6 +67,12 @@ def _target(
         catalog_generation=1,
         projection_namespace_id="projection-namespace-initial",
     )
+
+
+def _exact_v3(vault: Path) -> Path:
+    connection = store.open_connection(vault)
+    connection.close()
+    return store.sidecar_path(vault)
 
 
 def test_attachment_identity_is_stable_for_one_root_and_changes_for_a_copy(
@@ -140,6 +147,186 @@ def test_standalone_provisioning_refuses_opaque_hosted_attachment(
 
     with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
         authorization_custody.provision_standalone_custody(vault, now=now + 1)
+
+
+def test_existing_exact_v3_stages_identity_without_registering_or_serving(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    _exact_v3(vault)
+    now = 1_800_000_000
+
+    first = authorization_custody.stage_standalone_v3_custody(vault, now=now)
+    keyring_before = first.keyring_path.read_bytes()
+    replay = authorization_custody.stage_standalone_v3_custody(vault, now=now + 1)
+
+    assert replay == first
+    assert first.keyring_path.read_bytes() == keyring_before
+    assert first.registry_attachment_id == authorization_custody.standalone_attachment_id(
+        vault
+    )
+    keyring = authorization_custody.parse_keyring(keyring_before)
+    assert first.keyring_id == keyring.keyring_id
+    assert first.cell_id == keyring.cell_id
+    assert first.logical_vault_id == keyring.logical_vault_id
+    assert keyring.active_key.key.hex() not in repr(first)
+    if os.name != "nt":
+        assert stat.S_IMODE(first.keyring_path.stat().st_mode) == 0o600
+    assert not Path(os.environ[authorization_custody.CONTROL_FILE_ENV]).exists()
+    assert not Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV]).exists()
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_authorization_custody(vault, now=now + 1)
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.provision_standalone_custody(vault, now=now + 1)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "absent",
+        "corrupt",
+        "future",
+        "unknown-table",
+        "future-column",
+        "unknown-index",
+        "unknown-trigger",
+    ],
+)
+def test_v3_staging_refuses_nonexact_authority_without_external_registration(
+    tmp_path: Path,
+    source: str,
+) -> None:
+    vault = _vault(tmp_path)
+    if source != "absent":
+        sidecar = _exact_v3(vault)
+        if source == "corrupt":
+            sidecar.write_bytes(b"not a governance database")
+        else:
+            connection = sqlite3.connect(sidecar)
+            try:
+                if source == "future":
+                    connection.execute("PRAGMA user_version=4")
+                elif source == "unknown-table":
+                    connection.execute("CREATE TABLE migration_smuggled_state (value TEXT)")
+                elif source == "future-column":
+                    connection.execute(
+                        "ALTER TABLE governance_session_grants ADD COLUMN future_state TEXT"
+                    )
+                elif source == "unknown-index":
+                    connection.execute(
+                        "CREATE INDEX migration_smuggled_index "
+                        "ON compiled_policy(compiled_at)"
+                    )
+                else:
+                    connection.execute(
+                        "CREATE TRIGGER migration_smuggled_trigger "
+                        "AFTER INSERT ON compiled_policy BEGIN SELECT 1; END"
+                    )
+                connection.commit()
+            finally:
+                connection.close()
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.stage_standalone_v3_custody(
+            vault,
+            now=1_800_000_000,
+        )
+
+    assert not Path(os.environ[authorization_custody.KEYRING_FILE_ENV]).exists()
+    assert not Path(os.environ[authorization_custody.CONTROL_FILE_ENV]).exists()
+    assert not Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV]).exists()
+
+
+def test_v3_staging_keyring_cannot_be_claimed_by_a_copied_attachment(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    copied = _vault(tmp_path, "copied-vault")
+    original_sidecar = _exact_v3(vault)
+    copied_sidecar = store.sidecar_path(copied)
+    copied_sidecar.write_bytes(original_sidecar.read_bytes())
+    now = 1_800_000_000
+    first = authorization_custody.stage_standalone_v3_custody(vault, now=now)
+    keyring_before = first.keyring_path.read_bytes()
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.stage_standalone_v3_custody(copied, now=now + 1)
+
+    assert first.keyring_path.read_bytes() == keyring_before
+    assert not Path(os.environ[authorization_custody.CONTROL_FILE_ENV]).exists()
+
+
+def test_v3_staging_schema_drift_after_keyring_publish_remains_inert_and_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    sidecar = _exact_v3(vault)
+    now = 1_800_000_000
+    original = authorization_custody._publish_private_file
+    mutated = False
+
+    def publish_then_drift(path: Path, data: bytes) -> bytes:
+        nonlocal mutated
+        published = original(path, data)
+        if path == Path(os.environ[authorization_custody.KEYRING_FILE_ENV]) and not mutated:
+            mutated = True
+            connection = sqlite3.connect(sidecar)
+            try:
+                connection.execute("CREATE TABLE concurrent_schema_state (value TEXT)")
+                connection.commit()
+            finally:
+                connection.close()
+        return published
+
+    monkeypatch.setattr(
+        authorization_custody,
+        "_publish_private_file",
+        publish_then_drift,
+    )
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.stage_standalone_v3_custody(vault, now=now)
+
+    keyring_path = Path(os.environ[authorization_custody.KEYRING_FILE_ENV])
+    keyring_before = keyring_path.read_bytes()
+    assert not Path(os.environ[authorization_custody.CONTROL_FILE_ENV]).exists()
+    assert not Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV]).exists()
+
+    connection = sqlite3.connect(sidecar)
+    try:
+        connection.execute("DROP TABLE concurrent_schema_state")
+        connection.commit()
+    finally:
+        connection.close()
+    monkeypatch.setattr(authorization_custody, "_publish_private_file", original)
+
+    result = authorization_custody.stage_standalone_v3_custody(vault, now=now + 1)
+
+    assert result.keyring_path.read_bytes() == keyring_before
+
+
+def test_v3_staging_never_reclassifies_an_existing_registration(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = 1_800_000_000
+    provisioned = authorization_custody.provision_standalone_custody(vault, now=now)
+    control_before = provisioned.control_path.read_bytes()
+    membership_before = provisioned.membership_path.read_bytes()
+    _exact_v3(vault)
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.stage_standalone_v3_custody(vault, now=now + 1)
+
+    assert provisioned.control_path.read_bytes() == control_before
+    assert provisioned.membership_path.read_bytes() == membership_before
+    assert (
+        authorization_custody.load_authorization_custody(
+            vault,
+            now=now + 1,
+        ).control.governance_enrolled
+        is False
+    )
 
 
 def test_standalone_control_remains_valid_past_bootstrap_hour(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add an explicit owner-only staging seam for an existing exact schema-v3 governance sidecar
- publish only an attachment-bound external keyring; no control record, membership record, enrollment, session readiness, or vault mutation is created
- verify the complete current v3 SQLite schema before and after publication, rejecting absent, corrupt, future, copied, or structurally extended stores
- share identity minting with the existing never-governed provisioning path so the two paths cannot drift

This is the inert identity prerequisite for the later offline v3→v4 coordinator. It intentionally does not expose migration publicly or mark the broad migration/provisioning OpenSpec tasks complete.

## Verification

- red first: 6 focused failures for the missing staging API
- `tests/test_authorization_standalone_provisioning.py`: 27 passed
- Python 3.13 custody/schema/session packet: 170 passed, 1 Windows-only skip
- post-refactor custody packet: 112 passed, 1 Windows-only skip
- Ruff on all three changed Python files
- `uv lock --check`
- public repository artifact validation
- `openspec validate harden-governance-for-consolidation --strict`
- `git diff --check`

No live vault was touched. This PR is stacked after #866 and should not be merged independently or while the wider Exomem stabilization pass is still in flight.
