### PR TITLE
docs(governance): define restore and clone custody

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/design.md
+++ b/openspec/changes/harden-governance-for-consolidation/design.md
@@ -915,7 +915,9 @@ root plus the target attachment so retry never rotates identity. Under the targe
 schema, receipt, and held-filesystem fences, one `BEGIN EXCLUSIVE` transaction verifies
 the complete copied active tuple and its immutable publication chain, closes every copied
 session and invalidates every session-derived grant, purpose, and token, changes only the
-activation-store/logical-vault identity, increments the activation epoch, recomputes its
+activation-store/logical-vault identity, preserves copied receipt rows and evidence as
+historical input while replacing the active receipt singleton with a fresh target-derived
+instance, genesis head, and label-HMAC secret, increments the activation epoch, recomputes its
 activation digest over the unchanged active policy/projector/catalog tuple, and appends
 one immutable `attachment-clone` tuple publication whose predecessor is the copied active
 digest. The immutable policy generations, catalog descriptors, projection namespaces,
@@ -928,7 +930,9 @@ only the exact staged-keyring-derived clone publication and external records; it
 generates a second identity, rekeys the source, reopens a copied session, or treats an
 old copied keyring/control file as target authority. A crash before the transaction may
 retry or abandon the inert keyring; a crash after it must finish the exact new identity
-or remain blocked. The source logical vault and its registry record are untouched and may
+or remain blocked. The source receipt chain continues only under its original instance;
+the clone appends only under the fresh instance, so later evidence cannot fork one chain.
+The source logical vault and its registry record are untouched and may
 continue independently because the clone has a different cell, logical-vault, keyring,
 activation-store, attachment, and membership identity.
 

--- a/openspec/changes/harden-governance-for-consolidation/design.md
+++ b/openspec/changes/harden-governance-for-consolidation/design.md
@@ -913,7 +913,8 @@ target registry attachment. It publishes one inert target keyring first, derivin
 new cell, logical-vault, keyring, and activation-store ids from that one staged random
 root plus the target attachment so retry never rotates identity. Under the target writer,
 schema, receipt, and held-filesystem fences, one `BEGIN EXCLUSIVE` transaction verifies
-the complete copied active tuple and its immutable publication chain, closes every copied
+the complete copied active tuple, immutable publication chain, and unforked receipt
+evidence/anchor set, closes every copied
 session and invalidates every session-derived grant, purpose, and token, changes only the
 activation-store/logical-vault identity, preserves copied receipt rows and evidence as
 historical input while replacing the active receipt singleton with a fresh target-derived

--- a/openspec/changes/harden-governance-for-consolidation/design.md
+++ b/openspec/changes/harden-governance-for-consolidation/design.md
@@ -897,10 +897,40 @@ vault/sidecar copy presenting the same ids and keyring collides with the attachm
 lease and fails; copying the keyring/control file without registry ownership also fails.
 A move quiesces the old attachment, obtains its explicit detach acknowledgement,
 advances the registry attachment epoch, and attaches the same logical vault at the new
-location before serving. A restore may preserve unexpired sessions only when the exact
-vault, sidecar, keyring, control record, cell/logical-vault ids, and exclusive registry
-attachment are restored after the old instance is proven offline; clone/import into a
-new logical vault provisions a new cell/keyring and invalidates copied session rows.
+location before serving. Version 1 deliberately gives an exact offline restore the same
+protocol and the same conservative authority outcome: the old attachment reaches
+`DRAINING` plus `no_in_flight`, a short-lived target-bound detach acknowledgement names
+the exact source control and serving-membership digests, and target attachment invalidates
+every imported authorization session, grant, purpose, and token before it can advance the
+attachment/membership epochs and serve. No version-1 restore preserves an unexpired
+session. A future preservation mode would require its own reviewed snapshot/census and
+exclusive-offline proof and cannot be inferred from copied bytes, a stopped process, or
+the ordinary transfer acknowledgement.
+
+Clone/import into a new logical vault is a distinct authenticated offline operation. It
+requires a copied exact-v4 activation store with no target external custody files and no
+target registry attachment. It publishes one inert target keyring first, deriving stable
+new cell, logical-vault, keyring, and activation-store ids from that one staged random
+root plus the target attachment so retry never rotates identity. Under the target writer,
+schema, receipt, and held-filesystem fences, one `BEGIN EXCLUSIVE` transaction verifies
+the complete copied active tuple and its immutable publication chain, closes every copied
+session and invalidates every session-derived grant, purpose, and token, changes only the
+activation-store/logical-vault identity, increments the activation epoch, recomputes its
+activation digest over the unchanged active policy/projector/catalog tuple, and appends
+one immutable `attachment-clone` tuple publication whose predecessor is the copied active
+digest. The immutable policy generations, catalog descriptors, projection namespaces,
+and prior publication evidence remain append-only and byte-identical.
+
+Only after that transaction commits may the operation publish target control and
+serving-membership records and create the new host-registry attachment. Store/control/
+registry mismatch remains BLOCKED throughout those external steps. Recovery may finish
+only the exact staged-keyring-derived clone publication and external records; it never
+generates a second identity, rekeys the source, reopens a copied session, or treats an
+old copied keyring/control file as target authority. A crash before the transaction may
+retry or abandon the inert keyring; a crash after it must finish the exact new identity
+or remain blocked. The source logical vault and its registry record are untouched and may
+continue independently because the clone has a different cell, logical-vault, keyring,
+activation-store, attachment, and membership identity.
 
 The authoritative serving set is the external `serving_membership_epoch` control-plane
 record, never peer gossip, timeout inference, or the set of recently responding pods.

--- a/openspec/changes/harden-governance-for-consolidation/specs/authorization-session-binding/spec.md
+++ b/openspec/changes/harden-governance-for-consolidation/specs/authorization-session-binding/spec.md
@@ -252,9 +252,28 @@ SHALL fail content serving closed even when authorization-session issuance is di
 Hosted SHALL use its authenticated cell control plane. Concurrent copies presenting the same registration SHALL collide and fail; copied
 keyring/control files without registry ownership SHALL fail. A move SHALL quiesce and
 detach/ack the old attachment, advance the registry attachment epoch, then attach the
-same logical vault. Restore may preserve unexpired rows only for the exact coherent
-vault+sidecar+keyring+control identity after exclusive old-instance shutdown; cloning to
-a new logical vault SHALL provision new ids/keys and invalidate imported sessions.
+same logical vault. Version-1 exact offline restore SHALL use that same source-drain,
+`no_in_flight`, target-bound acknowledgement, and attachment-epoch protocol and SHALL
+invalidate every imported authorization session, grant, purpose, and token before the
+target becomes serving. Version 1 SHALL NOT preserve unexpired session authority across
+restore; copied bytes, process absence, or an ordinary detach acknowledgement SHALL NOT
+be upgraded into a preservation proof.
+
+Cloning/importing an exact-v4 copy into a new logical vault SHALL be a distinct
+authenticated offline operation. The target SHALL have no external custody files and no
+registry attachment. One staged random key SHALL deterministically bind fresh target
+cell, logical-vault, keyring, activation-store, and attachment identities across retries.
+Under the target writer/schema/receipt/held-filesystem fences, one exclusive SQLite
+transaction SHALL verify the copied active tuple and immutable publication chain, close
+all copied sessions and invalidate all session-derived grants/purposes/tokens, replace
+only activation-store/logical-vault identity, increment activation epoch, recompute the
+activation digest over the unchanged policy/projector/catalog tuple, and append an
+immutable `attachment-clone` tuple publication whose predecessor is the copied active
+digest. Only after commit may target control, serving membership, and the new host-
+registry attachment publish. Any intermediate mismatch SHALL remain BLOCKED; recovery
+SHALL use only the exact staged keyring plus committed clone publication and SHALL NOT
+rotate identity or accept copied external files. The source registry and authority SHALL
+remain unchanged and independent.
 
 The control plane SHALL publish an authoritative `serving_membership_epoch` enumerating
 every admitted replica and authenticated readiness attestation over epoch, replica id,
@@ -326,6 +345,32 @@ and no member or live verifier key may disappear merely because it is silent or 
 - **THEN** its authorization sessions are invalidated with the common credential refusal
   and no local first-use secret is generated
 
+#### Scenario: Version-one offline restore invalidates session authority
+
+- **WHEN** an exact copied vault and sidecar are attached after the source reaches
+  `DRAINING` plus `no_in_flight` and issues the target-bound acknowledgement
+- **THEN** the target keeps the same logical-vault/cell/keyring identity, advances the
+  attachment and serving-membership epochs, invalidates every imported session-derived
+  authority before serving, and the source attachment cannot resume
+
+#### Scenario: Exact-v4 clone gets a new activation identity
+
+- **WHEN** an authenticated owner clones an unattached exact-v4 copy with no target
+  external custody files
+- **THEN** one exclusive transaction retains the exact active policy/projector/catalog
+  and immutable history, closes copied session authority, commits a predecessor-bound
+  `attachment-clone` publication with fresh logical-vault/activation-store identity, and
+  the target publishes fresh cell/keyring/control/membership/registry custody only after
+  that transaction
+
+#### Scenario: Clone recovery never rotates staged identity
+
+- **WHEN** clone crashes after inert keyring publication, after the clone transaction, or
+  during control/membership/registry publication
+- **THEN** retry completes only the same staged-keyring-derived identity and publication,
+  while contradictory/copied external records or a different target make it remain
+  blocked
+
 #### Scenario: Standalone provisioning establishes external identity
 
 - **WHEN** an authenticated local owner provisions a never-registered standalone vault
@@ -368,7 +413,10 @@ keyring ids, status, created/rotated/expiry/closed timestamps, and no raw bearer
 v4 SHALL also add append-only `compiled_policy_generations`, immutable catalog
 descriptors, and singleton `active_governance_tuple` carrying exactly policy generation/
 fingerprint, projector version, and catalog generation as the atomic authority described
-by `governance-kernel`. Migration v3→v4 SHALL be monotonic,
+by `governance-kernel`. Its immutable publication-kind registry SHALL contain exactly
+`migration`, `policy`, `catalog`, and `attachment-clone`; the last kind may change only
+the activation-store/logical-vault identity and activation epoch/digest while retaining
+the exact active policy/projector/catalog tuple and predecessor digest. Migration v3→v4 SHALL be monotonic,
 transactional, crash-recoverable, and SHALL conservatively expire legacy unscoped grants
 or arbitrary-handle purpose/session rows that cannot prove exact new bindings. Unknown
 versions above v4 SHALL remain refused. Ordinary token/receipt/policy/session openers

--- a/openspec/changes/harden-governance-for-consolidation/specs/authorization-session-binding/spec.md
+++ b/openspec/changes/harden-governance-for-consolidation/specs/authorization-session-binding/spec.md
@@ -264,7 +264,8 @@ authenticated offline operation. The target SHALL have no external custody files
 registry attachment. One staged random key SHALL deterministically bind fresh target
 cell, logical-vault, keyring, activation-store, and attachment identities across retries.
 Under the target writer/schema/receipt/held-filesystem fences, one exclusive SQLite
-transaction SHALL verify the copied active tuple and immutable publication chain, close
+transaction SHALL verify the copied active tuple, immutable publication chain, and
+unforked receipt evidence/anchor set, close
 all copied sessions and invalidate all session-derived grants/purposes/tokens, replace
 only activation-store/logical-vault identity, preserve copied receipt rows/evidence as
 historical input while replacing the active receipt singleton with a fresh target-derived

--- a/openspec/changes/harden-governance-for-consolidation/specs/authorization-session-binding/spec.md
+++ b/openspec/changes/harden-governance-for-consolidation/specs/authorization-session-binding/spec.md
@@ -266,7 +266,9 @@ cell, logical-vault, keyring, activation-store, and attachment identities across
 Under the target writer/schema/receipt/held-filesystem fences, one exclusive SQLite
 transaction SHALL verify the copied active tuple and immutable publication chain, close
 all copied sessions and invalidate all session-derived grants/purposes/tokens, replace
-only activation-store/logical-vault identity, increment activation epoch, recompute the
+only activation-store/logical-vault identity, preserve copied receipt rows/evidence as
+historical input while replacing the active receipt singleton with a fresh target-derived
+instance, genesis head, and label-HMAC secret, increment activation epoch, recompute the
 activation digest over the unchanged policy/projector/catalog tuple, and append an
 immutable `attachment-clone` tuple publication whose predecessor is the copied active
 digest. Only after commit may target control, serving membership, and the new host-
@@ -358,7 +360,8 @@ and no member or live verifier key may disappear merely because it is silent or 
 - **WHEN** an authenticated owner clones an unattached exact-v4 copy with no target
   external custody files
 - **THEN** one exclusive transaction retains the exact active policy/projector/catalog
-  and immutable history, closes copied session authority, commits a predecessor-bound
+  and immutable history, closes copied session authority, starts a fresh receipt append
+  instance without deleting copied receipt evidence, commits a predecessor-bound
   `attachment-clone` publication with fresh logical-vault/activation-store identity, and
   the target publishes fresh cell/keyring/control/membership/registry custody only after
   that transaction
@@ -367,9 +370,9 @@ and no member or live verifier key may disappear merely because it is silent or 
 
 - **WHEN** clone crashes after inert keyring publication, after the clone transaction, or
   during control/membership/registry publication
-- **THEN** retry completes only the same staged-keyring-derived identity and publication,
-  while contradictory/copied external records or a different target make it remain
-  blocked
+- **THEN** retry completes only the same staged-keyring-derived identity, receipt
+  instance, label secret, and publication, while contradictory/copied external records
+  or a different target make it remain blocked
 
 #### Scenario: Standalone provisioning establishes external identity
 

--- a/openspec/changes/harden-governance-for-consolidation/specs/governance-kernel/spec.md
+++ b/openspec/changes/harden-governance-for-consolidation/specs/governance-kernel/spec.md
@@ -24,7 +24,9 @@ and `attachment-clone`. An authenticated offline clone publication SHALL retain 
 complete active policy/projector/catalog tuple and immutable history, while one exclusive
 transaction changes the activation-store/logical-vault identity, increments the
 activation epoch, recomputes the activation digest, invalidates all copied session-derived
-authority, and appends the predecessor-bound `attachment-clone` row. No other
+authority, preserves copied receipt evidence while atomically starting a fresh target
+receipt instance/genesis head/label secret, and appends the predecessor-bound
+`attachment-clone` row. No other
 publication kind may change logical-vault or activation-store identity.
 
 The protected external cell registry SHALL carry a monotonic `governance_enrolled` flag
@@ -82,8 +84,9 @@ knowledge, including to owner/L6 or through non-Markdown classification.
   one verified exact-v4 copy
 - **THEN** the active policy generation, projector version, catalog generation,
   immutable rows, and namespace remain byte-identical while the new activation identity,
-  epoch/digest, session invalidation, and predecessor-bound `attachment-clone`
-  publication commit atomically
+  epoch/digest, session invalidation, fresh receipt append identity, and predecessor-bound
+  `attachment-clone` publication commit atomically; copied receipt rows remain historical
+  and source/clone cannot append under one shared instance
 
 #### Scenario: Unknown version fails closed
 

--- a/openspec/changes/harden-governance-for-consolidation/specs/governance-kernel/spec.md
+++ b/openspec/changes/harden-governance-for-consolidation/specs/governance-kernel/spec.md
@@ -19,6 +19,13 @@ SHALL retain the exact ordered source-document bytes and source fingerprint from
 its canonical compiled bytes and fingerprint were derived; every catalog generation and
 projection namespace it names SHALL be immutable and independently verifiable.
 Historical generations SHALL be append-only.
+The exact v4 tuple-publication kind registry SHALL be `migration`, `policy`, `catalog`,
+and `attachment-clone`. An authenticated offline clone publication SHALL retain the
+complete active policy/projector/catalog tuple and immutable history, while one exclusive
+transaction changes the activation-store/logical-vault identity, increments the
+activation epoch, recomputes the activation digest, invalidates all copied session-derived
+authority, and appends the predecessor-bound `attachment-clone` row. No other
+publication kind may change logical-vault or activation-store identity.
 
 The protected external cell registry SHALL carry a monotonic `governance_enrolled` flag
 and, after irreversible enrollment, the expected
@@ -68,6 +75,15 @@ knowledge, including to owner/L6 or through non-Markdown classification.
   conflicted, symlinked, or unparsable while the process is stopped or running
 - **THEN** restart and warm-process reads both fail closed; the active tuple remains
   immutable but is not served until owner repair
+
+#### Scenario: Clone identity changes without relabeling policy or catalog
+
+- **WHEN** an authenticated offline clone transaction creates a new logical vault from
+  one verified exact-v4 copy
+- **THEN** the active policy generation, projector version, catalog generation,
+  immutable rows, and namespace remain byte-identical while the new activation identity,
+  epoch/digest, session invalidation, and predecessor-bound `attachment-clone`
+  publication commit atomically
 
 #### Scenario: Unknown version fails closed
 

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -321,7 +321,8 @@ made before both PRs and their combined verification are complete.
   restore uses the same drained/no-in-flight target-bound transfer protocol and
   invalidates every imported session-derived authority before serving. For exact-v4
   clone, prove one staged keyring fixes all fresh target ids across crash/retry, one
-  exclusive transaction preserves the active policy/projector/catalog plus immutable
+  exclusive transaction refuses receipt conflicts and preserves the active
+  policy/projector/catalog plus immutable
   history while committing session invalidation, a fresh receipt instance/genesis
   head/label secret that preserves copied evidence without sharing append identity, and a predecessor-bound
   `attachment-clone` activation publication, and copied or contradictory external

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -322,7 +322,8 @@ made before both PRs and their combined verification are complete.
   invalidates every imported session-derived authority before serving. For exact-v4
   clone, prove one staged keyring fixes all fresh target ids across crash/retry, one
   exclusive transaction preserves the active policy/projector/catalog plus immutable
-  history while committing session invalidation and a predecessor-bound
+  history while committing session invalidation, a fresh receipt instance/genesis
+  head/label secret that preserves copied evidence without sharing append identity, and a predecessor-bound
   `attachment-clone` activation publication, and copied or contradictory external
   custody files remain BLOCKED.
 - [x] 5.4 Add red lifecycle tests for exact typed `issued_credential` open/rotate,
@@ -362,7 +363,9 @@ made before both PRs and their combined verification are complete.
   before first migration. Freeze the tuple-publication kind registry as exactly
   `migration|policy|catalog|attachment-clone`; only the clone kind may atomically change
   logical-vault/activation-store identity while retaining the exact active
-  policy/projector/catalog tuple and predecessor chain.
+  policy/projector/catalog tuple and predecessor chain. Its transaction also preserves
+  old receipt rows/evidence but changes the active receipt append instance and label
+  secret to fresh target-derived values.
 - [ ] 5.11 Implement strict external keyring/control loading, authenticated owner/hosted
   provisioning, host/control-plane registry attachment with monotonic enrollment and
   activation-store tuple parity, copy collision, exclusive move/restore/clone rules, and
@@ -371,7 +374,8 @@ made before both PRs and their combined verification are complete.
   Implement exact-v4 clone with an inert staged keyring, stable derived target ids, the
   exclusive `attachment-clone` store transition, and control/membership/registry
   publication only after that commit; every partial or conflicting state stays BLOCKED
-  and recovery never rotates the staged identity or modifies the source registry.
+  and recovery never rotates the staged identity/receipt instance or modifies the source
+  registry.
 - [ ] 5.12 Integrate the serving-membership epoch with the existing deployment control
   plane/readiness surface: provisioner/cell control owns the Hosted record,
   `hosted_runtime.control_plane_readiness()` verifies/exposes content-free readiness, and
@@ -396,7 +400,7 @@ made before both PRs and their combined verification are complete.
   hosted, and both supported OS custody paths. Include restore-session invalidation and
   clone crash barriers after staged keyring, exclusive store publication, control,
   membership, and registry publication; prove retry keeps one identity and source and
-  clone serve independently only after distinct registry attachment.
+  clone serve independently only after distinct registry and receipt-instance attachment.
 
 ## 6. Real MCP REST Hosted And CLI Principal Binding
 

--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -317,7 +317,14 @@ made before both PRs and their combined verification are complete.
   and stopped/warm deletion/corruption/mismatch BLOCKED. Cover concurrent
   vault+sidecar+keyring/control copies, copied external files without registry ownership,
   exact offline restore, clone with new ids, and detach-ack/attachment-epoch move; no
-  colliding pair may serve simultaneously or synthesize identity.
+  colliding pair may serve simultaneously or synthesize identity. For version 1, prove
+  restore uses the same drained/no-in-flight target-bound transfer protocol and
+  invalidates every imported session-derived authority before serving. For exact-v4
+  clone, prove one staged keyring fixes all fresh target ids across crash/retry, one
+  exclusive transaction preserves the active policy/projector/catalog plus immutable
+  history while committing session invalidation and a predecessor-bound
+  `attachment-clone` activation publication, and copied or contradictory external
+  custody files remain BLOCKED.
 - [x] 5.4 Add red lifecycle tests for exact typed `issued_credential` open/rotate,
   status, close, replay of the old bearer, restart/resume, and two v4 processes/replicas.
   Add malformed/extra-copy/raised issuance tests proving the terminal scrubber exception
@@ -352,11 +359,19 @@ made before both PRs and their combined verification are complete.
   cell/logical-vault/keyring ids, status, and lifecycle timestamps only, plus the shared
   immutable policy/catalog and active-tuple schema. Conservatively expire v3 arbitrary-handle/
   unscoped authority and add the explicit offline downmigration tool; drain v3 replicas
-  before first migration.
+  before first migration. Freeze the tuple-publication kind registry as exactly
+  `migration|policy|catalog|attachment-clone`; only the clone kind may atomically change
+  logical-vault/activation-store identity while retaining the exact active
+  policy/projector/catalog tuple and predecessor chain.
 - [ ] 5.11 Implement strict external keyring/control loading, authenticated owner/hosted
   provisioning, host/control-plane registry attachment with monotonic enrollment and
   activation-store tuple parity, copy collision, exclusive move/restore/clone rules, and
-  no automatic key/cell identity or OPEN inference.
+  no automatic key/cell identity or OPEN inference. Implement version-1 restore as the
+  conservative transfer protocol with unconditional imported-session invalidation.
+  Implement exact-v4 clone with an inert staged keyring, stable derived target ids, the
+  exclusive `attachment-clone` store transition, and control/membership/registry
+  publication only after that commit; every partial or conflicting state stays BLOCKED
+  and recovery never rotates the staged identity or modifies the source registry.
 - [ ] 5.12 Integrate the serving-membership epoch with the existing deployment control
   plane/readiness surface: provisioner/cell control owns the Hosted record,
   `hosted_runtime.control_plane_readiness()` verifies/exposes content-free readiness, and
@@ -378,7 +393,10 @@ made before both PRs and their combined verification are complete.
 - [ ] 5.17 Run session, keyring/control/registry, membership epoch, migration/downmigration,
   actual old-binary probe/fence, token, store, governance-tool, receipt, and crash-
   recovery suites and preserve exact red-before-green commands/results for standalone,
-  hosted, and both supported OS custody paths.
+  hosted, and both supported OS custody paths. Include restore-session invalidation and
+  clone crash barriers after staged keyring, exclusive store publication, control,
+  membership, and registry publication; prove retry keeps one identity and source and
+  clone serve independently only after distinct registry attachment.
 
 ## 6. Real MCP REST Hosted And CLI Principal Binding
 


### PR DESCRIPTION
## Summary

- define version-one offline restore as the existing drained, target-bound transfer protocol with conservative session-authority invalidation
- define exact-v4 clone as a new activation identity committed through an immutable predecessor-bound `attachment-clone` publication
- make staged identity, crash recovery, external custody ordering, and source/clone independence normative and red-first

Stacked after #889. This changes OpenSpec artifacts only and does not touch any live vault.

## Verification

- `openspec validate harden-governance-for-consolidation --strict`
- `python3 scripts/validate-public-artifacts.py --repository`
- `UV_CACHE_DIR=/tmp/exomem-governance-restore-uv uv lock --check`
- `git diff --check`
