### PR TITLE
feat(governance): attest hosted replica readiness

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/adapters.py
+++ b/infra/provisioner/src/exomem_provisioner/adapters.py
@@ -21,6 +21,7 @@ from typing import Any, Literal
 from .authorization_membership import (
     AUTHORIZATION_SESSION_FILES,
     AUTHORIZATION_SESSION_SECRET_NAME,
+    MAX_ATTESTATION_TTL_SECONDS,
     MAX_BUNDLE_FILE_BYTES,
 )
 from .credentials import validate_machine_credential
@@ -1205,6 +1206,7 @@ class PrivateCellApiAdapter:
         .rstrip(b"=")
         .decode("ascii")
     )
+    _SHA256 = re.compile(r"[0-9a-f]{64}\Z")
 
     def __init__(self, *, request: CellRequester, internal_origin: str) -> None:
         if not internal_origin.startswith("http://") and not internal_origin.startswith("https://"):
@@ -1514,6 +1516,67 @@ class PrivateCellApiAdapter:
             routing_stopped=True,
             body={"timeout_seconds": 30},
         )
+
+    async def attest_authorization_session_membership(
+        self,
+        metadata: OpaqueProviderMetadata,
+        *,
+        credential: str,
+        protocol_version: str,
+        target_epoch: int,
+        previous_epoch_digest: str,
+        ttl_seconds: int,
+    ) -> bytes:
+        if (
+            isinstance(target_epoch, bool)
+            or not isinstance(target_epoch, int)
+            or target_epoch < 1
+            or not isinstance(previous_epoch_digest, str)
+            or self._SHA256.fullmatch(previous_epoch_digest) is None
+            or isinstance(ttl_seconds, bool)
+            or not isinstance(ttl_seconds, int)
+            or not 1 <= ttl_seconds <= MAX_ATTESTATION_TTL_SECONDS
+        ):
+            raise MetadataConflict("authorization membership challenge is invalid")
+        data = await self._call(
+            "POST",
+            metadata,
+            "authorization-membership/attest",
+            credential=credential,
+            protocol_version=protocol_version,
+            body={
+                "target_epoch": target_epoch,
+                "previous_epoch_digest": previous_epoch_digest,
+                "ttl_seconds": ttl_seconds,
+            },
+        )
+        if set(data) != {"version", "attestation", "attestation_sha256"}:
+            raise MetadataConflict("authorization membership attestation is invalid")
+        encoded = data.get("attestation")
+        digest = data.get("attestation_sha256")
+        if (
+            data.get("version") != 1
+            or not isinstance(encoded, str)
+            or not isinstance(digest, str)
+            or self._SHA256.fullmatch(digest) is None
+        ):
+            raise MetadataConflict("authorization membership attestation is invalid")
+        try:
+            encoded_bytes = encoded.encode("ascii")
+            raw = base64.b64decode(
+                encoded_bytes + b"=" * (-len(encoded_bytes) % 4),
+                altchars=b"-_",
+                validate=True,
+            )
+        except (UnicodeEncodeError, ValueError) as error:
+            raise MetadataConflict("authorization membership attestation is invalid") from error
+        if (
+            not 1 <= len(raw) <= MAX_BUNDLE_FILE_BYTES
+            or base64.urlsafe_b64encode(raw).rstrip(b"=") != encoded_bytes
+            or not hmac.compare_digest(hashlib.sha256(raw).hexdigest(), digest)
+        ):
+            raise MetadataConflict("authorization membership attestation is invalid")
+        return raw
 
     async def operator(
         self,

--- a/infra/provisioner/tests/test_provider_adapters.py
+++ b/infra/provisioner/tests/test_provider_adapters.py
@@ -1182,6 +1182,21 @@ async def test_private_cell_api_uses_fresh_identity_and_exact_lifecycle_routes()
                     "reason_code": "HOSTED_QUIESCED",
                 },
             )
+        if url.endswith("/authorization-membership/attest"):
+            return _Response(
+                200,
+                {
+                    "version": 1,
+                    "attestation": base64.urlsafe_b64encode(
+                        b'{"signed":"runtime-attestation"}'
+                    )
+                    .rstrip(b"=")
+                    .decode("ascii"),
+                    "attestation_sha256": hashlib.sha256(
+                        b'{"signed":"runtime-attestation"}'
+                    ).hexdigest(),
+                },
+            )
         return _Response(
             200,
             {"live": True, "cell_id": "cell-alpha", "protocol_version": "1"},
@@ -1246,6 +1261,15 @@ async def test_private_cell_api_uses_fresh_identity_and_exact_lifecycle_routes()
         "active_transfers": 0,
         "reason_code": "HOSTED_QUIESCED",
     }
+    attestation = await adapter.attest_authorization_session_membership(
+        _metadata(),
+        credential=_credential(),
+        protocol_version="1",
+        target_epoch=8,
+        previous_epoch_digest="a" * 64,
+        ttl_seconds=300,
+    )
+    assert attestation == b'{"signed":"runtime-attestation"}'
     await adapter.resume(
         _metadata(),
         credential=_credential(),
@@ -1279,8 +1303,14 @@ async def test_private_cell_api_uses_fresh_identity_and_exact_lifecycle_routes()
     request_ids = [call[2]["X-Exomem-Request-Id"] for call in calls]
     assert len(request_ids) == len(set(request_ids))
     assert all(call[2]["Authorization"] == "Bearer " + _credential() for call in calls)
-    assert calls[-3][1].endswith("/private/exomem/v1/lifecycle/quiesce")
-    assert calls[-3][2]["X-Exomem-Routing-Stopped"] == "true"
+    assert calls[-4][1].endswith("/private/exomem/v1/lifecycle/quiesce")
+    assert calls[-4][2]["X-Exomem-Routing-Stopped"] == "true"
+    assert calls[-3][1].endswith("/private/exomem/v1/authorization-membership/attest")
+    assert calls[-3][3] == {
+        "target_epoch": 8,
+        "previous_epoch_digest": "a" * 64,
+        "ttl_seconds": 300,
+    }
     assert calls[-2][1].endswith("/private/exomem/v1/lifecycle/resume")
     assert calls[-1][1].endswith("/private/exomem/v1/lifecycle/seal")
     assert calls[-1][2]["X-Exomem-Routing-Stopped"] == "true"

--- a/src/exomem/governance/authorization_serving_membership.py
+++ b/src/exomem/governance/authorization_serving_membership.py
@@ -298,6 +298,66 @@ def _signed_attestation_value(
     return value
 
 
+def _validate_attestation_shape(
+    attestation: ReplicaReadinessAttestation,
+    *,
+    now: int | None,
+) -> None:
+    if not isinstance(attestation, ReplicaReadinessAttestation) or attestation.version != 1:
+        raise ServingMembershipUnavailable
+    _integer(attestation.epoch)
+    _identifier(attestation.replica_id)
+    if attestation.state not in _STATES:
+        raise ServingMembershipUnavailable
+    _identifier(attestation.software_version)
+    _integer(attestation.schema_version)
+    _identifier(attestation.cell_id)
+    active_key_id = _identifier(attestation.active_key_id)
+    accepted_key_ids = tuple(_identifier(item) for item in attestation.accepted_key_ids)
+    signing_key_id = _identifier(attestation.signing_key_id)
+    attested_at = _integer(attestation.attested_at)
+    expires_at = _integer(attestation.expires_at)
+    if (
+        not 1 <= len(accepted_key_ids) <= 32
+        or accepted_key_ids != tuple(sorted(set(accepted_key_ids)))
+        or active_key_id not in accepted_key_ids
+        or signing_key_id != active_key_id
+        or attested_at >= expires_at
+        or expires_at - attested_at > MAX_ATTESTATION_TTL_SECONDS
+        or (now is not None and not attested_at <= now < expires_at)
+        or not isinstance(attestation.issuance_stopped, bool)
+        or not isinstance(attestation.no_in_flight, bool)
+        or (
+            attestation.state == "SERVING"
+            and (attestation.issuance_stopped or attestation.no_in_flight)
+        )
+        or (attestation.state == "DRAINING" and not attestation.issuance_stopped)
+    ):
+        raise ServingMembershipUnavailable
+    _digest(attestation.control_digest)
+    _digest(attestation.keyring_digest)
+
+
+def encode_replica_readiness_attestation(
+    attestation: ReplicaReadinessAttestation,
+    *,
+    verifier_keys: Mapping[str, bytes],
+) -> bytes:
+    """Return canonical authenticated bytes for one runtime readiness proof."""
+
+    _validate_attestation_shape(attestation, now=None)
+    encoded = json.dumps(
+        _signed_attestation_value(attestation, verifier_keys=verifier_keys),
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    if not 1 <= len(encoded) <= MAX_MEMBERSHIP_BYTES:
+        raise ServingMembershipUnavailable
+    return encoded
+
+
 def _record_value(
     record: ServingMembershipEpoch,
     *,
@@ -449,6 +509,49 @@ def _parse_attestation(
     )
 
 
+def parse_replica_readiness_attestation(
+    raw: bytes,
+    *,
+    verifier_keys: Mapping[str, bytes],
+    now: int,
+    expected_epoch: int,
+    expected_cell_id: str,
+) -> ReplicaReadinessAttestation:
+    """Authenticate exact canonical bytes emitted by one admitted replica."""
+
+    try:
+        if not isinstance(raw, bytes) or not 1 <= len(raw) <= MAX_MEMBERSHIP_BYTES:
+            raise ServingMembershipUnavailable
+        current = _integer(now)
+        epoch = _integer(expected_epoch)
+        cell_id = _identifier(expected_cell_id)
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_closed_object)
+        parsed = _parse_attestation(
+            value,
+            verifier_keys=verifier_keys,
+            now=current,
+            expected_epoch=epoch,
+            expected_cell_id=cell_id,
+        )
+        _validate_attestation_shape(parsed, now=current)
+        if encode_replica_readiness_attestation(
+            parsed,
+            verifier_keys=verifier_keys,
+        ) != raw:
+            raise ServingMembershipUnavailable
+        return parsed
+    except ServingMembershipUnavailable:
+        raise
+    except (
+        AttributeError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        TypeError,
+        ValueError,
+    ):
+        raise ServingMembershipUnavailable from None
+
+
 def parse_serving_membership(
     raw: bytes,
     *,
@@ -582,28 +685,14 @@ def _validate_record_shape(
         raise ServingMembershipUnavailable
     _identifier(record.signing_key_id)
     for item in record.replicas:
+        _validate_attestation_shape(item, now=now)
         if (
-            not isinstance(item, ReplicaReadinessAttestation)
-            or item.version != 1
-            or item.epoch != epoch
+            item.epoch != epoch
             or item.cell_id != record.cell_id
-            or item.state not in _STATES
-            or item.active_key_id not in item.accepted_key_ids
-            or item.signing_key_id != item.active_key_id
-            or tuple(item.accepted_key_ids)
-            != tuple(sorted(set(item.accepted_key_ids)))
             or item.attested_at > issued_at
             or item.expires_at < expires_at
-            or item.expires_at - item.attested_at > MAX_ATTESTATION_TTL_SECONDS
-            or (item.state == "SERVING" and (item.issuance_stopped or item.no_in_flight))
-            or (item.state == "DRAINING" and not item.issuance_stopped)
         ):
             raise ServingMembershipUnavailable
-        _identifier(item.replica_id)
-        _identifier(item.software_version)
-        _integer(item.schema_version)
-        _digest(item.control_digest)
-        _digest(item.keyring_digest)
 
 
 def evaluate_serving_membership(

--- a/src/exomem/governance/authorization_session_lifecycle.py
+++ b/src/exomem/governance/authorization_session_lifecycle.py
@@ -22,6 +22,7 @@ from . import (
 MAX_SESSION_TTL_SECONDS: Final = 3_600
 _MAX_SQLITE_INTEGER: Final = (1 << 63) - 1
 _HOSTED_ATTACHMENT = re.compile(r"hosted-attachment-v1-[0-9a-f]{64}\Z")
+_SHA256 = re.compile(r"[0-9a-f]{64}\Z")
 
 
 class AuthorizationSessionUnavailable(RuntimeError):
@@ -329,6 +330,143 @@ def hosted_serving_membership_readiness(
     finally:
         if connection is not None:
             connection.close()
+
+
+def _bounded_counter(value: object) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= _MAX_SQLITE_INTEGER
+    ):
+        raise AuthorizationSessionUnavailable
+    return value
+
+
+def mint_hosted_replica_readiness_attestation(
+    vault_root: Path,
+    *,
+    expected_cell_id: str,
+    expected_logical_vault_id: str,
+    expected_replica_id: str,
+    lifecycle_phase: str,
+    active_reads: int,
+    active_mutations: int,
+    active_transfers: int,
+    target_epoch: int,
+    previous_epoch_digest: str,
+    ttl_seconds: int,
+    now: int | None = None,
+) -> bytes:
+    """Sign one runtime-derived Hosted readiness statement for the next epoch."""
+
+    try:
+        current = int(time.time()) if now is None else _bounded_time(now)
+        cell_id = _bounded_identity(expected_cell_id)
+        logical_vault_id = _bounded_identity(expected_logical_vault_id)
+        replica_id = _bounded_identity(expected_replica_id)
+        epoch = _bounded_time(target_epoch)
+        reads = _bounded_counter(active_reads)
+        mutations = _bounded_counter(active_mutations)
+        transfers = _bounded_counter(active_transfers)
+        if (
+            not isinstance(previous_epoch_digest, str)
+            or _SHA256.fullmatch(previous_epoch_digest) is None
+            or isinstance(ttl_seconds, bool)
+            or not isinstance(ttl_seconds, int)
+            or not 1
+            <= ttl_seconds
+            <= authorization_serving_membership.MAX_ATTESTATION_TTL_SECONDS
+        ):
+            raise AuthorizationSessionUnavailable
+        fixed_paths = {
+            authorization_custody.KEYRING_FILE_ENV: authorization_custody.HOSTED_KEYRING_FILE,
+            authorization_custody.CONTROL_FILE_ENV: authorization_custody.HOSTED_CONTROL_FILE,
+            authorization_custody.MEMBERSHIP_FILE_ENV: authorization_custody.HOSTED_MEMBERSHIP_FILE,
+        }
+        if any(
+            os.environ.get(variable, "") != str(path)
+            for variable, path in fixed_paths.items()
+        ) or os.environ.get(authorization_custody.REPLICA_ID_ENV, "") != replica_id:
+            raise AuthorizationSessionUnavailable
+        custody = authorization_custody.load_authorization_custody(
+            Path(vault_root),
+            now=current,
+        )
+        membership = custody.serving_membership
+        control = custody.control
+        keyring = custody.keyring
+        active_key = keyring.active_key
+        if (
+            custody.keyring_path != authorization_custody.HOSTED_KEYRING_FILE
+            or custody.control_path != authorization_custody.HOSTED_CONTROL_FILE
+            or custody.membership_path != authorization_custody.HOSTED_MEMBERSHIP_FILE
+            or control.cell_id != cell_id
+            or control.logical_vault_id != logical_vault_id
+            or custody.local_replica_id != replica_id
+            or _HOSTED_ATTACHMENT.fullmatch(control.registry_attachment_id) is None
+            or membership is None
+            or membership.epoch != control.serving_membership_epoch
+            or epoch != control.serving_membership_epoch + 1
+            or previous_epoch_digest != control.serving_membership_digest
+            or (
+                membership.record_digest
+                and membership.record_digest != previous_epoch_digest
+            )
+            or not active_key.not_before <= current < active_key.not_after
+        ):
+            raise AuthorizationSessionUnavailable
+        if lifecycle_phase == "active":
+            state = "SERVING"
+            issuance_stopped = False
+            no_in_flight = False
+        elif lifecycle_phase == "quiesced" and not (reads or mutations or transfers):
+            state = "DRAINING"
+            issuance_stopped = True
+            no_in_flight = True
+        else:
+            raise AuthorizationSessionUnavailable
+        expires_at = min(
+            current + ttl_seconds,
+            control.expires_at,
+            active_key.not_after,
+        )
+        if expires_at <= current:
+            raise AuthorizationSessionUnavailable
+        attestation = authorization_serving_membership.ReplicaReadinessAttestation(
+            version=1,
+            epoch=epoch,
+            replica_id=replica_id,
+            state=state,
+            software_version=authorization_custody.runtime_software_version(),
+            schema_version=schema_v4.SCHEMA_USER_VERSION,
+            cell_id=cell_id,
+            active_key_id=keyring.active_key_id,
+            accepted_key_ids=tuple(
+                sorted(item.key_id for item in keyring.accepted_keys)
+            ),
+            control_digest=authorization_custody.control_attestation_digest(control),
+            keyring_digest=authorization_custody.keyring_attestation_digest(keyring),
+            attested_at=current,
+            expires_at=expires_at,
+            issuance_stopped=issuance_stopped,
+            no_in_flight=no_in_flight,
+            signing_key_id=keyring.active_key_id,
+        )
+        return authorization_serving_membership.encode_replica_readiness_attestation(
+            attestation,
+            verifier_keys={item.key_id: item.key for item in keyring.accepted_keys},
+        )
+    except (
+        AttributeError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+        authorization_custody.AuthorizationCustodyUnavailable,
+        authorization_serving_membership.ServingMembershipUnavailable,
+        AuthorizationSessionUnavailable,
+    ):
+        raise AuthorizationSessionUnavailable from None
 
 
 def _expiry(

--- a/src/exomem/hosted_runtime.py
+++ b/src/exomem/hosted_runtime.py
@@ -764,6 +764,27 @@ class HostedCellLifecycle:
                 "code": "CELL_READY" if readiness.ready else readiness.reason_code,
             }
 
+    def attest_authorization_membership(
+        self,
+        signer: Callable[[HostedLifecycleSnapshot], bytes],
+    ) -> bytes:
+        """Hold lifecycle state stable while the cell signs one readiness proof."""
+
+        with self._condition:
+            snapshot = self._snapshot_locked()
+            if snapshot.phase == "active" and not self._core_ready_locked():
+                raise HostedLifecycleError(
+                    "AUTHORIZATION_SESSION_UNAVAILABLE",
+                    "authorization membership attestation is unavailable",
+                )
+            result = signer(snapshot)
+            if not isinstance(result, bytes) or not result:
+                raise HostedLifecycleError(
+                    "AUTHORIZATION_SESSION_UNAVAILABLE",
+                    "authorization membership attestation is unavailable",
+                )
+            return result
+
     def complete_startup(
         self,
         *,

--- a/src/exomem/server_hosted.py
+++ b/src/exomem/server_hosted.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import errno
 import hashlib
 import hmac
@@ -38,7 +39,11 @@ from . import (
 )
 from . import commands as commands_module
 from . import hosted_gateway as gateway
-from .governance import authorization_request, authorization_transport
+from .governance import (
+    authorization_request,
+    authorization_session_lifecycle,
+    authorization_transport,
+)
 from .hosted_runtime import (
     HostedCellConfig,
     HostedCellLifecycle,
@@ -1338,6 +1343,79 @@ def register_hosted_routes(
             result.as_dict(),
             config=config,
             operation="quiesce",
+            request_id=context.request_id,
+            started=started,
+        )
+
+    @mcp_app.custom_route(
+        "/private/exomem/v1/authorization-membership/attest",
+        methods=["POST"],
+    )
+    async def _attest_authorization_membership(
+        request: Request,
+    ) -> HostedJSONResponse:
+        context, error, started = await lifecycle_context(
+            request,
+            "authorization-membership-attest",
+        )
+        if error is not None:
+            return error
+        assert context is not None
+        try:
+            body = await _json_body(request)
+            if set(body) != {
+                "target_epoch",
+                "previous_epoch_digest",
+                "ttl_seconds",
+            }:
+                raise gateway.HostedGatewayError(
+                    "INVALID_BODY",
+                    "authorization membership attestation challenge is invalid",
+                )
+            if config.vault_id is None or config.authorization_session_replica_id is None:
+                raise authorization_session_lifecycle.AuthorizationSessionUnavailable
+
+            def sign(snapshot: Any) -> bytes:
+                return authorization_session_lifecycle.mint_hosted_replica_readiness_attestation(
+                    config.vault_root,
+                    expected_cell_id=config.cell_id,
+                    expected_logical_vault_id=config.vault_id,
+                    expected_replica_id=config.authorization_session_replica_id,
+                    lifecycle_phase=snapshot.phase,
+                    active_reads=snapshot.active_reads,
+                    active_mutations=snapshot.active_mutations,
+                    active_transfers=snapshot.active_transfers,
+                    target_epoch=body["target_epoch"],
+                    previous_epoch_digest=body["previous_epoch_digest"],
+                    ttl_seconds=body["ttl_seconds"],
+                )
+
+            raw = await run_in_threadpool(
+                lifecycle.attest_authorization_membership,
+                sign,
+            )
+        except (
+            gateway.HostedGatewayError,
+            HostedLifecycleError,
+            authorization_session_lifecycle.AuthorizationSessionUnavailable,
+        ) as exc:
+            return _error_response(
+                exc.code,
+                config=config,
+                operation="authorization-membership-attest",
+                request_id=context.request_id,
+                started=started,
+            )
+        return _success_response(
+            {
+                "version": 1,
+                "attestation": base64.urlsafe_b64encode(raw)
+                .rstrip(b"=")
+                .decode("ascii"),
+                "attestation_sha256": hashlib.sha256(raw).hexdigest(),
+            },
+            config=config,
+            operation="authorization-membership-attest",
             request_id=context.request_id,
             started=started,
         )

--- a/tests/test_authorization_serving_membership.py
+++ b/tests/test_authorization_serving_membership.py
@@ -79,6 +79,36 @@ def _round_trip(
     )
 
 
+def test_replica_attestation_has_an_independent_canonical_wire_contract() -> None:
+    attestation = _replica("replica-a", epoch=8)
+
+    raw = membership.encode_replica_readiness_attestation(
+        attestation,
+        verifier_keys=KEYS,
+    )
+    parsed = membership.parse_replica_readiness_attestation(
+        raw,
+        verifier_keys=KEYS,
+        now=NOW,
+        expected_epoch=8,
+        expected_cell_id="cell-7",
+    )
+
+    assert parsed == attestation
+    assert membership.encode_replica_readiness_attestation(
+        parsed,
+        verifier_keys=KEYS,
+    ) == raw
+    with pytest.raises(membership.ServingMembershipUnavailable):
+        membership.parse_replica_readiness_attestation(
+            raw.replace(b'"replica-a"', b'"replica-x"'),
+            verifier_keys=KEYS,
+            now=NOW,
+            expected_epoch=8,
+            expected_cell_id="cell-7",
+        )
+
+
 def _readiness(
     record: membership.ServingMembershipEpoch,
     *,

--- a/tests/test_authorization_session_lifecycle.py
+++ b/tests/test_authorization_session_lifecycle.py
@@ -505,6 +505,132 @@ def test_hosted_readiness_rejects_a_standalone_attachment(
     assert refused == authorization_serving_membership.unavailable_readiness()
 
 
+@pytest.mark.parametrize(
+    ("phase", "active_reads", "expected_state", "issuance_stopped", "no_in_flight"),
+    [
+        ("active", 7, "SERVING", False, False),
+        ("quiesced", 0, "DRAINING", True, True),
+    ],
+)
+def test_hosted_runtime_mints_only_state_derived_replica_attestations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    phase: str,
+    active_reads: int,
+    expected_state: str,
+    issuance_stopped: bool,
+    no_in_flight: bool,
+) -> None:
+    custody = _hosted_custody("1" * 64)
+    monkeypatch.setenv(
+        authorization_custody.KEYRING_FILE_ENV,
+        str(authorization_custody.HOSTED_KEYRING_FILE),
+    )
+    monkeypatch.setenv(
+        authorization_custody.CONTROL_FILE_ENV,
+        str(authorization_custody.HOSTED_CONTROL_FILE),
+    )
+    monkeypatch.setenv(
+        authorization_custody.MEMBERSHIP_FILE_ENV,
+        str(authorization_custody.HOSTED_MEMBERSHIP_FILE),
+    )
+    monkeypatch.setenv(authorization_custody.REPLICA_ID_ENV, "replica-7")
+    monkeypatch.setattr(
+        authorization_custody,
+        "load_authorization_custody",
+        lambda _root, *, now: custody,
+    )
+
+    raw = authorization_session_lifecycle.mint_hosted_replica_readiness_attestation(
+        tmp_path,
+        expected_cell_id="cell-7",
+        expected_logical_vault_id="logical-vault-7",
+        expected_replica_id="replica-7",
+        lifecycle_phase=phase,
+        active_reads=active_reads,
+        active_mutations=0,
+        active_transfers=0,
+        target_epoch=2,
+        previous_epoch_digest="a" * 64,
+        ttl_seconds=300,
+        now=NOW,
+    )
+    parsed = authorization_serving_membership.parse_replica_readiness_attestation(
+        raw,
+        verifier_keys={item.key_id: item.key for item in custody.keyring.accepted_keys},
+        now=NOW,
+        expected_epoch=2,
+        expected_cell_id="cell-7",
+    )
+
+    assert parsed.replica_id == "replica-7"
+    assert parsed.state == expected_state
+    assert parsed.software_version == authorization_custody.runtime_software_version()
+    assert parsed.schema_version == schema_v4.SCHEMA_USER_VERSION
+    assert parsed.issuance_stopped is issuance_stopped
+    assert parsed.no_in_flight is no_in_flight
+    assert parsed.attested_at == NOW
+    assert parsed.expires_at == NOW + 300
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"expected_replica_id": "other-replica"},
+        {"previous_epoch_digest": "b" * 64},
+        {"target_epoch": 1},
+        {"lifecycle_phase": "quiescing"},
+        {"lifecycle_phase": "quiesced", "active_reads": 1},
+        {"lifecycle_phase": "quiesced", "active_mutations": 1},
+        {"lifecycle_phase": "quiesced", "active_transfers": 1},
+    ],
+)
+def test_hosted_runtime_attestation_refuses_caller_claims_and_incomplete_drain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    overrides: dict[str, object],
+) -> None:
+    custody = _hosted_custody("1" * 64)
+    monkeypatch.setenv(
+        authorization_custody.KEYRING_FILE_ENV,
+        str(authorization_custody.HOSTED_KEYRING_FILE),
+    )
+    monkeypatch.setenv(
+        authorization_custody.CONTROL_FILE_ENV,
+        str(authorization_custody.HOSTED_CONTROL_FILE),
+    )
+    monkeypatch.setenv(
+        authorization_custody.MEMBERSHIP_FILE_ENV,
+        str(authorization_custody.HOSTED_MEMBERSHIP_FILE),
+    )
+    monkeypatch.setenv(authorization_custody.REPLICA_ID_ENV, "replica-7")
+    monkeypatch.setattr(
+        authorization_custody,
+        "load_authorization_custody",
+        lambda _root, *, now: custody,
+    )
+    arguments: dict[str, object] = {
+        "expected_cell_id": "cell-7",
+        "expected_logical_vault_id": "logical-vault-7",
+        "expected_replica_id": "replica-7",
+        "lifecycle_phase": "active",
+        "active_reads": 0,
+        "active_mutations": 0,
+        "active_transfers": 0,
+        "target_epoch": 2,
+        "previous_epoch_digest": "a" * 64,
+        "ttl_seconds": 300,
+        "now": NOW,
+    }
+    arguments.update(overrides)
+
+    with pytest.raises(authorization_session_lifecycle.AuthorizationSessionUnavailable):
+        authorization_session_lifecycle.mint_hosted_replica_readiness_attestation(
+            tmp_path,
+            **arguments,  # type: ignore[arg-type]
+        )
+
+
 def test_resume_fails_when_a_live_row_key_drops_from_the_serving_intersection() -> None:
     connection, migration = _connection()
     old_key = _key("auth-key-old", b"o" * 32)

--- a/tests/test_hosted_cell.py
+++ b/tests/test_hosted_cell.py
@@ -889,6 +889,32 @@ def test_quiesce_drains_and_rejects_new_mutations_then_resume_is_idempotent(
     assert lifecycle.readiness().ready is True
 
 
+def test_runtime_membership_attestation_requires_admitted_active_state(
+    tmp_path: Path,
+) -> None:
+    _values, config = _provisioned(tmp_path)
+    lifecycle = HostedCellLifecycle(config)
+    lifecycle.complete_startup(
+        vault_ready=True,
+        mutation_authority_ready=True,
+        service_auth_ready=True,
+    )
+    observed: list[str] = []
+
+    assert lifecycle.attest_authorization_membership(
+        lambda snapshot: observed.append(snapshot.phase) or b"signed"
+    ) == b"signed"
+    lifecycle.set_mutation_authority(False)
+
+    with pytest.raises(HostedLifecycleError) as raised:
+        lifecycle.attest_authorization_membership(
+            lambda _snapshot: b"must-not-sign"
+        )
+
+    assert raised.value.code == "AUTHORIZATION_SESSION_UNAVAILABLE"
+    assert observed == ["active"]
+
+
 def test_deletion_seal_is_idempotent_and_rejects_reads_and_writes(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_hosted_private_routes.py
+++ b/tests/test_hosted_private_routes.py
@@ -35,6 +35,7 @@ from exomem import (
 from exomem import commands as commands_module
 from exomem import hosted_gateway as gateway
 from exomem.access_log import AccessLogMiddleware
+from exomem.governance import authorization_session_lifecycle
 from exomem.governance.authorization_transport import AuthorizationCarrierMiddleware
 from exomem.hosted_runtime import (
     HostedCellConfig,
@@ -246,6 +247,7 @@ def _cell(
     records_reader_version: int = 2,
     lifecycle_actions_enabled: bool = False,
     production_invoker: bool = False,
+    authorization_session_replica_id: str | None = None,
 ) -> tuple[_ASGIClient, HostedCellConfig, HostedCellLifecycle, IsolatedInvoker]:
     vault_root = tmp_path / cell_id / "vault"
     from exomem.init import init_vault
@@ -262,6 +264,7 @@ def _cell(
         enforce_transfer_v1_compatibility=False,
         records_reader_version=records_reader_version,
         lifecycle_actions_enabled=lifecycle_actions_enabled,
+        authorization_session_replica_id=authorization_session_replica_id,
         resource_limits=HostedResourceLimits(
             storage_bytes=1024 * 1024,
             upload_bytes=4096,
@@ -1015,6 +1018,7 @@ def test_every_private_custom_route_manually_requires_service_auth(tmp_path: Pat
         ("GET", "/private/exomem/v1/live"),
         ("GET", "/private/exomem/v1/ready"),
         ("POST", "/private/exomem/v1/lifecycle/quiesce"),
+        ("POST", "/private/exomem/v1/authorization-membership/attest"),
         ("POST", "/private/exomem/v1/lifecycle/export"),
         ("POST", "/private/exomem/v1/lifecycle/export/release"),
         ("POST", "/private/exomem/v1/lifecycle/resume"),
@@ -1032,6 +1036,72 @@ def test_every_private_custom_route_manually_requires_service_auth(tmp_path: Pat
         assert config.service_credential not in response.text
 
     assert client.get("/private/exomem/v1/live", headers=valid).status_code == 200
+
+
+def test_private_runtime_attestation_derives_lifecycle_and_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DynamicAuthority:
+        def authenticate(self, presented: str | None) -> object | None:
+            if presented == "dynamic-attestation-secret":
+                return SimpleNamespace(
+                    credential_version="active-v1",
+                    security_revision=1,
+                    preferred=True,
+                )
+            return None
+
+    client, config, lifecycle, _invoker = _cell(
+        tmp_path,
+        cell_id="cell-attestation",
+        credential="legacy-secret-must-not-work",
+        private_authenticator=DynamicAuthority(),
+        authorization_session_replica_id="cell-attestation-0",
+    )
+    captured: dict[str, object] = {}
+
+    def mint(vault_root: Path, **kwargs: object) -> bytes:
+        captured.update({"vault_root": vault_root, **kwargs})
+        return b'{"signed":"runtime-attestation"}'
+
+    monkeypatch.setattr(
+        authorization_session_lifecycle,
+        "mint_hosted_replica_readiness_attestation",
+        mint,
+    )
+    lifecycle.quiesce(timeout=1)
+
+    response = client.post(
+        "/private/exomem/v1/authorization-membership/attest",
+        headers=_headers(config, credential="dynamic-attestation-secret"),
+        json={
+            "target_epoch": 8,
+            "previous_epoch_digest": "a" * 64,
+            "ttl_seconds": 300,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    raw = b'{"signed":"runtime-attestation"}'
+    assert response.json()["data"] == {
+        "version": 1,
+        "attestation": base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii"),
+        "attestation_sha256": hashlib.sha256(raw).hexdigest(),
+    }
+    assert captured == {
+        "vault_root": config.vault_root,
+        "expected_cell_id": "cell-attestation",
+        "expected_logical_vault_id": "vault-cell-attestation",
+        "expected_replica_id": "cell-attestation-0",
+        "lifecycle_phase": "quiesced",
+        "active_reads": 0,
+        "active_mutations": 0,
+        "active_transfers": 0,
+        "target_epoch": 8,
+        "previous_epoch_digest": "a" * 64,
+        "ttl_seconds": 300,
+    }
 
 
 def test_private_readiness_is_a_complete_control_plane_binding_proof(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add a canonical independently verifiable per-replica readiness-attestation wire contract
- expose a private authenticated Hosted challenge that derives cell, replica, key, software, schema, and lifecycle facts inside the runtime
- hold lifecycle state stable while signing and refuse active attestations unless vault, service authentication, and mutation authority are admitted
- add a strict provisioner adapter for the bounded attestation envelope

Stacked after #894. This does not merge or touch any live vault. Periodic publication/synchronization remains the next slice.

## Verification

- red-first: 12 expected failures before the attestation encoder, runtime signer, route, and adapter existed
- runtime/membership/route focused: 45 passed
- provisioner adapter/membership focused: 28 passed
- Ruff on all 10 changed Python files
- `uv lock --check` for root and provisioner
- `openspec validate harden-governance-for-consolidation --strict`
- public repository artifact validation
- package sdist + wheel build
- `git diff --check`