### PR TITLE
fix(governance): isolate consolidation run state

### DIFF
--- a/openspec/changes/add-governed-vault-consolidation/tasks.md
+++ b/openspec/changes/add-governed-vault-consolidation/tasks.md
@@ -129,12 +129,12 @@
   identity, resumes after process restart, pages large inventories deterministically,
   and never stores an absolute artifact path, source body, conflict text, policy
   body, principal id, credential, archive bytes, or rollback-preimage bytes.
-- [ ] 2.2 Extend `tests/test_reserved_admin_paths.py` with red command-registry and
+- [x] 2.2 Extend `tests/test_reserved_admin_paths.py` with red command-registry and
   filesystem-alias coverage proving every generic read, write, move, copy, delete,
   restore, transfer, adoption, Records, media, dataset, audit, and canonical-ref
   path hides/refuses `_Consolidation` before existence/count/parse effects, while
   only a non-serializable consolidation authority can mutate it.
-- [ ] 2.3 Add red recall/index tests proving `scope="vault"`, keyword/vector/graph
+- [x] 2.3 Add red recall/index tests proving `scope="vault"`, keyword/vector/graph
   rebuilds, review queues, overview counts, resources, exports, and file watchers
   exclude run state and the entire private artifact root. Hold request input fixed
   and prove results are byte-identical with no run versus a run containing matching

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -326,17 +326,21 @@ def is_lexical_rebuild_runtime_file_name(name: str) -> bool:
 
 
 def in_excluded_scan_dir(rel_path: str) -> bool:
-    """True when any segment of `rel_path` is a reserved scan directory.
+    """True when `rel_path` is private state or has an excluded scan segment.
 
     The incremental-path counterpart of the exclusion every FULL walk applies
     (walk_vault_md, find's walker, the inbound scan): event-driven patchers
-    must not index a path their index's full rebuild would skip. The concrete
-    bug this guards: `delete_file` moves a note into `Knowledge Base/_trash/`,
-    the watcher sees that as a fresh markdown file, and the trashed content
-    gets re-embedded under its trash path — invisible to find (walks exclude
-    `_trash/`) but not to the corpus-aware near-dup sweep, which reads the raw
-    sidecar (observed 2026-07-04: dup warnings flagging trash entries).
+    must not index a path their index's full rebuild would skip. This includes
+    both the legacy excluded directory set and every family in the closed
+    private-state registry.
     """
+    # The closed private-state registry is the shared authority for both full
+    # walks and incremental events.  Checking it before the legacy name sets
+    # keeps a watcher write byte-identical to a later rebuild: operational
+    # state such as `_Consolidation/**` never enters freshness or index fanout.
+    if reserved_paths.classify_logical(rel_path).blocked:
+        return True
+
     segments = rel_path.replace("\\", "/").split("/")
     if (
         len(segments) >= 2

--- a/tests/test_consolidation_run_state_not_knowledge.py
+++ b/tests/test_consolidation_run_state_not_knowledge.py
@@ -1,0 +1,236 @@
+"""Consolidation control and private staging are operational state, not knowledge."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from exomem import (
+    attention,
+    bm25,
+    commands,
+    embeddings,
+    epistemic_graph,
+    file_watcher,
+    find_corpus,
+    hosted_portability,
+    index_paths,
+)
+from exomem import find as find_module
+from exomem import vault as vault_module
+from exomem.embedding_index import VECTOR_DIM, EmbeddingIndex
+
+SENTINEL = "zz-consolidation-private-oracle-7d91"
+
+
+def _seed_vault(vault: Path) -> None:
+    notes = vault / "Knowledge Base" / "Notes"
+    notes.mkdir(parents=True)
+    (notes / "source.md").write_text(
+        "---\ntype: insight\nstatus: active\n---\n"
+        "# Source\n\nVisible knowledge.\n\n"
+        "## Relations\n\n- supports [[Knowledge Base/Notes/target]]\n",
+        encoding="utf-8",
+    )
+    (notes / "target.md").write_text(
+        "---\ntype: insight\nstatus: active\n---\n# Target\n\nVisible target.\n",
+        encoding="utf-8",
+    )
+
+
+def _portability_context() -> hosted_portability.PortabilityContext:
+    return hosted_portability.PortabilityContext(
+        cell_id="cell-isolation-7d91",
+        vault_id="vault-isolation-7d91",
+        operation_id="operation-isolation-7d91",
+        created_at="2026-08-28T09:00:00+00:00",
+        operator_authorized=True,
+        lifecycle_state="quiesced",
+        routing_stopped=True,
+        active_mutations=0,
+        background_writers_stopped=True,
+        reads_allowed=True,
+    )
+
+
+def _normalize_graph_rows(rows: list[dict]) -> list[dict]:
+    return [
+        {
+            key: value
+            for key, value in row.items()
+            if key not in {"metadata", "source_hash"}
+        }
+        for row in rows
+    ]
+
+
+def _snapshot(
+    vault: Path,
+    artifact_root: Path,
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+) -> dict:
+    find_module.clear_cache()
+    bm25.clear_cache()
+    monkeypatch.setenv("EXOMEM_LEXICAL_BACKEND", "python")
+    monkeypatch.setenv("EXOMEM_INDEX_SCOPE", "vault")
+    monkeypatch.delenv("EXOMEM_DISABLE_GRAPH_INDEX", raising=False)
+
+    def embed_texts(texts, **_kwargs):  # noqa: ANN001
+        if not texts:
+            return np.zeros((0, VECTOR_DIM), dtype=np.float32)
+        return np.full(
+            (len(texts), VECTOR_DIM),
+            1.0 / np.sqrt(VECTOR_DIM),
+            dtype=np.float32,
+        )
+
+    monkeypatch.setattr(embeddings, "embed_texts", embed_texts)
+
+    keyword = {
+        scope: bm25.BM25Index().search(vault, SENTINEL, 20, scope=scope)
+        for scope in ("kb", "vault")
+    }
+
+    vector_index = EmbeddingIndex(vault)
+    vector_index.rebuild_all()
+    vector_metadata, _matrix = vector_index.all_vectors()
+
+    graph = epistemic_graph.EpistemicGraphIndex(vault)
+    graph.rebuild_all()
+
+    exported = hosted_portability.export_quiesced_vault(
+        vault,
+        artifact_root,
+        context=_portability_context(),
+        exomem_release="9.9.9",
+    )
+
+    watcher = file_watcher.FileWatcher(vault)
+    return {
+        "keyword": keyword,
+        "kb_walk": [
+            path.relative_to(vault).as_posix()
+            for path in sorted(find_corpus.walk_md(vault / "Knowledge Base"))
+        ],
+        "vault_walk": [
+            path.relative_to(vault).as_posix()
+            for path in sorted(vault_module.walk_vault_md(vault))
+        ],
+        "vector_paths": sorted({path for path, _chunk in vector_metadata}),
+        "graph_nodes": _normalize_graph_rows(graph.nodes()),
+        "graph_edges": _normalize_graph_rows(graph.edges()),
+        "review": attention.attention(
+            vault,
+            categories=["relation_debt"],
+            limit=25,
+            record_surfacing=False,
+        ).as_dict(),
+        "overview": commands.op_browse_memory(
+            vault,
+            mode="overview",
+            include_hidden=True,
+        ),
+        "resources": commands.op_browse_memory(
+            vault,
+            mode="list",
+            recursive=True,
+            include_hidden=True,
+        ),
+        "watcher_kb": sorted(watcher._walk_entries("kb")),
+        "watcher_vault": sorted(watcher._walk_entries("vault")),
+        "export_manifest": exported.manifest,
+        "export_bytes": exported.archive_path.read_bytes(),
+        "fingerprint": hosted_portability.canonical_vault_fingerprint(vault),
+    }
+
+
+def test_run_and_private_artifact_state_are_absent_from_every_knowledge_surface(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = tmp_path / "vault"
+    _seed_vault(vault)
+    before = _snapshot(vault, tmp_path / "export-before", monkeypatch=monkeypatch)
+
+    run_file = (
+        vault
+        / "Knowledge Base"
+        / "_Consolidation"
+        / "runs"
+        / "00000000-0000-4000-8000-000000000001"
+        / "run.json"
+    )
+    run_file.parent.mkdir(parents=True)
+    run_file.write_text(
+        json.dumps(
+            {
+                "schema": "exomem.consolidation-run/v1",
+                "phase": "planning",
+                "private_probe": SENTINEL,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_file.parent / "conflicted-copy.md").write_text(
+        f"# Private run conflict\n\n{SENTINEL}\n",
+        encoding="utf-8",
+    )
+    private_artifact = tmp_path / "private-artifacts" / "objects" / "payload.md"
+    private_artifact.parent.mkdir(parents=True)
+    private_artifact.write_text(f"# Private staging\n\n{SENTINEL}\n", encoding="utf-8")
+
+    after = _snapshot(vault, tmp_path / "export-after", monkeypatch=monkeypatch)
+
+    assert after == before
+    assert not any("_Consolidation" in path for path in after["vault_walk"])
+    assert not any("_Consolidation" in path for path in after["vector_paths"])
+
+
+def test_incremental_watcher_drops_consolidation_state_before_fanout(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    _seed_vault(vault)
+    run_file = (
+        vault
+        / "Knowledge Base"
+        / "_Consolidation"
+        / "runs"
+        / "00000000-0000-4000-8000-000000000001"
+        / "private-run-state.md"
+    )
+    run_file.parent.mkdir(parents=True)
+    run_file.write_text(f'{{"private_probe":"{SENTINEL}"}}\n', encoding="utf-8")
+    watcher = file_watcher.FileWatcher(vault)
+
+    watcher._record(run_file, deleted=False)
+    watcher._record(run_file, deleted=True)
+
+    assert vault_module.in_excluded_scan_dir(
+        run_file.relative_to(vault).as_posix()
+    )
+    assert watcher._pending_upsert == set()
+    assert watcher._pending_delete == set()
+    assert watcher._pending_media == set()
+    assert watcher._pending_external_epoch == 0
+
+
+def test_vector_index_walk_is_the_reserved_full_vault_walk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = tmp_path / "vault"
+    _seed_vault(vault)
+    monkeypatch.setenv("EXOMEM_INDEX_SCOPE", "vault")
+    run_file = vault / "Knowledge Base" / "_Consolidation" / "private.md"
+    run_file.parent.mkdir(parents=True)
+    run_file.write_text(SENTINEL, encoding="utf-8")
+
+    assert list(index_paths.iter_index_markdown(vault)) == list(
+        vault_module.walk_vault_md(vault)
+    )
+    assert run_file not in set(index_paths.iter_index_markdown(vault))

--- a/tests/test_reserved_admin_paths.py
+++ b/tests/test_reserved_admin_paths.py
@@ -940,6 +940,10 @@ def test_public_file_move_refuses_private_hardlink_destination_before_planning(
 @pytest.mark.parametrize(
     "private_relative",
     [
+        (
+            "Knowledge Base/_Consolidation/runs/"
+            "00000000-0000-4000-8000-000000000001/run.json"
+        ),
         "Knowledge Base/.graph-sync.json",
         "Knowledge Base/.graph-sync-floor.json",
         "Knowledge Base/.graph-commit-receipts/" + "1" * 24 + ".json",
@@ -2304,6 +2308,46 @@ def test_named_subsystem_authority_is_exact_and_nonserializable() -> None:
     with reserved_paths._subsystem_authority_scope("governance.projections"):
         assert reserved_paths.owner_authorized("authorization-projections")
         assert not reserved_paths.owner_authorized("governance-store")
+
+
+def test_consolidation_run_authority_is_exact_nonserializable_and_required(
+    tmp_path: Path,
+) -> None:
+    target = (
+        tmp_path
+        / "Knowledge Base"
+        / "_Consolidation"
+        / "runs"
+        / "00000000-0000-4000-8000-000000000001"
+        / "run.json"
+    )
+
+    with pytest.raises(RuntimeError, match="authority"):
+        reserved_paths._publish_owner_bytes(
+            tmp_path,
+            target,
+            "consolidation-tree",
+            b"{}\n",
+            require_missing=True,
+        )
+
+    with reserved_paths._subsystem_authority_scope("consolidation.run"):
+        authority = reserved_paths._active_owner_authority()
+        assert reserved_paths.owner_authorized("consolidation-tree")
+        assert not reserved_paths.owner_authorized("governance-tree")
+        assert not reserved_paths.owner_authorized("governance-store")
+        with pytest.raises((pickle.PickleError, TypeError)):
+            pickle.dumps(authority)
+        reserved_paths._publish_owner_bytes(
+            tmp_path,
+            target,
+            "consolidation-tree",
+            b"{}\n",
+            require_missing=True,
+        )
+
+    assert target.read_bytes() == b"{}\n"
+    assert reserved_paths._active_owner_authority() is None
 
 
 def test_owner_byte_publication_requires_exact_named_authority(


### PR DESCRIPTION
## Summary

- route the incremental file watcher through the closed reserved-state registry so consolidation control files never enter derived-index fanout
- prove every generic command path refuses the consolidation tree and only the exact non-serializable subsystem authority can publish run state
- prove keyword, vector, graph, review, overview/list resources, watcher snapshots, and deterministic exports are byte-identical with and without matching private run/staging content

Stacked after #913. This does not touch or migrate any live vault.

## Verification

- red first: incremental watcher exclusion failed for Knowledge Base/_Consolidation/**
- new isolation + full reserved-path + file-watcher suites: 265 passed
- adjacent adoption/vault/portability regressions: 169 passed, 3 expected Windows-only skips
- Ruff on changed Python files
- uv lock --check
- openspec validate add-governed-vault-consolidation --strict
- public repository artifact validation
- git diff --check