### PR TITLE
feat(governance): add source export attestations

### DIFF
--- a/openspec/changes/add-governed-vault-consolidation/verification.md
+++ b/openspec/changes/add-governed-vault-consolidation/verification.md
@@ -165,3 +165,28 @@ completion does not authorize rehearsal, cutover, or retirement.
 - Independent adversarial recheck: no P0/P1/P2 findings and GO for the explicit
   trusted-owner, same-host failover foundation after reproducing the conflicting
   live-transfer and expired-successor failures and verifying their corrections.
+
+## Detached source-attestation stack
+
+- Red: `tests/test_consolidation_intake.py` first failed one explicit assertion
+  because the detached source-attestation subsystem was absent; collection and
+  imports succeeded. Follow-on red assertions separately exposed the missing
+  API, valid-proof refusal, mixed registry-generation acceptance, mutable
+  verified claims, and a malformed trust-set exception leak.
+- Green: the focused file passes with the exact
+  `source-export-attestation/v1` JCS frame, RFC 8032 key plus fixed Exomem
+  signature vector, raw unpadded-base64url Ed25519 key/signature encodings,
+  closed local/Hosted claim shapes, exact source/artifact/checkpoint/fence
+  binding, one private verifier purpose/audience/source registry generation,
+  bounded two-key overlap, immutable verified claims, and the same content-free
+  refusal at intake, apply, retirement clearance, and retirement consumption.
+- This slice intentionally does not mark task 1.6 complete: the separately
+  trusted control-plane-receipt alternative and its issuer record remain for a
+  later bounded stack. It does not extract an archive or touch a live vault.
+- Final focused/adjoining gate:
+  `tests/test_consolidation_intake.py`,
+  `tests/test_consolidation_cell_identity.py`, and
+  `tests/test_hosted_portability.py` -> `172 passed`. Touched-file Ruff and
+  format checks, repository `F` lint, `uv lock --check`, strict change
+  validation, public repository artifact validation (`3396 files, 3464 text
+  payloads`), and `git diff --check` are green.

--- a/openspec/changes/add-governed-vault-consolidation/verification.md
+++ b/openspec/changes/add-governed-vault-consolidation/verification.md
@@ -172,7 +172,8 @@ completion does not authorize rehearsal, cutover, or retirement.
   because the detached source-attestation subsystem was absent; collection and
   imports succeeded. Follow-on red assertions separately exposed the missing
   API, valid-proof refusal, mixed registry-generation acceptance, mutable
-  verified claims, and a malformed trust-set exception leak.
+  verified claims, a malformed trust-set exception leak, and unbounded
+  pre-parse claim admission.
 - Green: the focused file passes with the exact
   `source-export-attestation/v1` JCS frame, RFC 8032 key plus fixed Exomem
   signature vector, raw unpadded-base64url Ed25519 key/signature encodings,
@@ -186,7 +187,7 @@ completion does not authorize rehearsal, cutover, or retirement.
 - Final focused/adjoining gate:
   `tests/test_consolidation_intake.py`,
   `tests/test_consolidation_cell_identity.py`, and
-  `tests/test_hosted_portability.py` -> `172 passed`. Touched-file Ruff and
+  `tests/test_hosted_portability.py` -> `173 passed`. Touched-file Ruff and
   format checks, repository `F` lint, `uv lock --check`, strict change
   validation, public repository artifact validation (`3396 files, 3464 text
   payloads`), and `git diff --check` are green.

--- a/src/exomem/governance/consolidation_attestation.py
+++ b/src/exomem/governance/consolidation_attestation.py
@@ -1,0 +1,465 @@
+"""Detached source authority for governed vault consolidation exports.
+
+The archive manifest proves byte consistency, not provenance.  This module
+owns the separate Ed25519 proof which binds one quiesced export to a
+destination-configured source identity.  It deliberately contains no archive
+extraction, request parsing, or trust-root provisioning.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import re
+import unicodedata
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from types import MappingProxyType
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+from .projections import ProjectionCanonicalizationError, canonical_jcs
+
+ATTESTATION_SCHEMA = "source-export-attestation/v1"
+VERIFIER_RECORD_SCHEMA = "SourceExportVerifierRecord/v1"
+SIGNING_DOMAIN = b"exomem.source-export-attestation/v1"
+VERIFIER_PURPOSE = "vault-consolidation-export"
+
+__all__ = [
+    "ATTESTATION_SCHEMA",
+    "SIGNING_DOMAIN",
+    "VERIFIER_PURPOSE",
+    "VERIFIER_RECORD_SCHEMA",
+    "SourceExportAttestationUnavailable",
+    "SourceExportExpectation",
+    "SourceExportVerifierRecord",
+    "VerifiedSourceExportAttestation",
+    "canonical_source_export_claims",
+    "sign_source_export_attestation",
+    "source_export_signing_bytes",
+    "verify_source_export_attestation",
+]
+
+_ALGORITHM = "ed25519"
+_GATES = frozenset({"intake", "apply", "retirement-clearance", "retirement-consumption"})
+_HEX_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}\Z")
+_RFC3339_MILLISECONDS = re.compile(
+    r"[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])"
+    r"T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{3}Z\Z"
+)
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_REQUIRED_CLAIMS = frozenset(
+    {
+        "schema",
+        "source_vault_id",
+        "source_installation_id",
+        "source_installation_generation",
+        "source_active_fence_digest",
+        "export_operation_id",
+        "quiescence_checkpoint_digest",
+        "archive_sha256",
+        "manifest_sha256",
+        "source_census_sha256",
+        "issued_at",
+        "expires_at",
+        "signer_key_id",
+    }
+)
+_OPTIONAL_CLAIMS = frozenset({"source_cell_id"})
+
+
+class SourceExportAttestationUnavailable(RuntimeError):
+    """Stable, content-free refusal to authenticate a source export."""
+
+    code = "SOURCE_EXPORT_ATTESTATION_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__("source export attestation is unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class SourceExportExpectation:
+    source_vault_id: str
+    source_installation_id: str
+    source_installation_generation: int
+    source_active_fence_digest: str
+    export_operation_id: str
+    quiescence_checkpoint_digest: str
+    archive_sha256: str
+    manifest_sha256: str
+    source_census_sha256: str
+    audience: str
+    source_cell_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SourceExportVerifierRecord:
+    schema: str
+    algorithm: str
+    key_id: str
+    public_key: str
+    purpose: str
+    audience: str
+    source_vault_id: str
+    source_installation_id: str
+    source_installation_generation: int
+    status: str
+    not_before: str
+    not_after: str
+    registry_generation: int
+    source_cell_id: str | None = None
+    revoked_at: str | None = None
+    revocation_reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedSourceExportAttestation:
+    claims: Mapping[str, str | int]
+    claims_sha256: str
+    key_id: str
+    verification_gate: str
+
+
+def _fail() -> None:
+    raise SourceExportAttestationUnavailable from None
+
+
+def _normalize_text(value: object) -> str:
+    if not isinstance(value, str):
+        _fail()
+    normalized = unicodedata.normalize("NFC", value)
+    try:
+        normalized.encode("utf-8")
+    except UnicodeEncodeError:
+        _fail()
+    return normalized
+
+
+def _identifier(value: object) -> str:
+    normalized = _normalize_text(value)
+    if _IDENTIFIER.fullmatch(normalized) is None:
+        _fail()
+    return normalized
+
+
+def _digest(value: object) -> str:
+    normalized = _normalize_text(value)
+    if _HEX_DIGEST.fullmatch(normalized) is None:
+        _fail()
+    return normalized
+
+
+def _generation(value: object) -> int:
+    if type(value) is not int or value < 1 or value > _MAX_SAFE_INTEGER:
+        _fail()
+    return value
+
+
+def _timestamp(value: object) -> tuple[str, datetime]:
+    normalized = _normalize_text(value)
+    if _RFC3339_MILLISECONDS.fullmatch(normalized) is None:
+        _fail()
+    try:
+        parsed = datetime.fromisoformat(normalized.removesuffix("Z") + "+00:00")
+    except ValueError:
+        _fail()
+    if parsed.tzinfo != UTC:
+        _fail()
+    return normalized, parsed
+
+
+def _reject_json_constant(_value: str) -> None:
+    _fail()
+
+
+def _reject_json_float(_value: str) -> None:
+    _fail()
+
+
+def _parse_json_integer(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError:
+        _fail()
+    if parsed < 0 or parsed > _MAX_SAFE_INTEGER:
+        _fail()
+    return parsed
+
+
+def _closed_json_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for raw_key, item in pairs:
+        key = _normalize_text(raw_key)
+        if key in value:
+            _fail()
+        value[key] = item
+    return value
+
+
+def _parse_claim_bytes(raw: bytes) -> dict[str, object]:
+    try:
+        parsed = json.loads(
+            raw,
+            object_pairs_hook=_closed_json_object,
+            parse_int=_parse_json_integer,
+            parse_float=_reject_json_float,
+            parse_constant=_reject_json_constant,
+        )
+    except (SourceExportAttestationUnavailable, UnicodeDecodeError, json.JSONDecodeError):
+        _fail()
+    if not isinstance(parsed, dict):
+        _fail()
+    return parsed
+
+
+def _normalize_claims(claims: Mapping[str, object]) -> dict[str, str | int]:
+    normalized: dict[str, object] = {}
+    for raw_key, item in claims.items():
+        key = _normalize_text(raw_key)
+        if key in normalized:
+            _fail()
+        normalized[key] = item
+    keys = frozenset(normalized)
+    if keys - (_REQUIRED_CLAIMS | _OPTIONAL_CLAIMS) or not _REQUIRED_CLAIMS <= keys:
+        _fail()
+
+    if normalized["schema"] != ATTESTATION_SCHEMA:
+        _fail()
+    result: dict[str, str | int] = {
+        "schema": ATTESTATION_SCHEMA,
+        "source_vault_id": _identifier(normalized["source_vault_id"]),
+        "source_installation_id": _identifier(normalized["source_installation_id"]),
+        "source_installation_generation": _generation(normalized["source_installation_generation"]),
+        "source_active_fence_digest": _digest(normalized["source_active_fence_digest"]),
+        "export_operation_id": _identifier(normalized["export_operation_id"]),
+        "quiescence_checkpoint_digest": _digest(normalized["quiescence_checkpoint_digest"]),
+        "archive_sha256": _digest(normalized["archive_sha256"]),
+        "manifest_sha256": _digest(normalized["manifest_sha256"]),
+        "source_census_sha256": _digest(normalized["source_census_sha256"]),
+        "issued_at": _timestamp(normalized["issued_at"])[0],
+        "expires_at": _timestamp(normalized["expires_at"])[0],
+        "signer_key_id": _normalize_text(normalized["signer_key_id"]),
+    }
+    if "source_cell_id" in normalized:
+        result["source_cell_id"] = _identifier(normalized["source_cell_id"])
+        if result["source_cell_id"] == result["source_vault_id"]:
+            _fail()
+    if _timestamp(result["issued_at"])[1] >= _timestamp(result["expires_at"])[1]:
+        _fail()
+    if not result["signer_key_id"].startswith("ed25519-sha256:") or not _HEX_DIGEST.fullmatch(
+        result["signer_key_id"].removeprefix("ed25519-sha256:")
+    ):
+        _fail()
+    return result
+
+
+def canonical_source_export_claims(claims: Mapping[str, object] | bytes) -> bytes:
+    """Return the one canonical JCS encoding accepted by the signature contract."""
+
+    raw = bytes(claims) if isinstance(claims, (bytes, bytearray)) else None
+    parsed = _parse_claim_bytes(raw) if raw is not None else claims
+    if not isinstance(parsed, Mapping):
+        _fail()
+    normalized = _normalize_claims(parsed)
+    try:
+        encoded = canonical_jcs(normalized)
+    except ProjectionCanonicalizationError:
+        _fail()
+    if raw is not None and raw != encoded:
+        _fail()
+    return encoded
+
+
+def source_export_signing_bytes(claim_bytes: bytes) -> bytes:
+    """Frame canonical claims exactly, without admitting an ambiguous prefix."""
+
+    canonical = canonical_source_export_claims(claim_bytes)
+    return (
+        len(SIGNING_DOMAIN).to_bytes(4, "big")
+        + SIGNING_DOMAIN
+        + len(canonical).to_bytes(8, "big")
+        + canonical
+    )
+
+
+def _base64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _decode_base64url(value: object, *, size: int) -> bytes:
+    text = _normalize_text(value)
+    if not text or "=" in text or re.fullmatch(r"[A-Za-z0-9_-]+", text) is None:
+        _fail()
+    try:
+        decoded = base64.urlsafe_b64decode(text + "=" * (-len(text) % 4))
+    except (ValueError, binascii.Error):
+        _fail()
+    if len(decoded) != size or _base64url(decoded) != text:
+        _fail()
+    return decoded
+
+
+def _public_key_bytes(private_key: Ed25519PrivateKey) -> bytes:
+    return private_key.public_key().public_bytes(
+        serialization.Encoding.Raw,
+        serialization.PublicFormat.Raw,
+    )
+
+
+def _key_id(public_key: bytes) -> str:
+    return f"ed25519-sha256:{hashlib.sha256(public_key).hexdigest()}"
+
+
+def sign_source_export_attestation(
+    claims: Mapping[str, object], private_key: Ed25519PrivateKey
+) -> tuple[bytes, str]:
+    """Sign exact claims with a source-custodied key and return a detached signature."""
+
+    if not isinstance(private_key, Ed25519PrivateKey):
+        _fail()
+    claim_bytes = canonical_source_export_claims(claims)
+    parsed = _normalize_claims(claims)
+    if parsed["signer_key_id"] != _key_id(_public_key_bytes(private_key)):
+        _fail()
+    signature = private_key.sign(source_export_signing_bytes(claim_bytes))
+    return claim_bytes, _base64url(signature)
+
+
+def _validate_record(record: SourceExportVerifierRecord) -> tuple[bytes, datetime, datetime]:
+    if not isinstance(record, SourceExportVerifierRecord):
+        _fail()
+    if record.schema != VERIFIER_RECORD_SCHEMA or record.algorithm != _ALGORITHM:
+        _fail()
+    public_key = _decode_base64url(record.public_key, size=32)
+    if record.key_id != _key_id(public_key):
+        _fail()
+    if record.purpose != VERIFIER_PURPOSE:
+        _fail()
+    _identifier(record.audience)
+    _identifier(record.source_vault_id)
+    _identifier(record.source_installation_id)
+    _generation(record.source_installation_generation)
+    if record.source_cell_id is not None:
+        _identifier(record.source_cell_id)
+        if record.source_cell_id == record.source_vault_id:
+            _fail()
+    _generation(record.registry_generation)
+    not_before = _timestamp(record.not_before)[1]
+    not_after = _timestamp(record.not_after)[1]
+    if not_before >= not_after or record.status not in {"active", "inactive", "revoked"}:
+        _fail()
+    if record.status == "revoked":
+        if record.revoked_at is None or not record.revocation_reason:
+            _fail()
+        _timestamp(record.revoked_at)
+        _normalize_text(record.revocation_reason)
+    elif record.revoked_at is not None or record.revocation_reason is not None:
+        _fail()
+    return public_key, not_before, not_after
+
+
+def _verify_expected_claims(
+    claims: Mapping[str, str | int], expectation: SourceExportExpectation
+) -> None:
+    if not isinstance(expectation, SourceExportExpectation):
+        _fail()
+    expected = {
+        "source_vault_id": _identifier(expectation.source_vault_id),
+        "source_installation_id": _identifier(expectation.source_installation_id),
+        "source_installation_generation": _generation(expectation.source_installation_generation),
+        "source_active_fence_digest": _digest(expectation.source_active_fence_digest),
+        "export_operation_id": _identifier(expectation.export_operation_id),
+        "quiescence_checkpoint_digest": _digest(expectation.quiescence_checkpoint_digest),
+        "archive_sha256": _digest(expectation.archive_sha256),
+        "manifest_sha256": _digest(expectation.manifest_sha256),
+        "source_census_sha256": _digest(expectation.source_census_sha256),
+    }
+    if any(claims[name] != value for name, value in expected.items()):
+        _fail()
+    if expectation.source_cell_id is None:
+        if "source_cell_id" in claims:
+            _fail()
+    elif claims.get("source_cell_id") != _identifier(expectation.source_cell_id):
+        _fail()
+
+
+def verify_source_export_attestation(
+    claim_bytes: bytes,
+    signature: str,
+    verifier_records: Sequence[SourceExportVerifierRecord],
+    *,
+    expectation: SourceExportExpectation,
+    verified_at: str,
+    verification_gate: str,
+) -> VerifiedSourceExportAttestation:
+    """Verify one detached proof against private destination trust and exact bytes."""
+
+    if not isinstance(verification_gate, str) or verification_gate not in _GATES:
+        _fail()
+    if not isinstance(verifier_records, Sequence) or not 1 <= len(verifier_records) <= 2:
+        _fail()
+    if any(not isinstance(record, SourceExportVerifierRecord) for record in verifier_records):
+        _fail()
+    if len({record.key_id for record in verifier_records}) != len(verifier_records):
+        _fail()
+
+    canonical = canonical_source_export_claims(claim_bytes)
+    claims = _normalize_claims(_parse_claim_bytes(canonical))
+    _verify_expected_claims(claims, expectation)
+    signature_bytes = _decode_base64url(signature, size=64)
+    now = _timestamp(verified_at)[1]
+    issued_at = _timestamp(claims["issued_at"])[1]
+    expires_at = _timestamp(claims["expires_at"])[1]
+
+    validated_records = [(record, *_validate_record(record)) for record in verifier_records]
+    if len({record.registry_generation for record, *_rest in validated_records}) != 1:
+        _fail()
+    for record, _public_key, _not_before, _not_after in validated_records:
+        if (
+            record.status != "active"
+            or record.audience != expectation.audience
+            or record.source_vault_id != claims["source_vault_id"]
+            or record.source_installation_id != claims["source_installation_id"]
+            or record.source_installation_generation != claims["source_installation_generation"]
+            or record.source_cell_id != claims.get("source_cell_id")
+        ):
+            _fail()
+    matches = [
+        validated
+        for validated in validated_records
+        if validated[0].key_id == claims["signer_key_id"]
+    ]
+    if len(matches) != 1:
+        _fail()
+    record, public_key, not_before, not_after = matches[0]
+    if (
+        issued_at < not_before
+        or issued_at > not_after
+        or now < not_before
+        or now > not_after
+        or now < issued_at
+        or now > expires_at
+    ):
+        _fail()
+    try:
+        Ed25519PublicKey.from_public_bytes(public_key).verify(
+            signature_bytes, source_export_signing_bytes(canonical)
+        )
+    except (InvalidSignature, ValueError):
+        _fail()
+
+    return VerifiedSourceExportAttestation(
+        claims=MappingProxyType(dict(claims)),
+        claims_sha256=hashlib.sha256(canonical).hexdigest(),
+        key_id=record.key_id,
+        verification_gate=verification_gate,
+    )

--- a/src/exomem/governance/consolidation_attestation.py
+++ b/src/exomem/governance/consolidation_attestation.py
@@ -32,9 +32,11 @@ ATTESTATION_SCHEMA = "source-export-attestation/v1"
 VERIFIER_RECORD_SCHEMA = "SourceExportVerifierRecord/v1"
 SIGNING_DOMAIN = b"exomem.source-export-attestation/v1"
 VERIFIER_PURPOSE = "vault-consolidation-export"
+MAX_ATTESTATION_CLAIM_BYTES = 8192
 
 __all__ = [
     "ATTESTATION_SCHEMA",
+    "MAX_ATTESTATION_CLAIM_BYTES",
     "SIGNING_DOMAIN",
     "VERIFIER_PURPOSE",
     "VERIFIER_RECORD_SCHEMA",
@@ -266,6 +268,8 @@ def canonical_source_export_claims(claims: Mapping[str, object] | bytes) -> byte
     """Return the one canonical JCS encoding accepted by the signature contract."""
 
     raw = bytes(claims) if isinstance(claims, (bytes, bytearray)) else None
+    if raw is not None and len(raw) > MAX_ATTESTATION_CLAIM_BYTES:
+        _fail()
     parsed = _parse_claim_bytes(raw) if raw is not None else claims
     if not isinstance(parsed, Mapping):
         _fail()
@@ -273,6 +277,8 @@ def canonical_source_export_claims(claims: Mapping[str, object] | bytes) -> byte
     try:
         encoded = canonical_jcs(normalized)
     except ProjectionCanonicalizationError:
+        _fail()
+    if len(encoded) > MAX_ATTESTATION_CLAIM_BYTES:
         _fail()
     if raw is not None and raw != encoded:
         _fail()

--- a/tests/test_consolidation_intake.py
+++ b/tests/test_consolidation_intake.py
@@ -1,0 +1,436 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib
+import inspect
+import json
+from dataclasses import replace
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+_SEED = bytes.fromhex("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60")
+_PUBLIC = bytes.fromhex("d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a")
+_D1 = "1" * 64
+_D2 = "2" * 64
+_D3 = "3" * 64
+_D4 = "4" * 64
+_D5 = "5" * 64
+_EXOMEM_VECTOR_SIGNATURE = (
+    "1aMkuhdSdAvQJ7ev9a_7iEbyBij-xirVgiRjuq5hub2U-Bth8zjuoPic-ktDqjrb00h0z7wS7TuNSC-DZD--Dw"
+)
+
+
+def _attestation_module():
+    try:
+        return importlib.import_module("exomem.governance.consolidation_attestation")
+    except ModuleNotFoundError:
+        pytest.fail("the detached source-export attestation boundary is missing")
+
+
+def _claims(*, source_cell_id: str | None = None) -> dict[str, object]:
+    claims: dict[str, object] = {
+        "schema": "source-export-attestation/v1",
+        "source_vault_id": "vault-source-01",
+        "source_installation_id": "installation-source-01",
+        "source_installation_generation": 7,
+        "source_active_fence_digest": _D1,
+        "export_operation_id": "export-operation-01",
+        "quiescence_checkpoint_digest": _D2,
+        "archive_sha256": _D3,
+        "manifest_sha256": _D4,
+        "source_census_sha256": _D5,
+        "issued_at": "2026-08-28T09:45:00.000Z",
+        "expires_at": "2026-08-28T10:45:00.000Z",
+        "signer_key_id": f"ed25519-sha256:{hashlib.sha256(_PUBLIC).hexdigest()}",
+    }
+    if source_cell_id is not None:
+        claims["source_cell_id"] = source_cell_id
+    return claims
+
+
+def _expectation(attestation, *, source_cell_id: str | None = None):
+    return attestation.SourceExportExpectation(
+        source_vault_id="vault-source-01",
+        source_installation_id="installation-source-01",
+        source_installation_generation=7,
+        source_active_fence_digest=_D1,
+        export_operation_id="export-operation-01",
+        quiescence_checkpoint_digest=_D2,
+        archive_sha256=_D3,
+        manifest_sha256=_D4,
+        source_census_sha256=_D5,
+        audience="destination-trust-domain-01",
+        source_cell_id=source_cell_id,
+    )
+
+
+def _record(attestation, **changes):
+    values: dict[str, object] = {
+        "schema": "SourceExportVerifierRecord/v1",
+        "algorithm": "ed25519",
+        "key_id": f"ed25519-sha256:{hashlib.sha256(_PUBLIC).hexdigest()}",
+        "public_key": base64.urlsafe_b64encode(_PUBLIC).decode().rstrip("="),
+        "purpose": "vault-consolidation-export",
+        "audience": "destination-trust-domain-01",
+        "source_vault_id": "vault-source-01",
+        "source_installation_id": "installation-source-01",
+        "source_installation_generation": 7,
+        "status": "active",
+        "not_before": "2026-08-28T00:00:00.000Z",
+        "not_after": "2026-08-28T23:59:59.999Z",
+        "registry_generation": 12,
+    }
+    values.update(changes)
+    return attestation.SourceExportVerifierRecord(**values)
+
+
+def test_source_export_attestation_contract_is_explicit() -> None:
+    attestation = _attestation_module()
+
+    assert attestation.ATTESTATION_SCHEMA == "source-export-attestation/v1"
+    assert attestation.VERIFIER_RECORD_SCHEMA == "SourceExportVerifierRecord/v1"
+    assert attestation.SIGNING_DOMAIN == b"exomem.source-export-attestation/v1"
+    assert attestation.VERIFIER_PURPOSE == "vault-consolidation-export"
+
+
+def test_source_export_attestation_exposes_only_detached_trust_primitives() -> None:
+    attestation = _attestation_module()
+
+    assert hasattr(attestation, "SourceExportExpectation")
+    assert hasattr(attestation, "SourceExportVerifierRecord")
+    assert hasattr(attestation, "VerifiedSourceExportAttestation")
+    assert hasattr(attestation, "canonical_source_export_claims")
+    assert hasattr(attestation, "source_export_signing_bytes")
+    assert hasattr(attestation, "sign_source_export_attestation")
+    assert hasattr(attestation, "verify_source_export_attestation")
+
+
+def test_source_export_attestation_uses_exact_jcs_frame_and_rfc8032_key() -> None:
+    attestation = _attestation_module()
+    private_key = Ed25519PrivateKey.from_private_bytes(_SEED)
+    assert (
+        private_key.public_key().public_bytes(
+            serialization.Encoding.Raw,
+            serialization.PublicFormat.Raw,
+        )
+        == _PUBLIC
+    )
+
+    try:
+        claims_bytes, signature = attestation.sign_source_export_attestation(_claims(), private_key)
+    except attestation.SourceExportAttestationUnavailable:
+        pytest.fail("valid detached source-export claims were refused")
+
+    assert (
+        claims_bytes
+        == json.dumps(_claims(), ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+    )
+    assert b"signature" not in claims_bytes
+    expected_frame = (
+        len(attestation.SIGNING_DOMAIN).to_bytes(4, "big")
+        + attestation.SIGNING_DOMAIN
+        + len(claims_bytes).to_bytes(8, "big")
+        + claims_bytes
+    )
+    assert attestation.source_export_signing_bytes(claims_bytes) == expected_frame
+    assert "=" not in signature
+    assert len(base64.urlsafe_b64decode(signature + "==")) == 64
+    assert signature == _EXOMEM_VECTOR_SIGNATURE
+
+
+@pytest.mark.parametrize(
+    "gate",
+    ("intake", "apply", "retirement-clearance", "retirement-consumption"),
+)
+def test_source_export_attestation_verifies_independently_at_every_gate(gate: str) -> None:
+    attestation = _attestation_module()
+    claims_bytes, signature = attestation.sign_source_export_attestation(
+        _claims(), Ed25519PrivateKey.from_private_bytes(_SEED)
+    )
+
+    try:
+        verified = attestation.verify_source_export_attestation(
+            claims_bytes,
+            signature,
+            (_record(attestation),),
+            expectation=_expectation(attestation),
+            verified_at="2026-08-28T10:00:00.000Z",
+            verification_gate=gate,
+        )
+    except attestation.SourceExportAttestationUnavailable:
+        pytest.fail(f"valid detached source-export claims were refused at {gate}")
+
+    assert verified.claims == _claims()
+    assert verified.key_id == _claims()["signer_key_id"]
+    assert verified.verification_gate == gate
+    assert verified.claims_sha256 == hashlib.sha256(claims_bytes).hexdigest()
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    (
+        ("source_vault_id", "vault-other-01"),
+        ("source_installation_id", "installation-other-01"),
+        ("source_installation_generation", 8),
+        ("source_active_fence_digest", "a" * 64),
+        ("export_operation_id", "export-operation-other"),
+        ("quiescence_checkpoint_digest", "b" * 64),
+        ("archive_sha256", "c" * 64),
+        ("manifest_sha256", "d" * 64),
+        ("source_census_sha256", "e" * 64),
+    ),
+)
+def test_source_export_attestation_refuses_every_changed_binding(
+    field: str, replacement: str | int
+) -> None:
+    attestation = _attestation_module()
+    changed = _claims()
+    changed[field] = replacement
+    claim_bytes, signature = attestation.sign_source_export_attestation(
+        changed, Ed25519PrivateKey.from_private_bytes(_SEED)
+    )
+
+    with pytest.raises(
+        attestation.SourceExportAttestationUnavailable,
+        match="^source export attestation is unavailable$",
+    ):
+        attestation.verify_source_export_attestation(
+            claim_bytes,
+            signature,
+            (_record(attestation),),
+            expectation=_expectation(attestation),
+            verified_at="2026-08-28T10:00:00.000Z",
+            verification_gate="intake",
+        )
+
+
+@pytest.mark.parametrize(
+    "record_changes",
+    (
+        {"schema": "SourceExportVerifierRecord/v2"},
+        {"algorithm": "hmac-sha256"},
+        {"purpose": "export-consolidation"},
+        {"audience": "other-destination"},
+        {"source_vault_id": "vault-other-01"},
+        {"source_installation_id": "installation-other-01"},
+        {"source_installation_generation": 8},
+        {"status": "inactive"},
+        {
+            "status": "revoked",
+            "revoked_at": "2026-08-28T09:50:00.000Z",
+            "revocation_reason": "retired",
+        },
+        {"not_before": "2026-08-28T09:46:00.000Z"},
+        {"not_after": "2026-08-28T09:59:59.999Z"},
+    ),
+)
+def test_source_export_attestation_refuses_unusable_private_trust_records(
+    record_changes: dict[str, object],
+) -> None:
+    attestation = _attestation_module()
+    claim_bytes, signature = attestation.sign_source_export_attestation(
+        _claims(), Ed25519PrivateKey.from_private_bytes(_SEED)
+    )
+
+    with pytest.raises(attestation.SourceExportAttestationUnavailable):
+        attestation.verify_source_export_attestation(
+            claim_bytes,
+            signature,
+            (_record(attestation, **record_changes),),
+            expectation=_expectation(attestation),
+            verified_at="2026-08-28T10:00:00.000Z",
+            verification_gate="intake",
+        )
+
+
+def test_source_export_attestation_rotation_is_explicitly_bounded_to_two_keys() -> None:
+    attestation = _attestation_module()
+    claim_bytes, signature = attestation.sign_source_export_attestation(
+        _claims(), Ed25519PrivateKey.from_private_bytes(_SEED)
+    )
+    other_public = (
+        Ed25519PrivateKey.generate()
+        .public_key()
+        .public_bytes(
+            serialization.Encoding.Raw,
+            serialization.PublicFormat.Raw,
+        )
+    )
+    other = _record(
+        attestation,
+        key_id=f"ed25519-sha256:{hashlib.sha256(other_public).hexdigest()}",
+        public_key=base64.urlsafe_b64encode(other_public).decode().rstrip("="),
+        registry_generation=13,
+    )
+
+    current_record = _record(attestation, registry_generation=13)
+    assert (
+        attestation.verify_source_export_attestation(
+            claim_bytes,
+            signature,
+            (current_record, other),
+            expectation=_expectation(attestation),
+            verified_at="2026-08-28T10:00:00.000Z",
+            verification_gate="apply",
+        ).key_id
+        == _claims()["signer_key_id"]
+    )
+    with pytest.raises(attestation.SourceExportAttestationUnavailable):
+        attestation.verify_source_export_attestation(
+            claim_bytes,
+            signature,
+            (current_record, other, replace(other, registry_generation=14)),
+            expectation=_expectation(attestation),
+            verified_at="2026-08-28T10:00:00.000Z",
+            verification_gate="apply",
+        )
+
+    with pytest.raises(attestation.SourceExportAttestationUnavailable):
+        attestation.verify_source_export_attestation(
+            claim_bytes,
+            signature,
+            (_record(attestation, registry_generation=12), other),
+            expectation=_expectation(attestation),
+            verified_at="2026-08-28T10:00:00.000Z",
+            verification_gate="apply",
+        )
+
+
+def test_source_export_attestation_refuses_invalid_signature_and_unknown_key() -> None:
+    attestation = _attestation_module()
+    claim_bytes, signature = attestation.sign_source_export_attestation(
+        _claims(), Ed25519PrivateKey.from_private_bytes(_SEED)
+    )
+    invalid_signature = ("A" if signature[0] != "A" else "B") + signature[1:]
+
+    with pytest.raises(attestation.SourceExportAttestationUnavailable):
+        attestation.verify_source_export_attestation(
+            claim_bytes,
+            invalid_signature,
+            (_record(attestation),),
+            expectation=_expectation(attestation),
+            verified_at="2026-08-28T10:00:00.000Z",
+            verification_gate="intake",
+        )
+    with pytest.raises(attestation.SourceExportAttestationUnavailable):
+        attestation.verify_source_export_attestation(
+            claim_bytes,
+            signature,
+            (),
+            expectation=_expectation(attestation),
+            verified_at="2026-08-28T10:00:00.000Z",
+            verification_gate="intake",
+        )
+
+
+def test_source_export_attestation_keeps_local_and_hosted_ids_typed() -> None:
+    attestation = _attestation_module()
+    private_key = Ed25519PrivateKey.from_private_bytes(_SEED)
+
+    hosted_claims, hosted_signature = attestation.sign_source_export_attestation(
+        _claims(source_cell_id="cell-source-01"), private_key
+    )
+    verified = attestation.verify_source_export_attestation(
+        hosted_claims,
+        hosted_signature,
+        (_record(attestation, source_cell_id="cell-source-01"),),
+        expectation=_expectation(attestation, source_cell_id="cell-source-01"),
+        verified_at="2026-08-28T10:00:00.000Z",
+        verification_gate="intake",
+    )
+    assert verified.claims["source_cell_id"] == "cell-source-01"
+
+    with pytest.raises(attestation.SourceExportAttestationUnavailable):
+        attestation.sign_source_export_attestation(
+            _claims(source_cell_id="vault-source-01"), private_key
+        )
+    with pytest.raises(attestation.SourceExportAttestationUnavailable):
+        attestation.verify_source_export_attestation(
+            hosted_claims,
+            hosted_signature,
+            (_record(attestation, source_cell_id="cell-source-01"),),
+            expectation=_expectation(attestation),
+            verified_at="2026-08-28T10:00:00.000Z",
+            verification_gate="intake",
+        )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        lambda claims: {**claims, "unknown": "value"},
+        lambda claims: {key: value for key, value in claims.items() if key != "manifest_sha256"},
+        lambda claims: {**claims, "schema": "source-export-attestation/v2"},
+        lambda claims: {**claims, "source_vault_id": None},
+        lambda claims: {**claims, "source_installation_generation": 1.5},
+        lambda claims: {**claims, "issued_at": "2026-08-28T09:45:00Z"},
+        lambda claims: {**claims, "expires_at": "2026-08-28T09:45:00.000Z"},
+        lambda claims: {**claims, "signer_key_id": "sha256:" + "1" * 64},
+    ),
+)
+def test_source_export_claims_reject_noncanonical_or_open_shapes(mutation) -> None:
+    attestation = _attestation_module()
+
+    with pytest.raises(attestation.SourceExportAttestationUnavailable):
+        attestation.canonical_source_export_claims(mutation(_claims()))
+
+
+def test_source_export_claim_parser_rejects_duplicate_and_noncanonical_json() -> None:
+    attestation = _attestation_module()
+    canonical = attestation.canonical_source_export_claims(_claims())
+    duplicate = canonical[:-1] + b',"schema":"source-export-attestation/v1"}'
+
+    for raw in (duplicate, b" " + canonical, canonical.replace(b'"schema":', b'"sche\\u006da":')):
+        with pytest.raises(attestation.SourceExportAttestationUnavailable):
+            attestation.canonical_source_export_claims(raw)
+
+
+def test_attestation_api_has_no_caller_key_or_shared_hmac_seam() -> None:
+    attestation = _attestation_module()
+    parameters = inspect.signature(attestation.verify_source_export_attestation).parameters
+
+    assert "public_key" not in parameters
+    assert "expected_hash" not in parameters
+    assert "hmac_secret" not in parameters
+    assert "shared_secret" not in parameters
+
+
+def test_verified_source_claims_cannot_be_mutated_after_verification() -> None:
+    attestation = _attestation_module()
+    claim_bytes, signature = attestation.sign_source_export_attestation(
+        _claims(), Ed25519PrivateKey.from_private_bytes(_SEED)
+    )
+    verified = attestation.verify_source_export_attestation(
+        claim_bytes,
+        signature,
+        (_record(attestation),),
+        expectation=_expectation(attestation),
+        verified_at="2026-08-28T10:00:00.000Z",
+        verification_gate="intake",
+    )
+
+    with pytest.raises(TypeError):
+        verified.claims["archive_sha256"] = "f" * 64
+
+
+def test_malformed_trust_set_refuses_with_the_same_content_free_error() -> None:
+    attestation = _attestation_module()
+    claim_bytes, signature = attestation.sign_source_export_attestation(
+        _claims(), Ed25519PrivateKey.from_private_bytes(_SEED)
+    )
+
+    with pytest.raises(
+        attestation.SourceExportAttestationUnavailable,
+        match="^source export attestation is unavailable$",
+    ):
+        attestation.verify_source_export_attestation(
+            claim_bytes,
+            signature,
+            ({"public_key": "caller-selected"},),
+            expectation=_expectation(attestation),
+            verified_at="2026-08-28T10:00:00.000Z",
+            verification_gate="intake",
+        )

--- a/tests/test_consolidation_intake.py
+++ b/tests/test_consolidation_intake.py
@@ -434,3 +434,18 @@ def test_malformed_trust_set_refuses_with_the_same_content_free_error() -> None:
             verified_at="2026-08-28T10:00:00.000Z",
             verification_gate="intake",
         )
+
+
+def test_oversized_claims_refuse_before_json_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    attestation = _attestation_module()
+    limit = getattr(attestation, "MAX_ATTESTATION_CLAIM_BYTES", None)
+    assert limit == 8192
+    oversized = b" " * (limit + 1)
+
+    monkeypatch.setattr(
+        attestation.json,
+        "loads",
+        lambda *_args, **_kwargs: pytest.fail("oversized claims reached the JSON parser"),
+    )
+    with pytest.raises(attestation.SourceExportAttestationUnavailable):
+        attestation.canonical_source_export_claims(oversized)


### PR DESCRIPTION
## Summary

- add the detached Ed25519 source-export attestation primitive for governed consolidation
- bind exact canonical claims to destination-configured source trust with bounded two-key rotation
- fail closed on malformed, stale, revoked, expired, mismatched, or noncanonical proofs at all four lifecycle gates

Stacked after #905. This is the cryptographic provenance boundary only: the control-plane receipt alternative and archive intake integration remain separate later slices.

## Verification

- red-first focused assertions recorded in the OpenSpec verification ledger
- 42 focused source-attestation tests
- 172 passed across attestation, consolidation identity/failover, and Hosted portability
- touched-file Ruff and format checks
- repository F lint
- uv lock --check
- strict OpenSpec change validation
- public artifact privacy validation
- git diff --check

No real vault was read, written, rehearsed, consolidated, or retired.