### PR TITLE
feat(governance): reserve consolidation approval JTI

### DIFF
--- a/src/exomem/governance/consolidation_approval.py
+++ b/src/exomem/governance/consolidation_approval.py
@@ -17,8 +17,10 @@ from typing import NoReturn
 from . import consolidation_plan, consolidation_review
 
 _CLAIM_SCHEMA = "exomem.consolidation-approval-token/v1"
+_CONFIRMATION_SCHEMA = "exomem.consolidation-owner-confirmation/v1"
 _WIRE_VERSION = "cap1"
 _DOMAIN = _CLAIM_SCHEMA.encode("ascii")
+_CONFIRMATION_DOMAIN = _CONFIRMATION_SCHEMA.encode("ascii")
 _CLAIM_FIELDS = frozenset(
     {
         "schema",
@@ -29,6 +31,23 @@ _CLAIM_FIELDS = frozenset(
         "jti",
         "expires_at",
         "signing_key_id",
+    }
+)
+_CONFIRMATION_FIELDS = frozenset(
+    {
+        "schema",
+        "owner_binding_digest",
+        "owner_principal_digest",
+        "authorization_session_digest",
+        "issuer",
+        "surface",
+        "action",
+        "run_id",
+        "plan_kind",
+        "plan_digest",
+        "rendering_completeness_digest",
+        "confirmed_at",
+        "nonce",
     }
 )
 _DIGEST = re.compile(r"[0-9a-f]{64}\Z")
@@ -70,6 +89,14 @@ class TrustedOwnerConfirmation:
 
 @dataclass(frozen=True, slots=True)
 class CanonicalApprovalClaim:
+    preimage: Mapping[str, object]
+    canonical_bytes: bytes
+    framed_bytes: bytes
+    digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalOwnerConfirmation:
     preimage: Mapping[str, object]
     canonical_bytes: bytes
     framed_bytes: bytes
@@ -135,6 +162,10 @@ def _key(value: object) -> bytes:
 
 def _framed(raw: bytes) -> bytes:
     return len(_DOMAIN).to_bytes(4, "big") + _DOMAIN + len(raw).to_bytes(8, "big") + raw
+
+
+def _frame(domain: bytes, raw: bytes) -> bytes:
+    return len(domain).to_bytes(4, "big") + domain + len(raw).to_bytes(8, "big") + raw
 
 
 def _claim(value: Mapping[str, object]) -> CanonicalApprovalClaim:
@@ -240,6 +271,42 @@ def _checked_confirmation(
     )
 
 
+def canonical_confirmation(
+    confirmation: TrustedOwnerConfirmation,
+) -> CanonicalOwnerConfirmation:
+    """Canonicalize only a trusted surface's exact owner-confirmation context."""
+
+    checked = _checked_confirmation(confirmation)
+    value = {
+        "schema": _CONFIRMATION_SCHEMA,
+        "owner_binding_digest": checked.owner_binding_digest,
+        "owner_principal_digest": checked.owner_principal_digest,
+        "authorization_session_digest": checked.authorization_session_digest,
+        "issuer": checked.issuer,
+        "surface": checked.surface,
+        "action": checked.action,
+        "run_id": checked.run_id,
+        "plan_kind": checked.plan_kind,
+        "plan_digest": checked.plan_digest,
+        "rendering_completeness_digest": checked.rendering_completeness_digest,
+        "confirmed_at": checked.confirmed_at,
+        "nonce": checked.nonce,
+    }
+    if frozenset(value) != _CONFIRMATION_FIELDS:
+        _fail()
+    try:
+        raw = consolidation_plan.canonical_closed_jcs(value)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    framed = _frame(_CONFIRMATION_DOMAIN, raw)
+    return CanonicalOwnerConfirmation(
+        preimage=MappingProxyType(value),
+        canonical_bytes=raw,
+        framed_bytes=framed,
+        digest=hashlib.sha256(framed).hexdigest(),
+    )
+
+
 def mint_approval(
     *,
     plan: consolidation_plan.CanonicalConsolidationPlan,
@@ -329,24 +396,7 @@ def verify_approval(
 ) -> ConsolidationApprovalToken:
     """Verify one canonical token against its exact plan and completeness proof."""
 
-    text = _text(wire, maximum=_MAX_WIRE_BYTES)
-    parts = text.split(".")
-    if len(parts) != 3 or parts[0] != _WIRE_VERSION:
-        _fail()
-    raw = _decode(parts[1])
-    authentication = _decode(parts[2])
-    if len(authentication) != hashlib.sha256().digest_size:
-        _fail()
-    try:
-        parsed = consolidation_plan._parse_canonical_mapping(  # noqa: SLF001
-            raw,
-            maximum=4 * 1024,
-        )
-    except consolidation_plan.ConsolidationPlanUnavailable:
-        _fail()
-    claim = _claim(parsed)
-    if claim.canonical_bytes != raw:
-        _fail()
+    text, claim, authentication = _parse_wire(wire)
     key_id = _identifier(claim.preimage["signing_key_id"])
     key = verifier_keys.get(key_id) if isinstance(verifier_keys, Mapping) else None
     if key is None:
@@ -378,11 +428,35 @@ def verify_approval(
     )
 
 
+def _parse_wire(wire: str) -> tuple[str, CanonicalApprovalClaim, bytes]:
+    text = _text(wire, maximum=_MAX_WIRE_BYTES)
+    parts = text.split(".")
+    if len(parts) != 3 or parts[0] != _WIRE_VERSION:
+        _fail()
+    raw = _decode(parts[1])
+    authentication = _decode(parts[2])
+    if len(authentication) != hashlib.sha256().digest_size:
+        _fail()
+    try:
+        parsed = consolidation_plan._parse_canonical_mapping(  # noqa: SLF001
+            raw,
+            maximum=4 * 1024,
+        )
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    claim = _claim(parsed)
+    if claim.canonical_bytes != raw:
+        _fail()
+    return text, claim, authentication
+
+
 __all__ = [
     "CanonicalApprovalClaim",
+    "CanonicalOwnerConfirmation",
     "ConsolidationApprovalToken",
     "ConsolidationApprovalUnavailable",
     "TrustedOwnerConfirmation",
+    "canonical_confirmation",
     "mint_approval",
     "verify_approval",
 ]

--- a/src/exomem/governance/consolidation_approval_store.py
+++ b/src/exomem/governance/consolidation_approval_store.py
@@ -1,0 +1,483 @@
+"""Durable issuance replay and single-operation approval JTI reservation."""
+
+from __future__ import annotations
+
+import re
+import secrets
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NoReturn
+
+from .. import reserved_paths
+from . import (
+    consolidation_approval,
+    consolidation_plan,
+    consolidation_review,
+    consolidation_review_store,
+)
+
+_DESCRIPTOR_ID = "consolidation-tree"
+_OWNER = "consolidation.run"
+_ISSUANCE_SCHEMA = "exomem.consolidation-approval-issuance/v1"
+_JTI_SCHEMA = "exomem.consolidation-approval-jti/v1"
+_RESERVATION_SCHEMA = "exomem.consolidation-approval-reservation/v1"
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_JTI = re.compile(r"[0-9a-f]{32}\Z")
+_UUID4 = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z")
+_ISSUANCE_FIELDS = frozenset(
+    {
+        "schema",
+        "operation_id",
+        "render_session_digest",
+        "owner_binding_digest",
+        "confirmation_digest",
+        "claim",
+        "claim_digest",
+        "token_digest",
+    }
+)
+_JTI_FIELDS = frozenset(
+    {
+        "schema",
+        "jti",
+        "approval_operation_id",
+        "claim_digest",
+        "token_digest",
+    }
+)
+_RESERVATION_FIELDS = frozenset(
+    {
+        "schema",
+        "jti",
+        "approval_operation_id",
+        "execution_operation_id",
+        "request_digest",
+        "claim_digest",
+        "token_digest",
+        "reserved_at",
+    }
+)
+_MAX_RECORD_BYTES = 16 * 1024
+
+
+class ConsolidationApprovalStoreUnavailable(RuntimeError):
+    """Content-free refusal for invalid, stale, or conflicting approval state."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationApprovalReservation:
+    jti: str
+    approval_operation_id: str
+    execution_operation_id: str
+    request_digest: str
+    claim_digest: str
+    token_digest: str
+    reserved_at: str
+
+
+def _fail(code: str) -> NoReturn:
+    raise ConsolidationApprovalStoreUnavailable(code) from None
+
+
+def _digest(value: object) -> str:
+    if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+        _fail("APPROVAL_STORE_INPUT_INVALID")
+    return value
+
+
+def _jti(value: object) -> str:
+    if not isinstance(value, str) or _JTI.fullmatch(value) is None:
+        _fail("APPROVAL_STORE_INPUT_INVALID")
+    return value
+
+
+def _operation_id(value: object) -> str:
+    if not isinstance(value, str) or _UUID4.fullmatch(value) is None:
+        _fail("APPROVAL_STORE_INPUT_INVALID")
+    return value
+
+
+def _mapping(value: object, fields: frozenset[str]) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or frozenset(value) != fields:
+        _fail("APPROVAL_STORE_CORRUPT")
+    return value
+
+
+def _exact_mapping(raw: bytes) -> Mapping[str, object]:
+    try:
+        parsed = consolidation_plan._parse_canonical_mapping(  # noqa: SLF001
+            raw,
+            maximum=_MAX_RECORD_BYTES,
+        )
+        if consolidation_plan.canonical_closed_jcs(parsed) != raw:
+            _fail("APPROVAL_STORE_CORRUPT")
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail("APPROVAL_STORE_CORRUPT")
+    return parsed
+
+
+@contextmanager
+def _authority(vault_root: Path, *, mutation: bool) -> Iterator[None]:
+    try:
+        with reserved_paths._subsystem_authority_scope(_OWNER):  # noqa: SLF001
+            with reserved_paths._identity_coordination_scope(  # noqa: SLF001
+                vault_root,
+                descriptor_ids=(_DESCRIPTOR_ID,),
+                identity_may_change=mutation,
+            ):
+                yield
+    except ConsolidationApprovalStoreUnavailable:
+        raise
+    except (
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+        consolidation_approval.ConsolidationApprovalUnavailable,
+        consolidation_review.ConsolidationReviewUnavailable,
+        consolidation_review_store.ConsolidationReviewStoreUnavailable,
+    ):
+        _fail("APPROVAL_STORE_UNAVAILABLE")
+
+
+class ConsolidationApprovalStore:
+    """Persist approval claims without token bytes, then reserve one execution."""
+
+    def __init__(self, vault_root: Path | str):
+        self.vault_root = Path(vault_root).absolute()
+        self.review_store = consolidation_review_store.ConsolidationReviewStore(self.vault_root)
+
+    def _approval_dir(
+        self,
+        plan: consolidation_plan.CanonicalConsolidationPlan,
+    ) -> Path:
+        return (
+            self.review_store.plan_store._plan_dir(  # noqa: SLF001
+                str(plan.preimage["run_id"]),
+                str(plan.preimage["plan_kind"]),
+                plan.digest,
+            )
+            / "approvals"
+        )
+
+    def _read_optional(self, path: Path) -> bytes | None:
+        try:
+            return reserved_paths._read_owner_bytes(  # noqa: SLF001
+                self.vault_root,
+                path,
+                _DESCRIPTOR_ID,
+                limit=_MAX_RECORD_BYTES,
+            )
+        except FileNotFoundError:
+            return None
+
+    def _publish_missing(self, path: Path, raw: bytes) -> None:
+        reserved_paths._publish_owner_bytes(  # noqa: SLF001
+            self.vault_root,
+            path,
+            _DESCRIPTOR_ID,
+            raw,
+            require_missing=True,
+        )
+
+    def _publish_jti(self, path: Path, raw: bytes) -> None:
+        existing = self._read_optional(path)
+        if existing is None:
+            self._publish_missing(path, raw)
+        elif existing != raw:
+            _fail("APPROVAL_JTI_CONFLICT")
+
+    @staticmethod
+    def _new_jti() -> str:
+        return secrets.token_hex(16)
+
+    @staticmethod
+    def _issuance_bytes(
+        *,
+        operation_id: str,
+        render_session_digest: str,
+        owner_binding_digest: str,
+        confirmation_digest: str,
+        token: consolidation_approval.ConsolidationApprovalToken,
+    ) -> bytes:
+        return consolidation_plan.canonical_closed_jcs(
+            {
+                "schema": _ISSUANCE_SCHEMA,
+                "operation_id": operation_id,
+                "render_session_digest": render_session_digest,
+                "owner_binding_digest": owner_binding_digest,
+                "confirmation_digest": confirmation_digest,
+                "claim": token.claim.preimage,
+                "claim_digest": token.claim.digest,
+                "token_digest": token.digest,
+            }
+        )
+
+    @staticmethod
+    def _jti_bytes(
+        *,
+        jti: str,
+        approval_operation_id: str,
+        claim_digest: str,
+        token_digest: str,
+    ) -> bytes:
+        return consolidation_plan.canonical_closed_jcs(
+            {
+                "schema": _JTI_SCHEMA,
+                "jti": jti,
+                "approval_operation_id": approval_operation_id,
+                "claim_digest": claim_digest,
+                "token_digest": token_digest,
+            }
+        )
+
+    @staticmethod
+    def _reservation_bytes(
+        reservation: ConsolidationApprovalReservation,
+    ) -> bytes:
+        return consolidation_plan.canonical_closed_jcs(
+            {
+                "schema": _RESERVATION_SCHEMA,
+                "jti": reservation.jti,
+                "approval_operation_id": reservation.approval_operation_id,
+                "execution_operation_id": reservation.execution_operation_id,
+                "request_digest": reservation.request_digest,
+                "claim_digest": reservation.claim_digest,
+                "token_digest": reservation.token_digest,
+                "reserved_at": reservation.reserved_at,
+            }
+        )
+
+    @staticmethod
+    def _checked_issuance(
+        raw: bytes,
+    ) -> tuple[Mapping[str, object], consolidation_approval.CanonicalApprovalClaim]:
+        value = _mapping(_exact_mapping(raw), _ISSUANCE_FIELDS)
+        if value["schema"] != _ISSUANCE_SCHEMA:
+            _fail("APPROVAL_STORE_CORRUPT")
+        _operation_id(value["operation_id"])
+        _digest(value["render_session_digest"])
+        _digest(value["owner_binding_digest"])
+        _digest(value["confirmation_digest"])
+        claim_value = value["claim"]
+        if not isinstance(claim_value, Mapping):
+            _fail("APPROVAL_STORE_CORRUPT")
+        try:
+            claim = consolidation_approval._claim(claim_value)  # noqa: SLF001
+        except consolidation_approval.ConsolidationApprovalUnavailable:
+            _fail("APPROVAL_STORE_CORRUPT")
+        if claim.digest != value["claim_digest"]:
+            _fail("APPROVAL_STORE_CORRUPT")
+        _digest(value["token_digest"])
+        return value, claim
+
+    @staticmethod
+    def _checked_jti(raw: bytes) -> Mapping[str, object]:
+        value = _mapping(_exact_mapping(raw), _JTI_FIELDS)
+        if value["schema"] != _JTI_SCHEMA:
+            _fail("APPROVAL_STORE_CORRUPT")
+        _jti(value["jti"])
+        _operation_id(value["approval_operation_id"])
+        _digest(value["claim_digest"])
+        _digest(value["token_digest"])
+        return value
+
+    @staticmethod
+    def _reservation(raw: bytes) -> ConsolidationApprovalReservation:
+        value = _mapping(_exact_mapping(raw), _RESERVATION_FIELDS)
+        if value["schema"] != _RESERVATION_SCHEMA:
+            _fail("APPROVAL_STORE_CORRUPT")
+        try:
+            reserved_at = consolidation_approval._timestamp(  # noqa: SLF001
+                value["reserved_at"]
+            )[0]
+        except consolidation_approval.ConsolidationApprovalUnavailable:
+            _fail("APPROVAL_STORE_CORRUPT")
+        return ConsolidationApprovalReservation(
+            jti=_jti(value["jti"]),
+            approval_operation_id=_operation_id(value["approval_operation_id"]),
+            execution_operation_id=_operation_id(value["execution_operation_id"]),
+            request_digest=_digest(value["request_digest"]),
+            claim_digest=_digest(value["claim_digest"]),
+            token_digest=_digest(value["token_digest"]),
+            reserved_at=reserved_at,
+        )
+
+    def _load_review(
+        self,
+        plan: consolidation_plan.CanonicalConsolidationPlan,
+        render_session_digest: str,
+    ) -> consolidation_review.CanonicalRenderReview:
+        try:
+            review = self.review_store.load(
+                str(plan.preimage["run_id"]),
+                plan_kind=str(plan.preimage["plan_kind"]),
+                plan_digest=plan.digest,
+                render_session_digest=_digest(render_session_digest),
+            )
+            return consolidation_review.validate_review(review, plan=plan)
+        except (
+            KeyError,
+            consolidation_review.ConsolidationReviewUnavailable,
+            consolidation_review_store.ConsolidationReviewStoreUnavailable,
+        ):
+            _fail("APPROVAL_STORE_UNAVAILABLE")
+
+    def issue(
+        self,
+        *,
+        plan: consolidation_plan.CanonicalConsolidationPlan,
+        render_session_digest: str,
+        identity: consolidation_review.TrustedRenderIdentity,
+        confirmation: consolidation_approval.TrustedOwnerConfirmation,
+        operation_id: str,
+        expires_at: str,
+        signing_key_id: str,
+        signing_key: bytes,
+    ) -> consolidation_approval.ConsolidationApprovalToken:
+        """Persist one issuance identity and replay the exact token after lost output."""
+
+        operation_id = _operation_id(operation_id)
+        render_session_digest = _digest(render_session_digest)
+        review = self._load_review(plan, render_session_digest)
+        try:
+            confirmation_artifact = consolidation_approval.canonical_confirmation(confirmation)
+        except consolidation_approval.ConsolidationApprovalUnavailable:
+            _fail("APPROVAL_STORE_INPUT_INVALID")
+        directory = self._approval_dir(plan)
+        operation_path = directory / "operations" / f"{operation_id}.json"
+
+        with _authority(self.vault_root, mutation=True):
+            existing = self._read_optional(operation_path)
+            if existing is None:
+                jti = _jti(self._new_jti())
+            else:
+                issuance, claim = self._checked_issuance(existing)
+                jti = _jti(claim.preimage["jti"])
+            try:
+                token = consolidation_approval.mint_approval(
+                    plan=plan,
+                    review=review,
+                    identity=identity,
+                    confirmation=confirmation,
+                    jti=jti,
+                    expires_at=expires_at,
+                    signing_key_id=signing_key_id,
+                    signing_key=signing_key,
+                )
+            except consolidation_approval.ConsolidationApprovalUnavailable:
+                _fail("APPROVAL_STORE_INPUT_INVALID")
+            issuance_raw = self._issuance_bytes(
+                operation_id=operation_id,
+                render_session_digest=render_session_digest,
+                owner_binding_digest=identity.owner_binding_digest,
+                confirmation_digest=confirmation_artifact.digest,
+                token=token,
+            )
+            if existing is None:
+                self._publish_missing(operation_path, issuance_raw)
+            elif existing != issuance_raw:
+                _fail("APPROVAL_OPERATION_CONFLICT")
+            jti_raw = self._jti_bytes(
+                jti=jti,
+                approval_operation_id=operation_id,
+                claim_digest=token.claim.digest,
+                token_digest=token.digest,
+            )
+            self._publish_jti(directory / "jtis" / f"{jti}.json", jti_raw)
+        return token
+
+    def reserve(
+        self,
+        *,
+        wire: str,
+        plan: consolidation_plan.CanonicalConsolidationPlan,
+        render_session_digest: str,
+        execution_operation_id: str,
+        request_digest: str,
+        reserved_at: str,
+        verifier_keys: Mapping[str, bytes],
+    ) -> ConsolidationApprovalReservation:
+        """Reserve one verified approval JTI for one exact execution request."""
+
+        render_session_digest = _digest(render_session_digest)
+        execution_operation_id = _operation_id(execution_operation_id)
+        request_digest = _digest(request_digest)
+        review = self._load_review(plan, render_session_digest)
+        try:
+            _wire_text, unverified_claim, _authentication = consolidation_approval._parse_wire(wire)  # noqa: SLF001
+            current_time = consolidation_approval._timestamp(reserved_at)[0]  # noqa: SLF001
+        except consolidation_approval.ConsolidationApprovalUnavailable:
+            _fail("APPROVAL_STORE_INPUT_INVALID")
+        jti = _jti(unverified_claim.preimage["jti"])
+        directory = self._approval_dir(plan)
+
+        with _authority(self.vault_root, mutation=True):
+            reservation_path = directory / "uses" / f"{jti}.json"
+            existing_reservation_raw = self._read_optional(reservation_path)
+            if existing_reservation_raw is None:
+                verification_time = current_time
+            else:
+                existing_reservation = self._reservation(existing_reservation_raw)
+                verification_time = existing_reservation.reserved_at
+            try:
+                token = consolidation_approval.verify_approval(
+                    wire,
+                    plan=plan,
+                    review=review,
+                    now=verification_time,
+                    verifier_keys=verifier_keys,
+                )
+            except consolidation_approval.ConsolidationApprovalUnavailable:
+                _fail("APPROVAL_STORE_INPUT_INVALID")
+            jti_raw = self._read_optional(directory / "jtis" / f"{jti}.json")
+            if jti_raw is None:
+                _fail("APPROVAL_NOT_ISSUED")
+            jti_record = self._checked_jti(jti_raw)
+            approval_operation_id = _operation_id(jti_record["approval_operation_id"])
+            issuance_raw = self._read_optional(
+                directory / "operations" / f"{approval_operation_id}.json"
+            )
+            if issuance_raw is None:
+                _fail("APPROVAL_STORE_CORRUPT")
+            issuance, claim = self._checked_issuance(issuance_raw)
+            if (
+                issuance["render_session_digest"] != render_session_digest
+                or claim != token.claim
+                or jti_record["jti"] != jti
+                or jti_record["claim_digest"] != token.claim.digest
+                or jti_record["token_digest"] != token.digest
+                or issuance["claim_digest"] != token.claim.digest
+                or issuance["token_digest"] != token.digest
+            ):
+                _fail("APPROVAL_STORE_CORRUPT")
+            reservation = ConsolidationApprovalReservation(
+                jti=jti,
+                approval_operation_id=approval_operation_id,
+                execution_operation_id=execution_operation_id,
+                request_digest=request_digest,
+                claim_digest=token.claim.digest,
+                token_digest=token.digest,
+                reserved_at=verification_time,
+            )
+            target = self._reservation_bytes(reservation)
+            if existing_reservation_raw is None:
+                self._publish_missing(reservation_path, target)
+            elif existing_reservation_raw != target:
+                _fail("APPROVAL_JTI_ALREADY_RESERVED")
+            else:
+                reservation = self._reservation(existing_reservation_raw)
+        return reservation
+
+
+__all__ = [
+    "ConsolidationApprovalReservation",
+    "ConsolidationApprovalStore",
+    "ConsolidationApprovalStoreUnavailable",
+]

--- a/tests/test_consolidation_plan.py
+++ b/tests/test_consolidation_plan.py
@@ -1401,3 +1401,225 @@ def test_approval_refuses_expiry_tamper_and_changed_plan() -> None:
                 now=now,
                 verifier_keys={"approval-key-01": b"k" * 32},
             )
+
+
+def _stored_completed_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[
+    Path,
+    consolidation_plan.CanonicalConsolidationPlan,
+    consolidation_review.CanonicalRenderReview,
+]:
+    from exomem.governance import consolidation_review_store
+
+    vault, plan, review = _stored_review(tmp_path, monkeypatch)
+    store = consolidation_review_store.ConsolidationReviewStore(vault)
+    store.persist(review, plan=plan, expected_state_digest=None)
+    for ordinal in range(6):
+        pending, page = consolidation_review.serve_page(
+            review,
+            plan=plan,
+            identity=_trusted_renderer(),
+            page_ordinal=ordinal,
+            served_at=f"2026-08-28T12:00:{ordinal:02d}.500Z",
+        )
+        store.persist(
+            pending,
+            plan=plan,
+            expected_state_digest=review.state.digest,
+        )
+        acknowledgement = consolidation_review.build_acknowledgement(
+            pending,
+            page=page,
+            identity=_trusted_renderer(),
+            issued_at=f"2026-08-28T12:00:{ordinal + 1:02d}.000Z",
+            nonce=f"render-ack-{ordinal:020d}",
+        )
+        review = consolidation_review.acknowledge_page(
+            pending,
+            plan=plan,
+            acknowledgement=acknowledgement,
+        )
+        store.persist(
+            review,
+            plan=plan,
+            expected_state_digest=pending.state.digest,
+        )
+    completed, _completeness = consolidation_review.complete_review(
+        review,
+        plan=plan,
+        identity=_trusted_renderer(),
+        issued_at="2026-08-28T12:10:00.000Z",
+        expires_at=VALID_UNTIL,
+        nonce="completeness-000000000001",
+    )
+    store.persist(
+        completed,
+        plan=plan,
+        expected_state_digest=review.state.digest,
+    )
+    return vault, plan, completed
+
+
+def _owner_confirmation(
+    plan: consolidation_plan.CanonicalConsolidationPlan,
+    review: consolidation_review.CanonicalRenderReview,
+):
+    from exomem.governance import consolidation_approval
+
+    return consolidation_approval.TrustedOwnerConfirmation(
+        owner_binding_digest=_trusted_renderer().owner_binding_digest,
+        owner_principal_digest=_trusted_renderer().owner_principal_digest,
+        authorization_session_digest=_trusted_renderer().authorization_session_digest,
+        issuer=_trusted_renderer().issuer,
+        surface=_trusted_renderer().surface,
+        action="approve",
+        run_id=RUN_ID,
+        plan_kind="cutover",
+        plan_digest=plan.digest,
+        rendering_completeness_digest=review.completeness.digest,
+        confirmed_at="2026-08-28T12:11:00.000Z",
+        nonce="owner-confirmation-00000001",
+    )
+
+
+def test_approval_store_replays_lost_issuance_without_persisting_token_or_secret(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_approval_store
+
+    vault, plan, review = _stored_completed_review(tmp_path, monkeypatch)
+    store = consolidation_approval_store.ConsolidationApprovalStore(vault)
+    generated = iter(
+        (
+            "0123456789abcdef0123456789abcdef",
+            "fedcba9876543210fedcba9876543210",
+        )
+    )
+    monkeypatch.setattr(store, "_new_jti", lambda: next(generated))
+    arguments = {
+        "plan": plan,
+        "render_session_digest": review.session.digest,
+        "identity": _trusted_renderer(),
+        "confirmation": _owner_confirmation(plan, review),
+        "operation_id": "00000000-0000-4000-8000-000000000041",
+        "expires_at": "2026-08-28T12:30:00.000Z",
+        "signing_key_id": "approval-key-01",
+        "signing_key": b"k" * 32,
+    }
+    issued = store.issue(**arguments)
+    assert store.issue(**arguments) == issued
+    assert next(generated) == "fedcba9876543210fedcba9876543210"
+    with pytest.raises(consolidation_approval_store.ConsolidationApprovalStoreUnavailable):
+        store.issue(
+            **{
+                **arguments,
+                "confirmation": replace(
+                    arguments["confirmation"],
+                    nonce="owner-confirmation-00000002",
+                ),
+            }
+        )
+
+    approval_dir = (
+        vault
+        / "Knowledge Base"
+        / "_Consolidation"
+        / "runs"
+        / RUN_ID
+        / "plans"
+        / "cutover"
+        / plan.digest
+        / "approvals"
+    )
+    persisted = b"".join(path.read_bytes() for path in sorted(approval_dir.rglob("*.json")))
+    assert issued.wire.encode() not in persisted
+    assert b"kkkkkkkk" not in persisted
+    assert b"approved" not in persisted
+
+
+def test_approval_store_repairs_operation_before_jti_index_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_approval_store
+
+    vault, plan, review = _stored_completed_review(tmp_path, monkeypatch)
+    store = consolidation_approval_store.ConsolidationApprovalStore(vault)
+    monkeypatch.setattr(
+        store,
+        "_new_jti",
+        lambda: "0123456789abcdef0123456789abcdef",
+    )
+    original_publish_jti = store._publish_jti
+
+    def crash_before_jti(*_args: object, **_kwargs: object) -> None:
+        raise OSError("injected JTI-index gap")
+
+    monkeypatch.setattr(store, "_publish_jti", crash_before_jti)
+    arguments = {
+        "plan": plan,
+        "render_session_digest": review.session.digest,
+        "identity": _trusted_renderer(),
+        "confirmation": _owner_confirmation(plan, review),
+        "operation_id": "00000000-0000-4000-8000-000000000041",
+        "expires_at": "2026-08-28T12:30:00.000Z",
+        "signing_key_id": "approval-key-01",
+        "signing_key": b"k" * 32,
+    }
+    with pytest.raises(consolidation_approval_store.ConsolidationApprovalStoreUnavailable):
+        store.issue(**arguments)
+    monkeypatch.setattr(store, "_publish_jti", original_publish_jti)
+    assert store.issue(**arguments).claim.preimage["jti"] == ("0123456789abcdef0123456789abcdef")
+
+
+def test_approval_jti_reserves_exactly_one_execution_operation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_approval_store
+
+    vault, plan, review = _stored_completed_review(tmp_path, monkeypatch)
+    store = consolidation_approval_store.ConsolidationApprovalStore(vault)
+    monkeypatch.setattr(
+        store,
+        "_new_jti",
+        lambda: "0123456789abcdef0123456789abcdef",
+    )
+    issued = store.issue(
+        plan=plan,
+        render_session_digest=review.session.digest,
+        identity=_trusted_renderer(),
+        confirmation=_owner_confirmation(plan, review),
+        operation_id="00000000-0000-4000-8000-000000000041",
+        expires_at="2026-08-28T12:30:00.000Z",
+        signing_key_id="approval-key-01",
+        signing_key=b"k" * 32,
+    )
+    arguments = {
+        "wire": issued.wire,
+        "plan": plan,
+        "render_session_digest": review.session.digest,
+        "execution_operation_id": "00000000-0000-4000-8000-000000000042",
+        "request_digest": _digest("apply-request"),
+        "reserved_at": "2026-08-28T12:12:00.000Z",
+        "verifier_keys": {"approval-key-01": b"k" * 32},
+    }
+    reservation = store.reserve(**arguments)
+    assert store.reserve(**arguments) == reservation
+    assert store.reserve(**{**arguments, "reserved_at": "2026-08-28T12:31:00.000Z"}) == reservation
+    assert reservation.jti == "0123456789abcdef0123456789abcdef"
+    for changed in (
+        {
+            **arguments,
+            "execution_operation_id": "00000000-0000-4000-8000-000000000043",
+        },
+        {**arguments, "request_digest": _digest("changed-request")},
+    ):
+        with pytest.raises(consolidation_approval_store.ConsolidationApprovalStoreUnavailable):
+            store.reserve(**changed)
+
+    restarted = consolidation_approval_store.ConsolidationApprovalStore(vault)
+    assert restarted.reserve(**arguments) == reservation


### PR DESCRIPTION
## Summary

- persist approval issuance as canonical claim metadata and digests without storing token bytes or signing material
- replay the exact token after lost output by adopting the original operation/JTI instead of minting another
- repair the crash gap between operation persistence and the JTI index
- reserve each verified JTI for exactly one execution operation and request digest
- allow only that already-reserved operation to resume after token expiry; fresh expired reservations still fail

This is stacked after #924. Receipt causality and command/transport integration remain follow-up slices. It does not touch or migrate any live vault.

## Verification

- 110 focused consolidation plan, successor-context, and run-state tests
- lost issuance, crash repair, competing operation, request drift, restart, and post-expiry exact replay coverage
- Ruff format/check
- targeted mypy
- strict OpenSpec validation
- public repository artifact validation
- uv lock --check
- package build
- git diff --check