### PR TITLE
feat(governance): publish hosted membership bootstrap

### DIFF
--- a/infra/helm/cell/templates/_helpers.tpl
+++ b/infra/helm/cell/templates/_helpers.tpl
@@ -28,6 +28,7 @@ exomem.io/recovery-envelope: {{ required (printf "providerRecoveryEnvelopes.%s i
   .Values.providerRecoveryEnvelopes.namespace
   .Values.providerRecoveryEnvelopes.vaultPvc
   .Values.providerRecoveryEnvelopes.credentialSecret
+  .Values.providerRecoveryEnvelopes.authorizationSessionSecret
   .Values.providerRecoveryEnvelopes.serviceAccount
   .Values.providerRecoveryEnvelopes.initRequestConfigMap
   .Values.providerRecoveryEnvelopes.providerOperationConfigMap
@@ -42,7 +43,7 @@ exomem.io/recovery-envelope: {{ required (printf "providerRecoveryEnvelopes.%s i
   .Values.providerRecoveryEnvelopes.controlIngressRoute
   .Values.providerRecoveryEnvelopes.transferIngressRoute
 -}}
-{{- if ne (len (uniq $values)) 16 -}}
+{{- if ne (len (uniq $values)) 17 -}}
 {{- fail "provider recovery envelopes must be unique per exact object" -}}
 {{- end -}}
 {{- end -}}

--- a/infra/helm/cell/templates/statefulset.yaml
+++ b/infra/helm/cell/templates/statefulset.yaml
@@ -20,6 +20,8 @@ spec:
     metadata:
       labels:
         {{- include "exomem-cell.selectorLabels" . | nindent 8 }}
+      annotations:
+        exomem.io/authorization-session-revision: {{ required "authorizationSessionRevision is required" .Values.authorizationSessionRevision | quote }}
     spec:
       serviceAccountName: {{ .Values.resourceName }}
       automountServiceAccountToken: false

--- a/infra/helm/cell/values.initialize.yaml
+++ b/infra/helm/cell/values.initialize.yaml
@@ -23,6 +23,7 @@ providerRecoveryEnvelopes:
   namespace: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   vaultPvc: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
   credentialSecret: cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+  authorizationSessionSecret: qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
   serviceAccount: dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
   initRequestConfigMap: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
   providerOperationConfigMap: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
@@ -53,6 +54,7 @@ browserOrigin: https://substratesystems.io
 transferHostname: transfer.example.test
 credentialsSecretName: exomem-cell-credentials
 credentialsManagedExternally: true
+authorizationSessionRevision: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 activeCredentialVersion: active-v1
 initRequestId: 123e4567-e89b-42d3-a456-426614174000
 initOperationId: provision-alpha-1

--- a/infra/helm/cell/values.schema.json
+++ b/infra/helm/cell/values.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": ["resourceName", "cellId", "vaultId", "workloadMode", "provisionMode", "image", "expectedRelease", "expectedProtocol", "workerPolicyDigest", "recordsReaderVersion", "lifecycleActionsEnabled", "runtimeUid", "runtimeGid", "storageClassName", "pvcSize", "providerIdentity", "providerRecoveryEnvelopes", "storageLimitBytes", "uploadLimitBytes", "workerLimit", "featureGrants", "cpuRequest", "cpuLimit", "memoryRequest", "memoryLimit", "embeddingThreads", "browserOrigin", "transferHostname", "credentialsSecretName", "credentialsManagedExternally", "authorizationSessionSecretName", "activeCredentialVersion", "initRequestId", "initOperationId", "routes"],
+  "required": ["resourceName", "cellId", "vaultId", "workloadMode", "provisionMode", "image", "expectedRelease", "expectedProtocol", "workerPolicyDigest", "recordsReaderVersion", "lifecycleActionsEnabled", "runtimeUid", "runtimeGid", "storageClassName", "pvcSize", "providerIdentity", "providerRecoveryEnvelopes", "storageLimitBytes", "uploadLimitBytes", "workerLimit", "featureGrants", "cpuRequest", "cpuLimit", "memoryRequest", "memoryLimit", "embeddingThreads", "browserOrigin", "transferHostname", "credentialsSecretName", "credentialsManagedExternally", "authorizationSessionSecretName", "authorizationSessionRevision", "activeCredentialVersion", "initRequestId", "initOperationId", "routes"],
   "properties": {
     "resourceName": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]{2,62}$"},
     "cellId": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$"},
@@ -36,11 +36,12 @@
     "providerRecoveryEnvelopes": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["namespace", "vaultPvc", "credentialSecret", "serviceAccount", "initRequestConfigMap", "providerOperationConfigMap", "initJob", "defaultDenyNetworkPolicy", "traefikIngressNetworkPolicy", "resourceQuota", "limitRange", "service", "statefulSet", "stripCellMiddleware", "controlIngressRoute", "transferIngressRoute"],
+      "required": ["namespace", "vaultPvc", "credentialSecret", "authorizationSessionSecret", "serviceAccount", "initRequestConfigMap", "providerOperationConfigMap", "initJob", "defaultDenyNetworkPolicy", "traefikIngressNetworkPolicy", "resourceQuota", "limitRange", "service", "statefulSet", "stripCellMiddleware", "controlIngressRoute", "transferIngressRoute"],
       "properties": {
         "namespace": {"type": "string", "minLength": 40, "maxLength": 4096, "pattern": "^[A-Za-z0-9_-]+$"},
         "vaultPvc": {"type": "string", "minLength": 40, "maxLength": 4096, "pattern": "^[A-Za-z0-9_-]+$"},
         "credentialSecret": {"type": "string", "minLength": 40, "maxLength": 4096, "pattern": "^[A-Za-z0-9_-]+$"},
+        "authorizationSessionSecret": {"type": "string", "minLength": 40, "maxLength": 4096, "pattern": "^[A-Za-z0-9_-]+$"},
         "serviceAccount": {"type": "string", "minLength": 40, "maxLength": 4096, "pattern": "^[A-Za-z0-9_-]+$"},
         "initRequestConfigMap": {"type": "string", "minLength": 40, "maxLength": 4096, "pattern": "^[A-Za-z0-9_-]+$"},
         "providerOperationConfigMap": {"type": "string", "minLength": 40, "maxLength": 4096, "pattern": "^[A-Za-z0-9_-]+$"},
@@ -70,6 +71,7 @@
     "credentialsSecretName": {"type": "string", "const": "exomem-cell-credentials"},
     "credentialsManagedExternally": {"type": "boolean", "const": true},
     "authorizationSessionSecretName": {"type": "string", "const": "exomem-authorization-session"},
+    "authorizationSessionRevision": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
     "activeCredentialVersion": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"},
     "initRequestId": {"type": "string", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"},
     "initOperationId": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$"},

--- a/infra/helm/cell/values.validation.yaml
+++ b/infra/helm/cell/values.validation.yaml
@@ -23,6 +23,7 @@ providerRecoveryEnvelopes:
   namespace: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   vaultPvc: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
   credentialSecret: cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+  authorizationSessionSecret: qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
   serviceAccount: dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
   initRequestConfigMap: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
   providerOperationConfigMap: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
@@ -54,6 +55,7 @@ transferHostname: transfer.example.test
 credentialsSecretName: exomem-cell-credentials
 credentialsManagedExternally: true
 authorizationSessionSecretName: exomem-authorization-session
+authorizationSessionRevision: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 activeCredentialVersion: active-v1
 initRequestId: 123e4567-e89b-42d3-a456-426614174000
 initOperationId: provision-alpha-1

--- a/infra/helm/cell/values.yaml
+++ b/infra/helm/cell/values.yaml
@@ -26,6 +26,7 @@ providerRecoveryEnvelopes:
   namespace: ""
   vaultPvc: ""
   credentialSecret: ""
+  authorizationSessionSecret: ""
   serviceAccount: ""
   initRequestConfigMap: ""
   providerOperationConfigMap: ""
@@ -56,6 +57,7 @@ transferHostname: ""
 credentialsSecretName: exomem-cell-credentials
 credentialsManagedExternally: true
 authorizationSessionSecretName: exomem-authorization-session
+authorizationSessionRevision: ""
 activeCredentialVersion: ""
 initRequestId: ""
 initOperationId: ""

--- a/infra/provisioner/src/exomem_provisioner/adapters.py
+++ b/infra/provisioner/src/exomem_provisioner/adapters.py
@@ -18,6 +18,11 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal
 
+from .authorization_membership import (
+    AUTHORIZATION_SESSION_FILES,
+    AUTHORIZATION_SESSION_SECRET_NAME,
+    MAX_BUNDLE_FILE_BYTES,
+)
 from .credentials import validate_machine_credential
 from .lifecycle import (
     HealthObservation,
@@ -588,6 +593,133 @@ class KubernetesCellAdapter:
         except ValueError as error:
             raise MetadataConflict("cell credential bundle is invalid") from error
         return values, annotations
+
+    async def write_authorization_session_bundle(
+        self,
+        metadata: OpaqueProviderMetadata,
+        files: dict[str, bytes],
+        *,
+        recovery_envelope: str,
+        membership_epoch: int,
+        membership_digest: str,
+        revision: str,
+    ) -> None:
+        if (
+            set(files) != AUTHORIZATION_SESSION_FILES
+            or any(
+                not isinstance(value, bytes)
+                or not 1 <= len(value) <= MAX_BUNDLE_FILE_BYTES
+                for value in files.values()
+            )
+            or not isinstance(membership_epoch, int)
+            or isinstance(membership_epoch, bool)
+            or membership_epoch < 1
+            or re.fullmatch(r"[0-9a-f]{64}", membership_digest) is None
+            or re.fullmatch(r"[0-9a-f]{64}", revision) is None
+            or not isinstance(recovery_envelope, str)
+            or not recovery_envelope
+        ):
+            raise MetadataConflict("authorization session bundle shape is invalid")
+        annotations = {
+            **metadata.kubernetes_annotations,
+            "exomem.io/recovery-envelope": recovery_envelope,
+            "exomem.io/authorization-membership-epoch": str(membership_epoch),
+            "exomem.io/authorization-membership-digest": membership_digest,
+            "exomem.io/authorization-session-revision": revision,
+        }
+        try:
+            string_data = {
+                name: value.decode("utf-8") for name, value in sorted(files.items())
+            }
+        except UnicodeDecodeError as error:
+            raise MetadataConflict("authorization session bundle shape is invalid") from error
+        body = {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {
+                "name": AUTHORIZATION_SESSION_SECRET_NAME,
+                "namespace": metadata.resource_name,
+                "annotations": annotations,
+                "labels": {
+                    "exomem.io/cell": metadata.resource_name,
+                    "exomem.io/resource-name": metadata.resource_name,
+                },
+            },
+            "type": "Opaque",
+            "immutable": False,
+            "stringData": string_data,
+        }
+        try:
+            await asyncio.to_thread(
+                self._core.patch_namespaced_secret,
+                AUTHORIZATION_SESSION_SECRET_NAME,
+                metadata.resource_name,
+                body,
+            )
+        except Exception as error:
+            if _api_status(error) != 404:
+                raise
+            await asyncio.to_thread(
+                self._core.create_namespaced_secret,
+                metadata.resource_name,
+                body,
+            )
+
+    async def read_authorization_session_bundle(
+        self,
+        metadata: OpaqueProviderMetadata,
+    ) -> dict[str, bytes] | None:
+        try:
+            secret = await asyncio.to_thread(
+                self._core.read_namespaced_secret,
+                AUTHORIZATION_SESSION_SECRET_NAME,
+                metadata.resource_name,
+            )
+        except Exception as error:
+            if _api_status(error) == 404:
+                return None
+            raise
+        annotations = dict(getattr(secret.metadata, "annotations", None) or {})
+        _require_annotations(annotations, metadata)
+        if self._identity_verifier is not None:
+            try:
+                self._identity_verifier.authenticate(
+                    str(annotations.get("exomem.io/recovery-envelope", "")),
+                    provider="kubernetes",
+                    provider_reference=ProviderReference.kubernetes(
+                        provider="kubernetes",
+                        api_version="v1",
+                        kind="Secret",
+                        namespace=metadata.resource_name,
+                        name=AUTHORIZATION_SESSION_SECRET_NAME,
+                    ),
+                    tenant_id=metadata.tenant_id,
+                    cell_id=metadata.subject_id,
+                    operation_id=metadata.operation_id,
+                    fence_generation=metadata.fence_generation,
+                )
+            except ProviderIdentityConflict as error:
+                raise MetadataConflict(
+                    "authorization Secret provider recovery identity did not authenticate"
+                ) from error
+        encoded = dict(getattr(secret, "data", None) or {})
+        if set(encoded) != AUTHORIZATION_SESSION_FILES:
+            raise MetadataConflict("authorization session bundle shape is invalid")
+        try:
+            files = {
+                name: base64.b64decode(value, validate=True)
+                for name, value in encoded.items()
+            }
+        except (ValueError, TypeError) as error:
+            raise MetadataConflict("authorization session bundle shape is invalid") from error
+        if any(not 1 <= len(value) <= MAX_BUNDLE_FILE_BYTES for value in files.values()):
+            raise MetadataConflict("authorization session bundle shape is invalid")
+        if any(
+            base64.b64encode(files[name]).decode("ascii") != encoded[name]
+            for name in files
+        ):
+            raise MetadataConflict("authorization session bundle shape is invalid")
+        return files
 
     async def scale(self, metadata: OpaqueProviderMetadata, replicas: int) -> None:
         if replicas not in {0, 1}:

--- a/infra/provisioner/src/exomem_provisioner/authorization_membership.py
+++ b/infra/provisioner/src/exomem_provisioner/authorization_membership.py
@@ -1,0 +1,571 @@
+"""Provisioner-owned bootstrap custody for Hosted authorization sessions.
+
+This module deliberately carries the exact version-one wire contract without
+importing the product package.  The provisioner and the cell ship separately;
+compatibility is proved by tests that feed these bytes to the runtime parser.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import re
+import secrets
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Final
+
+from .lifecycle import MetadataConflict
+
+AUTHORIZATION_SESSION_SECRET_NAME: Final = "exomem-authorization-session"
+AUTHORIZATION_SESSION_FILES: Final = frozenset(
+    {"keyring.json", "control.json", "serving-membership.json"}
+)
+AUTHORIZATION_SESSION_SCHEMA_VERSION: Final = 4
+MAX_BUNDLE_FILE_BYTES: Final = 64 * 1024
+MAX_ATTESTATION_TTL_SECONDS: Final = 3_630
+DEFAULT_ATTESTATION_TTL_SECONDS: Final = 3_600
+_KEY_TTL_SECONDS: Final = 366 * 24 * 60 * 60
+_MAX_INTEGER: Final = (1 << 63) - 1
+_IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:+/-]{0,511}\Z")
+_SHA256 = re.compile(r"[0-9a-f]{64}\Z")
+_CONTROL_MAC_DOMAIN = b"exomem.authorization-session.control/v1"
+_CONTROL_BASIS_DOMAIN = b"exomem.authorization-session.control-attestation-basis/v1"
+_ATTESTATION_MAC_DOMAIN = b"exomem.authorization-session.replica-readiness/v1"
+_MEMBERSHIP_MAC_DOMAIN = b"exomem.authorization-session.serving-membership/v1"
+_ATTACHMENT_DOMAIN = b"exomem.authorization-session.hosted-attachment/v1"
+_KEYRING_ID_DOMAIN = b"exomem.authorization-session.hosted-keyring/v1"
+_KEY_ID_DOMAIN = b"exomem.authorization-session.hosted-key/v1"
+
+
+@dataclass(frozen=True, slots=True)
+class HostedAuthorizationBundle:
+    keyring: bytes = field(repr=False)
+    control: bytes = field(repr=False)
+    membership: bytes = field(repr=False)
+    epoch: int
+    membership_digest: str
+    revision: str
+    registry_attachment_id: str
+    expires_at: int
+
+    @property
+    def files(self) -> dict[str, bytes]:
+        return {
+            "keyring.json": self.keyring,
+            "control.json": self.control,
+            "serving-membership.json": self.membership,
+        }
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _framed(domain: bytes, fields: tuple[bytes, ...]) -> bytes:
+    output = bytearray(domain)
+    output.append(0)
+    for value in fields:
+        output.extend(len(value).to_bytes(4, "big"))
+        output.extend(value)
+    return bytes(output)
+
+
+def _digest_identifier(domain: bytes, fields: tuple[bytes, ...], *, prefix: str) -> str:
+    return prefix + hashlib.sha256(_framed(domain, fields)).hexdigest()
+
+
+def _mac(key: bytes, payload: bytes) -> str:
+    return base64.urlsafe_b64encode(
+        hmac.new(key, payload, hashlib.sha256).digest()
+    ).rstrip(b"=").decode("ascii")
+
+
+def _keyring_digest(keyring: Mapping[str, object]) -> str:
+    return hashlib.sha256(_canonical(keyring)).hexdigest()
+
+
+def _control_basis_digest(control: Mapping[str, object]) -> str:
+    return hashlib.sha256(
+        _framed(
+            _CONTROL_BASIS_DOMAIN,
+            (
+                str(control["version"]).encode("ascii"),
+                str(control["keyring_id"]).encode("utf-8"),
+                str(control["cell_id"]).encode("utf-8"),
+                str(control["logical_vault_id"]).encode("utf-8"),
+                str(control["registry_attachment_id"]).encode("utf-8"),
+                str(control["attachment_epoch"]).encode("ascii"),
+            ),
+        )
+    ).hexdigest()
+
+
+def _attestation_mac_input(value: Mapping[str, object]) -> bytes:
+    accepted = value["accepted_key_ids"]
+    if not isinstance(accepted, list):
+        raise MetadataConflict("authorization membership attestation is invalid")
+    return _framed(
+        _ATTESTATION_MAC_DOMAIN,
+        (
+            str(value["version"]).encode("ascii"),
+            str(value["epoch"]).encode("ascii"),
+            str(value["replica_id"]).encode("utf-8"),
+            str(value["state"]).encode("ascii"),
+            str(value["software_version"]).encode("utf-8"),
+            str(value["schema_version"]).encode("ascii"),
+            str(value["cell_id"]).encode("utf-8"),
+            str(value["active_key_id"]).encode("utf-8"),
+            json.dumps(accepted, ensure_ascii=False, separators=(",", ":")).encode(
+                "utf-8"
+            ),
+            str(value["control_digest"]).encode("ascii"),
+            str(value["keyring_digest"]).encode("ascii"),
+            str(value["attested_at"]).encode("ascii"),
+            str(value["expires_at"]).encode("ascii"),
+            b"true" if value["issuance_stopped"] is True else b"false",
+            b"true" if value["no_in_flight"] is True else b"false",
+            str(value["signing_key_id"]).encode("utf-8"),
+        ),
+    )
+
+
+def _membership_mac_input(value: Mapping[str, object]) -> bytes:
+    replicas = value["replicas"]
+    previous = value["previous_epoch_digest"]
+    return _framed(
+        _MEMBERSHIP_MAC_DOMAIN,
+        (
+            str(value["version"]).encode("ascii"),
+            str(value["epoch"]).encode("ascii"),
+            str(value["cell_id"]).encode("utf-8"),
+            str(value["logical_vault_id"]).encode("utf-8"),
+            b"" if previous is None else str(previous).encode("ascii"),
+            str(value["issued_at"]).encode("ascii"),
+            str(value["expires_at"]).encode("ascii"),
+            _canonical(replicas),
+            str(value["signing_key_id"]).encode("utf-8"),
+        ),
+    )
+
+
+def _control_mac_input(value: Mapping[str, object]) -> bytes:
+    activation_store = value["activation_store_id"]
+    activation_epoch = value["activation_epoch"]
+    activation_digest = value["activation_state_digest"]
+    return _framed(
+        _CONTROL_MAC_DOMAIN,
+        (
+            str(value["version"]).encode("ascii"),
+            str(value["keyring_id"]).encode("utf-8"),
+            str(value["cell_id"]).encode("utf-8"),
+            str(value["logical_vault_id"]).encode("utf-8"),
+            str(value["registry_attachment_id"]).encode("utf-8"),
+            str(value["attachment_epoch"]).encode("ascii"),
+            b"true" if value["governance_enrolled"] is True else b"false",
+            b"" if activation_store is None else str(activation_store).encode("utf-8"),
+            b"" if activation_epoch is None else str(activation_epoch).encode("ascii"),
+            b"" if activation_digest is None else str(activation_digest).encode("ascii"),
+            str(value["serving_membership_epoch"]).encode("ascii"),
+            str(value["serving_membership_digest"]).encode("ascii"),
+            str(value["issued_at"]).encode("ascii"),
+            str(value["expires_at"]).encode("ascii"),
+            str(value["signing_key_id"]).encode("utf-8"),
+        ),
+    )
+
+
+def _required_identifier(value: object) -> str:
+    if not isinstance(value, str) or _IDENTIFIER.fullmatch(value) is None:
+        raise MetadataConflict("authorization membership identity is invalid")
+    return value
+
+
+def _required_time(value: object) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 1 <= value <= _MAX_INTEGER
+    ):
+        raise MetadataConflict("authorization membership time is invalid")
+    return value
+
+
+def _closed_json(raw: bytes, fields: frozenset[str], *, label: str) -> dict[str, object]:
+    if not isinstance(raw, bytes) or not 1 <= len(raw) <= MAX_BUNDLE_FILE_BYTES:
+        raise MetadataConflict(f"authorization {label} is invalid")
+
+    def closed(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for name, value in pairs:
+            if name in result:
+                raise MetadataConflict(f"authorization {label} is invalid")
+            result[name] = value
+        return result
+
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=closed)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError, TypeError) as error:
+        raise MetadataConflict(f"authorization {label} is invalid") from error
+    if not isinstance(value, dict) or set(value) != fields or _canonical(value) != raw:
+        raise MetadataConflict(f"authorization {label} is invalid")
+    return value
+
+
+def build_initial_hosted_authorization_bundle(
+    *,
+    cell_id: str,
+    logical_vault_id: str,
+    replica_id: str,
+    software_version: str,
+    schema_version: int,
+    recovery_envelope: str,
+    now: int,
+    entropy: Callable[[int], bytes] = secrets.token_bytes,
+    ttl_seconds: int = DEFAULT_ATTESTATION_TTL_SECONDS,
+) -> HostedAuthorizationBundle:
+    """Mint the first fail-closed Hosted custody generation before cell startup."""
+
+    cell = _required_identifier(cell_id)
+    vault = _required_identifier(logical_vault_id)
+    replica = _required_identifier(replica_id)
+    release = _required_identifier(software_version)
+    current = _required_time(now)
+    schema = _required_time(schema_version)
+    if (
+        not isinstance(recovery_envelope, str)
+        or not recovery_envelope
+        or not 1 <= ttl_seconds <= MAX_ATTESTATION_TTL_SECONDS
+    ):
+        raise MetadataConflict("authorization membership bootstrap input is invalid")
+    key = entropy(32)
+    if not isinstance(key, bytes) or len(key) != 32:
+        raise MetadataConflict("authorization membership entropy is invalid")
+    identity_fields = (key, cell.encode("utf-8"), vault.encode("utf-8"))
+    keyring_id = _digest_identifier(
+        _KEYRING_ID_DOMAIN, identity_fields, prefix="hosted-keyring-v1-"
+    )
+    key_id = _digest_identifier(_KEY_ID_DOMAIN, identity_fields, prefix="hosted-key-v1-")
+    attachment = _digest_identifier(
+        _ATTACHMENT_DOMAIN,
+        (
+            recovery_envelope.encode("utf-8"),
+            cell.encode("utf-8"),
+            vault.encode("utf-8"),
+        ),
+        prefix="hosted-attachment-v1-",
+    )
+    expires_at = current + ttl_seconds
+    keyring: dict[str, object] = {
+        "version": 1,
+        "keyring_id": keyring_id,
+        "cell_id": cell,
+        "logical_vault_id": vault,
+        "active_key_id": key_id,
+        "accepted_keys": [
+            {
+                "key_id": key_id,
+                "key": base64.urlsafe_b64encode(key).rstrip(b"=").decode("ascii"),
+                "not_before": current,
+                "not_after": current + _KEY_TTL_SECONDS,
+            }
+        ],
+    }
+    keyring_raw = _canonical(keyring)
+    control_basis: dict[str, object] = {
+        "version": 1,
+        "keyring_id": keyring_id,
+        "cell_id": cell,
+        "logical_vault_id": vault,
+        "registry_attachment_id": attachment,
+        "attachment_epoch": 1,
+    }
+    attestation: dict[str, object] = {
+        "version": 1,
+        "epoch": 1,
+        "replica_id": replica,
+        "state": "SERVING",
+        "software_version": release,
+        "schema_version": schema,
+        "cell_id": cell,
+        "active_key_id": key_id,
+        "accepted_key_ids": [key_id],
+        "control_digest": _control_basis_digest(control_basis),
+        "keyring_digest": _keyring_digest(keyring),
+        "attested_at": current,
+        "expires_at": expires_at,
+        "issuance_stopped": False,
+        "no_in_flight": False,
+        "signing_key_id": key_id,
+    }
+    attestation["mac"] = _mac(key, _attestation_mac_input(attestation))
+    membership: dict[str, object] = {
+        "version": 1,
+        "epoch": 1,
+        "cell_id": cell,
+        "logical_vault_id": vault,
+        "previous_epoch_digest": None,
+        "issued_at": current,
+        "expires_at": expires_at,
+        "replicas": [attestation],
+        "signing_key_id": key_id,
+    }
+    membership["mac"] = _mac(key, _membership_mac_input(membership))
+    membership_raw = _canonical(membership)
+    membership_digest = hashlib.sha256(membership_raw).hexdigest()
+    control: dict[str, object] = {
+        **control_basis,
+        "governance_enrolled": False,
+        "activation_store_id": None,
+        "activation_epoch": None,
+        "activation_state_digest": None,
+        "serving_membership_epoch": 1,
+        "serving_membership_digest": membership_digest,
+        "issued_at": current,
+        "expires_at": expires_at,
+        "signing_key_id": key_id,
+    }
+    control["mac"] = _mac(key, _control_mac_input(control))
+    control_raw = _canonical(control)
+    return HostedAuthorizationBundle(
+        keyring=keyring_raw,
+        control=control_raw,
+        membership=membership_raw,
+        epoch=1,
+        membership_digest=membership_digest,
+        revision=hashlib.sha256(keyring_raw + control_raw + membership_raw).hexdigest(),
+        registry_attachment_id=attachment,
+        expires_at=expires_at,
+    )
+
+
+def inspect_hosted_authorization_bundle(
+    files: Mapping[str, bytes],
+    *,
+    expected_cell_id: str,
+    expected_logical_vault_id: str,
+    expected_replica_id: str,
+    expected_software_version: str,
+    expected_schema_version: int,
+    expected_recovery_envelope: str,
+    now: int,
+) -> HostedAuthorizationBundle:
+    """Authenticate an existing initial generation for idempotent reconciliation."""
+
+    if set(files) != AUTHORIZATION_SESSION_FILES:
+        raise MetadataConflict("authorization session bundle shape is invalid")
+    keyring_raw = files["keyring.json"]
+    control_raw = files["control.json"]
+    membership_raw = files["serving-membership.json"]
+    keyring = _closed_json(
+        keyring_raw,
+        frozenset(
+            {
+                "version",
+                "keyring_id",
+                "cell_id",
+                "logical_vault_id",
+                "active_key_id",
+                "accepted_keys",
+            }
+        ),
+        label="keyring",
+    )
+    entries = keyring["accepted_keys"]
+    if not isinstance(entries, list) or len(entries) != 1 or not isinstance(entries[0], dict):
+        raise MetadataConflict("authorization keyring is invalid")
+    entry = entries[0]
+    if set(entry) != {"key_id", "key", "not_before", "not_after"}:
+        raise MetadataConflict("authorization keyring is invalid")
+    encoded_key = entry["key"]
+    if not isinstance(encoded_key, str) or len(encoded_key) != 43:
+        raise MetadataConflict("authorization keyring is invalid")
+    try:
+        key = base64.b64decode(
+            encoded_key.encode("ascii") + b"=", altchars=b"-_", validate=True
+        )
+    except (UnicodeEncodeError, ValueError) as error:
+        raise MetadataConflict("authorization keyring is invalid") from error
+    current = _required_time(now)
+    cell = _required_identifier(expected_cell_id)
+    vault = _required_identifier(expected_logical_vault_id)
+    replica = _required_identifier(expected_replica_id)
+    release = _required_identifier(expected_software_version)
+    schema = _required_time(expected_schema_version)
+    if not isinstance(expected_recovery_envelope, str) or not expected_recovery_envelope:
+        raise MetadataConflict("authorization Secret provider authority is absent")
+    key_id = _required_identifier(entry["key_id"])
+    if (
+        keyring["version"] != 1
+        or keyring["cell_id"] != cell
+        or keyring["logical_vault_id"] != vault
+        or keyring["active_key_id"] != key_id
+        or len(key) != 32
+        or base64.urlsafe_b64encode(key).rstrip(b"=").decode("ascii") != encoded_key
+        or not _required_time(entry["not_before"]) <= current < _required_time(
+            entry["not_after"]
+        )
+    ):
+        raise MetadataConflict("authorization keyring is invalid")
+    control = _closed_json(
+        control_raw,
+        frozenset(
+            {
+                "version",
+                "keyring_id",
+                "cell_id",
+                "logical_vault_id",
+                "registry_attachment_id",
+                "attachment_epoch",
+                "governance_enrolled",
+                "activation_store_id",
+                "activation_epoch",
+                "activation_state_digest",
+                "serving_membership_epoch",
+                "serving_membership_digest",
+                "issued_at",
+                "expires_at",
+                "signing_key_id",
+                "mac",
+            }
+        ),
+        label="control",
+    )
+    expected_attachment = _digest_identifier(
+        _ATTACHMENT_DOMAIN,
+        (
+            expected_recovery_envelope.encode("utf-8"),
+            cell.encode("utf-8"),
+            vault.encode("utf-8"),
+        ),
+        prefix="hosted-attachment-v1-",
+    )
+    supplied_control_mac = control.pop("mac")
+    if (
+        control["version"] != 1
+        or control["keyring_id"] != keyring["keyring_id"]
+        or control["cell_id"] != cell
+        or control["logical_vault_id"] != vault
+        or control["registry_attachment_id"] != expected_attachment
+        or control["attachment_epoch"] != 1
+        or control["governance_enrolled"] is not False
+        or any(
+            control[name] is not None
+            for name in (
+                "activation_store_id",
+                "activation_epoch",
+                "activation_state_digest",
+            )
+        )
+        or control["serving_membership_epoch"] != 1
+        or control["signing_key_id"] != key_id
+        or not _required_time(control["issued_at"])
+        <= current
+        < _required_time(control["expires_at"])
+        or _required_time(control["expires_at"])
+        - _required_time(control["issued_at"])
+        > MAX_ATTESTATION_TTL_SECONDS
+        or supplied_control_mac != _mac(key, _control_mac_input(control))
+    ):
+        raise MetadataConflict("authorization control is invalid")
+    membership = _closed_json(
+        membership_raw,
+        frozenset(
+            {
+                "version",
+                "epoch",
+                "cell_id",
+                "logical_vault_id",
+                "previous_epoch_digest",
+                "issued_at",
+                "expires_at",
+                "replicas",
+                "signing_key_id",
+                "mac",
+            }
+        ),
+        label="membership",
+    )
+    replicas = membership["replicas"]
+    if not isinstance(replicas, list) or len(replicas) != 1 or not isinstance(replicas[0], dict):
+        raise MetadataConflict("authorization membership is invalid")
+    attestation = replicas[0]
+    if set(attestation) != {
+        "version",
+        "epoch",
+        "replica_id",
+        "state",
+        "software_version",
+        "schema_version",
+        "cell_id",
+        "active_key_id",
+        "accepted_key_ids",
+        "control_digest",
+        "keyring_digest",
+        "attested_at",
+        "expires_at",
+        "issuance_stopped",
+        "no_in_flight",
+        "signing_key_id",
+        "mac",
+    }:
+        raise MetadataConflict("authorization membership is invalid")
+    supplied_attestation_mac = attestation.get("mac")
+    supplied_membership_mac = membership.pop("mac")
+    expected_membership_mac = _mac(key, _membership_mac_input(membership))
+    expected_attestation_mac = _mac(key, _attestation_mac_input(attestation))
+    digest = hashlib.sha256(membership_raw).hexdigest()
+    if (
+        membership["version"] != 1
+        or membership["epoch"] != 1
+        or membership["cell_id"] != cell
+        or membership["logical_vault_id"] != vault
+        or membership["previous_epoch_digest"] is not None
+        or membership["signing_key_id"] != key_id
+        or not _required_time(membership["issued_at"])
+        <= current
+        < _required_time(membership["expires_at"])
+        or digest != control["serving_membership_digest"]
+        or membership["issued_at"] != control["issued_at"]
+        or membership["expires_at"] != control["expires_at"]
+        or _required_time(membership["expires_at"])
+        - _required_time(membership["issued_at"])
+        > MAX_ATTESTATION_TTL_SECONDS
+        or supplied_membership_mac != expected_membership_mac
+        or supplied_attestation_mac != expected_attestation_mac
+        or attestation.get("replica_id") != replica
+        or attestation.get("version") != 1
+        or attestation.get("epoch") != 1
+        or attestation.get("state") != "SERVING"
+        or attestation.get("software_version") != release
+        or attestation.get("schema_version") != schema
+        or attestation.get("cell_id") != cell
+        or attestation.get("active_key_id") != key_id
+        or attestation.get("accepted_key_ids") != [key_id]
+        or attestation.get("attested_at") != membership["issued_at"]
+        or attestation.get("expires_at") != membership["expires_at"]
+        or attestation.get("issuance_stopped") is not False
+        or attestation.get("no_in_flight") is not False
+        or attestation.get("signing_key_id") != key_id
+        or attestation.get("control_digest") != _control_basis_digest(control)
+        or attestation.get("keyring_digest") != _keyring_digest(keyring)
+    ):
+        raise MetadataConflict("authorization membership is invalid")
+    return HostedAuthorizationBundle(
+        keyring=keyring_raw,
+        control=control_raw,
+        membership=membership_raw,
+        epoch=1,
+        membership_digest=digest,
+        revision=hashlib.sha256(keyring_raw + control_raw + membership_raw).hexdigest(),
+        registry_attachment_id=expected_attachment,
+        expires_at=_required_time(membership["expires_at"]),
+    )

--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -21,6 +21,11 @@ from .adapters import (
     _require_annotations,
     mint_maintenance_transfer_grant,
 )
+from .authorization_membership import (
+    AUTHORIZATION_SESSION_SCHEMA_VERSION,
+    build_initial_hosted_authorization_bundle,
+    inspect_hosted_authorization_bundle,
+)
 from .capacity import CapacityError
 from .driver import EffectContext
 from .lifecycle import (
@@ -591,6 +596,72 @@ class LiveLifecyclePlane:
         self._snapshots[self._key(metadata)] = snapshot
         return snapshot
 
+    async def _authorization_session_revision(
+        self,
+        metadata: OpaqueProviderMetadata,
+        request: dict[str, Any],
+    ) -> str:
+        """Ensure one authenticated bootstrap generation before Helm can start a pod."""
+
+        key = self._key(metadata)
+        owned = self._owner(metadata)
+        original = self._helm_requests.get(key, request)
+        envelopes = original.get("_providerRecoveryEnvelopes")
+        if not isinstance(envelopes, dict):
+            raise MetadataConflict("authorization Secret provider authority is absent")
+        recovery_envelope = envelopes.get("authorizationSessionSecret")
+        if not isinstance(recovery_envelope, str) or not recovery_envelope:
+            raise MetadataConflict("authorization Secret provider authority is absent")
+        target = self._config.runtime_target_for(
+            original,
+            v2="runtimeTarget" in original,
+        )
+        replica_id = owned.resource_name + "-0"
+        files = await self._cell.read_authorization_session_bundle(owned)
+        current = int(self._now())
+        if files is None:
+            bundle = build_initial_hosted_authorization_bundle(
+                cell_id=owned.subject_id,
+                logical_vault_id=owned.tenant_id,
+                replica_id=replica_id,
+                software_version=str(target["releaseVersion"]),
+                schema_version=AUTHORIZATION_SESSION_SCHEMA_VERSION,
+                recovery_envelope=recovery_envelope,
+                now=current,
+            )
+            await self._cell.write_authorization_session_bundle(
+                owned,
+                bundle.files,
+                recovery_envelope=recovery_envelope,
+                membership_epoch=bundle.epoch,
+                membership_digest=bundle.membership_digest,
+                revision=bundle.revision,
+            )
+        else:
+            bundle = inspect_hosted_authorization_bundle(
+                files,
+                expected_cell_id=owned.subject_id,
+                expected_logical_vault_id=owned.tenant_id,
+                expected_replica_id=replica_id,
+                expected_software_version=str(target["releaseVersion"]),
+                expected_schema_version=AUTHORIZATION_SESSION_SCHEMA_VERSION,
+                expected_recovery_envelope=recovery_envelope,
+                now=current,
+            )
+        return bundle.revision
+
+    async def _authorization_helm_values(
+        self,
+        metadata: OpaqueProviderMetadata,
+        request: dict[str, Any],
+        values: dict[str, Any],
+    ) -> dict[str, Any]:
+        desired = dict(values)
+        desired["authorizationSessionRevision"] = (
+            await self._authorization_session_revision(metadata, request)
+        )
+        return desired
+
     async def observed_fence(self, tenant_id: str) -> int:
         return await self._registry.observed_fence(tenant_id)
 
@@ -706,6 +777,7 @@ class LiveLifecyclePlane:
     ) -> None:
         await self._require_capacity_reservation(metadata, request)
         owned = self._owner(metadata)
+        revision = await self._authorization_session_revision(metadata, request)
         await self._cell.write_credential_bundle(
             owned,
             {"1": str(request["serviceCredential"])},
@@ -718,7 +790,9 @@ class LiveLifecyclePlane:
                 ],
             },
         )
-        await self._helm.ensure_release(owned, values)
+        desired = dict(values)
+        desired["authorizationSessionRevision"] = revision
+        await self._helm.ensure_release(owned, desired)
         await self._refresh(metadata)
 
     async def volume_claim_bound(self, metadata: OpaqueProviderMetadata) -> bool:
@@ -745,6 +819,7 @@ class LiveLifecyclePlane:
             except KeyError as error:
                 raise MetadataConflict("original Helm request was not authenticated") from error
             values = _fixed_helm_values(self._owner(metadata), helm_request, config)
+            values = await self._authorization_helm_values(metadata, helm_request, values)
             values["workloadMode"] = "initialize"
             await self._helm.ensure_release(self._owner(metadata), values)
             snapshot = await self._refresh(metadata)
@@ -753,6 +828,7 @@ class LiveLifecyclePlane:
             if not snapshot.init_complete:
                 return False
         values = _fixed_helm_values(self._owner(metadata), helm_request, config)
+        values = await self._authorization_helm_values(metadata, helm_request, values)
         values["workloadMode"] = "serve"
         await self._helm.ensure_release(self._owner(metadata), values)
         return (await self._refresh(metadata)).serving
@@ -788,6 +864,7 @@ class LiveLifecyclePlane:
             if "compatibilityDigest" in request
             else _fixed_helm_values(owner, request, self._config)
         )
+        values = await self._authorization_helm_values(metadata, request, values)
         values["workloadMode"] = "serve"
         values["routes"]["enabled"] = True
         if "compatibilityDigest" in request:
@@ -922,6 +999,7 @@ class LiveLifecyclePlane:
         if config.migration_mode != "binding-v1-to-v2":
             raise MetadataConflict("runtime migration was not declared by the deployment lock")
         values = self._rollforward_helm_values(metadata, request, config)
+        values = await self._authorization_helm_values(metadata, request, values)
         values["workloadMode"] = "migrate"
         values["routes"]["enabled"] = False
         values["initOperationId"] = operation_id
@@ -941,6 +1019,7 @@ class LiveLifecyclePlane:
         operation_id: str,
     ) -> None:
         values = self._rollforward_helm_values(metadata, request, config)
+        values = await self._authorization_helm_values(metadata, request, values)
         values["workloadMode"] = "serve"
         values["routes"]["enabled"] = False
         await self._helm.transition_release(

--- a/infra/provisioner/src/exomem_provisioner/provider_identity.py
+++ b/infra/provisioner/src/exomem_provisioner/provider_identity.py
@@ -128,6 +128,11 @@ _CELL_KUBERNETES_OBJECTS: Final[dict[str, tuple[str, str, str]]] = {
     "namespace": ("v1", "Namespace", ""),
     "vaultPvc": ("v1", "PersistentVolumeClaim", "{resource}-data"),
     "credentialSecret": ("v1", "Secret", "exomem-cell-credentials"),
+    "authorizationSessionSecret": (
+        "v1",
+        "Secret",
+        "exomem-authorization-session",
+    ),
     "serviceAccount": ("v1", "ServiceAccount", "{resource}"),
     "initRequestConfigMap": ("v1", "ConfigMap", "{resource}-init-request"),
     "providerOperationConfigMap": ("v1", "ConfigMap", "{operation_resource}"),

--- a/infra/provisioner/tests/test_api.py
+++ b/infra/provisioner/tests/test_api.py
@@ -618,8 +618,8 @@ async def test_api_seals_distinct_provider_recovery_envelopes_before_queueing(
     assert operation is not None
     queued = await repository.load_request(operation.id)
     envelopes = queued["_providerRecoveryEnvelopes"]
-    assert len(envelopes) == 16
-    assert len(set(envelopes.values())) == 16
+    assert len(envelopes) == 17
+    assert len(set(envelopes.values())) == 17
     assert all(value.startswith("eyJ") for value in envelopes.values())
 
 

--- a/infra/provisioner/tests/test_authorization_membership.py
+++ b/infra/provisioner/tests/test_authorization_membership.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import hashlib
+
+from exomem.governance import authorization_custody, authorization_serving_membership
+
+from exomem_provisioner.authorization_membership import (
+    build_initial_hosted_authorization_bundle,
+    inspect_hosted_authorization_bundle,
+)
+
+
+def _entropy(length: int) -> bytes:
+    assert length == 32
+    return bytes(range(32))
+
+
+def test_initial_hosted_bundle_is_byte_compatible_with_the_runtime_verifier() -> None:
+    now = 1_900_000_000
+    bundle = build_initial_hosted_authorization_bundle(
+        cell_id="cell-alpha",
+        logical_vault_id="tenant-alpha",
+        replica_id="exo-0123456789abcdef0123-0",
+        software_version="0.48.0",
+        schema_version=4,
+        recovery_envelope="signed-authorization-session-secret",
+        now=now,
+        entropy=_entropy,
+    )
+
+    keyring = authorization_custody.parse_keyring(bundle.keyring)
+    control = authorization_custody.parse_control_record(
+        bundle.control,
+        keyring=keyring,
+        now=now,
+    )
+    membership = authorization_serving_membership.parse_serving_membership(
+        bundle.membership,
+        verifier_keys={item.key_id: item.key for item in keyring.accepted_keys},
+        now=now,
+        expected_cell_id="cell-alpha",
+        expected_logical_vault_id="tenant-alpha",
+        expected_epoch=control.serving_membership_epoch,
+        expected_digest=control.serving_membership_digest,
+    )
+
+    assert control.governance_enrolled is False
+    assert (
+        control.activation_store_id,
+        control.activation_epoch,
+        control.activation_state_digest,
+    ) == (None, None, None)
+    assert control.registry_attachment_id.startswith("hosted-attachment-v1-")
+    assert membership.replicas[0].replica_id == "exo-0123456789abcdef0123-0"
+    assert membership.replicas[0].software_version == "0.48.0"
+    assert membership.replicas[0].schema_version == 4
+    assert bundle.revision == hashlib.sha256(
+        bundle.keyring + bundle.control + bundle.membership
+    ).hexdigest()
+
+
+def test_existing_hosted_bundle_is_exactly_bound_and_never_regenerated_on_retry() -> None:
+    now = 1_900_000_000
+    bundle = build_initial_hosted_authorization_bundle(
+        cell_id="cell-alpha",
+        logical_vault_id="tenant-alpha",
+        replica_id="exo-0123456789abcdef0123-0",
+        software_version="0.48.0",
+        schema_version=4,
+        recovery_envelope="signed-authorization-session-secret",
+        now=now,
+        entropy=_entropy,
+    )
+
+    inspected = inspect_hosted_authorization_bundle(
+        {
+            "keyring.json": bundle.keyring,
+            "control.json": bundle.control,
+            "serving-membership.json": bundle.membership,
+        },
+        expected_cell_id="cell-alpha",
+        expected_logical_vault_id="tenant-alpha",
+        expected_replica_id="exo-0123456789abcdef0123-0",
+        expected_software_version="0.48.0",
+        expected_schema_version=4,
+        expected_recovery_envelope="signed-authorization-session-secret",
+        now=now + 30,
+    )
+
+    assert inspected == bundle

--- a/infra/provisioner/tests/test_live_provider.py
+++ b/infra/provisioner/tests/test_live_provider.py
@@ -536,7 +536,15 @@ async def test_live_rollforward_uses_target_fingerprint_and_original_helm_author
             "releaseVersion": "0.54.1",
             "protocolVersion": "legacy-protocol",
         },
-        "_providerRecoveryEnvelopes": {"initJob": "original-init-envelope"},
+        "_providerRecoveryEnvelopes": cell_provider_recovery_envelopes(
+            IDENTITY_CODEC,
+            tenant_id=owner.tenant_id,
+            cell_id=owner.subject_id,
+            operation_id=owner.operation_id,
+            fence_generation=owner.fence_generation,
+            resource_name=owner.resource_name,
+            operation_resource_name=provider_operation_resource_name(owner.operation_id),
+        ),
     }
     request = {
         "serviceCredential": "credential-current",
@@ -574,10 +582,19 @@ async def test_live_rollforward_uses_target_fingerprint_and_original_helm_author
             assert operation_id == "rollforward-alpha"
             quiesced_protocols.append(protocol_version)
 
+    class Cell:
+        files = None
+
+        async def read_authorization_session_bundle(self, _owner):
+            return self.files
+
+        async def write_authorization_session_bundle(self, _owner, files, **_kwargs):
+            self.files = files
+
     plane = LiveLifecyclePlane(
         repository=SimpleNamespace(),  # type: ignore[arg-type]
         registry=Registry(),  # type: ignore[arg-type]
-        cell=SimpleNamespace(),  # type: ignore[arg-type]
+        cell=Cell(),  # type: ignore[arg-type]
         helm=Helm(),  # type: ignore[arg-type]
         runtime=Runtime(),  # type: ignore[arg-type]
         routes=SimpleNamespace(),  # type: ignore[arg-type]
@@ -613,7 +630,9 @@ async def test_live_rollforward_uses_target_fingerprint_and_original_helm_author
         assert transition_owner == owner
         assert operation == "rollforward-alpha"
         assert values["image"] == config.image
-        assert values["providerRecoveryEnvelopes"] == {"initJob": "original-init-envelope"}
+        assert values["providerRecoveryEnvelopes"] == original_request[
+            "_providerRecoveryEnvelopes"
+        ]
         assert values["routes"]["enabled"] is False
     assert transitions[0][1]["initOperationId"] == "rollforward-alpha"
     assert rollbacks == [(owner, "rollforward-alpha")]
@@ -645,16 +664,38 @@ async def test_live_route_enable_reconciles_the_original_authenticated_helm_rele
         transfer_hostname="transfer.example.invalid",
         protocol_version="1",
         release_version="0.22.0",
+        runtime_target_for=lambda _request, *, v2: {
+            "releaseVersion": "0.22.0",
+            "protocolVersion": "1",
+        },
+    )
+    envelopes = cell_provider_recovery_envelopes(
+        IDENTITY_CODEC,
+        tenant_id=metadata.tenant_id,
+        cell_id=metadata.subject_id,
+        operation_id=metadata.operation_id,
+        fence_generation=metadata.fence_generation,
+        resource_name=metadata.resource_name,
+        operation_resource_name=provider_operation_resource_name(metadata.operation_id),
     )
     request = {
         "provisionMode": "serve",
         "workerPolicy": {"workerCount": 2, "semantic": True, "media": False},
-        "_providerRecoveryEnvelopes": {"controlRoute": "signed-control"},
+        "_providerRecoveryEnvelopes": envelopes,
     }
+
+    class Cell:
+        files = None
+
+        async def read_authorization_session_bundle(self, _owner):
+            return self.files
+
+        async def write_authorization_session_bundle(self, _owner, files, **_kwargs):
+            self.files = files
     plane = LiveLifecyclePlane(
         repository=SimpleNamespace(),  # type: ignore[arg-type]
         registry=Registry(),  # type: ignore[arg-type]
-        cell=SimpleNamespace(),  # type: ignore[arg-type]
+        cell=Cell(),  # type: ignore[arg-type]
         helm=Helm(),  # type: ignore[arg-type]
         runtime=SimpleNamespace(),  # type: ignore[arg-type]
         routes=Routes(),  # type: ignore[arg-type]
@@ -673,7 +714,7 @@ async def test_live_route_enable_reconciles_the_original_authenticated_helm_rele
         "controlHostname": "control.example.invalid",
         "enabled": True,
     }
-    assert calls[0]["providerRecoveryEnvelopes"] == {"controlRoute": "signed-control"}
+    assert calls[0]["providerRecoveryEnvelopes"] == envelopes
 
 
 @pytest.mark.asyncio
@@ -1151,6 +1192,10 @@ def _init_recovery_config() -> SimpleNamespace:
         transfer_hostname="transfer.example.invalid",
         protocol_version="1",
         release_version="0.22.0",
+        runtime_target_for=lambda _request, *, v2: {
+            "releaseVersion": "0.22.0",
+            "protocolVersion": "1",
+        },
     )
 
 
@@ -1187,10 +1232,19 @@ def _init_recovery_plane(snapshots: list[SimpleNamespace]):
         async def ensure_release(self, owner, values):
             helm_calls.append((owner, values))
 
+    class Cell:
+        files = None
+
+        async def read_authorization_session_bundle(self, _owner):
+            return self.files
+
+        async def write_authorization_session_bundle(self, _owner, files, **_kwargs):
+            self.files = files
+
     plane = LiveLifecyclePlane(
         repository=SimpleNamespace(),  # type: ignore[arg-type]
         registry=Registry(),  # type: ignore[arg-type]
-        cell=SimpleNamespace(),  # type: ignore[arg-type]
+        cell=Cell(),  # type: ignore[arg-type]
         helm=Helm(),  # type: ignore[arg-type]
         runtime=SimpleNamespace(),  # type: ignore[arg-type]
         routes=SimpleNamespace(),  # type: ignore[arg-type]
@@ -1201,7 +1255,19 @@ def _init_recovery_plane(snapshots: list[SimpleNamespace]):
     )
     key = plane._key(metadata)
     plane._owned[key] = original_owner
-    plane._helm_requests[key] = _init_recovery_request(envelope="original-init-envelope")
+    original_request = _init_recovery_request(envelope="original-init-envelope")
+    original_request["_providerRecoveryEnvelopes"] = cell_provider_recovery_envelopes(
+        IDENTITY_CODEC,
+        tenant_id=original_owner.tenant_id,
+        cell_id=original_owner.subject_id,
+        operation_id=original_owner.operation_id,
+        fence_generation=original_owner.fence_generation,
+        resource_name=original_owner.resource_name,
+        operation_resource_name=provider_operation_resource_name(
+            original_owner.operation_id
+        ),
+    )
+    plane._helm_requests[key] = original_request
     return plane, metadata, original_owner, helm_calls
 
 
@@ -1225,8 +1291,10 @@ async def test_initialize_replays_absent_init_job_with_original_authenticated_re
     assert [owner for owner, _values in helm_calls] == [original_owner, original_owner]
     assert [values["workloadMode"] for _owner, values in helm_calls] == ["initialize", "serve"]
     assert helm_calls[0][1]["workerPolicyDigest"] == helm_calls[1][1]["workerPolicyDigest"]
-    assert helm_calls[0][1]["providerRecoveryEnvelopes"] == {"initJob": "original-init-envelope"}
-    assert helm_calls[1][1]["providerRecoveryEnvelopes"] == {"initJob": "original-init-envelope"}
+    assert (
+        helm_calls[0][1]["providerRecoveryEnvelopes"]["initJob"]
+        == helm_calls[1][1]["providerRecoveryEnvelopes"]["initJob"]
+    )
 
 
 @pytest.mark.asyncio
@@ -1316,9 +1384,17 @@ async def test_initializing_checkpoint_recovers_deleted_init_job_without_looping
             return original_request
 
     class Cell:
+        files = None
+
         async def volume_claim_bound(self, owner):
             assert owner == original_owner
             return True
+
+        async def read_authorization_session_bundle(self, _owner):
+            return self.files
+
+        async def write_authorization_session_bundle(self, _owner, files, **_kwargs):
+            self.files = files
 
     plane._repository = Repository()  # type: ignore[assignment]
     plane._cell = Cell()  # type: ignore[assignment]
@@ -1430,3 +1506,108 @@ async def test_live_plane_requires_exact_reservation_before_namespace_or_release
     capacity.reject = True
     with pytest.raises(MetadataConflict, match="exact active capacity reservation"):
         await plane.install_release(metadata, {"provisionMode": "serve"}, {})
+
+
+@pytest.mark.asyncio
+async def test_live_plane_publishes_authorization_custody_before_helm_and_reuses_it() -> None:
+    metadata = _metadata()
+    envelopes = cell_provider_recovery_envelopes(
+        IDENTITY_CODEC,
+        tenant_id=metadata.tenant_id,
+        cell_id=metadata.subject_id,
+        operation_id=metadata.operation_id,
+        fence_generation=metadata.fence_generation,
+        resource_name=metadata.resource_name,
+        operation_resource_name=provider_operation_resource_name(metadata.operation_id),
+    )
+    calls: list[str] = []
+
+    class Capacity:
+        async def require_active(self, **_identity):
+            return None
+
+    class Registry:
+        async def inspect(self, _current, _owner):
+            return SimpleNamespace(
+                namespace=True,
+                release=True,
+                init_complete=True,
+                init_failed=False,
+                serving=True,
+                runtime_admitted=False,
+                routes=(False, False),
+            )
+
+    class Cell:
+        files = None
+
+        async def read_authorization_session_bundle(self, _owner):
+            calls.append("authorization-read")
+            return self.files
+
+        async def write_authorization_session_bundle(self, _owner, files, **kwargs):
+            calls.append("authorization-write")
+            assert kwargs["recovery_envelope"] == envelopes[
+                "authorizationSessionSecret"
+            ]
+            self.files = files
+
+        async def write_credential_bundle(self, _owner, _credentials, **_kwargs):
+            calls.append("credential-write")
+
+    class Helm:
+        revisions: list[str] = []
+
+        async def ensure_release(self, _owner, values):
+            calls.append("helm")
+            self.revisions.append(values["authorizationSessionRevision"])
+
+    request = {
+        "provisionMode": "serve",
+        "serviceCredential": base64.urlsafe_b64encode(bytes(range(32)))
+        .rstrip(b"=")
+        .decode(),
+        "workerPolicy": {"workerCount": 2, "semantic": True, "media": False},
+        "runtimeTarget": {
+            "releaseVersion": "0.48.0",
+            "protocolVersion": "1",
+            "gatewayContractDigest": "a" * 64,
+        },
+        "_providerRecoveryEnvelopes": envelopes,
+    }
+    cell = Cell()
+    helm = Helm()
+    plane = LiveLifecyclePlane(
+        repository=SimpleNamespace(),  # type: ignore[arg-type]
+        registry=Registry(),  # type: ignore[arg-type]
+        cell=cell,  # type: ignore[arg-type]
+        helm=helm,  # type: ignore[arg-type]
+        runtime=SimpleNamespace(),  # type: ignore[arg-type]
+        routes=SimpleNamespace(),  # type: ignore[arg-type]
+        maintenance=SimpleNamespace(),  # type: ignore[arg-type]
+        capacity=Capacity(),  # type: ignore[arg-type]
+        identity_verifier=IDENTITY_CODEC.verifier(),
+        config=SimpleNamespace(
+            runtime_target_for=lambda value, *, v2: value["runtimeTarget"]
+        ),  # type: ignore[arg-type]
+        now=lambda: 1_900_000_000,
+    )
+    key = plane._key(metadata)
+    plane._operation_ids[key] = "internal-operation-alpha"
+    plane._owned[key] = metadata
+    plane._helm_requests[key] = request
+    plane._recovery_envelopes[key] = envelopes
+
+    await plane.install_release(metadata, request, {"workloadMode": "initialize"})
+    await plane.install_release(metadata, request, {"workloadMode": "initialize"})
+
+    assert calls == [
+        "authorization-read",
+        "authorization-write",
+        "credential-write",
+        "helm",
+        "authorization-read",
+        "credential-write",
+        "helm",
+    ]
+    assert len(set(helm.revisions)) == 1

--- a/infra/provisioner/tests/test_provider_adapters.py
+++ b/infra/provisioner/tests/test_provider_adapters.py
@@ -29,6 +29,7 @@ from exomem_provisioner.lifecycle import (
 from exomem_provisioner.provider_identity import (
     ProviderRecoveryIdentityCodec,
     ProviderReference,
+    cell_provider_recovery_envelopes,
     chunk_hcloud_identity_envelope,
 )
 
@@ -795,6 +796,83 @@ async def test_kubernetes_cell_adapter_scales_and_writes_atomic_bundle_shape() -
 
     with pytest.raises(MetadataConflict):
         await adapter.write_credential_bundle(_metadata(), {"3": "a" * 43})
+
+
+@pytest.mark.asyncio
+async def test_kubernetes_cell_adapter_persists_one_authenticated_authorization_bundle() -> None:
+    metadata = _metadata()
+    identity = ProviderRecoveryIdentityCodec.from_secret("provider-root")
+    envelopes = cell_provider_recovery_envelopes(
+        identity,
+        tenant_id=metadata.tenant_id,
+        cell_id=metadata.subject_id,
+        operation_id=metadata.operation_id,
+        fence_generation=metadata.fence_generation,
+        resource_name=metadata.resource_name,
+        operation_resource_name="exo-op-0123456789abcdef0123",
+    )
+
+    class Core:
+        secret = None
+
+        def patch_namespaced_secret(self, name, namespace, body):
+            if self.secret is None:
+                raise _ApiNotFound()
+            self.secret = _secret(body)
+
+        def create_namespaced_secret(self, namespace, body):
+            self.secret = _secret(body)
+
+        def read_namespaced_secret(self, name, namespace):
+            if self.secret is None:
+                raise _ApiNotFound()
+            return self.secret
+
+    def _secret(body):
+        assert body["metadata"]["name"] == "exomem-authorization-session"
+        assert set(body["stringData"]) == {
+            "keyring.json",
+            "control.json",
+            "serving-membership.json",
+        }
+        return SimpleNamespace(
+            metadata=SimpleNamespace(annotations=body["metadata"]["annotations"]),
+            data={
+                key: base64.b64encode(value.encode()).decode()
+                for key, value in body["stringData"].items()
+            },
+        )
+
+    core = Core()
+    adapter = KubernetesCellAdapter(
+        core_v1=core,
+        apps_v1=SimpleNamespace(),
+        identity_verifier=identity.verifier(),
+    )
+    files = {
+        "keyring.json": b'{"keyring":"value"}',
+        "control.json": b'{"control":"value"}',
+        "serving-membership.json": b'{"membership":"value"}',
+    }
+    assert await adapter.read_authorization_session_bundle(metadata) is None
+    await adapter.write_authorization_session_bundle(
+        metadata,
+        files,
+        recovery_envelope=envelopes["authorizationSessionSecret"],
+        membership_epoch=1,
+        membership_digest="a" * 64,
+        revision="b" * 64,
+    )
+
+    stored = await adapter.read_authorization_session_bundle(metadata)
+    assert stored == files
+    assert core.secret.metadata.annotations["exomem.io/recovery-envelope"] == envelopes[
+        "authorizationSessionSecret"
+    ]
+
+    core.secret.data["extra.json"] = base64.b64encode(b"{}").decode()
+    with pytest.raises(MetadataConflict, match="bundle shape"):
+        await adapter.read_authorization_session_bundle(metadata)
 
 
 @pytest.mark.asyncio

--- a/infra/provisioner/tests/test_provider_lifecycle.py
+++ b/infra/provisioner/tests/test_provider_lifecycle.py
@@ -786,8 +786,9 @@ def test_cell_provider_recovery_envelopes_are_unique_and_exact_per_object() -> N
         resource_name="exo-cell-alpha",
         operation_resource_name="exo-op-operation-alpha",
     )
+    assert "authorizationSessionSecret" in values
+    assert len(values) == 17
 
-    assert len(values) == 16
     assert len(set(values.values())) == len(values)
     codec.verifier().authenticate(
         values["controlIngressRoute"],

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -2435,6 +2435,9 @@ def test_cell_chart_renders_separate_privileged_init_and_restricted_serving_mode
         ]
         assert container["env"] == [{"name": "EXOMEM_LOG_DIR", "value": "/dev"}]
     else:
+        assert workload["spec"]["template"]["metadata"]["annotations"] == {
+            "exomem.io/authorization-session-revision": "a" * 64
+        }
         pod = workload["spec"]["template"]["spec"]
         assert pod["restartPolicy"] == "Always"
         assert "runtimeClassName" not in pod


### PR DESCRIPTION
## Summary

- mint the provisioner-owned Hosted authorization keyring, control record, and initial serving-membership epoch in the exact runtime wire format
- persist the closed three-file bundle in a separately recovery-authenticated Kubernetes Secret before Helm starts the cell
- bind the bundle revision into the StatefulSet pod template so custody changes force a new init-container snapshot
- preserve idempotency by authenticating and reusing an existing bootstrap generation instead of minting new authority on retry

Stacked after #892. This bootstrap remains fail-closed until governance enrollment; renewal and explicit drain/ack/rejoin follow in the next stack layer. It does not touch or merge any live vault.

## Verification

- red first: missing provisioner wire module, Secret adapter, and recovery-envelope member
- 102 focused provisioner lifecycle/provider tests
- 8 real pinned-Helm render/security tests
- cross-package runtime parser compatibility tests
- Ruff on all changed Python files
- `uv lock --check`
- `openspec validate harden-governance-for-consolidation --strict`
- public repository artifact validation
- `git diff --check`