### PR TITLE
fix(find): bound the recall follower wait and name every refusal site

### DIFF
--- a/openspec/changes/bound-graph-recovery-funnel/specs/recall-read-path/spec.md
+++ b/openspec/changes/bound-graph-recovery-funnel/specs/recall-read-path/spec.md
@@ -27,3 +27,61 @@ A transient failure to stat or read the access-policy file SHALL NOT install or 
 - **WHEN** the access-policy file exists at stat time and vanishes before the read completes
 - **THEN** the previously loaded policy and its fingerprint remain in effect
 - **AND** only an absence observed at stat time transitions to the missing-policy identity
+
+### Requirement: A managed recall follower declines within a bounded wait
+
+A refusal has to come back fast enough to be a refusal. When a recall
+resolver build is already in flight, a managed caller - one forbidden from
+building its own resolver inline - SHALL NOT wait on the leader longer than
+a small bounded follower window before declining with a `retry_after_ms`
+hint; it never inherits the leader's full build window. Only callers
+permitted to fall back to building their own resolver (warm-up, CLI, cold
+maintenance) may wait out the leader's full build bound, because for them
+waiting is cheaper than duplicating the whole-vault walk that single-flight
+exists to prevent. The wait selection SHALL be a single decision point so
+the two bounds cannot silently converge.
+
+#### Scenario: A managed follower refuses quickly instead of hanging
+
+- **WHEN** a managed recall request finds a resolver build in flight
+- **THEN** it declines within the bounded follower window with `retry_after_ms`
+- **AND** the refusal names the gate as `resolver_build_wait` with the wait actually spent
+
+#### Scenario: A fallback caller still waits out the leader
+
+- **WHEN** a fallback-permitted caller finds a resolver build in flight
+- **THEN** it waits up to the full build bound for the leader's resolver
+- **AND** it does not duplicate the leader's build while the leader publishes within that bound
+
+### Requirement: Retrieval warming refusals name their gate from a closed vocabulary
+
+Every retrieval warming refusal SHALL carry a machine-readable `site`
+discriminator identifying the exact gate that refused, drawn from a single
+closed vocabulary declared in code, and SHALL carry the wait actually spent
+(`waited_ms`) when the refusal followed a bounded wait. The vocabulary is
+closed at the constructor: constructing a warming refusal with a site
+outside the vocabulary SHALL fail, so no raise site can introduce an
+undeclared or content-bearing discriminator. `site` and `waited_ms` SHALL
+be content-free - never a path, a query, or a backend name - and SHALL
+project unchanged through the REST and MCP error envelopes. The public API
+schema SHALL express `site` as an enumeration derived from the declared
+vocabulary rather than a hand-copied list, and the vocabulary SHALL be
+bidirectionally checked against the raise sites: every declared site is
+used, and every used site is declared.
+
+#### Scenario: An out-of-vocabulary site is refused at construction
+
+- **WHEN** a warming refusal is constructed with a site outside the declared vocabulary
+- **THEN** construction fails before any envelope is produced
+
+#### Scenario: The envelope carries the discriminator unchanged
+
+- **WHEN** a retrieval warming refusal reaches a REST or MCP client
+- **THEN** the error body carries `site` from the closed vocabulary and an integer `waited_ms`
+- **AND** neither field carries a path, a query, or a backend name
+
+#### Scenario: Dead and undeclared vocabulary entries are both defects
+
+- **WHEN** the declared vocabulary and the raise sites are compared
+- **THEN** a declared site no raise site uses fails the check
+- **AND** a raise site using an undeclared site fails the check

--- a/openspec/changes/bound-graph-recovery-funnel/tasks.md
+++ b/openspec/changes/bound-graph-recovery-funnel/tasks.md
@@ -47,6 +47,16 @@
       the projection - measured live as the flapping-admission duty cycle).
 - [x] 2.5 Bounded startup validation: O(1) durable-checkpoint check in the
       watcher startup pass; whole-vault rebuild only on incoherence.
+- [x] 2.6 Bounded follower wait: managed recall callers decline within a
+      small bounded window when a resolver build is in flight (measured:
+      the 120 s follower wait exceeded every client deadline, so refusals
+      arrived as 31-90 s hangs); fallback callers keep the full build
+      bound, and the selection is pinned at the call site.
+- [x] 2.7 Refusal observability: every retrieval warming refusal carries a
+      `site` discriminator from a closed vocabulary enforced in the
+      constructor, plus `waited_ms`; the REST schema expresses the enum
+      derived from the code vocabulary; bidirectional vocabulary/raise-site
+      checks.
 
 ## 3. Verification and delivery
 

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -618,7 +618,10 @@ class FreshnessSnapshot:
                 )
             except freshness.RecallProjectionUnavailable as exc:
                 _set_recall_projection_timing_outcome(self._timings, "unavailable")
-                raise RetrievalIndexWarming(status="temporarily_unavailable") from exc
+                raise RetrievalIndexWarming(
+                    site="projection_unavailable",
+                    status="temporarily_unavailable",
+                ) from exc
 
 
 def _freshness_key(
@@ -954,11 +957,12 @@ def find(
                 lexstore.request_repair(vault_root)
             _set_recall_projection_timing_outcome(timings, state)
             raise RetrievalIndexWarming(
+                site="catalog_proof_incomplete",
                 status=(
                     "temporarily_unavailable"
                     if state == "unavailable"
                     else "warming"
-                )
+                ),
             )
         _set_recall_projection_timing_outcome(
             timings,
@@ -2068,7 +2072,7 @@ def _find_semantic_units(
                 # scheduled the single-flight repair, so raise the typed,
                 # non-cacheable warming outcome (page-level eligibility parity).
                 if algebra.status == "complete":
-                    raise RetrievalIndexWarming()
+                    raise RetrievalIndexWarming(site="semantic_unit_index")
                 if failed_out is not None:
                     failed_out.append("semantic_units_lexical")
                 _record_degradation("semantic_units_lexical")
@@ -2558,6 +2562,23 @@ def _eligible_filter_paths(
 
 _RETRIEVAL_WARMING_RETRY_MS = 250
 
+#: Closed, content-free vocabulary of retrieval-refusal sites. Each names ONE
+#: gate that can decline a maintained recall, so a live refusal is attributable
+#: from its envelope alone instead of by reading the server source.
+RETRIEVAL_WARMING_SITES = (
+    "projection_unavailable",
+    "catalog_proof_incomplete",
+    "semantic_unit_index",
+    "semantic_unit_seed",
+    "catalog_outcome",
+    "relation_graph",
+    "relation_graph_rebuilding",
+    "resolver_checkpoint_stale",
+    "resolver_checkpoint_absent",
+    "resolver_entries_unavailable",
+    "resolver_build_wait",
+)
+
 
 class RetrievalIndexWarming(cli_ops.OpError):
     """Typed, non-cacheable outcome for a safe exact recall plan the maintained
@@ -2571,24 +2592,46 @@ class RetrievalIndexWarming(cli_ops.OpError):
     def __init__(
         self,
         *,
+        site: str,
         status: str = "warming",
         retry_after_ms: int = _RETRIEVAL_WARMING_RETRY_MS,
+        waited_ms: int | None = None,
         message: str = (
             "the maintained semantic recall index is still warming; retry the exact recall shortly"
         ),
     ) -> None:
+        # The vocabulary is enforced HERE, not by a test reading source shapes.
+        # This envelope reaches REST and MCP verbatim, so a site built from an
+        # f-string could publish a vault path to every client; a single-quoted
+        # literal or a construct-then-raise is invisible to any source scan.
+        # No call shape can evade a constructor.
+        if site not in RETRIEVAL_WARMING_SITES:
+            raise ValueError(f"unknown retrieval refusal site: {site!r}")
         self.complete = False
         self.status = status
         self.retry_after_ms = retry_after_ms
-        super().__init__(
-            "RETRIEVAL_INDEX_WARMING",
-            message,
-            details={
-                "complete": False,
-                "status": status,
-                "retry_after_ms": retry_after_ms,
-            },
+        self.site = site
+        self.waited_ms = waited_ms
+        details: dict[str, object] = {
+            "complete": False,
+            "status": status,
+            "retry_after_ms": retry_after_ms,
+            # WHICH gate refused. Every site produced a byte-identical envelope
+            # before this, so a live refusal could not be attributed without
+            # reading the server's own source alongside its logs.
+            "site": site,
+        }
+        if waited_ms is not None:
+            details["waited_ms"] = waited_ms
+        # Exactly one content-free line per refusal: the decision trail this
+        # path never had. Names the gate, never the query or any path.
+        log.info(
+            "retrieval refusal: site=%s status=%s waited_ms=%s",
+            site,
+            status,
+            "n/a" if waited_ms is None else waited_ms,
         )
+        super().__init__("RETRIEVAL_INDEX_WARMING", message, details=details)
 
 
 def _raise_catalog_outcome(readiness: object) -> None:
@@ -2596,7 +2639,7 @@ def _raise_catalog_outcome(readiness: object) -> None:
     public_status = (
         "temporarily_unavailable" if outcome in {"transient_failure", "unsupported"} else "warming"
     )
-    raise RetrievalIndexWarming(status=public_status)
+    raise RetrievalIndexWarming(site="catalog_outcome", status=public_status)
 
 
 _RELATION_DIRECTIONS = ("any", "outbound", "inbound")
@@ -2692,12 +2735,15 @@ def _resolve_relation_filter(
         canonical, anchor=relation_of, direction=relation_direction
     )
     if result.status == "temporarily_unavailable":
-        raise RetrievalIndexWarming(status="temporarily_unavailable")
+        raise RetrievalIndexWarming(
+            site="relation_graph",
+            status="temporarily_unavailable",
+        )
     if result.status == "warming":
         epistemic_graph.schedule_background_rebuild(
             vault_root, mutation_coordinator=graph_index._canonical_mutation_coordinator()
         )
-        raise RetrievalIndexWarming(status="warming")
+        raise RetrievalIndexWarming(site="relation_graph_rebuilding", status="warming")
     return result.paths, dict(result.provenance), tuple(findings)
 
 
@@ -2739,7 +2785,7 @@ def _resolve_eligible_filter_paths(
         # has already scheduled the single-flight repair, so the honest outcome
         # is a typed, non-cacheable warming signal — not a false empty or a
         # divergent full-scan ranking.
-        raise RetrievalIndexWarming()
+        raise RetrievalIndexWarming(site="semantic_unit_seed")
     return _indexed_eligible_filter_paths(
         vault_root,
         plan=plan,
@@ -4067,8 +4113,45 @@ _RECALL_REBUILD_LOCK = threading.Lock()
 #: Long enough that a follower waits out a real build on a large vault rather
 #: than duplicating it, short enough that a wedged leader cannot hold a reader
 #: indefinitely -- the follower simply builds its own after this.
+#:
+#: Applies to callers that may FALL BACK to building their own resolver (CLI,
+#: cold, warm-up paths). A managed request cannot use it: see the follower
+#: bound below.
 _RECALL_RESOLVER_BUILD_WAIT_SECONDS = 120.0
+
+#: The bound for a MANAGED request, which cannot fall back.
+#:
+#: The leader's build is a full vault walk plus a parse per admitted page, so
+#: on a 3.3k-file vault it runs for tens of seconds. Letting a request wait the
+#: full 120s above is not an optimisation: it is longer than any client
+#: timeout, and it is how a warm, converged cell produced hybrid refusals at
+#: exactly the 60s client deadline with the server never answering, while
+#: keyword (which needs no projected resolver) served in 2.1s.
+#:
+#: A refusal has to come back fast enough to BE a refusal, so a managed
+#: follower waits briefly, then declines with `retry_after_ms` instead of
+#: either blocking or duplicating the leader's whole-vault walk.
+_RECALL_RESOLVER_FOLLOWER_WAIT_SECONDS = 3.0
 _RECALL_RESOLVER_REBUILDS: set[Path] = set()
+
+
+def _follower_wait_seconds(*, allow_fallback: bool) -> float:
+    """How long this caller may wait on the single-flight resolver leader.
+
+    A managed request cannot fall back to its own whole-vault build, so it gets
+    the short bound and declines afterwards. A caller that MAY fall back keeps
+    the long wait, because for it waiting really is cheaper than duplicating
+    the walk.
+
+    Its own function so the choice is assertable without having to sit through
+    the wait it selects — a guard that can only be tested by hanging is a guard
+    nobody tests.
+    """
+    return (
+        _RECALL_RESOLVER_BUILD_WAIT_SECONDS
+        if allow_fallback
+        else _RECALL_RESOLVER_FOLLOWER_WAIT_SECONDS
+    )
 
 
 def _recall_checkpoint_identity(
@@ -4275,7 +4358,10 @@ def recall_resolver_snapshot(
     if candidate is not None and not allow_fallback:
         if not freshness_module.recall_checkpoint_is_current(root, "vault", candidate):
             lexstore.request_repair(root)
-            raise RetrievalIndexWarming(status="temporarily_unavailable")
+            raise RetrievalIndexWarming(
+                site="resolver_checkpoint_stale",
+                status="temporarily_unavailable",
+            )
     if candidate is None:
         candidate = freshness_module.live_recall_checkpoint(root, "vault")
     if candidate is None and allow_fallback:
@@ -4284,7 +4370,10 @@ def recall_resolver_snapshot(
         checkpoint = candidate
     if not allow_fallback and checkpoint is None:
         lexstore.request_repair(root)
-        raise RetrievalIndexWarming(status="temporarily_unavailable")
+        raise RetrievalIndexWarming(
+            site="resolver_checkpoint_absent",
+            status="temporarily_unavailable",
+        )
     with _RESOLVER_LOCK:
         cached = _RECALL_RESOLVER_CACHE.get(root)
         if cached and cached[0] == identity:
@@ -4301,6 +4390,8 @@ def recall_resolver_snapshot(
     # behaviour and it stays correct; the wait is an optimisation, never a
     # dependency.
     leader = False
+    follower_wait = _follower_wait_seconds(allow_fallback=allow_fallback)
+    waited_started = time.monotonic()
     while True:
         with _RECALL_REBUILD_LOCK:
             building = _RECALL_RESOLVER_BUILDS.get(root)
@@ -4310,7 +4401,17 @@ def recall_resolver_snapshot(
                 leader = True
         if leader:
             break
-        if not building.wait(_RECALL_RESOLVER_BUILD_WAIT_SECONDS):
+        if not building.wait(follower_wait):
+            if not allow_fallback:
+                # Declining beats both alternatives: blocking past the client's
+                # deadline answers nobody, and building our own here would pay
+                # the same whole-vault walk the leader is already paying.
+                lexstore.request_repair(root)
+                raise RetrievalIndexWarming(
+                    site="resolver_build_wait",
+                    status="temporarily_unavailable",
+                    waited_ms=int((time.monotonic() - waited_started) * 1000),
+                )
             break
         with _RESOLVER_LOCK:
             cached = _RECALL_RESOLVER_CACHE.get(root)
@@ -4329,7 +4430,10 @@ def recall_resolver_snapshot(
         if entries is None:
             if not allow_fallback:
                 lexstore.request_repair(root)
-                raise RetrievalIndexWarming(status="temporarily_unavailable")
+                raise RetrievalIndexWarming(
+                    site="resolver_entries_unavailable",
+                    status="temporarily_unavailable",
+                )
             entries = []
             for path in walk_vault_md(root):
                 if not recall_policy.is_recall_candidate(root, path):

--- a/src/exomem/server_rest.py
+++ b/src/exomem/server_rest.py
@@ -139,6 +139,22 @@ _OPENAPI_MUTATION_HOLDER_SCHEMA = {
     ],
     "additionalProperties": False,
 }
+def _retrieval_warming_sites() -> tuple[str, ...]:
+    """The refusal-site vocabulary, read from its single source of truth.
+
+    The `find` import is deferred out of the module's top-level import block,
+    but the schema below calls this while the module loads, so `find` is
+    still imported at process start — deliberately: the schema must be
+    correct at import time, and any process serving recall pays for `find`
+    on its first request anyway. Deriving the enum here rather than
+    transcribing the list is the point — a hand-copied enum goes stale
+    silently, which is the drift the vocabulary exists to prevent.
+    """
+    from .find import RETRIEVAL_WARMING_SITES
+
+    return RETRIEVAL_WARMING_SITES
+
+
 _OPENAPI_ERROR_SCHEMA = {
     "type": "object",
     "properties": {
@@ -155,6 +171,12 @@ _OPENAPI_ERROR_SCHEMA = {
         "complete": {"type": "boolean"},
         "committed": {"type": ["boolean", "null"]},
         "retry_after_ms": {"type": "integer", "minimum": 0},
+        # Which gate declined a RETRIEVAL_INDEX_WARMING, and how long it waited
+        # before giving up, so a client can attribute a refusal from the
+        # response alone rather than from the server's logs. The enum is
+        # DERIVED from the single source of truth, never transcribed.
+        "site": {"type": "string", "enum": list(_retrieval_warming_sites())},
+        "waited_ms": {"type": "integer", "minimum": 0},
         "unresolved_sources": {
             "type": "array",
             "items": {"type": "string", "maxLength": 256},

--- a/tests/test_catalog_diagnostics.py
+++ b/tests/test_catalog_diagnostics.py
@@ -137,6 +137,9 @@ def test_incomplete_catalog_outcomes_are_typed_and_not_cached(
         "complete": False,
         "status": public_status,
         "retry_after_ms": 250,
+        # Every refusal now names WHICH gate declined; this one is the exact
+        # catalog outcome, distinct from a projection or resolver refusal.
+        "site": "catalog_outcome",
     }
 
     recovered = commands.op_find(tmp_path, **request)

--- a/tests/test_catalog_error_surfaces.py
+++ b/tests/test_catalog_error_surfaces.py
@@ -35,7 +35,23 @@ from exomem.__main__ import main as cli_main
 from exomem.governance import principal as principal_module
 
 _ALLOWED_WARMING_ERROR_KEYS = frozenset(
-    {"code", "message", "remediation", "ok", "error_code", "status", "complete", "retry_after_ms"}
+    {
+        "code",
+        "message",
+        "remediation",
+        "ok",
+        "error_code",
+        "status",
+        "complete",
+        "retry_after_ms",
+        # Content-free by CONSTRUCTION, not by assertion: RetrievalIndexWarming
+        # rejects any site outside `find.RETRIEVAL_WARMING_SITES` in its own
+        # constructor, so no call shape can smuggle a path or a query into this
+        # envelope. `waited_ms` is an integer duration. The checks below are a
+        # second layer over that runtime guarantee, not the guarantee itself.
+        "site",
+        "waited_ms",
+    }
 )
 _FORBIDDEN_SUBSTRINGS = (
     "warming-surface",  # the note's rel-path stem
@@ -133,6 +149,12 @@ def _assert_warming_error(error: dict) -> None:
 
 def _assert_no_leak(error: dict) -> None:
     assert set(error) <= _ALLOWED_WARMING_ERROR_KEYS, set(error) - _ALLOWED_WARMING_ERROR_KEYS
+    # The discriminator widens the envelope, so hold it to the closed
+    # vocabulary: an ad-hoc site string is exactly how content would get in.
+    if "site" in error:
+        assert error["site"] in find_module.RETRIEVAL_WARMING_SITES, error["site"]
+    if "waited_ms" in error:
+        assert isinstance(error["waited_ms"], int)
     blob = json.dumps(error, ensure_ascii=False)
     for sentinel in _FORBIDDEN_SUBSTRINGS:
         assert sentinel not in blob, f"leaked sentinel {sentinel!r} in {blob!r}"
@@ -215,6 +237,13 @@ def test_rest_openapi_error_schema_accepts_warming_fields(
     allowed_props = set(error_schema["properties"])
     assert error_schema["properties"]["retry_after_ms"]["type"] == "integer"
     assert error_schema["properties"]["complete"]["type"] == "boolean"
+    assert error_schema["properties"]["waited_ms"]["type"] == "integer"
+    # The published schema constrains `site` to the vocabulary itself, not to
+    # "some string": a client can rely on the enum, and a site added without
+    # updating the source of truth cannot be published.
+    site_schema = error_schema["properties"]["site"]
+    assert site_schema["type"] == "string"
+    assert tuple(site_schema["enum"]) == find_module.RETRIEVAL_WARMING_SITES
 
     ask_memory_responses = doc["paths"]["/api/ask_memory"]["post"]["responses"]
     assert "503" in ask_memory_responses

--- a/tests/test_keyword_lane_cold_cost.py
+++ b/tests/test_keyword_lane_cold_cost.py
@@ -658,7 +658,10 @@ def test_vector_graph_resolver_inherits_strict_server_projection_policy(
         expected_checkpoint=None,  # noqa: ANN001
     ):
         observed.append((allow_fallback, expected_checkpoint))
-        raise find_module.RetrievalIndexWarming(status="temporarily_unavailable")
+        raise find_module.RetrievalIndexWarming(
+            site="resolver_checkpoint_stale",
+            status="temporarily_unavailable",
+        )
 
     def collect(root: Path, **kwargs):  # noqa: ANN003
         kwargs["get_query_resolver"](

--- a/tests/test_refusal_observability.py
+++ b/tests/test_refusal_observability.py
@@ -1,0 +1,313 @@
+"""Every RETRIEVAL_INDEX_WARMING refusal names its site, and is bounded.
+
+Measured on the personal cell at 0.64.1, fully warm and converged, inside one
+minute: MCP ask_memory served real hits, REST keyword served in 2.1s, four REST
+hybrid calls refused at exactly the 60s client timeout with the server never
+answering, rerank=true served in 44s, rerank=false refused at 60s.
+
+Two defects that evidence exposes:
+
+* the envelope is IDENTICAL from all ten raise sites, so which gate refused is
+  unknowable from the response and diagnosis becomes archaeology; and
+* a refusal took 31-90s server-side, because a follower thread waits up to
+  ``_RECALL_RESOLVER_BUILD_WAIT_SECONDS`` (120s) for a leader doing a full
+  vault walk. A wait longer than any client timeout is not an optimisation,
+  it is a hang.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from exomem import find as find_module
+
+SOURCE = Path(find_module.__file__)
+
+
+def test_the_site_vocabulary_is_stable_and_distinct() -> None:
+    """The discriminator set is a closed, content-free vocabulary."""
+    sites = find_module.RETRIEVAL_WARMING_SITES
+
+    assert len(sites) == len(set(sites)), "duplicate refusal site discriminators"
+    for site in sites:
+        assert re.fullmatch(r"[a-z][a-z0-9_]*", site), site
+
+
+def test_every_raise_site_names_a_discriminator() -> None:
+    """No raise site may ship without a site, including ones added later.
+
+    A structural guard on purpose: the whole failure was that every raise site
+    produced the same envelope, and the next one added without a discriminator
+    would silently reopen it.
+    """
+    source = SOURCE.read_text(encoding="utf-8")
+    raises = re.findall(r"raise RetrievalIndexWarming\((.*?)\)\s*(?:from \w+)?\n", source, re.S)
+
+    assert raises, "no raise sites found; the guard is looking at the wrong shape"
+    for raw in raises:
+        assert "site=" in raw, f"a RetrievalIndexWarming raise carries no site: {raw!r}"
+
+
+def test_the_envelope_projects_the_site_and_wait() -> None:
+    """`site` and `waited_ms` ride OpError.details, so REST and MCP see them."""
+    error = find_module.RetrievalIndexWarming(
+        site="projection_unavailable",
+        waited_ms=1234,
+    )
+
+    assert error.details["site"] == "projection_unavailable"
+    assert error.details["waited_ms"] == 1234
+    assert error.site == "projection_unavailable"
+    # The pre-existing contract is unchanged.
+    assert error.details["complete"] is False
+    assert error.details["retry_after_ms"] > 0
+
+
+def test_a_refusal_logs_one_content_free_line(caplog: pytest.LogCaptureFixture) -> None:
+    """One INFO line per refusal, naming the site and nothing about content."""
+    with caplog.at_level("INFO", logger="exomem.find"):
+        find_module.RetrievalIndexWarming(site="catalog_proof_incomplete")
+
+    lines = [r for r in caplog.records if "catalog_proof_incomplete" in r.getMessage()]
+    assert len(lines) == 1, f"expected exactly one refusal log line, got {len(lines)}"
+    assert lines[0].levelname == "INFO"
+
+
+def test_the_catalog_outcome_site_is_named() -> None:
+    """`_raise_catalog_outcome` is a distinct gate and must say so."""
+    readiness = type("R", (), {"status": "stale"})()
+
+    with pytest.raises(find_module.RetrievalIndexWarming) as caught:
+        find_module._raise_catalog_outcome(readiness)
+
+    assert caught.value.details["site"] == "catalog_outcome"
+
+
+# --- The 60s server-side hang ----------------------------------------------
+
+
+def test_the_follower_wait_is_bounded_to_single_digit_seconds() -> None:
+    """A wait longer than any client timeout is a hang, not an optimisation."""
+    assert find_module._RECALL_RESOLVER_FOLLOWER_WAIT_SECONDS <= 9.0
+
+
+def test_a_managed_follower_refuses_quickly_instead_of_hanging(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A refusing request returns within the bound, carrying retry_after_ms.
+
+    The measured production shape: a leader is mid-build (holding the
+    single-flight event) while a managed request arrives on a warm vault. The
+    request must decline rather than wait out the leader's whole-vault walk.
+    """
+    from exomem import file_watcher, freshness
+
+    file_watcher.FileWatcher(vault)._reconcile_once(seed=True)
+    checkpoint = freshness.live_recall_checkpoint(vault, "vault")
+    assert checkpoint is not None, "the registry did not warm; wrong precondition"
+
+    monkeypatch.setattr(find_module, "_RECALL_RESOLVER_FOLLOWER_WAIT_SECONDS", 0.2)
+
+    # A leader that never finishes, exactly like a long vault walk in flight.
+    root = Path(vault)
+    stuck = threading.Event()
+    with find_module._RECALL_REBUILD_LOCK:
+        find_module._RECALL_RESOLVER_BUILDS[root] = stuck
+    try:
+        started = time.monotonic()
+        with pytest.raises(find_module.RetrievalIndexWarming) as caught:
+            find_module.recall_resolver_snapshot(
+                root,
+                allow_fallback=False,
+                expected_checkpoint=checkpoint,
+            )
+        elapsed = time.monotonic() - started
+    finally:
+        with find_module._RECALL_REBUILD_LOCK:
+            find_module._RECALL_RESOLVER_BUILDS.pop(root, None)
+        stuck.set()
+
+    assert elapsed < 5.0, f"a refusing request waited {elapsed:.1f}s on a leader"
+    assert caught.value.details["site"] == "resolver_build_wait"
+    assert caught.value.details["retry_after_ms"] > 0
+    assert caught.value.details["waited_ms"] >= 0
+
+
+def test_a_fallback_caller_still_waits_out_the_leader(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Counter-scenario: a CLI/cold caller may still wait and then build.
+
+    Bounding the managed request must not silently cut cold callers from 120s
+    to 3s — they have no client deadline, and duplicating the leader's
+    whole-vault walk is the more expensive option.
+
+    Asserting only "a resolver came back" does NOT discriminate: a caller
+    wrongly given the short bound also returns one, by timing out early and
+    building its own. So pin the SELECTION at the call site, with a
+    non-vacuity guard — a spy that was never called proves nothing.
+    """
+    from exomem import file_watcher
+
+    file_watcher.FileWatcher(vault)._reconcile_once(seed=True)
+
+    observed: list[bool] = []
+    real = find_module._follower_wait_seconds
+
+    def spy(*, allow_fallback: bool) -> float:
+        observed.append(allow_fallback)
+        return real(allow_fallback=allow_fallback)
+
+    monkeypatch.setattr(find_module, "_follower_wait_seconds", spy)
+    monkeypatch.setattr(find_module, "_RECALL_RESOLVER_BUILD_WAIT_SECONDS", 0.2)
+
+    root = Path(vault)
+    stuck = threading.Event()
+    with find_module._RECALL_REBUILD_LOCK:
+        find_module._RECALL_RESOLVER_BUILDS[root] = stuck
+    try:
+        resolver = find_module.recall_resolver_snapshot(root, allow_fallback=True)
+    finally:
+        with find_module._RECALL_REBUILD_LOCK:
+            find_module._RECALL_RESOLVER_BUILDS.pop(root, None)
+        stuck.set()
+
+    assert resolver is not None
+    assert observed == [True], (
+        "the call site did not select its wait through _follower_wait_seconds "
+        f"exactly once with allow_fallback=True (observed: {observed})"
+    )
+
+
+def test_a_managed_caller_selects_its_wait_through_the_same_seam(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The managed side of the same selection, so neither branch drifts."""
+    from exomem import file_watcher, freshness
+
+    file_watcher.FileWatcher(vault)._reconcile_once(seed=True)
+    checkpoint = freshness.live_recall_checkpoint(vault, "vault")
+    assert checkpoint is not None
+
+    observed: list[bool] = []
+
+    def spy(*, allow_fallback: bool) -> float:
+        observed.append(allow_fallback)
+        return 0.05
+
+    monkeypatch.setattr(find_module, "_follower_wait_seconds", spy)
+
+    root = Path(vault)
+    stuck = threading.Event()
+    with find_module._RECALL_REBUILD_LOCK:
+        find_module._RECALL_RESOLVER_BUILDS[root] = stuck
+    try:
+        with pytest.raises(find_module.RetrievalIndexWarming):
+            find_module.recall_resolver_snapshot(
+                root,
+                allow_fallback=False,
+                expected_checkpoint=checkpoint,
+            )
+    finally:
+        with find_module._RECALL_REBUILD_LOCK:
+            find_module._RECALL_RESOLVER_BUILDS.pop(root, None)
+        stuck.set()
+
+    assert observed == [False], f"managed selection bypassed the seam: {observed}"
+
+
+def test_the_public_envelope_carries_the_site() -> None:
+    """REST and MCP both project `OpError.as_public_dict()`, so pin it there."""
+    error = find_module.RetrievalIndexWarming(
+        site="resolver_build_wait",
+        status="temporarily_unavailable",
+        waited_ms=3000,
+    )
+
+    payload = error.as_public_dict()
+
+    assert payload["error_code"] == "RETRIEVAL_INDEX_WARMING"
+    assert payload["site"] == "resolver_build_wait"
+    assert payload["waited_ms"] == 3000
+    assert payload["retry_after_ms"] > 0
+
+
+def test_every_declared_site_is_actually_used() -> None:
+    """The vocabulary is a registry, not a wish list.
+
+    A name nobody raises is dead documentation that will drift; a raise that
+    uses a name outside the vocabulary escapes the closed set.
+    """
+    source = SOURCE.read_text(encoding="utf-8")
+    used = set(re.findall(r'site="([a-z0-9_]+)"', source))
+    declared = set(find_module.RETRIEVAL_WARMING_SITES)
+
+    assert used - declared == set(), f"raise sites outside the vocabulary: {used - declared}"
+    assert declared - used == set(), f"declared but never raised: {declared - used}"
+
+
+def test_a_managed_caller_never_selects_the_long_wait() -> None:
+    """Pin the wait SELECTION directly, without sitting through it.
+
+    The production defect was a managed request inheriting the 120s
+    fall-back wait. Asserting that by observing elapsed time means hanging for
+    two minutes to prove it; asserting the choice is instant and exact.
+    """
+    managed = find_module._follower_wait_seconds(allow_fallback=False)
+    cold = find_module._follower_wait_seconds(allow_fallback=True)
+
+    assert managed == find_module._RECALL_RESOLVER_FOLLOWER_WAIT_SECONDS
+    assert managed <= 9.0, "a managed request can outlive a client deadline"
+    assert cold == find_module._RECALL_RESOLVER_BUILD_WAIT_SECONDS
+    assert cold > managed
+
+
+# --- The vocabulary is enforced where it cannot be evaded ------------------
+#
+# The source-scan and registry tests below are a real second layer, but they
+# read SHAPES: a double-quoted literal, a `raise Cls(` call. Any construction
+# that does not match those shapes slips past them and reaches the public
+# envelope. The constructor is the only place the contract cannot be evaded.
+
+
+def test_an_unknown_site_is_refused_at_construction() -> None:
+    """An out-of-vocabulary site must not be constructible at all."""
+    with pytest.raises(ValueError, match="unknown retrieval refusal site"):
+        find_module.RetrievalIndexWarming(site="not_a_real_site")
+
+
+def test_a_site_carrying_content_is_refused_at_construction() -> None:
+    """The leak this closes: an f-string site interpolating a vault path.
+
+    A refusal envelope reaches REST and MCP verbatim, so a site built from a
+    path would publish that path to every client.
+    """
+    leaked = "Knowledge Base/Private/secret.md"
+
+    with pytest.raises(ValueError, match="unknown retrieval refusal site"):
+        find_module.RetrievalIndexWarming(site=f"projection_unavailable:{leaked}")
+
+
+def test_quote_style_cannot_evade_the_vocabulary() -> None:
+    """A single-quoted literal is invisible to a double-quote-only regex."""
+    with pytest.raises(ValueError, match="unknown retrieval refusal site"):
+        find_module.RetrievalIndexWarming(site='resolver_build_wait_typo')
+
+
+def test_an_indirect_raise_is_still_validated() -> None:
+    """Constructing then raising separately evades a `raise Cls(` scan."""
+    with pytest.raises(ValueError, match="unknown retrieval refusal site"):
+        _exc = find_module.RetrievalIndexWarming(site="smuggled_site")
+        raise _exc
+
+
+def test_every_declared_site_remains_constructible() -> None:
+    """The check must not be so strict it rejects the real vocabulary."""
+    for site in find_module.RETRIEVAL_WARMING_SITES:
+        error = find_module.RetrievalIndexWarming(site=site)
+        assert error.details["site"] == site


### PR DESCRIPTION
## Why

The remaining live symptom after 0.64.1: even on a warm, converged cell, hybrid recall oscillated between fast serves and 31-90s server-side hangs that ended in RETRIEVAL_INDEX_WARMING (keyword served ~2s throughout). The mechanism is the recall resolver single-flight follower wait: a managed caller (`allow_fallback=False`) that found a resolver build in flight waited up to **120s** on the leader before refusing - longer than every client deadline (claude.ai, ChatGPT, Cloudflare's ~100s edge cap), so refusals arrived as hangs and the projection-lag tolerance from #876 never got a chance to engage (different gate).

## What

- **Bounded follower decline**: managed callers now wait at most **3s** on an in-flight resolver build, then decline with `retry_after_ms`. Fallback-permitted callers (warm-up, CLI, cold maintenance) keep the full 120s build bound - for them waiting beats duplicating the whole-vault walk. The selection is a single seam (`_follower_wait_seconds`) pinned on **both** branches with non-vacuity spy guards.
- **Refusal observability**: every retrieval warming refusal carries a `site` discriminator from an 11-entry closed vocabulary (`find.RETRIEVAL_WARMING_SITES`) plus integer `waited_ms`, projected unchanged through REST and MCP envelopes. The vocabulary is **enforced in the constructor** - an out-of-vocabulary or content-bearing site raises `ValueError` before any envelope exists, so no raise shape can smuggle a path or query into the public surface. The OpenAPI `site` schema is an enum **derived** from the code vocabulary (a hand-copied or drifted enum fails the schema test in both directions).
- **Spec**: `bound-graph-recovery-funnel` recall-read-path delta gains the bounded-follower-decline and closed-vocabulary requirements; tasks 2.6/2.7.

## Verification

- Independent adversarial review: **APPROVE** after one correction round. The reviewer's original findings (vocabulary enforced only in tests - three one-line evasions reached the public envelope, one carrying a vault path; fallback branch unpinned at the call site; OpenAPI schema admitting any string) were each re-verified with the reviewer's own fresh mutations: constructor refuses every previous leak payload, P10/P12/P13 killed, and the identical f-string evasion at a reachable raise site killed by 14 tests.
- Mutation testing: 12/12 implementer mutants killed (P6-P11, C1-C7 families) in verified scratch copies.
- Focused suites (`test_find`, `test_rest_api`, `test_catalog_error_surfaces`, `test_catalog_diagnostics`, `test_keyword_lane_cold_cost`, `test_recall_resolver_warm`, `test_refusal_observability`): **136 passed**.
- Wider regression (REST/server runtime/lexstore/instant-start/bounded-retrieval/typed-graph/resolver lanes): **237 passed**.
- `uvx ruff check` clean vs origin/main baseline; privacy gate clean (3372 files); `openspec validate --all --strict` 168/0.
- Reviewer-adjudicated: no refusal-storm risk from the 3s decline (ordinary writes patch the resolver in place; evictions hand leadership to the background rebuild thread, so the refusal window is per-rebuild-episode, not per-write).

## Live prediction (post-deploy check)

Hybrid refusals during a resolver rebuild should now return in ~3s carrying `site="resolver_build_wait"` - and if the live gate is actually a different one, the discriminator names it on the first request.