### PR TITLE
feat(governance): stage forward migration namespace

### DIFF
--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -16,7 +16,7 @@ Subcommands:
   (requires the optional `tui` extra; needs an interactive terminal)
 - `doctor` — read-only local install/setup preflight
 - `auth sessions|revoke` — operator-only durable MCP session administration
-- `governance-schema status|plan-migration|downmigrate` — offline schema control
+- `governance-schema status|plan-migration|stage-migration|downmigrate` — offline schema control
 - `status` — resource posture/residency diagnostics without loading models
 - `warm` — pre-download/load the search models (bge, reranker, CLIP) so the first
   server start doesn't pay the download in the background; optional `--vault`
@@ -1547,6 +1547,21 @@ def _governance_schema_main(argv: list[str]) -> int:
     plan_parser.add_argument("--vault", required=True, help="explicit absolute vault root")
     plan_parser.add_argument("--json", action="store_true", help="emit stable JSON")
 
+    stage_parser = subcommands.add_parser(
+        "stage-migration",
+        help="publish the exact reviewed immutable namespace without activating it",
+    )
+    stage_parser.add_argument("--vault", required=True, help="explicit absolute vault root")
+    stage_parser.add_argument(
+        "--expected-plan-digest",
+        required=True,
+        help="64-character digest copied from the reviewed migration plan",
+    )
+    stage_parser.add_argument(
+        "--yes", action="store_true", help="confirm the reviewed inert publication"
+    )
+    stage_parser.add_argument("--json", action="store_true", help="emit stable JSON")
+
     downmigrate_parser = subcommands.add_parser(
         "downmigrate",
         help="restore exact schema v3 after every v4 replica is drained",
@@ -1593,6 +1608,55 @@ def _governance_schema_main(argv: list[str]) -> int:
             print(json.dumps(summary))
         else:
             for key, value in summary.items():
+                print(f"{key}: {value}")
+        return 0
+
+    if args.command == "stage-migration":
+        expected_plan_digest = args.expected_plan_digest
+        if not args.yes:
+            confirmation = {
+                "staged": False,
+                "reason": "confirmation_required",
+                "plan_digest": expected_plan_digest,
+            }
+            if as_json:
+                print(json.dumps(confirmation))
+            else:
+                for key, value in confirmation.items():
+                    print(f"{key}: {value}")
+            return 2
+        try:
+            terminal = schema_migration.stage_forward_migration(
+                vault,
+                expected_plan_digest=expected_plan_digest,
+                now=moment,
+            )
+        except schema_migration.ForwardMigrationPlanMismatch:
+            _governance_schema_print_error(
+                "GOVERNANCE_SCHEMA_PLAN_MISMATCH",
+                "the reviewed migration plan changed; no activation was attempted",
+                as_json=as_json,
+            )
+            return 1
+        except schema_migration.ForwardMigrationUnavailable:
+            _governance_schema_print_error(
+                "GOVERNANCE_SCHEMA_MIGRATION_UNAVAILABLE",
+                "the exact v3 migration namespace could not be staged",
+                as_json=as_json,
+            )
+            return 1
+        result = {
+            "staged": True,
+            "schema_version": 3,
+            "plan_digest": terminal.plan_digest,
+            "projection_namespace_id": terminal.projection_namespace_id,
+            "projection_rows_digest": terminal.projection_rows_digest,
+            "item_count": terminal.item_count,
+        }
+        if as_json:
+            print(json.dumps(result))
+        else:
+            for key, value in result.items():
                 print(f"{key}: {value}")
         return 0
 

--- a/src/exomem/governance/schema_migration.py
+++ b/src/exomem/governance/schema_migration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
@@ -29,6 +30,10 @@ class ForwardMigrationUnavailable(RuntimeError):
     """The exact v3 source cannot produce one reviewable migration target."""
 
 
+class ForwardMigrationPlanMismatch(ForwardMigrationUnavailable):
+    """The owner-confirmed plan is not the exact current migration plan."""
+
+
 @dataclass(frozen=True, slots=True)
 class ForwardMigrationPlan:
     """Private seed plus the content-free target an owner may review."""
@@ -39,6 +44,16 @@ class ForwardMigrationPlan:
     projection_rows_digest: str
     item_count: int
     plan_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class ForwardMigrationStageResult:
+    """Content-free terminal for one inert immutable namespace publication."""
+
+    plan_digest: str
+    projection_namespace_id: str
+    projection_rows_digest: str
+    item_count: int
 
 
 def _framed_digest(domain: bytes, *parts: bytes) -> str:
@@ -348,9 +363,105 @@ def plan_summary(plan: ForwardMigrationPlan) -> dict[str, object]:
     }
 
 
+def _stage_material(
+    vault_root: Path,
+    plan: ForwardMigrationPlan,
+) -> tuple[
+    projections.ProjectionNamespaceKey,
+    tuple[projection_store.ProjectionItemVariants, ...],
+    projection_store.VariantStoreManifest,
+]:
+    compiled = policy.compile_documents(dict(plan.seed.policy.source_documents))
+    key = projections.ProjectionNamespaceKey(
+        policy_fingerprint=plan.target.policy_fingerprint,
+        projector_schema_version=plan.target.projector_schema_version,
+        catalog_generation=plan.target.catalog_generation,
+    )
+    items = _catalog_items(vault_root, compiled=compiled, key=key)
+    manifest = projection_store.preview_variant_store(key=key, items=items)
+    if (
+        compiled.fingerprint != plan.target.policy_fingerprint
+        or projection_store.catalog_descriptor_bytes(key, items)
+        != plan.seed.catalog.descriptor
+        or projection_store.projection_namespace_evidence_bytes(manifest)
+        != plan.seed.namespace.evidence
+        or manifest.namespace_id != plan.target.projection_namespace_id
+        or manifest.rows_digest != plan.projection_rows_digest
+        or manifest.item_count != plan.item_count
+    ):
+        raise ForwardMigrationPlanMismatch
+    return key, items, manifest
+
+
+def stage_forward_migration(
+    vault_root: Path,
+    *,
+    expected_plan_digest: str,
+    now: int,
+) -> ForwardMigrationStageResult:
+    """Publish only the exact reviewed namespace while authority remains v3.
+
+    The immutable namespace is inert until a later coordinator enrolls and commits
+    its bound activation tuple.  A crash or late source drift can therefore leave
+    only an unreferenced, content-addressed store that an exact retry may reuse.
+    """
+
+    expected = str(expected_plan_digest)
+    if (
+        len(expected) != 64
+        or any(character not in "0123456789abcdef" for character in expected)
+    ):
+        raise ForwardMigrationPlanMismatch
+    root = Path(vault_root)
+    plan = prepare_forward_migration(root, now=now)
+    if not hmac.compare_digest(plan.plan_digest, expected):
+        raise ForwardMigrationPlanMismatch
+    try:
+        key, items, manifest = _stage_material(root, plan)
+        staged = projection_store.stage_variant_store(
+            root,
+            key=key,
+            items=items,
+        )
+        verified = projection_store.verify_variant_store(
+            root,
+            key=key,
+            expected_rows_digest=plan.projection_rows_digest,
+        )
+        current = prepare_forward_migration(root, now=now)
+    except ForwardMigrationPlanMismatch:
+        raise
+    except (
+        ForwardMigrationUnavailable,
+        projection_store.ProjectionStoreError,
+        projections.ProjectionError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ) as error:
+        raise ForwardMigrationUnavailable from error
+    if (
+        staged != manifest
+        or verified != manifest
+        or not hmac.compare_digest(current.plan_digest, expected)
+        or current != plan
+    ):
+        raise ForwardMigrationPlanMismatch
+    return ForwardMigrationStageResult(
+        plan_digest=plan.plan_digest,
+        projection_namespace_id=manifest.namespace_id,
+        projection_rows_digest=manifest.rows_digest,
+        item_count=manifest.item_count,
+    )
+
+
 __all__ = [
     "ForwardMigrationPlan",
+    "ForwardMigrationPlanMismatch",
+    "ForwardMigrationStageResult",
     "ForwardMigrationUnavailable",
     "plan_summary",
     "prepare_forward_migration",
+    "stage_forward_migration",
 ]

--- a/tests/test_governance_schema_cli.py
+++ b/tests/test_governance_schema_cli.py
@@ -67,6 +67,126 @@ def test_governance_schema_plan_migration_emits_reviewable_target(
     assert json.loads(capsys.readouterr().out) == summary
 
 
+def test_governance_schema_stage_migration_requires_digest_bound_confirmation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    calls: list[object] = []
+    monkeypatch.setattr(
+        schema_migration,
+        "stage_forward_migration",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    code = main(
+        [
+            "governance-schema",
+            "stage-migration",
+            "--vault",
+            str(vault),
+            "--expected-plan-digest",
+            "f" * 64,
+            "--json",
+        ]
+    )
+
+    assert code == 2
+    assert calls == []
+    assert json.loads(capsys.readouterr().out) == {
+        "staged": False,
+        "reason": "confirmation_required",
+        "plan_digest": "f" * 64,
+    }
+
+
+def test_governance_schema_stage_migration_returns_content_free_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    terminal = schema_migration.ForwardMigrationStageResult(
+        plan_digest="f" * 64,
+        projection_namespace_id="c" * 64,
+        projection_rows_digest="d" * 64,
+        item_count=7,
+    )
+    calls: list[tuple[Path, str, int]] = []
+
+    def stage(root: Path, *, expected_plan_digest: str, now: int):
+        calls.append((root, expected_plan_digest, now))
+        return terminal
+
+    monkeypatch.setattr(schema_migration, "stage_forward_migration", stage)
+
+    assert (
+        main(
+            [
+                "governance-schema",
+                "stage-migration",
+                "--vault",
+                str(vault),
+                "--expected-plan-digest",
+                "f" * 64,
+                "--yes",
+                "--json",
+            ]
+        )
+        == 0
+    )
+
+    assert len(calls) == 1
+    assert calls[0][0] == vault and calls[0][1] == "f" * 64
+    assert isinstance(calls[0][2], int) and calls[0][2] > 0
+    assert json.loads(capsys.readouterr().out) == {
+        "staged": True,
+        "schema_version": 3,
+        "plan_digest": "f" * 64,
+        "projection_namespace_id": "c" * 64,
+        "projection_rows_digest": "d" * 64,
+        "item_count": 7,
+    }
+
+
+def test_governance_schema_stage_migration_refuses_a_stale_plan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setattr(
+        schema_migration,
+        "stage_forward_migration",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            schema_migration.ForwardMigrationPlanMismatch
+        ),
+    )
+
+    code = main(
+        [
+            "governance-schema",
+            "stage-migration",
+            "--vault",
+            str(vault),
+            "--expected-plan-digest",
+            "f" * 64,
+            "--yes",
+            "--json",
+        ]
+    )
+
+    assert code == 1
+    assert json.loads(capsys.readouterr().out) == {
+        "error": "GOVERNANCE_SCHEMA_PLAN_MISMATCH",
+        "message": "the reviewed migration plan changed; no activation was attempted",
+    }
+
+
 @pytest.fixture
 def schema_state(tmp_path, monkeypatch: pytest.MonkeyPatch):
     vault = tmp_path / "vault"

--- a/tests/test_governance_schema_migration_plan.py
+++ b/tests/test_governance_schema_migration_plan.py
@@ -186,3 +186,113 @@ def test_forward_migration_plan_summary_is_content_free(tmp_path: Path) -> None:
         "schema_version",
         "source_store_digest",
     }
+
+
+def test_forward_migration_stage_publishes_only_the_reviewed_namespace(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    plan = schema_migration.prepare_forward_migration(vault, now=now)
+
+    result = schema_migration.stage_forward_migration(
+        vault,
+        expected_plan_digest=plan.plan_digest,
+        now=now + 1,
+    )
+
+    assert result.plan_digest == plan.plan_digest
+    assert result.projection_namespace_id == plan.target.projection_namespace_id
+    assert result.projection_rows_digest == plan.projection_rows_digest
+    assert result.item_count == plan.item_count
+    key = projections.ProjectionNamespaceKey(
+        policy_fingerprint=plan.target.policy_fingerprint,
+        projector_schema_version=plan.target.projector_schema_version,
+        catalog_generation=plan.target.catalog_generation,
+    )
+    assert projection_store.verify_variant_store(
+        vault,
+        key=key,
+        expected_rows_digest=plan.projection_rows_digest,
+    ).item_count == plan.item_count
+    assert _schema_version(vault) == 3
+    assert not Path(os.environ[authorization_custody.CONTROL_FILE_ENV]).exists()
+    assert not Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV]).exists()
+
+
+def test_forward_migration_stage_replays_without_changing_the_terminal(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    plan = schema_migration.prepare_forward_migration(vault, now=now)
+
+    first = schema_migration.stage_forward_migration(
+        vault,
+        expected_plan_digest=plan.plan_digest,
+        now=now + 1,
+    )
+    replay = schema_migration.stage_forward_migration(
+        vault,
+        expected_plan_digest=plan.plan_digest,
+        now=now + 2,
+    )
+
+    assert replay == first
+    assert _schema_version(vault) == 3
+
+
+def test_forward_migration_stage_refuses_stale_digest_before_publication(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    plan = schema_migration.prepare_forward_migration(vault, now=now)
+    (vault / "Knowledge Base" / "Notes" / "governed.md").write_bytes(
+        NOTE_BYTES.replace(b"Visible text.", b"Changed text.")
+    )
+
+    with pytest.raises(schema_migration.ForwardMigrationPlanMismatch):
+        schema_migration.stage_forward_migration(
+            vault,
+            expected_plan_digest=plan.plan_digest,
+            now=now + 1,
+        )
+
+    key = projections.ProjectionNamespaceKey(
+        policy_fingerprint=plan.target.policy_fingerprint,
+        projector_schema_version=plan.target.projector_schema_version,
+        catalog_generation=plan.target.catalog_generation,
+    )
+    assert not projection_store.variant_store_path(vault, key).exists()
+    assert _schema_version(vault) == 3
+
+
+def test_forward_migration_stage_refuses_drift_after_inert_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    plan = schema_migration.prepare_forward_migration(vault, now=now)
+    original = projection_store.stage_variant_store
+
+    def stage_then_drift(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        manifest = original(*args, **kwargs)
+        (vault / "Knowledge Base" / "Notes" / "governed.md").write_bytes(
+            NOTE_BYTES.replace(b"Visible text.", b"Changed during staging.")
+        )
+        return manifest
+
+    monkeypatch.setattr(projection_store, "stage_variant_store", stage_then_drift)
+
+    with pytest.raises(schema_migration.ForwardMigrationPlanMismatch):
+        schema_migration.stage_forward_migration(
+            vault,
+            expected_plan_digest=plan.plan_digest,
+            now=now + 1,
+        )
+
+    assert _schema_version(vault) == 3
+    assert not Path(os.environ[authorization_custody.CONTROL_FILE_ENV]).exists()
+    assert not Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV]).exists()


### PR DESCRIPTION
## Summary

- add an ops-only, digest-confirmed `governance-schema stage-migration` command
- publish and fully verify the exact immutable projection namespace from the reviewed migration plan
- keep the vault on exact schema v3 with governance unenrolled and no active tuple
- refuse stale preimages before publication and late drift after publication; a crash can leave only an inert, unreferenced content-addressed namespace

Stacked after #883. This does not merge anything, activate governance, or touch any live Personal/POLLY vault.

## Verification

- red first: 7 expected failures for the absent stage API/CLI
- focused planner/CLI on Python 3.13: 18 passed
- adjacent migration, downmigration, custody, and projection-store packet: 145 passed, 1 expected Windows-only skip
- Ruff on all four changed files
- `git diff --check`
- `uv lock --check`
- `openspec validate harden-governance-for-consolidation --strict`
- public repository artifact validation
- `uv build`
