### PR TITLE
test(governance): freeze rich schema v3 migration fixture

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -327,7 +327,7 @@ made before both PRs and their combined verification are complete.
   idempotency/control-plane rows, and corpus projection for the exact raw bearer and find zero copies outside the
   exact typed successful issue field/protected request input; scan retry/validation/
   exception copies and assert issuance text retrieved from content stays inert.
-- [ ] 5.6 Freeze an exact current schema-v3 fixture from `store.SCHEMA_USER_VERSION == 3`
+- [x] 5.6 Freeze an exact current schema-v3 fixture from `store.SCHEMA_USER_VERSION == 3`
   containing legacy handles, grants, purposes, tokens, receipts, and live recovery
   journals/direct-source policy. Prove every ordinary v3/v4-capable opener leaves v3 with
   no v4 DDL/DML; add red explicit v3→v4 session + immutable policy/catalog/tuple migration

--- a/tests/governance_v3_fixtures.py
+++ b/tests/governance_v3_fixtures.py
@@ -1,0 +1,218 @@
+"""Frozen schema-v3 governance authority used by migration compatibility tests."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from exomem.governance import store
+
+DIRECT_SOURCE_POLICY_PATH = "scopes/fixture.yaml"
+DIRECT_SOURCE_POLICY_BYTES = (
+    b"governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\npaths:\n  - Notes/**\n"
+)
+
+# This pins the complete logical SQLite schema plus all representative rows below.
+# An intentional schema-v3 change must regenerate and explicitly review this value.
+FROZEN_V3_DUMP_SHA256 = "6dd3b810a19ea810188a80f4b1e7387101616f81c2d838a9eb7634cacd688da8"
+
+
+def frozen_v3_dump(vault_root: Path) -> tuple[str, ...]:
+    """Return a deterministic logical dump without opening any product writer."""
+
+    connection = sqlite3.connect(store.sidecar_path(vault_root))
+    try:
+        return tuple(connection.iterdump())
+    finally:
+        connection.close()
+
+
+def install_frozen_v3_fixture(vault_root: Path) -> None:
+    """Install one exact rich v3 authority and its direct-source policy workspace."""
+
+    root = Path(vault_root)
+    governance = root / "Knowledge Base" / "_Governance"
+    policy_path = governance / DIRECT_SOURCE_POLICY_PATH
+    policy_path.parent.mkdir(parents=True)
+    policy_path.write_bytes(DIRECT_SOURCE_POLICY_BYTES)
+
+    connection = store.open_connection(root)
+    try:
+        connection.execute("UPDATE meta SET value=314159 WHERE key='instance'")
+        connection.execute(
+            "INSERT INTO compiled_policy (fingerprint, snapshot, compiled_at) VALUES (?, ?, ?)",
+            ("legacy-policy-fingerprint", '{"blocked":false,"rules":[]}', 10.0),
+        )
+        connection.execute(
+            "INSERT INTO receipt_instance (singleton, instance_id) VALUES (1, ?)",
+            ("legacy-receipt-instance",),
+        )
+        connection.execute(
+            "INSERT INTO receipts_head "
+            "(instance_id, durable_seq, durable_hash, observed_seq, observed_hash, "
+            "path, byte_offset) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                "legacy-receipt-instance",
+                7,
+                "d" * 64,
+                7,
+                "o" * 64,
+                "Knowledge Base/_Governance/receipts.jsonl",
+                777,
+            ),
+        )
+        connection.execute(
+            "INSERT INTO receipt_secrets (name, value) VALUES (?, ?)",
+            ("hmac-v1", b"fixture-secret-not-a-real-credential"),
+        )
+        connection.execute(
+            "INSERT INTO withhold_tokens "
+            "(jti, audience, max_level, fingerprints, paths, expires_at, minted_at, "
+            "consumed_at, authorization_session, purpose, org_ceiling, status, "
+            "prepared_event_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "legacy-token",
+                "external",
+                6,
+                '["content-fingerprint"]',
+                '["Notes/fixture.md"]',
+                4_000_000_000,
+                20.0,
+                None,
+                "legacy-session",
+                "fixture-review",
+                6,
+                "active",
+                "legacy-recovery-event",
+            ),
+        )
+        connection.execute(
+            "INSERT INTO governance_proposals "
+            "(proposal_id, created_at, expires_at, proposal_json, "
+            "fingerprint_at_propose, membership_manifest, status, reserved_event_id, "
+            "attempt_no, attempt_nonce, spent_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "legacy-proposal",
+                21.0,
+                4_000_000_000.0,
+                '{"operation":"suspend"}',
+                "legacy-policy-fingerprint",
+                '[{"path":"Notes/fixture.md","scope_ids":["fixture"]}]',
+                "pending",
+                "legacy-recovery-event",
+                1,
+                "legacy-attempt",
+                None,
+            ),
+        )
+        connection.execute(
+            "INSERT INTO governance_operation_journals "
+            "(event_id, operation, causation_id, authorization_session, principal_id, "
+            "phase, direction, prior_digest, prepared_digest, final_digest, affected_ids, "
+            "required_child_intents, required_child_terminals, proposal_id, attempt_no, "
+            "marker_required, created_at, updated_at, blocked_reason) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "legacy-recovery-event",
+                "suspend",
+                "legacy-causation",
+                "legacy-session",
+                "external",
+                "pending",
+                "widening",
+                "prior-digest",
+                "prepared-digest",
+                "final-digest",
+                '["01ARZ3NDEKTSV4RRFFQ69G5FAV"]',
+                '["policy-intent"]',
+                '["policy-terminal"]',
+                "legacy-proposal",
+                1,
+                1,
+                22.0,
+                23.0,
+                None,
+            ),
+        )
+        connection.execute(
+            "INSERT INTO governance_operation_components "
+            "(event_id, phase, ordinal, component_kind, component_key, value_json, "
+            "value_hash, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "legacy-recovery-event",
+                "prepared",
+                0,
+                "policy",
+                "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                '{"status":"prepared"}',
+                "component-digest",
+                "prepared",
+            ),
+        )
+        connection.execute(
+            "INSERT INTO governance_session_grants "
+            "(grant_id, authorization_session, audience, purpose, ceiling, paths, "
+            "fingerprints, token_jti, status, prepared_event_id, created_at, expires_at, "
+            "revoked_at, membership_manifest, policy_fingerprint) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "legacy-grant",
+                "legacy-session",
+                "external",
+                "fixture-review",
+                6,
+                '["Notes/fixture.md"]',
+                '["content-fingerprint"]',
+                "legacy-token",
+                "active",
+                "legacy-recovery-event",
+                20.0,
+                4_000_000_000.0,
+                None,
+                '[{"path":"Notes/fixture.md","scope_ids":["fixture"]}]',
+                "legacy-policy-fingerprint",
+            ),
+        )
+        connection.execute(
+            "INSERT INTO governance_session_purpose "
+            "(authorization_session, principal_id, purpose, status, prepared_event_id, "
+            "created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                "legacy-session",
+                "external",
+                "fixture-review",
+                "active",
+                "legacy-recovery-event",
+                20.0,
+                4_000_000_000.0,
+            ),
+        )
+        connection.execute(
+            "INSERT INTO governance_session_purpose_staging "
+            "(event_id, authorization_session, principal_id, purpose, created_at, expires_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "legacy-purpose-stage",
+                "legacy-session",
+                "external",
+                "fixture-review",
+                20.0,
+                4_000_000_000.0,
+            ),
+        )
+        connection.execute(
+            "INSERT INTO governance_policy_archives "
+            "(archive_id, event_id, path, prior_bytes, prior_hash, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "legacy-policy-archive",
+                "legacy-recovery-event",
+                DIRECT_SOURCE_POLICY_PATH,
+                DIRECT_SOURCE_POLICY_BYTES,
+                "archive-prior-hash",
+                20.0,
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()

--- a/tests/test_governance_v3_fixture.py
+++ b/tests/test_governance_v3_fixture.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from governance_v3_fixtures import (
+    DIRECT_SOURCE_POLICY_BYTES,
+    DIRECT_SOURCE_POLICY_PATH,
+    FROZEN_V3_DUMP_SHA256,
+    frozen_v3_dump,
+    install_frozen_v3_fixture,
+)
+
+from exomem import mutation_lock, writer_lease
+from exomem.governance import authorization_custody, policy, schema_v4, store
+
+
+@pytest.fixture(autouse=True)
+def _custody_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
+    external = tmp_path / "external"
+    external.mkdir(mode=0o700)
+    lease_state = tmp_path / "lease-state"
+    lease_state.mkdir(mode=0o700)
+    if os.name == "nt":  # pragma: no cover - exercised by Windows CI
+        sid = mutation_lock._windows_current_user_sid()
+        mutation_lock._windows_apply_private_dacl(external, sid)
+        mutation_lock._windows_apply_private_dacl(lease_state, sid)
+    monkeypatch.setenv(
+        authorization_custody.KEYRING_FILE_ENV,
+        str(external / "authorization-keyring.json"),
+    )
+    monkeypatch.setenv(
+        authorization_custody.CONTROL_FILE_ENV,
+        str(external / "authorization-control.json"),
+    )
+    monkeypatch.setenv(
+        authorization_custody.MEMBERSHIP_FILE_ENV,
+        str(external / "authorization-serving-membership.json"),
+    )
+    monkeypatch.setenv(authorization_custody.REPLICA_ID_ENV, "standalone")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(lease_state))
+    writer_lease.reset_managers_for_tests()
+    yield
+    writer_lease.reset_managers_for_tests()
+
+
+def _dump_digest(dump: tuple[str, ...]) -> str:
+    return hashlib.sha256(("\n".join(dump) + "\n").encode()).hexdigest()
+
+
+def _migration_seed(
+    vault: Path,
+    staged: authorization_custody.StandaloneV3StagingResult,
+    *,
+    now: int,
+) -> schema_v4.MigrationSeed:
+    snapshot = policy.observe_authoring_snapshot(vault)
+    assert snapshot is not None
+    compiled = policy.compile_documents(dict(snapshot.documents))
+    assert not compiled.empty and not compiled.blocked
+    descriptor = json.dumps(
+        {
+            "artifacts": [
+                {
+                    "content_hash": "a" * 64,
+                    "path": "Notes/fixture.md",
+                }
+            ]
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return schema_v4.MigrationSeed(
+        activation_store_id="activation-store-fixture",
+        logical_vault_id=staged.logical_vault_id,
+        activation_epoch=1,
+        policy=schema_v4.PolicyGenerationSeed(
+            generation_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            source_documents=snapshot.documents,
+            source_fingerprint=snapshot.source_fingerprint,
+            conflict_digest=snapshot.conflict_set_digest,
+            compiled_policy=policy.canonical_compiled_bytes(compiled),
+            policy_fingerprint=compiled.fingerprint,
+            compiler_schema_version=1,
+            projector_schema_version=1,
+            predecessor_generation_id=None,
+            authoring_event_id="event-v3-fixture-migration",
+            receipt_event_id="receipt-v3-fixture-migration",
+            created_at=now,
+        ),
+        catalog=schema_v4.CatalogGenerationSeed(
+            catalog_generation=1,
+            descriptor=descriptor,
+            artifact_count=1,
+            created_at=now,
+        ),
+        namespace=schema_v4.ProjectionNamespaceSeed(
+            namespace_id="projection-namespace-v3-fixture",
+            evidence=b'{"catalog_complete":true,"ready":true}',
+            ready_at=now,
+        ),
+        migrated_at=now,
+    )
+
+
+def test_frozen_v3_fixture_has_exact_schema_and_rich_legacy_authority(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    install_frozen_v3_fixture(vault)
+
+    dump = frozen_v3_dump(vault)
+    assert _dump_digest(dump) == FROZEN_V3_DUMP_SHA256
+    connection = sqlite3.connect(store.sidecar_path(vault))
+    try:
+        schema_v4.require_exact_v3_connection(connection)
+        assert connection.execute("PRAGMA user_version").fetchone() == (3,)
+        assert connection.execute(
+            "SELECT authorization_session FROM governance_session_grants"
+        ).fetchone() == ("legacy-session",)
+        assert connection.execute(
+            "SELECT authorization_session FROM governance_session_purpose"
+        ).fetchone() == ("legacy-session",)
+        assert connection.execute(
+            "SELECT authorization_session FROM withhold_tokens"
+        ).fetchone() == ("legacy-session",)
+        assert connection.execute(
+            "SELECT authorization_session, phase FROM governance_operation_journals"
+        ).fetchone() == ("legacy-session", "pending")
+        assert connection.execute(
+            "SELECT durable_seq, observed_seq FROM receipts_head"
+        ).fetchone() == (7, 7)
+    finally:
+        connection.close()
+    assert (
+        vault / "Knowledge Base" / "_Governance" / DIRECT_SOURCE_POLICY_PATH
+    ).read_bytes() == DIRECT_SOURCE_POLICY_BYTES
+
+
+def test_every_ordinary_store_opener_leaves_frozen_v3_logically_unchanged(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    install_frozen_v3_fixture(vault)
+    before = frozen_v3_dump(vault)
+
+    store.open_connection(vault).close()
+    readonly = store.open_readonly_connection(vault)
+    assert readonly is not None
+    readonly.close()
+    assert store.authorization_session_schema_version(vault) == 3
+    with pytest.raises(store.UnsupportedGovernanceSchema):
+        store.open_authorization_session_connection(vault)
+    with pytest.raises(store.UnsupportedGovernanceSchema):
+        store.open_active_governance_read_connection(vault)
+
+    after = frozen_v3_dump(vault)
+    assert after == before
+    assert not any("governance_authorization_sessions" in line for line in after)
+    assert not any("active_governance_tuple" in line for line in after)
+
+
+@pytest.mark.parametrize(
+    "crash_point",
+    ["after-legacy-archive", "after-schema", "after-seed", "before-commit"],
+)
+def test_rich_v3_fixture_rolls_back_every_precommit_migration_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    crash_point: str,
+) -> None:
+    vault = tmp_path / "vault"
+    install_frozen_v3_fixture(vault)
+    staged = authorization_custody.stage_standalone_v3_custody(vault, now=100)
+    seed = _migration_seed(vault, staged, now=101)
+    before = frozen_v3_dump(vault)
+
+    def crash(point: str) -> None:
+        if point == crash_point:
+            raise RuntimeError(f"injected {point}")
+
+    monkeypatch.setattr(schema_v4, "_crash_point", crash)
+    connection = sqlite3.connect(store.sidecar_path(vault))
+    try:
+        with pytest.raises(RuntimeError, match=crash_point):
+            schema_v4.migrate_v3_connection(connection, seed)
+    finally:
+        connection.close()
+
+    assert frozen_v3_dump(vault) == before
+
+
+def test_enrolled_rich_v3_fixture_migrates_authority_conservatively(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    install_frozen_v3_fixture(vault)
+    now = int(time.time())
+    staged = authorization_custody.stage_standalone_v3_custody(vault, now=now)
+    seed = _migration_seed(vault, staged, now=now + 1)
+    target = schema_v4.migration_target(seed)
+    authorization_custody.enroll_standalone_v3_migration(
+        vault,
+        target=target,
+        now=now,
+    )
+
+    assert (
+        store.migrate_enrolled_v3_store(
+            vault,
+            seed=seed,
+            now=now + 2,
+        )
+        == target
+    )
+
+    connection = sqlite3.connect(store.sidecar_path(vault))
+    try:
+        assert connection.execute("PRAGMA user_version").fetchone() == (4,)
+        archived = connection.execute(
+            "SELECT source_table, source_key, reason, expired_at "
+            "FROM governance_legacy_authority ORDER BY source_table, source_key"
+        ).fetchall()
+        assert archived == [
+            ("governance_session_grants", "legacy-grant", "v3-unbound-authorization", now + 1),
+            ("governance_session_purpose", "legacy-session", "v3-unbound-authorization", now + 1),
+            (
+                "governance_session_purpose_staging",
+                "legacy-purpose-stage",
+                "v3-unbound-authorization",
+                now + 1,
+            ),
+            ("withhold_tokens", "legacy-token", "v3-unbound-authorization", now + 1),
+        ]
+        assert connection.execute(
+            "SELECT phase, blocked_reason FROM governance_operation_journals "
+            "WHERE event_id='legacy-recovery-event'"
+        ).fetchone() == ("pending", "v3-unbound-authorization")
+        assert connection.execute(
+            "SELECT durable_seq, observed_seq FROM receipts_head"
+        ).fetchone() == (7, 7)
+        assert connection.execute("SELECT COUNT(*) FROM governance_proposals").fetchone() == (1,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM governance_operation_components"
+        ).fetchone() == (1,)
+        assert connection.execute("SELECT COUNT(*) FROM governance_session_grants").fetchone() == (
+            0,
+        )
+        assert connection.execute("SELECT COUNT(*) FROM governance_session_purpose").fetchone() == (
+            0,
+        )
+        assert connection.execute("SELECT COUNT(*) FROM withhold_tokens").fetchone() == (0,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM compiled_policy_generations"
+        ).fetchone() == (1,)
+        assert connection.execute(
+            "SELECT catalog_generation FROM active_governance_tuple"
+        ).fetchone() == (1,)
+    finally:
+        connection.close()


### PR DESCRIPTION
## Summary

- freeze the complete logical schema-v3 authority plus representative legacy handles, grants, purposes, tokens, receipt state, a pending recovery journal, and direct-source policy
- prove every ordinary v3/v4-capable store opener leaves the fixture byte-logically v3 with no v4 DDL or DML
- exercise all four pre-commit migration crash barriers and prove exact rollback, then prove enrolled migration archives legacy authority conservatively while preserving receipts/recovery evidence and publishing the first immutable policy/catalog/tuple
- complete OpenSpec task 5.6 across the preceding custody/enrollment/store-migration stack

## Verification

- red first: the new suite failed at collection because the frozen fixture module did not exist
- `89 passed`: model-reaper stability plus the rich v3 fixture, store migration, legacy store, and standalone provisioning packets
- 30/30 repeated event-driven model-reaper lifecycle checks on the updated #870 base
- Ruff on all touched and adjacent stability files
- `uv lock --check`
- public repository artifact validation
- `openspec validate harden-governance-for-consolidation --strict`
- `git diff --check`

Stacked after #870. This does not expose migration publicly, enable schema-v4 serving, merge branches, or touch any live Personal/POLLY vault.
