### PR TITLE
feat(governance): bind consolidation fingerprints

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/vault_fingerprint.py
+++ b/infra/provisioner/src/exomem_provisioner/vault_fingerprint.py
@@ -142,7 +142,7 @@ def _classification(path: str) -> str | None:
     lowered = tuple(part.casefold() for part in parts)
     basename = lowered[-1] if lowered else ""
     kb_dir = os.environ.get("EXOMEM_KB_DIRNAME", "").strip().strip("/") or "Knowledge Base"
-    if path == "Knowledge Base/.review-state.json":
+    if path == f"{kb_dir}/.review-state.json":
         return "portable-derived"
     if re.fullmatch(rf"{re.escape(kb_dir)}/\.graph-commit-receipts/[0-9a-f]{{24}}\.json", path):
         return "portable-derived"

--- a/openspec/changes/add-governed-vault-consolidation/design.md
+++ b/openspec/changes/add-governed-vault-consolidation/design.md
@@ -519,7 +519,8 @@ requires either:
 2. a detached Ed25519 `source-export-attestation/v1`.
 
 Both bind the source logical vault identity, source installation id/generation
-and active-fence digest, export operation, quiescence checkpoint, archive SHA-256, manifest SHA-256,
+and active-fence digest, authenticated identity/root-binding fingerprint, export
+operation, quiescence checkpoint, archive SHA-256, manifest SHA-256,
 canonical source-census SHA-256, issue/expiry times, and signer key id. These
 claims are outside the unsigned archive, so an attacker cannot recompute an
 archive and its manifest and thereby invent source authority. For Ed25519, the

--- a/openspec/changes/add-governed-vault-consolidation/specs/vault-consolidation/spec.md
+++ b/openspec/changes/add-governed-vault-consolidation/specs/vault-consolidation/spec.md
@@ -14,7 +14,8 @@ also require either an authenticated transport receipt from a configured trusted
 source/control-plane channel with an equally exact issuer record or a detached
 Ed25519 `source-export-attestation/v1` verified by configured destination trust.
 Either proof SHALL bind the source logical vault identity, source installation
-id/generation and active-fence digest, export operation identity, quiescence checkpoint,
+id/generation and active-fence digest, authenticated identity/root-binding
+fingerprint, export operation identity, quiescence checkpoint,
 archive SHA-256, manifest SHA-256, canonical source-census SHA-256, issued time,
 expiry time, and signer key identifier. Caller-supplied verifier keys or expected
 identity claims SHALL NOT create trust.

--- a/openspec/changes/add-governed-vault-consolidation/tasks.md
+++ b/openspec/changes/add-governed-vault-consolidation/tasks.md
@@ -160,17 +160,17 @@
   Pin the exact framed JCS domains
   `exomem.consolidation-source-fingerprint/v1` and
   `exomem.consolidation-destination-snapshot/v1` and their closed field sets.
-- [ ] 2.5 Implement the structurally reserved durable run store and local/Hosted
+- [x] 2.5 Implement the structurally reserved durable run store and local/Hosted
   private artifact abstraction with opaque references, content-addressed manifests,
   ownership/mode/no-follow checks, resource admission, atomic state revisions, and
   explicit missing/mismatched-artifact state. Reuse the Adoption run-store pattern
   and `batch_atomic_write` where compatible without storing source bodies in the
   canonical run.
-- [ ] 2.6 Implement the canonical census/fingerprint builders as pure functions with
+- [x] 2.6 Implement the canonical census/fingerprint builders as pure functions with
   domain separation, normalized relative paths, deterministic sorting, explicit
   entry types/sizes/SHA-256, and fixed exclusions. Re-read state under guarded
   acquisition rather than trusting caller inventory.
-- [ ] 2.7 Run
+- [x] 2.7 Run
   `uv run python -m pytest -q tests/test_consolidation_run_state.py tests/test_reserved_admin_paths.py tests/test_adoption_run_state_not_knowledge.py tests/test_adoption_run.py tests/test_vault.py`.
 
 ## 3. Exhaustive C1-C8 inventory and reconciliation

--- a/src/exomem/governance/consolidation_attestation.py
+++ b/src/exomem/governance/consolidation_attestation.py
@@ -66,6 +66,7 @@ _REQUIRED_CLAIMS = frozenset(
         "source_installation_id",
         "source_installation_generation",
         "source_active_fence_digest",
+        "source_identity_binding_digest",
         "export_operation_id",
         "quiescence_checkpoint_digest",
         "archive_sha256",
@@ -94,6 +95,7 @@ class SourceExportExpectation:
     source_installation_id: str
     source_installation_generation: int
     source_active_fence_digest: str
+    source_identity_binding_digest: str
     export_operation_id: str
     quiescence_checkpoint_digest: str
     archive_sha256: str
@@ -242,6 +244,9 @@ def _normalize_claims(claims: Mapping[str, object]) -> dict[str, str | int]:
         "source_installation_id": _identifier(normalized["source_installation_id"]),
         "source_installation_generation": _generation(normalized["source_installation_generation"]),
         "source_active_fence_digest": _digest(normalized["source_active_fence_digest"]),
+        "source_identity_binding_digest": _digest(
+            normalized["source_identity_binding_digest"]
+        ),
         "export_operation_id": _identifier(normalized["export_operation_id"]),
         "quiescence_checkpoint_digest": _digest(normalized["quiescence_checkpoint_digest"]),
         "archive_sha256": _digest(normalized["archive_sha256"]),
@@ -383,6 +388,9 @@ def _verify_expected_claims(
         "source_installation_id": _identifier(expectation.source_installation_id),
         "source_installation_generation": _generation(expectation.source_installation_generation),
         "source_active_fence_digest": _digest(expectation.source_active_fence_digest),
+        "source_identity_binding_digest": _digest(
+            expectation.source_identity_binding_digest
+        ),
         "export_operation_id": _identifier(expectation.export_operation_id),
         "quiescence_checkpoint_digest": _digest(expectation.quiescence_checkpoint_digest),
         "archive_sha256": _digest(expectation.archive_sha256),

--- a/src/exomem/governance/consolidation_fingerprints.py
+++ b/src/exomem/governance/consolidation_fingerprints.py
@@ -1,0 +1,560 @@
+"""Immutable content fingerprints for governed vault consolidation.
+
+The source fingerprint authenticates one quiesced export.  The destination
+snapshot independently binds the current active installation and every
+canonical byte that a consolidation plan may change.  Mutable run, receipt,
+seal, journal, and rebuild state never enters either content preimage.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import unicodedata
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from types import MappingProxyType
+
+from .. import access, hosted_portability
+from ..kbdir import kb_dirname
+from . import authorization_custody, schema_v4, store
+from .consolidation_attestation import canonical_source_export_claims
+from .consolidation_identity import ConsolidationCellIdentity, load_local_identity
+from .projections import ProjectionCanonicalizationError, canonical_jcs
+
+SOURCE_FINGERPRINT_SCHEMA = "exomem.consolidation-source-fingerprint/v1"
+DESTINATION_SNAPSHOT_SCHEMA = "exomem.consolidation-destination-snapshot/v1"
+CANONICAL_CENSUS_SCHEMA = "exomem.consolidation-canonical-census/v1"
+
+_SOURCE_DOMAIN = SOURCE_FINGERPRINT_SCHEMA.encode("ascii")
+_DESTINATION_DOMAIN = DESTINATION_SNAPSHOT_SCHEMA.encode("ascii")
+_CENSUS_DOMAIN = CANONICAL_CENSUS_SCHEMA.encode("ascii")
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,511}\Z")
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+
+__all__ = [
+    "CANONICAL_CENSUS_SCHEMA",
+    "DESTINATION_SNAPSHOT_SCHEMA",
+    "SOURCE_FINGERPRINT_SCHEMA",
+    "CanonicalCensus",
+    "CanonicalCensusEntry",
+    "ConsolidationFingerprintUnavailable",
+    "DestinationSnapshot",
+    "SourceFingerprint",
+    "canonical_content_census",
+    "destination_snapshot",
+    "load_local_destination_snapshot",
+    "load_local_source_content_census",
+    "source_fingerprint",
+    "source_content_census_from_manifest",
+]
+
+
+class ConsolidationFingerprintUnavailable(RuntimeError):
+    """Stable, content-free refusal to construct an exact snapshot."""
+
+    code = "CONSOLIDATION_FINGERPRINT_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__("consolidation fingerprint is unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalCensusEntry:
+    path: str
+    entry_type: str
+    size: int
+    sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalCensus:
+    schema: str
+    entries: tuple[CanonicalCensusEntry, ...]
+    digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class SourceFingerprint:
+    schema: str
+    verified_claims: Mapping[str, str | int]
+    authentication_proof_digest: str
+    digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class DestinationSnapshot:
+    schema: str
+    vault_id: str
+    installation_id: str
+    installation_generation: int
+    active_fence_digest: str
+    identity_root_binding_fingerprint: str
+    canonical_census_digest: str
+    active_policy_fingerprint: str
+    access_state_fingerprint: str
+    review_state_fingerprint: str
+    digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class _DestinationSample:
+    identity: ConsolidationCellIdentity
+    entries: tuple[CanonicalCensusEntry, ...]
+    active_policy_fingerprint: str
+    access_state_fingerprint: str
+    review_state_fingerprint: str
+
+
+def _fail() -> None:
+    raise ConsolidationFingerprintUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _state_fingerprint(value: object) -> str:
+    if value == access.MISSING_POLICY_FINGERPRINT:
+        return access.MISSING_POLICY_FINGERPRINT
+    return _digest(value)
+
+
+def _identifier(value: object) -> str:
+    if not isinstance(value, str) or _IDENTIFIER.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _integer(value: object, *, minimum: int = 0) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < minimum
+        or value > _MAX_SAFE_INTEGER
+    ):
+        _fail()
+    return value
+
+
+def _normalized_path(value: object) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value or "\\" in value:
+        _fail()
+    normalized = unicodedata.normalize("NFC", value)
+    candidate = PurePosixPath(normalized)
+    if (
+        normalized != value
+        or candidate.is_absolute()
+        or any(part in {"", ".", ".."} for part in value.split("/"))
+    ):
+        _fail()
+    try:
+        normalized.encode("utf-8")
+    except UnicodeEncodeError:
+        _fail()
+    return candidate.as_posix()
+
+
+def _access_state_path() -> str:
+    return f"{kb_dirname()}/_access.yaml"
+
+
+def _review_state_path() -> str:
+    return f"{kb_dirname()}/.review-state.json"
+
+
+def _active_policy_prefix() -> str:
+    return f"{kb_dirname()}/_Governance"
+
+
+def _canonical_bytes(value: object) -> bytes:
+    try:
+        return canonical_jcs(value)
+    except ProjectionCanonicalizationError:
+        _fail()
+
+
+def _framed_digest(domain: bytes, value: object) -> str:
+    payload = _canonical_bytes(value)
+    framed = (
+        len(domain).to_bytes(4, "big")
+        + domain
+        + len(payload).to_bytes(8, "big")
+        + payload
+    )
+    return hashlib.sha256(framed).hexdigest()
+
+
+def _entry_value(entry: CanonicalCensusEntry) -> dict[str, str | int]:
+    return {
+        "entry_type": entry.entry_type,
+        "path": entry.path,
+        "sha256": entry.sha256,
+        "size": entry.size,
+    }
+
+
+def canonical_content_census(
+    entries: tuple[CanonicalCensusEntry, ...],
+) -> CanonicalCensus:
+    """Canonicalize a trusted filesystem inventory without consulting live state."""
+
+    if not isinstance(entries, tuple):
+        _fail()
+    normalized: list[CanonicalCensusEntry] = []
+    if len(entries) > 100_000:
+        _fail()
+    seen: set[str] = set()
+    folded: set[str] = set()
+    for item in entries:
+        if not isinstance(item, CanonicalCensusEntry):
+            _fail()
+        path = _normalized_path(item.path)
+        if item.entry_type != "file":
+            _fail()
+        size = _integer(item.size)
+        digest = _digest(item.sha256)
+        collision = path.casefold()
+        if path in seen or collision in folded:
+            _fail()
+        seen.add(path)
+        folded.add(collision)
+        normalized.append(
+            CanonicalCensusEntry(
+                path=path,
+                entry_type="file",
+                size=size,
+                sha256=digest,
+            )
+        )
+    ordered = tuple(sorted(normalized, key=lambda item: item.path))
+    value = {
+        "schema": CANONICAL_CENSUS_SCHEMA,
+        "entries": [_entry_value(item) for item in ordered],
+    }
+    return CanonicalCensus(
+        schema=CANONICAL_CENSUS_SCHEMA,
+        entries=ordered,
+        digest=_framed_digest(_CENSUS_DOMAIN, value),
+    )
+
+
+def source_content_census_from_manifest(
+    manifest: Mapping[str, object],
+) -> CanonicalCensus:
+    """Derive the consolidation content census from an authenticated archive manifest.
+
+    The archive digest still authenticates every admitted portable byte.  This
+    separate census deliberately omits derived evidence/receipt state so its
+    later append-only churn cannot stale an already-reviewed content plan.
+    """
+
+    if not isinstance(manifest, Mapping):
+        _fail()
+    records = manifest.get("files")
+    if not isinstance(records, list):
+        _fail()
+    entries: list[CanonicalCensusEntry] = []
+    for raw in records:
+        if not isinstance(raw, dict) or set(raw) != {
+            "path",
+            "size",
+            "sha256",
+            "classification",
+        }:
+            _fail()
+        path = _normalized_path(raw["path"])
+        classification = raw["classification"]
+        if classification not in {
+            hosted_portability.ArtifactClass.CANONICAL.value,
+            hosted_portability.ArtifactClass.PORTABLE_DERIVED.value,
+        }:
+            _fail()
+        if (
+            classification != hosted_portability.ArtifactClass.CANONICAL.value
+            and path != _review_state_path()
+        ):
+            continue
+        entries.append(
+            CanonicalCensusEntry(
+                path=path,
+                entry_type="file",
+                size=_integer(raw["size"]),
+                sha256=_digest(raw["sha256"]),
+            )
+        )
+    return canonical_content_census(tuple(entries))
+
+
+def source_fingerprint(
+    claims: Mapping[str, object],
+    *,
+    authentication_proof_digest: str,
+) -> SourceFingerprint:
+    """Bind exact verified source claims to their detached proof bytes."""
+
+    if not isinstance(claims, Mapping):
+        _fail()
+    try:
+        canonical_claims = canonical_source_export_claims(claims)
+        decoded = json.loads(canonical_claims)
+    except Exception:  # noqa: BLE001 - one content-free fingerprint refusal
+        _fail()
+    if not isinstance(decoded, dict):
+        _fail()
+    proof_digest = _digest(authentication_proof_digest)
+    value = {
+        "schema": SOURCE_FINGERPRINT_SCHEMA,
+        "verified_claims": decoded,
+        "authentication_proof_digest": proof_digest,
+    }
+    return SourceFingerprint(
+        schema=SOURCE_FINGERPRINT_SCHEMA,
+        verified_claims=MappingProxyType(dict(decoded)),
+        authentication_proof_digest=proof_digest,
+        digest=_framed_digest(_SOURCE_DOMAIN, value),
+    )
+
+
+def destination_snapshot(
+    identity: ConsolidationCellIdentity,
+    *,
+    census: CanonicalCensus,
+    active_policy_fingerprint: str,
+    access_state_fingerprint: str,
+    review_state_fingerprint: str,
+) -> DestinationSnapshot:
+    """Construct the immutable destination preimage from already-verified facts."""
+
+    if (
+        not isinstance(identity, ConsolidationCellIdentity)
+        or not isinstance(census, CanonicalCensus)
+        or census.schema != CANONICAL_CENSUS_SCHEMA
+    ):
+        _fail()
+    vault_id = _identifier(identity.vault_id)
+    installation_id = _identifier(identity.installation_id)
+    generation = _integer(identity.installation_generation, minimum=1)
+    active_fence = _digest(identity.active_fence_digest)
+    binding = _digest(identity.record_digest)
+    census_digest = _digest(census.digest)
+    policy_fingerprint = _digest(active_policy_fingerprint)
+    access_fingerprint = _state_fingerprint(access_state_fingerprint)
+    review_fingerprint = _state_fingerprint(review_state_fingerprint)
+    value = {
+        "schema": DESTINATION_SNAPSHOT_SCHEMA,
+        "vault_id": vault_id,
+        "installation_id": installation_id,
+        "installation_generation": generation,
+        "active_fence_digest": active_fence,
+        "identity_root_binding_fingerprint": binding,
+        "canonical_census_digest": census_digest,
+        "active_policy_fingerprint": policy_fingerprint,
+        "access_state_fingerprint": access_fingerprint,
+        "review_state_fingerprint": review_fingerprint,
+    }
+    return DestinationSnapshot(
+        schema=DESTINATION_SNAPSHOT_SCHEMA,
+        vault_id=vault_id,
+        installation_id=installation_id,
+        installation_generation=generation,
+        active_fence_digest=active_fence,
+        identity_root_binding_fingerprint=binding,
+        canonical_census_digest=census_digest,
+        active_policy_fingerprint=policy_fingerprint,
+        access_state_fingerprint=access_fingerprint,
+        review_state_fingerprint=review_fingerprint,
+        digest=_framed_digest(_DESTINATION_DOMAIN, value),
+    )
+
+
+def _load_active_policy_snapshot(vault_root: Path, *, now: int) -> schema_v4.ActivePolicySnapshot:
+    connection: sqlite3.Connection | None = None
+    try:
+        custody = authorization_custody.load_authorization_custody(vault_root, now=now)
+        control = custody.control
+        if (
+            not control.governance_enrolled
+            or control.activation_store_id is None
+            or control.activation_epoch is None
+            or control.activation_state_digest is None
+        ):
+            _fail()
+        connection = store.open_active_governance_read_connection(vault_root)
+        connection.execute("BEGIN")
+        snapshot = schema_v4.load_active_policy(
+            connection,
+            expected_logical_vault_id=control.logical_vault_id,
+            expected_activation_store_id=control.activation_store_id,
+            expected_activation_epoch=control.activation_epoch,
+            expected_activation_state_digest=control.activation_state_digest,
+        )
+        connection.commit()
+        return snapshot
+    except ConsolidationFingerprintUnavailable:
+        raise
+    except (
+        authorization_custody.AuthorizationCustodyUnavailable,
+        schema_v4.SchemaV4Error,
+        store.UnsupportedGovernanceSchema,
+        FileNotFoundError,
+        OSError,
+        sqlite3.Error,
+        RuntimeError,
+        ValueError,
+    ):
+        if connection is not None and connection.in_transaction:
+            connection.rollback()
+        _fail()
+    finally:
+        if connection is not None:
+            connection.close()
+
+
+def _entry_from_snapshot(snapshot: object) -> CanonicalCensusEntry:
+    try:
+        return CanonicalCensusEntry(
+            path=str(snapshot.path),
+            entry_type="file",
+            size=int(snapshot.size),
+            sha256=str(snapshot.sha256),
+        )
+    except (AttributeError, TypeError, ValueError):
+        _fail()
+
+
+def _content_entries_from_snapshots(
+    snapshots: Iterable[object],
+) -> tuple[CanonicalCensusEntry, ...]:
+    return tuple(
+        _entry_from_snapshot(item)
+        for item in snapshots
+        if item.classification == hosted_portability.ArtifactClass.CANONICAL.value
+        or item.path == _review_state_path()
+    )
+
+
+def load_local_source_content_census(
+    vault_root: Path,
+    *,
+    limits: hosted_portability.PortabilityLimits | None = None,
+) -> CanonicalCensus:
+    """Re-read one live source census using the consolidation exclusions."""
+
+    root = Path(vault_root)
+    effective_limits = limits or hosted_portability.PortabilityLimits()
+    try:
+        hosted_portability._validate_limits(effective_limits)  # noqa: SLF001
+        first = canonical_content_census(
+            _content_entries_from_snapshots(
+                hosted_portability._enumerate_source(root, effective_limits)  # noqa: SLF001
+            )
+        )
+        repeated = canonical_content_census(
+            _content_entries_from_snapshots(
+                hosted_portability._enumerate_source(root, effective_limits)  # noqa: SLF001
+            )
+        )
+        if repeated != first:
+            _fail()
+        return first
+    except ConsolidationFingerprintUnavailable:
+        raise
+    except (OSError, RuntimeError, TypeError, ValueError, hosted_portability.PortabilityError):
+        _fail()
+
+
+def _policy_entries(
+    documents: tuple[tuple[str, bytes], ...],
+) -> tuple[CanonicalCensusEntry, ...]:
+    entries: list[CanonicalCensusEntry] = []
+    for relative, content in documents:
+        if not isinstance(relative, str) or not isinstance(content, bytes):
+            _fail()
+        path = _normalized_path(f"{_active_policy_prefix()}/{relative}")
+        entries.append(
+            CanonicalCensusEntry(
+                path=path,
+                entry_type="file",
+                size=len(content),
+                sha256=hashlib.sha256(content).hexdigest(),
+            )
+        )
+    return tuple(entries)
+
+
+def _state_digest(
+    entries: tuple[CanonicalCensusEntry, ...], path: str
+) -> str:
+    matches = [entry.sha256 for entry in entries if entry.path == path]
+    if not matches:
+        return access.MISSING_POLICY_FINGERPRINT
+    if len(matches) != 1:
+        _fail()
+    return matches[0]
+
+
+def _sample_local_destination(
+    vault_root: Path,
+    *,
+    now: int,
+    limits: hosted_portability.PortabilityLimits | None,
+) -> _DestinationSample:
+    root = Path(vault_root)
+    effective_limits = limits or hosted_portability.PortabilityLimits()
+    try:
+        hosted_portability._validate_limits(effective_limits)  # noqa: SLF001
+        identity = load_local_identity(root, now=now)
+        active = _load_active_policy_snapshot(root, now=now)
+        if active.active.logical_vault_id != identity.vault_id:
+            _fail()
+        snapshots = hosted_portability._enumerate_source(  # noqa: SLF001
+            root, effective_limits
+        )
+        content_entries = _content_entries_from_snapshots(snapshots)
+        entries = content_entries + _policy_entries(active.source_documents)
+        canonical = canonical_content_census(entries)
+        return _DestinationSample(
+            identity=identity,
+            entries=canonical.entries,
+            active_policy_fingerprint=active.active.policy_fingerprint,
+            access_state_fingerprint=_state_digest(
+                canonical.entries, _access_state_path()
+            ),
+            review_state_fingerprint=_state_digest(
+                canonical.entries, _review_state_path()
+            ),
+        )
+    except ConsolidationFingerprintUnavailable:
+        raise
+    except (OSError, RuntimeError, TypeError, ValueError, hosted_portability.PortabilityError):
+        _fail()
+
+
+def load_local_destination_snapshot(
+    vault_root: Path,
+    *,
+    now: int,
+    limits: hosted_portability.PortabilityLimits | None = None,
+) -> DestinationSnapshot:
+    """Re-read every trusted component and return one stable local snapshot."""
+
+    root = Path(vault_root)
+    first = _sample_local_destination(root, now=now, limits=limits)
+    repeated = _sample_local_destination(root, now=now, limits=limits)
+    if repeated != first:
+        _fail()
+    census = canonical_content_census(first.entries)
+    return destination_snapshot(
+        first.identity,
+        census=census,
+        active_policy_fingerprint=first.active_policy_fingerprint,
+        access_state_fingerprint=first.access_state_fingerprint,
+        review_state_fingerprint=first.review_state_fingerprint,
+    )

--- a/src/exomem/governance/consolidation_intake.py
+++ b/src/exomem/governance/consolidation_intake.py
@@ -22,7 +22,7 @@ from pathlib import Path, PurePosixPath
 from typing import Protocol
 
 from .. import hosted_portability
-from . import authorization_custody, consolidation_attestation
+from . import authorization_custody, consolidation_attestation, consolidation_fingerprints
 
 _ARCHIVE_REF = re.compile(r"exomem-export://sha256/([0-9a-f]{64})\Z")
 _SOURCE_PROOF_REF = re.compile(r"exomem-source-attestation://sha256/([0-9a-f]{64})\Z")
@@ -97,6 +97,7 @@ class ConsolidationIntakeResult:
     source_proof_artifact_ref: str
     source_proof_digest: str
     source_claims_digest: str
+    source_fingerprint: str
     object_count: int
     total_bytes: int
     inventory: tuple[ConsolidationInventoryItem, ...]
@@ -110,6 +111,7 @@ class ConsolidationIntakeResult:
             "source_proof_artifact_ref": self.source_proof_artifact_ref,
             "source_proof_digest": self.source_proof_digest,
             "source_claims_digest": self.source_claims_digest,
+            "source_fingerprint": self.source_fingerprint,
             "object_count": self.object_count,
             "total_bytes": self.total_bytes,
             "inventory": [item.to_bounded_dict() for item in self.inventory],
@@ -401,7 +403,9 @@ def intake_source_export(
             expected_vault_id=proof.expectation.source_vault_id,
             limits=limits,
         )
-        census = hosted_portability.canonical_source_census_sha256(verified.manifest)
+        census = consolidation_fingerprints.source_content_census_from_manifest(
+            verified.manifest
+        ).digest
         if (
             verified.archive_sha256 != archive_match.group(1)
             or verified.archive_sha256 != proof.expectation.archive_sha256
@@ -455,6 +459,10 @@ def intake_source_export(
 
         proof_bytes = _proof_bytes(proof.claim_bytes, proof.signature)
         proof_digest = hashlib.sha256(proof_bytes).hexdigest()
+        source_fingerprint = consolidation_fingerprints.source_fingerprint(
+            dict(trusted.claims),
+            authentication_proof_digest=proof_digest,
+        ).digest
         proof_path = transaction / "proof.json"
         proof_path.write_bytes(proof_bytes)
         os.chmod(proof_path, 0o600)
@@ -501,6 +509,7 @@ def intake_source_export(
             ),
             source_proof_digest=proof_digest,
             source_claims_digest=trusted.claims_sha256,
+            source_fingerprint=source_fingerprint,
             object_count=len(inventory),
             total_bytes=sum(item.size for item in inventory),
             inventory=tuple(inventory),

--- a/src/exomem/governance/consolidation_run_state.py
+++ b/src/exomem/governance/consolidation_run_state.py
@@ -80,6 +80,7 @@ _IDENTITY_FIELDS = frozenset(
         "destination_generation",
         "destination_identity_binding_digest",
         "destination_installation_id",
+        "destination_snapshot_fingerprint",
         "destination_vault_id",
         "manifest_sha256",
         "run_id",
@@ -87,6 +88,7 @@ _IDENTITY_FIELDS = frozenset(
         "source_artifact_ref",
         "source_attestation_ref",
         "source_census_sha256",
+        "source_fingerprint",
         "source_proof_digest",
         "start_operation_id",
     }
@@ -111,12 +113,14 @@ class ConsolidationRunIdentity:
     destination_generation: int
     destination_fence_digest: str
     destination_identity_binding_digest: str
+    destination_snapshot_fingerprint: str
     source_artifact_ref: str
     source_attestation_ref: str
     archive_sha256: str
     manifest_sha256: str
     source_census_sha256: str
     source_proof_digest: str
+    source_fingerprint: str
     created_at: str
 
 
@@ -216,6 +220,7 @@ def _validated_identity(value: object) -> ConsolidationRunIdentity:
     _integer(value.destination_generation, minimum=1)
     _digest(value.destination_fence_digest)
     _digest(value.destination_identity_binding_digest)
+    _digest(value.destination_snapshot_fingerprint)
     archive = (
         _EXPORT_REF.fullmatch(value.source_artifact_ref)
         if isinstance(value.source_artifact_ref, str)
@@ -237,6 +242,7 @@ def _validated_identity(value: object) -> ConsolidationRunIdentity:
         value.manifest_sha256,
         value.source_census_sha256,
         value.source_proof_digest,
+        value.source_fingerprint,
     ):
         _digest(digest)
     _timestamp(value.created_at)
@@ -253,6 +259,7 @@ def _identity_dict(identity: ConsolidationRunIdentity) -> dict[str, str | int]:
             identity.destination_identity_binding_digest
         ),
         "destination_installation_id": identity.destination_installation_id,
+        "destination_snapshot_fingerprint": identity.destination_snapshot_fingerprint,
         "destination_vault_id": identity.destination_vault_id,
         "manifest_sha256": identity.manifest_sha256,
         "run_id": identity.run_id,
@@ -260,6 +267,7 @@ def _identity_dict(identity: ConsolidationRunIdentity) -> dict[str, str | int]:
         "source_artifact_ref": identity.source_artifact_ref,
         "source_attestation_ref": identity.source_attestation_ref,
         "source_census_sha256": identity.source_census_sha256,
+        "source_fingerprint": identity.source_fingerprint,
         "source_proof_digest": identity.source_proof_digest,
         "start_operation_id": identity.start_operation_id,
     }

--- a/src/exomem/hosted_portability.py
+++ b/src/exomem/hosted_portability.py
@@ -78,7 +78,7 @@ class _ClassificationRule:
 
 
 def _is_review_state(path: str, _parts: tuple[str, ...]) -> bool:
-    return path == "Knowledge Base/.review-state.json"
+    return path == f"{kb_dirname()}/.review-state.json"
 
 
 def _is_graph_commit_receipt(path: str, _parts: tuple[str, ...]) -> bool:

--- a/tests/test_consolidation_fingerprints.py
+++ b/tests/test_consolidation_fingerprints.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from exomem.governance import consolidation_attestation, consolidation_fingerprints
+from exomem.governance.consolidation_identity import ConsolidationCellIdentity
+
+_D1 = "1" * 64
+_D2 = "2" * 64
+_D3 = "3" * 64
+_D4 = "4" * 64
+_D5 = "5" * 64
+_D6 = "6" * 64
+_D7 = "7" * 64
+_D8 = "8" * 64
+_D9 = "9" * 64
+
+
+def _claims() -> dict[str, object]:
+    return {
+        "schema": consolidation_attestation.ATTESTATION_SCHEMA,
+        "source_vault_id": "vault-source-01",
+        "source_installation_id": "installation-source-01",
+        "source_installation_generation": 7,
+        "source_active_fence_digest": _D1,
+        "source_identity_binding_digest": _D2,
+        "export_operation_id": "export-operation-01",
+        "quiescence_checkpoint_digest": _D2,
+        "archive_sha256": _D3,
+        "manifest_sha256": _D4,
+        "source_census_sha256": _D5,
+        "issued_at": "2026-08-28T09:45:00.000Z",
+        "expires_at": "2026-08-28T10:45:00.000Z",
+        "signer_key_id": f"ed25519-sha256:{_D6}",
+    }
+
+
+def _identity(tmp_path: Path) -> ConsolidationCellIdentity:
+    return ConsolidationCellIdentity(
+        schema="exomem.consolidation-cell-identity/v1",
+        cell_id="cell-destination-01",
+        vault_id="vault-destination-01",
+        installation_id="installation-destination-01",
+        installation_generation=3,
+        active_fence_digest=_D1,
+        root_binding_id="attachment-destination-01",
+        root_binding_digest=_D2,
+        machine_key_id="key-destination-01",
+        adoption_census_digest=_D3,
+        clone_of_vault_id=None,
+        clone_of_installation_id=None,
+        clone_of_snapshot_digest=None,
+        created_at=1_777_777_777,
+        authentication_algorithm="HMAC-SHA256",
+        record_digest=_D4,
+        identity_path=tmp_path / "identity.json",
+    )
+
+
+def _entries() -> tuple[consolidation_fingerprints.CanonicalCensusEntry, ...]:
+    return (
+        consolidation_fingerprints.CanonicalCensusEntry(
+            path="Knowledge Base/Notes/alpha.md",
+            entry_type="file",
+            size=5,
+            sha256=hashlib.sha256(b"alpha").hexdigest(),
+        ),
+        consolidation_fingerprints.CanonicalCensusEntry(
+            path="Knowledge Base/Sources/\u00e9vidence.md",
+            entry_type="file",
+            size=8,
+            sha256=hashlib.sha256("\u00e9vidence".encode()).hexdigest(),
+        ),
+    )
+
+
+def test_source_fingerprint_has_a_fixed_closed_jcs_vector() -> None:
+    result = consolidation_fingerprints.source_fingerprint(
+        _claims(), authentication_proof_digest=_D7
+    )
+
+    assert result.schema == "exomem.consolidation-source-fingerprint/v1"
+    assert result.authentication_proof_digest == _D7
+    assert result.digest == "733289ad12b5f27c97ff2ed4853bc6f638174888db9b7f0f988b973f1081fc54"
+    with pytest.raises(TypeError):
+        result.verified_claims["source_vault_id"] = "vault-other"  # type: ignore[index]
+
+    with pytest.raises(consolidation_fingerprints.ConsolidationFingerprintUnavailable):
+        consolidation_fingerprints.source_fingerprint(
+            {**_claims(), "caller_extension": "not-closed"},
+            authentication_proof_digest=_D7,
+        )
+
+
+def test_canonical_census_is_permutation_stable_and_change_sensitive() -> None:
+    entries = _entries()
+    first = consolidation_fingerprints.canonical_content_census(entries)
+    reversed_result = consolidation_fingerprints.canonical_content_census(
+        tuple(reversed(entries))
+    )
+
+    assert first.entries == tuple(sorted(entries, key=lambda item: item.path))
+    assert reversed_result == first
+    assert first.digest == "0528d803a65b055ebe45d46936d898e230f28d57de6fa58c8ec4caa0f8331a5c"
+    with pytest.raises(consolidation_fingerprints.ConsolidationFingerprintUnavailable):
+        consolidation_fingerprints.canonical_content_census(
+            (replace(entries[0], entry_type="symlink"), entries[1])
+        )
+    assert consolidation_fingerprints.canonical_content_census(
+        (replace(entries[0], path="Knowledge Base/Notes/renamed.md"), entries[1])
+    ).digest != first.digest
+    assert consolidation_fingerprints.canonical_content_census(
+        (replace(entries[0], sha256=_D8), entries[1])
+    ).digest != first.digest
+
+
+def test_source_content_census_excludes_receipts_but_keeps_review_state() -> None:
+    manifest = {
+        "files": [
+            {
+                "path": "Knowledge Base/.graph-commit-receipts/0123456789abcdef01234567.json",
+                "size": 7,
+                "sha256": _D1,
+                "classification": "portable-derived",
+            },
+            {
+                "path": "Knowledge Base/.review-state.json",
+                "size": 8,
+                "sha256": _D2,
+                "classification": "portable-derived",
+            },
+            {
+                "path": "Knowledge Base/Notes/alpha.md",
+                "size": 9,
+                "sha256": _D3,
+                "classification": "canonical",
+            },
+        ]
+    }
+    baseline = consolidation_fingerprints.source_content_census_from_manifest(manifest)
+    receipt_changed = {
+        "files": [{**manifest["files"][0], "sha256": _D9}, *manifest["files"][1:]]
+    }
+    review_changed = {
+        "files": [manifest["files"][0], {**manifest["files"][1], "sha256": _D9}, manifest["files"][2]]
+    }
+
+    assert tuple(item.path for item in baseline.entries) == (
+        "Knowledge Base/.review-state.json",
+        "Knowledge Base/Notes/alpha.md",
+    )
+    assert consolidation_fingerprints.source_content_census_from_manifest(
+        receipt_changed
+    ) == baseline
+    assert consolidation_fingerprints.source_content_census_from_manifest(
+        review_changed
+    ).digest != baseline.digest
+
+
+@pytest.mark.parametrize(
+    "entries",
+    [
+        (
+            consolidation_fingerprints.CanonicalCensusEntry(
+                path="Knowledge Base/Notes/../secret.md",
+                entry_type="file",
+                size=1,
+                sha256=_D1,
+            ),
+        ),
+        (
+            consolidation_fingerprints.CanonicalCensusEntry(
+                path="Knowledge Base/Notes/a.md",
+                entry_type="file",
+                size=1,
+                sha256=_D1,
+            ),
+            consolidation_fingerprints.CanonicalCensusEntry(
+                path="Knowledge Base/Notes/a.md",
+                entry_type="file",
+                size=1,
+                sha256=_D1,
+            ),
+        ),
+    ],
+)
+def test_canonical_census_refuses_unsafe_or_duplicate_entries(
+    entries: tuple[consolidation_fingerprints.CanonicalCensusEntry, ...],
+) -> None:
+    with pytest.raises(consolidation_fingerprints.ConsolidationFingerprintUnavailable):
+        consolidation_fingerprints.canonical_content_census(entries)
+
+
+def test_destination_snapshot_has_a_fixed_vector_and_binds_identity(
+    tmp_path: Path,
+) -> None:
+    identity = _identity(tmp_path)
+    census = consolidation_fingerprints.canonical_content_census(_entries())
+    result = consolidation_fingerprints.destination_snapshot(
+        identity,
+        census=census,
+        active_policy_fingerprint=_D6,
+        access_state_fingerprint=_D7,
+        review_state_fingerprint=_D8,
+    )
+
+    assert result.schema == "exomem.consolidation-destination-snapshot/v1"
+    assert result.identity_root_binding_fingerprint == identity.record_digest
+    assert result.digest == "60ac7cec68f8766953f908853eb935abb7e86fbc88e4c4c521b402a72ae0c520"
+
+    for changed in (
+        replace(identity, vault_id="vault-destination-02"),
+        replace(identity, installation_id="installation-destination-02"),
+        replace(identity, installation_generation=4),
+        replace(identity, active_fence_digest=_D9),
+        replace(identity, record_digest=_D9),
+    ):
+        assert consolidation_fingerprints.destination_snapshot(
+            changed,
+            census=census,
+            active_policy_fingerprint=_D6,
+            access_state_fingerprint=_D7,
+            review_state_fingerprint=_D8,
+        ).digest != result.digest
+
+
+def test_guarded_local_snapshot_repeats_every_trusted_component(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sample = consolidation_fingerprints._DestinationSample(
+        identity=_identity(tmp_path),
+        entries=_entries(),
+        active_policy_fingerprint=_D6,
+        access_state_fingerprint=_D7,
+        review_state_fingerprint=_D8,
+    )
+    calls: list[int] = []
+
+    def stable(_vault: Path, *, now: int, limits: object) -> object:
+        calls.append(now)
+        return sample
+
+    monkeypatch.setattr(consolidation_fingerprints, "_sample_local_destination", stable)
+    result = consolidation_fingerprints.load_local_destination_snapshot(
+        tmp_path / "vault", now=123
+    )
+
+    assert calls == [123, 123]
+    assert result.canonical_census_digest == consolidation_fingerprints.canonical_content_census(
+        sample.entries
+    ).digest
+
+    samples = iter((sample, replace(sample, review_state_fingerprint=_D9)))
+    monkeypatch.setattr(
+        consolidation_fingerprints,
+        "_sample_local_destination",
+        lambda *_args, **_kwargs: next(samples),
+    )
+    with pytest.raises(consolidation_fingerprints.ConsolidationFingerprintUnavailable):
+        consolidation_fingerprints.load_local_destination_snapshot(
+            tmp_path / "vault", now=123
+        )
+
+
+def test_local_snapshot_excludes_control_churn_but_binds_owned_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = tmp_path / "vault"
+    notes = vault / "Knowledge Base/Notes"
+    notes.mkdir(parents=True)
+    (notes / "alpha.md").write_text("alpha\n", encoding="utf-8")
+    (vault / "Knowledge Base/Sources").mkdir()
+    (vault / "Knowledge Base/Sources/evidence.md").write_text(
+        "evidence\n", encoding="utf-8"
+    )
+    (vault / "Knowledge Base/_access.yaml").write_text(
+        "readonly: []\n", encoding="utf-8"
+    )
+    (vault / "Knowledge Base/.review-state.json").write_text(
+        '{"version":2,"records":{}}', encoding="utf-8"
+    )
+    policy_documents = (("rules/default.yaml", b"governance_version: 1\n"),)
+    policy_fingerprint = _D6
+
+    monkeypatch.setattr(
+        consolidation_fingerprints,
+        "load_local_identity",
+        lambda *_args, **_kwargs: _identity(tmp_path),
+    )
+
+    def active(*_args: object, **_kwargs: object) -> object:
+        return SimpleNamespace(
+            active=SimpleNamespace(
+                logical_vault_id="vault-destination-01",
+                policy_fingerprint=policy_fingerprint,
+            ),
+            source_documents=policy_documents,
+        )
+
+    monkeypatch.setattr(
+        consolidation_fingerprints, "_load_active_policy_snapshot", active
+    )
+
+    baseline = consolidation_fingerprints.load_local_destination_snapshot(vault, now=123)
+    source_baseline = consolidation_fingerprints.load_local_source_content_census(vault)
+    assert baseline.access_state_fingerprint == hashlib.sha256(b"readonly: []\n").hexdigest()
+    assert baseline.review_state_fingerprint == hashlib.sha256(
+        b'{"version":2,"records":{}}'
+    ).hexdigest()
+    (vault / "Knowledge Base/_Consolidation/runs/run-1").mkdir(parents=True)
+    (vault / "Knowledge Base/_Consolidation/runs/run-1/state.json").write_text(
+        "matching alpha secret", encoding="utf-8"
+    )
+    (vault / "Knowledge Base/_Governance/events").mkdir(parents=True)
+    (vault / "Knowledge Base/_Governance/events/receipt.json").write_text(
+        "receipt churn", encoding="utf-8"
+    )
+    (vault / "Knowledge Base/.graph.sqlite").write_bytes(b"derived")
+    assert (
+        consolidation_fingerprints.load_local_destination_snapshot(vault, now=123)
+        == baseline
+    )
+    assert consolidation_fingerprints.load_local_source_content_census(
+        vault
+    ) == source_baseline
+
+    (notes / "alpha.md").write_text("changed alpha\n", encoding="utf-8")
+    assert consolidation_fingerprints.load_local_destination_snapshot(
+        vault, now=123
+    ).digest != baseline.digest
+    assert consolidation_fingerprints.load_local_source_content_census(
+        vault
+    ).digest != source_baseline.digest
+    (notes / "alpha.md").write_text("alpha\n", encoding="utf-8")
+
+    (vault / "Knowledge Base/_access.yaml").write_text(
+        "readonly:\n  - external\n", encoding="utf-8"
+    )
+    assert consolidation_fingerprints.load_local_destination_snapshot(
+        vault, now=123
+    ).digest != baseline.digest
+    (vault / "Knowledge Base/_access.yaml").write_text(
+        "readonly: []\n", encoding="utf-8"
+    )
+
+    (vault / "Knowledge Base/.review-state.json").write_text(
+        '{"version":2,"records":{"a":{}}}', encoding="utf-8"
+    )
+    assert consolidation_fingerprints.load_local_destination_snapshot(
+        vault, now=123
+    ).digest != baseline.digest
+    (vault / "Knowledge Base/.review-state.json").write_text(
+        '{"version":2,"records":{}}', encoding="utf-8"
+    )
+
+    policy_documents = (("rules/default.yaml", b"governance_version: 2\n"),)
+    policy_fingerprint = _D9
+    assert consolidation_fingerprints.load_local_destination_snapshot(
+        vault, now=123
+    ).digest != baseline.digest
+
+
+def test_custom_kb_review_state_stales_source_and_destination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXOMEM_KB_DIRNAME", "Brain")
+    vault = tmp_path / "vault"
+    notes = vault / "Brain/Notes"
+    notes.mkdir(parents=True)
+    (notes / "alpha.md").write_text("alpha\n", encoding="utf-8")
+    review = vault / "Brain/.review-state.json"
+    review.write_text('{"version":2,"records":{}}', encoding="utf-8")
+    monkeypatch.setattr(
+        consolidation_fingerprints,
+        "load_local_identity",
+        lambda *_args, **_kwargs: _identity(tmp_path),
+    )
+    monkeypatch.setattr(
+        consolidation_fingerprints,
+        "_load_active_policy_snapshot",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            active=SimpleNamespace(
+                logical_vault_id="vault-destination-01",
+                policy_fingerprint=_D6,
+            ),
+            source_documents=(("rules/default.yaml", b"governance_version: 1\n"),),
+        ),
+    )
+
+    source_before = consolidation_fingerprints.load_local_source_content_census(vault)
+    destination_before = consolidation_fingerprints.load_local_destination_snapshot(
+        vault, now=123
+    )
+    review.write_text(
+        '{"version":2,"records":{"changed":{}}}', encoding="utf-8"
+    )
+    source_after = consolidation_fingerprints.load_local_source_content_census(vault)
+    destination_after = consolidation_fingerprints.load_local_destination_snapshot(
+        vault, now=123
+    )
+
+    assert "Brain/.review-state.json" in {item.path for item in source_before.entries}
+    assert source_after.digest != source_before.digest
+    assert (
+        destination_after.review_state_fingerprint
+        != destination_before.review_state_fingerprint
+    )
+    assert destination_after.digest != destination_before.digest

--- a/tests/test_consolidation_intake.py
+++ b/tests/test_consolidation_intake.py
@@ -14,6 +14,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from exomem import hosted_portability
+from exomem.governance import consolidation_fingerprints
 
 _SEED = bytes.fromhex("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60")
 _PUBLIC = bytes.fromhex("d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a")
@@ -23,7 +24,7 @@ _D3 = "3" * 64
 _D4 = "4" * 64
 _D5 = "5" * 64
 _EXOMEM_VECTOR_SIGNATURE = (
-    "1aMkuhdSdAvQJ7ev9a_7iEbyBij-xirVgiRjuq5hub2U-Bth8zjuoPic-ktDqjrb00h0z7wS7TuNSC-DZD--Dw"
+    "8KW3d2q2F5x_j8iJdSiTkym-JfMBg12uHrx_9ajssZGreqVHmUa10GTLXslUYMijOSQYv1A2vTT_Te_wmfm5Cg"
 )
 
 
@@ -41,6 +42,7 @@ def _claims(*, source_cell_id: str | None = None) -> dict[str, object]:
         "source_installation_id": "installation-source-01",
         "source_installation_generation": 7,
         "source_active_fence_digest": _D1,
+        "source_identity_binding_digest": _D2,
         "export_operation_id": "export-operation-01",
         "quiescence_checkpoint_digest": _D2,
         "archive_sha256": _D3,
@@ -61,6 +63,7 @@ def _expectation(attestation, *, source_cell_id: str | None = None):
         source_installation_id="installation-source-01",
         source_installation_generation=7,
         source_active_fence_digest=_D1,
+        source_identity_binding_digest=_D2,
         export_operation_id="export-operation-01",
         quiescence_checkpoint_digest=_D2,
         archive_sha256=_D3,
@@ -180,6 +183,7 @@ def test_source_export_attestation_verifies_independently_at_every_gate(gate: st
         ("source_installation_id", "installation-other-01"),
         ("source_installation_generation", 8),
         ("source_active_fence_digest", "a" * 64),
+        ("source_identity_binding_digest", "f" * 64),
         ("export_operation_id", "export-operation-other"),
         ("quiescence_checkpoint_digest", "b" * 64),
         ("archive_sha256", "c" * 64),
@@ -499,11 +503,14 @@ def _export(root: Path):
 
 def _resolved_proof(intake, exported):
     attestation = _attestation_module()
+    consolidation_census = consolidation_fingerprints.source_content_census_from_manifest(
+        exported.manifest
+    ).digest
     claims = _claims(source_cell_id="cell-source-01")
     claims.update(
         archive_sha256=exported.archive_sha256,
         manifest_sha256=exported.manifest_sha256,
-        source_census_sha256=exported.source_census_sha256,
+        source_census_sha256=consolidation_census,
     )
     claim_bytes, signature = attestation.sign_source_export_attestation(
         claims,
@@ -513,7 +520,7 @@ def _resolved_proof(intake, exported):
         _expectation(attestation, source_cell_id="cell-source-01"),
         archive_sha256=exported.archive_sha256,
         manifest_sha256=exported.manifest_sha256,
-        source_census_sha256=exported.source_census_sha256,
+        source_census_sha256=consolidation_census,
     )
     proof = intake.ResolvedSourceExportProof(
         claim_bytes=claim_bytes,
@@ -694,7 +701,9 @@ def test_intake_extracts_only_private_content_addressed_objects(
 ) -> None:
     intake, _vault, exported, request, resolver, store = _intake_fixture(tmp_path)
     archive_before = exported.archive_path.read_bytes()
-    census_before = exported.source_census_sha256
+    census_before = consolidation_fingerprints.source_content_census_from_manifest(
+        exported.manifest
+    ).digest
 
     monkeypatch.setattr(
         hosted_portability,
@@ -715,6 +724,10 @@ def test_intake_extracts_only_private_content_addressed_objects(
     assert result.archive_sha256 == exported.archive_sha256
     assert result.manifest_sha256 == exported.manifest_sha256
     assert result.source_census_sha256 == census_before
+    assert result.source_fingerprint == consolidation_fingerprints.source_fingerprint(
+        json.loads(resolver.proof.claim_bytes),
+        authentication_proof_digest=result.source_proof_digest,
+    ).digest
     assert result.object_count == len(exported.manifest["files"])
     assert result.total_bytes == sum(item["size"] for item in exported.manifest["files"])
     assert result.archive_artifact_ref.startswith("exomem-consolidation-archive://sha256/")
@@ -738,7 +751,12 @@ def test_intake_extracts_only_private_content_addressed_objects(
     assert str(tmp_path) not in rendered
     assert "archive_path" not in rendered
     assert exported.archive_path.read_bytes() == archive_before
-    assert hosted_portability.canonical_source_census_sha256(exported.manifest) == census_before
+    assert (
+        consolidation_fingerprints.source_content_census_from_manifest(
+            exported.manifest
+        ).digest
+        == census_before
+    )
 
 
 def test_intake_is_idempotent_and_deduplicates_equal_content(tmp_path: Path) -> None:

--- a/tests/test_consolidation_run_state.py
+++ b/tests/test_consolidation_run_state.py
@@ -48,12 +48,14 @@ def _identity(module):
         destination_generation=3,
         destination_fence_digest="1" * 64,
         destination_identity_binding_digest="2" * 64,
+        destination_snapshot_fingerprint="7" * 64,
         source_artifact_ref="exomem-export://sha256/" + "3" * 64,
         source_attestation_ref="exomem-source-attestation://sha256/" + "4" * 64,
         archive_sha256="3" * 64,
         manifest_sha256="5" * 64,
         source_census_sha256="6" * 64,
         source_proof_digest="4" * 64,
+        source_fingerprint="8" * 64,
         created_at=CREATED_AT,
     )
 
@@ -88,12 +90,14 @@ def test_run_identity_schema_has_no_caller_or_private_body_fields() -> None:
         "destination_generation",
         "destination_fence_digest",
         "destination_identity_binding_digest",
+        "destination_snapshot_fingerprint",
         "source_artifact_ref",
         "source_attestation_ref",
         "archive_sha256",
         "manifest_sha256",
         "source_census_sha256",
         "source_proof_digest",
+        "source_fingerprint",
         "created_at",
     )
     for forbidden in (
@@ -144,6 +148,8 @@ def test_create_is_idempotent_but_conflicting_identity_or_inventory_refuses(
     assert store.create(identity, tuple(reversed(_inventory()))) == first
     for conflicting_identity, inventory in (
         (replace(identity, source_census_sha256="8" * 64), _inventory()),
+        (replace(identity, source_fingerprint="9" * 64), _inventory()),
+        (replace(identity, destination_snapshot_fingerprint="9" * 64), _inventory()),
         (identity, _inventory(6)),
     ):
         with pytest.raises(module.ConsolidationRunUnavailable) as caught:


### PR DESCRIPTION
## Summary

- add canonical framed-JCS source and destination fingerprint builders with deterministic content censuses and fixed control/evidence exclusions
- bind source export proofs to authenticated identity/root-binding state and persist source/destination fingerprints in durable run identity
- cover active v4 policy source, access state, review state, canonical and append-only content, including configurable KB directory names

Stacked after #914. This does not merge or touch any live vault.

## Verification

- red-first coverage for the missing module, run identity fields, source identity binding, and configurable-KB review-state drift
- focused and adjacent suites: 210 passed
- exact OpenSpec 2.7 gate: 253 passed, 3 native-Windows skips
- independent security review: GO after correcting configurable-KB review-state classification
- Ruff on changed Python files
- `uv lock --check`
- `openspec validate add-governed-vault-consolidation --strict`
- public repository artifact validation
- `git diff --check`
