### PR TITLE
fix(graph): harden the recovery funnel and tolerate cold-registry recall

### DIFF
--- a/openspec/changes/bound-graph-recovery-funnel/specs/live-index-freshness/spec.md
+++ b/openspec/changes/bound-graph-recovery-funnel/specs/live-index-freshness/spec.md
@@ -72,11 +72,12 @@ A service restart that finds a coherent durable graph checkpoint SHALL admit gra
 
 Semantic recall SHALL NOT refuse solely because the maintained recall projection lags current content by in-flight writes; it SHALL serve from the last published projection while the projection refresh is pending, disclosing bounded staleness, and SHALL refuse only when no published projection exists or the projection's identity (policy, access fingerprint, catalog identity) no longer matches. The write path SHALL refresh the projection proportionally to the delta, never by whole-vault work.
 
-#### Scenario: A write does not interrupt semantic recall
+#### Scenario: A cold recall registry does not interrupt semantic recall
 
-- **WHEN** semantic recall arrives while writes have advanced content past the last published recall projection
+- **WHEN** semantic recall arrives while the live recall registry is cold or reprojection-evicted and a published, identity-matching recall projection exists
 - **THEN** the recall serves from the last published projection with a bounded-staleness disclosure
-- **AND** the projection refresh proceeds proportionally to the delta
+- **AND** the projection refresh proceeds proportionally to the delta rather than by whole-vault work
+- **AND** per-page access enforcement at egress remains live, so staleness is confined to ranking and recall-set membership
 
 #### Scenario: Identity changes still refuse
 

--- a/openspec/changes/bound-graph-recovery-funnel/tasks.md
+++ b/openspec/changes/bound-graph-recovery-funnel/tasks.md
@@ -2,14 +2,14 @@
 
 ## 1. Regression tests (red first)
 
-- [ ] 1.1 Pin the funnel: during `recovery_required`, a batch write whose
+- [x] 1.1 Pin the funnel: during `recovery_required`, a batch write whose
       graph deferral durably covers its graph-input paths currently fails
       `full_upsert_succeeded` and mints a full receipt. After the fix the
       pin inverts: report succeeds, no full receipt, telemetry counts the
       covered acceptance.
-- [ ] 1.2 Fail-closed pin: a graph deferral WITHOUT covering per-path
+- [x] 1.2 Fail-closed pin: a graph deferral WITHOUT covering per-path
       receipts still fails the report and mints the demand.
-- [ ] 1.3 Alarm pin: recovery_required persisting beyond the bound surfaces
+- [x] 1.3 Alarm pin: recovery_required persisting beyond the bound surfaces
       in health telemetry and turns the doctor finding into a FAIL; the
       graph-disabled-while-recovery-checkpoint-exists combination FAILs
       immediately, including when the kill switch comes from an unowned
@@ -19,7 +19,7 @@
       startup pass (measured: ~30 min of suspended reads per restart on a
       3.3k-file vault); after the fix it admits after O(1) validation, and
       only genuine incoherence rebuilds.
-- [ ] 1.5 Drain-refusal pin: `exomem index` against a vault whose live
+- [x] 1.5 Drain-refusal pin: `exomem index` against a vault whose live
       service owns graph work refuses with the documented remediation
       instead of taking the claim.
 
@@ -35,12 +35,12 @@
 
 - [x] 2.0 Access-policy fail-closed loading per the recall-read-path delta
       (precondition for trusting the projection-lag identity guard).
-- [ ] 2.1 Extend the `epistemic_graph` clause of `full_upsert_succeeded`
+- [x] 2.1 Extend the `epistemic_graph` clause of `full_upsert_succeeded`
       with the durable-coverage carve-out (mirror of the embeddings
       warm-up carve-out from #850).
-- [ ] 2.2 Recovery-age telemetry + health surfacing + doctor FAIL findings.
-- [ ] 2.3 Live-service ownership probe and refusal in the CLI index path.
-- [ ] 2.4 Projection-lag tolerance: serve semantic recall from the last
+- [x] 2.2 Recovery-age telemetry + health surfacing + doctor FAIL findings.
+- [x] 2.3 Live-service ownership probe and refusal in the CLI index path.
+- [x] 2.4 Projection-lag tolerance: serve semantic recall from the last
       published projection during refresh; refuse only on identity change or
       absent projection (red-first pin: a single write currently flips
       semantic recall to RETRIEVAL_INDEX_WARMING until the graph republishes
@@ -50,8 +50,8 @@
 
 ## 3. Verification and delivery
 
-- [ ] 3.1 Focused suites, lint, privacy, strict OpenSpec validation.
-- [ ] 3.2 Independent adversarial review; resolve findings.
+- [x] 3.1 Focused suites, lint, privacy, strict OpenSpec validation.
+- [x] 3.2 Independent adversarial review; resolve findings.
 - [ ] 3.3 Live acceptance: induce recovery_required on a test vault, write
       through it, verify zero minting with covered deferrals and a firing
       alarm; verify the drain refusal against a running service.

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -617,6 +617,25 @@ def _index_main(argv: list[str]) -> int:
     if not args.vault:
         print("index: set --vault or EXOMEM_VAULT_PATH", file=sys.stderr)
         return 2
+    # Refuse BEFORE any graph claim is taken. Two processes contending for the
+    # same graph ownership is not slow, it soft-deadlocks: the 2026-08 incident
+    # had this CLI holding the claim at 0 CPU while the live service minted
+    # ~2,143 receipts in 40 minutes, of which draining re-embedded 3 files.
+    # Contending is never the right move, so make it unrepresentable.
+    from . import graph_sync as _graph_sync
+
+    owner = _graph_sync.live_graph_owner(Path(args.vault).expanduser())
+    if owner is not None:
+        print(
+            "index: refusing to start — a live service currently owns graph work "
+            f"for this vault (operation={owner.get('operation')!r}, "
+            f"held {owner.get('age_seconds')}s). Two processes contending for the "
+            "graph claim soft-deadlock rather than sharing it.\n"
+            "index: take a stop window — stop the exomem service, run this drain "
+            "to completion, then restart the service.",
+            file=sys.stderr,
+        )
+        return 2
     # Scope override flows through the env var the whole stack reads, so a single
     # source of truth governs the walk, the drift check, and freshness.
     if args.scope:

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -181,6 +181,147 @@ def _check(
     )
 
 
+#: Graph kill switches. Either one, held while a durable recovery checkpoint
+#: exists, makes recovery provably impossible rather than merely slow.
+_GRAPH_KILL_SWITCHES = ("EXOMEM_DISABLE_GRAPH_INDEX", "EXOMEM_DISABLE_GRAPH_SCHEDULING")
+
+#: How long `recovery_required` may hold before it stops being normal. Recovery
+#: is minutes of work; the 2026-08 incident held it for days while every write
+#: minted a durable full-index receipt behind it.
+RECOVERY_AGE_FAIL_SECONDS = 6 * 60 * 60.0
+
+
+def _site_package_dirs() -> list[Path]:
+    """Interpreter site directories to scan for startup-file kill switches."""
+    import site
+
+    candidates: list[Path] = []
+    for getter in ("getsitepackages", "getusersitepackages"):
+        try:
+            found = getattr(site, getter)()
+        except (AttributeError, TypeError):
+            continue
+        if isinstance(found, str):
+            found = [found]
+        candidates.extend(Path(item) for item in found)
+    return candidates
+
+
+def graph_kill_switch_sources() -> list[str]:
+    """Startup files that inject a graph kill switch into every interpreter.
+
+    A `.pth` in site-packages executes at interpreter start, so one left behind
+    by an old install disables the graph in a process whose ENVIRONMENT looks
+    clean. That is why the incident's root cause stayed invisible: `env` showed
+    nothing. Reports the file paths, never their contents.
+    """
+    sources: list[str] = []
+    seen: set[str] = set()
+    for directory in _site_package_dirs():
+        try:
+            entries = sorted(directory.glob("*.pth"))
+        except OSError:
+            continue
+        for entry in entries:
+            key = str(entry)
+            if key in seen:
+                continue
+            try:
+                text = entry.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            if any(switch in text for switch in _GRAPH_KILL_SWITCHES):
+                seen.add(key)
+                sources.append(key)
+    return sources
+
+
+def check_graph_recovery_age(vault_root: Path | None) -> DoctorCheck:
+    """Persistent graph recovery is an alarmed, bounded condition.
+
+    Two FAILURES, not warnings. Graph work disabled while a durable recovery
+    checkpoint exists is provably unrecoverable and fails immediately, naming
+    the disabling source including a site-packages `.pth`. Recovery merely
+    required beyond its bound fails on elapsed time.
+    """
+    from . import graph_sync
+
+    details: dict[str, object] = {}
+    if vault_root is None:
+        return _check(
+            "write_path.graph_recovery",
+            "pass",
+            "No vault selected; graph recovery state not evaluated.",
+            details=details,
+        )
+    checkpoint = graph_sync.read_checkpoint(vault_root)
+    age = graph_sync.recovery_age_seconds(vault_root)
+    clock_state = graph_sync.recovery_clock_state(vault_root)
+    env_switches = [name for name in _GRAPH_KILL_SWITCHES if os.environ.get(name, "").strip()]
+    details["recovery_checkpoint"] = checkpoint is not None
+    details["recovery_age_s"] = None if age is None else round(age, 1)
+    details["recovery_clock"] = clock_state
+    details["graph_kill_switches"] = env_switches
+
+    if checkpoint is not None and env_switches:
+        pth_sources = graph_kill_switch_sources()
+        details["graph_kill_switch_files"] = pth_sources
+        origin = ", ".join(env_switches)
+        if pth_sources:
+            origin += f" (injected by {', '.join(pth_sources)})"
+        return _check(
+            "write_path.graph_recovery",
+            "fail",
+            "A durable graph recovery checkpoint exists while graph work is "
+            f"disabled by {origin}. Recovery cannot complete in this "
+            "configuration, and every batch write keeps minting durable refresh "
+            "demand behind it.",
+            "Unset the kill switch (and delete the .pth that injects it, if any), "
+            "then let the graph drain complete.",
+            details=details,
+        )
+    if clock_state == "corrupt":
+        # An unreadable clock is its own failure, never a zero-age warning.
+        # Reported as "just now" it would hold the age permanently below the
+        # bound below, so the alarm could never fire again.
+        return _check(
+            "write_path.graph_recovery",
+            "fail",
+            "Graph synchronization recorded a recovery condition but its "
+            "durable clock is unreadable, so how long recovery has been "
+            "required cannot be measured and the age bound cannot fire.",
+            "Run `exomem index --scope vault` during a stop window; the next "
+            "observation republishes the clock atomically.",
+            details=details,
+        )
+    if age is not None and age > RECOVERY_AGE_FAIL_SECONDS:
+        return _check(
+            "write_path.graph_recovery",
+            "fail",
+            "Graph synchronization has continuously required recovery for "
+            f"{age / 3600.0:.1f}h, beyond the "
+            f"{RECOVERY_AGE_FAIL_SECONDS / 3600.0:.0f}h bound. Recovery is "
+            "minutes of work; this long means it is blocked.",
+            "Run `exomem index --scope vault` during a stop window, then confirm "
+            "graph_sync status returns to current.",
+            details=details,
+        )
+    if age is not None:
+        return _check(
+            "write_path.graph_recovery",
+            "warn",
+            f"Graph synchronization requires recovery ({age / 60.0:.1f} min so far).",
+            "Normal for a short window; investigate if it persists.",
+            details=details,
+        )
+    return _check(
+        "write_path.graph_recovery",
+        "pass",
+        "Graph synchronization does not require recovery.",
+        details=details,
+    )
+
+
 def _module_available(module: str) -> bool:
     return importlib.util.find_spec(module) is not None
 
@@ -2761,6 +2902,7 @@ def doctor(
         _check_graph_sync_state(vault_root),
         _check_rebuild_temp_orphans(vault_root),
         _check_write_path_env_flags(vault_root),
+        check_graph_recovery_age(vault_root),
     ]
     runtime_processes = _check_runtime_processes()
     if runtime_processes is not None:

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -85,6 +85,13 @@ _collapse = find_results.collapse
 _DEGRADATION_LOCK = threading.Lock()
 _DEGRADATION_COUNTS: dict[str, int] = {}
 
+# Bounded-staleness disclosure. A request answered from the catalog's last
+# published recall projection — rather than one proven exactly current — rides
+# the existing `warming.components` envelope under this name, so a caller can
+# tell "these hits may not include the newest writes" from a fully current
+# answer without a new envelope field.
+_RECALL_PROJECTION_STALE_COMPONENT = "recall_projection"
+
 
 def _record_degradation(lane: str) -> None:
     """Increment the process-lifetime silent-degradation counter for `lane`."""
@@ -430,11 +437,17 @@ class FreshnessSnapshot:
             str, freshness.RecallFreshnessCheckpoint
         ]
         | None = None,
+        stale_recall_scopes: frozenset[str] = frozenset(),
     ) -> None:
         self._root = vault_root
         self._require_live_recall = require_live_recall
         self._timings = timings
         self._expected_recall_checkpoints = expected_recall_checkpoints or {}
+        # Scopes admitted at the catalog's published projection rather than an
+        # exactly-current live one. For those the live registry has no
+        # checkpoint to require, so liveness is not a precondition and the
+        # published projection is the answer.
+        self._stale_recall_scopes = stale_recall_scopes
         self._kb: tuple[int, int, str] | None = None
         self._vault: tuple[int, int, str] | None = None
         self._recall: dict[str, freshness.RecallFreshnessCheckpoint] = {}
@@ -510,20 +523,30 @@ class FreshnessSnapshot:
             try:
                 root = self._root.absolute()
                 cache_key = (root, scope)
+                # A scope admitted as stale is answered from the published
+                # projection the admission already identity-checked, so it does
+                # not additionally require a live registry.
+                stale = scope in self._stale_recall_scopes
+                require_live = self._require_live_recall and not stale
                 projection_live = freshness.recall_is_live(self._root, scope)
                 checkpoint = (
                     freshness.live_recall_checkpoint(self._root, scope)
-                    if self._require_live_recall
+                    if require_live
                     else freshness.recall_checkpoint(self._root, scope)
                     if projection_live
                     else None
                 )
-                if checkpoint is None and self._require_live_recall:
+                if checkpoint is None and require_live:
                     raise freshness.RecallProjectionUnavailable(
                         f"maintained recall projection is not live for scope={scope!r}"
                     )
                 expected = self._expected_recall_checkpoints.get(scope)
-                if checkpoint is not None and expected is not None and checkpoint != expected:
+                if (
+                    not stale
+                    and checkpoint is not None
+                    and expected is not None
+                    and checkpoint != expected
+                ):
                     raise freshness.RecallProjectionUnavailable(
                         f"maintained recall projection advanced for scope={scope!r}"
                     )
@@ -536,11 +559,16 @@ class FreshnessSnapshot:
                             self._recall_paths[scope] = cached[1]
                             _set_recall_projection_timing_outcome(
                                 self._timings,
-                                "live_cache" if self._require_live_recall else "cache",
+                                # `require_live`, not the request-wide flag: a
+                                # stale-admitted scope is served from the
+                                # published projection, so labelling its cache
+                                # hit `live_cache` would misreport it as an
+                                # exactly-current answer.
+                                "live_cache" if require_live else "cache",
                             )
                             return
 
-                if self._require_live_recall:
+                if require_live:
                     checkpoint, entries = freshness.recall_projection_snapshot(
                         self._root,
                         scope,
@@ -559,7 +587,7 @@ class FreshnessSnapshot:
                         self._vault = scope_triple
                     else:
                         self._kb = scope_triple
-                if expected is not None and checkpoint != expected:
+                if not stale and expected is not None and checkpoint != expected:
                     raise freshness.RecallProjectionUnavailable(
                         f"maintained recall projection advanced for scope={scope!r}"
                     )
@@ -889,9 +917,16 @@ def find(
     state = str(admission["state"]) if managed_runtime else "unverified"
     require_live_recall = managed_runtime and freshness.event_indexes_enabled()
     catalog_proof: dict[str, freshness.RecallFreshnessCheckpoint] | None = None
+    stale_recall_scopes: frozenset[str] = frozenset()
     with _span(timings, "recall_projection"):
         if state == "ready" and require_live_recall:
-            raw_proof = lexstore.runtime_retrieval_catalog_proof(vault_root)
+            # Bounded projection lag is served, not refused. `admission` takes
+            # the strict proof when it binds and otherwise falls back to the
+            # catalog's own published projection under an unchanged identity —
+            # so a cold or reprojection-evicted registry answers from the last
+            # published projection instead of blanking semantic recall.
+            admitted = lexstore.runtime_retrieval_catalog_admission(vault_root)
+            raw_proof = admitted.checkpoints if admitted is not None else None
             if raw_proof is None:
                 readiness.mark_unready("retrieval_catalog")
                 state = "unavailable"
@@ -905,8 +940,15 @@ def find(
                     readiness.mark_unready("retrieval_catalog")
                     catalog_proof = None
                     state = "unavailable"
-                elif catalog_proof_out is not None:
-                    catalog_proof_out.update(catalog_proof)
+                else:
+                    stale_recall_scopes = frozenset(admitted.lagging_scopes)
+                    if stale_recall_scopes and degraded_out is not None:
+                        # Rides the existing warming disclosure: the envelope
+                        # already projects `warming.components`, so a stale
+                        # answer is disclosed without a new envelope field.
+                        degraded_out.append(_RECALL_PROJECTION_STALE_COMPONENT)
+                    if catalog_proof_out is not None:
+                        catalog_proof_out.update(catalog_proof)
         if state in {"warming", "unavailable"}:
             if state == "unavailable":
                 lexstore.request_repair(vault_root)
@@ -1017,6 +1059,7 @@ def find(
         require_live_recall=require_live_recall,
         timings=timings,
         expected_recall_checkpoints=catalog_proof,
+        stale_recall_scopes=stale_recall_scopes,
     )
     page_memo: dict[str, ParsedPage | None] = {}
 

--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -8,6 +8,7 @@ import hashlib
 import hmac
 import json
 import logging
+import math
 import os
 import re
 import secrets
@@ -34,6 +35,9 @@ _TEMP_PREFIX = ".graph-rebuild-"
 _CHECKPOINT_FILENAME = ".graph-sync.json"
 _FLOOR_FILENAME = ".graph-sync-floor.json"
 _RECEIPT_DIRNAME = ".graph-commit-receipts"
+#: Durable start instant of a continuous `recovery_required` condition. Durable
+#: on purpose: a restart loop must not keep resetting the alarm clock.
+_RECOVERY_MARKER_FILENAME = ".graph-sync-recovery.json"
 _RESET_PREFIX = ".graph-reset-"
 _RESET_MANIFEST = ".manifest.json"
 _RESET_MEMBERS = (
@@ -937,6 +941,147 @@ def floor_path(vault_root: Path) -> Path:
     return Path(vault_root) / kb_dirname() / _FLOOR_FILENAME
 
 
+def recovery_marker_path(vault_root: Path) -> Path:
+    from .kbdir import kb_dirname
+
+    return Path(vault_root) / kb_dirname() / _RECOVERY_MARKER_FILENAME
+
+
+def observe_recovery_state(vault_root: Path) -> float | None:
+    """Record and return how long recovery has CONTINUOUSLY been required.
+
+    `recovery_required` is correct for minutes and pathological for hours, so
+    the alarm needs elapsed time, not a boolean. The start instant is durable:
+    a restart must not reset the clock, because a restart loop is exactly the
+    shape the 2026-08 incident took.
+
+    Idempotent. Entering recovery stamps the marker; leaving it removes the
+    marker, so the condition can never be sticky. Returns None whenever
+    recovery is not currently required.
+    """
+    root = Path(vault_root)
+    marker = recovery_marker_path(root)
+    if status(root)["state"] != "recovery_required":
+        try:
+            marker.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError:
+            logger.warning("could not clear the graph recovery marker", exc_info=True)
+        return None
+    state, age = _recovery_clock(root)
+    if state == "valid":
+        # A well-formed clock is authoritative: leave it exactly as it is, or a
+        # restart loop would keep resetting the age and the bound could never
+        # be crossed.
+        return age
+    # Absent OR corrupt. A corrupt clock must be REPLACED, never accepted: read
+    # as "just now" it silences the alarm permanently, because the age can then
+    # never exceed the bound.
+    try:
+        _write_recovery_marker(root, time.time())
+    except Exception:  # noqa: BLE001 - an unwritable marker must not break writes
+        logger.warning("could not record the graph recovery marker", exc_info=True)
+    return 0.0
+
+
+def _recovery_clock(vault_root: Path) -> tuple[str, float | None]:
+    """Classify the durable recovery clock: absent, valid, or corrupt.
+
+    The three states are genuinely different, and collapsing them is what made
+    the alarm silenceable. Absent means the condition is not recorded. Valid
+    carries an age. Corrupt means the condition WAS recorded but its clock is
+    unreadable -- a fault in its own right, never an age of zero.
+    """
+    marker = recovery_marker_path(Path(vault_root))
+    try:
+        raw = marker.read_text(encoding="utf-8")
+    except (FileNotFoundError, NotADirectoryError):
+        return "absent", None
+    except OSError:
+        return "corrupt", None
+    try:
+        since = float(json.loads(raw)["since"])
+    except (ValueError, TypeError, KeyError, json.JSONDecodeError):
+        return "corrupt", None
+    if not math.isfinite(since):
+        return "corrupt", None
+    return "valid", max(0.0, time.time() - since)
+
+
+def recovery_clock_state(vault_root: Path) -> str:
+    """``absent``, ``valid`` or ``corrupt`` for the durable recovery clock."""
+    return _recovery_clock(vault_root)[0]
+
+
+def recovery_age_seconds(vault_root: Path) -> float | None:
+    """Seconds since recovery was first continuously required, else None.
+
+    A pure read: doctor and health call this without writing. It reports an age
+    ONLY for a well-formed clock. A corrupt clock returns None and is surfaced
+    through :func:`recovery_clock_state` instead, because answering 0.0 there
+    let a torn marker hold the age permanently below the alarm bound.
+    """
+    return _recovery_clock(vault_root)[1]
+
+
+def _write_recovery_marker(vault_root: Path, since: float) -> None:
+    """Publish the recovery clock atomically through the graph_sync owner path.
+
+    The same owner-bound publication as `.graph-sync.json`, and it matters more
+    here than for ordinary state: this marker is written during exactly the
+    crashes the subsystem monitors, so an in-place `write_text` could tear and
+    leave behind the corrupt clock that silences the alarm.
+    """
+    from . import reserved_paths
+
+    payload = json.dumps({"since": since}, separators=(",", ":")).encode("utf-8")
+    with reserved_paths._subsystem_authority_scope("graph_sync"):
+        reserved_paths._publish_owner_bytes(
+            vault_root,
+            recovery_marker_path(vault_root),
+            "graph-handoff",
+            payload,
+        )
+
+
+#: Mutation-boundary holder kind used by every epistemic-graph operation.
+_GRAPH_HOLDER_KIND = "graph"
+
+
+def live_graph_owner(vault_root: Path) -> dict[str, object] | None:
+    """The cross-process holder currently doing GRAPH work for this vault.
+
+    A pure probe of the mutation boundary that takes NO graph claim, so a
+    caller can decide whether to start before contending for one. That ordering
+    is the whole point: the 2026-08 soft-deadlock was an out-of-process drain
+    holding the graph claim at 0 CPU while the live service minted receipts
+    behind it.
+
+    Deliberately narrow. Only a holder whose kind is `graph` counts — refusing
+    on ANY holder would make the drain unusable on a vault that merely has
+    write traffic. Returns None when nothing holds the boundary, when the
+    holder is doing something else, or when the boundary cannot be probed at
+    all: a drain must not be blocked by an unreadable runtime root.
+    """
+    try:
+        from . import mutation_lock
+        from .writer_lease import active_manager
+
+        coordinator = mutation_lock.VaultMutationCoordinator(
+            active_manager().config.state_dir, vault_root
+        )
+        snapshot = coordinator.snapshot()
+    except Exception:  # noqa: BLE001 - an unprobeable boundary is not a refusal
+        logger.debug("could not probe the graph mutation boundary", exc_info=True)
+        return None
+    if snapshot.get("state") != "held":
+        return None
+    if str(snapshot.get("holder_kind")) != _GRAPH_HOLDER_KIND:
+        return None
+    return snapshot
+
+
 def graph_commit_receipt_path(vault_root: Path, commit_token: str) -> Path:
     """Return the hidden portable receipt location for one opaque claim token."""
     if _MUTATION_ID.fullmatch(commit_token) is None:
@@ -1019,7 +1164,13 @@ def checkpoint_state(vault_root: Path) -> tuple[str, GraphSyncCheckpoint | None]
 def is_graph_input_path(relative_path: str) -> bool:
     normalized = relative_path.replace("\\", "/")
     return (
-        not normalized.endswith((f"/{_CHECKPOINT_FILENAME}", f"/{_FLOOR_FILENAME}"))
+        not normalized.endswith(
+            (
+                f"/{_CHECKPOINT_FILENAME}",
+                f"/{_FLOOR_FILENAME}",
+                f"/{_RECOVERY_MARKER_FILENAME}",
+            )
+        )
         and f"/{_RECEIPT_DIRNAME}/" not in f"/{normalized.lstrip('/')}"
     )
 

--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -67,6 +67,12 @@ _DEFERRAL_TELEMETRY_KEYS = (
 _DEFERRAL_TELEMETRY: dict[str, int] = dict.fromkeys(_DEFERRAL_TELEMETRY_KEYS, 0)
 _DEFERRAL_TELEMETRY_LOCK = threading.Lock()
 
+#: Graph deferral codes that CLAIM durable per-path coverage. `graph_repair_queued`
+#: is emitted only on the branch that proved the durable queue holds the affected
+#: paths. The disabled codes record nothing and are deliberately absent, so a
+#: stale queue entry naming the same path can never bless them.
+_GRAPH_COVERAGE_CODES = frozenset({"graph_repair_queued"})
+
 
 def _note_deferral(reason: str) -> None:
     """Count one stable deferral-accounting outcome (never content).
@@ -631,6 +637,7 @@ def full_upsert_succeeded(vault_root: Path, replaced: list[Path], report: object
     ):
         return False
     receipt_rels: set[str] | None = None
+    graph_receipt_rels: set[str] | None = None
     replaced_rels: set[str] = set()
     root = Path(vault_root).resolve()
     for path in replaced:
@@ -659,6 +666,32 @@ def full_upsert_succeeded(vault_root: Path, replaced: list[Path], report: object
                 and graph_sync.registered_checkpoint(vault_root) == checkpoint
             ):
                 continue
+            if component.outcome == "deferred" and component.code in _GRAPH_COVERAGE_CODES:
+                # Mirror of the embeddings warm-up carve-out above: per-path
+                # graph receipts ARE the exact durable demand for those paths,
+                # so minting a whole-component refresh on top is the same
+                # double-accounting. This matters most precisely where it used
+                # to hurt: during `recovery_required` the registered checkpoint
+                # never equals the live one, so the clause above never fires and
+                # EVERY write minted — backlog feeding the backlog.
+                #
+                # Only a code that means "durably queued" may be blessed;
+                # `graph_index_disabled`/`graph_scheduling_disabled` record
+                # nothing, so a stale queue entry can never launder them.
+                graph_rels = {
+                    rel for rel in replaced_rels if graph_sync.is_graph_input_path(rel)
+                }
+                if graph_rels:
+                    if graph_receipt_rels is None:
+                        graph_receipt_rels = {
+                            receipt.rel_path
+                            for receipt in deferred_index.snapshot_graph(vault_root)
+                        }
+                    if graph_rels <= graph_receipt_rels:
+                        _note_deferral("covered_deferral_accepted")
+                        continue
+                _note_deferral("uncovered_deferral_escalated")
+                return False
         if component.component == "embeddings" and component.outcome == "deferred":
             # A deferral that is already durably queued path-by-path is not a
             # batch failure — declaring it one is what escalated an O(1) cause

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -605,6 +605,88 @@ def runtime_retrieval_catalog_proof(
     return checkpoints
 
 
+@dataclass(frozen=True, slots=True)
+class RecallProjectionAdmission:
+    """Request-path admission for maintained semantic recall.
+
+    ``checkpoints`` is the projection each scope is answered at.
+    ``lagging_scopes`` names the scopes served from the catalog's published
+    projection rather than an exactly-current live one — the bounded staleness
+    a caller must disclose. Empty means the answer is exactly current.
+    """
+
+    checkpoints: dict[str, object]
+    lagging_scopes: tuple[str, ...]
+
+    @property
+    def stale(self) -> bool:
+        return bool(self.lagging_scopes)
+
+
+def runtime_retrieval_catalog_admission(
+    vault_root: Path,
+    *,
+    schedule_repair: bool = True,
+) -> RecallProjectionAdmission | None:
+    """Admit maintained recall, tolerating bounded projection lag.
+
+    :func:`runtime_retrieval_catalog_proof` answers a stricter question — "is
+    the catalog exactly at the LIVE projection" — and health, warm-up and the
+    repair worker all need that strictness. A request does not. Refusing a
+    request whenever the live registry has no projection for a scope turns
+    every cold, restarted or reprojection-evicted registry window into a total
+    semantic-recall outage, even though the sidecar holds a perfectly good
+    published projection (measured: `live_ckpt=None` while `stored_gen=2/4`).
+
+    So: take the strict proof when it binds, and otherwise fall back to the
+    catalog's own published checkpoint per scope. The fallback is admitted only
+    when every scope has a well-formed published projection whose policy
+    version and access fingerprint still equal this vault's current identity,
+    and whose semantic catalog identity still matches — the exact conditions
+    under which those rows still describe what this process may serve. Anything
+    else returns None and the caller refuses as before.
+    """
+    from . import freshness as freshness_module
+    from . import recall_policy
+
+    # Call shape matters, not just the result: the request path has always
+    # proved with the vault root alone, and that seam is pinned by callers who
+    # substitute their own proof. Only the side-effect-free probe passes the
+    # keyword.
+    strict = (
+        runtime_retrieval_catalog_proof(vault_root)
+        if schedule_repair
+        else runtime_retrieval_catalog_proof(vault_root, schedule_repair=False)
+    )
+    if strict is not None:
+        return RecallProjectionAdmission(dict(strict), ())
+
+    root = Path(vault_root)
+    store = get_store(root)
+    identity = recall_policy.recall_policy_identity(root)
+    checkpoints: dict[str, object] = {}
+    lagging: list[str] = []
+    for scope in ("kb", "vault"):
+        published = store.published_recall_checkpoint(scope)
+        if published is None or published.triple is None:
+            return None
+        if (published.policy_version, published.access_policy_fingerprint) != identity:
+            # The projection was published under an access identity this
+            # process no longer has; serving it could disclose pages the
+            # current policy hides. Refuse until republication.
+            return None
+        live = freshness_module.live_recall_checkpoint(root, scope)
+        if live is not None and live == published:
+            checkpoints[scope] = live
+            continue
+        checkpoints[scope] = published
+        lagging.append(scope)
+    if schedule_repair:
+        # Serving stale is a bridge, not a resting state: keep converging.
+        _schedule_runtime_catalog_repair(root)
+    return RecallProjectionAdmission(checkpoints, tuple(lagging))
+
+
 def runtime_retrieval_catalog_current(
     vault_root: Path,
     *,
@@ -2590,6 +2672,34 @@ class LexicalStore:
         self._write_checkpoint(
             conn, scope, freshness_module.recall_checkpoint(self.vault_root, scope)
         )
+
+    def published_recall_checkpoint(self, scope: str):
+        """This sidecar's own published recall checkpoint for `scope`, or None.
+
+        Read-only and O(1): a schema probe, the catalog identity row and one
+        checkpoint row. It never walks the vault, applies a delta, or schedules
+        repair. A checkpoint is returned ONLY when the sidecar is structurally
+        usable and its semantic catalog identity still matches the vault's, so
+        the rows it describes are still the ones this process would serve.
+
+        This is deliberately weaker than `catalog_readiness`: it answers "what
+        projection is published here", not "is that projection current".
+        """
+        if backend() == "python" or self._failed or not self.path.exists():
+            return None
+        conn: sqlite3.Connection | None = None
+        try:
+            conn = self._connect()
+            if not self._schema_is_current(conn):
+                return None
+            if self._meta_catalog_identity(conn) != catalog_semantic_identity(self.vault_root):
+                return None
+            return self._meta_checkpoint(conn, scope)
+        except sqlite3.Error:
+            return None
+        finally:
+            if conn is not None:
+                conn.close()
 
     def _meta_checkpoint(self, conn: sqlite3.Connection, scope: str):
         """The projected recall checkpoint stored for `scope`, or None.

--- a/src/exomem/readiness.py
+++ b/src/exomem/readiness.py
@@ -282,6 +282,26 @@ def warming_info() -> dict | None:
         }
 
 
+def graph_recovery_payload(vault_root) -> dict:
+    """Stable, content-free graph-recovery telemetry for the readiness payload.
+
+    Persistent `recovery_required` is the condition the 2026-08 incident ran on
+    for days unalarmed, so ELAPSED time is the signal, not a boolean. This
+    observes and records the condition, so whoever serves readiness keeps the
+    durable clock advancing. It names no path and no note — an age and a flag.
+    """
+    from . import graph_sync
+
+    try:
+        age = graph_sync.observe_recovery_state(vault_root)
+    except Exception:  # noqa: BLE001 - telemetry must never break readiness
+        return {"recovery_required": False, "recovery_age_s": None}
+    return {
+        "recovery_required": age is not None,
+        "recovery_age_s": None if age is None else round(age, 1),
+    }
+
+
 def wait(component: str, timeout: float | None = None) -> bool:
     _check(component)
     return _events[component].wait(timeout)

--- a/src/exomem/reserved_paths.py
+++ b/src/exomem/reserved_paths.py
@@ -383,7 +383,15 @@ _REGISTRY = (
     InternalStateDescriptor(
         "graph-handoff",
         "graph_sync",
-        exact=(".graph-sync.json", ".graph-sync-floor.json"),
+        exact=(
+            ".graph-sync.json",
+            ".graph-sync-floor.json",
+            # The durable recovery clock, reserved for the same reason as its
+            # siblings: graph_sync-owned state whose corruption silences an
+            # alarm, so it is published atomically through the owner path
+            # rather than written in place.
+            ".graph-sync-recovery.json",
+        ),
     ),
     InternalStateDescriptor(
         "graph-receipts", "graph_sync", trees=(".graph-commit-receipts",)

--- a/tests/test_drain_ownership_refusal.py
+++ b/tests/test_drain_ownership_refusal.py
@@ -1,0 +1,148 @@
+"""The out-of-process index drain refuses contended graph ownership (1.5 / 2.3).
+
+Measured in the 2026-08 incident: an `exomem index` drain and the live service
+contended for the same graph claim. The CLI held it at 0 CPU while the service
+kept minting receipts behind it -- ~2,143 receipts in 40 minutes, of which
+draining the backlog re-embedded exactly 3 files. The drain has to detect that
+a live service currently performs graph work for the target vault BEFORE taking
+any graph claim, and refuse with the stop-window remediation instead of
+contending for it.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from exomem import graph_sync, mutation_lock
+from exomem.writer_lease import active_manager
+
+
+def _coordinator(vault: Path) -> mutation_lock.VaultMutationCoordinator:
+    return mutation_lock.VaultMutationCoordinator(active_manager().config.state_dir, vault)
+
+
+def test_no_holder_means_no_live_graph_owner(vault: Path) -> None:
+    """Counter-scenario: an uncontended vault drains normally."""
+    assert graph_sync.live_graph_owner(vault) is None
+
+
+def test_a_live_graph_holder_is_detected(vault: Path) -> None:
+    """A service holding the boundary for GRAPH work is the refusal condition."""
+    held = threading.Event()
+    release = threading.Event()
+    observed: list[object] = []
+
+    def service() -> None:
+        with _coordinator(vault).hold(
+            operation="epistemic_graph_rebuild",
+            holder_kind="graph",
+        ):
+            held.set()
+            release.wait(timeout=30)
+
+    worker = threading.Thread(target=service, daemon=True)
+    worker.start()
+    try:
+        assert held.wait(timeout=30)
+        observed.append(graph_sync.live_graph_owner(vault))
+    finally:
+        release.set()
+        worker.join(timeout=30)
+
+    owner = observed[0]
+    assert owner is not None, "a live graph holder was not detected"
+    assert owner["holder_kind"] == "graph"
+
+
+def test_a_non_graph_holder_is_not_a_graph_owner(vault: Path) -> None:
+    """Counter-scenario: ordinary write traffic is not graph contention.
+
+    Refusing on any holder would make the drain unusable on a busy vault.
+    """
+    held = threading.Event()
+    release = threading.Event()
+    observed: list[object] = []
+
+    def writer() -> None:
+        with _coordinator(vault).hold(
+            operation="write_note",
+            holder_kind="write",
+        ):
+            held.set()
+            release.wait(timeout=30)
+
+    worker = threading.Thread(target=writer, daemon=True)
+    worker.start()
+    try:
+        assert held.wait(timeout=30)
+        observed.append(graph_sync.live_graph_owner(vault))
+    finally:
+        release.set()
+        worker.join(timeout=30)
+
+    assert observed[0] is None
+
+
+def test_the_cli_drain_refuses_and_names_the_stop_window(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Scenario: the drain exits without taking the claim, naming the remedy."""
+    from exomem import __main__ as main_module
+
+    monkeypatch.setattr(
+        graph_sync,
+        "live_graph_owner",
+        lambda _root: {
+            "state": "held",
+            "holder_kind": "graph",
+            "operation": "epistemic_graph_rebuild",
+            "age_seconds": 12.0,
+        },
+    )
+
+    def forbidden(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("the drain took a graph claim despite a live owner")
+
+    monkeypatch.setattr(graph_sync, "claim_rebuild_owner", forbidden)
+
+    code = main_module._index_main(["--vault", str(vault), "--dry-run"])
+
+    assert code != 0
+    message = capsys.readouterr().err
+    assert "stop window" in message.lower()
+    assert "graph" in message.lower()
+
+
+def test_the_cli_drain_proceeds_without_a_live_graph_owner(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Counter-scenario: no live graph owner means the drain is not blocked."""
+    from exomem import __main__ as main_module
+
+    monkeypatch.setattr(graph_sync, "live_graph_owner", lambda _root: None)
+
+    code = main_module._index_main(["--vault", str(vault), "--dry-run"])
+
+    assert code == 0
+
+
+def test_state_is_authoritative_over_a_stale_holder_kind(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`state` decides, not the leftover holder fields.
+
+    A free boundary happens to carry no `holder_kind` today, so the kind check
+    alone would pass by accident. Pin the intended precedence directly: if the
+    boundary is not held, nothing owns graph work, whatever else the payload
+    still says.
+    """
+    monkeypatch.setattr(
+        mutation_lock.VaultMutationCoordinator,
+        "snapshot",
+        lambda _self: {"state": "free", "holder_kind": "graph", "operation": "stale"},
+    )
+
+    assert graph_sync.live_graph_owner(vault) is None

--- a/tests/test_graph_recovery_alarm.py
+++ b/tests/test_graph_recovery_alarm.py
@@ -1,0 +1,251 @@
+"""Persistent graph recovery is an alarmed, bounded condition (tasks 1.3 / 2.2).
+
+The 2026-08 incident ran for days with no alarm. `recovery_required` is
+correct for minutes and pathological for hours: while it holds, every batch
+write used to mint a durable full-index receipt, so the backlog fed itself.
+Two conditions must stop being silent:
+
+* recovery has been required continuously beyond a configured bound; and
+* graph work is DISABLED while a durable recovery checkpoint exists -- the
+  provably unrecoverable combination, including when the kill switch comes
+  from an unowned site-packages `.pth` rather than the process environment.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from exomem import doctor, graph_sync
+
+
+def _durable_checkpoint(vault: Path) -> graph_sync.GraphSyncCheckpoint:
+    """Write a real durable checkpoint the graph has not acknowledged."""
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="a1b2c3d4e5f6a7b8c9d0e1f2",
+        paths=(("Knowledge Base/Notes/recovery-alarm.md", "0" * 64),),
+        created_paths=("Knowledge Base/Notes/recovery-alarm.md",),
+    )
+    graph_sync._write_checkpoint(vault, checkpoint)
+    return checkpoint
+
+
+def test_recovery_age_is_measured_and_persists(vault: Path) -> None:
+    """The age is durable: a restart must not reset the alarm clock."""
+    _durable_checkpoint(vault)
+    assert graph_sync.status(vault)["state"] == "recovery_required"
+
+    first = graph_sync.observe_recovery_state(vault)
+    assert first is not None and first >= 0.0
+
+    # A second observation must not restart the clock.
+    graph_sync.observe_recovery_state(vault)
+    assert graph_sync.recovery_age_seconds(vault) is not None
+
+
+def test_recovery_age_clears_when_recovery_completes(vault: Path) -> None:
+    """Returning to `current` clears the marker, so the alarm is not sticky."""
+    _durable_checkpoint(vault)
+    graph_sync.observe_recovery_state(vault)
+    assert graph_sync.recovery_age_seconds(vault) is not None
+
+    graph_sync.checkpoint_path(vault).unlink()
+    assert graph_sync.status(vault)["state"] == "current"
+
+    assert graph_sync.observe_recovery_state(vault) is None
+    assert graph_sync.recovery_age_seconds(vault) is None
+
+
+def test_recovery_beyond_the_bound_is_a_doctor_failure(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Scenario: recovery outlasting its bound raises a diagnostic FAILURE."""
+    _durable_checkpoint(vault)
+    graph_sync.observe_recovery_state(vault)
+    monkeypatch.setattr(
+        graph_sync,
+        "recovery_age_seconds",
+        lambda _root: doctor.RECOVERY_AGE_FAIL_SECONDS + 1.0,
+    )
+
+    check = doctor.check_graph_recovery_age(vault)
+
+    assert check.status == "fail"
+    assert "recovery" in check.message.lower()
+    assert check.remediation
+
+
+def test_recovery_within_the_bound_is_not_a_failure(vault: Path) -> None:
+    """Counter-scenario: minutes of recovery is normal, not an alarm."""
+    _durable_checkpoint(vault)
+    graph_sync.observe_recovery_state(vault)
+
+    check = doctor.check_graph_recovery_age(vault)
+
+    assert check.status != "fail"
+
+
+def test_graph_disabled_with_a_recovery_checkpoint_fails_immediately(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Scenario: the provably unrecoverable combination FAILs at once."""
+    _durable_checkpoint(vault)
+    monkeypatch.setenv("EXOMEM_DISABLE_GRAPH_INDEX", "1")
+
+    check = doctor.check_graph_recovery_age(vault)
+
+    assert check.status == "fail"
+    assert "EXOMEM_DISABLE_GRAPH_INDEX" in str(check.details) + check.message
+
+
+def test_graph_disabled_without_a_checkpoint_is_not_a_failure(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Counter-scenario: the kill switch alone is a deliberate choice, not a fault."""
+    monkeypatch.setenv("EXOMEM_DISABLE_GRAPH_INDEX", "1")
+    assert graph_sync.read_checkpoint(vault) is None
+
+    check = doctor.check_graph_recovery_age(vault)
+
+    assert check.status != "fail"
+
+
+def test_pth_injected_kill_switch_is_identified(
+    vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The disabling SOURCE must be named, including a site-packages `.pth`.
+
+    A stale `.pth` force-disabling the graph is what made recovery impossible
+    for days while the environment itself looked clean.
+    """
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    (site_packages / "zz-stale-exomem.pth").write_text(
+        "import os; os.environ.setdefault('EXOMEM_DISABLE_GRAPH_SCHEDULING', '1')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(doctor, "_site_package_dirs", lambda: [site_packages])
+
+    sources = doctor.graph_kill_switch_sources()
+
+    assert any("zz-stale-exomem.pth" in str(source) for source in sources)
+
+
+def test_pth_without_a_kill_switch_is_not_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Counter-scenario: an ordinary `.pth` is not a finding."""
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    (site_packages / "ordinary.pth").write_text("some/other/path\n", encoding="utf-8")
+    monkeypatch.setattr(doctor, "_site_package_dirs", lambda: [site_packages])
+
+    assert doctor.graph_kill_switch_sources() == []
+
+
+def test_readiness_payload_exposes_recovery_age(vault: Path) -> None:
+    """Scenario: the readiness payload exposes the recovery age."""
+    from exomem import readiness
+
+    _durable_checkpoint(vault)
+    graph_sync.observe_recovery_state(vault)
+
+    payload = readiness.graph_recovery_payload(vault)
+
+    assert payload["recovery_required"] is True
+    assert isinstance(payload["recovery_age_s"], float)
+    assert payload["recovery_age_s"] >= 0.0
+
+
+def test_the_recovery_check_actually_runs_in_the_doctor(vault: Path) -> None:
+    """A check nobody runs is not an alarm. Pin its presence in the real run."""
+    report = doctor.doctor(vault=str(vault))
+    ids = {check.id for check in report.checks}
+
+    assert "write_path.graph_recovery" in ids
+
+
+# --- The alarm clock itself must not be silenceable (HIGH) ------------------
+#
+# A corrupt marker used to read as age 0.0. That is not merely wrong, it is
+# self-silencing: `observe_recovery_state` saw 0.0 (not None) and never
+# restamped, and doctor's `age > bound` could never fire, so the FAIL was
+# permanently downgraded to a WARN. The marker is written during exactly the
+# crashes this subsystem exists to monitor, so a torn write is reachable.
+
+
+def _corrupt_marker(vault: Path) -> Path:
+    marker = graph_sync.recovery_marker_path(vault)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text('{"since": ', encoding="utf-8")  # torn write
+    return marker
+
+
+def test_a_corrupt_clock_is_restamped_not_treated_as_zero(vault: Path) -> None:
+    """(a) Observation must repair a corrupt clock, not accept it as 'just now'."""
+    _durable_checkpoint(vault)
+    marker = _corrupt_marker(vault)
+    assert graph_sync.recovery_clock_state(vault) == "corrupt"
+
+    graph_sync.observe_recovery_state(vault)
+
+    assert graph_sync.recovery_clock_state(vault) == "valid", (
+        "a corrupt recovery clock was left corrupt, so the alarm can never fire"
+    )
+    assert marker.exists()
+
+
+def test_a_corrupt_clock_during_recovery_is_a_doctor_failure(vault: Path) -> None:
+    """(b) An unreadable clock is its own FAIL, never a 0.0 warn."""
+    _durable_checkpoint(vault)
+    _corrupt_marker(vault)
+
+    check = doctor.check_graph_recovery_age(vault)
+
+    assert check.status == "fail", "a corrupt recovery clock downgraded FAIL to WARN"
+    assert check.remediation
+
+
+def test_recovery_age_is_none_for_a_corrupt_clock(vault: Path) -> None:
+    """`recovery_age_seconds` reports an age only when it has a real one."""
+    _durable_checkpoint(vault)
+    _corrupt_marker(vault)
+
+    assert graph_sync.recovery_age_seconds(vault) is None
+    assert graph_sync.recovery_clock_state(vault) == "corrupt"
+
+
+def test_observation_preserves_the_age_across_a_restart(vault: Path) -> None:
+    """The docstring's central property: a restart must not reset the clock.
+
+    Back-date the marker, then observe again as a restarted process would.
+    An implementation that restamps unconditionally zeroes the age here, which
+    is precisely how a restart loop keeps an alarm permanently silent.
+    """
+    import json
+    import time
+
+    _durable_checkpoint(vault)
+    graph_sync.observe_recovery_state(vault)
+    marker = graph_sync.recovery_marker_path(vault)
+    backdated = time.time() - 9000.0
+    marker.write_text(json.dumps({"since": backdated}), encoding="utf-8")
+
+    age = graph_sync.observe_recovery_state(vault)
+
+    assert age is not None
+    assert age > 8000.0, f"observation reset the durable recovery clock (age={age})"
+
+
+def test_the_recovery_marker_is_reserved_owner_bound_state(vault: Path) -> None:
+    """The durable clock is graph_sync state, like its checkpoint siblings."""
+    from exomem import reserved_paths
+    from exomem.kbdir import kb_dirname
+
+    marker = graph_sync.recovery_marker_path(vault)
+    result = reserved_paths.classify_logical(f"{kb_dirname()}/{marker.name}")
+
+    assert result.disposition is reserved_paths.PathDisposition.RESERVED
+    assert result.descriptor_id == "graph-handoff"

--- a/tests/test_index_sync.py
+++ b/tests/test_index_sync.py
@@ -983,3 +983,136 @@ def test_contended_lexical_upsert_stays_swallowed_from_the_batch_report(
     ]
     # The only recovery for the refused rows is the process-local registry.
     assert scheduled == [{"root": tmp_path, "deferred_paths": [page]}]
+
+
+# --- Graph durable-coverage carve-out (tasks 1.1 / 1.2 / 2.1) ---------------
+#
+# During `recovery_required` the registered checkpoint never equals the live
+# one, so EVERY batch write's graph deferral fails the report and mints a
+# durable full-component receipt -- even when the deferral already recorded
+# per-path graph receipts covering exactly that batch. That funnel is what
+# self-sustains: backlog -> recovery_required -> every write mints -> backlog.
+
+
+_GRAPH_REL = "Knowledge Base/Notes/graph-accounting.md"
+
+
+def _graph_deferral_report(code: str = "graph_repair_queued") -> index_sync.IndexSyncReport:
+    """A batch report whose graph component deferred, everything else done."""
+    return index_sync.IndexSyncReport(
+        operation="upsert",
+        requested_paths=(_GRAPH_REL,),
+        eligible_paths=(_GRAPH_REL,),
+        components=(
+            index_sync.IndexComponentOutcome("memory_refs", "completed", "ok"),
+            index_sync.IndexComponentOutcome("resolver", "completed", "ok"),
+            index_sync.IndexComponentOutcome("semantic_purge", "completed", "ok"),
+            index_sync.IndexComponentOutcome("lexstore", "completed", "ok"),
+            index_sync.IndexComponentOutcome("epistemic_graph", "deferred", code),
+            index_sync.IndexComponentOutcome("embeddings", "completed", "ok"),
+        ),
+    )
+
+
+def test_covered_graph_deferral_during_recovery_is_batch_success(
+    tmp_path: Path,
+) -> None:
+    """Task 1.1: per-path graph receipts covering the batch ARE the demand."""
+    target = tmp_path / _GRAPH_REL
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# Graph accounting\n", encoding="utf-8")
+    report = _graph_deferral_report()
+
+    # No registered checkpoint equals the live one: this is recovery_required,
+    # the state in which every graph deferral currently escalates.
+    assert graph_sync.registered_checkpoint(tmp_path) is None
+
+    index_sync.reset_deferral_telemetry()
+    # Uncovered first: nothing durably queued, so the report must still fail.
+    assert index_sync.full_upsert_succeeded(tmp_path, [target], report) is False
+    assert index_sync.deferral_telemetry()["uncovered_deferral_escalated"] == 1
+
+    # Now the deferral durably covers the batch's graph-input paths.
+    deferred_index.add_graph(tmp_path, [_GRAPH_REL])
+    assert deferred_index.snapshot_graph(tmp_path) != []
+
+    index_sync.reset_deferral_telemetry()
+    assert index_sync.full_upsert_succeeded(tmp_path, [target], report) is True
+    assert index_sync.deferral_telemetry() == {
+        "covered_deferral_accepted": 1,
+        "uncovered_deferral_escalated": 0,
+    }
+
+
+def test_uncovered_graph_deferral_still_fails_closed(tmp_path: Path) -> None:
+    """Task 1.2: a deferral with no covering receipts still mints the demand."""
+    target = tmp_path / _GRAPH_REL
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# Graph accounting\n", encoding="utf-8")
+
+    # A queue entry for a DIFFERENT path cannot bless this batch.
+    deferred_index.add_graph(tmp_path, ["Knowledge Base/Notes/unrelated.md"])
+    report = _graph_deferral_report()
+
+    index_sync.reset_deferral_telemetry()
+    assert index_sync.full_upsert_succeeded(tmp_path, [target], report) is False
+    assert index_sync.deferral_telemetry()["uncovered_deferral_escalated"] == 1
+
+
+def test_graph_deferral_without_a_coverage_claiming_code_fails_closed(
+    tmp_path: Path,
+) -> None:
+    """Only a code that means "durably queued" may be blessed by receipts.
+
+    `graph_index_disabled` records nothing, so a stale queue entry naming the
+    same path must not launder it into a success.
+    """
+    target = tmp_path / _GRAPH_REL
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# Graph accounting\n", encoding="utf-8")
+    deferred_index.add_graph(tmp_path, [_GRAPH_REL])
+
+    report = _graph_deferral_report(code="graph_index_disabled")
+
+    assert index_sync.full_upsert_succeeded(tmp_path, [target], report) is False
+
+
+def test_empty_graph_batch_cannot_be_blessed_by_coverage(tmp_path: Path) -> None:
+    """The empty set is a subset of every queue; acceptance must not be vacuous."""
+    deferred_index.add_graph(tmp_path, [_GRAPH_REL])
+    report = _graph_deferral_report()
+
+    assert index_sync.full_upsert_succeeded(tmp_path, [], report) is False
+
+
+def test_non_graph_input_paths_cannot_bless_a_graph_deferral(tmp_path: Path) -> None:
+    """Coverage is over GRAPH-INPUT paths, not merely over Markdown.
+
+    A note living inside graph_sync's own receipt directory is not a graph
+    input, so a batch made only of such paths has nothing to cover and must
+    fail closed rather than be accepted vacuously.
+    """
+    rel = "Knowledge Base/Notes/.graph-commit-receipts/receipt-note.md"
+    assert graph_sync.is_graph_input_path(rel) is False
+    target = tmp_path / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# Receipt note\n", encoding="utf-8")
+    deferred_index.add_graph(tmp_path, [rel])
+
+    report = index_sync.IndexSyncReport(
+        operation="upsert",
+        requested_paths=(rel,),
+        eligible_paths=(rel,),
+        components=(
+            index_sync.IndexComponentOutcome("memory_refs", "completed", "ok"),
+            index_sync.IndexComponentOutcome("resolver", "completed", "ok"),
+            index_sync.IndexComponentOutcome("semantic_purge", "completed", "ok"),
+            index_sync.IndexComponentOutcome("lexstore", "completed", "ok"),
+            index_sync.IndexComponentOutcome(
+                "epistemic_graph", "deferred", "graph_repair_queued"
+            ),
+            index_sync.IndexComponentOutcome("embeddings", "completed", "ok"),
+        ),
+    )
+
+    assert index_sync.full_upsert_succeeded(tmp_path, [target], report) is False

--- a/tests/test_projection_lag_tolerance.py
+++ b/tests/test_projection_lag_tolerance.py
@@ -1,0 +1,219 @@
+"""Semantic recall admission tolerates bounded projection lag (task 2.4).
+
+The maintained catalog is published with its own exact recall checkpoint. When
+the live freshness registry has no projection for a scope -- a cold or
+restarted registry, or one evicted by a reprojection/catch-up window -- the
+strict proof returns None and every semantic recall in that window refuses with
+RETRIEVAL_INDEX_WARMING, even though a perfectly good published projection is
+sitting in the sidecar.
+
+Measured on a warmed tmp vault (`rebuild_atomic()` then `freshness.clear()`):
+
+    strict proof = REFUSE   recall_is_live={'kb': False, 'vault': False}
+    kb:    live_ckpt=None  stored_gen=2
+    vault: live_ckpt=None  stored_gen=4
+
+Admission must serve from that published projection and disclose the staleness,
+refusing only when no published projection exists or its identity no longer
+matches.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from exomem import epistemic_graph, file_watcher, freshness, lexstore
+
+
+def _warm_catalog(vault: Path) -> file_watcher.FileWatcher:
+    """Seed the registry and bless the catalog through the real publish path."""
+    watcher = file_watcher.FileWatcher(vault)
+    watcher._reconcile_once(seed=True)
+    assert lexstore.get_store(vault).rebuild_atomic() is True
+    assert lexstore.runtime_retrieval_catalog_proof(vault, schedule_repair=False) is not None
+    return watcher
+
+
+def _go_cold() -> None:
+    """Drop the live registry, leaving the published projection intact."""
+    freshness.clear()
+
+
+def test_cold_registry_with_published_projection_admits_as_stale(vault: Path) -> None:
+    """A cold registry must serve the last published projection, not refuse."""
+    _warm_catalog(vault)
+    _go_cold()
+
+    # The strict proof stays strict: health, warm-up and repair still require
+    # the catalog to sit exactly at the live projection.
+    assert lexstore.runtime_retrieval_catalog_proof(vault, schedule_repair=False) is None
+    assert freshness.recall_is_live(vault, "kb") is False
+
+    admission = lexstore.runtime_retrieval_catalog_admission(vault, schedule_repair=False)
+
+    assert admission is not None, "a valid published projection was refused"
+    assert admission.stale is True
+    assert set(admission.checkpoints) == set(freshness.SCOPES)
+    assert set(admission.lagging_scopes) == set(freshness.SCOPES)
+
+
+def test_live_registry_at_the_catalog_admits_without_staleness(vault: Path) -> None:
+    """The exact-match case keeps admitting, and discloses nothing."""
+    _warm_catalog(vault)
+
+    admission = lexstore.runtime_retrieval_catalog_admission(vault, schedule_repair=False)
+
+    assert admission is not None
+    assert admission.stale is False
+    assert admission.lagging_scopes == ()
+
+
+def test_access_identity_change_still_refuses(vault: Path) -> None:
+    """Counter-scenario: an identity change refuses until republication."""
+    _warm_catalog(vault)
+    _go_cold()
+    assert lexstore.runtime_retrieval_catalog_admission(vault, schedule_repair=False) is not None
+
+    # A real access-policy change moves the access fingerprint, so the
+    # published projection no longer describes what this process may serve.
+    (vault / "Knowledge Base" / "_access.yaml").write_text(
+        "excluded:\n  - Private\n", encoding="utf-8"
+    )
+
+    assert lexstore.runtime_retrieval_catalog_admission(vault, schedule_repair=False) is None
+
+
+def test_absent_published_projection_still_refuses(vault: Path) -> None:
+    """Counter-scenario: nothing published means nothing to serve."""
+    watcher = file_watcher.FileWatcher(vault)
+    watcher._reconcile_once(seed=True)
+    _go_cold()
+
+    # No rebuild_atomic() ever ran, so no scope carries a published checkpoint.
+    assert lexstore.runtime_retrieval_catalog_admission(vault, schedule_repair=False) is None
+
+
+def test_graph_reprojection_window_does_not_refuse(vault: Path) -> None:
+    """The live-reported window: a graph rebuild must not blank semantic recall."""
+    _warm_catalog(vault)
+    graph = epistemic_graph.EpistemicGraphIndex(vault)
+    graph.rebuild_all()
+    _go_cold()
+
+    admission = lexstore.runtime_retrieval_catalog_admission(vault, schedule_repair=False)
+
+    assert admission is not None, "a graph reprojection window blanked semantic recall"
+    assert admission.stale is True
+
+
+def _managed_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    from exomem import readiness
+
+    monkeypatch.setattr(readiness, "runtime_managed", lambda: True)
+    monkeypatch.setattr(
+        readiness,
+        "retrieval_admission",
+        lambda _root=None: {"state": "ready", "admitted": True},
+    )
+
+
+def test_find_serves_a_cold_registry_with_a_staleness_disclosure(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The behaviour that matters: serve, disclose, do not refuse."""
+    from exomem import find as find_module
+
+    _warm_catalog(vault)
+    _go_cold()
+    _managed_runtime(monkeypatch)
+
+    degraded: list[str] = []
+    hits = find_module.find(vault, query="memory", limit=5, degraded_out=degraded)
+
+    assert isinstance(hits, list)
+    assert "recall_projection" in degraded, (
+        "a stale answer must disclose bounded staleness on the warming envelope"
+    )
+
+
+def test_find_at_an_exact_projection_discloses_nothing(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fully current answer must not carry the staleness marker."""
+    from exomem import find as find_module
+
+    _warm_catalog(vault)
+    _managed_runtime(monkeypatch)
+
+    degraded: list[str] = []
+    find_module.find(vault, query="memory", limit=5, degraded_out=degraded)
+
+    assert "recall_projection" not in degraded
+
+
+def test_find_still_refuses_when_nothing_is_published(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Counter-scenario: no published projection is still a refusal."""
+    from exomem import find as find_module
+
+    watcher = file_watcher.FileWatcher(vault)
+    watcher._reconcile_once(seed=True)
+    _go_cold()
+    _managed_runtime(monkeypatch)
+
+    with pytest.raises(find_module.RetrievalIndexWarming):
+        find_module.find(vault, query="memory", limit=5)
+
+
+def test_catalog_identity_change_still_refuses(vault: Path) -> None:
+    """Counter-scenario: the third identity component the spec names.
+
+    `catalog_semantic_identity` hashes the semantic-language registry, so
+    changing it invalidates the catalog's parsed rows WITHOUT touching recall
+    policy or the access fingerprint. The published projection's rows no longer
+    describe the corpus, so it must not be served.
+    """
+    from exomem import semantic_language_registry
+
+    _warm_catalog(vault)
+    _go_cold()
+    assert lexstore.runtime_retrieval_catalog_admission(vault, schedule_repair=False) is not None
+
+    registry = semantic_language_registry.registry_path(vault)
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text("kinds:\n  invented-kind:\n    label: Invented\n", encoding="utf-8")
+
+    assert lexstore.runtime_retrieval_catalog_admission(vault, schedule_repair=False) is None
+
+
+def test_a_published_row_without_a_triple_still_refuses(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A well-formed row whose triple is None proves no projection.
+
+    The checkpoint parses, so the row-shape guard passes it; without the
+    triple there is no projected corpus identity to serve against, and the
+    admission must refuse rather than answer from nothing.
+    """
+    _warm_catalog(vault)
+    _go_cold()
+    published = lexstore.get_store(vault).published_recall_checkpoint("kb")
+    assert published is not None
+
+    triple_less = freshness.RecallFreshnessCheckpoint(
+        published.instance_id,
+        published.generation,
+        None,
+        published.policy_version,
+        published.access_policy_fingerprint,
+    )
+    monkeypatch.setattr(
+        lexstore.LexicalStore,
+        "published_recall_checkpoint",
+        lambda _self, _scope: triple_less,
+    )
+
+    assert lexstore.runtime_retrieval_catalog_admission(vault, schedule_repair=False) is None


### PR DESCRIPTION
Completes `bound-graph-recovery-funnel`: projection-lag tolerance (the measured 60–90s hang-then-refuse windows during reprojection now serve from the published projection with a staleness disclosure; refusal bounded to absent projection or identity mismatch; strict proof untouched for health/warm-up/repair; access enforced per-page at egress), the epistemic_graph durable-coverage carve-out, a durable owner-bound recovery-age alarm with corrupt/NaN-clock handling and doctor FAILs (including .pth kill-switch detection), and the CLI drain ownership refusal. Harness evidence overturned the filed premise — writes never lag the catalog; the cold-registry window is the real trigger, and the spec scenario was realigned accordingly. Red-first, 24/24 mutation kills across two rounds; adversarial review REQUEST_CHANGES (HIGH: corrupt marker permanently silenced the alarm) → correction → recheck APPROVE with the reviewer re-running its own reproduction on the final bytes. 836 focused tests; ruff zero-regression; privacy clean; openspec strict 168/168. Tasks 1.x/2.x/3.1/3.2 complete; 3.3 live acceptance + 3.4 archive follow deploy.