### PR TITLE
fix(governance): enroll staged v3 migration

### DIFF
--- a/src/exomem/governance/authorization_custody.py
+++ b/src/exomem/governance/authorization_custody.py
@@ -1316,6 +1316,167 @@ def stage_standalone_v3_custody(
     )
 
 
+def enroll_standalone_v3_migration(
+    vault_root: Path,
+    *,
+    target: VerifiedActiveGovernanceState,
+    now: int,
+) -> ActivationRegistryAcknowledgement:
+    """Bind staged exact-v3 custody to one irreversible initial v4 tuple.
+
+    The sidecar remains exact v3 throughout this operation.  Publishing the
+    enrolled control record first deliberately turns the crash interval into a
+    fail-closed state; an exact retry may then restore the precomputed serving
+    membership without rewriting identity or activation authority.  A later
+    offline coordinator owns the actual transactional v3-to-v4 migration.
+    """
+
+    from . import schema_v4
+
+    if (
+        not isinstance(target, schema_v4.VerifiedActiveGovernanceState)
+        or target.activation_epoch != 1
+    ):
+        raise AuthorizationCustodyUnavailable
+    _bounded_identifier(target.logical_vault_id)
+    _bounded_identifier(target.activation_store_id)
+    _sha256_hex(target.activation_state_digest)
+
+    root = Path(vault_root)
+    current_time = _bounded_time(now)
+    attachment_id = standalone_attachment_id(root)
+    keyring_path = _configured_external_path(KEYRING_FILE_ENV, root)
+    control_path = _configured_external_path(CONTROL_FILE_ENV, root)
+    membership_path = _configured_external_path(MEMBERSHIP_FILE_ENV, root)
+    replica_id = _bounded_identifier(os.environ.get(REPLICA_ID_ENV, ""))
+    if len({keyring_path, control_path, membership_path}) != 3:
+        raise AuthorizationCustodyUnavailable
+
+    acknowledgement = schema_v4.ActivationRegistryAcknowledgement(
+        activation_store_id=target.activation_store_id,
+        activation_epoch=target.activation_epoch,
+        activation_state_digest=target.activation_state_digest,
+    )
+
+    from .. import reserved_paths
+
+    with reserved_paths._identity_coordination_scope(root):
+        _require_exact_v3_authority(root)
+        keyring = parse_keyring(_load_file(keyring_path).data)
+        _verify_standalone_staging_keyring(
+            keyring,
+            attachment_id=attachment_id,
+        )
+        if (
+            target.logical_vault_id != keyring.logical_vault_id
+            or not keyring.active_key.not_before
+            <= current_time
+            < keyring.active_key.not_after
+        ):
+            raise AuthorizationCustodyUnavailable
+
+        control_loaded: _LoadedCustodyFile | None = None
+        membership_loaded: _LoadedCustodyFile | None = None
+        try:
+            control_loaded = _load_file(control_path)
+        except AuthorizationCustodyUnavailable:
+            if os.path.lexists(control_path):
+                raise
+        try:
+            membership_loaded = _load_file(membership_path)
+        except AuthorizationCustodyUnavailable:
+            if os.path.lexists(membership_path):
+                raise
+        if membership_loaded is not None and control_loaded is None:
+            raise AuthorizationCustodyUnavailable
+
+        if control_loaded is None:
+            provisional_control = AuthorizationControlRecord(
+                version=1,
+                keyring_id=keyring.keyring_id,
+                cell_id=keyring.cell_id,
+                logical_vault_id=keyring.logical_vault_id,
+                registry_attachment_id=attachment_id,
+                attachment_epoch=1,
+                governance_enrolled=True,
+                activation_store_id=target.activation_store_id,
+                activation_epoch=target.activation_epoch,
+                activation_state_digest=target.activation_state_digest,
+                serving_membership_epoch=1,
+                serving_membership_digest="0" * 64,
+                issued_at=current_time,
+                expires_at=keyring.active_key.not_after,
+                signing_key_id=keyring.active_key_id,
+            )
+            encoded_membership = _standalone_membership_bytes(
+                keyring=keyring,
+                control=provisional_control,
+                replica_id=replica_id,
+            )
+            control = replace(
+                provisional_control,
+                serving_membership_digest=(
+                    authorization_serving_membership.serving_membership_digest(
+                        encoded_membership
+                    )
+                ),
+            )
+            _require_exact_v3_authority(root)
+            _publish_private_file(
+                control_path,
+                _signed_control_bytes(
+                    control,
+                    signing_key=keyring.active_key.key,
+                ),
+            )
+        else:
+            control = parse_control_record(
+                control_loaded.data,
+                keyring=keyring,
+                now=current_time,
+            )
+            _verify_registered_attachment(root, control.registry_attachment_id)
+            if (
+                control.registry_attachment_id != attachment_id
+                or control.attachment_epoch != 1
+                or not control.governance_enrolled
+                or control.activation_store_id != target.activation_store_id
+                or control.activation_epoch != target.activation_epoch
+                or control.activation_state_digest != target.activation_state_digest
+                or control.serving_membership_epoch != 1
+            ):
+                raise AuthorizationCustodyUnavailable
+            encoded_membership = _standalone_membership_bytes(
+                keyring=keyring,
+                control=control,
+                replica_id=replica_id,
+            )
+            if (
+                authorization_serving_membership.serving_membership_digest(
+                    encoded_membership
+                )
+                != control.serving_membership_digest
+            ):
+                raise AuthorizationCustodyUnavailable
+
+        if membership_loaded is None:
+            _publish_private_file(membership_path, encoded_membership)
+        elif not hmac.compare_digest(membership_loaded.data, encoded_membership):
+            raise AuthorizationCustodyUnavailable
+        _require_exact_v3_authority(root)
+
+    verified = load_authorization_custody(root, now=current_time)
+    if (
+        not verified.control.governance_enrolled
+        or verified.control.activation_store_id != target.activation_store_id
+        or verified.control.activation_epoch != target.activation_epoch
+        or verified.control.activation_state_digest != target.activation_state_digest
+        or verified.serving_membership is None
+    ):
+        raise AuthorizationCustodyUnavailable
+    return acknowledgement
+
+
 def provision_standalone_custody(
     vault_root: Path,
     *,

--- a/tests/test_authorization_standalone_provisioning.py
+++ b/tests/test_authorization_standalone_provisioning.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sqlite3
 import stat
+import time
 from collections.abc import Iterator
 from dataclasses import replace
 from pathlib import Path
@@ -10,7 +11,13 @@ from pathlib import Path
 import pytest
 
 from exomem import mutation_lock, writer_lease
-from exomem.governance import authorization_custody, policy, schema_v4, store
+from exomem.governance import (
+    authorization_custody,
+    authorization_session_lifecycle,
+    policy,
+    schema_v4,
+    store,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -73,6 +80,24 @@ def _exact_v3(vault: Path) -> Path:
     connection = store.open_connection(vault)
     connection.close()
     return store.sidecar_path(vault)
+
+
+def _staged_target(
+    staged: authorization_custody.StandaloneV3StagingResult,
+    *,
+    digest: str = "d" * 64,
+) -> schema_v4.VerifiedActiveGovernanceState:
+    return schema_v4.VerifiedActiveGovernanceState(
+        logical_vault_id=staged.logical_vault_id,
+        activation_store_id="activation-store-initial",
+        activation_epoch=1,
+        activation_state_digest=digest,
+        policy_generation_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        policy_fingerprint="a" * 64,
+        projector_schema_version=1,
+        catalog_generation=1,
+        projection_namespace_id="projection-namespace-initial",
+    )
 
 
 def test_attachment_identity_is_stable_for_one_root_and_changes_for_a_copy(
@@ -615,3 +640,210 @@ def test_control_before_membership_interruption_retries_without_session_fail_ope
         vault,
         now=now + 1,
     ).serving_membership is not None
+
+
+def test_staged_v3_enrollment_is_irreversible_but_remains_fail_closed(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    sidecar = _exact_v3(vault)
+    staged = authorization_custody.stage_standalone_v3_custody(vault, now=now)
+    target = _staged_target(staged)
+
+    acknowledgement = authorization_custody.enroll_standalone_v3_migration(
+        vault,
+        target=target,
+        now=now + 1,
+    )
+    custody = authorization_custody.load_authorization_custody(
+        vault,
+        now=now + 2,
+    )
+
+    assert acknowledgement == schema_v4.ActivationRegistryAcknowledgement(
+        activation_store_id=target.activation_store_id,
+        activation_epoch=1,
+        activation_state_digest=target.activation_state_digest,
+    )
+    assert custody.control.governance_enrolled is True
+    assert custody.control.activation_store_id == target.activation_store_id
+    assert custody.control.activation_epoch == target.activation_epoch
+    assert custody.control.activation_state_digest == target.activation_state_digest
+    assert custody.serving_membership is not None
+    assert custody.serving_membership.epoch == 1
+    assert custody.local_replica_id == "standalone"
+    assert sidecar.exists()
+    connection = sqlite3.connect(sidecar)
+    try:
+        assert connection.execute("PRAGMA user_version").fetchone() == (3,)
+    finally:
+        connection.close()
+    assert policy.load(vault).blocked
+    assert not authorization_session_lifecycle.serving_membership_readiness(
+        vault,
+        now=now + 2,
+    ).ready
+
+
+def test_staged_v3_enrollment_replay_recovers_missing_membership(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    _exact_v3(vault)
+    staged = authorization_custody.stage_standalone_v3_custody(vault, now=now)
+    target = _staged_target(staged)
+    original = authorization_custody._publish_private_file
+    failed = False
+
+    def interrupt_membership(path: Path, data: bytes) -> bytes:
+        nonlocal failed
+        if path.name == "authorization-serving-membership.json" and not failed:
+            failed = True
+            raise authorization_custody.AuthorizationCustodyUnavailable
+        return original(path, data)
+
+    monkeypatch.setattr(
+        authorization_custody,
+        "_publish_private_file",
+        interrupt_membership,
+    )
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.enroll_standalone_v3_migration(
+            vault,
+            target=target,
+            now=now + 1,
+        )
+
+    control_path = Path(os.environ[authorization_custody.CONTROL_FILE_ENV])
+    membership_path = Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV])
+    control_before = control_path.read_bytes()
+    interrupted = authorization_custody.load_authorization_custody(
+        vault,
+        now=now + 2,
+    )
+    assert interrupted.control.governance_enrolled is True
+    assert interrupted.serving_membership is None
+    assert not membership_path.exists()
+    assert policy.load(vault).blocked
+
+    monkeypatch.setattr(authorization_custody, "_publish_private_file", original)
+    replay = authorization_custody.enroll_standalone_v3_migration(
+        vault,
+        target=target,
+        now=now + 3,
+    )
+
+    assert replay.activation_state_digest == target.activation_state_digest
+    assert control_path.read_bytes() == control_before
+    assert membership_path.exists()
+    assert authorization_custody.load_authorization_custody(
+        vault,
+        now=now + 4,
+    ).serving_membership is not None
+
+
+@pytest.mark.parametrize(
+    ("change", "target_change"),
+    [
+        (None, {"logical_vault_id": "wrong-vault"}),
+        (None, {"activation_epoch": 2}),
+        ("schema", {}),
+    ],
+)
+def test_staged_v3_enrollment_refuses_wrong_target_or_changed_schema(
+    tmp_path: Path,
+    change: str | None,
+    target_change: dict[str, object],
+) -> None:
+    vault = _vault(tmp_path)
+    now = 1_800_000_000
+    sidecar = _exact_v3(vault)
+    staged = authorization_custody.stage_standalone_v3_custody(vault, now=now)
+    target = replace(_staged_target(staged), **target_change)
+    if change == "schema":
+        connection = sqlite3.connect(sidecar)
+        try:
+            connection.execute("CREATE TABLE unexpected_enrollment_state(value TEXT)")
+            connection.commit()
+        finally:
+            connection.close()
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.enroll_standalone_v3_migration(
+            vault,
+            target=target,
+            now=now + 1,
+        )
+
+    assert not Path(
+        os.environ[authorization_custody.CONTROL_FILE_ENV]
+    ).exists()
+    assert not Path(
+        os.environ[authorization_custody.MEMBERSHIP_FILE_ENV]
+    ).exists()
+
+
+def test_staged_v3_enrollment_refuses_copied_attachment_and_target_rewrite(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    copied = _vault(tmp_path, "copied-vault")
+    now = 1_800_000_000
+    _exact_v3(vault)
+    _exact_v3(copied)
+    staged = authorization_custody.stage_standalone_v3_custody(vault, now=now)
+    target = _staged_target(staged)
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.enroll_standalone_v3_migration(
+            copied,
+            target=target,
+            now=now + 1,
+        )
+
+    authorization_custody.enroll_standalone_v3_migration(
+        vault,
+        target=target,
+        now=now + 1,
+    )
+    control_path = Path(os.environ[authorization_custody.CONTROL_FILE_ENV])
+    membership_path = Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV])
+    control_before = control_path.read_bytes()
+    membership_before = membership_path.read_bytes()
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.enroll_standalone_v3_migration(
+            vault,
+            target=_staged_target(staged, digest="e" * 64),
+            now=now + 2,
+        )
+
+    assert control_path.read_bytes() == control_before
+    assert membership_path.read_bytes() == membership_before
+
+
+def test_staged_v3_enrollment_refuses_corrupt_existing_membership(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = 1_800_000_000
+    _exact_v3(vault)
+    staged = authorization_custody.stage_standalone_v3_custody(vault, now=now)
+    target = _staged_target(staged)
+    authorization_custody.enroll_standalone_v3_migration(
+        vault,
+        target=target,
+        now=now + 1,
+    )
+    membership_path = Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV])
+    membership_path.write_bytes(b"{}")
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.enroll_standalone_v3_migration(
+            vault,
+            target=target,
+            now=now + 2,
+        )


### PR DESCRIPTION
## Summary

- bind one staged exact-v3 standalone identity to an irreversible initial v4 activation tuple
- publish the enrolled control record before membership so every crash interval remains fail closed
- recover an interrupted membership publication without rewriting identity or activation authority
- refuse copied attachments, changed v3 schemas, target rewrites, and corrupt pre-existing membership

This is an internal migration prerequisite only. It does not migrate the database, enable v4 serving, expose a command, merge the stack, or touch any live vault.

## Verification

- red first: 7 expected failures before the enrollment API existed
- exact enrollment/recovery set: 7 passed
- complete standalone provisioning suite: 34 passed
- custody/schema/session packet on Python 3.13: 177 passed, 1 Windows-DACL-only skip
- policy/request-context packet with isolated runtime state: 135 passed
- Ruff on both changed files
- uv lock --check
- public repository artifact validation
- openspec validate harden-governance-for-consolidation --strict
- git diff --check