### PR TITLE
fix(governance): fence old schema replicas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -558,6 +558,19 @@ jobs:
           enable-cache: true
       - name: Validate public build inputs before packaging
         run: python scripts/validate-public-artifacts.py --repository
+      - name: Prove the pinned pre-v4 binary is externally fenced
+        env:
+          EXOMEM_DISABLE_EMBEDDINGS: "1"
+          EXOMEM_DISABLE_MEDIA_EXTRACTION: "1"
+          EXOMEM_DISABLE_CLIP: "1"
+          EXOMEM_DISABLE_RANKING: "1"
+          EXOMEM_OLD_V3_PYTHON: ${{ runner.temp }}/exomem-old-v3/bin/python
+        run: |
+          uv venv "$RUNNER_TEMP/exomem-old-v3" --python 3.13
+          uv pip install --python "$EXOMEM_OLD_V3_PYTHON" "exomem==0.57.0"
+          uv run --frozen --python 3.13 python -m pytest -q \
+            tests/test_governance_old_v3_binary_fence.py \
+            --session-timeout=120
       - name: Build package
         run: uv build
       - name: Build generic standalone skill archives

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -35,6 +35,7 @@ import importlib.util
 import json
 import os
 import sys
+from dataclasses import replace
 from pathlib import Path
 
 from .kbdir import kb_dirname, kb_prefix
@@ -1379,13 +1380,51 @@ def _lease_release_main(config, *, confirmed: bool, as_json: bool) -> int:  # no
     return 0
 
 
+def _lease_schema_admission_main(
+    config, *, schema_version: int, as_json: bool  # noqa: ANN001
+) -> int:
+    from . import writer_lease
+
+    operator_token = os.environ.get("EXOMEM_LEASE_COORDINATOR_OPERATOR_TOKEN", "").strip()
+    if not operator_token:
+        _lease_print_error(
+            "schema admission requires EXOMEM_LEASE_COORDINATOR_OPERATOR_TOKEN.",
+            as_json=as_json,
+        )
+        return 1
+    try:
+        admission = writer_lease.LeaseCoordinatorClient(
+            replace(config, token=operator_token)
+        ).schema_admission(schema_version)
+    except writer_lease.OpError as error:
+        _lease_print_error(f"{error.code}: {error.message}", as_json=as_json)
+        return 1
+    payload = admission.as_dict()
+    if as_json:
+        print(json.dumps(payload))
+    elif admission.admitted:
+        print(
+            f"schema {schema_version} is admitted by external fence generation "
+            f"{admission.schema_fence_generation}."
+        )
+    else:
+        required = admission.required_schema_version
+        print(
+            f"schema {schema_version} is refused; external fence requires "
+            f"{required if required is not None else 'an enrolled schema'}.",
+            file=sys.stderr,
+        )
+    return 0 if admission.admitted else 1
+
+
 def _lease_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="exomem lease",
         description=(
-            "Ops-only writer-lease inspection and manual release. Not an MCP or REST "
-            "product command; 'steal'/'force-acquire' are deliberately absent — release "
-            "plus preferred-writer reclaim already hands over within roughly one lease TTL."
+            "Ops-only writer-lease inspection, schema admission, and manual release. "
+            "Not an MCP or REST product command; 'steal'/'force-acquire' are deliberately "
+            "absent — release plus preferred-writer reclaim already hands over within "
+            "roughly one lease TTL."
         ),
     )
     subcommands = parser.add_subparsers(dest="command", required=True)
@@ -1403,6 +1442,19 @@ def _lease_main(argv: list[str]) -> int:
     )
     release_parser.add_argument("--json", action="store_true", help="emit stable JSON")
 
+    admission_parser = subcommands.add_parser(
+        "schema-admission",
+        help="fail unless a release schema may join the externally fenced cell",
+    )
+    admission_parser.add_argument(
+        "--schema-version",
+        type=int,
+        choices=(3, 4),
+        required=True,
+        help="schema contract declared by the release being admitted",
+    )
+    admission_parser.add_argument("--json", action="store_true", help="emit stable JSON")
+
     args = parser.parse_args(argv)
 
     from . import writer_lease
@@ -1417,6 +1469,12 @@ def _lease_main(argv: list[str]) -> int:
 
     if args.command == "status":
         return _lease_status_main(config, as_json=args.json)
+    if args.command == "schema-admission":
+        return _lease_schema_admission_main(
+            config,
+            schema_version=args.schema_version,
+            as_json=args.json,
+        )
     return _lease_release_main(config, confirmed=args.yes, as_json=args.json)
 
 

--- a/src/exomem/lease_coordinator.py
+++ b/src/exomem/lease_coordinator.py
@@ -32,6 +32,13 @@ class SQLiteLeaseStore:
                 "vault_id TEXT PRIMARY KEY, holder TEXT, expires_at REAL, "
                 "fencing_token INTEGER NOT NULL DEFAULT 0)"
             )
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS lease_schema_fences ("
+                "vault_id TEXT PRIMARY KEY, governance_enrolled INTEGER NOT NULL "
+                "CHECK(governance_enrolled=1), schema_version INTEGER NOT NULL "
+                "CHECK(schema_version IN (3,4)), generation INTEGER NOT NULL "
+                "CHECK(generation>0))"
+            )
 
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(self.path, timeout=10, isolation_level=None)
@@ -39,62 +46,112 @@ class SQLiteLeaseStore:
         return conn
 
     @staticmethod
-    def _record(row, *, granted: bool = False) -> dict:  # noqa: ANN001
-        return {
+    def _record(row, *, granted: bool = False, fence=None) -> dict:  # noqa: ANN001
+        record = {
             "holder": row[0] if row else None,
             "expires_at": row[1] if row and row[0] else None,
             "fencing_token": int(row[2]) if row else 0,
             "granted": granted,
         }
+        if fence is not None:
+            record.update(
+                required_schema_version=int(fence[0]),
+                schema_fence_generation=int(fence[1]),
+                governance_enrolled=True,
+            )
+        return record
 
-    def acquire(self, vault_id: str, replica_id: str, ttl_seconds: float) -> dict:
+    @staticmethod
+    def _schema_version(value: object) -> int:
+        if isinstance(value, bool) or not isinstance(value, int) or value not in {3, 4}:
+            raise ValueError("schema_version must be 3 or 4")
+        return value
+
+    @staticmethod
+    def _generation(value: object, *, minimum: int = 0) -> int:
+        if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+            raise ValueError("expected_generation is invalid")
+        return value
+
+    @staticmethod
+    def _fence_row(conn: sqlite3.Connection, vault_id: str):  # noqa: ANN205
+        return conn.execute(
+            "SELECT schema_version, generation FROM lease_schema_fences WHERE vault_id=?",
+            (vault_id,),
+        ).fetchone()
+
+    @staticmethod
+    def _client_schema(value: object | None) -> int:
+        # Released pre-v4 coordinators sent no schema field. Once a vault is
+        # enrolled, that exact legacy wire shape means schema 3; it must never
+        # be interpreted as "whatever the coordinator currently requires".
+        if value is None:
+            return 3
+        return SQLiteLeaseStore._schema_version(value)
+
+    def acquire(
+        self,
+        vault_id: str,
+        replica_id: str,
+        ttl_seconds: float,
+        *,
+        schema_version: object | None = None,
+    ) -> dict:
         now = self.clock()
         expires = now + ttl_seconds
         with self._connect() as conn:
             conn.execute("BEGIN IMMEDIATE")
+            fence = self._fence_row(conn, vault_id)
             row = conn.execute(
                 "SELECT holder, expires_at, fencing_token FROM leases WHERE vault_id = ?",
                 (vault_id,),
             ).fetchone()
+            if fence is not None and self._client_schema(schema_version) != int(fence[0]):
+                conn.execute("COMMIT")
+                return self._record(row, fence=fence)
             if row is None:
                 conn.execute(
                     "INSERT INTO leases(vault_id, holder, expires_at, fencing_token) VALUES (?, ?, ?, 1)",
                     (vault_id, replica_id, expires),
                 )
                 conn.execute("COMMIT")
-                return {
-                    "holder": replica_id,
-                    "expires_at": expires,
-                    "fencing_token": 1,
-                    "granted": True,
-                }
+                return self._record((replica_id, expires, 1), granted=True, fence=fence)
             holder, old_expiry, token = row
             active = holder is not None and old_expiry is not None and old_expiry > now
             if active and holder != replica_id:
                 conn.execute("COMMIT")
-                return self._record(row)
+                return self._record(row, fence=fence)
             new_token = token if active and holder == replica_id else token + 1
             conn.execute(
                 "UPDATE leases SET holder = ?, expires_at = ?, fencing_token = ? WHERE vault_id = ?",
                 (replica_id, expires, new_token, vault_id),
             )
             conn.execute("COMMIT")
-            return {
-                "holder": replica_id,
-                "expires_at": expires,
-                "fencing_token": new_token,
-                "granted": True,
-            }
+            return self._record(
+                (replica_id, expires, new_token), granted=True, fence=fence
+            )
 
-    def renew(self, vault_id: str, replica_id: str, fencing_token: int, ttl_seconds: float) -> dict:
+    def renew(
+        self,
+        vault_id: str,
+        replica_id: str,
+        fencing_token: int,
+        ttl_seconds: float,
+        *,
+        schema_version: object | None = None,
+    ) -> dict:
         now = self.clock()
         expires = now + ttl_seconds
         with self._connect() as conn:
             conn.execute("BEGIN IMMEDIATE")
+            fence = self._fence_row(conn, vault_id)
             row = conn.execute(
                 "SELECT holder, expires_at, fencing_token FROM leases WHERE vault_id = ?",
                 (vault_id,),
             ).fetchone()
+            if fence is not None and self._client_schema(schema_version) != int(fence[0]):
+                conn.execute("COMMIT")
+                return self._record(row, fence=fence)
             valid = bool(
                 row
                 and row[0] == replica_id
@@ -108,7 +165,7 @@ class SQLiteLeaseStore:
                 )
                 row = (replica_id, expires, fencing_token)
             conn.execute("COMMIT")
-            return self._record(row, granted=valid)
+            return self._record(row, granted=valid, fence=fence)
 
     def release(self, vault_id: str, replica_id: str, fencing_token: int) -> dict:
         with self._connect() as conn:
@@ -131,6 +188,7 @@ class SQLiteLeaseStore:
         now = self.clock()
         with self._connect() as conn:
             conn.execute("BEGIN IMMEDIATE")
+            fence = self._fence_row(conn, vault_id)
             row = conn.execute(
                 "SELECT holder, expires_at, fencing_token FROM leases WHERE vault_id = ?",
                 (vault_id,),
@@ -142,7 +200,102 @@ class SQLiteLeaseStore:
                 )
                 row = (None, None, row[2])
             conn.execute("COMMIT")
-            return self._record(row)
+            return self._record(row, fence=fence)
+
+    def schema_fence(self, vault_id: str) -> dict | None:
+        with self._connect() as conn:
+            row = self._fence_row(conn, vault_id)
+        if row is None:
+            return None
+        return {
+            "governance_enrolled": True,
+            "schema_version": int(row[0]),
+            "generation": int(row[1]),
+        }
+
+    def schema_admission(self, vault_id: str, *, schema_version: object) -> dict:
+        requested = self._schema_version(schema_version)
+        with self._connect() as conn:
+            row = self._fence_row(conn, vault_id)
+        if row is None:
+            return {
+                "admitted": False,
+                "governance_enrolled": False,
+                "required_schema_version": None,
+                "schema_fence_generation": None,
+            }
+        required, generation = int(row[0]), int(row[1])
+        return {
+            "admitted": requested == required,
+            "governance_enrolled": True,
+            "required_schema_version": required,
+            "schema_fence_generation": generation,
+        }
+
+    def transition_schema_fence(
+        self,
+        vault_id: str,
+        *,
+        expected_generation: object,
+        schema_version: object,
+    ) -> tuple[dict, bool]:
+        expected = self._generation(expected_generation)
+        target = self._schema_version(schema_version)
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            current = self._fence_row(conn, vault_id)
+            if current is None:
+                if expected != 0:
+                    conn.execute("COMMIT")
+                    return {}, False
+                generation = 1
+                conn.execute(
+                    "INSERT INTO lease_schema_fences"
+                    "(vault_id, governance_enrolled, schema_version, generation) "
+                    "VALUES (?, 1, ?, ?)",
+                    (vault_id, target, generation),
+                )
+            else:
+                current_schema, current_generation = int(current[0]), int(current[1])
+                # A lost acknowledgement replays the already-published target
+                # instead of advancing the generation a second time.
+                if current_schema == target and expected in {
+                    current_generation,
+                    current_generation - 1,
+                }:
+                    conn.execute("COMMIT")
+                    return {
+                        "governance_enrolled": True,
+                        "schema_version": current_schema,
+                        "generation": current_generation,
+                    }, True
+                if expected != current_generation:
+                    conn.execute("COMMIT")
+                    return {
+                        "governance_enrolled": True,
+                        "schema_version": current_schema,
+                        "generation": current_generation,
+                    }, False
+                generation = current_generation + 1
+                conn.execute(
+                    "UPDATE lease_schema_fences SET schema_version=?, generation=? "
+                    "WHERE vault_id=?",
+                    (target, generation, vault_id),
+                )
+            # The schema cut and writer cut are one coordinator transaction.
+            # Any holder from the predecessor generation is fenced before the
+            # new schema can admit a replacement.
+            conn.execute(
+                "UPDATE leases SET holder=NULL, expires_at=NULL, "
+                "fencing_token=fencing_token+1 WHERE vault_id=?",
+                (vault_id,),
+            )
+            conn.execute("COMMIT")
+        return {
+            "governance_enrolled": True,
+            "schema_version": target,
+            "generation": generation,
+        }, True
 
 
 class SQLiteStateStore:
@@ -267,7 +420,11 @@ class SQLiteStateStore:
 
 
 def create_app(
-    *, database: Path | None = None, bearer_token: str | None = None, clock=time.time
+    *,
+    database: Path | None = None,
+    bearer_token: str | None = None,
+    operator_token: str | None = None,
+    clock=time.time,
 ) -> Starlette:
     database = database or Path(
         os.environ.get("EXOMEM_LEASE_COORDINATOR_DB", "writer-leases.sqlite")
@@ -277,6 +434,17 @@ def create_app(
         if bearer_token is not None
         else (os.environ.get("EXOMEM_LEASE_COORDINATOR_TOKEN", "").strip() or None)
     )
+    operator_token = (
+        operator_token
+        if operator_token is not None
+        else (os.environ.get("EXOMEM_LEASE_COORDINATOR_OPERATOR_TOKEN", "").strip() or None)
+    )
+    if (
+        bearer_token is not None
+        and operator_token is not None
+        and secrets.compare_digest(bearer_token, operator_token)
+    ):
+        raise ValueError("operator token must differ from the normal lease bearer")
     store = SQLiteLeaseStore(database, clock=clock)
     state_store = SQLiteStateStore(database, clock=clock)
 
@@ -286,6 +454,14 @@ def create_app(
         header = request.headers.get("authorization", "")
         return header.startswith("Bearer ") and secrets.compare_digest(
             header[7:].strip(), bearer_token
+        )
+
+    def operator_authorized(request: Request) -> bool:
+        if not operator_token:
+            return False
+        header = request.headers.get("authorization", "")
+        return header.startswith("Bearer ") and secrets.compare_digest(
+            header[7:].strip(), operator_token
         )
 
     async def lease(request: Request) -> JSONResponse:
@@ -299,14 +475,65 @@ def create_app(
             body = await request.json()
             replica_id = str(body["replica_id"])
             if operation == "acquire":
-                result = store.acquire(vault_id, replica_id, _ttl(body))
+                result = store.acquire(
+                    vault_id,
+                    replica_id,
+                    _ttl(body),
+                    schema_version=body.get("schema_version"),
+                )
             elif operation == "renew":
-                result = store.renew(vault_id, replica_id, int(body["fencing_token"]), _ttl(body))
+                result = store.renew(
+                    vault_id,
+                    replica_id,
+                    int(body["fencing_token"]),
+                    _ttl(body),
+                    schema_version=body.get("schema_version"),
+                )
             elif operation == "release":
                 result = store.release(vault_id, replica_id, int(body["fencing_token"]))
             else:
                 return JSONResponse({"error": "unknown operation"}, status_code=404)
         except (KeyError, TypeError, ValueError):
+            return JSONResponse({"error": "invalid request"}, status_code=400)
+        return JSONResponse(result)
+
+    async def schema_fence(request: Request) -> JSONResponse:
+        if not operator_authorized(request):
+            return JSONResponse({"error": "unauthorized"}, status_code=401)
+        vault_id = request.path_params["vault_id"]
+        if request.method == "GET":
+            result = store.schema_fence(vault_id)
+            if result is None:
+                return JSONResponse({"error": "not found"}, status_code=404)
+            return JSONResponse(result)
+        try:
+            body = await request.json()
+            result, accepted = store.transition_schema_fence(
+                vault_id,
+                expected_generation=body["expected_generation"],
+                schema_version=body["schema_version"],
+            )
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            return JSONResponse({"error": "invalid request"}, status_code=400)
+        if not accepted:
+            return JSONResponse(
+                {"error": "schema fence conflict", "current": result}, status_code=409
+            )
+        return JSONResponse(result)
+
+    async def schema_admission(request: Request) -> JSONResponse:
+        if not operator_authorized(request):
+            return JSONResponse({"error": "unauthorized"}, status_code=401)
+        try:
+            body = await request.json()
+            replica_id = body["replica_id"]
+            if not isinstance(replica_id, str) or not 1 <= len(replica_id) <= 512:
+                raise ValueError
+            result = store.schema_admission(
+                request.path_params["vault_id"],
+                schema_version=body["schema_version"],
+            )
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
             return JSONResponse({"error": "invalid request"}, status_code=400)
         return JSONResponse(result)
 
@@ -364,6 +591,16 @@ def create_app(
         routes=[
             Route("/v1/vaults/{vault_id:str}/lease", lease, methods=["GET"]),
             Route("/v1/vaults/{vault_id:str}/lease/{operation:str}", lease, methods=["POST"]),
+            Route(
+                "/v1/vaults/{vault_id:str}/schema-fence",
+                schema_fence,
+                methods=["GET", "PUT"],
+            ),
+            Route(
+                "/v1/vaults/{vault_id:str}/schema-fence/admit",
+                schema_admission,
+                methods=["POST"],
+            ),
             Route("/v1/state/{namespace:str}/{operation:str}", state, methods=["POST"]),
         ]
     )

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -698,6 +698,10 @@ class LeaseConfig:
     # `0` disables idle release entirely. A preferred replica is exempt —
     # see writer_lease.py's `_maybe_idle_release` docstring for why.
     idle_release_seconds: float = 60.0
+    # This is the binary's writer-side schema contract, not a caller-selected
+    # view of the vault. Pre-v4 clients omit the field entirely; the external
+    # coordinator interprets that released wire shape as schema 3.
+    schema_version: int = 4
 
     @property
     def enabled(self) -> bool:
@@ -775,24 +779,96 @@ class LeaseRecord:
     expires_at: float | None
     fencing_token: int
     granted: bool = False
+    required_schema_version: int | None = None
+    schema_fence_generation: int | None = None
+    governance_enrolled: bool = False
 
     @classmethod
     def from_json(cls, data: Mapping[str, Any]) -> LeaseRecord:
         holder = data.get("holder")
         expires = data.get("expires_at")
         token = data.get("fencing_token", 0)
+        granted = data.get("granted", False)
+        enrolled = data.get("governance_enrolled", False)
         if holder is not None and not isinstance(holder, str):
             raise ValueError("holder must be a string or null")
         if expires is not None and not isinstance(expires, (int, float)):
             raise ValueError("expires_at must be a number or null")
         if isinstance(token, bool) or not isinstance(token, int):
             raise ValueError("fencing_token must be an integer")
+        if not isinstance(granted, bool) or not isinstance(enrolled, bool):
+            raise ValueError("lease booleans are invalid")
+        required_schema = data.get("required_schema_version")
+        fence_generation = data.get("schema_fence_generation")
+        if required_schema is not None and (
+            isinstance(required_schema, bool)
+            or not isinstance(required_schema, int)
+            or required_schema not in {3, 4}
+        ):
+            raise ValueError("required_schema_version must be 3, 4, or null")
+        if fence_generation is not None and (
+            isinstance(fence_generation, bool)
+            or not isinstance(fence_generation, int)
+            or fence_generation < 1
+        ):
+            raise ValueError("schema_fence_generation must be a positive integer or null")
+        has_fence = required_schema is not None and fence_generation is not None
+        if enrolled != has_fence:
+            raise ValueError("schema fence metadata is inconsistent")
         return cls(
             holder,
             float(expires) if expires is not None else None,
             token,
-            bool(data.get("granted")),
+            granted,
+            required_schema,
+            fence_generation,
+            enrolled,
         )
+
+
+@dataclass(frozen=True)
+class SchemaAdmission:
+    admitted: bool
+    governance_enrolled: bool
+    required_schema_version: int | None
+    schema_fence_generation: int | None
+
+    @classmethod
+    def from_json(cls, data: Mapping[str, Any]) -> SchemaAdmission:
+        expected_fields = {
+            "admitted",
+            "governance_enrolled",
+            "required_schema_version",
+            "schema_fence_generation",
+        }
+        if set(data) != expected_fields:
+            raise ValueError("schema admission response fields are invalid")
+        admitted = data.get("admitted")
+        enrolled = data.get("governance_enrolled")
+        required = data.get("required_schema_version")
+        generation = data.get("schema_fence_generation")
+        if not isinstance(admitted, bool) or not isinstance(enrolled, bool):
+            raise ValueError("schema admission booleans are invalid")
+        if required is not None and (
+            isinstance(required, bool) or not isinstance(required, int) or required not in {3, 4}
+        ):
+            raise ValueError("required_schema_version is invalid")
+        if generation is not None and (
+            isinstance(generation, bool) or not isinstance(generation, int) or generation < 1
+        ):
+            raise ValueError("schema_fence_generation is invalid")
+        has_fence = required is not None and generation is not None
+        if enrolled != has_fence or (admitted and not enrolled):
+            raise ValueError("schema admission response has inconsistent authority")
+        return cls(admitted, enrolled, required, generation)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "admitted": self.admitted,
+            "governance_enrolled": self.governance_enrolled,
+            "required_schema_version": self.required_schema_version,
+            "schema_fence_generation": self.schema_fence_generation,
+        }
 
 
 #: Statuses that mean the URL answered and does not implement the lease
@@ -834,7 +910,7 @@ def _coordinator_unavailable_error(exc: BaseException) -> OpError:
     )
 
 
-def _contract_absent_error(url: str, operation: str, status: int) -> OpError:
+def _contract_absent_error(url: str, route: str, status: int) -> OpError:
     """A URL that answers but does not serve the writer-lease contract.
 
     Fail-closed exactly like an unavailable coordinator -- authority is still
@@ -842,7 +918,6 @@ def _contract_absent_error(url: str, operation: str, status: int) -> OpError:
     configuration fault instead of an outage, and callers that poll can slow
     down instead of asking a 404 the same question every five seconds.
     """
-    route = "/v1/vaults/<id>/lease" + (f"/{operation}" if operation else "")
     safe_url = _redacted_coordinator_url(url)
     logger.warning(
         "writer-lease coordinator %s answered %d for %s; "
@@ -874,7 +949,11 @@ class LeaseCoordinatorClient:
         return self._request(
             "POST",
             "acquire",
-            {"replica_id": self.config.replica_id, "ttl_seconds": self.config.ttl_seconds},
+            {
+                "replica_id": self.config.replica_id,
+                "ttl_seconds": self.config.ttl_seconds,
+                "schema_version": self.config.schema_version,
+            },
         )
 
     def renew(self, fencing_token: int) -> LeaseRecord:
@@ -885,6 +964,7 @@ class LeaseCoordinatorClient:
                 "replica_id": self.config.replica_id,
                 "fencing_token": fencing_token,
                 "ttl_seconds": self.config.ttl_seconds,
+                "schema_version": self.config.schema_version,
             },
         )
 
@@ -909,10 +989,55 @@ class LeaseCoordinatorClient:
     def status(self) -> LeaseRecord:
         return self._request("GET", "", None)
 
+    def schema_admission(self, schema_version: int) -> SchemaAdmission:
+        if isinstance(schema_version, bool) or schema_version not in {3, 4}:
+            raise ValueError("schema_version must be 3 or 4")
+        vault = urllib.parse.quote(str(self.config.vault_id), safe="")
+        payload = self._request_json(
+            "POST",
+            f"/v1/vaults/{vault}/schema-fence/admit",
+            {
+                "replica_id": self.config.replica_id,
+                "schema_version": schema_version,
+            },
+            contract_route="/v1/vaults/<id>/schema-fence/admit",
+        )
+        try:
+            admission = SchemaAdmission.from_json(payload)
+            expected_admission = bool(
+                admission.governance_enrolled
+                and admission.required_schema_version == schema_version
+            )
+            if admission.admitted != expected_admission:
+                raise ValueError("schema admission decision disagrees with its fence")
+            return admission
+        except ValueError as exc:
+            raise _coordinator_unavailable_error(exc) from None
+
     def _request(self, method: str, operation: str, body: dict | None) -> LeaseRecord:
         vault = urllib.parse.quote(str(self.config.vault_id), safe="")
         suffix = f"/{operation}" if operation else ""
-        url = f"{self.config.url}/v1/vaults/{vault}/lease{suffix}"
+        route = f"/v1/vaults/{vault}/lease{suffix}"
+        payload = self._request_json(
+            method,
+            route,
+            body,
+            contract_route="/v1/vaults/<id>/lease" + (f"/{operation}" if operation else ""),
+        )
+        try:
+            return LeaseRecord.from_json(payload)
+        except ValueError as exc:
+            raise _coordinator_unavailable_error(exc) from None
+
+    def _request_json(
+        self,
+        method: str,
+        route: str,
+        body: dict | None,
+        *,
+        contract_route: str,
+    ) -> dict[str, Any]:
+        url = f"{self.config.url}{route}"
         headers = {"Accept": "application/json", "User-Agent": _COORDINATOR_USER_AGENT}
         data = None
         if body is not None:
@@ -926,12 +1051,14 @@ class LeaseCoordinatorClient:
                 payload = json.loads(response.read().decode("utf-8"))
             if not isinstance(payload, dict):
                 raise ValueError("response is not an object")
-            return LeaseRecord.from_json(payload)
+            return payload
         except urllib.error.HTTPError as exc:
             # HTTPError subclasses URLError, so it has to be caught first for
             # the status to be visible at all.
             if exc.code in _CONTRACT_ABSENT_STATUSES:
-                raise _contract_absent_error(self.config.url, operation, exc.code) from None
+                raise _contract_absent_error(
+                    self.config.url, contract_route, exc.code
+                ) from None
             raise _coordinator_unavailable_error(exc) from None
         except (
             urllib.error.URLError,
@@ -2311,6 +2438,22 @@ class LeaseManager:
                 self._record_coordinator_error(error.code)
                 self._record_lease_op("acquire", "error")
                 raise
+            if (
+                record.governance_enrolled
+                and record.required_schema_version is not None
+                and record.required_schema_version != self.config.schema_version
+            ):
+                self._record_lease_op("acquire", "schema_refused")
+                raise OpError(
+                    "WRITER_SCHEMA_FENCE_MISMATCH",
+                    "this replica does not match the enrolled writer schema",
+                    "Drain this replica and deploy the schema version selected by the "
+                    "external lease fence.",
+                    details={
+                        "required_schema_version": record.required_schema_version,
+                        "schema_fence_generation": record.schema_fence_generation,
+                    },
+                )
             if not record.granted or record.holder != self.config.replica_id:
                 self._record_lease_op("acquire", "refused")
                 raise OpError(

--- a/tests/test_governance_old_v3_binary_fence.py
+++ b/tests/test_governance_old_v3_binary_fence.py
@@ -1,0 +1,413 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import socket
+import sqlite3
+import subprocess
+import threading
+import time
+import urllib.request
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+import uvicorn
+
+from exomem import init as init_module
+from exomem.governance import policy, schema_v4, store
+from exomem.lease_coordinator import SQLiteLeaseStore, create_app
+
+OLD_V3_PYTHON_ENV = "EXOMEM_OLD_V3_PYTHON"
+OLD_V3_VERSION = "0.57.0"
+POLICY_DOCUMENTS = (
+    (
+        "scopes/old-binary-probe.yaml",
+        b"governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\npaths:\n  - Notes/**\n",
+    ),
+)
+
+
+def _old_python() -> Path:
+    raw = os.environ.get(OLD_V3_PYTHON_ENV, "").strip()
+    if not raw:
+        pytest.skip(f"{OLD_V3_PYTHON_ENV} does not name the pinned old binary")
+    executable = Path(raw)
+    if not executable.is_file():
+        pytest.fail(f"{OLD_V3_PYTHON_ENV} does not name a file")
+    observed = subprocess.run(
+        [
+            str(executable),
+            "-c",
+            "import importlib.metadata; print(importlib.metadata.version('exomem'))",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    ).stdout.strip()
+    assert observed == OLD_V3_VERSION
+    return executable
+
+
+def _v4_vault(tmp_path: Path) -> tuple[Path, schema_v4.VerifiedActiveGovernanceState]:
+    vault = tmp_path / "vault"
+    init_module.init_vault(vault)
+    legacy_schema = vault / "Knowledge Base" / "_Schema"
+    legacy_schema.mkdir(parents=True, exist_ok=True)
+    legacy_schema.joinpath("SKILL.md").write_bytes(
+        (Path(init_module.__file__).parent / "_scaffold" / "_Schema" / "SKILL.md").read_bytes()
+    )
+    governance = vault / "Knowledge Base" / "_Governance"
+    for relative, content in POLICY_DOCUMENTS:
+        target = governance / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+    note = vault / "Knowledge Base" / "Notes" / "Insights" / "visible.md"
+    note.write_text(
+        "---\ntype: insight\nstatus: active\n---\n\n# Visible\n\nlantern baseline\n",
+        encoding="utf-8",
+    )
+
+    compiled = policy.compile_documents(dict(POLICY_DOCUMENTS))
+    assert not compiled.empty and not compiled.blocked
+    connection = sqlite3.connect(store.sidecar_path(vault))
+    try:
+        store._migrate(connection)
+        connection.commit()
+        migration = schema_v4.migrate_v3_connection(
+            connection,
+            schema_v4.MigrationSeed(
+                activation_store_id="activation-store-old-binary-probe",
+                logical_vault_id="logical-vault-old-binary-probe",
+                activation_epoch=1,
+                policy=schema_v4.PolicyGenerationSeed(
+                    generation_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                    source_documents=POLICY_DOCUMENTS,
+                    source_fingerprint=compiled.fingerprint,
+                    conflict_digest="1" * 64,
+                    compiled_policy=policy.canonical_compiled_bytes(compiled),
+                    policy_fingerprint=compiled.fingerprint,
+                    compiler_schema_version=1,
+                    projector_schema_version=1,
+                    predecessor_generation_id=None,
+                    authoring_event_id="event-old-binary-probe",
+                    receipt_event_id="receipt-old-binary-probe",
+                    created_at=1_800_000_000,
+                ),
+                catalog=schema_v4.CatalogGenerationSeed(
+                    catalog_generation=1,
+                    descriptor=b'{"artifacts":[]}',
+                    artifact_count=0,
+                    created_at=1_800_000_000,
+                ),
+                namespace=schema_v4.ProjectionNamespaceSeed(
+                    namespace_id="projection-namespace-old-binary-probe",
+                    evidence=b'{"ready":true}',
+                    ready_at=1_800_000_000,
+                ),
+                migrated_at=1_800_000_000,
+            ),
+        )
+        active = schema_v4.load_active_state(
+            connection,
+            expected_logical_vault_id="logical-vault-old-binary-probe",
+            expected_activation_store_id="activation-store-old-binary-probe",
+            expected_activation_epoch=1,
+            expected_activation_state_digest=migration.activation_state_digest,
+        )
+    finally:
+        connection.close()
+    return vault, active
+
+
+def _database_digest(vault: Path) -> str:
+    with sqlite3.connect(store.sidecar_path(vault)) as connection:
+        payload = "\n".join(connection.iterdump()).encode("utf-8")
+        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+    return hashlib.sha256(str(version).encode("ascii") + b"\0" + payload).hexdigest()
+
+
+@contextmanager
+def _lease_server(database: Path):
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    port = int(listener.getsockname()[1])
+    server = uvicorn.Server(
+        uvicorn.Config(
+            create_app(
+                database=database,
+                bearer_token="lease-secret",
+                operator_token="operator-secret",
+            ),
+            log_level="error",
+            lifespan="off",
+        )
+    )
+    thread = threading.Thread(
+        target=server.run,
+        kwargs={"sockets": [listener]},
+        daemon=True,
+    )
+    thread.start()
+    deadline = time.monotonic() + 10
+    while not server.started and thread.is_alive() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert server.started and thread.is_alive()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=10)
+        listener.close()
+        assert not thread.is_alive()
+
+
+def _old_environment(
+    tmp_path: Path,
+    vault: Path,
+    coordinator_url: str | None,
+    *,
+    state_name: str,
+) -> dict[str, str]:
+    state = tmp_path / state_name
+    state.mkdir(mode=0o700, exist_ok=True)
+    env = {
+        **os.environ,
+        "EXOMEM_VAULT_PATH": str(vault),
+        "EXOMEM_WRITER_LEASE_STATE_DIR": str(state),
+        "XDG_STATE_HOME": str(state),
+        "EXOMEM_DISABLE_EMBEDDINGS": "1",
+        "EXOMEM_DISABLE_MEDIA_EXTRACTION": "1",
+        "EXOMEM_DISABLE_CLIP": "1",
+        "EXOMEM_DISABLE_RANKING": "1",
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    for name in (
+        "EXOMEM_WRITER_LEASE_URL",
+        "EXOMEM_WRITER_LEASE_VAULT_ID",
+        "EXOMEM_WRITER_LEASE_REPLICA_ID",
+        "EXOMEM_WRITER_LEASE_TOKEN",
+        "EXOMEM_WRITER_LEASE_PREFERRED",
+    ):
+        env.pop(name, None)
+    if coordinator_url is not None:
+        env.update(
+            EXOMEM_WRITER_LEASE_URL=coordinator_url,
+            EXOMEM_WRITER_LEASE_VAULT_ID="old-binary-probe",
+            EXOMEM_WRITER_LEASE_REPLICA_ID="old-v3",
+            EXOMEM_WRITER_LEASE_TOKEN="lease-secret",
+            EXOMEM_WRITER_LEASE_PREFERRED="1",
+        )
+    return env
+
+
+def _old_cli(
+    old_python: Path,
+    env: dict[str, str],
+    *arguments: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(old_python), "-m", "exomem", *arguments],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _old_server_starts(old_python: Path, env: dict[str, str]) -> bool:
+    process = subprocess.Popen(
+        [str(old_python), "-m", "exomem", "--transport", "stdio"],
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        time.sleep(0.75)
+        return process.poll() is None
+    finally:
+        if process.poll() is None:
+            process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=10)
+
+
+def _deployment_admission(coordinator_url: str, schema_version: int) -> dict[str, object]:
+    request = urllib.request.Request(
+        f"{coordinator_url}/v1/vaults/old-binary-probe/schema-fence/admit",
+        data=json.dumps(
+            {"replica_id": "old-v3", "schema_version": schema_version},
+            separators=(",", ":"),
+        ).encode("utf-8"),
+        headers={
+            "Authorization": "Bearer operator-secret",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:
+        value = json.loads(response.read())
+    assert isinstance(value, dict)
+    return value
+
+
+def test_actual_old_v3_binary_is_write_fenced_from_v4_and_reopens_only_after_rollback(
+    tmp_path: Path,
+) -> None:
+    old_python = _old_python()
+    vault, active = _v4_vault(tmp_path)
+    coordinator_database = tmp_path / "coordinator.sqlite"
+    lease_store = SQLiteLeaseStore(coordinator_database)
+    fence, accepted = lease_store.transition_schema_fence(
+        "old-binary-probe",
+        expected_generation=0,
+        schema_version=4,
+    )
+    assert accepted and fence["generation"] == 1
+    before_database = _database_digest(vault)
+    visible = vault / "Knowledge Base" / "Notes" / "Insights" / "visible.md"
+    before_visible = visible.read_bytes()
+
+    # Record the actual released behavior on a disposable copy. v0.57 both
+    # starts and reads a v4 store, and that nominal read performs governance
+    # DML. The live-copy assertion below therefore cannot rely on self-refusal
+    # or on a writer-only fence.
+    probe = tmp_path / "isolated-old-binary-probe"
+    shutil.copytree(vault, probe)
+    probe_before = _database_digest(probe)
+    probe_env = _old_environment(
+        tmp_path,
+        probe,
+        None,
+        state_name="isolated-old-state",
+    )
+    assert _old_server_starts(old_python, probe_env) is True
+    read = _old_cli(old_python, probe_env, "find", "lantern", "--json")
+    assert read.returncode == 0, read.stderr
+    assert _database_digest(probe) != probe_before
+    before_probe_write = _database_digest(probe)
+    write = _old_cli(
+        old_python,
+        probe_env,
+        "capture_source",
+        "--content",
+        "old writer can mutate the isolated v4 probe",
+        "--title",
+        "Unsafe Old Writer Probe",
+        "--source-type",
+        "article",
+        "--url",
+        "https://example.invalid/unsafe-old-writer-probe",
+        "--json",
+    )
+    assert write.returncode == 0, write.stderr
+    assert _database_digest(probe) == before_probe_write
+    assert list((probe / "Knowledge Base" / "Sources").rglob("*unsafe-old-writer-probe.md"))
+    with sqlite3.connect(store.sidecar_path(probe)) as connection:
+        assert int(connection.execute("PRAGMA user_version").fetchone()[0]) == 4
+
+    with _lease_server(coordinator_database) as coordinator_url:
+        lease_probe = tmp_path / "isolated-old-binary-lease-probe"
+        shutil.copytree(vault, lease_probe)
+        lease_probe_before = _database_digest(lease_probe)
+        lease_probe_env = _old_environment(
+            tmp_path,
+            lease_probe,
+            coordinator_url,
+            state_name="isolated-old-lease-state",
+        )
+        rejected_write = _old_cli(
+            old_python,
+            lease_probe_env,
+            "capture_source",
+            "--content",
+            "the lease fence must reject this old writer",
+            "--title",
+            "Rejected Old Writer Probe",
+            "--source-type",
+            "article",
+            "--url",
+            "https://example.invalid/rejected-old-writer-probe",
+            "--json",
+        )
+        assert rejected_write.returncode != 0
+        assert _database_digest(lease_probe) == lease_probe_before
+        assert not list(
+            (lease_probe / "Knowledge Base" / "Sources").rglob(
+                "*rejected-old-writer-probe.md"
+            )
+        )
+
+        env = _old_environment(
+            tmp_path,
+            vault,
+            coordinator_url,
+            state_name="live-old-state",
+        )
+        admission = _deployment_admission(coordinator_url, 3)
+        assert admission == {
+            "admitted": False,
+            "governance_enrolled": True,
+            "required_schema_version": 4,
+            "schema_fence_generation": 1,
+        }
+        # Deployment stops here: the old process is never started against the
+        # live v4 root, so even its read-path DML cannot occur.
+        assert _database_digest(vault) == before_database
+        assert visible.read_bytes() == before_visible
+        assert not list((vault / "Knowledge Base" / "Notes").rglob("old-writer-must-not-land.md"))
+
+        with sqlite3.connect(store.sidecar_path(vault)) as connection:
+            result = schema_v4.downmigrate_v4_connection(
+                connection,
+                expected=active,
+                expected_source_documents=POLICY_DOCUMENTS,
+                expected_catalog_descriptor=b'{"artifacts":[]}',
+                verified_workspace_digest=schema_v4.source_documents_digest(POLICY_DOCUMENTS),
+                verified_catalog_digest=schema_v4.catalog_rebuild_digest(b'{"artifacts":[]}'),
+                recovery_event_id="d" * 64,
+                recovery_plan_digest="e" * 64,
+                recovery_target_digest="f" * 64,
+                downmigrated_at=1_800_000_100,
+            )
+        assert result.schema_version == 3
+        rollback_fence, accepted = lease_store.transition_schema_fence(
+            "old-binary-probe",
+            expected_generation=1,
+            schema_version=3,
+        )
+        assert accepted and rollback_fence["generation"] == 2
+        assert _deployment_admission(coordinator_url, 3) == {
+            "admitted": True,
+            "governance_enrolled": True,
+            "required_schema_version": 3,
+            "schema_fence_generation": 2,
+        }
+
+        allowed = _old_cli(
+            old_python,
+            env,
+            "capture_source",
+            "--content",
+            "old writer is allowed only after proven rollback",
+            "--title",
+            "Old Writer After Rollback",
+            "--source-type",
+            "article",
+            "--url",
+            "https://example.invalid/old-writer-after-rollback",
+            "--json",
+        )
+
+    assert allowed.returncode == 0, allowed.stderr
+    assert list((vault / "Knowledge Base" / "Sources").rglob("*old-writer-after-rollback.md"))
+    with sqlite3.connect(store.sidecar_path(vault)) as connection:
+        assert int(connection.execute("PRAGMA user_version").fetchone()[0]) == 3

--- a/tests/test_lease_cli.py
+++ b/tests/test_lease_cli.py
@@ -1,4 +1,4 @@
-"""`exomem lease status|release` — ops-only CLI (R6). Not an MCP/REST product
+"""`exomem lease status|schema-admission|release` — ops-only CLI (R6). Not an MCP/REST product
 command. Exercises the CLI's own argument handling, --yes gate, --json
 output, and exit codes against a FakeClient (fast, deterministic); the
 coordinator's own release-on-behalf-of contract is proven separately in
@@ -14,7 +14,7 @@ import pytest
 from exomem import writer_lease
 from exomem.__main__ import main
 from exomem.cli_ops import OpError
-from exomem.writer_lease import LeaseRecord
+from exomem.writer_lease import LeaseRecord, SchemaAdmission
 
 
 class FakeCoordinatorClient:
@@ -32,6 +32,15 @@ class FakeCoordinatorClient:
             return _STATE["record"]
         return LeaseRecord(record.holder, record.expires_at, record.fencing_token, False)
 
+    def schema_admission(self, schema_version: int) -> SchemaAdmission:
+        required = _STATE["required_schema"]
+        return SchemaAdmission(
+            admitted=schema_version == required,
+            governance_enrolled=True,
+            required_schema_version=required,
+            schema_fence_generation=7,
+        )
+
 
 _STATE: dict = {}
 
@@ -42,9 +51,11 @@ def _lease_env(tmp_path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("EXOMEM_WRITER_LEASE_VAULT_ID", "main")
     monkeypatch.setenv("EXOMEM_WRITER_LEASE_REPLICA_ID", "desktop")
     monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("EXOMEM_LEASE_COORDINATOR_OPERATOR_TOKEN", "operator-secret")
     monkeypatch.setattr(writer_lease, "LeaseCoordinatorClient", FakeCoordinatorClient)
     _STATE["record"] = LeaseRecord("laptop", 999999999.0, 3, True)
     _STATE["release_calls"] = []
+    _STATE["required_schema"] = 4
     yield
 
 
@@ -143,3 +154,20 @@ def test_lease_steal_and_force_acquire_are_not_offered(capsys: pytest.CaptureFix
         main(["lease", "steal"])
     assert exc.value.code == 2
     assert "invalid choice" in capsys.readouterr().err
+
+
+def test_lease_schema_admission_is_an_exit_code_gate_for_deployment(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    assert main(["lease", "schema-admission", "--schema-version", "3", "--json"]) == 1
+    refused = json.loads(capsys.readouterr().out)
+    assert refused == {
+        "admitted": False,
+        "governance_enrolled": True,
+        "required_schema_version": 4,
+        "schema_fence_generation": 7,
+    }
+
+    assert main(["lease", "schema-admission", "--schema-version", "4", "--json"]) == 0
+    admitted = json.loads(capsys.readouterr().out)
+    assert admitted["admitted"] is True

--- a/tests/test_lease_coordinator.py
+++ b/tests/test_lease_coordinator.py
@@ -99,3 +99,153 @@ async def test_release_endpoint_is_a_no_op_when_unheld_or_mismatched(tmp_path: P
             headers=headers,
         )
     assert released.json()["granted"] is False
+
+
+@pytest.mark.anyio
+async def test_schema_fence_cas_revokes_the_old_holder_and_rejects_legacy_acquire(
+    tmp_path: Path,
+) -> None:
+    app = create_app(
+        database=tmp_path / "coordinator.sqlite",
+        bearer_token="lease-secret",
+        operator_token="operator-secret",
+    )
+    transport = httpx.ASGITransport(app=app)
+    lease_headers = {"Authorization": "Bearer lease-secret"}
+    operator_headers = {"Authorization": "Bearer operator-secret"}
+
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://coordinator.example"
+    ) as client:
+        legacy = await client.post(
+            "/v1/vaults/main/lease/acquire",
+            json={"replica_id": "old-v3", "ttl_seconds": 30},
+            headers=lease_headers,
+        )
+        assert legacy.json()["granted"] is True
+
+        fenced = await client.put(
+            "/v1/vaults/main/schema-fence",
+            json={"expected_generation": 0, "schema_version": 4},
+            headers=operator_headers,
+        )
+        assert fenced.status_code == 200
+        assert fenced.json() == {
+            "governance_enrolled": True,
+            "schema_version": 4,
+            "generation": 1,
+        }
+
+        rejected = await client.post(
+            "/v1/vaults/main/lease/acquire",
+            json={"replica_id": "old-v3", "ttl_seconds": 30},
+            headers=lease_headers,
+        )
+        deployment_rejected = await client.post(
+            "/v1/vaults/main/schema-fence/admit",
+            json={"replica_id": "old-v3", "schema_version": 3},
+            headers=operator_headers,
+        )
+        admitted = await client.post(
+            "/v1/vaults/main/lease/acquire",
+            json={
+                "replica_id": "current-v4",
+                "ttl_seconds": 30,
+                "schema_version": 4,
+            },
+            headers=lease_headers,
+        )
+
+    assert rejected.status_code == 200
+    assert rejected.json()["granted"] is False
+    assert rejected.json()["required_schema_version"] == 4
+    assert rejected.json()["schema_fence_generation"] == 1
+    assert deployment_rejected.json() == {
+        "admitted": False,
+        "governance_enrolled": True,
+        "required_schema_version": 4,
+        "schema_fence_generation": 1,
+    }
+    assert admitted.json()["granted"] is True
+    assert admitted.json()["holder"] == "current-v4"
+    assert admitted.json()["fencing_token"] > legacy.json()["fencing_token"]
+
+
+@pytest.mark.anyio
+async def test_schema_fence_is_operator_only_monotonic_and_rollback_reopens_v3(
+    tmp_path: Path,
+) -> None:
+    app = create_app(
+        database=tmp_path / "coordinator.sqlite",
+        bearer_token="lease-secret",
+        operator_token="operator-secret",
+    )
+    transport = httpx.ASGITransport(app=app)
+    lease_headers = {"Authorization": "Bearer lease-secret"}
+    operator_headers = {"Authorization": "Bearer operator-secret"}
+
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://coordinator.example"
+    ) as client:
+        denied = await client.put(
+            "/v1/vaults/main/schema-fence",
+            json={"expected_generation": 0, "schema_version": 4},
+            headers=lease_headers,
+        )
+        assert denied.status_code == 401
+        admission_denied = await client.post(
+            "/v1/vaults/main/schema-fence/admit",
+            json={"replica_id": "old-v3", "schema_version": 3},
+            headers=lease_headers,
+        )
+        assert admission_denied.status_code == 401
+
+        first = await client.put(
+            "/v1/vaults/main/schema-fence",
+            json={"expected_generation": 0, "schema_version": 4},
+            headers=operator_headers,
+        )
+        stale = await client.put(
+            "/v1/vaults/main/schema-fence",
+            json={"expected_generation": 0, "schema_version": 3},
+            headers=operator_headers,
+        )
+        rollback = await client.put(
+            "/v1/vaults/main/schema-fence",
+            json={"expected_generation": 1, "schema_version": 3},
+            headers=operator_headers,
+        )
+        legacy = await client.post(
+            "/v1/vaults/main/lease/acquire",
+            json={"replica_id": "old-v3", "ttl_seconds": 30},
+            headers=lease_headers,
+        )
+        deployment_admitted = await client.post(
+            "/v1/vaults/main/schema-fence/admit",
+            json={"replica_id": "old-v3", "schema_version": 3},
+            headers=operator_headers,
+        )
+
+    assert first.json()["generation"] == 1
+    assert stale.status_code == 409
+    assert rollback.json() == {
+        "governance_enrolled": True,
+        "schema_version": 3,
+        "generation": 2,
+    }
+    assert legacy.json()["granted"] is True
+    assert deployment_admitted.json() == {
+        "admitted": True,
+        "governance_enrolled": True,
+        "required_schema_version": 3,
+        "schema_fence_generation": 2,
+    }
+
+
+def test_schema_fence_rejects_reusing_the_normal_lease_bearer(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="operator token must differ"):
+        create_app(
+            database=tmp_path / "coordinator.sqlite",
+            bearer_token="shared-secret",
+            operator_token="shared-secret",
+        )

--- a/tests/test_writer_lease.py
+++ b/tests/test_writer_lease.py
@@ -30,10 +30,10 @@ from exomem.writer_lease import (
     LeaseConfig,
     LeaseManager,
     LeaseRecord,
+    SchemaAdmission,
     invoke_command,
     reset_managers_for_tests,
 )
-
 
 #: The wall-clock shape of every contention test in this file.
 #:
@@ -514,6 +514,7 @@ def _row(manager: LeaseManager, public_key: str) -> tuple[str, str, bytes | None
 
 def test_config_is_default_off_and_requires_identities() -> None:
     assert LeaseConfig.from_env({}).enabled is False
+    assert LeaseConfig.from_env({}).schema_version == 4
     with pytest.raises(ValueError, match="WRITER_LEASE_CONFIG"):
         LeaseConfig.from_env({"EXOMEM_WRITER_LEASE_URL": "https://lease.example"})
 
@@ -764,6 +765,188 @@ def test_coordinator_requests_use_cloudflare_compatible_user_agent(monkeypatch) 
     assert "Exomem-Coordinator" in seen["user_agent"]
 
 
+def test_coordinator_acquire_and_renew_attest_the_current_schema(monkeypatch) -> None:
+    from exomem.writer_lease import LeaseCoordinatorClient
+
+    bodies: list[dict] = []
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def read(self):
+            return b'{"holder":"desktop","expires_at":99,"fencing_token":7,"granted":true}'
+
+    def fake_urlopen(request, timeout):  # noqa: ANN001, ARG001
+        bodies.append(json.loads(request.data))
+        return Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    client = LeaseCoordinatorClient(
+        LeaseConfig(url="https://lease.example", vault_id="main", replica_id="desktop")
+    )
+
+    client.acquire()
+    client.renew(7)
+
+    assert bodies == [
+        {"replica_id": "desktop", "ttl_seconds": 30.0, "schema_version": 4},
+        {
+            "replica_id": "desktop",
+            "fencing_token": 7,
+            "ttl_seconds": 30.0,
+            "schema_version": 4,
+        },
+    ]
+
+
+def test_coordinator_schema_admission_uses_the_external_gate(monkeypatch) -> None:
+    from exomem.writer_lease import LeaseCoordinatorClient
+
+    seen: dict[str, object] = {}
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def read(self):
+            return (
+                b'{"admitted":false,"governance_enrolled":true,'
+                b'"required_schema_version":4,"schema_fence_generation":8}'
+            )
+
+    def fake_urlopen(request, timeout):  # noqa: ANN001, ARG001
+        seen["url"] = request.full_url
+        seen["body"] = json.loads(request.data)
+        return Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    client = LeaseCoordinatorClient(
+        LeaseConfig(url="https://lease.example", vault_id="main", replica_id="old-v3")
+    )
+
+    result = client.schema_admission(3)
+
+    assert seen == {
+        "url": "https://lease.example/v1/vaults/main/schema-fence/admit",
+        "body": {"replica_id": "old-v3", "schema_version": 3},
+    }
+    assert result.admitted is False
+    assert result.required_schema_version == 4
+    assert result.schema_fence_generation == 8
+
+
+@pytest.mark.parametrize(
+    ("response", "operation"),
+    [
+        (
+            b'{"holder":"desktop","expires_at":99,"fencing_token":7,'
+            b'"granted":"true"}',
+            "acquire",
+        ),
+        (
+            b'{"admitted":true,"governance_enrolled":true,'
+            b'"required_schema_version":4,"schema_fence_generation":8}',
+            "schema_admission",
+        ),
+    ],
+)
+def test_coordinator_schema_responses_fail_closed_as_unavailable(
+    monkeypatch,
+    response: bytes,
+    operation: str,
+) -> None:
+    from exomem.writer_lease import LeaseCoordinatorClient
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def read(self):
+            return response
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda request, timeout: Response())
+    client = LeaseCoordinatorClient(
+        LeaseConfig(url="https://lease.example", vault_id="main", replica_id="desktop")
+    )
+
+    with pytest.raises(OpError) as raised:
+        if operation == "acquire":
+            client.acquire()
+        else:
+            client.schema_admission(3)
+
+    assert raised.value.code == "WRITER_COORDINATOR_UNAVAILABLE"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "admitted": False,
+            "governance_enrolled": True,
+            "required_schema_version": None,
+            "schema_fence_generation": None,
+        },
+        {
+            "admitted": False,
+            "governance_enrolled": False,
+            "required_schema_version": 4,
+            "schema_fence_generation": 8,
+        },
+        {
+            "admitted": True,
+            "governance_enrolled": True,
+            "required_schema_version": 4,
+            "schema_fence_generation": 8,
+            "unexpected": "field",
+        },
+    ],
+)
+def test_schema_admission_rejects_inconsistent_or_open_responses(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError, match="schema admission"):
+        SchemaAdmission.from_json(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "holder": None,
+            "expires_at": None,
+            "fencing_token": 9,
+            "granted": False,
+            "governance_enrolled": True,
+        },
+        {
+            "holder": None,
+            "expires_at": None,
+            "fencing_token": 9,
+            "granted": False,
+            "governance_enrolled": False,
+            "required_schema_version": 4,
+            "schema_fence_generation": 8,
+        },
+    ],
+)
+def test_lease_record_rejects_inconsistent_schema_fence_metadata(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError, match="schema fence metadata"):
+        LeaseRecord.from_json(payload)
+
+
 def _coordinator_answering(monkeypatch, error: Exception):
     """Point the lease client at a URL that answers with `error`."""
 
@@ -940,6 +1123,40 @@ class StoreClient:
     def release(self, fencing_token: int) -> LeaseRecord:
         return LeaseRecord.from_json(self.store.release("main", self.replica_id, fencing_token))
 
+
+def test_manager_names_schema_fence_refusal_without_acquiring_writer(
+    tmp_path: Path,
+) -> None:
+    class RefusingClient:
+        def acquire(self) -> LeaseRecord:
+            return LeaseRecord(
+                None,
+                None,
+                9,
+                False,
+                required_schema_version=3,
+                schema_fence_generation=7,
+                governance_enrolled=True,
+            )
+
+    manager = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="current-v4",
+            state_dir=tmp_path,
+        ),
+        client=RefusingClient(),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(OpError) as raised:
+        manager.ensure_writer()
+
+    assert raised.value.code == "WRITER_SCHEMA_FENCE_MISMATCH"
+    assert raised.value.details == {
+        "required_schema_version": 3,
+        "schema_fence_generation": 7,
+    }
 
 class BlockingRejectedRenewalClient(FakeClient):
     def __init__(self):


### PR DESCRIPTION
## Summary

- add a monotonic schema fence to the external writer-lease coordinator and revoke the predecessor holder in the same transaction
- make current replicas attest schema v4 on acquire/renew while treating the released pre-v4 wire shape as schema v3
- add an operator-only deployment admission probe with a credential distinct from the normal lease bearer
- exercise the actual PyPI `exomem==0.57.0` binary: it starts on v4, reads with governance DML, and authors content unless the external deployment/lease fence stops it
- prove the old binary can write again only after exact offline v4→v3 rollback and a fenced generation transition

Stacked after #875. This is the external fence and pinned-artifact proof; it does not yet wire fence transitions into the migration coordinator, mark OpenSpec 5.7/5.10 complete, or touch any live vault.

## Verification

- 323 focused lease, coordinator, CLI, v3/v4 migration, downmigration, serving-membership, pinned-old-binary, and CI-contract tests passed
- actual `exomem==0.57.0` probe passed
- configured Ruff on changed Python files passed
- repository Ruff correctness baseline (`--select F`) passed
- `openspec validate harden-governance-for-consolidation --strict`
- `uv lock --check`
- public repository artifact validation: 3,345 files / 3,413 text payloads clean
- `uv build`
- `git diff --check`

No Personal or delegated vault was opened or modified.
