### PR TITLE
fix(governance): coordinate schema fence transitions

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -332,7 +332,7 @@ made before both PRs and their combined verification are complete.
   journals/direct-source policy. Prove every ordinary v3/v4-capable opener leaves v3 with
   no v4 DDL/DML; add red explicit v3→v4 session + immutable policy/catalog/tuple migration
   crash tests, irreversible enrollment, and unknown >v4 refusal.
-- [ ] 5.7 Add actual rollback/rollout tests: run the real pre-change v3 binary against an
+- [x] 5.7 Add actual rollback/rollout tests: run the real pre-change v3 binary against an
   isolated v4 copy and record exact startup/read/authoring behavior without permitting
   DDL/DML; prove the deployment schema/lease fence bars it from a live v4 cell even if a
   path does not self-refuse. Restore the v3 snapshot and test offline v4→v3 closure/

--- a/src/exomem/governance/schema_downmigration.py
+++ b/src/exomem/governance/schema_downmigration.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
 
-from .. import held_fs, reserved_paths
+from .. import held_fs, reserved_paths, writer_lease
 from . import authorization_custody, policy, receipts, schema_v4, store
 
 _OPERATION: Final = "governance_schema_v4_downmigration"
@@ -88,6 +88,7 @@ class _RecoveryPlan:
     keyring_digest: str
     membership_epoch: int
     membership_digest: str
+    schema_fence_generation: int | None
     created_at: int
     value_json: str
     plan_digest: str
@@ -470,6 +471,7 @@ def _plan_from_parts(
     custody: authorization_custody.AuthorizationCustody,
     control_digest: str,
     keyring_digest: str,
+    schema_fence_generation: int | None,
     created_at: int,
 ) -> _RecoveryPlan:
     workspace_digest = schema_v4.source_documents_digest(active_snapshot.source_documents)
@@ -489,6 +491,7 @@ def _plan_from_parts(
         "keyring_digest": keyring_digest,
         "membership_epoch": membership.epoch,
         "membership_digest": membership.record_digest,
+        "schema_fence_generation": schema_fence_generation,
     }
     encoded = json.dumps(
         value,
@@ -529,6 +532,7 @@ def _plan_from_parts(
         keyring_digest=keyring_digest,
         membership_epoch=membership.epoch,
         membership_digest=membership.record_digest,
+        schema_fence_generation=schema_fence_generation,
         created_at=created_at,
         value_json=encoded.decode("utf-8"),
         plan_digest=plan_digest,
@@ -564,6 +568,7 @@ def _plan_from_json(
             "keyring_digest",
             "membership_epoch",
             "membership_digest",
+            "schema_fence_generation",
         }
         or value["schema"] != _PLAN_SCHEMA
     ):
@@ -595,6 +600,12 @@ def _plan_from_json(
         source_documents
     ) or catalog_digest != schema_v4.catalog_rebuild_digest(descriptor):
         raise DownmigrationUnavailable
+    raw_fence_generation = value["schema_fence_generation"]
+    schema_fence_generation = (
+        None
+        if raw_fence_generation is None
+        else _bounded_integer(raw_fence_generation, minimum=1)
+    )
     plan_digest = _framed_digest(_PLAN_DOMAIN, value_json.encode("utf-8"))
     target_digest = _framed_digest(
         _TARGET_DOMAIN,
@@ -621,6 +632,7 @@ def _plan_from_json(
         keyring_digest=_digest(value["keyring_digest"]),
         membership_epoch=_bounded_integer(value["membership_epoch"], minimum=1),
         membership_digest=_digest(value["membership_digest"]),
+        schema_fence_generation=schema_fence_generation,
         created_at=_sqlite_integer(created_at, minimum=1),
         value_json=value_json,
         plan_digest=plan_digest,
@@ -648,6 +660,58 @@ def _verify_plan_custody(
         or control.activation_store_id != plan.active.activation_store_id
         or control.activation_epoch != plan.active.activation_epoch
         or control.activation_state_digest != plan.active.activation_state_digest
+    ):
+        raise DownmigrationUnavailable
+
+
+def _require_plan_schema_fence(plan: _RecoveryPlan) -> None:
+    try:
+        client = writer_lease.configured_schema_fence_operator_client()
+        if plan.schema_fence_generation is None:
+            if client is not None:
+                raise DownmigrationUnavailable
+            return
+        if client is None:
+            raise DownmigrationUnavailable
+        current = client.schema_fence()
+    except writer_lease.OpError:
+        raise DownmigrationUnavailable from None
+    if (
+        current.schema_version != schema_v4.SCHEMA_USER_VERSION
+        or current.generation != plan.schema_fence_generation
+    ):
+        raise DownmigrationUnavailable
+
+
+def _complete_plan_schema_fence(plan: _RecoveryPlan) -> None:
+    try:
+        client = writer_lease.configured_schema_fence_operator_client()
+        if plan.schema_fence_generation is None:
+            if client is not None:
+                raise DownmigrationUnavailable
+            return
+        if client is None:
+            raise DownmigrationUnavailable
+        current = client.schema_fence()
+        if (
+            current.schema_version == store.SCHEMA_USER_VERSION
+            and current.generation == plan.schema_fence_generation + 1
+        ):
+            return
+        if (
+            current.schema_version != schema_v4.SCHEMA_USER_VERSION
+            or current.generation != plan.schema_fence_generation
+        ):
+            raise DownmigrationUnavailable
+        advanced = client.transition_schema_fence(
+            expected_generation=plan.schema_fence_generation,
+            schema_version=store.SCHEMA_USER_VERSION,
+        )
+    except writer_lease.OpError:
+        raise DownmigrationUnavailable from None
+    if (
+        advanced.schema_version != store.SCHEMA_USER_VERSION
+        or advanced.generation != plan.schema_fence_generation + 1
     ):
         raise DownmigrationUnavailable
 
@@ -849,6 +913,12 @@ def _load_or_prepare_plan(
     custody: authorization_custody.AuthorizationCustody,
     now: int,
 ) -> _RecoveryPlan:
+    try:
+        fence = writer_lease.require_configured_schema_fence(
+            schema_v4.SCHEMA_USER_VERSION
+        )
+    except writer_lease.OpError:
+        raise DownmigrationUnavailable from None
     with _owned_store_connection(
         vault_root,
         schema_version=schema_v4.SCHEMA_USER_VERSION,
@@ -878,6 +948,7 @@ def _load_or_prepare_plan(
         custody=custody,
         control_digest=control_digest,
         keyring_digest=keyring_digest,
+        schema_fence_generation=None if fence is None else fence.generation,
         created_at=now,
     )
 
@@ -1115,6 +1186,9 @@ def downmigrate_enrolled_v4_store(
         _verify_plan_custody(plan, custody, vault_root=root)
         _verify_completed_state(root, plan, now=moment)
         _ensure_receipt_intent(root, plan, must_exist=True)
+        _complete_plan_schema_fence(plan)
+        if plan.schema_fence_generation is not None:
+            _downmigration_barrier("after_schema_fence")
         _complete_receipt(root, plan)
         return OfflineDownmigrationResult(
             schema_version=3,
@@ -1127,7 +1201,6 @@ def downmigrate_enrolled_v4_store(
         )
     if version != schema_v4.SCHEMA_USER_VERSION:
         raise DownmigrationUnavailable
-
     plan = _load_or_prepare_plan(root, custody=custody, now=moment)
     _verify_plan_custody(plan, custody, vault_root=root)
     _ensure_receipt_intent(root, plan, must_exist=False)
@@ -1138,9 +1211,13 @@ def downmigrate_enrolled_v4_store(
     _downmigration_barrier("after_workspace_mirror")
     current_custody = _require_drained_custody(root, now=moment)
     _verify_plan_custody(plan, current_custody, vault_root=root)
+    _require_plan_schema_fence(plan)
     terminal_digest = _commit_database(root, plan, now=moment)
     _downmigration_barrier("after_store_commit")
     _verify_completed_state(root, plan, now=moment)
+    _complete_plan_schema_fence(plan)
+    if plan.schema_fence_generation is not None:
+        _downmigration_barrier("after_schema_fence")
     _complete_receipt(root, plan)
     _downmigration_barrier("after_receipt_commit")
     return OfflineDownmigrationResult(

--- a/src/exomem/governance/store.py
+++ b/src/exomem/governance/store.py
@@ -264,6 +264,7 @@ def migrate_enrolled_v3_store(
     detected by the post-commit observation.
     """
 
+    from .. import writer_lease
     from . import authorization_custody, policy, schema_v4
 
     root = Path(vault_root)
@@ -349,6 +350,16 @@ def migrate_enrolled_v3_store(
                                 "migration policy workspace does not match the reviewed seed"
                             )
 
+                    try:
+                        fenced = writer_lease.advance_configured_schema_fence(
+                            source_schema_version=SCHEMA_USER_VERSION,
+                            target_schema_version=schema_v4.SCHEMA_USER_VERSION,
+                        )
+                    except writer_lease.OpError:
+                        raise authorization_custody.AuthorizationCustodyUnavailable from None
+                    if fenced is not None:
+                        _schema_migration_barrier("after_schema_fence")
+
                     result = schema_v4.migrate_v3_connection(connection, seed)
                     reserved_paths._publish_sqlite_owner_family(
                         root,
@@ -357,6 +368,17 @@ def migrate_enrolled_v3_store(
                         connection,
                     )
                     _schema_migration_barrier("after_store_commit")
+                    if fenced is not None:
+                        try:
+                            confirmed_fence = (
+                                writer_lease.require_configured_schema_fence(
+                                    schema_v4.SCHEMA_USER_VERSION
+                                )
+                            )
+                        except writer_lease.OpError:
+                            raise authorization_custody.AuthorizationCustodyUnavailable from None
+                        if confirmed_fence != fenced:
+                            raise authorization_custody.AuthorizationCustodyUnavailable
                     active = schema_v4.load_active_policy(
                         connection,
                         expected_logical_vault_id=target.logical_vault_id,

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -871,6 +871,36 @@ class SchemaAdmission:
         }
 
 
+@dataclass(frozen=True)
+class SchemaFenceState:
+    governance_enrolled: bool
+    schema_version: int
+    generation: int
+
+    @classmethod
+    def from_json(cls, data: Mapping[str, Any]) -> SchemaFenceState:
+        if set(data) != {"governance_enrolled", "schema_version", "generation"}:
+            raise ValueError("schema fence response fields are invalid")
+        enrolled = data.get("governance_enrolled")
+        schema_version = data.get("schema_version")
+        generation = data.get("generation")
+        if enrolled is not True:
+            raise ValueError("schema fence enrollment is invalid")
+        if (
+            isinstance(schema_version, bool)
+            or not isinstance(schema_version, int)
+            or schema_version not in {3, 4}
+        ):
+            raise ValueError("schema fence version is invalid")
+        if (
+            isinstance(generation, bool)
+            or not isinstance(generation, int)
+            or generation < 1
+        ):
+            raise ValueError("schema fence generation is invalid")
+        return cls(enrolled, schema_version, generation)
+
+
 #: Statuses that mean the URL answered and does not implement the lease
 #: contract at this route: 404 (no such route or operation), 405 (route exists,
 #: wrong method), 501 (the server does not implement it). A real coordinator
@@ -1014,6 +1044,54 @@ class LeaseCoordinatorClient:
         except ValueError as exc:
             raise _coordinator_unavailable_error(exc) from None
 
+    def schema_fence(self) -> SchemaFenceState:
+        vault = urllib.parse.quote(str(self.config.vault_id), safe="")
+        payload = self._request_json(
+            "GET",
+            f"/v1/vaults/{vault}/schema-fence",
+            None,
+            contract_route="/v1/vaults/<id>/schema-fence",
+        )
+        try:
+            return SchemaFenceState.from_json(payload)
+        except ValueError as exc:
+            raise _coordinator_unavailable_error(exc) from None
+
+    def transition_schema_fence(
+        self,
+        *,
+        expected_generation: int,
+        schema_version: int,
+    ) -> SchemaFenceState:
+        if (
+            isinstance(expected_generation, bool)
+            or not isinstance(expected_generation, int)
+            or expected_generation < 1
+        ):
+            raise ValueError("expected_generation must be a positive integer")
+        if isinstance(schema_version, bool) or schema_version not in {3, 4}:
+            raise ValueError("schema_version must be 3 or 4")
+        vault = urllib.parse.quote(str(self.config.vault_id), safe="")
+        payload = self._request_json(
+            "PUT",
+            f"/v1/vaults/{vault}/schema-fence",
+            {
+                "expected_generation": expected_generation,
+                "schema_version": schema_version,
+            },
+            contract_route="/v1/vaults/<id>/schema-fence",
+        )
+        try:
+            state = SchemaFenceState.from_json(payload)
+            if (
+                state.schema_version != schema_version
+                or state.generation != expected_generation + 1
+            ):
+                raise ValueError("schema fence transition result is inconsistent")
+            return state
+        except ValueError as exc:
+            raise _coordinator_unavailable_error(exc) from None
+
     def _request(self, method: str, operation: str, body: dict | None) -> LeaseRecord:
         vault = urllib.parse.quote(str(self.config.vault_id), safe="")
         suffix = f"/{operation}" if operation else ""
@@ -1068,6 +1146,105 @@ class LeaseCoordinatorClient:
             ValueError,
         ) as exc:
             raise _coordinator_unavailable_error(exc) from None
+
+
+def configured_schema_fence_operator_client(
+    env: Mapping[str, str] | None = None,
+) -> LeaseCoordinatorClient | None:
+    """Return the protected rollout client when writer coordination is configured."""
+
+    values = os.environ if env is None else env
+    config = LeaseConfig.from_env(values)
+    if not config.enabled:
+        return None
+    operator_token = values.get(
+        "EXOMEM_LEASE_COORDINATOR_OPERATOR_TOKEN", ""
+    ).strip()
+    if not operator_token:
+        raise OpError(
+            "SCHEMA_FENCE_OPERATOR_UNAVAILABLE",
+            "schema fence operator credential is unavailable",
+            "Set EXOMEM_LEASE_COORDINATOR_OPERATOR_TOKEN only in the protected "
+            "offline rollout environment.",
+        )
+    if operator_token == config.token:
+        raise OpError(
+            "SCHEMA_FENCE_OPERATOR_UNAVAILABLE",
+            "schema fence operator credential must be distinct from the writer lease credential",
+            "Provision a separate operator credential before changing the schema fence.",
+        )
+    return LeaseCoordinatorClient(replace(config, token=operator_token))
+
+
+def require_configured_schema_fence(
+    schema_version: int,
+) -> SchemaFenceState | None:
+    """Verify an optional external rollout fence without widening its state."""
+
+    if isinstance(schema_version, bool) or schema_version not in {3, 4}:
+        raise ValueError("schema_version must be 3 or 4")
+    client = configured_schema_fence_operator_client()
+    if client is None:
+        return None
+    state = client.schema_fence()
+    if state.schema_version != schema_version:
+        raise OpError(
+            "SCHEMA_FENCE_CONFLICT",
+            f"external schema fence requires v{state.schema_version}, not v{schema_version}",
+            "Reconcile the durable store and schema-fence generation before retrying.",
+            details={
+                "required_schema_version": state.schema_version,
+                "schema_fence_generation": state.generation,
+            },
+        )
+    return state
+
+
+def advance_configured_schema_fence(
+    *,
+    source_schema_version: int,
+    target_schema_version: int,
+) -> SchemaFenceState | None:
+    """CAS an optional rollout fence, accepting an exact lost-ack replay."""
+
+    if (
+        isinstance(source_schema_version, bool)
+        or isinstance(target_schema_version, bool)
+        or source_schema_version not in {3, 4}
+        or target_schema_version not in {3, 4}
+        or source_schema_version == target_schema_version
+    ):
+        raise ValueError("schema fence transition must be between v3 and v4")
+    client = configured_schema_fence_operator_client()
+    if client is None:
+        return None
+    current = client.schema_fence()
+    if current.schema_version == target_schema_version:
+        return current
+    if current.schema_version != source_schema_version:
+        raise OpError(
+            "SCHEMA_FENCE_CONFLICT",
+            "external schema fence does not match the transition predecessor",
+            "Reconcile the durable store and schema-fence generation before retrying.",
+            details={
+                "required_schema_version": current.schema_version,
+                "schema_fence_generation": current.generation,
+            },
+        )
+    advanced = client.transition_schema_fence(
+        expected_generation=current.generation,
+        schema_version=target_schema_version,
+    )
+    if (
+        advanced.schema_version != target_schema_version
+        or advanced.generation != current.generation + 1
+    ):
+        raise OpError(
+            "SCHEMA_FENCE_CONFLICT",
+            "external schema fence returned an inconsistent transition terminal",
+            "Reconcile the durable store and schema-fence generation before retrying.",
+        )
+    return advanced
 
 
 def _mutation_outcome_unknown_error() -> OpError:

--- a/tests/test_governance_schema_downmigration.py
+++ b/tests/test_governance_schema_downmigration.py
@@ -247,6 +247,112 @@ def test_offline_downmigration_replays_receipt_after_post_commit_crash(
     ]
 
 
+def test_downmigration_admits_v3_only_after_the_v3_store_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    _migrate(vault, now=now)
+    _set_pending_workspace(vault)
+    _drain_verified_membership(monkeypatch)
+    state_holder = [writer_lease.SchemaFenceState(True, 4, 11)]
+    transitions: list[tuple[int, int, int]] = []
+
+    class Client:
+        def schema_fence(self) -> writer_lease.SchemaFenceState:
+            return state_holder[0]
+
+        def transition_schema_fence(
+            self, *, expected_generation: int, schema_version: int
+        ) -> writer_lease.SchemaFenceState:
+            transitions.append(
+                (expected_generation, schema_version, _schema_version(vault))
+            )
+            state_holder[0] = writer_lease.SchemaFenceState(
+                True, schema_version, expected_generation + 1
+            )
+            return state_holder[0]
+
+    monkeypatch.setattr(
+        writer_lease,
+        "configured_schema_fence_operator_client",
+        lambda: Client(),
+    )
+
+    def crash(point: str) -> None:
+        if point == "after_store_commit":
+            raise RuntimeError("injected post-v3-commit crash")
+
+    monkeypatch.setattr(schema_downmigration, "_downmigration_barrier", crash)
+    with pytest.raises(RuntimeError, match="post-v3-commit"):
+        schema_downmigration.downmigrate_enrolled_v4_store(vault, now=now + 3)
+
+    assert _schema_version(vault) == 3
+    assert state_holder == [writer_lease.SchemaFenceState(True, 4, 11)]
+    assert transitions == []
+
+    def crash_after_fence(point: str) -> None:
+        if point == "after_schema_fence":
+            raise RuntimeError("injected fence-ack crash")
+
+    monkeypatch.setattr(schema_downmigration, "_downmigration_barrier", crash_after_fence)
+    with pytest.raises(RuntimeError, match="fence-ack"):
+        schema_downmigration.downmigrate_enrolled_v4_store(vault, now=now + 4)
+
+    assert state_holder == [writer_lease.SchemaFenceState(True, 3, 12)]
+    assert transitions == [(11, 3, 3)]
+    assert [item["phase"] for item in _receipt_records(vault)[-1:]] == ["intent"]
+
+    monkeypatch.setattr(schema_downmigration, "_downmigration_barrier", lambda _point: None)
+    replay = schema_downmigration.downmigrate_enrolled_v4_store(vault, now=now + 5)
+
+    assert replay.replayed is True
+    assert transitions == [(11, 3, 3)]
+    assert [item["phase"] for item in _receipt_records(vault)[-2:]] == [
+        "intent",
+        "committed",
+    ]
+
+
+def test_downmigration_refuses_external_fence_generation_drift_before_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    _migrate(vault, now=now)
+    _set_pending_workspace(vault)
+    _drain_verified_membership(monkeypatch)
+    state_holder = [writer_lease.SchemaFenceState(True, 4, 21)]
+
+    class Client:
+        def schema_fence(self) -> writer_lease.SchemaFenceState:
+            return state_holder[0]
+
+        def transition_schema_fence(
+            self, *, expected_generation: int, schema_version: int
+        ) -> writer_lease.SchemaFenceState:
+            raise AssertionError((expected_generation, schema_version))
+
+    monkeypatch.setattr(
+        writer_lease,
+        "configured_schema_fence_operator_client",
+        lambda: Client(),
+    )
+
+    def drift(point: str) -> None:
+        if point == "after_workspace_mirror":
+            state_holder[0] = writer_lease.SchemaFenceState(True, 4, 23)
+
+    monkeypatch.setattr(schema_downmigration, "_downmigration_barrier", drift)
+    with pytest.raises(schema_downmigration.DownmigrationUnavailable):
+        schema_downmigration.downmigrate_enrolled_v4_store(vault, now=now + 3)
+
+    assert _schema_version(vault) == 4
+    assert [item["phase"] for item in _receipt_records(vault)[-1:]] == ["intent"]
+
+
 def test_offline_downmigration_reuses_intent_after_prepared_plan_was_not_written(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_governance_v3_store_migration.py
+++ b/tests/test_governance_v3_store_migration.py
@@ -229,6 +229,105 @@ def test_store_migration_post_commit_crash_replays_exact_v4(
     assert custody.serving_membership.epoch == 2
 
 
+def test_store_migration_advances_external_fence_before_the_v4_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    seed, target = _stage_and_enroll(vault, now=now)
+    state = writer_lease.SchemaFenceState(True, 3, 7)
+    transitions: list[tuple[int, int]] = []
+
+    class Client:
+        def schema_fence(self) -> writer_lease.SchemaFenceState:
+            return state_holder[0]
+
+        def transition_schema_fence(
+            self, *, expected_generation: int, schema_version: int
+        ) -> writer_lease.SchemaFenceState:
+            transitions.append((expected_generation, schema_version))
+            assert state_holder[0] == writer_lease.SchemaFenceState(
+                True, 3, expected_generation
+            )
+            state_holder[0] = writer_lease.SchemaFenceState(
+                True, schema_version, expected_generation + 1
+            )
+            return state_holder[0]
+
+    state_holder = [state]
+    monkeypatch.setattr(
+        writer_lease,
+        "configured_schema_fence_operator_client",
+        lambda: Client(),
+    )
+
+    def crash(point: str) -> None:
+        if point == "after_schema_fence":
+            raise RuntimeError("injected fence-first crash")
+
+    monkeypatch.setattr(store, "_schema_migration_barrier", crash)
+    with pytest.raises(RuntimeError, match="fence-first"):
+        store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 2)
+
+    assert _schema_version(vault) == 3
+    assert state_holder == [writer_lease.SchemaFenceState(True, 4, 8)]
+    assert transitions == [(7, 4)]
+
+    monkeypatch.setattr(store, "_schema_migration_barrier", lambda _point: None)
+    assert store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 3) == target
+    assert _schema_version(vault) == 4
+    assert transitions == [(7, 4)]
+
+
+def test_store_migration_refuses_fence_generation_drift_after_the_v4_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    seed, target = _stage_and_enroll(vault, now=now)
+    state_holder = [writer_lease.SchemaFenceState(True, 3, 17)]
+
+    class Client:
+        def schema_fence(self) -> writer_lease.SchemaFenceState:
+            return state_holder[0]
+
+        def transition_schema_fence(
+            self, *, expected_generation: int, schema_version: int
+        ) -> writer_lease.SchemaFenceState:
+            state_holder[0] = writer_lease.SchemaFenceState(
+                True, schema_version, expected_generation + 1
+            )
+            return state_holder[0]
+
+    monkeypatch.setattr(
+        writer_lease,
+        "configured_schema_fence_operator_client",
+        lambda: Client(),
+    )
+
+    def drift(point: str) -> None:
+        if point == "after_store_commit":
+            state_holder[0] = writer_lease.SchemaFenceState(True, 4, 20)
+
+    monkeypatch.setattr(store, "_schema_migration_barrier", drift)
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 2)
+
+    assert _schema_version(vault) == 4
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 3)
+    assert custody.control.serving_membership_epoch == 1
+    assert custody.serving_membership is not None
+    assert custody.serving_membership.epoch == 1
+
+    monkeypatch.setattr(store, "_schema_migration_barrier", lambda _point: None)
+    assert store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 3) == target
+    assert _schema_version(vault) == 4
+    recovered = authorization_custody.load_authorization_custody(vault, now=now + 4)
+    assert recovered.control.serving_membership_epoch == 2
+
+
 def test_store_migration_refuses_membership_without_complete_v3_drain(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_writer_lease.py
+++ b/tests/test_writer_lease.py
@@ -842,6 +842,96 @@ def test_coordinator_schema_admission_uses_the_external_gate(monkeypatch) -> Non
     assert result.schema_fence_generation == 8
 
 
+def test_coordinator_schema_fence_operator_reads_and_advances_exact_generation(
+    monkeypatch,
+) -> None:
+    from exomem.writer_lease import LeaseCoordinatorClient
+
+    seen: list[tuple[str, str, object]] = []
+    responses = iter(
+        (
+            b'{"governance_enrolled":true,"schema_version":3,"generation":8}',
+            b'{"governance_enrolled":true,"schema_version":4,"generation":9}',
+        )
+    )
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def read(self):
+            return next(responses)
+
+    def fake_urlopen(request, timeout):  # noqa: ANN001, ARG001
+        seen.append(
+            (
+                request.method,
+                request.full_url,
+                None if request.data is None else json.loads(request.data),
+            )
+        )
+        assert request.headers["Authorization"] == "Bearer operator-secret"
+        return Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    client = LeaseCoordinatorClient(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="offline-coordinator",
+            token="operator-secret",
+        )
+    )
+
+    current = client.schema_fence()
+    advanced = client.transition_schema_fence(
+        expected_generation=current.generation,
+        schema_version=4,
+    )
+
+    assert (current.schema_version, current.generation) == (3, 8)
+    assert (advanced.schema_version, advanced.generation) == (4, 9)
+    assert seen == [
+        (
+            "GET",
+            "https://lease.example/v1/vaults/main/schema-fence",
+            None,
+        ),
+        (
+            "PUT",
+            "https://lease.example/v1/vaults/main/schema-fence",
+            {"expected_generation": 8, "schema_version": 4},
+        ),
+    ]
+
+
+def test_configured_schema_fence_operator_requires_a_distinct_protected_token() -> None:
+    from exomem.writer_lease import configured_schema_fence_operator_client
+
+    base = {
+        "EXOMEM_WRITER_LEASE_URL": "https://lease.example",
+        "EXOMEM_WRITER_LEASE_VAULT_ID": "main",
+        "EXOMEM_WRITER_LEASE_REPLICA_ID": "offline-coordinator",
+        "EXOMEM_WRITER_LEASE_TOKEN": "ordinary-secret",
+    }
+
+    with pytest.raises(OpError, match="operator credential"):
+        configured_schema_fence_operator_client(base)
+    with pytest.raises(OpError, match="distinct"):
+        configured_schema_fence_operator_client(
+            {**base, "EXOMEM_LEASE_COORDINATOR_OPERATOR_TOKEN": "ordinary-secret"}
+        )
+
+    client = configured_schema_fence_operator_client(
+        {**base, "EXOMEM_LEASE_COORDINATOR_OPERATOR_TOKEN": "operator-secret"}
+    )
+    assert client is not None
+    assert client.config.token == "operator-secret"
+
+
 @pytest.mark.parametrize(
     ("response", "operation"),
     [


### PR DESCRIPTION
## Summary

- move the external lease schema fence to v4 before the transactional v3→v4 store commit, and recheck its exact generation before enabling v4 membership
- bind v4→v3 recovery plans to the reviewed fence generation, commit schema 3 before admitting v3, and replay lost fence/receipt acknowledgements without another generation bump
- reject operator-token reuse, malformed fence terminals, and any intervening fence generation change
- close OpenSpec task 5.7 with the installed v0.57 binary rollout/rollback evidence

Stacked after #877. This does not merge, deploy, or touch any live Personal/POLLY vault.

## Verification

- red-first: missing operator client/order/replay contract failed before implementation
- `296 passed` — lease coordinator/client/CLI, v3→v4, v4→v3, exact v3/v4 schema and fixture suites
- installed `exomem==0.57.0` probe: `1 passed`
- changed-file Ruff clean; `writer_lease.py` checked with its five pre-existing B009/BLE001 findings excluded
- repository Ruff F gate clean
- `openspec validate harden-governance-for-consolidation --strict`
- `uv lock --check`
- public repository artifact validation: 3345 files / 3413 text payloads clean
- `uv build`
- `git diff --check`
