### PR TITLE
feat(governance): add consolidation cell identity

### DIFF
--- a/openspec/changes/add-governed-vault-consolidation/design.md
+++ b/openspec/changes/add-governed-vault-consolidation/design.md
@@ -108,17 +108,17 @@ cross-installation, cross-session, or cross-issuer contexts are equivalent
 content-free denials.
 
 Hosted exposure is additive rather than a mutation of a closed surface. A new
-`hosted-alpha-agent-v3` profile contains the exact v2 command sequence plus
-`consolidate_memory`; v1 and v2 descriptors, hashes, generated plugin/manifest
-fixtures, locks, clients, and registered evidence remain byte-identical. The v3
+`hosted-alpha-agent-v5` profile contains the exact v4 command sequence plus
+`consolidate_memory`; v1 through v4 descriptors, hashes, generated plugin/manifest
+fixtures, locks, clients, and registered evidence remain byte-identical. The v5
 profile has its own descriptor/hash, generated fixtures, compatibility and
 promotion evidence, and explicit deployment selection. A cell not explicitly
-configured for v3 does not advertise or admit consolidation, and creation of v3
+configured for v5 does not advertise or admit consolidation, and creation of v5
 does not auto-promote any deployment. Private artifact delivery and trusted
-confirmation remain operator/control-plane seams beneath the registered v3
+confirmation remain operator/control-plane seams beneath the registered v5
 product command rather than public request fields.
 
-V3 selection is authorized only by a closed private
+V5 selection is authorized only by a closed private
 `HostedProfileSelection/v1` record from the deployment/control plane. It binds
 typed cell and logical vault identities, installation id/generation/active fence,
 profile id and descriptor hash, release and
@@ -131,9 +131,9 @@ exact-cell transport-supervisor readiness fingerprint, rollback/recovery closure
 digest, operation id,
 issue/expiry, and control-plane signature/record digest. Startup validates the
 whole tuple against the running image and private dependencies before advertising
-or admitting v3. Missing, unknown, partial, stale, incompatible, or caller-made
-selection keeps existing explicitly selected v1/v2 behavior byte-identical; it
-never infers v3 from a lifecycle flag or capability presence and never promotes
+or admitting v5. Missing, unknown, partial, stale, incompatible, or caller-made
+selection keeps existing explicitly selected v1 through v4 behavior byte-identical; it
+never infers v5 from a lifecycle flag or capability presence and never promotes
 it automatically.
 
 The closed field names are `schema`, `cell_id`, `vault_id`, `installation_id`,
@@ -165,14 +165,14 @@ Private `HostedProfileSelectionVerifierRecord/v1` trust records contain exactly
 `registry_generation`, and `revoked_at`/`revocation_reason_digest` exactly for
 revoked records. They bind the raw 32-byte unpadded-base64url Ed25519 public key
 and derived key id, purpose `hosted-profile-selection`, issuer/control-plane
-identity, deployment audience, allowed `hosted-alpha-agent-v3` profile, status
+identity, deployment audience, allowed `hosted-alpha-agent-v5` profile, status
 `active|inactive|revoked`, bounded integer registry generation, and ordered
 validity interval. Startup verifies record
 validity at the selection issue time and current startup time. Rotation permits
 only an explicitly bounded two-key overlap; unknown, inactive, premature,
 expired, revoked, wrong-purpose/issuer/audience/profile, or caller-supplied keys
 fail. Fixed signing/rotation/revocation vectors are shared across runtimes.
-Unknown fields, a mismatched digest/signature, or a non-v3 profile in this
+Unknown fields, a mismatched digest/signature, or a non-v5 profile in this
 schema fails closed.
 
 The command accepts opaque artifact references and structured facts, never an
@@ -1451,9 +1451,9 @@ runs and does not justify calling a real consolidation complete.
    batches, recovery, rollback, and receipts behind crash-seam tests.
 4. Add `consolidate_memory` to the command registry and regenerate MCP, REST,
    OpenAPI, CLI, scaffold/bootstrap, and connector contracts. Add the exact
-   v2-plus-command `hosted-alpha-agent-v3` descriptor and its own generated
+   v4-plus-command `hosted-alpha-agent-v5` descriptor and its own generated
    plugin/manifest, compatibility, selection, and promotion artifacts without
-   changing or auto-promoting v1/v2.
+   changing or auto-promoting v1 through v4.
 5. Run installed-wheel local and Hosted E2E, an adversarial security review, and
    the full release gates. Ship the capability without touching real vaults.
 6. In a later operation, make verified clones and run the full rehearsal plus

--- a/openspec/changes/add-governed-vault-consolidation/pre-consolidation-baseline.json
+++ b/openspec/changes/add-governed-vault-consolidation/pre-consolidation-baseline.json
@@ -1,0 +1,282 @@
+{
+  "bootstrap": {
+    "compact": {
+      "advanced_order": [
+        "coordination_status",
+        "process_media",
+        "maintain_memory",
+        "schema_memory",
+        "govern_memory",
+        "manage_memory_file",
+        "query_dataset",
+        "read_media"
+      ],
+      "canonical_sha256": "a586ebc02827418cd8074174ffa8f9f182ada20f88acb4daadc3504a7a197c75",
+      "first_run_safe_order": [
+        "coordination_status",
+        "bootstrap",
+        "ask_memory",
+        "read_memory",
+        "browse_memory",
+        "compile_source",
+        "transfer_artifact",
+        "review_memory",
+        "review_item_context",
+        "connect_memory",
+        "adopt_vault",
+        "adoption_studio",
+        "maintain_memory",
+        "schema_memory",
+        "govern_memory",
+        "query_dataset",
+        "read_media"
+      ],
+      "json_default_bytes": 61376,
+      "primary_order": [
+        "bootstrap",
+        "ask_memory",
+        "read_memory",
+        "browse_memory",
+        "remember",
+        "edit_memory",
+        "observe_memory",
+        "replace_memory",
+        "capture_source",
+        "compile_source",
+        "preserve_evidence",
+        "preserve_artifacts",
+        "transfer_artifact",
+        "review_memory",
+        "review_item_context",
+        "triage_memory",
+        "connect_memory",
+        "adopt_vault",
+        "adoption_studio",
+        "record_memory",
+        "plan_memory"
+      ],
+      "route_order": [
+        "coordination_status",
+        "bootstrap",
+        "ask_memory",
+        "read_memory",
+        "browse_memory",
+        "remember",
+        "edit_memory",
+        "observe_memory",
+        "replace_memory",
+        "capture_source",
+        "compile_source",
+        "preserve_evidence",
+        "preserve_artifacts",
+        "transfer_artifact",
+        "process_media",
+        "review_memory",
+        "review_item_context",
+        "triage_memory",
+        "connect_memory",
+        "adopt_vault",
+        "adoption_studio",
+        "maintain_memory",
+        "schema_memory",
+        "govern_memory",
+        "manage_memory_file",
+        "record_memory",
+        "plan_memory",
+        "query_dataset",
+        "read_media"
+      ]
+    },
+    "diagnostics": {
+      "canonical_sha256": "a60ac9677da633b1c6aa9976651f9817d35ed1442888a449c1aa4fb7d9aed9d4",
+      "json_default_bytes": 94390
+    },
+    "full": {
+      "canonical_sha256": "daa6cd18b8d888d4579ade635d21c2c41f213ca1fa97a2a1aa5e8379e7b05719",
+      "json_default_bytes": 94360
+    }
+  },
+  "core_file_sha256": {
+    "docs/capabilities.md": "1b0a93305653872a22d72be68868e871929f69dca895552fd99833f7596f068b",
+    "infra/contracts/exomem-hosted-deployment-lock-pair-v2.json": "8431fab0912e68f75d5eb452df1c321b743e06d91a66d526cd1172f44719815f",
+    "infra/contracts/exomem-hosted-deployment-lock-v2.schema.json": "d1f0c6fdffef8a4e4c22c5cf5a241cbf02cfe67fc41398fc901535c7a7168d62",
+    "infra/contracts/exomem-hosted-deployment-lock-v3.schema.json": "3c01a55153d4bb067727ae85f09cfe609379f20ef3a8d1b115f99690dc2dcade",
+    "infra/contracts/exomem-hosted-release-v1.json": "58a18cc36f854519682066aca8722db14f1e2635579939405394ef431f4dcd9f",
+    "plugins/hosted/candidates/hosted-alpha-agent-v2/definition.json": "e9bf353e8e73957cc894ab903b98066dc2c46575a483d849e6e7ddd70412ea54",
+    "plugins/hosted/candidates/hosted-alpha-agent-v3/definition.json": "4618e39a87ace4a9f75dddc368dcb281960d6a6c799f59c090d2cb2e98e5f81c",
+    "plugins/hosted/candidates/hosted-alpha-agent-v4/definition.json": "162f1d4f9e4b55a47fcbd3258eb91e0ff54631cdbf14fced396252555a50d257",
+    "plugins/hosted/definition.json": "96f92d72b47b2578d28e8cc60fe65a3d1dbb0f0ea11d3ee8ecc44d895e443196",
+    "src/exomem/tool_surface_contract.json": "3af1e3c050d24af17511dec25f898f5ba74fcb861e8b4f46ada8898a8b497d30",
+    "tests/fixtures/mcp_tool_schemas.json": "f2c4912204d5d4c5a2cdc858d5e40419d59e86b300b65e5f999b0c3b1745e9a5"
+  },
+  "hosted_profiles": {
+    "hosted-alpha-agent-v1": {
+      "command_surface_sha256": "eddd997c22885ca913aa57dea2e6a2afaa7cb5f0dd52d87b564c1c3d7bbadc7f",
+      "commands": [
+        "bootstrap",
+        "ask_memory",
+        "read_memory",
+        "browse_memory",
+        "remember",
+        "observe_memory",
+        "capture_source",
+        "compile_source",
+        "preserve_evidence",
+        "review_memory",
+        "review_item_context",
+        "triage_memory",
+        "connect_memory"
+      ],
+      "compatibility_sha256": "fc0098ffa8c0c3cf0f41c94943930701ad6ac2ff1d3ac9e6a1e7615c44f4c93f",
+      "definition_sha256": "be79a05714036554726ef688cc57b41580c06ac9a6d170b969168cfdd9d50ab2"
+    },
+    "hosted-alpha-agent-v2": {
+      "command_surface_sha256": "9397885e979200ea9f72251fcffbe35042ad41addf4df79051f2e066da04923e",
+      "commands": [
+        "bootstrap",
+        "ask_memory",
+        "read_memory",
+        "browse_memory",
+        "remember",
+        "observe_memory",
+        "capture_source",
+        "compile_source",
+        "preserve_evidence",
+        "review_memory",
+        "review_item_context",
+        "triage_memory",
+        "connect_memory",
+        "record_memory"
+      ],
+      "compatibility_sha256": "ebb45eba774d080379984220c2c205fb3b934ed688fff669a8832eac9e353545",
+      "definition_sha256": "e967d2dc056fdc5977953d719db4e785a64838a795be956ff2cf9f9bf1aa9a13"
+    },
+    "hosted-alpha-agent-v3": {
+      "command_surface_sha256": "4bc83f2e5509099c6f5b829d61dadb66560e0ccf941aa3d681b6fb847ddfeaa5",
+      "commands": [
+        "bootstrap",
+        "ask_memory",
+        "read_memory",
+        "browse_memory",
+        "remember",
+        "observe_memory",
+        "capture_source",
+        "compile_source",
+        "preserve_evidence",
+        "review_memory",
+        "review_item_context",
+        "triage_memory",
+        "connect_memory",
+        "record_memory",
+        "replace_memory",
+        "plan_memory",
+        "edit_memory"
+      ],
+      "compatibility_sha256": "e67845c386032144914c642140efacee2b38aca5fde37d8d86621e1b080f6a3f",
+      "definition_sha256": "3a60523f23976f5cb7289f207404b2dbec335cfad4d41385d69418008d0aed0d"
+    },
+    "hosted-alpha-agent-v4": {
+      "command_surface_sha256": "4b4b71280fec7915042483207b1ab0e15e916148ac1b88ef965e03671de80968",
+      "commands": [
+        "coordination_status",
+        "bootstrap",
+        "ask_memory",
+        "read_memory",
+        "browse_memory",
+        "remember",
+        "edit_memory",
+        "observe_memory",
+        "replace_memory",
+        "capture_source",
+        "compile_source",
+        "preserve_evidence",
+        "preserve_artifacts",
+        "review_memory",
+        "review_item_context",
+        "triage_memory",
+        "connect_memory",
+        "adoption_studio",
+        "maintain_memory",
+        "schema_memory",
+        "govern_memory",
+        "manage_memory_file",
+        "record_memory",
+        "plan_memory",
+        "query_dataset"
+      ],
+      "compatibility_sha256": "4a12a115086166c5b37cde02e6bfcc6aa2c095b6d073dc23f5634803b13c0ce9",
+      "definition_sha256": "447f9e01207f32cd42f19f5230a7da721d6d0fa90f622e16e9831f9795d7ac5d"
+    }
+  },
+  "openapi": {
+    "operation_count": 28,
+    "operations": [
+      "POST /api/adopt_vault",
+      "POST /api/adoption_studio",
+      "POST /api/ask_memory",
+      "POST /api/bootstrap",
+      "POST /api/browse_memory",
+      "POST /api/capture_source",
+      "POST /api/compile_source",
+      "POST /api/connect_memory",
+      "POST /api/coordination_status",
+      "POST /api/edit_memory",
+      "POST /api/govern_memory",
+      "POST /api/maintain_memory",
+      "POST /api/manage_memory_file",
+      "POST /api/observe_memory",
+      "POST /api/plan_memory",
+      "POST /api/preserve_artifacts",
+      "POST /api/preserve_evidence",
+      "POST /api/process_media",
+      "POST /api/query_dataset",
+      "POST /api/read_memory",
+      "POST /api/record_memory",
+      "POST /api/remember",
+      "POST /api/replace_memory",
+      "POST /api/review_item_context",
+      "POST /api/review_memory",
+      "POST /api/schema_memory",
+      "POST /api/transfer_artifact",
+      "POST /api/triage_memory"
+    ],
+    "operations_sha256": "630ec67d8cab461a69e1721fef1550a13b79154334d6e077ba4f61f3041b88f3"
+  },
+  "repository_head": "32170d098970a409fd3305fe8f59d302439ebed3",
+  "schema": "exomem.governed-consolidation-prechange-baseline/v1",
+  "tree_digest_algorithm": "sha256(canonical-json([{path,sha256}], paths sorted, UTF-8, sorted keys, compact separators))",
+  "tree_sha256": {
+    "hosted_candidate_v2": {
+      "file_count": 3,
+      "sha256": "a1897e75b77764a5344f4deb4f30c71061b1b48d121928c48d67112473c916f5"
+    },
+    "hosted_candidate_v3": {
+      "file_count": 4,
+      "sha256": "3a9b58dc07612e4bf66e1e708d250d445ac5380b4eed7908703fd30a06af3a6d"
+    },
+    "hosted_candidate_v4": {
+      "file_count": 4,
+      "sha256": "359cd5571e5b57298589c3aec32e0c7b3ee4df0c29fb060a61dd34aee0cdc538"
+    },
+    "hosted_generated_candidate_v2": {
+      "file_count": 29,
+      "sha256": "f706078c9c6ee5353ff87ae73bf6c2bcfee5dce762f9682fa865c18295307753"
+    },
+    "hosted_generated_candidate_v3": {
+      "file_count": 15,
+      "sha256": "76857e8b97236bce91ed697689365a6fac541b1eaeb2a4e3063c071e4332fec9"
+    },
+    "hosted_generated_candidate_v4": {
+      "file_count": 29,
+      "sha256": "0d9b7c6dad60771c14cf1e02776413ac035b50506c3897d272ef95312ae30441"
+    },
+    "hosted_generated_v1": {
+      "file_count": 27,
+      "sha256": "b954db2523775e4327c3e13035037d3e5f5619580516eb4f447ff26b9396c1d3"
+    },
+    "hosted_promotion": {
+      "file_count": 6,
+      "sha256": "3e7b6fcd4a051ced9efead21490bbbf6a012c7ae7dc2e7e5f4707946469d6b89"
+    }
+  }
+}

--- a/openspec/changes/add-governed-vault-consolidation/specs/command-surface/spec.md
+++ b/openspec/changes/add-governed-vault-consolidation/specs/command-surface/spec.md
@@ -19,18 +19,18 @@ Unknown actions and arguments from a different action's schema SHALL be refused
 rather than ignored.
 
 Hosted SHALL expose the product command only through a new additive
-`hosted-alpha-agent-v3` profile whose ordered command surface is exactly the v2
-profile plus `consolidate_memory`. V1 and v2 profile membership, descriptors,
+`hosted-alpha-agent-v5` profile whose ordered command surface is exactly the v4
+profile plus `consolidate_memory`. V1 through v4 profile membership, descriptors,
 hashes, generated plugins/manifests, locks, clients, and registered evidence
-SHALL remain byte-identical. V3 SHALL have its own versioned descriptor and hash,
+SHALL remain byte-identical. V5 SHALL have its own versioned descriptor and hash,
 generated plugin/manifest fixtures, compatibility/promotion evidence, and
-explicit deployment selection; defining v3 SHALL NOT auto-promote an active
-deployment. A cell not explicitly configured for v3 SHALL not advertise or
+explicit deployment selection; defining v5 SHALL NOT auto-promote an active
+deployment. A cell not explicitly configured for v5 SHALL not advertise or
 admit consolidation. Private artifact and trusted-confirmation routes SHALL
-remain operator/control-plane seams beneath the v3 product command and SHALL
+remain operator/control-plane seams beneath the v5 product command and SHALL
 not become public command parameters.
 
-V3 selection SHALL require a closed signed private
+V5 selection SHALL require a closed signed private
 `HostedProfileSelection/v1` control-plane record binding typed cell/vault,
 installation id/generation/active fence, profile id
 and descriptor hash, release/protocol, Records reader version, identity schema,
@@ -41,8 +41,8 @@ owner-entitlement-verifier readiness, exact-cell transport-supervisor readiness,
 rollback/recovery closure, operation id, validity, signer, and record digest. Startup
 SHALL validate the whole tuple against the running image/dependencies before
 advertise/admit. Missing, partial, stale, unknown, incompatible, inferred, or
-caller-made selection SHALL not choose v3 and SHALL leave an explicitly selected
-v1/v2 surface byte-identical.
+caller-made selection SHALL not choose v5 and SHALL leave an explicitly selected
+v1 through v4 surface byte-identical.
 
 Its exact fields SHALL be `schema`, `cell_id`, `vault_id`, `installation_id`,
 `installation_generation`, `active_fence_digest`, `profile_id`,
@@ -74,7 +74,7 @@ exactly `schema`, `algorithm`, `key_id`, `public_key`, `purpose`,
 `revoked_at` plus `revocation_reason_digest` exactly when `status=revoked`.
 `algorithm=Ed25519`; `public_key` is the raw 32-byte key in unpadded base64url;
 `key_id` is its derived `ed25519-sha256:` id; `purpose` is
-`hosted-profile-selection`; `profile_id` is `hosted-alpha-agent-v3`; `status`
+`hosted-profile-selection`; `profile_id` is `hosted-alpha-agent-v5`; `status`
 is `active|inactive|revoked`; registry generation is an integer in
 `0..2^53-1`; and `not_before < not_after` SHALL hold. The issuer and deployment
 audience digests SHALL bind the configured control plane and cell deployment.
@@ -83,25 +83,25 @@ at issue and startup time; rotation SHALL permit only an explicit bounded
 two-key overlap. Unknown/caller-supplied, premature, expired, revoked,
 wrong-purpose/issuer/audience/profile keys SHALL fail. Fixed signing, rotation,
 and revocation vectors SHALL be generated across supported runtimes. Unknown
-fields, digest/signature mismatch, or non-v3 profile SHALL fail closed.
+fields, digest/signature mismatch, or non-v5 profile SHALL fail closed.
 
 #### Scenario: One registry entry generates every selected surface
 
-- **WHEN** the command registry and selected v3 artifacts are built
-- **THEN** MCP, REST, OpenAPI, CLI, v3 Hosted, and capability documentation expose the same eleven actions and parameter semantics
+- **WHEN** the command registry and selected v5 artifacts are built
+- **THEN** MCP, REST, OpenAPI, CLI, v5 Hosted, and capability documentation expose the same eleven actions and parameter semantics
 - **AND** no surface-specific consolidation action list or implementation exists
 
 #### Scenario: Existing Hosted profiles remain closed
 
-- **WHEN** v3 is added and a cell is configured for v1 or v2
+- **WHEN** v5 is added and a cell is configured for any profile from v1 through v4
 - **THEN** its command membership, descriptor/hash, generated plugin/manifest, client contract, and registered evidence remain byte-identical and omit `consolidate_memory`
-- **AND** only explicit selection of a compatible v3 deployment makes the product command available
+- **AND** only explicit selection of a compatible v5 deployment makes the product command available
 
-#### Scenario: V3 selection readiness tuple is incomplete
+#### Scenario: V5 selection readiness tuple is incomplete
 
 - **WHEN** the private selection record lacks any reader, artifact, source-export/control-receipt verifier, archive-custodian verifier, owner confirmation, owner-entitlement verifier, transport-supervisor, or rollback/recovery readiness binding, has invalid signer trust, or mismatches the running image
-- **THEN** startup does not advertise or admit v3
-- **AND** it neither infers promotion nor changes configured v1/v2 behavior
+- **THEN** startup does not advertise or admit v5
+- **AND** it neither infers promotion nor changes configured v1 through v4 behavior
 
 #### Scenario: Unknown action is invoked
 
@@ -668,15 +668,15 @@ Schema-fidelity tests SHALL intentionally add only the new
 copy changes to the committed generated baselines. Contract tests SHALL prove
 identical action validation, normalized result fields, stable error codes,
 content-free sealed outcomes, idempotent retry terminals, and trusted-context
-handling across MCP, REST, CLI, and v3 Hosted. OpenAPI and generated capability
+handling across MCP, REST, CLI, and v5 Hosted. OpenAPI and generated capability
 documentation SHALL describe the same finite schemas, owner-inclusive seal,
 three distinct approvals, and Exomem-mediated enforcement boundary.
 
 #### Scenario: Generated schema changes are reviewed
 
 - **WHEN** schema, OpenAPI, Hosted manifest, bootstrap, and capability fixtures are regenerated
-- **THEN** the gate reports an explicit bounded diff attributable to consolidation and the new v3 artifacts
-- **AND** unrelated command schemas/descriptions and all v1/v2 artifacts remain byte-identical
+- **THEN** the gate reports an explicit bounded diff attributable to consolidation and the new v5 artifacts
+- **AND** unrelated command schemas/descriptions and all v1 through v4 artifacts remain byte-identical
 
 #### Scenario: Success wrapper fixtures are exact
 

--- a/openspec/changes/add-governed-vault-consolidation/specs/hosted-mutation-safety/spec.md
+++ b/openspec/changes/add-governed-vault-consolidation/specs/hosted-mutation-safety/spec.md
@@ -94,7 +94,7 @@ its own human review and token reservation have committed.
 
 #### Scenario: Apply seals without waiting on itself
 
-- **WHEN** Hosted v3 admits apply as a control mutation and begins seal drain
+- **WHEN** Hosted v5 admits apply as a control mutation and begins seal drain
 - **THEN** its own exact operation has been converted out of the ordinary active counter while all other participants must drain
 - **AND** apply cannot deadlock on `active_mutations == 0` or exclude another mutation
 

--- a/openspec/changes/add-governed-vault-consolidation/specs/product-e2e/spec.md
+++ b/openspec/changes/add-governed-vault-consolidation/specs/product-e2e/spec.md
@@ -169,7 +169,7 @@ binds that reference and observed digest; no caller field selects K.
 
 Contract E2E SHALL invoke `consolidate_memory` through a real stdio MCP client,
 authenticated REST application, installed CLI, and an explicitly selected
-`hosted-alpha-agent-v3` cell/control-plane
+`hosted-alpha-agent-v5` cell/control-plane
 adapter. Each surface SHALL expose the same finite actions, selector
 classification, normalized schema, logical results, stable errors, idempotent
 mutation terminals, fresh principal/session binding, and trusted-confirmation
@@ -177,12 +177,12 @@ semantics. The suite SHALL exercise at least one full lifecycle through stdio
 MCP and one through Hosted, with REST/CLI parity probes at every externally
 observable state and action boundary.
 
-Generated OpenAPI, MCP schema, v3 Hosted descriptor/hash and plugin/manifest,
+Generated OpenAPI, MCP schema, v5 Hosted descriptor/hash and plugin/manifest,
 CLI help, bootstrap, and capability documentation SHALL be checked against
-committed bounded fixtures. V1/v2 membership, descriptors, hashes,
+committed bounded fixtures. V1 through v4 membership, descriptors, hashes,
 plugins/manifests, locks, clients, and registered evidence SHALL be asserted
-byte-identical, and the test SHALL prove that defining v3 neither selects nor
-promotes it. V3 startup SHALL consume a valid signed private
+byte-identical, and the test SHALL prove that defining v5 neither selects nor
+promotes it. V5 startup SHALL consume a valid signed private
 `HostedProfileSelection/v1` whose typed cell/vault/installation-generation-fence,
 release/protocol, descriptor,
 Records/identity/run/seal/receipt reader, artifact store, source-export/control-
@@ -193,8 +193,8 @@ The record SHALL be detached Ed25519-signed over its exact framed JCS bytes,
 name its `ed25519-sha256:` signer key id, and verify through the private
 purpose/audience/profile-scoped selection registry with status, validity,
 revocation, generation, and bounded rotation overlap. Missing, unsigned,
-unknown-key, revoked, expired, or one-field-mismatched records SHALL leave v1/v2
-behavior unchanged and v3 unavailable. Every process and request SHALL have a timeout and
+unknown-key, revoked, expired, or one-field-mismatched records SHALL leave v1 through v4
+behavior unchanged and v5 unavailable. Every process and request SHALL have a timeout and
 SHALL fail rather than hang. The gate SHALL assert that caller fields cannot forge owner
 confirmation, destination identity, principal attestations, artifact trust, or
 internal consolidation authority.
@@ -225,23 +225,23 @@ terminal MAY use `delivery=replayed`.
 - **THEN** initial delivery is exactly `{"success":true,"data":{"delivery":"initial","terminal":T}}` and replay is exactly `{"success":true,"data":{"delivery":"replayed","terminal":T}}`, with byte-identical canonical `T`, `outcome=committed`, and no second effect
 - **AND** changed tenant, principal/session, action, token, artifact, plan, or payload conflicts
 
-#### Scenario: Hosted deployment remains on v2
+#### Scenario: Existing Hosted deployment remains on an earlier profile
 
-- **WHEN** v3 artifacts exist but the cell deployment explicitly selects v2
-- **THEN** Hosted discovery and dispatch omit `consolidate_memory` and the v2 descriptor/hash remain unchanged
-- **AND** the command becomes available only after a separately compatible v3 candidate is explicitly selected and its promotion evidence verifies
+- **WHEN** v5 artifacts exist but the cell deployment explicitly selects any profile from v1 through v4
+- **THEN** Hosted discovery and dispatch omit `consolidate_memory` and that selected profile's descriptor/hash remain unchanged
+- **AND** the command becomes available only after a separately compatible v5 candidate is explicitly selected and its promotion evidence verifies
 
 #### Scenario: Hosted apply drains its own cell
 
-- **WHEN** v3 apply is admitted while ordinary Hosted mutations are active
+- **WHEN** v5 apply is admitted while ordinary Hosted mutations are active
 - **THEN** the exact apply operation atomically converts out of the ordinary active-mutation counter before seal drain and waits for every other participant
 - **AND** it completes without self-deadlock, double admission, or excluding another operation
 
-#### Scenario: Hosted v3 selection trust is incomplete
+#### Scenario: Hosted v5 selection trust is incomplete
 
 - **WHEN** the selection signature algorithm/encoding, signer key, registry purpose/audience/profile, validity/revocation, source-export or custodian verifier readiness, owner-entitlement readiness, or exact-cell transport-supervisor readiness is absent or mismatched
 - **THEN** startup neither advertises nor admits `consolidate_memory` for that cell
-- **AND** v1/v2 descriptors, dispatch, and active deployment selection remain byte-identical
+- **AND** v1 through v4 descriptors, dispatch, and active deployment selection remain byte-identical
 
 ### Requirement: Crash-matrix E2E proves sealed recovery, abort, and truthful rollback
 

--- a/openspec/changes/add-governed-vault-consolidation/specs/release-gate/spec.md
+++ b/openspec/changes/add-governed-vault-consolidation/specs/release-gate/spec.md
@@ -103,7 +103,7 @@ transport work drained.
 
 For a Hosted exact cell, the transport basis SHALL also bind the validated
 signed `HostedProfileSelection/v1` record and its current verifier-registry
-generation, including the selected v3 descriptor hash and the record's bound
+generation, including the selected v5 descriptor hash and the record's bound
 owner-entitlement-verifier and exact-cell transport-supervisor readiness
 digests. The release gate SHALL revalidate the selection signature, signer
 status/validity/revocation, and both readiness components before transport-stop
@@ -149,9 +149,9 @@ consolidation seal or retain owner-only recovery with rollback reachable.
 
 #### Scenario: Hosted transport supervisor readiness drifts
 
-- **WHEN** the selected v3 record's signer is revoked or its bound owner-entitlement or transport-supervisor readiness digest changes before routing-open
+- **WHEN** the selected v5 record's signer is revoked or its bound owner-entitlement or transport-supervisor readiness digest changes before routing-open
 - **THEN** exact-cell transport verification fails closed and public routing remains stopped
-- **AND** v1/v2 behavior is not widened or promoted as a fallback
+- **AND** v1 through v4 behavior is not widened or promoted as a fallback
 
 ### Requirement: Seal coverage is registered, closed-world, and restart-safe
 

--- a/openspec/changes/add-governed-vault-consolidation/tasks.md
+++ b/openspec/changes/add-governed-vault-consolidation/tasks.md
@@ -1,18 +1,18 @@
 ## 0. Prerequisite and red-first evidence gate
 
-- [ ] 0.1 Before touching consolidation product code, verify that
+- [x] 0.1 Before touching consolidation product code, verify that
   `harden-governance-for-consolidation` is merged, its six delta capabilities are
   canonical, its sidecar migrations are deployed, its independent security
   review/recheck is closed, and its independent verifier evidence is green. Run
   `openspec validate harden-governance-for-consolidation --strict` against the
   merged tree and stop if any prerequisite is only specified rather than shipped.
-- [ ] 0.2 Record immutable pre-change baselines for the MCP schema fixture,
-  OpenAPI operations, capability document, bootstrap ordering/size, Hosted v1/v2
-  command membership and descriptor hashes, generated v1/v2 plugin/manifest
+- [x] 0.2 Record immutable pre-change baselines for the MCP schema fixture,
+  OpenAPI operations, capability document, bootstrap ordering/size, Hosted v1-v4
+  command membership and descriptor hashes, generated v1-v4 plugin/manifest
   fixtures, deployment locks, client contracts, and registered promotion
-  evidence. These hashes are the negative assertion that consolidation adds v3
-  without widening or auto-promoting v1/v2.
-- [ ] 0.3 Create a red-first evidence log for this change. For every test task
+  evidence. These hashes are the negative assertion that consolidation adds v5
+  without widening or auto-promoting v1-v4.
+- [x] 0.3 Create a red-first evidence log for this change. For every test task
   below, run the named test before implementation, record its exact assertion
   failure (not collection/import failure), then rerun it green after the smallest
   implementation slice. A test introduced already green because it does not
@@ -24,7 +24,7 @@
 
 ## 1. Durable cell identity and authenticated portable intake
 
-- [ ] 1.1 Add red tests in `tests/test_consolidation_cell_identity.py` for
+- [x] 1.1 Add red tests in `tests/test_consolidation_cell_identity.py` for
   standalone local and Hosted private identity records containing generated
   logical `vault_id`, generated `installation_id`, authenticated root binding,
   monotonic installation generation/fence, stable filesystem/root identity,
@@ -36,7 +36,7 @@
   before export or run creation. Add a Hosted regression proving typed routing
   `cell_id`, logical `vault_id`, and `installation_id` are independent and
   `cell_id == vault_id` fails before readiness/owner-context construction.
-- [ ] 1.2 Add red legacy-adoption tests proving only an authenticated local owner
+- [x] 1.2 Add red legacy-adoption tests proving only an authenticated local owner
   under exclusive lifetime/writer authority can adopt an unbound vault; adoption
   generates rather than accepts both ids, binds the stable root/filesystem and
   installation registry atomically, records its one-time census as provenance,
@@ -889,7 +889,7 @@ binds that reference and observed digest; no caller field selects K.
 - [ ] 10.8 Run
   `uv run python -m pytest -q tests/test_consolidation_verification.py tests/test_consolidation_transport_verification.py tests/test_consolidation_oracle_closure.py tests/test_governance_oracle_closure.py tests/test_governance_egress.py tests/test_governance_postfilter.py tests/test_record_governance.py tests/test_media_deletion_propagation.py`.
 
-## 11. Command parity and additive Hosted v3
+## 11. Command parity and additive Hosted v5
 
 - [ ] 11.1 Add a red owner-authorization matrix in
   `tests/test_consolidation_surface.py` for all eleven actions. Resolve owner at
@@ -979,12 +979,12 @@ binds that reference and observed digest; no caller field selects K.
   surfaces; no adapter-local envelope or optional flattened delivery is allowed.
 - [ ] 11.5 Extend `tests/test_hosted_agent_surface.py`, Hosted plugin/manifest tests,
   deployment-lock tests, client fixtures, and promotion guards red-first for
-  additive `hosted-alpha-agent-v3`. Assert its ordered membership is byte-for-byte
-  v2 membership followed by `consolidate_memory`, it has a distinct descriptor/hash
-  and generated plugin/manifest fixtures, and v1/v2 membership, descriptors/hashes,
+  additive `hosted-alpha-agent-v5`. Assert its ordered membership is byte-for-byte
+  v4 membership followed by `consolidate_memory`, it has a distinct descriptor/hash
+  and generated plugin/manifest fixtures, and v1-v4 membership, descriptors/hashes,
   plugins/manifests, locks, clients, and registered evidence remain byte-identical.
-- [ ] 11.6 Add red Hosted selection/promotion tests proving defining/building v3 does
-  not select or auto-promote it; v1/v2 cells omit/refuse consolidation; explicit v3
+- [ ] 11.6 Add red Hosted selection/promotion tests proving defining/building v5 does
+  not select or auto-promote it; v1-v4 cells omit/refuse consolidation; explicit v5
   deployment selection requires a closed signed private
   `HostedProfileSelection/v1` binding typed cell/vault and installation/
   generation/active-fence, profile/descriptor hash,
@@ -1012,14 +1012,14 @@ binds that reference and observed digest; no caller field selects K.
 - [ ] 11.7 Add the common owner-control authorization guard before consolidation
   coercion/existence/allocation, then register the engine once in `_PRODUCT_SPEC`,
   action validation, classifier, bootstrap/capability docs, and generated surfaces.
-  Add v3 as a new immutable
+  Add v5 as a new immutable
   profile and wire Hosted through generic discovery plus the lifecycle owner-
   control admission lane. Validate/consume the closed profile-selection record at
   startup before advertise/admit; do not infer it from lifecycle flags, add a
-  public bespoke consolidation route, modify v1/v2, or put the product command in
+  public bespoke consolidation route, modify v1-v4, or put the product command in
   the transfer intercept set.
 - [ ] 11.8 Regenerate only intentional MCP schema, OpenAPI/capability/bootstrap/help,
-  and new v3 descriptor/plugin/manifest/compatibility artifacts. Inspect the exact
+  and new v5 descriptor/plugin/manifest/compatibility artifacts. Inspect the exact
   diff against task 0.2 baselines and reject unrelated drift.
 - [ ] 11.9 Run
   `uv run python -m pytest -q tests/test_consolidation_surface.py tests/test_mcp_schema_fidelity.py tests/test_rest_registry.py tests/test_rest_api.py tests/test_cli_ops.py tests/test_bootstrap_capabilities.py tests/test_hosted_agent_surface.py tests/test_hosted_plugin_definition.py tests/test_hosted_plugin_rendering.py tests/test_hosted_release_manifest.py tests/test_hosted_plugin_promotion.py tests/test_hosted_deployment_lock_consumption.py`.
@@ -1059,12 +1059,12 @@ binds that reference and observed digest; no caller field selects K.
   pending-forward-only, and retirement-finalize, and exhaustively refuse every
   nonrow product terminal/phase/mode/run-mode/eligibility combination.
 - [ ] 12.3 Add an authenticated REST/CLI parity pass at every observable state and a
-  complete disposable Hosted v3 lifecycle using an explicitly selected compatible
-  v3 candidate plus valid signed `HostedProfileSelection/v1` and verifier record,
+  complete disposable Hosted v5 lifecycle using an explicitly selected compatible
+  v5 candidate plus valid signed `HostedProfileSelection/v1` and verifier record,
   including source-export/custodian, owner-entitlement, and exact-cell transport-
   supervisor readiness. Add
   unsigned/unknown-key/expired/revoked/wrong-scope and every one-field readiness
-  negative while proving v1/v2 remain byte-identical. During the seal, black-box
+  negative while proving v1-v4 remain byte-identical. During the seal, black-box
   calls prove only the ordinary content-free sealed response; during exact-cell
   transport verification they run only under routing-stop supervision; after
   routing-open they prove persistent parity with no serialized internal authority.
@@ -1148,7 +1148,7 @@ binds that reference and observed digest; no caller field selects K.
 - [ ] 13.1 Update only generic product/bootstrap/capability/operator documentation
   needed to discover consolidation, its owner-inclusive maintenance seal, fresh
   destination principal requirement, three distinct confirmations, source-retention
-  obligation, v3 Hosted selection, and Exomem-mediated boundary. Keep scaffold
+  obligation, v5 Hosted selection, and Exomem-mediated boundary. Keep scaffold
   examples generic and do not mention a personal, client, or operator vault.
 - [ ] 13.2 Add a software rollback compatibility test: new starts may be disabled,
   but a deployment may not remove a reader/recovery implementation needed by any
@@ -1199,15 +1199,15 @@ binds that reference and observed digest; no caller field selects K.
   routing race, post-unseal rollback overwrite, post-retirement zero-copy loss,
   C1 provenance loss, custody-receipt signer/domain/retention/artifact drift,
   archive-disposition/clearance-consume replay ambiguity,
-  source-retirement conflation, v3 selection signature/verifier/readiness and Hosted v1/v2
+  source-retirement conflation, v5 selection signature/verifier/readiness and Hosted v1-v4
   drift, and path/rank/graph/count/error/timing oracles.
 - [ ] 14.2 Record every review finding with severity and exact file/test evidence. For
   each accepted finding, add a reproducing red test before the smallest fix, rerun
   the focused and affected regression gates, and require the same reviewer to
   recheck the amended exact diff and explicitly close or retain the blocker.
 - [ ] 14.3 Have a separate independent verifier run tasks 13.3-13.7 and the installed
-  stdio, REST, CLI, and explicitly selected Hosted v3 E2E from a clean environment.
-  The verifier SHALL inspect v1/v2 byte-identity baselines, kill/restart seams,
+  stdio, REST, CLI, and explicitly selected Hosted v5 E2E from a clean environment.
+  The verifier SHALL inspect v1-v4 byte-identity baselines, kill/restart seams,
   same-input negative pairs, receipt plaintext scans, rehearsal rollback, distinct
   confirmation gates, and source/archive/destination final fingerprints rather than
   accepting self-reported terminals.

--- a/openspec/changes/add-governed-vault-consolidation/verification.md
+++ b/openspec/changes/add-governed-vault-consolidation/verification.md
@@ -1,0 +1,100 @@
+# Governed vault consolidation verification ledger
+
+This ledger is append-only evidence for the active change. Product implementation
+and tests use generated temporary vaults only. It is not rehearsal, cutover, or
+source-retirement approval for any real operator vault.
+
+## Prerequisite gate
+
+- Base revision: `32170d098970a409fd3305fe8f59d302439ebed3`.
+- The prerequisite change is archived at
+  `openspec/changes/archive/2026-08-28-harden-governance-for-consolidation/`;
+  therefore its old active change name is intentionally no longer accepted by
+  `openspec validate <name>`.
+- Its archived `verification.md` records umbrella PR `#900`, merged as
+  `7c5a315797340d89c07d74de6d61de9a1c0c3c9c`, exact-head CI run
+  `33137995631` with 19 successes, 8 intentional skips, and no failure, Hosted
+  run `33137995634` green, wire run `33048555592` with 58/58 green, independent
+  security review/recheck GO, independent verifier GO, canonical sync, and no
+  real-vault execution.
+- Fresh replacement validation on this merged base:
+  `openspec validate --all --strict` -> `168 passed, 0 failed`.
+
+## Immutable pre-change surface
+
+`pre-consolidation-baseline.json` freezes the MCP fixture, tool/client contract,
+capability document, OpenAPI operations, bootstrap byte sizes and ordering,
+Hosted v1-v4 command memberships and descriptor hashes, generated plugin and
+manifest trees, deployment locks, and registered promotion evidence. Later v5
+work must reproduce every v1-v4/core hash and must add v5 only through explicit
+selection.
+
+## Red-first protocol
+
+For each implementation slice below, record the focused test command and the
+missing-invariant assertion before product code, then the exact green result
+after the smallest production change. Collection/import failures do not count.
+
+## Real-vault exclusion
+
+All commands in this ledger must use pytest temporary paths or explicitly
+generated fixtures. The personal and POLLY vaults are out of scope. Capability
+completion does not authorize rehearsal, cutover, or retirement.
+
+## Identity/adoption evidence
+
+### Dedicated identity subsystem
+
+- Red: `uv run --frozen python -m pytest -q tests/test_consolidation_cell_identity.py`
+  -> `1 failed`; the assertion reported that
+  `exomem.governance.consolidation_identity` did not exist. Collection and
+  imports succeeded.
+- Green: the same focused command -> `1 passed` after adding the explicit
+  private subsystem boundary.
+
+### Local and Hosted identity/adoption
+
+- Red: focused identity run -> `4 failed, 1 passed`; the four assertions named
+  the missing local adoption/load and Hosted adoption APIs.
+- Green: focused identity run -> `5 passed` after the smallest authenticated
+  record/adoption implementation.
+- Red: reused-installation regression -> `1 failed`; two independently
+  provisioned roots accepted the same generated installation id.
+- Green: the identity registry now serializes through one host-wide mutation
+  boundary, verifies every retained owner-only claim, and refuses duplicate
+  installation or root binding.
+- Red: Hosted alias regression -> `1 failed`; `HostedBindingV2` admitted equal
+  routing `cell_id` and logical `vault_id`.
+- Green: the binding constructor now refuses the alias before root/readiness or
+  owner-context work.
+- Red: Hosted explicit-load regression -> `1 failed`; the private record could
+  only be reached through the provisioning operation.
+- Green: Hosted loading is explicit, verifies the trusted binding/root and an
+  accepted cell key, and never provisions a missing record.
+- Final focused/adjoining gate:
+  `tests/test_consolidation_cell_identity.py`,
+  `tests/test_authorization_standalone_provisioning.py`, and
+  `tests/test_hosted_binding_v2.py` -> `94 passed, 1 skipped` (privileged device
+  node only). The identity file tests cover closed schema/version, malformed
+  authentication, forged fence, missing machine key, wrong mode, symlink,
+  hard-link, copied local/Hosted roots, idempotent replay, ordinary post-adoption
+  content drift, pre-commit failure, and lost-ack recovery.
+- Red: owner-authorized move/rebind regression -> `1 failed`; the existing
+  attachment transfer correctly fenced the old root, but consolidation identity
+  had no operation that could bind the new stable root while preserving logical
+  and installation ids.
+- Green: the rebind operation composes the existing drained attachment-transfer
+  proof, verifies both stable roots and the target host registry, CAS-replaces
+  only the authenticated root/fence commitment, preserves immutable adoption
+  provenance and both ids, and replays idempotently.
+
+## First-stack acceptance
+
+- Python 3.13 focused/adjoining gate: `94 passed, 1 skipped`.
+- Touched-file Ruff: green. Repository-wide required `ruff --select F`: green.
+- `uv lock --check`: green.
+- `openspec validate add-governed-vault-consolidation --strict`: green.
+- `openspec validate --all --strict`: `168 passed, 0 failed`.
+- OpenSpec archive discipline: green.
+- Public repository artifact validation: `3394 files, 3462 text payloads`, green.
+- `git diff --check`: green.

--- a/src/exomem/governance/consolidation_identity.py
+++ b/src/exomem/governance/consolidation_identity.py
@@ -1,0 +1,782 @@
+"""Private, authenticated cell identity for governed vault consolidation.
+
+This module is deliberately separate from request schemas and vault content.
+It composes the existing authorization-custody trust root; callers never supply
+logical, installation, root-binding, signing, or registry identity material.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import stat
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .. import hosted_portability, writer_lease
+from . import authorization_custody
+from .principal import OWNER_AUDIENCE, RequestPrincipal
+
+IDENTITY_SCHEMA = "exomem.consolidation-cell-identity/v1"
+IDENTITY_RECORD_FIELDS = frozenset(
+    {
+        "schema",
+        "cell_id",
+        "vault_id",
+        "installation_id",
+        "installation_generation",
+        "active_fence_digest",
+        "root_binding_id",
+        "root_binding_digest",
+        "machine_key_id",
+        "adoption_census_digest",
+        "clone_of_vault_id",
+        "clone_of_installation_id",
+        "clone_of_snapshot_digest",
+        "created_at",
+        "authentication_algorithm",
+        "record_digest",
+        "authentication",
+    }
+)
+
+_IDENTITY_DOMAIN = b"exomem.consolidation-cell-identity/v1"
+_FENCE_DOMAIN = b"exomem.consolidation-installation-fence/v1"
+_IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,511}\Z")
+_INSTALLATION_ID = re.compile(r"installation-v1-[0-9a-f]{64}\Z")
+_SHA256 = re.compile(r"[0-9a-f]{64}\Z")
+_LOCAL_IDENTITY_DIRECTORY = "consolidation-cell-identities-v1"
+_HOSTED_IDENTITY_NAME = "consolidation-cell-identity-v1.json"
+_AUTH_ALGORITHM = "HMAC-SHA256"
+_LOCAL_IDENTITY_FILE = re.compile(r"[0-9a-f]{64}\.json\Z")
+_LOCAL_OWNER_ISSUERS = frozenset(
+    {
+        "cli-local-owner",
+        "library-local-owner",
+        "mcp-local-stdio",
+        "rest-api-key",
+        "transfer-local-owner",
+    }
+)
+
+
+class ConsolidationIdentityUnavailable(RuntimeError):
+    """Stable, content-free refusal to establish consolidation identity."""
+
+    code = "CONSOLIDATION_IDENTITY_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__("consolidation identity is unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationCellIdentity:
+    """Authenticated, non-secret identity facts for one active installation."""
+
+    schema: str
+    cell_id: str
+    vault_id: str
+    installation_id: str
+    installation_generation: int
+    active_fence_digest: str
+    root_binding_id: str
+    root_binding_digest: str
+    machine_key_id: str
+    adoption_census_digest: str
+    clone_of_vault_id: str | None
+    clone_of_installation_id: str | None
+    clone_of_snapshot_digest: str | None
+    created_at: int
+    authentication_algorithm: str
+    record_digest: str
+    identity_path: Path = field(compare=False)
+
+
+def _canonical_json(value: object) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    except (TypeError, ValueError, UnicodeError):
+        raise ConsolidationIdentityUnavailable from None
+
+
+def _identifier(value: object) -> str:
+    if not isinstance(value, str) or _IDENTIFIER.fullmatch(value) is None:
+        raise ConsolidationIdentityUnavailable
+    return value
+
+
+def _digest(value: object) -> str:
+    if not isinstance(value, str) or _SHA256.fullmatch(value) is None:
+        raise ConsolidationIdentityUnavailable
+    return value
+
+
+def _time(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ConsolidationIdentityUnavailable
+    return value
+
+
+def _closed_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ConsolidationIdentityUnavailable
+        value[key] = item
+    return value
+
+
+def _without_authentication(value: dict[str, object]) -> dict[str, object]:
+    return {key: item for key, item in value.items() if key != "authentication"}
+
+
+def _without_commitments(value: dict[str, object]) -> dict[str, object]:
+    return {
+        key: item
+        for key, item in value.items()
+        if key not in {"record_digest", "authentication"}
+    }
+
+
+def _record_digest(value: dict[str, object]) -> str:
+    return hashlib.sha256(_IDENTITY_DOMAIN + b"\0" + _canonical_json(value)).hexdigest()
+
+
+def _authentication(value: dict[str, object], *, key: bytes) -> str:
+    if not isinstance(key, bytes) or len(key) != 32:
+        raise ConsolidationIdentityUnavailable
+    return (
+        base64.urlsafe_b64encode(
+            hmac.new(
+                key,
+                _IDENTITY_DOMAIN + b"\0" + _canonical_json(value),
+                hashlib.sha256,
+            ).digest()
+        )
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+
+
+def _new_installation_id() -> str:
+    return f"installation-v1-{secrets.token_hex(32)}"
+
+
+def _root_binding_digest(root_binding_id: str) -> str:
+    return hashlib.sha256(root_binding_id.encode("utf-8")).hexdigest()
+
+
+def _active_fence_digest(
+    *,
+    vault_id: str,
+    installation_id: str,
+    generation: int,
+    root_binding_digest: str,
+    machine_key_id: str,
+) -> str:
+    return hashlib.sha256(
+        _FENCE_DOMAIN
+        + b"\0"
+        + _canonical_json(
+            {
+                "generation": generation,
+                "installation_id": installation_id,
+                "machine_key_id": machine_key_id,
+                "root_binding_digest": root_binding_digest,
+                "vault_id": vault_id,
+            }
+        )
+    ).hexdigest()
+
+
+def _canonical_adoption_census(vault_root: Path) -> str:
+    try:
+        return hosted_portability.canonical_vault_fingerprint(Path(vault_root))
+    except hosted_portability.PortabilityError:
+        raise ConsolidationIdentityUnavailable from None
+
+
+def _identity_value(
+    *,
+    cell_id: str,
+    vault_id: str,
+    installation_id: str,
+    root_binding_id: str,
+    machine_key_id: str,
+    adoption_census_digest: str,
+    created_at: int,
+) -> dict[str, object]:
+    binding_digest = _root_binding_digest(root_binding_id)
+    value: dict[str, object] = {
+        "schema": IDENTITY_SCHEMA,
+        "cell_id": _identifier(cell_id),
+        "vault_id": _identifier(vault_id),
+        "installation_id": _identifier(installation_id),
+        "installation_generation": 1,
+        "active_fence_digest": _active_fence_digest(
+            vault_id=vault_id,
+            installation_id=installation_id,
+            generation=1,
+            root_binding_digest=binding_digest,
+            machine_key_id=machine_key_id,
+        ),
+        "root_binding_id": _identifier(root_binding_id),
+        "root_binding_digest": binding_digest,
+        "machine_key_id": _identifier(machine_key_id),
+        "adoption_census_digest": _digest(adoption_census_digest),
+        "clone_of_vault_id": None,
+        "clone_of_installation_id": None,
+        "clone_of_snapshot_digest": None,
+        "created_at": _time(created_at),
+        "authentication_algorithm": _AUTH_ALGORITHM,
+    }
+    value["record_digest"] = _record_digest(value)
+    return value
+
+
+def _encode_identity(value: dict[str, object], *, key: bytes) -> bytes:
+    if set(value) != IDENTITY_RECORD_FIELDS - {"authentication"}:
+        raise ConsolidationIdentityUnavailable
+    encoded = dict(value)
+    encoded["authentication"] = _authentication(encoded, key=key)
+    return _canonical_json(encoded)
+
+
+def _parse_identity(
+    raw: bytes,
+    *,
+    key: bytes,
+    expected_path: Path,
+) -> ConsolidationCellIdentity:
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_closed_object)
+        if not isinstance(value, dict) or set(value) != IDENTITY_RECORD_FIELDS:
+            raise ConsolidationIdentityUnavailable
+        if value["schema"] != IDENTITY_SCHEMA:
+            raise ConsolidationIdentityUnavailable
+        if value["authentication_algorithm"] != _AUTH_ALGORITHM:
+            raise ConsolidationIdentityUnavailable
+        installation_id = _identifier(value["installation_id"])
+        if _INSTALLATION_ID.fullmatch(installation_id) is None:
+            raise ConsolidationIdentityUnavailable
+        generation = _time(value["installation_generation"])
+        if generation != 1:
+            raise ConsolidationIdentityUnavailable
+        for optional in (
+            "clone_of_vault_id",
+            "clone_of_installation_id",
+            "clone_of_snapshot_digest",
+        ):
+            if value[optional] is not None:
+                raise ConsolidationIdentityUnavailable
+        expected_digest = _record_digest(_without_commitments(value))
+        if not hmac.compare_digest(_digest(value["record_digest"]), expected_digest):
+            raise ConsolidationIdentityUnavailable
+        expected_authentication = _authentication(
+            _without_authentication(value),
+            key=key,
+        )
+        authentication = value["authentication"]
+        if not isinstance(authentication, str) or not hmac.compare_digest(
+            authentication,
+            expected_authentication,
+        ):
+            raise ConsolidationIdentityUnavailable
+        identity = ConsolidationCellIdentity(
+            schema=IDENTITY_SCHEMA,
+            cell_id=_identifier(value["cell_id"]),
+            vault_id=_identifier(value["vault_id"]),
+            installation_id=installation_id,
+            installation_generation=generation,
+            active_fence_digest=_digest(value["active_fence_digest"]),
+            root_binding_id=_identifier(value["root_binding_id"]),
+            root_binding_digest=_digest(value["root_binding_digest"]),
+            machine_key_id=_identifier(value["machine_key_id"]),
+            adoption_census_digest=_digest(value["adoption_census_digest"]),
+            clone_of_vault_id=None,
+            clone_of_installation_id=None,
+            clone_of_snapshot_digest=None,
+            created_at=_time(value["created_at"]),
+            authentication_algorithm=_AUTH_ALGORITHM,
+            record_digest=_digest(value["record_digest"]),
+            identity_path=expected_path,
+        )
+        if not hmac.compare_digest(
+            identity.root_binding_digest,
+            _root_binding_digest(identity.root_binding_id),
+        ) or not hmac.compare_digest(
+            identity.active_fence_digest,
+            _active_fence_digest(
+                vault_id=identity.vault_id,
+                installation_id=identity.installation_id,
+                generation=identity.installation_generation,
+                root_binding_digest=identity.root_binding_digest,
+                machine_key_id=identity.machine_key_id,
+            ),
+        ):
+            raise ConsolidationIdentityUnavailable
+        return identity
+    except ConsolidationIdentityUnavailable:
+        raise
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        raise ConsolidationIdentityUnavailable from None
+
+
+def _require_local_owner(who: RequestPrincipal) -> None:
+    if (
+        not isinstance(who, RequestPrincipal)
+        or not who.resolved
+        or who.audience_id != OWNER_AUDIENCE
+        or who.issuer_family not in _LOCAL_OWNER_ISSUERS
+    ):
+        raise ConsolidationIdentityUnavailable
+
+
+def _local_identity_path(vault_id: str) -> Path:
+    digest = hashlib.sha256(_identifier(vault_id).encode("utf-8")).hexdigest()
+    return _local_identity_directory() / f"{digest}.json"
+
+
+def _local_identity_directory() -> Path:
+    return (
+        authorization_custody._standalone_host_control_root()  # noqa: SLF001
+        / _LOCAL_IDENTITY_DIRECTORY
+    )
+
+
+def _assert_unique_local_claim(
+    *,
+    target_path: Path,
+    target_value: dict[str, object],
+    host_key: bytes,
+) -> None:
+    directory = _local_identity_directory()
+    target_installation = _identifier(target_value["installation_id"])
+    target_binding = _identifier(target_value["root_binding_id"])
+    try:
+        for path in sorted(directory.iterdir(), key=lambda item: item.name):
+            if path == target_path:
+                continue
+            if _LOCAL_IDENTITY_FILE.fullmatch(path.name) is None:
+                raise ConsolidationIdentityUnavailable
+            loaded = authorization_custody._load_private_artifact(  # noqa: SLF001
+                path,
+                maximum_bytes=authorization_custody.MAX_CUSTODY_FILE_BYTES,
+            )
+            identity = _parse_identity(loaded.data, key=host_key, expected_path=path)
+            if (
+                hmac.compare_digest(identity.installation_id, target_installation)
+                or hmac.compare_digest(identity.root_binding_id, target_binding)
+            ):
+                raise ConsolidationIdentityUnavailable
+    except FileNotFoundError:
+        return
+    except authorization_custody.AuthorizationCustodyUnavailable:
+        raise ConsolidationIdentityUnavailable from None
+
+
+def _assert_registered_local_identity(
+    identity: ConsolidationCellIdentity,
+    *,
+    host_key: bytes,
+) -> None:
+    _assert_unique_local_claim(
+        target_path=identity.identity_path,
+        target_value={
+            "installation_id": identity.installation_id,
+            "root_binding_id": identity.root_binding_id,
+        },
+        host_key=host_key,
+    )
+
+
+def _load_local_with_custody(
+    vault_root: Path,
+    *,
+    custody: authorization_custody.AuthorizationCustody,
+    now: int,
+) -> ConsolidationCellIdentity:
+    authorization_custody.require_current_standalone_registry(
+        custody,
+        now=now,
+        require_serving=True,
+    )
+    path = _local_identity_path(custody.control.logical_vault_id)
+    try:
+        host_key = authorization_custody._load_host_control_key()  # noqa: SLF001
+        loaded = authorization_custody._load_private_artifact(  # noqa: SLF001
+            path,
+            maximum_bytes=authorization_custody.MAX_CUSTODY_FILE_BYTES,
+        )
+        identity = _parse_identity(loaded.data, key=host_key, expected_path=path)
+        current_binding = authorization_custody.standalone_attachment_id(vault_root)
+        expected_key_id = authorization_custody._host_control_key_id(host_key)  # noqa: SLF001
+        if (
+            identity.cell_id != custody.control.cell_id
+            or identity.vault_id != custody.control.logical_vault_id
+            or identity.machine_key_id != expected_key_id
+            or identity.root_binding_id != current_binding
+            or identity.root_binding_id != custody.control.registry_attachment_id
+        ):
+            raise ConsolidationIdentityUnavailable
+        _assert_registered_local_identity(identity, host_key=host_key)
+        return identity
+    except authorization_custody.AuthorizationCustodyUnavailable:
+        raise ConsolidationIdentityUnavailable from None
+
+
+def load_local_identity(
+    vault_root: Path,
+    *,
+    now: int,
+) -> ConsolidationCellIdentity:
+    try:
+        custody = authorization_custody.load_authorization_custody(
+            Path(vault_root),
+            now=now,
+        )
+        with writer_lease.get_manager().consistency_guard(
+            _local_identity_directory(),
+            operation="consolidation-identity-registry-read",
+            holder_kind="consolidation-identity-registry",
+        ):
+            return _load_local_with_custody(
+                Path(vault_root),
+                custody=custody,
+                now=now,
+            )
+    except authorization_custody.AuthorizationCustodyUnavailable:
+        raise ConsolidationIdentityUnavailable from None
+
+
+def adopt_local_identity(
+    vault_root: Path,
+    *,
+    principal: RequestPrincipal,
+    now: int,
+) -> ConsolidationCellIdentity:
+    """Adopt one local vault without accepting any identity or trust material."""
+
+    _require_local_owner(principal)
+    root = Path(vault_root)
+    try:
+        authorization_custody.provision_standalone_custody(root, now=now)
+        custody = authorization_custody.load_authorization_custody(root, now=now)
+        with writer_lease.get_manager().mutation_guard(
+            root,
+            operation="consolidation-identity-adopt",
+            holder_kind="consolidation-identity-control",
+            attachment_control=True,
+            attachment_now=now,
+        ):
+            with writer_lease.get_manager().consistency_guard(
+                _local_identity_directory(),
+                operation="consolidation-identity-registry-write",
+                holder_kind="consolidation-identity-registry",
+            ):
+                authorization_custody.require_current_standalone_registry(
+                    custody,
+                    now=now,
+                    require_serving=True,
+                )
+                path = _local_identity_path(custody.control.logical_vault_id)
+                if path.exists() or path.is_symlink():
+                    return _load_local_with_custody(root, custody=custody, now=now)
+                adoption_census = _canonical_adoption_census(root)
+                host_key = authorization_custody._load_host_control_key()  # noqa: SLF001
+                machine_key_id = authorization_custody._host_control_key_id(host_key)  # noqa: SLF001
+                value = _identity_value(
+                    cell_id=custody.control.cell_id,
+                    vault_id=custody.control.logical_vault_id,
+                    installation_id=_new_installation_id(),
+                    root_binding_id=custody.control.registry_attachment_id,
+                    machine_key_id=machine_key_id,
+                    adoption_census_digest=adoption_census,
+                    created_at=now,
+                )
+                authorization_custody._prepare_private_directory(path.parent)  # noqa: SLF001
+                _assert_unique_local_claim(
+                    target_path=path,
+                    target_value=value,
+                    host_key=host_key,
+                )
+                authorization_custody._publish_private_artifact(  # noqa: SLF001
+                    path,
+                    _encode_identity(value, key=host_key),
+                    maximum_bytes=authorization_custody.MAX_CUSTODY_FILE_BYTES,
+                )
+                return _load_local_with_custody(root, custody=custody, now=now)
+    except ConsolidationIdentityUnavailable:
+        raise
+    except authorization_custody.AuthorizationCustodyUnavailable:
+        raise ConsolidationIdentityUnavailable from None
+    except (OSError, RuntimeError, TypeError, ValueError):
+        raise ConsolidationIdentityUnavailable from None
+
+
+def rebind_local_identity(
+    source_vault_root: Path,
+    target_vault_root: Path,
+    *,
+    principal: RequestPrincipal,
+    now: int,
+) -> ConsolidationCellIdentity:
+    """Move one already-fenced installation binding without changing its ids."""
+
+    _require_local_owner(principal)
+    source = Path(source_vault_root)
+    target = Path(target_vault_root)
+    if source == target:
+        raise ConsolidationIdentityUnavailable
+    try:
+        custody = authorization_custody.load_authorization_custody(target, now=now)
+        with writer_lease.get_manager().mutation_guard(
+            target,
+            operation="consolidation-identity-rebind",
+            holder_kind="consolidation-identity-control",
+            attachment_control=True,
+            attachment_now=now,
+        ):
+            with writer_lease.get_manager().consistency_guard(
+                _local_identity_directory(),
+                operation="consolidation-identity-registry-rebind",
+                holder_kind="consolidation-identity-registry",
+            ):
+                authorization_custody.require_current_standalone_registry(
+                    custody,
+                    now=now,
+                    require_serving=True,
+                )
+                target_binding = authorization_custody.standalone_attachment_id(target)
+                if target_binding != custody.control.registry_attachment_id:
+                    raise ConsolidationIdentityUnavailable
+                path = _local_identity_path(custody.control.logical_vault_id)
+                host_key = authorization_custody._load_host_control_key()  # noqa: SLF001
+                loaded = authorization_custody._load_private_artifact(  # noqa: SLF001
+                    path,
+                    maximum_bytes=authorization_custody.MAX_CUSTODY_FILE_BYTES,
+                )
+                current = _parse_identity(
+                    loaded.data,
+                    key=host_key,
+                    expected_path=path,
+                )
+                expected_key_id = authorization_custody._host_control_key_id(  # noqa: SLF001
+                    host_key
+                )
+                if (
+                    current.cell_id != custody.control.cell_id
+                    or current.vault_id != custody.control.logical_vault_id
+                    or current.machine_key_id != expected_key_id
+                ):
+                    raise ConsolidationIdentityUnavailable
+                if current.root_binding_id == target_binding:
+                    return _load_local_with_custody(target, custody=custody, now=now)
+                source_binding = authorization_custody.standalone_attachment_id(source)
+                if (
+                    current.root_binding_id != source_binding
+                    or source_binding == target_binding
+                ):
+                    raise ConsolidationIdentityUnavailable
+                value = _identity_value(
+                    cell_id=current.cell_id,
+                    vault_id=current.vault_id,
+                    installation_id=current.installation_id,
+                    root_binding_id=target_binding,
+                    machine_key_id=current.machine_key_id,
+                    adoption_census_digest=current.adoption_census_digest,
+                    created_at=current.created_at,
+                )
+                _assert_unique_local_claim(
+                    target_path=path,
+                    target_value=value,
+                    host_key=host_key,
+                )
+                authorization_custody._replace_control_bytes(  # noqa: SLF001
+                    path,
+                    expected=loaded.data,
+                    target=_encode_identity(value, key=host_key),
+                )
+                return _load_local_with_custody(target, custody=custody, now=now)
+    except ConsolidationIdentityUnavailable:
+        raise
+    except authorization_custody.AuthorizationCustodyUnavailable:
+        raise ConsolidationIdentityUnavailable from None
+    except (OSError, RuntimeError, TypeError, ValueError):
+        raise ConsolidationIdentityUnavailable from None
+
+
+def _hosted_root_binding(binding: Any) -> str:
+    identities: list[dict[str, object]] = []
+    try:
+        for kind, root in binding.roots():
+            info = os.lstat(root)
+            if (
+                not stat.S_ISDIR(info.st_mode)
+                or stat.S_ISLNK(info.st_mode)
+                or (os.name != "nt" and int(info.st_uid) != os.geteuid())
+            ):
+                raise ConsolidationIdentityUnavailable
+            identities.append(
+                {
+                    "device": int(info.st_dev),
+                    "inode": int(info.st_ino),
+                    "kind": kind,
+                }
+            )
+        return "hosted-binding-v2:" + hashlib.sha256(
+            _canonical_json(
+                {
+                    "binding_digest": binding.binding_digest,
+                    "root_identities": identities,
+                }
+            )
+        ).hexdigest()
+    except ConsolidationIdentityUnavailable:
+        raise
+    except (AttributeError, OSError, TypeError, ValueError):
+        raise ConsolidationIdentityUnavailable from None
+
+
+def _hosted_identity_path(binding: Any) -> Path:
+    return Path(binding.state_root) / _HOSTED_IDENTITY_NAME
+
+
+def _require_hosted_custody(
+    binding: Any,
+    custody: authorization_custody.AuthorizationCustody,
+    *,
+    now: int,
+) -> authorization_custody.AuthorizationVerifierKey:
+    if (
+        binding.cell_id == binding.vault_id
+        or custody.control.cell_id != binding.cell_id
+        or custody.control.logical_vault_id != binding.vault_id
+        or custody.keyring.cell_id != binding.cell_id
+        or custody.keyring.logical_vault_id != binding.vault_id
+        or custody.control.keyring_id != custody.keyring.keyring_id
+    ):
+        raise ConsolidationIdentityUnavailable
+    current_time = _time(now)
+    if not custody.control.issued_at <= current_time < custody.control.expires_at:
+        raise ConsolidationIdentityUnavailable
+    key = custody.keyring.active_key
+    if not key.not_before <= current_time < key.not_after:
+        raise ConsolidationIdentityUnavailable
+    return key
+
+
+def _hosted_record_key(
+    raw: bytes,
+    custody: authorization_custody.AuthorizationCustody,
+) -> authorization_custody.AuthorizationVerifierKey:
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_closed_object)
+        if not isinstance(value, dict) or set(value) != IDENTITY_RECORD_FIELDS:
+            raise ConsolidationIdentityUnavailable
+        key_id = _identifier(value["machine_key_id"])
+        for key in custody.keyring.accepted_keys:
+            if hmac.compare_digest(key.key_id, key_id):
+                return key
+        raise ConsolidationIdentityUnavailable
+    except ConsolidationIdentityUnavailable:
+        raise
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        raise ConsolidationIdentityUnavailable from None
+
+
+def load_hosted_identity(
+    binding: Any,
+    *,
+    custody: authorization_custody.AuthorizationCustody,
+    now: int,
+) -> ConsolidationCellIdentity:
+    """Load one Hosted identity without silently provisioning a missing record."""
+
+    _require_hosted_custody(binding, custody, now=now)
+    path = _hosted_identity_path(binding)
+    root_binding_id = _hosted_root_binding(binding)
+    try:
+        loaded = authorization_custody._load_private_artifact(  # noqa: SLF001
+            path,
+            maximum_bytes=authorization_custody.MAX_CUSTODY_FILE_BYTES,
+        )
+    except authorization_custody.AuthorizationCustodyUnavailable:
+        raise ConsolidationIdentityUnavailable from None
+    key = _hosted_record_key(loaded.data, custody)
+    identity = _parse_identity(loaded.data, key=key.key, expected_path=path)
+    if (
+        identity.cell_id != binding.cell_id
+        or identity.vault_id != binding.vault_id
+        or identity.machine_key_id != key.key_id
+        or identity.root_binding_id != root_binding_id
+    ):
+        raise ConsolidationIdentityUnavailable
+    return identity
+
+
+def adopt_hosted_identity(
+    binding: Any,
+    *,
+    custody: authorization_custody.AuthorizationCustody,
+    now: int,
+) -> ConsolidationCellIdentity:
+    """Create or load one Hosted record from trusted binding/custody inputs."""
+
+    key = _require_hosted_custody(binding, custody, now=now)
+    path = _hosted_identity_path(binding)
+    root_binding_id = _hosted_root_binding(binding)
+    try:
+        authorization_custody._load_private_artifact(  # noqa: SLF001
+            path,
+            maximum_bytes=authorization_custody.MAX_CUSTODY_FILE_BYTES,
+        )
+    except authorization_custody.AuthorizationCustodyUnavailable:
+        if path.exists() or path.is_symlink():
+            raise ConsolidationIdentityUnavailable from None
+    else:
+        return load_hosted_identity(binding, custody=custody, now=now)
+
+    value = _identity_value(
+        cell_id=binding.cell_id,
+        vault_id=binding.vault_id,
+        installation_id=_new_installation_id(),
+        root_binding_id=root_binding_id,
+        machine_key_id=key.key_id,
+        adoption_census_digest=_canonical_adoption_census(Path(binding.vault_root)),
+        created_at=now,
+    )
+    try:
+        authorization_custody._publish_private_artifact(  # noqa: SLF001
+            path,
+            _encode_identity(value, key=key.key),
+            maximum_bytes=authorization_custody.MAX_CUSTODY_FILE_BYTES,
+        )
+        return load_hosted_identity(binding, custody=custody, now=now)
+    except authorization_custody.AuthorizationCustodyUnavailable:
+        raise ConsolidationIdentityUnavailable from None
+
+
+__all__ = [
+    "IDENTITY_RECORD_FIELDS",
+    "IDENTITY_SCHEMA",
+    "ConsolidationCellIdentity",
+    "ConsolidationIdentityUnavailable",
+    "adopt_hosted_identity",
+    "adopt_local_identity",
+    "load_hosted_identity",
+    "load_local_identity",
+    "rebind_local_identity",
+]

--- a/src/exomem/hosted_runtime.py
+++ b/src/exomem/hosted_runtime.py
@@ -1469,6 +1469,11 @@ class HostedBindingV2:
             raise HostedConfigError(
                 "HOSTED_BINDING_CONFLICT", "hosted binding identity is invalid"
             )
+        if self.cell_id == self.vault_id:
+            raise HostedConfigError(
+                "HOSTED_BINDING_CONFLICT",
+                "hosted routing and logical vault identities must be distinct",
+            )
         if not _valid_runtime_identity(self.runtime_uid) or not _valid_runtime_identity(
             self.runtime_gid
         ):

--- a/tests/test_consolidation_cell_identity.py
+++ b/tests/test_consolidation_cell_identity.py
@@ -1,0 +1,494 @@
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import json
+import os
+import shutil
+import stat
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from exomem import hosted_portability, hosted_runtime, writer_lease
+from exomem.governance import authorization_custody, consolidation_identity, principal
+
+
+def test_consolidation_identity_store_is_an_explicit_private_subsystem() -> None:
+    assert importlib.util.find_spec("exomem.governance.consolidation_identity") is not None, (
+        "consolidation-capable cells need a dedicated authenticated identity store"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _private_custody(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
+    external = tmp_path / "external"
+    host_control = tmp_path / "host-control"
+    lease_state = tmp_path / "lease-state"
+    external.mkdir(mode=0o700)
+    lease_state.mkdir(mode=0o700)
+    monkeypatch.setattr(
+        authorization_custody,
+        "_standalone_host_control_root",
+        lambda: host_control,
+    )
+    monkeypatch.setenv(
+        authorization_custody.KEYRING_FILE_ENV,
+        str(external / "authorization-keyring.json"),
+    )
+    monkeypatch.setenv(
+        authorization_custody.CONTROL_FILE_ENV,
+        str(external / "authorization-control.json"),
+    )
+    monkeypatch.setenv(
+        authorization_custody.MEMBERSHIP_FILE_ENV,
+        str(external / "authorization-serving-membership.json"),
+    )
+    monkeypatch.setenv(authorization_custody.REPLICA_ID_ENV, "standalone")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(lease_state))
+    writer_lease.reset_managers_for_tests()
+    yield
+    writer_lease.reset_managers_for_tests()
+
+
+def _vault(tmp_path: Path, name: str = "vault") -> Path:
+    root = tmp_path / name
+    (root / "Knowledge Base/Notes").mkdir(parents=True)
+    (root / "Knowledge Base/Notes/identity.md").write_text(
+        "---\ntype: insight\n---\nidentity baseline\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def _required(name: str):
+    value = getattr(consolidation_identity, name, None)
+    assert callable(value), f"missing consolidation identity API: {name}"
+    return value
+
+
+def test_local_owner_adoption_generates_and_authenticates_private_identity(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    adopt = _required("adopt_local_identity")
+    load = _required("load_local_identity")
+
+    adopted = adopt(
+        vault,
+        principal=principal.owner_principal(surface="cli"),
+        now=1_800_000_000,
+    )
+    loaded = load(vault, now=1_800_000_001)
+
+    assert loaded == adopted
+    assert adopted.schema == consolidation_identity.IDENTITY_SCHEMA
+    assert adopted.installation_generation == 1
+    assert len(adopted.adoption_census_digest) == 64
+    assert len(adopted.root_binding_digest) == 64
+    assert len(adopted.active_fence_digest) == 64
+    assert adopted.vault_id != adopted.installation_id
+    assert adopted.machine_key_id
+    assert adopted.identity_path.is_relative_to(
+        authorization_custody._standalone_host_control_root()
+    )
+    assert not adopted.identity_path.is_relative_to(vault)
+    assert stat.S_IMODE(adopted.identity_path.stat().st_mode) == 0o600
+    stored = json.loads(adopted.identity_path.read_text(encoding="utf-8"))
+    assert set(stored) == consolidation_identity.IDENTITY_RECORD_FIELDS
+
+
+def test_local_adoption_refuses_untrusted_or_caller_selected_identity(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    adopt = _required("adopt_local_identity")
+    parameters = inspect.signature(adopt).parameters
+    assert "vault_id" not in parameters
+    assert "installation_id" not in parameters
+    assert "machine_key" not in parameters
+    assert "root_binding" not in parameters
+
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        adopt(
+            vault,
+            principal=principal.most_restrictive_principal(surface="rest"),
+            now=1_800_000_000,
+        )
+    assert not authorization_custody._standalone_host_control_root().exists()
+
+
+def _hosted_custody(
+    binding: hosted_runtime.HostedBindingV2,
+    *,
+    now: int,
+) -> authorization_custody.AuthorizationCustody:
+    verifier = authorization_custody.AuthorizationVerifierKey(
+        key_id="hosted-cell-key-v1",
+        key=b"h" * 32,
+        not_before=now - 10,
+        not_after=now + 10_000,
+    )
+    keyring = authorization_custody.AuthorizationKeyring(
+        version=4,
+        keyring_id="hosted-keyring-v1",
+        cell_id=binding.cell_id,
+        logical_vault_id=binding.vault_id,
+        active_key_id=verifier.key_id,
+        accepted_keys=(verifier,),
+    )
+    control = authorization_custody.AuthorizationControlRecord(
+        version=4,
+        keyring_id=keyring.keyring_id,
+        cell_id=binding.cell_id,
+        logical_vault_id=binding.vault_id,
+        registry_attachment_id="hosted-control-attachment-v1",
+        attachment_epoch=1,
+        governance_enrolled=True,
+        activation_store_id="hosted-activation-store-v1",
+        activation_epoch=1,
+        activation_state_digest="a" * 64,
+        serving_membership_epoch=1,
+        serving_membership_digest="b" * 64,
+        issued_at=now - 1,
+        expires_at=now + 1_000,
+        signing_key_id=verifier.key_id,
+    )
+    return authorization_custody.AuthorizationCustody(
+        keyring_path=binding.state_root / "authorization-keyring.json",
+        control_path=binding.state_root / "authorization-control.json",
+        keyring=keyring,
+        control=control,
+    )
+
+
+def test_hosted_identity_keeps_routing_logical_and_installation_ids_distinct(
+    tmp_path: Path,
+) -> None:
+    now = 1_800_000_000
+    binding = hosted_runtime.HostedBindingV2(
+        cell_id="hosted-cell-alpha",
+        vault_id="logical-vault-alpha",
+        vault_root=tmp_path / "vault",
+        state_root=tmp_path / "state",
+        log_root=tmp_path / "logs",
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+    )
+    for root in binding.roots():
+        root[1].mkdir(mode=0o700)
+    custody = _hosted_custody(binding, now=now)
+    adopt = _required("adopt_hosted_identity")
+    load = _required("load_hosted_identity")
+
+    identity = adopt(binding, custody=custody, now=now)
+    loaded = load(binding, custody=custody, now=now + 1)
+
+    assert loaded == identity
+    assert identity.cell_id == binding.cell_id
+    assert identity.vault_id == binding.vault_id
+    assert identity.installation_id not in {binding.cell_id, binding.vault_id}
+    assert identity.identity_path.parent == binding.state_root
+    assert not identity.identity_path.is_relative_to(binding.vault_root)
+
+
+def test_hosted_cell_vault_alias_fails_before_identity_work(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(hosted_runtime.HostedConfigError) as error:
+        hosted_runtime.HostedBindingV2(
+            cell_id="same-typed-value",
+            vault_id="same-typed-value",
+            vault_root=tmp_path / "vault",
+            state_root=tmp_path / "state",
+            log_root=tmp_path / "logs",
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+        )
+    assert error.value.code == "HOSTED_BINDING_CONFLICT"
+
+
+def test_local_registry_rejects_reused_installation_id_across_vaults(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_800_000_000
+    fixed = "installation-v1-" + "c" * 64
+    monkeypatch.setattr(consolidation_identity, "_new_installation_id", lambda: fixed)
+    first = _vault(tmp_path, "first")
+    second = _vault(tmp_path, "second")
+    adopt = _required("adopt_local_identity")
+    owner = principal.owner_principal(surface="cli")
+
+    adopted = adopt(first, principal=owner, now=now)
+    assert adopted.installation_id == fixed
+
+    second_external = tmp_path / "second-external"
+    second_external.mkdir(mode=0o700)
+    monkeypatch.setenv(
+        authorization_custody.KEYRING_FILE_ENV,
+        str(second_external / "authorization-keyring.json"),
+    )
+    monkeypatch.setenv(
+        authorization_custody.CONTROL_FILE_ENV,
+        str(second_external / "authorization-control.json"),
+    )
+    monkeypatch.setenv(
+        authorization_custody.MEMBERSHIP_FILE_ENV,
+        str(second_external / "authorization-serving-membership.json"),
+    )
+
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        adopt(second, principal=owner, now=now + 1)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        "unknown-field",
+        "unknown-version",
+        "bad-authentication",
+        "forged-fence",
+        "wrong-mode",
+        "symlink",
+        "hard-link",
+        "missing-machine-key",
+    ),
+)
+def test_local_identity_refuses_malformed_or_aliased_private_state(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    now = 1_800_000_000
+    vault = _vault(tmp_path)
+    identity = _required("adopt_local_identity")(
+        vault,
+        principal=principal.owner_principal(surface="cli"),
+        now=now,
+    )
+    path = identity.identity_path
+
+    if mutation == "wrong-mode":
+        path.chmod(0o644)
+    elif mutation == "symlink":
+        saved = path.with_name("saved-identity")
+        path.rename(saved)
+        path.symlink_to(saved)
+    elif mutation == "hard-link":
+        saved = path.with_name("saved-identity")
+        path.rename(saved)
+        os.link(saved, path)
+    elif mutation == "missing-machine-key":
+        authorization_custody._host_control_key_path().unlink()
+    else:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if mutation == "unknown-field":
+            value["unexpected"] = "not allowed"
+        elif mutation == "unknown-version":
+            value["schema"] = "exomem.consolidation-cell-identity/v2"
+        elif mutation == "bad-authentication":
+            value["authentication"] = "A" * 43
+        elif mutation == "forged-fence":
+            value["active_fence_digest"] = "f" * 64
+            value["record_digest"] = consolidation_identity._record_digest(
+                consolidation_identity._without_commitments(value)
+            )
+            host_key = authorization_custody._load_host_control_key()
+            value["authentication"] = consolidation_identity._authentication(
+                consolidation_identity._without_authentication(value),
+                key=host_key,
+            )
+        path.write_text(
+            json.dumps(value, sort_keys=True, separators=(",", ":")),
+            encoding="utf-8",
+        )
+
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        _required("load_local_identity")(vault, now=now + 1)
+
+
+def test_copied_local_identity_cannot_claim_a_second_root(tmp_path: Path) -> None:
+    now = 1_800_000_000
+    source = _vault(tmp_path, "source")
+    _required("adopt_local_identity")(
+        source,
+        principal=principal.owner_principal(surface="cli"),
+        now=now,
+    )
+    copied = tmp_path / "copied"
+    shutil.copytree(source, copied)
+
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        _required("load_local_identity")(copied, now=now + 1)
+
+
+def test_adoption_is_idempotent_and_content_changes_do_not_rewrite_identity(
+    tmp_path: Path,
+) -> None:
+    now = 1_800_000_000
+    vault = _vault(tmp_path)
+    adopt = _required("adopt_local_identity")
+    owner = principal.owner_principal(surface="cli")
+    first = adopt(vault, principal=owner, now=now)
+    before = first.identity_path.read_bytes()
+
+    (vault / "Knowledge Base/Notes/after-adoption.md").write_text(
+        "---\ntype: insight\n---\nlegitimate later write\n",
+        encoding="utf-8",
+    )
+    current_census = hosted_portability.canonical_vault_fingerprint(vault)
+    second = adopt(vault, principal=owner, now=now + 1)
+
+    assert second == first
+    assert second.adoption_census_digest != current_census
+    assert second.identity_path.read_bytes() == before
+
+
+def test_adoption_failure_before_commit_leaves_no_identity_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    monkeypatch.setattr(
+        consolidation_identity,
+        "_canonical_adoption_census",
+        lambda _root: (_ for _ in ()).throw(
+            consolidation_identity.ConsolidationIdentityUnavailable()
+        ),
+    )
+
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        _required("adopt_local_identity")(
+            vault,
+            principal=principal.owner_principal(surface="cli"),
+            now=1_800_000_000,
+        )
+
+    directory = (
+        authorization_custody._standalone_host_control_root()
+        / "consolidation-cell-identities-v1"
+    )
+    assert not directory.exists()
+
+
+def test_lost_adoption_ack_leaves_one_complete_idempotent_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_800_000_000
+    vault = _vault(tmp_path)
+    original = consolidation_identity._load_local_with_custody
+
+    def lose_ack(*args, **kwargs):
+        original(*args, **kwargs)
+        raise RuntimeError("simulated abrupt loss after durable identity commit")
+
+    with monkeypatch.context() as fault:
+        fault.setattr(consolidation_identity, "_load_local_with_custody", lose_ack)
+        with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+            _required("adopt_local_identity")(
+                vault,
+                principal=principal.owner_principal(surface="cli"),
+                now=now,
+            )
+
+    recovered = _required("load_local_identity")(vault, now=now + 1)
+    replayed = _required("adopt_local_identity")(
+        vault,
+        principal=principal.owner_principal(surface="cli"),
+        now=now + 1,
+    )
+    assert replayed == recovered
+
+
+def test_copied_hosted_record_cannot_claim_different_bound_roots(
+    tmp_path: Path,
+) -> None:
+    now = 1_800_000_000
+    source = hosted_runtime.HostedBindingV2(
+        cell_id="hosted-cell-copy",
+        vault_id="logical-vault-copy",
+        vault_root=tmp_path / "source-vault",
+        state_root=tmp_path / "source-state",
+        log_root=tmp_path / "source-logs",
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+    )
+    for _kind, root in source.roots():
+        root.mkdir(mode=0o700)
+    custody = _hosted_custody(source, now=now)
+    _required("adopt_hosted_identity")(source, custody=custody, now=now)
+
+    copied = hosted_runtime.HostedBindingV2(
+        cell_id=source.cell_id,
+        vault_id=source.vault_id,
+        vault_root=tmp_path / "copied-vault",
+        state_root=tmp_path / "copied-state",
+        log_root=tmp_path / "copied-logs",
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+    )
+    shutil.copytree(source.vault_root, copied.vault_root)
+    shutil.copytree(source.state_root, copied.state_root)
+    shutil.copytree(source.log_root, copied.log_root)
+
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        _required("adopt_hosted_identity")(copied, custody=custody, now=now + 1)
+
+
+def test_owner_authorized_attachment_move_rebinds_root_but_preserves_identity(
+    tmp_path: Path,
+) -> None:
+    now = 1_800_000_000
+    source = _vault(tmp_path, "source")
+    owner = principal.owner_principal(surface="cli")
+    before = _required("adopt_local_identity")(
+        source,
+        principal=owner,
+        now=now,
+    )
+    target = tmp_path / "target"
+    shutil.copytree(source, target)
+    serving = authorization_custody.load_authorization_custody(source, now=now + 1)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        source,
+        expected_control=serving.control,
+        now=now + 2,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        source,
+        expected_control=draining.control,
+        now=now + 3,
+    )
+    acknowledgement = authorization_custody.prepare_standalone_attachment_transfer(
+        source,
+        target,
+        expected_control=drained.control,
+        now=now + 3,
+    )
+    authorization_custody.complete_standalone_attachment_transfer(
+        target,
+        acknowledgement=acknowledgement,
+        now=now + 4,
+    )
+
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        _required("load_local_identity")(target, now=now + 4)
+
+    rebind = _required("rebind_local_identity")
+    assert "vault_id" not in inspect.signature(rebind).parameters
+    assert "installation_id" not in inspect.signature(rebind).parameters
+    moved = rebind(source, target, principal=owner, now=now + 4)
+    replay = rebind(source, target, principal=owner, now=now + 4)
+
+    assert moved == replay
+    assert moved.vault_id == before.vault_id
+    assert moved.installation_id == before.installation_id
+    assert moved.installation_generation == before.installation_generation
+    assert moved.adoption_census_digest == before.adoption_census_digest
+    assert moved.root_binding_id != before.root_binding_id
+    assert moved.active_fence_digest != before.active_fence_digest


### PR DESCRIPTION
## Summary

- rebase the governed-consolidation contract onto additive `hosted-alpha-agent-v5`, keeping v1-v4 byte-identical and explicitly selected
- freeze the pre-change MCP/OpenAPI/bootstrap/Hosted v1-v4/plugin/deployment/promotion surface as a negative compatibility baseline
- add private authenticated local and Hosted consolidation identities with distinct logical, routing, and installation ids
- add owner-only local adoption, host-wide installation/root collision refusal, idempotent lost-ack recovery, and attachment-transfer-backed root rebind
- reject Hosted `cell_id == vault_id` at binding construction, before readiness or owner-context work

This is a deliberately non-serving foundation. It does not expose `consolidate_memory`, migrate a live vault, combine vaults, rehearse cutover, or retire a source. No personal or POLLY vault was touched.

## Verification

- Python 3.13 focused/adjoining identity and custody suites: 94 passed, 1 privilege-only skip
- touched-file Ruff: passed
- repository required Ruff F baseline: passed
- `uv lock --check`: passed
- `openspec validate add-governed-vault-consolidation --strict`: passed
- `openspec validate --all --strict`: 168 passed, 0 failed
- OpenSpec archive discipline: passed
- public repository artifact validation: passed (3394 files, 3462 text payloads)
- `git diff --check`: passed
