### PR TITLE
feat(governance): plan forward schema migration

### DIFF
--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -16,7 +16,7 @@ Subcommands:
   (requires the optional `tui` extra; needs an interactive terminal)
 - `doctor` — read-only local install/setup preflight
 - `auth sessions|revoke` — operator-only durable MCP session administration
-- `governance-schema status|downmigrate` — explicit offline schema inspection/rollback
+- `governance-schema status|plan-migration|downmigrate` — offline schema control
 - `status` — resource posture/residency diagnostics without loading models
 - `warm` — pre-download/load the search models (bge, reranker, CLIP) so the first
   server start doesn't pay the download in the background; optional `--vault`
@@ -1527,7 +1527,7 @@ def _governance_schema_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="exomem governance-schema",
         description=(
-            "Ops-only governance schema inspection and explicit offline rollback. "
+            "Ops-only governance schema inspection, planning, and explicit rollback. "
             "This command is not exposed through MCP, REST, or Hosted agent surfaces."
         ),
     )
@@ -1539,6 +1539,13 @@ def _governance_schema_main(argv: list[str]) -> int:
     )
     status_parser.add_argument("--vault", required=True, help="explicit absolute vault root")
     status_parser.add_argument("--json", action="store_true", help="emit stable JSON")
+
+    plan_parser = subcommands.add_parser(
+        "plan-migration",
+        help="stage and review an inert exact-v3 to exact-v4 migration target",
+    )
+    plan_parser.add_argument("--vault", required=True, help="explicit absolute vault root")
+    plan_parser.add_argument("--json", action="store_true", help="emit stable JSON")
 
     downmigrate_parser = subcommands.add_parser(
         "downmigrate",
@@ -1568,9 +1575,27 @@ def _governance_schema_main(argv: list[str]) -> int:
         )
         return 1
 
-    from .governance import authorization_custody, schema_downmigration
+    from .governance import authorization_custody, schema_downmigration, schema_migration
 
     moment = int(time.time())
+    if args.command == "plan-migration":
+        try:
+            plan = schema_migration.prepare_forward_migration(vault, now=moment)
+            summary = schema_migration.plan_summary(plan)
+        except schema_migration.ForwardMigrationUnavailable:
+            _governance_schema_print_error(
+                "GOVERNANCE_SCHEMA_MIGRATION_UNAVAILABLE",
+                "the exact quiesced v3 policy and catalog could not be prepared",
+                as_json=as_json,
+            )
+            return 1
+        if as_json:
+            print(json.dumps(summary))
+        else:
+            for key, value in summary.items():
+                print(f"{key}: {value}")
+        return 0
+
     try:
         status = _governance_schema_status(vault, now=moment)
     except (

--- a/src/exomem/governance/authorization_custody.py
+++ b/src/exomem/governance/authorization_custody.py
@@ -180,6 +180,7 @@ class StandaloneV3StagingResult:
     logical_vault_id: str
     registry_attachment_id: str
     attachment_epoch: int
+    staged_at: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -1320,6 +1321,7 @@ def stage_standalone_v3_custody(
         logical_vault_id=keyring.logical_vault_id,
         registry_attachment_id=attachment_id,
         attachment_epoch=1,
+        staged_at=keyring.active_key.not_before,
     )
 
 

--- a/src/exomem/governance/schema_migration.py
+++ b/src/exomem/governance/schema_migration.py
@@ -1,0 +1,356 @@
+"""Prepare the exact inert target for an offline governance v3-to-v4 migration."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from .. import find_corpus, reserved_paths
+from ..kbdir import kb_dirname
+from . import (
+    authorization_custody,
+    membership,
+    policy,
+    projection_store,
+    projections,
+    receipts,
+    schema_v4,
+    store,
+)
+
+_CROCKFORD32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+_CATALOG_GENERATION = 1
+_COMPILER_SCHEMA_VERSION = 1
+
+
+class ForwardMigrationUnavailable(RuntimeError):
+    """The exact v3 source cannot produce one reviewable migration target."""
+
+
+@dataclass(frozen=True, slots=True)
+class ForwardMigrationPlan:
+    """Private seed plus the content-free target an owner may review."""
+
+    seed: schema_v4.MigrationSeed
+    target: schema_v4.VerifiedActiveGovernanceState
+    source_store_digest: str
+    projection_rows_digest: str
+    item_count: int
+    plan_digest: str
+
+
+def _framed_digest(domain: bytes, *parts: bytes) -> str:
+    value = bytearray(domain)
+    for part in parts:
+        value.extend(len(part).to_bytes(8, "big"))
+        value.extend(part)
+    return hashlib.sha256(value).hexdigest()
+
+
+def _deterministic_ulid(*, timestamp: int, entropy: bytes) -> str:
+    if timestamp < 0 or timestamp * 1000 >= 1 << 48:
+        raise ForwardMigrationUnavailable
+    value = (timestamp * 1000 << 80) | int.from_bytes(
+        hashlib.sha256(entropy).digest()[:10],
+        "big",
+    )
+    return "".join(
+        _CROCKFORD32[(value >> shift) & 31] for shift in range(125, -1, -5)
+    )
+
+
+def _search_fields(page: find_corpus.ParsedPage) -> dict[str, str]:
+    fields = {"title": page.title}
+    for name, value in (
+        ("body", page.body),
+        ("status", page.frontmatter.get("status")),
+        ("type", page.page_type),
+        ("updated", page.updated),
+        ("media_type", page.frontmatter.get("media_type")),
+        ("parent_media", page.frontmatter.get("parent_media")),
+    ):
+        if value:
+            fields[name] = str(value)
+    return fields
+
+
+def _source_store_digest(vault_root: Path) -> str:
+    source = store.open_readonly_connection(vault_root)
+    if source is None:
+        raise ForwardMigrationUnavailable
+    snapshot = sqlite3.connect(":memory:")
+    try:
+        schema_v4.require_exact_v3_connection(source)
+        source.backup(snapshot)
+        schema_v4.require_exact_v3_connection(snapshot)
+        serialized = snapshot.serialize()
+    except (AttributeError, OSError, RuntimeError, sqlite3.Error) as error:
+        raise ForwardMigrationUnavailable from error
+    finally:
+        snapshot.close()
+        source.close()
+    return _framed_digest(b"exomem.governance-v3-snapshot.v1", serialized)
+
+
+def _catalog_items(
+    vault_root: Path,
+    *,
+    compiled: policy.Policy,
+    key: projections.ProjectionNamespaceKey,
+) -> tuple[projection_store.ProjectionItemVariants, ...]:
+    kb = vault_root / kb_dirname()
+    if not kb.is_dir():
+        raise ForwardMigrationUnavailable
+    items: list[projection_store.ProjectionItemVariants] = []
+    for path in sorted(find_corpus.walk_md(kb)):
+        if path.name.casefold() in find_corpus.NAVIGATION_BASENAMES:
+            continue
+        try:
+            relative = path.relative_to(vault_root).as_posix()
+            snapshot = reserved_paths.read_generic_bytes(vault_root, relative)
+            parsed = find_corpus.parse_page(
+                path,
+                snapshot.mtime,
+                vault_root,
+                content=snapshot.data,
+                resolved_relative=relative,
+            )
+            if parsed is None:
+                raise ForwardMigrationUnavailable
+            content_hash = hashlib.sha256(snapshot.data).hexdigest()
+            scope_ids = tuple(
+                sorted(
+                    membership.evaluate_snapshot(
+                        parsed,
+                        compiled,
+                        content_hash=content_hash,
+                    )
+                )
+            )
+            variants = projections.enumerate_projection_variants(
+                item_identity=relative,
+                content_hash=content_hash,
+                scope_ids=scope_ids,
+                policy=compiled,
+                projector_schema_version=key.projector_schema_version,
+                full_search_fields=_search_fields(parsed),
+            )
+        except ForwardMigrationUnavailable:
+            raise
+        except (
+            OSError,
+            RuntimeError,
+            UnicodeError,
+            ValueError,
+            membership.MembershipUnresolved,
+            projections.ProjectionError,
+            reserved_paths.ReservedPathLeafError,
+        ) as error:
+            raise ForwardMigrationUnavailable from error
+        items.append(
+            projection_store.ProjectionItemVariants(
+                item_identity=relative,
+                content_hash=content_hash,
+                scope_ids=scope_ids,
+                variants=variants,
+            )
+        )
+    return tuple(items)
+
+
+def _policy_seed(
+    snapshot: policy.AuthoringSnapshot,
+    compiled: policy.Policy,
+    *,
+    staged_at: int,
+    keyring_id: str,
+) -> schema_v4.PolicyGenerationSeed:
+    generation_id = _deterministic_ulid(
+        timestamp=staged_at,
+        entropy=(
+            b"exomem.initial-policy-generation.v1\0"
+            + keyring_id.encode("ascii")
+            + snapshot.source_fingerprint.encode("ascii")
+            + snapshot.conflict_set_digest.encode("ascii")
+        ),
+    )
+    identity = {
+        "operation": "governance_schema_v3_to_v4",
+        "generation_id": generation_id,
+        "keyring_id": keyring_id,
+        "source_fingerprint": snapshot.source_fingerprint,
+        "conflict_digest": snapshot.conflict_set_digest,
+        "staged_at": staged_at,
+    }
+    authoring_event_id = receipts.critical_event_id(
+        {**identity, "phase": "initial-policy-reviewed"}
+    )
+    receipt_event_id = receipts.critical_event_id(
+        {
+            **identity,
+            "phase": "initial-policy-publication",
+            "authoring_event_id": authoring_event_id,
+        }
+    )
+    return schema_v4.PolicyGenerationSeed(
+        generation_id=generation_id,
+        source_documents=snapshot.documents,
+        source_fingerprint=snapshot.source_fingerprint,
+        conflict_digest=snapshot.conflict_set_digest,
+        compiled_policy=policy.canonical_compiled_bytes(compiled),
+        policy_fingerprint=compiled.fingerprint,
+        compiler_schema_version=_COMPILER_SCHEMA_VERSION,
+        projector_schema_version=projections.PROJECTOR_SCHEMA_VERSION,
+        predecessor_generation_id=None,
+        authoring_event_id=authoring_event_id,
+        receipt_event_id=receipt_event_id,
+        created_at=staged_at,
+    )
+
+
+def _plan_value(
+    target: schema_v4.VerifiedActiveGovernanceState,
+    *,
+    source_store_digest: str,
+    projection_rows_digest: str,
+    item_count: int,
+) -> dict[str, str | int]:
+    return {
+        "schema_version": 3,
+        "logical_vault_id": target.logical_vault_id,
+        "activation_store_id": target.activation_store_id,
+        "activation_epoch": target.activation_epoch,
+        "activation_state_digest": target.activation_state_digest,
+        "policy_generation_id": target.policy_generation_id,
+        "policy_fingerprint": target.policy_fingerprint,
+        "projector_schema_version": target.projector_schema_version,
+        "catalog_generation": target.catalog_generation,
+        "projection_namespace_id": target.projection_namespace_id,
+        "source_store_digest": source_store_digest,
+        "projection_rows_digest": projection_rows_digest,
+        "item_count": item_count,
+    }
+
+
+def prepare_forward_migration(
+    vault_root: Path,
+    *,
+    now: int,
+) -> ForwardMigrationPlan:
+    """Stage an immutable v4 target without enrolling or changing schema v3."""
+
+    root = Path(vault_root)
+    try:
+        staged = authorization_custody.stage_standalone_v3_custody(root, now=now)
+        before = policy.observe_authoring_snapshot(root)
+        if before is None:
+            raise ForwardMigrationUnavailable
+        source_store_digest = _source_store_digest(root)
+        compiled = policy.compile_documents(dict(before.documents))
+        if compiled.empty or compiled.blocked:
+            raise ForwardMigrationUnavailable
+        policy_seed = _policy_seed(
+            before,
+            compiled,
+            staged_at=staged.staged_at,
+            keyring_id=staged.keyring_id,
+        )
+        key = projections.ProjectionNamespaceKey(
+            policy_fingerprint=compiled.fingerprint,
+            projector_schema_version=projections.PROJECTOR_SCHEMA_VERSION,
+            catalog_generation=_CATALOG_GENERATION,
+        )
+        items = _catalog_items(root, compiled=compiled, key=key)
+        descriptor = projection_store.catalog_descriptor_bytes(key, items)
+        manifest = projection_store.preview_variant_store(key=key, items=items)
+        evidence = projection_store.projection_namespace_evidence_bytes(manifest)
+        after = policy.observe_authoring_snapshot(root)
+        if (
+            after != before
+            or _catalog_items(root, compiled=compiled, key=key) != items
+            or _source_store_digest(root) != source_store_digest
+        ):
+            raise ForwardMigrationUnavailable
+        seed = schema_v4.MigrationSeed(
+            activation_store_id=(
+                "activation-store-"
+                + _framed_digest(
+                    b"exomem.initial-activation-store.v1",
+                    staged.keyring_id.encode("ascii"),
+                    staged.logical_vault_id.encode("ascii"),
+                )[:32]
+            ),
+            logical_vault_id=staged.logical_vault_id,
+            activation_epoch=1,
+            policy=policy_seed,
+            catalog=schema_v4.CatalogGenerationSeed(
+                catalog_generation=_CATALOG_GENERATION,
+                descriptor=descriptor,
+                artifact_count=len(items),
+                created_at=staged.staged_at,
+            ),
+            namespace=schema_v4.ProjectionNamespaceSeed(
+                namespace_id=key.namespace_id,
+                evidence=evidence,
+                ready_at=staged.staged_at,
+            ),
+            migrated_at=staged.staged_at,
+        )
+        target = schema_v4.migration_target(seed)
+        plan_value = _plan_value(
+            target,
+            source_store_digest=source_store_digest,
+            projection_rows_digest=manifest.rows_digest,
+            item_count=len(items),
+        )
+        plan_digest = _framed_digest(
+            b"exomem.governance-schema-migration-plan.v1",
+            projections.canonical_jcs(plan_value),
+        )
+    except ForwardMigrationUnavailable:
+        raise
+    except (
+        authorization_custody.AuthorizationCustodyUnavailable,
+        projection_store.ProjectionStoreError,
+        projections.ProjectionError,
+        schema_v4.SchemaV4Error,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ) as error:
+        raise ForwardMigrationUnavailable from error
+    return ForwardMigrationPlan(
+        seed=seed,
+        target=target,
+        source_store_digest=source_store_digest,
+        projection_rows_digest=manifest.rows_digest,
+        item_count=len(items),
+        plan_digest=plan_digest,
+    )
+
+
+def plan_summary(plan: ForwardMigrationPlan) -> dict[str, object]:
+    """Return the closed, content-free owner review surface."""
+
+    if not isinstance(plan, ForwardMigrationPlan):
+        raise ForwardMigrationUnavailable
+    return {
+        **_plan_value(
+            plan.target,
+            source_store_digest=plan.source_store_digest,
+            projection_rows_digest=plan.projection_rows_digest,
+            item_count=plan.item_count,
+        ),
+        "plan_digest": plan.plan_digest,
+    }
+
+
+__all__ = [
+    "ForwardMigrationPlan",
+    "ForwardMigrationUnavailable",
+    "plan_summary",
+    "prepare_forward_migration",
+]

--- a/tests/test_governance_schema_cli.py
+++ b/tests/test_governance_schema_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -9,10 +10,61 @@ from exomem.__main__ import main
 from exomem.governance import (
     authorization_custody,
     schema_downmigration,
+    schema_migration,
     store,
 )
 
 ACTIVE_DIGEST = "a" * 64
+
+
+def test_governance_schema_plan_migration_emits_reviewable_target(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    summary = {
+        "schema_version": 3,
+        "logical_vault_id": "logical-vault-cli",
+        "activation_store_id": "activation-store-cli",
+        "activation_epoch": 1,
+        "activation_state_digest": ACTIVE_DIGEST,
+        "policy_generation_id": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "policy_fingerprint": "b" * 64,
+        "projector_schema_version": 1,
+        "catalog_generation": 1,
+        "projection_namespace_id": "c" * 64,
+        "source_store_digest": "e" * 64,
+        "projection_rows_digest": "d" * 64,
+        "item_count": 7,
+        "plan_digest": "f" * 64,
+    }
+    calls: list[tuple[Path, int]] = []
+
+    def prepare(root: Path, *, now: int):
+        calls.append((root, now))
+        return object()
+
+    monkeypatch.setattr(schema_migration, "prepare_forward_migration", prepare)
+    monkeypatch.setattr(schema_migration, "plan_summary", lambda _plan: summary)
+
+    assert (
+        main(
+            [
+                "governance-schema",
+                "plan-migration",
+                "--vault",
+                str(vault),
+                "--json",
+            ]
+        )
+        == 0
+    )
+
+    assert len(calls) == 1 and calls[0][0] == vault
+    assert isinstance(calls[0][1], int) and calls[0][1] > 0
+    assert json.loads(capsys.readouterr().out) == summary
 
 
 @pytest.fixture

--- a/tests/test_governance_schema_migration_plan.py
+++ b/tests/test_governance_schema_migration_plan.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from exomem import mutation_lock, writer_lease
+from exomem.governance import (
+    authorization_custody,
+    projection_store,
+    projections,
+    schema_migration,
+    schema_v4,
+    store,
+)
+
+POLICY_BYTES = (
+    b"governance_version: 1\n"
+    b"id: 01ARZ3NDEKTSV4RRFFQ69G5FAV\n"
+    b"types: [insight]\n"
+)
+NOTE_BYTES = b"---\ntype: insight\n---\n\n# Governed note\n\nVisible text.\n"
+
+
+@pytest.fixture(autouse=True)
+def _offline_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
+    external = tmp_path / "external"
+    external.mkdir(mode=0o700)
+    lease_state = tmp_path / "lease-state"
+    lease_state.mkdir(mode=0o700)
+    if os.name == "nt":  # pragma: no cover - exercised by Windows CI
+        sid = mutation_lock._windows_current_user_sid()
+        mutation_lock._windows_apply_private_dacl(external, sid)
+        mutation_lock._windows_apply_private_dacl(lease_state, sid)
+    monkeypatch.setenv(
+        authorization_custody.KEYRING_FILE_ENV,
+        str(external / "authorization-keyring.json"),
+    )
+    monkeypatch.setenv(
+        authorization_custody.CONTROL_FILE_ENV,
+        str(external / "authorization-control.json"),
+    )
+    monkeypatch.setenv(
+        authorization_custody.MEMBERSHIP_FILE_ENV,
+        str(external / "authorization-serving-membership.json"),
+    )
+    monkeypatch.setenv(authorization_custody.REPLICA_ID_ENV, "standalone")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(lease_state))
+    writer_lease.reset_managers_for_tests()
+    yield
+    writer_lease.reset_managers_for_tests()
+
+
+def _vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    governance = vault / "Knowledge Base" / "_Governance" / "scopes"
+    governance.mkdir(parents=True)
+    (governance / "migration.yaml").write_bytes(POLICY_BYTES)
+    notes = vault / "Knowledge Base" / "Notes"
+    notes.mkdir()
+    (notes / "governed.md").write_bytes(NOTE_BYTES)
+    connection = store.open_connection(vault)
+    connection.close()
+    return vault
+
+
+def _schema_version(vault: Path) -> int:
+    connection = sqlite3.connect(store.sidecar_path(vault))
+    try:
+        return int(connection.execute("PRAGMA user_version").fetchone()[0])
+    finally:
+        connection.close()
+
+
+def test_forward_migration_plan_is_replayable_and_inert(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+
+    first = schema_migration.prepare_forward_migration(vault, now=now)
+    replay = schema_migration.prepare_forward_migration(vault, now=now + 1)
+
+    assert replay == first
+    assert first.target.activation_epoch == 1
+    assert first.target.catalog_generation == 1
+    assert first.item_count == 1
+    assert first.seed.policy.source_documents == (
+        ("scopes/migration.yaml", POLICY_BYTES),
+    )
+    assert schema_v4.migration_target(first.seed) == first.target
+    assert _schema_version(vault) == 3
+    assert not Path(os.environ[authorization_custody.CONTROL_FILE_ENV]).exists()
+    assert not Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV]).exists()
+
+    key = projections.ProjectionNamespaceKey(
+        policy_fingerprint=first.target.policy_fingerprint,
+        projector_schema_version=first.target.projector_schema_version,
+        catalog_generation=first.target.catalog_generation,
+    )
+    assert not projection_store.variant_store_path(vault, key).exists()
+
+
+def test_forward_migration_plan_binds_current_canonical_content(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    first = schema_migration.prepare_forward_migration(vault, now=now)
+
+    (vault / "Knowledge Base" / "Notes" / "governed.md").write_bytes(
+        NOTE_BYTES.replace(b"Visible text.", b"Changed text.")
+    )
+    second = schema_migration.prepare_forward_migration(vault, now=now + 1)
+
+    assert second.target.activation_state_digest != first.target.activation_state_digest
+    assert second.projection_rows_digest != first.projection_rows_digest
+    assert _schema_version(vault) == 3
+
+
+def test_forward_migration_plan_binds_the_wal_consistent_v3_store(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    first = schema_migration.prepare_forward_migration(vault, now=now)
+
+    connection = store.open_connection(vault)
+    try:
+        connection.execute(
+            "INSERT INTO governance_session_purpose "
+            "(authorization_session, principal_id, purpose, status, prepared_event_id, "
+            "created_at, expires_at) VALUES "
+            "('legacy-session', 'legacy-principal', 'review', 'active', NULL, ?, ?)",
+            (now, now + 60),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    second = schema_migration.prepare_forward_migration(vault, now=now + 1)
+
+    assert second.target == first.target
+    assert second.source_store_digest != first.source_store_digest
+    assert second.plan_digest != first.plan_digest
+
+
+def test_forward_migration_plan_refuses_ambiguous_markdown(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    (vault / "Knowledge Base" / "Notes" / "governed.md").write_text(
+        "---\ntype: [unterminated\n---\n# Ambiguous\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(schema_migration.ForwardMigrationUnavailable):
+        schema_migration.prepare_forward_migration(vault, now=int(time.time()))
+
+    assert _schema_version(vault) == 3
+    assert not Path(os.environ[authorization_custody.CONTROL_FILE_ENV]).exists()
+    assert not Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV]).exists()
+
+
+def test_forward_migration_plan_summary_is_content_free(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    plan = schema_migration.prepare_forward_migration(vault, now=int(time.time()))
+
+    encoded = json.dumps(schema_migration.plan_summary(plan), sort_keys=True)
+
+    assert "Visible text" not in encoded
+    assert "governed.md" not in encoded
+    assert set(json.loads(encoded)) == {
+        "activation_epoch",
+        "activation_state_digest",
+        "activation_store_id",
+        "catalog_generation",
+        "item_count",
+        "logical_vault_id",
+        "policy_fingerprint",
+        "policy_generation_id",
+        "plan_digest",
+        "projection_namespace_id",
+        "projection_rows_digest",
+        "projector_schema_version",
+        "schema_version",
+        "source_store_digest",
+    }


### PR DESCRIPTION
## Summary

- add an ops-only `governance-schema plan-migration` command for exact v3 vaults
- derive a deterministic initial v4 policy/catalog/projection tuple from held canonical bytes
- bind the review surface to a WAL-consistent digest of the full v3 governance store
- keep planning inert: stage only external identity, without enrollment, schema migration, or projection-store publication

Stacked after #880. This PR does not merge the stack and does not touch any live vault.

## Verification

- red-first planner/CLI coverage, then 11 focused tests passed
- adjacent migration/downmigration/custody packet: 152 passed, 1 Windows-only DACL test skipped locally
- Ruff on all five changed files
- `uv lock --check`
- `openspec validate harden-governance-for-consolidation --strict`
- public repository artifact validation
- wheel and sdist build
- tracked and new-file diff checks
