### PR TITLE
feat(governance): publish semantic policy transitions

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -156,7 +156,7 @@ this reconciliation is `origin/main` at `9dc37201` plus stacked evidence PR #832
   source/catalog recheck; atomic initial tuple; stopped/running deletion and corrupt/
   missing/aliased registry/workspace/store/tuple/policy/catalog/namespace fail-closed;
   WAL-consistent restore and no last-good/OPEN/historical fallback.
-- [ ] 3.7 Add red `govern_memory` suspend/resume/undo matrices: semantic widening and
+- [x] 3.7 Add red `govern_memory` suspend/resume/undo matrices: semantic widening and
   narrowing; changed dependent scope/member identity/hash/set with deterministic expire/
   review state; exact policy generation + grant manifest + ready namespace identity;
   races against content create/edit/delete and companion publication; cooperatively fenced

--- a/src/exomem/governance/policy.py
+++ b/src/exomem/governance/policy.py
@@ -1498,8 +1498,14 @@ def compile_prospective(
     documents: dict[str, str | None],
     *,
     _expected_pending_event_id: str | None = None,
+    _replace_document_set: bool = False,
 ) -> ProspectiveCompile | None:
-    """Compile an overlay only after a stable no-follow workspace acquisition."""
+    """Compile an exact target after a stable no-follow workspace acquisition.
+
+    Ordinary authoring proposals overlay reviewed edits onto the captured workspace.
+    Internal semantic operations may instead supply the complete immutable target;
+    their target must not inherit unrelated pending workspace YAML.
+    """
 
     vault_root = Path(vault_root)
     guard_before = _clear_guard_generation(
@@ -1547,7 +1553,7 @@ def compile_prospective(
         directory_identities=read.directory_identities,
         governance_root_identity=read.root_identity,
     )
-    target_documents = dict(current_documents)
+    target_documents = {} if _replace_document_set else dict(current_documents)
     for relative, content in documents.items():
         normalized = relative.replace("\\", "/")
         if content is None:

--- a/src/exomem/governance/recovery.py
+++ b/src/exomem/governance/recovery.py
@@ -1204,6 +1204,24 @@ def _reconcile_orphan_reservations(vault_root: Path) -> tuple[int, bool]:
         ).fetchall()
     finally:
         conn.close()
+    legacy_rows = []
+    for row in rows:
+        try:
+            payload = json.loads(str(row[1]))
+        except (TypeError, ValueError):
+            legacy_rows.append(row)
+            continue
+        binding = payload.get("authority_binding") if isinstance(payload, dict) else None
+        if isinstance(binding, dict) and binding.get("schema") in {
+            "exomem.governance-policy-proposal/v3",
+            "exomem.governance-policy-proposal/v4",
+        }:
+            # Immutable-generation proposals own receipt reservation and recovery in
+            # the v4 policy publisher.  They intentionally have no legacy YAML
+            # operation journal and must not be classified as orphaned here.
+            continue
+        legacy_rows.append(row)
+    rows = legacy_rows
     if not rows:
         return 0, False
     if _marker_path(vault_root).exists():

--- a/src/exomem/governance/schema_v4.py
+++ b/src/exomem/governance/schema_v4.py
@@ -162,6 +162,18 @@ class ProjectionNamespaceSeed:
 
 
 @dataclass(frozen=True, slots=True)
+class DependentGrantTransition:
+    """One exact active-grant successor bound to a policy publication."""
+
+    grant_id: str
+    expected_policy_fingerprint: str
+    expected_membership_manifest: str
+    target_status: str
+    target_policy_fingerprint: str
+    target_membership_manifest: str
+
+
+@dataclass(frozen=True, slots=True)
 class MigrationSeed:
     activation_store_id: str
     logical_vault_id: str
@@ -285,6 +297,87 @@ class ActivationRegistryAcknowledgement:
 RegistryAcknowledger = Callable[
     [VerifiedActiveGovernanceState], ActivationRegistryAcknowledgement
 ]
+
+
+def _canonical_membership_manifest(value: object, name: str) -> str:
+    if not isinstance(value, str):
+        raise SchemaV4Error(f"{name} must be canonical bounded JSON")
+    try:
+        encoded = value.encode("utf-8")
+        decoded = json.loads(value)
+    except (UnicodeEncodeError, json.JSONDecodeError) as exc:
+        raise SchemaV4Error(f"{name} must be canonical bounded JSON") from exc
+    if (
+        not isinstance(decoded, list)
+        or len(encoded) > _MAX_BLOB_BYTES
+        or json.dumps(
+            decoded,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        != value
+    ):
+        raise SchemaV4Error(f"{name} must be canonical bounded JSON")
+    return value
+
+
+def _dependent_grant_transitions(
+    value: tuple[DependentGrantTransition, ...] | None,
+    *,
+    expected_policy_fingerprint: str,
+    target_policy_fingerprint: str,
+) -> tuple[DependentGrantTransition, ...] | None:
+    if value is None:
+        return None
+    if not isinstance(value, tuple) or len(value) > 100_000:
+        raise SchemaV4Error("dependent_grants must be one bounded ordered tuple")
+    normalized: list[DependentGrantTransition] = []
+    seen: set[str] = set()
+    for ordinal, transition in enumerate(value):
+        if not isinstance(transition, DependentGrantTransition):
+            raise SchemaV4Error("dependent_grants contains an invalid transition")
+        grant_id = _text(transition.grant_id, f"dependent_grants[{ordinal}].grant_id")
+        if grant_id in seen:
+            raise SchemaV4Error("dependent_grants contains a duplicate grant")
+        seen.add(grant_id)
+        expected_fingerprint = _digest(
+            transition.expected_policy_fingerprint,
+            f"dependent_grants[{ordinal}].expected_policy_fingerprint",
+        )
+        target_fingerprint = _digest(
+            transition.target_policy_fingerprint,
+            f"dependent_grants[{ordinal}].target_policy_fingerprint",
+        )
+        if (
+            expected_fingerprint != expected_policy_fingerprint
+            or target_fingerprint != target_policy_fingerprint
+            or transition.target_status not in {"expired", "review"}
+        ):
+            raise SchemaV4Error(
+                "dependent grant transition does not match the policy publication"
+            )
+        normalized.append(
+            DependentGrantTransition(
+                grant_id=grant_id,
+                expected_policy_fingerprint=expected_fingerprint,
+                expected_membership_manifest=_canonical_membership_manifest(
+                    transition.expected_membership_manifest,
+                    f"dependent_grants[{ordinal}].expected_membership_manifest",
+                ),
+                target_status=transition.target_status,
+                target_policy_fingerprint=target_fingerprint,
+                target_membership_manifest=_canonical_membership_manifest(
+                    transition.target_membership_manifest,
+                    f"dependent_grants[{ordinal}].target_membership_manifest",
+                ),
+            )
+        )
+    ordered = tuple(sorted(normalized, key=lambda item: item.grant_id))
+    if tuple(normalized) != ordered:
+        raise SchemaV4Error("dependent_grants must be ordered by grant identity")
+    return ordered
 
 
 @dataclass(frozen=True, slots=True)
@@ -1918,6 +2011,68 @@ def load_active_policy(
     )
 
 
+def load_policy_generation(
+    connection: sqlite3.Connection,
+    generation_id: str,
+) -> PolicyGenerationSeed:
+    """Verify and return one immutable historical policy generation."""
+
+    identity = _text(generation_id, "policy.generation_id")
+    try:
+        row = connection.execute(
+            "SELECT generation_id, source_documents, source_fingerprint, "
+            "conflict_digest, compiled_policy, policy_fingerprint, "
+            "compiler_schema_version, projector_schema_version, "
+            "predecessor_generation_id, authoring_event_id, receipt_event_id, "
+            "immutable_row_digest, created_at FROM compiled_policy_generations "
+            "WHERE generation_id=?",
+            (identity,),
+        ).fetchone()
+        if row is None:
+            raise SchemaV4Error("policy generation is unavailable")
+        stored = tuple(row)
+        if not hmac.compare_digest(
+            _stored_policy_row_digest(stored),
+            _digest(stored[11], "policy.immutable_row_digest"),
+        ):
+            raise SchemaV4Error("policy generation digest does not verify")
+        seed = PolicyGenerationSeed(
+            generation_id=_text(stored[0], "policy.generation_id"),
+            source_documents=_decode_source_document_bytes(stored[1]),
+            source_fingerprint=_digest(
+                stored[2], "policy.source_fingerprint"
+            ),
+            conflict_digest=_digest(stored[3], "policy.conflict_digest"),
+            compiled_policy=_blob(
+                stored[4], "policy.compiled_policy", allow_empty=True
+            ),
+            policy_fingerprint=_digest(
+                stored[5], "policy.policy_fingerprint"
+            ),
+            compiler_schema_version=_integer(
+                stored[6], "policy.compiler_schema_version"
+            ),
+            projector_schema_version=_integer(
+                stored[7], "policy.projector_schema_version"
+            ),
+            predecessor_generation_id=(
+                None
+                if stored[8] is None
+                else _text(stored[8], "policy.predecessor_generation_id")
+            ),
+            authoring_event_id=_text(stored[9], "policy.authoring_event_id"),
+            receipt_event_id=_text(stored[10], "policy.receipt_event_id"),
+            created_at=_integer(stored[12], "policy.created_at"),
+        )
+        source_documents, row_digest = _validate_policy(seed)
+        if not hmac.compare_digest(row_digest, str(stored[11])):
+            raise SchemaV4Error("policy generation digest does not verify")
+        _verify_policy_source_parity(seed, source_documents)
+        return seed
+    except (IndexError, TypeError, ValueError, sqlite3.Error, SchemaV4Error):
+        raise SchemaV4Error("policy generation is unavailable") from None
+
+
 def _projection_namespace_id(value: object) -> str:
     if (
         not isinstance(value, str)
@@ -2123,8 +2278,15 @@ def publish_policy_generation(
     namespace: ProjectionNamespaceSeed,
     activated_at: int,
     acknowledge_registry: RegistryAcknowledger,
+    dependent_grants: tuple[DependentGrantTransition, ...] | None = None,
+    catalog: CatalogGenerationSeed | None = None,
 ) -> TuplePublicationResult:
-    """Insert and CAS one complete policy generation against its reviewed tuple."""
+    """Insert and CAS one complete policy/catalog generation successor.
+
+    Policy changes that alter selector membership supply ``catalog`` so the
+    immutable target catalog and its namespace enter the same tuple CAS.  A
+    policy-only change may reuse the reviewed catalog by passing ``None``.
+    """
 
     if not isinstance(expected, VerifiedActiveGovernanceState):
         raise SchemaV4Error("expected active tuple is invalid")
@@ -2145,6 +2307,44 @@ def publish_policy_generation(
     namespace_ready_at = _integer(namespace.ready_at, "namespace.ready_at")
     if namespace_ready_at > activated:
         raise SchemaV4Error("projection namespace is not ready at activation")
+    grant_transitions = _dependent_grant_transitions(
+        dependent_grants,
+        expected_policy_fingerprint=expected.policy_fingerprint,
+        target_policy_fingerprint=policy.policy_fingerprint,
+    )
+    if catalog is None:
+        target_catalog_generation = expected.catalog_generation
+        catalog_descriptor = None
+        catalog_artifact_count = None
+        catalog_created_at = None
+        catalog_descriptor_digest = None
+    else:
+        if not isinstance(catalog, CatalogGenerationSeed):
+            raise SchemaV4Error("catalog generation is invalid")
+        target_catalog_generation = _integer(
+            catalog.catalog_generation,
+            "catalog.catalog_generation",
+        )
+        if target_catalog_generation != expected.catalog_generation + 1:
+            raise ActiveTupleStale("catalog generation is not the reviewed successor")
+        catalog_descriptor = _blob(
+            catalog.descriptor,
+            "catalog.descriptor",
+            allow_empty=True,
+        )
+        catalog_artifact_count = _integer(
+            catalog.artifact_count,
+            "catalog.artifact_count",
+            minimum=0,
+        )
+        catalog_created_at = _integer(catalog.created_at, "catalog.created_at")
+        catalog_descriptor_digest = _framed_digest(
+            b"exomem.catalog-generation-descriptor.v1",
+            _ascii_integer(target_catalog_generation),
+            catalog_descriptor,
+            _ascii_integer(catalog_artifact_count),
+            _ascii_integer(catalog_created_at),
+        )
 
     _verify_policy_source_parity(policy, source_documents)
 
@@ -2166,21 +2366,22 @@ def publish_policy_generation(
             raise ActiveTupleStale(
                 "active tuple no longer matches the reviewed predecessor"
             )
-        catalog = connection.execute(
-            "SELECT descriptor_digest FROM catalog_generation_descriptors "
-            "WHERE catalog_generation=?",
-            (expected.catalog_generation,),
-        ).fetchone()
-        if catalog is None:
-            raise SchemaV4Error("reviewed catalog descriptor is unavailable")
-        catalog_descriptor_digest = _digest(
-            catalog[0], "catalog.descriptor_digest"
-        )
+        if catalog_descriptor_digest is None:
+            current_catalog = connection.execute(
+                "SELECT descriptor_digest FROM catalog_generation_descriptors "
+                "WHERE catalog_generation=?",
+                (expected.catalog_generation,),
+            ).fetchone()
+            if current_catalog is None:
+                raise SchemaV4Error("reviewed catalog descriptor is unavailable")
+            catalog_descriptor_digest = _digest(
+                current_catalog[0], "catalog.descriptor_digest"
+            )
         namespace_digest = _framed_digest(
             b"exomem.authorization-projection-namespace.v1",
             policy.policy_fingerprint.encode("ascii"),
             _ascii_integer(policy.projector_schema_version),
-            _ascii_integer(expected.catalog_generation),
+            _ascii_integer(target_catalog_generation),
             namespace_id.encode(),
             namespace_evidence,
             _ascii_integer(namespace_ready_at),
@@ -2197,10 +2398,51 @@ def publish_policy_generation(
             policy_fingerprint=policy.policy_fingerprint,
             policy_row_digest=policy_row_digest,
             projector_schema_version=policy.projector_schema_version,
-            catalog_generation=expected.catalog_generation,
+            catalog_generation=target_catalog_generation,
             catalog_descriptor_digest=catalog_descriptor_digest,
             projection_namespace_identity=namespace_digest,
         )
+        if grant_transitions is not None:
+            active_grants = connection.execute(
+                "SELECT grant_id, policy_fingerprint, membership_manifest, status, "
+                "prepared_event_id FROM governance_session_grants "
+                "WHERE status='active' ORDER BY grant_id"
+            ).fetchall()
+            expected_grants = [
+                (
+                    transition.grant_id,
+                    transition.expected_policy_fingerprint,
+                    transition.expected_membership_manifest,
+                    "active",
+                    None,
+                )
+                for transition in grant_transitions
+            ]
+            if active_grants != expected_grants:
+                raise ActiveTupleStale(
+                    "dependent grant manifest no longer matches the reviewed predecessor"
+                )
+            for transition in grant_transitions:
+                updated_grant = connection.execute(
+                    "UPDATE governance_session_grants SET status=?, "
+                    "policy_fingerprint=?, membership_manifest=?, "
+                    "prepared_event_id=NULL, revoked_at=? WHERE grant_id=? "
+                    "AND status='active' AND prepared_event_id IS NULL "
+                    "AND policy_fingerprint=? AND membership_manifest=?",
+                    (
+                        transition.target_status,
+                        transition.target_policy_fingerprint,
+                        transition.target_membership_manifest,
+                        activated,
+                        transition.grant_id,
+                        transition.expected_policy_fingerprint,
+                        transition.expected_membership_manifest,
+                    ),
+                )
+                if updated_grant.rowcount != 1:
+                    raise ActiveTupleStale(
+                        "dependent grant changed during policy publication"
+                    )
         connection.execute(
             "INSERT INTO compiled_policy_generations "
             "(generation_id, source_documents, source_fingerprint, conflict_digest, "
@@ -2224,30 +2466,62 @@ def publish_policy_generation(
                 policy.created_at,
             ),
         )
-        connection.execute(
-            "INSERT INTO governance_projection_namespaces "
-            "(policy_fingerprint, projector_schema_version, catalog_generation, "
-            "namespace_id, namespace_digest, evidence, ready_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        if catalog_descriptor is not None:
+            connection.execute(
+                "INSERT INTO catalog_generation_descriptors "
+                "(catalog_generation, descriptor, descriptor_digest, artifact_count, "
+                "created_at) VALUES (?, ?, ?, ?, ?)",
+                (
+                    target_catalog_generation,
+                    catalog_descriptor,
+                    catalog_descriptor_digest,
+                    catalog_artifact_count,
+                    catalog_created_at,
+                ),
+            )
+        namespace_row = connection.execute(
+            "SELECT namespace_id, namespace_digest, evidence, ready_at "
+            "FROM governance_projection_namespaces WHERE policy_fingerprint=? "
+            "AND projector_schema_version=? AND catalog_generation=?",
             (
                 policy.policy_fingerprint,
                 policy.projector_schema_version,
-                expected.catalog_generation,
-                namespace_id,
-                namespace_digest,
-                namespace_evidence,
-                namespace_ready_at,
+                target_catalog_generation,
             ),
+        ).fetchone()
+        expected_namespace_row = (
+            namespace_id,
+            namespace_digest,
+            namespace_evidence,
+            namespace_ready_at,
         )
+        if namespace_row is None:
+            connection.execute(
+                "INSERT INTO governance_projection_namespaces "
+                "(policy_fingerprint, projector_schema_version, catalog_generation, "
+                "namespace_id, namespace_digest, evidence, ready_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    policy.policy_fingerprint,
+                    policy.projector_schema_version,
+                    target_catalog_generation,
+                    *expected_namespace_row,
+                ),
+            )
+        elif tuple(namespace_row) != expected_namespace_row:
+            raise SchemaV4Error(
+                "existing projection namespace does not match the policy publication"
+            )
         active_update = connection.execute(
             "UPDATE active_governance_tuple SET policy_generation_id=?, "
-            "policy_fingerprint=?, projector_schema_version=? "
+            "policy_fingerprint=?, projector_schema_version=?, catalog_generation=? "
             "WHERE singleton=1 AND policy_generation_id=? AND policy_fingerprint=? "
             "AND projector_schema_version=? AND catalog_generation=?",
             (
                 policy.generation_id,
                 policy.policy_fingerprint,
                 policy.projector_schema_version,
+                target_catalog_generation,
                 expected.policy_generation_id,
                 expected.policy_fingerprint,
                 expected.projector_schema_version,
@@ -2285,7 +2559,7 @@ def publish_policy_generation(
                 policy.generation_id,
                 policy.policy_fingerprint,
                 policy.projector_schema_version,
-                expected.catalog_generation,
+                target_catalog_generation,
                 target_epoch,
                 activated,
             ),

--- a/src/exomem/governance/store.py
+++ b/src/exomem/governance/store.py
@@ -774,6 +774,84 @@ def _delete_expired_except(
     return int(cursor.rowcount or 0)
 
 
+def _retained_v4_policy_components(
+    conn: sqlite3.Connection,
+) -> tuple[frozenset[str], frozenset[str]]:
+    """Return immutable policy-history rows that TTL sweeping cannot retire.
+
+    A spent v4 proposal is the retained semantic/publication history for its
+    compiled generation, and its reviewed dependent-grant targets remain part
+    of crash recovery evidence.  They are intentionally durable until a later
+    schema supplies an equivalent immutable history table.
+    """
+
+    proposal_ids: set[str] = set()
+    grant_ids: set[str] = set()
+
+    def retain_all_grants() -> None:
+        grant_ids.update(
+            str(row[0])
+            for row in conn.execute(
+                "SELECT grant_id FROM governance_session_grants"
+            ).fetchall()
+        )
+
+    rows = conn.execute(
+        "SELECT proposal_id, proposal_json, status, reserved_event_id "
+        "FROM governance_proposals WHERE status IN ('pending','spent') "
+        "ORDER BY proposal_id"
+    ).fetchall()
+    for proposal_id, proposal_json, status, reserved_event_id in rows:
+        if status == "pending" and reserved_event_id is None:
+            continue
+        try:
+            payload = json.loads(str(proposal_json))
+        except json.JSONDecodeError:
+            if "exomem.governance-policy-proposal/v" in str(proposal_json):
+                proposal_ids.add(str(proposal_id))
+                retain_all_grants()
+            continue
+        binding = payload.get("authority_binding") if isinstance(payload, dict) else None
+        schema = binding.get("schema") if isinstance(binding, dict) else None
+        if schema not in {
+            "exomem.governance-policy-proposal/v3",
+            "exomem.governance-policy-proposal/v4",
+        }:
+            continue
+        proposal_ids.add(str(proposal_id))
+        dependent = binding.get("dependent_grants", [])
+        if not isinstance(dependent, list):
+            retain_all_grants()
+            continue
+        seen_grants: set[str] = set()
+        malformed = False
+        expected_transition_keys = {
+            "grant_id",
+            "expected_policy_fingerprint",
+            "expected_membership_manifest",
+            "target_status",
+            "target_policy_fingerprint",
+            "target_membership_manifest",
+        }
+        for transition in dependent:
+            grant_id = transition.get("grant_id") if isinstance(transition, dict) else None
+            if (
+                not isinstance(transition, dict)
+                or set(transition) != expected_transition_keys
+                or not isinstance(grant_id, str)
+                or not grant_id
+                or grant_id in seen_grants
+            ):
+                malformed = True
+                break
+            seen_grants.add(grant_id)
+        if malformed:
+            retain_all_grants()
+        else:
+            grant_ids.update(seen_grants)
+    return frozenset(proposal_ids), frozenset(grant_ids)
+
+
 def sweep_authoring_state(vault_root: Path, *, now: float | None = None) -> int:
     """Physically retire expired tool state while pinning live composites."""
     if not sidecar_path(vault_root).exists():
@@ -784,17 +862,18 @@ def sweep_authoring_state(vault_root: Path, *, now: float | None = None) -> int:
     conn.execute("BEGIN IMMEDIATE")
     try:
         pinned = pinned_component_keys(vault_root, conn=conn)
+        retained_proposals, retained_grants = _retained_v4_policy_components(conn)
         removed = _delete_expired_except(
             conn,
             table="governance_proposals",
             key_column="proposal_id",
             expiry_column="expires_at",
             now=moment,
-            pinned=pinned.get("proposal", frozenset()),
+            pinned=pinned.get("proposal", frozenset()) | retained_proposals,
         )
         grant_pins = pinned.get("grant", frozenset()) | pinned.get(
             "dependent_grant", frozenset()
-        )
+        ) | retained_grants
         removed += _delete_expired_except(
             conn,
             table="governance_session_grants",

--- a/src/exomem/governance/tool.py
+++ b/src/exomem/governance/tool.py
@@ -97,10 +97,16 @@ _LEXICAL_REBUILD_TEMP_RE = re.compile(
 _CROCKFORD32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 _ULID_RE = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
-_V4_POLICY_PROPOSAL_SCHEMA = "exomem.governance-policy-proposal/v3"
+_V4_POLICY_PROPOSAL_SCHEMA_V3 = "exomem.governance-policy-proposal/v3"
+_V4_POLICY_PROPOSAL_SCHEMA = "exomem.governance-policy-proposal/v4"
+_V4_POLICY_PUBLICATION_RECEIPT_SCHEMA = (
+    "exomem.governance-policy-publication-receipt/v1"
+)
+_V4_POLICY_PUBLICATION_RECEIPT_OPERATION = "governance_policy_publication"
 _V4_POLICY_MIRROR_SCHEMA = "exomem.governance-policy-workspace-mirror/v1"
 _V4_POLICY_MIRROR_OPERATION = "governance_policy_workspace_mirror"
 _V4_POLICY_MIRROR_OUTCOMES = frozenset({"complete", "diverged"})
+_V4_POLICY_RECOVERY_EXPIRES_AT = 253_402_300_799.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -108,9 +114,20 @@ class _DecodedV4PolicyProposal:
     payload: dict[str, Any]
     expected: schema_v4.VerifiedActiveGovernanceState
     policy: schema_v4.PolicyGenerationSeed
+    catalog: schema_v4.CatalogGenerationSeed | None
     namespace: schema_v4.ProjectionNamespaceSeed
     direction: str
     authoring_snapshot: policy_module.AuthoringSnapshot
+    authoring_snapshot_value: dict[str, Any]
+    dependent_grants: tuple[schema_v4.DependentGrantTransition, ...] | None
+
+
+@dataclass(frozen=True, slots=True)
+class _StagedTargetProjection:
+    catalog: schema_v4.CatalogGenerationSeed | None
+    namespace: dict[str, Any]
+    predecessor_items: tuple[projection_store.ProjectionItemVariants, ...]
+    items: tuple[projection_store.ProjectionItemVariants, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -222,7 +239,11 @@ def _stable_identity_value(value: Any) -> dict[str, Any] | None:
         "device": int(value.device),
         "inode": int(value.inode),
         "kind": str(value.kind),
-        "link_count": int(value.link_count),
+        # A directory link count changes when excluded operational state (for
+        # example the receipt events directory) is created beside the policy
+        # workspace. Authoring identity deliberately binds the held directory
+        # object, not that mutable count; files remain single-link exact.
+        "link_count": int(value.link_count) if value.kind == "file" else 1,
     }
 
 
@@ -363,7 +384,7 @@ def _stage_target_projection_namespace(
     active_snapshot: schema_v4.ActivePolicySnapshot,
     target_policy: policy_module.Policy,
     ready_at: int,
-) -> dict[str, Any]:
+) -> _StagedTargetProjection:
     try:
         active_evidence = projection_store.namespace_evidence_from_snapshot(
             active_snapshot
@@ -383,46 +404,138 @@ def _stage_target_projection_namespace(
                 "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
                 "the active model/graph lanes require a prepared measurement rebuild",
             )
+        target_memberships: list[tuple[str, ...]] = []
+        for item in active_items:
+            snapshot = reserved_paths.read_generic_bytes(
+                vault_root,
+                item.item_identity,
+            )
+            if not __import__("hmac").compare_digest(
+                hashlib.sha256(snapshot.data).hexdigest(),
+                item.content_hash,
+            ):
+                raise GovernanceError(
+                    "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
+                    "the live corpus no longer matches the active catalog",
+                )
+            if Path(item.item_identity).suffix.casefold() == ".md":
+                page = find_corpus.parse_page(
+                    vault_root / item.item_identity,
+                    snapshot.mtime,
+                    vault_root,
+                    content=snapshot.data,
+                    resolved_relative=item.item_identity,
+                )
+                if page is None:
+                    raise GovernanceError(
+                        "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
+                        "the active Markdown catalog item cannot be classified",
+                    )
+                scope_ids = membership.evaluate(page, target_policy)
+            else:
+                scope_ids = membership.evaluate_path_only(
+                    vault_root,
+                    item.item_identity,
+                    target_policy,
+                ).require_classified()
+            target_memberships.append(tuple(sorted(scope_ids)))
+
+        membership_changed = any(
+            target_scope_ids != item.scope_ids
+            for item, target_scope_ids in zip(
+                active_items,
+                target_memberships,
+                strict=True,
+            )
+        )
+        target_catalog_generation = active_snapshot.active.catalog_generation + int(
+            membership_changed
+        )
         key = projections.ProjectionNamespaceKey(
             policy_fingerprint=target_policy.fingerprint,
             projector_schema_version=active_snapshot.active.projector_schema_version,
-            catalog_generation=active_snapshot.active.catalog_generation,
+            catalog_generation=target_catalog_generation,
         )
         target_items = tuple(
             projection_store.ProjectionItemVariants(
                 item_identity=item.item_identity,
                 content_hash=item.content_hash,
-                scope_ids=item.scope_ids,
+                scope_ids=target_scope_ids,
                 variants=projections.enumerate_projection_variants(
                     item_identity=item.item_identity,
                     content_hash=item.content_hash,
-                    scope_ids=item.scope_ids,
+                    scope_ids=target_scope_ids,
                     policy=target_policy,
                     projector_schema_version=key.projector_schema_version,
                     full_search_fields=_full_search_fields(item),
                 ),
             )
-            for item in active_items
+            for item, target_scope_ids in zip(
+                active_items,
+                target_memberships,
+                strict=True,
+            )
         )
-        if not __import__("hmac").compare_digest(
-            projection_store.catalog_descriptor_bytes(key, target_items),
+        target_catalog_descriptor = projection_store.catalog_descriptor_bytes(
+            key,
+            target_items,
+        )
+        if not membership_changed and not __import__("hmac").compare_digest(
+            target_catalog_descriptor,
             active_snapshot.catalog_descriptor,
         ):
             raise GovernanceError(
                 "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
                 "the prepared projection catalog does not match the reviewed catalog",
             )
+        target_catalog = (
+            schema_v4.CatalogGenerationSeed(
+                catalog_generation=target_catalog_generation,
+                descriptor=target_catalog_descriptor,
+                artifact_count=len(target_items),
+                created_at=ready_at,
+            )
+            if membership_changed
+            else None
+        )
         target_manifest = projection_store.stage_variant_store(
             vault_root,
             key=key,
             items=target_items,
         )
         evidence = projection_store.projection_namespace_evidence_bytes(target_manifest)
+        connection = store.open_authorization_session_connection(vault_root)
+        try:
+            existing_namespace = connection.execute(
+                "SELECT namespace_id, evidence, ready_at "
+                "FROM governance_projection_namespaces "
+                "WHERE policy_fingerprint=? AND projector_schema_version=? "
+                "AND catalog_generation=?",
+                (
+                    key.policy_fingerprint,
+                    key.projector_schema_version,
+                    key.catalog_generation,
+                ),
+            ).fetchone()
+        finally:
+            connection.close()
+        if existing_namespace is not None:
+            if (
+                existing_namespace[0] != key.namespace_id
+                or bytes(existing_namespace[1]) != evidence
+            ):
+                raise GovernanceError(
+                    "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
+                    "the reusable projection namespace does not verify",
+                )
+            ready_at = int(existing_namespace[2])
     except GovernanceError:
         raise
     except (
+        membership.MembershipUnresolved,
         projection_store.ProjectionStoreError,
         projections.ProjectionError,
+        reserved_paths.ReservedPathLeafError,
         FileNotFoundError,
         OSError,
         sqlite3.Error,
@@ -433,33 +546,186 @@ def _stage_target_projection_namespace(
             "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
             "the target authorization-projection namespace is unavailable",
         ) from None
+    return _StagedTargetProjection(
+        catalog=target_catalog,
+        namespace={
+            "namespace_id": key.namespace_id,
+            "projector_schema_version": key.projector_schema_version,
+            "catalog_generation": key.catalog_generation,
+            "projection_rows_digest": target_manifest.rows_digest,
+            "evidence": base64.b64encode(evidence).decode("ascii"),
+            "ready_at": ready_at,
+        },
+        predecessor_items=active_items,
+        items=target_items,
+    )
+
+
+def _v4_dependent_grant_transitions(
+    vault_root: Path,
+    *,
+    current_policy: policy_module.Policy,
+    target_policy: policy_module.Policy,
+    predecessor_items: tuple[projection_store.ProjectionItemVariants, ...],
+    target_items: tuple[projection_store.ProjectionItemVariants, ...],
+) -> tuple[schema_v4.DependentGrantTransition, ...]:
+    connection = store.open_authorization_session_connection(vault_root)
+    try:
+        rows = connection.execute(
+            "SELECT grant_id, paths, fingerprints, scope_ids, membership_manifest, "
+            "policy_fingerprint, prepared_event_id FROM governance_session_grants "
+            "WHERE status='active' ORDER BY grant_id"
+        ).fetchall()
+    except sqlite3.Error:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "dependent grant authority cannot be reviewed exactly",
+        ) from None
+    finally:
+        connection.close()
+    predecessor_by_path = {item.item_identity: item for item in predecessor_items}
+    target_by_path = {item.item_identity: item for item in target_items}
+    transitions: list[schema_v4.DependentGrantTransition] = []
+    for row in rows:
+        try:
+            grant_id = str(row[0])
+            paths = json.loads(str(row[1]))
+            fingerprints = json.loads(str(row[2]))
+            scope_ids = json.loads(str(row[3]))
+            expected_manifest = str(row[4])
+            stored_policy_fingerprint = str(row[5])
+            reviewed_membership = authorization_session_authority._load_membership(
+                expected_manifest
+            )
+            if (
+                not grant_id
+                or not isinstance(paths, list)
+                or not all(isinstance(path, str) and path for path in paths)
+                or not isinstance(fingerprints, list)
+                or not all(isinstance(value, str) for value in fingerprints)
+                or len(paths) != len(fingerprints)
+                or not isinstance(scope_ids, list)
+                or not scope_ids
+                or not all(isinstance(scope_id, str) and scope_id for scope_id in scope_ids)
+                or scope_ids != sorted(set(scope_ids))
+                or tuple(paths) != tuple(item.path for item in reviewed_membership)
+                or tuple(fingerprints)
+                != tuple(item.fingerprint for item in reviewed_membership)
+                or any(
+                    path not in predecessor_by_path
+                    for path in paths
+                )
+                or not set(scope_ids).issubset(
+                    {
+                        scope_id
+                        for item in reviewed_membership
+                        for scope_id in item.scope_ids
+                    }
+                )
+                or stored_policy_fingerprint != current_policy.fingerprint
+                or row[6] is not None
+            ):
+                raise ValueError
+            target_membership = [
+                {
+                    "path": path,
+                    "fingerprint": target_by_path[path].content_hash,
+                    "scope_ids": list(target_by_path[path].scope_ids),
+                }
+                for path in paths
+                if path in target_by_path
+            ]
+            target_manifest = _canonical_json(target_membership)
+        except (
+            GovernanceError,
+            authorization_session_lifecycle.AuthorizationSessionUnavailable,
+            json.JSONDecodeError,
+            TypeError,
+            ValueError,
+        ):
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "dependent grant authority cannot be reviewed exactly",
+            ) from None
+        transitions.append(
+            schema_v4.DependentGrantTransition(
+                grant_id=grant_id,
+                expected_policy_fingerprint=stored_policy_fingerprint,
+                expected_membership_manifest=expected_manifest,
+                target_status=(
+                    "expired"
+                    if target_manifest != expected_manifest
+                    else "review"
+                ),
+                target_policy_fingerprint=target_policy.fingerprint,
+                target_membership_manifest=target_manifest,
+            )
+        )
+    return tuple(transitions)
+
+
+def _direction_with_dependent_grants(
+    policy_direction: str,
+    transitions: tuple[schema_v4.DependentGrantTransition, ...],
+) -> str:
+    """Classify the complete policy/grant transition conservatively.
+
+    Every dependent transition removes an active widening grant by moving it to
+    ``review`` or ``expired``.  That cannot make a pointwise policy narrowing more
+    permissive.  If policy widens anywhere, grant removal can make the combined
+    lattice incomparable, which belongs to the widening/unknown release class.
+    """
+
+    if policy_direction not in {"narrowing", "widening"} or any(
+        transition.target_status not in {"review", "expired"}
+        for transition in transitions
+    ):
+        return "widening"
+    return policy_direction
+
+
+def _dependent_grant_value(
+    transitions: tuple[schema_v4.DependentGrantTransition, ...],
+) -> list[dict[str, str]]:
+    return [
+        {
+            "grant_id": transition.grant_id,
+            "expected_policy_fingerprint": transition.expected_policy_fingerprint,
+            "expected_membership_manifest": transition.expected_membership_manifest,
+            "target_status": transition.target_status,
+            "target_policy_fingerprint": transition.target_policy_fingerprint,
+            "target_membership_manifest": transition.target_membership_manifest,
+        }
+        for transition in transitions
+    ]
+
+
+def _catalog_seed_value(
+    catalog: schema_v4.CatalogGenerationSeed | None,
+) -> dict[str, Any] | None:
+    if catalog is None:
+        return None
     return {
-        "namespace_id": key.namespace_id,
-        "projector_schema_version": key.projector_schema_version,
-        "catalog_generation": key.catalog_generation,
-        "projection_rows_digest": target_manifest.rows_digest,
-        "evidence": base64.b64encode(evidence).decode("ascii"),
-        "ready_at": ready_at,
+        "catalog_generation": catalog.catalog_generation,
+        "descriptor": base64.b64encode(catalog.descriptor).decode("ascii"),
+        "artifact_count": catalog.artifact_count,
+        "created_at": catalog.created_at,
     }
 
 
 def _v4_proposal_authority_binding(
-    vault_root: Path,
     *,
     proposal_id: str,
     created_at: float,
     active_snapshot: schema_v4.ActivePolicySnapshot,
     prospective: policy_module.ProspectiveCompile,
+    staged_projection: _StagedTargetProjection,
     membership_manifest: list[dict[str, Any]],
     transition_direction: str,
-    ready_at: int,
+    dependent_grants: tuple[schema_v4.DependentGrantTransition, ...],
 ) -> dict[str, Any]:
-    namespace = _stage_target_projection_namespace(
-        vault_root,
-        active_snapshot=active_snapshot,
-        target_policy=prospective.policy,
-        ready_at=ready_at,
-    )
+    namespace = dict(staged_projection.namespace)
+    catalog = staged_projection.catalog
     target = {
         "source_documents": [
             {
@@ -474,6 +740,7 @@ def _v4_proposal_authority_binding(
             policy_module.canonical_compiled_bytes(prospective.policy)
         ).decode("ascii"),
         "compiler_schema_version": 1,
+        "catalog": _catalog_seed_value(catalog),
         "projection_rows_digest": namespace.pop("projection_rows_digest"),
         "projection_namespace": namespace,
     }
@@ -483,6 +750,7 @@ def _v4_proposal_authority_binding(
         "reviewed_active_tuple": _active_tuple_value(active_snapshot.active),
         "authoring_snapshot": _snapshot_value(prospective.snapshot),
         "membership_manifest": membership_manifest,
+        "dependent_grants": _dependent_grant_value(dependent_grants),
         "target": target,
     }
     generation_id, authoring_event_id, receipt_event_id = (
@@ -802,8 +1070,8 @@ def _proposal_analysis(
         {rule.purpose for policy in (current, prospective) for rule in policy.rules if rule.purpose}
     )
     purposes = [None, *purposes]
-    before: dict[str, int] = {}
-    after: dict[str, int] = {}
+    before: dict[str, tuple[int, str]] = {}
+    after: dict[str, tuple[int, str]] = {}
     rule_ids: set[str] = set()
     # `target_ceiling` remains the highest level the proposal leaves an
     # AUTHORED audience at. The default has its own owner-visible ceiling so the
@@ -831,8 +1099,8 @@ def _proposal_analysis(
                 key = f"{audience}:{purpose or '-'}:{rel}"
                 old = decisions.decide(current_scopes, audience=audience, purpose=purpose, policy=current)
                 new = decisions.decide(prospective_scopes, audience=audience, purpose=purpose, policy=prospective)
-                before[key] = old.level
-                after[key] = new.level
+                before[key] = _decision_direction_state(old)
+                after[key] = _decision_direction_state(new)
                 if audience != UNNAMED_AUDIENCE_PROBE:
                     named_after.append(new.level)
                 else:
@@ -845,11 +1113,17 @@ def _proposal_analysis(
                 )
                 all_open = all_open and old.level == policy_module.DISCLOSURE_MAX and new.level == policy_module.DISCLOSURE_MAX and old.release_reason is None and new.release_reason is None
     consequences = {
-        "narrowed": sum(after[key] < before[key] for key in before),
-        "widened": sum(after[key] > before[key] for key in before),
+        "narrowed": sum(after[key][0] < before[key][0] for key in before),
+        "widened": sum(
+            after[key][0] > before[key][0]
+            or (after[key][0] == before[key][0] and after[key][1] != before[key][1])
+            for key in before
+        ),
         "unchanged": sum(after[key] == before[key] for key in before),
     }
     direction = classify_transition_direction(before, after)
+    if current.release_grants != prospective.release_grants:
+        direction = "widening"
     samples = [str(row["path"]) for row in manifest[:5]] if all_open else []
     return (
         consequences,
@@ -927,7 +1201,12 @@ def _proposal(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
     )
     if current_policy.blocked:
         raise GovernanceError("GOVERNANCE_BLOCKED", "current policy cannot be evaluated")
-    prospective_compile = policy_module.compile_prospective(vault_root, documents)
+    semantic_operation = kwargs.get("_semantic_operation")
+    prospective_compile = policy_module.compile_prospective(
+        vault_root,
+        documents,
+        _replace_document_set=semantic_operation in {"suspend", "resume", "undo"},
+    )
     if prospective_compile is None:
         raise GovernanceError(
             "GOVERNANCE_AUTHORING_UNSTABLE",
@@ -969,21 +1248,78 @@ def _proposal(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
         "documents": documents,
         "duration": kwargs.get("duration"),
     }
+    if semantic_operation is not None:
+        if semantic_operation not in {"commit", "suspend", "resume", "undo"}:
+            raise GovernanceError(
+                "INVALID_GOVERNANCE_PROPOSAL",
+                "semantic policy operation is invalid",
+            )
+        payload["semantic_operation"] = semantic_operation
+    undo_source_generation_id = kwargs.get("_undo_source_generation_id")
+    if undo_source_generation_id is not None:
+        if semantic_operation != "undo" or not isinstance(
+            undo_source_generation_id, str
+        ) or not undo_source_generation_id:
+            raise GovernanceError(
+                "INVALID_GOVERNANCE_PROPOSAL",
+                "undo source generation is invalid",
+            )
+        payload["undo_source_generation_id"] = undo_source_generation_id
+    semantic_rule_ids = kwargs.get("_semantic_rule_ids")
+    if semantic_rule_ids is not None:
+        if (
+            semantic_operation not in {"suspend", "resume"}
+            or not isinstance(semantic_rule_ids, list)
+            or not semantic_rule_ids
+            or not all(isinstance(rule_id, str) and rule_id for rule_id in semantic_rule_ids)
+            or semantic_rule_ids != sorted(set(semantic_rule_ids))
+        ):
+            raise GovernanceError(
+                "INVALID_GOVERNANCE_PROPOSAL",
+                "semantic policy rule set is invalid",
+            )
+        payload["semantic_rule_ids"] = semantic_rule_ids
+    semantic_request_digest = kwargs.get("_semantic_request_digest")
+    if semantic_request_digest is not None:
+        if (
+            semantic_operation not in {"suspend", "resume", "undo"}
+            or not isinstance(semantic_request_digest, str)
+            or _SHA256_RE.fullmatch(semantic_request_digest) is None
+        ):
+            raise GovernanceError(
+                "INVALID_GOVERNANCE_PROPOSAL",
+                "semantic policy request identity is invalid",
+            )
+        payload["semantic_request_digest"] = semantic_request_digest
     if active_snapshot is not None:
         if current_policy.fingerprint != active_snapshot.active.policy_fingerprint:
             raise GovernanceError(
                 "GOVERNANCE_BLOCKED",
                 "the active governance policy does not match its tuple",
             )
-        payload["authority_binding"] = _v4_proposal_authority_binding(
+        staged_projection = _stage_target_projection_namespace(
             vault_root,
+            active_snapshot=active_snapshot,
+            target_policy=prospective,
+            ready_at=int(now),
+        )
+        dependent_grants = _v4_dependent_grant_transitions(
+            vault_root,
+            current_policy=active_snapshot.policy,
+            target_policy=prospective,
+            predecessor_items=staged_projection.predecessor_items,
+            target_items=staged_projection.items,
+        )
+        direction = _direction_with_dependent_grants(direction, dependent_grants)
+        payload["authority_binding"] = _v4_proposal_authority_binding(
             proposal_id=proposal_id,
             created_at=now,
             active_snapshot=active_snapshot,
             prospective=prospective_compile,
+            staged_projection=staged_projection,
             membership_manifest=manifest,
             transition_direction=direction,
-            ready_at=int(now),
+            dependent_grants=dependent_grants,
         )
     conn = store.open_connection(vault_root)
     try:
@@ -1022,15 +1358,53 @@ def _proposal(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
     }
 
 
+def _decision_direction_state(decision: decisions.Decision) -> tuple[int, str]:
+    return (
+        decision.level,
+        _digest(
+            {
+                "options": decision.options,
+                "notice": decision.notice,
+                "bridge_abstraction": decision.bridge_abstraction,
+                "bridge": decision.bridge,
+                "release_reason": decision.release_reason,
+                "release_grant_id": decision.release_grant_id,
+                "release_strip": list(decision.release_strip),
+                "release_dependency_digest": decision.release_dependency_digest,
+            }
+        ),
+    )
+
+
 def classify_transition_direction(
-    before: Mapping[str, int] | None, after: Mapping[str, int] | None
+    before: Mapping[str, object] | None, after: Mapping[str, object] | None
 ) -> str:
     """Only a complete pointwise proof can classify a transition narrowing."""
     if before is None or after is None or set(before) != set(after):
         return "widening"
-    if any(not isinstance(level, int) for level in (*before.values(), *after.values())):
-        return "widening"
-    return "narrowing" if all(after[key] <= before[key] for key in before) else "widening"
+
+    def no_more_permissive(prior: object, target: object) -> bool:
+        if isinstance(prior, int) and isinstance(target, int):
+            return target <= prior
+        if (
+            isinstance(prior, tuple)
+            and isinstance(target, tuple)
+            and len(prior) == len(target) == 2
+            and isinstance(prior[0], int)
+            and isinstance(target[0], int)
+            and isinstance(prior[1], str)
+            and isinstance(target[1], str)
+        ):
+            return target[0] < prior[0] or (
+                target[0] == prior[0] and target[1] == prior[1]
+            )
+        return False
+
+    return (
+        "narrowing"
+        if all(no_more_permissive(before[key], after[key]) for key in before)
+        else "widening"
+    )
 
 
 def _component(
@@ -2433,8 +2807,8 @@ def _effective_transition_direction(
                 }
             ),
         ]
-        before: dict[str, int] = {}
-        after: dict[str, int] = {}
+        before: dict[str, tuple[int, str]] = {}
+        after: dict[str, tuple[int, str]] = {}
         for row in manifest:
             rel = str(row["path"])
             current_scopes = _memberships_for_path(vault_root, vault_root / rel, current)
@@ -2444,18 +2818,22 @@ def _effective_transition_direction(
             for audience in audiences:
                 for purpose in purposes:
                     key = f"{audience}:{purpose or '-'}:{rel}"
-                    before[key] = decisions.decide(
-                        current_scopes,
-                        audience=audience,
-                        purpose=purpose,
-                        policy=current,
-                    ).level
-                    after[key] = decisions.decide(
-                        prospective_scopes,
-                        audience=audience,
-                        purpose=purpose,
-                        policy=prospective,
-                    ).level
+                    before[key] = _decision_direction_state(
+                        decisions.decide(
+                            current_scopes,
+                            audience=audience,
+                            purpose=purpose,
+                            policy=current,
+                        )
+                    )
+                    after[key] = _decision_direction_state(
+                        decisions.decide(
+                            prospective_scopes,
+                            audience=audience,
+                            purpose=purpose,
+                            policy=prospective,
+                        )
+                    )
     except (GovernanceError, OSError, TypeError, ValueError):
         return "widening"
     return classify_transition_direction(before, after)
@@ -3206,6 +3584,39 @@ def _reviewed_active_state(value: object) -> schema_v4.VerifiedActiveGovernanceS
     return schema_v4.VerifiedActiveGovernanceState(**value)
 
 
+def _decoded_dependent_grants(
+    value: object,
+) -> tuple[schema_v4.DependentGrantTransition, ...]:
+    if not isinstance(value, list):
+        raise GovernanceError(
+            "INVALID_GOVERNANCE_PROPOSAL",
+            "stored dependent grant manifest is malformed",
+        )
+    expected_keys = {
+        "grant_id",
+        "expected_policy_fingerprint",
+        "expected_membership_manifest",
+        "target_status",
+        "target_policy_fingerprint",
+        "target_membership_manifest",
+    }
+    transitions: list[schema_v4.DependentGrantTransition] = []
+    for item in value:
+        if not isinstance(item, dict) or set(item) != expected_keys:
+            raise GovernanceError(
+                "INVALID_GOVERNANCE_PROPOSAL",
+                "stored dependent grant manifest is malformed",
+            )
+        transitions.append(schema_v4.DependentGrantTransition(**item))
+    ordered = tuple(sorted(transitions, key=lambda transition: transition.grant_id))
+    if tuple(transitions) != ordered or _dependent_grant_value(ordered) != value:
+        raise GovernanceError(
+            "INVALID_GOVERNANCE_PROPOSAL",
+            "stored dependent grant manifest is malformed",
+        )
+    return ordered
+
+
 def _decode_v4_proposal_binding(
     vault_root: Path,
     *,
@@ -3213,6 +3624,7 @@ def _decode_v4_proposal_binding(
     proposal_json: str,
     membership_manifest: str,
     created_at: float,
+    verify_projection_store: bool = True,
 ) -> _DecodedV4PolicyProposal:
     try:
         payload = json.loads(proposal_json)
@@ -3227,18 +3639,21 @@ def _decode_v4_proposal_binding(
             "stored governance proposal is not canonical",
         )
     binding = payload.get("authority_binding")
-    if (
-        not isinstance(binding, dict)
-        or set(binding)
-        != {
+    schema = binding.get("schema") if isinstance(binding, dict) else None
+    expected_binding_keys = {
             "schema",
             "transition_direction",
             "reviewed_active_tuple",
             "authoring_snapshot",
             "membership_manifest",
             "target",
-        }
-        or binding.get("schema") != _V4_POLICY_PROPOSAL_SCHEMA
+    }
+    if schema == _V4_POLICY_PROPOSAL_SCHEMA:
+        expected_binding_keys.add("dependent_grants")
+    if (
+        not isinstance(binding, dict)
+        or set(binding) != expected_binding_keys
+        or schema not in {_V4_POLICY_PROPOSAL_SCHEMA_V3, _V4_POLICY_PROPOSAL_SCHEMA}
     ):
         raise GovernanceError(
             "INVALID_GOVERNANCE_PROPOSAL",
@@ -3266,9 +3681,14 @@ def _decode_v4_proposal_binding(
             "INVALID_GOVERNANCE_PROPOSAL",
             "stored governance transition direction is invalid",
         )
+    dependent_grants = (
+        None
+        if schema == _V4_POLICY_PROPOSAL_SCHEMA_V3
+        else _decoded_dependent_grants(binding["dependent_grants"])
+    )
 
     target = binding["target"]
-    if not isinstance(target, dict) or set(target) != {
+    expected_target_keys = {
         "source_documents",
         "generation_id",
         "authoring_event_id",
@@ -3279,7 +3699,10 @@ def _decode_v4_proposal_binding(
         "compiler_schema_version",
         "projection_rows_digest",
         "projection_namespace",
-    }:
+    }
+    if schema == _V4_POLICY_PROPOSAL_SCHEMA:
+        expected_target_keys.add("catalog")
+    if not isinstance(target, dict) or set(target) != expected_target_keys:
         raise GovernanceError(
             "INVALID_GOVERNANCE_PROPOSAL",
             "stored governance target is invalid",
@@ -3335,6 +3758,55 @@ def _decode_v4_proposal_binding(
             "INVALID_GOVERNANCE_PROPOSAL",
             "stored governance publication identities do not verify",
         )
+    catalog_value = target.get("catalog")
+    catalog: schema_v4.CatalogGenerationSeed | None
+    if catalog_value is None:
+        catalog = None
+        target_catalog_generation = expected.catalog_generation
+    else:
+        if not isinstance(catalog_value, dict) or set(catalog_value) != {
+            "catalog_generation",
+            "descriptor",
+            "artifact_count",
+            "created_at",
+        }:
+            raise GovernanceError(
+                "INVALID_GOVERNANCE_PROPOSAL",
+                "stored target catalog is invalid",
+            )
+        try:
+            descriptor = base64.b64decode(
+                catalog_value["descriptor"],
+                validate=True,
+            )
+        except (TypeError, ValueError):
+            raise GovernanceError(
+                "INVALID_GOVERNANCE_PROPOSAL",
+                "stored target catalog is invalid",
+            ) from None
+        target_catalog_generation = catalog_value["catalog_generation"]
+        if (
+            isinstance(target_catalog_generation, bool)
+            or not isinstance(target_catalog_generation, int)
+            or target_catalog_generation != expected.catalog_generation + 1
+            or isinstance(catalog_value["artifact_count"], bool)
+            or not isinstance(catalog_value["artifact_count"], int)
+            or catalog_value["artifact_count"] < 0
+            or isinstance(catalog_value["created_at"], bool)
+            or not isinstance(catalog_value["created_at"], int)
+            or catalog_value["created_at"] < 0
+        ):
+            raise GovernanceError(
+                "INVALID_GOVERNANCE_PROPOSAL",
+                "stored target catalog is invalid",
+            )
+        catalog = schema_v4.CatalogGenerationSeed(
+            catalog_generation=target_catalog_generation,
+            descriptor=descriptor,
+            artifact_count=catalog_value["artifact_count"],
+            created_at=catalog_value["created_at"],
+        )
+
     namespace = target["projection_namespace"]
     if not isinstance(namespace, dict) or set(namespace) != {
         "namespace_id",
@@ -3347,21 +3819,33 @@ def _decode_v4_proposal_binding(
             "INVALID_GOVERNANCE_PROPOSAL",
             "stored projection namespace is invalid",
         )
+    if (
+        not isinstance(target["projection_rows_digest"], str)
+        or _SHA256_RE.fullmatch(target["projection_rows_digest"]) is None
+    ):
+        raise GovernanceError(
+            "INVALID_GOVERNANCE_PROPOSAL",
+            "stored projection row digest is invalid",
+        )
     try:
         key = projections.ProjectionNamespaceKey(
             policy_fingerprint=compiled.fingerprint,
             projector_schema_version=namespace["projector_schema_version"],
             catalog_generation=namespace["catalog_generation"],
         )
-        manifest = projection_store.verify_variant_store(
-            vault_root,
-            key=key,
-            expected_rows_digest=target["projection_rows_digest"],
-        )
-        expected_evidence = projection_store.projection_namespace_evidence_bytes(
-            manifest
-        )
         stored_evidence = base64.b64decode(namespace["evidence"], validate=True)
+        if verify_projection_store:
+            manifest, target_items = projection_store.load_projection_catalog(
+                vault_root,
+                key=key,
+                expected_rows_digest=target["projection_rows_digest"],
+            )
+            expected_evidence = projection_store.projection_namespace_evidence_bytes(
+                manifest
+            )
+        else:
+            target_items = ()
+            expected_evidence = stored_evidence
     except (
         projection_store.ProjectionStoreError,
         projections.ProjectionError,
@@ -3377,7 +3861,7 @@ def _decode_v4_proposal_binding(
         ) from None
     if (
         namespace["namespace_id"] != key.namespace_id
-        or namespace["catalog_generation"] != expected.catalog_generation
+        or namespace["catalog_generation"] != target_catalog_generation
         or namespace["projector_schema_version"]
         != expected.projector_schema_version
         or stored_evidence != expected_evidence
@@ -3386,6 +3870,41 @@ def _decode_v4_proposal_binding(
             "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
             "the reviewed target projection namespace does not verify",
         )
+    if verify_projection_store:
+        target_catalog_descriptor = projection_store.catalog_descriptor_bytes(
+            key,
+            target_items,
+        )
+        if catalog is not None:
+            if (
+                catalog.artifact_count != len(target_items)
+                or not __import__("hmac").compare_digest(
+                    catalog.descriptor,
+                    target_catalog_descriptor,
+                )
+            ):
+                raise GovernanceError(
+                    "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
+                    "the reviewed target catalog does not verify",
+                )
+        else:
+            connection = store.open_authorization_session_connection(vault_root)
+            try:
+                catalog_row = connection.execute(
+                    "SELECT descriptor FROM catalog_generation_descriptors "
+                    "WHERE catalog_generation=?",
+                    (expected.catalog_generation,),
+                ).fetchone()
+            finally:
+                connection.close()
+            if catalog_row is None or not __import__("hmac").compare_digest(
+                bytes(catalog_row[0]),
+                target_catalog_descriptor,
+            ):
+                raise GovernanceError(
+                    "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
+                    "the reviewed catalog reuse does not verify",
+                )
     snapshot = _decoded_v4_authoring_snapshot(binding["authoring_snapshot"])
     return _DecodedV4PolicyProposal(
         payload=payload,
@@ -3404,6 +3923,7 @@ def _decode_v4_proposal_binding(
             receipt_event_id=target["receipt_event_id"],
             created_at=int(created_at),
         ),
+        catalog=catalog,
         namespace=schema_v4.ProjectionNamespaceSeed(
             namespace_id=namespace["namespace_id"],
             evidence=stored_evidence,
@@ -3411,6 +3931,8 @@ def _decode_v4_proposal_binding(
         ),
         direction=direction,
         authoring_snapshot=snapshot,
+        authoring_snapshot_value=binding["authoring_snapshot"],
+        dependent_grants=dependent_grants,
     )
 
 
@@ -3442,14 +3964,21 @@ def _validate_v4_proposal_binding(
             "INVALID_GOVERNANCE_PROPOSAL",
             "stored governance documents are malformed",
         )
-    prospective = policy_module.compile_prospective(vault_root, documents)
+    prospective = policy_module.compile_prospective(
+        vault_root,
+        documents,
+        _replace_document_set=decoded.payload.get("semantic_operation")
+        in {"suspend", "resume", "undo"},
+    )
     if prospective is None:
         raise GovernanceError(
             "GOVERNANCE_AUTHORING_UNSTABLE",
             "the policy workspace changed or could not be acquired safely",
         )
     binding = decoded.payload["authority_binding"]
-    if binding["authoring_snapshot"] != _snapshot_value(prospective.snapshot):
+    if _snapshot_value(decoded.authoring_snapshot) != _snapshot_value(
+        prospective.snapshot
+    ):
         raise GovernanceError(
             "STALE_GOVERNANCE_POLICY",
             "the reviewed policy workspace changed",
@@ -3458,6 +3987,24 @@ def _validate_v4_proposal_binding(
         raise GovernanceError(
             "STALE_GOVERNANCE_POLICY",
             "the reviewed immutable policy target changed",
+        )
+    staged_projection = _stage_target_projection_namespace(
+        vault_root,
+        active_snapshot=active_snapshot,
+        target_policy=prospective.policy,
+        ready_at=decoded.namespace.ready_at,
+    )
+    staged_namespace = dict(staged_projection.namespace)
+    staged_rows_digest = staged_namespace.pop("projection_rows_digest")
+    target_binding = binding["target"]
+    if (
+        _catalog_seed_value(staged_projection.catalog) != target_binding.get("catalog")
+        or staged_namespace != target_binding["projection_namespace"]
+        or staged_rows_digest != target_binding["projection_rows_digest"]
+    ):
+        raise GovernanceError(
+            "STALE_GOVERNANCE_POLICY",
+            "the reviewed policy catalog target changed",
         )
     current_manifest = _membership_manifest(
         vault_root,
@@ -3481,6 +4028,24 @@ def _validate_v4_proposal_binding(
             "STALE_GOVERNANCE_POLICY",
             "the reviewed transition direction changed",
         )
+    current_dependent_grants = _v4_dependent_grant_transitions(
+        vault_root,
+        current_policy=active_snapshot.policy,
+        target_policy=prospective.policy,
+        predecessor_items=staged_projection.predecessor_items,
+        target_items=staged_projection.items,
+    )
+    if (
+        decoded.dependent_grants is None
+        and current_dependent_grants
+    ) or (
+        decoded.dependent_grants is not None
+        and current_dependent_grants != decoded.dependent_grants
+    ):
+        raise GovernanceError(
+            "STALE_GOVERNANCE_POLICY",
+            "the reviewed dependent grant manifest changed",
+        )
     return _ValidatedV4PolicyProposal(decoded, custody)
 
 
@@ -3501,6 +4066,11 @@ def _committed_v4_policy_target(
     connection: sqlite3.Connection,
     decoded: _DecodedV4PolicyProposal,
 ) -> schema_v4.VerifiedActiveGovernanceState | None:
+    target_catalog_generation = (
+        decoded.expected.catalog_generation
+        if decoded.catalog is None
+        else decoded.catalog.catalog_generation
+    )
     row = connection.execute(
         "SELECT publication_kind, predecessor_activation_state_digest, "
         "target_activation_state_digest, policy_generation_id, policy_fingerprint, "
@@ -3520,7 +4090,7 @@ def _committed_v4_policy_target(
             decoded.policy.generation_id,
             decoded.policy.policy_fingerprint,
             decoded.policy.projector_schema_version,
-            decoded.expected.catalog_generation,
+            target_catalog_generation,
             decoded.expected.activation_epoch + 1,
             "committed",
         )
@@ -3530,14 +4100,146 @@ def _committed_v4_policy_target(
         or target.policy_generation_id != decoded.policy.generation_id
         or target.policy_fingerprint != decoded.policy.policy_fingerprint
         or target.projector_schema_version != decoded.policy.projector_schema_version
-        or target.catalog_generation != decoded.expected.catalog_generation
+        or target.catalog_generation != target_catalog_generation
         or target.projection_namespace_id != decoded.namespace.namespace_id
     ):
         raise GovernanceError(
             "GOVERNANCE_BLOCKED",
             "committed policy publication does not match the reviewed proposal",
         )
+    active_count = connection.execute(
+        "SELECT COUNT(*) FROM governance_session_grants WHERE status='active'"
+    ).fetchone()
+    if decoded.dependent_grants is not None:
+        committed_grants = connection.execute(
+            "SELECT grant_id, status, policy_fingerprint, membership_manifest, "
+            "prepared_event_id FROM governance_session_grants "
+            "WHERE grant_id IN ("
+            + ",".join("?" for _ in decoded.dependent_grants)
+            + ") ORDER BY grant_id",
+            tuple(transition.grant_id for transition in decoded.dependent_grants),
+        ).fetchall() if decoded.dependent_grants else []
+        expected_grants = [
+            (
+                transition.grant_id,
+                transition.target_status,
+                transition.target_policy_fingerprint,
+                transition.target_membership_manifest,
+                None,
+            )
+            for transition in decoded.dependent_grants
+        ]
+        if committed_grants != expected_grants or active_count != (0,):
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "committed dependent grants do not match the reviewed proposal",
+            )
+    elif active_count != (0,):
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "legacy policy publication did not bind the active dependent grants",
+        )
     return target
+
+
+def _verify_recorded_v4_policy_terminal(
+    vault_root: Path,
+    decoded: _DecodedV4PolicyProposal,
+) -> None:
+    """Verify one historical committed terminal without reopening live authority.
+
+    Exact request retries may arrive after a later publication or projection
+    GC.  Their response is fixed by the retained proposal plus committed
+    publication/receipt/mirror evidence; replay must not require the historical
+    tuple to still be active.
+    """
+
+    target_catalog_generation = (
+        decoded.expected.catalog_generation
+        if decoded.catalog is None
+        else decoded.catalog.catalog_generation
+    )
+    connection = store.open_authorization_session_connection(vault_root)
+    try:
+        publication = connection.execute(
+            "SELECT predecessor_activation_state_digest, target_activation_state_digest, "
+            "policy_generation_id, policy_fingerprint, projector_schema_version, "
+            "catalog_generation, activation_epoch, status FROM governance_tuple_publications "
+            "WHERE event_id=? AND publication_kind='policy'",
+            (decoded.policy.receipt_event_id,),
+        ).fetchone()
+        if (
+            publication is None
+            or publication[0] != decoded.expected.activation_state_digest
+            or not isinstance(publication[1], str)
+            or _SHA256_RE.fullmatch(publication[1]) is None
+            or tuple(publication[2:])
+            != (
+                decoded.policy.generation_id,
+                decoded.policy.policy_fingerprint,
+                decoded.policy.projector_schema_version,
+                target_catalog_generation,
+                decoded.expected.activation_epoch + 1,
+                "committed",
+            )
+            or schema_v4.load_policy_generation(
+                connection,
+                decoded.policy.generation_id,
+            )
+            != decoded.policy
+        ):
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "historical policy publication terminal does not verify",
+            )
+        namespace = connection.execute(
+            "SELECT namespace_id, evidence, ready_at FROM governance_projection_namespaces "
+            "WHERE policy_fingerprint=? AND projector_schema_version=? "
+            "AND catalog_generation=?",
+            (
+                decoded.policy.policy_fingerprint,
+                decoded.policy.projector_schema_version,
+                target_catalog_generation,
+            ),
+        ).fetchone()
+        if namespace != (
+            decoded.namespace.namespace_id,
+            decoded.namespace.evidence,
+            decoded.namespace.ready_at,
+        ):
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "historical policy namespace terminal does not verify",
+            )
+        if decoded.catalog is not None:
+            catalog = connection.execute(
+                "SELECT descriptor, artifact_count, created_at "
+                "FROM catalog_generation_descriptors WHERE catalog_generation=?",
+                (target_catalog_generation,),
+            ).fetchone()
+            if catalog != (
+                decoded.catalog.descriptor,
+                decoded.catalog.artifact_count,
+                decoded.catalog.created_at,
+            ):
+                raise GovernanceError(
+                    "GOVERNANCE_BLOCKED",
+                    "historical policy catalog terminal does not verify",
+                )
+    except GovernanceError:
+        raise
+    except (schema_v4.SchemaV4Error, sqlite3.Error, TypeError, ValueError):
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "historical policy publication terminal does not verify",
+        ) from None
+    finally:
+        connection.close()
+    if _v4_policy_publication_receipt_terminal(vault_root, decoded) != "committed":
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "historical policy publication receipt does not verify",
+        )
 
 
 def _recover_v4_policy_publication(
@@ -3658,6 +4360,260 @@ def _spend_v4_policy_proposal(
         connection.close()
 
 
+def _reserve_v4_policy_proposal(
+    vault_root: Path,
+    *,
+    proposal_id: str,
+    proposal_json: str,
+    membership_manifest: str,
+    receipt_event_id: str,
+) -> None:
+    connection = store.open_authorization_session_connection(vault_root)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        updated = connection.execute(
+            "UPDATE governance_proposals SET reserved_event_id=?, expires_at=MAX(expires_at, ?) "
+            "WHERE proposal_id=? AND proposal_json=? AND membership_manifest=? "
+            "AND status='pending' AND (reserved_event_id IS NULL OR reserved_event_id=?)",
+            (
+                receipt_event_id,
+                _V4_POLICY_RECOVERY_EXPIRES_AT,
+                proposal_id,
+                proposal_json,
+                membership_manifest,
+                receipt_event_id,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "policy publication recovery reservation changed",
+            )
+        connection.commit()
+    except BaseException:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+
+
+def _expire_v4_policy_proposal(
+    vault_root: Path,
+    *,
+    proposal_id: str,
+    expired_at: int,
+) -> None:
+    connection = store.open_authorization_session_connection(vault_root)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        connection.execute(
+            "UPDATE governance_proposals SET status='expired', spent_at=?, "
+            "reserved_event_id=NULL, attempt_nonce=NULL WHERE proposal_id=? "
+            "AND status='pending'",
+            (expired_at, proposal_id),
+        )
+        connection.commit()
+    except BaseException:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+
+
+def _v4_policy_publication_receipt_digests(
+    decoded: _DecodedV4PolicyProposal,
+) -> tuple[str, str, str, list[str]]:
+    dependent_grants = decoded.dependent_grants or ()
+    prior = _digest(
+        {
+            "schema": _V4_POLICY_PUBLICATION_RECEIPT_SCHEMA,
+            "active_tuple": _active_tuple_value(decoded.expected),
+            "dependent_grants": [
+                {
+                    "grant_id": transition.grant_id,
+                    "policy_fingerprint": transition.expected_policy_fingerprint,
+                    "membership_manifest": transition.expected_membership_manifest,
+                    "status": "active",
+                }
+                for transition in dependent_grants
+            ],
+        }
+    )
+    prepared = _digest(
+        {
+            "schema": _V4_POLICY_PUBLICATION_RECEIPT_SCHEMA,
+            "generation_id": decoded.policy.generation_id,
+            "policy_fingerprint": decoded.policy.policy_fingerprint,
+            "namespace_id": decoded.namespace.namespace_id,
+            "dependent_grants": _dependent_grant_value(dependent_grants),
+        }
+    )
+    target = _digest(
+        {
+            "schema": _V4_POLICY_PUBLICATION_RECEIPT_SCHEMA,
+            "authority_binding": decoded.payload["authority_binding"],
+        }
+    )
+    affected = [
+        hashlib.sha256(
+            f"policy_generation:{decoded.policy.generation_id}".encode()
+        ).hexdigest(),
+        *(
+            hashlib.sha256(f"dependent_grant:{transition.grant_id}".encode()).hexdigest()
+            for transition in dependent_grants
+        ),
+    ]
+    return prior, prepared, target, sorted(affected)
+
+
+def _v4_policy_publication_receipt_terminal(
+    vault_root: Path,
+    decoded: _DecodedV4PolicyProposal,
+) -> str | None:
+    prior, prepared, target, affected = _v4_policy_publication_receipt_digests(
+        decoded
+    )
+    try:
+        records = receipts.event_records(vault_root)
+    except receipts.ReceiptError:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy publication receipt evidence cannot be verified",
+        ) from None
+    intents = [
+        record
+        for record in records
+        if record.get("event_id") == decoded.policy.receipt_event_id
+        and record.get("phase") == "intent"
+    ]
+    terminals = [
+        record
+        for record in records
+        if record.get("causation_id") == decoded.policy.receipt_event_id
+        and record.get("phase") in {"committed", "aborted"}
+    ]
+    if not intents and not terminals:
+        return None
+    if len(intents) != 1 or any(
+        intents[0].get(field) != expected
+        for field, expected in {
+            "event_type": "critical",
+            "operation": _V4_POLICY_PUBLICATION_RECEIPT_OPERATION,
+            "prior": prior,
+            "prepared": prepared,
+            "target": target,
+            "affected_ids": affected,
+        }.items()
+    ):
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy publication receipt intent is contradictory",
+        )
+    if not terminals:
+        return "pending"
+    if len(terminals) != 1:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy publication receipt terminal is contradictory",
+        )
+    phase = terminals[0].get("phase")
+    outcome = terminals[0].get("outcome")
+    if phase == "committed" and outcome == "committed":
+        return "committed"
+    if phase == "aborted" and isinstance(outcome, str) and outcome:
+        return "aborted"
+    raise GovernanceError(
+        "GOVERNANCE_BLOCKED",
+        "policy publication receipt terminal is contradictory",
+    )
+
+
+def _begin_v4_policy_publication_receipt(
+    vault_root: Path,
+    decoded: _DecodedV4PolicyProposal,
+) -> None:
+    terminal = _v4_policy_publication_receipt_terminal(vault_root, decoded)
+    if terminal == "committed":
+        return
+    if terminal == "aborted":
+        raise GovernanceError(
+            "STALE_GOVERNANCE_POLICY",
+            "the reviewed policy publication was already refused",
+        )
+    if terminal == "pending":
+        return
+    prior, prepared, target, affected = _v4_policy_publication_receipt_digests(
+        decoded
+    )
+    try:
+        receipts.begin_event(
+            vault_root,
+            operation=_V4_POLICY_PUBLICATION_RECEIPT_OPERATION,
+            prior=prior,
+            prepared=prepared,
+            target=target,
+            affected_ids=affected,
+            event_id=decoded.policy.receipt_event_id,
+        )
+    except receipts.ReceiptError:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy publication receipt intent could not be recorded",
+        ) from None
+
+
+def _commit_v4_policy_publication_receipt(
+    vault_root: Path,
+    decoded: _DecodedV4PolicyProposal,
+) -> None:
+    terminal = _v4_policy_publication_receipt_terminal(vault_root, decoded)
+    if terminal == "committed":
+        return
+    if terminal == "aborted":
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "committed policy publication has an aborted receipt",
+        )
+    if terminal is None:
+        _begin_v4_policy_publication_receipt(vault_root, decoded)
+    try:
+        receipts.commit_event(
+            vault_root,
+            decoded.policy.receipt_event_id,
+            outcome="committed",
+        )
+    except receipts.ReceiptError:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy publication receipt terminal could not be recorded",
+        ) from None
+
+
+def _abort_v4_policy_publication_receipt(
+    vault_root: Path,
+    decoded: _DecodedV4PolicyProposal,
+) -> None:
+    terminal = _v4_policy_publication_receipt_terminal(vault_root, decoded)
+    if terminal in {None, "aborted"}:
+        return
+    if terminal == "committed":
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "committed policy publication cannot be expired as stale",
+        )
+    try:
+        receipts.abort_event(
+            vault_root,
+            decoded.policy.receipt_event_id,
+            outcome="stale_predecessor",
+        )
+    except receipts.ReceiptError:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "stale policy publication receipt could not be closed",
+        ) from None
+
+
 def _v4_workspace_mirror_barrier(_phase: str, _path: str | None = None) -> None:
     """Deterministic test seam around the non-authoritative workspace mirror."""
 
@@ -3739,7 +4695,11 @@ def _v4_workspace_mirror_receipt_digests(
             "schema": _V4_POLICY_MIRROR_SCHEMA,
             "policy_generation_id": decoded.expected.policy_generation_id,
             "source_fingerprint": reviewed.source_fingerprint,
-            "authoring_snapshot": _snapshot_value(reviewed),
+            # Receipt identity is the exact reviewed representation.  Older
+            # v4 proposals recorded physical directory link counts; decoding
+            # may normalize those for live identity comparison, but recovery
+            # must never rewrite their already-durable receipt preimage.
+            "authoring_snapshot": decoded.authoring_snapshot_value,
         }
     )
     prepared = _digest(
@@ -3783,6 +4743,23 @@ def _apply_v4_workspace_mirror(
     *,
     crash_at: object,
 ) -> str:
+    if decoded.payload.get("semantic_operation") in {"suspend", "resume", "undo"}:
+        connection = store.open_authorization_session_connection(vault_root)
+        try:
+            predecessor = schema_v4.load_policy_generation(
+                connection,
+                decoded.expected.policy_generation_id,
+            )
+        except (schema_v4.SchemaV4Error, sqlite3.Error):
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "semantic policy mirror predecessor cannot be verified",
+            ) from None
+        finally:
+            connection.close()
+        if predecessor.source_documents != decoded.authoring_snapshot.documents:
+            return "diverged"
+
     effect_index = 0
 
     def barrier(phase: str, relative: str) -> None:
@@ -3884,7 +4861,8 @@ def _commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
         connection = store.open_authorization_session_connection(vault_root)
         try:
             row = connection.execute(
-                "SELECT proposal_json, membership_manifest, status, expires_at, created_at "
+                "SELECT proposal_json, membership_manifest, status, expires_at, created_at, "
+                "reserved_event_id "
                 "FROM governance_proposals WHERE proposal_id=?",
                 (proposal_id,),
             ).fetchone()
@@ -3917,6 +4895,7 @@ def _commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
                     "GOVERNANCE_BLOCKED",
                     "spent policy proposal has no exact committed publication",
                 )
+            _commit_v4_policy_publication_receipt(vault_root, decoded)
             mirror_status = _mirror_v4_policy_workspace(
                 vault_root,
                 decoded,
@@ -3928,6 +4907,14 @@ def _commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
                 mirror_status=mirror_status,
             )
         if recovered is not None:
+            _reserve_v4_policy_proposal(
+                vault_root,
+                proposal_id=proposal_id,
+                proposal_json=proposal_json,
+                membership_manifest=manifest_json,
+                receipt_event_id=decoded.policy.receipt_event_id,
+            )
+            _commit_v4_policy_publication_receipt(vault_root, decoded)
             _spend_v4_policy_proposal(
                 vault_root,
                 proposal_id=proposal_id,
@@ -3945,7 +4932,13 @@ def _commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
                 decoded=decoded,
                 mirror_status=mirror_status,
             )
-        if float(row[3]) < now:
+        reserved_event_id = row[5]
+        if reserved_event_id not in {None, decoded.policy.receipt_event_id}:
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "policy publication recovery reservation is contradictory",
+            )
+        if float(row[3]) < now and reserved_event_id is None:
             raise GovernanceError("PROPOSAL_EXPIRED", "proposal is not active")
         validated = _validate_v4_proposal_binding(
             vault_root,
@@ -3955,6 +4948,19 @@ def _commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
             created_at=created_at,
             now=int(now),
         )
+        _reserve_v4_policy_proposal(
+            vault_root,
+            proposal_id=proposal_id,
+            proposal_json=proposal_json,
+            membership_manifest=manifest_json,
+            receipt_event_id=validated.decoded.policy.receipt_event_id,
+        )
+        _begin_v4_policy_publication_receipt(
+            vault_root,
+            validated.decoded,
+        )
+        if kwargs.get("crash_at") == "v4_after_policy_receipt_intent":
+            raise GovernanceCrash("v4_after_policy_receipt_intent")
         connection = store.open_authorization_session_connection(vault_root)
         try:
             try:
@@ -3962,7 +4968,12 @@ def _commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
                     connection,
                     expected=validated.decoded.expected,
                     policy=validated.decoded.policy,
+                    catalog=validated.decoded.catalog,
                     namespace=validated.decoded.namespace,
+                    # A pre-v4 proposal did not bind grants. Passing an exact
+                    # empty tuple makes the transaction prove there are none;
+                    # it must never silently preserve unreviewed active rows.
+                    dependent_grants=validated.decoded.dependent_grants or (),
                     activated_at=int(now),
                     acknowledge_registry=lambda active: (
                         authorization_custody.acknowledge_activation_tuple(
@@ -3981,6 +4992,15 @@ def _commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
                     now=int(now),
                 )
                 if recovered is None:
+                    _abort_v4_policy_publication_receipt(
+                        vault_root,
+                        validated.decoded,
+                    )
+                    _expire_v4_policy_proposal(
+                        vault_root,
+                        proposal_id=proposal_id,
+                        expired_at=int(now),
+                    )
                     raise GovernanceError(
                         "STALE_GOVERNANCE_POLICY",
                         "the reviewed active policy tuple changed",
@@ -3999,6 +5019,9 @@ def _commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
             connection.close()
         if kwargs.get("crash_at") == "v4_after_registry_ack":
             raise GovernanceCrash("v4_after_registry_ack")
+        _commit_v4_policy_publication_receipt(vault_root, validated.decoded)
+        if kwargs.get("crash_at") == "v4_after_policy_receipt_terminal":
+            raise GovernanceCrash("v4_after_policy_receipt_terminal")
         _spend_v4_policy_proposal(
             vault_root,
             proposal_id=proposal_id,
@@ -4729,26 +5752,254 @@ def _yaml_transition(
     }
 
 
+def _resume_v4_semantic_policy_operation(
+    vault_root: Path,
+    *,
+    operation: str,
+    rule_ids: list[str] | None,
+    request_digest: str | None,
+    who: RequestPrincipal,
+    crash_at: object,
+    now: float,
+) -> dict[str, Any] | None:
+    connection = store.open_authorization_session_connection(vault_root)
+    try:
+        rows = connection.execute(
+            "SELECT proposal_id, proposal_json, membership_manifest, status, created_at "
+            "FROM governance_proposals WHERE status IN ('pending','spent') "
+            "ORDER BY created_at, proposal_id"
+        ).fetchall()
+    finally:
+        connection.close()
+    incomplete: list[tuple[str, str, _DecodedV4PolicyProposal]] = []
+    historical_mirrors: list[tuple[str, str, _DecodedV4PolicyProposal]] = []
+    response_replays: list[tuple[str, str, _DecodedV4PolicyProposal]] = []
+    for proposal_id, proposal_json, membership_manifest, status, created_at in rows:
+        try:
+            payload = json.loads(str(proposal_json))
+        except json.JSONDecodeError:
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "semantic policy recovery found a malformed proposal",
+            ) from None
+        stored_operation = payload.get("semantic_operation")
+        if stored_operation is None:
+            continue
+        if stored_operation not in {"suspend", "resume", "undo"}:
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "semantic policy recovery found an invalid operation",
+            )
+        stored_rule_ids = payload.get("semantic_rule_ids")
+        if stored_operation in {"suspend", "resume"}:
+            if (
+                not isinstance(stored_rule_ids, list)
+                or not stored_rule_ids
+                or not all(
+                    isinstance(rule_id, str) and rule_id
+                    for rule_id in stored_rule_ids
+                )
+                or stored_rule_ids != sorted(set(stored_rule_ids))
+            ):
+                raise GovernanceError(
+                    "GOVERNANCE_BLOCKED",
+                    "semantic policy recovery found an invalid rule set",
+                )
+        elif stored_rule_ids is not None:
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "semantic policy recovery found an invalid undo rule set",
+            )
+        stored_request_digest = payload.get("semantic_request_digest")
+        if stored_request_digest is not None and (
+            not isinstance(stored_request_digest, str)
+            or _SHA256_RE.fullmatch(stored_request_digest) is None
+        ):
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "semantic policy recovery found an invalid request identity",
+            )
+        decoded = _decode_v4_proposal_binding(
+            vault_root,
+            proposal_id=str(proposal_id),
+            proposal_json=str(proposal_json),
+            membership_manifest=str(membership_manifest),
+            created_at=float(created_at),
+            verify_projection_store=status == "pending",
+        )
+        mirror_terminal = (
+            _v4_workspace_mirror_terminal(vault_root, decoded)
+            if status == "spent"
+            else None
+        )
+        candidate = (str(proposal_id), str(stored_operation), decoded)
+        same_request = (
+            stored_operation == operation
+            and (stored_operation == "undo" or stored_rule_ids == rule_ids)
+            and request_digest is not None
+            and stored_request_digest == request_digest
+        )
+        if status == "pending":
+            incomplete.append(candidate)
+        elif mirror_terminal is None:
+            historical_mirrors.append(candidate)
+        elif same_request:
+            response_replays.append(candidate)
+    if historical_mirrors:
+        if len(historical_mirrors) != 1 or incomplete:
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "semantic policy recovery is ambiguous",
+            )
+        _proposal_id, stored_operation, decoded = historical_mirrors[0]
+        _verify_recorded_v4_policy_terminal(vault_root, decoded)
+        mirror_status = _mirror_v4_policy_workspace(
+            vault_root,
+            decoded,
+            crash_at=crash_at,
+        )
+        return {
+            "status": "committed",
+            "event_id": decoded.policy.receipt_event_id,
+            "operation": stored_operation,
+            "direction": decoded.direction,
+            "mirror_status": mirror_status,
+        }
+    if not incomplete and response_replays:
+        if len(response_replays) != 1:
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "semantic policy recovery is ambiguous",
+            )
+        _proposal_id, stored_operation, decoded = response_replays[0]
+        _verify_recorded_v4_policy_terminal(vault_root, decoded)
+        return {
+            "status": "committed",
+            "event_id": decoded.policy.receipt_event_id,
+            "operation": stored_operation,
+            "direction": decoded.direction,
+            "mirror_status": _v4_workspace_mirror_terminal(vault_root, decoded),
+        }
+    candidates = incomplete
+    if not candidates:
+        return None
+    if len(candidates) != 1:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "semantic policy recovery is ambiguous",
+        )
+    try:
+        committed = _commit(
+            vault_root,
+            principal=who,
+            proposal_id=candidates[0][0],
+            crash_at=crash_at,
+            now=now,
+        )
+    except GovernanceError as exc:
+        if exc.code != "STALE_GOVERNANCE_POLICY":
+            raise
+        _abort_v4_policy_publication_receipt(vault_root, candidates[0][2])
+        _expire_v4_policy_proposal(
+            vault_root,
+            proposal_id=candidates[0][0],
+            expired_at=int(now),
+        )
+        raise
+    return {
+        "status": committed["status"],
+        "event_id": committed["event_id"],
+        "operation": candidates[0][1],
+        "direction": committed["direction"],
+        "mirror_status": committed["mirror_status"],
+    }
+
+
+def _active_semantic_request_digest() -> str | None:
+    from .. import writer_lease
+
+    request_id = writer_lease.active_mutation_request_id()
+    if request_id is None:
+        return None
+    return hashlib.sha256(
+        b"exomem.govern-memory-semantic-request.v1\0" + request_id.encode("utf-8")
+    ).hexdigest()
+
+
 def _toggle_rules(vault_root: Path, operation: str, **kwargs: Any) -> dict[str, Any]:
     who = _require_owner(kwargs.get("principal"))
     reconciliation = reconcile_governance_operations(vault_root)
     if reconciliation["blocked"]:
         raise GovernanceError("GOVERNANCE_BLOCKED", "pending operation needs manual repair")
-    store.require_authoring_schema(vault_root)
     raw_ids = kwargs.get("rule_ids")
     if not isinstance(raw_ids, list) or not raw_ids or not all(
         isinstance(rule_id, str) and rule_id for rule_id in raw_ids
     ):
         raise GovernanceError("INVALID_RULE_SET", "rule_ids must be a non-empty list")
     rule_ids = set(raw_ids)
-    current = policy_module.load(vault_root)
+    now = float(kwargs.get("now", time.time()))
+    schema_version = store.authorization_session_schema_version(vault_root)
+    if schema_version == schema_v4.SCHEMA_USER_VERSION:
+        request_digest = _active_semantic_request_digest()
+        recovered = _resume_v4_semantic_policy_operation(
+            vault_root,
+            operation=operation,
+            rule_ids=sorted(rule_ids),
+            request_digest=request_digest,
+            who=who,
+            crash_at=kwargs.get("crash_at"),
+            now=now,
+        )
+        if recovered is not None:
+            return recovered
+    active_snapshot = (
+        _v4_active_policy_snapshot(vault_root, now=int(now))
+        if schema_version == schema_v4.SCHEMA_USER_VERSION
+        else None
+    )
+    if active_snapshot is None:
+        store.require_authoring_schema(vault_root)
+    current = (
+        active_snapshot.policy
+        if active_snapshot is not None
+        else policy_module.load(vault_root)
+    )
     selected = [rule for rule in current.rules if rule.id in rule_ids]
     if {rule.id for rule in selected} != rule_ids:
         raise GovernanceError("RULE_UNKNOWN", "one or more rules do not exist")
     documents: dict[str, str | None] = {}
+    active_documents = (
+        dict(active_snapshot.source_documents)
+        if active_snapshot is not None
+        else None
+    )
+    if active_documents is not None:
+        try:
+            documents.update(
+                {
+                    relative: content.decode("utf-8")
+                    for relative, content in active_documents.items()
+                }
+            )
+        except UnicodeDecodeError:
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "active policy source bytes are not valid UTF-8 policy documents",
+            ) from None
     for source in sorted({rule.source for rule in selected}):
-        path = policy_module.governance_root(vault_root) / source
-        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if active_documents is None:
+            source_text = (
+                policy_module.governance_root(vault_root) / source
+            ).read_text(encoding="utf-8")
+        else:
+            source_bytes = active_documents.get(source)
+            if source_bytes is None:
+                raise GovernanceError(
+                    "GOVERNANCE_BLOCKED",
+                    "the active policy generation is missing a rule source",
+                )
+            source_text = source_bytes.decode("utf-8")
+        data = yaml.safe_load(source_text)
         if not isinstance(data, dict):
             raise GovernanceError("INVALID_POLICY_DOCUMENT", f"{source} is not a mapping")
         options = data.get("options")
@@ -4767,6 +6018,33 @@ def _toggle_rules(vault_root: Path, operation: str, **kwargs: Any) -> dict[str, 
         else:
             data.pop("options", None)
         documents[source] = yaml.safe_dump(data, sort_keys=False, allow_unicode=True)
+    if active_snapshot is not None:
+        proposed = _proposal(
+            vault_root,
+            principal=who,
+            documents=documents,
+            selector_paths=[],
+            intent=f"{operation} reviewed governance rules",
+            target_ceiling=policy_module.DISCLOSURE_MAX,
+            _semantic_operation=operation,
+            _semantic_rule_ids=sorted(rule_ids),
+            _semantic_request_digest=request_digest,
+            now=now,
+        )
+        committed = _commit(
+            vault_root,
+            principal=who,
+            proposal_id=proposed["proposal_id"],
+            crash_at=kwargs.get("crash_at"),
+            now=now,
+        )
+        return {
+            "status": committed["status"],
+            "event_id": committed["event_id"],
+            "operation": operation,
+            "direction": committed["direction"],
+            "mirror_status": committed["mirror_status"],
+        }
     direction = _effective_transition_direction(vault_root, documents)
     return _yaml_transition(
         vault_root,
@@ -4775,8 +6053,92 @@ def _toggle_rules(vault_root: Path, operation: str, **kwargs: Any) -> dict[str, 
         documents=documents,
         direction=direction,
         crash_at=kwargs.get("crash_at"),
-        now=float(kwargs.get("now", time.time())),
+        now=now,
     )
+
+
+def _v4_generation_operations(
+    connection: sqlite3.Connection,
+) -> dict[str, tuple[str, str | None]]:
+    operations: dict[str, tuple[str, str | None]] = {}
+    try:
+        rows = connection.execute(
+            "SELECT proposal_json FROM governance_proposals "
+            "WHERE status='spent' ORDER BY proposal_id"
+        ).fetchall()
+        for row in rows:
+            payload = json.loads(str(row[0]))
+            binding = payload.get("authority_binding")
+            target = binding.get("target") if isinstance(binding, dict) else None
+            generation_id = (
+                target.get("generation_id") if isinstance(target, dict) else None
+            )
+            if not isinstance(generation_id, str) or not generation_id:
+                continue
+            operation = payload.get("semantic_operation", "commit")
+            source = payload.get("undo_source_generation_id")
+            if operation not in {"commit", "suspend", "resume", "undo"} or (
+                operation == "undo" and (not isinstance(source, str) or not source)
+            ):
+                raise ValueError
+            value = (operation, source if isinstance(source, str) else None)
+            if generation_id in operations and operations[generation_id] != value:
+                raise ValueError
+            operations[generation_id] = value
+    except (json.JSONDecodeError, sqlite3.Error, TypeError, ValueError):
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy generation history cannot be interpreted exactly",
+        ) from None
+    return operations
+
+
+def _v4_undo_generations(
+    connection: sqlite3.Connection,
+    *,
+    active_generation_id: str,
+) -> tuple[str, schema_v4.PolicyGenerationSeed]:
+    operations = _v4_generation_operations(connection)
+    undone = {
+        source
+        for operation, source in operations.values()
+        if operation == "undo" and source is not None
+    }
+    candidate_id: str | None = active_generation_id
+    seen: set[str] = set()
+    while candidate_id is not None:
+        if candidate_id in seen:
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "policy generation history contains a cycle",
+            )
+        seen.add(candidate_id)
+        try:
+            candidate = schema_v4.load_policy_generation(connection, candidate_id)
+        except schema_v4.SchemaV4Error:
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "policy generation history cannot be verified",
+            ) from None
+        operation = operations.get(candidate_id, ("migration", None))[0]
+        if (
+            operation != "undo"
+            and candidate_id not in undone
+            and candidate.predecessor_generation_id is not None
+        ):
+            try:
+                target = schema_v4.load_policy_generation(
+                    connection,
+                    candidate.predecessor_generation_id,
+                )
+            except schema_v4.SchemaV4Error:
+                raise GovernanceError(
+                    "GOVERNANCE_BLOCKED",
+                    "undo target generation cannot be verified",
+                ) from None
+            return candidate_id, target
+        candidate_id = candidate.predecessor_generation_id
+    raise GovernanceError("NOTHING_TO_UNDO", "no policy generation is available to undo")
 
 
 def _undo(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
@@ -4784,6 +6146,65 @@ def _undo(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
     reconciliation = reconcile_governance_operations(vault_root)
     if reconciliation["blocked"]:
         raise GovernanceError("GOVERNANCE_BLOCKED", "pending operation needs manual repair")
+    now = float(kwargs.get("now", time.time()))
+    if store.authorization_session_schema_version(vault_root) == schema_v4.SCHEMA_USER_VERSION:
+        request_digest = _active_semantic_request_digest()
+        recovered = _resume_v4_semantic_policy_operation(
+            vault_root,
+            operation="undo",
+            rule_ids=None,
+            request_digest=request_digest,
+            who=who,
+            crash_at=kwargs.get("crash_at"),
+            now=now,
+        )
+        if recovered is not None:
+            return recovered
+        active_snapshot = _v4_active_policy_snapshot(vault_root, now=int(now))
+        connection = store.open_authorization_session_connection(vault_root)
+        try:
+            source_generation_id, target_generation = _v4_undo_generations(
+                connection,
+                active_generation_id=active_snapshot.active.policy_generation_id,
+            )
+        finally:
+            connection.close()
+        try:
+            documents = {
+                relative: content.decode("utf-8")
+                for relative, content in target_generation.source_documents
+            }
+        except UnicodeDecodeError:
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "undo target source bytes are not valid UTF-8 policy documents",
+            ) from None
+        proposed = _proposal(
+            vault_root,
+            principal=who,
+            documents=documents,
+            selector_paths=[],
+            intent="undo the last reviewed governance policy change",
+            target_ceiling=policy_module.DISCLOSURE_MAX,
+            _semantic_operation="undo",
+            _undo_source_generation_id=source_generation_id,
+            _semantic_request_digest=request_digest,
+            now=now,
+        )
+        committed = _commit(
+            vault_root,
+            principal=who,
+            proposal_id=proposed["proposal_id"],
+            crash_at=kwargs.get("crash_at"),
+            now=now,
+        )
+        return {
+            "status": committed["status"],
+            "event_id": committed["event_id"],
+            "operation": "undo",
+            "direction": committed["direction"],
+            "mirror_status": committed["mirror_status"],
+        }
     store.require_authoring_schema(vault_root)
     conn = store.open_connection(vault_root)
     try:
@@ -4843,7 +6264,7 @@ def _undo(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
         dependent_targets=dependent_targets,
         source_event_id=source_event_id,
         crash_at=kwargs.get("crash_at"),
-        now=float(kwargs.get("now", time.time())),
+        now=now,
     )
 
 

--- a/tests/test_govern_memory_tool.py
+++ b/tests/test_govern_memory_tool.py
@@ -644,6 +644,47 @@ def test_commit_direction_is_proven_from_effective_rule_change(vault: Path) -> N
     )["direction"] == "narrowing"
 
 
+def test_proposal_direction_treats_equal_level_option_change_as_unknown(
+    vault: Path,
+) -> None:
+    from exomem.governance.tool import op_govern_memory
+
+    original = _proposal_documents(ceiling=1)
+    original["rules/confidential-patterns.yaml"] += (
+        "options:\n  notice: Original notice\n"
+    )
+    proposed = op_govern_memory(
+        vault,
+        operation="propose",
+        principal=owner_principal(),
+        intent="Install the original reviewed notice",
+        documents=original,
+        target_ceiling=1,
+    )
+    op_govern_memory(
+        vault,
+        operation="commit",
+        principal=owner_principal(),
+        proposal_id=proposed["proposal_id"],
+    )
+    changed = dict(original)
+    changed["rules/confidential-patterns.yaml"] = changed[
+        "rules/confidential-patterns.yaml"
+    ].replace("Original notice", "Different notice")
+
+    reviewed = op_govern_memory(
+        vault,
+        operation="propose",
+        principal=owner_principal(),
+        intent="Review a different notice at the same ceiling",
+        documents=changed,
+        target_ceiling=1,
+    )
+
+    assert reviewed["consequences"]["direction"] == "widening"
+    assert reviewed["consequences"]["widened"] > 0
+
+
 @pytest.mark.parametrize(
     ("before", "after", "expected"),
     [
@@ -657,6 +698,16 @@ def test_transition_direction_requires_pointwise_proof(before, after, expected) 
     from exomem.governance.tool import classify_transition_direction
 
     assert classify_transition_direction(before, after) == expected
+
+
+def test_transition_direction_requires_equal_disclosure_at_equal_level() -> None:
+    from exomem.governance.tool import classify_transition_direction
+
+    old = (2, "old-disclosure")
+    new = (2, "new-disclosure")
+    assert classify_transition_direction({"a": old}, {"a": old}) == "narrowing"
+    assert classify_transition_direction({"a": old}, {"a": new}) == "widening"
+    assert classify_transition_direction({"a": old}, {"a": (1, new[1])}) == "narrowing"
 
 
 def _external(session: str | None = "conversation-a") -> RequestPrincipal:
@@ -4006,6 +4057,35 @@ def test_adding_default_deny_is_classified_as_a_narrowing(vault: Path) -> None:
     )
 
     assert direction == "narrowing"
+
+
+def test_v4_proposal_analysis_never_calls_release_grant_change_narrowing(
+    vault: Path,
+) -> None:
+    from exomem.governance import policy
+    from exomem.governance.tool import _proposal_analysis
+
+    current = policy.Policy(fingerprint="a" * 64)
+    release = policy.ReleaseGrant(
+        id="01ARZ3NDEKTSV4RRFFQ69G5FZZ",
+        source="grants/release.yaml",
+        path="Knowledge Base/Notes/released.md",
+        ref="mem:01ARZ3NDEKTSV4RRFFQ69G5FZY",
+        content_hash="b" * 64,
+        to_audience="external",
+        released_at="2026-08-27T00:00:00Z",
+        why="reviewed release",
+        bridge_scope="exact",
+        bridge_of=(),
+        strip_provenance=(),
+    )
+    prospective = dataclasses.replace(
+        current,
+        fingerprint="c" * 64,
+        release_grants=(release,),
+    )
+
+    assert _proposal_analysis(vault, current, prospective, [])[2] == "widening"
 
 
 def test_a_proposal_removing_default_deny_counts_the_widened_audience(

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -104,6 +104,41 @@ def _documents(*, ceiling: int) -> tuple[tuple[str, bytes], ...]:
     )
 
 
+def _documents_with_suspension(*, suspended: bool) -> tuple[tuple[str, bytes], ...]:
+    documents = dict(_documents(ceiling=2))
+    rule = documents["rules/external.yaml"].decode()
+    if suspended:
+        rule += "options:\n  suspended: true\n"
+    documents["rules/external.yaml"] = rule.encode()
+    return tuple(sorted(documents.items()))
+
+
+def _open_scope_documents(*, suspended: bool) -> tuple[tuple[str, bytes], ...]:
+    rule = (
+        "governance_version: 1\n"
+        f"id: {RULE_ID}\n"
+        "scope_ids:\n"
+        f"  - {SCOPE_ID}\n"
+        "audience: external\n"
+        "ceiling: 2\n"
+    )
+    if suspended:
+        rule += "options:\n  suspended: true\n"
+    return (
+        ("rules/external.yaml", rule.encode()),
+        (
+            "scopes/private.yaml",
+            (
+                "governance_version: 1\n"
+                f"id: {SCOPE_ID}\n"
+                "name: private\n"
+                "paths:\n"
+                "  - Knowledge Base/Notes/**\n"
+            ).encode(),
+        ),
+    )
+
+
 def _compiled(documents: tuple[tuple[str, bytes], ...]) -> policy.Policy:
     compiled = policy.compile_documents(dict(documents))
     assert not compiled.empty and not compiled.blocked
@@ -168,6 +203,30 @@ def _write_workspace(vault: Path, documents: tuple[tuple[str, bytes], ...]) -> N
         path = root / relative
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(content)
+
+
+def _write_dependent_member(
+    vault: Path,
+    *,
+    name: str,
+) -> tuple[str, str, str]:
+    relative = f"Knowledge Base/Notes/{name}.md"
+    path = vault / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\ntype: note\n---\nreviewed member {name}\n", encoding="utf-8")
+    fingerprint = hashlib.sha256(path.read_bytes()).hexdigest()
+    manifest = json.dumps(
+        [
+            {
+                "fingerprint": fingerprint,
+                "path": relative,
+                "scope_ids": [SCOPE_ID],
+            }
+        ],
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return relative, fingerprint, manifest
 
 
 def _protected_file(path: Path, value: bytes) -> None:
@@ -415,10 +474,15 @@ def _migrate_with_projection_items(
     *,
     items: tuple[tuple[str, str], ...],
     ceiling: int = 2,
+    policy_documents: tuple[tuple[str, bytes], ...] | None = None,
     graph_edges: tuple[projected_graph.ProjectionGraphEdge, ...] | None = None,
     now: int,
 ) -> schema_v4.MigrationResult:
-    documents = _documents(ceiling=ceiling)
+    documents = (
+        _documents(ceiling=ceiling)
+        if policy_documents is None
+        else policy_documents
+    )
     compiled = _compiled(documents)
     key = projections.ProjectionNamespaceKey(
         policy_fingerprint=compiled.fingerprint,
@@ -1168,7 +1232,8 @@ def test_govern_memory_v4_proposal_persists_exact_authority_binding(
         catalog_generation=1,
     )
 
-    assert binding["schema"] == "exomem.governance-policy-proposal/v3"
+    assert binding["schema"] == "exomem.governance-policy-proposal/v4"
+    assert binding["dependent_grants"] == []
     assert reviewed == {
         "activation_epoch": 1,
         "activation_state_digest": migration.activation_state_digest,
@@ -1195,6 +1260,11 @@ def test_govern_memory_v4_proposal_persists_exact_authority_binding(
         "rules",
         "scopes",
     ]
+    assert all(
+        item["identity"]["link_count"] == 1
+        for item in snapshot["directory_identities"]
+    )
+    assert snapshot["governance_root_identity"]["link_count"] == 1
     assert target["policy_fingerprint"] == target_policy.fingerprint
     assert target["source_fingerprint"] == target_policy.fingerprint
     assert re.fullmatch(r"[0-9A-HJKMNP-TV-Z]{26}", target["generation_id"])
@@ -1344,6 +1414,19 @@ def test_govern_memory_v4_commit_publishes_the_exact_reviewed_authority(
     assert re.fullmatch(r"[0-9a-f]{64}", mirror_records[0]["prior"])
     assert re.fullmatch(r"[0-9a-f]{64}", mirror_records[0]["prepared"])
     assert re.fullmatch(r"[0-9a-f]{64}", mirror_records[0]["target"])
+    publication_records = [
+        record
+        for record in receipts.event_records(vault)
+        if record.get("operation") == "governance_policy_publication"
+        or record.get("causation_id") == committed["event_id"]
+        and record.get("outcome") == "committed"
+    ]
+    assert [record["phase"] for record in publication_records] == [
+        "intent",
+        "committed",
+    ]
+    assert publication_records[0]["event_id"] == committed["event_id"]
+    assert publication_records[1]["causation_id"] == committed["event_id"]
 
     with sqlite3.connect(store.sidecar_path(vault)) as connection:
         assert connection.execute(
@@ -1362,6 +1445,1184 @@ def test_govern_memory_v4_commit_publishes_the_exact_reviewed_authority(
             "SELECT COUNT(*) FROM governance_tuple_publications "
             "WHERE publication_kind='policy'"
         ).fetchone() == (1,)
+
+
+def test_govern_memory_v4_suspend_and_resume_publish_complete_grant_tuple(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.tool import op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    initial_documents = _documents_with_suspension(suspended=False)
+    _write_workspace(vault, initial_documents)
+    member_path = "Knowledge Base/Notes/granted.md"
+    member = vault / member_path
+    member.parent.mkdir(parents=True)
+    member.write_text("---\ntype: note\n---\nreviewed grant member\n", encoding="utf-8")
+    member_fingerprint = hashlib.sha256(member.read_bytes()).hexdigest()
+    membership_manifest = json.dumps(
+        [
+            {
+                "fingerprint": member_fingerprint,
+                "path": member_path,
+                "scope_ids": [SCOPE_ID],
+            }
+        ],
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((member_path, member.read_text(encoding="utf-8")),),
+        policy_documents=initial_documents,
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        _insert_active_dependent_grant(
+            connection,
+            grant_id="grant-toggle",
+            policy_fingerprint=_compiled(initial_documents).fingerprint,
+            membership_manifest=membership_manifest,
+            now=now,
+            paths=(member_path,),
+            fingerprints=(member_fingerprint,),
+            scope_ids=(SCOPE_ID,),
+        )
+    finally:
+        connection.close()
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        suspended = op_govern_memory(
+            vault,
+            operation="suspend",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + 1,
+        )
+
+    assert suspended == {
+        "status": "committed",
+        "event_id": suspended["event_id"],
+        "operation": "suspend",
+        "direction": "narrowing",
+        "mirror_status": "complete",
+    }
+    suspended_policy = policy.load(vault)
+    assert suspended_policy.rules[0].options["suspended"] is True
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        assert connection.execute(
+            "SELECT status, policy_fingerprint, membership_manifest, revoked_at "
+            "FROM governance_session_grants WHERE grant_id='grant-toggle'"
+        ).fetchone() == (
+            "review",
+            suspended_policy.fingerprint,
+            membership_manifest,
+            now + 1,
+        )
+    finally:
+        connection.close()
+
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 2
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        resumed = op_govern_memory(
+            vault,
+            operation="resume",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + 2,
+        )
+
+    assert resumed == {
+        "status": "committed",
+        "event_id": resumed["event_id"],
+        "operation": "resume",
+        "direction": "widening",
+        "mirror_status": "complete",
+    }
+    resumed_policy = policy.load(vault)
+    assert "suspended" not in resumed_policy.rules[0].options
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 2)
+    assert custody.control.activation_epoch == 3
+
+
+def test_govern_memory_v4_suspend_expires_changed_grant_member_with_valid_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.tool import op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    documents = _documents_with_suspension(suspended=False)
+    _write_workspace(vault, documents)
+    member_path, member_fingerprint, membership_manifest = _write_dependent_member(
+        vault,
+        name="changed-grant",
+    )
+    member = vault / member_path
+    original_source = member.read_text(encoding="utf-8")
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((member_path, original_source),),
+        policy_documents=documents,
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        _insert_active_dependent_grant(
+            connection,
+            grant_id="grant-changed-member",
+            policy_fingerprint=_compiled(documents).fingerprint,
+            membership_manifest=membership_manifest,
+            now=now,
+            paths=(member_path,),
+            fingerprints=(member_fingerprint,),
+            scope_ids=(SCOPE_ID,),
+        )
+    finally:
+        connection.close()
+    changed_source = "---\ntype: note\n---\nchanged member bytes\n"
+    changed_fingerprint = hashlib.sha256(changed_source.encode()).hexdigest()
+    preflight = semantic_writes.preflight_existing(
+        vault,
+        path=member_path,
+        after_source=changed_source,
+        operation="edit",
+        expected_before_hash=vault_module.content_hash(original_source),
+    )
+    semantic_writes.commit_existing(vault, preflight=preflight)
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        suspended = op_govern_memory(
+            vault,
+            operation="suspend",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + 1,
+        )
+
+    assert suspended["status"] == "committed"
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        status, target_manifest = connection.execute(
+            "SELECT status, membership_manifest FROM governance_session_grants "
+            "WHERE grant_id='grant-changed-member'"
+        ).fetchone()
+    finally:
+        connection.close()
+    assert status == "expired"
+    assert json.loads(target_manifest) == [
+        {
+            "fingerprint": changed_fingerprint,
+            "path": member_path,
+            "scope_ids": [SCOPE_ID],
+        }
+    ]
+
+
+def test_govern_memory_v4_widening_suspend_keeps_predecessor_on_tuple_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.tool import op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    documents = _open_scope_documents(suspended=False)
+    _write_workspace(vault, documents)
+    note = vault / "Knowledge Base" / "Notes" / "secret.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("---\ntype: note\n---\nsecret context\n", encoding="utf-8")
+    member_path, member_fingerprint, membership_manifest = _write_dependent_member(
+        vault,
+        name="grant-widening",
+    )
+    migration = _migrate_with_projection_items(
+        vault,
+        items=(
+            ("Knowledge Base/Notes/secret.md", note.read_text(encoding="utf-8")),
+            (member_path, (vault / member_path).read_text(encoding="utf-8")),
+        ),
+        policy_documents=documents,
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        _insert_active_dependent_grant(
+            connection,
+            grant_id="grant-widening",
+            policy_fingerprint=_compiled(documents).fingerprint,
+            membership_manifest=membership_manifest,
+            now=now,
+            paths=(member_path,),
+            fingerprints=(member_fingerprint,),
+            scope_ids=(SCOPE_ID,),
+        )
+    finally:
+        connection.close()
+
+    def crash(point: str) -> None:
+        if point == "policy-publication-before-commit":
+            raise RuntimeError("injected widening suspend crash")
+
+    monkeypatch.setattr(schema_v4, "_crash_point", crash)
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        with pytest.raises(RuntimeError, match="injected widening suspend crash"):
+            op_govern_memory(
+                vault,
+                operation="suspend",
+                principal=owner_principal(),
+                rule_ids=[RULE_ID],
+                now=now + 1,
+            )
+
+    active = policy.load(vault)
+    assert "suspended" not in active.rules[0].options
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        proposal_json = connection.execute(
+            "SELECT proposal_json FROM governance_proposals "
+            "ORDER BY created_at DESC, proposal_id DESC LIMIT 1"
+        ).fetchone()
+        assert proposal_json is not None
+        assert json.loads(str(proposal_json[0]))["authority_binding"][
+            "transition_direction"
+        ] == "widening"
+        assert connection.execute(
+            "SELECT status, policy_fingerprint, revoked_at "
+            "FROM governance_session_grants WHERE grant_id='grant-widening'"
+        ).fetchone() == ("active", active.fingerprint, None)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM governance_tuple_publications "
+            "WHERE publication_kind='policy'"
+        ).fetchone() == (0,)
+    finally:
+        connection.close()
+
+
+def test_govern_memory_v4_undo_restores_exact_generation_without_reactivating_grant(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.tool import GovernanceError, op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    initial_documents = _documents_with_suspension(suspended=False)
+    _write_workspace(vault, initial_documents)
+    member_path, member_fingerprint, membership_manifest = _write_dependent_member(
+        vault,
+        name="grant-undo",
+    )
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((member_path, (vault / member_path).read_text(encoding="utf-8")),),
+        policy_documents=initial_documents,
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        _insert_active_dependent_grant(
+            connection,
+            grant_id="grant-undo",
+            policy_fingerprint=_compiled(initial_documents).fingerprint,
+            membership_manifest=membership_manifest,
+            now=now,
+            paths=(member_path,),
+            fingerprints=(member_fingerprint,),
+            scope_ids=(SCOPE_ID,),
+        )
+    finally:
+        connection.close()
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        op_govern_memory(
+            vault,
+            operation="suspend",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + 1,
+        )
+        undone = op_govern_memory(
+            vault,
+            operation="undo",
+            principal=owner_principal(),
+            now=now + 2,
+        )
+
+    assert undone == {
+        "status": "committed",
+        "event_id": undone["event_id"],
+        "operation": "undo",
+        "direction": "widening",
+        "mirror_status": "complete",
+    }
+    active = policy.load(vault)
+    assert "suspended" not in active.rules[0].options
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        active_pointer = schema_v4.load_active_tuple_pointer(connection)
+        active_generation = schema_v4.load_policy_generation(
+            connection,
+            active_pointer.policy_generation_id,
+        )
+        assert dict(active_generation.source_documents) == dict(initial_documents)
+        assert connection.execute(
+            "SELECT status FROM governance_session_grants WHERE grant_id='grant-undo'"
+        ).fetchone() == ("review",)
+    finally:
+        connection.close()
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        with pytest.raises(GovernanceError) as exhausted:
+            op_govern_memory(
+                vault,
+                operation="undo",
+                principal=owner_principal(),
+                now=now + 3,
+            )
+    assert exhausted.value.code == "NOTHING_TO_UNDO"
+
+
+def test_v4_semantic_history_survives_sweep_and_keeps_undo_idempotent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.tool import GovernanceError, op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    documents = _documents_with_suspension(suspended=False)
+    _write_workspace(vault, documents)
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        op_govern_memory(
+            vault,
+            operation="suspend",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + 1,
+        )
+        op_govern_memory(
+            vault,
+            operation="undo",
+            principal=owner_principal(),
+            now=now + 2,
+        )
+
+    store.sweep_authoring_state(vault, now=300_000_000_000.0)
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        with pytest.raises(GovernanceError) as exhausted:
+            op_govern_memory(
+                vault,
+                operation="undo",
+                principal=owner_principal(),
+                now=now + 3,
+            )
+    assert exhausted.value.code == "NOTHING_TO_UNDO"
+
+
+def test_completed_semantic_history_does_not_reopen_collected_projection_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import tool as governance_tool
+    from exomem.governance.tool import op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    documents = _documents_with_suspension(suspended=False)
+    _write_workspace(vault, documents)
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        op_govern_memory(
+            vault,
+            operation="suspend",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + 1,
+        )
+
+    def collected(*_args, **_kwargs):
+        raise AssertionError("completed history reopened an inactive projection store")
+
+    monkeypatch.setattr(projection_store, "load_projection_catalog", collected)
+    assert governance_tool._resume_v4_semantic_policy_operation(
+        vault,
+        operation="resume",
+        rule_ids=[RULE_ID],
+        request_digest=None,
+        who=owner_principal(),
+        crash_at=None,
+        now=float(now + 2),
+    ) is None
+
+
+def test_committed_semantic_tuple_and_grant_survive_sweep_before_recovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.tool import GovernanceCrash, op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    documents = _documents_with_suspension(suspended=False)
+    _write_workspace(vault, documents)
+    member_path, member_fingerprint, membership_manifest = _write_dependent_member(
+        vault,
+        name="grant-sweep-recovery",
+    )
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((member_path, (vault / member_path).read_text(encoding="utf-8")),),
+        policy_documents=documents,
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        _insert_active_dependent_grant(
+            connection,
+            grant_id="grant-sweep-recovery",
+            policy_fingerprint=_compiled(documents).fingerprint,
+            membership_manifest=membership_manifest,
+            now=now,
+            paths=(member_path,),
+            fingerprints=(member_fingerprint,),
+            scope_ids=(SCOPE_ID,),
+        )
+    finally:
+        connection.close()
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        with pytest.raises(GovernanceCrash, match="v4_after_registry_ack"):
+            op_govern_memory(
+                vault,
+                operation="suspend",
+                principal=owner_principal(),
+                rule_ids=[RULE_ID],
+                crash_at="v4_after_registry_ack",
+                now=now + 1,
+            )
+    store.sweep_authoring_state(vault, now=300_000_000_000.0)
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        recovered = op_govern_memory(
+            vault,
+            operation="suspend",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + 2,
+        )
+    assert recovered["status"] == "committed"
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        assert connection.execute(
+            "SELECT status FROM governance_session_grants "
+            "WHERE grant_id='grant-sweep-recovery'"
+        ).fetchone() == ("review",)
+    finally:
+        connection.close()
+
+
+def test_govern_memory_v4_suspend_does_not_activate_or_overwrite_pending_yaml(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.tool import op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    active_documents = _documents_with_suspension(suspended=False)
+    _write_workspace(vault, active_documents)
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    pending_scope = dict(active_documents)["scopes/private.yaml"].replace(
+        b"default_deny: true\n",
+        b"default_deny: false\n",
+    )
+    scope_path = (
+        vault
+        / "Knowledge Base"
+        / "_Governance"
+        / "scopes"
+        / "private.yaml"
+    )
+    scope_path.write_bytes(pending_scope)
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        suspended = op_govern_memory(
+            vault,
+            operation="suspend",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + 1,
+        )
+
+    assert suspended["status"] == "committed"
+    assert suspended["mirror_status"] == "diverged"
+    assert scope_path.read_bytes() == pending_scope
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        active_pointer = schema_v4.load_active_tuple_pointer(connection)
+        generation = schema_v4.load_policy_generation(
+            connection,
+            active_pointer.policy_generation_id,
+        )
+    finally:
+        connection.close()
+    active_sources = dict(generation.source_documents)
+    assert active_sources["scopes/private.yaml"] == dict(active_documents)[
+        "scopes/private.yaml"
+    ]
+    assert b"suspended: true" in active_sources["rules/external.yaml"]
+
+
+def test_govern_memory_v4_undo_removes_policy_file_added_by_last_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.tool import op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    initial_documents = _documents_with_suspension(suspended=False)
+    _write_workspace(vault, initial_documents)
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    added_relative = "rules/added.yaml"
+    added_document = (
+        "governance_version: 1\n"
+        "id: 01ARZ3NDEKTSV4RRFFQ69G5FAT\n"
+        "scope_ids:\n"
+        f"  - {SCOPE_ID}\n"
+        "audience: external\n"
+        "ceiling: 1\n"
+    )
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        proposed = op_govern_memory(
+            vault,
+            operation="propose",
+            principal=owner_principal(),
+            intent="Add one reviewed restriction",
+            documents={added_relative: added_document},
+            target_ceiling=2,
+            now=now + 1,
+        )
+        committed = op_govern_memory(
+            vault,
+            operation="commit",
+            principal=owner_principal(),
+            proposal_id=proposed["proposal_id"],
+            now=now + 2,
+        )
+        undone = op_govern_memory(
+            vault,
+            operation="undo",
+            principal=owner_principal(),
+            now=now + 3,
+        )
+
+    assert committed["status"] == "committed"
+    assert undone["status"] == "committed"
+    assert undone["mirror_status"] == "complete"
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        active_pointer = schema_v4.load_active_tuple_pointer(connection)
+        generation = schema_v4.load_policy_generation(
+            connection,
+            active_pointer.policy_generation_id,
+        )
+    finally:
+        connection.close()
+    assert dict(generation.source_documents) == dict(initial_documents)
+    assert not (
+        vault / "Knowledge Base" / "_Governance" / added_relative
+    ).exists()
+
+
+def test_govern_memory_v4_undo_rebuilds_catalog_membership_for_restored_selectors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.tool import op_govern_memory
+
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR",
+        str(tmp_path / "writer-state"),
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    relative = "Knowledge Base/Notes/selector-undo.md"
+    before = "---\ntitle: Selector undo\nstatus: draft\n---\n\nbefore\n"
+    after = before.replace("before", "after")
+    target = vault / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(before, encoding="utf-8")
+    restrictive_documents = _open_scope_documents(suspended=False)
+    _write_workspace(vault, restrictive_documents)
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((relative, before),),
+        policy_documents=restrictive_documents,
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    permissive_documents = dict(restrictive_documents)
+    permissive_documents["scopes/private.yaml"] = permissive_documents[
+        "scopes/private.yaml"
+    ].replace(b"Knowledge Base/Notes/**", b"Knowledge Base/Public/**")
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        proposed = op_govern_memory(
+            vault,
+            operation="propose",
+            principal=owner_principal(),
+            intent="Move the reviewed scope away from notes",
+            documents={
+                path: source.decode("utf-8")
+                for path, source in permissive_documents.items()
+            },
+            target_ceiling=6,
+            now=now + 1,
+        )
+        op_govern_memory(
+            vault,
+            operation="commit",
+            principal=owner_principal(),
+            proposal_id=proposed["proposal_id"],
+            now=now + 2,
+        )
+    preflight = semantic_writes.preflight_existing(
+        vault,
+        path=relative,
+        after_source=after,
+        operation="edit",
+        expected_before_hash=vault_module.content_hash(before),
+    )
+    semantic_writes.commit_existing(vault, preflight=preflight)
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        undone = op_govern_memory(
+            vault,
+            operation="undo",
+            principal=owner_principal(),
+            now=now + 3,
+        )
+
+    assert undone["status"] == "committed"
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 3)
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        active = schema_v4.load_active_policy(
+            connection,
+            expected_logical_vault_id=LOGICAL_VAULT_ID,
+            expected_activation_store_id=ACTIVATION_STORE_ID,
+            expected_activation_epoch=4,
+            expected_activation_state_digest=custody.control.activation_state_digest or "",
+        )
+    finally:
+        connection.close()
+    evidence = projection_store.namespace_evidence_from_snapshot(active)
+    _manifest, items = projection_store.load_projection_catalog(
+        vault,
+        key=evidence.manifest.namespace_key,
+        expected_rows_digest=evidence.manifest.rows_digest,
+    )
+    # The selector-changing commit and undo each publish a new immutable
+    # membership catalog; the intervening content edit publishes the third.
+    assert active.active.catalog_generation == 4
+    assert active.policy.scopes[SCOPE_ID].paths == ("Knowledge Base/Notes/**",)
+    assert [(item.item_identity, item.scope_ids) for item in items] == [
+        (relative, (SCOPE_ID,))
+    ]
+
+
+def test_govern_memory_v4_suspend_recovers_exact_tuple_after_registry_gap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.tool import op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    documents = _documents_with_suspension(suspended=False)
+    _write_workspace(vault, documents)
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    def crash(point: str) -> None:
+        if point == "policy-publication-after-commit-before-registry":
+            raise RuntimeError("injected registry gap")
+
+    monkeypatch.setattr(schema_v4, "_crash_point", crash)
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        with pytest.raises(RuntimeError, match="injected registry gap"):
+            op_govern_memory(
+                vault,
+                operation="suspend",
+                principal=owner_principal(),
+                rule_ids=[RULE_ID],
+                now=now + 1,
+            )
+
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    assert custody.control.activation_epoch == 1
+    assert policy.load(vault).blocked
+    monkeypatch.setattr(schema_v4, "_crash_point", lambda _point: None)
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        recovered = op_govern_memory(
+            vault,
+            operation="suspend",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + 2,
+        )
+
+    assert recovered["status"] == "committed"
+    assert recovered["operation"] == "suspend"
+    assert recovered["mirror_status"] == "complete"
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 2)
+    assert custody.control.activation_epoch == 2
+    assert policy.load(vault).rules[0].options["suspended"] is True
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM governance_tuple_publications "
+            "WHERE publication_kind='policy'"
+        ).fetchone() == (1,)
+        assert connection.execute(
+            "SELECT status FROM governance_proposals "
+            "WHERE proposal_json LIKE '%\"semantic_operation\":\"suspend\"%'"
+        ).fetchone() == ("spent",)
+    finally:
+        connection.close()
+
+
+def test_govern_memory_v4_suspend_recovers_exact_receipt_intent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.tool import (
+        DEFAULT_PROPOSAL_TTL_SECONDS,
+        GovernanceCrash,
+        op_govern_memory,
+    )
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    documents = _documents_with_suspension(suspended=False)
+    _write_workspace(vault, documents)
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        with pytest.raises(GovernanceCrash, match="v4_after_policy_receipt_intent"):
+            op_govern_memory(
+                vault,
+                operation="suspend",
+                principal=owner_principal(),
+                rule_ids=[RULE_ID],
+                crash_at="v4_after_policy_receipt_intent",
+                now=now + 1,
+            )
+
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM governance_tuple_publications "
+            "WHERE publication_kind='policy'"
+        ).fetchone() == (0,)
+        reservation = connection.execute(
+            "SELECT reserved_event_id, expires_at FROM governance_proposals "
+            "WHERE status='pending'"
+        ).fetchone()
+        assert reservation is not None
+        assert re.fullmatch(r"[0-9a-f]{64}", str(reservation[0]))
+        assert float(reservation[1]) > now + 100_000
+    finally:
+        connection.close()
+    publication_records = [
+        record
+        for record in receipts.event_records(vault)
+        if record.get("operation") == "governance_policy_publication"
+    ]
+    assert [record["phase"] for record in publication_records] == ["intent"]
+    assert store.sweep_authoring_state(
+        vault,
+        now=now + DEFAULT_PROPOSAL_TTL_SECONDS + 100,
+    ) == 0
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        recovered = op_govern_memory(
+            vault,
+            operation="suspend",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + DEFAULT_PROPOSAL_TTL_SECONDS + 101,
+        )
+
+    terminal_records = [
+        record
+        for record in receipts.event_records(vault)
+        if record.get("event_id") == recovered["event_id"]
+        or record.get("causation_id") == recovered["event_id"]
+    ]
+    assert [record["phase"] for record in terminal_records] == [
+        "intent",
+        "committed",
+    ]
+    assert policy.load(vault).rules[0].options["suspended"] is True
+
+
+@pytest.mark.parametrize(
+    "crash_at",
+    [
+        "v4_after_registry_ack",
+        "v4_after_policy_receipt_terminal",
+        "v4_after_mirror_intent",
+        "v4_after_mirror_write:1",
+        "v4_after_mirror_effect",
+        "v4_after_mirror_terminal",
+    ],
+)
+def test_govern_memory_v4_suspend_crash_retries_exact_semantic_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    crash_at: str,
+) -> None:
+    from exomem import writer_lease
+    from exomem.governance.tool import GovernanceCrash, op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    documents = _documents_with_suspension(suspended=False)
+    _write_workspace(vault, documents)
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    monkeypatch.setattr(
+        writer_lease,
+        "active_mutation_request_id",
+        lambda: "11111111-1111-4111-8111-111111111111",
+    )
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        with pytest.raises(GovernanceCrash, match=re.escape(crash_at)):
+            op_govern_memory(
+                vault,
+                operation="suspend",
+                principal=owner_principal(),
+                rule_ids=[RULE_ID],
+                crash_at=crash_at,
+                now=now + 1,
+            )
+        recovered = op_govern_memory(
+            vault,
+            operation="suspend",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + 2,
+        )
+
+    assert recovered["status"] == "committed"
+    assert recovered["operation"] == "suspend"
+    assert recovered["mirror_status"] == "complete"
+    assert policy.load(vault).rules[0].options["suspended"] is True
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM governance_tuple_publications "
+            "WHERE publication_kind='policy'"
+        ).fetchone() == (1,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM compiled_policy_generations"
+        ).fetchone() == (2,)
+    finally:
+        connection.close()
+
+
+def test_v4_delayed_exact_retry_replays_after_later_tuple_and_projection_gc(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import writer_lease
+    from exomem.governance.tool import op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    documents = _documents_with_suspension(suspended=False)
+    _write_workspace(vault, documents)
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    request_id = "11111111-1111-4111-8111-111111111111"
+    monkeypatch.setattr(
+        writer_lease,
+        "active_mutation_request_id",
+        lambda: request_id,
+    )
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        suspended = op_govern_memory(
+            vault,
+            operation="suspend",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + 1,
+        )
+        request_id = "22222222-2222-4222-8222-222222222222"
+        op_govern_memory(
+            vault,
+            operation="resume",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + 2,
+        )
+
+    def collected(*_args, **_kwargs):
+        raise AssertionError("exact terminal replay reopened projection storage")
+
+    monkeypatch.setattr(projection_store, "load_projection_catalog", collected)
+    request_id = "11111111-1111-4111-8111-111111111111"
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        replayed = op_govern_memory(
+            vault,
+            operation="suspend",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + 3,
+        )
+    assert replayed == suspended
+    assert "suspended" not in policy.load(vault).rules[0].options
+
+
+def test_v4_incomplete_historical_mirror_recovers_after_content_tuple_and_gc(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import writer_lease
+    from exomem.governance.tool import GovernanceCrash, op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    documents = _documents_with_suspension(suspended=False)
+    _write_workspace(vault, documents)
+    relative = "Knowledge Base/Notes/mirror-recovery.md"
+    before = "---\ntype: note\n---\nbefore\n"
+    after = before.replace("before", "after")
+    note = vault / relative
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(before, encoding="utf-8")
+    migration = _migrate_with_projection_items(
+        vault,
+        items=((relative, before),),
+        policy_documents=documents,
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    request_id = "11111111-1111-4111-8111-111111111111"
+    monkeypatch.setattr(
+        writer_lease,
+        "active_mutation_request_id",
+        lambda: request_id,
+    )
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        with pytest.raises(GovernanceCrash, match="v4_after_mirror_intent"):
+            op_govern_memory(
+                vault,
+                operation="suspend",
+                principal=owner_principal(),
+                rule_ids=[RULE_ID],
+                crash_at="v4_after_mirror_intent",
+                now=now + 1,
+            )
+
+    preflight = semantic_writes.preflight_existing(
+        vault,
+        path=relative,
+        after_source=after,
+        operation="edit",
+        expected_before_hash=vault_module.content_hash(before),
+    )
+    semantic_writes.commit_existing(vault, preflight=preflight)
+
+    def collected(*_args, **_kwargs):
+        raise AssertionError("historical mirror reopened projection storage")
+
+    monkeypatch.setattr(projection_store, "load_projection_catalog", collected)
+    request_id = "22222222-2222-4222-8222-222222222222"
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        recovered = op_govern_memory(
+            vault,
+            operation="resume",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + 2,
+        )
+    assert recovered["operation"] == "suspend"
+    assert recovered["mirror_status"] == "complete"
+    assert policy.load(vault).rules[0].options["suspended"] is True
+    assert note.read_text(encoding="utf-8") == after
+
+
+def test_govern_memory_v4_new_semantic_action_finishes_prior_recovery_first(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance.tool import GovernanceCrash, op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    documents = _documents_with_suspension(suspended=False)
+    _write_workspace(vault, documents)
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        with pytest.raises(GovernanceCrash, match="v4_after_registry_ack"):
+            op_govern_memory(
+                vault,
+                operation="suspend",
+                principal=owner_principal(),
+                rule_ids=[RULE_ID],
+                crash_at="v4_after_registry_ack",
+                now=now + 1,
+            )
+        recovered = op_govern_memory(
+            vault,
+            operation="resume",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + 2,
+        )
+
+    assert recovered["operation"] == "suspend"
+    assert policy.load(vault).rules[0].options["suspended"] is True
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM governance_tuple_publications "
+            "WHERE publication_kind='policy'"
+        ).fetchone() == (1,)
+    finally:
+        connection.close()
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        resumed = op_govern_memory(
+            vault,
+            operation="resume",
+            principal=owner_principal(),
+            rule_ids=[RULE_ID],
+            now=now + 3,
+        )
+    assert resumed["operation"] == "resume"
+    assert "suspended" not in policy.load(vault).rules[0].options
 
 
 def test_govern_memory_v4_commit_recovers_mirror_after_lost_terminal(
@@ -1453,6 +2714,103 @@ def test_govern_memory_v4_commit_recovers_mirror_after_lost_terminal(
             "SELECT COUNT(*) FROM governance_tuple_publications "
             "WHERE publication_kind='policy'"
         ).fetchone() == (1,)
+
+
+def test_v4_mirror_recovers_old_directory_link_count_receipt_preimage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import tool as governance_tool
+    from exomem.governance.tool import GovernanceCrash, op_govern_memory
+
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    initial = _documents(ceiling=2)
+    target = _documents(ceiling=1)
+    _write_workspace(vault, initial)
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        proposed = op_govern_memory(
+            vault,
+            operation="propose",
+            principal=owner_principal(),
+            intent="Lower the external ceiling",
+            documents={path: source.decode() for path, source in target},
+            target_ceiling=1,
+            now=now + 1,
+        )
+
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        proposal_json, created_at = connection.execute(
+            "SELECT proposal_json, created_at FROM governance_proposals "
+            "WHERE proposal_id=?",
+            (proposed["proposal_id"],),
+        ).fetchone()
+        payload = json.loads(str(proposal_json))
+        binding = payload["authority_binding"]
+        snapshot = binding["authoring_snapshot"]
+        for item in snapshot["directory_identities"]:
+            if item["identity"] is not None:
+                item["identity"]["link_count"] = 2
+        if snapshot["governance_root_identity"] is not None:
+            snapshot["governance_root_identity"]["link_count"] = 2
+        bound_target = binding["target"]
+        review_target = {
+            key: value
+            for key, value in bound_target.items()
+            if key not in {"generation_id", "authoring_event_id", "receipt_event_id"}
+        }
+        review_binding = {
+            key: (review_target if key == "target" else value)
+            for key, value in binding.items()
+        }
+        generation_id, authoring_event_id, receipt_event_id = (
+            governance_tool._policy_publication_identities(
+                proposal_id=proposed["proposal_id"],
+                created_at=float(created_at),
+                review_digest=governance_tool._digest(review_binding),
+            )
+        )
+        bound_target.update(
+            generation_id=generation_id,
+            authoring_event_id=authoring_event_id,
+            receipt_event_id=receipt_event_id,
+        )
+        connection.execute(
+            "UPDATE governance_proposals SET proposal_json=? WHERE proposal_id=?",
+            (governance_tool._canonical_json(payload), proposed["proposal_id"]),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        with pytest.raises(GovernanceCrash, match="v4_after_mirror_intent"):
+            op_govern_memory(
+                vault,
+                operation="commit",
+                principal=owner_principal(),
+                proposal_id=proposed["proposal_id"],
+                crash_at="v4_after_mirror_intent",
+                now=now + 2,
+            )
+        recovered = op_govern_memory(
+            vault,
+            operation="commit",
+            principal=owner_principal(),
+            proposal_id=proposed["proposal_id"],
+            now=now + 3,
+        )
+    assert recovered["status"] == "committed"
+    assert recovered["mirror_status"] == "complete"
 
 
 def test_govern_memory_v4_commit_retries_transient_mirror_refusal(
@@ -2570,6 +3928,224 @@ def test_policy_publication_cas_has_one_winner_and_no_losing_rows(
         first.close()
 
 
+def _insert_active_dependent_grant(
+    connection: sqlite3.Connection,
+    *,
+    grant_id: str,
+    policy_fingerprint: str,
+    membership_manifest: str,
+    now: int,
+    paths: tuple[str, ...] = (),
+    fingerprints: tuple[str, ...] = (),
+    scope_ids: tuple[str, ...] = (),
+) -> None:
+    connection.execute(
+        "INSERT INTO governance_session_grants "
+        "(grant_id, authorization_session_id, principal_id, issuer_family, audience, "
+        "purpose, ceiling, paths, fingerprints, scope_ids, membership_manifest, "
+        "policy_fingerprint, token_jti, status, prepared_event_id, created_at, "
+        "expires_at, revoked_at) VALUES (?, ?, ?, 'rest', ?, NULL, 6, ?, ?, "
+        "?, ?, ?, ?, 'active', NULL, ?, ?, NULL)",
+        (
+            grant_id,
+            f"session-{grant_id}",
+            f"principal-{grant_id}",
+            f"principal-{grant_id}",
+            json.dumps(list(paths), separators=(",", ":")),
+            json.dumps(list(fingerprints), separators=(",", ":")),
+            json.dumps(list(scope_ids), separators=(",", ":")),
+            membership_manifest,
+            policy_fingerprint,
+            f"token-{grant_id}",
+            now,
+            now + 3_600,
+        ),
+    )
+    connection.commit()
+
+
+def test_policy_publication_applies_complete_dependent_grant_manifest_atomically(
+    tmp_path: Path,
+) -> None:
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _write_workspace(vault, _documents(ceiling=2))
+    result = _migrate(vault, now=now)
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        predecessor_policy = _compiled(_documents(ceiling=2)).fingerprint
+        target_policy = _compiled(_documents(ceiling=1)).fingerprint
+        first_manifest = '[{"fingerprint":"' + "1" * 64 + '","path":"Notes/a.md","scope_ids":[]}]'
+        second_manifest = '[{"fingerprint":"' + "2" * 64 + '","path":"Notes/b.md","scope_ids":[]}]'
+        _insert_active_dependent_grant(
+            connection,
+            grant_id="grant-a",
+            policy_fingerprint=predecessor_policy,
+            membership_manifest=first_manifest,
+            now=now,
+        )
+        _insert_active_dependent_grant(
+            connection,
+            grant_id="grant-b",
+            policy_fingerprint=predecessor_policy,
+            membership_manifest=second_manifest,
+            now=now,
+        )
+        expected = schema_v4.load_active_state(
+            connection,
+            expected_logical_vault_id=LOGICAL_VAULT_ID,
+            expected_activation_store_id=ACTIVATION_STORE_ID,
+            expected_activation_epoch=1,
+            expected_activation_state_digest=result.activation_state_digest,
+        )
+
+        published = schema_v4.publish_policy_generation(
+            connection,
+            expected=expected,
+            policy=_policy_seed(
+                generation_id=SECOND_GENERATION_ID,
+                documents=_documents(ceiling=1),
+                predecessor_generation_id=FIRST_GENERATION_ID,
+                event_suffix="dependent-grants",
+                now=now + 1,
+            ),
+            namespace=schema_v4.ProjectionNamespaceSeed(
+                namespace_id="namespace-dependent-grants",
+                evidence=b'{"ready":true}',
+                ready_at=now + 1,
+            ),
+            dependent_grants=(
+                schema_v4.DependentGrantTransition(
+                    grant_id="grant-a",
+                    expected_policy_fingerprint=predecessor_policy,
+                    expected_membership_manifest=first_manifest,
+                    target_status="expired",
+                    target_policy_fingerprint=target_policy,
+                    target_membership_manifest=first_manifest,
+                ),
+                schema_v4.DependentGrantTransition(
+                    grant_id="grant-b",
+                    expected_policy_fingerprint=predecessor_policy,
+                    expected_membership_manifest=second_manifest,
+                    target_status="review",
+                    target_policy_fingerprint=target_policy,
+                    target_membership_manifest=second_manifest,
+                ),
+            ),
+            activated_at=now + 1,
+            acknowledge_registry=_acknowledge,
+        )
+
+        assert published.active.policy_fingerprint == target_policy
+        assert connection.execute(
+            "SELECT grant_id, status, policy_fingerprint, membership_manifest, "
+            "prepared_event_id, revoked_at FROM governance_session_grants "
+            "ORDER BY grant_id"
+        ).fetchall() == [
+            ("grant-a", "expired", target_policy, first_manifest, None, now + 1),
+            ("grant-b", "review", target_policy, second_manifest, None, now + 1),
+        ]
+    finally:
+        connection.close()
+
+
+def test_policy_publication_refuses_stale_dependent_grant_without_partial_tuple(
+    tmp_path: Path,
+) -> None:
+    now = int(time.time())
+    vault = tmp_path / "vault"
+    _write_workspace(vault, _documents(ceiling=2))
+    result = _migrate(vault, now=now)
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        predecessor_policy = _compiled(_documents(ceiling=2)).fingerprint
+        target_policy = _compiled(_documents(ceiling=1)).fingerprint
+        manifest = '[{"fingerprint":"' + "3" * 64 + '","path":"Notes/a.md","scope_ids":[]}]'
+        _insert_active_dependent_grant(
+            connection,
+            grant_id="grant-a",
+            policy_fingerprint=predecessor_policy,
+            membership_manifest=manifest,
+            now=now,
+        )
+        expected = schema_v4.load_active_state(
+            connection,
+            expected_logical_vault_id=LOGICAL_VAULT_ID,
+            expected_activation_store_id=ACTIVATION_STORE_ID,
+            expected_activation_epoch=1,
+            expected_activation_state_digest=result.activation_state_digest,
+        )
+
+        with pytest.raises(schema_v4.ActiveTupleStale):
+            schema_v4.publish_policy_generation(
+                connection,
+                expected=expected,
+                policy=_policy_seed(
+                    generation_id=SECOND_GENERATION_ID,
+                    documents=_documents(ceiling=1),
+                    predecessor_generation_id=FIRST_GENERATION_ID,
+                    event_suffix="stale-dependent-grant",
+                    now=now + 1,
+                ),
+                namespace=schema_v4.ProjectionNamespaceSeed(
+                    namespace_id="namespace-stale-dependent-grant",
+                    evidence=b'{"ready":true}',
+                    ready_at=now + 1,
+                ),
+                dependent_grants=(
+                    schema_v4.DependentGrantTransition(
+                        grant_id="grant-a",
+                        expected_policy_fingerprint=predecessor_policy,
+                        expected_membership_manifest="[]",
+                        target_status="expired",
+                        target_policy_fingerprint=target_policy,
+                        target_membership_manifest=manifest,
+                    ),
+                ),
+                activated_at=now + 1,
+                acknowledge_registry=_acknowledge,
+            )
+        with pytest.raises(schema_v4.ActiveTupleStale):
+            schema_v4.publish_policy_generation(
+                connection,
+                expected=expected,
+                policy=_policy_seed(
+                    generation_id=SECOND_GENERATION_ID,
+                    documents=_documents(ceiling=1),
+                    predecessor_generation_id=FIRST_GENERATION_ID,
+                    event_suffix="legacy-unbound-dependent-grant",
+                    now=now + 1,
+                ),
+                namespace=schema_v4.ProjectionNamespaceSeed(
+                    namespace_id="namespace-legacy-unbound-dependent-grant",
+                    evidence=b'{"ready":true}',
+                    ready_at=now + 1,
+                ),
+                dependent_grants=(),
+                activated_at=now + 1,
+                acknowledge_registry=_acknowledge,
+            )
+
+        assert connection.execute(
+            "SELECT policy_generation_id, policy_fingerprint FROM active_governance_tuple"
+        ).fetchone() == (FIRST_GENERATION_ID, predecessor_policy)
+        assert connection.execute(
+            "SELECT status, policy_fingerprint, membership_manifest, revoked_at "
+            "FROM governance_session_grants WHERE grant_id='grant-a'"
+        ).fetchone() == ("active", predecessor_policy, manifest, None)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM compiled_policy_generations "
+            "WHERE generation_id=?",
+            (SECOND_GENERATION_ID,),
+        ).fetchone() == (0,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM governance_projection_namespaces "
+            "WHERE namespace_id='namespace-stale-dependent-grant'"
+        ).fetchone() == (0,)
+    finally:
+        connection.close()
+
+
 @pytest.mark.parametrize(
     ("winner_kind", "loser_kind"),
     [
@@ -2931,7 +4507,7 @@ def test_content_publication_wins_a_race_with_a_reviewed_policy_commit(
         assert connection.execute(
             "SELECT status FROM governance_proposals WHERE proposal_id=?",
             (policy_proposal["proposal_id"],),
-        ).fetchone() == ("pending",)
+        ).fetchone() == ("expired",)
     finally:
         connection.close()
 
@@ -3145,6 +4721,20 @@ def test_policy_publication_crash_before_commit_restores_exact_predecessor(
     migration = _migrate(vault, now=now)
     connection = store.open_authorization_session_connection(vault)
     try:
+        predecessor_policy = _compiled(_documents(ceiling=2)).fingerprint
+        target_policy = _compiled(_documents(ceiling=1)).fingerprint
+        membership_manifest = (
+            '[{"fingerprint":"'
+            + "4" * 64
+            + '","path":"Notes/crash.md","scope_ids":[]}]'
+        )
+        _insert_active_dependent_grant(
+            connection,
+            grant_id="grant-crash",
+            policy_fingerprint=predecessor_policy,
+            membership_manifest=membership_manifest,
+            now=now,
+        )
         expected = schema_v4.load_active_state(
             connection,
             expected_logical_vault_id=LOGICAL_VAULT_ID,
@@ -3174,6 +4764,16 @@ def test_policy_publication_crash_before_commit_restores_exact_predecessor(
                     evidence=b'{"ready":true}',
                     ready_at=now + 1,
                 ),
+                dependent_grants=(
+                    schema_v4.DependentGrantTransition(
+                        grant_id="grant-crash",
+                        expected_policy_fingerprint=predecessor_policy,
+                        expected_membership_manifest=membership_manifest,
+                        target_status="expired",
+                        target_policy_fingerprint=target_policy,
+                        target_membership_manifest=membership_manifest,
+                    ),
+                ),
                 activated_at=now + 1,
                 acknowledge_registry=_acknowledge,
             )
@@ -3194,6 +4794,10 @@ def test_policy_publication_crash_before_commit_restores_exact_predecessor(
             "SELECT COUNT(*) FROM governance_tuple_publications "
             "WHERE event_id='receipt-crash'"
         ).fetchone() == (0,)
+        assert connection.execute(
+            "SELECT status, policy_fingerprint, membership_manifest, revoked_at "
+            "FROM governance_session_grants WHERE grant_id='grant-crash'"
+        ).fetchone() == ("active", predecessor_policy, membership_manifest, None)
     finally:
         connection.close()
 


### PR DESCRIPTION
## Summary

- publish `govern_memory` suspend, resume, and undo as immutable v4 policy generations with exact dependent-grant transitions
- rebuild selector-sensitive catalog membership and its projected namespace in the same full-tuple CAS
- recover publication, registry, receipt, idempotent replay, and non-authoritative workspace-mirror crash gaps without semantic replay or historical projection reopening
- retain reviewed v4 proposal/grant history needed for deterministic undo and recovery

Stacked after #886. This PR does not merge, migrate, or touch any live vault.

## Verification

- `tests/test_governance_active_tuple.py`: 129 passed
- `tests/test_govern_memory_tool.py`: 172 passed
- `tests/test_governance_policy.py tests/test_governance_policy_workspace_mirror.py`: 105 passed
- Ruff on all changed Python files
- `uv lock --check`
- `openspec validate harden-governance-for-consolidation --strict`
- public repository artifact validation
- `git diff --check`
- independent adversarial review: GO, no P0/P1/P2 findings