### PR TITLE
feat(governance): transfer standalone attachment custody

### DIFF
--- a/src/exomem/governance/authorization_custody.py
+++ b/src/exomem/governance/authorization_custody.py
@@ -71,15 +71,56 @@ _CONTROL_FIELDS = frozenset(
 )
 _CONTROL_MAC_DOMAIN = b"exomem.authorization-session.control/v1"
 _ATTACHMENT_DOMAIN = b"exomem.authorization-session.attachment/v1"
+_DETACH_ACK_MAC_DOMAIN = b"exomem.authorization-session.detach-ack/v1"
+_HOST_REGISTRY_MAC_DOMAIN = b"exomem.authorization-session.host-registry/v1"
 _STANDALONE_STAGING_DOMAIN = b"exomem.authorization-session.standalone-staging/v1"
 _SHA256_HEX = re.compile(r"[0-9a-f]{64}\Z")
 _STANDALONE_ATTACHMENT = re.compile(r"attachment-v1-[0-9a-f]{64}\Z")
 _DEFAULT_KEY_TTL_SECONDS = 366 * 24 * 60 * 60
+_HOST_REGISTRY_CLOCK_SKEW_SECONDS = 30
+_HOST_CONTROL_KEY_BYTES = 32
+_HOST_CONTROL_KEY_NAME = "authorization-attachment-host-key-v1"
 _GOVERNANCE_AUTHORITY_NAMES = (
     ".governance.sqlite",
     ".governance.sqlite-wal",
     ".governance.sqlite-shm",
     ".governance.sqlite-journal",
+)
+_DETACH_ACK_FIELDS = frozenset(
+    {
+        "version",
+        "cell_id",
+        "logical_vault_id",
+        "keyring_id",
+        "source_registry_attachment_id",
+        "target_registry_attachment_id",
+        "source_attachment_epoch",
+        "target_attachment_epoch",
+        "source_membership_epoch",
+        "source_membership_digest",
+        "source_control_digest",
+        "issued_at",
+        "expires_at",
+        "signing_key_id",
+        "mac",
+    }
+)
+_HOST_REGISTRY_FIELDS = frozenset(
+    {
+        "version",
+        "cell_id",
+        "logical_vault_id",
+        "keyring_id",
+        "registry_attachment_id",
+        "attachment_epoch",
+        "serving_membership_epoch",
+        "serving_membership_digest",
+        "state",
+        "no_in_flight",
+        "updated_at",
+        "signing_key_id",
+        "mac",
+    }
 )
 
 
@@ -181,6 +222,40 @@ class StandaloneV3StagingResult:
     registry_attachment_id: str
     attachment_epoch: int
     staged_at: int
+
+
+@dataclass(frozen=True, slots=True)
+class _StandaloneDetachAcknowledgement:
+    version: int
+    cell_id: str
+    logical_vault_id: str
+    keyring_id: str
+    source_registry_attachment_id: str
+    target_registry_attachment_id: str
+    source_attachment_epoch: int
+    target_attachment_epoch: int
+    source_membership_epoch: int
+    source_membership_digest: str
+    source_control_digest: str
+    issued_at: int
+    expires_at: int
+    signing_key_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class _StandaloneHostRegistryRecord:
+    version: int
+    cell_id: str
+    logical_vault_id: str
+    keyring_id: str
+    registry_attachment_id: str
+    attachment_epoch: int
+    serving_membership_epoch: int
+    serving_membership_digest: str
+    state: str
+    no_in_flight: bool
+    updated_at: int
+    signing_key_id: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -767,7 +842,7 @@ def load_authorization_custody(
             now=now,
         )
     )
-    return AuthorizationCustody(
+    custody = AuthorizationCustody(
         keyring_path=external.keyring_path,
         control_path=external.control_path,
         keyring=keyring,
@@ -776,6 +851,12 @@ def load_authorization_custody(
         local_replica_id=local_replica_id,
         membership_path=membership_path,
     )
+    require_current_standalone_registry(
+        custody,
+        now=now,
+        require_serving=False,
+    )
+    return custody
 
 
 def _load_optional_serving_membership(
@@ -870,6 +951,679 @@ def _signed_control_bytes(
     if not 1 <= len(encoded) <= MAX_CUSTODY_FILE_BYTES:
         raise AuthorizationCustodyUnavailable
     return encoded
+
+
+def _detach_ack_value(
+    acknowledgement: _StandaloneDetachAcknowledgement,
+) -> dict[str, object]:
+    return {
+        "version": acknowledgement.version,
+        "cell_id": acknowledgement.cell_id,
+        "logical_vault_id": acknowledgement.logical_vault_id,
+        "keyring_id": acknowledgement.keyring_id,
+        "source_registry_attachment_id": (
+            acknowledgement.source_registry_attachment_id
+        ),
+        "target_registry_attachment_id": (
+            acknowledgement.target_registry_attachment_id
+        ),
+        "source_attachment_epoch": acknowledgement.source_attachment_epoch,
+        "target_attachment_epoch": acknowledgement.target_attachment_epoch,
+        "source_membership_epoch": acknowledgement.source_membership_epoch,
+        "source_membership_digest": acknowledgement.source_membership_digest,
+        "source_control_digest": acknowledgement.source_control_digest,
+        "issued_at": acknowledgement.issued_at,
+        "expires_at": acknowledgement.expires_at,
+        "signing_key_id": acknowledgement.signing_key_id,
+    }
+
+
+def _detach_ack_mac_input(value: dict[str, object]) -> bytes:
+    return _framed(
+        _DETACH_ACK_MAC_DOMAIN,
+        tuple(
+            str(value[name]).encode("utf-8")
+            for name in (
+                "version",
+                "cell_id",
+                "logical_vault_id",
+                "keyring_id",
+                "source_registry_attachment_id",
+                "target_registry_attachment_id",
+                "source_attachment_epoch",
+                "target_attachment_epoch",
+                "source_membership_epoch",
+                "source_membership_digest",
+                "source_control_digest",
+                "issued_at",
+                "expires_at",
+                "signing_key_id",
+            )
+        ),
+    )
+
+
+def _signed_detach_ack_bytes(
+    acknowledgement: _StandaloneDetachAcknowledgement,
+    *,
+    signing_key: bytes,
+) -> bytes:
+    value = _detach_ack_value(acknowledgement)
+    value["mac"] = (
+        base64.urlsafe_b64encode(
+            hmac.new(
+                signing_key,
+                _detach_ack_mac_input(value),
+                hashlib.sha256,
+            ).digest()
+        )
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    if not 1 <= len(encoded) <= MAX_CUSTODY_FILE_BYTES:
+        raise AuthorizationCustodyUnavailable
+    return encoded
+
+
+def _parse_detach_ack(
+    raw: bytes,
+    *,
+    keyring: AuthorizationKeyring,
+    now: int,
+) -> _StandaloneDetachAcknowledgement:
+    try:
+        if not isinstance(raw, bytes) or not 1 <= len(raw) <= MAX_CUSTODY_FILE_BYTES:
+            raise AuthorizationCustodyUnavailable
+        value = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=_closed_object,
+        )
+        if not isinstance(value, dict) or set(value) != _DETACH_ACK_FIELDS:
+            raise AuthorizationCustodyUnavailable
+        version = value["version"]
+        if version != 1 or isinstance(version, bool):
+            raise AuthorizationCustodyUnavailable
+        source_attachment = _bounded_identifier(
+            value["source_registry_attachment_id"]
+        )
+        target_attachment = _bounded_identifier(
+            value["target_registry_attachment_id"]
+        )
+        if (
+            _STANDALONE_ATTACHMENT.fullmatch(source_attachment) is None
+            or _STANDALONE_ATTACHMENT.fullmatch(target_attachment) is None
+            or hmac.compare_digest(source_attachment, target_attachment)
+        ):
+            raise AuthorizationCustodyUnavailable
+        source_attachment_epoch = _bounded_time(value["source_attachment_epoch"])
+        target_attachment_epoch = _bounded_time(value["target_attachment_epoch"])
+        source_membership_epoch = _bounded_time(value["source_membership_epoch"])
+        issued_at = _bounded_time(value["issued_at"])
+        expires_at = _bounded_time(value["expires_at"])
+        current_time = _bounded_time(now)
+        if (
+            target_attachment_epoch != source_attachment_epoch + 1
+            or not issued_at <= current_time < expires_at
+            or expires_at - issued_at
+            > authorization_serving_membership.MAX_ATTESTATION_TTL_SECONDS
+        ):
+            raise AuthorizationCustodyUnavailable
+        signing_key_id = _bounded_identifier(value["signing_key_id"])
+        signing_key = next(
+            (
+                item
+                for item in keyring.accepted_keys
+                if item.key_id == signing_key_id
+            ),
+            None,
+        )
+        if (
+            signing_key is None
+            or not signing_key.not_before <= current_time < signing_key.not_after
+            or not hmac.compare_digest(
+                _decode_key(value["mac"]),
+                hmac.new(
+                    signing_key.key,
+                    _detach_ack_mac_input(value),
+                    hashlib.sha256,
+                ).digest(),
+            )
+        ):
+            raise AuthorizationCustodyUnavailable
+        acknowledgement = _StandaloneDetachAcknowledgement(
+            version=1,
+            cell_id=_bounded_identifier(value["cell_id"]),
+            logical_vault_id=_bounded_identifier(value["logical_vault_id"]),
+            keyring_id=_bounded_identifier(value["keyring_id"]),
+            source_registry_attachment_id=source_attachment,
+            target_registry_attachment_id=target_attachment,
+            source_attachment_epoch=source_attachment_epoch,
+            target_attachment_epoch=target_attachment_epoch,
+            source_membership_epoch=source_membership_epoch,
+            source_membership_digest=_sha256_hex(value["source_membership_digest"]),
+            source_control_digest=_sha256_hex(value["source_control_digest"]),
+            issued_at=issued_at,
+            expires_at=expires_at,
+            signing_key_id=signing_key_id,
+        )
+        if not hmac.compare_digest(
+            _signed_detach_ack_bytes(
+                acknowledgement,
+                signing_key=signing_key.key,
+            ),
+            raw,
+        ):
+            raise AuthorizationCustodyUnavailable
+        return acknowledgement
+    except AuthorizationCustodyUnavailable:
+        raise
+    except (
+        AttributeError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        TypeError,
+        ValueError,
+    ):
+        raise AuthorizationCustodyUnavailable from None
+
+
+def _host_registry_value(
+    record: _StandaloneHostRegistryRecord,
+) -> dict[str, object]:
+    return {
+        "version": record.version,
+        "cell_id": record.cell_id,
+        "logical_vault_id": record.logical_vault_id,
+        "keyring_id": record.keyring_id,
+        "registry_attachment_id": record.registry_attachment_id,
+        "attachment_epoch": record.attachment_epoch,
+        "serving_membership_epoch": record.serving_membership_epoch,
+        "serving_membership_digest": record.serving_membership_digest,
+        "state": record.state,
+        "no_in_flight": record.no_in_flight,
+        "updated_at": record.updated_at,
+        "signing_key_id": record.signing_key_id,
+    }
+
+
+def _host_registry_mac_input(value: dict[str, object]) -> bytes:
+    return _framed(
+        _HOST_REGISTRY_MAC_DOMAIN,
+        tuple(
+            str(value[name]).encode("utf-8")
+            for name in (
+                "version",
+                "cell_id",
+                "logical_vault_id",
+                "keyring_id",
+                "registry_attachment_id",
+                "attachment_epoch",
+                "serving_membership_epoch",
+                "serving_membership_digest",
+                "state",
+                "no_in_flight",
+                "updated_at",
+                "signing_key_id",
+            )
+        ),
+    )
+
+
+def _signed_host_registry_bytes(
+    record: _StandaloneHostRegistryRecord,
+    *,
+    signing_key: bytes,
+) -> bytes:
+    value = _host_registry_value(record)
+    value["mac"] = (
+        base64.urlsafe_b64encode(
+            hmac.new(
+                signing_key,
+                _host_registry_mac_input(value),
+                hashlib.sha256,
+            ).digest()
+        )
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    if not 1 <= len(encoded) <= MAX_CUSTODY_FILE_BYTES:
+        raise AuthorizationCustodyUnavailable
+    return encoded
+
+
+def _parse_host_registry(
+    raw: bytes,
+    *,
+    host_key: bytes,
+    now: int,
+) -> _StandaloneHostRegistryRecord:
+    try:
+        if not isinstance(raw, bytes) or not 1 <= len(raw) <= MAX_CUSTODY_FILE_BYTES:
+            raise AuthorizationCustodyUnavailable
+        value = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=_closed_object,
+        )
+        if not isinstance(value, dict) or set(value) != _HOST_REGISTRY_FIELDS:
+            raise AuthorizationCustodyUnavailable
+        version = value["version"]
+        if version != 1 or isinstance(version, bool):
+            raise AuthorizationCustodyUnavailable
+        state = value["state"]
+        no_in_flight = value["no_in_flight"]
+        if (
+            state not in {"SERVING", "DRAINING"}
+            or not isinstance(no_in_flight, bool)
+            or (state == "SERVING" and no_in_flight)
+        ):
+            raise AuthorizationCustodyUnavailable
+        updated_at = _bounded_time(value["updated_at"])
+        current_time = _bounded_time(now)
+        if updated_at > current_time + _HOST_REGISTRY_CLOCK_SKEW_SECONDS:
+            raise AuthorizationCustodyUnavailable
+        signing_key_id = _bounded_identifier(value["signing_key_id"])
+        if (
+            not isinstance(host_key, bytes)
+            or len(host_key) != _HOST_CONTROL_KEY_BYTES
+            or not hmac.compare_digest(signing_key_id, _host_control_key_id(host_key))
+            or not hmac.compare_digest(
+                _decode_key(value["mac"]),
+                hmac.new(
+                    host_key,
+                    _host_registry_mac_input(value),
+                    hashlib.sha256,
+                ).digest(),
+            )
+        ):
+            raise AuthorizationCustodyUnavailable
+        attachment_id = _bounded_identifier(value["registry_attachment_id"])
+        if _STANDALONE_ATTACHMENT.fullmatch(attachment_id) is None:
+            raise AuthorizationCustodyUnavailable
+        record = _StandaloneHostRegistryRecord(
+            version=1,
+            cell_id=_bounded_identifier(value["cell_id"]),
+            logical_vault_id=_bounded_identifier(value["logical_vault_id"]),
+            keyring_id=_bounded_identifier(value["keyring_id"]),
+            registry_attachment_id=attachment_id,
+            attachment_epoch=_bounded_time(value["attachment_epoch"]),
+            serving_membership_epoch=_bounded_time(
+                value["serving_membership_epoch"]
+            ),
+            serving_membership_digest=_sha256_hex(
+                value["serving_membership_digest"]
+            ),
+            state=str(state),
+            no_in_flight=no_in_flight,
+            updated_at=updated_at,
+            signing_key_id=signing_key_id,
+        )
+        if not hmac.compare_digest(
+            _signed_host_registry_bytes(record, signing_key=host_key),
+            raw,
+        ):
+            raise AuthorizationCustodyUnavailable
+        return record
+    except AuthorizationCustodyUnavailable:
+        raise
+    except (
+        AttributeError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        TypeError,
+        ValueError,
+    ):
+        raise AuthorizationCustodyUnavailable from None
+
+
+def _windows_program_data_root() -> Path:
+    """Resolve ProgramData from the OS known-folder service, never the environment."""
+
+    if os.name != "nt":
+        raise AuthorizationCustodyUnavailable
+    try:  # pragma: no cover - exercised by Windows CI
+        import ctypes
+        from ctypes import wintypes
+
+        class _Guid(ctypes.Structure):
+            _fields_ = (
+                ("data1", wintypes.DWORD),
+                ("data2", wintypes.WORD),
+                ("data3", wintypes.WORD),
+                ("data4", ctypes.c_ubyte * 8),
+            )
+
+        program_data = _Guid(
+            0x62AB5D82,
+            0xFDC1,
+            0x4DC3,
+            (ctypes.c_ubyte * 8)(0xA9, 0xDD, 0x07, 0x0D, 0x1D, 0x49, 0x5D, 0x97),
+        )
+        shell32 = ctypes.WinDLL("shell32", use_last_error=True)
+        ole32 = ctypes.WinDLL("ole32", use_last_error=True)
+        shell32.SHGetKnownFolderPath.argtypes = (
+            ctypes.POINTER(_Guid),
+            wintypes.DWORD,
+            wintypes.HANDLE,
+            ctypes.POINTER(ctypes.c_wchar_p),
+        )
+        shell32.SHGetKnownFolderPath.restype = ctypes.c_long
+        ole32.CoTaskMemFree.argtypes = (ctypes.c_void_p,)
+        ole32.CoTaskMemFree.restype = None
+        resolved = ctypes.c_wchar_p()
+        result = shell32.SHGetKnownFolderPath(
+            ctypes.byref(program_data),
+            0,
+            None,
+            ctypes.byref(resolved),
+        )
+        try:
+            if result != 0 or not resolved.value:
+                raise AuthorizationCustodyUnavailable
+            root = Path(resolved.value)
+        finally:
+            if resolved:
+                ole32.CoTaskMemFree(ctypes.cast(resolved, ctypes.c_void_p))
+        if not root.is_absolute():
+            raise AuthorizationCustodyUnavailable
+        return root
+    except AuthorizationCustodyUnavailable:
+        raise
+    except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
+        raise AuthorizationCustodyUnavailable from None
+
+
+def _standalone_host_control_root() -> Path:
+    """Return the non-configurable OS account/machine host-control root."""
+
+    if os.name == "nt":  # pragma: no cover - exercised by Windows CI
+        return _windows_program_data_root() / "exomem" / "standalone-host-control-v1"
+    try:
+        import pwd
+
+        home = Path(pwd.getpwuid(os.geteuid()).pw_dir)
+    except (KeyError, OSError, RuntimeError, TypeError, ValueError):
+        raise AuthorizationCustodyUnavailable from None
+    if not home.is_absolute():
+        raise AuthorizationCustodyUnavailable
+    return home / ".local" / "state" / "exomem" / "standalone-host-control-v1"
+
+
+def _host_registry_path(logical_vault_id: str) -> Path:
+
+    identity = _bounded_identifier(logical_vault_id)
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()
+    return (
+        _standalone_host_control_root()
+        / "authorization-attachment-registry"
+        / f"{digest}.json"
+    )
+
+
+def _prepare_private_directory(path: Path) -> None:
+    try:
+        if os.name == "nt":  # pragma: no cover - exercised by Windows CI
+            mutation_lock._prepare_windows_private_directory(path)
+        else:
+            existed = path.exists()
+            path.mkdir(parents=True, mode=0o700, exist_ok=True)
+            if not existed:
+                os.chmod(path, 0o700)
+        if not _private_parent_is_safe(path):
+            raise AuthorizationCustodyUnavailable
+    except AuthorizationCustodyUnavailable:
+        raise
+    except (OSError, RuntimeError, ValueError):
+        raise AuthorizationCustodyUnavailable from None
+
+
+def _prepare_host_registry_parent(path: Path) -> None:
+    root = _standalone_host_control_root()
+    if path.parent.parent != root:
+        raise AuthorizationCustodyUnavailable
+    _prepare_private_directory(root)
+    _prepare_private_directory(path.parent)
+
+
+def _host_control_key_path() -> Path:
+    return _standalone_host_control_root() / _HOST_CONTROL_KEY_NAME
+
+
+def _host_control_key_id(host_key: bytes) -> str:
+    if not isinstance(host_key, bytes) or len(host_key) != _HOST_CONTROL_KEY_BYTES:
+        raise AuthorizationCustodyUnavailable
+    return f"standalone-host-key-v1-{hashlib.sha256(host_key).hexdigest()}"
+
+
+def _load_host_control_key() -> bytes:
+    loaded = _load_private_artifact(
+        _host_control_key_path(),
+        maximum_bytes=_HOST_CONTROL_KEY_BYTES,
+    )
+    if len(loaded.data) != _HOST_CONTROL_KEY_BYTES:
+        raise AuthorizationCustodyUnavailable
+    return loaded.data
+
+
+def _ensure_host_control_key() -> bytes:
+    root = _standalone_host_control_root()
+    _prepare_private_directory(root)
+    path = _host_control_key_path()
+    try:
+        return _load_host_control_key()
+    except AuthorizationCustodyUnavailable:
+        if path.exists():
+            raise
+    candidate = secrets.token_bytes(_HOST_CONTROL_KEY_BYTES)
+    _publish_private_artifact(
+        path,
+        candidate,
+        maximum_bytes=_HOST_CONTROL_KEY_BYTES,
+    )
+    return _load_host_control_key()
+
+
+def _host_registry_record(
+    control: AuthorizationControlRecord,
+    *,
+    state: str,
+    no_in_flight: bool,
+    updated_at: int,
+    host_key_id: str,
+) -> _StandaloneHostRegistryRecord:
+    if (
+        _STANDALONE_ATTACHMENT.fullmatch(control.registry_attachment_id) is None
+        or state not in {"SERVING", "DRAINING"}
+        or not isinstance(no_in_flight, bool)
+        or (state == "SERVING" and no_in_flight)
+    ):
+        raise AuthorizationCustodyUnavailable
+    return _StandaloneHostRegistryRecord(
+        version=1,
+        cell_id=control.cell_id,
+        logical_vault_id=control.logical_vault_id,
+        keyring_id=control.keyring_id,
+        registry_attachment_id=control.registry_attachment_id,
+        attachment_epoch=control.attachment_epoch,
+        serving_membership_epoch=control.serving_membership_epoch,
+        serving_membership_digest=control.serving_membership_digest,
+        state=state,
+        no_in_flight=no_in_flight,
+        updated_at=_bounded_time(updated_at),
+        signing_key_id=_bounded_identifier(host_key_id),
+    )
+
+
+def _host_registry_matches_control(
+    record: _StandaloneHostRegistryRecord,
+    control: AuthorizationControlRecord,
+    *,
+    state: str | None = None,
+    no_in_flight: bool | None = None,
+) -> bool:
+    return (
+        record.cell_id == control.cell_id
+        and record.logical_vault_id == control.logical_vault_id
+        and record.keyring_id == control.keyring_id
+        and record.registry_attachment_id == control.registry_attachment_id
+        and record.attachment_epoch == control.attachment_epoch
+        and record.serving_membership_epoch == control.serving_membership_epoch
+        and record.serving_membership_digest == control.serving_membership_digest
+        and (state is None or record.state == state)
+        and (no_in_flight is None or record.no_in_flight is no_in_flight)
+    )
+
+
+def _load_host_registry(
+    control: AuthorizationControlRecord,
+    *,
+    now: int,
+) -> tuple[Path, bytes, _StandaloneHostRegistryRecord, bytes]:
+    path = _host_registry_path(control.logical_vault_id)
+    loaded = _load_file(path)
+    host_key = _load_host_control_key()
+    return (
+        path,
+        loaded.data,
+        _parse_host_registry(loaded.data, host_key=host_key, now=now),
+        host_key,
+    )
+
+
+def require_current_standalone_registry(
+    custody: AuthorizationCustody,
+    *,
+    now: int,
+    require_serving: bool,
+) -> None:
+    """Recheck the non-portable host attachment before session authority commits."""
+
+    if not isinstance(custody, AuthorizationCustody):
+        raise AuthorizationCustodyUnavailable
+    control = custody.control
+    if not control.registry_attachment_id.startswith("attachment-v1-"):
+        return
+    _path, _raw, record, _host_key = _load_host_registry(control, now=now)
+    if not _host_registry_matches_control(record, control) or (
+        require_serving and record.state != "SERVING"
+    ):
+        raise AuthorizationCustodyUnavailable
+
+
+def require_standalone_mutation_admission(
+    vault_root: Path,
+    *,
+    now: int,
+) -> None:
+    """Block ordinary mutations while the host attachment is draining."""
+
+    root = Path(vault_root)
+    if not root.is_absolute():
+        return
+    configured = (
+        os.environ.get(KEYRING_FILE_ENV, "").strip(),
+        os.environ.get(CONTROL_FILE_ENV, "").strip(),
+    )
+    if configured == ("", ""):
+        return
+    if not all(configured):
+        raise AuthorizationCustodyUnavailable
+    custody = load_authorization_custody(root, now=now)
+    require_current_standalone_registry(
+        custody,
+        now=now,
+        require_serving=True,
+    )
+
+
+def _publish_initial_host_registry(
+    control: AuthorizationControlRecord,
+    *,
+    now: int,
+    state: str = "SERVING",
+    no_in_flight: bool = False,
+) -> None:
+    path = _host_registry_path(control.logical_vault_id)
+    _prepare_host_registry_parent(path)
+    host_key = _ensure_host_control_key()
+    try:
+        _existing_path, _raw, existing, _existing_host_key = _load_host_registry(
+            control,
+            now=now,
+        )
+    except AuthorizationCustodyUnavailable:
+        if path.exists():
+            raise
+    else:
+        if not _host_registry_matches_control(
+            existing,
+            control,
+            state=state,
+            no_in_flight=no_in_flight,
+        ):
+            raise AuthorizationCustodyUnavailable
+        return
+    record = _host_registry_record(
+        control,
+        state=state,
+        no_in_flight=no_in_flight,
+        updated_at=now,
+        host_key_id=_host_control_key_id(host_key),
+    )
+    encoded = _signed_host_registry_bytes(record, signing_key=host_key)
+    _publish_private_file(path, encoded)
+
+
+def _advance_host_registry(
+    *,
+    source_control: AuthorizationControlRecord,
+    source_state: str,
+    source_no_in_flight: bool,
+    target_control: AuthorizationControlRecord,
+    target_state: str,
+    target_no_in_flight: bool,
+    now: int,
+) -> None:
+    path, raw, current, host_key = _load_host_registry(source_control, now=now)
+    if _host_registry_matches_control(
+        current,
+        target_control,
+        state=target_state,
+        no_in_flight=target_no_in_flight,
+    ):
+        return
+    if not _host_registry_matches_control(
+        current,
+        source_control,
+        state=source_state,
+        no_in_flight=source_no_in_flight,
+    ):
+        raise AuthorizationCustodyUnavailable
+    target = _host_registry_record(
+        target_control,
+        state=target_state,
+        no_in_flight=target_no_in_flight,
+        updated_at=now,
+        host_key_id=_host_control_key_id(host_key),
+    )
+    _replace_control_bytes(
+        path,
+        expected=raw,
+        target=_signed_host_registry_bytes(target, signing_key=host_key),
+    )
 
 
 def _prepare_private_stage(target_path: Path, staged: held_fs.HeldFile) -> None:
@@ -1527,6 +2281,12 @@ def enroll_standalone_v3_migration(
         elif not hmac.compare_digest(membership_loaded.data, encoded_membership):
             raise AuthorizationCustodyUnavailable
         _require_exact_v3_authority(root)
+        _publish_initial_host_registry(
+            control,
+            now=current_time,
+            state="DRAINING",
+            no_in_flight=True,
+        )
 
     verified = load_authorization_custody(root, now=current_time)
     if (
@@ -1776,6 +2536,21 @@ def complete_standalone_v4_migration(
     else:
         raise AuthorizationCustodyUnavailable
 
+    if successor.previous_epoch_digest is None:
+        raise AuthorizationCustodyUnavailable
+    _advance_host_registry(
+        source_control=replace(
+            target_control,
+            serving_membership_epoch=1,
+            serving_membership_digest=successor.previous_epoch_digest,
+        ),
+        source_state="DRAINING",
+        source_no_in_flight=True,
+        target_control=target_control,
+        target_state="SERVING",
+        target_no_in_flight=False,
+        now=current_time,
+    )
     verified = load_authorization_custody(root, now=current_time)
     if (
         verified.control != target_control
@@ -1785,6 +2560,697 @@ def complete_standalone_v4_migration(
     ):
         raise AuthorizationCustodyUnavailable
     return verified
+
+
+def _standalone_membership_file(
+    vault_root: Path,
+    *,
+    external: ExternalAuthorizationCustody,
+) -> tuple[Path, bytes, str]:
+    membership_path = _configured_external_path(MEMBERSHIP_FILE_ENV, vault_root)
+    replica_id = _bounded_identifier(os.environ.get(REPLICA_ID_ENV, ""))
+    if membership_path in {external.keyring_path, external.control_path}:
+        raise AuthorizationCustodyUnavailable
+    return membership_path, _load_file(membership_path).data, replica_id
+
+
+def _require_standalone_membership(
+    record: ServingMembershipEpoch,
+    *,
+    keyring: AuthorizationKeyring,
+    control: AuthorizationControlRecord,
+    replica_id: str,
+    state: str,
+    no_in_flight: bool,
+) -> None:
+    if (
+        len(record.replicas) != 1
+        or record.cell_id != control.cell_id
+        or record.logical_vault_id != control.logical_vault_id
+    ):
+        raise AuthorizationCustodyUnavailable
+    replica = record.replicas[0]
+    expected_keys = tuple(sorted(item.key_id for item in keyring.accepted_keys))
+    if (
+        replica.replica_id != replica_id
+        or replica.state != state
+        or replica.software_version != runtime_software_version()
+        or replica.schema_version != 4
+        or replica.issuance_stopped is not (state == "DRAINING")
+        or replica.no_in_flight is not no_in_flight
+        or replica.active_key_id != keyring.active_key_id
+        or replica.accepted_key_ids != expected_keys
+        or replica.control_digest != control_attestation_digest(control)
+        or replica.keyring_digest != keyring_attestation_digest(keyring)
+    ):
+        raise AuthorizationCustodyUnavailable
+
+
+def _standalone_membership_successor(
+    raw: bytes,
+    *,
+    keyring: AuthorizationKeyring,
+    expected_control: AuthorizationControlRecord,
+    target_control: AuthorizationControlRecord,
+    replica_id: str,
+    target_state: str,
+    target_no_in_flight: bool,
+    now: int,
+) -> ServingMembershipEpoch:
+    digest = authorization_serving_membership.serving_membership_digest(raw)
+    successor = _parse_migration_membership(
+        raw,
+        keyring=keyring,
+        control=target_control,
+        now=now,
+        epoch=expected_control.serving_membership_epoch + 1,
+        digest=digest,
+    )
+    if successor.previous_epoch_digest != expected_control.serving_membership_digest:
+        raise AuthorizationCustodyUnavailable
+    _require_standalone_membership(
+        successor,
+        keyring=keyring,
+        control=target_control,
+        replica_id=replica_id,
+        state=target_state,
+        no_in_flight=target_no_in_flight,
+    )
+    return successor
+
+
+def _standalone_transition_replay_control(
+    current: AuthorizationControlRecord,
+    *,
+    expected: AuthorizationControlRecord,
+) -> bool:
+    return (
+        current.serving_membership_epoch == expected.serving_membership_epoch + 1
+        and replace(
+            current,
+            serving_membership_epoch=expected.serving_membership_epoch,
+            serving_membership_digest=expected.serving_membership_digest,
+        )
+        == expected
+    )
+
+
+def _transition_standalone_attachment_membership(
+    vault_root: Path,
+    *,
+    expected_control: AuthorizationControlRecord,
+    source_state: str,
+    source_no_in_flight: bool,
+    target_state: str,
+    target_no_in_flight: bool,
+    now: int,
+) -> AuthorizationCustody:
+    if not isinstance(expected_control, AuthorizationControlRecord):
+        raise AuthorizationCustodyUnavailable
+    root = Path(vault_root)
+    current_time = _bounded_time(now)
+
+    from .. import reserved_paths
+
+    with reserved_paths._identity_coordination_scope(root):
+        external = load_external_custody(root)
+        keyring = parse_keyring(external.keyring)
+        current_control = parse_control_record(
+            external.control,
+            keyring=keyring,
+            now=current_time,
+        )
+        _verify_registered_attachment(root, current_control.registry_attachment_id)
+        membership_path, membership_raw, replica_id = _standalone_membership_file(
+            root,
+            external=external,
+        )
+
+        if current_control != expected_control:
+            if not _standalone_transition_replay_control(
+                current_control,
+                expected=expected_control,
+            ):
+                raise AuthorizationCustodyUnavailable
+            current_record = _parse_migration_membership(
+                membership_raw,
+                keyring=keyring,
+                control=current_control,
+                now=current_time,
+                epoch=current_control.serving_membership_epoch,
+                digest=current_control.serving_membership_digest,
+            )
+            _require_standalone_membership(
+                current_record,
+                keyring=keyring,
+                control=current_control,
+                replica_id=replica_id,
+                state=target_state,
+                no_in_flight=target_no_in_flight,
+            )
+            target_control = current_control
+        else:
+            source_record: ServingMembershipEpoch | None
+            try:
+                source_record = _parse_migration_membership(
+                    membership_raw,
+                    keyring=keyring,
+                    control=current_control,
+                    now=current_time,
+                    epoch=current_control.serving_membership_epoch,
+                    digest=current_control.serving_membership_digest,
+                )
+            except AuthorizationCustodyUnavailable:
+                source_record = None
+
+            provisional_target = replace(
+                current_control,
+                serving_membership_epoch=current_control.serving_membership_epoch + 1,
+                serving_membership_digest="0" * 64,
+            )
+            if source_record is None:
+                successor = _standalone_membership_successor(
+                    membership_raw,
+                    keyring=keyring,
+                    expected_control=current_control,
+                    target_control=provisional_target,
+                    replica_id=replica_id,
+                    target_state=target_state,
+                    target_no_in_flight=target_no_in_flight,
+                    now=current_time,
+                )
+                target_membership = membership_raw
+            else:
+                _require_standalone_membership(
+                    source_record,
+                    keyring=keyring,
+                    control=current_control,
+                    replica_id=replica_id,
+                    state=source_state,
+                    no_in_flight=source_no_in_flight,
+                )
+                target_membership = _standalone_membership_bytes(
+                    keyring=keyring,
+                    control=provisional_target,
+                    replica_id=replica_id,
+                    state=target_state,
+                    issuance_stopped=target_state == "DRAINING",
+                    no_in_flight=target_no_in_flight,
+                    previous_epoch_digest=source_record.record_digest,
+                    attested_at=current_time,
+                )
+                successor = _standalone_membership_successor(
+                    target_membership,
+                    keyring=keyring,
+                    expected_control=current_control,
+                    target_control=provisional_target,
+                    replica_id=replica_id,
+                    target_state=target_state,
+                    target_no_in_flight=target_no_in_flight,
+                    now=current_time,
+                )
+                try:
+                    authorization_serving_membership.validate_membership_successor(
+                        source_record,
+                        successor,
+                        now=current_time,
+                    )
+                except authorization_serving_membership.ServingMembershipUnavailable:
+                    raise AuthorizationCustodyUnavailable from None
+                _replace_control_bytes(
+                    membership_path,
+                    expected=membership_raw,
+                    target=target_membership,
+                )
+
+            target_control = replace(
+                provisional_target,
+                serving_membership_digest=successor.record_digest,
+            )
+            signing_key = next(
+                (
+                    item.key
+                    for item in keyring.accepted_keys
+                    if item.key_id == target_control.signing_key_id
+                ),
+                None,
+            )
+            if signing_key is None:
+                raise AuthorizationCustodyUnavailable
+            _replace_control_bytes(
+                external.control_path,
+                expected=external.control,
+                target=_signed_control_bytes(
+                    target_control,
+                    signing_key=signing_key,
+                ),
+            )
+        _advance_host_registry(
+            source_control=expected_control,
+            source_state=source_state,
+            source_no_in_flight=source_no_in_flight,
+            target_control=target_control,
+            target_state=target_state,
+            target_no_in_flight=target_no_in_flight,
+            now=current_time,
+        )
+
+    verified = load_authorization_custody(root, now=current_time)
+    if verified.serving_membership is None:
+        raise AuthorizationCustodyUnavailable
+    _require_standalone_membership(
+        verified.serving_membership,
+        keyring=verified.keyring,
+        control=verified.control,
+        replica_id=_bounded_identifier(os.environ.get(REPLICA_ID_ENV, "")),
+        state=target_state,
+        no_in_flight=target_no_in_flight,
+    )
+    return verified
+
+
+def begin_standalone_attachment_drain(
+    vault_root: Path,
+    *,
+    expected_control: AuthorizationControlRecord,
+    now: int,
+) -> AuthorizationCustody:
+    """Stop standalone session issuance before an attachment can detach."""
+
+    root = Path(vault_root)
+    from .. import writer_lease
+
+    with writer_lease.get_manager().mutation_guard(
+        root,
+        operation="authorization-attachment-drain",
+        holder_kind="authorization-attachment-control",
+        attachment_control=True,
+        attachment_now=now,
+    ):
+        return _transition_standalone_attachment_membership(
+            root,
+            expected_control=expected_control,
+            source_state="SERVING",
+            source_no_in_flight=False,
+            target_state="DRAINING",
+            target_no_in_flight=False,
+            now=now,
+        )
+
+
+def acknowledge_standalone_attachment_drain(
+    vault_root: Path,
+    *,
+    expected_control: AuthorizationControlRecord,
+    now: int,
+) -> AuthorizationCustody:
+    """Record the explicit no-in-flight acknowledgement for one drained root."""
+
+    root = Path(vault_root)
+    from .. import writer_lease
+
+    with writer_lease.get_manager().mutation_guard(
+        root,
+        operation="authorization-attachment-drain-acknowledgement",
+        holder_kind="authorization-attachment-control",
+        attachment_control=True,
+        attachment_now=now,
+    ):
+        return _transition_standalone_attachment_membership(
+            root,
+            expected_control=expected_control,
+            source_state="DRAINING",
+            source_no_in_flight=False,
+            target_state="DRAINING",
+            target_no_in_flight=True,
+            now=now,
+        )
+
+
+def prepare_standalone_attachment_transfer(
+    source_vault_root: Path,
+    target_vault_root: Path,
+    *,
+    expected_control: AuthorizationControlRecord,
+    now: int,
+) -> bytes:
+    """Mint a short-lived target-bound detach acknowledgement after drain."""
+
+    source = Path(source_vault_root)
+    current_time = _bounded_time(now)
+    custody = load_authorization_custody(source, now=current_time)
+    if custody.control != expected_control or custody.serving_membership is None:
+        raise AuthorizationCustodyUnavailable
+    replica_id = _bounded_identifier(os.environ.get(REPLICA_ID_ENV, ""))
+    _require_standalone_membership(
+        custody.serving_membership,
+        keyring=custody.keyring,
+        control=custody.control,
+        replica_id=replica_id,
+        state="DRAINING",
+        no_in_flight=True,
+    )
+    target_attachment = standalone_attachment_id(Path(target_vault_root))
+    if hmac.compare_digest(
+        custody.control.registry_attachment_id,
+        target_attachment,
+    ):
+        raise AuthorizationCustodyUnavailable
+    external = load_external_custody(source)
+    signing_key = next(
+        (
+            item
+            for item in custody.keyring.accepted_keys
+            if item.key_id == custody.control.signing_key_id
+        ),
+        None,
+    )
+    if signing_key is None:
+        raise AuthorizationCustodyUnavailable
+    acknowledgement = _StandaloneDetachAcknowledgement(
+        version=1,
+        cell_id=custody.control.cell_id,
+        logical_vault_id=custody.control.logical_vault_id,
+        keyring_id=custody.control.keyring_id,
+        source_registry_attachment_id=custody.control.registry_attachment_id,
+        target_registry_attachment_id=target_attachment,
+        source_attachment_epoch=custody.control.attachment_epoch,
+        target_attachment_epoch=custody.control.attachment_epoch + 1,
+        source_membership_epoch=custody.control.serving_membership_epoch,
+        source_membership_digest=custody.control.serving_membership_digest,
+        source_control_digest=hashlib.sha256(external.control).hexdigest(),
+        issued_at=current_time,
+        expires_at=min(
+            custody.control.expires_at,
+            current_time
+            + authorization_serving_membership.MAX_ATTESTATION_TTL_SECONDS,
+        ),
+        signing_key_id=custody.control.signing_key_id,
+    )
+    return _signed_detach_ack_bytes(
+        acknowledgement,
+        signing_key=signing_key.key,
+    )
+
+
+def _require_attachment_target_authority(
+    vault_root: Path,
+    *,
+    control: AuthorizationControlRecord,
+    now: int,
+    invalidate_sessions: bool,
+) -> None:
+    if not control.governance_enrolled:
+        _governance_negative_scan(vault_root)
+        return
+    if (
+        control.activation_store_id is None
+        or control.activation_epoch is None
+        or control.activation_state_digest is None
+    ):
+        raise AuthorizationCustodyUnavailable
+    from . import schema_v4, store
+
+    try:
+        connection = (
+            store.open_authorization_session_connection(vault_root)
+            if invalidate_sessions
+            else store.open_active_governance_read_connection(vault_root)
+        )
+    except (store.UnsupportedGovernanceSchema, OSError, RuntimeError):
+        raise AuthorizationCustodyUnavailable from None
+    try:
+        active = schema_v4.load_active_state(
+            connection,
+            expected_logical_vault_id=control.logical_vault_id,
+            expected_activation_store_id=control.activation_store_id,
+            expected_activation_epoch=control.activation_epoch,
+            expected_activation_state_digest=control.activation_state_digest,
+        )
+        if (
+            active.logical_vault_id != control.logical_vault_id
+            or active.activation_store_id != control.activation_store_id
+            or active.activation_epoch != control.activation_epoch
+            or active.activation_state_digest != control.activation_state_digest
+        ):
+            raise AuthorizationCustodyUnavailable
+        if invalidate_sessions:
+            schema_v4.invalidate_attachment_session_authority(
+                connection,
+                invalidated_at=now,
+            )
+            schema_v4.load_active_state(
+                connection,
+                expected_logical_vault_id=control.logical_vault_id,
+                expected_activation_store_id=control.activation_store_id,
+                expected_activation_epoch=control.activation_epoch,
+                expected_activation_state_digest=control.activation_state_digest,
+            )
+    except (schema_v4.SchemaV4Error, OSError, RuntimeError, TypeError, ValueError):
+        raise AuthorizationCustodyUnavailable from None
+    finally:
+        connection.close()
+
+
+def _complete_standalone_attachment_transfer(
+    target_vault_root: Path,
+    *,
+    acknowledgement: bytes,
+    now: int,
+) -> AuthorizationCustody:
+    """Consume one detach acknowledgement and move the exclusive attachment."""
+
+    target = Path(target_vault_root)
+    current_time = _bounded_time(now)
+    external = load_external_custody(target)
+    keyring = parse_keyring(external.keyring)
+    control = parse_control_record(
+        external.control,
+        keyring=keyring,
+        now=current_time,
+    )
+    detached = _parse_detach_ack(
+        acknowledgement,
+        keyring=keyring,
+        now=current_time,
+    )
+    target_attachment = standalone_attachment_id(target)
+    if (
+        detached.cell_id != keyring.cell_id
+        or detached.logical_vault_id != keyring.logical_vault_id
+        or detached.keyring_id != keyring.keyring_id
+        or detached.target_registry_attachment_id != target_attachment
+    ):
+        raise AuthorizationCustodyUnavailable
+    membership_path, membership_raw, replica_id = _standalone_membership_file(
+        target,
+        external=external,
+    )
+
+    if (
+        control.registry_attachment_id == detached.target_registry_attachment_id
+        and control.attachment_epoch == detached.target_attachment_epoch
+    ):
+        if (
+            control.serving_membership_epoch
+            != detached.source_membership_epoch + 1
+            or control.cell_id != detached.cell_id
+            or control.logical_vault_id != detached.logical_vault_id
+            or control.keyring_id != detached.keyring_id
+        ):
+            raise AuthorizationCustodyUnavailable
+        _require_attachment_target_authority(
+            target,
+            control=control,
+            now=current_time,
+            invalidate_sessions=False,
+        )
+        successor = _parse_migration_membership(
+            membership_raw,
+            keyring=keyring,
+            control=control,
+            now=current_time,
+            epoch=control.serving_membership_epoch,
+            digest=control.serving_membership_digest,
+        )
+        if successor.previous_epoch_digest != detached.source_membership_digest:
+            raise AuthorizationCustodyUnavailable
+        _require_standalone_membership(
+            successor,
+            keyring=keyring,
+            control=control,
+            replica_id=replica_id,
+            state="SERVING",
+            no_in_flight=False,
+        )
+        source_control = replace(
+            control,
+            registry_attachment_id=detached.source_registry_attachment_id,
+            attachment_epoch=detached.source_attachment_epoch,
+            serving_membership_epoch=detached.source_membership_epoch,
+            serving_membership_digest=detached.source_membership_digest,
+        )
+        _advance_host_registry(
+            source_control=source_control,
+            source_state="DRAINING",
+            source_no_in_flight=True,
+            target_control=control,
+            target_state="SERVING",
+            target_no_in_flight=False,
+            now=current_time,
+        )
+        return load_authorization_custody(target, now=current_time)
+
+    if (
+        control.registry_attachment_id
+        != detached.source_registry_attachment_id
+        or control.attachment_epoch != detached.source_attachment_epoch
+        or control.serving_membership_epoch != detached.source_membership_epoch
+        or control.serving_membership_digest != detached.source_membership_digest
+        or hashlib.sha256(external.control).hexdigest()
+        != detached.source_control_digest
+        or control.cell_id != detached.cell_id
+        or control.logical_vault_id != detached.logical_vault_id
+        or control.keyring_id != detached.keyring_id
+    ):
+        raise AuthorizationCustodyUnavailable
+    _require_attachment_target_authority(
+        target,
+        control=control,
+        now=current_time,
+        invalidate_sessions=True,
+    )
+
+    provisional_target = replace(
+        control,
+        registry_attachment_id=detached.target_registry_attachment_id,
+        attachment_epoch=detached.target_attachment_epoch,
+        serving_membership_epoch=control.serving_membership_epoch + 1,
+        serving_membership_digest="0" * 64,
+    )
+    source_record: ServingMembershipEpoch | None
+    try:
+        source_record = _parse_migration_membership(
+            membership_raw,
+            keyring=keyring,
+            control=control,
+            now=current_time,
+            epoch=control.serving_membership_epoch,
+            digest=control.serving_membership_digest,
+        )
+    except AuthorizationCustodyUnavailable:
+        source_record = None
+    if source_record is None:
+        successor = _standalone_membership_successor(
+            membership_raw,
+            keyring=keyring,
+            expected_control=control,
+            target_control=provisional_target,
+            replica_id=replica_id,
+            target_state="SERVING",
+            target_no_in_flight=False,
+            now=current_time,
+        )
+    else:
+        if source_record.record_digest != detached.source_membership_digest:
+            raise AuthorizationCustodyUnavailable
+        _require_standalone_membership(
+            source_record,
+            keyring=keyring,
+            control=control,
+            replica_id=replica_id,
+            state="DRAINING",
+            no_in_flight=True,
+        )
+        target_membership = _standalone_membership_bytes(
+            keyring=keyring,
+            control=provisional_target,
+            replica_id=replica_id,
+            previous_epoch_digest=source_record.record_digest,
+            attested_at=current_time,
+        )
+        successor = _standalone_membership_successor(
+            target_membership,
+            keyring=keyring,
+            expected_control=control,
+            target_control=provisional_target,
+            replica_id=replica_id,
+            target_state="SERVING",
+            target_no_in_flight=False,
+            now=current_time,
+        )
+        try:
+            authorization_serving_membership.validate_membership_successor(
+                source_record,
+                successor,
+                now=current_time,
+            )
+        except authorization_serving_membership.ServingMembershipUnavailable:
+            raise AuthorizationCustodyUnavailable from None
+        _replace_control_bytes(
+            membership_path,
+            expected=membership_raw,
+            target=target_membership,
+        )
+
+    target_control = replace(
+        provisional_target,
+        serving_membership_digest=successor.record_digest,
+    )
+    signing_key = next(
+        (
+            item.key
+            for item in keyring.accepted_keys
+            if item.key_id == target_control.signing_key_id
+        ),
+        None,
+    )
+    if signing_key is None:
+        raise AuthorizationCustodyUnavailable
+    _replace_control_bytes(
+        external.control_path,
+        expected=external.control,
+        target=_signed_control_bytes(target_control, signing_key=signing_key),
+    )
+    _advance_host_registry(
+        source_control=control,
+        source_state="DRAINING",
+        source_no_in_flight=True,
+        target_control=target_control,
+        target_state="SERVING",
+        target_no_in_flight=False,
+        now=current_time,
+    )
+    verified = load_authorization_custody(target, now=current_time)
+    if verified.control != target_control or verified.serving_membership is None:
+        raise AuthorizationCustodyUnavailable
+    return verified
+
+
+def complete_standalone_attachment_transfer(
+    target_vault_root: Path,
+    *,
+    acknowledgement: bytes,
+    now: int,
+) -> AuthorizationCustody:
+    """Consume one detach acknowledgement under the target identity fence."""
+
+    target = Path(target_vault_root)
+    from .. import reserved_paths, writer_lease
+
+    with writer_lease.get_manager().mutation_guard(
+        target,
+        operation="authorization-attachment-transfer",
+        holder_kind="authorization-attachment-control",
+        attachment_control=True,
+        attachment_now=now,
+    ):
+        with reserved_paths._identity_coordination_scope(target):
+            return _complete_standalone_attachment_transfer(
+                target,
+                acknowledgement=acknowledgement,
+                now=now,
+            )
 
 
 def provision_standalone_custody(
@@ -1929,6 +3395,7 @@ def provision_standalone_custody(
                 _publish_private_file(membership_path, encoded_membership)
             elif not hmac.compare_digest(membership_loaded.data, encoded_membership):
                 raise AuthorizationCustodyUnavailable
+        _publish_initial_host_registry(control, now=current_time)
 
     return _provisioning_result(load_authorization_custody(root, now=current_time))
 

--- a/src/exomem/governance/authorization_session_lifecycle.py
+++ b/src/exomem/governance/authorization_session_lifecycle.py
@@ -117,6 +117,11 @@ def _ready_custody(
         current = _bounded_time(now)
         if not isinstance(custody, authorization_custody.AuthorizationCustody):
             raise AuthorizationSessionUnavailable
+        authorization_custody.require_current_standalone_registry(
+            custody,
+            now=current,
+            require_serving=True,
+        )
         keyring = custody.keyring
         control = custody.control
         if (
@@ -361,6 +366,7 @@ def open_session(
     )
     _begin_immediate(connection)
     try:
+        _ready_custody(connection, custody, now=now)
         schema_v4.insert_authorization_session(
             connection,
             issued.record,
@@ -710,6 +716,7 @@ def _rotate_resolved_session(
     )
     _begin_immediate(connection)
     try:
+        _ready_custody(connection, custody, now=now)
         updated = connection.execute(
             "UPDATE governance_authorization_sessions SET locator_digest=?, verifier=?, "
             "verifier_key_id=?, credential_generation=?, principal_id=?, issuer_family=?, "

--- a/src/exomem/governance/schema_v4.py
+++ b/src/exomem/governance/schema_v4.py
@@ -1390,6 +1390,73 @@ def _close_downmigration_authority(
     return sessions, grants, purposes, tokens, proposals
 
 
+def invalidate_attachment_session_authority(
+    connection: sqlite3.Connection,
+    *,
+    invalidated_at: int,
+) -> tuple[int, int, int, int]:
+    """Invalidate every imported session-derived authority before attachment.
+
+    A copied activation store can be policy-current while its ephemeral session
+    rows predate a close or rotation on the source.  Attachment transfer is
+    therefore conservative: unless a later protocol proves an exact source
+    snapshot, the target closes all imported session authority transactionally
+    before the external host registry can make that target reachable.
+    """
+
+    moment = _integer(invalidated_at, "invalidated_at")
+    if connection.in_transaction:
+        raise SchemaV4Error("attachment invalidation requires an idle connection")
+    require_exact_v4_connection(connection)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        sessions = int(
+            connection.execute(
+                "UPDATE governance_authorization_sessions "
+                "SET status='closed', closed_at=? WHERE status='active'",
+                (moment,),
+            ).rowcount
+            or 0
+        )
+        grants = int(
+            connection.execute(
+                "UPDATE governance_session_grants SET status='revoked', "
+                "prepared_event_id=NULL, revoked_at=? WHERE status<>'revoked'",
+                (moment,),
+            ).rowcount
+            or 0
+        )
+        purposes = int(
+            connection.execute(
+                "UPDATE governance_session_purpose SET status='revoked', "
+                "prepared_event_id=NULL WHERE status<>'revoked'"
+            ).rowcount
+            or 0
+        )
+        purposes += int(
+            connection.execute(
+                "DELETE FROM governance_session_purpose_staging"
+            ).rowcount
+            or 0
+        )
+        tokens = int(
+            connection.execute(
+                "UPDATE withhold_tokens SET status='expired', prepared_event_id=NULL, "
+                "consumed_at=COALESCE(consumed_at, ?) WHERE status<>'expired'",
+                (moment,),
+            ).rowcount
+            or 0
+        )
+        connection.commit()
+        return sessions, grants, purposes, tokens
+    except (sqlite3.Error, SchemaV4Error):
+        connection.rollback()
+        raise SchemaV4Error("attachment session invalidation failed") from None
+    except BaseException:
+        connection.rollback()
+        raise
+
+
 def _downmigration_terminal(
     *,
     event_id: str,

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -2755,6 +2755,8 @@ class LeaseManager:
         request_id: str | None = None,
         operation: str | None = None,
         holder_kind: str = "command",
+        attachment_control: bool = False,
+        attachment_now: int | None = None,
     ) -> Iterator[VaultMutationCoordinator]:
         """Hold the shared vault mutation boundary and revalidate writer authority."""
         direct_boundary: tuple[str, Path] | None = None
@@ -2781,7 +2783,11 @@ class LeaseManager:
                 holder_kind=holder_kind,
             ) as mutation:
                 try:
-                    with self.writer_authority_guard():
+                    with self.writer_authority_guard(
+                        vault_root=vault_root,
+                        attachment_control=attachment_control,
+                        attachment_now=attachment_now,
+                    ):
                         yield mutation
                 finally:
                     # Bump while the boundary is still held, so the counter is
@@ -2827,7 +2833,13 @@ class LeaseManager:
                 )
 
     @contextmanager
-    def writer_authority_guard(self) -> Iterator[None]:
+    def writer_authority_guard(
+        self,
+        *,
+        vault_root: os.PathLike[str] | str | None = None,
+        attachment_control: bool = False,
+        attachment_now: int | None = None,
+    ) -> Iterator[None]:
         """Revalidate writer authority without holding the vault mutation lock.
 
         The single choke point for idle-release accounting (R5): this is the
@@ -2837,6 +2849,24 @@ class LeaseManager:
         """
         fence_context: Token[tuple[Any, int] | None] | None = None
         counted = False
+        if vault_root is not None and not attachment_control:
+            from .governance import authorization_custody
+
+            try:
+                authorization_custody.require_standalone_mutation_admission(
+                    Path(vault_root),
+                    now=(
+                        int(time.time())
+                        if attachment_now is None
+                        else attachment_now
+                    ),
+                )
+            except authorization_custody.AuthorizationCustodyUnavailable:
+                raise OpError(
+                    "ATTACHMENT_DRAINING",
+                    "the registered vault attachment is not serving mutations",
+                    "Complete or recover the authenticated attachment transition before retrying.",
+                ) from None
         if self.config.enabled:
             lease = self.ensure_writer()
             fence_context = _ACTIVE_WRITE_FENCE.set((self, lease.fencing_token))

--- a/tests/test_authorization_standalone_provisioning.py
+++ b/tests/test_authorization_standalone_provisioning.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
 import os
+import shutil
 import sqlite3
 import stat
+import threading
 import time
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
-from exomem import mutation_lock, writer_lease
+from exomem import mutation_lock, sidecar_store, writer_lease
 from exomem.governance import (
     authorization_custody,
     authorization_session_lifecycle,
@@ -18,6 +21,8 @@ from exomem.governance import (
     schema_v4,
     store,
 )
+
+_PRODUCTION_HOST_CONTROL_ROOT = authorization_custody._standalone_host_control_root
 
 
 @pytest.fixture(autouse=True)
@@ -27,12 +32,18 @@ def _custody_paths(
 ) -> Iterator[None]:
     external = tmp_path / "external"
     external.mkdir(mode=0o700)
+    host_control = tmp_path / "host-control"
     lease_state = tmp_path / "lease-state"
     lease_state.mkdir(mode=0o700)
     if os.name == "nt":  # pragma: no cover - exercised by Windows CI
         sid = mutation_lock._windows_current_user_sid()
         mutation_lock._windows_apply_private_dacl(external, sid)
         mutation_lock._windows_apply_private_dacl(lease_state, sid)
+    monkeypatch.setattr(
+        authorization_custody,
+        "_standalone_host_control_root",
+        lambda: host_control,
+    )
     monkeypatch.setenv(
         authorization_custody.KEYRING_FILE_ENV,
         str(external / "authorization-keyring.json"),
@@ -58,6 +69,21 @@ def _vault(tmp_path: Path, name: str = "vault") -> Path:
     return vault
 
 
+def test_host_control_root_ignores_portable_runtime_path_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    before = _PRODUCTION_HOST_CONTROL_ROOT()
+    monkeypatch.setenv("HOME", str(tmp_path / "copied-home"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "copied-state"))
+    monkeypatch.setenv("PROGRAMDATA", str(tmp_path / "copied-program-data"))
+    monkeypatch.setenv("ALLUSERSPROFILE", str(tmp_path / "copied-profile"))
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "copied-lease"))
+
+    assert _PRODUCTION_HOST_CONTROL_ROOT() == before
+    assert before.is_absolute()
+
+
 def _target(
     custody: authorization_custody.AuthorizationCustody,
     *,
@@ -73,6 +99,92 @@ def _target(
         projector_schema_version=1,
         catalog_generation=1,
         projection_namespace_id="projection-namespace-initial",
+    )
+
+
+def _migration_seed(
+    *,
+    logical_vault_id: str,
+    now: int,
+) -> schema_v4.MigrationSeed:
+    documents = (
+        (
+            "scopes/transfer.yaml",
+            b"governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\n"
+            b"paths:\n  - Notes/**\n",
+        ),
+    )
+    compiled = policy.compile_documents(dict(documents))
+    assert not compiled.empty and not compiled.blocked
+    return schema_v4.MigrationSeed(
+        activation_store_id="activation-store-transfer",
+        logical_vault_id=logical_vault_id,
+        activation_epoch=1,
+        policy=schema_v4.PolicyGenerationSeed(
+            generation_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            source_documents=documents,
+            source_fingerprint=compiled.fingerprint,
+            conflict_digest="2" * 64,
+            compiled_policy=policy.canonical_compiled_bytes(compiled),
+            policy_fingerprint=compiled.fingerprint,
+            compiler_schema_version=1,
+            projector_schema_version=1,
+            predecessor_generation_id=None,
+            authoring_event_id="event-transfer-policy",
+            receipt_event_id="receipt-transfer-policy",
+            created_at=now,
+        ),
+        catalog=schema_v4.CatalogGenerationSeed(
+            catalog_generation=1,
+            descriptor=b'{"artifacts":[]}',
+            artifact_count=0,
+            created_at=now,
+        ),
+        namespace=schema_v4.ProjectionNamespaceSeed(
+            namespace_id="projection-namespace-transfer",
+            evidence=b'{"ready":true}',
+            ready_at=now,
+        ),
+        migrated_at=now,
+    )
+
+
+def _enrolled_v4(
+    vault: Path,
+    *,
+    now: int,
+) -> tuple[
+    authorization_custody.AuthorizationCustody,
+    schema_v4.VerifiedActiveGovernanceState,
+]:
+    authorization_custody.provision_standalone_custody(vault, now=now)
+    registered = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    seed = _migration_seed(
+        logical_vault_id=registered.control.logical_vault_id,
+        now=now,
+    )
+    target = schema_v4.migration_target(seed)
+    authorization_custody.enroll_initial_activation_tuple(
+        vault,
+        expected_control=registered.control,
+        target=target,
+        now=now + 1,
+    )
+    connection = sqlite3.connect(store.sidecar_path(vault))
+    try:
+        store._migrate(connection)
+        sidecar_store.ensure_meta_table(
+            connection,
+            store.DATA_TABLE,
+            "governance-attachment-transfer-test",
+        )
+        connection.commit()
+        schema_v4.migrate_v3_connection(connection, seed)
+    finally:
+        connection.close()
+    return (
+        authorization_custody.load_authorization_custody(vault, now=now + 2),
+        target,
     )
 
 
@@ -150,6 +262,34 @@ def test_explicit_standalone_provisioning_is_private_idempotent_and_copy_bound(
     copied = _vault(tmp_path, "copied-vault")
     with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
         authorization_custody.load_authorization_custody(copied, now=now + 1)
+
+
+def test_host_registry_rejects_record_forged_with_portable_vault_key(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = 1_800_000_000
+    authorization_custody.provision_standalone_custody(vault, now=now)
+    custody = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    forged = authorization_custody._host_registry_record(
+        custody.control,
+        state="SERVING",
+        no_in_flight=False,
+        updated_at=now + 1,
+        host_key_id=custody.keyring.active_key_id,
+    )
+    registry_path = authorization_custody._host_registry_path(
+        custody.control.logical_vault_id
+    )
+    registry_path.write_bytes(
+        authorization_custody._signed_host_registry_bytes(
+            forged,
+            signing_key=custody.keyring.active_key.key,
+        )
+    )
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_authorization_custody(vault, now=now + 1)
 
 
 def test_standalone_provisioning_refuses_opaque_hosted_attachment(
@@ -625,11 +765,11 @@ def test_control_before_membership_interruption_retries_without_session_fail_ope
     membership_path = Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV])
     control_before = control_path.read_bytes()
     assert not membership_path.exists()
-    interrupted = authorization_custody.load_authorization_custody(
-        vault,
-        now=now + 1,
-    )
-    assert interrupted.serving_membership is None
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_authorization_custody(
+            vault,
+            now=now + 1,
+        )
 
     monkeypatch.setattr(authorization_custody, "_publish_private_file", original)
     result = authorization_custody.provision_standalone_custody(vault, now=now)
@@ -640,6 +780,724 @@ def test_control_before_membership_interruption_retries_without_session_fail_ope
         vault,
         now=now + 1,
     ).serving_membership is not None
+
+
+def test_standalone_attachment_transfer_requires_drain_ack_and_moves_exclusively(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    copied = tmp_path / "copied-vault"
+    now = 1_800_000_000
+    authorization_custody.provision_standalone_custody(vault, now=now)
+    shutil.copytree(vault, copied)
+    serving = authorization_custody.load_authorization_custody(vault, now=now + 1)
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.prepare_standalone_attachment_transfer(
+            vault,
+            copied,
+            expected_control=serving.control,
+            now=now + 1,
+        )
+
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        vault,
+        expected_control=serving.control,
+        now=now + 2,
+    )
+    assert draining.serving_membership is not None
+    assert draining.serving_membership.replicas[0].state == "DRAINING"
+    assert draining.serving_membership.replicas[0].issuance_stopped is True
+    assert draining.serving_membership.replicas[0].no_in_flight is False
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.prepare_standalone_attachment_transfer(
+            vault,
+            copied,
+            expected_control=draining.control,
+            now=now + 2,
+        )
+
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        vault,
+        expected_control=draining.control,
+        now=now + 3,
+    )
+    assert drained.serving_membership is not None
+    assert drained.serving_membership.replicas[0].no_in_flight is True
+
+    acknowledgement = authorization_custody.prepare_standalone_attachment_transfer(
+        vault,
+        copied,
+        expected_control=drained.control,
+        now=now + 3,
+    )
+    moved = authorization_custody.complete_standalone_attachment_transfer(
+        copied,
+        acknowledgement=acknowledgement,
+        now=now + 4,
+    )
+    replay = authorization_custody.complete_standalone_attachment_transfer(
+        copied,
+        acknowledgement=acknowledgement,
+        now=now + 4,
+    )
+
+    assert replay == moved
+    assert moved.control.attachment_epoch == drained.control.attachment_epoch + 1
+    assert moved.control.registry_attachment_id == (
+        authorization_custody.standalone_attachment_id(copied)
+    )
+    assert moved.keyring.cell_id == drained.keyring.cell_id
+    assert moved.keyring.logical_vault_id == drained.keyring.logical_vault_id
+    assert moved.keyring.keyring_id == drained.keyring.keyring_id
+    assert moved.serving_membership is not None
+    assert moved.serving_membership.epoch == drained.serving_membership.epoch + 1
+    assert moved.serving_membership.replicas[0].state == "SERVING"
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_authorization_custody(vault, now=now + 4)
+
+
+def test_standalone_attachment_transfer_recovers_membership_first_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    copied = tmp_path / "copied-vault"
+    now = 1_800_000_000
+    authorization_custody.provision_standalone_custody(vault, now=now)
+    shutil.copytree(vault, copied)
+    serving = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        vault,
+        expected_control=serving.control,
+        now=now + 2,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        vault,
+        expected_control=draining.control,
+        now=now + 3,
+    )
+    acknowledgement = authorization_custody.prepare_standalone_attachment_transfer(
+        vault,
+        copied,
+        expected_control=drained.control,
+        now=now + 3,
+    )
+    control_path = Path(os.environ[authorization_custody.CONTROL_FILE_ENV])
+    membership_path = Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV])
+    control_before = control_path.read_bytes()
+    membership_before = membership_path.read_bytes()
+    original = authorization_custody._replace_control_bytes
+    interrupted = False
+
+    def stop_before_control(
+        path: Path,
+        *,
+        expected: bytes,
+        target: bytes,
+    ) -> None:
+        nonlocal interrupted
+        if path == control_path and not interrupted:
+            interrupted = True
+            raise authorization_custody.AuthorizationCustodyUnavailable
+        original(path, expected=expected, target=target)
+
+    monkeypatch.setattr(
+        authorization_custody,
+        "_replace_control_bytes",
+        stop_before_control,
+    )
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.complete_standalone_attachment_transfer(
+            copied,
+            acknowledgement=acknowledgement,
+            now=now + 4,
+        )
+
+    assert control_path.read_bytes() == control_before
+    assert membership_path.read_bytes() != membership_before
+    assert authorization_custody.load_authorization_custody(
+        vault,
+        now=now + 4,
+    ).serving_membership is None
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_authorization_custody(copied, now=now + 4)
+
+    monkeypatch.setattr(
+        authorization_custody,
+        "_replace_control_bytes",
+        original,
+    )
+    recovered = authorization_custody.complete_standalone_attachment_transfer(
+        copied,
+        acknowledgement=acknowledgement,
+        now=now + 4,
+    )
+
+    assert recovered.control.attachment_epoch == drained.control.attachment_epoch + 1
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_authorization_custody(vault, now=now + 4)
+
+
+def test_standalone_attachment_transfer_rejects_tampered_acknowledgement(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    copied = tmp_path / "copied-vault"
+    now = 1_800_000_000
+    authorization_custody.provision_standalone_custody(vault, now=now)
+    shutil.copytree(vault, copied)
+    serving = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        vault,
+        expected_control=serving.control,
+        now=now + 2,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        vault,
+        expected_control=draining.control,
+        now=now + 3,
+    )
+    acknowledgement = authorization_custody.prepare_standalone_attachment_transfer(
+        vault,
+        copied,
+        expected_control=drained.control,
+        now=now + 3,
+    )
+    tampered = bytearray(acknowledgement)
+    tampered[-2] = ord("A") if tampered[-2] != ord("A") else ord("B")
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.complete_standalone_attachment_transfer(
+            copied,
+            acknowledgement=bytes(tampered),
+            now=now + 4,
+        )
+
+    assert authorization_custody.load_authorization_custody(
+        vault,
+        now=now + 4,
+    ).control == drained.control
+
+
+def test_stale_external_bundle_cannot_reattach_source_after_transfer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    copied = tmp_path / "copied-vault"
+    copied_external = tmp_path / "copied-external"
+    copied_external.mkdir(mode=0o700)
+    now = 1_800_000_000
+    authorization_custody.provision_standalone_custody(vault, now=now)
+    shutil.copytree(vault, copied)
+    for variable in (
+        authorization_custody.KEYRING_FILE_ENV,
+        authorization_custody.CONTROL_FILE_ENV,
+        authorization_custody.MEMBERSHIP_FILE_ENV,
+    ):
+        source = Path(os.environ[variable])
+        shutil.copy2(source, copied_external / source.name)
+    serving = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        vault,
+        expected_control=serving.control,
+        now=now + 2,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        vault,
+        expected_control=draining.control,
+        now=now + 3,
+    )
+    acknowledgement = authorization_custody.prepare_standalone_attachment_transfer(
+        vault,
+        copied,
+        expected_control=drained.control,
+        now=now + 3,
+    )
+    authorization_custody.complete_standalone_attachment_transfer(
+        copied,
+        acknowledgement=acknowledgement,
+        now=now + 4,
+    )
+
+    for variable in (
+        authorization_custody.KEYRING_FILE_ENV,
+        authorization_custody.CONTROL_FILE_ENV,
+        authorization_custody.MEMBERSHIP_FILE_ENV,
+    ):
+        source = Path(os.environ[variable])
+        monkeypatch.setenv(variable, str(copied_external / source.name))
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_authorization_custody(vault, now=now + 4)
+
+
+def test_predrain_writer_state_snapshot_cannot_revive_source_after_transfer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    copied = tmp_path / "copied-vault"
+    stale_external = tmp_path / "stale-external"
+    stale_writer_state = tmp_path / "stale-writer-state"
+    stale_external.mkdir(mode=0o700)
+    now = 1_800_000_000
+    authorization_custody.provision_standalone_custody(vault, now=now)
+    shutil.copytree(vault, copied)
+    for variable in (
+        authorization_custody.KEYRING_FILE_ENV,
+        authorization_custody.CONTROL_FILE_ENV,
+        authorization_custody.MEMBERSHIP_FILE_ENV,
+    ):
+        source = Path(os.environ[variable])
+        shutil.copy2(source, stale_external / source.name)
+    shutil.copytree(
+        writer_lease.get_manager().config.state_dir,
+        stale_writer_state,
+    )
+
+    serving = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        vault,
+        expected_control=serving.control,
+        now=now + 2,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        vault,
+        expected_control=draining.control,
+        now=now + 3,
+    )
+    acknowledgement = authorization_custody.prepare_standalone_attachment_transfer(
+        vault,
+        copied,
+        expected_control=drained.control,
+        now=now + 3,
+    )
+    moved = authorization_custody.complete_standalone_attachment_transfer(
+        copied,
+        acknowledgement=acknowledgement,
+        now=now + 4,
+    )
+    assert moved.control.attachment_epoch == serving.control.attachment_epoch + 1
+
+    for variable in (
+        authorization_custody.KEYRING_FILE_ENV,
+        authorization_custody.CONTROL_FILE_ENV,
+        authorization_custody.MEMBERSHIP_FILE_ENV,
+    ):
+        source = Path(os.environ[variable])
+        monkeypatch.setenv(variable, str(stale_external / source.name))
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR",
+        str(stale_writer_state),
+    )
+    writer_lease.reset_managers_for_tests()
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_authorization_custody(vault, now=now + 4)
+
+
+def test_stale_predrain_custody_cannot_issue_after_drain_begins(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = 1_800_000_000
+    serving, _target_state = _enrolled_v4(vault, now=now)
+    connection = store.open_authorization_session_connection(vault)
+    try:
+        authorization_custody.begin_standalone_attachment_drain(
+            vault,
+            expected_control=serving.control,
+            now=now + 3,
+        )
+
+        with pytest.raises(
+            authorization_session_lifecycle.AuthorizationSessionUnavailable
+        ):
+            authorization_session_lifecycle.open_session(
+                connection,
+                custody=serving,
+                principal_id="principal-owner",
+                issuer_family="cli",
+                now=now + 4,
+                ttl_seconds=60,
+            )
+    finally:
+        connection.close()
+
+
+def test_paused_session_issuance_rechecks_host_registry_before_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    now = 1_800_000_000
+    serving, _target_state = _enrolled_v4(vault, now=now)
+    connection = store.open_authorization_session_connection(
+        vault,
+        check_same_thread=False,
+    )
+    entered = threading.Event()
+    release = threading.Event()
+    original = authorization_session_lifecycle.authorization_sessions.issue_credential
+
+    def pause_after_first_readiness(*args: object, **kwargs: object) -> object:
+        issued = original(*args, **kwargs)
+        entered.set()
+        assert release.wait(5)
+        return issued
+
+    monkeypatch.setattr(
+        authorization_session_lifecycle.authorization_sessions,
+        "issue_credential",
+        pause_after_first_readiness,
+    )
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(
+                authorization_session_lifecycle.open_session,
+                connection,
+                custody=serving,
+                principal_id="principal-owner",
+                issuer_family="cli",
+                now=now + 3,
+                ttl_seconds=60,
+            )
+            assert entered.wait(5)
+            authorization_custody.begin_standalone_attachment_drain(
+                vault,
+                expected_control=serving.control,
+                now=now + 3,
+            )
+            release.set()
+            with pytest.raises(
+                authorization_session_lifecycle.AuthorizationSessionUnavailable
+            ):
+                future.result(timeout=5)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM governance_authorization_sessions"
+        ).fetchone() == (0,)
+    finally:
+        release.set()
+        connection.close()
+
+
+def test_drain_waits_for_mutation_boundary_and_blocks_new_mutations(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    now = 1_800_000_000
+    authorization_custody.provision_standalone_custody(vault, now=now)
+    serving = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    manager = writer_lease.get_manager()
+    entered = threading.Event()
+    release = threading.Event()
+
+    def hold_mutation() -> None:
+        with manager.mutation_guard(vault, attachment_now=now + 1):
+            entered.set()
+            assert release.wait(5)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        mutation = executor.submit(hold_mutation)
+        assert entered.wait(5)
+        drain = executor.submit(
+            authorization_custody.begin_standalone_attachment_drain,
+            vault,
+            expected_control=serving.control,
+            now=now + 2,
+        )
+        assert not drain.done()
+        release.set()
+        mutation.result(timeout=5)
+        draining = drain.result(timeout=5)
+
+    assert draining.serving_membership is not None
+    assert draining.serving_membership.replicas[0].state == "DRAINING"
+    with pytest.raises(writer_lease.OpError, match="registered vault attachment") as error:
+        with manager.mutation_guard(vault, attachment_now=now + 3):
+            pass
+    assert error.value.code == "ATTACHMENT_DRAINING"
+
+
+def test_attachment_transfer_invalidates_sessions_from_stale_copy(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    copied = tmp_path / "copied-vault"
+    now = 1_800_000_000
+    serving, target_state = _enrolled_v4(vault, now=now)
+    source_connection = store.open_authorization_session_connection(vault)
+    try:
+        issued = authorization_session_lifecycle.open_session(
+            source_connection,
+            custody=serving,
+            principal_id="principal-owner",
+            issuer_family="cli",
+            now=now + 3,
+            ttl_seconds=120,
+        )
+        common = (
+            issued.context.session_id,
+            issued.context.principal_id,
+            issued.context.issuer_family,
+            "external",
+        )
+        source_connection.execute(
+            "INSERT INTO governance_session_purpose "
+            "(authorization_session_id, principal_id, issuer_family, audience, purpose, "
+            "status, created_at, expires_at) "
+            "VALUES (?, ?, ?, ?, 'support', 'active', ?, ?)",
+            (*common, now + 3, now + 120),
+        )
+        source_connection.execute(
+            "INSERT INTO governance_session_grants "
+            "(grant_id, authorization_session_id, principal_id, issuer_family, audience, "
+            "purpose, ceiling, paths, fingerprints, scope_ids, membership_manifest, "
+            "policy_fingerprint, token_jti, status, created_at, expires_at) "
+            "VALUES ('grant-stale-copy', ?, ?, ?, ?, 'support', 5, '[]', '[]', '[]', "
+            "'[]', ?, 'token-stale-copy', 'active', ?, ?)",
+            (*common, target_state.policy_fingerprint, now + 3, now + 120),
+        )
+        source_connection.execute(
+            "INSERT INTO withhold_tokens "
+            "(jti, authorization_session_id, principal_id, issuer_family, audience, "
+            "max_level, fingerprints, paths, scope_ids, purpose, org_ceiling, status, "
+            "expires_at, minted_at) "
+            "VALUES ('token-stale-copy', ?, ?, ?, ?, 5, '[]', '[]', '[]', 'support', "
+            "6, 'active', ?, ?)",
+            (*common, now + 120, now + 3),
+        )
+        source_connection.commit()
+    finally:
+        source_connection.close()
+    shutil.copytree(vault, copied)
+    source_connection = store.open_authorization_session_connection(vault)
+    try:
+        authorization_session_lifecycle.close_session(
+            source_connection,
+            custody=serving,
+            bearer=issued.bearer,
+            principal_id="principal-owner",
+            issuer_family="cli",
+            now=now + 4,
+        )
+    finally:
+        source_connection.close()
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        vault,
+        expected_control=serving.control,
+        now=now + 5,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        vault,
+        expected_control=draining.control,
+        now=now + 6,
+    )
+    acknowledgement = authorization_custody.prepare_standalone_attachment_transfer(
+        vault,
+        copied,
+        expected_control=drained.control,
+        now=now + 6,
+    )
+    moved = authorization_custody.complete_standalone_attachment_transfer(
+        copied,
+        acknowledgement=acknowledgement,
+        now=now + 7,
+    )
+    target_connection = store.open_authorization_session_connection(copied)
+    try:
+        with pytest.raises(
+            authorization_session_lifecycle.AuthorizationSessionUnavailable
+        ):
+            authorization_session_lifecycle.resume_session(
+                target_connection,
+                custody=moved,
+                bearer=issued.bearer,
+                principal_id="principal-owner",
+                issuer_family="cli",
+                now=now + 7,
+            )
+        assert target_connection.execute(
+            "SELECT status FROM governance_authorization_sessions WHERE session_id=?",
+            (issued.context.session_id,),
+        ).fetchone() == ("closed",)
+        assert target_connection.execute(
+            "SELECT status FROM governance_session_purpose "
+            "WHERE authorization_session_id=?",
+            (issued.context.session_id,),
+        ).fetchone() == ("revoked",)
+        assert target_connection.execute(
+            "SELECT status FROM governance_session_grants "
+            "WHERE grant_id='grant-stale-copy'"
+        ).fetchone() == ("revoked",)
+        assert target_connection.execute(
+            "SELECT status FROM withhold_tokens WHERE jti='token-stale-copy'"
+        ).fetchone() == ("expired",)
+    finally:
+        target_connection.close()
+
+
+def test_attachment_transfer_replay_preserves_new_target_session(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    copied = tmp_path / "copied-vault"
+    now = 1_800_000_000
+    serving, _target_state = _enrolled_v4(vault, now=now)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        vault,
+        expected_control=serving.control,
+        now=now + 3,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        vault,
+        expected_control=draining.control,
+        now=now + 4,
+    )
+    shutil.copytree(vault, copied)
+    acknowledgement = authorization_custody.prepare_standalone_attachment_transfer(
+        vault,
+        copied,
+        expected_control=drained.control,
+        now=now + 4,
+    )
+    moved = authorization_custody.complete_standalone_attachment_transfer(
+        copied,
+        acknowledgement=acknowledgement,
+        now=now + 5,
+    )
+    connection = store.open_authorization_session_connection(copied)
+    try:
+        issued = authorization_session_lifecycle.open_session(
+            connection,
+            custody=moved,
+            principal_id="principal-owner",
+            issuer_family="cli",
+            now=now + 6,
+            ttl_seconds=60,
+        )
+        replay = authorization_custody.complete_standalone_attachment_transfer(
+            copied,
+            acknowledgement=acknowledgement,
+            now=now + 7,
+        )
+        resumed = authorization_session_lifecycle.resume_session(
+            connection,
+            custody=replay,
+            bearer=issued.bearer,
+            principal_id="principal-owner",
+            issuer_family="cli",
+            now=now + 7,
+        )
+    finally:
+        connection.close()
+
+    assert resumed.session_id == issued.context.session_id
+
+
+def test_enrolled_attachment_transfer_requires_exact_target_activation_store(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    copied = tmp_path / "copied-vault"
+    now = 1_800_000_000
+    authorization_custody.provision_standalone_custody(vault, now=now)
+    registered = authorization_custody.load_authorization_custody(vault, now=now + 1)
+    authorization_custody.enroll_initial_activation_tuple(
+        vault,
+        expected_control=registered.control,
+        target=_target(registered),
+        now=now + 1,
+    )
+    enrolled = authorization_custody.load_authorization_custody(vault, now=now + 2)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        vault,
+        expected_control=enrolled.control,
+        now=now + 2,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        vault,
+        expected_control=draining.control,
+        now=now + 3,
+    )
+    shutil.copytree(vault, copied)
+    acknowledgement = authorization_custody.prepare_standalone_attachment_transfer(
+        vault,
+        copied,
+        expected_control=drained.control,
+        now=now + 3,
+    )
+    control_path = Path(os.environ[authorization_custody.CONTROL_FILE_ENV])
+    membership_path = Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV])
+    control_before = control_path.read_bytes()
+    membership_before = membership_path.read_bytes()
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.complete_standalone_attachment_transfer(
+            copied,
+            acknowledgement=acknowledgement,
+            now=now + 4,
+        )
+
+    assert control_path.read_bytes() == control_before
+    assert membership_path.read_bytes() == membership_before
+    assert authorization_custody.load_authorization_custody(
+        vault,
+        now=now + 4,
+    ).control == drained.control
+
+
+def test_enrolled_attachment_transfer_preserves_exact_active_store(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    copied = tmp_path / "copied-vault"
+    now = 1_800_000_000
+    enrolled, target = _enrolled_v4(vault, now=now)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        vault,
+        expected_control=enrolled.control,
+        now=now + 2,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        vault,
+        expected_control=draining.control,
+        now=now + 3,
+    )
+    shutil.copytree(vault, copied)
+    acknowledgement = authorization_custody.prepare_standalone_attachment_transfer(
+        vault,
+        copied,
+        expected_control=drained.control,
+        now=now + 3,
+    )
+
+    moved = authorization_custody.complete_standalone_attachment_transfer(
+        copied,
+        acknowledgement=acknowledgement,
+        now=now + 4,
+    )
+    copied_connection = store.open_active_governance_read_connection(copied)
+    try:
+        active = schema_v4.load_active_state(
+            copied_connection,
+            expected_logical_vault_id=moved.control.logical_vault_id,
+            expected_activation_store_id=str(moved.control.activation_store_id),
+            expected_activation_epoch=int(moved.control.activation_epoch or 0),
+            expected_activation_state_digest=str(
+                moved.control.activation_state_digest
+            ),
+        )
+    finally:
+        copied_connection.close()
+
+    assert active == target
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_authorization_custody(vault, now=now + 4)
 
 
 def test_staged_v3_enrollment_is_irreversible_but_remains_fail_closed(
@@ -720,12 +1578,11 @@ def test_staged_v3_enrollment_replay_recovers_missing_membership(
     control_path = Path(os.environ[authorization_custody.CONTROL_FILE_ENV])
     membership_path = Path(os.environ[authorization_custody.MEMBERSHIP_FILE_ENV])
     control_before = control_path.read_bytes()
-    interrupted = authorization_custody.load_authorization_custody(
-        vault,
-        now=now + 2,
-    )
-    assert interrupted.control.governance_enrolled is True
-    assert interrupted.serving_membership is None
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_authorization_custody(
+            vault,
+            now=now + 2,
+        )
     assert not membership_path.exists()
     assert policy.load(vault).blocked
 


### PR DESCRIPTION
## Summary

- add an exclusive standalone attachment-transfer protocol with `SERVING -> DRAINING -> no-in-flight`, a target-bound detach acknowledgement, monotonic membership/control epochs, and exact crash replay
- keep attachment ownership in a fixed OS-derived host-control root signed by a separate host-local key, so copied vault custody or writer-state snapshots cannot revive the old root
- serialize drain with ordinary mutations and recheck attachment authority before session issuance commits
- transactionally invalidate imported session, grant, purpose, and token authority before a copied v4 target becomes reachable; exact transfer replay preserves new target sessions

Stacked after #888. This PR does not merge branches or touch any live vault.

## Security boundary

The standalone file protocol excludes rollback by the trusted OS owner/administrator of the fixed host-control root itself. Resisting that privileged rollback requires an external or TPM-backed monotonic authority and is not claimed here.

## Verification

- red-first regressions reproduced stale external-bundle revival, pre-drain issuance, copied-session resurrection, and complete pre-drain writer-state snapshot split-brain before correction
- `tests/test_authorization_standalone_provisioning.py`: 48 passed
- independent security re-review: GO, no P0/P1/P2 findings
- Ruff clean on the changed custody/session/schema/test files; `writer_lease.py` retains only its five pre-existing untouched findings
- changed production files compile
- `openspec validate harden-governance-for-consolidation --strict`
- public repository artifact validation
- `git diff --check`
