### PR TITLE
feat(governance): add private consolidation intake

### DIFF
--- a/openspec/changes/add-governed-vault-consolidation/tasks.md
+++ b/openspec/changes/add-governed-vault-consolidation/tasks.md
@@ -101,11 +101,11 @@
   duplicate normalized paths, case collisions, unsupported entries, source
   runtime/credential/lifecycle/lease/idempotency/log state, and source-derived
   indexes. Assert the destination and archive are unchanged on every refusal.
-- [ ] 1.9 Add red tests proving intake accepts only opaque archive/proof references,
+- [x] 1.9 Add red tests proving intake accepts only opaque archive/proof references,
   rejects inline archive bytes and active-root or `Knowledge Base/` extraction,
   cannot use a live source MCP crawl as a complete inventory, and returns only
   bounded inventory facts plus content hashes from private extraction.
-- [ ] 1.10 Extend the portability export seam to calculate the canonical source
+- [x] 1.10 Extend the portability export seam to calculate the canonical source
   census and issue/accept Ed25519 detached claims through configured verifier
   records/rotation, or the equally exact named control receipt. Hosted binds its
   distinct typed cell id; local omits that Hosted-only field and uses its
@@ -113,11 +113,11 @@
   `hosted_portability` manifest verification and extraction rules; exclude private
   identity/key state from the archive and do not add a second archive format or
   caller-selected trust.
-- [ ] 1.11 Add a reusable consolidation intake adapter that writes only to the
+- [x] 1.11 Add a reusable consolidation intake adapter that writes only to the
   private artifact abstraction, keeps the archive immutable and content-addressed,
   and never calls restore publication or overlays a destination root. Verify the
   archive and source census are byte-identical before and after every test.
-- [ ] 1.12 Run the red/green identity/intake set plus existing portability/restore
+- [x] 1.12 Run the red/green identity/intake set plus existing portability/restore
   regressions:
   `uv run python -m pytest -q tests/test_consolidation_cell_identity.py tests/test_consolidation_intake.py tests/test_hosted_binding_v2.py tests/test_hosted_portability.py tests/test_hosted_restore_candidate.py`.
 

--- a/src/exomem/governance/consolidation_intake.py
+++ b/src/exomem/governance/consolidation_intake.py
@@ -1,0 +1,527 @@
+"""Opaque, authenticated, private intake for governed vault consolidation.
+
+This module is deliberately below the product command.  Public requests carry
+only opaque archive/proof references; a configured resolver supplies their
+private bytes and trust records.  Verified source bytes are copied into a
+content-addressed private store, never restored into a vault or exposed through
+ordinary recall.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Protocol
+
+from .. import hosted_portability
+from . import authorization_custody, consolidation_attestation
+
+_ARCHIVE_REF = re.compile(r"exomem-export://sha256/([0-9a-f]{64})\Z")
+_SOURCE_PROOF_REF = re.compile(r"exomem-source-attestation://sha256/([0-9a-f]{64})\Z")
+_PRIVATE_ARCHIVE_REF = re.compile(
+    r"exomem-consolidation-archive://sha256/([0-9a-f]{64})\Z"
+)
+_PRIVATE_PROOF_REF = re.compile(
+    r"exomem-consolidation-proof://sha256/([0-9a-f]{64})\Z"
+)
+_PRIVATE_OBJECT_REF = re.compile(
+    r"exomem-consolidation-object://sha256/([0-9a-f]{64})\Z"
+)
+
+
+class ConsolidationIntakeUnavailable(RuntimeError):
+    """Stable, content-free refusal at the private intake boundary."""
+
+    code = "CONSOLIDATION_INTAKE_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__("consolidation intake is unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationIntakeRequest:
+    source_artifact_ref: str
+    source_attestation_ref: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedSourceExportProof:
+    """Proof and trust facts returned by a configured private resolver."""
+
+    claim_bytes: bytes
+    signature: str
+    expectation: consolidation_attestation.SourceExportExpectation
+    verifier_records: tuple[consolidation_attestation.SourceExportVerifierRecord, ...]
+
+
+class ConsolidationIntakeResolver(Protocol):
+    """Private control-plane resolver; never implemented by request content."""
+
+    def resolve_archive(self, reference: str) -> Path: ...
+
+    def resolve_source_proof(self, reference: str) -> ResolvedSourceExportProof: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationInventoryItem:
+    path: str
+    size: int
+    sha256: str
+    classification: str
+    artifact_ref: str
+
+    def to_bounded_dict(self) -> dict[str, str | int]:
+        return {
+            "path": self.path,
+            "size": self.size,
+            "sha256": self.sha256,
+            "classification": self.classification,
+            "artifact_ref": self.artifact_ref,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationIntakeResult:
+    archive_artifact_ref: str
+    archive_sha256: str
+    manifest_sha256: str
+    source_census_sha256: str
+    source_proof_artifact_ref: str
+    source_proof_digest: str
+    source_claims_digest: str
+    object_count: int
+    total_bytes: int
+    inventory: tuple[ConsolidationInventoryItem, ...]
+
+    def to_bounded_dict(self) -> dict[str, object]:
+        return {
+            "archive_artifact_ref": self.archive_artifact_ref,
+            "archive_sha256": self.archive_sha256,
+            "manifest_sha256": self.manifest_sha256,
+            "source_census_sha256": self.source_census_sha256,
+            "source_proof_artifact_ref": self.source_proof_artifact_ref,
+            "source_proof_digest": self.source_proof_digest,
+            "source_claims_digest": self.source_claims_digest,
+            "object_count": self.object_count,
+            "total_bytes": self.total_bytes,
+            "inventory": [item.to_bounded_dict() for item in self.inventory],
+        }
+
+
+def _proof_bytes(claim_bytes: bytes, signature: str) -> bytes:
+    if not isinstance(claim_bytes, bytes) or not isinstance(signature, str):
+        raise ConsolidationIntakeUnavailable
+    try:
+        value = {
+            "claim_bytes": base64.urlsafe_b64encode(claim_bytes)
+            .decode("ascii")
+            .rstrip("="),
+            "signature": signature,
+        }
+        return json.dumps(
+            value,
+            ensure_ascii=True,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("ascii")
+    except (TypeError, ValueError, UnicodeError):
+        raise ConsolidationIntakeUnavailable from None
+
+
+def detached_source_proof_digest(claim_bytes: bytes, signature: str) -> str:
+    return hashlib.sha256(_proof_bytes(claim_bytes, signature)).hexdigest()
+
+
+def _content_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            while chunk := handle.read(1024 * 1024):
+                digest.update(chunk)
+    except OSError:
+        raise ConsolidationIntakeUnavailable from None
+    return digest.hexdigest()
+
+
+def _overlap(left: Path, right: Path) -> bool:
+    try:
+        left.relative_to(right)
+        return True
+    except ValueError:
+        pass
+    try:
+        right.relative_to(left)
+        return True
+    except ValueError:
+        return False
+
+
+def _existing_ancestor_is_unsafe(path: Path) -> bool:
+    reparse = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    for current in (path, *path.parents):
+        if not os.path.lexists(current):
+            continue
+        try:
+            info = current.lstat()
+        except OSError:
+            return True
+        if stat.S_ISLNK(info.st_mode) or bool(
+            getattr(info, "st_file_attributes", 0) & reparse
+        ):
+            return True
+    return False
+
+
+def _ensure_private_directory(path: Path) -> None:
+    if _existing_ancestor_is_unsafe(path):
+        raise ConsolidationIntakeUnavailable
+    try:
+        authorization_custody._prepare_private_directory(path)  # noqa: SLF001
+        info = path.lstat()
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+            raise ConsolidationIntakeUnavailable
+        if os.name != "nt" and (
+            info.st_uid != os.geteuid() or stat.S_IMODE(info.st_mode) & 0o077
+        ):
+            raise ConsolidationIntakeUnavailable
+    except ConsolidationIntakeUnavailable:
+        raise
+    except (authorization_custody.AuthorizationCustodyUnavailable, OSError):
+        raise ConsolidationIntakeUnavailable from None
+
+
+def _fsync_file(path: Path) -> None:
+    try:
+        with path.open("r+b") as handle:
+            os.fsync(handle.fileno())
+    except OSError:
+        raise ConsolidationIntakeUnavailable from None
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        if os.name == "nt":
+            return
+        raise ConsolidationIntakeUnavailable from None
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        if os.name != "nt":
+            raise ConsolidationIntakeUnavailable from None
+    finally:
+        os.close(descriptor)
+
+
+class PrivateConsolidationArtifactStore:
+    """Durable private content-addressed store outside every active vault."""
+
+    def __init__(self, root: Path | str, *, active_vault_roots: tuple[Path | str, ...]):
+        if not isinstance(active_vault_roots, tuple):
+            raise ConsolidationIntakeUnavailable
+        self.root = Path(root).absolute()
+        try:
+            resolved_root = self.root.resolve(strict=False)
+            active = tuple(
+                Path(item).absolute().resolve(strict=False)
+                for item in active_vault_roots
+            )
+        except (OSError, RuntimeError, ValueError):
+            raise ConsolidationIntakeUnavailable from None
+        if any(part.casefold() == "knowledge base" for part in resolved_root.parts) or any(
+            _overlap(resolved_root, item) for item in active
+        ):
+            raise ConsolidationIntakeUnavailable
+        if _existing_ancestor_is_unsafe(self.root):
+            raise ConsolidationIntakeUnavailable
+        self._active_vault_roots = active
+
+    def _ensure(self) -> None:
+        _ensure_private_directory(self.root)
+        for name in ("archives", "proofs", "objects"):
+            _ensure_private_directory(self.root / name)
+
+    def _object_path(self, digest: str) -> Path:
+        return self.root / "objects" / digest[:2] / digest
+
+    def _resolve(
+        self,
+        reference: str,
+        *,
+        pattern: re.Pattern[str],
+        directory: str,
+        suffix: str,
+    ) -> Path:
+        match = pattern.fullmatch(reference) if isinstance(reference, str) else None
+        if match is None:
+            raise ConsolidationIntakeUnavailable
+        digest = match.group(1)
+        path = (
+            self._object_path(digest)
+            if directory == "objects"
+            else self.root / directory / f"{digest}{suffix}"
+        )
+        try:
+            info = path.lstat()
+        except OSError:
+            raise ConsolidationIntakeUnavailable from None
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+            raise ConsolidationIntakeUnavailable
+        if os.name != "nt" and (
+            info.st_uid != os.geteuid() or stat.S_IMODE(info.st_mode) & 0o077
+        ):
+            raise ConsolidationIntakeUnavailable
+        if _content_digest(path) != digest:
+            raise ConsolidationIntakeUnavailable
+        return path
+
+    def resolve_object(self, reference: str) -> Path:
+        return self._resolve(
+            reference,
+            pattern=_PRIVATE_OBJECT_REF,
+            directory="objects",
+            suffix="",
+        )
+
+    def resolve_archive(self, reference: str) -> Path:
+        return self._resolve(
+            reference,
+            pattern=_PRIVATE_ARCHIVE_REF,
+            directory="archives",
+            suffix=".zip",
+        )
+
+    def resolve_source_proof(self, reference: str) -> Path:
+        return self._resolve(
+            reference,
+            pattern=_PRIVATE_PROOF_REF,
+            directory="proofs",
+            suffix=".json",
+        )
+
+    def _install(self, staged: Path, destination: Path, expected_digest: str) -> None:
+        _ensure_private_directory(destination.parent)
+        try:
+            os.chmod(staged, 0o600)
+            info = staged.lstat()
+            if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+                raise ConsolidationIntakeUnavailable
+            if _content_digest(staged) != expected_digest:
+                raise ConsolidationIntakeUnavailable
+            try:
+                os.link(staged, destination)
+                created = True
+            except FileExistsError:
+                created = False
+            if not created:
+                existing = destination.lstat()
+                if stat.S_ISLNK(existing.st_mode) or not stat.S_ISREG(existing.st_mode):
+                    raise ConsolidationIntakeUnavailable
+                if _content_digest(destination) != expected_digest:
+                    raise ConsolidationIntakeUnavailable
+            _fsync_file(destination)
+            _fsync_directory(destination.parent)
+        except ConsolidationIntakeUnavailable:
+            raise
+        except OSError:
+            raise ConsolidationIntakeUnavailable from None
+
+
+def _request_refs(request: ConsolidationIntakeRequest) -> tuple[str, str]:
+    if not isinstance(request, ConsolidationIntakeRequest):
+        raise ConsolidationIntakeUnavailable
+    archive = request.source_artifact_ref
+    proof = request.source_attestation_ref
+    if (
+        not isinstance(archive, str)
+        or _ARCHIVE_REF.fullmatch(archive) is None
+        or not isinstance(proof, str)
+        or _SOURCE_PROOF_REF.fullmatch(proof) is None
+    ):
+        raise ConsolidationIntakeUnavailable
+    return archive, proof
+
+
+def _resolved_proof(
+    value: object,
+) -> ResolvedSourceExportProof:
+    if not isinstance(value, ResolvedSourceExportProof):
+        raise ConsolidationIntakeUnavailable
+    if not isinstance(value.claim_bytes, bytes) or not isinstance(value.signature, str):
+        raise ConsolidationIntakeUnavailable
+    if not isinstance(value.expectation, consolidation_attestation.SourceExportExpectation):
+        raise ConsolidationIntakeUnavailable
+    if not isinstance(value.verifier_records, tuple):
+        raise ConsolidationIntakeUnavailable
+    return value
+
+
+def intake_source_export(
+    request: ConsolidationIntakeRequest,
+    *,
+    resolver: ConsolidationIntakeResolver,
+    artifact_store: PrivateConsolidationArtifactStore,
+    verified_at: str,
+    limits: hosted_portability.PortabilityLimits | None = None,
+) -> ConsolidationIntakeResult:
+    """Resolve, authenticate, and privately content-address one source export."""
+
+    archive_ref, proof_ref = _request_refs(request)
+    if not isinstance(artifact_store, PrivateConsolidationArtifactStore):
+        raise ConsolidationIntakeUnavailable
+    try:
+        archive_path = resolver.resolve_archive(archive_ref)
+        proof = _resolved_proof(resolver.resolve_source_proof(proof_ref))
+    except ConsolidationIntakeUnavailable:
+        raise
+    except Exception:  # noqa: BLE001 - private resolver failures share one refusal
+        raise ConsolidationIntakeUnavailable from None
+
+    archive_match = _ARCHIVE_REF.fullmatch(archive_ref)
+    proof_match = _SOURCE_PROOF_REF.fullmatch(proof_ref)
+    assert archive_match is not None and proof_match is not None
+    if detached_source_proof_digest(proof.claim_bytes, proof.signature) != proof_match.group(1):
+        raise ConsolidationIntakeUnavailable
+
+    try:
+        verified = hosted_portability.verify_export_archive(
+            archive_path,
+            expected_cell_id=proof.expectation.source_cell_id,
+            expected_vault_id=proof.expectation.source_vault_id,
+            limits=limits,
+        )
+        census = hosted_portability.canonical_source_census_sha256(verified.manifest)
+        if (
+            verified.archive_sha256 != archive_match.group(1)
+            or verified.archive_sha256 != proof.expectation.archive_sha256
+            or str(verified.manifest["overall_digest"]["value"])
+            != proof.expectation.manifest_sha256
+            or census != proof.expectation.source_census_sha256
+        ):
+            raise ConsolidationIntakeUnavailable
+        trusted = consolidation_attestation.verify_source_export_attestation(
+            proof.claim_bytes,
+            proof.signature,
+            proof.verifier_records,
+            expectation=proof.expectation,
+            verified_at=verified_at,
+            verification_gate="intake",
+        )
+    except ConsolidationIntakeUnavailable:
+        raise
+    except (
+        hosted_portability.PortabilityError,
+        consolidation_attestation.SourceExportAttestationUnavailable,
+        KeyError,
+        TypeError,
+        ValueError,
+    ):
+        raise ConsolidationIntakeUnavailable from None
+
+    artifact_store._ensure()
+    transaction = Path(tempfile.mkdtemp(prefix=".intake-", dir=artifact_store.root))
+    try:
+        os.chmod(transaction, 0o700)
+        archive_copy = transaction / "archive.zip"
+        shutil.copyfile(verified.archive_path, archive_copy)
+        os.chmod(archive_copy, 0o600)
+        _fsync_file(archive_copy)
+        copied = hosted_portability.verify_export_archive(
+            archive_copy,
+            expected_cell_id=proof.expectation.source_cell_id,
+            expected_vault_id=proof.expectation.source_vault_id,
+            limits=limits,
+        )
+        if copied.archive_sha256 != verified.archive_sha256 or copied.manifest != verified.manifest:
+            raise ConsolidationIntakeUnavailable
+
+        extracted_root = transaction / "extracted"
+        extracted = hosted_portability.extract_verified_archive(
+            copied,
+            extracted_root,
+            limits=limits,
+        )
+
+        proof_bytes = _proof_bytes(proof.claim_bytes, proof.signature)
+        proof_digest = hashlib.sha256(proof_bytes).hexdigest()
+        proof_path = transaction / "proof.json"
+        proof_path.write_bytes(proof_bytes)
+        os.chmod(proof_path, 0o600)
+        _fsync_file(proof_path)
+
+        inventory: list[ConsolidationInventoryItem] = []
+        for record in copied.manifest["files"]:
+            relative = str(record["path"])
+            source = extracted.staging_root.joinpath(*PurePosixPath(relative).parts)
+            digest = str(record["sha256"])
+            destination = artifact_store._object_path(digest)
+            artifact_store._install(source, destination, digest)
+            inventory.append(
+                ConsolidationInventoryItem(
+                    path=relative,
+                    size=int(record["size"]),
+                    sha256=digest,
+                    classification=str(record["classification"]),
+                    artifact_ref=f"exomem-consolidation-object://sha256/{digest}",
+                )
+            )
+
+        archive_destination = (
+            artifact_store.root / "archives" / f"{verified.archive_sha256}.zip"
+        )
+        artifact_store._install(
+            archive_copy,
+            archive_destination,
+            verified.archive_sha256,
+        )
+        proof_destination = artifact_store.root / "proofs" / f"{proof_digest}.json"
+        artifact_store._install(proof_path, proof_destination, proof_digest)
+
+        _fsync_directory(artifact_store.root)
+        result = ConsolidationIntakeResult(
+            archive_artifact_ref=(
+                f"exomem-consolidation-archive://sha256/{verified.archive_sha256}"
+            ),
+            archive_sha256=verified.archive_sha256,
+            manifest_sha256=str(verified.manifest["overall_digest"]["value"]),
+            source_census_sha256=census,
+            source_proof_artifact_ref=(
+                f"exomem-consolidation-proof://sha256/{proof_digest}"
+            ),
+            source_proof_digest=proof_digest,
+            source_claims_digest=trusted.claims_sha256,
+            object_count=len(inventory),
+            total_bytes=sum(item.size for item in inventory),
+            inventory=tuple(inventory),
+        )
+    except ConsolidationIntakeUnavailable:
+        raise
+    except Exception:  # noqa: BLE001 - intake never exposes private failure details
+        raise ConsolidationIntakeUnavailable from None
+    finally:
+        shutil.rmtree(transaction, ignore_errors=True)
+    return result
+
+
+__all__ = [
+    "ConsolidationIntakeRequest",
+    "ConsolidationIntakeResolver",
+    "ConsolidationIntakeResult",
+    "ConsolidationIntakeUnavailable",
+    "ConsolidationInventoryItem",
+    "PrivateConsolidationArtifactStore",
+    "ResolvedSourceExportProof",
+    "detached_source_proof_digest",
+    "intake_source_export",
+]

--- a/src/exomem/hosted_portability.py
+++ b/src/exomem/hosted_portability.py
@@ -358,6 +358,7 @@ class ExportResult:
     archive_format: str
     artifact_reference: str
     manifest: dict[str, Any]
+    source_census_sha256: str
 
     @property
     def manifest_sha256(self) -> str:
@@ -381,6 +382,16 @@ class PreparedRestore:
     manifest: dict[str, Any]
     context: PortabilityContext
     state: str = "prepared"
+
+
+@dataclass(frozen=True, slots=True)
+class ExtractedArchive:
+    """Verified archive bytes extracted into a new, non-published directory."""
+
+    staging_root: Path
+    source_archive: Path
+    archive_sha256: str
+    manifest: dict[str, Any]
 
 
 @dataclass(frozen=True, slots=True)
@@ -731,16 +742,48 @@ def canonical_vault_fingerprint(
     repeated = records(_enumerate_source(vault_root, effective_limits))
     if repeated != first:
         _fail("SOURCE_CHANGED_DURING_EXPORT", "the vault changed during fingerprinting")
+    return _source_census_sha256(first)
+
+
+def _source_census_sha256(records: Iterable[Mapping[str, Any]]) -> str:
     return _sha256_bytes(
         _canonical_json(
             {
                 "artifact": "exomem-hosted-canonical-vault",
                 "schema_version": 1,
                 "classification_version": CLASSIFICATION_VERSION,
-                "files": first,
+                "files": [dict(record) for record in records],
             }
         )
     )
+
+
+def canonical_source_census_sha256(manifest: Mapping[str, Any]) -> str:
+    """Derive the export's exact canonical source census from its file records.
+
+    Callers authenticate this digest separately from the archive.  The archive
+    and manifest digests still cover every admitted byte; this census is the
+    stable content inventory used by consolidation identity and drift checks.
+    """
+
+    if not isinstance(manifest, Mapping):
+        _fail("INVALID_MANIFEST", "manifest root must be an object")
+    files = manifest.get("files")
+    if not isinstance(files, list):
+        _fail("INVALID_MANIFEST", "manifest files must be a list")
+    records: list[dict[str, Any]] = []
+    for raw_record in files:
+        if not isinstance(raw_record, dict) or set(raw_record) != {
+            "path",
+            "size",
+            "sha256",
+            "classification",
+        }:
+            _fail("INVALID_MANIFEST", "manifest file record is invalid")
+        records.append(dict(raw_record))
+    if [record["path"] for record in records] != sorted(record["path"] for record in records):
+        _fail("INVALID_MANIFEST", "manifest file records must be sorted")
+    return _source_census_sha256(records)
 
 
 def _zip_info(path: str) -> zipfile.ZipInfo:
@@ -915,6 +958,15 @@ def export_quiesced_vault(
         archive_format=ARCHIVE_FORMAT,
         artifact_reference=f"exomem-export://sha256/{verified.archive_sha256}",
         manifest=verified.manifest,
+        source_census_sha256=_source_census_sha256(
+            {
+                "path": item.path,
+                "size": item.size,
+                "sha256": item.sha256,
+                "classification": item.classification,
+            }
+            for item in snapshots
+        ),
     )
 
 
@@ -1342,6 +1394,66 @@ def _verify_staged_files(
             _fail("STAGING_DIGEST_MISMATCH", "canonical staged bytes do not match the manifest")
 
 
+def extract_verified_archive(
+    verified: VerifiedArchive,
+    staging_root: Path | str,
+    *,
+    limits: PortabilityLimits | None = None,
+) -> ExtractedArchive:
+    """Extract exact verified bytes into a new directory without publishing them."""
+
+    if not isinstance(verified, VerifiedArchive):
+        _fail("INVALID_ARCHIVE", "verified archive has the wrong type")
+    expected_cell_id = verified.manifest.get("cell_id")
+    expected_vault_id = verified.manifest.get("vault_id")
+    before = verify_export_archive(
+        verified.archive_path,
+        expected_cell_id=expected_cell_id,
+        expected_vault_id=expected_vault_id,
+        limits=limits,
+    )
+    if (
+        before.archive_sha256 != verified.archive_sha256
+        or before.archive_size != verified.archive_size
+        or before.manifest != verified.manifest
+    ):
+        _fail("ARCHIVE_CHANGED", "verified archive changed before extraction")
+
+    destination = Path(staging_root).absolute()
+    if os.path.lexists(destination):
+        _fail("STAGING_ROOT_EXISTS", "extraction staging root must be new")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{destination.name}-", dir=destination.parent))
+    try:
+        _extract_verified_archive(before.archive_path, before.manifest["files"], temporary)
+        _verify_staged_files(temporary, before.manifest)
+        after = verify_export_archive(
+            before.archive_path,
+            expected_cell_id=expected_cell_id,
+            expected_vault_id=expected_vault_id,
+            limits=limits,
+        )
+        if (
+            after.archive_sha256 != before.archive_sha256
+            or after.archive_size != before.archive_size
+            or after.manifest != before.manifest
+        ):
+            _fail("ARCHIVE_CHANGED", "verified archive changed during extraction")
+        if os.path.lexists(destination):
+            _fail("STAGING_ROOT_EXISTS", "extraction staging root was claimed concurrently")
+        os.rename(temporary, destination)
+        _fsync_directory(destination.parent)
+    except BaseException:
+        _remove_tree(temporary)
+        raise
+    return ExtractedArchive(
+        staging_root=destination,
+        source_archive=before.archive_path,
+        archive_sha256=before.archive_sha256,
+        manifest=before.manifest,
+    )
+
+
 def prepare_restore(
     archive_path: Path | str,
     staging_root: Path | str,
@@ -1364,24 +1476,11 @@ def prepare_restore(
         expected_vault_id=expected_source_vault_id or context.vault_id,
         limits=limits,
     )
-    destination = Path(staging_root).absolute()
-    if os.path.lexists(destination):
-        _fail("STAGING_ROOT_EXISTS", "restore staging root must be new")
     records = verified.manifest["files"]
     _verify_required_scaffold(records)
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    temporary = Path(tempfile.mkdtemp(prefix=f".{destination.name}-", dir=destination.parent))
-    try:
-        _extract_verified_archive(verified.archive_path, records, temporary)
-        _verify_staged_files(temporary, verified.manifest)
-        if os.path.lexists(destination):
-            _fail("STAGING_ROOT_EXISTS", "restore staging root was claimed concurrently")
-        os.rename(temporary, destination)
-    except BaseException:
-        _remove_tree(temporary)
-        raise
+    extracted = extract_verified_archive(verified, staging_root, limits=limits)
     return PreparedRestore(
-        staging_root=destination,
+        staging_root=extracted.staging_root,
         source_archive=verified.archive_path,
         archive_sha256=verified.archive_sha256,
         manifest=verified.manifest,
@@ -1738,6 +1837,7 @@ __all__ = [
     "MANIFEST_SCHEMA_VERSION",
     "ArtifactClass",
     "ArtifactClassification",
+    "ExtractedArchive",
     "ExportResult",
     "LifecycleCheckpoint",
     "LifecycleCheckpointStore",
@@ -1747,10 +1847,12 @@ __all__ = [
     "PreparedRestore",
     "PublishedRestore",
     "VerifiedArchive",
+    "canonical_source_census_sha256",
     "classification_registry",
     "classify_artifact",
     "canonical_vault_fingerprint",
     "export_quiesced_vault",
+    "extract_verified_archive",
     "prepare_restore",
     "publish_prepared_restore",
     "verify_export_archive",

--- a/tests/test_consolidation_intake.py
+++ b/tests/test_consolidation_intake.py
@@ -6,10 +6,14 @@ import importlib
 import inspect
 import json
 from dataclasses import replace
+from pathlib import Path
+from typing import Any
 
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from exomem import hosted_portability
 
 _SEED = bytes.fromhex("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60")
 _PUBLIC = bytes.fromhex("d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a")
@@ -449,3 +453,337 @@ def test_oversized_claims_refuse_before_json_parsing(monkeypatch: pytest.MonkeyP
     )
     with pytest.raises(attestation.SourceExportAttestationUnavailable):
         attestation.canonical_source_export_claims(oversized)
+
+
+def _intake_module():
+    try:
+        return importlib.import_module("exomem.governance.consolidation_intake")
+    except ModuleNotFoundError:
+        pytest.fail("the private consolidation intake boundary is missing")
+
+
+def _portable_vault(root: Path) -> Path:
+    vault = root / "source-vault"
+    (vault / "Knowledge Base" / "_Schema").mkdir(parents=True)
+    (vault / "Knowledge Base" / "_Schema" / "SKILL.md").write_text(
+        "# schema\n", encoding="utf-8"
+    )
+    (vault / "Knowledge Base" / "Notes").mkdir()
+    (vault / "Knowledge Base" / "Notes" / "private.md").write_text(
+        "# Private\n\nsource-only sentinel\n", encoding="utf-8"
+    )
+    (vault / "Knowledge Base" / "asset.bin").write_bytes(b"\x00\x01\x02")
+    return vault
+
+
+def _export(root: Path):
+    vault = _portable_vault(root)
+    exported = hosted_portability.export_quiesced_vault(
+        vault,
+        root / "exports",
+        context=hosted_portability.PortabilityContext(
+            cell_id="cell-source-01",
+            vault_id="vault-source-01",
+            operation_id="export-operation-01",
+            created_at="2026-08-28T09:44:00.000+00:00",
+            operator_authorized=True,
+            lifecycle_state="quiesced",
+            routing_stopped=True,
+            active_mutations=0,
+            background_writers_stopped=True,
+            reads_allowed=True,
+        ),
+    )
+    return vault, exported
+
+
+def _resolved_proof(intake, exported):
+    attestation = _attestation_module()
+    claims = _claims(source_cell_id="cell-source-01")
+    claims.update(
+        archive_sha256=exported.archive_sha256,
+        manifest_sha256=exported.manifest_sha256,
+        source_census_sha256=exported.source_census_sha256,
+    )
+    claim_bytes, signature = attestation.sign_source_export_attestation(
+        claims,
+        Ed25519PrivateKey.from_private_bytes(_SEED),
+    )
+    expectation = replace(
+        _expectation(attestation, source_cell_id="cell-source-01"),
+        archive_sha256=exported.archive_sha256,
+        manifest_sha256=exported.manifest_sha256,
+        source_census_sha256=exported.source_census_sha256,
+    )
+    proof = intake.ResolvedSourceExportProof(
+        claim_bytes=claim_bytes,
+        signature=signature,
+        expectation=expectation,
+        verifier_records=(
+            _record(attestation, source_cell_id="cell-source-01"),
+        ),
+    )
+    proof_ref = (
+        "exomem-source-attestation://sha256/"
+        + intake.detached_source_proof_digest(claim_bytes, signature)
+    )
+    return proof_ref, proof
+
+
+class _Resolver:
+    def __init__(self, *, archive_ref: str, archive_path: Path, proof_ref: str, proof: Any):
+        self.archive_ref = archive_ref
+        self.archive_path = archive_path
+        self.proof_ref = proof_ref
+        self.proof = proof
+        self.calls: list[tuple[str, str]] = []
+
+    def resolve_archive(self, reference: str) -> Path:
+        self.calls.append(("archive", reference))
+        if reference != self.archive_ref:
+            raise LookupError
+        return self.archive_path
+
+    def resolve_source_proof(self, reference: str):
+        self.calls.append(("proof", reference))
+        if reference != self.proof_ref:
+            raise LookupError
+        return self.proof
+
+
+def _intake_fixture(tmp_path: Path):
+    intake = _intake_module()
+    vault, exported = _export(tmp_path)
+    proof_ref, proof = _resolved_proof(intake, exported)
+    request = intake.ConsolidationIntakeRequest(
+        source_artifact_ref=exported.artifact_reference,
+        source_attestation_ref=proof_ref,
+    )
+    resolver = _Resolver(
+        archive_ref=exported.artifact_reference,
+        archive_path=exported.archive_path,
+        proof_ref=proof_ref,
+        proof=proof,
+    )
+    store = intake.PrivateConsolidationArtifactStore(
+        tmp_path / "private-intake",
+        active_vault_roots=(vault, tmp_path / "destination-vault"),
+    )
+    return intake, vault, exported, request, resolver, store
+
+
+def test_portable_export_carries_the_exact_current_source_census(tmp_path: Path) -> None:
+    vault, exported = _export(tmp_path)
+
+    assert exported.source_census_sha256 == hosted_portability.canonical_source_census_sha256(
+        exported.manifest
+    )
+    assert exported.source_census_sha256 == hosted_portability.canonical_vault_fingerprint(vault)
+
+    (vault / "Knowledge Base" / "Notes" / "private.md").write_text(
+        "# Private\n\nchanged after export\n", encoding="utf-8"
+    )
+    assert hosted_portability.canonical_vault_fingerprint(vault) != exported.source_census_sha256
+
+
+def test_intake_request_has_only_opaque_archive_and_proof_references() -> None:
+    intake = _intake_module()
+
+    assert tuple(inspect.signature(intake.ConsolidationIntakeRequest).parameters) == (
+        "source_artifact_ref",
+        "source_attestation_ref",
+    )
+    for forbidden in (
+        "archive",
+        "archive_bytes",
+        "archive_path",
+        "source_root",
+        "staging_root",
+        "crawler",
+        "mcp",
+        "public_key",
+    ):
+        assert forbidden not in inspect.signature(intake.intake_source_export).parameters
+
+
+@pytest.mark.parametrize(
+    ("artifact_ref", "proof_ref"),
+    (
+        ("/tmp/source.zip", "exomem-source-attestation://sha256/" + "a" * 64),
+        ("exomem-export://sha256/" + "a" * 64, "/tmp/proof.json"),
+        ("data:application/zip;base64,AAAA", "exomem-source-attestation://sha256/" + "a" * 64),
+        ("exomem-export://sha256/" + "a" * 64, "inline:{\"signature\":\"x\"}"),
+    ),
+)
+def test_intake_rejects_inline_or_path_inputs_before_resolution(
+    tmp_path: Path,
+    artifact_ref: str,
+    proof_ref: str,
+) -> None:
+    intake = _intake_module()
+
+    class NeverResolve:
+        def resolve_archive(self, _reference: str) -> Path:
+            pytest.fail("invalid archive reference reached resolution")
+
+        def resolve_source_proof(self, _reference: str):
+            pytest.fail("invalid proof reference reached resolution")
+
+    store = intake.PrivateConsolidationArtifactStore(tmp_path / "private", active_vault_roots=())
+    with pytest.raises(
+        intake.ConsolidationIntakeUnavailable,
+        match="^consolidation intake is unavailable$",
+    ):
+        intake.intake_source_export(
+            intake.ConsolidationIntakeRequest(artifact_ref, proof_ref),
+            resolver=NeverResolve(),
+            artifact_store=store,
+            verified_at="2026-08-28T10:00:00.000Z",
+        )
+
+
+@pytest.mark.parametrize("relative", ("private-intake", "Knowledge Base/private-intake"))
+def test_intake_refuses_private_extraction_beneath_an_active_vault(
+    tmp_path: Path, relative: str
+) -> None:
+    intake, vault, _exported, request, resolver, _store = _intake_fixture(tmp_path)
+
+    with pytest.raises(intake.ConsolidationIntakeUnavailable):
+        intake.PrivateConsolidationArtifactStore(
+            vault / relative,
+            active_vault_roots=(vault,),
+        )
+    assert resolver.calls == []
+
+    # The valid request still has no caller-controlled extraction target.
+    assert not hasattr(request, "staging_root")
+
+
+def test_intake_refuses_any_knowledge_base_extraction_root(tmp_path: Path) -> None:
+    intake = _intake_module()
+
+    with pytest.raises(intake.ConsolidationIntakeUnavailable):
+        intake.PrivateConsolidationArtifactStore(
+            tmp_path / "detached" / "Knowledge Base" / "private-intake",
+            active_vault_roots=(),
+        )
+
+
+def test_intake_refuses_a_private_root_beneath_a_nested_symlink(
+    tmp_path: Path,
+) -> None:
+    intake = _intake_module()
+    actual = tmp_path / "actual"
+    existing = actual / "existing"
+    existing.mkdir(parents=True)
+    alias = tmp_path / "alias"
+    try:
+        alias.symlink_to(actual, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(intake.ConsolidationIntakeUnavailable):
+        intake.PrivateConsolidationArtifactStore(
+            alias / "existing" / "private-intake",
+            active_vault_roots=(),
+        )
+
+
+def test_intake_extracts_only_private_content_addressed_objects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    intake, _vault, exported, request, resolver, store = _intake_fixture(tmp_path)
+    archive_before = exported.archive_path.read_bytes()
+    census_before = exported.source_census_sha256
+
+    monkeypatch.setattr(
+        hosted_portability,
+        "prepare_restore",
+        lambda *_args, **_kwargs: pytest.fail("consolidation called restore staging"),
+    )
+    result = intake.intake_source_export(
+        request,
+        resolver=resolver,
+        artifact_store=store,
+        verified_at="2026-08-28T10:00:00.000Z",
+    )
+
+    assert resolver.calls == [
+        ("archive", request.source_artifact_ref),
+        ("proof", request.source_attestation_ref),
+    ]
+    assert result.archive_sha256 == exported.archive_sha256
+    assert result.manifest_sha256 == exported.manifest_sha256
+    assert result.source_census_sha256 == census_before
+    assert result.object_count == len(exported.manifest["files"])
+    assert result.total_bytes == sum(item["size"] for item in exported.manifest["files"])
+    assert result.archive_artifact_ref.startswith("exomem-consolidation-archive://sha256/")
+    assert result.source_proof_artifact_ref.startswith(
+        "exomem-consolidation-proof://sha256/"
+    )
+    assert tuple(item.path for item in result.inventory) == tuple(
+        item["path"] for item in exported.manifest["files"]
+    )
+    assert all(
+        item.artifact_ref == f"exomem-consolidation-object://sha256/{item.sha256}"
+        for item in result.inventory
+    )
+    assert all(store.resolve_object(item.artifact_ref).read_bytes() for item in result.inventory)
+    assert store.resolve_archive(result.archive_artifact_ref).read_bytes() == archive_before
+    proof_bytes = store.resolve_source_proof(result.source_proof_artifact_ref).read_bytes()
+    assert hashlib.sha256(proof_bytes).hexdigest() == result.source_proof_digest
+
+    rendered = json.dumps(result.to_bounded_dict(), sort_keys=True)
+    assert "source-only sentinel" not in rendered
+    assert str(tmp_path) not in rendered
+    assert "archive_path" not in rendered
+    assert exported.archive_path.read_bytes() == archive_before
+    assert hosted_portability.canonical_source_census_sha256(exported.manifest) == census_before
+
+
+def test_intake_is_idempotent_and_deduplicates_equal_content(tmp_path: Path) -> None:
+    intake, _vault, _exported, request, resolver, store = _intake_fixture(tmp_path)
+
+    first = intake.intake_source_export(
+        request,
+        resolver=resolver,
+        artifact_store=store,
+        verified_at="2026-08-28T10:00:00.000Z",
+    )
+    second = intake.intake_source_export(
+        request,
+        resolver=resolver,
+        artifact_store=store,
+        verified_at="2026-08-28T10:00:00.000Z",
+    )
+
+    assert second == first
+    assert len(list((store.root / "archives").glob("*.zip"))) == 1
+    assert len(list((store.root / "proofs").glob("*.json"))) == 1
+    assert not list(store.root.rglob("*.partial"))
+    assert not list(store.root.rglob(".intake-*"))
+
+
+def test_intake_refuses_changed_proof_or_archive_without_publishing(
+    tmp_path: Path,
+) -> None:
+    intake, _vault, exported, request, resolver, store = _intake_fixture(tmp_path)
+    resolver.proof = replace(
+        resolver.proof,
+        expectation=replace(resolver.proof.expectation, source_census_sha256="f" * 64),
+    )
+    archive_before = exported.archive_path.read_bytes()
+
+    with pytest.raises(
+        intake.ConsolidationIntakeUnavailable,
+        match="^consolidation intake is unavailable$",
+    ):
+        intake.intake_source_export(
+            request,
+            resolver=resolver,
+            artifact_store=store,
+            verified_at="2026-08-28T10:00:00.000Z",
+        )
+
+    assert exported.archive_path.read_bytes() == archive_before
+    assert not store.root.exists() or not [path for path in store.root.rglob("*") if path.is_file()]


### PR DESCRIPTION
## Summary

- bind portability exports to an exact canonical source census
- resolve only opaque archive and detached-proof references through configured private control seams
- verify archive, census, source identity, and Ed25519 trust before private extraction
- publish immutable content-addressed archive, proof, and object artifacts without invoking restore publication or touching an active vault
- reject active-vault, `Knowledge Base`, and symlink-aliased private roots

Stacked after #911. This does not merge or touch any live vault.

## Verification

- red-first intake suite: 11 expected failures before implementation
- exact OpenSpec identity/intake/portability/restore gate: 267 passed, 2 environment-only skips
- Ruff on all changed Python files
- `uv lock --check`
- `openspec validate add-governed-vault-consolidation --strict`
- public repository artifact validation
- `git diff --check`
