### PR TITLE
feat(governance): clone standalone attachment custody

### DIFF
--- a/src/exomem/governance/authorization_custody.py
+++ b/src/exomem/governance/authorization_custody.py
@@ -74,6 +74,7 @@ _ATTACHMENT_DOMAIN = b"exomem.authorization-session.attachment/v1"
 _DETACH_ACK_MAC_DOMAIN = b"exomem.authorization-session.detach-ack/v1"
 _HOST_REGISTRY_MAC_DOMAIN = b"exomem.authorization-session.host-registry/v1"
 _STANDALONE_STAGING_DOMAIN = b"exomem.authorization-session.standalone-staging/v1"
+_STANDALONE_CLONE_RECEIPT_DOMAIN = b"exomem.authorization-session.standalone-clone-receipt/v1"
 _SHA256_HEX = re.compile(r"[0-9a-f]{64}\Z")
 _STANDALONE_ATTACHMENT = re.compile(r"attachment-v1-[0-9a-f]{64}\Z")
 _DEFAULT_KEY_TTL_SECONDS = 366 * 24 * 60 * 60
@@ -3251,6 +3252,226 @@ def complete_standalone_attachment_transfer(
                 acknowledgement=acknowledgement,
                 now=now,
             )
+
+
+def _clone_publication_barrier(point: str) -> None:
+    """Crash-injection seam between durable exact-v4 clone effects."""
+
+    del point
+
+
+def _optional_custody_file(path: Path) -> _LoadedCustodyFile | None:
+    try:
+        return _load_file(path)
+    except AuthorizationCustodyUnavailable:
+        if os.path.lexists(path):
+            raise
+        return None
+
+
+def _clone_publication_event_id(
+    keyring: AuthorizationKeyring,
+    *,
+    attachment_id: str,
+) -> str:
+    return _standalone_staging_identifier(
+        "attachment-clone",
+        attachment_id=attachment_id,
+        key=keyring.active_key.key,
+    )
+
+
+def _clone_receipt_identity(
+    keyring: AuthorizationKeyring,
+    *,
+    attachment_id: str,
+) -> tuple[str, bytes]:
+    material = _framed(
+        _STANDALONE_CLONE_RECEIPT_DOMAIN,
+        (attachment_id.encode("ascii"),),
+    )
+    instance_id = hmac.new(
+        keyring.active_key.key,
+        material + b"\0instance",
+        hashlib.sha256,
+    ).hexdigest()[:32]
+    label_secret = hmac.new(
+        keyring.active_key.key,
+        material + b"\0label-hmac",
+        hashlib.sha256,
+    ).digest()
+    return instance_id, label_secret
+
+
+def _clone_standalone_exact_v4_custody(
+    vault_root: Path,
+    *,
+    now: int,
+) -> AuthorizationCustody:
+    root = Path(vault_root)
+    current_time = _bounded_time(now)
+    if current_time > _MAX_SIGNED_SQLITE_INTEGER - _DEFAULT_KEY_TTL_SECONDS:
+        raise AuthorizationCustodyUnavailable
+    attachment_id = standalone_attachment_id(root)
+    keyring_path = _configured_external_path(KEYRING_FILE_ENV, root)
+    control_path = _configured_external_path(CONTROL_FILE_ENV, root)
+    membership_path = _configured_external_path(MEMBERSHIP_FILE_ENV, root)
+    replica_id = _bounded_identifier(os.environ.get(REPLICA_ID_ENV, ""))
+    if len({keyring_path, control_path, membership_path}) != 3:
+        raise AuthorizationCustodyUnavailable
+
+    keyring_loaded = _optional_custody_file(keyring_path)
+    control_loaded = _optional_custody_file(control_path)
+    membership_loaded = _optional_custody_file(membership_path)
+    if (
+        (control_loaded is not None and keyring_loaded is None)
+        or (membership_loaded is not None and control_loaded is None)
+    ):
+        raise AuthorizationCustodyUnavailable
+
+    from . import schema_v4, store
+
+    if keyring_loaded is None:
+        try:
+            preflight = store.open_authorization_session_connection(root)
+            try:
+                schema_v4.require_exact_v4_connection(preflight)
+            finally:
+                preflight.close()
+        except (
+            OSError,
+            RuntimeError,
+            schema_v4.SchemaV4Error,
+            store.UnsupportedGovernanceSchema,
+        ):
+            raise AuthorizationCustodyUnavailable from None
+        keyring = _new_standalone_staging_keyring(
+            attachment_id=attachment_id,
+            current_time=current_time,
+        )
+        _publish_private_file(keyring_path, _keyring_bytes(keyring))
+    else:
+        keyring = parse_keyring(keyring_loaded.data)
+    _verify_standalone_staging_keyring(keyring, attachment_id=attachment_id)
+    if not keyring.active_key.not_before <= current_time < keyring.active_key.not_after:
+        raise AuthorizationCustodyUnavailable
+    _clone_publication_barrier("after-staged-keyring")
+
+    activation_store_id = _standalone_staging_identifier(
+        "activation-store",
+        attachment_id=attachment_id,
+        key=keyring.active_key.key,
+    )
+    receipt_instance_id, receipt_label_secret = _clone_receipt_identity(
+        keyring,
+        attachment_id=attachment_id,
+    )
+    try:
+        connection = store.open_authorization_session_connection(root)
+        try:
+            active = schema_v4.clone_attachment_identity(
+                connection,
+                logical_vault_id=keyring.logical_vault_id,
+                activation_store_id=activation_store_id,
+                publication_event_id=_clone_publication_event_id(
+                    keyring,
+                    attachment_id=attachment_id,
+                ),
+                receipt_instance_id=receipt_instance_id,
+                receipt_label_secret=receipt_label_secret,
+                activated_at=keyring.active_key.not_before,
+            )
+        finally:
+            connection.close()
+    except (
+        OSError,
+        RuntimeError,
+        schema_v4.SchemaV4Error,
+        store.UnsupportedGovernanceSchema,
+    ):
+        raise AuthorizationCustodyUnavailable from None
+    _clone_publication_barrier("after-clone-transaction")
+
+    provisional_control = AuthorizationControlRecord(
+        version=1,
+        keyring_id=keyring.keyring_id,
+        cell_id=keyring.cell_id,
+        logical_vault_id=keyring.logical_vault_id,
+        registry_attachment_id=attachment_id,
+        attachment_epoch=1,
+        governance_enrolled=True,
+        activation_store_id=active.activation_store_id,
+        activation_epoch=active.activation_epoch,
+        activation_state_digest=active.activation_state_digest,
+        serving_membership_epoch=1,
+        serving_membership_digest="0" * 64,
+        issued_at=keyring.active_key.not_before,
+        expires_at=keyring.active_key.not_after,
+        signing_key_id=keyring.active_key_id,
+    )
+    encoded_membership = _standalone_membership_bytes(
+        keyring=keyring,
+        control=provisional_control,
+        replica_id=replica_id,
+    )
+    control = replace(
+        provisional_control,
+        serving_membership_digest=(
+            authorization_serving_membership.serving_membership_digest(
+                encoded_membership
+            )
+        ),
+    )
+    encoded_control = _signed_control_bytes(
+        control,
+        signing_key=keyring.active_key.key,
+    )
+    if control_loaded is None:
+        _publish_private_file(control_path, encoded_control)
+    elif not hmac.compare_digest(control_loaded.data, encoded_control):
+        raise AuthorizationCustodyUnavailable
+    _clone_publication_barrier("after-control")
+    if membership_loaded is None:
+        _publish_private_file(membership_path, encoded_membership)
+    elif not hmac.compare_digest(membership_loaded.data, encoded_membership):
+        raise AuthorizationCustodyUnavailable
+    _clone_publication_barrier("after-membership")
+    _publish_initial_host_registry(control, now=current_time)
+    _clone_publication_barrier("after-registry")
+
+    verified = load_authorization_custody(root, now=current_time)
+    if verified.control != control or verified.serving_membership is None:
+        raise AuthorizationCustodyUnavailable
+    return verified
+
+
+def clone_standalone_exact_v4_custody(
+    vault_root: Path,
+    *,
+    now: int,
+) -> AuthorizationCustody:
+    """Give an unattached exact-v4 copy one fresh standalone identity."""
+
+    root = Path(vault_root)
+    from .. import reserved_paths, writer_lease
+    from . import receipts
+
+    with writer_lease.get_manager().mutation_guard(
+        root,
+        operation="authorization-attachment-clone",
+        holder_kind="authorization-attachment-control",
+        attachment_control=True,
+        attachment_now=now,
+    ):
+        with receipts._receipt_lock(root):  # noqa: SLF001
+            try:
+                receipt_report = receipts.verify_chain(root)
+            except (OSError, RuntimeError, TypeError, ValueError):
+                raise AuthorizationCustodyUnavailable from None
+            if receipt_report.get("valid") is not True:
+                raise AuthorizationCustodyUnavailable
+            with reserved_paths._identity_coordination_scope(root):
+                return _clone_standalone_exact_v4_custody(root, now=now)
 
 
 def provision_standalone_custody(

--- a/src/exomem/governance/schema_v4.py
+++ b/src/exomem/governance/schema_v4.py
@@ -818,7 +818,7 @@ def _create_v4_schema(connection: sqlite3.Connection) -> None:
     connection.execute(
         "CREATE TABLE governance_tuple_publications ("
         "event_id TEXT PRIMARY KEY, publication_kind TEXT NOT NULL "
-        "CHECK(publication_kind IN ('migration','policy','catalog')), "
+        "CHECK(publication_kind IN ('migration','policy','catalog','attachment-clone')), "
         "predecessor_activation_state_digest TEXT, "
         "target_activation_state_digest TEXT NOT NULL UNIQUE "
         "CHECK(length(target_activation_state_digest)=64), "
@@ -1390,6 +1390,52 @@ def _close_downmigration_authority(
     return sessions, grants, purposes, tokens, proposals
 
 
+def _invalidate_attachment_session_authority_rows(
+    connection: sqlite3.Connection,
+    *,
+    invalidated_at: int,
+) -> tuple[int, int, int, int]:
+    moment = _integer(invalidated_at, "invalidated_at")
+    sessions = int(
+        connection.execute(
+            "UPDATE governance_authorization_sessions "
+            "SET status='closed', closed_at=? WHERE status='active'",
+            (moment,),
+        ).rowcount
+        or 0
+    )
+    grants = int(
+        connection.execute(
+            "UPDATE governance_session_grants SET status='revoked', "
+            "prepared_event_id=NULL, revoked_at=? WHERE status<>'revoked'",
+            (moment,),
+        ).rowcount
+        or 0
+    )
+    purposes = int(
+        connection.execute(
+            "UPDATE governance_session_purpose SET status='revoked', "
+            "prepared_event_id=NULL WHERE status<>'revoked'"
+        ).rowcount
+        or 0
+    )
+    purposes += int(
+        connection.execute(
+            "DELETE FROM governance_session_purpose_staging"
+        ).rowcount
+        or 0
+    )
+    tokens = int(
+        connection.execute(
+            "UPDATE withhold_tokens SET status='expired', prepared_event_id=NULL, "
+            "consumed_at=COALESCE(consumed_at, ?) WHERE status<>'expired'",
+            (moment,),
+        ).rowcount
+        or 0
+    )
+    return sessions, grants, purposes, tokens
+
+
 def invalidate_attachment_session_authority(
     connection: sqlite3.Connection,
     *,
@@ -1410,51 +1456,223 @@ def invalidate_attachment_session_authority(
     require_exact_v4_connection(connection)
     try:
         connection.execute("BEGIN IMMEDIATE")
-        sessions = int(
-            connection.execute(
-                "UPDATE governance_authorization_sessions "
-                "SET status='closed', closed_at=? WHERE status='active'",
-                (moment,),
-            ).rowcount
-            or 0
-        )
-        grants = int(
-            connection.execute(
-                "UPDATE governance_session_grants SET status='revoked', "
-                "prepared_event_id=NULL, revoked_at=? WHERE status<>'revoked'",
-                (moment,),
-            ).rowcount
-            or 0
-        )
-        purposes = int(
-            connection.execute(
-                "UPDATE governance_session_purpose SET status='revoked', "
-                "prepared_event_id=NULL WHERE status<>'revoked'"
-            ).rowcount
-            or 0
-        )
-        purposes += int(
-            connection.execute(
-                "DELETE FROM governance_session_purpose_staging"
-            ).rowcount
-            or 0
-        )
-        tokens = int(
-            connection.execute(
-                "UPDATE withhold_tokens SET status='expired', prepared_event_id=NULL, "
-                "consumed_at=COALESCE(consumed_at, ?) WHERE status<>'expired'",
-                (moment,),
-            ).rowcount
-            or 0
+        result = _invalidate_attachment_session_authority_rows(
+            connection,
+            invalidated_at=moment,
         )
         connection.commit()
-        return sessions, grants, purposes, tokens
+        return result
     except (sqlite3.Error, SchemaV4Error):
         connection.rollback()
         raise SchemaV4Error("attachment session invalidation failed") from None
     except BaseException:
         connection.rollback()
         raise
+
+
+def clone_attachment_identity(
+    connection: sqlite3.Connection,
+    *,
+    logical_vault_id: str,
+    activation_store_id: str,
+    publication_event_id: str,
+    receipt_instance_id: str,
+    receipt_label_secret: bytes,
+    activated_at: int,
+) -> VerifiedActiveGovernanceState:
+    """Commit one fresh activation identity for an unattached exact-v4 copy.
+
+    The policy, projector, catalog, namespace, and immutable publication history
+    remain unchanged. Copied session-derived authority is closed in the same
+    exclusive transaction that advances the activation identity.
+    """
+
+    target_vault = _text(logical_vault_id, "logical_vault_id")
+    target_store = _text(activation_store_id, "activation_store_id")
+    event_id = _text(publication_event_id, "publication_event_id")
+    target_receipt_instance = _text(
+        receipt_instance_id,
+        "receipt_instance_id",
+        maximum=32,
+    )
+    if len(target_receipt_instance) != 32 or any(
+        character not in _HEX_DIGITS for character in target_receipt_instance
+    ):
+        raise SchemaV4Error("receipt_instance_id must be lowercase hex")
+    if not isinstance(receipt_label_secret, bytes) or len(receipt_label_secret) != 32:
+        raise SchemaV4Error("receipt label secret must be 32 bytes")
+    target_receipt_secret = bytes(receipt_label_secret)
+    activated = _integer(activated_at, "activated_at")
+    if connection.in_transaction:
+        raise SchemaV4Error("attachment clone requires an idle connection")
+    require_exact_v4_connection(connection)
+    pointer = load_active_tuple_pointer(connection)
+    current = load_active_state(
+        connection,
+        expected_logical_vault_id=pointer.logical_vault_id,
+        expected_activation_store_id=pointer.activation_store_id,
+        expected_activation_epoch=pointer.activation_epoch,
+        expected_activation_state_digest=pointer.activation_state_digest,
+    )
+    if (
+        current.logical_vault_id == target_vault
+        and current.activation_store_id == target_store
+    ):
+        publication = connection.execute(
+            "SELECT event_id, publication_kind FROM governance_tuple_publications "
+            "WHERE target_activation_state_digest=?",
+            (current.activation_state_digest,),
+        ).fetchone()
+        if publication != (event_id, "attachment-clone"):
+            raise ActiveTupleStale("clone activation identity is already claimed")
+        receipt_instance = connection.execute(
+            "SELECT instance_id FROM receipt_instance WHERE singleton=1"
+        ).fetchone()
+        receipt_secret = connection.execute(
+            "SELECT value FROM receipt_secrets WHERE name='label_hmac'"
+        ).fetchone()
+        if receipt_instance != (target_receipt_instance,) or receipt_secret != (
+            target_receipt_secret,
+        ):
+            raise ActiveTupleStale("clone receipt identity is unavailable")
+        return current
+    if (
+        current.logical_vault_id == target_vault
+        or current.activation_store_id == target_store
+    ):
+        raise ActiveTupleStale("clone activation identity is only partially fresh")
+
+    material = _publication_result(connection, current)
+    target_epoch = _integer(
+        current.activation_epoch + 1,
+        "target_activation_epoch",
+    )
+    target_digest = activation_state_digest(
+        logical_vault_id=target_vault,
+        activation_store_id=target_store,
+        activation_epoch=target_epoch,
+        policy_generation_id=current.policy_generation_id,
+        policy_fingerprint=current.policy_fingerprint,
+        policy_row_digest=material.policy_row_digest,
+        projector_schema_version=current.projector_schema_version,
+        catalog_generation=current.catalog_generation,
+        catalog_descriptor_digest=material.catalog_descriptor_digest,
+        projection_namespace_identity=material.projection_namespace_digest,
+    )
+
+    try:
+        connection.execute("BEGIN EXCLUSIVE")
+        reviewed = load_active_state(
+            connection,
+            expected_logical_vault_id=current.logical_vault_id,
+            expected_activation_store_id=current.activation_store_id,
+            expected_activation_epoch=current.activation_epoch,
+            expected_activation_state_digest=current.activation_state_digest,
+        )
+        if reviewed != current:
+            raise ActiveTupleStale("copied activation tuple changed during clone")
+        _invalidate_attachment_session_authority_rows(
+            connection,
+            invalidated_at=activated,
+        )
+        receipt_instance = connection.execute(
+            "SELECT instance_id FROM receipt_instance WHERE singleton=1"
+        ).fetchone()
+        if receipt_instance is not None:
+            source_receipt_instance = _text(
+                receipt_instance[0],
+                "source_receipt_instance_id",
+                maximum=32,
+            )
+            if (
+                len(source_receipt_instance) != 32
+                or any(
+                    character not in _HEX_DIGITS
+                    for character in source_receipt_instance
+                )
+                or hmac.compare_digest(
+                    source_receipt_instance,
+                    target_receipt_instance,
+                )
+            ):
+                raise SchemaV4Error("copied receipt identity is invalid")
+            connection.execute(
+                "UPDATE receipt_instance SET instance_id=? WHERE singleton=1",
+                (target_receipt_instance,),
+            )
+        else:
+            connection.execute(
+                "INSERT INTO receipt_instance(singleton, instance_id) VALUES (1, ?)",
+                (target_receipt_instance,),
+            )
+        existing_target_head = connection.execute(
+            "SELECT 1 FROM receipts_head WHERE instance_id=?",
+            (target_receipt_instance,),
+        ).fetchone()
+        if existing_target_head is not None:
+            raise SchemaV4Error("clone receipt head already exists")
+        connection.execute(
+            "INSERT INTO receipts_head "
+            "(instance_id, durable_seq, durable_hash, observed_seq, observed_hash, "
+            "path, byte_offset) VALUES (?, 0, ?, 0, ?, '', 0)",
+            (target_receipt_instance, "0" * 64, "0" * 64),
+        )
+        connection.execute(
+            "INSERT INTO receipt_secrets(name, value) VALUES ('label_hmac', ?) "
+            "ON CONFLICT(name) DO UPDATE SET value=excluded.value",
+            (target_receipt_secret,),
+        )
+        updated = connection.execute(
+            "UPDATE governance_activation_store SET activation_store_id=?, "
+            "logical_vault_id=?, activation_epoch=?, activation_state_digest=? "
+            "WHERE singleton=1 AND activation_store_id=? AND logical_vault_id=? "
+            "AND activation_epoch=? AND activation_state_digest=?",
+            (
+                target_store,
+                target_vault,
+                target_epoch,
+                target_digest,
+                current.activation_store_id,
+                current.logical_vault_id,
+                current.activation_epoch,
+                current.activation_state_digest,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise ActiveTupleStale("copied activation tuple changed during clone")
+        connection.execute(
+            "INSERT INTO governance_tuple_publications "
+            "(event_id, publication_kind, predecessor_activation_state_digest, "
+            "target_activation_state_digest, policy_generation_id, policy_fingerprint, "
+            "projector_schema_version, catalog_generation, activation_epoch, status, "
+            "activated_at) VALUES (?, 'attachment-clone', ?, ?, ?, ?, ?, ?, ?, "
+            "'committed', ?)",
+            (
+                event_id,
+                current.activation_state_digest,
+                target_digest,
+                current.policy_generation_id,
+                current.policy_fingerprint,
+                current.projector_schema_version,
+                current.catalog_generation,
+                target_epoch,
+                activated,
+            ),
+        )
+        _crash_point("attachment-clone-before-commit")
+        connection.commit()
+    except BaseException:
+        connection.rollback()
+        raise
+
+    _crash_point("attachment-clone-after-commit")
+    return load_active_state(
+        connection,
+        expected_logical_vault_id=target_vault,
+        expected_activation_store_id=target_store,
+        expected_activation_epoch=target_epoch,
+        expected_activation_state_digest=target_digest,
+    )
 
 
 def _downmigration_terminal(
@@ -1878,7 +2096,12 @@ def load_active_state(
         publication = tuple(publication_rows[0])
         publication_event_id = _text(publication[0], "publication.event_id")
         publication_kind = _text(publication[1], "publication.publication_kind")
-        if publication_kind not in {"migration", "policy", "catalog"}:
+        if publication_kind not in {
+            "migration",
+            "policy",
+            "catalog",
+            "attachment-clone",
+        }:
             raise SchemaV4Error("active tuple publication kind is invalid")
         predecessor_digest = publication[2]
         if publication_kind == "migration":
@@ -1896,6 +2119,24 @@ def load_active_state(
             ).fetchone()
             if predecessor_rows != (1,):
                 raise SchemaV4Error("active tuple publication predecessor is unavailable")
+            if publication_kind == "attachment-clone":
+                predecessor_tuple = connection.execute(
+                    "SELECT policy_generation_id, policy_fingerprint, "
+                    "projector_schema_version, catalog_generation, activation_epoch "
+                    "FROM governance_tuple_publications "
+                    "WHERE target_activation_state_digest=?",
+                    (predecessor,),
+                ).fetchone()
+                if predecessor_tuple != (
+                    generation_id,
+                    policy_fingerprint,
+                    projector_schema_version,
+                    catalog_generation,
+                    activation_epoch - 1,
+                ):
+                    raise SchemaV4Error(
+                        "attachment clone changed the active policy or catalog tuple"
+                    )
         if (
             (
                 publication_kind in {"migration", "policy"}

--- a/tests/test_authorization_standalone_provisioning.py
+++ b/tests/test_authorization_standalone_provisioning.py
@@ -18,6 +18,7 @@ from exomem.governance import (
     authorization_custody,
     authorization_session_lifecycle,
     policy,
+    receipts,
     schema_v4,
     store,
 )
@@ -67,6 +68,20 @@ def _vault(tmp_path: Path, name: str = "vault") -> Path:
     vault = tmp_path / name
     (vault / "Knowledge Base").mkdir(parents=True)
     return vault
+
+
+def _select_custody_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    root: Path,
+) -> tuple[Path, Path, Path]:
+    root.mkdir(mode=0o700)
+    keyring = root / "authorization-keyring.json"
+    control = root / "authorization-control.json"
+    membership = root / "authorization-serving-membership.json"
+    monkeypatch.setenv(authorization_custody.KEYRING_FILE_ENV, str(keyring))
+    monkeypatch.setenv(authorization_custody.CONTROL_FILE_ENV, str(control))
+    monkeypatch.setenv(authorization_custody.MEMBERSHIP_FILE_ENV, str(membership))
+    return keyring, control, membership
 
 
 def test_host_control_root_ignores_portable_runtime_path_environment(
@@ -1397,6 +1412,387 @@ def test_attachment_transfer_replay_preserves_new_target_session(
         connection.close()
 
     assert resumed.session_id == issued.context.session_id
+
+
+def test_exact_v4_clone_gets_fresh_activation_identity_and_closes_copied_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _vault(tmp_path)
+    target = tmp_path / "cloned-vault"
+    now = 1_800_000_000
+    source_paths = tuple(
+        Path(os.environ[name])
+        for name in (
+            authorization_custody.KEYRING_FILE_ENV,
+            authorization_custody.CONTROL_FILE_ENV,
+            authorization_custody.MEMBERSHIP_FILE_ENV,
+        )
+    )
+    source_custody, source_active = _enrolled_v4(source, now=now)
+    receipt_intent = receipts.begin_event(
+        source,
+        operation="clone-source-fixture",
+        prior="a" * 64,
+        target="b" * 64,
+    )
+    receipts.commit_event(source, str(receipt_intent["event_id"]))
+    receipts.label_digest(source, "source-receipt-label")
+    source_connection = store.open_authorization_session_connection(source)
+    try:
+        issued = authorization_session_lifecycle.open_session(
+            source_connection,
+            custody=source_custody,
+            principal_id="principal-owner",
+            issuer_family="cli",
+            now=now + 3,
+            ttl_seconds=120,
+        )
+        source_receipt_instance = str(
+            source_connection.execute(
+                "SELECT instance_id FROM receipt_instance WHERE singleton=1"
+            ).fetchone()[0]
+        )
+        source_receipt_secret = bytes(
+            source_connection.execute(
+                "SELECT value FROM receipt_secrets WHERE name='label_hmac'"
+            ).fetchone()[0]
+        )
+    finally:
+        source_connection.close()
+    shutil.copytree(source, target)
+    target_paths = _select_custody_paths(monkeypatch, tmp_path / "clone-external")
+
+    cloned = authorization_custody.clone_standalone_exact_v4_custody(
+        target,
+        now=now + 4,
+    )
+
+    assert cloned.control.governance_enrolled is True
+    assert cloned.control.cell_id != source_custody.control.cell_id
+    assert cloned.control.logical_vault_id != source_custody.control.logical_vault_id
+    assert cloned.control.keyring_id != source_custody.control.keyring_id
+    assert cloned.control.activation_store_id != source_active.activation_store_id
+    assert cloned.control.activation_epoch == source_active.activation_epoch + 1
+    assert cloned.control.registry_attachment_id == (
+        authorization_custody.standalone_attachment_id(target)
+    )
+    assert all(path.exists() for path in target_paths)
+
+    target_connection = store.open_authorization_session_connection(target)
+    try:
+        cloned_active = schema_v4.load_active_state(
+            target_connection,
+            expected_logical_vault_id=cloned.control.logical_vault_id,
+            expected_activation_store_id=str(cloned.control.activation_store_id),
+            expected_activation_epoch=int(cloned.control.activation_epoch or 0),
+            expected_activation_state_digest=str(
+                cloned.control.activation_state_digest
+            ),
+        )
+        publication = target_connection.execute(
+            "SELECT publication_kind, predecessor_activation_state_digest "
+            "FROM governance_tuple_publications "
+            "WHERE target_activation_state_digest=?",
+            (cloned_active.activation_state_digest,),
+        ).fetchone()
+        assert publication == ("attachment-clone", source_active.activation_state_digest)
+        target_receipt_instance = str(
+            target_connection.execute(
+                "SELECT instance_id FROM receipt_instance WHERE singleton=1"
+            ).fetchone()[0]
+        )
+        target_receipt_secret = bytes(
+            target_connection.execute(
+                "SELECT value FROM receipt_secrets WHERE name='label_hmac'"
+            ).fetchone()[0]
+        )
+        assert target_receipt_instance != source_receipt_instance
+        assert target_receipt_secret != source_receipt_secret
+        assert target_connection.execute(
+            "SELECT durable_seq, durable_hash, observed_seq, observed_hash, path, "
+            "byte_offset FROM receipts_head WHERE instance_id=?",
+            (target_receipt_instance,),
+        ).fetchone() == (0, "0" * 64, 0, "0" * 64, "", 0)
+        assert target_connection.execute(
+            "SELECT COUNT(*) FROM receipts_head WHERE instance_id=?",
+            (source_receipt_instance,),
+        ).fetchone() == (1,)
+        assert (
+            cloned_active.policy_generation_id,
+            cloned_active.policy_fingerprint,
+            cloned_active.projector_schema_version,
+            cloned_active.catalog_generation,
+            cloned_active.projection_namespace_id,
+        ) == (
+            source_active.policy_generation_id,
+            source_active.policy_fingerprint,
+            source_active.projector_schema_version,
+            source_active.catalog_generation,
+            source_active.projection_namespace_id,
+        )
+        assert target_connection.execute(
+            "SELECT status FROM governance_authorization_sessions WHERE session_id=?",
+            (issued.context.session_id,),
+        ).fetchone() == ("closed",)
+        with pytest.raises(
+            authorization_session_lifecycle.AuthorizationSessionUnavailable
+        ):
+            authorization_session_lifecycle.resume_session(
+                target_connection,
+                custody=cloned,
+                bearer=issued.bearer,
+                principal_id="principal-owner",
+                issuer_family="cli",
+                now=now + 5,
+            )
+    finally:
+        target_connection.close()
+
+    for name, path in zip(
+        (
+            authorization_custody.KEYRING_FILE_ENV,
+            authorization_custody.CONTROL_FILE_ENV,
+            authorization_custody.MEMBERSHIP_FILE_ENV,
+        ),
+        source_paths,
+        strict=True,
+    ):
+        monkeypatch.setenv(name, str(path))
+    assert authorization_custody.load_authorization_custody(
+        source,
+        now=now + 5,
+    ).control == source_custody.control
+
+
+@pytest.mark.parametrize(
+    "crash_point",
+    [
+        "after-staged-keyring",
+        "after-clone-transaction",
+        "after-control",
+        "after-membership",
+        "after-registry",
+    ],
+)
+def test_exact_v4_clone_retry_keeps_one_staged_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    crash_point: str,
+) -> None:
+    source = _vault(tmp_path)
+    target = tmp_path / "cloned-vault"
+    now = 1_800_000_000
+    _enrolled_v4(source, now=now)
+    shutil.copytree(source, target)
+    keyring_path, _control_path, _membership_path = _select_custody_paths(
+        monkeypatch,
+        tmp_path / "clone-external",
+    )
+    original = authorization_custody._clone_publication_barrier
+    raised = False
+
+    def crash(point: str) -> None:
+        nonlocal raised
+        if point == crash_point and not raised:
+            raised = True
+            raise RuntimeError("simulated clone crash")
+
+    monkeypatch.setattr(authorization_custody, "_clone_publication_barrier", crash)
+    with pytest.raises(RuntimeError, match="simulated clone crash"):
+        authorization_custody.clone_standalone_exact_v4_custody(
+            target,
+            now=now + 3,
+        )
+    staged = keyring_path.read_bytes()
+    staged_identity = authorization_custody.parse_keyring(staged)
+
+    monkeypatch.setattr(
+        authorization_custody,
+        "_clone_publication_barrier",
+        original,
+    )
+    recovered = authorization_custody.clone_standalone_exact_v4_custody(
+        target,
+        now=now + 4,
+    )
+    replay = authorization_custody.clone_standalone_exact_v4_custody(
+        target,
+        now=now + 5,
+    )
+
+    assert keyring_path.read_bytes() == staged
+    assert recovered.control == replay.control
+    assert recovered.control.cell_id == staged_identity.cell_id
+    assert recovered.control.logical_vault_id == staged_identity.logical_vault_id
+    assert recovered.control.keyring_id == staged_identity.keyring_id
+
+
+def test_exact_v4_clone_rolls_back_identity_session_and_receipt_together(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _vault(tmp_path)
+    target = tmp_path / "cloned-vault"
+    now = 1_800_000_000
+    source_custody, source_active = _enrolled_v4(source, now=now)
+    receipt_intent = receipts.begin_event(
+        source,
+        operation="clone-rollback-fixture",
+        prior="a" * 64,
+        target="b" * 64,
+    )
+    receipts.commit_event(source, str(receipt_intent["event_id"]))
+    source_connection = store.open_authorization_session_connection(source)
+    try:
+        issued = authorization_session_lifecycle.open_session(
+            source_connection,
+            custody=source_custody,
+            principal_id="principal-owner",
+            issuer_family="cli",
+            now=now + 3,
+            ttl_seconds=120,
+        )
+        source_receipt_instance = str(
+            source_connection.execute(
+                "SELECT instance_id FROM receipt_instance WHERE singleton=1"
+            ).fetchone()[0]
+        )
+    finally:
+        source_connection.close()
+    shutil.copytree(source, target)
+    _select_custody_paths(monkeypatch, tmp_path / "clone-external")
+    original = schema_v4._crash_point
+
+    def crash(point: str) -> None:
+        if point == "attachment-clone-before-commit":
+            raise RuntimeError("simulated transaction crash")
+
+    monkeypatch.setattr(schema_v4, "_crash_point", crash)
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.clone_standalone_exact_v4_custody(
+            target,
+            now=now + 4,
+        )
+
+    target_connection = store.open_authorization_session_connection(target)
+    try:
+        assert schema_v4.load_active_state(
+            target_connection,
+            expected_logical_vault_id=source_active.logical_vault_id,
+            expected_activation_store_id=source_active.activation_store_id,
+            expected_activation_epoch=source_active.activation_epoch,
+            expected_activation_state_digest=source_active.activation_state_digest,
+        ) == source_active
+        assert target_connection.execute(
+            "SELECT status FROM governance_authorization_sessions WHERE session_id=?",
+            (issued.context.session_id,),
+        ).fetchone() == ("active",)
+        assert target_connection.execute(
+            "SELECT instance_id FROM receipt_instance WHERE singleton=1"
+        ).fetchone() == (source_receipt_instance,)
+        assert target_connection.execute(
+            "SELECT COUNT(*) FROM governance_tuple_publications "
+            "WHERE publication_kind='attachment-clone'"
+        ).fetchone() == (0,)
+    finally:
+        target_connection.close()
+
+    monkeypatch.setattr(schema_v4, "_crash_point", original)
+    cloned = authorization_custody.clone_standalone_exact_v4_custody(
+        target,
+        now=now + 5,
+    )
+    assert cloned.control.activation_epoch == source_active.activation_epoch + 1
+
+
+def test_exact_v4_clone_refuses_copied_external_custody(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _vault(tmp_path)
+    target = tmp_path / "cloned-vault"
+    now = 1_800_000_000
+    source_custody, source_active = _enrolled_v4(source, now=now)
+    source_files = tuple(
+        Path(os.environ[name]).read_bytes()
+        for name in (
+            authorization_custody.KEYRING_FILE_ENV,
+            authorization_custody.CONTROL_FILE_ENV,
+            authorization_custody.MEMBERSHIP_FILE_ENV,
+        )
+    )
+    shutil.copytree(source, target)
+    target_paths = _select_custody_paths(monkeypatch, tmp_path / "clone-external")
+    for path, data in zip(target_paths, source_files, strict=True):
+        path.write_bytes(data)
+        if os.name != "nt":
+            os.chmod(path, 0o600)
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.clone_standalone_exact_v4_custody(
+            target,
+            now=now + 3,
+        )
+
+    connection = store.open_active_governance_read_connection(target)
+    try:
+        active = schema_v4.load_active_state(
+            connection,
+            expected_logical_vault_id=source_active.logical_vault_id,
+            expected_activation_store_id=source_active.activation_store_id,
+            expected_activation_epoch=source_active.activation_epoch,
+            expected_activation_state_digest=source_active.activation_state_digest,
+        )
+    finally:
+        connection.close()
+    assert active == source_active
+    assert source_custody.control.logical_vault_id == source_active.logical_vault_id
+
+
+def test_exact_v4_clone_refuses_a_forked_copied_receipt_chain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _vault(tmp_path)
+    target = tmp_path / "cloned-vault"
+    now = 1_800_000_000
+    _source_custody, source_active = _enrolled_v4(source, now=now)
+    receipt_intent = receipts.begin_event(
+        source,
+        operation="clone-corrupt-receipt-fixture",
+        prior="a" * 64,
+        target="b" * 64,
+    )
+    receipts.commit_event(source, str(receipt_intent["event_id"]))
+    shutil.copytree(source, target)
+    receipt_file = next(
+        (target / "Knowledge Base" / "_Governance" / "events").rglob("*.jsonl")
+    )
+    receipt_file.write_bytes(receipt_file.read_bytes() + b"not-json\n")
+    keyring_path, _control_path, _membership_path = _select_custody_paths(
+        monkeypatch,
+        tmp_path / "clone-external",
+    )
+
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.clone_standalone_exact_v4_custody(
+            target,
+            now=now + 3,
+        )
+
+    assert not keyring_path.exists()
+    connection = store.open_active_governance_read_connection(target)
+    try:
+        assert schema_v4.load_active_state(
+            connection,
+            expected_logical_vault_id=source_active.logical_vault_id,
+            expected_activation_store_id=source_active.activation_store_id,
+            expected_activation_epoch=source_active.activation_epoch,
+            expected_activation_state_digest=source_active.activation_state_digest,
+        ) == source_active
+    finally:
+        connection.close()
 
 
 def test_enrolled_attachment_transfer_requires_exact_target_activation_store(


### PR DESCRIPTION
## Summary

- give an unattached exact-v4 copy fresh cell, logical-vault, keyring, activation-store, attachment, and serving-membership identity
- commit copied-session invalidation, receipt-chain append-identity fork, activation digest/epoch advance, and a predecessor-bound `attachment-clone` publication in one exclusive transaction
- preserve policy, projector, catalog, projection namespace, prior tuple publications, receipt rows, and receipt evidence without allowing source and clone to append under one receipt instance
- recover every external publication crash using the same staged keyring; reject copied custody files and corrupt/forked receipt history before attachment

Stacked after #890. This does not touch any live vault.

## Verification

- red-first exact clone slice: 7 expected failures before implementation
- `PYTHONPATH=$PWD/src EXOMEM_DISABLE_EMBEDDINGS=1 EXOMEM_DISABLE_MEDIA_EXTRACTION=1 EXOMEM_DISABLE_CLIP=1 .../python -m pytest -q tests/test_authorization_standalone_provisioning.py` — 57 passed
- `uvx ruff check` on all three changed Python files
- `openspec validate harden-governance-for-consolidation --strict`
- `python3 scripts/validate-public-artifacts.py --repository`
- `uv lock --check`
- `git diff --check`
