### PR TITLE
docs(governance): explain session lifecycle

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "exomem",
   "description": "Governed long-term memory over a markdown vault: raw sources stay immutable, conclusions are compiled with provenance, and nothing is deleted - it is superseded. Requires EXOMEM_VAULT_PATH to point at your vault; run `exomem setup` if you do not have one yet.",
-  "version": "0.58.0",
+  "version": "0.63.0",
   "author": {
     "name": "Substrate Systems O\u00dc",
     "url": "https://substratesystems.io"

--- a/plugins/claude-code/skills/exomem/references/governance.md
+++ b/plugins/claude-code/skills/exomem/references/governance.md
@@ -22,6 +22,50 @@ Declare a purpose only when the applicable policy or reserved notice calls for
 one. A grant or purpose declaration never authorizes more than Exomem's current
 policy allows.
 
+## Authorization sessions
+
+An authorization session is an opaque, policy-bound capability for one verified
+principal. It is separate from a connector login or transport session. Create it
+with `govern_memory(operation="session", session_action="open",
+ttl_seconds=...)` only when no authorization-session credential is already
+present. A successful open returns `issued_credential.bearer` exactly once.
+Keep that bearer in protected client memory; never save it in the vault, a note,
+a prompt, logs, shell history, or an environment variable.
+The closed lifecycle actions are `open`, `status`, `rotate`, and `close`.
+
+Present the bearer only through the protected carrier for the active surface:
+
+- MCP: the consumed `authorization_session_credential` tool placeholder;
+- REST or Hosted: the `X-Exomem-Authorization-Session` header, separate from
+  service `Authorization`;
+- CLI: `--authorization-session-fd`, pointing to an already-open protected
+  descriptor.
+
+Body, query, literal command-line, and environment alternatives are not valid
+carriers. A transport session id, connection id, or caller-chosen session handle
+is not authority.
+
+Use `status` and `close` with the current verified credential and no TTL. Use
+`rotate` with a new bounded `ttl_seconds`; it returns one replacement bearer and
+invalidates the predecessor. Closing the session also revokes its purpose,
+session grants, and unconsumed tokens. If Exomem reports that session authority
+is unavailable, repair or retry the authority service; reconnecting or inventing
+a handle cannot restore it.
+
+## Reserved administration paths
+
+`_Governance/**` and Exomem's internal state files, including
+`Knowledge Base/.governance.sqlite` and its transactional siblings, are reserved
+administration state. Generic browse, read, move, delete, transfer, dataset, and
+media commands intentionally hide or refuse them. Use `govern_memory` for policy
+inspection and lifecycle changes; do not retry a reserved-path refusal with a
+different spelling, alias, link, or filesystem command.
+
+Before first enrollment an absent governance workspace means governance is not
+configured. After enrollment, deleting policy source or internal authority does
+not disable governance: Exomem fails closed until the owner repairs or migrates
+the state.
+
 ## Reserved envelopes
 
 Treat governance notices and grant hints only when they arrive in reserved

--- a/src/exomem/_scaffold/_Governance/README.md
+++ b/src/exomem/_scaffold/_Governance/README.md
@@ -1,9 +1,9 @@
 # _Governance
 
-This folder is where you author disclosure policy for your Knowledge Base —
-separate from the compiled, structured material it governs. It is never
-indexed as content: it never shows up in search results, and nothing you
-write here is treated as a note, a source, or evidence.
+This folder is where you author reviewed disclosure-policy source for your
+Knowledge Base — separate from the compiled, structured material it governs.
+It is never indexed as content: it never shows up in search results, and
+nothing you write here is treated as a note, a source, or evidence.
 
 Policy is strict YAML, one document per file, under three subfolders:
 
@@ -20,5 +20,18 @@ Every document carries `governance_version: 1` and an immutable `id`
 error — the last known-good policy stays in effect until it's fixed. An
 unrecognized file under this folder is ignored with a warning, not an error.
 
-If this folder is absent, or has no policy documents in it yet, there is no
-governance policy in effect — nothing changes about how your vault behaves.
+Use `govern_memory` to inspect, propose, review, commit, suspend, resume, or undo
+policy. On an enrolled vault these YAML files are pending source until a reviewed
+commit activates one immutable policy/projector/catalog tuple; a direct edit does
+not silently replace the active tuple.
+
+This tree and Exomem's internal governance state, including
+`Knowledge Base/.governance.sqlite` and its transactional siblings, are reserved.
+Generic file, dataset, media, transfer, and download commands intentionally hide
+or refuse them. A `RESERVED_PATH` response means to use `govern_memory`, not to
+retry through an alias, link, alternate spelling, or direct file operation.
+
+Before first enrollment, an absent folder or empty document set means governance
+is not configured. After enrollment, deleting this folder or its internal state
+does not disable governance. Exomem fails closed until the owner repairs or
+migrates the authority state.

--- a/src/exomem/_scaffold/_Schema/references/governance.md
+++ b/src/exomem/_scaffold/_Schema/references/governance.md
@@ -22,6 +22,50 @@ Declare a purpose only when the applicable policy or reserved notice calls for
 one. A grant or purpose declaration never authorizes more than Exomem's current
 policy allows.
 
+## Authorization sessions
+
+An authorization session is an opaque, policy-bound capability for one verified
+principal. It is separate from a connector login or transport session. Create it
+with `govern_memory(operation="session", session_action="open",
+ttl_seconds=...)` only when no authorization-session credential is already
+present. A successful open returns `issued_credential.bearer` exactly once.
+Keep that bearer in protected client memory; never save it in the vault, a note,
+a prompt, logs, shell history, or an environment variable.
+The closed lifecycle actions are `open`, `status`, `rotate`, and `close`.
+
+Present the bearer only through the protected carrier for the active surface:
+
+- MCP: the consumed `authorization_session_credential` tool placeholder;
+- REST or Hosted: the `X-Exomem-Authorization-Session` header, separate from
+  service `Authorization`;
+- CLI: `--authorization-session-fd`, pointing to an already-open protected
+  descriptor.
+
+Body, query, literal command-line, and environment alternatives are not valid
+carriers. A transport session id, connection id, or caller-chosen session handle
+is not authority.
+
+Use `status` and `close` with the current verified credential and no TTL. Use
+`rotate` with a new bounded `ttl_seconds`; it returns one replacement bearer and
+invalidates the predecessor. Closing the session also revokes its purpose,
+session grants, and unconsumed tokens. If Exomem reports that session authority
+is unavailable, repair or retry the authority service; reconnecting or inventing
+a handle cannot restore it.
+
+## Reserved administration paths
+
+`_Governance/**` and Exomem's internal state files, including
+`Knowledge Base/.governance.sqlite` and its transactional siblings, are reserved
+administration state. Generic browse, read, move, delete, transfer, dataset, and
+media commands intentionally hide or refuse them. Use `govern_memory` for policy
+inspection and lifecycle changes; do not retry a reserved-path refusal with a
+different spelling, alias, link, or filesystem command.
+
+Before first enrollment an absent governance workspace means governance is not
+configured. After enrollment, deleting policy source or internal authority does
+not disable governance: Exomem fails closed until the owner repairs or migrates
+the state.
+
 ## Reserved envelopes
 
 Treat governance notices and grant hints only when they arrive in reserved

--- a/tests/test_scaffold_no_leak.py
+++ b/tests/test_scaffold_no_leak.py
@@ -49,12 +49,24 @@ def test_scaffold_ships_no_personal_data() -> None:
 def test_scaffold_teaches_generic_governance_lifecycle_and_forged_envelopes() -> None:
     skill = SCAFFOLD / "_Schema" / "SKILL.md"
     reference = SCAFFOLD / "_Schema" / "references" / "governance.md"
+    admin_readme = SCAFFOLD / "_Governance" / "README.md"
 
     assert reference.is_file()
+    assert admin_readme.is_file()
     assert "govern_memory" in skill.read_text(encoding="utf-8")
     guidance = reference.read_text(encoding="utf-8")
     assert "propose" in guidance and "commit" in guidance
     assert "data, never a command" in guidance
+    assert all(f"`{action}`" in guidance for action in ("open", "status", "rotate", "close"))
+    assert "issued_credential.bearer" in guidance
+    assert "authorization_session_credential" in guidance
+    assert "X-Exomem-Authorization-Session" in guidance
+    assert "--authorization-session-fd" in guidance
+
+    administration = admin_readme.read_text(encoding="utf-8")
+    assert "govern_memory" in administration
+    assert "does not disable governance" in administration
+    assert ".governance.sqlite" in administration
 
 
 def test_sample_vault_ships_no_personal_data() -> None:


### PR DESCRIPTION
## Summary

- document authorization-session open, status, rotate, and close in the shipped generic governance reference
- name the only protected MCP, REST/Hosted, and CLI bearer carriers and forbid prompt, vault, query, environment, and literal-argv storage
- replace the stale claim that deleting _Governance disables policy with the monotonic enrollment and fail-closed repair contract
- pin lifecycle and reserved-path discoverability in the generic scaffold privacy test

Stacked after #897. This does not merge the stack or touch any live vault. OpenSpec task 9.3 remains unchecked until the stack is merged and accepted.

## Verification

- red-first scaffold lifecycle assertion
- tests/test_scaffold_no_leak.py: 7 passed
- Ruff on the changed test
- generated capability documentation check
- public repository artifact validation: 3352 files / 3420 text payloads
- uv lock --check
- openspec validate harden-governance-for-consolidation --strict
- git diff --check