### PR TITLE
feat(governance): commit forward migration cutover

### DIFF
--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -16,7 +16,7 @@ Subcommands:
   (requires the optional `tui` extra; needs an interactive terminal)
 - `doctor` — read-only local install/setup preflight
 - `auth sessions|revoke` — operator-only durable MCP session administration
-- `governance-schema status|plan-migration|stage-migration|downmigrate` — offline schema control
+- `governance-schema status|plan-migration|stage-migration|commit-migration|downmigrate` — offline schema control
 - `status` — resource posture/residency diagnostics without loading models
 - `warm` — pre-download/load the search models (bge, reranker, CLIP) so the first
   server start doesn't pay the download in the background; optional `--vault`
@@ -1562,6 +1562,23 @@ def _governance_schema_main(argv: list[str]) -> int:
     )
     stage_parser.add_argument("--json", action="store_true", help="emit stable JSON")
 
+    commit_parser = subcommands.add_parser(
+        "commit-migration",
+        help="back up exact v3 and commit the reviewed staged v4 target",
+    )
+    commit_parser.add_argument(
+        "--vault", required=True, help="explicit absolute vault root"
+    )
+    commit_parser.add_argument(
+        "--expected-plan-digest",
+        required=True,
+        help="64-character digest copied from the reviewed migration plan",
+    )
+    commit_parser.add_argument(
+        "--yes", action="store_true", help="confirm the irreversible reviewed cutover"
+    )
+    commit_parser.add_argument("--json", action="store_true", help="emit stable JSON")
+
     downmigrate_parser = subcommands.add_parser(
         "downmigrate",
         help="restore exact schema v3 after every v4 replica is drained",
@@ -1658,6 +1675,70 @@ def _governance_schema_main(argv: list[str]) -> int:
         else:
             for key, value in result.items():
                 print(f"{key}: {value}")
+        return 0
+
+    if args.command == "commit-migration":
+        expected_plan_digest = args.expected_plan_digest
+        if not args.yes:
+            confirmation = {
+                "migrated": False,
+                "reason": "confirmation_required",
+                "plan_digest": expected_plan_digest,
+            }
+            if as_json:
+                print(json.dumps(confirmation))
+            else:
+                print(
+                    "migration cutover requires --yes after reviewing this exact plan: "
+                    f"{expected_plan_digest}",
+                    file=sys.stderr,
+                )
+            return 2
+        try:
+            result = schema_migration.commit_forward_migration(
+                vault,
+                expected_plan_digest=expected_plan_digest,
+                now=moment,
+            )
+        except schema_migration.ForwardMigrationPlanMismatch:
+            _governance_schema_print_error(
+                "GOVERNANCE_SCHEMA_PLAN_MISMATCH",
+                "the reviewed migration plan changed; no activation was attempted",
+                as_json=as_json,
+            )
+            return 1
+        except schema_migration.ForwardMigrationUnavailable:
+            _governance_schema_print_error(
+                "GOVERNANCE_SCHEMA_MIGRATION_UNAVAILABLE",
+                "the verified backup and exact v3-to-v4 cutover could not complete",
+                as_json=as_json,
+            )
+            return 1
+        target = result.target
+        terminal = {
+            "migrated": True,
+            "schema_version": result.schema_version,
+            "logical_vault_id": target.logical_vault_id,
+            "activation_store_id": target.activation_store_id,
+            "activation_epoch": target.activation_epoch,
+            "activation_state_digest": target.activation_state_digest,
+            "policy_generation_id": target.policy_generation_id,
+            "policy_fingerprint": target.policy_fingerprint,
+            "projector_schema_version": target.projector_schema_version,
+            "catalog_generation": target.catalog_generation,
+            "projection_namespace_id": target.projection_namespace_id,
+            "plan_digest": result.plan_digest,
+            "source_store_digest": result.source_store_digest,
+            "backup_reference": result.backup_reference,
+            "replayed": result.replayed,
+        }
+        if as_json:
+            print(json.dumps(terminal))
+        else:
+            delivery = "replayed" if result.replayed else "committed"
+            print(
+                f"schema v4 migration {delivery}; backup {result.backup_reference}"
+            )
         return 0
 
     try:

--- a/src/exomem/governance/authorization_custody.py
+++ b/src/exomem/governance/authorization_custody.py
@@ -362,10 +362,15 @@ def _file_is_owner_protected(descriptor: int, info: os.stat_result) -> bool:
     )
 
 
-def _read_retained(descriptor: int, expected_size: int) -> bytes:
+def _read_retained(
+    descriptor: int,
+    expected_size: int,
+    *,
+    maximum_bytes: int = MAX_CUSTODY_FILE_BYTES,
+) -> bytes:
     os.lseek(descriptor, 0, os.SEEK_SET)
     chunks: list[bytes] = []
-    remaining = MAX_CUSTODY_FILE_BYTES + 1
+    remaining = maximum_bytes + 1
     while remaining:
         chunk = os.read(descriptor, min(remaining, 4096))
         if not chunk:
@@ -373,12 +378,24 @@ def _read_retained(descriptor: int, expected_size: int) -> bytes:
         chunks.append(chunk)
         remaining -= len(chunk)
     data = b"".join(chunks)
-    if len(data) != expected_size or len(data) > MAX_CUSTODY_FILE_BYTES:
+    if len(data) != expected_size or len(data) > maximum_bytes:
         raise AuthorizationCustodyUnavailable
     return data
 
 
 def _load_file(path: Path) -> _LoadedCustodyFile:
+    return _load_private_artifact(path, maximum_bytes=MAX_CUSTODY_FILE_BYTES)
+
+
+def _load_private_artifact(
+    path: Path,
+    *,
+    maximum_bytes: int,
+) -> _LoadedCustodyFile:
+    """Load one bounded owner-only external artifact through a retained handle."""
+
+    if maximum_bytes < 1:
+        raise AuthorizationCustodyUnavailable
     held: mutation_lock.RetainedRegularFile | None = None
     try:
         held = mutation_lock.retain_regular_file(path)
@@ -386,11 +403,15 @@ def _load_file(path: Path) -> _LoadedCustodyFile:
         if (
             not stat.S_ISREG(before.st_mode)
             or before.st_nlink != 1
-            or not 1 <= before.st_size <= MAX_CUSTODY_FILE_BYTES
+            or not 1 <= before.st_size <= maximum_bytes
             or not _file_is_owner_protected(held.fd, before)
         ):
             raise AuthorizationCustodyUnavailable
-        data = _read_retained(held.fd, before.st_size)
+        data = _read_retained(
+            held.fd,
+            before.st_size,
+            maximum_bytes=maximum_bytes,
+        )
         after = os.fstat(held.fd)
         if (
             _stat_identity(before) != _stat_identity(after)
@@ -895,7 +916,26 @@ def _private_parent_is_safe(path: Path) -> bool:
 def _publish_private_file(path: Path, data: bytes) -> bytes:
     """Create one exact private custody file, or adopt an exact concurrent retry."""
 
-    if not isinstance(data, bytes) or not 1 <= len(data) <= MAX_CUSTODY_FILE_BYTES:
+    return _publish_private_artifact(
+        path,
+        data,
+        maximum_bytes=MAX_CUSTODY_FILE_BYTES,
+    )
+
+
+def _publish_private_artifact(
+    path: Path,
+    data: bytes,
+    *,
+    maximum_bytes: int,
+) -> bytes:
+    """Publish one immutable bounded private artifact, or adopt an exact retry."""
+
+    if (
+        maximum_bytes < 1
+        or not isinstance(data, bytes)
+        or not 1 <= len(data) <= maximum_bytes
+    ):
         raise AuthorizationCustodyUnavailable
     parent_path = path.parent
     anchor = parent_path.parent
@@ -925,14 +965,20 @@ def _publish_private_file(path: Path, data: bytes) -> bytes:
                 if not published.ok:
                     if published.error is None or published.error.code != "DESTINATION_EXISTS":
                         raise AuthorizationCustodyUnavailable
-                    installed = _load_file(path)
+                    installed = _load_private_artifact(
+                        path,
+                        maximum_bytes=maximum_bytes,
+                    )
                     if not hmac.compare_digest(installed.data, data):
                         raise AuthorizationCustodyUnavailable
                     return installed.data
                 flushed = filesystem.flush_directory(parent)
                 if not flushed.ok:
                     raise AuthorizationCustodyUnavailable
-        installed = _load_file(path)
+        installed = _load_private_artifact(
+            path,
+            maximum_bytes=maximum_bytes,
+        )
         if not hmac.compare_digest(installed.data, data):
             raise AuthorizationCustodyUnavailable
         return installed.data

--- a/src/exomem/governance/schema_migration.py
+++ b/src/exomem/governance/schema_migration.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import hmac
+import json
 import sqlite3
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from .. import find_corpus, reserved_paths
@@ -24,6 +26,28 @@ from . import (
 _CROCKFORD32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 _CATALOG_GENERATION = 1
 _COMPILER_SCHEMA_VERSION = 1
+_BACKUP_SCHEMA = "exomem.governance-v3-backup/v1"
+_BACKUP_MAGIC = b"EXOMEM-GOVERNANCE-V3-BACKUP-V1\0"
+_BACKUP_DOMAIN = b"exomem.governance-v3-backup.v1"
+_MAX_BACKUP_BYTES = 512 * 1024 * 1024
+_PLAN_FIELDS = frozenset(
+    {
+        "schema_version",
+        "logical_vault_id",
+        "activation_store_id",
+        "activation_epoch",
+        "activation_state_digest",
+        "policy_generation_id",
+        "policy_fingerprint",
+        "projector_schema_version",
+        "catalog_generation",
+        "projection_namespace_id",
+        "source_store_digest",
+        "projection_rows_digest",
+        "item_count",
+        "plan_digest",
+    }
+)
 
 
 class ForwardMigrationUnavailable(RuntimeError):
@@ -32,6 +56,10 @@ class ForwardMigrationUnavailable(RuntimeError):
 
 class ForwardMigrationPlanMismatch(ForwardMigrationUnavailable):
     """The owner-confirmed plan is not the exact current migration plan."""
+
+
+class _ForwardMigrationCrash(RuntimeError):
+    """Test-only crash seam that must cross the coordinator boundary."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -54,6 +82,35 @@ class ForwardMigrationStageResult:
     projection_namespace_id: str
     projection_rows_digest: str
     item_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class ForwardMigrationBackup:
+    """Verified private predecessor snapshot for one reviewed cutover."""
+
+    plan_digest: str
+    source_store_digest: str
+    projection_rows_digest: str
+    item_count: int
+    backup_digest: str
+    backup_reference: str
+    target: schema_v4.VerifiedActiveGovernanceState
+    source_documents: tuple[tuple[str, bytes], ...] = field(repr=False)
+    catalog_descriptor: bytes = field(repr=False)
+    projection_namespace_evidence: bytes = field(repr=False)
+    serialized_v3: bytes = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ForwardMigrationResult:
+    """Content-free terminal derived from the verified backup and active tuple."""
+
+    schema_version: int
+    target: schema_v4.VerifiedActiveGovernanceState
+    plan_digest: str
+    source_store_digest: str
+    backup_reference: str
+    replayed: bool
 
 
 def _framed_digest(domain: bytes, *parts: bytes) -> str:
@@ -91,7 +148,7 @@ def _search_fields(page: find_corpus.ParsedPage) -> dict[str, str]:
     return fields
 
 
-def _source_store_digest(vault_root: Path) -> str:
+def _source_store_snapshot(vault_root: Path) -> tuple[bytes, str]:
     source = store.open_readonly_connection(vault_root)
     if source is None:
         raise ForwardMigrationUnavailable
@@ -99,6 +156,7 @@ def _source_store_digest(vault_root: Path) -> str:
     try:
         schema_v4.require_exact_v3_connection(source)
         source.backup(snapshot)
+        snapshot.execute("VACUUM")
         schema_v4.require_exact_v3_connection(snapshot)
         serialized = snapshot.serialize()
     except (AttributeError, OSError, RuntimeError, sqlite3.Error) as error:
@@ -106,7 +164,67 @@ def _source_store_digest(vault_root: Path) -> str:
     finally:
         snapshot.close()
         source.close()
-    return _framed_digest(b"exomem.governance-v3-snapshot.v1", serialized)
+    return serialized, _framed_digest(
+        b"exomem.governance-v3-snapshot.v1",
+        serialized,
+    )
+
+
+def _source_store_digest(vault_root: Path) -> str:
+    return _source_store_snapshot(vault_root)[1]
+
+
+def _migration_identity(
+    vault_root: Path,
+    *,
+    now: int,
+) -> tuple[
+    authorization_custody.StandaloneV3StagingResult,
+    authorization_custody.AuthorizationControlRecord | None,
+]:
+    """Stage inert identity or recover the exact enrolled-v3 identity."""
+
+    try:
+        return authorization_custody.stage_standalone_v3_custody(
+            vault_root,
+            now=now,
+        ), None
+    except authorization_custody.AuthorizationCustodyUnavailable:
+        custody = authorization_custody.load_authorization_custody(
+            vault_root,
+            now=now,
+        )
+        control = custody.control
+        membership_record = custody.serving_membership
+        active_key = custody.keyring.active_key
+        if (
+            not control.governance_enrolled
+            or control.activation_epoch != 1
+            or custody.local_replica_id is None
+            or membership_record is None
+            or membership_record.epoch != 1
+            or not membership_record.replicas
+            or any(
+                replica.state != "DRAINING"
+                or replica.schema_version != store.SCHEMA_USER_VERSION
+                or not replica.issuance_stopped
+                or not replica.no_in_flight
+                for replica in membership_record.replicas
+            )
+        ):
+            raise
+        return (
+            authorization_custody.StandaloneV3StagingResult(
+                keyring_path=custody.keyring_path,
+                keyring_id=custody.keyring.keyring_id,
+                cell_id=custody.keyring.cell_id,
+                logical_vault_id=custody.keyring.logical_vault_id,
+                registry_attachment_id=control.registry_attachment_id,
+                attachment_epoch=control.attachment_epoch,
+                staged_at=active_key.not_before,
+            ),
+            control,
+        )
 
 
 def _catalog_items(
@@ -258,7 +376,7 @@ def prepare_forward_migration(
 
     root = Path(vault_root)
     try:
-        staged = authorization_custody.stage_standalone_v3_custody(root, now=now)
+        staged, enrolled_control = _migration_identity(root, now=now)
         before = policy.observe_authoring_snapshot(root)
         if before is None:
             raise ForwardMigrationUnavailable
@@ -314,6 +432,14 @@ def prepare_forward_migration(
             migrated_at=staged.staged_at,
         )
         target = schema_v4.migration_target(seed)
+        if enrolled_control is not None and (
+            enrolled_control.logical_vault_id != target.logical_vault_id
+            or enrolled_control.activation_store_id != target.activation_store_id
+            or enrolled_control.activation_epoch != target.activation_epoch
+            or enrolled_control.activation_state_digest
+            != target.activation_state_digest
+        ):
+            raise ForwardMigrationPlanMismatch
         plan_value = _plan_value(
             target,
             source_store_digest=source_store_digest,
@@ -456,12 +582,522 @@ def stage_forward_migration(
     )
 
 
+def _require_digest(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ForwardMigrationUnavailable
+    return value
+
+
+def forward_migration_backup_path(
+    vault_root: Path,
+    *,
+    plan_digest: str,
+) -> Path:
+    """Return the fixed external path for one plan-bound private backup."""
+
+    digest = _require_digest(plan_digest)
+    root = Path(vault_root)
+    keyring_path = authorization_custody._configured_external_path(  # noqa: SLF001
+        authorization_custody.KEYRING_FILE_ENV,
+        root,
+    )
+    backup_path = keyring_path.with_name(f"governance-v3-backup-{digest}.bin")
+    custody_paths = {
+        keyring_path,
+        authorization_custody._configured_external_path(  # noqa: SLF001
+            authorization_custody.CONTROL_FILE_ENV,
+            root,
+        ),
+        authorization_custody._configured_external_path(  # noqa: SLF001
+            authorization_custody.MEMBERSHIP_FILE_ENV,
+            root,
+        ),
+    }
+    if backup_path in custody_paths or len(custody_paths) != 3:
+        raise ForwardMigrationUnavailable
+    return backup_path
+
+
+def _backup_manifest(
+    plan: ForwardMigrationPlan,
+    *,
+    serialized_v3: bytes,
+) -> bytes:
+    value = {
+        "schema": _BACKUP_SCHEMA,
+        "plan": {**_plan_value(
+            plan.target,
+            source_store_digest=plan.source_store_digest,
+            projection_rows_digest=plan.projection_rows_digest,
+            item_count=plan.item_count,
+        ), "plan_digest": plan.plan_digest},
+        "source_documents": [
+            {
+                "path": relative,
+                "base64url": base64.urlsafe_b64encode(data).decode("ascii"),
+            }
+            for relative, data in plan.seed.policy.source_documents
+        ],
+        "catalog_descriptor_base64url": base64.urlsafe_b64encode(
+            plan.seed.catalog.descriptor
+        ).decode("ascii"),
+        "projection_namespace_evidence_base64url": base64.urlsafe_b64encode(
+            plan.seed.namespace.evidence
+        ).decode("ascii"),
+        "serialized_v3_size": len(serialized_v3),
+        "serialized_v3_sha256": hashlib.sha256(serialized_v3).hexdigest(),
+        "created_at": plan.seed.migrated_at,
+    }
+    return projections.canonical_jcs(value)
+
+
+def _backup_bytes(
+    plan: ForwardMigrationPlan,
+    *,
+    serialized_v3: bytes,
+) -> bytes:
+    manifest = _backup_manifest(plan, serialized_v3=serialized_v3)
+    return b"".join(
+        (
+            _BACKUP_MAGIC,
+            len(manifest).to_bytes(8, "big"),
+            manifest,
+            len(serialized_v3).to_bytes(8, "big"),
+            serialized_v3,
+        )
+    )
+
+
+def _decode_base64(value: object) -> bytes:
+    if not isinstance(value, str) or len(value) > _MAX_BACKUP_BYTES * 2:
+        raise ForwardMigrationUnavailable
+    try:
+        decoded = base64.b64decode(value, altchars=b"-_", validate=True)
+    except (ValueError, TypeError) as error:
+        raise ForwardMigrationUnavailable from error
+    if base64.urlsafe_b64encode(decoded).decode("ascii") != value:
+        raise ForwardMigrationUnavailable
+    return decoded
+
+
+def _closed_json(raw: bytes) -> dict[str, object]:
+    def closed(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        value: dict[str, object] = {}
+        for key, item in pairs:
+            if key in value:
+                raise ForwardMigrationUnavailable
+            value[key] = item
+        return value
+
+    try:
+        parsed = json.loads(raw, object_pairs_hook=closed)
+    except (json.JSONDecodeError, UnicodeError, TypeError, ValueError) as error:
+        raise ForwardMigrationUnavailable from error
+    if not isinstance(parsed, dict) or projections.canonical_jcs(parsed) != raw:
+        raise ForwardMigrationUnavailable
+    return parsed
+
+
+def _bounded_integer(value: object, *, minimum: int = 0) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not minimum <= value < 1 << 63
+    ):
+        raise ForwardMigrationUnavailable
+    return value
+
+
+def _target_from_plan(value: dict[str, object]) -> schema_v4.VerifiedActiveGovernanceState:
+    if set(value) != _PLAN_FIELDS or value.get("schema_version") != 3:
+        raise ForwardMigrationUnavailable
+    for name in (
+        "activation_state_digest",
+        "policy_fingerprint",
+        "source_store_digest",
+        "projection_rows_digest",
+        "plan_digest",
+    ):
+        _require_digest(value.get(name))
+    text_fields = (
+        "logical_vault_id",
+        "activation_store_id",
+        "policy_generation_id",
+        "projection_namespace_id",
+    )
+    if any(not isinstance(value.get(name), str) or not value[name] for name in text_fields):
+        raise ForwardMigrationUnavailable
+    target = schema_v4.VerifiedActiveGovernanceState(
+        logical_vault_id=str(value["logical_vault_id"]),
+        activation_store_id=str(value["activation_store_id"]),
+        activation_epoch=_bounded_integer(value["activation_epoch"], minimum=1),
+        activation_state_digest=str(value["activation_state_digest"]),
+        policy_generation_id=str(value["policy_generation_id"]),
+        policy_fingerprint=str(value["policy_fingerprint"]),
+        projector_schema_version=_bounded_integer(
+            value["projector_schema_version"],
+            minimum=1,
+        ),
+        catalog_generation=_bounded_integer(value["catalog_generation"], minimum=1),
+        projection_namespace_id=str(value["projection_namespace_id"]),
+    )
+    _bounded_integer(value["item_count"])
+    unsigned = {name: item for name, item in value.items() if name != "plan_digest"}
+    computed_plan_digest = _framed_digest(
+        b"exomem.governance-schema-migration-plan.v1",
+        projections.canonical_jcs(unsigned),
+    )
+    if not hmac.compare_digest(str(value["plan_digest"]), computed_plan_digest):
+        raise ForwardMigrationUnavailable
+    return target
+
+
+def verify_forward_migration_backup(
+    vault_root: Path,
+    *,
+    expected_plan_digest: str,
+) -> ForwardMigrationBackup:
+    """Verify the private bundle, exact v3 payload, and reviewed target binding."""
+
+    expected = _require_digest(expected_plan_digest)
+    path = forward_migration_backup_path(vault_root, plan_digest=expected)
+    try:
+        loaded = authorization_custody._load_private_artifact(  # noqa: SLF001
+            path,
+            maximum_bytes=_MAX_BACKUP_BYTES,
+        ).data
+        if not loaded.startswith(_BACKUP_MAGIC):
+            raise ForwardMigrationUnavailable
+        cursor = len(_BACKUP_MAGIC)
+        manifest_size = int.from_bytes(loaded[cursor : cursor + 8], "big")
+        cursor += 8
+        if not 1 <= manifest_size <= _MAX_BACKUP_BYTES or cursor + manifest_size + 8 > len(loaded):
+            raise ForwardMigrationUnavailable
+        manifest_raw = loaded[cursor : cursor + manifest_size]
+        cursor += manifest_size
+        payload_size = int.from_bytes(loaded[cursor : cursor + 8], "big")
+        cursor += 8
+        serialized = loaded[cursor:]
+        if payload_size != len(serialized) or not serialized:
+            raise ForwardMigrationUnavailable
+        manifest = _closed_json(manifest_raw)
+        expected_fields = {
+            "schema",
+            "plan",
+            "source_documents",
+            "catalog_descriptor_base64url",
+            "projection_namespace_evidence_base64url",
+            "serialized_v3_size",
+            "serialized_v3_sha256",
+            "created_at",
+        }
+        if set(manifest) != expected_fields or manifest["schema"] != _BACKUP_SCHEMA:
+            raise ForwardMigrationUnavailable
+        plan_value = manifest["plan"]
+        if not isinstance(plan_value, dict):
+            raise ForwardMigrationUnavailable
+        target = _target_from_plan(plan_value)
+        if not hmac.compare_digest(str(plan_value["plan_digest"]), expected):
+            raise ForwardMigrationUnavailable
+        if (
+            _bounded_integer(manifest["serialized_v3_size"], minimum=1)
+            != len(serialized)
+            or not hmac.compare_digest(
+                _require_digest(manifest["serialized_v3_sha256"]),
+                hashlib.sha256(serialized).hexdigest(),
+            )
+        ):
+            raise ForwardMigrationUnavailable
+        source_store_digest = _framed_digest(
+            b"exomem.governance-v3-snapshot.v1",
+            serialized,
+        )
+        if not hmac.compare_digest(
+            str(plan_value["source_store_digest"]),
+            source_store_digest,
+        ):
+            raise ForwardMigrationUnavailable
+        snapshot = sqlite3.connect(":memory:")
+        try:
+            snapshot.deserialize(serialized)
+            schema_v4.require_exact_v3_connection(snapshot)
+        finally:
+            snapshot.close()
+        raw_documents = manifest["source_documents"]
+        if not isinstance(raw_documents, list):
+            raise ForwardMigrationUnavailable
+        documents: list[tuple[str, bytes]] = []
+        for record in raw_documents:
+            if (
+                not isinstance(record, dict)
+                or set(record) != {"path", "base64url"}
+                or not isinstance(record["path"], str)
+                or not record["path"]
+            ):
+                raise ForwardMigrationUnavailable
+            documents.append((record["path"], _decode_base64(record["base64url"])))
+        source_documents = tuple(documents)
+        if (
+            tuple(sorted(source_documents)) != source_documents
+            or len({relative for relative, _data in source_documents})
+            != len(source_documents)
+        ):
+            raise ForwardMigrationUnavailable
+        compiled = policy.compile_documents(dict(source_documents))
+        if compiled.blocked or compiled.empty or compiled.fingerprint != target.policy_fingerprint:
+            raise ForwardMigrationUnavailable
+        catalog_descriptor = _decode_base64(
+            manifest["catalog_descriptor_base64url"]
+        )
+        namespace_evidence = _decode_base64(
+            manifest["projection_namespace_evidence_base64url"]
+        )
+        if not catalog_descriptor or not namespace_evidence:
+            raise ForwardMigrationUnavailable
+        _bounded_integer(manifest["created_at"], minimum=1)
+    except ForwardMigrationUnavailable:
+        raise
+    except (
+        authorization_custody.AuthorizationCustodyUnavailable,
+        schema_v4.SchemaV4Error,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+        sqlite3.Error,
+    ) as error:
+        raise ForwardMigrationUnavailable from error
+    backup_digest = _framed_digest(_BACKUP_DOMAIN, loaded)
+    return ForwardMigrationBackup(
+        plan_digest=expected,
+        source_store_digest=source_store_digest,
+        projection_rows_digest=str(plan_value["projection_rows_digest"]),
+        item_count=_bounded_integer(plan_value["item_count"]),
+        backup_digest=backup_digest,
+        backup_reference=f"exomem-governance-v3-backup://sha256/{backup_digest}",
+        target=target,
+        source_documents=source_documents,
+        catalog_descriptor=catalog_descriptor,
+        projection_namespace_evidence=namespace_evidence,
+        serialized_v3=serialized,
+    )
+
+
+def _forward_migration_barrier(point: str) -> None:
+    """Crash-injection seam around the separately durable cutover effects."""
+
+    del point
+
+
+def _verify_active_target(
+    vault_root: Path,
+    backup: ForwardMigrationBackup,
+) -> None:
+    connection = store.open_active_governance_read_connection(vault_root)
+    try:
+        snapshot = schema_v4.load_active_policy(
+            connection,
+            expected_logical_vault_id=backup.target.logical_vault_id,
+            expected_activation_store_id=backup.target.activation_store_id,
+            expected_activation_epoch=backup.target.activation_epoch,
+            expected_activation_state_digest=backup.target.activation_state_digest,
+        )
+    finally:
+        connection.close()
+    if (
+        snapshot.active != backup.target
+        or snapshot.source_documents != backup.source_documents
+        or snapshot.catalog_descriptor != backup.catalog_descriptor
+        or snapshot.projection_namespace_evidence
+        != backup.projection_namespace_evidence
+    ):
+        raise ForwardMigrationUnavailable
+
+
+def _verify_live_source_material(
+    vault_root: Path,
+    backup: ForwardMigrationBackup,
+) -> None:
+    """Recheck exact workspace and catalog bytes before v4 may serve."""
+
+    try:
+        observed = policy.observe_authoring_snapshot(vault_root)
+        compiled = policy.compile_documents(dict(backup.source_documents))
+        if (
+            observed is None
+            or observed.documents != backup.source_documents
+            or compiled.empty
+            or compiled.blocked
+            or compiled.fingerprint != backup.target.policy_fingerprint
+        ):
+            raise ForwardMigrationUnavailable
+        key = projections.ProjectionNamespaceKey(
+            policy_fingerprint=backup.target.policy_fingerprint,
+            projector_schema_version=backup.target.projector_schema_version,
+            catalog_generation=backup.target.catalog_generation,
+        )
+        items = _catalog_items(vault_root, compiled=compiled, key=key)
+        manifest = projection_store.preview_variant_store(key=key, items=items)
+        if (
+            projection_store.catalog_descriptor_bytes(key, items)
+            != backup.catalog_descriptor
+            or projection_store.projection_namespace_evidence_bytes(manifest)
+            != backup.projection_namespace_evidence
+            or manifest.namespace_id != backup.target.projection_namespace_id
+            or manifest.rows_digest != backup.projection_rows_digest
+            or manifest.item_count != backup.item_count
+        ):
+            raise ForwardMigrationUnavailable
+    except ForwardMigrationUnavailable:
+        raise
+    except (
+        membership.MembershipUnresolved,
+        projection_store.ProjectionStoreError,
+        projections.ProjectionError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ) as error:
+        raise ForwardMigrationUnavailable from error
+
+
+def commit_forward_migration(
+    vault_root: Path,
+    *,
+    expected_plan_digest: str,
+    now: int,
+) -> ForwardMigrationResult:
+    """Commit the reviewed staged target after a verified private v3 backup."""
+
+    expected = _require_digest(expected_plan_digest)
+    root = Path(vault_root)
+    version = store.authorization_session_schema_version(root)
+    if version == schema_v4.SCHEMA_USER_VERSION:
+        with reserved_paths._identity_coordination_scope(
+            root,
+            identity_may_change=False,
+        ):
+            backup = verify_forward_migration_backup(
+                root,
+                expected_plan_digest=expected,
+            )
+            _verify_active_target(root, backup)
+            _verify_live_source_material(root, backup)
+            authorization_custody.complete_standalone_v4_migration(
+                root,
+                target=backup.target,
+                now=now,
+            )
+        return ForwardMigrationResult(
+            schema_version=schema_v4.SCHEMA_USER_VERSION,
+            target=backup.target,
+            plan_digest=expected,
+            source_store_digest=backup.source_store_digest,
+            backup_reference=backup.backup_reference,
+            replayed=True,
+        )
+    if version != store.SCHEMA_USER_VERSION:
+        raise ForwardMigrationUnavailable
+
+    try:
+        with reserved_paths._identity_coordination_scope(
+            root,
+            identity_may_change=False,
+        ):
+            plan = prepare_forward_migration(root, now=now)
+            if not hmac.compare_digest(plan.plan_digest, expected):
+                raise ForwardMigrationPlanMismatch
+            key, _items, manifest = _stage_material(root, plan)
+            if projection_store.verify_variant_store(
+                root,
+                key=key,
+                expected_rows_digest=plan.projection_rows_digest,
+            ) != manifest:
+                raise ForwardMigrationPlanMismatch
+            serialized, source_digest = _source_store_snapshot(root)
+            if not hmac.compare_digest(source_digest, plan.source_store_digest):
+                raise ForwardMigrationPlanMismatch
+            backup_bytes = _backup_bytes(plan, serialized_v3=serialized)
+            backup_path = forward_migration_backup_path(root, plan_digest=expected)
+            authorization_custody._publish_private_artifact(  # noqa: SLF001
+                backup_path,
+                backup_bytes,
+                maximum_bytes=_MAX_BACKUP_BYTES,
+            )
+            backup = verify_forward_migration_backup(
+                root,
+                expected_plan_digest=expected,
+            )
+            if (
+                backup.target != plan.target
+                or backup.source_documents != plan.seed.policy.source_documents
+                or backup.catalog_descriptor != plan.seed.catalog.descriptor
+                or backup.projection_namespace_evidence != plan.seed.namespace.evidence
+                or not hmac.compare_digest(
+                    backup.source_store_digest,
+                    plan.source_store_digest,
+                )
+            ):
+                raise ForwardMigrationPlanMismatch
+            _forward_migration_barrier("after_backup")
+            current = prepare_forward_migration(root, now=now)
+            if current != plan:
+                raise ForwardMigrationPlanMismatch
+            authorization_custody.enroll_standalone_v3_migration(
+                root,
+                target=plan.target,
+                now=now,
+            )
+            _forward_migration_barrier("after_enrollment")
+            active = store.migrate_enrolled_v3_store(
+                root,
+                seed=plan.seed,
+                expected_source_store_digest=plan.source_store_digest,
+                now=now,
+                source_recheck=lambda: _verify_live_source_material(root, backup),
+            )
+    except (ForwardMigrationPlanMismatch, _ForwardMigrationCrash):
+        raise
+    except (
+        authorization_custody.AuthorizationCustodyUnavailable,
+        projection_store.ProjectionStoreError,
+        schema_v4.SchemaV4Error,
+        store.UnsupportedGovernanceSchema,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+        sqlite3.Error,
+    ) as error:
+        raise ForwardMigrationUnavailable from error
+    if active != plan.target:
+        raise ForwardMigrationUnavailable
+    return ForwardMigrationResult(
+        schema_version=schema_v4.SCHEMA_USER_VERSION,
+        target=active,
+        plan_digest=expected,
+        source_store_digest=backup.source_store_digest,
+        backup_reference=backup.backup_reference,
+        replayed=False,
+    )
+
+
 __all__ = [
+    "ForwardMigrationBackup",
     "ForwardMigrationPlan",
     "ForwardMigrationPlanMismatch",
+    "ForwardMigrationResult",
     "ForwardMigrationStageResult",
     "ForwardMigrationUnavailable",
+    "commit_forward_migration",
+    "forward_migration_backup_path",
     "plan_summary",
     "prepare_forward_migration",
     "stage_forward_migration",
+    "verify_forward_migration_backup",
 ]

--- a/src/exomem/governance/store.py
+++ b/src/exomem/governance/store.py
@@ -16,6 +16,7 @@ import os
 import sqlite3
 import threading
 from collections import OrderedDict
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -247,11 +248,27 @@ def _schema_migration_barrier(point: str) -> None:
     del point
 
 
+def _v3_snapshot_digest(connection: sqlite3.Connection) -> str:
+    snapshot = sqlite3.connect(":memory:")
+    try:
+        connection.backup(snapshot)
+        snapshot.execute("VACUUM")
+        serialized = snapshot.serialize()
+    finally:
+        snapshot.close()
+    domain = b"exomem.governance-v3-snapshot.v1"
+    return hashlib.sha256(
+        domain + len(serialized).to_bytes(8, "big") + serialized
+    ).hexdigest()
+
+
 def migrate_enrolled_v3_store(
     vault_root: Path,
     *,
     seed: MigrationSeed,
+    expected_source_store_digest: str,
     now: int,
+    source_recheck: Callable[[], None] | None = None,
 ) -> VerifiedActiveGovernanceState:
     """Commit one pre-enrolled exact-v3 store to its exact v4 target.
 
@@ -269,6 +286,15 @@ def migrate_enrolled_v3_store(
 
     root = Path(vault_root)
     path = sidecar_path(root)
+    if (
+        not isinstance(expected_source_store_digest, str)
+        or len(expected_source_store_digest) != 64
+        or any(
+            character not in "0123456789abcdef"
+            for character in expected_source_store_digest
+        )
+    ):
+        raise schema_v4.SchemaV4Error("migration source store digest is invalid")
     with reserved_paths._subsystem_authority_scope("governance.store"):
         with reserved_paths._identity_coordination_scope(
             root,
@@ -334,6 +360,12 @@ def migrate_enrolled_v3_store(
                         )
                     ):
                         raise authorization_custody.AuthorizationCustodyUnavailable
+                    if version == SCHEMA_USER_VERSION and (
+                        _v3_snapshot_digest(connection) != expected_source_store_digest
+                    ):
+                        raise schema_v4.SchemaV4Error(
+                            "migration source store changed after owner review"
+                        )
 
                     before = None
                     if version == SCHEMA_USER_VERSION:
@@ -404,6 +436,8 @@ def migrate_enrolled_v3_store(
                             raise schema_v4.SchemaV4Error(
                                 "migration policy workspace changed during commit"
                             )
+                    if source_recheck is not None:
+                        source_recheck()
                 finally:
                     connection.close()
 

--- a/tests/test_governance_schema_cli.py
+++ b/tests/test_governance_schema_cli.py
@@ -11,6 +11,7 @@ from exomem.governance import (
     authorization_custody,
     schema_downmigration,
     schema_migration,
+    schema_v4,
     store,
 )
 
@@ -184,6 +185,115 @@ def test_governance_schema_stage_migration_refuses_a_stale_plan(
     assert json.loads(capsys.readouterr().out) == {
         "error": "GOVERNANCE_SCHEMA_PLAN_MISMATCH",
         "message": "the reviewed migration plan changed; no activation was attempted",
+    }
+
+
+def test_governance_schema_commit_migration_requires_digest_bound_confirmation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    calls: list[object] = []
+    monkeypatch.setattr(
+        schema_migration,
+        "commit_forward_migration",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    code = main(
+        [
+            "governance-schema",
+            "commit-migration",
+            "--vault",
+            str(vault),
+            "--expected-plan-digest",
+            "f" * 64,
+            "--json",
+        ]
+    )
+
+    assert code == 2
+    assert calls == []
+    assert json.loads(capsys.readouterr().out) == {
+        "migrated": False,
+        "reason": "confirmation_required",
+        "plan_digest": "f" * 64,
+    }
+
+
+@pytest.mark.parametrize("replayed", [False, True])
+def test_governance_schema_commit_migration_returns_content_free_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    replayed: bool,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    target = schema_v4.VerifiedActiveGovernanceState(
+        logical_vault_id="logical-vault-cli",
+        activation_store_id="activation-store-cli",
+        activation_epoch=1,
+        activation_state_digest="a" * 64,
+        policy_generation_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        policy_fingerprint="b" * 64,
+        projector_schema_version=1,
+        catalog_generation=1,
+        projection_namespace_id="c" * 64,
+    )
+    result = schema_migration.ForwardMigrationResult(
+        schema_version=4,
+        target=target,
+        plan_digest="f" * 64,
+        source_store_digest="e" * 64,
+        backup_reference="exomem-governance-v3-backup://sha256/" + "d" * 64,
+        replayed=replayed,
+    )
+    calls: list[tuple[Path, str, int]] = []
+
+    def commit(root: Path, *, expected_plan_digest: str, now: int):  # noqa: ANN202
+        calls.append((root, expected_plan_digest, now))
+        return result
+
+    monkeypatch.setattr(schema_migration, "commit_forward_migration", commit)
+
+    assert (
+        main(
+            [
+                "governance-schema",
+                "commit-migration",
+                "--vault",
+                str(vault),
+                "--expected-plan-digest",
+                "f" * 64,
+                "--yes",
+                "--json",
+            ]
+        )
+        == 0
+    )
+
+    assert len(calls) == 1
+    assert calls[0][0] == vault and calls[0][1] == "f" * 64
+    assert isinstance(calls[0][2], int) and calls[0][2] > 0
+    assert json.loads(capsys.readouterr().out) == {
+        "migrated": True,
+        "schema_version": 4,
+        "logical_vault_id": "logical-vault-cli",
+        "activation_store_id": "activation-store-cli",
+        "activation_epoch": 1,
+        "activation_state_digest": "a" * 64,
+        "policy_generation_id": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "policy_fingerprint": "b" * 64,
+        "projector_schema_version": 1,
+        "catalog_generation": 1,
+        "projection_namespace_id": "c" * 64,
+        "plan_digest": "f" * 64,
+        "source_store_digest": "e" * 64,
+        "backup_reference": "exomem-governance-v3-backup://sha256/" + "d" * 64,
+        "replayed": replayed,
     }
 
 

--- a/tests/test_governance_schema_downmigration.py
+++ b/tests/test_governance_schema_downmigration.py
@@ -117,12 +117,23 @@ def _migrate(vault: Path, *, now: int) -> schema_v4.VerifiedActiveGovernanceStat
         migrated_at=now + 1,
     )
     target = schema_v4.migration_target(seed)
+    source = store.open_readonly_connection(vault)
+    assert source is not None
+    try:
+        source_store_digest = store._v3_snapshot_digest(source)
+    finally:
+        source.close()
     authorization_custody.enroll_standalone_v3_migration(
         vault,
         target=target,
         now=now,
     )
-    return store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 2)
+    return store.migrate_enrolled_v3_store(
+        vault,
+        seed=seed,
+        expected_source_store_digest=source_store_digest,
+        now=now + 2,
+    )
 
 
 def _set_pending_workspace(vault: Path) -> None:

--- a/tests/test_governance_schema_migration_plan.py
+++ b/tests/test_governance_schema_migration_plan.py
@@ -5,6 +5,7 @@ import os
 import sqlite3
 import time
 from collections.abc import Iterator
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -296,3 +297,359 @@ def test_forward_migration_stage_refuses_drift_after_inert_publication(
     assert _schema_version(vault) == 3
     assert not Path(os.environ[authorization_custody.CONTROL_FILE_ENV]).exists()
     assert not Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV]).exists()
+
+
+def _stage_reviewed_migration(vault: Path, *, now: int):  # noqa: ANN202
+    plan = schema_migration.prepare_forward_migration(vault, now=now)
+    schema_migration.stage_forward_migration(
+        vault,
+        expected_plan_digest=plan.plan_digest,
+        now=now + 1,
+    )
+    return plan
+
+
+def test_forward_migration_cutover_backs_up_v3_before_enrollment_and_replays(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    plan = _stage_reviewed_migration(vault, now=now)
+
+    committed = schema_migration.commit_forward_migration(
+        vault,
+        expected_plan_digest=plan.plan_digest,
+        now=now + 2,
+    )
+
+    assert committed.schema_version == 4
+    assert committed.target == plan.target
+    assert committed.plan_digest == plan.plan_digest
+    assert committed.source_store_digest == plan.source_store_digest
+    assert committed.backup_reference.startswith(
+        "exomem-governance-v3-backup://sha256/"
+    )
+    assert committed.replayed is False
+    assert _schema_version(vault) == 4
+    backup_path = schema_migration.forward_migration_backup_path(
+        vault,
+        plan_digest=plan.plan_digest,
+    )
+    if os.name != "nt":
+        assert backup_path.stat().st_mode & 0o777 == 0o600
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 3)
+    assert custody.control.governance_enrolled is True
+    assert custody.control.serving_membership_epoch == 2
+    assert custody.serving_membership is not None
+    assert custody.serving_membership.epoch == 2
+    assert [
+        (replica.state, replica.schema_version)
+        for replica in custody.serving_membership.replicas
+    ] == [("SERVING", 4)]
+
+    backup = schema_migration.verify_forward_migration_backup(
+        vault,
+        expected_plan_digest=plan.plan_digest,
+    )
+    assert backup.plan_digest == plan.plan_digest
+    assert backup.source_store_digest == plan.source_store_digest
+    assert backup.target == plan.target
+    restored = sqlite3.connect(":memory:")
+    try:
+        restored.deserialize(backup.serialized_v3)
+        schema_v4.require_exact_v3_connection(restored)
+    finally:
+        restored.close()
+
+    replay = schema_migration.commit_forward_migration(
+        vault,
+        expected_plan_digest=plan.plan_digest,
+        now=now + 4,
+    )
+    assert replay == replace(committed, replayed=True)
+
+
+def test_forward_migration_cutover_refuses_source_drift_before_enrollment(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    plan = _stage_reviewed_migration(vault, now=now)
+    connection = store.open_connection(vault)
+    try:
+        connection.execute(
+            "INSERT INTO governance_session_purpose "
+            "(authorization_session, principal_id, purpose, status, prepared_event_id, "
+            "created_at, expires_at) VALUES "
+            "('late-session', 'late-principal', 'review', 'active', NULL, ?, ?)",
+            (now, now + 60),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    with pytest.raises(schema_migration.ForwardMigrationPlanMismatch):
+        schema_migration.commit_forward_migration(
+            vault,
+            expected_plan_digest=plan.plan_digest,
+            now=now + 2,
+        )
+
+    assert _schema_version(vault) == 3
+    assert not Path(os.environ[authorization_custody.CONTROL_FILE_ENV]).exists()
+    assert not Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV]).exists()
+
+
+def test_forward_migration_cutover_rechecks_v3_after_backup_before_enrollment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    plan = _stage_reviewed_migration(vault, now=now)
+
+    def drift(point: str) -> None:
+        if point != "after_backup":
+            return
+        connection = store.open_connection(vault)
+        try:
+            connection.execute(
+                "INSERT INTO governance_session_purpose "
+                "(authorization_session, principal_id, purpose, status, "
+                "prepared_event_id, created_at, expires_at) VALUES "
+                "('racing-session', 'racing-principal', 'review', 'active', NULL, ?, ?)",
+                (now, now + 60),
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+    monkeypatch.setattr(schema_migration, "_forward_migration_barrier", drift)
+
+    with pytest.raises(schema_migration.ForwardMigrationPlanMismatch):
+        schema_migration.commit_forward_migration(
+            vault,
+            expected_plan_digest=plan.plan_digest,
+            now=now + 2,
+        )
+
+    assert _schema_version(vault) == 3
+    assert not Path(os.environ[authorization_custody.CONTROL_FILE_ENV]).exists()
+    assert schema_migration.forward_migration_backup_path(
+        vault,
+        plan_digest=plan.plan_digest,
+    ).exists()
+
+
+def test_forward_migration_cutover_recovers_after_irreversible_enrollment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    plan = _stage_reviewed_migration(vault, now=now)
+    crashed = False
+
+    def crash(point: str) -> None:
+        nonlocal crashed
+        if point == "after_enrollment" and not crashed:
+            crashed = True
+            raise schema_migration._ForwardMigrationCrash("enrollment crash")
+
+    monkeypatch.setattr(schema_migration, "_forward_migration_barrier", crash)
+    with pytest.raises(schema_migration._ForwardMigrationCrash, match="enrollment crash"):
+        schema_migration.commit_forward_migration(
+            vault,
+            expected_plan_digest=plan.plan_digest,
+            now=now + 2,
+        )
+
+    assert _schema_version(vault) == 3
+    interrupted = authorization_custody.load_authorization_custody(vault, now=now + 3)
+    assert interrupted.control.governance_enrolled is True
+    assert interrupted.serving_membership is not None
+    assert interrupted.serving_membership.epoch == 1
+    assert interrupted.serving_membership.replicas[0].state == "DRAINING"
+
+    monkeypatch.setattr(
+        schema_migration,
+        "_forward_migration_barrier",
+        lambda _point: None,
+    )
+    recovered = schema_migration.commit_forward_migration(
+        vault,
+        expected_plan_digest=plan.plan_digest,
+        now=now + 4,
+    )
+    assert recovered.schema_version == 4
+    assert recovered.target == plan.target
+    assert recovered.replayed is False
+
+
+def test_forward_migration_cutover_fails_closed_on_store_drift_after_enrollment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    plan = _stage_reviewed_migration(vault, now=now)
+    enroll = authorization_custody.enroll_standalone_v3_migration
+
+    def enroll_then_drift(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        acknowledgement = enroll(*args, **kwargs)
+        connection = sqlite3.connect(store.sidecar_path(vault))
+        try:
+            connection.execute(
+                "INSERT INTO governance_session_purpose "
+                "(authorization_session, principal_id, purpose, status, "
+                "prepared_event_id, created_at, expires_at) VALUES "
+                "('post-enroll', 'post-enroll-principal', 'review', 'active', NULL, ?, ?)",
+                (now, now + 60),
+            )
+            connection.commit()
+        finally:
+            connection.close()
+        return acknowledgement
+
+    monkeypatch.setattr(
+        authorization_custody,
+        "enroll_standalone_v3_migration",
+        enroll_then_drift,
+    )
+
+    with pytest.raises(schema_migration.ForwardMigrationUnavailable):
+        schema_migration.commit_forward_migration(
+            vault,
+            expected_plan_digest=plan.plan_digest,
+            now=now + 2,
+        )
+
+    assert _schema_version(vault) == 3
+    blocked = authorization_custody.load_authorization_custody(vault, now=now + 3)
+    assert blocked.control.governance_enrolled is True
+    assert blocked.serving_membership is not None
+    assert blocked.serving_membership.replicas[0].state == "DRAINING"
+
+
+def test_forward_migration_cutover_recovers_store_commit_before_membership_ack(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    plan = _stage_reviewed_migration(vault, now=now)
+    crashed = False
+
+    def crash(point: str) -> None:
+        nonlocal crashed
+        if point == "after_store_commit" and not crashed:
+            crashed = True
+            raise schema_migration._ForwardMigrationCrash("store commit crash")
+
+    monkeypatch.setattr(store, "_schema_migration_barrier", crash)
+    with pytest.raises(schema_migration._ForwardMigrationCrash, match="store commit"):
+        schema_migration.commit_forward_migration(
+            vault,
+            expected_plan_digest=plan.plan_digest,
+            now=now + 2,
+        )
+
+    assert _schema_version(vault) == 4
+    interrupted = authorization_custody.load_authorization_custody(vault, now=now + 3)
+    assert interrupted.control.serving_membership_epoch == 1
+    assert interrupted.serving_membership is not None
+    assert interrupted.serving_membership.epoch == 1
+
+    monkeypatch.setattr(store, "_schema_migration_barrier", lambda _point: None)
+    recovered = schema_migration.commit_forward_migration(
+        vault,
+        expected_plan_digest=plan.plan_digest,
+        now=now + 4,
+    )
+    assert recovered.schema_version == 4
+    assert recovered.target == plan.target
+    assert recovered.replayed is True
+
+
+def test_forward_migration_cutover_refuses_catalog_drift_before_serving_v4(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    note = vault / "Knowledge Base" / "Notes" / "governed.md"
+    now = int(time.time())
+    plan = _stage_reviewed_migration(vault, now=now)
+    drifted = False
+
+    def drift(point: str) -> None:
+        nonlocal drifted
+        if point == "after_store_commit" and not drifted:
+            drifted = True
+            note.write_bytes(NOTE_BYTES.replace(b"Visible text.", b"Late direct edit."))
+
+    monkeypatch.setattr(store, "_schema_migration_barrier", drift)
+    with pytest.raises(schema_migration.ForwardMigrationUnavailable):
+        schema_migration.commit_forward_migration(
+            vault,
+            expected_plan_digest=plan.plan_digest,
+            now=now + 2,
+        )
+
+    assert _schema_version(vault) == 4
+    blocked = authorization_custody.load_authorization_custody(vault, now=now + 3)
+    assert blocked.control.serving_membership_epoch == 1
+    assert blocked.serving_membership is not None
+    assert blocked.serving_membership.replicas[0].state == "DRAINING"
+
+    note.write_bytes(NOTE_BYTES)
+    monkeypatch.setattr(store, "_schema_migration_barrier", lambda _point: None)
+    recovered = schema_migration.commit_forward_migration(
+        vault,
+        expected_plan_digest=plan.plan_digest,
+        now=now + 4,
+    )
+    assert recovered.schema_version == 4
+    assert recovered.replayed is True
+
+
+def test_forward_migration_cutover_refuses_a_tampered_backup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    now = int(time.time())
+    plan = _stage_reviewed_migration(vault, now=now)
+
+    def crash(point: str) -> None:
+        if point == "after_backup":
+            raise schema_migration._ForwardMigrationCrash("stop after backup")
+
+    monkeypatch.setattr(schema_migration, "_forward_migration_barrier", crash)
+    with pytest.raises(schema_migration._ForwardMigrationCrash, match="stop after backup"):
+        schema_migration.commit_forward_migration(
+            vault,
+            expected_plan_digest=plan.plan_digest,
+            now=now + 2,
+        )
+    backup_path = schema_migration.forward_migration_backup_path(
+        vault,
+        plan_digest=plan.plan_digest,
+    )
+    raw = bytearray(backup_path.read_bytes())
+    raw[-1] ^= 1
+    backup_path.write_bytes(raw)
+
+    monkeypatch.setattr(
+        schema_migration,
+        "_forward_migration_barrier",
+        lambda _point: None,
+    )
+    with pytest.raises(schema_migration.ForwardMigrationUnavailable):
+        schema_migration.commit_forward_migration(
+            vault,
+            expected_plan_digest=plan.plan_digest,
+            now=now + 3,
+        )
+
+    assert _schema_version(vault) == 3
+    assert not Path(os.environ[authorization_custody.CONTROL_FILE_ENV]).exists()

--- a/tests/test_governance_v3_fixture.py
+++ b/tests/test_governance_v3_fixture.py
@@ -208,6 +208,12 @@ def test_enrolled_rich_v3_fixture_migrates_authority_conservatively(
     staged = authorization_custody.stage_standalone_v3_custody(vault, now=now)
     seed = _migration_seed(vault, staged, now=now + 1)
     target = schema_v4.migration_target(seed)
+    source = store.open_readonly_connection(vault)
+    assert source is not None
+    try:
+        source_store_digest = store._v3_snapshot_digest(source)
+    finally:
+        source.close()
     authorization_custody.enroll_standalone_v3_migration(
         vault,
         target=target,
@@ -218,6 +224,7 @@ def test_enrolled_rich_v3_fixture_migrates_authority_conservatively(
         store.migrate_enrolled_v3_store(
             vault,
             seed=seed,
+            expected_source_store_digest=source_store_digest,
             now=now + 2,
         )
         == target

--- a/tests/test_governance_v3_store_migration.py
+++ b/tests/test_governance_v3_store_migration.py
@@ -111,7 +111,17 @@ def _stage_and_enroll(
     vault: Path,
     *,
     now: int,
-) -> tuple[schema_v4.MigrationSeed, schema_v4.VerifiedActiveGovernanceState]:
+) -> tuple[
+    schema_v4.MigrationSeed,
+    schema_v4.VerifiedActiveGovernanceState,
+    str,
+]:
+    source = store.open_readonly_connection(vault)
+    assert source is not None
+    try:
+        source_store_digest = store._v3_snapshot_digest(source)
+    finally:
+        source.close()
     staged = authorization_custody.stage_standalone_v3_custody(vault, now=now)
     seed = _seed(vault, staged, now=now + 1)
     target = schema_v4.migration_target(seed)
@@ -120,7 +130,7 @@ def _stage_and_enroll(
         target=target,
         now=now,
     )
-    return seed, target
+    return seed, target, source_store_digest
 
 
 def _schema_version(vault: Path) -> int:
@@ -136,7 +146,7 @@ def test_enrolled_exact_v3_store_migrates_to_the_precommitted_target(
 ) -> None:
     vault = _vault(tmp_path)
     now = int(time.time())
-    seed, target = _stage_and_enroll(vault, now=now)
+    seed, target, source_store_digest = _stage_and_enroll(vault, now=now)
     assert policy.load(vault).blocked
     enrolled = authorization_custody.load_authorization_custody(
         vault,
@@ -155,7 +165,12 @@ def test_enrolled_exact_v3_store_migrates_to_the_precommitted_target(
         for item in enrolled.serving_membership.replicas
     ] == [("DRAINING", 3, True, True)]
 
-    active = store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 2)
+    active = store.migrate_enrolled_v3_store(
+        vault,
+        seed=seed,
+        expected_source_store_digest=source_store_digest,
+        now=now + 2,
+    )
 
     assert active == target
     assert _schema_version(vault) == 4
@@ -203,7 +218,7 @@ def test_store_migration_post_commit_crash_replays_exact_v4(
 ) -> None:
     vault = _vault(tmp_path)
     now = int(time.time())
-    seed, target = _stage_and_enroll(vault, now=now)
+    seed, target, source_store_digest = _stage_and_enroll(vault, now=now)
     crashed = False
 
     def crash(point: str) -> None:
@@ -214,13 +229,19 @@ def test_store_migration_post_commit_crash_replays_exact_v4(
 
     monkeypatch.setattr(store, "_schema_migration_barrier", crash)
     with pytest.raises(RuntimeError, match="post-commit"):
-        store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 2)
+        store.migrate_enrolled_v3_store(
+            vault,
+            seed=seed,
+            expected_source_store_digest=source_store_digest,
+            now=now + 2,
+        )
 
     assert _schema_version(vault) == 4
     monkeypatch.setattr(store, "_schema_migration_barrier", lambda _point: None)
     assert store.migrate_enrolled_v3_store(
         vault,
         seed=seed,
+        expected_source_store_digest=source_store_digest,
         now=now + 3,
     ) == target
     custody = authorization_custody.load_authorization_custody(vault, now=now + 4)
@@ -235,7 +256,7 @@ def test_store_migration_advances_external_fence_before_the_v4_commit(
 ) -> None:
     vault = _vault(tmp_path)
     now = int(time.time())
-    seed, target = _stage_and_enroll(vault, now=now)
+    seed, target, source_store_digest = _stage_and_enroll(vault, now=now)
     state = writer_lease.SchemaFenceState(True, 3, 7)
     transitions: list[tuple[int, int]] = []
 
@@ -268,14 +289,24 @@ def test_store_migration_advances_external_fence_before_the_v4_commit(
 
     monkeypatch.setattr(store, "_schema_migration_barrier", crash)
     with pytest.raises(RuntimeError, match="fence-first"):
-        store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 2)
+        store.migrate_enrolled_v3_store(
+            vault,
+            seed=seed,
+            expected_source_store_digest=source_store_digest,
+            now=now + 2,
+        )
 
     assert _schema_version(vault) == 3
     assert state_holder == [writer_lease.SchemaFenceState(True, 4, 8)]
     assert transitions == [(7, 4)]
 
     monkeypatch.setattr(store, "_schema_migration_barrier", lambda _point: None)
-    assert store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 3) == target
+    assert store.migrate_enrolled_v3_store(
+        vault,
+        seed=seed,
+        expected_source_store_digest=source_store_digest,
+        now=now + 3,
+    ) == target
     assert _schema_version(vault) == 4
     assert transitions == [(7, 4)]
 
@@ -286,7 +317,7 @@ def test_store_migration_refuses_fence_generation_drift_after_the_v4_commit(
 ) -> None:
     vault = _vault(tmp_path)
     now = int(time.time())
-    seed, target = _stage_and_enroll(vault, now=now)
+    seed, target, source_store_digest = _stage_and_enroll(vault, now=now)
     state_holder = [writer_lease.SchemaFenceState(True, 3, 17)]
 
     class Client:
@@ -313,7 +344,12 @@ def test_store_migration_refuses_fence_generation_drift_after_the_v4_commit(
 
     monkeypatch.setattr(store, "_schema_migration_barrier", drift)
     with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
-        store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 2)
+        store.migrate_enrolled_v3_store(
+            vault,
+            seed=seed,
+            expected_source_store_digest=source_store_digest,
+            now=now + 2,
+        )
 
     assert _schema_version(vault) == 4
     custody = authorization_custody.load_authorization_custody(vault, now=now + 3)
@@ -322,7 +358,12 @@ def test_store_migration_refuses_fence_generation_drift_after_the_v4_commit(
     assert custody.serving_membership.epoch == 1
 
     monkeypatch.setattr(store, "_schema_migration_barrier", lambda _point: None)
-    assert store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 3) == target
+    assert store.migrate_enrolled_v3_store(
+        vault,
+        seed=seed,
+        expected_source_store_digest=source_store_digest,
+        now=now + 3,
+    ) == target
     assert _schema_version(vault) == 4
     recovered = authorization_custody.load_authorization_custody(vault, now=now + 4)
     assert recovered.control.serving_membership_epoch == 2
@@ -334,7 +375,7 @@ def test_store_migration_refuses_membership_without_complete_v3_drain(
 ) -> None:
     vault = _vault(tmp_path)
     now = int(time.time())
-    seed, _target = _stage_and_enroll(vault, now=now)
+    seed, _target, source_store_digest = _stage_and_enroll(vault, now=now)
     custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
     assert custody.serving_membership is not None
     replica = custody.serving_membership.replicas[0]
@@ -358,7 +399,12 @@ def test_store_migration_refuses_membership_without_complete_v3_drain(
     )
 
     with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
-        store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 2)
+        store.migrate_enrolled_v3_store(
+            vault,
+            seed=seed,
+            expected_source_store_digest=source_store_digest,
+            now=now + 2,
+        )
 
     monkeypatch.setattr(
         authorization_custody,
@@ -374,7 +420,7 @@ def test_store_migration_recovers_membership_publish_before_control_ack(
 ) -> None:
     vault = _vault(tmp_path)
     now = int(time.time())
-    seed, target = _stage_and_enroll(vault, now=now)
+    seed, target, source_store_digest = _stage_and_enroll(vault, now=now)
     crashed = False
 
     def crash(point: str) -> None:
@@ -385,7 +431,12 @@ def test_store_migration_recovers_membership_publish_before_control_ack(
 
     monkeypatch.setattr(authorization_custody, "_migration_membership_barrier", crash)
     with pytest.raises(RuntimeError, match="membership publication"):
-        store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 2)
+        store.migrate_enrolled_v3_store(
+            vault,
+            seed=seed,
+            expected_source_store_digest=source_store_digest,
+            now=now + 2,
+        )
 
     assert _schema_version(vault) == 4
     interrupted = authorization_custody.load_authorization_custody(vault, now=now + 3)
@@ -398,6 +449,7 @@ def test_store_migration_recovers_membership_publish_before_control_ack(
     assert store.migrate_enrolled_v3_store(
         vault,
         seed=seed,
+        expected_source_store_digest=source_store_digest,
         now=now + 3,
     ) == target
     recovered = authorization_custody.load_authorization_custody(vault, now=now + 4)
@@ -415,6 +467,12 @@ def test_store_migration_refuses_unsafe_preconditions_without_changing_v3(
     now = int(time.time())
     staged = authorization_custody.stage_standalone_v3_custody(vault, now=now)
     seed = _seed(vault, staged, now=now + 1)
+    source = store.open_readonly_connection(vault)
+    assert source is not None
+    try:
+        source_store_digest = store._v3_snapshot_digest(source)
+    finally:
+        source.close()
     target = schema_v4.migration_target(seed)
     if fault != "not-enrolled":
         authorization_custody.enroll_standalone_v3_migration(
@@ -443,7 +501,12 @@ def test_store_migration_refuses_unsafe_preconditions_without_changing_v3(
             store.UnsupportedGovernanceSchema,
         )
     ):
-        store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 2)
+        store.migrate_enrolled_v3_store(
+            vault,
+            seed=seed,
+            expected_source_store_digest=source_store_digest,
+            now=now + 2,
+        )
 
     assert _schema_version(vault) == 3
 
@@ -454,10 +517,15 @@ def test_store_migration_refuses_a_copied_attachment(
     vault = _vault(tmp_path)
     copied = _vault(tmp_path, "copied-vault")
     now = int(time.time())
-    seed, _target = _stage_and_enroll(vault, now=now)
+    seed, _target, source_store_digest = _stage_and_enroll(vault, now=now)
 
     with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
-        store.migrate_enrolled_v3_store(copied, seed=seed, now=now + 2)
+        store.migrate_enrolled_v3_store(
+            copied,
+            seed=seed,
+            expected_source_store_digest=source_store_digest,
+            now=now + 2,
+        )
 
     assert _schema_version(copied) == 3
 
@@ -477,6 +545,7 @@ def test_store_migration_refuses_future_schema_before_parsing_seed(
         store.migrate_enrolled_v3_store(
             vault,
             seed=object(),  # type: ignore[arg-type]
+            expected_source_store_digest="0" * 64,
             now=int(time.time()),
         )
 
@@ -488,8 +557,13 @@ def test_store_migration_replay_refuses_extended_v4_without_writes(
 ) -> None:
     vault = _vault(tmp_path)
     now = int(time.time())
-    seed, _target = _stage_and_enroll(vault, now=now)
-    store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 2)
+    seed, _target, source_store_digest = _stage_and_enroll(vault, now=now)
+    store.migrate_enrolled_v3_store(
+        vault,
+        seed=seed,
+        expected_source_store_digest=source_store_digest,
+        now=now + 2,
+    )
     connection = sqlite3.connect(store.sidecar_path(vault))
     try:
         connection.execute(
@@ -500,7 +574,12 @@ def test_store_migration_replay_refuses_extended_v4_without_writes(
         connection.close()
 
     with pytest.raises(schema_v4.SchemaV4Error):
-        store.migrate_enrolled_v3_store(vault, seed=seed, now=now + 3)
+        store.migrate_enrolled_v3_store(
+            vault,
+            seed=seed,
+            expected_source_store_digest=source_store_digest,
+            now=now + 3,
+        )
 
     connection = sqlite3.connect(store.sidecar_path(vault))
     try:


### PR DESCRIPTION
## Summary

- add digest-confirmed, owner-only commit-migration execution
- publish and verify a private exact-v3 backup before irreversible enrollment
- hold the cooperative whole-tree fence and recheck source policy, catalog, and staged projections before v4 serving
- replay backup, enrollment, store-commit, and membership-ack crash gaps to the same reviewed target

Stacked after #884. This does not merge or touch any live vault.

## Verification

- red-first cutover API: 4 expected failures before implementation
- red-first CLI: 3 expected failures before implementation
- focused migration/custody/projection packet on Python 3.13: 112 passed
- exact cutover packet on Python 3.11: 8 passed, 9 deselected
- Ruff on all 9 changed files
- git diff --check
- uv lock --check
- openspec validate harden-governance-for-consolidation --strict
- public repository artifact validation
- uv build