### PR TITLE
feat(governance): add fenced failover identity

### DIFF
--- a/openspec/changes/add-governed-vault-consolidation/verification.md
+++ b/openspec/changes/add-governed-vault-consolidation/verification.md
@@ -116,3 +116,52 @@ completion does not authorize rehearsal, cutover, or retirement.
 - Touched-file Ruff, `uv lock --check`, strict change validation, public
   repository artifact validation (`3394 files, 3462 text payloads`), and
   `git diff --check`: green.
+
+## Local failover identity stack
+
+- Red: the first logical-id-preserving transfer failed because no authenticated
+  failover identity API existed. Green: a separate owner-only target-candidate
+  step mints and authenticates the fresh installation id and challenge before
+  the source transfer is prepared; the target activates at generation N+1,
+  preserves the logical vault id, and stale-source mutation/admission refuses.
+- Red: matching source/target roots could still use an older valid export.
+  Green: the verified archive manifest is projected into the canonical census
+  frame and must equal both quiesced roots.
+- Red: a later attachment move reset generation N to 1 and erased clone
+  provenance. Green: rebind and failover preserve generation and immutable
+  clone lineage while changing only the authenticated installation/root/fence
+  binding.
+- Red: one operation id could prepare different targets, and target bytes could
+  drift after the first census but before authority reservation. Green: the
+  private registry binds an operation to one target and repeats the census
+  check after the source is fenced and the target is durably `DRAINING`.
+- Red: crashes inside membership/control/host-registry publication could leave
+  an exact transfer without a reachable recovery path. Green: the outer four
+  gaps plus all three inner publication gaps recover by exact predecessor and
+  target replay. Before activation the target remains non-serving; after
+  fencing the old source cannot regain admission.
+- Red: the signed reservation and its DRAINING membership could expire after a
+  durable reservation but before the transfer journal advanced. Green: expiry
+  may recover only that exact already-published reservation, authenticates its
+  historical predecessor at the record's original validity time, and publishes
+  a fresh current successor. A separate no-progress regression proves an
+  expired acknowledgement cannot start a new reservation or change custody.
+- Red: two distinct live operation ids could reserve the same source fence and
+  let the second candidate adopt the first operation's attachment reservation.
+  Green: the serialized private registry admits only one live transfer for an
+  exact vault/installation/generation/fence tuple while preserving exact replay.
+- Red: an activation successor published immediately before a crash became
+  unrecoverable if that successor expired before retry. Green: exact
+  uncommitted successors are historically authenticated and refreshed at the
+  same epoch before control publication; exact committed successors first
+  finish host-registry publication and then advance to a fresh current epoch.
+  A 2x2 crash matrix interrupts both the original activation and the recovery
+  after membership/control publication, then proves a later exact retry.
+- Python 3.13 focused/adjoining gate: `116 passed, 1 skipped` (privileged device
+  node only). Touched-file Ruff, repository `F` lint, `uv lock --check`, strict
+  change validation, all OpenSpec validation (`168 passed, 0 failed`), archive
+  discipline, public artifact validation (`3394 files, 3462 text payloads`),
+  and `git diff --check`: green.
+- Independent adversarial recheck: no P0/P1/P2 findings and GO for the explicit
+  trusted-owner, same-host failover foundation after reproducing the conflicting
+  live-transfer and expired-successor failures and verifying their corrections.

--- a/src/exomem/governance/authorization_custody.py
+++ b/src/exomem/governance/authorization_custody.py
@@ -1042,6 +1042,7 @@ def _parse_detach_ack(
     *,
     keyring: AuthorizationKeyring,
     now: int,
+    allow_expired: bool = False,
 ) -> _StandaloneDetachAcknowledgement:
     try:
         if not isinstance(raw, bytes) or not 1 <= len(raw) <= MAX_CUSTODY_FILE_BYTES:
@@ -1075,7 +1076,8 @@ def _parse_detach_ack(
         current_time = _bounded_time(now)
         if (
             target_attachment_epoch != source_attachment_epoch + 1
-            or not issued_at <= current_time < expires_at
+            or current_time < issued_at
+            or (not allow_expired and current_time >= expires_at)
             or expires_at - issued_at
             > authorization_serving_membership.MAX_ATTESTATION_TTL_SECONDS
         ):
@@ -2644,6 +2646,24 @@ def _standalone_membership_successor(
     return successor
 
 
+def _historical_membership_verification_time(raw: bytes, *, now: int) -> int:
+    """Choose a bounded time for authenticating an exact expired predecessor."""
+
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_closed_object)
+        if not isinstance(value, dict):
+            raise AuthorizationCustodyUnavailable
+        issued_at = _bounded_time(value["issued_at"])
+        expires_at = _bounded_time(value["expires_at"])
+        if issued_at >= expires_at:
+            raise AuthorizationCustodyUnavailable
+        return min(_bounded_time(now), expires_at - 1)
+    except AuthorizationCustodyUnavailable:
+        raise
+    except (KeyError, UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        raise AuthorizationCustodyUnavailable from None
+
+
 def _standalone_transition_replay_control(
     current: AuthorizationControlRecord,
     *,
@@ -2660,6 +2680,28 @@ def _standalone_transition_replay_control(
     )
 
 
+def _standalone_transition_descendant_control(
+    current: AuthorizationControlRecord,
+    *,
+    expected: AuthorizationControlRecord,
+) -> bool:
+    return (
+        current.serving_membership_epoch > expected.serving_membership_epoch
+        and replace(
+            current,
+            serving_membership_epoch=expected.serving_membership_epoch,
+            serving_membership_digest=expected.serving_membership_digest,
+        )
+        == expected
+    )
+
+
+def _standalone_transition_barrier(point: str) -> None:
+    """Crash-injection seam between standalone membership publications."""
+
+    del point
+
+
 def _transition_standalone_attachment_membership(
     vault_root: Path,
     *,
@@ -2669,6 +2711,7 @@ def _transition_standalone_attachment_membership(
     target_state: str,
     target_no_in_flight: bool,
     now: int,
+    recover_expired_source: bool = False,
 ) -> AuthorizationCustody:
     if not isinstance(expected_control, AuthorizationControlRecord):
         raise AuthorizationCustodyUnavailable
@@ -2691,37 +2734,266 @@ def _transition_standalone_attachment_membership(
             external=external,
         )
 
+        registry_source_control = expected_control
+        registry_source_state = source_state
+        registry_source_no_in_flight = source_no_in_flight
         if current_control != expected_control:
-            if not _standalone_transition_replay_control(
+            replay_is_valid = _standalone_transition_replay_control(
                 current_control,
                 expected=expected_control,
-            ):
+            )
+            if recover_expired_source:
+                replay_is_valid = _standalone_transition_descendant_control(
+                    current_control,
+                    expected=expected_control,
+                )
+            if not replay_is_valid:
                 raise AuthorizationCustodyUnavailable
-            current_record = _parse_migration_membership(
-                membership_raw,
-                keyring=keyring,
-                control=current_control,
-                now=current_time,
-                epoch=current_control.serving_membership_epoch,
-                digest=current_control.serving_membership_digest,
+            verification_time = (
+                _historical_membership_verification_time(
+                    membership_raw,
+                    now=current_time,
+                )
+                if recover_expired_source
+                else current_time
             )
-            _require_standalone_membership(
-                current_record,
-                keyring=keyring,
-                control=current_control,
-                replica_id=replica_id,
-                state=target_state,
-                no_in_flight=target_no_in_flight,
-            )
-            target_control = current_control
+            try:
+                current_record = _parse_migration_membership(
+                    membership_raw,
+                    keyring=keyring,
+                    control=current_control,
+                    now=verification_time,
+                    epoch=current_control.serving_membership_epoch,
+                    digest=current_control.serving_membership_digest,
+                )
+            except AuthorizationCustodyUnavailable:
+                if not recover_expired_source:
+                    raise
+                provisional_target = replace(
+                    current_control,
+                    serving_membership_epoch=(
+                        current_control.serving_membership_epoch + 1
+                    ),
+                    serving_membership_digest="0" * 64,
+                )
+                successor = _standalone_membership_successor(
+                    membership_raw,
+                    keyring=keyring,
+                    expected_control=current_control,
+                    target_control=provisional_target,
+                    replica_id=replica_id,
+                    target_state=target_state,
+                    target_no_in_flight=target_no_in_flight,
+                    now=verification_time,
+                )
+                if successor.expires_at <= current_time:
+                    target_membership = _standalone_membership_bytes(
+                        keyring=keyring,
+                        control=provisional_target,
+                        replica_id=replica_id,
+                        state=target_state,
+                        issuance_stopped=target_state == "DRAINING",
+                        no_in_flight=target_no_in_flight,
+                        previous_epoch_digest=(
+                            current_control.serving_membership_digest
+                        ),
+                        attested_at=current_time,
+                    )
+                    successor = _standalone_membership_successor(
+                        target_membership,
+                        keyring=keyring,
+                        expected_control=current_control,
+                        target_control=provisional_target,
+                        replica_id=replica_id,
+                        target_state=target_state,
+                        target_no_in_flight=target_no_in_flight,
+                        now=current_time,
+                    )
+                    _replace_control_bytes(
+                        membership_path,
+                        expected=membership_raw,
+                        target=target_membership,
+                    )
+                    _standalone_transition_barrier("after-membership")
+                if (
+                    current_control.serving_membership_epoch
+                    == expected_control.serving_membership_epoch + 1
+                ):
+                    _advance_host_registry(
+                        source_control=expected_control,
+                        source_state=source_state,
+                        source_no_in_flight=source_no_in_flight,
+                        target_control=current_control,
+                        target_state=target_state,
+                        target_no_in_flight=target_no_in_flight,
+                        now=current_time,
+                    )
+                else:
+                    _path, _raw, registry, _host_key = _load_host_registry(
+                        current_control,
+                        now=current_time,
+                    )
+                    if not _host_registry_matches_control(
+                        registry,
+                        current_control,
+                        state=target_state,
+                        no_in_flight=target_no_in_flight,
+                    ):
+                        raise AuthorizationCustodyUnavailable from None
+                target_control = replace(
+                    provisional_target,
+                    serving_membership_digest=successor.record_digest,
+                )
+                signing_key = next(
+                    (
+                        item.key
+                        for item in keyring.accepted_keys
+                        if item.key_id == target_control.signing_key_id
+                    ),
+                    None,
+                )
+                if signing_key is None:
+                    raise AuthorizationCustodyUnavailable from None
+                _replace_control_bytes(
+                    external.control_path,
+                    expected=external.control,
+                    target=_signed_control_bytes(
+                        target_control,
+                        signing_key=signing_key,
+                    ),
+                )
+                _standalone_transition_barrier("after-control")
+                registry_source_control = current_control
+                registry_source_state = target_state
+                registry_source_no_in_flight = target_no_in_flight
+            else:
+                _require_standalone_membership(
+                    current_record,
+                    keyring=keyring,
+                    control=current_control,
+                    replica_id=replica_id,
+                    state=target_state,
+                    no_in_flight=target_no_in_flight,
+                )
+                if (
+                    current_control.serving_membership_epoch
+                    == expected_control.serving_membership_epoch + 1
+                ):
+                    predecessor_control = expected_control
+                    predecessor_state = source_state
+                    predecessor_no_in_flight = source_no_in_flight
+                else:
+                    if current_record.previous_epoch_digest is None:
+                        raise AuthorizationCustodyUnavailable
+                    predecessor_control = replace(
+                        current_control,
+                        serving_membership_epoch=(
+                            current_control.serving_membership_epoch - 1
+                        ),
+                        serving_membership_digest=(
+                            current_record.previous_epoch_digest
+                        ),
+                    )
+                    predecessor_state = target_state
+                    predecessor_no_in_flight = target_no_in_flight
+                _advance_host_registry(
+                    source_control=predecessor_control,
+                    source_state=predecessor_state,
+                    source_no_in_flight=predecessor_no_in_flight,
+                    target_control=current_control,
+                    target_state=target_state,
+                    target_no_in_flight=target_no_in_flight,
+                    now=current_time,
+                )
+                if recover_expired_source and current_record.expires_at <= current_time:
+                    provisional_target = replace(
+                        current_control,
+                        serving_membership_epoch=(
+                            current_control.serving_membership_epoch + 1
+                        ),
+                        serving_membership_digest="0" * 64,
+                    )
+                    target_membership = _standalone_membership_bytes(
+                        keyring=keyring,
+                        control=provisional_target,
+                        replica_id=replica_id,
+                        state=target_state,
+                        issuance_stopped=target_state == "DRAINING",
+                        no_in_flight=target_no_in_flight,
+                        previous_epoch_digest=current_record.record_digest,
+                        attested_at=current_time,
+                    )
+                    successor = _standalone_membership_successor(
+                        target_membership,
+                        keyring=keyring,
+                        expected_control=current_control,
+                        target_control=provisional_target,
+                        replica_id=replica_id,
+                        target_state=target_state,
+                        target_no_in_flight=target_no_in_flight,
+                        now=current_time,
+                    )
+                    try:
+                        authorization_serving_membership.validate_membership_successor(
+                            current_record,
+                            successor,
+                            now=current_time,
+                        )
+                    except authorization_serving_membership.ServingMembershipUnavailable:
+                        raise AuthorizationCustodyUnavailable from None
+                    _replace_control_bytes(
+                        membership_path,
+                        expected=membership_raw,
+                        target=target_membership,
+                    )
+                    _standalone_transition_barrier("after-membership")
+                    target_control = replace(
+                        provisional_target,
+                        serving_membership_digest=successor.record_digest,
+                    )
+                    signing_key = next(
+                        (
+                            item.key
+                            for item in keyring.accepted_keys
+                            if item.key_id == target_control.signing_key_id
+                        ),
+                        None,
+                    )
+                    if signing_key is None:
+                        raise AuthorizationCustodyUnavailable
+                    _replace_control_bytes(
+                        external.control_path,
+                        expected=external.control,
+                        target=_signed_control_bytes(
+                            target_control,
+                            signing_key=signing_key,
+                        ),
+                    )
+                    _standalone_transition_barrier("after-control")
+                    registry_source_control = current_control
+                    registry_source_state = target_state
+                    registry_source_no_in_flight = target_no_in_flight
+                else:
+                    target_control = current_control
+                    registry_source_control = current_control
+                    registry_source_state = target_state
+                    registry_source_no_in_flight = target_no_in_flight
         else:
             source_record: ServingMembershipEpoch | None
+            source_verification_time = (
+                _historical_membership_verification_time(
+                    membership_raw,
+                    now=current_time,
+                )
+                if recover_expired_source
+                else current_time
+            )
             try:
                 source_record = _parse_migration_membership(
                     membership_raw,
                     keyring=keyring,
                     control=current_control,
-                    now=current_time,
+                    now=source_verification_time,
                     epoch=current_control.serving_membership_epoch,
                     digest=current_control.serving_membership_digest,
                 )
@@ -2742,9 +3014,46 @@ def _transition_standalone_attachment_membership(
                     replica_id=replica_id,
                     target_state=target_state,
                     target_no_in_flight=target_no_in_flight,
-                    now=current_time,
+                    now=(
+                        _historical_membership_verification_time(
+                            membership_raw,
+                            now=current_time,
+                        )
+                        if recover_expired_source
+                        else current_time
+                    ),
                 )
-                target_membership = membership_raw
+                if successor.expires_at <= current_time:
+                    target_membership = _standalone_membership_bytes(
+                        keyring=keyring,
+                        control=provisional_target,
+                        replica_id=replica_id,
+                        state=target_state,
+                        issuance_stopped=target_state == "DRAINING",
+                        no_in_flight=target_no_in_flight,
+                        previous_epoch_digest=(
+                            current_control.serving_membership_digest
+                        ),
+                        attested_at=current_time,
+                    )
+                    successor = _standalone_membership_successor(
+                        target_membership,
+                        keyring=keyring,
+                        expected_control=current_control,
+                        target_control=provisional_target,
+                        replica_id=replica_id,
+                        target_state=target_state,
+                        target_no_in_flight=target_no_in_flight,
+                        now=current_time,
+                    )
+                    _replace_control_bytes(
+                        membership_path,
+                        expected=membership_raw,
+                        target=target_membership,
+                    )
+                    _standalone_transition_barrier("after-membership")
+                else:
+                    target_membership = membership_raw
             else:
                 _require_standalone_membership(
                     source_record,
@@ -2787,6 +3096,7 @@ def _transition_standalone_attachment_membership(
                     expected=membership_raw,
                     target=target_membership,
                 )
+                _standalone_transition_barrier("after-membership")
 
             target_control = replace(
                 provisional_target,
@@ -2810,15 +3120,17 @@ def _transition_standalone_attachment_membership(
                     signing_key=signing_key,
                 ),
             )
+            _standalone_transition_barrier("after-control")
         _advance_host_registry(
-            source_control=expected_control,
-            source_state=source_state,
-            source_no_in_flight=source_no_in_flight,
+            source_control=registry_source_control,
+            source_state=registry_source_state,
+            source_no_in_flight=registry_source_no_in_flight,
             target_control=target_control,
             target_state=target_state,
             target_no_in_flight=target_no_in_flight,
             now=current_time,
         )
+        _standalone_transition_barrier("after-registry")
 
     verified = load_authorization_custody(root, now=current_time)
     if verified.serving_membership is None:
@@ -3021,7 +3333,10 @@ def _complete_standalone_attachment_transfer(
     target_vault_root: Path,
     *,
     acknowledgement: bytes,
+    target_state: str,
+    target_no_in_flight: bool,
     now: int,
+    recover_expired_reservation: bool = False,
 ) -> AuthorizationCustody:
     """Consume one detach acknowledgement and move the exclusive attachment."""
 
@@ -3038,6 +3353,7 @@ def _complete_standalone_attachment_transfer(
         acknowledgement,
         keyring=keyring,
         now=current_time,
+        allow_expired=recover_expired_reservation,
     )
     target_attachment = standalone_attachment_id(target)
     if (
@@ -3051,6 +3367,49 @@ def _complete_standalone_attachment_transfer(
         target,
         external=external,
     )
+
+    if current_time >= detached.expires_at:
+        if not recover_expired_reservation:
+            raise AuthorizationCustodyUnavailable
+        reservation_started = (
+            control.registry_attachment_id
+            == detached.target_registry_attachment_id
+            and control.attachment_epoch == detached.target_attachment_epoch
+        )
+        if not reservation_started:
+            if (
+                control.registry_attachment_id
+                != detached.source_registry_attachment_id
+                or control.attachment_epoch != detached.source_attachment_epoch
+                or control.serving_membership_epoch
+                != detached.source_membership_epoch
+                or control.serving_membership_digest
+                != detached.source_membership_digest
+            ):
+                raise AuthorizationCustodyUnavailable
+            provisional_target = replace(
+                control,
+                registry_attachment_id=detached.target_registry_attachment_id,
+                attachment_epoch=detached.target_attachment_epoch,
+                serving_membership_epoch=control.serving_membership_epoch + 1,
+                serving_membership_digest="0" * 64,
+            )
+            try:
+                _standalone_membership_successor(
+                    membership_raw,
+                    keyring=keyring,
+                    expected_control=control,
+                    target_control=provisional_target,
+                    replica_id=replica_id,
+                    target_state="DRAINING",
+                    target_no_in_flight=True,
+                    now=current_time,
+                )
+            except AuthorizationCustodyUnavailable:
+                raise AuthorizationCustodyUnavailable from None
+            reservation_started = True
+        if not reservation_started:
+            raise AuthorizationCustodyUnavailable
 
     if (
         control.registry_attachment_id == detached.target_registry_attachment_id
@@ -3074,7 +3433,14 @@ def _complete_standalone_attachment_transfer(
             membership_raw,
             keyring=keyring,
             control=control,
-            now=current_time,
+            now=(
+                _historical_membership_verification_time(
+                    membership_raw,
+                    now=current_time,
+                )
+                if current_time >= detached.expires_at
+                else current_time
+            ),
             epoch=control.serving_membership_epoch,
             digest=control.serving_membership_digest,
         )
@@ -3085,8 +3451,8 @@ def _complete_standalone_attachment_transfer(
             keyring=keyring,
             control=control,
             replica_id=replica_id,
-            state="SERVING",
-            no_in_flight=False,
+            state=target_state,
+            no_in_flight=target_no_in_flight,
         )
         source_control = replace(
             control,
@@ -3100,10 +3466,20 @@ def _complete_standalone_attachment_transfer(
             source_state="DRAINING",
             source_no_in_flight=True,
             target_control=control,
-            target_state="SERVING",
-            target_no_in_flight=False,
+            target_state=target_state,
+            target_no_in_flight=target_no_in_flight,
             now=current_time,
         )
+        if current_time >= detached.expires_at:
+            return AuthorizationCustody(
+                keyring_path=external.keyring_path,
+                control_path=external.control_path,
+                keyring=keyring,
+                control=control,
+                serving_membership=successor,
+                local_replica_id=replica_id,
+                membership_path=membership_path,
+            )
         return load_authorization_custody(target, now=current_time)
 
     if (
@@ -3152,8 +3528,8 @@ def _complete_standalone_attachment_transfer(
             expected_control=control,
             target_control=provisional_target,
             replica_id=replica_id,
-            target_state="SERVING",
-            target_no_in_flight=False,
+            target_state=target_state,
+            target_no_in_flight=target_no_in_flight,
             now=current_time,
         )
     else:
@@ -3171,6 +3547,9 @@ def _complete_standalone_attachment_transfer(
             keyring=keyring,
             control=provisional_target,
             replica_id=replica_id,
+            state=target_state,
+            issuance_stopped=target_state == "DRAINING",
+            no_in_flight=target_no_in_flight,
             previous_epoch_digest=source_record.record_digest,
             attested_at=current_time,
         )
@@ -3180,8 +3559,8 @@ def _complete_standalone_attachment_transfer(
             expected_control=control,
             target_control=provisional_target,
             replica_id=replica_id,
-            target_state="SERVING",
-            target_no_in_flight=False,
+            target_state=target_state,
+            target_no_in_flight=target_no_in_flight,
             now=current_time,
         )
         try:
@@ -3222,10 +3601,20 @@ def _complete_standalone_attachment_transfer(
         source_state="DRAINING",
         source_no_in_flight=True,
         target_control=target_control,
-        target_state="SERVING",
-        target_no_in_flight=False,
+        target_state=target_state,
+        target_no_in_flight=target_no_in_flight,
         now=current_time,
     )
+    if current_time >= detached.expires_at:
+        return AuthorizationCustody(
+            keyring_path=external.keyring_path,
+            control_path=external.control_path,
+            keyring=keyring,
+            control=target_control,
+            serving_membership=successor,
+            local_replica_id=replica_id,
+            membership_path=membership_path,
+        )
     verified = load_authorization_custody(target, now=current_time)
     if verified.control != target_control or verified.serving_membership is None:
         raise AuthorizationCustodyUnavailable
@@ -3254,8 +3643,71 @@ def complete_standalone_attachment_transfer(
             return _complete_standalone_attachment_transfer(
                 target,
                 acknowledgement=acknowledgement,
+                target_state="SERVING",
+                target_no_in_flight=False,
                 now=now,
             )
+
+
+def reserve_standalone_attachment_transfer(
+    target_vault_root: Path,
+    *,
+    acknowledgement: bytes,
+    now: int,
+    recover_expired_reservation: bool = False,
+) -> AuthorizationCustody:
+    """Move attachment authority to an exact target without serving it."""
+
+    target = Path(target_vault_root)
+    from .. import reserved_paths, writer_lease
+
+    with writer_lease.get_manager().mutation_guard(
+        target,
+        operation="authorization-attachment-transfer-reserve",
+        holder_kind="authorization-attachment-control",
+        attachment_control=True,
+        attachment_now=now,
+    ):
+        with reserved_paths._identity_coordination_scope(target):
+            return _complete_standalone_attachment_transfer(
+                target,
+                acknowledgement=acknowledgement,
+                target_state="DRAINING",
+                target_no_in_flight=True,
+                now=now,
+                recover_expired_reservation=recover_expired_reservation,
+            )
+
+
+def activate_reserved_standalone_attachment(
+    target_vault_root: Path,
+    *,
+    expected_control: AuthorizationControlRecord,
+    now: int,
+    recover_expired_reservation: bool = False,
+) -> AuthorizationCustody:
+    """Activate one exact already-reserved target attachment."""
+
+    target = Path(target_vault_root)
+    from .. import writer_lease
+
+    with writer_lease.get_manager().mutation_guard(
+        target,
+        operation="authorization-attachment-transfer-activate",
+        holder_kind="authorization-attachment-control",
+        attachment_control=True,
+        attachment_now=now,
+    ):
+        return _transition_standalone_attachment_membership(
+            target,
+            expected_control=expected_control,
+            source_state="DRAINING",
+            source_no_in_flight=True,
+            target_state="SERVING",
+            target_no_in_flight=False,
+            now=now,
+            recover_expired_source=recover_expired_reservation,
+        )
 
 
 def _clone_publication_barrier(point: str) -> None:

--- a/src/exomem/governance/consolidation_identity.py
+++ b/src/exomem/governance/consolidation_identity.py
@@ -20,10 +20,14 @@ from pathlib import Path
 from typing import Any
 
 from .. import hosted_portability, writer_lease
-from . import authorization_custody
+from . import authorization_custody, authorization_serving_membership
 from .principal import OWNER_AUDIENCE, RequestPrincipal
 
 IDENTITY_SCHEMA = "exomem.consolidation-cell-identity/v1"
+IDENTITY_TRANSFER_SCHEMA = "vault-identity-transfer/v1"
+FAILOVER_TARGET_CANDIDATE_SCHEMA = (
+    "exomem.consolidation-failover-target-candidate/v1"
+)
 IDENTITY_RECORD_FIELDS = frozenset(
     {
         "schema",
@@ -45,13 +49,71 @@ IDENTITY_RECORD_FIELDS = frozenset(
         "authentication",
     }
 )
+IDENTITY_TRANSFER_RECORD_FIELDS = frozenset(
+    {
+        "schema",
+        "transfer_id",
+        "operation_id",
+        "vault_id",
+        "source_installation_id",
+        "source_installation_generation",
+        "source_active_fence_digest",
+        "source_root_binding_id",
+        "target_installation_id",
+        "target_installation_generation",
+        "target_challenge",
+        "target_root_binding_id",
+        "target_candidate_id",
+        "target_candidate_digest",
+        "source_clone_of_vault_id",
+        "source_clone_of_installation_id",
+        "source_clone_of_snapshot_digest",
+        "archive_digest",
+        "manifest_digest",
+        "census_digest",
+        "checkpoint_digest",
+        "attachment_acknowledgement",
+        "attachment_acknowledgement_digest",
+        "reserved_control",
+        "reserved_control_digest",
+        "state",
+        "issued_at",
+        "expires_at",
+        "machine_key_id",
+        "authentication_algorithm",
+        "record_digest",
+        "authentication",
+    }
+)
+FAILOVER_TARGET_CANDIDATE_RECORD_FIELDS = frozenset(
+    {
+        "schema",
+        "candidate_id",
+        "operation_id",
+        "target_installation_id",
+        "target_challenge",
+        "target_root_binding_id",
+        "target_census_digest",
+        "issued_at",
+        "expires_at",
+        "machine_key_id",
+        "authentication_algorithm",
+        "record_digest",
+        "authentication",
+    }
+)
 
 _IDENTITY_DOMAIN = b"exomem.consolidation-cell-identity/v1"
 _FENCE_DOMAIN = b"exomem.consolidation-installation-fence/v1"
+_TRANSFER_DOMAIN = b"exomem.vault-identity-transfer/v1"
+_TRANSFER_CHECKPOINT_DOMAIN = b"exomem.vault-identity-transfer-checkpoint/v1"
+_TARGET_CANDIDATE_DOMAIN = b"exomem.consolidation-failover-target-candidate/v1"
 _IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,511}\Z")
 _INSTALLATION_ID = re.compile(r"installation-v1-[0-9a-f]{64}\Z")
 _SHA256 = re.compile(r"[0-9a-f]{64}\Z")
 _LOCAL_IDENTITY_DIRECTORY = "consolidation-cell-identities-v1"
+_LOCAL_TRANSFER_DIRECTORY = "consolidation-identity-transfers-v1"
+_LOCAL_TARGET_CANDIDATE_DIRECTORY = "consolidation-failover-target-candidates-v1"
 _HOSTED_IDENTITY_NAME = "consolidation-cell-identity-v1.json"
 _AUTH_ALGORITHM = "HMAC-SHA256"
 _LOCAL_IDENTITY_FILE = re.compile(r"[0-9a-f]{64}\.json\Z")
@@ -96,6 +158,63 @@ class ConsolidationCellIdentity:
     authentication_algorithm: str
     record_digest: str
     identity_path: Path = field(compare=False)
+
+
+@dataclass(frozen=True, slots=True)
+class LocalFailoverTargetCandidate:
+    """Target-minted installation identity held under target host trust."""
+
+    schema: str
+    candidate_id: str
+    operation_id: str
+    target_installation_id: str
+    target_challenge: str
+    target_root_binding_id: str
+    target_census_digest: str
+    issued_at: int
+    expires_at: int
+    machine_key_id: str
+    authentication_algorithm: str
+    record_digest: str
+    candidate_path: Path = field(compare=False)
+
+
+@dataclass(frozen=True, slots=True)
+class LocalIdentityTransfer:
+    """Authenticated local failover transfer and its exact recovery basis."""
+
+    schema: str
+    transfer_id: str
+    operation_id: str
+    vault_id: str
+    source_installation_id: str
+    source_installation_generation: int
+    source_active_fence_digest: str
+    source_root_binding_id: str
+    target_installation_id: str
+    target_installation_generation: int
+    target_challenge: str
+    target_root_binding_id: str
+    target_candidate_id: str
+    target_candidate_digest: str
+    source_clone_of_vault_id: str | None
+    source_clone_of_installation_id: str | None
+    source_clone_of_snapshot_digest: str | None
+    archive_digest: str
+    manifest_digest: str
+    census_digest: str
+    checkpoint_digest: str
+    attachment_acknowledgement: bytes = field(repr=False)
+    attachment_acknowledgement_digest: str
+    reserved_control: bytes | None = field(repr=False)
+    reserved_control_digest: str | None
+    state: str
+    issued_at: int
+    expires_at: int
+    machine_key_id: str
+    authentication_algorithm: str
+    record_digest: str
+    transfer_path: Path = field(compare=False)
 
 
 def _canonical_json(value: object) -> bytes:
@@ -170,6 +289,77 @@ def _authentication(value: dict[str, object], *, key: bytes) -> str:
     )
 
 
+def _transfer_record_digest(value: dict[str, object]) -> str:
+    return hashlib.sha256(_TRANSFER_DOMAIN + b"\0" + _canonical_json(value)).hexdigest()
+
+
+def _transfer_authentication(value: dict[str, object], *, key: bytes) -> str:
+    if not isinstance(key, bytes) or len(key) != 32:
+        raise ConsolidationIdentityUnavailable
+    return (
+        base64.urlsafe_b64encode(
+            hmac.new(
+                key,
+                _TRANSFER_DOMAIN + b"\0" + _canonical_json(value),
+                hashlib.sha256,
+            ).digest()
+        )
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+
+
+def _target_candidate_record_digest(value: dict[str, object]) -> str:
+    return hashlib.sha256(
+        _TARGET_CANDIDATE_DOMAIN + b"\0" + _canonical_json(value)
+    ).hexdigest()
+
+
+def _target_candidate_authentication(
+    value: dict[str, object],
+    *,
+    key: bytes,
+) -> str:
+    if not isinstance(key, bytes) or len(key) != 32:
+        raise ConsolidationIdentityUnavailable
+    return (
+        base64.urlsafe_b64encode(
+            hmac.new(
+                key,
+                _TARGET_CANDIDATE_DOMAIN + b"\0" + _canonical_json(value),
+                hashlib.sha256,
+            ).digest()
+        )
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+
+
+def _decode_base64url(value: object) -> bytes:
+    if not isinstance(value, str) or not value or "=" in value:
+        raise ConsolidationIdentityUnavailable
+    try:
+        decoded = base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+    except (ValueError, TypeError):
+        raise ConsolidationIdentityUnavailable from None
+    if base64.urlsafe_b64encode(decoded).rstrip(b"=").decode("ascii") != value:
+        raise ConsolidationIdentityUnavailable
+    return decoded
+
+
+def _derived_transfer_identifier(
+    prefix: str,
+    *,
+    basis: bytes,
+    key: bytes,
+) -> str:
+    if not isinstance(key, bytes) or len(key) != 32:
+        raise ConsolidationIdentityUnavailable
+    material = _TRANSFER_DOMAIN + b"\0" + prefix.encode("ascii") + b"\0" + basis
+    digest = hmac.new(key, material, hashlib.sha256).hexdigest()
+    return f"{prefix}-{digest}"
+
+
 def _new_installation_id() -> str:
     return f"installation-v1-{secrets.token_hex(32)}"
 
@@ -217,6 +407,7 @@ def _identity_value(
     machine_key_id: str,
     adoption_census_digest: str,
     created_at: int,
+    installation_generation: int = 1,
     clone_of_vault_id: str | None = None,
     clone_of_installation_id: str | None = None,
     clone_of_snapshot_digest: str | None = None,
@@ -234,17 +425,18 @@ def _identity_value(
         clone_of_vault_id = _identifier(clone_of_vault_id)
         clone_of_installation_id = _identifier(clone_of_installation_id)
         clone_of_snapshot_digest = _digest(clone_of_snapshot_digest)
+    generation = _time(installation_generation)
     binding_digest = _root_binding_digest(root_binding_id)
     value: dict[str, object] = {
         "schema": IDENTITY_SCHEMA,
         "cell_id": _identifier(cell_id),
         "vault_id": _identifier(vault_id),
         "installation_id": _identifier(installation_id),
-        "installation_generation": 1,
+        "installation_generation": generation,
         "active_fence_digest": _active_fence_digest(
             vault_id=vault_id,
             installation_id=installation_id,
-            generation=1,
+            generation=generation,
             root_binding_digest=binding_digest,
             machine_key_id=machine_key_id,
         ),
@@ -288,8 +480,6 @@ def _parse_identity(
         if _INSTALLATION_ID.fullmatch(installation_id) is None:
             raise ConsolidationIdentityUnavailable
         generation = _time(value["installation_generation"])
-        if generation != 1:
-            raise ConsolidationIdentityUnavailable
         clone_values = (
             value["clone_of_vault_id"],
             value["clone_of_installation_id"],
@@ -361,6 +551,377 @@ def _parse_identity(
         raise ConsolidationIdentityUnavailable from None
 
 
+def _target_candidate_value(
+    *,
+    candidate_id: str,
+    operation_id: str,
+    target_installation_id: str,
+    target_challenge: str,
+    target_root_binding_id: str,
+    target_census_digest: str,
+    issued_at: int,
+    expires_at: int,
+    machine_key_id: str,
+) -> dict[str, object]:
+    issued = _time(issued_at)
+    expires = _time(expires_at)
+    if expires <= issued:
+        raise ConsolidationIdentityUnavailable
+    value: dict[str, object] = {
+        "schema": FAILOVER_TARGET_CANDIDATE_SCHEMA,
+        "candidate_id": _identifier(candidate_id),
+        "operation_id": _identifier(operation_id),
+        "target_installation_id": _identifier(target_installation_id),
+        "target_challenge": _identifier(target_challenge),
+        "target_root_binding_id": _identifier(target_root_binding_id),
+        "target_census_digest": _digest(target_census_digest),
+        "issued_at": issued,
+        "expires_at": expires,
+        "machine_key_id": _identifier(machine_key_id),
+        "authentication_algorithm": _AUTH_ALGORITHM,
+    }
+    if _INSTALLATION_ID.fullmatch(str(value["target_installation_id"])) is None:
+        raise ConsolidationIdentityUnavailable
+    value["record_digest"] = _target_candidate_record_digest(value)
+    return value
+
+
+def _encode_target_candidate(value: dict[str, object], *, key: bytes) -> bytes:
+    if set(value) != FAILOVER_TARGET_CANDIDATE_RECORD_FIELDS - {"authentication"}:
+        raise ConsolidationIdentityUnavailable
+    encoded = dict(value)
+    encoded["authentication"] = _target_candidate_authentication(encoded, key=key)
+    return _canonical_json(encoded)
+
+
+def _parse_target_candidate(
+    raw: bytes,
+    *,
+    key: bytes,
+    expected_path: Path,
+    now: int,
+    allow_expired: bool = False,
+) -> LocalFailoverTargetCandidate:
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_closed_object)
+        if (
+            not isinstance(value, dict)
+            or set(value) != FAILOVER_TARGET_CANDIDATE_RECORD_FIELDS
+            or value["schema"] != FAILOVER_TARGET_CANDIDATE_SCHEMA
+            or value["authentication_algorithm"] != _AUTH_ALGORITHM
+        ):
+            raise ConsolidationIdentityUnavailable
+        issued_at = _time(value["issued_at"])
+        expires_at = _time(value["expires_at"])
+        current_time = _time(now)
+        if (
+            expires_at <= issued_at
+            or current_time < issued_at
+            or (not allow_expired and current_time >= expires_at)
+        ):
+            raise ConsolidationIdentityUnavailable
+        expected_digest = _target_candidate_record_digest(
+            _without_commitments(value)
+        )
+        if not hmac.compare_digest(_digest(value["record_digest"]), expected_digest):
+            raise ConsolidationIdentityUnavailable
+        authentication = value["authentication"]
+        expected_authentication = _target_candidate_authentication(
+            _without_authentication(value),
+            key=key,
+        )
+        if not isinstance(authentication, str) or not hmac.compare_digest(
+            authentication,
+            expected_authentication,
+        ):
+            raise ConsolidationIdentityUnavailable
+        installation_id = _identifier(value["target_installation_id"])
+        if _INSTALLATION_ID.fullmatch(installation_id) is None:
+            raise ConsolidationIdentityUnavailable
+        return LocalFailoverTargetCandidate(
+            schema=FAILOVER_TARGET_CANDIDATE_SCHEMA,
+            candidate_id=_identifier(value["candidate_id"]),
+            operation_id=_identifier(value["operation_id"]),
+            target_installation_id=installation_id,
+            target_challenge=_identifier(value["target_challenge"]),
+            target_root_binding_id=_identifier(value["target_root_binding_id"]),
+            target_census_digest=_digest(value["target_census_digest"]),
+            issued_at=issued_at,
+            expires_at=expires_at,
+            machine_key_id=_identifier(value["machine_key_id"]),
+            authentication_algorithm=_AUTH_ALGORITHM,
+            record_digest=_digest(value["record_digest"]),
+            candidate_path=expected_path,
+        )
+    except ConsolidationIdentityUnavailable:
+        raise
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        raise ConsolidationIdentityUnavailable from None
+
+
+def _transfer_value(
+    *,
+    transfer_id: str,
+    operation_id: str,
+    vault_id: str,
+    source_installation_id: str,
+    source_installation_generation: int,
+    source_active_fence_digest: str,
+    source_root_binding_id: str,
+    target_installation_id: str,
+    target_installation_generation: int,
+    target_challenge: str,
+    target_root_binding_id: str,
+    target_candidate_id: str,
+    target_candidate_digest: str,
+    source_clone_of_vault_id: str | None,
+    source_clone_of_installation_id: str | None,
+    source_clone_of_snapshot_digest: str | None,
+    archive_digest: str,
+    manifest_digest: str,
+    census_digest: str,
+    checkpoint_digest: str,
+    attachment_acknowledgement: bytes,
+    reserved_control: bytes | None,
+    state: str,
+    issued_at: int,
+    expires_at: int,
+    machine_key_id: str,
+) -> dict[str, object]:
+    source_generation = _time(source_installation_generation)
+    target_generation = _time(target_installation_generation)
+    issued = _time(issued_at)
+    expires = _time(expires_at)
+    clone_values = (
+        source_clone_of_vault_id,
+        source_clone_of_installation_id,
+        source_clone_of_snapshot_digest,
+    )
+    if any(item is None for item in clone_values) and any(
+        item is not None for item in clone_values
+    ):
+        raise ConsolidationIdentityUnavailable
+    if source_clone_of_vault_id is not None:
+        source_clone_of_vault_id = _identifier(source_clone_of_vault_id)
+        source_clone_of_installation_id = _identifier(
+            source_clone_of_installation_id
+        )
+        source_clone_of_snapshot_digest = _digest(source_clone_of_snapshot_digest)
+    if (
+        target_generation != source_generation + 1
+        or expires <= issued
+        or state not in {"source-active", "source-fenced-target-pending", "target-active"}
+        or not isinstance(attachment_acknowledgement, bytes)
+        or not 1 <= len(attachment_acknowledgement) <= authorization_custody.MAX_CUSTODY_FILE_BYTES
+    ):
+        raise ConsolidationIdentityUnavailable
+    if state == "source-active":
+        if reserved_control is not None:
+            raise ConsolidationIdentityUnavailable
+    elif (
+        not isinstance(reserved_control, bytes)
+        or not 1
+        <= len(reserved_control)
+        <= authorization_custody.MAX_CUSTODY_FILE_BYTES
+    ):
+        raise ConsolidationIdentityUnavailable
+    value: dict[str, object] = {
+        "schema": IDENTITY_TRANSFER_SCHEMA,
+        "transfer_id": _identifier(transfer_id),
+        "operation_id": _identifier(operation_id),
+        "vault_id": _identifier(vault_id),
+        "source_installation_id": _identifier(source_installation_id),
+        "source_installation_generation": source_generation,
+        "source_active_fence_digest": _digest(source_active_fence_digest),
+        "source_root_binding_id": _identifier(source_root_binding_id),
+        "target_installation_id": _identifier(target_installation_id),
+        "target_installation_generation": target_generation,
+        "target_challenge": _identifier(target_challenge),
+        "target_root_binding_id": _identifier(target_root_binding_id),
+        "target_candidate_id": _identifier(target_candidate_id),
+        "target_candidate_digest": _digest(target_candidate_digest),
+        "source_clone_of_vault_id": source_clone_of_vault_id,
+        "source_clone_of_installation_id": source_clone_of_installation_id,
+        "source_clone_of_snapshot_digest": source_clone_of_snapshot_digest,
+        "archive_digest": _digest(archive_digest),
+        "manifest_digest": _digest(manifest_digest),
+        "census_digest": _digest(census_digest),
+        "checkpoint_digest": _digest(checkpoint_digest),
+        "attachment_acknowledgement": (
+            base64.urlsafe_b64encode(attachment_acknowledgement)
+            .rstrip(b"=")
+            .decode("ascii")
+        ),
+        "attachment_acknowledgement_digest": hashlib.sha256(
+            attachment_acknowledgement
+        ).hexdigest(),
+        "reserved_control": (
+            None
+            if reserved_control is None
+            else base64.urlsafe_b64encode(reserved_control)
+            .rstrip(b"=")
+            .decode("ascii")
+        ),
+        "reserved_control_digest": (
+            None
+            if reserved_control is None
+            else hashlib.sha256(reserved_control).hexdigest()
+        ),
+        "state": state,
+        "issued_at": issued,
+        "expires_at": expires,
+        "machine_key_id": _identifier(machine_key_id),
+        "authentication_algorithm": _AUTH_ALGORITHM,
+    }
+    value["record_digest"] = _transfer_record_digest(value)
+    return value
+
+
+def _encode_transfer(value: dict[str, object], *, key: bytes) -> bytes:
+    if set(value) != IDENTITY_TRANSFER_RECORD_FIELDS - {"authentication"}:
+        raise ConsolidationIdentityUnavailable
+    encoded = dict(value)
+    encoded["authentication"] = _transfer_authentication(encoded, key=key)
+    return _canonical_json(encoded)
+
+
+def _parse_transfer(
+    raw: bytes,
+    *,
+    key: bytes,
+    expected_path: Path,
+    now: int,
+    allow_expired: bool = False,
+) -> LocalIdentityTransfer:
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_closed_object)
+        if not isinstance(value, dict) or set(value) != IDENTITY_TRANSFER_RECORD_FIELDS:
+            raise ConsolidationIdentityUnavailable
+        if (
+            value["schema"] != IDENTITY_TRANSFER_SCHEMA
+            or value["authentication_algorithm"] != _AUTH_ALGORITHM
+        ):
+            raise ConsolidationIdentityUnavailable
+        acknowledgement = _decode_base64url(value["attachment_acknowledgement"])
+        if not hmac.compare_digest(
+            _digest(value["attachment_acknowledgement_digest"]),
+            hashlib.sha256(acknowledgement).hexdigest(),
+        ):
+            raise ConsolidationIdentityUnavailable
+        source_generation = _time(value["source_installation_generation"])
+        target_generation = _time(value["target_installation_generation"])
+        issued_at = _time(value["issued_at"])
+        expires_at = _time(value["expires_at"])
+        current_time = _time(now)
+        state = value["state"]
+        reserved_control_value = value["reserved_control"]
+        reserved_control_digest_value = value["reserved_control_digest"]
+        if state == "source-active":
+            if reserved_control_value is not None or reserved_control_digest_value is not None:
+                raise ConsolidationIdentityUnavailable
+            reserved_control = None
+            reserved_control_digest = None
+        else:
+            reserved_control = _decode_base64url(reserved_control_value)
+            reserved_control_digest = _digest(reserved_control_digest_value)
+            if not hmac.compare_digest(
+                hashlib.sha256(reserved_control).hexdigest(),
+                reserved_control_digest,
+            ):
+                raise ConsolidationIdentityUnavailable
+        if (
+            target_generation != source_generation + 1
+            or state
+            not in {"source-active", "source-fenced-target-pending", "target-active"}
+            or not issued_at <= current_time
+            or (
+                not allow_expired
+                and state != "target-active"
+                and current_time >= expires_at
+            )
+        ):
+            raise ConsolidationIdentityUnavailable
+        expected_digest = _transfer_record_digest(_without_commitments(value))
+        if not hmac.compare_digest(_digest(value["record_digest"]), expected_digest):
+            raise ConsolidationIdentityUnavailable
+        expected_authentication = _transfer_authentication(
+            _without_authentication(value),
+            key=key,
+        )
+        authentication = value["authentication"]
+        if not isinstance(authentication, str) or not hmac.compare_digest(
+            authentication,
+            expected_authentication,
+        ):
+            raise ConsolidationIdentityUnavailable
+        source_installation = _identifier(value["source_installation_id"])
+        target_installation = _identifier(value["target_installation_id"])
+        if (
+            _INSTALLATION_ID.fullmatch(source_installation) is None
+            or _INSTALLATION_ID.fullmatch(target_installation) is None
+            or hmac.compare_digest(source_installation, target_installation)
+        ):
+            raise ConsolidationIdentityUnavailable
+        clone_values = (
+            value["source_clone_of_vault_id"],
+            value["source_clone_of_installation_id"],
+            value["source_clone_of_snapshot_digest"],
+        )
+        if any(item is None for item in clone_values) and any(
+            item is not None for item in clone_values
+        ):
+            raise ConsolidationIdentityUnavailable
+        clone_of_vault_id = (
+            None if clone_values[0] is None else _identifier(clone_values[0])
+        )
+        clone_of_installation_id = (
+            None if clone_values[1] is None else _identifier(clone_values[1])
+        )
+        clone_of_snapshot_digest = (
+            None if clone_values[2] is None else _digest(clone_values[2])
+        )
+        return LocalIdentityTransfer(
+            schema=IDENTITY_TRANSFER_SCHEMA,
+            transfer_id=_identifier(value["transfer_id"]),
+            operation_id=_identifier(value["operation_id"]),
+            vault_id=_identifier(value["vault_id"]),
+            source_installation_id=source_installation,
+            source_installation_generation=source_generation,
+            source_active_fence_digest=_digest(value["source_active_fence_digest"]),
+            source_root_binding_id=_identifier(value["source_root_binding_id"]),
+            target_installation_id=target_installation,
+            target_installation_generation=target_generation,
+            target_challenge=_identifier(value["target_challenge"]),
+            target_root_binding_id=_identifier(value["target_root_binding_id"]),
+            target_candidate_id=_identifier(value["target_candidate_id"]),
+            target_candidate_digest=_digest(value["target_candidate_digest"]),
+            source_clone_of_vault_id=clone_of_vault_id,
+            source_clone_of_installation_id=clone_of_installation_id,
+            source_clone_of_snapshot_digest=clone_of_snapshot_digest,
+            archive_digest=_digest(value["archive_digest"]),
+            manifest_digest=_digest(value["manifest_digest"]),
+            census_digest=_digest(value["census_digest"]),
+            checkpoint_digest=_digest(value["checkpoint_digest"]),
+            attachment_acknowledgement=acknowledgement,
+            attachment_acknowledgement_digest=_digest(
+                value["attachment_acknowledgement_digest"]
+            ),
+            reserved_control=reserved_control,
+            reserved_control_digest=reserved_control_digest,
+            state=state,
+            issued_at=issued_at,
+            expires_at=expires_at,
+            machine_key_id=_identifier(value["machine_key_id"]),
+            authentication_algorithm=_AUTH_ALGORITHM,
+            record_digest=_digest(value["record_digest"]),
+            transfer_path=expected_path,
+        )
+    except ConsolidationIdentityUnavailable:
+        raise
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        raise ConsolidationIdentityUnavailable from None
+
+
 def _require_local_owner(who: RequestPrincipal) -> None:
     if (
         not isinstance(who, RequestPrincipal)
@@ -381,6 +942,195 @@ def _local_identity_directory() -> Path:
         authorization_custody._standalone_host_control_root()  # noqa: SLF001
         / _LOCAL_IDENTITY_DIRECTORY
     )
+
+
+def _local_transfer_directory() -> Path:
+    return (
+        authorization_custody._standalone_host_control_root()  # noqa: SLF001
+        / _LOCAL_TRANSFER_DIRECTORY
+    )
+
+
+def _local_target_candidate_directory() -> Path:
+    return (
+        authorization_custody._standalone_host_control_root()  # noqa: SLF001
+        / _LOCAL_TARGET_CANDIDATE_DIRECTORY
+    )
+
+
+def _local_target_candidate_path(candidate_id: str) -> Path:
+    digest = hashlib.sha256(_identifier(candidate_id).encode("utf-8")).hexdigest()
+    return _local_target_candidate_directory() / f"{digest}.json"
+
+
+def _load_local_target_candidate(
+    candidate_id: str,
+    *,
+    host_key: bytes,
+    now: int,
+    allow_expired: bool = False,
+) -> tuple[LocalFailoverTargetCandidate, bytes]:
+    path = _local_target_candidate_path(candidate_id)
+    try:
+        loaded = authorization_custody._load_private_artifact(  # noqa: SLF001
+            path,
+            maximum_bytes=authorization_custody.MAX_CUSTODY_FILE_BYTES,
+        )
+        return (
+            _parse_target_candidate(
+                loaded.data,
+                key=host_key,
+                expected_path=path,
+                now=now,
+                allow_expired=allow_expired,
+            ),
+            loaded.data,
+        )
+    except authorization_custody.AuthorizationCustodyUnavailable:
+        raise ConsolidationIdentityUnavailable from None
+
+
+def _local_transfer_path(transfer_id: str) -> Path:
+    digest = hashlib.sha256(_identifier(transfer_id).encode("utf-8")).hexdigest()
+    return _local_transfer_directory() / f"{digest}.json"
+
+
+def _load_local_transfer(
+    transfer_id: str,
+    *,
+    host_key: bytes,
+    now: int,
+    allow_expired: bool = False,
+) -> tuple[LocalIdentityTransfer, bytes]:
+    path = _local_transfer_path(transfer_id)
+    try:
+        loaded = authorization_custody._load_private_artifact(  # noqa: SLF001
+            path,
+            maximum_bytes=authorization_custody.MAX_CUSTODY_FILE_BYTES,
+        )
+        return (
+            _parse_transfer(
+                loaded.data,
+                key=host_key,
+                expected_path=path,
+                now=now,
+                allow_expired=allow_expired,
+            ),
+            loaded.data,
+        )
+    except authorization_custody.AuthorizationCustodyUnavailable:
+        raise ConsolidationIdentityUnavailable from None
+
+
+def _replace_transfer_state(
+    transfer: LocalIdentityTransfer,
+    *,
+    raw: bytes,
+    state: str,
+    reserved_control: bytes | None = None,
+    host_key: bytes,
+    now: int,
+) -> tuple[LocalIdentityTransfer, bytes]:
+    target = _transfer_value(
+        transfer_id=transfer.transfer_id,
+        operation_id=transfer.operation_id,
+        vault_id=transfer.vault_id,
+        source_installation_id=transfer.source_installation_id,
+        source_installation_generation=transfer.source_installation_generation,
+        source_active_fence_digest=transfer.source_active_fence_digest,
+        source_root_binding_id=transfer.source_root_binding_id,
+        target_installation_id=transfer.target_installation_id,
+        target_installation_generation=transfer.target_installation_generation,
+        target_challenge=transfer.target_challenge,
+        target_root_binding_id=transfer.target_root_binding_id,
+        target_candidate_id=transfer.target_candidate_id,
+        target_candidate_digest=transfer.target_candidate_digest,
+        source_clone_of_vault_id=transfer.source_clone_of_vault_id,
+        source_clone_of_installation_id=transfer.source_clone_of_installation_id,
+        source_clone_of_snapshot_digest=transfer.source_clone_of_snapshot_digest,
+        archive_digest=transfer.archive_digest,
+        manifest_digest=transfer.manifest_digest,
+        census_digest=transfer.census_digest,
+        checkpoint_digest=transfer.checkpoint_digest,
+        attachment_acknowledgement=transfer.attachment_acknowledgement,
+        reserved_control=(
+            transfer.reserved_control
+            if reserved_control is None and state != "source-active"
+            else reserved_control
+        ),
+        state=state,
+        issued_at=transfer.issued_at,
+        expires_at=transfer.expires_at,
+        machine_key_id=transfer.machine_key_id,
+    )
+    encoded = _encode_transfer(target, key=host_key)
+    authorization_custody._replace_control_bytes(  # noqa: SLF001
+        transfer.transfer_path,
+        expected=raw,
+        target=encoded,
+    )
+    return (
+        _parse_transfer(
+            encoded,
+            key=host_key,
+            expected_path=transfer.transfer_path,
+            now=now,
+            allow_expired=state != "source-active",
+        ),
+        encoded,
+    )
+
+
+def _assert_unique_transfer_operation(
+    operation_id: str,
+    *,
+    target_path: Path,
+    vault_id: str,
+    source_installation_id: str,
+    source_installation_generation: int,
+    source_active_fence_digest: str,
+    host_key: bytes,
+    now: int,
+) -> None:
+    try:
+        for path in sorted(
+            _local_transfer_directory().iterdir(),
+            key=lambda item: item.name,
+        ):
+            if _LOCAL_IDENTITY_FILE.fullmatch(path.name) is None:
+                raise ConsolidationIdentityUnavailable
+            loaded = authorization_custody._load_private_artifact(  # noqa: SLF001
+                path,
+                maximum_bytes=authorization_custody.MAX_CUSTODY_FILE_BYTES,
+            )
+            existing = _parse_transfer(
+                loaded.data,
+                key=host_key,
+                expected_path=path,
+                now=now,
+                allow_expired=True,
+            )
+            if existing.operation_id == operation_id and path != target_path:
+                raise ConsolidationIdentityUnavailable
+            same_live_source_fence = (
+                path != target_path
+                and existing.vault_id == vault_id
+                and existing.source_installation_id == source_installation_id
+                and existing.source_installation_generation
+                == source_installation_generation
+                and existing.source_active_fence_digest
+                == source_active_fence_digest
+                and (
+                    existing.state != "source-active"
+                    or now < existing.expires_at
+                )
+            )
+            if same_live_source_fence:
+                raise ConsolidationIdentityUnavailable
+    except FileNotFoundError:
+        return
+    except authorization_custody.AuthorizationCustodyUnavailable:
+        raise ConsolidationIdentityUnavailable from None
 
 
 def _assert_unique_local_claim(
@@ -651,10 +1401,14 @@ def rebind_local_identity(
                     cell_id=current.cell_id,
                     vault_id=current.vault_id,
                     installation_id=current.installation_id,
+                    installation_generation=current.installation_generation,
                     root_binding_id=target_binding,
                     machine_key_id=current.machine_key_id,
                     adoption_census_digest=current.adoption_census_digest,
                     created_at=current.created_at,
+                    clone_of_vault_id=current.clone_of_vault_id,
+                    clone_of_installation_id=current.clone_of_installation_id,
+                    clone_of_snapshot_digest=current.clone_of_snapshot_digest,
                 )
                 _assert_unique_local_claim(
                     target_path=path,
@@ -775,6 +1529,614 @@ def create_rehearsal_clone_identity(
                         custody=custody,
                         now=now,
                     )
+    except ConsolidationIdentityUnavailable:
+        raise
+    except authorization_custody.AuthorizationCustodyUnavailable:
+        raise ConsolidationIdentityUnavailable from None
+    except (OSError, RuntimeError, TypeError, ValueError):
+        raise ConsolidationIdentityUnavailable from None
+
+
+def _failover_identity_barrier(point: str) -> None:
+    """Crash-injection seam between durable failover identity effects."""
+
+    del point
+
+
+def _drained_source_custody(
+    source: Path,
+    *,
+    expected_control: authorization_custody.AuthorizationControlRecord,
+    now: int,
+) -> authorization_custody.AuthorizationCustody:
+    custody = authorization_custody.load_authorization_custody(source, now=now)
+    membership = custody.serving_membership
+    if (
+        custody.control != expected_control
+        or membership is None
+        or custody.local_replica_id is None
+        or len(membership.replicas) != 1
+    ):
+        raise ConsolidationIdentityUnavailable
+    replica = membership.replicas[0]
+    if (
+        replica.replica_id != custody.local_replica_id
+        or replica.state != "DRAINING"
+        or not replica.issuance_stopped
+        or not replica.no_in_flight
+        or membership.record_digest != custody.control.serving_membership_digest
+    ):
+        raise ConsolidationIdentityUnavailable
+    return custody
+
+
+def _transfer_checkpoint_digest(
+    *,
+    identity: ConsolidationCellIdentity,
+    custody: authorization_custody.AuthorizationCustody,
+    target_root_binding_id: str,
+    archive_digest: str,
+    manifest_digest: str,
+    census_digest: str,
+) -> str:
+    return hashlib.sha256(
+        _TRANSFER_CHECKPOINT_DOMAIN
+        + b"\0"
+        + _canonical_json(
+            {
+                "archive_digest": archive_digest,
+                "census_digest": census_digest,
+                "control_digest": authorization_custody.control_attestation_digest(
+                    custody.control
+                ),
+                "manifest_digest": manifest_digest,
+                "source_active_fence_digest": identity.active_fence_digest,
+                "source_installation_generation": identity.installation_generation,
+                "source_installation_id": identity.installation_id,
+                "source_membership_digest": custody.control.serving_membership_digest,
+                "source_root_binding_id": identity.root_binding_id,
+                "target_root_binding_id": target_root_binding_id,
+                "vault_id": identity.vault_id,
+            }
+        )
+    ).hexdigest()
+
+
+def _archive_census_digest(manifest: dict[str, Any]) -> str:
+    try:
+        value = {
+            "artifact": "exomem-hosted-canonical-vault",
+            "schema_version": 1,
+            "classification_version": manifest["classification_version"],
+            "files": manifest["files"],
+        }
+        return hashlib.sha256(
+            hosted_portability._canonical_json(value)  # noqa: SLF001
+        ).hexdigest()
+    except (KeyError, TypeError, ValueError):
+        raise ConsolidationIdentityUnavailable from None
+
+
+def prepare_local_failover_target_candidate(
+    target_vault_root: Path,
+    *,
+    operation_id: str,
+    principal: RequestPrincipal,
+    now: int,
+) -> LocalFailoverTargetCandidate:
+    """Mint target installation authority under the target host trust root."""
+
+    _require_local_owner(principal)
+    target = Path(target_vault_root)
+    operation = _identifier(operation_id)
+    try:
+        with writer_lease.get_manager().consistency_guard(
+            target,
+            operation="consolidation-failover-target-candidate-snapshot",
+            holder_kind="consolidation-identity-control",
+        ):
+            with writer_lease.get_manager().consistency_guard(
+                _local_target_candidate_directory(),
+                operation="consolidation-failover-target-candidate-write",
+                holder_kind="consolidation-identity-registry",
+            ):
+                host_key = authorization_custody._load_host_control_key()  # noqa: SLF001
+                machine_key_id = authorization_custody._host_control_key_id(  # noqa: SLF001
+                    host_key
+                )
+                target_binding = authorization_custody.standalone_attachment_id(
+                    target
+                )
+                target_census = _canonical_adoption_census(target)
+                candidate_id = _derived_transfer_identifier(
+                    "target-candidate-v1",
+                    basis=operation.encode("utf-8"),
+                    key=host_key,
+                )
+                path = _local_target_candidate_path(candidate_id)
+                if path.exists() or path.is_symlink():
+                    existing, _raw = _load_local_target_candidate(
+                        candidate_id,
+                        host_key=host_key,
+                        now=now,
+                    )
+                    if (
+                        existing.operation_id != operation
+                        or existing.target_root_binding_id != target_binding
+                        or existing.target_census_digest != target_census
+                        or existing.machine_key_id != machine_key_id
+                    ):
+                        raise ConsolidationIdentityUnavailable
+                    return existing
+                value = _target_candidate_value(
+                    candidate_id=candidate_id,
+                    operation_id=operation,
+                    target_installation_id=_new_installation_id(),
+                    target_challenge=f"challenge-v1-{secrets.token_hex(32)}",
+                    target_root_binding_id=target_binding,
+                    target_census_digest=target_census,
+                    issued_at=now,
+                    expires_at=(
+                        now
+                        + authorization_serving_membership.MAX_ATTESTATION_TTL_SECONDS
+                    ),
+                    machine_key_id=machine_key_id,
+                )
+                authorization_custody._prepare_private_directory(path.parent)  # noqa: SLF001
+                authorization_custody._publish_private_artifact(  # noqa: SLF001
+                    path,
+                    _encode_target_candidate(value, key=host_key),
+                    maximum_bytes=authorization_custody.MAX_CUSTODY_FILE_BYTES,
+                )
+                prepared, _raw = _load_local_target_candidate(
+                    candidate_id,
+                    host_key=host_key,
+                    now=now,
+                )
+                return prepared
+    except ConsolidationIdentityUnavailable:
+        raise
+    except authorization_custody.AuthorizationCustodyUnavailable:
+        raise ConsolidationIdentityUnavailable from None
+    except (OSError, RuntimeError, TypeError, ValueError):
+        raise ConsolidationIdentityUnavailable from None
+
+
+def prepare_local_failover_identity_transfer(
+    source_vault_root: Path,
+    target_vault_root: Path,
+    *,
+    operation_id: str,
+    target_candidate: LocalFailoverTargetCandidate,
+    archive_path: Path,
+    expected_control: authorization_custody.AuthorizationControlRecord,
+    principal: RequestPrincipal,
+    now: int,
+) -> LocalIdentityTransfer:
+    """Prepare one target-generated, archive-bound local failover transfer."""
+
+    _require_local_owner(principal)
+    source = Path(source_vault_root)
+    target = Path(target_vault_root)
+    operation = _identifier(operation_id)
+    if source == target or not isinstance(
+        target_candidate,
+        LocalFailoverTargetCandidate,
+    ):
+        raise ConsolidationIdentityUnavailable
+    try:
+        with writer_lease.get_manager().mutation_guard(
+            source,
+            operation="consolidation-identity-failover-prepare",
+            holder_kind="consolidation-identity-control",
+            attachment_control=True,
+            attachment_now=now,
+        ):
+            with writer_lease.get_manager().consistency_guard(
+                target,
+                operation="consolidation-identity-failover-target-snapshot",
+                holder_kind="consolidation-identity-control",
+            ):
+                with writer_lease.get_manager().consistency_guard(
+                    _local_identity_directory(),
+                    operation="consolidation-identity-failover-registry",
+                    holder_kind="consolidation-identity-registry",
+                ):
+                    custody = _drained_source_custody(
+                        source,
+                        expected_control=expected_control,
+                        now=now,
+                    )
+                    host_key = authorization_custody._load_host_control_key()  # noqa: SLF001
+                    candidate, _candidate_raw = _load_local_target_candidate(
+                        target_candidate.candidate_id,
+                        host_key=host_key,
+                        now=now,
+                    )
+                    identity = _local_identity_for_root(source, host_key=host_key)
+                    if (
+                        identity.vault_id != custody.control.logical_vault_id
+                        or identity.cell_id != custody.control.cell_id
+                    ):
+                        raise ConsolidationIdentityUnavailable
+                    target_binding = authorization_custody.standalone_attachment_id(
+                        target
+                    )
+                    if (
+                        candidate != target_candidate
+                        or candidate.operation_id != operation
+                        or candidate.target_root_binding_id != target_binding
+                        or hmac.compare_digest(identity.root_binding_id, target_binding)
+                    ):
+                        raise ConsolidationIdentityUnavailable
+                    verified = hosted_portability.verify_export_archive(
+                        archive_path,
+                        expected_cell_id=identity.cell_id,
+                        expected_vault_id=identity.vault_id,
+                    )
+                    source_census = _canonical_adoption_census(source)
+                    target_census = _canonical_adoption_census(target)
+                    archive_census = _archive_census_digest(verified.manifest)
+                    if not (
+                        hmac.compare_digest(source_census, target_census)
+                        and hmac.compare_digest(source_census, archive_census)
+                        and hmac.compare_digest(
+                            source_census,
+                            candidate.target_census_digest,
+                        )
+                    ):
+                        raise ConsolidationIdentityUnavailable
+                    manifest_digest = _digest(
+                        verified.manifest["overall_digest"]["value"]
+                    )
+                    checkpoint_digest = _transfer_checkpoint_digest(
+                        identity=identity,
+                        custody=custody,
+                        target_root_binding_id=target_binding,
+                        archive_digest=verified.archive_sha256,
+                        manifest_digest=manifest_digest,
+                        census_digest=source_census,
+                    )
+                    basis = _canonical_json(
+                        {
+                            "archive_digest": verified.archive_sha256,
+                            "checkpoint_digest": checkpoint_digest,
+                            "manifest_digest": manifest_digest,
+                            "operation_id": operation,
+                            "source_active_fence_digest": identity.active_fence_digest,
+                            "source_installation_generation": (
+                                identity.installation_generation
+                            ),
+                            "source_installation_id": identity.installation_id,
+                            "target_root_binding_id": target_binding,
+                            "target_candidate_digest": candidate.record_digest,
+                            "vault_id": identity.vault_id,
+                        }
+                    )
+                    transfer_id = _derived_transfer_identifier(
+                        "transfer-v1",
+                        basis=basis,
+                        key=host_key,
+                    )
+                    path = _local_transfer_path(transfer_id)
+                    _assert_unique_transfer_operation(
+                        operation,
+                        target_path=path,
+                        vault_id=identity.vault_id,
+                        source_installation_id=identity.installation_id,
+                        source_installation_generation=(
+                            identity.installation_generation
+                        ),
+                        source_active_fence_digest=identity.active_fence_digest,
+                        host_key=host_key,
+                        now=now,
+                    )
+                    if path.exists() or path.is_symlink():
+                        existing, _raw = _load_local_transfer(
+                            transfer_id,
+                            host_key=host_key,
+                            now=now,
+                        )
+                        if (
+                            existing.operation_id != operation
+                            or existing.vault_id != identity.vault_id
+                            or existing.source_installation_id
+                            != identity.installation_id
+                            or existing.source_installation_generation
+                            != identity.installation_generation
+                            or existing.source_active_fence_digest
+                            != identity.active_fence_digest
+                            or existing.target_root_binding_id != target_binding
+                            or existing.target_candidate_id != candidate.candidate_id
+                            or existing.target_candidate_digest
+                            != candidate.record_digest
+                            or existing.archive_digest != verified.archive_sha256
+                            or existing.manifest_digest != manifest_digest
+                            or existing.census_digest != source_census
+                            or existing.checkpoint_digest != checkpoint_digest
+                        ):
+                            raise ConsolidationIdentityUnavailable
+                        return existing
+                    acknowledgement = (
+                        authorization_custody.prepare_standalone_attachment_transfer(
+                            source,
+                            target,
+                            expected_control=custody.control,
+                            now=now,
+                        )
+                    )
+                    expires_at = min(
+                        custody.control.expires_at,
+                        now
+                        + authorization_serving_membership.MAX_ATTESTATION_TTL_SECONDS,
+                    )
+                    value = _transfer_value(
+                        transfer_id=transfer_id,
+                        operation_id=operation,
+                        vault_id=identity.vault_id,
+                        source_installation_id=identity.installation_id,
+                        source_installation_generation=identity.installation_generation,
+                        source_active_fence_digest=identity.active_fence_digest,
+                        source_root_binding_id=identity.root_binding_id,
+                        target_installation_id=candidate.target_installation_id,
+                        target_installation_generation=(
+                            identity.installation_generation + 1
+                        ),
+                        target_challenge=candidate.target_challenge,
+                        target_root_binding_id=target_binding,
+                        target_candidate_id=candidate.candidate_id,
+                        target_candidate_digest=candidate.record_digest,
+                        source_clone_of_vault_id=identity.clone_of_vault_id,
+                        source_clone_of_installation_id=(
+                            identity.clone_of_installation_id
+                        ),
+                        source_clone_of_snapshot_digest=(
+                            identity.clone_of_snapshot_digest
+                        ),
+                        archive_digest=verified.archive_sha256,
+                        manifest_digest=manifest_digest,
+                        census_digest=source_census,
+                        checkpoint_digest=checkpoint_digest,
+                        attachment_acknowledgement=acknowledgement,
+                        reserved_control=None,
+                        state="source-active",
+                        issued_at=now,
+                        expires_at=expires_at,
+                        machine_key_id=identity.machine_key_id,
+                    )
+                    authorization_custody._prepare_private_directory(path.parent)  # noqa: SLF001
+                    authorization_custody._publish_private_artifact(  # noqa: SLF001
+                        path,
+                        _encode_transfer(value, key=host_key),
+                        maximum_bytes=authorization_custody.MAX_CUSTODY_FILE_BYTES,
+                    )
+                    prepared, _raw = _load_local_transfer(
+                        transfer_id,
+                        host_key=host_key,
+                        now=now,
+                    )
+                    return prepared
+    except ConsolidationIdentityUnavailable:
+        raise
+    except (
+        authorization_custody.AuthorizationCustodyUnavailable,
+        hosted_portability.PortabilityError,
+    ):
+        raise ConsolidationIdentityUnavailable from None
+    except (OSError, RuntimeError, TypeError, ValueError):
+        raise ConsolidationIdentityUnavailable from None
+
+
+def complete_local_failover_identity_transfer(
+    source_vault_root: Path,
+    target_vault_root: Path,
+    *,
+    transfer: LocalIdentityTransfer,
+    principal: RequestPrincipal,
+    now: int,
+) -> ConsolidationCellIdentity:
+    """Fence source N, install target N+1, then open target readiness."""
+
+    _require_local_owner(principal)
+    if not isinstance(transfer, LocalIdentityTransfer):
+        raise ConsolidationIdentityUnavailable
+    source = Path(source_vault_root)
+    target = Path(target_vault_root)
+    if source == target:
+        raise ConsolidationIdentityUnavailable
+    try:
+        host_key = authorization_custody._load_host_control_key()  # noqa: SLF001
+        current, raw = _load_local_transfer(
+            transfer.transfer_id,
+            host_key=host_key,
+            now=now,
+            allow_expired=True,
+        )
+        candidate, _candidate_raw = _load_local_target_candidate(
+            current.target_candidate_id,
+            host_key=host_key,
+            now=now,
+            allow_expired=True,
+        )
+        target_binding = authorization_custody.standalone_attachment_id(target)
+        if (
+            current.vault_id != transfer.vault_id
+            or current.target_root_binding_id != target_binding
+            or current.machine_key_id
+            != authorization_custody._host_control_key_id(host_key)  # noqa: SLF001
+            or current.census_digest != _canonical_adoption_census(target)
+            or candidate.record_digest != current.target_candidate_digest
+            or candidate.target_installation_id
+            != current.target_installation_id
+            or candidate.target_challenge != current.target_challenge
+            or candidate.target_root_binding_id != target_binding
+            or candidate.target_census_digest != current.census_digest
+        ):
+            raise ConsolidationIdentityUnavailable
+        if current.state != "target-active" and (
+            current.source_root_binding_id
+            != authorization_custody.standalone_attachment_id(source)
+            or current.census_digest != _canonical_adoption_census(source)
+        ):
+            raise ConsolidationIdentityUnavailable
+
+        if current.state == "source-active":
+            reserved = authorization_custody.reserve_standalone_attachment_transfer(
+                target,
+                acknowledgement=current.attachment_acknowledgement,
+                now=now,
+                recover_expired_reservation=now >= current.expires_at,
+            )
+            if (
+                current.census_digest != _canonical_adoption_census(source)
+                or current.census_digest != _canonical_adoption_census(target)
+            ):
+                raise ConsolidationIdentityUnavailable
+            _failover_identity_barrier("after-reservation")
+            reserved_external = authorization_custody.load_external_custody(target)
+            if (
+                authorization_custody.parse_control_record(
+                    reserved_external.control,
+                    keyring=reserved.keyring,
+                    now=now,
+                )
+                != reserved.control
+            ):
+                raise ConsolidationIdentityUnavailable
+            with writer_lease.get_manager().consistency_guard(
+                _local_identity_directory(),
+                operation="consolidation-identity-failover-pending",
+                holder_kind="consolidation-identity-registry",
+            ):
+                current, raw = _replace_transfer_state(
+                    current,
+                    raw=raw,
+                    state="source-fenced-target-pending",
+                    reserved_control=reserved_external.control,
+                    host_key=host_key,
+                    now=now,
+                )
+            _failover_identity_barrier("after-pending-record")
+        else:
+            if current.reserved_control is None:
+                raise ConsolidationIdentityUnavailable
+            external = authorization_custody.load_external_custody(target)
+            keyring = authorization_custody.parse_keyring(external.keyring)
+            reserved_control = authorization_custody.parse_control_record(
+                current.reserved_control,
+                keyring=keyring,
+                now=now,
+            )
+            reserved = authorization_custody.AuthorizationCustody(
+                keyring_path=external.keyring_path,
+                control_path=external.control_path,
+                keyring=keyring,
+                control=reserved_control,
+            )
+
+        if current.state != "target-active":
+            with writer_lease.get_manager().consistency_guard(
+                _local_identity_directory(),
+                operation="consolidation-identity-failover-install",
+                holder_kind="consolidation-identity-registry",
+            ):
+                identity_path = _local_identity_path(current.vault_id)
+                loaded = authorization_custody._load_private_artifact(  # noqa: SLF001
+                    identity_path,
+                    maximum_bytes=authorization_custody.MAX_CUSTODY_FILE_BYTES,
+                )
+                installed = _parse_identity(
+                    loaded.data,
+                    key=host_key,
+                    expected_path=identity_path,
+                )
+                if installed.installation_id == current.source_installation_id:
+                    if (
+                        installed.installation_generation
+                        != current.source_installation_generation
+                        or installed.active_fence_digest
+                        != current.source_active_fence_digest
+                        or installed.root_binding_id
+                        != current.source_root_binding_id
+                        or installed.vault_id != current.vault_id
+                    ):
+                        raise ConsolidationIdentityUnavailable
+                    target_value = _identity_value(
+                        cell_id=reserved.control.cell_id,
+                        vault_id=current.vault_id,
+                        installation_id=current.target_installation_id,
+                        installation_generation=(
+                            current.target_installation_generation
+                        ),
+                        root_binding_id=current.target_root_binding_id,
+                        machine_key_id=current.machine_key_id,
+                        adoption_census_digest=installed.adoption_census_digest,
+                        created_at=now,
+                        clone_of_vault_id=current.source_clone_of_vault_id,
+                        clone_of_installation_id=(
+                            current.source_clone_of_installation_id
+                        ),
+                        clone_of_snapshot_digest=(
+                            current.source_clone_of_snapshot_digest
+                        ),
+                    )
+                    _assert_unique_local_claim(
+                        target_path=identity_path,
+                        target_value=target_value,
+                        host_key=host_key,
+                    )
+                    authorization_custody._replace_control_bytes(  # noqa: SLF001
+                        identity_path,
+                        expected=loaded.data,
+                        target=_encode_identity(target_value, key=host_key),
+                    )
+                elif (
+                    installed.installation_id != current.target_installation_id
+                    or installed.installation_generation
+                    != current.target_installation_generation
+                    or installed.root_binding_id != current.target_root_binding_id
+                    or installed.vault_id != current.vault_id
+                    or installed.clone_of_vault_id
+                    != current.source_clone_of_vault_id
+                    or installed.clone_of_installation_id
+                    != current.source_clone_of_installation_id
+                    or installed.clone_of_snapshot_digest
+                    != current.source_clone_of_snapshot_digest
+                ):
+                    raise ConsolidationIdentityUnavailable
+            _failover_identity_barrier("after-target-identity")
+
+            activated_custody = (
+                authorization_custody.activate_reserved_standalone_attachment(
+                    target,
+                    expected_control=reserved.control,
+                    now=now,
+                    recover_expired_reservation=now >= current.expires_at,
+                )
+            )
+            _failover_identity_barrier("after-activation")
+            with writer_lease.get_manager().consistency_guard(
+                _local_identity_directory(),
+                operation="consolidation-identity-failover-active",
+                holder_kind="consolidation-identity-registry",
+            ):
+                current, _raw = _replace_transfer_state(
+                    current,
+                    raw=raw,
+                    state="target-active",
+                    host_key=host_key,
+                    now=now,
+                )
+        else:
+            activated_custody = authorization_custody.load_authorization_custody(
+                target,
+                now=now,
+            )
+        return _load_local_with_custody(
+            target,
+            custody=activated_custody,
+            now=now,
+        )
     except ConsolidationIdentityUnavailable:
         raise
     except authorization_custody.AuthorizationCustodyUnavailable:
@@ -937,12 +2299,17 @@ def adopt_hosted_identity(
 __all__ = [
     "IDENTITY_RECORD_FIELDS",
     "IDENTITY_SCHEMA",
+    "IDENTITY_TRANSFER_RECORD_FIELDS",
+    "IDENTITY_TRANSFER_SCHEMA",
     "ConsolidationCellIdentity",
     "ConsolidationIdentityUnavailable",
+    "LocalIdentityTransfer",
     "adopt_hosted_identity",
     "adopt_local_identity",
+    "complete_local_failover_identity_transfer",
     "create_rehearsal_clone_identity",
     "load_hosted_identity",
     "load_local_identity",
+    "prepare_local_failover_identity_transfer",
     "rebind_local_identity",
 ]

--- a/tests/test_consolidation_cell_identity.py
+++ b/tests/test_consolidation_cell_identity.py
@@ -90,6 +90,73 @@ def _required(name: str):
     return value
 
 
+def _failover_target_candidate(
+    target: Path,
+    *,
+    operation_id: str,
+    owner: principal.RequestPrincipal,
+    now: int,
+):
+    return _required("prepare_local_failover_target_candidate")(
+        target,
+        operation_id=operation_id,
+        principal=owner,
+        now=now,
+    )
+
+
+def _quiesced_failover_basis(
+    tmp_path: Path,
+    *,
+    now: int,
+    export_operation_id: str,
+) -> tuple[
+    Path,
+    Path,
+    principal.RequestPrincipal,
+    consolidation_identity.ConsolidationCellIdentity,
+    authorization_custody.AuthorizationCustody,
+    hosted_portability.ExportResult,
+]:
+    source = _vault(tmp_path, "source")
+    target = tmp_path / "target"
+    owner = principal.owner_principal(surface="cli")
+    identity = _required("adopt_local_identity")(
+        source,
+        principal=owner,
+        now=now,
+    )
+    shutil.copytree(source, target)
+    serving = authorization_custody.load_authorization_custody(source, now=now + 1)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        source,
+        expected_control=serving.control,
+        now=now + 2,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        source,
+        expected_control=draining.control,
+        now=now + 3,
+    )
+    exported = hosted_portability.export_quiesced_vault(
+        source,
+        tmp_path / "artifacts",
+        context=hosted_portability.PortabilityContext(
+            cell_id=identity.cell_id,
+            vault_id=identity.vault_id,
+            operation_id=export_operation_id,
+            created_at="2027-01-15T08:00:00+00:00",
+            operator_authorized=True,
+            lifecycle_state="quiesced",
+            routing_stopped=True,
+            active_mutations=0,
+            background_writers_stopped=True,
+            reads_allowed=True,
+        ),
+    )
+    return source, target, owner, identity, drained, exported
+
+
 def test_local_owner_adoption_generates_and_authenticates_private_identity(
     tmp_path: Path,
 ) -> None:
@@ -470,6 +537,26 @@ def test_owner_authorized_attachment_move_rebinds_root_but_preserves_identity(
         principal=owner,
         now=now,
     )
+    host_key = authorization_custody._load_host_control_key()
+    encoded = consolidation_identity._identity_value(
+        cell_id=before.cell_id,
+        vault_id=before.vault_id,
+        installation_id=before.installation_id,
+        installation_generation=2,
+        root_binding_id=before.root_binding_id,
+        machine_key_id=before.machine_key_id,
+        adoption_census_digest=before.adoption_census_digest,
+        created_at=before.created_at,
+        clone_of_vault_id="vault-source-lineage",
+        clone_of_installation_id="installation-v1-" + "a" * 64,
+        clone_of_snapshot_digest="b" * 64,
+    )
+    authorization_custody._replace_control_bytes(
+        before.identity_path,
+        expected=before.identity_path.read_bytes(),
+        target=consolidation_identity._encode_identity(encoded, key=host_key),
+    )
+    before = _required("load_local_identity")(source, now=now + 1)
     target = tmp_path / "target"
     shutil.copytree(source, target)
     serving = authorization_custody.load_authorization_custody(source, now=now + 1)
@@ -509,6 +596,9 @@ def test_owner_authorized_attachment_move_rebinds_root_but_preserves_identity(
     assert moved.installation_id == before.installation_id
     assert moved.installation_generation == before.installation_generation
     assert moved.adoption_census_digest == before.adoption_census_digest
+    assert moved.clone_of_vault_id == before.clone_of_vault_id
+    assert moved.clone_of_installation_id == before.clone_of_installation_id
+    assert moved.clone_of_snapshot_digest == before.clone_of_snapshot_digest
     assert moved.root_binding_id != before.root_binding_id
     assert moved.active_fence_digest != before.active_fence_digest
 
@@ -625,3 +715,944 @@ def test_two_rehearsal_clones_never_share_active_identity(
         == created[1].clone_of_installation_id
     )
     assert created[0].clone_of_snapshot_digest == created[1].clone_of_snapshot_digest
+
+
+def test_failover_transfer_preserves_logical_vault_and_fences_source(
+    tmp_path: Path,
+) -> None:
+    now = 1_800_000_000
+    source = _vault(tmp_path, "source")
+    target = tmp_path / "target"
+    owner = principal.owner_principal(surface="cli")
+    source_identity = _required("adopt_local_identity")(
+        source,
+        principal=owner,
+        now=now,
+    )
+    shutil.copytree(source, target)
+    serving = authorization_custody.load_authorization_custody(source, now=now + 1)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        source,
+        expected_control=serving.control,
+        now=now + 2,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        source,
+        expected_control=draining.control,
+        now=now + 3,
+    )
+    exported = hosted_portability.export_quiesced_vault(
+        source,
+        tmp_path / "artifacts",
+        context=hosted_portability.PortabilityContext(
+            cell_id=source_identity.cell_id,
+            vault_id=source_identity.vault_id,
+            operation_id="failover-export-1",
+            created_at="2027-01-15T08:00:00+00:00",
+            operator_authorized=True,
+            lifecycle_state="quiesced",
+            routing_stopped=True,
+            active_mutations=0,
+            background_writers_stopped=True,
+            reads_allowed=True,
+        ),
+    )
+    prepare = _required("prepare_local_failover_identity_transfer")
+    complete = _required("complete_local_failover_identity_transfer")
+    parameters = inspect.signature(prepare).parameters
+    assert "vault_id" not in parameters
+    assert "installation_id" not in parameters
+    assert "target_installation_id" not in parameters
+    assert "target_challenge" not in parameters
+    assert "target_generation" not in parameters
+
+    candidate = _failover_target_candidate(
+        target,
+        operation_id="failover-transfer-1",
+        owner=owner,
+        now=now + 3,
+    )
+
+    transfer = prepare(
+        source,
+        target,
+        operation_id="failover-transfer-1",
+        target_candidate=candidate,
+        archive_path=exported.archive_path,
+        expected_control=drained.control,
+        principal=owner,
+        now=now + 3,
+    )
+    activated = complete(
+        source,
+        target,
+        transfer=transfer,
+        principal=owner,
+        now=now + 4,
+    )
+
+    assert transfer.schema == "vault-identity-transfer/v1"
+    assert transfer.operation_id == "failover-transfer-1"
+    assert transfer.source_installation_id == source_identity.installation_id
+    assert transfer.source_installation_generation == 1
+    assert transfer.target_installation_generation == 2
+    assert transfer.target_installation_id != source_identity.installation_id
+    assert transfer.target_challenge
+    assert transfer.target_installation_id == candidate.target_installation_id
+    assert transfer.target_challenge == candidate.target_challenge
+    assert transfer.archive_digest == exported.archive_sha256
+    assert transfer.census_digest == source_identity.adoption_census_digest
+    assert activated.vault_id == source_identity.vault_id
+    assert activated.installation_id == transfer.target_installation_id
+    assert activated.installation_generation == 2
+    assert activated.clone_of_vault_id is None
+    assert activated.clone_of_installation_id is None
+    assert activated.clone_of_snapshot_digest is None
+    assert _required("load_local_identity")(target, now=now + 4) == activated
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        _required("load_local_identity")(source, now=now + 4)
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.require_standalone_mutation_admission(
+            source,
+            now=now + 4,
+        )
+    shutil.rmtree(source)
+    replay = complete(
+        source,
+        target,
+        transfer=transfer,
+        principal=owner,
+        now=now + 5,
+    )
+    assert replay == activated
+
+
+def test_failover_preserves_authenticated_rehearsal_clone_lineage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_800_000_000
+    original = _vault(tmp_path, "original")
+    owner = principal.owner_principal(surface="cli")
+    _required("adopt_local_identity")(original, principal=owner, now=now)
+    source = tmp_path / "rehearsal-source"
+    shutil.copytree(original, source)
+    _select_custody_paths(tmp_path / "rehearsal-external", monkeypatch)
+    authorization_custody.provision_standalone_custody(source, now=now + 1)
+    source_identity = _required("create_rehearsal_clone_identity")(
+        original,
+        source,
+        principal=owner,
+        now=now + 1,
+    )
+    target = tmp_path / "failover-target"
+    shutil.copytree(source, target)
+    serving = authorization_custody.load_authorization_custody(source, now=now + 2)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        source,
+        expected_control=serving.control,
+        now=now + 3,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        source,
+        expected_control=draining.control,
+        now=now + 4,
+    )
+    exported = hosted_portability.export_quiesced_vault(
+        source,
+        tmp_path / "artifacts",
+        context=hosted_portability.PortabilityContext(
+            cell_id=source_identity.cell_id,
+            vault_id=source_identity.vault_id,
+            operation_id="failover-clone-export",
+            created_at="2027-01-15T08:00:00+00:00",
+            operator_authorized=True,
+            lifecycle_state="quiesced",
+            routing_stopped=True,
+            active_mutations=0,
+            background_writers_stopped=True,
+            reads_allowed=True,
+        ),
+    )
+    candidate = _failover_target_candidate(
+        target,
+        operation_id="failover-clone-transfer",
+        owner=owner,
+        now=now + 4,
+    )
+    transfer = _required("prepare_local_failover_identity_transfer")(
+        source,
+        target,
+        operation_id="failover-clone-transfer",
+        target_candidate=candidate,
+        archive_path=exported.archive_path,
+        expected_control=drained.control,
+        principal=owner,
+        now=now + 4,
+    )
+    activated = _required("complete_local_failover_identity_transfer")(
+        source,
+        target,
+        transfer=transfer,
+        principal=owner,
+        now=now + 5,
+    )
+
+    assert activated.clone_of_vault_id == source_identity.clone_of_vault_id
+    assert (
+        activated.clone_of_installation_id
+        == source_identity.clone_of_installation_id
+    )
+    assert (
+        activated.clone_of_snapshot_digest
+        == source_identity.clone_of_snapshot_digest
+    )
+
+
+def test_failover_transfer_refuses_stale_export_even_when_roots_match(
+    tmp_path: Path,
+) -> None:
+    now = 1_800_000_000
+    source = _vault(tmp_path, "source")
+    target = tmp_path / "target"
+    owner = principal.owner_principal(surface="cli")
+    identity = _required("adopt_local_identity")(
+        source,
+        principal=owner,
+        now=now,
+    )
+    shutil.copytree(source, target)
+    serving = authorization_custody.load_authorization_custody(source, now=now + 1)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        source,
+        expected_control=serving.control,
+        now=now + 2,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        source,
+        expected_control=draining.control,
+        now=now + 3,
+    )
+    exported = hosted_portability.export_quiesced_vault(
+        source,
+        tmp_path / "artifacts",
+        context=hosted_portability.PortabilityContext(
+            cell_id=identity.cell_id,
+            vault_id=identity.vault_id,
+            operation_id="failover-export-stale",
+            created_at="2027-01-15T08:00:00+00:00",
+            operator_authorized=True,
+            lifecycle_state="quiesced",
+            routing_stopped=True,
+            active_mutations=0,
+            background_writers_stopped=True,
+            reads_allowed=True,
+        ),
+    )
+    changed = "---\ntype: insight\n---\nchanged after the signed export\n"
+    (source / "Knowledge Base/Notes/identity.md").write_text(
+        changed,
+        encoding="utf-8",
+    )
+    (target / "Knowledge Base/Notes/identity.md").write_text(
+        changed,
+        encoding="utf-8",
+    )
+
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        candidate = _failover_target_candidate(
+            target,
+            operation_id="failover-transfer-stale",
+            owner=owner,
+            now=now + 3,
+        )
+        _required("prepare_local_failover_identity_transfer")(
+            source,
+            target,
+            operation_id="failover-transfer-stale",
+            target_candidate=candidate,
+            archive_path=exported.archive_path,
+            expected_control=drained.control,
+            principal=owner,
+            now=now + 3,
+        )
+
+
+@pytest.mark.parametrize(
+    "crash_point",
+    (
+        "after-reservation",
+        "after-pending-record",
+        "after-target-identity",
+        "after-activation",
+        "activation-after-membership",
+        "activation-after-control",
+        "activation-after-registry",
+    ),
+)
+def test_failover_transfer_recovers_every_identity_publication_gap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    crash_point: str,
+) -> None:
+    now = 1_800_000_000
+    source = _vault(tmp_path, "source")
+    target = tmp_path / "target"
+    owner = principal.owner_principal(surface="cli")
+    identity = _required("adopt_local_identity")(
+        source,
+        principal=owner,
+        now=now,
+    )
+    shutil.copytree(source, target)
+    serving = authorization_custody.load_authorization_custody(source, now=now + 1)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        source,
+        expected_control=serving.control,
+        now=now + 2,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        source,
+        expected_control=draining.control,
+        now=now + 3,
+    )
+    exported = hosted_portability.export_quiesced_vault(
+        source,
+        tmp_path / "artifacts",
+        context=hosted_portability.PortabilityContext(
+            cell_id=identity.cell_id,
+            vault_id=identity.vault_id,
+            operation_id=f"export-{crash_point}",
+            created_at="2027-01-15T08:00:00+00:00",
+            operator_authorized=True,
+            lifecycle_state="quiesced",
+            routing_stopped=True,
+            active_mutations=0,
+            background_writers_stopped=True,
+            reads_allowed=True,
+        ),
+    )
+    operation_id = f"transfer-{crash_point}"
+    candidate = _failover_target_candidate(
+        target,
+        operation_id=operation_id,
+        owner=owner,
+        now=now + 3,
+    )
+    transfer = _required("prepare_local_failover_identity_transfer")(
+        source,
+        target,
+        operation_id=operation_id,
+        target_candidate=candidate,
+        archive_path=exported.archive_path,
+        expected_control=drained.control,
+        principal=owner,
+        now=now + 3,
+    )
+    raised = False
+
+    def crash_once(point: str) -> None:
+        nonlocal raised
+        if point == crash_point and not raised:
+            raised = True
+            raise RuntimeError("simulated failover crash")
+
+    monkeypatch.setattr(
+        consolidation_identity,
+        "_failover_identity_barrier",
+        crash_once,
+    )
+    monkeypatch.setattr(
+        authorization_custody,
+        "_standalone_transition_barrier",
+        lambda point: crash_once(f"activation-{point}"),
+    )
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        _required("complete_local_failover_identity_transfer")(
+            source,
+            target,
+            transfer=transfer,
+            principal=owner,
+            now=now + 4,
+        )
+    assert raised
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.require_standalone_mutation_admission(
+            source,
+            now=now + 4,
+        )
+    if crash_point in {
+        "activation-after-membership",
+        "activation-after-control",
+    }:
+        with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+            authorization_custody.require_standalone_mutation_admission(
+                target,
+                now=now + 4,
+            )
+    else:
+        interrupted = authorization_custody.load_authorization_custody(
+            target,
+            now=now + 4,
+        )
+        assert interrupted.serving_membership is not None
+        expected_state = (
+            "SERVING"
+            if crash_point in {"after-activation", "activation-after-registry"}
+            else "DRAINING"
+        )
+        assert interrupted.serving_membership.replicas[0].state == expected_state
+    if crash_point in {
+        "after-reservation",
+        "after-pending-record",
+        "after-target-identity",
+    }:
+        with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+            _required("load_local_identity")(target, now=now + 4)
+
+    monkeypatch.setattr(
+        consolidation_identity,
+        "_failover_identity_barrier",
+        lambda _point: None,
+    )
+    monkeypatch.setattr(
+        authorization_custody,
+        "_standalone_transition_barrier",
+        lambda _point: None,
+    )
+    recovered = _required("complete_local_failover_identity_transfer")(
+        source,
+        target,
+        transfer=transfer,
+        principal=owner,
+        now=now + 5,
+    )
+
+    assert recovered.vault_id == identity.vault_id
+    assert recovered.installation_id == transfer.target_installation_id
+    assert recovered.installation_generation == 2
+    assert _required("load_local_identity")(target, now=now + 5) == recovered
+
+
+def test_failover_recovers_durable_reservation_after_issuance_expiry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_800_000_000
+    source = _vault(tmp_path, "source")
+    target = tmp_path / "target"
+    owner = principal.owner_principal(surface="cli")
+    identity = _required("adopt_local_identity")(
+        source,
+        principal=owner,
+        now=now,
+    )
+    shutil.copytree(source, target)
+    serving = authorization_custody.load_authorization_custody(source, now=now + 1)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        source,
+        expected_control=serving.control,
+        now=now + 2,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        source,
+        expected_control=draining.control,
+        now=now + 3,
+    )
+    exported = hosted_portability.export_quiesced_vault(
+        source,
+        tmp_path / "artifacts",
+        context=hosted_portability.PortabilityContext(
+            cell_id=identity.cell_id,
+            vault_id=identity.vault_id,
+            operation_id="failover-expiry-export",
+            created_at="2027-01-15T08:00:00+00:00",
+            operator_authorized=True,
+            lifecycle_state="quiesced",
+            routing_stopped=True,
+            active_mutations=0,
+            background_writers_stopped=True,
+            reads_allowed=True,
+        ),
+    )
+    candidate = _failover_target_candidate(
+        target,
+        operation_id="failover-expiry-transfer",
+        owner=owner,
+        now=now + 3,
+    )
+    transfer = _required("prepare_local_failover_identity_transfer")(
+        source,
+        target,
+        operation_id="failover-expiry-transfer",
+        target_candidate=candidate,
+        archive_path=exported.archive_path,
+        expected_control=drained.control,
+        principal=owner,
+        now=now + 3,
+    )
+
+    monkeypatch.setattr(
+        consolidation_identity,
+        "_failover_identity_barrier",
+        lambda point: (_ for _ in ()).throw(RuntimeError("crash"))
+        if point == "after-reservation"
+        else None,
+    )
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        _required("complete_local_failover_identity_transfer")(
+            source,
+            target,
+            transfer=transfer,
+            principal=owner,
+            now=now + 4,
+        )
+    monkeypatch.setattr(
+        consolidation_identity,
+        "_failover_identity_barrier",
+        lambda _point: None,
+    )
+
+    recovered = _required("complete_local_failover_identity_transfer")(
+        source,
+        target,
+        transfer=transfer,
+        principal=owner,
+        now=transfer.expires_at + 1,
+    )
+    assert recovered.installation_id == transfer.target_installation_id
+    assert recovered.installation_generation == 2
+
+
+def test_failover_expiry_cannot_start_a_new_reservation(
+    tmp_path: Path,
+) -> None:
+    now = 1_800_000_000
+    source = _vault(tmp_path, "source")
+    target = tmp_path / "target"
+    owner = principal.owner_principal(surface="cli")
+    identity = _required("adopt_local_identity")(
+        source,
+        principal=owner,
+        now=now,
+    )
+    shutil.copytree(source, target)
+    serving = authorization_custody.load_authorization_custody(source, now=now + 1)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        source,
+        expected_control=serving.control,
+        now=now + 2,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        source,
+        expected_control=draining.control,
+        now=now + 3,
+    )
+    exported = hosted_portability.export_quiesced_vault(
+        source,
+        tmp_path / "artifacts",
+        context=hosted_portability.PortabilityContext(
+            cell_id=identity.cell_id,
+            vault_id=identity.vault_id,
+            operation_id="failover-expiry-no-progress-export",
+            created_at="2027-01-15T08:00:00+00:00",
+            operator_authorized=True,
+            lifecycle_state="quiesced",
+            routing_stopped=True,
+            active_mutations=0,
+            background_writers_stopped=True,
+            reads_allowed=True,
+        ),
+    )
+    candidate = _failover_target_candidate(
+        target,
+        operation_id="failover-expiry-no-progress-transfer",
+        owner=owner,
+        now=now + 3,
+    )
+    transfer = _required("prepare_local_failover_identity_transfer")(
+        source,
+        target,
+        operation_id="failover-expiry-no-progress-transfer",
+        target_candidate=candidate,
+        archive_path=exported.archive_path,
+        expected_control=drained.control,
+        principal=owner,
+        now=now + 3,
+    )
+    before = authorization_custody.load_external_custody(target)
+    before_identity = identity.identity_path.read_bytes()
+    membership_path = Path(
+        os.environ[authorization_custody.MEMBERSHIP_FILE_ENV]
+    )
+    before_membership = membership_path.read_bytes()
+
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        _required("complete_local_failover_identity_transfer")(
+            source,
+            target,
+            transfer=transfer,
+            principal=owner,
+            now=transfer.expires_at + 1,
+        )
+
+    after = authorization_custody.load_external_custody(target)
+    assert after.keyring == before.keyring
+    assert after.control == before.control
+    assert membership_path.read_bytes() == before_membership
+    assert identity.identity_path.read_bytes() == before_identity
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        _required("load_local_identity")(target, now=now + 4)
+
+
+def test_failover_refuses_two_live_operations_for_one_source_fence(
+    tmp_path: Path,
+) -> None:
+    now = 1_800_000_000
+    source, target, owner, _identity, drained, exported = (
+        _quiesced_failover_basis(
+            tmp_path,
+            now=now,
+            export_operation_id="failover-double-prepare-export",
+        )
+    )
+    prepare = _required("prepare_local_failover_identity_transfer")
+    first_candidate = _failover_target_candidate(
+        target,
+        operation_id="failover-double-prepare-a",
+        owner=owner,
+        now=now + 3,
+    )
+    first = prepare(
+        source,
+        target,
+        operation_id="failover-double-prepare-a",
+        target_candidate=first_candidate,
+        archive_path=exported.archive_path,
+        expected_control=drained.control,
+        principal=owner,
+        now=now + 3,
+    )
+    second_candidate = _failover_target_candidate(
+        target,
+        operation_id="failover-double-prepare-b",
+        owner=owner,
+        now=now + 3,
+    )
+
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        prepare(
+            source,
+            target,
+            operation_id="failover-double-prepare-b",
+            target_candidate=second_candidate,
+            archive_path=exported.archive_path,
+            expected_control=drained.control,
+            principal=owner,
+            now=now + 3,
+        )
+
+    assert (
+        prepare(
+            source,
+            target,
+            operation_id=first.operation_id,
+            target_candidate=first_candidate,
+            archive_path=exported.archive_path,
+            expected_control=drained.control,
+            principal=owner,
+            now=now + 3,
+        )
+        == first
+    )
+
+
+@pytest.mark.parametrize(
+    "crash_point",
+    ("after-membership", "after-control"),
+)
+@pytest.mark.parametrize(
+    "recovery_crash_point",
+    ("after-membership", "after-control"),
+)
+def test_failover_recovers_expired_activation_successor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    crash_point: str,
+    recovery_crash_point: str,
+) -> None:
+    now = 1_800_000_000
+    source, target, owner, _identity, drained, exported = (
+        _quiesced_failover_basis(
+            tmp_path,
+            now=now,
+            export_operation_id=f"failover-expired-activation-{crash_point}-export",
+        )
+    )
+    operation_id = f"failover-expired-activation-{crash_point}"
+    candidate = _failover_target_candidate(
+        target,
+        operation_id=operation_id,
+        owner=owner,
+        now=now + 3,
+    )
+    transfer = _required("prepare_local_failover_identity_transfer")(
+        source,
+        target,
+        operation_id=operation_id,
+        target_candidate=candidate,
+        archive_path=exported.archive_path,
+        expected_control=drained.control,
+        principal=owner,
+        now=now + 3,
+    )
+    raised = False
+
+    def crash_once(point: str) -> None:
+        nonlocal raised
+        if point == crash_point and not raised:
+            raised = True
+            raise RuntimeError("simulated activation crash")
+
+    monkeypatch.setattr(
+        authorization_custody,
+        "_standalone_transition_barrier",
+        crash_once,
+    )
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        _required("complete_local_failover_identity_transfer")(
+            source,
+            target,
+            transfer=transfer,
+            principal=owner,
+            now=now + 4,
+        )
+    assert raised
+
+    membership_path = Path(
+        os.environ[authorization_custody.MEMBERSHIP_FILE_ENV]
+    )
+    expired_at = int(
+        json.loads(membership_path.read_text(encoding="utf-8"))["expires_at"]
+    )
+    recovery_raised = False
+
+    def crash_recovery_once(point: str) -> None:
+        nonlocal recovery_raised
+        if point == recovery_crash_point and not recovery_raised:
+            recovery_raised = True
+            raise RuntimeError("simulated recovery crash")
+
+    monkeypatch.setattr(
+        authorization_custody,
+        "_standalone_transition_barrier",
+        crash_recovery_once,
+    )
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        _required("complete_local_failover_identity_transfer")(
+            source,
+            target,
+            transfer=transfer,
+            principal=owner,
+            now=expired_at + 1,
+        )
+    assert recovery_raised
+
+    monkeypatch.setattr(
+        authorization_custody,
+        "_standalone_transition_barrier",
+        lambda _point: None,
+    )
+    recovered = _required("complete_local_failover_identity_transfer")(
+        source,
+        target,
+        transfer=transfer,
+        principal=owner,
+        now=expired_at + 2,
+    )
+
+    assert recovered.installation_id == transfer.target_installation_id
+    active = authorization_custody.load_authorization_custody(
+        target,
+        now=expired_at + 2,
+    )
+    assert active.serving_membership is not None
+    assert active.serving_membership.replicas[0].state == "SERVING"
+
+
+def test_failover_operation_id_cannot_be_rebound_to_a_second_target(
+    tmp_path: Path,
+) -> None:
+    now = 1_800_000_000
+    source = _vault(tmp_path, "source")
+    first_target = tmp_path / "target-a"
+    second_target = tmp_path / "target-b"
+    owner = principal.owner_principal(surface="cli")
+    identity = _required("adopt_local_identity")(
+        source,
+        principal=owner,
+        now=now,
+    )
+    shutil.copytree(source, first_target)
+    shutil.copytree(source, second_target)
+    serving = authorization_custody.load_authorization_custody(source, now=now + 1)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        source,
+        expected_control=serving.control,
+        now=now + 2,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        source,
+        expected_control=draining.control,
+        now=now + 3,
+    )
+    exported = hosted_portability.export_quiesced_vault(
+        source,
+        tmp_path / "artifacts",
+        context=hosted_portability.PortabilityContext(
+            cell_id=identity.cell_id,
+            vault_id=identity.vault_id,
+            operation_id="failover-export-operation-conflict",
+            created_at="2027-01-15T08:00:00+00:00",
+            operator_authorized=True,
+            lifecycle_state="quiesced",
+            routing_stopped=True,
+            active_mutations=0,
+            background_writers_stopped=True,
+            reads_allowed=True,
+        ),
+    )
+    prepare = _required("prepare_local_failover_identity_transfer")
+    first_candidate = _failover_target_candidate(
+        first_target,
+        operation_id="failover-operation-one",
+        owner=owner,
+        now=now + 3,
+    )
+    first = prepare(
+        source,
+        first_target,
+        operation_id="failover-operation-one",
+        target_candidate=first_candidate,
+        archive_path=exported.archive_path,
+        expected_control=drained.control,
+        principal=owner,
+        now=now + 3,
+    )
+    replay = prepare(
+        source,
+        first_target,
+        operation_id="failover-operation-one",
+        target_candidate=first_candidate,
+        archive_path=exported.archive_path,
+        expected_control=drained.control,
+        principal=owner,
+        now=now + 3,
+    )
+    assert replay == first
+
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        second_candidate = _failover_target_candidate(
+            second_target,
+            operation_id=first.operation_id,
+            owner=owner,
+            now=now + 3,
+        )
+        prepare(
+            source,
+            second_target,
+            operation_id=first.operation_id,
+            target_candidate=second_candidate,
+            archive_path=exported.archive_path,
+            expected_control=drained.control,
+            principal=owner,
+            now=now + 3,
+        )
+
+
+def test_failover_rechecks_target_census_after_authority_reservation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_800_000_000
+    source = _vault(tmp_path, "source")
+    target = tmp_path / "target"
+    owner = principal.owner_principal(surface="cli")
+    identity = _required("adopt_local_identity")(
+        source,
+        principal=owner,
+        now=now,
+    )
+    shutil.copytree(source, target)
+    serving = authorization_custody.load_authorization_custody(source, now=now + 1)
+    draining = authorization_custody.begin_standalone_attachment_drain(
+        source,
+        expected_control=serving.control,
+        now=now + 2,
+    )
+    drained = authorization_custody.acknowledge_standalone_attachment_drain(
+        source,
+        expected_control=draining.control,
+        now=now + 3,
+    )
+    exported = hosted_portability.export_quiesced_vault(
+        source,
+        tmp_path / "artifacts",
+        context=hosted_portability.PortabilityContext(
+            cell_id=identity.cell_id,
+            vault_id=identity.vault_id,
+            operation_id="failover-export-reservation-race",
+            created_at="2027-01-15T08:00:00+00:00",
+            operator_authorized=True,
+            lifecycle_state="quiesced",
+            routing_stopped=True,
+            active_mutations=0,
+            background_writers_stopped=True,
+            reads_allowed=True,
+        ),
+    )
+    candidate = _failover_target_candidate(
+        target,
+        operation_id="failover-transfer-reservation-race",
+        owner=owner,
+        now=now + 3,
+    )
+    transfer = _required("prepare_local_failover_identity_transfer")(
+        source,
+        target,
+        operation_id="failover-transfer-reservation-race",
+        target_candidate=candidate,
+        archive_path=exported.archive_path,
+        expected_control=drained.control,
+        principal=owner,
+        now=now + 3,
+    )
+    original = authorization_custody.reserve_standalone_attachment_transfer
+
+    def drift_after_reservation(*args: object, **kwargs: object):
+        reserved = original(*args, **kwargs)
+        (target / "Knowledge Base/Notes/identity.md").write_text(
+            "---\ntype: insight\n---\ndrifted after reservation\n",
+            encoding="utf-8",
+        )
+        return reserved
+
+    monkeypatch.setattr(
+        authorization_custody,
+        "reserve_standalone_attachment_transfer",
+        drift_after_reservation,
+    )
+    with pytest.raises(consolidation_identity.ConsolidationIdentityUnavailable):
+        _required("complete_local_failover_identity_transfer")(
+            source,
+            target,
+            transfer=transfer,
+            principal=owner,
+            now=now + 4,
+        )
+    interrupted = authorization_custody.load_authorization_custody(
+        target,
+        now=now + 4,
+    )
+    assert interrupted.serving_membership is not None
+    assert interrupted.serving_membership.replicas[0].state == "DRAINING"


### PR DESCRIPTION
## Summary

- add an owner-only, same-host failover identity foundation stacked on #904
- mint a separately authenticated target candidate, preserve the logical vault and clone lineage, and advance the target installation to generation N+1
- reserve the target as DRAINING before identity activation, fence the old source, and bind the exact archive, census, checkpoint, source fence, operation, and candidate
- recover every outer and inner membership/control/registry crash gap, including expired-but-already-durable reservations and activation successors
- refuse competing live transfers for the same source fence and refuse expired acknowledgements that have not produced durable reservation evidence

Task 1.4 remains intentionally unchecked: this PR is the local/same-host identity and custody foundation only. It does not add the Hosted/product command, claim cross-machine failover completion, touch a real vault, or authorize rehearsal/cutover/retirement. The OS owner remains trusted.

## Verification

- Python 3.13 focused/adjoining packet: 116 passed, 1 existing privileged device-node skip
- independent adversarial review: GO, no P0/P1/P2 findings
- touched-file Ruff and repository undefined-name lint
- uv lock --check
- strict OpenSpec change validation and all-spec validation: 168/168
- OpenSpec archive discipline
- public artifact privacy validation: 3394 files / 3462 text payloads
- git diff --check

Stacked after #904. No real personal or POLLY vault was read or modified.