### PR TITLE
feat(governance): advance hosted membership epochs

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/adapters.py
+++ b/infra/provisioner/src/exomem_provisioner/adapters.py
@@ -603,12 +603,12 @@ class KubernetesCellAdapter:
         membership_epoch: int,
         membership_digest: str,
         revision: str,
+        expected_revision: str | None = None,
     ) -> None:
         if (
             set(files) != AUTHORIZATION_SESSION_FILES
             or any(
-                not isinstance(value, bytes)
-                or not 1 <= len(value) <= MAX_BUNDLE_FILE_BYTES
+                not isinstance(value, bytes) or not 1 <= len(value) <= MAX_BUNDLE_FILE_BYTES
                 for value in files.values()
             )
             or not isinstance(membership_epoch, int)
@@ -616,8 +616,16 @@ class KubernetesCellAdapter:
             or membership_epoch < 1
             or re.fullmatch(r"[0-9a-f]{64}", membership_digest) is None
             or re.fullmatch(r"[0-9a-f]{64}", revision) is None
+            or revision
+            != hashlib.sha256(
+                files["keyring.json"] + files["control.json"] + files["serving-membership.json"]
+            ).hexdigest()
             or not isinstance(recovery_envelope, str)
             or not recovery_envelope
+            or (
+                expected_revision is not None
+                and re.fullmatch(r"[0-9a-f]{64}", expected_revision) is None
+            )
         ):
             raise MetadataConflict("authorization session bundle shape is invalid")
         annotations = {
@@ -628,9 +636,7 @@ class KubernetesCellAdapter:
             "exomem.io/authorization-session-revision": revision,
         }
         try:
-            string_data = {
-                name: value.decode("utf-8") for name, value in sorted(files.items())
-            }
+            string_data = {name: value.decode("utf-8") for name, value in sorted(files.items())}
         except UnicodeDecodeError as error:
             raise MetadataConflict("authorization session bundle shape is invalid") from error
         body = {
@@ -649,6 +655,51 @@ class KubernetesCellAdapter:
             "immutable": False,
             "stringData": string_data,
         }
+        if expected_revision is not None:
+            try:
+                current = await asyncio.to_thread(
+                    self._core.read_namespaced_secret,
+                    AUTHORIZATION_SESSION_SECRET_NAME,
+                    metadata.resource_name,
+                )
+            except Exception as error:
+                raise MetadataConflict(
+                    "authorization session bundle predecessor is absent"
+                ) from error
+            current_annotations = dict(
+                getattr(getattr(current, "metadata", None), "annotations", None) or {}
+            )
+            _require_annotations(current_annotations, metadata)
+            current_encoded = dict(getattr(current, "data", None) or {})
+            try:
+                current_files = {
+                    name: base64.b64decode(value, validate=True)
+                    for name, value in current_encoded.items()
+                }
+            except (TypeError, ValueError) as error:
+                raise MetadataConflict(
+                    "authorization session bundle predecessor differs"
+                ) from error
+            current_revision = (
+                hashlib.sha256(
+                    current_files["keyring.json"]
+                    + current_files["control.json"]
+                    + current_files["serving-membership.json"]
+                ).hexdigest()
+                if set(current_files) == AUTHORIZATION_SESSION_FILES
+                else None
+            )
+            resource_version = getattr(getattr(current, "metadata", None), "resource_version", None)
+            if (
+                current_annotations.get("exomem.io/recovery-envelope") != recovery_envelope
+                or current_revision != expected_revision
+                or current_annotations.get("exomem.io/authorization-session-revision")
+                != expected_revision
+                or not isinstance(resource_version, str)
+                or not resource_version
+            ):
+                raise MetadataConflict("authorization session bundle predecessor differs")
+            body["metadata"]["resourceVersion"] = resource_version
         try:
             await asyncio.to_thread(
                 self._core.patch_namespaced_secret,
@@ -657,13 +708,48 @@ class KubernetesCellAdapter:
                 body,
             )
         except Exception as error:
-            if _api_status(error) != 404:
+            if _api_status(error) == 409:
+                raise MetadataConflict(
+                    "authorization session bundle changed concurrently"
+                ) from error
+            if _api_status(error) != 404 or expected_revision is not None:
                 raise
             await asyncio.to_thread(
                 self._core.create_namespaced_secret,
                 metadata.resource_name,
                 body,
             )
+
+    async def stage_authorization_session_revision(
+        self,
+        metadata: OpaqueProviderMetadata,
+        revision: str,
+    ) -> None:
+        """Bind the next pod generation to an already-published Secret revision."""
+
+        if re.fullmatch(r"[0-9a-f]{64}", revision) is None:
+            raise MetadataConflict("authorization session revision is invalid")
+        try:
+            await asyncio.to_thread(
+                self._apps.patch_namespaced_stateful_set,
+                metadata.resource_name,
+                metadata.resource_name,
+                {
+                    "spec": {
+                        "template": {
+                            "metadata": {
+                                "annotations": {
+                                    "exomem.io/authorization-session-revision": revision
+                                }
+                            }
+                        }
+                    }
+                },
+            )
+        except Exception as error:
+            raise MetadataConflict(
+                "authorization session pod generation could not be staged"
+            ) from error
 
     async def read_authorization_session_bundle(
         self,
@@ -707,17 +793,13 @@ class KubernetesCellAdapter:
             raise MetadataConflict("authorization session bundle shape is invalid")
         try:
             files = {
-                name: base64.b64decode(value, validate=True)
-                for name, value in encoded.items()
+                name: base64.b64decode(value, validate=True) for name, value in encoded.items()
             }
         except (ValueError, TypeError) as error:
             raise MetadataConflict("authorization session bundle shape is invalid") from error
         if any(not 1 <= len(value) <= MAX_BUNDLE_FILE_BYTES for value in files.values()):
             raise MetadataConflict("authorization session bundle shape is invalid")
-        if any(
-            base64.b64encode(files[name]).decode("ascii") != encoded[name]
-            for name in files
-        ):
+        if any(base64.b64encode(files[name]).decode("ascii") != encoded[name] for name in files):
             raise MetadataConflict("authorization session bundle shape is invalid")
         return files
 
@@ -1421,8 +1503,8 @@ class PrivateCellApiAdapter:
         credential: str,
         protocol_version: str,
         operation_id: str,
-    ) -> None:
-        await self._call(
+    ) -> dict[str, Any]:
+        return await self._call(
             "POST",
             metadata,
             "lifecycle/quiesce",

--- a/infra/provisioner/src/exomem_provisioner/authorization_membership.py
+++ b/infra/provisioner/src/exomem_provisioner/authorization_membership.py
@@ -50,6 +50,10 @@ class HostedAuthorizationBundle:
     revision: str
     registry_attachment_id: str
     expires_at: int
+    replica_state: str
+    software_version: str
+    issuance_stopped: bool
+    no_in_flight: bool
 
     @property
     def files(self) -> dict[str, bytes]:
@@ -84,9 +88,11 @@ def _digest_identifier(domain: bytes, fields: tuple[bytes, ...], *, prefix: str)
 
 
 def _mac(key: bytes, payload: bytes) -> str:
-    return base64.urlsafe_b64encode(
-        hmac.new(key, payload, hashlib.sha256).digest()
-    ).rstrip(b"=").decode("ascii")
+    return (
+        base64.urlsafe_b64encode(hmac.new(key, payload, hashlib.sha256).digest())
+        .rstrip(b"=")
+        .decode("ascii")
+    )
 
 
 def _keyring_digest(keyring: Mapping[str, object]) -> str:
@@ -124,9 +130,7 @@ def _attestation_mac_input(value: Mapping[str, object]) -> bytes:
             str(value["schema_version"]).encode("ascii"),
             str(value["cell_id"]).encode("utf-8"),
             str(value["active_key_id"]).encode("utf-8"),
-            json.dumps(accepted, ensure_ascii=False, separators=(",", ":")).encode(
-                "utf-8"
-            ),
+            json.dumps(accepted, ensure_ascii=False, separators=(",", ":")).encode("utf-8"),
             str(value["control_digest"]).encode("ascii"),
             str(value["keyring_digest"]).encode("ascii"),
             str(value["attested_at"]).encode("ascii"),
@@ -190,11 +194,7 @@ def _required_identifier(value: object) -> str:
 
 
 def _required_time(value: object) -> int:
-    if (
-        isinstance(value, bool)
-        or not isinstance(value, int)
-        or not 1 <= value <= _MAX_INTEGER
-    ):
+    if isinstance(value, bool) or not isinstance(value, int) or not 1 <= value <= _MAX_INTEGER:
         raise MetadataConflict("authorization membership time is invalid")
     return value
 
@@ -344,6 +344,10 @@ def build_initial_hosted_authorization_bundle(
         revision=hashlib.sha256(keyring_raw + control_raw + membership_raw).hexdigest(),
         registry_attachment_id=attachment,
         expires_at=expires_at,
+        replica_state="SERVING",
+        software_version=release,
+        issuance_stopped=False,
+        no_in_flight=False,
     )
 
 
@@ -353,12 +357,13 @@ def inspect_hosted_authorization_bundle(
     expected_cell_id: str,
     expected_logical_vault_id: str,
     expected_replica_id: str,
-    expected_software_version: str,
+    expected_software_version: str | None,
     expected_schema_version: int,
     expected_recovery_envelope: str,
     now: int,
+    _require_fresh: bool = True,
 ) -> HostedAuthorizationBundle:
-    """Authenticate an existing initial generation for idempotent reconciliation."""
+    """Authenticate one exact singleton Hosted authorization generation."""
 
     if set(files) != AUTHORIZATION_SESSION_FILES:
         raise MetadataConflict("authorization session bundle shape is invalid")
@@ -389,16 +394,18 @@ def inspect_hosted_authorization_bundle(
     if not isinstance(encoded_key, str) or len(encoded_key) != 43:
         raise MetadataConflict("authorization keyring is invalid")
     try:
-        key = base64.b64decode(
-            encoded_key.encode("ascii") + b"=", altchars=b"-_", validate=True
-        )
+        key = base64.b64decode(encoded_key.encode("ascii") + b"=", altchars=b"-_", validate=True)
     except (UnicodeEncodeError, ValueError) as error:
         raise MetadataConflict("authorization keyring is invalid") from error
     current = _required_time(now)
     cell = _required_identifier(expected_cell_id)
     vault = _required_identifier(expected_logical_vault_id)
     replica = _required_identifier(expected_replica_id)
-    release = _required_identifier(expected_software_version)
+    release = (
+        None
+        if expected_software_version is None
+        else _required_identifier(expected_software_version)
+    )
     schema = _required_time(expected_schema_version)
     if not isinstance(expected_recovery_envelope, str) or not expected_recovery_envelope:
         raise MetadataConflict("authorization Secret provider authority is absent")
@@ -410,9 +417,7 @@ def inspect_hosted_authorization_bundle(
         or keyring["active_key_id"] != key_id
         or len(key) != 32
         or base64.urlsafe_b64encode(key).rstrip(b"=").decode("ascii") != encoded_key
-        or not _required_time(entry["not_before"]) <= current < _required_time(
-            entry["not_after"]
-        )
+        or not _required_time(entry["not_before"]) <= current < _required_time(entry["not_after"])
     ):
         raise MetadataConflict("authorization keyring is invalid")
     control = _closed_json(
@@ -455,23 +460,39 @@ def inspect_hosted_authorization_bundle(
         or control["cell_id"] != cell
         or control["logical_vault_id"] != vault
         or control["registry_attachment_id"] != expected_attachment
-        or control["attachment_epoch"] != 1
-        or control["governance_enrolled"] is not False
-        or any(
-            control[name] is not None
-            for name in (
-                "activation_store_id",
-                "activation_epoch",
-                "activation_state_digest",
+        or _required_time(control["attachment_epoch"]) < 1
+        or not isinstance(control["governance_enrolled"], bool)
+        or (
+            control["governance_enrolled"] is False
+            and any(
+                control[name] is not None
+                for name in (
+                    "activation_store_id",
+                    "activation_epoch",
+                    "activation_state_digest",
+                )
             )
         )
-        or control["serving_membership_epoch"] != 1
+        or (
+            control["governance_enrolled"] is True
+            and (
+                not isinstance(control["activation_store_id"], str)
+                or not control["activation_store_id"]
+                or _required_time(control["activation_epoch"]) < 1
+                or not isinstance(control["activation_state_digest"], str)
+                or _SHA256.fullmatch(control["activation_state_digest"]) is None
+            )
+        )
+        or _required_time(control["serving_membership_epoch"]) < 1
         or control["signing_key_id"] != key_id
-        or not _required_time(control["issued_at"])
-        <= current
-        < _required_time(control["expires_at"])
-        or _required_time(control["expires_at"])
-        - _required_time(control["issued_at"])
+        or _required_time(control["issued_at"]) >= _required_time(control["expires_at"])
+        or (
+            _require_fresh
+            and not _required_time(control["issued_at"])
+            <= current
+            < _required_time(control["expires_at"])
+        )
+        or _required_time(control["expires_at"]) - _required_time(control["issued_at"])
         > MAX_ATTESTATION_TTL_SECONDS
         or supplied_control_mac != _mac(key, _control_mac_input(control))
     ):
@@ -525,35 +546,55 @@ def inspect_hosted_authorization_bundle(
     digest = hashlib.sha256(membership_raw).hexdigest()
     if (
         membership["version"] != 1
-        or membership["epoch"] != 1
+        or _required_time(membership["epoch"])
+        != _required_time(control["serving_membership_epoch"])
         or membership["cell_id"] != cell
         or membership["logical_vault_id"] != vault
-        or membership["previous_epoch_digest"] is not None
+        or (
+            membership["previous_epoch_digest"] is not None
+            if membership["epoch"] == 1
+            else not isinstance(membership["previous_epoch_digest"], str)
+            or _SHA256.fullmatch(membership["previous_epoch_digest"]) is None
+        )
         or membership["signing_key_id"] != key_id
-        or not _required_time(membership["issued_at"])
-        <= current
-        < _required_time(membership["expires_at"])
+        or _required_time(membership["issued_at"]) >= _required_time(membership["expires_at"])
+        or (
+            _require_fresh
+            and not _required_time(membership["issued_at"])
+            <= current
+            < _required_time(membership["expires_at"])
+        )
         or digest != control["serving_membership_digest"]
         or membership["issued_at"] != control["issued_at"]
         or membership["expires_at"] != control["expires_at"]
-        or _required_time(membership["expires_at"])
-        - _required_time(membership["issued_at"])
+        or _required_time(membership["expires_at"]) - _required_time(membership["issued_at"])
         > MAX_ATTESTATION_TTL_SECONDS
         or supplied_membership_mac != expected_membership_mac
         or supplied_attestation_mac != expected_attestation_mac
         or attestation.get("replica_id") != replica
         or attestation.get("version") != 1
-        or attestation.get("epoch") != 1
-        or attestation.get("state") != "SERVING"
-        or attestation.get("software_version") != release
+        or attestation.get("epoch") != membership["epoch"]
+        or attestation.get("state") not in {"SERVING", "DRAINING"}
+        or (release is not None and attestation.get("software_version") != release)
         or attestation.get("schema_version") != schema
         or attestation.get("cell_id") != cell
         or attestation.get("active_key_id") != key_id
         or attestation.get("accepted_key_ids") != [key_id]
         or attestation.get("attested_at") != membership["issued_at"]
         or attestation.get("expires_at") != membership["expires_at"]
-        or attestation.get("issuance_stopped") is not False
-        or attestation.get("no_in_flight") is not False
+        or not isinstance(attestation.get("issuance_stopped"), bool)
+        or not isinstance(attestation.get("no_in_flight"), bool)
+        or (
+            attestation.get("state") == "SERVING"
+            and (
+                attestation.get("issuance_stopped") is not False
+                or attestation.get("no_in_flight") is not False
+            )
+        )
+        or (
+            attestation.get("state") == "DRAINING"
+            and attestation.get("issuance_stopped") is not True
+        )
         or attestation.get("signing_key_id") != key_id
         or attestation.get("control_digest") != _control_basis_digest(control)
         or attestation.get("keyring_digest") != _keyring_digest(keyring)
@@ -563,9 +604,194 @@ def inspect_hosted_authorization_bundle(
         keyring=keyring_raw,
         control=control_raw,
         membership=membership_raw,
-        epoch=1,
+        epoch=_required_time(membership["epoch"]),
         membership_digest=digest,
         revision=hashlib.sha256(keyring_raw + control_raw + membership_raw).hexdigest(),
         registry_attachment_id=expected_attachment,
         expires_at=_required_time(membership["expires_at"]),
+        replica_state=str(attestation["state"]),
+        software_version=str(attestation["software_version"]),
+        issuance_stopped=bool(attestation["issuance_stopped"]),
+        no_in_flight=bool(attestation["no_in_flight"]),
+    )
+
+
+def transition_hosted_authorization_bundle(
+    files: Mapping[str, bytes],
+    *,
+    expected_cell_id: str,
+    expected_logical_vault_id: str,
+    expected_replica_id: str,
+    expected_software_version: str | None,
+    expected_schema_version: int,
+    expected_recovery_envelope: str,
+    target_state: str,
+    target_no_in_flight: bool,
+    target_software_version: str | None = None,
+    now: int,
+    ttl_seconds: int = DEFAULT_ATTESTATION_TTL_SECONDS,
+    renew: bool = False,
+) -> HostedAuthorizationBundle:
+    """Publish one authenticated singleton successor, never a liveness inference."""
+
+    if (
+        target_state not in {"SERVING", "DRAINING"}
+        or not isinstance(target_no_in_flight, bool)
+        or (target_state == "SERVING" and target_no_in_flight)
+        or not isinstance(renew, bool)
+        or not 1 <= ttl_seconds <= MAX_ATTESTATION_TTL_SECONDS
+    ):
+        raise MetadataConflict("authorization membership transition is invalid")
+    current = _required_time(now)
+    source = inspect_hosted_authorization_bundle(
+        files,
+        expected_cell_id=expected_cell_id,
+        expected_logical_vault_id=expected_logical_vault_id,
+        expected_replica_id=expected_replica_id,
+        expected_software_version=expected_software_version,
+        expected_schema_version=expected_schema_version,
+        expected_recovery_envelope=expected_recovery_envelope,
+        now=current,
+        _require_fresh=False,
+    )
+    target_release = _required_identifier(
+        source.software_version if target_software_version is None else target_software_version
+    )
+    if (
+        source.replica_state == target_state
+        and source.no_in_flight is target_no_in_flight
+        and source.software_version == target_release
+        and not renew
+    ):
+        return source
+    if source.expires_at <= current and not (
+        source.replica_state == "DRAINING" and source.no_in_flight and target_state == "SERVING"
+    ):
+        raise MetadataConflict("stale authorization membership cannot be renewed")
+    if source.replica_state == "SERVING" and target_state == "DRAINING":
+        if not target_no_in_flight:
+            raise MetadataConflict("authorization drain acknowledgement is incomplete")
+    elif source.replica_state == "DRAINING" and target_state == "SERVING":
+        if not source.no_in_flight:
+            raise MetadataConflict("authorization membership is not fully drained")
+    elif source.replica_state != target_state:
+        raise MetadataConflict("authorization membership transition is invalid")
+
+    keyring_raw = files["keyring.json"]
+    keyring = _closed_json(
+        keyring_raw,
+        frozenset(
+            {
+                "version",
+                "keyring_id",
+                "cell_id",
+                "logical_vault_id",
+                "active_key_id",
+                "accepted_keys",
+            }
+        ),
+        label="keyring",
+    )
+    entries = keyring["accepted_keys"]
+    if not isinstance(entries, list) or len(entries) != 1 or not isinstance(entries[0], dict):
+        raise MetadataConflict("authorization keyring is invalid")
+    entry = entries[0]
+    try:
+        encoded_key = entry["key"]
+        if not isinstance(encoded_key, str):
+            raise ValueError
+        key = base64.b64decode(encoded_key.encode("ascii") + b"=", altchars=b"-_", validate=True)
+    except (KeyError, UnicodeEncodeError, ValueError) as error:
+        raise MetadataConflict("authorization keyring is invalid") from error
+    if len(key) != 32:
+        raise MetadataConflict("authorization keyring is invalid")
+    control = _closed_json(
+        files["control.json"],
+        frozenset(
+            {
+                "version",
+                "keyring_id",
+                "cell_id",
+                "logical_vault_id",
+                "registry_attachment_id",
+                "attachment_epoch",
+                "governance_enrolled",
+                "activation_store_id",
+                "activation_epoch",
+                "activation_state_digest",
+                "serving_membership_epoch",
+                "serving_membership_digest",
+                "issued_at",
+                "expires_at",
+                "signing_key_id",
+                "mac",
+            }
+        ),
+        label="control",
+    )
+    control.pop("mac")
+    epoch = source.epoch + 1
+    expires_at = current + ttl_seconds
+    key_id = _required_identifier(keyring["active_key_id"])
+    accepted_key_ids = sorted(
+        _required_identifier(item["key_id"]) for item in entries if isinstance(item, dict)
+    )
+    if accepted_key_ids != [key_id]:
+        raise MetadataConflict("authorization keyring is invalid")
+    attestation: dict[str, object] = {
+        "version": 1,
+        "epoch": epoch,
+        "replica_id": _required_identifier(expected_replica_id),
+        "state": target_state,
+        "software_version": target_release,
+        "schema_version": _required_time(expected_schema_version),
+        "cell_id": _required_identifier(expected_cell_id),
+        "active_key_id": key_id,
+        "accepted_key_ids": accepted_key_ids,
+        "control_digest": _control_basis_digest(control),
+        "keyring_digest": _keyring_digest(keyring),
+        "attested_at": current,
+        "expires_at": expires_at,
+        "issuance_stopped": target_state == "DRAINING",
+        "no_in_flight": target_no_in_flight,
+        "signing_key_id": key_id,
+    }
+    attestation["mac"] = _mac(key, _attestation_mac_input(attestation))
+    membership: dict[str, object] = {
+        "version": 1,
+        "epoch": epoch,
+        "cell_id": expected_cell_id,
+        "logical_vault_id": expected_logical_vault_id,
+        "previous_epoch_digest": source.membership_digest,
+        "issued_at": current,
+        "expires_at": expires_at,
+        "replicas": [attestation],
+        "signing_key_id": key_id,
+    }
+    membership["mac"] = _mac(key, _membership_mac_input(membership))
+    membership_raw = _canonical(membership)
+    membership_digest = hashlib.sha256(membership_raw).hexdigest()
+    control.update(
+        {
+            "serving_membership_epoch": epoch,
+            "serving_membership_digest": membership_digest,
+            "issued_at": current,
+            "expires_at": expires_at,
+        }
+    )
+    control["mac"] = _mac(key, _control_mac_input(control))
+    control_raw = _canonical(control)
+    return HostedAuthorizationBundle(
+        keyring=keyring_raw,
+        control=control_raw,
+        membership=membership_raw,
+        epoch=epoch,
+        membership_digest=membership_digest,
+        revision=hashlib.sha256(keyring_raw + control_raw + membership_raw).hexdigest(),
+        registry_attachment_id=source.registry_attachment_id,
+        expires_at=expires_at,
+        replica_state=target_state,
+        software_version=target_release,
+        issuance_stopped=target_state == "DRAINING",
+        no_in_flight=target_no_in_flight,
     )

--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -25,6 +25,7 @@ from .authorization_membership import (
     AUTHORIZATION_SESSION_SCHEMA_VERSION,
     build_initial_hosted_authorization_bundle,
     inspect_hosted_authorization_bundle,
+    transition_hosted_authorization_bundle,
 )
 from .capacity import CapacityError
 from .driver import EffectContext
@@ -170,9 +171,7 @@ class KubernetesProviderRegistry:
                 await asyncio.to_thread(
                     self._core.list_namespaced_config_map,
                     metadata.resource_name,
-                    label_selector=(
-                        f"owner=helm,name={metadata.resource_name},status=deployed"
-                    ),
+                    label_selector=(f"owner=helm,name={metadata.resource_name},status=deployed"),
                 ),
                 "items",
                 (),
@@ -199,7 +198,11 @@ class KubernetesProviderRegistry:
             metadata,
             provider="kubernetes",
             provider_reference=ProviderReference.kubernetes(
-                provider="kubernetes", api_version="v1", kind="Namespace", namespace="", name=metadata.resource_name
+                provider="kubernetes",
+                api_version="v1",
+                kind="Namespace",
+                namespace="",
+                name=metadata.resource_name,
             ),
         )
         self._authenticate_annotations(
@@ -207,7 +210,11 @@ class KubernetesProviderRegistry:
             metadata,
             provider="kubernetes",
             provider_reference=ProviderReference.kubernetes(
-                provider="kubernetes", api_version="v1", kind="PersistentVolumeClaim", namespace=metadata.resource_name, name=metadata.resource_name + "-data"
+                provider="kubernetes",
+                api_version="v1",
+                kind="PersistentVolumeClaim",
+                namespace=metadata.resource_name,
+                name=metadata.resource_name + "-data",
             ),
         )
         self._authenticate_annotations(
@@ -215,7 +222,11 @@ class KubernetesProviderRegistry:
             metadata,
             provider="kubernetes",
             provider_reference=ProviderReference.kubernetes(
-                provider="kubernetes", api_version="v1", kind="ConfigMap", namespace=metadata.resource_name, name=provider_operation_resource_name(metadata.operation_id)
+                provider="kubernetes",
+                api_version="v1",
+                kind="ConfigMap",
+                namespace=metadata.resource_name,
+                name=provider_operation_resource_name(metadata.operation_id),
             ),
         )
         try:
@@ -235,12 +246,14 @@ class KubernetesProviderRegistry:
                 metadata,
                 provider="kubernetes",
                 provider_reference=ProviderReference.kubernetes(
-                    provider="kubernetes", api_version="batch/v1", kind="Job", namespace=metadata.resource_name, name=metadata.resource_name + "-init"
+                    provider="kubernetes",
+                    api_version="batch/v1",
+                    kind="Job",
+                    namespace=metadata.resource_name,
+                    name=metadata.resource_name + "-init",
                 ),
             )
-        return self._recovery_digest(
-            namespace, pvc, operation_record, helm_record, init_job
-        )
+        return self._recovery_digest(namespace, pvc, operation_record, helm_record, init_job)
 
     async def inspect(
         self,
@@ -323,8 +336,7 @@ class KubernetesProviderRegistry:
         )
         init_failed = not init_complete and (
             any(
-                getattr(item, "type", None) == "Failed"
-                and getattr(item, "status", None) == "True"
+                getattr(item, "type", None) == "Failed" and getattr(item, "status", None) == "True"
                 for item in conditions
             )
             or bool(getattr(getattr(init_job, "status", None), "failed", 0))
@@ -400,9 +412,7 @@ class KubernetesProviderRegistry:
                 "exomem.io/vault-id": helm_values["vaultId"],
                 "exomem.io/expected-release": helm_values["expectedRelease"],
                 "exomem.io/worker-policy-digest": helm_values["workerPolicyDigest"],
-                "exomem.io/records-reader-version": str(
-                    helm_values["recordsReaderVersion"]
-                ),
+                "exomem.io/records-reader-version": str(helm_values["recordsReaderVersion"]),
                 "exomem.io/lifecycle-actions-enabled": str(
                     helm_values["lifecycleActionsEnabled"]
                 ).lower(),
@@ -440,9 +450,7 @@ class KubernetesProviderRegistry:
                 )
                 != provision_mode
             ):
-                raise MetadataConflict(
-                    "Kubernetes namespace provision mode differs"
-                ) from error
+                raise MetadataConflict("Kubernetes namespace provision mode differs") from error
 
     async def record_operation(
         self, metadata: OpaqueProviderMetadata, recovery_envelope: str
@@ -643,7 +651,7 @@ class LiveLifecyclePlane:
                 expected_cell_id=owned.subject_id,
                 expected_logical_vault_id=owned.tenant_id,
                 expected_replica_id=replica_id,
-                expected_software_version=str(target["releaseVersion"]),
+                expected_software_version=None,
                 expected_schema_version=AUTHORIZATION_SESSION_SCHEMA_VERSION,
                 expected_recovery_envelope=recovery_envelope,
                 now=current,
@@ -657,10 +665,74 @@ class LiveLifecyclePlane:
         values: dict[str, Any],
     ) -> dict[str, Any]:
         desired = dict(values)
-        desired["authorizationSessionRevision"] = (
-            await self._authorization_session_revision(metadata, request)
+        desired["authorizationSessionRevision"] = await self._authorization_session_revision(
+            metadata, request
         )
         return desired
+
+    async def _transition_authorization_session_membership(
+        self,
+        metadata: OpaqueProviderMetadata,
+        *,
+        target_state: str,
+        target_no_in_flight: bool,
+        target_software_version: str | None = None,
+    ) -> str:
+        """Commit one authenticated successor under the lifecycle maintenance lease."""
+
+        key = self._key(metadata)
+        owned = self._owner(metadata)
+        try:
+            original = self._helm_requests[key]
+        except KeyError as error:
+            raise MetadataConflict(
+                "original authorization session identity is unavailable"
+            ) from error
+        envelopes = original.get("_providerRecoveryEnvelopes")
+        if not isinstance(envelopes, dict):
+            raise MetadataConflict("authorization Secret provider authority is absent")
+        recovery_envelope = envelopes.get("authorizationSessionSecret")
+        if not isinstance(recovery_envelope, str) or not recovery_envelope:
+            raise MetadataConflict("authorization Secret provider authority is absent")
+        files = await self._cell.read_authorization_session_bundle(owned)
+        if files is None:
+            raise MetadataConflict("authorization session bundle is absent")
+        current = int(self._now())
+        source = inspect_hosted_authorization_bundle(
+            files,
+            expected_cell_id=owned.subject_id,
+            expected_logical_vault_id=owned.tenant_id,
+            expected_replica_id=owned.resource_name + "-0",
+            expected_software_version=None,
+            expected_schema_version=AUTHORIZATION_SESSION_SCHEMA_VERSION,
+            expected_recovery_envelope=recovery_envelope,
+            now=current,
+            _require_fresh=False,
+        )
+        successor = transition_hosted_authorization_bundle(
+            files,
+            expected_cell_id=owned.subject_id,
+            expected_logical_vault_id=owned.tenant_id,
+            expected_replica_id=owned.resource_name + "-0",
+            expected_software_version=None,
+            expected_schema_version=AUTHORIZATION_SESSION_SCHEMA_VERSION,
+            expected_recovery_envelope=recovery_envelope,
+            target_state=target_state,
+            target_no_in_flight=target_no_in_flight,
+            target_software_version=target_software_version,
+            now=current,
+        )
+        if successor.revision != source.revision:
+            await self._cell.write_authorization_session_bundle(
+                owned,
+                successor.files,
+                recovery_envelope=recovery_envelope,
+                membership_epoch=successor.epoch,
+                membership_digest=successor.membership_digest,
+                revision=successor.revision,
+                expected_revision=source.revision,
+            )
+        return successor.revision
 
     async def observed_fence(self, tenant_id: str) -> int:
         return await self._registry.observed_fence(tenant_id)
@@ -855,7 +927,9 @@ class LiveLifecyclePlane:
     def runtime_admitted(self, metadata: OpaqueProviderMetadata) -> bool:
         return self._snapshot(metadata).runtime_admitted
 
-    async def enable_routes(self, metadata: OpaqueProviderMetadata, request: dict[str, Any]) -> None:
+    async def enable_routes(
+        self, metadata: OpaqueProviderMetadata, request: dict[str, Any]
+    ) -> None:
         owner = self._owner(metadata)
         if self._key(metadata) not in self._helm_requests:
             raise MetadataConflict("original Helm request was not authenticated")
@@ -928,14 +1002,48 @@ class LiveLifecyclePlane:
             except KeyError as error:
                 raise MetadataConflict("original runtime identity is unavailable") from error
         target = runtime_identity(runtime_request)
-        await self._runtime.quiesce(
+        snapshot = await self._runtime.quiesce(
             self._owner(metadata),
             credential=str(request["serviceCredential"]),
             protocol_version=target["protocolVersion"],
             operation_id=operation_id,
         )
+        if (
+            not isinstance(snapshot, dict)
+            or set(snapshot)
+            != {
+                "phase",
+                "active_reads",
+                "active_mutations",
+                "active_transfers",
+                "reason_code",
+            }
+            or snapshot.get("phase") != "quiesced"
+            or any(
+                type(snapshot.get(name)) is not int or snapshot[name] != 0
+                for name in ("active_reads", "active_mutations", "active_transfers")
+            )
+            or not isinstance(snapshot.get("reason_code"), str)
+            or not snapshot["reason_code"]
+        ):
+            raise MetadataConflict("runtime did not acknowledge a complete authorization drain")
+        await self._transition_authorization_session_membership(
+            metadata,
+            target_state="DRAINING",
+            target_no_in_flight=True,
+        )
 
     async def scale(self, metadata: OpaqueProviderMetadata, replicas: int) -> None:
+        if replicas == 1:
+            revision = await self._transition_authorization_session_membership(
+                metadata,
+                target_state="SERVING",
+                target_no_in_flight=False,
+            )
+            await self._cell.stage_authorization_session_revision(
+                self._owner(metadata),
+                revision,
+            )
         await self._cell.scale(self._owner(metadata), replicas)
 
     async def resume(
@@ -1018,8 +1126,15 @@ class LiveLifecyclePlane:
         config: LifecycleConfig,
         operation_id: str,
     ) -> None:
+        target_release = runtime_identity(request)["releaseVersion"]
+        revision = await self._transition_authorization_session_membership(
+            metadata,
+            target_state="SERVING",
+            target_no_in_flight=False,
+            target_software_version=target_release,
+        )
         values = self._rollforward_helm_values(metadata, request, config)
-        values = await self._authorization_helm_values(metadata, request, values)
+        values["authorizationSessionRevision"] = revision
         values["workloadMode"] = "serve"
         values["routes"]["enabled"] = False
         await self._helm.transition_release(
@@ -1037,6 +1152,20 @@ class LiveLifecyclePlane:
         await self._helm.rollback_release(
             self._owner(metadata),
             operation_id=operation_id,
+        )
+        try:
+            original = self._helm_requests[self._key(metadata)]
+        except KeyError as error:
+            raise MetadataConflict("original runtime identity is unavailable") from error
+        revision = await self._transition_authorization_session_membership(
+            metadata,
+            target_state="SERVING",
+            target_no_in_flight=False,
+            target_software_version=runtime_identity(original)["releaseVersion"],
+        )
+        await self._cell.stage_authorization_session_revision(
+            self._owner(metadata),
+            revision,
         )
         await self._refresh(metadata)
 
@@ -1146,9 +1275,7 @@ class LiveLifecyclePlane:
                 raise MetadataConflict("pending credential version is immutable")
             return
         credentials[pending] = credential
-        target = self._config.runtime_target_for(
-            request, v2="runtimeTarget" in request
-        )
+        target = self._config.runtime_target_for(request, v2="runtimeTarget" in request)
         result = await self._credential_transition(
             owned,
             credentials=credentials,
@@ -1188,9 +1315,7 @@ class LiveLifecyclePlane:
             return True
         revision = int(annotations.get("exomem.io/security-revision", "0"))
         probe_operation = operation_id + ":credential-probe"
-        target = self._config.runtime_target_for(
-            request, v2="runtimeTarget" in request
-        )
+        target = self._config.runtime_target_for(request, v2="runtimeTarget" in request)
         operator_request = {
             "request_id": _deterministic_uuid4(probe_operation),
             "operation_id": probe_operation,
@@ -1238,9 +1363,7 @@ class LiveLifecyclePlane:
         credentials, annotations = await self._cell.read_credential_bundle(owned)
         pending = str(version)
         old_version = annotations.get("exomem.io/active-credential-version")
-        target = self._config.runtime_target_for(
-            request, v2="runtimeTarget" in request
-        )
+        target = self._config.runtime_target_for(request, v2="runtimeTarget" in request)
         if old_version == pending and set(credentials) == {pending}:
             return await self._runtime.credential_rejected(
                 owned,
@@ -1256,9 +1379,9 @@ class LiveLifecyclePlane:
                 credentials=credentials,
                 annotations=annotations,
                 action="promote",
-            operation_id=operation_id,
-            version=pending,
-            protocol_version=target["protocolVersion"],
+                operation_id=operation_id,
+                version=pending,
+                protocol_version=target["protocolVersion"],
             )
             if result.get("phase") != "promoted":
                 raise MetadataConflict("hosted credential did not promote")
@@ -1277,9 +1400,9 @@ class LiveLifecyclePlane:
                 credentials=credentials,
                 annotations=annotations,
                 action="finalize",
-            operation_id=operation_id,
-            version=pending,
-            protocol_version=target["protocolVersion"],
+                operation_id=operation_id,
+                version=pending,
+                protocol_version=target["protocolVersion"],
             )
             if result.get("phase") != "stable" or result.get("active_version") != pending:
                 raise MetadataConflict("hosted credential did not finalize")

--- a/infra/provisioner/tests/test_authorization_membership.py
+++ b/infra/provisioner/tests/test_authorization_membership.py
@@ -2,17 +2,39 @@ from __future__ import annotations
 
 import hashlib
 
+import pytest
 from exomem.governance import authorization_custody, authorization_serving_membership
 
 from exomem_provisioner.authorization_membership import (
     build_initial_hosted_authorization_bundle,
     inspect_hosted_authorization_bundle,
+    transition_hosted_authorization_bundle,
 )
+from exomem_provisioner.lifecycle import MetadataConflict
 
 
 def _entropy(length: int) -> bytes:
     assert length == 32
     return bytes(range(32))
+
+
+def _runtime_membership(bundle, *, now: int):
+    keyring = authorization_custody.parse_keyring(bundle.keyring)
+    control = authorization_custody.parse_control_record(
+        bundle.control,
+        keyring=keyring,
+        now=now,
+    )
+    record = authorization_serving_membership.parse_serving_membership(
+        bundle.membership,
+        verifier_keys={item.key_id: item.key for item in keyring.accepted_keys},
+        now=now,
+        expected_cell_id="cell-alpha",
+        expected_logical_vault_id="tenant-alpha",
+        expected_epoch=control.serving_membership_epoch,
+        expected_digest=control.serving_membership_digest,
+    )
+    return control, record
 
 
 def test_initial_hosted_bundle_is_byte_compatible_with_the_runtime_verifier() -> None:
@@ -54,9 +76,10 @@ def test_initial_hosted_bundle_is_byte_compatible_with_the_runtime_verifier() ->
     assert membership.replicas[0].replica_id == "exo-0123456789abcdef0123-0"
     assert membership.replicas[0].software_version == "0.48.0"
     assert membership.replicas[0].schema_version == 4
-    assert bundle.revision == hashlib.sha256(
-        bundle.keyring + bundle.control + bundle.membership
-    ).hexdigest()
+    assert (
+        bundle.revision
+        == hashlib.sha256(bundle.keyring + bundle.control + bundle.membership).hexdigest()
+    )
 
 
 def test_existing_hosted_bundle_is_exactly_bound_and_never_regenerated_on_retry() -> None:
@@ -88,3 +111,123 @@ def test_existing_hosted_bundle_is_exactly_bound_and_never_regenerated_on_retry(
     )
 
     assert inspected == bundle
+
+
+def test_drain_and_current_epoch_rejoin_are_authenticated_runtime_successors() -> None:
+    now = 1_900_000_000
+    initial = build_initial_hosted_authorization_bundle(
+        cell_id="cell-alpha",
+        logical_vault_id="tenant-alpha",
+        replica_id="exo-0123456789abcdef0123-0",
+        software_version="0.48.0",
+        schema_version=4,
+        recovery_envelope="signed-authorization-session-secret",
+        now=now,
+        entropy=_entropy,
+    )
+    _initial_control, initial_record = _runtime_membership(initial, now=now)
+
+    drained = transition_hosted_authorization_bundle(
+        initial.files,
+        expected_cell_id="cell-alpha",
+        expected_logical_vault_id="tenant-alpha",
+        expected_replica_id="exo-0123456789abcdef0123-0",
+        expected_software_version="0.48.0",
+        expected_schema_version=4,
+        expected_recovery_envelope="signed-authorization-session-secret",
+        target_state="DRAINING",
+        target_no_in_flight=True,
+        now=now + 30,
+    )
+    _drained_control, drained_record = _runtime_membership(drained, now=now + 30)
+    authorization_serving_membership.validate_membership_successor(
+        initial_record,
+        drained_record,
+        now=now + 30,
+    )
+    assert (drained.epoch, drained.replica_state, drained.issuance_stopped) == (
+        2,
+        "DRAINING",
+        True,
+    )
+    assert drained.no_in_flight is True
+    assert (
+        transition_hosted_authorization_bundle(
+            drained.files,
+            expected_cell_id="cell-alpha",
+            expected_logical_vault_id="tenant-alpha",
+            expected_replica_id="exo-0123456789abcdef0123-0",
+            expected_software_version="0.48.0",
+            expected_schema_version=4,
+            expected_recovery_envelope="signed-authorization-session-secret",
+            target_state="DRAINING",
+            target_no_in_flight=True,
+            now=now + 31,
+        )
+        == drained
+    )
+
+    rejoined = transition_hosted_authorization_bundle(
+        drained.files,
+        expected_cell_id="cell-alpha",
+        expected_logical_vault_id="tenant-alpha",
+        expected_replica_id="exo-0123456789abcdef0123-0",
+        expected_software_version="0.48.0",
+        expected_schema_version=4,
+        expected_recovery_envelope="signed-authorization-session-secret",
+        target_state="SERVING",
+        target_no_in_flight=False,
+        target_software_version="0.49.0",
+        now=now + 4_000,
+    )
+    _rejoined_control, rejoined_record = _runtime_membership(rejoined, now=now + 4_000)
+    authorization_serving_membership.validate_membership_successor(
+        drained_record,
+        rejoined_record,
+        now=now + 4_000,
+    )
+    assert (rejoined.epoch, rejoined.replica_state, rejoined.no_in_flight) == (
+        3,
+        "SERVING",
+        False,
+    )
+    assert rejoined_record.replicas[0].software_version == "0.49.0"
+
+
+def test_membership_transition_never_infers_drain_or_renews_stale_serving_state() -> None:
+    now = 1_900_000_000
+    initial = build_initial_hosted_authorization_bundle(
+        cell_id="cell-alpha",
+        logical_vault_id="tenant-alpha",
+        replica_id="exo-0123456789abcdef0123-0",
+        software_version="0.48.0",
+        schema_version=4,
+        recovery_envelope="signed-authorization-session-secret",
+        now=now,
+        entropy=_entropy,
+    )
+    common = {
+        "expected_cell_id": "cell-alpha",
+        "expected_logical_vault_id": "tenant-alpha",
+        "expected_replica_id": "exo-0123456789abcdef0123-0",
+        "expected_software_version": "0.48.0",
+        "expected_schema_version": 4,
+        "expected_recovery_envelope": "signed-authorization-session-secret",
+    }
+    with pytest.raises(MetadataConflict, match="drain acknowledgement"):
+        transition_hosted_authorization_bundle(
+            initial.files,
+            **common,
+            target_state="DRAINING",
+            target_no_in_flight=False,
+            now=now + 30,
+        )
+    with pytest.raises(MetadataConflict, match="stale"):
+        transition_hosted_authorization_bundle(
+            initial.files,
+            **common,
+            target_state="SERVING",
+            target_no_in_flight=False,
+            now=now + 4_000,
+            renew=True,
+        )

--- a/infra/provisioner/tests/test_live_provider.py
+++ b/infra/provisioner/tests/test_live_provider.py
@@ -9,6 +9,10 @@ from types import SimpleNamespace
 import pytest
 from pydantic import ValidationError
 
+from exomem_provisioner.authorization_membership import (
+    build_initial_hosted_authorization_bundle,
+    inspect_hosted_authorization_bundle,
+)
 from exomem_provisioner.capacity import CapacityConflict
 from exomem_provisioner.config import (
     ProviderWorkerSettings,
@@ -581,15 +585,36 @@ async def test_live_rollforward_uses_target_fingerprint_and_original_helm_author
             assert credential == "credential-current"
             assert operation_id == "rollforward-alpha"
             quiesced_protocols.append(protocol_version)
+            return {
+                "phase": "quiesced",
+                "active_reads": 0,
+                "active_mutations": 0,
+                "active_transfers": 0,
+                "reason_code": "HOSTED_QUIESCED",
+            }
 
     class Cell:
-        files = None
+        files = build_initial_hosted_authorization_bundle(
+            cell_id=owner.subject_id,
+            logical_vault_id=owner.tenant_id,
+            replica_id=owner.resource_name + "-0",
+            software_version="0.54.1",
+            schema_version=4,
+            recovery_envelope=original_request["_providerRecoveryEnvelopes"][
+                "authorizationSessionSecret"
+            ],
+            now=1_900_000_000,
+            entropy=lambda length: bytes(range(length)),
+        ).files
 
         async def read_authorization_session_bundle(self, _owner):
             return self.files
 
         async def write_authorization_session_bundle(self, _owner, files, **_kwargs):
             self.files = files
+
+        async def stage_authorization_session_revision(self, _owner, _revision):
+            return None
 
     plane = LiveLifecyclePlane(
         repository=SimpleNamespace(),  # type: ignore[arg-type]
@@ -603,6 +628,7 @@ async def test_live_rollforward_uses_target_fingerprint_and_original_helm_author
         identity_verifier=IDENTITY_CODEC.verifier(),
         config=config,
         fingerprint=Fingerprint(),  # type: ignore[arg-type]
+        now=lambda: 1_900_000_030,
     )
     key = plane._key(current)
     plane._owned[key] = owner
@@ -620,6 +646,20 @@ async def test_live_rollforward_uses_target_fingerprint_and_original_helm_author
     await plane.upgrade_runtime(current, request, config, "rollforward-alpha")
     await plane.rollback_runtime(current, "rollforward-alpha")
 
+    rolled_back = inspect_hosted_authorization_bundle(
+        plane._cell.files,
+        expected_cell_id=owner.subject_id,
+        expected_logical_vault_id=owner.tenant_id,
+        expected_replica_id=owner.resource_name + "-0",
+        expected_software_version="0.54.1",
+        expected_schema_version=4,
+        expected_recovery_envelope=original_request["_providerRecoveryEnvelopes"][
+            "authorizationSessionSecret"
+        ],
+        now=1_900_000_030,
+    )
+    assert (rolled_back.epoch, rolled_back.replica_state) == (4, "SERVING")
+
     assert fingerprints == [(current, "rollforward-alpha", "before")]
     assert quiesced_protocols == ["legacy-protocol"]
     assert [values["workloadMode"] for _owner, values, _operation in transitions] == [
@@ -630,12 +670,136 @@ async def test_live_rollforward_uses_target_fingerprint_and_original_helm_author
         assert transition_owner == owner
         assert operation == "rollforward-alpha"
         assert values["image"] == config.image
-        assert values["providerRecoveryEnvelopes"] == original_request[
-            "_providerRecoveryEnvelopes"
-        ]
+        assert values["providerRecoveryEnvelopes"] == original_request["_providerRecoveryEnvelopes"]
         assert values["routes"]["enabled"] is False
     assert transitions[0][1]["initOperationId"] == "rollforward-alpha"
     assert rollbacks == [(owner, "rollforward-alpha")]
+
+
+@pytest.mark.asyncio
+async def test_membership_drain_requires_zero_runtime_snapshot_and_rejoin_precedes_scale() -> None:
+    metadata = _metadata()
+    now = 1_900_000_000
+    envelopes = cell_provider_recovery_envelopes(
+        IDENTITY_CODEC,
+        tenant_id=metadata.tenant_id,
+        cell_id=metadata.subject_id,
+        operation_id=metadata.operation_id,
+        fence_generation=metadata.fence_generation,
+        resource_name=metadata.resource_name,
+        operation_resource_name=provider_operation_resource_name(metadata.operation_id),
+    )
+    request = {
+        "serviceCredential": "credential-current",
+        "runtimeTarget": {
+            "releaseVersion": "0.48.0",
+            "protocolVersion": "1",
+            "agentProfile": "hosted-alpha-agent-v1",
+            "gatewayContractDigest": "a" * 64,
+            "commandFingerprint": "b" * 64,
+            "schemaDigest": "c" * 64,
+        },
+        "_providerRecoveryEnvelopes": envelopes,
+    }
+    initial = build_initial_hosted_authorization_bundle(
+        cell_id=metadata.subject_id,
+        logical_vault_id=metadata.tenant_id,
+        replica_id=metadata.resource_name + "-0",
+        software_version="0.48.0",
+        schema_version=4,
+        recovery_envelope=envelopes["authorizationSessionSecret"],
+        now=now,
+        entropy=lambda length: bytes(range(length)),
+    )
+    events: list[tuple[object, ...]] = []
+
+    class Runtime:
+        active_reads = 1
+
+        async def quiesce(self, *_args, **_kwargs):
+            return {
+                "phase": "quiesced",
+                "active_reads": self.active_reads,
+                "active_mutations": 0,
+                "active_transfers": 0,
+                "reason_code": "HOSTED_QUIESCED",
+            }
+
+    class Cell:
+        files = initial.files
+
+        async def read_authorization_session_bundle(self, _owner):
+            return self.files
+
+        async def write_authorization_session_bundle(
+            self, _owner, files, *, expected_revision, **_kwargs
+        ):
+            events.append(("write", expected_revision))
+            self.files = files
+
+        async def stage_authorization_session_revision(self, _owner, revision):
+            events.append(("stage", revision))
+
+        async def scale(self, _owner, replicas):
+            events.append(("scale", replicas))
+
+    runtime = Runtime()
+    cell = Cell()
+    plane = LiveLifecyclePlane(
+        repository=SimpleNamespace(),  # type: ignore[arg-type]
+        registry=SimpleNamespace(),  # type: ignore[arg-type]
+        cell=cell,  # type: ignore[arg-type]
+        helm=SimpleNamespace(),  # type: ignore[arg-type]
+        runtime=runtime,  # type: ignore[arg-type]
+        routes=SimpleNamespace(),  # type: ignore[arg-type]
+        maintenance=SimpleNamespace(),  # type: ignore[arg-type]
+        capacity=SimpleNamespace(),  # type: ignore[arg-type]
+        identity_verifier=IDENTITY_CODEC.verifier(),
+        config=SimpleNamespace(
+            runtime_target_for=lambda _request, **_kwargs: request["runtimeTarget"]
+        ),  # type: ignore[arg-type]
+        now=lambda: now + 30,
+    )
+    plane._owned[plane._key(metadata)] = metadata
+    plane._helm_requests[plane._key(metadata)] = request
+
+    with pytest.raises(MetadataConflict, match="complete authorization drain"):
+        await plane.quiesce(metadata, request, "quiesce-alpha")
+    assert events == []
+    assert cell.files == initial.files
+
+    runtime.active_reads = 0
+    await plane.quiesce(metadata, request, "quiesce-alpha")
+    drained = inspect_hosted_authorization_bundle(
+        cell.files,
+        expected_cell_id=metadata.subject_id,
+        expected_logical_vault_id=metadata.tenant_id,
+        expected_replica_id=metadata.resource_name + "-0",
+        expected_software_version="0.48.0",
+        expected_schema_version=4,
+        expected_recovery_envelope=envelopes["authorizationSessionSecret"],
+        now=now + 30,
+    )
+    assert (drained.epoch, drained.replica_state, drained.no_in_flight) == (
+        2,
+        "DRAINING",
+        True,
+    )
+
+    await plane.scale(metadata, 1)
+    serving = inspect_hosted_authorization_bundle(
+        cell.files,
+        expected_cell_id=metadata.subject_id,
+        expected_logical_vault_id=metadata.tenant_id,
+        expected_replica_id=metadata.resource_name + "-0",
+        expected_software_version="0.48.0",
+        expected_schema_version=4,
+        expected_recovery_envelope=envelopes["authorizationSessionSecret"],
+        now=now + 30,
+    )
+    assert (serving.epoch, serving.replica_state) == (3, "SERVING")
+    assert [event[0] for event in events] == ["write", "write", "stage", "scale"]
+    assert events[-2][1] == serving.revision
 
 
 @pytest.mark.asyncio
@@ -692,6 +856,7 @@ async def test_live_route_enable_reconciles_the_original_authenticated_helm_rele
 
         async def write_authorization_session_bundle(self, _owner, files, **_kwargs):
             self.files = files
+
     plane = LiveLifecyclePlane(
         repository=SimpleNamespace(),  # type: ignore[arg-type]
         registry=Registry(),  # type: ignore[arg-type]
@@ -1263,9 +1428,7 @@ def _init_recovery_plane(snapshots: list[SimpleNamespace]):
         operation_id=original_owner.operation_id,
         fence_generation=original_owner.fence_generation,
         resource_name=original_owner.resource_name,
-        operation_resource_name=provider_operation_resource_name(
-            original_owner.operation_id
-        ),
+        operation_resource_name=provider_operation_resource_name(original_owner.operation_id),
     )
     plane._helm_requests[key] = original_request
     return plane, metadata, original_owner, helm_calls
@@ -1547,9 +1710,7 @@ async def test_live_plane_publishes_authorization_custody_before_helm_and_reuses
 
         async def write_authorization_session_bundle(self, _owner, files, **kwargs):
             calls.append("authorization-write")
-            assert kwargs["recovery_envelope"] == envelopes[
-                "authorizationSessionSecret"
-            ]
+            assert kwargs["recovery_envelope"] == envelopes["authorizationSessionSecret"]
             self.files = files
 
         async def write_credential_bundle(self, _owner, _credentials, **_kwargs):
@@ -1564,9 +1725,7 @@ async def test_live_plane_publishes_authorization_custody_before_helm_and_reuses
 
     request = {
         "provisionMode": "serve",
-        "serviceCredential": base64.urlsafe_b64encode(bytes(range(32)))
-        .rstrip(b"=")
-        .decode(),
+        "serviceCredential": base64.urlsafe_b64encode(bytes(range(32))).rstrip(b"=").decode(),
         "workerPolicy": {"workerCount": 2, "semantic": True, "media": False},
         "runtimeTarget": {
             "releaseVersion": "0.48.0",
@@ -1587,9 +1746,7 @@ async def test_live_plane_publishes_authorization_custody_before_helm_and_reuses
         maintenance=SimpleNamespace(),  # type: ignore[arg-type]
         capacity=Capacity(),  # type: ignore[arg-type]
         identity_verifier=IDENTITY_CODEC.verifier(),
-        config=SimpleNamespace(
-            runtime_target_for=lambda value, *, v2: value["runtimeTarget"]
-        ),  # type: ignore[arg-type]
+        config=SimpleNamespace(runtime_target_for=lambda value, *, v2: value["runtimeTarget"]),  # type: ignore[arg-type]
         now=lambda: 1_900_000_000,
     )
     key = plane._key(metadata)

--- a/infra/provisioner/tests/test_provider_adapters.py
+++ b/infra/provisioner/tests/test_provider_adapters.py
@@ -818,6 +818,8 @@ async def test_kubernetes_cell_adapter_persists_one_authenticated_authorization_
         def patch_namespaced_secret(self, name, namespace, body):
             if self.secret is None:
                 raise _ApiNotFound()
+            if "resourceVersion" in body["metadata"]:
+                assert body["metadata"]["resourceVersion"] == "7"
             self.secret = _secret(body)
 
         def create_namespaced_secret(self, namespace, body):
@@ -836,17 +838,27 @@ async def test_kubernetes_cell_adapter_persists_one_authenticated_authorization_
             "serving-membership.json",
         }
         return SimpleNamespace(
-            metadata=SimpleNamespace(annotations=body["metadata"]["annotations"]),
+            metadata=SimpleNamespace(
+                annotations=body["metadata"]["annotations"],
+                resource_version="7",
+            ),
             data={
                 key: base64.b64encode(value.encode()).decode()
                 for key, value in body["stringData"].items()
             },
         )
 
+    class Apps:
+        staged = None
+
+        def patch_namespaced_stateful_set(self, name, namespace, body):
+            self.staged = (name, namespace, body)
+
     core = Core()
+    apps = Apps()
     adapter = KubernetesCellAdapter(
         core_v1=core,
-        apps_v1=SimpleNamespace(),
+        apps_v1=apps,
         identity_verifier=identity.verifier(),
     )
     files = {
@@ -854,6 +866,9 @@ async def test_kubernetes_cell_adapter_persists_one_authenticated_authorization_
         "control.json": b'{"control":"value"}',
         "serving-membership.json": b'{"membership":"value"}',
     }
+    revision = hashlib.sha256(
+        files["keyring.json"] + files["control.json"] + files["serving-membership.json"]
+    ).hexdigest()
     assert await adapter.read_authorization_session_bundle(metadata) is None
     await adapter.write_authorization_session_bundle(
         metadata,
@@ -861,14 +876,61 @@ async def test_kubernetes_cell_adapter_persists_one_authenticated_authorization_
         recovery_envelope=envelopes["authorizationSessionSecret"],
         membership_epoch=1,
         membership_digest="a" * 64,
-        revision="b" * 64,
+        revision=revision,
     )
 
     stored = await adapter.read_authorization_session_bundle(metadata)
     assert stored == files
-    assert core.secret.metadata.annotations["exomem.io/recovery-envelope"] == envelopes[
-        "authorizationSessionSecret"
-    ]
+    assert (
+        core.secret.metadata.annotations["exomem.io/recovery-envelope"]
+        == envelopes["authorizationSessionSecret"]
+    )
+
+    successor_files = {
+        **files,
+        "serving-membership.json": b'{"membership":"successor"}',
+    }
+    successor_revision = hashlib.sha256(
+        successor_files["keyring.json"]
+        + successor_files["control.json"]
+        + successor_files["serving-membership.json"]
+    ).hexdigest()
+    await adapter.write_authorization_session_bundle(
+        metadata,
+        successor_files,
+        recovery_envelope=envelopes["authorizationSessionSecret"],
+        membership_epoch=2,
+        membership_digest="c" * 64,
+        revision=successor_revision,
+        expected_revision=revision,
+    )
+    await adapter.stage_authorization_session_revision(metadata, successor_revision)
+    assert apps.staged == (
+        metadata.resource_name,
+        metadata.resource_name,
+        {
+            "spec": {
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "exomem.io/authorization-session-revision": successor_revision
+                        }
+                    }
+                }
+            }
+        },
+    )
+
+    with pytest.raises(MetadataConflict, match="predecessor differs"):
+        await adapter.write_authorization_session_bundle(
+            metadata,
+            successor_files,
+            recovery_envelope=envelopes["authorizationSessionSecret"],
+            membership_epoch=3,
+            membership_digest="e" * 64,
+            revision=successor_revision,
+            expected_revision=revision,
+        )
 
     core.secret.data["extra.json"] = base64.b64encode(b"{}").decode()
     with pytest.raises(MetadataConflict, match="bundle shape"):
@@ -1109,6 +1171,17 @@ async def test_private_cell_api_uses_fresh_identity_and_exact_lifecycle_routes()
             )
         if url.endswith("/ready"):
             return _Response(200, ready)
+        if url.endswith("/lifecycle/quiesce"):
+            return _Response(
+                200,
+                {
+                    "phase": "quiesced",
+                    "active_reads": 0,
+                    "active_mutations": 0,
+                    "active_transfers": 0,
+                    "reason_code": "HOSTED_QUIESCED",
+                },
+            )
         return _Response(
             200,
             {"live": True, "cell_id": "cell-alpha", "protocol_version": "1"},
@@ -1160,12 +1233,19 @@ async def test_private_cell_api_uses_fresh_identity_and_exact_lifecycle_routes()
         expected_worker_policy=worker_policy,
         expected_contract_digest="b" * 64,
     )
-    await adapter.quiesce(
+    quiesced = await adapter.quiesce(
         _metadata(),
         credential=_credential(),
         protocol_version="1",
         operation_id="quiesce-alpha",
     )
+    assert quiesced == {
+        "phase": "quiesced",
+        "active_reads": 0,
+        "active_mutations": 0,
+        "active_transfers": 0,
+        "reason_code": "HOSTED_QUIESCED",
+    }
     await adapter.resume(
         _metadata(),
         credential=_credential(),


### PR DESCRIPTION
## Summary

- publish authenticated singleton membership successors for drain, rejoin, and runtime-version transitions
- require an exact quiesced snapshot with zero reads, mutations, and transfers before recording `DRAINING/no_in_flight`
- compare-and-swap the three-file Kubernetes Secret by authenticated predecessor bytes and resource version
- bind rejoining or upgraded pods to the successor revision before scale or rollout
- preserve fail-closed rollback by publishing a fresh predecessor-runtime successor

Stacked after #893. This PR does not merge the stack, enable governed consolidation, or touch any live vault.

## Verification

- red baseline: new transition API absent on #893
- 136 focused runtime/provisioner tests passed
- Ruff on all six changed Python files
- `uv lock --check`
- `openspec validate harden-governance-for-consolidation --strict`
- public repository artifact validation: 3352 files / 3420 text payloads clean
- `git diff --check`

## Remaining boundary

This lands explicit drain/ack/epoch-advance/rejoin mechanics. Periodic authenticated renewal and its long-running publication loop remain a separate follow-up; OpenSpec task 5.12 stays open until that is proven.