### PR TITLE
fix(access): fail closed on transient policy errors and bound graph startup

### DIFF
--- a/openspec/changes/bound-graph-recovery-funnel/specs/live-index-freshness/spec.md
+++ b/openspec/changes/bound-graph-recovery-funnel/specs/live-index-freshness/spec.md
@@ -60,7 +60,7 @@ A service restart that finds a coherent durable graph checkpoint SHALL admit gra
 #### Scenario: Restart with a coherent graph admits without a full rebuild
 
 - **WHEN** the service restarts and the durable graph checkpoint matches the published sidecar's digest and generation
-- **THEN** graph reads are admitted after the O(1) validation
+- **THEN** graph reads are admitted after bounded validation that never suspends reads and never rebuilds
 - **AND** no whole-vault graph rebuild is scheduled by the startup pass
 
 #### Scenario: Genuine incoherence still rebuilds

--- a/openspec/changes/bound-graph-recovery-funnel/specs/recall-read-path/spec.md
+++ b/openspec/changes/bound-graph-recovery-funnel/specs/recall-read-path/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Access-policy loading fails closed on transient errors
 
-A transient failure to stat or read the access-policy file SHALL NOT install or cache a policy more permissive than the last successfully loaded one, and SHALL NOT change the access fingerprint used in recall identity. While the last successful load remains valid under an unchanged stat signature, transient errors reuse it; when no successful load exists, the system SHALL treat every path as excluded (fail closed) until a read succeeds. Recall identity SHALL only change when the policy content provably changed.
+A transient failure to stat or read the access-policy file SHALL NOT install or cache a policy more permissive than the last successfully loaded one, and SHALL NOT change the access fingerprint used in recall identity. Transient errors reuse the last successfully loaded policy and fingerprint regardless of whether the stat signature moved - reuse never widens visibility, and convergence to the changed content happens at the next successful read; when no successful load exists, the system SHALL treat every path as excluded (fail closed) until a read succeeds. A failure in the read position after a successful stat - including the file vanishing between stat and read - is a transient error, never a policy change; only an absence observed at stat time is the genuine missing-policy identity. Recall identity SHALL only change when the policy content provably changed.
 
 #### Scenario: A transient read error cannot widen visibility
 
@@ -21,3 +21,9 @@ A transient failure to stat or read the access-policy file SHALL NOT install or 
 - **WHEN** a stat or read blip occurs with the policy file's content unchanged
 - **THEN** the recall identity and its access fingerprint are unchanged
 - **AND** no recall generation advances and no admission refusal results
+
+#### Scenario: A file vanishing between stat and read is transient
+
+- **WHEN** the access-policy file exists at stat time and vanishes before the read completes
+- **THEN** the previously loaded policy and its fingerprint remain in effect
+- **AND** only an absence observed at stat time transitions to the missing-policy identity

--- a/openspec/changes/bound-graph-recovery-funnel/tasks.md
+++ b/openspec/changes/bound-graph-recovery-funnel/tasks.md
@@ -14,7 +14,7 @@
       graph-disabled-while-recovery-checkpoint-exists combination FAILs
       immediately, including when the kill switch comes from an unowned
       site-packages `.pth`.
-- [ ] 1.4 Startup-bound pin: a restart over a coherent durable graph
+- [x] 1.4 Startup-bound pin: a restart over a coherent durable graph
       checkpoint currently schedules a whole-vault rebuild in the watcher
       startup pass (measured: ~30 min of suspended reads per restart on a
       3.3k-file vault); after the fix it admits after O(1) validation, and
@@ -23,7 +23,7 @@
       service owns graph work refuses with the documented remediation
       instead of taking the claim.
 
-- [ ] 1.6 Access fail-open pin (red first): a transient OSError reading the
+- [x] 1.6 Access fail-open pin (red first): a transient OSError reading the
       access-policy file currently caches an EMPTY policy (nothing excluded)
       under the unchanged stat signature and flips the access fingerprint,
       widening visibility and flapping recall identity with zero writes.
@@ -33,7 +33,7 @@
 
 ## 2. Implementation
 
-- [ ] 2.0 Access-policy fail-closed loading per the recall-read-path delta
+- [x] 2.0 Access-policy fail-closed loading per the recall-read-path delta
       (precondition for trusting the projection-lag identity guard).
 - [ ] 2.1 Extend the `epistemic_graph` clause of `full_upsert_succeeded`
       with the durable-coverage carve-out (mirror of the embeddings
@@ -45,7 +45,7 @@
       absent projection (red-first pin: a single write currently flips
       semantic recall to RETRIEVAL_INDEX_WARMING until the graph republishes
       the projection - measured live as the flapping-admission duty cycle).
-- [ ] 2.5 Bounded startup validation: O(1) durable-checkpoint check in the
+- [x] 2.5 Bounded startup validation: O(1) durable-checkpoint check in the
       watcher startup pass; whole-vault rebuild only on incoherence.
 
 ## 3. Verification and delivery

--- a/src/exomem/access.py
+++ b/src/exomem/access.py
@@ -49,9 +49,19 @@ _APPEND_ONLY = ("Sources", "Evidence")
 # (stat signature, byte fingerprint, parsed config) per config-file path. Find
 # refreshes the byte fingerprint once before its hot-cache lookup; page-level
 # access checks then reuse this parsed snapshot without rereading the policy.
+# ONLY a successful load is ever stored here: caching a degraded read would
+# install a policy more permissive than the real one under an unchanged stat
+# signature, which is a cached fail-open on a privacy boundary.
 _PolicySignature = tuple[int, int, int, int, int]
 _CACHE: dict[str, tuple[_PolicySignature, str, dict[str, list[str]]]] = {}
 PUBLICATION_POLICY_MAX_BYTES = 64 * 1024
+
+# Identity reported while the policy file exists but has never been read
+# successfully in this process. Deliberately stable rather than per-error-type:
+# a retry storm must not churn recall identity.
+UNAVAILABLE_POLICY_FINGERPRINT = "unavailable"
+# Identity of a genuinely absent policy file — a real state, not an error.
+MISSING_POLICY_FINGERPRINT = "missing"
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,19 +79,12 @@ def _load_config(vault_root: Path) -> dict[str, list[str]]:
     """Read ``_access.yaml`` → ``{"readonly": [...], "excluded": [...]}``.
 
     Missing/malformed → empty policy (never raises — a broken config must not
-    take down search). Live-reloaded on mtime change.
+    take down search). Live-reloaded on content change. A transient stat/read
+    error retains the last known-good policy instead of widening; callers that
+    ENFORCE tiers must go through :func:`access_tier`, which additionally
+    honors the fail-closed state this function cannot express.
     """
-    p = access_config_path(vault_root)
-    try:
-        signature = _policy_signature(p)
-    except OSError:
-        _CACHE.pop(str(p), None)
-        return {"readonly": [], "excluded": []}
-    key = str(p)
-    cached = _CACHE.get(key)
-    if cached is not None and cached[0] == signature:
-        return cached[2]
-    return _refresh_config(p, signature)[1]
+    return _policy_state(vault_root)[1]
 
 
 def policy_fingerprint(vault_root: Path) -> str:
@@ -90,14 +93,15 @@ def policy_fingerprint(vault_root: Path) -> str:
     This is intentionally content-based rather than mtime-based: access policy
     changes are security boundaries and must invalidate find's hot result cache
     even after a same-size or timestamp-preserving replacement.
+
+    A transient stat/read failure deliberately reports the LAST GOOD identity.
+    Moving it would flip ``recall_policy.recall_policy_identity``, which makes
+    ``live_recall_checkpoint`` fail closed and drives ``recall_checkpoint``
+    into its O(corpus) reprojection branch — advancing the recall generation
+    with zero writes and refusing semantic admission until the next
+    republication.
     """
-    path = access_config_path(vault_root)
-    try:
-        signature = _policy_signature(path)
-    except OSError:
-        _CACHE.pop(str(path), None)
-        return "missing"
-    return _refresh_config(path, signature)[0]
+    return _policy_state(vault_root)[0]
 
 
 def publication_policy_snapshot(vault_root: Path) -> PublicationPolicySnapshot | None:
@@ -111,7 +115,7 @@ def publication_policy_snapshot(vault_root: Path) -> PublicationPolicySnapshot |
     try:
         path.lstat()
     except FileNotFoundError:
-        return PublicationPolicySnapshot("missing")
+        return PublicationPolicySnapshot(MISSING_POLICY_FINGERPRINT)
     except OSError:
         return None
     try:
@@ -138,37 +142,84 @@ def _policy_signature(path: Path) -> _PolicySignature:
     )
 
 
-def _refresh_config(
-    path: Path,
-    signature: _PolicySignature,
-) -> tuple[str, dict[str, list[str]]]:
+def _empty_policy() -> dict[str, list[str]]:
+    return {"readonly": [], "excluded": []}
+
+
+def _degraded_state(key: str) -> tuple[str, dict[str, list[str]], bool]:
+    """Resolve a transient stat/read failure without ever widening visibility.
+
+    The last successful load stays in force under its own fingerprint — and it
+    is reused REGARDLESS of whether the stat signature moved. Reuse can only
+    hold visibility narrower or equal to the real policy, never wider, and
+    convergence to changed content happens at the next successful read. With no
+    successful load to fall back on there is nothing safe to serve, so every
+    path is excluded until a read succeeds.
+    """
+    cached = _CACHE.get(key)
+    if cached is not None:
+        return cached[1], cached[2], False
+    return UNAVAILABLE_POLICY_FINGERPRINT, _empty_policy(), True
+
+
+def _policy_state(vault_root: Path) -> tuple[str, dict[str, list[str]], bool]:
+    """Return ``(fingerprint, config, fail_closed)`` for the access policy.
+
+    An ABSENT file is a real state carrying the stable ``missing`` identity:
+    only the built-in defaults apply. A stat/read ERROR is not a state — it is
+    a transient failure, and is resolved by :func:`_degraded_state` rather than
+    by installing (or caching) an empty policy.
+    """
+    path = access_config_path(vault_root)
+    key = str(path)
+    try:
+        signature = _policy_signature(path)
+    except FileNotFoundError:
+        _CACHE.pop(key, None)
+        return MISSING_POLICY_FINGERPRINT, _empty_policy(), False
+    except OSError as error:
+        log.warning(
+            "could not stat %s (%s); retaining the last known-good access policy",
+            path.name,
+            error,
+        )
+        return _degraded_state(key)
+    cached = _CACHE.get(key)
+    if cached is not None and cached[0] == signature:
+        return cached[1], cached[2], False
     try:
         raw = path.read_bytes()
     except OSError as error:
-        log.warning("could not read %s (%s); treating as no access policy", path.name, error)
-        fingerprint = f"unavailable:{type(error).__name__}"
-        cfg: dict[str, list[str]] = {"readonly": [], "excluded": []}
-        _CACHE[str(path)] = (signature, fingerprint, cfg)
-        return fingerprint, cfg
+        # Deliberately no FileNotFoundError branch here. The file was present
+        # at stat, so its disappearance before the read is a RACE — a
+        # delete-then-write save from an editor or sync client — not a settled
+        # absence. Treating it as one both widened visibility and popped the
+        # last known-good entry, destroying the fallback every later transient
+        # error depends on. Only an absence seen at stat position (above) is
+        # the genuine missing-policy identity.
+        log.warning(
+            "could not read %s (%s); retaining the last known-good access policy",
+            path.name,
+            error,
+        )
+        return _degraded_state(key)
     fingerprint = hashlib.sha256(raw).hexdigest()
-    cached = _CACHE.get(str(path))
     if cached is not None and cached[1] == fingerprint:
-        if cached[0] != signature:
-            _CACHE[str(path)] = (signature, fingerprint, cached[2])
-        return fingerprint, cached[2]
+        _CACHE[key] = (signature, fingerprint, cached[2])
+        return fingerprint, cached[2], False
     try:
         data = yaml.safe_load(raw.decode("utf-8")) or {}
         if not isinstance(data, dict):
             data = {}
     except (UnicodeError, yaml.YAMLError) as error:
-        log.warning("could not read %s (%s); treating as no access policy", path.name, error)
+        log.warning("could not parse %s (%s); treating as no access policy", path.name, error)
         data = {}
     cfg = {
         "readonly": [str(x) for x in (data.get("readonly") or [])],
         "excluded": [str(x) for x in (data.get("excluded") or [])],
     }
-    _CACHE[str(path)] = (signature, fingerprint, cfg)
-    return fingerprint, cfg
+    _CACHE[key] = (signature, fingerprint, cfg)
+    return fingerprint, cfg, False
 
 
 def _kb_relative(rel_path: str) -> str:
@@ -197,10 +248,15 @@ def _matches(prefixes: list[str], kb_rel: str) -> bool:
 def access_tier(vault_root: Path, rel_path: str) -> str:
     """Return the tier governing `rel_path` (vault-relative, either prefix form).
 
-    Resolution order: excluded → readonly (config) → append-only
-    (Sources/Evidence) → read-write.
+    Resolution order: fail-closed → excluded → readonly (config) →
+    append-only (Sources/Evidence) → read-write.
     """
-    cfg = _load_config(vault_root)
+    _fingerprint, cfg, fail_closed = _policy_state(vault_root)
+    if fail_closed:
+        # The policy file exists but has never been read successfully in this
+        # process. Falling back to the built-in defaults here would publish
+        # every `excluded` tree, so refuse the whole vault until a read lands.
+        return TIER_EXCLUDED
     kb_rel = _kb_relative(rel_path)
     if _matches(cfg["excluded"], kb_rel):
         return TIER_EXCLUDED

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -2744,6 +2744,65 @@ class EpistemicGraphIndex:
             if conn is not None:
                 conn.close()
 
+    def durable_checkpoint_is_coherent(self) -> bool:
+        """O(1) durable evidence that a whole-vault rebuild is unjustified.
+
+        Reads four `graph_meta` rows and the durable checkpoint file. It never
+        walks the vault, hashes a source, or opens the graph for reading, so a
+        startup pass can consult it without suspending reads.
+
+        This is a cheap CONSERVATIVE negative pre-filter, not a second
+        admission authority. `available()` remains the sole authority, and is
+        strictly stronger today: every state this accepts, `available()`
+        independently re-checks. The two are separate code paths and may drift,
+        but because the startup pass requires BOTH, the drift is bounded to a
+        spurious rebuild — this returning False where `available()` would have
+        admitted. It can never admit something `available()` would reject.
+
+        The classification tracks the graph_sync clause of
+        :meth:`_open_read_snapshot`:
+
+        - a malformed durable checkpoint is incoherent;
+        - a valid one must be acknowledged by matching generation AND digest;
+        - acknowledgement rows with no durable checkpoint are recovery state,
+          not a legacy sidecar;
+        - a persisted read barrier is a recorded crash marker.
+
+        True means only that the rebuild has no durable justification — it is
+        NOT a freshness claim. Every public read still passes
+        `_open_read_snapshot`, which independently proves source bytes and
+        resolver topology for a cold reader and fails closed, so a graph that
+        drifted from disk while the process was down is still caught there.
+        """
+        if not self.path.exists():
+            return False
+        graph_sync_state, required = graph_sync.checkpoint_state(self.vault_root)
+        if graph_sync_state == "malformed":
+            return False
+        conn: sqlite3.Connection | None = None
+        try:
+            conn = self._connect_existing(readonly=True)
+            values = dict(
+                conn.execute(
+                    "SELECT key, value FROM graph_meta WHERE key IN "
+                    "('read_barrier', 'graph_sync_generation', 'graph_sync_digest', "
+                    "'graph_sync_checkpoint')"
+                ).fetchall()
+            )
+        except sqlite3.Error:
+            return False
+        finally:
+            if conn is not None:
+                conn.close()
+        if values.get(_READ_BARRIER_KEY) is not None:
+            return False
+        if required is not None:
+            return _graph_sync_acknowledgement(values) == required
+        return (
+            values.get("graph_sync_generation") is None
+            and values.get("graph_sync_digest") is None
+        )
+
     def _publish_available_marker(
         self,
         identity: tuple[tuple[int, int, str], str, str],

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -734,13 +734,29 @@ class FileWatcher:
         epistemic_graph.recover_suspended_graph(self._vault_root)
 
     def _validate_existing_graph_on_seed(self) -> bool:
-        """Rebuild an existing graph after startup's exact disk baselines.
+        """Validate an existing graph after startup's exact disk baselines.
 
         A process can die before watchdog delivers an edit or while the event is
         still debouncing, before any in-memory epoch can persist a read barrier.
-        Filesystem metadata can also collide across such an edit. Rebuilding in
-        the watcher's background startup pass is the only complete proof of
-        source bytes and resolver topology across that crash boundary.
+        Filesystem metadata can also collide across such an edit, so the graph
+        does need a proof of source bytes and resolver topology across that
+        crash boundary — but a whole-vault REBUILD is not that proof, it is the
+        repair. Paying the repair unconditionally cost 12-30 minutes of
+        suspended reads on every restart of a 3.3k-file vault, turning every
+        restart into an outage.
+
+        Validation is therefore bounded and layered: an O(1) durable check
+        first, then a non-suspending source-bytes proof. The second step is
+        `available()`, which for a cold reader re-proves the sidecar against
+        canonical source bytes and resolver topology — O(corpus) hashing, but
+        it neither suspends reads nor rebuilds. Reads are suspended and the
+        graph rebuilt only when one of those proofs fails, which is the
+        genuine-incoherence case.
+
+        The O(1) check is a conservative negative pre-filter: when durable
+        state already proves a rebuild is needed, it short-circuits ahead of
+        the source-bytes proof so the expensive hashing is not paid before a
+        rebuild that was already certain.
         """
         from . import epistemic_graph, graph_sync
         from . import find as find_module
@@ -751,6 +767,9 @@ class FileWatcher:
         graph = epistemic_graph.EpistemicGraphIndex(self._vault_root)
         try:
             if not epistemic_graph.graph_enabled():
+                return True
+            if graph.durable_checkpoint_is_coherent() and graph.available():
+                log.info("file watcher: startup graph validation admitted a coherent graph")
                 return True
             graph.suspend_reads()
             find_module.evict_resolver_caches(self._vault_root)

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -150,3 +150,197 @@ def test_publication_policy_snapshot_is_bounded_and_fails_closed(
         lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("unreadable")),
     )
     assert access.publication_policy_snapshot(vault) is None
+
+
+# --- Access-policy loading fails closed on transient errors (task 1.6) -------
+#
+# A transient stat/read failure on `_access.yaml` must never install a policy
+# more permissive than the last good one, and must never move the access
+# fingerprint that recall identity is built from.
+
+
+class _Blip:
+    """Toggle for a path-scoped transient filesystem error."""
+
+    def __init__(self) -> None:
+        self.active = False
+
+
+def _install_blip(
+    monkeypatch: pytest.MonkeyPatch,
+    method: str,
+    target: Path,
+    error: OSError,
+) -> _Blip:
+    """Make `target` (and only `target`) raise `error` from `Path.<method>`."""
+    blip = _Blip()
+    real = getattr(Path, method)
+
+    def fake(self: Path, *args: object, **kwargs: object) -> object:
+        if blip.active and os.path.normcase(str(self)) == os.path.normcase(str(target)):
+            raise error
+        return real(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, method, fake)
+    return blip
+
+
+def _sharing_violation() -> OSError:
+    return PermissionError(13, "The process cannot access the file")
+
+
+def _bump_signature(config: Path) -> None:
+    """Move the stat signature without touching content.
+
+    The loader short-circuits on an unchanged signature, so a read-error pin
+    that skips this never reaches `read_bytes` and silently tests nothing.
+
+    A MOVED signature is also the contract under test: transient errors reuse
+    the last successfully loaded policy and fingerprint regardless of whether
+    the signature moved. Reuse can only hold visibility narrower or equal to
+    the real policy, never wider, and convergence to the changed content
+    happens at the next successful read.
+    """
+    stamp = config.stat().st_mtime + 10
+    os.utime(config, (stamp, stamp))
+
+
+def test_transient_policy_read_error_cannot_widen_visibility(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A read blip must never install a policy wider than the last good one.
+
+    Regression: `_refresh_config` stored `{"readonly": [], "excluded": []}`
+    with an `unavailable:` fingerprint on OSError, so every later
+    `_load_config` under the unchanged stat signature served a policy in
+    which nothing was excluded — a cached fail-open on a privacy boundary.
+
+    The signature is deliberately moved first: the contract is that a
+    transient error reuses the last successfully loaded policy and fingerprint
+    REGARDLESS of signature movement, converging at the next successful read.
+    """
+    config = _write_cfg(vault, "excluded:\n  - Private\n")
+    secret = "Knowledge Base/Private/secret.md"
+    assert access.access_tier(vault, secret) == access.TIER_EXCLUDED
+    good = access.policy_fingerprint(vault)
+
+    blip = _install_blip(monkeypatch, "read_bytes", config, _sharing_violation())
+    _bump_signature(config)
+    blip.active = True
+    during = access.policy_fingerprint(vault)
+    assert during == good, "a read blip moved the access fingerprint"
+    assert access.access_tier(vault, secret) == access.TIER_EXCLUDED
+
+    blip.active = False
+    assert access.access_tier(vault, secret) == access.TIER_EXCLUDED
+    assert access.policy_fingerprint(vault) == good
+
+
+def test_transient_policy_stat_error_cannot_widen_visibility(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stat blip must reuse the last good policy, not fall back to `missing`."""
+    config = _write_cfg(vault, "excluded:\n  - Private\n")
+    secret = "Knowledge Base/Private/secret.md"
+    assert access.access_tier(vault, secret) == access.TIER_EXCLUDED
+    good = access.policy_fingerprint(vault)
+
+    blip = _install_blip(monkeypatch, "stat", config, _sharing_violation())
+    blip.active = True
+    assert access.policy_fingerprint(vault) == good, "a stat blip moved the fingerprint"
+    assert access.access_tier(vault, secret) == access.TIER_EXCLUDED
+
+
+def test_unreadable_policy_without_prior_load_fails_closed(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no successful load yet, an unreadable policy excludes everything."""
+    config = _write_cfg(vault, "excluded:\n  - Private\n")
+    ordinary = "Knowledge Base/Notes/ordinary.md"
+    blip = _install_blip(monkeypatch, "read_bytes", config, _sharing_violation())
+    blip.active = True
+
+    assert access.access_tier(vault, ordinary) == access.TIER_EXCLUDED
+    assert access.is_indexable(vault, ordinary) is False
+    assert access.refuse_if_excluded(vault, ordinary) is True
+    assert access.writable_reason(vault, ordinary) is not None
+
+    blip.active = False
+    assert access.access_tier(vault, ordinary) == access.TIER_READ_WRITE
+
+
+def test_transient_policy_blip_does_not_flip_recall_identity(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Recall identity changes only when policy content provably changed.
+
+    A blip that flips the fingerprint makes `live_recall_checkpoint` fail
+    closed and drives `recall_checkpoint` into its reprojection branch, which
+    advances the recall generation with zero writes — the measured
+    serve/refuse admission flap.
+    """
+    from exomem import recall_policy
+
+    config = _write_cfg(vault, "excluded:\n  - Private\n")
+    before = recall_policy.recall_policy_identity(vault)
+
+    read_blip = _install_blip(monkeypatch, "read_bytes", config, _sharing_violation())
+    _bump_signature(config)
+    read_blip.active = True
+    assert recall_policy.recall_policy_identity(vault) == before
+    read_blip.active = False
+
+    stat_blip = _install_blip(monkeypatch, "stat", config, _sharing_violation())
+    stat_blip.active = True
+    assert recall_policy.recall_policy_identity(vault) == before
+    stat_blip.active = False
+
+    assert recall_policy.recall_policy_identity(vault) == before
+
+
+def test_policy_vanishing_between_stat_and_read_is_transient(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file present at stat and gone at read is a race, not a deletion.
+
+    Delete-then-write saves (editors, sync clients) briefly unlink the file.
+    Treating that read-position FileNotFoundError as a settled absence both
+    widened visibility AND popped the last-known-good entry, destroying the
+    fallback every later transient error depends on. Only an absence observed
+    at stat time is the genuine missing-policy identity.
+    """
+    config = _write_cfg(vault, "excluded:\n  - Private\n")
+    secret = "Knowledge Base/Private/secret.md"
+    ordinary = "Knowledge Base/Notes/ordinary.md"
+    assert access.access_tier(vault, secret) == access.TIER_EXCLUDED
+    good = access.policy_fingerprint(vault)
+
+    blip = _install_blip(
+        monkeypatch, "read_bytes", config, FileNotFoundError(2, "No such file or directory")
+    )
+    _bump_signature(config)
+    blip.active = True
+
+    assert access.policy_fingerprint(vault) == good, "a read-position FNF moved the fingerprint"
+    assert access.access_tier(vault, secret) == access.TIER_EXCLUDED
+    # Still reusing the last known-good entry rather than failing closed proves
+    # the cache survived the race: a popped entry would leave `_degraded_state`
+    # with nothing and exclude every ordinary path too.
+    assert access.access_tier(vault, ordinary) == access.TIER_READ_WRITE
+
+    blip.active = False
+    assert access.access_tier(vault, secret) == access.TIER_EXCLUDED
+    assert access.policy_fingerprint(vault) == good
+
+
+def test_policy_deleted_before_stat_becomes_the_missing_identity(vault: Path) -> None:
+    """A genuine deletion, observed at stat time, is a real policy change."""
+    config = _write_cfg(vault, "excluded:\n  - Private\n")
+    secret = "Knowledge Base/Private/secret.md"
+    assert access.access_tier(vault, secret) == access.TIER_EXCLUDED
+    assert access.policy_fingerprint(vault) != access.MISSING_POLICY_FINGERPRINT
+
+    config.unlink()
+
+    assert access.policy_fingerprint(vault) == access.MISSING_POLICY_FINGERPRINT
+    assert access.access_tier(vault, secret) == access.TIER_READ_WRITE

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -2012,3 +2012,270 @@ def test_reconcile_delta_dual_form_collapse_missing_file_routes_as_deleted_only(
 
     assert ups == []
     assert dels == [[rel]]
+
+
+# --- Graph startup validation is bounded (task 1.4) -------------------------
+#
+# The startup pass suspended reads and rebuilt the WHOLE graph on every process
+# start whenever the sidecar existed (measured: ~30 min of suspended reads per
+# restart on a 3.3k-file vault). Durable evidence that the published sidecar
+# already acknowledges the graph_sync checkpoint must admit instead.
+
+
+def _startup_rebuild_spy(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record whole-graph rebuilds without suppressing them."""
+    calls: list[str] = []
+    real = epistemic_graph.EpistemicGraphIndex._rebuild_all_locked
+
+    def spy(self: epistemic_graph.EpistemicGraphIndex, *args: object, **kwargs: object) -> object:
+        calls.append("rebuild_all")
+        return real(self, *args, **kwargs)
+
+    monkeypatch.setattr(epistemic_graph.EpistemicGraphIndex, "_rebuild_all_locked", spy)
+    return calls
+
+
+def _suspend_spy(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    calls: list[str] = []
+    real = epistemic_graph.EpistemicGraphIndex.suspend_reads
+
+    def spy(self: epistemic_graph.EpistemicGraphIndex) -> object:
+        calls.append("suspend_reads")
+        return real(self)
+
+    monkeypatch.setattr(epistemic_graph.EpistemicGraphIndex, "suspend_reads", spy)
+    return calls
+
+
+def test_startup_over_a_coherent_graph_admits_without_a_rebuild(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A restart over a coherent durable checkpoint must not rebuild."""
+    watcher = file_watcher.FileWatcher(vault)
+    watcher._reconcile_once(seed=True)
+    graph = epistemic_graph.EpistemicGraphIndex(vault)
+    graph.rebuild_all()
+    assert graph.available() is True
+
+    freshness.clear()  # process restart: the in-memory epoch is gone
+    restarted = file_watcher.FileWatcher(vault)
+    restarted._reconcile_once(seed=True)
+
+    rebuilds = _startup_rebuild_spy(monkeypatch)
+    suspensions = _suspend_spy(monkeypatch)
+    restarted.finish_startup_recovery()
+
+    assert rebuilds == [], "a coherent restart rebuilt the whole graph"
+    assert suspensions == [], "a coherent restart suspended reads"
+    assert graph.available() is True
+    assert graph.reads_suspended() is False
+
+
+def test_startup_over_an_unacknowledged_checkpoint_still_rebuilds(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Genuine incoherence (unacknowledged checkpoint) still rebuilds.
+
+    The published sidecar carries no graph_sync acknowledgement, so a durable
+    checkpoint written behind it is exactly the digest-mismatch class: the
+    graph has not been built up to the handoff that checkpoint records.
+    """
+    from exomem import graph_sync
+
+    watcher = file_watcher.FileWatcher(vault)
+    watcher._reconcile_once(seed=True)
+    graph = epistemic_graph.EpistemicGraphIndex(vault)
+    graph.rebuild_all()
+    assert graph.available() is True
+
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="a1b2c3d4e5f6a7b8c9d0e1f2",
+        paths=(("Knowledge Base/Notes/startup-incoherent.md", "0" * 64),),
+        created_paths=("Knowledge Base/Notes/startup-incoherent.md",),
+    )
+    graph_sync._write_checkpoint(vault, checkpoint)
+    assert graph_sync.read_checkpoint(vault) == checkpoint
+
+    freshness.clear()
+    restarted = file_watcher.FileWatcher(vault)
+    restarted._reconcile_once(seed=True)
+
+    rebuilds = _startup_rebuild_spy(monkeypatch)
+    restarted.finish_startup_recovery()
+
+    assert rebuilds, "an unacknowledged durable checkpoint did not rebuild"
+
+
+def test_startup_over_a_persisted_barrier_still_rebuilds(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recorded crash marker is genuine incoherence and still rebuilds."""
+    watcher = file_watcher.FileWatcher(vault)
+    watcher._reconcile_once(seed=True)
+    graph = epistemic_graph.EpistemicGraphIndex(vault)
+    graph.rebuild_all()
+    graph.suspend_reads()
+    assert graph.reads_suspended() is True
+
+    freshness.clear()
+    restarted = file_watcher.FileWatcher(vault)
+    restarted._reconcile_once(seed=True)
+
+    rebuilds = _startup_rebuild_spy(monkeypatch)
+    restarted.finish_startup_recovery()
+
+    assert rebuilds, "a persisted read barrier did not rebuild"
+    assert graph.available() is True
+
+
+def test_durable_coherence_classifies_each_incoherence_class(vault: Path) -> None:
+    """Pin the O(1) predicate directly.
+
+    `available()` independently rejects every one of these, so the predicate
+    changes no startup OUTCOME — its job is to reach that verdict without the
+    O(corpus) source-bytes proof, and only these four classes may do so.
+    """
+    from exomem import graph_sync
+
+    watcher = file_watcher.FileWatcher(vault)
+    watcher._reconcile_once(seed=True)
+    graph = epistemic_graph.EpistemicGraphIndex(vault)
+    graph.rebuild_all()
+
+    # Legacy: no durable checkpoint and no acknowledgement rows.
+    assert graph_sync.checkpoint_state(vault)[0] == "absent"
+    assert graph.durable_checkpoint_is_coherent() is True
+
+    # A recorded crash marker.
+    graph.suspend_reads()
+    assert graph.durable_checkpoint_is_coherent() is False
+    graph.rebuild_all()
+    assert graph.durable_checkpoint_is_coherent() is True
+
+    # Acknowledgement rows with no durable checkpoint are recovery state.
+    conn = graph._connect_existing(readonly=False)
+    try:
+        with conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO graph_meta(key, value) VALUES (?, ?)",
+                ("graph_sync_generation", "7"),
+            )
+    finally:
+        conn.close()
+    assert graph.durable_checkpoint_is_coherent() is False
+    conn = graph._connect_existing(readonly=False)
+    try:
+        with conn:
+            conn.execute("DELETE FROM graph_meta WHERE key = ?", ("graph_sync_generation",))
+    finally:
+        conn.close()
+    assert graph.durable_checkpoint_is_coherent() is True
+
+    # A durable checkpoint this sidecar never acknowledged.
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="a1b2c3d4e5f6a7b8c9d0e1f2",
+        paths=(("Knowledge Base/Notes/unacknowledged.md", "0" * 64),),
+        created_paths=("Knowledge Base/Notes/unacknowledged.md",),
+    )
+    graph_sync._write_checkpoint(vault, checkpoint)
+    assert graph.durable_checkpoint_is_coherent() is False
+
+    # A malformed durable checkpoint.
+    graph_sync.checkpoint_path(vault).write_bytes(b"{not a checkpoint")
+    assert graph_sync.checkpoint_state(vault)[0] == "malformed"
+    assert graph.durable_checkpoint_is_coherent() is False
+
+
+def test_access_policy_blip_does_not_withdraw_graph_availability(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin the in-process availability wedge to its real cause.
+
+    `_open_read_snapshot` compares the sidecar's stored
+    `recall_access_fingerprint` against `recall_policy.recall_policy_identity`.
+    A transient read error on `_access.yaml` used to move that fingerprint, so
+    `available()` went False while the durable sidecar metadata was complete
+    and barrier-free — reported live, and misattributed to a stale retained
+    owner-leaf connection. It is the access loader, not the connection.
+    """
+    from exomem import access
+
+    config = vault / "Knowledge Base" / "_access.yaml"
+    config.write_text("excluded:\n  - Private\n", encoding="utf-8")
+
+    watcher = file_watcher.FileWatcher(vault)
+    watcher._reconcile_once(seed=True)
+    graph = epistemic_graph.EpistemicGraphIndex(vault)
+    graph.rebuild_all()
+    assert graph.available() is True
+    assert graph.reads_suspended() is False
+    assert graph.durable_checkpoint_is_coherent() is True
+    good = access.policy_fingerprint(vault)
+
+    real_read_bytes = Path.read_bytes
+    target = os.path.normcase(str(config))
+
+    def blipping(self: Path) -> bytes:
+        if os.path.normcase(str(self)) == target:
+            raise PermissionError(13, "The process cannot access the file")
+        return real_read_bytes(self)
+
+    stamp = config.stat().st_mtime + 10
+    os.utime(config, (stamp, stamp))
+    monkeypatch.setattr(Path, "read_bytes", blipping)
+
+    assert access.policy_fingerprint(vault) == good
+    assert graph.available() is True, "an access-policy blip withdrew graph availability"
+
+
+def test_incoherent_startup_short_circuits_before_the_source_proof(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin the call site, not just the predicate.
+
+    `durable_checkpoint_is_coherent()` earns its place only as a cheap
+    NEGATIVE pre-filter: when durable state already proves a rebuild is
+    needed, the startup pass must reach that verdict without paying
+    `available()`'s O(corpus) source-bytes proof first. Dropping the conjunct
+    leaves behaviour identical and costs a full corpus hash before every
+    rebuild, so only call ORDER can pin it.
+    """
+    watcher = file_watcher.FileWatcher(vault)
+    watcher._reconcile_once(seed=True)
+    graph = epistemic_graph.EpistemicGraphIndex(vault)
+    graph.rebuild_all()
+    graph.suspend_reads()  # a recorded crash marker: durably incoherent
+    assert graph.durable_checkpoint_is_coherent() is False
+
+    freshness.clear()
+    restarted = file_watcher.FileWatcher(vault)
+    restarted._reconcile_once(seed=True)
+
+    events: list[str] = []
+    real_available = epistemic_graph.EpistemicGraphIndex.available
+    real_suspend = epistemic_graph.EpistemicGraphIndex.suspend_reads
+
+    def spy_available(self: epistemic_graph.EpistemicGraphIndex) -> bool:
+        events.append("available")
+        return real_available(self)
+
+    def spy_suspend(self: epistemic_graph.EpistemicGraphIndex) -> None:
+        events.append("suspend_reads")
+        return real_suspend(self)
+
+    monkeypatch.setattr(epistemic_graph.EpistemicGraphIndex, "available", spy_available)
+    monkeypatch.setattr(epistemic_graph.EpistemicGraphIndex, "suspend_reads", spy_suspend)
+    restarted.finish_startup_recovery()
+
+    assert events, "the startup pass took neither branch"
+    assert events[0] == "suspend_reads", (
+        "durable incoherence must short-circuit ahead of the O(corpus) source proof; "
+        f"observed call order: {events}"
+    )


### PR DESCRIPTION
## Why

Live acceptance of 0.63.1 surfaced two coupled defects behind the persistent `RETRIEVAL_INDEX_WARMING` flapping and the restart outages on the personal cell:

1. **Access-policy loading failed open on transient errors.** A transient `OSError` reading `_access.yaml` cached an **empty** policy (nothing excluded) under the unchanged stat signature, and a read-position `FileNotFoundError` — the delete-then-write save race of editors and sync clients — returned a wide-open policy while destroying the last-known-good cache. Reproduced end-to-end: an `excluded` page leaked through `find` during the race window. The same blip flipped the recall access fingerprint with **zero writes**, advancing the recall generation and failing admission closed — the measured serve/refuse duty cycle, and the in-process graph availability wedge (`available()` false while the durable sidecar was provably coherent) are the same defect.
2. **The watcher startup pass rebuilt the whole graph on every process start** (~12–30 min of suspended reads per restart on a 3.3k-file vault) — the graph-side violation of the restart-stays-ready property the lexical side got in 0.63.0. Also disqualifying for hosted (every redeploy would rebuild every tenant vault).

## What

- `access.py`: transient stat/read errors reuse the last successfully loaded policy and fingerprint (reuse never widens; convergence at next successful read); no prior successful load fails closed (everything excluded) until a read succeeds; only stat-position absence is the genuine missing-policy identity; the fail-closed state is a distinct channel (`fail_closed`) rather than an overloaded empty policy.
- `file_watcher.py` + `epistemic_graph.py`: a coherent durable graph checkpoint admits at startup via an O(1) durable check plus the existing non-suspending source-bytes proof; genuine incoherence (missing/malformed checkpoint, digest mismatch, read barrier, unacknowledged checkpoint) still rebuilds; `available()` remains the sole admission authority.

## Verification

- **Red-first**: every behavior pinned failing on the unmodified tree with verbatim evidence, including the privacy leak itself (`assert 'read-write' == 'excluded'`) and the coherent-restart rebuild (`assert ['rebuild_all'] == []`).
- **Mutation-proofed 12/12** in scratch copies with import-path verification — including the reviewer's two originally surviving mutants (the read-position FNF reinstatement and the startup pre-filter deletion, the latter pinned by call order with a non-vacuity guard).
- **Independent adversarial review**: REQUEST_CHANGES (1 CRITICAL — the read-position FNF fail-open; 3 MEDIUM) → correction round → targeted recheck **APPROVE**; the reviewer reproduced the leak closure end-to-end on the actual bytes and re-ran its own mutant battery (all killed, coverage strengthened, no new findings).
- Gates: 326 focused tests passed; ruff clean (zero repo-wide regression vs baseline); privacy validator clean; `openspec validate --all --strict` 168/168.

## OpenSpec

`bound-graph-recovery-funnel` tasks 1.4/1.6/2.0/2.5 delivered; spec deltas amended (signature-agnostic last-known-good reuse authorized as a strengthened contract; startup validation cost stated accurately; read-position-vanish scenario added). Remaining tasks (graph-deferral carve-out, recovery alarm, drain refusal, projection-lag tolerance) are the follow-up packets.

Note: sidecars durably stamped with the old `unavailable:*` fingerprint format reproject once on upgrade — expected and self-healing.
