### PR TITLE
fix(governance): migrate enrolled v3 store

### DIFF
--- a/src/exomem/governance/schema_v4.py
+++ b/src/exomem/governance/schema_v4.py
@@ -599,6 +599,23 @@ def _seed_material(seed: MigrationSeed) -> _SeedMaterial:
     )
 
 
+def migration_target(seed: MigrationSeed) -> VerifiedActiveGovernanceState:
+    """Derive the exact initial active tuple before irreversible enrollment."""
+
+    material = _seed_material(seed)
+    return VerifiedActiveGovernanceState(
+        logical_vault_id=seed.logical_vault_id,
+        activation_store_id=seed.activation_store_id,
+        activation_epoch=seed.activation_epoch,
+        activation_state_digest=material.activation_digest,
+        policy_generation_id=seed.policy.generation_id,
+        policy_fingerprint=seed.policy.policy_fingerprint,
+        projector_schema_version=seed.policy.projector_schema_version,
+        catalog_generation=seed.catalog.catalog_generation,
+        projection_namespace_id=seed.namespace.namespace_id,
+    )
+
+
 def _json_archive_value(value: object) -> object:
     if value is None or isinstance(value, (str, int, float)):
         return value
@@ -1146,6 +1163,85 @@ def _require_downmigration_schema(connection: sqlite3.Connection) -> None:
         raise SchemaV4Error("schema v4 downmigration source has unknown state")
     if _versioned_schema_signature(connection) != _expected_versioned_schema_signature():
         raise SchemaV4Error("schema v4 downmigration source is not exact")
+
+
+@functools.cache
+def _expected_v4_schema_signature() -> tuple[tuple[object, ...], ...]:
+    from .. import sidecar_store
+    from . import policy as policy_module
+    from . import store
+
+    documents = (
+        (
+            "scopes/reference.yaml",
+            b"governance_version: 1\n"
+            b"id: 01ARZ3NDEKTSV4RRFFQ69G5FAV\n"
+            b"paths:\n"
+            b"  - Notes/**\n",
+        ),
+    )
+    compiled = policy_module.compile_documents(dict(documents))
+    seed = MigrationSeed(
+        activation_store_id="activation-store-reference",
+        logical_vault_id="logical-vault-reference",
+        activation_epoch=1,
+        policy=PolicyGenerationSeed(
+            generation_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            source_documents=documents,
+            source_fingerprint=compiled.fingerprint,
+            conflict_digest="0" * 64,
+            compiled_policy=policy_module.canonical_compiled_bytes(compiled),
+            policy_fingerprint=compiled.fingerprint,
+            compiler_schema_version=1,
+            projector_schema_version=1,
+            predecessor_generation_id=None,
+            authoring_event_id="event-schema-reference",
+            receipt_event_id="receipt-schema-reference",
+            created_at=1,
+        ),
+        catalog=CatalogGenerationSeed(
+            catalog_generation=1,
+            descriptor=b"",
+            artifact_count=0,
+            created_at=1,
+        ),
+        namespace=ProjectionNamespaceSeed(
+            namespace_id="projection-namespace-reference",
+            evidence=b"",
+            ready_at=1,
+        ),
+        migrated_at=1,
+    )
+    reference = sqlite3.connect(":memory:")
+    try:
+        store._migrate(reference)
+        sidecar_store.ensure_meta_table(
+            reference,
+            store.DATA_TABLE,
+            "governance-v4-reference",
+        )
+        reference.commit()
+        migrate_v3_connection(reference, seed)
+        return _complete_schema_signature(reference)
+    finally:
+        reference.close()
+
+
+def require_exact_v4_connection(connection: sqlite3.Connection) -> None:
+    """Refuse any incomplete, corrupt, or extended schema-v4 authority."""
+
+    try:
+        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        quick_check = tuple(connection.execute("PRAGMA quick_check(1)"))
+        signature = _complete_schema_signature(connection)
+    except (AttributeError, TypeError, ValueError, sqlite3.Error) as exc:
+        raise SchemaV4Error("schema v4 authority is unavailable") from exc
+    if version != SCHEMA_USER_VERSION:
+        raise SchemaV4Error(
+            f"schema v4 authority requires exact schema v4, found v{version}"
+        )
+    if quick_check != (("ok",),) or signature != _expected_v4_schema_signature():
+        raise SchemaV4Error("schema v4 authority is not exact")
 
 
 def _close_downmigration_authority(

--- a/src/exomem/governance/store.py
+++ b/src/exomem/governance/store.py
@@ -17,8 +17,12 @@ import sqlite3
 import threading
 from collections import OrderedDict
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .. import index_paths, reserved_paths, sidecar_store
+
+if TYPE_CHECKING:
+    from .schema_v4 import MigrationSeed, VerifiedActiveGovernanceState
 
 SCHEMA_USER_VERSION = 3
 DATA_TABLE = "compiled_policy"
@@ -235,6 +239,152 @@ def authorization_session_schema_version(vault_root: Path) -> int | None:
     finally:
         if connection is not None:
             connection.close()
+
+
+def _schema_migration_barrier(point: str) -> None:
+    """Test seam after the only durable database effect."""
+
+    del point
+
+
+def migrate_enrolled_v3_store(
+    vault_root: Path,
+    *,
+    seed: MigrationSeed,
+    now: int,
+) -> VerifiedActiveGovernanceState:
+    """Commit one pre-enrolled exact-v3 store to its exact v4 target.
+
+    This is the filesystem-backed database half of the offline migration.  Its
+    caller must already have drained old binaries and prepared the immutable
+    catalog/projection evidence.  The cooperative identity guard keeps current
+    Exomem writers out while the exact policy workspace is rechecked; external
+    direct OS mutation remains outside that guarantee and is detected by the
+    post-commit observation.
+    """
+
+    from . import authorization_custody, policy, schema_v4
+
+    root = Path(vault_root)
+    path = sidecar_path(root)
+    with reserved_paths._subsystem_authority_scope("governance.store"):
+        with reserved_paths._identity_coordination_scope(
+            root,
+            descriptor_ids=("governance-store",),
+            identity_may_change=False,
+        ):
+            with reserved_paths._sqlite_owner_target_scope(
+                root,
+                path,
+                "governance-store",
+                create=False,
+            ) as retained_path:
+                connection = sqlite3.connect(
+                    f"{retained_path.as_uri()}?mode=rw",
+                    uri=True,
+                )
+                try:
+                    connection.execute("PRAGMA synchronous=FULL")
+                    connection.execute("PRAGMA busy_timeout=0")
+                    reserved_paths._publish_sqlite_owner_family(
+                        root,
+                        path,
+                        "governance-store",
+                        connection,
+                    )
+                    version = int(
+                        connection.execute("PRAGMA user_version").fetchone()[0]
+                    )
+                    if version == SCHEMA_USER_VERSION:
+                        schema_v4.require_exact_v3_connection(connection)
+                    elif version == schema_v4.SCHEMA_USER_VERSION:
+                        schema_v4.require_exact_v4_connection(connection)
+                    else:
+                        raise UnsupportedGovernanceSchema(
+                            "explicit governance migration requires exact schema v3 or v4"
+                        )
+
+                    target = schema_v4.migration_target(seed)
+                    custody = authorization_custody.load_authorization_custody(
+                        root,
+                        now=now,
+                    )
+                    control = custody.control
+                    if (
+                        not control.governance_enrolled
+                        or control.activation_store_id != target.activation_store_id
+                        or control.activation_epoch != target.activation_epoch
+                        or control.activation_state_digest
+                        != target.activation_state_digest
+                        or control.logical_vault_id != target.logical_vault_id
+                        or custody.serving_membership is None
+                        or custody.local_replica_id is None
+                    ):
+                        raise authorization_custody.AuthorizationCustodyUnavailable
+
+                    before = None
+                    if version == SCHEMA_USER_VERSION:
+                        before = policy.observe_authoring_snapshot(root)
+                        if (
+                            before is None
+                            or before.documents != seed.policy.source_documents
+                            or before.source_fingerprint
+                            != seed.policy.source_fingerprint
+                            or before.conflict_set_digest
+                            != seed.policy.conflict_digest
+                        ):
+                            raise schema_v4.SchemaV4Error(
+                                "migration policy workspace does not match the reviewed seed"
+                            )
+
+                    result = schema_v4.migrate_v3_connection(connection, seed)
+                    reserved_paths._publish_sqlite_owner_family(
+                        root,
+                        path,
+                        "governance-store",
+                        connection,
+                    )
+                    _schema_migration_barrier("after_store_commit")
+                    active = schema_v4.load_active_state(
+                        connection,
+                        expected_logical_vault_id=target.logical_vault_id,
+                        expected_activation_store_id=target.activation_store_id,
+                        expected_activation_epoch=target.activation_epoch,
+                        expected_activation_state_digest=(
+                            target.activation_state_digest
+                        ),
+                    )
+                    if (
+                        result.schema_version != schema_v4.SCHEMA_USER_VERSION
+                        or result.activation_store_id != target.activation_store_id
+                        or result.activation_state_digest
+                        != target.activation_state_digest
+                        or active != target
+                    ):
+                        raise schema_v4.SchemaV4Error(
+                            "migration result does not match the enrolled target"
+                        )
+                    if before is not None:
+                        after = policy.observe_authoring_snapshot(root)
+                        if after != before:
+                            raise schema_v4.SchemaV4Error(
+                                "migration policy workspace changed during commit"
+                            )
+                finally:
+                    connection.close()
+
+            verified = authorization_custody.load_authorization_custody(
+                root,
+                now=now,
+            )
+            if (
+                verified.keyring != custody.keyring
+                or verified.control != custody.control
+                or verified.serving_membership != custody.serving_membership
+                or verified.local_replica_id != custody.local_replica_id
+            ):
+                raise authorization_custody.AuthorizationCustodyUnavailable
+    return active
 
 
 def _open_connection_owned(

--- a/tests/test_governance_v3_store_migration.py
+++ b/tests/test_governance_v3_store_migration.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from exomem import mutation_lock, writer_lease
+from exomem.governance import authorization_custody, policy, schema_v4, store
+
+POLICY_PATH = "scopes/migration.yaml"
+POLICY_BYTES = (
+    b"governance_version: 1\n"
+    b"id: 01ARZ3NDEKTSV4RRFFQ69G5FAV\n"
+    b"paths:\n"
+    b"  - Notes/**\n"
+)
+
+
+@pytest.fixture(autouse=True)
+def _custody_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
+    external = tmp_path / "external"
+    external.mkdir(mode=0o700)
+    lease_state = tmp_path / "lease-state"
+    lease_state.mkdir(mode=0o700)
+    if os.name == "nt":  # pragma: no cover - exercised by Windows CI
+        sid = mutation_lock._windows_current_user_sid()
+        mutation_lock._windows_apply_private_dacl(external, sid)
+        mutation_lock._windows_apply_private_dacl(lease_state, sid)
+    monkeypatch.setenv(
+        authorization_custody.KEYRING_FILE_ENV,
+        str(external / "authorization-keyring.json"),
+    )
+    monkeypatch.setenv(
+        authorization_custody.CONTROL_FILE_ENV,
+        str(external / "authorization-control.json"),
+    )
+    monkeypatch.setenv(
+        authorization_custody.MEMBERSHIP_FILE_ENV,
+        str(external / "authorization-serving-membership.json"),
+    )
+    monkeypatch.setenv(authorization_custody.REPLICA_ID_ENV, "standalone")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(lease_state))
+    writer_lease.reset_managers_for_tests()
+    yield
+    writer_lease.reset_managers_for_tests()
+
+
+def _vault(tmp_path: Path, name: str = "vault") -> Path:
+    vault = tmp_path / name
+    governance = vault / "Knowledge Base" / "_Governance" / "scopes"
+    governance.mkdir(parents=True)
+    (governance / "migration.yaml").write_bytes(POLICY_BYTES)
+    connection = store.open_connection(vault)
+    connection.close()
+    return vault
+
+
+def _seed(
+    vault: Path,
+    staged: authorization_custody.StandaloneV3StagingResult,
+    *,
+    now: int,
+    catalog_generation: int = 1,
+) -> schema_v4.MigrationSeed:
+    snapshot = policy.observe_authoring_snapshot(vault)
+    assert snapshot is not None
+    compiled = policy.compile_documents(dict(snapshot.documents))
+    assert not compiled.empty and not compiled.blocked
+    return schema_v4.MigrationSeed(
+        activation_store_id="activation-store-initial",
+        logical_vault_id=staged.logical_vault_id,
+        activation_epoch=1,
+        policy=schema_v4.PolicyGenerationSeed(
+            generation_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            source_documents=snapshot.documents,
+            source_fingerprint=snapshot.source_fingerprint,
+            conflict_digest=snapshot.conflict_set_digest,
+            compiled_policy=policy.canonical_compiled_bytes(compiled),
+            policy_fingerprint=compiled.fingerprint,
+            compiler_schema_version=1,
+            projector_schema_version=1,
+            predecessor_generation_id=None,
+            authoring_event_id="event-migration-policy",
+            receipt_event_id="receipt-migration-policy",
+            created_at=now,
+        ),
+        catalog=schema_v4.CatalogGenerationSeed(
+            catalog_generation=catalog_generation,
+            descriptor=b'{"artifacts":[]}',
+            artifact_count=0,
+            created_at=now,
+        ),
+        namespace=schema_v4.ProjectionNamespaceSeed(
+            namespace_id=f"projection-namespace-{catalog_generation}",
+            evidence=b'{"ready":true}',
+            ready_at=now,
+        ),
+        migrated_at=now,
+    )
+
+
+def _stage_and_enroll(
+    vault: Path,
+    *,
+    now: int,
+) -> tuple[schema_v4.MigrationSeed, schema_v4.VerifiedActiveGovernanceState]:
+    staged = authorization_custody.stage_standalone_v3_custody(vault, now=now)
+    seed = _seed(vault, staged, now=now + 1)
+    target = schema_v4.migration_target(seed)
+    authorization_custody.enroll_standalone_v3_migration(
+        vault,
+        target=target,
+        now=now,
+    )
+    return seed, target
+
+
+def _schema_version(vault: Path) -> int:
+    connection = sqlite3.connect(store.sidecar_path(vault))
+    try:
+        return int(connection.execute("PRAGMA user_version").fetchone()[0])
+    finally:
+        connection.close()
+
+
+def test_enrolled_exact_v3_store_migrates_to_the_precommitted_target(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    seed, target = _stage_and_enroll(vault, now=now)
+    assert policy.load(vault).blocked
+
+    active = store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 2)
+
+    assert active == target
+    assert _schema_version(vault) == 4
+    custody = authorization_custody.load_authorization_custody(
+        vault,
+        now=now + 3,
+    )
+    assert custody.control.governance_enrolled is True
+    assert custody.control.activation_store_id == target.activation_store_id
+    assert custody.control.activation_epoch == target.activation_epoch
+    assert custody.control.activation_state_digest == target.activation_state_digest
+    connection = store.open_active_governance_read_connection(vault)
+    try:
+        snapshot = schema_v4.load_active_policy(
+            connection,
+            expected_logical_vault_id=target.logical_vault_id,
+            expected_activation_store_id=target.activation_store_id,
+            expected_activation_epoch=target.activation_epoch,
+            expected_activation_state_digest=target.activation_state_digest,
+        )
+    finally:
+        connection.close()
+    assert snapshot.active == target
+    loaded = policy.load(vault)
+    assert not loaded.empty
+    assert not loaded.blocked
+    assert loaded.fingerprint == target.policy_fingerprint
+
+
+def test_store_migration_post_commit_crash_replays_exact_v4(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    seed, target = _stage_and_enroll(vault, now=now)
+    crashed = False
+
+    def crash(point: str) -> None:
+        nonlocal crashed
+        if point == "after_store_commit" and not crashed:
+            crashed = True
+            raise RuntimeError("injected post-commit crash")
+
+    monkeypatch.setattr(store, "_schema_migration_barrier", crash)
+    with pytest.raises(RuntimeError, match="post-commit"):
+        store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 2)
+
+    assert _schema_version(vault) == 4
+    monkeypatch.setattr(store, "_schema_migration_barrier", lambda _point: None)
+    assert store.migrate_enrolled_v3_store(
+        vault,
+        seed=seed,
+        now=now + 3,
+    ) == target
+
+
+@pytest.mark.parametrize("fault", ["not-enrolled", "target", "workspace", "schema"])
+def test_store_migration_refuses_unsafe_preconditions_without_changing_v3(
+    tmp_path: Path,
+    fault: str,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    staged = authorization_custody.stage_standalone_v3_custody(vault, now=now)
+    seed = _seed(vault, staged, now=now + 1)
+    target = schema_v4.migration_target(seed)
+    if fault != "not-enrolled":
+        authorization_custody.enroll_standalone_v3_migration(
+            vault,
+            target=target,
+            now=now,
+        )
+    if fault == "target":
+        seed = _seed(vault, staged, now=now + 1, catalog_generation=2)
+    elif fault == "workspace":
+        (vault / "Knowledge Base" / "_Governance" / POLICY_PATH).write_bytes(
+            POLICY_BYTES + b"description: changed after review\n"
+        )
+    elif fault == "schema":
+        connection = sqlite3.connect(store.sidecar_path(vault))
+        try:
+            connection.execute("CREATE TABLE unexpected_migration_state(value TEXT)")
+            connection.commit()
+        finally:
+            connection.close()
+
+    with pytest.raises(
+        (
+            authorization_custody.AuthorizationCustodyUnavailable,
+            schema_v4.SchemaV4Error,
+            store.UnsupportedGovernanceSchema,
+        )
+    ):
+        store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 2)
+
+    assert _schema_version(vault) == 3
+
+
+def test_store_migration_refuses_a_copied_attachment(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    copied = _vault(tmp_path, "copied-vault")
+    now = int(time.time())
+    seed, _target = _stage_and_enroll(vault, now=now)
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        store.migrate_enrolled_v3_store(copied, seed=seed, now=now + 2)
+
+    assert _schema_version(copied) == 3
+
+
+def test_store_migration_refuses_future_schema_before_parsing_seed(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    connection = sqlite3.connect(store.sidecar_path(vault))
+    try:
+        connection.execute("PRAGMA user_version=5")
+        connection.commit()
+    finally:
+        connection.close()
+
+    with pytest.raises(store.UnsupportedGovernanceSchema):
+        store.migrate_enrolled_v3_store(
+            vault,
+            seed=object(),  # type: ignore[arg-type]
+            now=int(time.time()),
+        )
+
+    assert _schema_version(vault) == 5
+
+
+def test_store_migration_replay_refuses_extended_v4_without_writes(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    seed, _target = _stage_and_enroll(vault, now=now)
+    store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 2)
+    connection = sqlite3.connect(store.sidecar_path(vault))
+    try:
+        connection.execute(
+            "ALTER TABLE compiled_policy ADD COLUMN unexpected_v4_state TEXT"
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    with pytest.raises(schema_v4.SchemaV4Error):
+        store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 3)
+
+    connection = sqlite3.connect(store.sidecar_path(vault))
+    try:
+        assert connection.execute("PRAGMA user_version").fetchone() == (4,)
+        assert "unexpected_v4_state" in {
+            str(row[1])
+            for row in connection.execute("PRAGMA table_info(compiled_policy)")
+        }
+    finally:
+        connection.close()

--- a/tests/test_model_unload.py
+++ b/tests/test_model_unload.py
@@ -8,6 +8,7 @@ gpu_mem) are exercised with a fake torch module. Proves the concurrency-safety c
 from __future__ import annotations
 
 import sys
+import threading
 import time
 import types
 
@@ -277,10 +278,21 @@ def test_default_cache_slots_reap_only_when_cpu_caches_are_evictable(
 
 def test_reaper_start_fires_then_stops() -> None:
     slot, un = _slot(inflight=0, last=0.0)  # always stale; is_loaded flips False after unload
-    model_reaper.start(threshold=0.0, tick=0.01, slots=[slot])
-    time.sleep(0.08)
+    fired = threading.Event()
+    original_unload = slot.unload
+
+    def unload() -> bool:
+        result = original_unload()
+        fired.set()
+        return result
+
+    slot.unload = unload
+
+    thread = model_reaper.start(threshold=0.0, tick=0.01, slots=[slot])
+    assert fired.wait(timeout=1.0)
     model_reaper.stop()
-    time.sleep(0.05)
+    thread.join(timeout=1.0)
+
     assert un == [1]  # unloaded exactly once (is_loaded False afterwards)
     assert not model_reaper.is_running()
 

--- a/tests/test_model_unload.py
+++ b/tests/test_model_unload.py
@@ -289,11 +289,14 @@ def test_reaper_start_fires_then_stops() -> None:
     slot.unload = unload
 
     thread = model_reaper.start(threshold=0.0, tick=0.01, slots=[slot])
-    assert fired.wait(timeout=1.0)
-    model_reaper.stop()
-    thread.join(timeout=1.0)
+    try:
+        assert fired.wait(timeout=5.0), "reaper thread never reached the stale slot"
+    finally:
+        model_reaper.stop()
+        thread.join(timeout=5.0)
 
     assert un == [1]  # unloaded exactly once (is_loaded False afterwards)
+    assert not thread.is_alive()
     assert not model_reaper.is_running()
 
 

--- a/tests/test_model_unload.py
+++ b/tests/test_model_unload.py
@@ -17,16 +17,25 @@ import pytest
 from exomem import accel, embeddings, model_reaper, readiness
 
 
+def _stop_test_reaper() -> None:
+    model_reaper.stop()
+    thread = model_reaper._thread
+    if thread is not None:
+        thread.join(timeout=5.0)
+        assert not thread.is_alive(), "prior reaper thread did not stop"
+    model_reaper._thread = None
+
+
 @pytest.fixture(autouse=True)
 def _reset() -> None:
+    _stop_test_reaper()
     embeddings._MODEL = embeddings._RERANKER = embeddings._CLIP_MODEL = None
     for g in (embeddings.BGE_GUARD, embeddings.RERANKER_GUARD, embeddings.CLIP_GUARD):
         g._inflight = 0
         g._last_activity = 0.0
     readiness.reset()
     yield
-    model_reaper.stop()
-    model_reaper._thread = None
+    _stop_test_reaper()
     embeddings._MODEL = embeddings._RERANKER = embeddings._CLIP_MODEL = None
     readiness.reset()
 


### PR DESCRIPTION
## Summary

- derive the exact initial v4 active tuple from one validated immutable migration seed before enrollment
- migrate an enrolled exact-v3 sidecar in place under the held governance-store identity and cooperative writer guard
- require the external registry target, live standalone membership, and stable conflict-free policy workspace to match before any schema write
- replay an exact post-commit v4 result without consulting mutable workspace, while refusing copied custody, target drift, future schemas, and any extended v3/v4 schema

This is still an internal offline migration primitive. Its caller must drain old binaries and prepare verified catalog/projection evidence. It exposes no command, enables no live rollout, merges nothing, and touches no live vault.

## Verification

- red first: 7 expected failures before target/store APIs existed
- focused migration/refusal/replay suite: 9 passed
- migration/custody/policy packet on Python 3.13: 182 passed
- adjacent store/session lifecycle packet: 38 passed
- Ruff on all three changed files
- uv lock --check
- public repository artifact validation
- openspec validate harden-governance-for-consolidation --strict
- git diff --check