### PR TITLE
feat(governance): verify hosted replica attestations

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/authorization_membership.py
+++ b/infra/provisioner/src/exomem_provisioner/authorization_membership.py
@@ -631,6 +631,7 @@ def transition_hosted_authorization_bundle(
     now: int,
     ttl_seconds: int = DEFAULT_ATTESTATION_TTL_SECONDS,
     renew: bool = False,
+    runtime_attestation: bytes | None = None,
 ) -> HostedAuthorizationBundle:
     """Publish one authenticated singleton successor, never a liveness inference."""
 
@@ -639,6 +640,7 @@ def transition_hosted_authorization_bundle(
         or not isinstance(target_no_in_flight, bool)
         or (target_state == "SERVING" and target_no_in_flight)
         or not isinstance(renew, bool)
+        or (runtime_attestation is not None and not isinstance(runtime_attestation, bytes))
         or not 1 <= ttl_seconds <= MAX_ATTESTATION_TTL_SECONDS
     ):
         raise MetadataConflict("authorization membership transition is invalid")
@@ -731,39 +733,98 @@ def transition_hosted_authorization_bundle(
     )
     control.pop("mac")
     epoch = source.epoch + 1
-    expires_at = current + ttl_seconds
     key_id = _required_identifier(keyring["active_key_id"])
     accepted_key_ids = sorted(
         _required_identifier(item["key_id"]) for item in entries if isinstance(item, dict)
     )
     if accepted_key_ids != [key_id]:
         raise MetadataConflict("authorization keyring is invalid")
-    attestation: dict[str, object] = {
-        "version": 1,
-        "epoch": epoch,
-        "replica_id": _required_identifier(expected_replica_id),
-        "state": target_state,
-        "software_version": target_release,
-        "schema_version": _required_time(expected_schema_version),
-        "cell_id": _required_identifier(expected_cell_id),
-        "active_key_id": key_id,
-        "accepted_key_ids": accepted_key_ids,
-        "control_digest": _control_basis_digest(control),
-        "keyring_digest": _keyring_digest(keyring),
-        "attested_at": current,
-        "expires_at": expires_at,
-        "issuance_stopped": target_state == "DRAINING",
-        "no_in_flight": target_no_in_flight,
-        "signing_key_id": key_id,
-    }
-    attestation["mac"] = _mac(key, _attestation_mac_input(attestation))
+    if runtime_attestation is None:
+        expires_at = current + ttl_seconds
+        attestation: dict[str, object] = {
+            "version": 1,
+            "epoch": epoch,
+            "replica_id": _required_identifier(expected_replica_id),
+            "state": target_state,
+            "software_version": target_release,
+            "schema_version": _required_time(expected_schema_version),
+            "cell_id": _required_identifier(expected_cell_id),
+            "active_key_id": key_id,
+            "accepted_key_ids": accepted_key_ids,
+            "control_digest": _control_basis_digest(control),
+            "keyring_digest": _keyring_digest(keyring),
+            "attested_at": current,
+            "expires_at": expires_at,
+            "issuance_stopped": target_state == "DRAINING",
+            "no_in_flight": target_no_in_flight,
+            "signing_key_id": key_id,
+        }
+        attestation["mac"] = _mac(key, _attestation_mac_input(attestation))
+    else:
+        attestation = _closed_json(
+            runtime_attestation,
+            frozenset(
+                {
+                    "version",
+                    "epoch",
+                    "replica_id",
+                    "state",
+                    "software_version",
+                    "schema_version",
+                    "cell_id",
+                    "active_key_id",
+                    "accepted_key_ids",
+                    "control_digest",
+                    "keyring_digest",
+                    "attested_at",
+                    "expires_at",
+                    "issuance_stopped",
+                    "no_in_flight",
+                    "signing_key_id",
+                    "mac",
+                }
+            ),
+            label="runtime attestation",
+        )
+        try:
+            attested_at = _required_time(attestation["attested_at"])
+            expires_at = _required_time(attestation["expires_at"])
+            supplied_mac = attestation["mac"]
+            if (
+                attestation["version"] != 1
+                or attestation["epoch"] != epoch
+                or attestation["replica_id"] != _required_identifier(expected_replica_id)
+                or attestation["state"] != target_state
+                or attestation["software_version"] != target_release
+                or attestation["schema_version"] != _required_time(expected_schema_version)
+                or attestation["cell_id"] != _required_identifier(expected_cell_id)
+                or attestation["active_key_id"] != key_id
+                or attestation["accepted_key_ids"] != accepted_key_ids
+                or attestation["control_digest"] != _control_basis_digest(control)
+                or attestation["keyring_digest"] != _keyring_digest(keyring)
+                or not attested_at <= current < expires_at
+                or expires_at - attested_at > ttl_seconds
+                or expires_at - attested_at > MAX_ATTESTATION_TTL_SECONDS
+                or expires_at > _required_time(entry["not_after"])
+                or attestation["issuance_stopped"] is not (target_state == "DRAINING")
+                or attestation["no_in_flight"] is not target_no_in_flight
+                or attestation["signing_key_id"] != key_id
+                or not isinstance(supplied_mac, str)
+                or not hmac.compare_digest(
+                    supplied_mac,
+                    _mac(key, _attestation_mac_input(attestation)),
+                )
+            ):
+                raise MetadataConflict("authorization runtime attestation is invalid")
+        except (KeyError, TypeError, ValueError):
+            raise MetadataConflict("authorization runtime attestation is invalid") from None
     membership: dict[str, object] = {
         "version": 1,
         "epoch": epoch,
         "cell_id": expected_cell_id,
         "logical_vault_id": expected_logical_vault_id,
         "previous_epoch_digest": source.membership_digest,
-        "issued_at": current,
+        "issued_at": attestation["attested_at"],
         "expires_at": expires_at,
         "replicas": [attestation],
         "signing_key_id": key_id,
@@ -775,7 +836,7 @@ def transition_hosted_authorization_bundle(
         {
             "serving_membership_epoch": epoch,
             "serving_membership_digest": membership_digest,
-            "issued_at": current,
+            "issued_at": attestation["attested_at"],
             "expires_at": expires_at,
         }
     )

--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -23,6 +23,7 @@ from .adapters import (
 )
 from .authorization_membership import (
     AUTHORIZATION_SESSION_SCHEMA_VERSION,
+    DEFAULT_ATTESTATION_TTL_SECONDS,
     build_initial_hosted_authorization_bundle,
     inspect_hosted_authorization_bundle,
     transition_hosted_authorization_bundle,
@@ -677,6 +678,9 @@ class LiveLifecyclePlane:
         target_state: str,
         target_no_in_flight: bool,
         target_software_version: str | None = None,
+        require_runtime_attestation: bool = False,
+        runtime_credential: str | None = None,
+        runtime_protocol_version: str | None = None,
     ) -> str:
         """Commit one authenticated successor under the lifecycle maintenance lease."""
 
@@ -709,6 +713,20 @@ class LiveLifecyclePlane:
             now=current,
             _require_fresh=False,
         )
+        runtime_attestation = None
+        if require_runtime_attestation:
+            if not runtime_credential or not runtime_protocol_version:
+                raise MetadataConflict("runtime attestation authority is unavailable")
+            runtime_attestation = (
+                await self._runtime.attest_authorization_session_membership(
+                    owned,
+                    credential=runtime_credential,
+                    protocol_version=runtime_protocol_version,
+                    target_epoch=source.epoch + 1,
+                    previous_epoch_digest=source.membership_digest,
+                    ttl_seconds=DEFAULT_ATTESTATION_TTL_SECONDS,
+                )
+            )
         successor = transition_hosted_authorization_bundle(
             files,
             expected_cell_id=owned.subject_id,
@@ -721,6 +739,7 @@ class LiveLifecyclePlane:
             target_no_in_flight=target_no_in_flight,
             target_software_version=target_software_version,
             now=current,
+            runtime_attestation=runtime_attestation,
         )
         if successor.revision != source.revision:
             await self._cell.write_authorization_session_bundle(
@@ -1031,6 +1050,9 @@ class LiveLifecyclePlane:
             metadata,
             target_state="DRAINING",
             target_no_in_flight=True,
+            require_runtime_attestation=True,
+            runtime_credential=str(request["serviceCredential"]),
+            runtime_protocol_version=str(target["protocolVersion"]),
         )
 
     async def scale(self, metadata: OpaqueProviderMetadata, replicas: int) -> None:

--- a/infra/provisioner/tests/test_authorization_membership.py
+++ b/infra/provisioner/tests/test_authorization_membership.py
@@ -231,3 +231,101 @@ def test_membership_transition_never_infers_drain_or_renews_stale_serving_state(
             now=now + 4_000,
             renew=True,
         )
+
+
+def test_membership_transition_commits_only_the_exact_runtime_attestation() -> None:
+    now = 1_900_000_000
+    initial = build_initial_hosted_authorization_bundle(
+        cell_id="cell-alpha",
+        logical_vault_id="tenant-alpha",
+        replica_id="exo-0123456789abcdef0123-0",
+        software_version="0.48.0",
+        schema_version=4,
+        recovery_envelope="signed-authorization-session-secret",
+        now=now,
+        entropy=_entropy,
+    )
+    keyring = authorization_custody.parse_keyring(initial.keyring)
+    control = authorization_custody.parse_control_record(
+        initial.control,
+        keyring=keyring,
+        now=now + 30,
+    )
+    attestation = authorization_serving_membership.ReplicaReadinessAttestation(
+        version=1,
+        epoch=2,
+        replica_id="exo-0123456789abcdef0123-0",
+        state="DRAINING",
+        software_version="0.48.0",
+        schema_version=4,
+        cell_id="cell-alpha",
+        active_key_id=keyring.active_key_id,
+        accepted_key_ids=tuple(item.key_id for item in keyring.accepted_keys),
+        control_digest=authorization_custody.control_attestation_digest(control),
+        keyring_digest=authorization_custody.keyring_attestation_digest(keyring),
+        attested_at=now + 29,
+        expires_at=now + 329,
+        issuance_stopped=True,
+        no_in_flight=True,
+        signing_key_id=keyring.active_key_id,
+    )
+    raw = authorization_serving_membership.encode_replica_readiness_attestation(
+        attestation,
+        verifier_keys={item.key_id: item.key for item in keyring.accepted_keys},
+    )
+
+    successor = transition_hosted_authorization_bundle(
+        initial.files,
+        expected_cell_id="cell-alpha",
+        expected_logical_vault_id="tenant-alpha",
+        expected_replica_id="exo-0123456789abcdef0123-0",
+        expected_software_version="0.48.0",
+        expected_schema_version=4,
+        expected_recovery_envelope="signed-authorization-session-secret",
+        target_state="DRAINING",
+        target_no_in_flight=True,
+        now=now + 30,
+        ttl_seconds=300,
+        runtime_attestation=raw,
+    )
+
+    assert (
+        inspect_hosted_authorization_bundle(
+            successor.files,
+            expected_cell_id="cell-alpha",
+            expected_logical_vault_id="tenant-alpha",
+            expected_replica_id="exo-0123456789abcdef0123-0",
+            expected_software_version="0.48.0",
+            expected_schema_version=4,
+            expected_recovery_envelope="signed-authorization-session-secret",
+            now=now + 30,
+        )
+        == successor
+    )
+
+    _successor_control, successor_record = _runtime_membership(
+        successor,
+        now=now + 30,
+    )
+    assert successor_record.replicas == (attestation,)
+    assert (successor_record.issued_at, successor_record.expires_at) == (
+        attestation.attested_at,
+        attestation.expires_at,
+    )
+
+    tampered = raw.replace(b'"no_in_flight":true', b'"no_in_flight":false')
+    with pytest.raises(MetadataConflict, match="runtime attestation"):
+        transition_hosted_authorization_bundle(
+            initial.files,
+            expected_cell_id="cell-alpha",
+            expected_logical_vault_id="tenant-alpha",
+            expected_replica_id="exo-0123456789abcdef0123-0",
+            expected_software_version="0.48.0",
+            expected_schema_version=4,
+            expected_recovery_envelope="signed-authorization-session-secret",
+            target_state="DRAINING",
+            target_no_in_flight=True,
+            now=now + 30,
+            ttl_seconds=300,
+            runtime_attestation=tampered,
+        )

--- a/infra/provisioner/tests/test_live_provider.py
+++ b/infra/provisioner/tests/test_live_provider.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from exomem.governance import authorization_custody, authorization_serving_membership
 from pydantic import ValidationError
 
 from exomem_provisioner.authorization_membership import (
@@ -147,6 +148,47 @@ def _capacity_contract(path: Path) -> Path:
 
 def _metadata() -> OpaqueProviderMetadata:
     return OpaqueProviderMetadata("tenant-alpha", "cell-alpha", "operation-alpha", 7)
+
+
+def _signed_runtime_attestation(
+    files: dict[str, bytes],
+    *,
+    cell_id: str,
+    replica_id: str,
+    software_version: str,
+    epoch: int,
+    now: int,
+    ttl_seconds: int,
+    state: str = "DRAINING",
+) -> bytes:
+    keyring = authorization_custody.parse_keyring(files["keyring.json"])
+    control = authorization_custody.parse_control_record(
+        files["control.json"],
+        keyring=keyring,
+        now=now,
+    )
+    attestation = authorization_serving_membership.ReplicaReadinessAttestation(
+        version=1,
+        epoch=epoch,
+        replica_id=replica_id,
+        state=state,
+        software_version=software_version,
+        schema_version=4,
+        cell_id=cell_id,
+        active_key_id=keyring.active_key_id,
+        accepted_key_ids=tuple(item.key_id for item in keyring.accepted_keys),
+        control_digest=authorization_custody.control_attestation_digest(control),
+        keyring_digest=authorization_custody.keyring_attestation_digest(keyring),
+        attested_at=now,
+        expires_at=now + ttl_seconds,
+        issuance_stopped=state == "DRAINING",
+        no_in_flight=state == "DRAINING",
+        signing_key_id=keyring.active_key_id,
+    )
+    return authorization_serving_membership.encode_replica_readiness_attestation(
+        attestation,
+        verifier_keys={item.key_id: item.key for item in keyring.accepted_keys},
+    )
 
 
 def _settings(**overrides: object) -> ProviderWorkerSettings:
@@ -593,6 +635,44 @@ async def test_live_rollforward_uses_target_fingerprint_and_original_helm_author
                 "reason_code": "HOSTED_QUIESCED",
             }
 
+        async def attest_authorization_session_membership(
+            self,
+            metadata,
+            *,
+            credential,
+            protocol_version,
+            target_epoch,
+            previous_epoch_digest,
+            ttl_seconds,
+        ):
+            assert metadata == owner
+            assert credential == "credential-current"
+            assert protocol_version == "legacy-protocol"
+            inspected = inspect_hosted_authorization_bundle(
+                Cell.files,
+                expected_cell_id=owner.subject_id,
+                expected_logical_vault_id=owner.tenant_id,
+                expected_replica_id=owner.resource_name + "-0",
+                expected_software_version=None,
+                expected_schema_version=4,
+                expected_recovery_envelope=original_request["_providerRecoveryEnvelopes"][
+                    "authorizationSessionSecret"
+                ],
+                now=1_900_000_030,
+                _require_fresh=False,
+            )
+            assert target_epoch == inspected.epoch + 1
+            assert previous_epoch_digest == inspected.membership_digest
+            return _signed_runtime_attestation(
+                Cell.files,
+                cell_id=owner.subject_id,
+                replica_id=owner.resource_name + "-0",
+                software_version=inspected.software_version,
+                epoch=target_epoch,
+                now=1_900_000_030,
+                ttl_seconds=ttl_seconds,
+            )
+
     class Cell:
         files = build_initial_hosted_authorization_bundle(
             cell_id=owner.subject_id,
@@ -725,6 +805,49 @@ async def test_membership_drain_requires_zero_runtime_snapshot_and_rejoin_preced
                 "reason_code": "HOSTED_QUIESCED",
             }
 
+        async def attest_authorization_session_membership(
+            self,
+            _metadata,
+            *,
+            credential,
+            protocol_version,
+            target_epoch,
+            previous_epoch_digest,
+            ttl_seconds,
+        ):
+            assert credential == "credential-current"
+            assert protocol_version == "1"
+            keyring = authorization_custody.parse_keyring(cell.files["keyring.json"])
+            control = authorization_custody.parse_control_record(
+                cell.files["control.json"],
+                keyring=keyring,
+                now=now + 30,
+            )
+            attestation = authorization_serving_membership.ReplicaReadinessAttestation(
+                version=1,
+                epoch=target_epoch,
+                replica_id=metadata.resource_name + "-0",
+                state="DRAINING",
+                software_version="0.48.0",
+                schema_version=4,
+                cell_id=metadata.subject_id,
+                active_key_id=keyring.active_key_id,
+                accepted_key_ids=tuple(item.key_id for item in keyring.accepted_keys),
+                control_digest=authorization_custody.control_attestation_digest(control),
+                keyring_digest=authorization_custody.keyring_attestation_digest(keyring),
+                attested_at=now + 30,
+                expires_at=now + 30 + ttl_seconds,
+                issuance_stopped=True,
+                no_in_flight=True,
+                signing_key_id=keyring.active_key_id,
+            )
+            raw = authorization_serving_membership.encode_replica_readiness_attestation(
+                attestation,
+                verifier_keys={item.key_id: item.key for item in keyring.accepted_keys},
+            )
+            events.append(("attest", target_epoch, previous_epoch_digest))
+            return raw
+
     class Cell:
         files = initial.files
 
@@ -798,7 +921,14 @@ async def test_membership_drain_requires_zero_runtime_snapshot_and_rejoin_preced
         now=now + 30,
     )
     assert (serving.epoch, serving.replica_state) == (3, "SERVING")
-    assert [event[0] for event in events] == ["write", "write", "stage", "scale"]
+    assert [event[0] for event in events] == [
+        "attest",
+        "write",
+        "write",
+        "stage",
+        "scale",
+    ]
+    assert events[0][1:] == (2, initial.membership_digest)
     assert events[-2][1] == serving.revision
 
 

--- a/src/exomem/governance/authorization_session_lifecycle.py
+++ b/src/exomem/governance/authorization_session_lifecycle.py
@@ -427,7 +427,6 @@ def mint_hosted_replica_readiness_attestation(
             raise AuthorizationSessionUnavailable
         expires_at = min(
             current + ttl_seconds,
-            control.expires_at,
             active_key.not_after,
         )
         if expires_at <= current:

--- a/tests/test_authorization_session_lifecycle.py
+++ b/tests/test_authorization_session_lifecycle.py
@@ -631,6 +631,64 @@ def test_hosted_runtime_attestation_refuses_caller_claims_and_incomplete_drain(
         )
 
 
+def test_hosted_runtime_attestation_can_extend_the_next_control_epoch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    custody = _hosted_custody("1" * 64)
+    assert custody.serving_membership is not None
+    custody = replace(
+        custody,
+        control=replace(custody.control, expires_at=NOW + 300),
+        serving_membership=replace(
+            custody.serving_membership,
+            expires_at=NOW + 300,
+            replicas=(
+                replace(
+                    custody.serving_membership.replicas[0],
+                    expires_at=NOW + 300,
+                ),
+            ),
+        ),
+    )
+    for variable, path in {
+        authorization_custody.KEYRING_FILE_ENV: authorization_custody.HOSTED_KEYRING_FILE,
+        authorization_custody.CONTROL_FILE_ENV: authorization_custody.HOSTED_CONTROL_FILE,
+        authorization_custody.MEMBERSHIP_FILE_ENV: authorization_custody.HOSTED_MEMBERSHIP_FILE,
+    }.items():
+        monkeypatch.setenv(variable, str(path))
+    monkeypatch.setenv(authorization_custody.REPLICA_ID_ENV, "replica-7")
+    monkeypatch.setattr(
+        authorization_custody,
+        "load_authorization_custody",
+        lambda _root, *, now: custody,
+    )
+
+    raw = authorization_session_lifecycle.mint_hosted_replica_readiness_attestation(
+        tmp_path,
+        expected_cell_id="cell-7",
+        expected_logical_vault_id="logical-vault-7",
+        expected_replica_id="replica-7",
+        lifecycle_phase="active",
+        active_reads=0,
+        active_mutations=0,
+        active_transfers=0,
+        target_epoch=2,
+        previous_epoch_digest="a" * 64,
+        ttl_seconds=300,
+        now=NOW + 200,
+    )
+    parsed = authorization_serving_membership.parse_replica_readiness_attestation(
+        raw,
+        verifier_keys={item.key_id: item.key for item in custody.keyring.accepted_keys},
+        now=NOW + 200,
+        expected_epoch=2,
+        expected_cell_id="cell-7",
+    )
+
+    assert parsed.expires_at == NOW + 500
+
+
 def test_resume_fails_when_a_live_row_key_drops_from_the_serving_intersection() -> None:
     connection, migration = _connection()
     old_key = _key("auth-key-old", b"o" * 32)


### PR DESCRIPTION
## Summary

- challenge the quiesced Hosted cell for the exact next membership epoch and predecessor digest
- verify the returned canonical attestation against the current cell, replica, release, schema, keyring, control basis, lifecycle state, TTL, and MAC before Secret publication
- commit the verified runtime statement under the existing Kubernetes resource-version CAS instead of fabricating it in the provisioner
- allow a fresh next-epoch attestation to extend beyond the predecessor control record while remaining bounded by the active verifier key

Stacked after #895. This does not merge or touch any live vault.

## Verification

- red-first: missing runtime-attestation input/verification and predecessor-expiry extension
- focused membership/lifecycle/provisioner suites: 99 passed
- Ruff on all six changed Python files
- `uv lock --check` for root and provisioner
- `openspec validate harden-governance-for-consolidation --strict`
- public repository artifact validation: 3352 files / 3420 payloads
- root and provisioner sdist/wheel builds
- `git diff --check`
