### PR TITLE
fix(governance): close portability manifest schemas

### DIFF
--- a/openspec/changes/add-governed-vault-consolidation/verification.md
+++ b/openspec/changes/add-governed-vault-consolidation/verification.md
@@ -191,3 +191,24 @@ completion does not authorize rehearsal, cutover, or retirement.
   format checks, repository `F` lint, `uv lock --check`, strict change
   validation, public repository artifact validation (`3396 files, 3464 text
   payloads`), and `git diff --check` are green.
+
+## Closed portability-manifest stack
+
+- Red: two exact restore regressions failed because the v1 parser accepted an
+  unknown manifest-root field and an unknown `overall_digest` field. The first
+  remained acceptable after an attacker recomputed the self-consistent digest;
+  the second was outside the digest preimage entirely. Both malformed archives
+  were extracted instead of refused.
+- Green: v1 admission now requires the exact manifest-root and digest-object
+  field sets. Both malformed forms fail with the same content-free
+  `INVALID_MANIFEST` result before staging, while archive bytes and the existing
+  destination parent remain byte-identical.
+- This is a bounded part of task 1.8 and does not mark that task complete; its
+  wider path, entry-type, resource, and runtime-state adversarial matrix remains
+  explicit work. No live vault or artifact store is touched.
+- Python 3.13 focused/adjoining gate:
+  `tests/test_hosted_portability.py` and `tests/test_consolidation_intake.py` ->
+  `133 passed`. Touched-file Ruff, repository `F` lint, `uv lock --check`, strict
+  change validation, all OpenSpec validation (`168 passed, 0 failed`), public
+  repository artifact validation (`3396 files, 3464 text payloads`), and
+  `git diff --check` are green.

--- a/src/exomem/hosted_portability.py
+++ b/src/exomem/hosted_portability.py
@@ -1075,6 +1075,8 @@ def _require_manifest_shape(manifest: Any) -> dict[str, Any]:
             "UNSUPPORTED_CLASSIFICATION_VERSION", "classification registry version is not supported"
         )
     required = {
+        "schema_version",
+        "classification_version",
         "archive_format",
         "cell_id",
         "vault_id",
@@ -1085,8 +1087,8 @@ def _require_manifest_shape(manifest: Any) -> dict[str, Any]:
         "signature",
         "overall_digest",
     }
-    if not required.issubset(manifest):
-        _fail("INVALID_MANIFEST", "manifest is missing required fields")
+    if set(manifest) != required:
+        _fail("INVALID_MANIFEST", "manifest fields do not match the supported schema")
     if manifest["archive_format"] != ARCHIVE_FORMAT:
         _fail("UNSUPPORTED_ARCHIVE_FORMAT", "archive format is not supported")
     for field in ("cell_id", "vault_id", "operation_id"):
@@ -1104,6 +1106,7 @@ def _require_manifest_shape(manifest: Any) -> dict[str, Any]:
     overall = manifest["overall_digest"]
     if (
         not isinstance(overall, dict)
+        or set(overall) != {"algorithm", "value"}
         or overall.get("algorithm") != "sha256"
         or not isinstance(overall.get("value"), str)
         or not _SHA256_RE.fullmatch(overall["value"])

--- a/tests/test_hosted_portability.py
+++ b/tests/test_hosted_portability.py
@@ -91,6 +91,37 @@ def _raw_zip(
                 archive.writestr(info, body)
 
 
+def _rewrite_export_manifest(
+    source: Path,
+    destination: Path,
+    *,
+    unknown_at: str,
+) -> None:
+    with zipfile.ZipFile(source, "r") as archive:
+        entries = [(info.filename, archive.read(info), None) for info in archive.infolist()]
+    manifest_index = next(
+        index
+        for index, (name, _body, _mode) in enumerate(entries)
+        if name == portability.MANIFEST_NAME
+    )
+    manifest = json.loads(entries[manifest_index][1])
+    if unknown_at == "manifest":
+        manifest["unsupported_extension"] = "must-not-be-accepted"
+        digest_payload = dict(manifest)
+        digest_payload.pop("overall_digest")
+        manifest["overall_digest"]["value"] = portability._manifest_digest(digest_payload)
+    elif unknown_at == "overall_digest":
+        manifest["overall_digest"]["unsupported_extension"] = "not-covered-by-digest"
+    else:  # pragma: no cover - test helper misuse
+        raise AssertionError(f"unknown mutation target: {unknown_at}")
+    entries[manifest_index] = (
+        portability.MANIFEST_NAME,
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode("utf-8"),
+        None,
+    )
+    _raw_zip(destination, entries)
+
+
 @pytest.mark.parametrize(
     ("path", "expected"),
     [
@@ -509,6 +540,47 @@ def test_archive_verification_rejects_unsupported_manifest_version(tmp_path: Pat
         portability.verify_export_archive(archive)
 
     assert _error_code(exc) == "UNSUPPORTED_MANIFEST_VERSION"
+
+
+@pytest.mark.parametrize("unknown_at", ["manifest", "overall_digest"])
+def test_restore_rejects_unknown_manifest_fields_without_mutating_inputs(
+    tmp_path: Path,
+    unknown_at: str,
+) -> None:
+    source = tmp_path / "source"
+    _seed_vault(source, "closed manifest")
+    exported = portability.export_quiesced_vault(
+        source,
+        tmp_path / "artifacts",
+        context=_context(),
+    )
+    archive = tmp_path / f"unknown-{unknown_at}.zip"
+    _rewrite_export_manifest(exported.archive_path, archive, unknown_at=unknown_at)
+    archive_before = archive.read_bytes()
+    restore_parent = tmp_path / "restore-parent"
+    _write(restore_parent / "sentinel.txt", "must remain unchanged\n")
+    destination = restore_parent / "candidate"
+    parent_before = {
+        path.relative_to(restore_parent).as_posix(): path.read_bytes()
+        for path in restore_parent.rglob("*")
+        if path.is_file()
+    }
+
+    with pytest.raises(portability.PortabilityError) as exc:
+        portability.prepare_restore(
+            archive,
+            destination,
+            context=_context(lifecycle_state="restore-staging"),
+        )
+
+    assert _error_code(exc) == "INVALID_MANIFEST"
+    assert archive.read_bytes() == archive_before
+    assert not destination.exists()
+    assert {
+        path.relative_to(restore_parent).as_posix(): path.read_bytes()
+        for path in restore_parent.rglob("*")
+        if path.is_file()
+    } == parent_before
 
 
 def test_manifest_rejects_a_non_null_signature_algorithm_even_without_value(


### PR DESCRIPTION
## Summary

- require the exact v1 portability manifest root fields
- require the exact `overall_digest` object fields
- prove malformed archives fail before staging without changing the archive or destination parent

Stacked after #906. This is a bounded part of governed-consolidation task 1.8; it does not mark the full portability fuzz matrix complete and does not touch a live vault.

## Why

The existing parser accepted unknown root fields when an attacker recomputed the self-consistent digest. It also accepted unknown `overall_digest` fields that were outside the digest preimage entirely. Both malformed archives proceeded through restore extraction.

## Verification

- red-first: 2 expected failures; both malformed archives were accepted before the fix
- Python 3.13 focused/adjoining: 133 passed
- touched-file Ruff: pass
- repository `F` lint: pass
- `uv lock --check`: pass
- `openspec validate add-governed-vault-consolidation --strict`: pass
- `openspec validate --all --strict`: 168 passed, 0 failed
- public repository artifact validation: 3396 files, 3464 text payloads
- `git diff --check`: pass
