### PR TITLE
feat(governance): add destination policy planning

### DIFF
--- a/openspec/changes/add-governed-vault-consolidation/tasks.md
+++ b/openspec/changes/add-governed-vault-consolidation/tasks.md
@@ -215,32 +215,32 @@
 
 ## 4. Fresh destination principals and prospective policy
 
-- [ ] 4.1 Add red tests in `tests/test_consolidation_policy.py` proving source policy,
+- [x] 4.1 Add red tests in `tests/test_consolidation_policy.py` proving source policy,
   audience ids, grants, credentials, escalation tokens, authorization sessions,
   release approvals, receipts, runtime bindings, and review authority never become
   live destination authority. Include coincident-looking source/destination ids and
   prove provenance retention cannot make them executable.
-- [ ] 4.2 Add fixed-vector tests for
+- [x] 4.2 Add fixed-vector tests for
   `destination-principal-attestation/v1`: trusted destination issuer/surface,
   resolved canonical principal, destination vault, purposes, issued/expiry,
   authentication/session binding, nonce, and attestation fingerprint. Cover
   missing/expired/stale/cross-vault/cross-session/cross-issuer/copied/replayed
   attestations and caller-selected principal/audience fields; every invalid case
   must fail before approval/apply without consuming authority.
-- [ ] 4.3 Add red prospective-compile tests for the exact newly authored destination
+- [x] 4.3 Add red prospective-compile tests for the exact newly authored destination
   scope/rule/bridge/exact-release documents, using the hardening change's stable
   conflict-bound acquisition. Cover per-scope grant crossover, default deny, deny
   dominance, overlapping conservative options, non-Markdown unresolved membership,
   pending-policy guard drift, and document/conflict changes between planning and
   apply.
-- [ ] 4.4 Implement the trusted destination attestation verifier on top of the common
+- [x] 4.4 Implement the trusted destination attestation verifier on top of the common
   per-surface authorization context. The surface resolves principal and issuer;
   request data may declare intended purpose but cannot select identity or trust.
-- [ ] 4.5 Implement policy translation inputs as newly authored destination
+- [x] 4.5 Implement policy translation inputs as newly authored destination
   documents compiled through existing governance authoring/bridge/exact-release
   primitives. Store source policy only as authenticated review input/digests and
   reject any copied live-authority artifact.
-- [ ] 4.6 Run
+- [x] 4.6 Run
   `uv run python -m pytest -q tests/test_consolidation_policy.py tests/test_governance_decisions.py tests/test_governance_membership.py tests/test_governance_policy.py tests/test_governance_bridges.py tests/test_governance_tokens.py tests/test_authorization_session_binding.py`.
 
 ## 5. Canonical joint plan and single-use owner confirmation

--- a/src/exomem/governance/consolidation_policy.py
+++ b/src/exomem/governance/consolidation_policy.py
@@ -1,0 +1,758 @@
+"""Fresh destination authority and prospective policy for consolidation.
+
+Source-side policy is evidence, never authority.  This module accepts only
+digest-only source review records, resolves destination principals from the
+already-verified request context, and compiles newly authored destination
+documents against the exact live authoring snapshot.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import secrets
+import unicodedata
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+from typing import NoReturn, cast
+
+from ..held_fs import StableIdentity
+from . import policy
+from .principal import MOST_RESTRICTIVE_AUDIENCE, RequestPrincipal
+from .projections import ProjectionCanonicalizationError, canonical_jcs
+
+DESTINATION_PRINCIPAL_ATTESTATION_SCHEMA = "destination-principal-attestation/v1"
+DESTINATION_POLICY_PLAN_SCHEMA = "exomem.consolidation-destination-policy/v1"
+
+_AUTHENTICATION_BINDING_SCHEMA = "exomem.destination-authentication-binding/v1"
+_ATTESTATION_DOMAIN = b"exomem.destination-principal-attestation/v1"
+_AUTHENTICATION_BINDING_DOMAIN = b"exomem.destination-authentication-binding/v1"
+_SOURCE_AUTHORITY_REVIEW_DOMAIN = b"exomem.source-authority-review/v1"
+_ATTESTATION_SET_DOMAIN = b"exomem.destination-principal-attestation-set/v1"
+_DOCUMENT_SET_DOMAIN = b"exomem.consolidation-destination-documents/v1"
+_AUTHORING_SNAPSHOT_DOMAIN = b"exomem.consolidation-authoring-snapshot/v1"
+_PLAN_DOMAIN = b"exomem.consolidation-destination-policy-plan/v1"
+
+_TRUSTED_SURFACES = frozenset({"cli", "hosted", "mcp", "rest"})
+_SOURCE_AUTHORITY_KINDS = frozenset(
+    {
+        "access_control",
+        "audience",
+        "authorization_session",
+        "credential",
+        "grant",
+        "policy",
+        "receipt",
+        "release_approval",
+        "review_authority",
+        "runtime_binding",
+        "token",
+    }
+)
+_HEX_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}\Z")
+_REFERENCE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:/-]{0,511}\Z")
+_RFC3339_MILLISECONDS = re.compile(
+    r"[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])"
+    r"T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{3}Z\Z"
+)
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_MAX_DOCUMENTS = 1024
+_MAX_DOCUMENT_BYTES = 1 << 20
+
+__all__ = [
+    "DESTINATION_POLICY_PLAN_SCHEMA",
+    "DESTINATION_PRINCIPAL_ATTESTATION_SCHEMA",
+    "DestinationPolicyPlan",
+    "DestinationPolicyUnavailable",
+    "DestinationPrincipalAttestation",
+    "SourceAuthorityReviewArtifact",
+    "VerifiedDestinationPrincipalAttestation",
+    "compile_destination_policy",
+    "issue_destination_principal_attestation",
+    "principal_attestation_set_digest",
+    "revalidate_destination_policy",
+    "source_authority_review_digest",
+    "verify_destination_principal_attestation",
+]
+
+
+class DestinationPolicyUnavailable(RuntimeError):
+    """Content-free refusal for an unavailable destination policy plan."""
+
+    code = "DESTINATION_POLICY_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__("destination policy is unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class DestinationPrincipalAttestation:
+    schema: str
+    destination_vault_id: str
+    issuer_family: str
+    surface: str
+    principal_id: str
+    purposes: tuple[str, ...]
+    issued_at: str
+    expires_at: str
+    authentication_binding_digest: str
+    nonce: str
+    fingerprint: str
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedDestinationPrincipalAttestation:
+    attestation: DestinationPrincipalAttestation
+    verified_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class SourceAuthorityReviewArtifact:
+    """Authenticated source provenance with no executable bytes or credentials."""
+
+    object_ref: str
+    object_kind: str
+    object_sha256: str
+    bundle_sha256: str
+    provenance_ref: str
+
+
+@dataclass(frozen=True, slots=True)
+class DestinationPolicyPlan:
+    schema: str
+    destination_vault_id: str
+    prospective: policy.ProspectiveCompile
+    document_edits: tuple[tuple[str, str | None], ...]
+    document_set_digest: str
+    authoring_snapshot_digest: str
+    source_authority: tuple[SourceAuthorityReviewArtifact, ...]
+    source_authority_review_digest: str
+    attestations: tuple[DestinationPrincipalAttestation, ...]
+    principal_attestation_set_digest: str
+    principal_requirements: tuple[tuple[str, tuple[str, ...]], ...]
+    named_principals: tuple[str, ...]
+    digest: str
+
+
+def _fail() -> NoReturn:
+    raise DestinationPolicyUnavailable from None
+
+
+def _text(value: object) -> str:
+    if not isinstance(value, str):
+        _fail()
+    normalized = unicodedata.normalize("NFC", value)
+    try:
+        normalized.encode("utf-8")
+    except UnicodeEncodeError:
+        _fail()
+    if normalized != value:
+        _fail()
+    return normalized
+
+
+def _identifier(value: object) -> str:
+    normalized = _text(value)
+    if _IDENTIFIER.fullmatch(normalized) is None:
+        _fail()
+    return normalized
+
+
+def _reference(value: object) -> str:
+    normalized = _text(value)
+    if _REFERENCE.fullmatch(normalized) is None:
+        _fail()
+    return normalized
+
+
+def _digest(value: object) -> str:
+    normalized = _text(value)
+    if _HEX_DIGEST.fullmatch(normalized) is None:
+        _fail()
+    return normalized
+
+
+def _timestamp(value: object) -> tuple[str, datetime]:
+    normalized = _text(value)
+    if _RFC3339_MILLISECONDS.fullmatch(normalized) is None:
+        _fail()
+    try:
+        parsed = datetime.fromisoformat(normalized.removesuffix("Z") + "+00:00")
+    except ValueError:
+        _fail()
+    if parsed.tzinfo != UTC:
+        _fail()
+    return normalized, parsed
+
+
+def _canonical(value: object) -> bytes:
+    try:
+        return canonical_jcs(value)
+    except ProjectionCanonicalizationError:
+        _fail()
+
+
+def _framed_digest(domain: bytes, value: object) -> str:
+    raw = _canonical(value)
+    framed = len(domain).to_bytes(4, "big") + domain + len(raw).to_bytes(8, "big") + raw
+    return hashlib.sha256(framed).hexdigest()
+
+
+def _purposes(values: Sequence[str]) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)) or len(values) > 64:
+        _fail()
+    normalized = tuple(_identifier(item) for item in values)
+    if tuple(sorted(set(normalized))) != normalized:
+        _fail()
+    return normalized
+
+
+def _authentication_binding(
+    principal: RequestPrincipal, destination_vault_id: str
+) -> dict[str, object]:
+    if (
+        not isinstance(principal, RequestPrincipal)
+        or not principal.resolved
+        or principal.audience_id == MOST_RESTRICTIVE_AUDIENCE
+        or principal.surface not in _TRUSTED_SURFACES
+        or principal.verified_authorization_session is None
+    ):
+        _fail()
+    context = principal.verified_authorization_session
+    principal_id = _identifier(principal.audience_id)
+    issuer_family = _identifier(principal.issuer_family)
+    if (
+        principal_id != _identifier(context.principal_id)
+        or issuer_family != _identifier(context.issuer_family)
+        or destination_vault_id != _identifier(context.logical_vault_id)
+        or principal.authorization_session_id != context.session_id
+    ):
+        _fail()
+    if type(context.credential_generation) is not int or not (
+        1 <= context.credential_generation <= _MAX_SAFE_INTEGER
+    ):
+        _fail()
+    if type(context.expires_at) is not int or not 1 <= context.expires_at <= _MAX_SAFE_INTEGER:
+        _fail()
+    binding: dict[str, object] = {
+        "schema": _AUTHENTICATION_BINDING_SCHEMA,
+        "destination_vault_id": _identifier(destination_vault_id),
+        "surface": principal.surface,
+        "principal_id": principal_id,
+        "issuer_family": issuer_family,
+        "authorization_session_id": _identifier(context.session_id),
+        "cell_id": _identifier(context.cell_id),
+        "logical_vault_id": _identifier(context.logical_vault_id),
+        "keyring_id": _identifier(context.keyring_id),
+        "credential_generation": context.credential_generation,
+        "session_expires_at": context.expires_at,
+    }
+    if principal.session_id is not None:
+        binding["transport_session_id"] = _identifier(principal.session_id)
+    return binding
+
+
+def _authentication_binding_digest(principal: RequestPrincipal, destination_vault_id: str) -> str:
+    return _framed_digest(
+        _AUTHENTICATION_BINDING_DOMAIN,
+        _authentication_binding(principal, destination_vault_id),
+    )
+
+
+def _attestation_claims(
+    attestation: DestinationPrincipalAttestation,
+) -> dict[str, object]:
+    return {
+        "schema": attestation.schema,
+        "destination_vault_id": attestation.destination_vault_id,
+        "issuer_family": attestation.issuer_family,
+        "surface": attestation.surface,
+        "principal_id": attestation.principal_id,
+        "purposes": list(attestation.purposes),
+        "issued_at": attestation.issued_at,
+        "expires_at": attestation.expires_at,
+        "authentication_binding_digest": attestation.authentication_binding_digest,
+        "nonce": attestation.nonce,
+    }
+
+
+def _validate_attestation_shape(
+    attestation: DestinationPrincipalAttestation,
+) -> tuple[datetime, datetime]:
+    if not isinstance(attestation, DestinationPrincipalAttestation):
+        _fail()
+    if attestation.schema != DESTINATION_PRINCIPAL_ATTESTATION_SCHEMA:
+        _fail()
+    _identifier(attestation.destination_vault_id)
+    _identifier(attestation.issuer_family)
+    if attestation.surface not in _TRUSTED_SURFACES:
+        _fail()
+    _identifier(attestation.principal_id)
+    _purposes(attestation.purposes)
+    _digest(attestation.authentication_binding_digest)
+    _identifier(attestation.nonce)
+    _digest(attestation.fingerprint)
+    _issued_text, issued = _timestamp(attestation.issued_at)
+    _expires_text, expires = _timestamp(attestation.expires_at)
+    if issued >= expires:
+        _fail()
+    expected = _framed_digest(_ATTESTATION_DOMAIN, _attestation_claims(attestation))
+    if not secrets.compare_digest(expected, attestation.fingerprint):
+        _fail()
+    return issued, expires
+
+
+def issue_destination_principal_attestation(
+    principal: RequestPrincipal,
+    *,
+    destination_vault_id: str,
+    purposes: Sequence[str],
+    issued_at: str,
+    expires_at: str,
+    nonce: str,
+) -> DestinationPrincipalAttestation:
+    """Issue from a trusted, already-resolved destination request context."""
+
+    vault_id = _identifier(destination_vault_id)
+    normalized_purposes = _purposes(purposes)
+    issued_text, issued = _timestamp(issued_at)
+    expires_text, expires = _timestamp(expires_at)
+    normalized_nonce = _identifier(nonce)
+    binding = _authentication_binding(principal, vault_id)
+    if issued >= expires or expires.timestamp() > cast(int, binding["session_expires_at"]):
+        _fail()
+    unsigned = DestinationPrincipalAttestation(
+        schema=DESTINATION_PRINCIPAL_ATTESTATION_SCHEMA,
+        destination_vault_id=vault_id,
+        issuer_family=_identifier(principal.issuer_family),
+        surface=principal.surface,
+        principal_id=_identifier(principal.audience_id),
+        purposes=normalized_purposes,
+        issued_at=issued_text,
+        expires_at=expires_text,
+        authentication_binding_digest=_framed_digest(_AUTHENTICATION_BINDING_DOMAIN, binding),
+        nonce=normalized_nonce,
+        fingerprint="0" * 64,
+    )
+    return DestinationPrincipalAttestation(
+        schema=unsigned.schema,
+        destination_vault_id=unsigned.destination_vault_id,
+        issuer_family=unsigned.issuer_family,
+        surface=unsigned.surface,
+        principal_id=unsigned.principal_id,
+        purposes=unsigned.purposes,
+        issued_at=unsigned.issued_at,
+        expires_at=unsigned.expires_at,
+        authentication_binding_digest=unsigned.authentication_binding_digest,
+        nonce=unsigned.nonce,
+        fingerprint=_framed_digest(_ATTESTATION_DOMAIN, _attestation_claims(unsigned)),
+    )
+
+
+def verify_destination_principal_attestation(
+    attestation: DestinationPrincipalAttestation,
+    *,
+    principal: RequestPrincipal,
+    destination_vault_id: str,
+    required_purpose: str | None,
+    expected_nonce: str,
+    verified_at: str,
+) -> VerifiedDestinationPrincipalAttestation:
+    """Bind one attestation to the current trusted destination session."""
+
+    issued, expires = _validate_attestation_shape(attestation)
+    vault_id = _identifier(destination_vault_id)
+    nonce = _identifier(expected_nonce)
+    verified_text, verified = _timestamp(verified_at)
+    binding_digest = _authentication_binding_digest(principal, vault_id)
+    if (
+        attestation.destination_vault_id != vault_id
+        or attestation.issuer_family != principal.issuer_family
+        or attestation.surface != principal.surface
+        or attestation.principal_id != principal.audience_id
+        or attestation.authentication_binding_digest != binding_digest
+        or attestation.nonce != nonce
+        or verified < issued
+        or verified >= expires
+    ):
+        _fail()
+    if required_purpose is not None and _identifier(required_purpose) not in attestation.purposes:
+        _fail()
+    return VerifiedDestinationPrincipalAttestation(
+        attestation=attestation,
+        verified_at=verified_text,
+    )
+
+
+def _source_authority_value(
+    artifacts: Sequence[SourceAuthorityReviewArtifact],
+) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for artifact in artifacts:
+        if not isinstance(artifact, SourceAuthorityReviewArtifact):
+            _fail()
+        row = {
+            "object_ref": _reference(artifact.object_ref),
+            "object_kind": _identifier(artifact.object_kind),
+            "object_sha256": _digest(artifact.object_sha256),
+            "bundle_sha256": _digest(artifact.bundle_sha256),
+            "provenance_ref": _reference(artifact.provenance_ref),
+        }
+        if row["object_kind"] not in _SOURCE_AUTHORITY_KINDS or row["object_ref"] in seen:
+            _fail()
+        seen.add(row["object_ref"])
+        rows.append(row)
+    if len(rows) > 4096:
+        _fail()
+    rows.sort(key=lambda item: item["object_ref"])
+    return rows
+
+
+def source_authority_review_digest(
+    artifacts: Sequence[SourceAuthorityReviewArtifact],
+) -> str:
+    return _framed_digest(_SOURCE_AUTHORITY_REVIEW_DOMAIN, _source_authority_value(artifacts))
+
+
+def _attestation_value(
+    attestations: Sequence[DestinationPrincipalAttestation],
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for attestation in attestations:
+        _validate_attestation_shape(attestation)
+        if attestation.fingerprint in seen:
+            _fail()
+        seen.add(attestation.fingerprint)
+        rows.append({**_attestation_claims(attestation), "fingerprint": attestation.fingerprint})
+    rows.sort(key=lambda item: str(item["fingerprint"]))
+    return rows
+
+
+def principal_attestation_set_digest(
+    attestations: Sequence[DestinationPrincipalAttestation],
+) -> str:
+    return _framed_digest(_ATTESTATION_SET_DOMAIN, _attestation_value(attestations))
+
+
+def _document_edits(documents: Mapping[str, str | None]) -> tuple[tuple[str, str | None], ...]:
+    if not isinstance(documents, Mapping) or len(documents) > _MAX_DOCUMENTS:
+        _fail()
+    normalized: dict[str, str | None] = {}
+    for raw_path, raw_content in documents.items():
+        path = _text(raw_path)
+        if "\\" in path:
+            _fail()
+        parsed = PurePosixPath(path)
+        if (
+            path != parsed.as_posix()
+            or parsed.is_absolute()
+            or any(part in {"", ".", ".."} for part in parsed.parts)
+            or parsed.parts[0] not in {"grants", "rules", "scopes"}
+            or parsed.suffix not in {".yaml", ".yml"}
+            or path in normalized
+        ):
+            _fail()
+        if raw_content is None:
+            content = None
+        else:
+            content = _text(raw_content)
+            if len(content.encode("utf-8")) > _MAX_DOCUMENT_BYTES:
+                _fail()
+        normalized[path] = content
+    return tuple(sorted(normalized.items()))
+
+
+def _document_set_digest(documents: Sequence[tuple[str, bytes]]) -> str:
+    rows = [
+        {"path": _text(path), "byte_size": len(raw), "sha256": hashlib.sha256(raw).hexdigest()}
+        for path, raw in documents
+    ]
+    return _framed_digest(_DOCUMENT_SET_DOMAIN, rows)
+
+
+def _stable_identity_value(identity: StableIdentity) -> dict[str, object]:
+    device = identity.device
+    inode = identity.inode
+    kind = identity.kind
+    link_count = identity.link_count
+    if any(type(value) is not int or value < 0 for value in (device, inode, link_count)):
+        _fail()
+    return {
+        "device": device,
+        "inode": inode,
+        "kind": _identifier(kind),
+        "link_count": link_count,
+    }
+
+
+def _authoring_snapshot_digest(snapshot: policy.AuthoringSnapshot) -> str:
+    root: dict[str, object]
+    if snapshot.governance_root_identity is None:
+        root = {"state": "absent"}
+    else:
+        root = {
+            "state": "present",
+            "identity": _stable_identity_value(snapshot.governance_root_identity),
+        }
+    value = {
+        "source_fingerprint": _digest(snapshot.source_fingerprint),
+        "conflict_set_digest": _digest(snapshot.conflict_set_digest),
+        "guard_generation": _text(snapshot.guard_generation),
+        "documents": [
+            {
+                "path": _text(path),
+                "byte_size": len(raw),
+                "sha256": hashlib.sha256(raw).hexdigest(),
+            }
+            for path, raw in snapshot.documents
+        ],
+        "file_identities": [
+            {
+                "path": _text(item.path),
+                "sha256": _digest(item.sha256),
+                "identity": _stable_identity_value(item.identity),
+            }
+            for item in snapshot.file_identities
+        ],
+        "directory_identities": [
+            {"path": _text(path), "identity": _stable_identity_value(identity)}
+            for path, identity in snapshot.directory_identities
+        ],
+        "governance_root": root,
+    }
+    return _framed_digest(_AUTHORING_SNAPSHOT_DOMAIN, value)
+
+
+def _requirements(compiled: policy.Policy) -> dict[str, set[str]]:
+    required: dict[str, set[str]] = {}
+    for rule in compiled.rules:
+        required.setdefault(rule.audience, set())
+        if rule.purpose is not None:
+            required[rule.audience].add(rule.purpose)
+    for grant in compiled.grants:
+        required.setdefault(grant.audience, set())
+    for release in compiled.release_grants:
+        required.setdefault(release.to_audience, set())
+    for principal_id in required:
+        _identifier(principal_id)
+    return required
+
+
+def _complete_requirements(
+    compiled: policy.Policy,
+    representative: Mapping[str, Sequence[str]] | None,
+) -> dict[str, set[str]]:
+    required = _requirements(compiled)
+    if representative is None:
+        return required
+    if not isinstance(representative, Mapping) or len(representative) > 1024:
+        _fail()
+    normalized: dict[str, tuple[str, ...]] = {}
+    for raw_principal, raw_purposes in representative.items():
+        principal_id = _identifier(raw_principal)
+        if principal_id in normalized:
+            _fail()
+        normalized[principal_id] = _purposes(raw_purposes)
+    for principal_id, purposes in normalized.items():
+        required.setdefault(principal_id, set()).update(purposes)
+    return required
+
+
+def _requirements_tuple(
+    requirements: Mapping[str, set[str]],
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    return tuple(
+        (principal_id, tuple(sorted(purposes)))
+        for principal_id, purposes in sorted(requirements.items())
+    )
+
+
+def _principal_map(principals: Sequence[RequestPrincipal]) -> dict[str, RequestPrincipal]:
+    result: dict[str, RequestPrincipal] = {}
+    for principal in principals:
+        if not isinstance(principal, RequestPrincipal):
+            _fail()
+        principal_id = _identifier(principal.audience_id)
+        if principal_id in result:
+            _fail()
+        result[principal_id] = principal
+    return result
+
+
+def _verify_attestation_set(
+    attestations: Sequence[DestinationPrincipalAttestation],
+    principals: Sequence[RequestPrincipal],
+    requirements: Mapping[str, set[str]],
+    *,
+    destination_vault_id: str,
+    expected_nonce: str,
+    verified_at: str,
+) -> tuple[DestinationPrincipalAttestation, ...]:
+    principal_by_id = _principal_map(principals)
+    attestation_by_principal: dict[str, DestinationPrincipalAttestation] = {}
+    for attestation in attestations:
+        if attestation.principal_id in attestation_by_principal:
+            _fail()
+        principal = principal_by_id.get(attestation.principal_id)
+        if principal is None:
+            _fail()
+        verify_destination_principal_attestation(
+            attestation,
+            principal=principal,
+            destination_vault_id=destination_vault_id,
+            required_purpose=None,
+            expected_nonce=expected_nonce,
+            verified_at=verified_at,
+        )
+        attestation_by_principal[attestation.principal_id] = attestation
+    if set(attestation_by_principal) != set(requirements):
+        _fail()
+    for principal_id, purposes in requirements.items():
+        if not purposes <= set(attestation_by_principal[principal_id].purposes):
+            _fail()
+    return tuple(sorted(attestation_by_principal.values(), key=lambda item: item.principal_id))
+
+
+def _plan_digest(plan: DestinationPolicyPlan) -> str:
+    snapshot = plan.prospective.snapshot
+    value = {
+        "schema": plan.schema,
+        "destination_vault_id": plan.destination_vault_id,
+        "source_fingerprint": snapshot.source_fingerprint,
+        "conflict_set_digest": snapshot.conflict_set_digest,
+        "guard_generation": snapshot.guard_generation,
+        "document_set_digest": plan.document_set_digest,
+        "authoring_snapshot_digest": plan.authoring_snapshot_digest,
+        "policy_fingerprint": plan.prospective.policy.fingerprint,
+        "source_authority_review_digest": plan.source_authority_review_digest,
+        "principal_attestation_set_digest": plan.principal_attestation_set_digest,
+        "principal_requirements": [
+            {"principal_id": principal_id, "purposes": list(purposes)}
+            for principal_id, purposes in plan.principal_requirements
+        ],
+        "named_principals": list(plan.named_principals),
+    }
+    return _framed_digest(_PLAN_DOMAIN, value)
+
+
+def compile_destination_policy(
+    vault_root: Path,
+    *,
+    documents: Mapping[str, str | None],
+    source_authority: Sequence[SourceAuthorityReviewArtifact],
+    attestations: Sequence[DestinationPrincipalAttestation],
+    principal_contexts: Sequence[RequestPrincipal],
+    representative_principal_purposes: Mapping[str, Sequence[str]] | None = None,
+    destination_vault_id: str,
+    expected_nonce: str,
+    verified_at: str,
+) -> DestinationPolicyPlan:
+    """Compile newly authored destination documents without activating them."""
+
+    vault_id = _identifier(destination_vault_id)
+    edits = _document_edits(documents)
+    prospective = policy.compile_prospective(Path(vault_root), dict(edits))
+    if prospective is None or prospective.policy.blocked or prospective.policy.conflicted:
+        _fail()
+    requirements = _complete_requirements(prospective.policy, representative_principal_purposes)
+    verified_attestations = _verify_attestation_set(
+        attestations,
+        principal_contexts,
+        requirements,
+        destination_vault_id=vault_id,
+        expected_nonce=expected_nonce,
+        verified_at=verified_at,
+    )
+    source_rows = _source_authority_value(source_authority)
+    ordered_source = tuple(sorted(source_authority, key=lambda item: item.object_ref))
+    source_digest = _framed_digest(_SOURCE_AUTHORITY_REVIEW_DOMAIN, source_rows)
+    attestation_digest = principal_attestation_set_digest(verified_attestations)
+    plan = DestinationPolicyPlan(
+        schema=DESTINATION_POLICY_PLAN_SCHEMA,
+        destination_vault_id=vault_id,
+        prospective=prospective,
+        document_edits=edits,
+        document_set_digest=_document_set_digest(prospective.target_documents),
+        authoring_snapshot_digest=_authoring_snapshot_digest(prospective.snapshot),
+        source_authority=ordered_source,
+        source_authority_review_digest=source_digest,
+        attestations=verified_attestations,
+        principal_attestation_set_digest=attestation_digest,
+        principal_requirements=_requirements_tuple(requirements),
+        named_principals=tuple(sorted(requirements)),
+        digest="0" * 64,
+    )
+    return DestinationPolicyPlan(
+        schema=plan.schema,
+        destination_vault_id=plan.destination_vault_id,
+        prospective=plan.prospective,
+        document_edits=plan.document_edits,
+        document_set_digest=plan.document_set_digest,
+        authoring_snapshot_digest=plan.authoring_snapshot_digest,
+        source_authority=plan.source_authority,
+        source_authority_review_digest=plan.source_authority_review_digest,
+        attestations=plan.attestations,
+        principal_attestation_set_digest=plan.principal_attestation_set_digest,
+        principal_requirements=plan.principal_requirements,
+        named_principals=plan.named_principals,
+        digest=_plan_digest(plan),
+    )
+
+
+def revalidate_destination_policy(
+    vault_root: Path,
+    plan: DestinationPolicyPlan,
+    *,
+    principal_contexts: Sequence[RequestPrincipal],
+    destination_vault_id: str,
+    expected_nonce: str,
+    verified_at: str,
+) -> DestinationPolicyPlan:
+    """Recheck exact policy and live destination sessions immediately before apply."""
+
+    if (
+        not isinstance(plan, DestinationPolicyPlan)
+        or plan.schema != DESTINATION_POLICY_PLAN_SCHEMA
+        or plan.destination_vault_id != _identifier(destination_vault_id)
+        or plan.digest != _plan_digest(plan)
+        or plan.source_authority_review_digest
+        != source_authority_review_digest(plan.source_authority)
+        or plan.principal_attestation_set_digest
+        != principal_attestation_set_digest(plan.attestations)
+        or plan.authoring_snapshot_digest != _authoring_snapshot_digest(plan.prospective.snapshot)
+    ):
+        _fail()
+    prospective = policy.compile_prospective(Path(vault_root), dict(plan.document_edits))
+    if (
+        prospective is None
+        or prospective.policy.blocked
+        or prospective.policy.conflicted
+        or prospective != plan.prospective
+        or _document_set_digest(prospective.target_documents) != plan.document_set_digest
+        or _authoring_snapshot_digest(prospective.snapshot) != plan.authoring_snapshot_digest
+    ):
+        _fail()
+    requirements = {
+        principal_id: set(purposes) for principal_id, purposes in plan.principal_requirements
+    }
+    if _requirements_tuple(requirements) != plan.principal_requirements or any(
+        not purposes <= requirements.get(principal_id, set())
+        for principal_id, purposes in _requirements(prospective.policy).items()
+    ):
+        _fail()
+    verified = _verify_attestation_set(
+        plan.attestations,
+        principal_contexts,
+        requirements,
+        destination_vault_id=plan.destination_vault_id,
+        expected_nonce=expected_nonce,
+        verified_at=verified_at,
+    )
+    if tuple(sorted(requirements)) != plan.named_principals or verified != plan.attestations:
+        _fail()
+    return plan

--- a/tests/test_consolidation_policy.py
+++ b/tests/test_consolidation_policy.py
@@ -1,0 +1,766 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from exomem import held_fs
+from exomem.governance import consolidation_policy, decisions, membership, policy, store
+from exomem.governance.authorization_session_lifecycle import AuthorizationSessionContext
+from exomem.governance.principal import RequestPrincipal
+
+DESTINATION_VAULT_ID = "destination-vault"
+PRINCIPAL_ID = "principal:destination-owner"
+MATRIX_PRINCIPAL_ID = "principal:destination-reviewer"
+ISSUER = "mcp-oauth:destination-issuer"
+NONCE = "run-00000000000000000001"
+ISSUED_AT = "2026-08-28T09:00:00.000Z"
+EXPIRES_AT = "2026-08-28T10:00:00.000Z"
+VERIFIED_AT = "2026-08-28T09:30:00.000Z"
+SCOPE_A = "01ARZ3NDEKTSV4RRFFQ69G5FA1"
+SCOPE_B = "01ARZ3NDEKTSV4RRFFQ69G5FA2"
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _principal(
+    *,
+    principal_id: str = PRINCIPAL_ID,
+    issuer: str = ISSUER,
+    session_id: str = "destination-session",
+    generation: int = 3,
+    vault_id: str = DESTINATION_VAULT_ID,
+) -> RequestPrincipal:
+    context = AuthorizationSessionContext(
+        session_id=session_id,
+        principal_id=principal_id,
+        issuer_family=issuer,
+        cell_id="destination-cell",
+        logical_vault_id=vault_id,
+        keyring_id="destination-keyring",
+        credential_generation=generation,
+        expires_at=1_800_000_000,
+    )
+    return RequestPrincipal(
+        audience_id=principal_id,
+        surface="mcp",
+        authorization_session_id=session_id,
+        resolved=True,
+        issuer_family=issuer,
+        verified_authorization_session=context,
+    )
+
+
+def _attestation(
+    *,
+    principal: RequestPrincipal | None = None,
+    purposes: tuple[str, ...] = ("audit",),
+    nonce: str = NONCE,
+) -> consolidation_policy.DestinationPrincipalAttestation:
+    return consolidation_policy.issue_destination_principal_attestation(
+        principal or _principal(),
+        destination_vault_id=DESTINATION_VAULT_ID,
+        purposes=purposes,
+        issued_at=ISSUED_AT,
+        expires_at=EXPIRES_AT,
+        nonce=nonce,
+    )
+
+
+def _review(kind: str = "policy") -> consolidation_policy.SourceAuthorityReviewArtifact:
+    return consolidation_policy.SourceAuthorityReviewArtifact(
+        object_ref=f"source-{kind}",
+        object_kind=kind,
+        object_sha256=_digest(f"{kind}-object"),
+        bundle_sha256=_digest(f"{kind}-bundle"),
+        provenance_ref=f"exomem-source-artifact://sha256/{_digest(kind)}",
+    )
+
+
+def _documents(*, audience: str = PRINCIPAL_ID) -> dict[str, str]:
+    return {
+        "scopes/private.yaml": (
+            "governance_version: 1\n"
+            f"id: {SCOPE_A}\n"
+            "name: Private notes\n"
+            "default_deny: true\n"
+            'paths: ["Notes/Private/**"]\n'
+        ),
+        "rules/private-audit.yaml": (
+            "governance_version: 1\n"
+            "id: 01ARZ3NDEKTSV4RRFFQ69G5FB1\n"
+            f'scope_ids: ["{SCOPE_A}"]\n'
+            f"audience: {audience}\n"
+            "purpose: audit\n"
+            "ceiling: 2\n"
+            "options:\n"
+            "  constraint: reviewed-only\n"
+        ),
+    }
+
+
+def _vault(tmp_path: Path) -> Path:
+    (tmp_path / "Knowledge Base").mkdir()
+    return tmp_path
+
+
+def test_destination_principal_attestation_has_one_fixed_vector() -> None:
+    attestation = _attestation()
+
+    assert attestation == consolidation_policy.DestinationPrincipalAttestation(
+        schema="destination-principal-attestation/v1",
+        destination_vault_id=DESTINATION_VAULT_ID,
+        issuer_family=ISSUER,
+        surface="mcp",
+        principal_id=PRINCIPAL_ID,
+        purposes=("audit",),
+        issued_at=ISSUED_AT,
+        expires_at=EXPIRES_AT,
+        authentication_binding_digest=(
+            "4128ec7ce82de35d791fb00327a94018403a9d2f1b38a365720482d45633d2c9"
+        ),
+        nonce=NONCE,
+        fingerprint="5d9235fd561319b494048c348572709ab495d59256f1d2cf89485b1ef23e2ae6",
+    )
+    verified = consolidation_policy.verify_destination_principal_attestation(
+        attestation,
+        principal=_principal(),
+        destination_vault_id=DESTINATION_VAULT_ID,
+        required_purpose="audit",
+        expected_nonce=NONCE,
+        verified_at=VERIFIED_AT,
+    )
+    assert verified.attestation == attestation
+    assert verified.verified_at == VERIFIED_AT
+
+
+@pytest.mark.parametrize(
+    ("mutation", "principal", "vault_id", "purpose", "nonce", "verified_at"),
+    [
+        (
+            {"schema": "source-export-attestation/v1"},
+            None,
+            DESTINATION_VAULT_ID,
+            "audit",
+            NONCE,
+            VERIFIED_AT,
+        ),
+        (
+            {"destination_vault_id": "source-vault"},
+            None,
+            DESTINATION_VAULT_ID,
+            "audit",
+            NONCE,
+            VERIFIED_AT,
+        ),
+        (
+            {"issuer_family": "mcp-oauth:other"},
+            None,
+            DESTINATION_VAULT_ID,
+            "audit",
+            NONCE,
+            VERIFIED_AT,
+        ),
+        ({"surface": "hosted"}, None, DESTINATION_VAULT_ID, "audit", NONCE, VERIFIED_AT),
+        (
+            {"principal_id": "principal:caller-selected"},
+            None,
+            DESTINATION_VAULT_ID,
+            "audit",
+            NONCE,
+            VERIFIED_AT,
+        ),
+        ({"purposes": ("research",)}, None, DESTINATION_VAULT_ID, "audit", NONCE, VERIFIED_AT),
+        (
+            {"issued_at": "2026-08-28T09:45:00.000Z"},
+            None,
+            DESTINATION_VAULT_ID,
+            "audit",
+            NONCE,
+            VERIFIED_AT,
+        ),
+        (
+            {"expires_at": "2026-08-28T09:15:00.000Z"},
+            None,
+            DESTINATION_VAULT_ID,
+            "audit",
+            NONCE,
+            VERIFIED_AT,
+        ),
+        ({"nonce": "source-run"}, None, DESTINATION_VAULT_ID, "audit", NONCE, VERIFIED_AT),
+        ({}, {"session_id": "other-session"}, DESTINATION_VAULT_ID, "audit", NONCE, VERIFIED_AT),
+        ({}, {"generation": 4}, DESTINATION_VAULT_ID, "audit", NONCE, VERIFIED_AT),
+        ({}, None, "other-vault", "audit", NONCE, VERIFIED_AT),
+        ({}, None, DESTINATION_VAULT_ID, "research", NONCE, VERIFIED_AT),
+        ({}, None, DESTINATION_VAULT_ID, "audit", "other-run", VERIFIED_AT),
+        ({}, None, DESTINATION_VAULT_ID, "audit", NONCE, "2026-08-28T10:00:00.001Z"),
+    ],
+)
+def test_destination_attestation_refuses_forgery_copy_staleness_and_replay(
+    mutation: dict[str, object],
+    principal: dict[str, object] | None,
+    vault_id: str,
+    purpose: str,
+    nonce: str,
+    verified_at: str,
+) -> None:
+    attestation = replace(_attestation(), **mutation)
+    live_principal = _principal(**(principal or {}))
+
+    with pytest.raises(consolidation_policy.DestinationPolicyUnavailable):
+        consolidation_policy.verify_destination_principal_attestation(
+            attestation,
+            principal=live_principal,
+            destination_vault_id=vault_id,
+            required_purpose=purpose,
+            expected_nonce=nonce,
+            verified_at=verified_at,
+        )
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "access_control",
+        "audience",
+        "authorization_session",
+        "credential",
+        "grant",
+        "policy",
+        "receipt",
+        "release_approval",
+        "review_authority",
+        "runtime_binding",
+        "token",
+    ],
+)
+def test_source_authority_is_digest_only_review_input_never_destination_authority(
+    tmp_path: Path, kind: str
+) -> None:
+    plan = consolidation_policy.compile_destination_policy(
+        _vault(tmp_path),
+        documents=_documents(),
+        source_authority=(_review(kind),),
+        attestations=(_attestation(),),
+        principal_contexts=(_principal(),),
+        destination_vault_id=DESTINATION_VAULT_ID,
+        expected_nonce=NONCE,
+        verified_at=VERIFIED_AT,
+    )
+
+    assert plan.prospective.policy.rules[0].audience == PRINCIPAL_ID
+    assert (
+        plan.source_authority_review_digest
+        == consolidation_policy.source_authority_review_digest((_review(kind),))
+    )
+    assert plan.document_edits == tuple(sorted(_documents().items()))
+    assert plan.source_authority == (_review(kind),)
+    assert set(_review(kind).__slots__) == {
+        "object_ref",
+        "object_kind",
+        "object_sha256",
+        "bundle_sha256",
+        "provenance_ref",
+    }
+    assert not hasattr(plan, "source_documents")
+    assert not hasattr(plan, "source_credentials")
+
+
+def test_destination_policy_requires_fresh_attestation_for_every_named_principal(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    with pytest.raises(consolidation_policy.DestinationPolicyUnavailable):
+        consolidation_policy.compile_destination_policy(
+            vault,
+            documents=_documents(),
+            source_authority=(_review(),),
+            attestations=(),
+            principal_contexts=(),
+            destination_vault_id=DESTINATION_VAULT_ID,
+            expected_nonce=NONCE,
+            verified_at=VERIFIED_AT,
+        )
+
+
+def test_representative_disclosure_principal_requires_its_own_fresh_attestation(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    reviewer = _principal(
+        principal_id=MATRIX_PRINCIPAL_ID,
+        session_id="reviewer-session",
+    )
+    reviewer_attestation = _attestation(
+        principal=reviewer,
+        purposes=("research",),
+    )
+
+    with pytest.raises(consolidation_policy.DestinationPolicyUnavailable):
+        consolidation_policy.compile_destination_policy(
+            vault,
+            documents=_documents(),
+            source_authority=(_review(),),
+            attestations=(_attestation(),),
+            principal_contexts=(_principal(), reviewer),
+            representative_principal_purposes={MATRIX_PRINCIPAL_ID: ("research",)},
+            destination_vault_id=DESTINATION_VAULT_ID,
+            expected_nonce=NONCE,
+            verified_at=VERIFIED_AT,
+        )
+
+    plan = consolidation_policy.compile_destination_policy(
+        vault,
+        documents=_documents(),
+        source_authority=(_review(),),
+        attestations=(_attestation(), reviewer_attestation),
+        principal_contexts=(_principal(), reviewer),
+        representative_principal_purposes={MATRIX_PRINCIPAL_ID: ("research",)},
+        destination_vault_id=DESTINATION_VAULT_ID,
+        expected_nonce=NONCE,
+        verified_at=VERIFIED_AT,
+    )
+    assert plan.named_principals == (PRINCIPAL_ID, MATRIX_PRINCIPAL_ID)
+    assert plan.principal_requirements == (
+        (PRINCIPAL_ID, ("audit",)),
+        (MATRIX_PRINCIPAL_ID, ("research",)),
+    )
+    assert (
+        consolidation_policy.revalidate_destination_policy(
+            vault,
+            plan,
+            principal_contexts=(_principal(), reviewer),
+            destination_vault_id=DESTINATION_VAULT_ID,
+            expected_nonce=NONCE,
+            verified_at=VERIFIED_AT,
+        )
+        == plan
+    )
+    with pytest.raises(consolidation_policy.DestinationPolicyUnavailable):
+        consolidation_policy.revalidate_destination_policy(
+            vault,
+            plan,
+            principal_contexts=(_principal(),),
+            destination_vault_id=DESTINATION_VAULT_ID,
+            expected_nonce=NONCE,
+            verified_at=VERIFIED_AT,
+        )
+
+    source_attestation = consolidation_policy.issue_destination_principal_attestation(
+        _principal(vault_id="source-vault"),
+        destination_vault_id="source-vault",
+        purposes=("audit",),
+        issued_at=ISSUED_AT,
+        expires_at=EXPIRES_AT,
+        nonce=NONCE,
+    )
+    with pytest.raises(consolidation_policy.DestinationPolicyUnavailable):
+        consolidation_policy.compile_destination_policy(
+            vault,
+            documents=_documents(),
+            source_authority=(_review(),),
+            attestations=(source_attestation,),
+            principal_contexts=(_principal(vault_id="source-vault"),),
+            destination_vault_id=DESTINATION_VAULT_ID,
+            expected_nonce=NONCE,
+            verified_at=VERIFIED_AT,
+        )
+
+
+def test_coincident_source_audience_provenance_cannot_supply_destination_authority(
+    tmp_path: Path,
+) -> None:
+    source_audience = replace(
+        _review("audience"),
+        object_ref=PRINCIPAL_ID,
+        provenance_ref=f"exomem-source-artifact://sha256/{_digest('source-audience')}",
+    )
+
+    with pytest.raises(consolidation_policy.DestinationPolicyUnavailable):
+        consolidation_policy.compile_destination_policy(
+            _vault(tmp_path),
+            documents=_documents(audience=source_audience.object_ref),
+            source_authority=(source_audience,),
+            attestations=(),
+            principal_contexts=(),
+            destination_vault_id=DESTINATION_VAULT_ID,
+            expected_nonce=NONCE,
+            verified_at=VERIFIED_AT,
+        )
+
+
+def test_empty_source_authority_and_no_new_destination_documents_are_valid(
+    tmp_path: Path,
+) -> None:
+    plan = consolidation_policy.compile_destination_policy(
+        _vault(tmp_path),
+        documents={},
+        source_authority=(),
+        attestations=(),
+        principal_contexts=(),
+        destination_vault_id=DESTINATION_VAULT_ID,
+        expected_nonce=NONCE,
+        verified_at=VERIFIED_AT,
+    )
+
+    assert plan.prospective.policy.scopes == {}
+    assert plan.prospective.policy.rules == ()
+    assert plan.source_authority == ()
+    assert plan.named_principals == ()
+
+
+def test_prospective_policy_prevents_sibling_grant_crossover(tmp_path: Path) -> None:
+    documents = _documents()
+    del documents["rules/private-audit.yaml"]
+    documents.update(
+        {
+            "scopes/sibling.yaml": (
+                "governance_version: 1\n"
+                f"id: {SCOPE_B}\n"
+                "name: Sibling\n"
+                "default_deny: true\n"
+                'paths: ["Notes/Private/**"]\n'
+            ),
+            "grants/sibling.yaml": (
+                "governance_version: 1\n"
+                "id: 01ARZ3NDEKTSV4RRFFQ69G5FB3\n"
+                "kind: standing\n"
+                f'scope_ids: ["{SCOPE_B}"]\n'
+                f"audience: {PRINCIPAL_ID}\n"
+                "ceiling: 5\n"
+            ),
+        }
+    )
+    plan = consolidation_policy.compile_destination_policy(
+        _vault(tmp_path),
+        documents=documents,
+        source_authority=(_review(),),
+        attestations=(_attestation(),),
+        principal_contexts=(_principal(),),
+        destination_vault_id=DESTINATION_VAULT_ID,
+        expected_nonce=NONCE,
+        verified_at=VERIFIED_AT,
+    )
+
+    decision = decisions.decide(
+        (SCOPE_A, SCOPE_B),
+        audience=PRINCIPAL_ID,
+        purpose="audit",
+        policy=plan.prospective.policy,
+    )
+    assert decision.level == 0
+    assert decision.default_deny_scope_ids == (SCOPE_A, SCOPE_B)
+    contributions = {item.scope_id: item for item in decision.scope_contributions}
+    assert contributions[SCOPE_A].final_ceiling == 0
+    assert contributions[SCOPE_B].final_ceiling == 5
+
+
+def test_prospective_policy_preserves_deny_dominance_over_a_grant(tmp_path: Path) -> None:
+    documents = _documents()
+    documents["scopes/private.yaml"] = documents["scopes/private.yaml"].replace(
+        "default_deny: true\n", ""
+    )
+    documents["rules/private-audit.yaml"] = (
+        "governance_version: 1\n"
+        "id: 01ARZ3NDEKTSV4RRFFQ69G5FB2\n"
+        f'scope_ids: ["{SCOPE_A}"]\n'
+        f"audience: {PRINCIPAL_ID}\n"
+        "kind: org_cap\n"
+        "ceiling: 0\n"
+    )
+    documents["grants/private.yaml"] = (
+        "governance_version: 1\n"
+        "id: 01ARZ3NDEKTSV4RRFFQ69G5FB3\n"
+        "kind: standing\n"
+        f'scope_ids: ["{SCOPE_A}"]\n'
+        f"audience: {PRINCIPAL_ID}\n"
+        "ceiling: 6\n"
+    )
+    plan = consolidation_policy.compile_destination_policy(
+        _vault(tmp_path),
+        documents=documents,
+        source_authority=(_review(),),
+        attestations=(_attestation(),),
+        principal_contexts=(_principal(),),
+        destination_vault_id=DESTINATION_VAULT_ID,
+        expected_nonce=NONCE,
+        verified_at=VERIFIED_AT,
+    )
+
+    decision = decisions.decide((SCOPE_A,), audience=PRINCIPAL_ID, policy=plan.prospective.policy)
+    assert decision.level == 0
+    assert decision.scope_contributions[0].grant_contribution == 6
+    assert decision.scope_contributions[0].organization_cap == 0
+
+
+def test_prospective_policy_preserves_conservative_option_meet(tmp_path: Path) -> None:
+    documents = _documents()
+    documents["rules/private-audit.yaml"] = documents["rules/private-audit.yaml"].replace(
+        "purpose: audit\n", ""
+    )
+    documents["rules/private-audit-other.yaml"] = (
+        "governance_version: 1\n"
+        "id: 01ARZ3NDEKTSV4RRFFQ69G5FB5\n"
+        f'scope_ids: ["{SCOPE_A}"]\n'
+        f"audience: {PRINCIPAL_ID}\n"
+        "ceiling: 2\n"
+        "options:\n"
+        "  constraint: independently-reviewed\n"
+    )
+    plan = consolidation_policy.compile_destination_policy(
+        _vault(tmp_path),
+        documents=documents,
+        source_authority=(_review(),),
+        attestations=(_attestation(),),
+        principal_contexts=(_principal(),),
+        destination_vault_id=DESTINATION_VAULT_ID,
+        expected_nonce=NONCE,
+        verified_at=VERIFIED_AT,
+    )
+
+    decision = decisions.decide(
+        (SCOPE_A,),
+        audience=PRINCIPAL_ID,
+        purpose=None,
+        policy=plan.prospective.policy,
+    )
+    assert decision.level == 1
+    assert "constraint" not in decision.options
+    assert decision.options["constraint_ambiguous"] is True
+
+
+def test_prospective_policy_compiles_bridge_and_exact_release_for_fresh_principal(
+    tmp_path: Path,
+) -> None:
+    documents = _documents()
+    documents["rules/private-audit.yaml"] = documents["rules/private-audit.yaml"].replace(
+        "  constraint: reviewed-only\n",
+        "  constraint: reviewed-only\n  bridge: destination-review\n",
+    )
+    documents["grants/exact-release.yaml"] = (
+        "governance_version: 1\n"
+        "id: 01ARZ3NDEKTSV4RRFFQ69G5FB6\n"
+        "kind: release\n"
+        "path: Knowledge Base/Notes/released.md\n"
+        "ref: exomem://memory/00000000-0000-0000-0000-000000000001\n"
+        f"content_hash: {'a' * 64}\n"
+        f"to_audience: {PRINCIPAL_ID}\n"
+        "released_at: '2026-08-28T09:00:00Z'\n"
+        "why: Destination owner reviewed the exact release\n"
+        "bridge_scope: destination-review\n"
+        "bridge_of:\n"
+        "  - ref: exomem://memory/00000000-0000-0000-0000-000000000002\n"
+        "    path: Knowledge Base/Sources/source.md\n"
+        f"    content_hash: {'b' * 64}\n"
+        f"    restriction_signature: {'c' * 64}\n"
+        "options:\n"
+        "  strip_provenance:\n"
+        "    - exomem://memory/00000000-0000-0000-0000-000000000002\n"
+    )
+
+    plan = consolidation_policy.compile_destination_policy(
+        _vault(tmp_path),
+        documents=documents,
+        source_authority=(_review(),),
+        attestations=(_attestation(),),
+        principal_contexts=(_principal(),),
+        destination_vault_id=DESTINATION_VAULT_ID,
+        expected_nonce=NONCE,
+        verified_at=VERIFIED_AT,
+    )
+
+    assert plan.prospective.policy.rules[0].options["bridge"] == "destination-review"
+    assert plan.prospective.policy.release_grants[0].to_audience == PRINCIPAL_ID
+
+
+def test_prospective_semantic_scope_keeps_non_markdown_membership_unresolved(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    asset = vault / "Knowledge Base" / "Notes" / "opaque.bin"
+    asset.parent.mkdir(parents=True)
+    asset.write_bytes(b"\x00private")
+    documents = _documents()
+    documents["scopes/private.yaml"] = (
+        "governance_version: 1\n"
+        f"id: {SCOPE_A}\n"
+        "name: Private sources\n"
+        "default_deny: true\n"
+        'types: ["source"]\n'
+    )
+    plan = consolidation_policy.compile_destination_policy(
+        vault,
+        documents=documents,
+        source_authority=(_review(),),
+        attestations=(_attestation(),),
+        principal_contexts=(_principal(),),
+        destination_vault_id=DESTINATION_VAULT_ID,
+        expected_nonce=NONCE,
+        verified_at=VERIFIED_AT,
+    )
+
+    outcome = membership.evaluate_path_only(
+        vault,
+        "Knowledge Base/Notes/opaque.bin",
+        plan.prospective.policy,
+    )
+    assert outcome.state == "unresolved"
+    with pytest.raises(membership.MembershipUnresolved):
+        outcome.require_classified()
+
+
+def test_prospective_policy_refuses_pending_guard_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    probes = iter(
+        (
+            {"state": "clear", "generation": "guard-before", "event_ids": ()},
+            {"state": "clear", "generation": "guard-after", "event_ids": ()},
+        )
+    )
+    monkeypatch.setattr(store, "guard_generation_probe", lambda _vault: next(probes))
+
+    with pytest.raises(consolidation_policy.DestinationPolicyUnavailable):
+        consolidation_policy.compile_destination_policy(
+            _vault(tmp_path),
+            documents=_documents(),
+            source_authority=(_review(),),
+            attestations=(_attestation(),),
+            principal_contexts=(_principal(),),
+            destination_vault_id=DESTINATION_VAULT_ID,
+            expected_nonce=NONCE,
+            verified_at=VERIFIED_AT,
+        )
+
+
+def test_prospective_policy_refuses_document_change_during_acquisition(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = _vault(tmp_path)
+    scope = vault / "Knowledge Base" / "_Governance" / "scopes" / "existing.yaml"
+    scope.parent.mkdir(parents=True)
+    scope.write_text(_documents()["scopes/private.yaml"], encoding="utf-8")
+    changed = False
+
+    def barrier(phase: str, _path: str | None = None) -> None:
+        nonlocal changed
+        if phase == "after_read" and not changed:
+            changed = True
+            scope.write_text(
+                _documents()["scopes/private.yaml"].replace("Private notes", "Changed"),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr(policy, "_authoring_snapshot_barrier", barrier)
+
+    with pytest.raises(consolidation_policy.DestinationPolicyUnavailable):
+        consolidation_policy.compile_destination_policy(
+            vault,
+            documents=_documents(),
+            source_authority=(_review(),),
+            attestations=(_attestation(),),
+            principal_contexts=(_principal(),),
+            destination_vault_id=DESTINATION_VAULT_ID,
+            expected_nonce=NONCE,
+            verified_at=VERIFIED_AT,
+        )
+    assert changed
+
+
+def test_prospective_policy_refuses_a_preexisting_conflict_copy(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    governance = vault / "Knowledge Base" / "_Governance" / "scopes"
+    governance.mkdir(parents=True)
+    (governance / "private.yaml").write_text(_documents()["scopes/private.yaml"], encoding="utf-8")
+    (governance / "private.sync-conflict-20260828-120000-ABCDEFG.yaml").write_text(
+        _documents()["scopes/private.yaml"], encoding="utf-8"
+    )
+
+    with pytest.raises(consolidation_policy.DestinationPolicyUnavailable):
+        consolidation_policy.compile_destination_policy(
+            vault,
+            documents=_documents(),
+            source_authority=(_review(),),
+            attestations=(_attestation(),),
+            principal_contexts=(_principal(),),
+            destination_vault_id=DESTINATION_VAULT_ID,
+            expected_nonce=NONCE,
+            verified_at=VERIFIED_AT,
+        )
+
+
+def test_apply_revalidation_refuses_policy_or_session_drift(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    plan = consolidation_policy.compile_destination_policy(
+        vault,
+        documents=_documents(),
+        source_authority=(_review(),),
+        attestations=(_attestation(),),
+        principal_contexts=(_principal(),),
+        destination_vault_id=DESTINATION_VAULT_ID,
+        expected_nonce=NONCE,
+        verified_at=VERIFIED_AT,
+    )
+    assert (
+        consolidation_policy.revalidate_destination_policy(
+            vault,
+            plan,
+            principal_contexts=(_principal(),),
+            destination_vault_id=DESTINATION_VAULT_ID,
+            expected_nonce=NONCE,
+            verified_at=VERIFIED_AT,
+        )
+        == plan
+    )
+
+    forged_snapshot = replace(
+        plan.prospective.snapshot,
+        governance_root_identity=held_fs.StableIdentity(7, 11, "directory", 1),
+    )
+    forged_plan = replace(
+        plan,
+        prospective=replace(plan.prospective, snapshot=forged_snapshot),
+    )
+    with pytest.raises(consolidation_policy.DestinationPolicyUnavailable):
+        consolidation_policy.revalidate_destination_policy(
+            vault,
+            forged_plan,
+            principal_contexts=(_principal(),),
+            destination_vault_id=DESTINATION_VAULT_ID,
+            expected_nonce=NONCE,
+            verified_at=VERIFIED_AT,
+        )
+
+    governance = vault / "Knowledge Base" / "_Governance" / "rules"
+    governance.mkdir(parents=True)
+    (governance / "foreign.yaml").write_text(
+        "governance_version: 1\n"
+        "id: 01ARZ3NDEKTSV4RRFFQ69G5FB4\n"
+        f'scope_ids: ["{SCOPE_A}"]\n'
+        f"audience: {PRINCIPAL_ID}\n"
+        "ceiling: 6\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(consolidation_policy.DestinationPolicyUnavailable):
+        consolidation_policy.revalidate_destination_policy(
+            vault,
+            plan,
+            principal_contexts=(_principal(),),
+            destination_vault_id=DESTINATION_VAULT_ID,
+            expected_nonce=NONCE,
+            verified_at=VERIFIED_AT,
+        )
+
+    with pytest.raises(consolidation_policy.DestinationPolicyUnavailable):
+        consolidation_policy.revalidate_destination_policy(
+            vault,
+            plan,
+            principal_contexts=(_principal(session_id="rotated-session"),),
+            destination_vault_id=DESTINATION_VAULT_ID,
+            expected_nonce=NONCE,
+            verified_at=VERIFIED_AT,
+        )


### PR DESCRIPTION
## Summary

- bind every executable destination audience to a fresh trusted destination authorization-session attestation
- retain source authority only as authenticated digest-only review evidence
- compile newly authored destination scope, rule, bridge, and exact-release documents against the stable conflict-bound prospective snapshot
- revalidate policy bytes, physical authoring identities, session bindings, nonce, expiry, and disclosure-matrix principals before apply

Stacked after #916. This does not touch or merge any live vault.

## Verification

- red-first focused test: missing module refused collection
- task 4 focused gate: 415 passed
- focused policy tests: 40 passed
- Ruff correctness and full checks on changed Python files
- mypy targeted contract check
- `uv lock --check --offline`
- `openspec validate add-governed-vault-consolidation --strict`
- public repository artifact validation
- source distribution and wheel build
- `git diff --check`