### PR TITLE
refactor(governance): share exact policy workspace mirror

### DIFF
--- a/src/exomem/governance/policy.py
+++ b/src/exomem/governance/policy.py
@@ -31,14 +31,14 @@ import re
 import sqlite3
 import stat
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import yaml
 
-from .. import held_fs, memory_refs
+from .. import held_fs, memory_refs, reserved_paths
 from ..kbdir import kb_dirname
 from . import store as store_module
 
@@ -424,6 +424,261 @@ def observe_authoring_snapshot(vault_root: Path) -> AuthoringSnapshot | None:
         directory_identities=read.directory_identities,
         governance_root_identity=read.root_identity,
     )
+
+
+def _mirror_relative_path(relative: str) -> bool:
+    path = Path(relative)
+    return (
+        not path.is_absolute()
+        and len(path.parts) == 2
+        and path.parts[0] in {"scopes", "rules", "grants"}
+        and path.parts[1] not in {"", ".", ".."}
+        and path.parts[1].endswith(".yaml")
+        and relative == path.as_posix()
+    )
+
+
+def _same_authoring_identity(
+    observed: held_fs.StableIdentity | None,
+    expected: held_fs.StableIdentity | None,
+) -> bool:
+    if observed is None or expected is None:
+        return observed is expected
+    return (
+        observed.device == expected.device
+        and observed.inode == expected.inode
+        and observed.kind == expected.kind
+        and (observed.kind != "file" or observed.link_count == expected.link_count == 1)
+    )
+
+
+def _workspace_mirror_plan(
+    current: AuthoringSnapshot,
+    reviewed: AuthoringSnapshot,
+    target_documents: tuple[tuple[str, bytes], ...],
+) -> list[tuple[str, bytes | None, AuthoringFileIdentity | None]] | None:
+    prior = dict(reviewed.documents)
+    target = dict(target_documents)
+    observed = dict(current.documents)
+    reviewed_identities = {item.path: item for item in reviewed.file_identities}
+    observed_identities = {item.path: item for item in current.file_identities}
+    reviewed_directories = dict(reviewed.directory_identities)
+    observed_directories = dict(current.directory_identities)
+    target_directories = {Path(relative).parent.as_posix() for relative in target}
+    if reviewed.governance_root_identity is not None and not _same_authoring_identity(
+        current.governance_root_identity,
+        reviewed.governance_root_identity,
+    ):
+        return None
+    if set(observed) - (set(prior) | set(target)):
+        return None
+    if set(observed_directories) - (set(reviewed_directories) | target_directories):
+        return None
+    for relative, expected in reviewed_directories.items():
+        if not _same_authoring_identity(observed_directories.get(relative), expected):
+            return None
+    effects: list[tuple[str, bytes | None, AuthoringFileIdentity | None]] = []
+    for relative in sorted(set(prior) | set(target)):
+        prior_bytes = prior.get(relative)
+        target_bytes = target.get(relative)
+        observed_bytes = observed.get(relative)
+        reviewed_identity = reviewed_identities.get(relative)
+        observed_identity = observed_identities.get(relative)
+        if prior_bytes == target_bytes:
+            if (
+                observed_bytes != prior_bytes
+                or reviewed_identity is None
+                or observed_identity != reviewed_identity
+            ):
+                return None
+            continue
+        if observed_bytes == target_bytes:
+            continue
+        if observed_bytes != prior_bytes:
+            return None
+        if prior_bytes is not None and (
+            reviewed_identity is None or observed_identity != reviewed_identity
+        ):
+            return None
+        effects.append((relative, target_bytes, observed_identity))
+    return effects
+
+
+def _workspace_mirror_failure(error: held_fs.HeldFsError | None) -> str:
+    if error is not None and error.code in {
+        "DESTINATION_EXISTS",
+        "IDENTITY_CHANGED",
+        "MISSING",
+        "UNSAFE_PATH",
+    }:
+        return "diverged"
+    return "pending"
+
+
+def mirror_authoring_workspace(
+    vault_root: Path,
+    *,
+    reviewed: AuthoringSnapshot,
+    target_documents: tuple[tuple[str, bytes], ...],
+    barrier: Callable[[str, str], None] | None = None,
+) -> str:
+    """Mirror reviewed immutable policy bytes through held filesystem handles.
+
+    The caller chooses the reviewed preimage and owns durable intent/recovery.
+    This primitive performs no authority selection and returns only the closed
+    effect status ``complete``, ``diverged``, or ``pending``.
+    """
+
+    if not isinstance(reviewed, AuthoringSnapshot):
+        return "diverged"
+    if not reserved_paths.owner_authorized("governance-tree"):
+        raise RuntimeError("policy workspace mirror lacks governance owner authority")
+    if (
+        not isinstance(target_documents, tuple)
+        or target_documents != tuple(sorted(target_documents))
+        or len(dict(target_documents)) != len(target_documents)
+        or any(
+            not isinstance(relative, str)
+            or not isinstance(content, bytes)
+            or not _mirror_relative_path(relative)
+            for relative, content in target_documents
+        )
+    ):
+        return "diverged"
+    notify = barrier if barrier is not None else lambda _phase, _relative: None
+    root = Path(vault_root)
+    base = f"{kb_dirname()}/{GOVERNANCE_DIRNAME}"
+    reviewed_directories = dict(reviewed.directory_identities)
+    with reserved_paths._identity_coordination_scope(
+        root,
+        descriptor_ids=("governance-tree",),
+        identity_may_change=True,
+    ):
+        current = observe_authoring_snapshot(root)
+        if current is None:
+            return "diverged"
+        effects = _workspace_mirror_plan(current, reviewed, target_documents)
+        if effects is None:
+            return "diverged"
+        acquired = held_fs.acquire(root)
+        if not acquired.ok:
+            return _workspace_mirror_failure(acquired.error)
+        publications = reserved_paths._reachable_owner_publications(
+            root, "governance-tree"
+        )
+        with acquired.require() as filesystem:
+            root_result = filesystem.parent(
+                base,
+                create=reviewed.governance_root_identity is None,
+                access="flush",
+            )
+            if not root_result.ok:
+                return _workspace_mirror_failure(root_result.error)
+            with root_result.require() as governance_root:
+                if reviewed.governance_root_identity is not None and not (
+                    _same_authoring_identity(
+                        governance_root.identity,
+                        reviewed.governance_root_identity,
+                    )
+                ):
+                    return "diverged"
+                publications[base] = governance_root.identity
+                for relative, target_bytes, current_identity in effects:
+                    notify("before_write", relative)
+                    path = Path(relative)
+                    parent_relative = Path(base, path.parent).as_posix()
+                    parent_result = filesystem.parent(
+                        parent_relative,
+                        create=current_identity is None,
+                        access="flush",
+                    )
+                    if not parent_result.ok:
+                        return _workspace_mirror_failure(parent_result.error)
+                    with parent_result.require() as parent:
+                        expected_parent = reviewed_directories.get(path.parent.as_posix())
+                        if expected_parent is not None and not _same_authoring_identity(
+                            parent.identity,
+                            expected_parent,
+                        ):
+                            return "diverged"
+                        publications[parent_relative] = parent.identity
+                        if target_bytes is None:
+                            mutable = filesystem.file(parent, path.name, access="mutate")
+                            if not mutable.ok:
+                                return _workspace_mirror_failure(mutable.error)
+                            with mutable.require() as existing:
+                                if current_identity is None or (
+                                    existing.identity != current_identity.identity
+                                ):
+                                    return "diverged"
+                                observed = filesystem.read(existing)
+                                if (
+                                    not observed.ok
+                                    or hashlib.sha256(observed.require()).hexdigest()
+                                    != current_identity.sha256
+                                ):
+                                    return "diverged"
+                                removed = filesystem.unlink(existing)
+                                if not removed.ok:
+                                    return _workspace_mirror_failure(removed.error)
+                            flushed = filesystem.flush_directory(parent)
+                            if not flushed.ok:
+                                return _workspace_mirror_failure(flushed.error)
+                            publications.pop(f"{base}/{relative}", None)
+                        else:
+                            published = held_fs.publish_bytes(
+                                filesystem,
+                                parent,
+                                path.name,
+                                target_bytes,
+                                expected_identity=(
+                                    None
+                                    if current_identity is None
+                                    else current_identity.identity
+                                ),
+                                expected_sha256=(
+                                    None
+                                    if current_identity is None
+                                    else current_identity.sha256
+                                ),
+                            )
+                            if not published.ok:
+                                return _workspace_mirror_failure(published.error)
+                            flushed = filesystem.flush_directory(parent)
+                            if not flushed.ok:
+                                return _workspace_mirror_failure(flushed.error)
+                            publications[f"{base}/{relative}"] = published.require()
+                        if (
+                            not filesystem.validate_directory(parent).ok
+                            or not filesystem.validate_directory(governance_root).ok
+                        ):
+                            return "diverged"
+                    notify("after_write", relative)
+                if not filesystem.validate_directory(governance_root).ok:
+                    return "diverged"
+        final = observe_authoring_snapshot(root)
+        if (
+            final is None
+            or final.documents != target_documents
+            or (
+                reviewed.governance_root_identity is not None
+                and not _same_authoring_identity(
+                    final.governance_root_identity,
+                    reviewed.governance_root_identity,
+                )
+            )
+        ):
+            return "diverged"
+        for item in final.file_identities:
+            publications[f"{base}/{item.path}"] = item.identity
+        for relative, identity in final.directory_identities:
+            publications[f"{base}/{relative}"] = identity
+        reserved_paths._publish_owner_identities(
+            root,
+            "governance-tree",
+            publications,
+        )
+    return "complete"
 
 
 @dataclass(frozen=True)

--- a/src/exomem/governance/tool.py
+++ b/src/exomem/governance/tool.py
@@ -3777,230 +3777,32 @@ def _v4_workspace_mirror_receipt_digests(
     return prior, prepared, target, affected
 
 
-def _same_v4_mirror_identity(
-    observed: held_fs.StableIdentity | None,
-    expected: held_fs.StableIdentity | None,
-) -> bool:
-    if observed is None or expected is None:
-        return observed is expected
-    return (
-        observed.device == expected.device
-        and observed.inode == expected.inode
-        and observed.kind == expected.kind
-        and (observed.kind != "file" or observed.link_count == expected.link_count == 1)
-    )
-
-
-def _v4_workspace_mirror_plan(
-    current: policy_module.AuthoringSnapshot,
-    reviewed: policy_module.AuthoringSnapshot,
-    target_documents: tuple[tuple[str, bytes], ...],
-) -> list[tuple[str, bytes | None, policy_module.AuthoringFileIdentity | None]] | None:
-    prior = dict(reviewed.documents)
-    target = dict(target_documents)
-    observed = dict(current.documents)
-    reviewed_identities = {item.path: item for item in reviewed.file_identities}
-    observed_identities = {item.path: item for item in current.file_identities}
-    reviewed_directories = dict(reviewed.directory_identities)
-    observed_directories = dict(current.directory_identities)
-    target_directories = {Path(relative).parent.as_posix() for relative in target}
-    if reviewed.governance_root_identity is not None and not _same_v4_mirror_identity(
-        current.governance_root_identity,
-        reviewed.governance_root_identity,
-    ):
-        return None
-    if set(observed) - (set(prior) | set(target)):
-        return None
-    if set(observed_directories) - (set(reviewed_directories) | target_directories):
-        return None
-    for relative, expected in reviewed_directories.items():
-        if not _same_v4_mirror_identity(observed_directories.get(relative), expected):
-            return None
-    effects: list[
-        tuple[str, bytes | None, policy_module.AuthoringFileIdentity | None]
-    ] = []
-    for relative in sorted(set(prior) | set(target)):
-        prior_bytes = prior.get(relative)
-        target_bytes = target.get(relative)
-        observed_bytes = observed.get(relative)
-        reviewed_identity = reviewed_identities.get(relative)
-        observed_identity = observed_identities.get(relative)
-        if prior_bytes == target_bytes:
-            if (
-                observed_bytes != prior_bytes
-                or reviewed_identity is None
-                or observed_identity != reviewed_identity
-            ):
-                return None
-            continue
-        if observed_bytes == target_bytes:
-            continue
-        if observed_bytes != prior_bytes:
-            return None
-        if prior_bytes is not None and (
-            reviewed_identity is None or observed_identity != reviewed_identity
-        ):
-            return None
-        effects.append((relative, target_bytes, observed_identity))
-    return effects
-
-
-def _v4_mirror_failure_status(error: held_fs.HeldFsError | None) -> str:
-    if error is not None and error.code in {
-        "DESTINATION_EXISTS",
-        "IDENTITY_CHANGED",
-        "MISSING",
-        "UNSAFE_PATH",
-    }:
-        return "diverged"
-    return "pending"
-
-
 def _apply_v4_workspace_mirror(
     vault_root: Path,
     decoded: _DecodedV4PolicyProposal,
     *,
     crash_at: object,
 ) -> str:
-    base = f"{kb_dirname()}/{policy_module.GOVERNANCE_DIRNAME}"
-    reviewed = decoded.authoring_snapshot
-    target_documents = decoded.policy.source_documents
-    reviewed_directories = dict(reviewed.directory_identities)
-    with reserved_paths._identity_coordination_scope(
+    effect_index = 0
+
+    def barrier(phase: str, relative: str) -> None:
+        nonlocal effect_index
+        _v4_workspace_mirror_barrier(phase, relative)
+        if phase != "after_write":
+            return
+        effect_index += 1
+        if crash_at in {
+            "v4_after_mirror_write",
+            f"v4_after_mirror_write:{effect_index}",
+        }:
+            raise GovernanceCrash(str(crash_at))
+
+    return policy_module.mirror_authoring_workspace(
         vault_root,
-        descriptor_ids=("governance-tree",),
-        identity_may_change=True,
-    ):
-        current = policy_module.observe_authoring_snapshot(vault_root)
-        if current is None:
-            return "diverged"
-        effects = _v4_workspace_mirror_plan(current, reviewed, target_documents)
-        if effects is None:
-            return "diverged"
-        acquired = held_fs.acquire(vault_root)
-        if not acquired.ok:
-            return _v4_mirror_failure_status(acquired.error)
-        publications = reserved_paths._reachable_owner_publications(
-            vault_root, "governance-tree"
-        )
-        with acquired.require() as filesystem:
-            root_result = filesystem.parent(
-                base,
-                create=reviewed.governance_root_identity is None,
-                access="flush",
-            )
-            if not root_result.ok:
-                return _v4_mirror_failure_status(root_result.error)
-            with root_result.require() as governance_root:
-                if reviewed.governance_root_identity is not None and not (
-                    _same_v4_mirror_identity(
-                        governance_root.identity,
-                        reviewed.governance_root_identity,
-                    )
-                ):
-                    return "diverged"
-                publications[base] = governance_root.identity
-                for index, (relative, target_bytes, current_identity) in enumerate(
-                    effects, start=1
-                ):
-                    _v4_workspace_mirror_barrier("before_write", relative)
-                    path = Path(relative)
-                    parent_relative = Path(base, path.parent).as_posix()
-                    parent_result = filesystem.parent(
-                        parent_relative,
-                        create=current_identity is None,
-                        access="flush",
-                    )
-                    if not parent_result.ok:
-                        return _v4_mirror_failure_status(parent_result.error)
-                    with parent_result.require() as parent:
-                        expected_parent = reviewed_directories.get(path.parent.as_posix())
-                        if expected_parent is not None and not _same_v4_mirror_identity(
-                            parent.identity,
-                            expected_parent,
-                        ):
-                            return "diverged"
-                        publications[parent_relative] = parent.identity
-                        if target_bytes is None:
-                            mutable = filesystem.file(parent, path.name, access="mutate")
-                            if not mutable.ok:
-                                return _v4_mirror_failure_status(mutable.error)
-                            with mutable.require() as existing:
-                                if current_identity is None or (
-                                    existing.identity != current_identity.identity
-                                ):
-                                    return "diverged"
-                                observed = filesystem.read(existing)
-                                if (
-                                    not observed.ok
-                                    or hashlib.sha256(observed.require()).hexdigest()
-                                    != current_identity.sha256
-                                ):
-                                    return "diverged"
-                                removed = filesystem.unlink(existing)
-                                if not removed.ok:
-                                    return _v4_mirror_failure_status(removed.error)
-                            flushed = filesystem.flush_directory(parent)
-                            if not flushed.ok:
-                                return _v4_mirror_failure_status(flushed.error)
-                            publications.pop(f"{base}/{relative}", None)
-                        else:
-                            published = held_fs.publish_bytes(
-                                filesystem,
-                                parent,
-                                path.name,
-                                target_bytes,
-                                expected_identity=(
-                                    None
-                                    if current_identity is None
-                                    else current_identity.identity
-                                ),
-                                expected_sha256=(
-                                    None
-                                    if current_identity is None
-                                    else current_identity.sha256
-                                ),
-                            )
-                            if not published.ok:
-                                return _v4_mirror_failure_status(published.error)
-                            flushed = filesystem.flush_directory(parent)
-                            if not flushed.ok:
-                                return _v4_mirror_failure_status(flushed.error)
-                            publications[f"{base}/{relative}"] = published.require()
-                        if (
-                            not filesystem.validate_directory(parent).ok
-                            or not filesystem.validate_directory(governance_root).ok
-                        ):
-                            return "diverged"
-                    _v4_workspace_mirror_barrier("after_write", relative)
-                    if crash_at in {
-                        "v4_after_mirror_write",
-                        f"v4_after_mirror_write:{index}",
-                    }:
-                        raise GovernanceCrash(str(crash_at))
-                if not filesystem.validate_directory(governance_root).ok:
-                    return "diverged"
-        final = policy_module.observe_authoring_snapshot(vault_root)
-        if (
-            final is None
-            or final.documents != target_documents
-            or (
-                reviewed.governance_root_identity is not None
-                and not _same_v4_mirror_identity(
-                    final.governance_root_identity,
-                    reviewed.governance_root_identity,
-                )
-            )
-        ):
-            return "diverged"
-        for item in final.file_identities:
-            publications[f"{base}/{item.path}"] = item.identity
-        for relative, identity in final.directory_identities:
-            publications[f"{base}/{relative}"] = identity
-        reserved_paths._publish_owner_identities(
-            vault_root, "governance-tree", publications
-        )
-    return "complete"
+        reviewed=decoded.authoring_snapshot,
+        target_documents=decoded.policy.source_documents,
+        barrier=barrier,
+    )
 
 
 def _mirror_v4_policy_workspace(

--- a/tests/test_governance_policy_workspace_mirror.py
+++ b/tests/test_governance_policy_workspace_mirror.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import pytest
+
+from exomem import reserved_paths, writer_lease
+from exomem.governance import policy
+
+POLICY_A = b"governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\npaths:\n  - Notes/**\n"
+POLICY_B = b"governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAW\npaths:\n  - Sources/**\n"
+POLICY_C = b"governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAX\npaths:\n  - Evidence/**\n"
+
+
+@pytest.fixture(autouse=True)
+def _lease_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
+    state = tmp_path / "lease-state"
+    state.mkdir(mode=0o700)
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(state))
+    writer_lease.reset_managers_for_tests()
+    yield
+    writer_lease.reset_managers_for_tests()
+
+
+def _workspace(vault: Path) -> Path:
+    root = vault / "Knowledge Base" / "_Governance"
+    (root / "scopes").mkdir(parents=True)
+    return root
+
+
+def _mirror(
+    vault: Path,
+    *,
+    reviewed: policy.AuthoringSnapshot,
+    target_documents: tuple[tuple[str, bytes], ...],
+    barrier: Callable[[str, str], None] | None = None,
+) -> str:
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        return policy.mirror_authoring_workspace(
+            vault,
+            reviewed=reviewed,
+            target_documents=target_documents,
+            barrier=barrier,
+        )
+
+
+def test_exact_workspace_mirror_replaces_adds_and_removes_under_one_guard(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    root = _workspace(vault)
+    (root / "scopes" / "a.yaml").write_bytes(POLICY_A)
+    (root / "scopes" / "remove.yaml").write_bytes(POLICY_B)
+    reviewed = policy.observe_authoring_snapshot(vault)
+    assert reviewed is not None
+    target = (
+        ("scopes/a.yaml", POLICY_B),
+        ("scopes/added.yaml", POLICY_C),
+    )
+
+    assert (
+        _mirror(
+            vault,
+            reviewed=reviewed,
+            target_documents=target,
+        )
+        == "complete"
+    )
+
+    final = policy.observe_authoring_snapshot(vault)
+    assert final is not None
+    assert final.documents == target
+    assert not (root / "scopes" / "remove.yaml").exists()
+
+
+def test_exact_workspace_mirror_refuses_unreviewed_drift_without_writes(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    root = _workspace(vault)
+    path = root / "scopes" / "a.yaml"
+    path.write_bytes(POLICY_A)
+    reviewed = policy.observe_authoring_snapshot(vault)
+    assert reviewed is not None
+    path.write_bytes(POLICY_C)
+
+    assert (
+        _mirror(
+            vault,
+            reviewed=reviewed,
+            target_documents=(("scopes/a.yaml", POLICY_B),),
+        )
+        == "diverged"
+    )
+    assert path.read_bytes() == POLICY_C
+
+
+def test_exact_workspace_mirror_reports_each_effect_to_the_caller(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    root = _workspace(vault)
+    (root / "scopes" / "a.yaml").write_bytes(POLICY_A)
+    reviewed = policy.observe_authoring_snapshot(vault)
+    assert reviewed is not None
+    observed: list[tuple[str, str]] = []
+
+    result = _mirror(
+        vault,
+        reviewed=reviewed,
+        target_documents=(("scopes/a.yaml", POLICY_B),),
+        barrier=lambda phase, relative: observed.append((phase, relative)),
+    )
+
+    assert result == "complete"
+    assert observed == [
+        ("before_write", "scopes/a.yaml"),
+        ("after_write", "scopes/a.yaml"),
+    ]
+
+
+def test_exact_workspace_mirror_requires_owner_authority_before_writing(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    root = _workspace(vault)
+    path = root / "scopes" / "a.yaml"
+    path.write_bytes(POLICY_A)
+    reviewed = policy.observe_authoring_snapshot(vault)
+    assert reviewed is not None
+
+    with pytest.raises(RuntimeError, match="lacks governance owner authority"):
+        policy.mirror_authoring_workspace(
+            vault,
+            reviewed=reviewed,
+            target_documents=(("scopes/a.yaml", POLICY_B),),
+        )
+
+    assert path.read_bytes() == POLICY_A


### PR DESCRIPTION
## Summary

- move the exact held-handle `_Governance` workspace mirror into a reusable policy primitive
- keep the live v4 authoring path on that one implementation, preserving its crash barriers and closed `complete` / `diverged` / `pending` outcomes
- require exact governance-tree owner authority before the first mutation and retain the existing identity-coordination/publication contract
- add direct replacement/addition/removal, drift-refusal, effect-callback, and unauthorized-call regressions

This is stacked after #871. It is the reusable filesystem half required by the explicit offline v4→v3 rollback coordinator; durable external rollback recovery metadata remains the next slice. It does not expose a rollback command, enable v4 serving, merge vaults, or touch any live vault.

## Verification

- red first: 3 expected failures because `policy.mirror_authoring_workspace` did not exist
- shared primitive + existing mirror crash/race slice: 8 passed, 101 deselected
- authoring snapshot / prospective compile slice: 12 passed, 89 deselected
- Ruff on all three changed Python files
- `uv lock --check`
- `openspec validate harden-governance-for-consolidation --strict`
- `git diff --check`
