### PR TITLE
fix(governance): reject nonportable archive metadata

### DIFF
--- a/openspec/changes/add-governed-vault-consolidation/verification.md
+++ b/openspec/changes/add-governed-vault-consolidation/verification.md
@@ -212,3 +212,21 @@ completion does not authorize rehearsal, cutover, or retirement.
   change validation, all OpenSpec validation (`168 passed, 0 failed`), public
   repository artifact validation (`3396 files, 3464 text payloads`), and
   `git diff --check` are green.
+
+## Portable archive-metadata stack
+
+- Red: five Windows-unsafe component forms and an unmanifested per-entry ZIP
+  comment all reached manifest parsing. The path corpus included alternate-data-
+  stream syntax, reserved device names, trailing dot/space aliases, and a control
+  byte.
+- Green: normalized archive paths now reject the closed Windows-invalid
+  character/device/ending set on every host, and preflight rejects any per-entry
+  comment as metadata outside the export format. Existing POSIX path, link,
+  collision, compression, and resource checks remain unchanged.
+- Python 3.13 focused/adjoining gate:
+  `tests/test_hosted_portability.py` and `tests/test_consolidation_intake.py` ->
+  `141 passed`. Touched-file Ruff, repository `F` lint, `uv lock --check`, strict
+  change validation, public repository artifact validation (`3396 files, 3464
+  text payloads`), and `git diff --check` are green. This is another bounded
+  part of task 1.8; the full forged-runtime and resource-refusal matrix remains
+  explicit and no live vault is touched.

--- a/src/exomem/hosted_portability.py
+++ b/src/exomem/hosted_portability.py
@@ -38,6 +38,10 @@ _ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 _WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+_WINDOWS_RESERVED_COMPONENT_RE = re.compile(
+    r"^(?:CON|PRN|AUX|NUL|CONIN\$|CONOUT\$|COM[1-9¹²³]|LPT[1-9¹²³])(?:\..*)?$",
+    re.IGNORECASE,
+)
 _EXPORT_REF_RE = re.compile(r"^exomem-export://sha256/[0-9a-f]{64}$")
 
 
@@ -486,6 +490,13 @@ def _normalized_relative_path(path: str) -> str:
         or any(part in {"", ".", ".."} for part in path.split("/"))
     ):
         _fail("UNSAFE_ARCHIVE_PATH", "archive paths must remain beneath the vault root")
+    for part in candidate.parts:
+        if (
+            part.endswith((".", " "))
+            or _WINDOWS_RESERVED_COMPONENT_RE.fullmatch(part)
+            or any(ord(character) < 32 or character in '<>:"|?*' for character in part)
+        ):
+            _fail("UNSAFE_ARCHIVE_PATH", "archive path contains a non-portable component")
     return candidate.as_posix()
 
 
@@ -1029,6 +1040,7 @@ def _preflight_entries(
             info.is_dir()
             or not _entry_type_is_safe(info)
             or not _entry_extra_fields_are_safe(info)
+            or bool(info.comment)
             or info.flag_bits & 0x1
         ):
             _fail("UNSAFE_ARCHIVE_ENTRY", "archive contains a link or unsupported entry type")

--- a/tests/test_hosted_portability.py
+++ b/tests/test_hosted_portability.py
@@ -528,6 +528,50 @@ def test_archive_verification_rejects_unsafe_entry_shapes(
     assert _error_code(exc) == code
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "Knowledge Base/note.md:alternate-stream",
+        "Knowledge Base/CON.md",
+        "Knowledge Base/CONOUT$",
+        "Knowledge Base/COM¹.txt",
+        "Knowledge Base/trailing-dot.",
+        "Knowledge Base/trailing-space ",
+        "Knowledge Base/control-\x1f.md",
+    ],
+)
+def test_archive_verification_rejects_windows_unsafe_path_components(
+    tmp_path: Path,
+    path: str,
+) -> None:
+    archive = tmp_path / "windows-unsafe.zip"
+    _raw_zip(
+        archive,
+        [
+            (portability.MANIFEST_NAME, b"{}", None),
+            (path, b"unsafe", None),
+        ],
+    )
+
+    with pytest.raises(portability.PortabilityError) as exc:
+        portability.verify_export_archive(archive)
+
+    assert _error_code(exc) == "UNSAFE_ARCHIVE_PATH"
+
+
+def test_archive_verification_rejects_unmanifested_entry_comments(tmp_path: Path) -> None:
+    archive_path = tmp_path / "entry-comment.zip"
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_STORED) as archive:
+        manifest = zipfile.ZipInfo(portability.MANIFEST_NAME)
+        manifest.comment = b"unmanifested metadata"
+        archive.writestr(manifest, b"{}")
+
+    with pytest.raises(portability.PortabilityError) as exc:
+        portability.verify_export_archive(archive_path)
+
+    assert _error_code(exc) == "UNSAFE_ARCHIVE_ENTRY"
+
+
 def test_archive_verification_rejects_unsupported_manifest_version(tmp_path: Path) -> None:
     archive = tmp_path / "future.zip"
     manifest = {"schema_version": 999, "files": []}


### PR DESCRIPTION
## Summary

- reject Windows-unsafe archive components on every host, including alternate streams, reserved devices, trailing dot/space aliases, and control bytes
- reject per-entry ZIP comments because they are outside the versioned manifest and its digest
- add red-first regressions without touching restore publication or any live vault

Stacked after #908. This is another bounded part of governed-consolidation task 1.8; the forged runtime/resource refusal matrix remains separate work.

## Why

A Linux-built archive could carry path components that alias, fail, or become alternate streams during Windows restore. ZIP entry comments also allowed unmanifested bytes outside the archive format. Both classes previously reached manifest parsing instead of structural refusal.

## Verification

- red-first: 7 expected path failures plus 1 entry-comment failure before implementation
- Python 3.13 focused/adjoining: 141 passed
- touched-file Ruff: pass
- repository `F` lint: pass
- `uv lock --check`: pass
- `openspec validate add-governed-vault-consolidation --strict`: pass
- `openspec validate --all --strict`: 168 passed, 0 failed
- public repository artifact validation: 3396 files, 3464 text payloads
- `git diff --check`: pass
