### PR TITLE
feat(governance): persist trusted consolidation plans

### DIFF
--- a/src/exomem/governance/consolidation_plan.py
+++ b/src/exomem/governance/consolidation_plan.py
@@ -32,6 +32,8 @@ _PLAN_INPUT_SET_DOMAIN = PLAN_INPUT_SET_SCHEMA.encode("ascii")
 _AUTOMATON_DOMAIN = PLAN_SUCCESSOR_AUTOMATON_SCHEMA.encode("ascii")
 _IMPACT_SUMMARY_DOMAIN = b"exomem.consolidation-impact-summary/v1"
 _RENDERING_DEFINITION_DOMAIN = b"exomem.consolidation-rendering-definition/v1"
+_RENDER_SECTION_DOMAIN = b"exomem.consolidation-render-section/v1"
+_RENDER_PAGE_DOMAIN = b"exomem.consolidation-render-page/v1"
 
 _MAX_SAFE_INTEGER = (1 << 53) - 1
 _DIGEST = re.compile(r"[0-9a-f]{64}\Z")
@@ -61,6 +63,8 @@ _SECTION_IDS = (
     "verification",
     "rollback-retention",
 )
+RENDER_SECTION_IDS = _SECTION_IDS
+RENDER_PAGE_SIZE = 20
 
 _BASE_FIELDS = frozenset(
     {
@@ -187,12 +191,18 @@ __all__ = [
     "PLAN_SUCCESSOR_AUTOMATON_SCHEMA",
     "CanonicalConsolidationPlan",
     "CanonicalObject",
+    "CanonicalPlanPage",
     "ConsolidationPlanUnavailable",
     "PlanMaterializationContext",
+    "RENDER_PAGE_SIZE",
+    "RENDER_SECTION_IDS",
     "canonical_closed_jcs",
+    "derive_rendering_definition",
     "materialize_plan",
     "parse_canonical_plan",
+    "parse_control_basis",
     "plan_successor_automaton",
+    "render_plan_page",
 ]
 
 
@@ -231,6 +241,25 @@ class CanonicalConsolidationPlan:
     control_basis: CanonicalObject
     impact_summary_digest: str
     rendering_definition_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalPlanPage:
+    plan_digest: str
+    plan_kind: str
+    run_id: str
+    page_ordinal: int
+    section_id: str
+    section_page_ordinal: int
+    total_pages: int
+    total_rows: int
+    section_row_count: int
+    page_row_start: int
+    page_row_stop: int
+    impact_summary: Mapping[str, object]
+    rows: tuple[Mapping[str, object], ...]
+    canonical_bytes: bytes
+    digest: str
 
 
 def _fail() -> NoReturn:
@@ -524,11 +553,126 @@ def _identifier_or_prose(value: object) -> str:
     return text
 
 
+def _render_section_rows(
+    value: Mapping[str, object],
+) -> tuple[tuple[str, tuple[Mapping[str, object], ...]], ...]:
+    impact = _mapping(value["impact_summary"], _IMPACT_FIELDS)
+    actions = tuple(_mapping(item, _ACTION_FIELDS) for item in _sequence(value["content_actions"]))
+    documents = tuple(
+        {
+            "row_kind": "policy-document",
+            **dict(_mapping(item, _POLICY_DOCUMENT_FIELDS)),
+        }
+        for item in _sequence(value["policy_documents"], maximum=1024)
+    )
+    policy_fingerprints: Mapping[str, object] = {
+        "row_kind": "policy-fingerprints",
+        "prospective_policy_fingerprint": value["prospective_policy_fingerprint"],
+        "bridge_fingerprints": tuple(_sequence(value["bridge_fingerprints"], maximum=4096)),
+        "exact_release_approval_fingerprints": tuple(
+            _sequence(value["exact_release_approval_fingerprints"], maximum=4096)
+        ),
+    }
+    principal_disclosure: Mapping[str, object] = {
+        "row_kind": "principal-disclosure",
+        "principal_attestation_set_digest": value["principal_attestation_set_digest"],
+        "disclosure_matrix_digest": value["disclosure_matrix_digest"],
+    }
+    verification: Mapping[str, object] = {
+        "row_kind": "verification",
+        **dict(_mapping(value["verification_plan"], _VERIFICATION_FIELDS)),
+    }
+    rollback_retention: Mapping[str, object] = {
+        "row_kind": "rollback-retention",
+        "rollback_contingency": dict(_mapping(value["rollback_contingency"], _ROLLBACK_FIELDS)),
+        "source_retention": dict(_mapping(value["source_retention"], _RETENTION_FIELDS)),
+    }
+    return (
+        ("impact-summary", (impact,)),
+        ("content-actions", actions),
+        ("policy", (*documents, policy_fingerprints)),
+        ("principals-disclosure", (principal_disclosure,)),
+        ("verification", (verification,)),
+        ("rollback-retention", (rollback_retention,)),
+    )
+
+
+def _derived_rendering_definition(value: Mapping[str, object]) -> dict[str, object]:
+    sections: list[dict[str, object]] = []
+    total_rows = 0
+    first_page = 0
+    for ordinal, (section_id, rows) in enumerate(_render_section_rows(value)):
+        row_count = len(rows)
+        if row_count == 0:
+            _fail()
+        page_count = (row_count + RENDER_PAGE_SIZE - 1) // RENDER_PAGE_SIZE
+        section_digest = _canonical_object(
+            {
+                "schema": "exomem.consolidation-render-section/v1",
+                "section_id": section_id,
+                "rows": rows,
+            },
+            _RENDER_SECTION_DOMAIN,
+        ).digest
+        sections.append(
+            {
+                "ordinal": ordinal,
+                "section_id": section_id,
+                "row_count": row_count,
+                "first_page_ordinal": first_page,
+                "page_count": page_count,
+                "content_digest": section_digest,
+            }
+        )
+        total_rows += row_count
+        first_page += page_count
+    return {
+        "schema": "exomem.consolidation-rendering-definition/v1",
+        "page_size": RENDER_PAGE_SIZE,
+        "page_count": first_page,
+        "total_rows": total_rows,
+        "sections": sections,
+    }
+
+
+def derive_rendering_definition(
+    plan_fields: Mapping[str, object],
+) -> Mapping[str, object]:
+    """Derive the trusted review topology from immutable plan rows."""
+
+    if not isinstance(plan_fields, Mapping):
+        _fail()
+    fields = frozenset(plan_fields)
+    if fields == _BASE_FIELDS:
+        source = {key: item for key, item in plan_fields.items() if key != "rendering_definition"}
+    elif fields == _BASE_FIELDS - {"rendering_definition"}:
+        source = dict(plan_fields)
+    else:
+        _fail()
+    actions = _validate_content_actions(source["content_actions"])
+    documents = _validate_policy_documents(source["policy_documents"])
+    _validate_impact(source["impact_summary"], actions)
+    _validate_verification(source["verification_plan"])
+    _validate_rollback(source["rollback_contingency"])
+    _validate_retention(source["source_retention"])
+    _digest(source["prospective_policy_fingerprint"])
+    source["content_actions"] = actions
+    source["policy_documents"] = documents
+    source["bridge_fingerprints"] = _sorted_digests(source["bridge_fingerprints"])
+    source["exact_release_approval_fingerprints"] = _sorted_digests(
+        source["exact_release_approval_fingerprints"]
+    )
+    _digest(source["principal_attestation_set_digest"])
+    _digest(source["disclosure_matrix_digest"])
+    return _derived_rendering_definition(source)
+
+
 def _validate_rendering(value: object) -> Mapping[str, object]:
     item = _mapping(value, _RENDERING_FIELDS)
     if item["schema"] != "exomem.consolidation-rendering-definition/v1":
         _fail()
-    _integer(item["page_size"], minimum=1, maximum=1000)
+    if _integer(item["page_size"], minimum=1, maximum=1000) != RENDER_PAGE_SIZE:
+        _fail()
     page_count = _integer(item["page_count"], minimum=1, maximum=(1 << 31) - 1)
     total_rows = _integer(item["total_rows"])
     sections = _sequence(item["sections"], maximum=len(_SECTION_IDS))
@@ -592,7 +736,10 @@ def _validate_base(value: Mapping[str, object]) -> dict[str, object]:
     if item["plan_successor_automaton_digest"] != automaton.digest:
         _fail()
     _validate_impact(item["impact_summary"], actions)
-    _validate_rendering(item["rendering_definition"])
+    provided_rendering = _validate_rendering(item["rendering_definition"])
+    expected_rendering = derive_rendering_definition(item)
+    if canonical_closed_jcs(provided_rendering) != canonical_closed_jcs(expected_rendering):
+        _fail()
     created_text, created = _timestamp(item["created_at"])
     valid_text, valid = _timestamp(item["valid_until"])
     if created >= valid or valid > retention_deadline:
@@ -601,6 +748,7 @@ def _validate_base(value: Mapping[str, object]) -> dict[str, object]:
     normalized = dict(item)
     normalized["bridge_fingerprints"] = bridge_fingerprints
     normalized["exact_release_approval_fingerprints"] = release_fingerprints
+    normalized["rendering_definition"] = expected_rendering
     normalized["created_at"] = created_text
     normalized["valid_until"] = valid_text
     return normalized
@@ -764,6 +912,83 @@ def materialize_plan(
     return _build_plan(full, control_basis=control)
 
 
+def render_plan_page(
+    plan: CanonicalConsolidationPlan,
+    *,
+    page_ordinal: int,
+) -> CanonicalPlanPage:
+    """Derive one bounded trusted-human page from stored canonical plan bytes."""
+
+    if not isinstance(plan, CanonicalConsolidationPlan):
+        _fail()
+    checked = _build_plan(plan.preimage, control_basis=plan.control_basis)
+    if checked != plan:
+        _fail()
+    ordinal = _integer(page_ordinal)
+    definition = _mapping(plan.preimage["rendering_definition"], _RENDERING_FIELDS)
+    total_pages = _integer(definition["page_count"], minimum=1)
+    total_rows = _integer(definition["total_rows"], minimum=1)
+    if ordinal >= total_pages:
+        _fail()
+    sections = _render_section_rows(plan.preimage)
+    selected_section_id = ""
+    selected_rows: tuple[Mapping[str, object], ...] = ()
+    selected_section_page = -1
+    selected_row_start = -1
+    for section_id, rows in sections:
+        section_pages = (len(rows) + RENDER_PAGE_SIZE - 1) // RENDER_PAGE_SIZE
+        if ordinal < section_pages:
+            selected_section_id = section_id
+            selected_rows = rows
+            selected_section_page = ordinal
+            selected_row_start = ordinal * RENDER_PAGE_SIZE
+            break
+        ordinal -= section_pages
+    if selected_section_page < 0:
+        _fail()
+    selected_row_stop = min(selected_row_start + RENDER_PAGE_SIZE, len(selected_rows))
+    page_rows = selected_rows[selected_row_start:selected_row_stop]
+    impact = _mapping(plan.preimage["impact_summary"], _IMPACT_FIELDS)
+    page_preimage = {
+        "schema": "exomem.consolidation-render-page/v1",
+        "run_id": plan.preimage["run_id"],
+        "plan_kind": plan.preimage["plan_kind"],
+        "plan_digest": plan.digest,
+        "page_ordinal": page_ordinal,
+        "section_id": selected_section_id,
+        "section_page_ordinal": selected_section_page,
+        "section_row_count": len(selected_rows),
+        "page_row_start": selected_row_start,
+        "page_row_stop": selected_row_stop,
+        "total_pages": total_pages,
+        "total_rows": total_rows,
+        "impact_summary": impact,
+        "rows": page_rows,
+    }
+    page = _canonical_object(page_preimage, _RENDER_PAGE_DOMAIN)
+    frozen_rows = _freeze(page_rows)
+    frozen_impact = _freeze(impact)
+    if not isinstance(frozen_rows, tuple) or not isinstance(frozen_impact, Mapping):
+        _fail()
+    return CanonicalPlanPage(
+        plan_digest=plan.digest,
+        plan_kind=_identifier(plan.preimage["plan_kind"]),
+        run_id=_uuid4(plan.preimage["run_id"]),
+        page_ordinal=page_ordinal,
+        section_id=selected_section_id,
+        section_page_ordinal=selected_section_page,
+        total_pages=total_pages,
+        total_rows=total_rows,
+        section_row_count=len(selected_rows),
+        page_row_start=selected_row_start,
+        page_row_stop=selected_row_stop,
+        impact_summary=frozen_impact,
+        rows=frozen_rows,
+        canonical_bytes=page.canonical_bytes,
+        digest=page.digest,
+    )
+
+
 def _reject_constant(_value: str) -> NoReturn:
     _fail()
 
@@ -792,14 +1017,8 @@ def _closed_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
     return value
 
 
-def parse_canonical_plan(
-    raw: bytes,
-    *,
-    control_basis: CanonicalObject,
-) -> CanonicalConsolidationPlan:
-    """Parse only exact canonical stored bytes and rebind their control basis."""
-
-    if not isinstance(raw, bytes) or len(raw) > 16 * 1024 * 1024:
+def _parse_canonical_mapping(raw: bytes, *, maximum: int) -> Mapping[str, object]:
+    if not isinstance(raw, bytes) or len(raw) > maximum:
         _fail()
     try:
         parsed = json.loads(
@@ -813,6 +1032,27 @@ def parse_canonical_plan(
         _fail()
     if not isinstance(parsed, Mapping):
         _fail()
+    return parsed
+
+
+def parse_control_basis(raw: bytes) -> CanonicalObject:
+    """Parse exact stored control-basis bytes and recompute their framed digest."""
+
+    parsed = _parse_canonical_mapping(raw, maximum=64 * 1024)
+    control = _canonical_object(_validate_control(parsed), _CONTROL_BASIS_DOMAIN)
+    if control.canonical_bytes != raw:
+        _fail()
+    return control
+
+
+def parse_canonical_plan(
+    raw: bytes,
+    *,
+    control_basis: CanonicalObject,
+) -> CanonicalConsolidationPlan:
+    """Parse only exact canonical stored bytes and rebind their control basis."""
+
+    parsed = _parse_canonical_mapping(raw, maximum=16 * 1024 * 1024)
     plan = _build_plan(parsed, control_basis=control_basis)
     if plan.canonical_bytes != raw:
         _fail()

--- a/src/exomem/governance/consolidation_plan_store.py
+++ b/src/exomem/governance/consolidation_plan_store.py
@@ -1,0 +1,223 @@
+"""Owner-only persistence for canonical governed-consolidation plans."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import NoReturn
+
+from .. import reserved_paths
+from . import consolidation_plan, consolidation_run_state
+
+_DESCRIPTOR_ID = "consolidation-tree"
+_OWNER = "consolidation.run"
+_PLAN_KINDS = frozenset({"cutover", "retirement", "rollback"})
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_UUID4 = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z")
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_MAX_PLAN_BYTES = 16 * 1024 * 1024
+_MAX_CONTROL_BYTES = 64 * 1024
+
+
+class ConsolidationPlanStoreUnavailable(RuntimeError):
+    """Content-free refusal for missing, stale, or corrupt stored plans."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+def _fail(code: str) -> NoReturn:
+    raise ConsolidationPlanStoreUnavailable(code) from None
+
+
+def _run_id(value: object) -> str:
+    if not isinstance(value, str) or _UUID4.fullmatch(value) is None:
+        _fail("PLAN_STORE_INPUT_INVALID")
+    return value
+
+
+def _plan_kind(value: object) -> str:
+    if not isinstance(value, str) or value not in _PLAN_KINDS:
+        _fail("PLAN_STORE_INPUT_INVALID")
+    return value
+
+
+def _digest(value: object) -> str:
+    if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+        _fail("PLAN_STORE_INPUT_INVALID")
+    return value
+
+
+def _revision(value: object) -> int:
+    if type(value) is not int or not 1 <= value <= _MAX_SAFE_INTEGER:
+        _fail("PLAN_STORE_INPUT_INVALID")
+    return value
+
+
+@contextmanager
+def _authority(vault_root: Path, *, mutation: bool) -> Iterator[None]:
+    try:
+        with reserved_paths._subsystem_authority_scope(_OWNER):  # noqa: SLF001
+            with reserved_paths._identity_coordination_scope(  # noqa: SLF001
+                vault_root,
+                descriptor_ids=(_DESCRIPTOR_ID,),
+                identity_may_change=mutation,
+            ):
+                yield
+    except ConsolidationPlanStoreUnavailable:
+        raise
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        consolidation_plan.ConsolidationPlanUnavailable,
+        consolidation_run_state.ConsolidationRunUnavailable,
+    ):
+        _fail("PLAN_STORE_UNAVAILABLE")
+
+
+class ConsolidationPlanStore:
+    """Persist exact plan/control bytes beneath the private run subtree."""
+
+    def __init__(self, vault_root: Path | str):
+        self.vault_root = Path(vault_root).absolute()
+        self.run_store = consolidation_run_state.ConsolidationRunStore(self.vault_root)
+
+    def _plan_dir(self, run_id: str, plan_kind: str, plan_digest: str) -> Path:
+        return self.run_store.base / run_id / "plans" / plan_kind / plan_digest
+
+    def _read_optional(self, path: Path, *, limit: int) -> bytes | None:
+        try:
+            return reserved_paths._read_owner_bytes(  # noqa: SLF001
+                self.vault_root,
+                path,
+                _DESCRIPTOR_ID,
+                limit=limit,
+            )
+        except FileNotFoundError:
+            return None
+
+    def _publish_missing(self, path: Path, value: bytes) -> None:
+        reserved_paths._publish_owner_bytes(  # noqa: SLF001
+            self.vault_root,
+            path,
+            _DESCRIPTOR_ID,
+            value,
+            require_missing=True,
+        )
+
+    @staticmethod
+    def _bind_run(
+        record: consolidation_run_state.ConsolidationRunRecord,
+        plan: consolidation_plan.CanonicalConsolidationPlan,
+    ) -> None:
+        if (
+            plan.preimage["run_id"] != record.run_id
+            or plan.preimage["run_mode"] != record.identity.run_mode
+            or plan.preimage["source_snapshot_fingerprint"] != record.identity.source_fingerprint
+            or plan.preimage["destination_snapshot_fingerprint"]
+            != record.identity.destination_snapshot_fingerprint
+        ):
+            _fail("PLAN_RUN_MISMATCH")
+
+    def persist(
+        self,
+        plan: consolidation_plan.CanonicalConsolidationPlan,
+        *,
+        expected_run_revision: int,
+    ) -> consolidation_plan.CanonicalConsolidationPlan:
+        """Create or adopt one byte-identical immutable plan."""
+
+        if not isinstance(plan, consolidation_plan.CanonicalConsolidationPlan):
+            _fail("PLAN_STORE_INPUT_INVALID")
+        revision = _revision(expected_run_revision)
+        try:
+            checked = consolidation_plan.parse_canonical_plan(
+                plan.canonical_bytes,
+                control_basis=plan.control_basis,
+            )
+        except consolidation_plan.ConsolidationPlanUnavailable:
+            _fail("PLAN_STORE_INPUT_INVALID")
+        if checked != plan:
+            _fail("PLAN_STORE_INPUT_INVALID")
+        run_id = _run_id(plan.preimage["run_id"])
+        kind = _plan_kind(plan.preimage["plan_kind"])
+        digest = _digest(plan.digest)
+        if plan.control_basis.preimage["basis_run_revision"] != revision:
+            _fail("PLAN_RUN_REVISION_CONFLICT")
+        directory = self._plan_dir(run_id, kind, digest)
+        control_path = directory / "control-basis.json"
+        plan_path = directory / "plan.json"
+
+        with _authority(self.vault_root, mutation=True):
+            record, _inventory, _raw = self.run_store._load_locked(run_id)  # noqa: SLF001
+            if record.revision != revision:
+                _fail("PLAN_RUN_REVISION_CONFLICT")
+            self._bind_run(record, plan)
+            existing_control = self._read_optional(
+                control_path,
+                limit=_MAX_CONTROL_BYTES,
+            )
+            existing_plan = self._read_optional(plan_path, limit=_MAX_PLAN_BYTES)
+            if existing_control is None and existing_plan is not None:
+                _fail("PLAN_STORE_CORRUPT")
+            if (
+                existing_control is not None
+                and existing_control != plan.control_basis.canonical_bytes
+            ) or (existing_plan is not None and existing_plan != plan.canonical_bytes):
+                _fail("PLAN_STORE_CONFLICT")
+            if existing_control is None:
+                self._publish_missing(control_path, plan.control_basis.canonical_bytes)
+            if existing_plan is None:
+                self._publish_missing(plan_path, plan.canonical_bytes)
+        return plan
+
+    def load(
+        self,
+        run_id: str,
+        *,
+        plan_kind: str,
+        plan_digest: str,
+    ) -> consolidation_plan.CanonicalConsolidationPlan:
+        """Load an exact stored plan by its opaque run/kind/digest key."""
+
+        run_id = _run_id(run_id)
+        kind = _plan_kind(plan_kind)
+        digest = _digest(plan_digest)
+        directory = self._plan_dir(run_id, kind, digest)
+        with _authority(self.vault_root, mutation=False):
+            record, _inventory, _raw = self.run_store._load_locked(run_id)  # noqa: SLF001
+            control_raw = self._read_optional(
+                directory / "control-basis.json",
+                limit=_MAX_CONTROL_BYTES,
+            )
+            plan_raw = self._read_optional(
+                directory / "plan.json",
+                limit=_MAX_PLAN_BYTES,
+            )
+            if control_raw is None and plan_raw is None:
+                _fail("PLAN_NOT_FOUND")
+            if control_raw is None or plan_raw is None:
+                _fail("PLAN_STORE_CORRUPT")
+            try:
+                control = consolidation_plan.parse_control_basis(control_raw)
+                plan = consolidation_plan.parse_canonical_plan(
+                    plan_raw,
+                    control_basis=control,
+                )
+            except consolidation_plan.ConsolidationPlanUnavailable:
+                _fail("PLAN_STORE_CORRUPT")
+            if (
+                plan.digest != digest
+                or plan.preimage["run_id"] != run_id
+                or plan.preimage["plan_kind"] != kind
+            ):
+                _fail("PLAN_STORE_CORRUPT")
+            self._bind_run(record, plan)
+        return plan
+
+
+__all__ = ["ConsolidationPlanStore", "ConsolidationPlanStoreUnavailable"]

--- a/tests/test_consolidation_plan.py
+++ b/tests/test_consolidation_plan.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import os
 from collections.abc import Callable
+from pathlib import Path
 
 import pytest
 
@@ -37,36 +39,8 @@ def _policy_document() -> dict[str, object]:
     }
 
 
-def _rendering_definition() -> dict[str, object]:
-    section_ids = (
-        "impact-summary",
-        "content-actions",
-        "policy",
-        "principals-disclosure",
-        "verification",
-        "rollback-retention",
-    )
-    return {
-        "schema": "exomem.consolidation-rendering-definition/v1",
-        "page_size": 20,
-        "page_count": len(section_ids),
-        "total_rows": len(section_ids),
-        "sections": [
-            {
-                "ordinal": ordinal,
-                "section_id": section_id,
-                "row_count": 1,
-                "first_page_ordinal": ordinal,
-                "page_count": 1,
-                "content_digest": _digest(f"section:{section_id}"),
-            }
-            for ordinal, section_id in enumerate(section_ids)
-        ],
-    }
-
-
 def _plan_input() -> dict[str, object]:
-    return {
+    value = {
         "schema": "exomem.consolidation-plan/v1",
         "protocol_version": 1,
         "plan_kind": "cutover",
@@ -140,26 +114,30 @@ def _plan_input() -> dict[str, object]:
             "rollback_consequence": "The prior destination bytes remain recoverable.",
             "surviving_copy_obligation": "Keep one verified source copy through recovery.",
         },
-        "rendering_definition": _rendering_definition(),
         "created_at": CREATED_AT,
         "valid_until": VALID_UNTIL,
         "nonce": NONCE,
     }
+    value["rendering_definition"] = consolidation_plan.derive_rendering_definition(value)
+    return value
 
 
-def _materialization() -> consolidation_plan.PlanMaterializationContext:
+def _materialization(
+    *,
+    basis_run_revision: int = 7,
+) -> consolidation_plan.PlanMaterializationContext:
     return consolidation_plan.PlanMaterializationContext(
         operation_id=OPERATION_ID,
-        basis_run_revision=7,
+        basis_run_revision=basis_run_revision,
         predecessor_event_id=_digest("reconcile-terminal"),
         predecessor_payload_digest=_digest("reconcile-payload"),
     )
 
 
-def _plan() -> consolidation_plan.CanonicalConsolidationPlan:
+def _plan(*, basis_run_revision: int = 7) -> consolidation_plan.CanonicalConsolidationPlan:
     return consolidation_plan.materialize_plan(
         _plan_input(),
-        materialization=_materialization(),
+        materialization=_materialization(basis_run_revision=basis_run_revision),
     )
 
 
@@ -219,22 +197,22 @@ def test_plan_has_one_closed_cross_runtime_canonical_vector() -> None:
 
     assert set(plan.preimage) == EXPECTED_TOP_LEVEL_FIELDS
     assert set(plan.control_basis.preimage) == EXPECTED_CONTROL_BASIS_FIELDS
-    assert plan.digest == "062739152e58992e29a8a224f01f7aee45f6941a6622aeb82ed76f374c4d1f76"
+    assert plan.digest == "8a999da89e1ffea6fc39a5be071f11b697733674f98b383a2786a25bc52819e8"
     assert plan.plan_input_set_digest == (
-        "14313cde01a2586e455ae0235ad5971451d5c7b7d34aaec34772338f7c90ae09"
+        "1c2498af2ee36226a2d8a2f492a4a701c26ec18a8b5d7ac0f2f8d5de19689b76"
     )
     assert plan.control_basis.digest == (
-        "4adcd528d34f4784ceaef8b67c33998a34af8fff0c3d418ba97b44efc34d9a04"
+        "9d34ae072e4bb0a1210ed7b5ce64d112978d2f295af84bf38c2852a7c39aadb5"
     )
     assert plan.impact_summary_digest == (
         "e6ec13c6d5a662678910a04d60d67cc095480b907cb8f30751399977ac6ec46f"
     )
     assert plan.rendering_definition_digest == (
-        "feafeaf811ca3c02b13afaacd0e731846b812e753fc519e7dd9a9d15422b0172"
+        "f156fef8cac9c177c52b17038bb16be32ee3e3cac680cf9d115c6f8c25dd6d57"
     )
     assert len(plan.canonical_bytes) == 5178
     assert hashlib.sha256(plan.canonical_bytes).hexdigest() == (
-        "e03ad068536f73875d679c39f0298463d94d32ced350cf28c794a9f5c8c8b816"
+        "863fbd64bc8ede83bea2cbc6a090bd5d448e177c6487ee5a20a553bb54305443"
     )
     assert len(plan.framed_bytes) == 5218
     assert plan.framed_bytes[:40].hex() == (
@@ -319,6 +297,7 @@ def test_closed_plan_jcs_accepts_both_integer_boundaries() -> None:
     value = _plan_input()
     value["impact_summary"]["principal_change_count"] = (1 << 53) - 1
     value["source_retention"]["recovery_window_ttl_ms"] = (1 << 53) - 1
+    value["rendering_definition"] = consolidation_plan.derive_rendering_definition(value)
     plan = consolidation_plan.materialize_plan(
         value,
         materialization=consolidation_plan.PlanMaterializationContext(
@@ -442,7 +421,7 @@ def _mutate_impact(value: dict[str, object]) -> None:
 
 
 def _mutate_rendering(value: dict[str, object]) -> None:
-    value["rendering_definition"]["sections"][0]["content_digest"] = _digest("changed-section")
+    value["impact_summary"]["rollback_consequence"] = "Changed trusted rendering consequence."
 
 
 @pytest.mark.parametrize(
@@ -479,6 +458,9 @@ def test_every_mutable_plan_input_changes_the_plan_digest(mutation: Mutation) ->
     original = _plan()
     changed_input = copy.deepcopy(_plan_input())
     mutation(changed_input)
+    changed_input["rendering_definition"] = consolidation_plan.derive_rendering_definition(
+        changed_input
+    )
     changed = consolidation_plan.materialize_plan(
         changed_input,
         materialization=_materialization(),
@@ -504,3 +486,206 @@ def test_control_basis_predecessor_changes_the_plan_without_entering_input_set()
     assert changed.plan_input_set_digest == original.plan_input_set_digest
     assert changed.control_basis.digest != original.control_basis.digest
     assert changed.digest != original.digest
+
+
+def test_rendering_definition_is_derived_from_the_exact_plan_rows() -> None:
+    draft = _plan_input()
+    draft.pop("rendering_definition")
+
+    definition = consolidation_plan.derive_rendering_definition(draft)
+    draft["rendering_definition"] = definition
+    plan = consolidation_plan.materialize_plan(
+        draft,
+        materialization=_materialization(),
+    )
+
+    assert definition["page_size"] == 20
+    assert definition["page_count"] == 6
+    assert definition["total_rows"] == 7
+    assert [section["section_id"] for section in definition["sections"]] == list(
+        consolidation_plan.RENDER_SECTION_IDS
+    )
+    assert consolidation_plan.canonical_closed_jcs(
+        plan.preimage["rendering_definition"]
+    ) == consolidation_plan.canonical_closed_jcs(definition)
+    assert consolidation_plan.render_plan_page(plan, page_ordinal=0).digest == (
+        "2b001af5360c42fcbf94f1d6003d77c32961aea966be4e9815ec820f020a857a"
+    )
+
+    injected = copy.deepcopy(draft)
+    injected["rendering_definition"]["sections"][0]["content_digest"] = _digest("caller-defined")
+    with pytest.raises(consolidation_plan.ConsolidationPlanUnavailable):
+        consolidation_plan.materialize_plan(
+            injected,
+            materialization=_materialization(),
+        )
+
+
+def test_rendered_plan_pages_are_bounded_complete_and_digest_stable() -> None:
+    draft = _plan_input()
+    actions = []
+    for ordinal in range(45):
+        action = copy.deepcopy(draft["content_actions"][0])
+        action["ordinal"] = ordinal
+        action["batch_ordinal"] = ordinal // 10
+        action["object_ref"] = f"source-object-{ordinal:03d}"
+        action["source_path"] = f"Knowledge Base/Notes/source-{ordinal:03d}.md"
+        action["destination_path"] = f"Knowledge Base/Notes/destination-{ordinal:03d}.md"
+        actions.append(action)
+    draft["content_actions"] = actions
+    draft["impact_summary"]["overwrite_count"] = 45
+    draft["impact_summary"]["batch_count"] = 5
+    draft.pop("rendering_definition")
+    draft["rendering_definition"] = consolidation_plan.derive_rendering_definition(draft)
+    plan = consolidation_plan.materialize_plan(
+        draft,
+        materialization=_materialization(),
+    )
+
+    pages = tuple(
+        consolidation_plan.render_plan_page(plan, page_ordinal=ordinal)
+        for ordinal in range(plan.preimage["rendering_definition"]["page_count"])
+    )
+    assert len(pages) == 8
+    assert sum(len(page.rows) for page in pages) == 51
+    assert max(len(page.rows) for page in pages) == 20
+    assert len({page.digest for page in pages}) == len(pages)
+    assert all(page.plan_digest == plan.digest for page in pages)
+    assert all(page.total_pages == 8 for page in pages)
+    assert all(page.total_rows == 51 for page in pages)
+    assert pages[1].section_id == "content-actions"
+    assert pages[1].rows[0]["ordinal"] == 0
+    assert pages[3].rows[-1]["ordinal"] == 44
+    assert consolidation_plan.render_plan_page(plan, page_ordinal=3) == pages[3]
+    with pytest.raises(consolidation_plan.ConsolidationPlanUnavailable):
+        consolidation_plan.render_plan_page(plan, page_ordinal=8)
+
+
+def _create_run(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from exomem import writer_lease
+    from exomem.governance import consolidation_run_state
+    from exomem.governance.consolidation_intake import ConsolidationInventoryItem
+
+    manager = writer_lease.LeaseManager(
+        writer_lease.LeaseConfig(state_dir=vault.parent / "writer-state")
+    )
+    monkeypatch.setattr(writer_lease, "active_manager", lambda: manager)
+    identity = consolidation_run_state.ConsolidationRunIdentity(
+        run_id=RUN_ID,
+        start_operation_id="00000000-0000-4000-8000-000000000003",
+        run_mode="cloned-rehearsal",
+        destination_vault_id="vault-destination-01",
+        destination_installation_id="installation-destination-01",
+        destination_generation=3,
+        destination_fence_digest=_digest("destination-fence"),
+        destination_identity_binding_digest=_digest("destination-identity"),
+        destination_snapshot_fingerprint=_digest("destination-snapshot"),
+        source_artifact_ref="exomem-export://sha256/" + _digest("archive"),
+        source_attestation_ref="exomem-source-attestation://sha256/" + _digest("proof"),
+        archive_sha256=_digest("archive"),
+        manifest_sha256=_digest("manifest"),
+        source_census_sha256=_digest("source-census"),
+        source_proof_digest=_digest("proof"),
+        source_fingerprint=_digest("source-snapshot"),
+        created_at=CREATED_AT,
+    )
+    item = ConsolidationInventoryItem(
+        path="Knowledge Base/Notes/source.md",
+        size=10,
+        sha256=_digest("source-item"),
+        classification="canonical",
+        artifact_ref="exomem-consolidation-object://sha256/" + _digest("source-item"),
+    )
+    consolidation_run_state.ConsolidationRunStore(vault).create(identity, (item,))
+
+
+def test_owner_only_plan_store_reloads_exact_bytes_and_replays_idempotently(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_plan_store
+
+    vault = tmp_path / "vault"
+    _create_run(vault, monkeypatch)
+    plan = _plan(basis_run_revision=1)
+    store = consolidation_plan_store.ConsolidationPlanStore(vault)
+
+    first = store.persist(plan, expected_run_revision=1)
+    assert store.persist(plan, expected_run_revision=1) == first
+    assert store.load(RUN_ID, plan_kind="cutover", plan_digest=plan.digest) == plan
+    plan_dir = (
+        vault
+        / "Knowledge Base"
+        / "_Consolidation"
+        / "runs"
+        / RUN_ID
+        / "plans"
+        / "cutover"
+        / plan.digest
+    )
+    assert sorted(path.name for path in plan_dir.iterdir()) == [
+        "control-basis.json",
+        "plan.json",
+    ]
+    if os.name != "nt":
+        assert plan_dir.stat().st_mode & 0o777 == 0o700
+        assert all(path.stat().st_mode & 0o777 == 0o600 for path in plan_dir.iterdir())
+
+    restarted = consolidation_plan_store.ConsolidationPlanStore(vault)
+    assert restarted.load(RUN_ID, plan_kind="cutover", plan_digest=plan.digest) == plan
+
+
+def test_plan_store_refuses_wrong_run_revision_or_partial_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_plan_store
+
+    vault = tmp_path / "vault"
+    _create_run(vault, monkeypatch)
+    plan = _plan(basis_run_revision=1)
+    store = consolidation_plan_store.ConsolidationPlanStore(vault)
+
+    with pytest.raises(consolidation_plan_store.ConsolidationPlanStoreUnavailable):
+        store.persist(plan, expected_run_revision=2)
+    store.persist(plan, expected_run_revision=1)
+    control_path = (
+        vault
+        / "Knowledge Base"
+        / "_Consolidation"
+        / "runs"
+        / RUN_ID
+        / "plans"
+        / "cutover"
+        / plan.digest
+        / "control-basis.json"
+    )
+    control_path.unlink()
+    with pytest.raises(consolidation_plan_store.ConsolidationPlanStoreUnavailable):
+        store.load(RUN_ID, plan_kind="cutover", plan_digest=plan.digest)
+
+
+def test_plan_store_recovers_control_first_crash_without_changing_plan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_plan_store
+
+    vault = tmp_path / "vault"
+    _create_run(vault, monkeypatch)
+    plan = _plan(basis_run_revision=1)
+    store = consolidation_plan_store.ConsolidationPlanStore(vault)
+    original_publish = store._publish_missing
+
+    def crash_before_plan(path: Path, value: bytes) -> None:
+        if path.name == "plan.json":
+            raise OSError("injected crash gap")
+        original_publish(path, value)
+
+    monkeypatch.setattr(store, "_publish_missing", crash_before_plan)
+    with pytest.raises(consolidation_plan_store.ConsolidationPlanStoreUnavailable):
+        store.persist(plan, expected_run_revision=1)
+
+    monkeypatch.setattr(store, "_publish_missing", original_publish)
+    assert store.persist(plan, expected_run_revision=1) == plan
+    assert store.load(RUN_ID, plan_kind="cutover", plan_digest=plan.digest) == plan


### PR DESCRIPTION
## Summary

- derive the six ordered human-review sections and bounded page topology from exact canonical plan rows
- reject caller-injected rendering definitions and bind every page to the stored plan, impact summary, section, and stable digest
- persist canonical plan/control-basis bytes owner-only beneath the reserved run tree
- make control-first crash recovery idempotent while refusing partial, mismatched, stale-revision, or corrupt state

Stacked after #919. No command surface is enabled and no live vault is touched.

## Verification

- red first: 4 expected failures for missing derived rendering and plan-store APIs
- canonical plan/render/store suite: 55 passed
- adjacent run-state/reserved-authority slice: 69 passed
- targeted mypy: clean
- Ruff: clean
- strict OpenSpec validation
- public repository artifact validation
- `uv lock --check`
- wheel and sdist build
- diff/whitespace checks
