### PR TITLE
feat(governance): add consolidation admission boundary

### DIFF
--- a/src/exomem/governance/consolidation_admission.py
+++ b/src/exomem/governance/consolidation_admission.py
@@ -1,0 +1,562 @@
+"""Owner-inclusive process-safe admission and drain for consolidation seals."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+import platform
+import re
+import time
+import uuid
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Event, Thread
+from typing import NoReturn
+
+from .. import held_fs, reserved_paths, writer_lease
+from ..cli_ops import OpError
+from ..mutation_lock import VaultMutationCoordinator
+from . import consolidation_authority, consolidation_plan, consolidation_seal
+
+_DESCRIPTOR_ID = "consolidation-tree"
+_OWNER = "consolidation.run"
+_PARTICIPANT_SCHEMA = "exomem.consolidation-admission-participant/v1"
+_PARTICIPANT_KINDS = frozenset({"read", "mutation", "transfer", "background"})
+_PARTICIPANT_FIELDS = frozenset(
+    {"schema", "participant_id", "kind", "state_domain_digest"}
+)
+_PARTICIPANT_NAME = re.compile(r"([0-9a-f]{32})\.json\Z")
+_MAX_PARTICIPANT_BYTES = 1024
+
+
+class ConsolidationAdmissionUnavailable(RuntimeError):
+    """Stable content-free refusal from the outer consolidation boundary."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+def _fail(code: str) -> NoReturn:
+    raise ConsolidationAdmissionUnavailable(code) from None
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationAdmissionSnapshot:
+    """Content-private durable coordination state for trusted control code."""
+
+    state: consolidation_seal.ConsolidationSealState
+    active_reads: int
+    active_mutations: int
+    active_transfers: int
+    active_background: int
+    draining: bool
+
+    @property
+    def active_total(self) -> int:
+        return (
+            self.active_reads
+            + self.active_mutations
+            + self.active_transfers
+            + self.active_background
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _Participant:
+    participant_id: str
+    kind: str
+    state_domain_digest: str
+
+
+@contextmanager
+def _authority(vault_root: Path, *, mutation: bool) -> Iterator[None]:
+    try:
+        with reserved_paths._subsystem_authority_scope(_OWNER):  # noqa: SLF001
+            with reserved_paths._identity_coordination_scope(  # noqa: SLF001
+                vault_root,
+                descriptor_ids=(_DESCRIPTOR_ID,),
+                identity_may_change=mutation,
+            ):
+                yield
+    except ConsolidationAdmissionUnavailable:
+        raise
+    except (OSError, RuntimeError, ValueError):
+        _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
+
+
+class ConsolidationAdmission:
+    """Coordinate ordinary participants with one vault's durable outer seal.
+
+    Every admitted operation owns an OS lock and a content-free durable record.
+    The seal intent is published under a shared gate before the controller waits
+    for those locks. This makes the boundary common to sibling objects and
+    processes rather than relying on process-local counters.
+    """
+
+    def __init__(
+        self,
+        vault_root: Path | str,
+        *,
+        vault_binding_digest: str,
+        store: consolidation_seal.ConsolidationSealStore | None = None,
+    ) -> None:
+        self.vault_root = Path(vault_root).absolute()
+        self.vault_binding_digest = vault_binding_digest
+        self._store = store or consolidation_seal.ConsolidationSealStore(self.vault_root)
+        self._participants = (
+            self.vault_root
+            / "Knowledge Base"
+            / "_Consolidation"
+            / "admission"
+            / "participants"
+        )
+        try:
+            self._state_root = Path(
+                writer_lease.active_manager().config.state_dir
+            ).expanduser().resolve(strict=False)
+            self._store.load(vault_binding_digest=vault_binding_digest)
+        except consolidation_seal.ConsolidationSealUnavailable:
+            _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
+        except (OSError, RuntimeError, ValueError):
+            _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
+        try:
+            with self._gate().hold(
+                operation="admission_bootstrap",
+                holder_kind="reserved-state",
+                publish_holder_metadata=False,
+            ):
+                state_identity = self._state_root.stat()
+        except (OSError, OpError):
+            _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
+        host_identity = self._host_identity()
+        domain = (
+            f"{host_identity}\0{os.path.normcase(str(self._state_root))}\0"
+            f"{state_identity.st_dev}\0{state_identity.st_ino}"
+        )
+        self._state_domain_digest = hashlib.sha256(domain.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _host_identity() -> str:
+        """Return a stable host discriminator without persisting host details."""
+
+        try:
+            machine_id = Path("/etc/machine-id").read_text(encoding="ascii").strip()
+        except (OSError, UnicodeError):
+            machine_id = ""
+        return machine_id or platform.node() or f"node-{uuid.getnode():012x}"
+
+    def _coordinator(
+        self,
+        namespace: str,
+        identity: str,
+        *,
+        timeout: float,
+        state_root: Path | None = None,
+    ) -> VaultMutationCoordinator:
+        boundary = (
+            "consolidation-admission:"
+            f"{self.vault_binding_digest}:{namespace}:{identity}"
+        )
+        return VaultMutationCoordinator(
+            self._state_root if state_root is None else state_root,
+            boundary,
+            timeout_seconds=timeout,
+        )
+
+    def _gate(self, *, timeout: float = 5.0) -> VaultMutationCoordinator:
+        return self._coordinator("gate", "shared", timeout=timeout)
+
+    def _participant_lock(
+        self,
+        participant_id: str,
+        *,
+        timeout: float,
+    ) -> VaultMutationCoordinator:
+        return self._coordinator("participant", participant_id, timeout=timeout)
+
+    @staticmethod
+    def _participant_bytes(participant: _Participant) -> bytes:
+        return consolidation_plan.canonical_closed_jcs(
+            {
+                "schema": _PARTICIPANT_SCHEMA,
+                "participant_id": participant.participant_id,
+                "kind": participant.kind,
+                "state_domain_digest": participant.state_domain_digest,
+            }
+        )
+
+    @staticmethod
+    def _parse_participant(raw: bytes, *, expected_id: str) -> _Participant:
+        try:
+            parsed = consolidation_plan._parse_canonical_mapping(  # noqa: SLF001
+                raw,
+                maximum=_MAX_PARTICIPANT_BYTES,
+            )
+            if frozenset(parsed) != _PARTICIPANT_FIELDS:
+                raise ValueError
+            if consolidation_plan.canonical_closed_jcs(parsed) != raw:
+                raise ValueError
+            participant_id = parsed["participant_id"]
+            kind = parsed["kind"]
+            state_domain_digest = parsed["state_domain_digest"]
+            if participant_id != expected_id:
+                raise ValueError
+            if not isinstance(kind, str) or kind not in _PARTICIPANT_KINDS:
+                raise ValueError
+            if (
+                not isinstance(state_domain_digest, str)
+                or re.fullmatch(r"[0-9a-f]{64}", state_domain_digest) is None
+            ):
+                raise ValueError
+        except (KeyError, TypeError, ValueError, consolidation_plan.ConsolidationPlanUnavailable):
+            _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
+        return _Participant(participant_id, kind, state_domain_digest)
+
+    def _participant_path(self, participant_id: str) -> Path:
+        return self._participants / f"{participant_id}.json"
+
+    def _publish_participant(self, participant: _Participant) -> None:
+        try:
+            with _authority(self.vault_root, mutation=True):
+                reserved_paths._publish_owner_bytes(  # noqa: SLF001
+                    self.vault_root,
+                    self._participant_path(participant.participant_id),
+                    _DESCRIPTOR_ID,
+                    self._participant_bytes(participant),
+                    require_missing=True,
+                )
+        except ConsolidationAdmissionUnavailable:
+            raise
+        except (OSError, RuntimeError, ValueError):
+            _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
+
+    def _remove_participant(self, participant_id: str) -> None:
+        try:
+            with _authority(self.vault_root, mutation=True):
+                reserved_paths._remove_owner_file(  # noqa: SLF001
+                    self.vault_root,
+                    self._participant_path(participant_id),
+                    _DESCRIPTOR_ID,
+                    missing_ok=True,
+                )
+        except ConsolidationAdmissionUnavailable:
+            raise
+        except (OSError, RuntimeError, ValueError):
+            _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
+
+    def _participant_names(self) -> tuple[str, ...]:
+        try:
+            with _authority(self.vault_root, mutation=False):
+                acquired = held_fs.acquire(self.vault_root)
+                if not acquired.ok:
+                    _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
+                with acquired.require() as filesystem:
+                    relative = self._participants.relative_to(self.vault_root).as_posix()
+                    parent_result = filesystem.parent(relative)
+                    if not parent_result.ok:
+                        if (
+                            parent_result.error is not None
+                            and parent_result.error.code == "MISSING"
+                        ):
+                            return ()
+                        _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
+                    with parent_result.require() as parent:
+                        children = filesystem.children(parent)
+                        if not children.ok:
+                            _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
+                        names: list[str] = []
+                        for child in children.require():
+                            match = _PARTICIPANT_NAME.fullmatch(child.relative_path)
+                            if match is None or child.identity.kind != "file":
+                                _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
+                            names.append(match.group(1))
+                        return tuple(sorted(names))
+        except ConsolidationAdmissionUnavailable:
+            raise
+        except (OSError, RuntimeError, ValueError, held_fs.HeldFsError):
+            _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
+
+    def _load_participant(self, participant_id: str) -> _Participant | None:
+        try:
+            with _authority(self.vault_root, mutation=False):
+                raw = reserved_paths._read_owner_bytes(  # noqa: SLF001
+                    self.vault_root,
+                    self._participant_path(participant_id),
+                    _DESCRIPTOR_ID,
+                    limit=_MAX_PARTICIPANT_BYTES,
+                )
+        except FileNotFoundError:
+            return None
+        except ConsolidationAdmissionUnavailable:
+            raise
+        except (OSError, RuntimeError, ValueError):
+            _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
+        return self._parse_participant(raw, expected_id=participant_id)
+
+    def _load_participants(self) -> tuple[_Participant, ...]:
+        participants: list[_Participant] = []
+        for participant_id in self._participant_names():
+            participant = self._load_participant(participant_id)
+            if participant is not None:
+                participants.append(participant)
+        return tuple(participants)
+
+    def _load_state(self) -> consolidation_seal.ConsolidationSealState:
+        try:
+            return self._store.load(vault_binding_digest=self.vault_binding_digest)
+        except consolidation_seal.ConsolidationSealUnavailable:
+            _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
+
+    @staticmethod
+    def _snapshot_from(
+        state: consolidation_seal.ConsolidationSealState,
+        participants: Sequence[_Participant],
+    ) -> ConsolidationAdmissionSnapshot:
+        counts = {kind: 0 for kind in _PARTICIPANT_KINDS}
+        for participant in participants:
+            counts[participant.kind] += 1
+        return ConsolidationAdmissionSnapshot(
+            state=state,
+            active_reads=counts["read"],
+            active_mutations=counts["mutation"],
+            active_transfers=counts["transfer"],
+            active_background=counts["background"],
+            draining=state.kind == "consolidation-sealed" and state.phase == "sealing",
+        )
+
+    def snapshot(self) -> ConsolidationAdmissionSnapshot:
+        try:
+            with self._gate().hold(
+                operation="admission_snapshot",
+                holder_kind="reserved-state",
+                publish_holder_metadata=False,
+            ):
+                return self._snapshot_from(self._load_state(), self._load_participants())
+        except OpError:
+            _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
+
+    def reload(self) -> ConsolidationAdmissionSnapshot:
+        """Reconcile durable seal and participants before restart readiness."""
+
+        return self.snapshot()
+
+    @contextmanager
+    def _admit(self, kind: str) -> Iterator[None]:
+        if kind not in _PARTICIPANT_KINDS:
+            raise ValueError("unknown consolidation admission participant")
+        participant_id = uuid.uuid4().hex
+        participant = _Participant(participant_id, kind, self._state_domain_digest)
+        lock = self._participant_lock(participant_id, timeout=5.0)
+        published = False
+        try:
+            with lock.hold(
+                request_id=participant_id,
+                operation=f"admit_{kind}",
+                holder_kind="reserved-state",
+                publish_holder_metadata=False,
+            ):
+                try:
+                    with self._gate().hold(
+                        request_id=participant_id,
+                        operation=f"admit_{kind}",
+                        holder_kind="reserved-state",
+                        publish_holder_metadata=False,
+                    ):
+                        if self._load_state().kind != "open":
+                            _fail("CONSOLIDATION_SEALED")
+                        self._publish_participant(participant)
+                        published = True
+                    # Another configured coordination root cannot share this
+                    # gate. Rechecking the seal closes that publication race.
+                    if self._load_state().kind != "open":
+                        self._remove_participant(participant_id)
+                        published = False
+                        _fail("CONSOLIDATION_SEALED")
+                    yield
+                finally:
+                    if published:
+                        self._remove_participant(participant_id)
+        except OpError:
+            _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
+
+    def admit_read(self) -> AbstractContextManager[None]:
+        return self._admit("read")
+
+    def admit_mutation(self) -> AbstractContextManager[None]:
+        return self._admit("mutation")
+
+    def admit_transfer(self) -> AbstractContextManager[None]:
+        return self._admit("transfer")
+
+    def admit_background(self) -> AbstractContextManager[None]:
+        return self._admit("background")
+
+    @staticmethod
+    def _remaining(deadline: float) -> float:
+        return max(0.0, deadline - time.monotonic())
+
+    def _stop_background(
+        self,
+        stopper: Callable[[], object],
+        *,
+        deadline: float,
+    ) -> None:
+        remaining = self._remaining(deadline)
+        if remaining <= 0:
+            _fail("CONSOLIDATION_DRAIN_TIMEOUT")
+        stopped = Event()
+        failure: list[BaseException] = []
+
+        def run() -> None:
+            try:
+                stopper()
+            except BaseException as error:  # noqa: BLE001 - retain no private detail
+                failure.append(error)
+            finally:
+                stopped.set()
+
+        Thread(
+            target=run,
+            name="exomem-consolidation-background-stop",
+            daemon=True,
+        ).start()
+        if not stopped.wait(remaining):
+            _fail("CONSOLIDATION_DRAIN_TIMEOUT")
+        if failure:
+            _fail("CONSOLIDATION_DRAIN_FAILED")
+
+    def _wait_participant(self, participant: _Participant, *, deadline: float) -> None:
+        if participant.state_domain_digest == self._state_domain_digest:
+            try:
+                with self._participant_lock(
+                    participant.participant_id,
+                    timeout=self._remaining(deadline),
+                ).hold(
+                    request_id=participant.participant_id,
+                    operation="drain_participant",
+                    holder_kind="reserved-state",
+                    publish_holder_metadata=False,
+                ):
+                    self._remove_participant(participant.participant_id)
+            except OpError:
+                _fail("CONSOLIDATION_DRAIN_TIMEOUT")
+            return
+
+        # Another external coordination domain cannot prove this participant's
+        # liveness or released lock. Preserve its evidence and require the later
+        # cross-replica lifecycle/fencing layer to resolve the configuration.
+        _fail("CONSOLIDATION_ADMISSION_DOMAIN_CONFLICT")
+
+    def seal_and_drain(
+        self,
+        *,
+        authority: object,
+        run_id: str,
+        operation_id: str,
+        journal_digest: str,
+        sealed_at: str,
+        completed_at: str,
+        expected_revision: int,
+        timeout: float,
+        stoppers: Sequence[Callable[[], object]] = (),
+    ) -> ConsolidationAdmissionSnapshot:
+        """Persist intent, close admission, drain every process, then seal."""
+
+        if (
+            not isinstance(timeout, (int, float))
+            or isinstance(timeout, bool)
+            or not math.isfinite(float(timeout))
+            or timeout < 0
+        ):
+            raise ValueError("consolidation drain timeout must be finite and non-negative")
+        if not all(callable(stopper) for stopper in stoppers):
+            raise TypeError("consolidation background stoppers must be callable")
+        try:
+            consolidation_authority.require_authority(
+                authority,
+                vault_binding_digest=self.vault_binding_digest,
+                run_id=run_id,
+                operation_id=operation_id,
+                journal_digest=journal_digest,
+                phase="sealing",
+                action="apply",
+            )
+        except consolidation_authority.ConsolidationAuthorityUnavailable:
+            _fail("CONSOLIDATION_AUTHORITY_UNAVAILABLE")
+
+        deadline = time.monotonic() + float(timeout)
+        control_id = operation_id.replace("-", "")
+        try:
+            with self._coordinator(
+                "control",
+                control_id,
+                timeout=self._remaining(deadline),
+            ).hold(
+                request_id=control_id,
+                operation="seal_and_drain",
+                holder_kind="reserved-state",
+                publish_holder_metadata=False,
+            ):
+                with self._gate(timeout=self._remaining(deadline)).hold(
+                    request_id=control_id,
+                    operation="seal_intent",
+                    holder_kind="reserved-state",
+                    publish_holder_metadata=False,
+                ):
+                    try:
+                        state = self._store.begin_consolidation(
+                            vault_binding_digest=self.vault_binding_digest,
+                            run_id=run_id,
+                            operation_id=operation_id,
+                            journal_digest=journal_digest,
+                            sealed_at=sealed_at,
+                            expected_revision=expected_revision,
+                        )
+                    except consolidation_seal.ConsolidationSealUnavailable:
+                        _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
+
+                for stopper in tuple(stoppers):
+                    self._stop_background(stopper, deadline=deadline)
+
+                while True:
+                    participants = self._load_participants()
+                    if not participants:
+                        break
+                    for participant in participants:
+                        self._wait_participant(participant, deadline=deadline)
+
+                with self._gate(timeout=self._remaining(deadline)).hold(
+                    request_id=control_id,
+                    operation="seal_terminal",
+                    holder_kind="reserved-state",
+                    publish_holder_metadata=False,
+                ):
+                    if self._load_participants():
+                        _fail("CONSOLIDATION_DRAIN_BUSY")
+                    try:
+                        state = self._store.advance_consolidation(
+                            authority,
+                            vault_binding_digest=self.vault_binding_digest,
+                            action="apply",
+                            target_phase="sealed",
+                            recorded_at=completed_at,
+                            expected_revision=state.revision,
+                        )
+                    except consolidation_seal.ConsolidationSealUnavailable:
+                        _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
+        except OpError:
+            if self._load_state().kind == "consolidation-sealed":
+                _fail("CONSOLIDATION_DRAIN_TIMEOUT")
+            _fail("CONSOLIDATION_DRAIN_BUSY")
+        return self._snapshot_from(state, ())
+
+
+__all__ = [
+    "ConsolidationAdmission",
+    "ConsolidationAdmissionSnapshot",
+    "ConsolidationAdmissionUnavailable",
+]

--- a/tests/test_consolidation_control_admission.py
+++ b/tests/test_consolidation_control_admission.py
@@ -1,0 +1,555 @@
+from __future__ import annotations
+
+import hashlib
+import multiprocessing
+import os
+import threading
+import time
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+VAULT_BINDING = hashlib.sha256(b"admission-vault").hexdigest()
+OTHER_VAULT_BINDING = hashlib.sha256(b"other-admission-vault").hexdigest()
+RUN_ID = "00000000-0000-4000-8000-000000000061"
+OPERATION_ID = "00000000-0000-4000-8000-000000000062"
+JOURNAL_DIGEST = hashlib.sha256(b"admission-journal").hexdigest()
+T0 = "2026-08-28T16:00:00.000Z"
+T1 = "2026-08-28T16:00:01.000Z"
+T2 = "2026-08-28T16:00:02.000Z"
+
+
+def _open_admission(vault: Path, *, binding: str = VAULT_BINDING):
+    from exomem.governance import consolidation_admission, consolidation_seal
+
+    store = consolidation_seal.ConsolidationSealStore(vault)
+    store.initialize_open(vault_binding_digest=binding, recorded_at=T0)
+    return consolidation_admission.ConsolidationAdmission(
+        vault,
+        vault_binding_digest=binding,
+    )
+
+
+def _apply_authority():
+    from exomem.governance import consolidation_authority
+
+    return consolidation_authority.issue_authority(
+        vault_binding_digest=VAULT_BINDING,
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        phase="sealing",
+        action="apply",
+    )
+
+
+def _assert_admission_error(code: str):
+    from exomem.governance import consolidation_admission
+
+    return pytest.raises(
+        consolidation_admission.ConsolidationAdmissionUnavailable,
+        match=f"^{code}$",
+    )
+
+
+def _hold_process_read(
+    vault: str,
+    entered: Any,
+    release: Any,
+) -> None:
+    from exomem.governance import consolidation_admission
+
+    admission = consolidation_admission.ConsolidationAdmission(
+        Path(vault),
+        vault_binding_digest=VAULT_BINDING,
+    )
+    with admission.admit_read():
+        entered.set()
+        release.wait(5.0)
+
+
+def _crash_process_read(vault: str, entered: Any) -> None:
+    from exomem.governance import consolidation_admission
+
+    admission = consolidation_admission.ConsolidationAdmission(
+        Path(vault),
+        vault_binding_digest=VAULT_BINDING,
+    )
+    with admission.admit_read():
+        entered.set()
+        os._exit(0)
+
+
+def test_seal_intent_precedes_stop_and_new_work_while_admitted_read_drains(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import consolidation_admission, consolidation_seal
+
+    controller = _open_admission(tmp_path)
+    admission = consolidation_admission.ConsolidationAdmission(
+        tmp_path,
+        vault_binding_digest=VAULT_BINDING,
+    )
+    admitted = admission.admit_read()
+    admitted.__enter__()
+    stopper_observed = threading.Event()
+    finished = threading.Event()
+    failure: list[Exception] = []
+
+    def stop_background() -> None:
+        state = consolidation_seal.ConsolidationSealStore(tmp_path).load(
+            vault_binding_digest=VAULT_BINDING
+        )
+        assert state.phase == "sealing"
+        for enter in (
+            admission.admit_read,
+            admission.admit_mutation,
+            admission.admit_transfer,
+            admission.admit_background,
+        ):
+            with _assert_admission_error("CONSOLIDATION_SEALED"):
+                with enter():
+                    pass
+        stopper_observed.set()
+
+    def seal() -> None:
+        try:
+            controller.seal_and_drain(
+                authority=_apply_authority(),
+                run_id=RUN_ID,
+                operation_id=OPERATION_ID,
+                journal_digest=JOURNAL_DIGEST,
+                sealed_at=T1,
+                completed_at=T2,
+                expected_revision=0,
+                timeout=2.0,
+                stoppers=(stop_background,),
+            )
+        except Exception as error:  # noqa: BLE001  # pragma: no cover - asserted below
+            failure.append(error)
+        finally:
+            finished.set()
+
+    worker = threading.Thread(target=seal)
+    worker.start()
+    assert stopper_observed.wait(1.0)
+    assert not finished.wait(0.05)
+
+    admitted.__exit__(None, None, None)
+    worker.join(2.0)
+    assert not worker.is_alive()
+    assert failure == []
+    assert controller.snapshot().state.phase == "sealed"
+    assert admission.snapshot().state.phase == "sealed"
+    assert controller.snapshot().active_total == 0
+    with _assert_admission_error("CONSOLIDATION_SEALED"):
+        with admission.admit_read():
+            pass
+
+
+def test_seal_drains_participant_admitted_by_another_process(tmp_path: Path) -> None:
+    from exomem.governance import consolidation_seal
+
+    admission = _open_admission(tmp_path)
+    context = multiprocessing.get_context("spawn")
+    entered = context.Event()
+    release = context.Event()
+    participant = context.Process(
+        target=_hold_process_read,
+        args=(str(tmp_path), entered, release),
+    )
+    participant.start()
+    assert entered.wait(3.0)
+    finished = threading.Event()
+    failures: list[Exception] = []
+
+    def seal() -> None:
+        try:
+            admission.seal_and_drain(
+                authority=_apply_authority(),
+                run_id=RUN_ID,
+                operation_id=OPERATION_ID,
+                journal_digest=JOURNAL_DIGEST,
+                sealed_at=T1,
+                completed_at=T2,
+                expected_revision=0,
+                timeout=4.0,
+            )
+        except Exception as error:  # noqa: BLE001  # pragma: no cover - asserted below
+            failures.append(error)
+        finally:
+            finished.set()
+
+    controller = threading.Thread(target=seal)
+    controller.start()
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        state = consolidation_seal.ConsolidationSealStore(tmp_path).load(
+            vault_binding_digest=VAULT_BINDING
+        )
+        if state.phase == "sealing":
+            break
+        time.sleep(0.005)
+    assert state.phase == "sealing"
+    assert not finished.wait(0.05)
+    with _assert_admission_error("CONSOLIDATION_SEALED"):
+        with admission.admit_mutation():
+            pass
+
+    release.set()
+    participant.join(3.0)
+    controller.join(3.0)
+    assert participant.exitcode == 0
+    assert not controller.is_alive()
+    assert failures == []
+    assert admission.snapshot().state.phase == "sealed"
+
+
+def test_seal_reclaims_same_domain_record_after_participant_process_crash(
+    tmp_path: Path,
+) -> None:
+    admission = _open_admission(tmp_path)
+    context = multiprocessing.get_context("spawn")
+    entered = context.Event()
+    participant = context.Process(
+        target=_crash_process_read,
+        args=(str(tmp_path), entered),
+    )
+    participant.start()
+    assert entered.wait(3.0)
+    participant.join(3.0)
+    assert participant.exitcode == 0
+    assert admission.snapshot().active_reads == 1
+
+    sealed = admission.seal_and_drain(
+        authority=_apply_authority(),
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        sealed_at=T1,
+        completed_at=T2,
+        expected_revision=0,
+        timeout=2.0,
+    )
+
+    assert sealed.state.phase == "sealed"
+    assert sealed.active_total == 0
+    assert admission.snapshot().active_total == 0
+
+
+def test_foreign_state_domain_fails_immediately_without_deleting_evidence(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import consolidation_admission, consolidation_seal
+
+    admission = _open_admission(tmp_path)
+    participant_id = "a" * 32
+    admission._publish_participant(  # noqa: SLF001 - adversarial stored-state fixture
+        consolidation_admission._Participant(  # noqa: SLF001
+            participant_id,
+            "read",
+            hashlib.sha256(b"foreign-state-domain").hexdigest(),
+        )
+    )
+
+    started = time.monotonic()
+    with _assert_admission_error("CONSOLIDATION_ADMISSION_DOMAIN_CONFLICT"):
+        admission.seal_and_drain(
+            authority=_apply_authority(),
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            sealed_at=T1,
+            completed_at=T2,
+            expected_revision=0,
+            timeout=2.0,
+        )
+    assert time.monotonic() - started < 0.5
+
+    durable = consolidation_seal.ConsolidationSealStore(tmp_path).load(
+        vault_binding_digest=VAULT_BINDING
+    )
+    assert durable.phase == "sealing"
+    assert admission.snapshot().active_reads == 1
+    assert admission._load_participant(participant_id) is not None  # noqa: SLF001
+
+
+def test_drain_timeout_leaves_recoverable_durable_sealing_state(tmp_path: Path) -> None:
+    from exomem.governance import consolidation_seal
+
+    admission = _open_admission(tmp_path)
+    entered = threading.Event()
+    release = threading.Event()
+
+    def hold_transfer() -> None:
+        with admission.admit_transfer():
+            entered.set()
+            release.wait(2.0)
+
+    participant = threading.Thread(target=hold_transfer)
+    participant.start()
+    assert entered.wait(1.0)
+    with _assert_admission_error("CONSOLIDATION_DRAIN_TIMEOUT"):
+        admission.seal_and_drain(
+            authority=_apply_authority(),
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            sealed_at=T1,
+            completed_at=T2,
+            expected_revision=0,
+            timeout=0.05,
+        )
+    release.set()
+    participant.join(2.0)
+    assert not participant.is_alive()
+
+    durable = consolidation_seal.ConsolidationSealStore(tmp_path).load(
+        vault_binding_digest=VAULT_BINDING
+    )
+    assert durable.kind == "consolidation-sealed"
+    assert durable.phase == "sealing"
+    assert durable.revision == 1
+    with _assert_admission_error("CONSOLIDATION_SEALED"):
+        with admission.admit_mutation():
+            pass
+
+    recovered = admission.seal_and_drain(
+        authority=_apply_authority(),
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        sealed_at=T1,
+        completed_at=T2,
+        expected_revision=0,
+        timeout=1.0,
+    )
+    assert recovered.state.phase == "sealed"
+    assert recovered.draining is False
+
+
+def test_restart_loads_nonterminal_seal_before_any_ordinary_admission(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import consolidation_admission, consolidation_seal
+
+    store = consolidation_seal.ConsolidationSealStore(tmp_path)
+    store.initialize_open(vault_binding_digest=VAULT_BINDING, recorded_at=T0)
+    store.begin_consolidation(
+        vault_binding_digest=VAULT_BINDING,
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        sealed_at=T1,
+        expected_revision=0,
+    )
+
+    restarted = consolidation_admission.ConsolidationAdmission(
+        tmp_path,
+        vault_binding_digest=VAULT_BINDING,
+    )
+    assert restarted.snapshot().state.phase == "sealing"
+    for enter in (
+        restarted.admit_read,
+        restarted.admit_mutation,
+        restarted.admit_transfer,
+        restarted.admit_background,
+    ):
+        with _assert_admission_error("CONSOLIDATION_SEALED"):
+            with enter():
+                pass
+
+
+def test_enrolled_admission_never_interprets_missing_seal_as_open(tmp_path: Path) -> None:
+    from exomem.governance import consolidation_admission
+
+    with _assert_admission_error("CONSOLIDATION_SEAL_UNAVAILABLE"):
+        consolidation_admission.ConsolidationAdmission(
+            tmp_path,
+            vault_binding_digest=VAULT_BINDING,
+        )
+
+
+def test_all_ordinary_participant_kinds_are_counted_until_exit(tmp_path: Path) -> None:
+    admission = _open_admission(tmp_path)
+    with ExitStack() as stack:
+        stack.enter_context(admission.admit_read())
+        stack.enter_context(admission.admit_mutation())
+        stack.enter_context(admission.admit_transfer())
+        stack.enter_context(admission.admit_background())
+        snapshot = admission.snapshot()
+        assert snapshot.active_reads == 1
+        assert snapshot.active_mutations == 1
+        assert snapshot.active_transfers == 1
+        assert snapshot.active_background == 1
+        assert snapshot.active_total == 4
+    assert admission.snapshot().active_total == 0
+
+
+def test_other_canonical_vault_remains_independently_open(tmp_path: Path) -> None:
+    first = _open_admission(tmp_path / "first")
+    second = _open_admission(tmp_path / "second", binding=OTHER_VAULT_BINDING)
+    entered = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def hold_first() -> None:
+        with first.admit_read():
+            entered.set()
+            release.wait(2.0)
+
+    def seal_first() -> None:
+        first.seal_and_drain(
+            authority=_apply_authority(),
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            sealed_at=T1,
+            completed_at=T2,
+            expected_revision=0,
+            timeout=2.0,
+        )
+        finished.set()
+
+    participant = threading.Thread(target=hold_first)
+    participant.start()
+    assert entered.wait(1.0)
+    controller = threading.Thread(target=seal_first)
+    controller.start()
+    deadline = time.monotonic() + 1.0
+    while first.reload().state.phase != "sealing" and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert first.reload().state.phase == "sealing"
+    assert not finished.is_set()
+    try:
+        with second.admit_mutation():
+            assert second.snapshot().active_mutations == 1
+    finally:
+        release.set()
+    participant.join(2.0)
+    controller.join(2.0)
+    assert not participant.is_alive()
+    assert not controller.is_alive()
+    assert finished.is_set()
+
+
+@pytest.mark.parametrize("timeout", [float("inf"), float("-inf"), float("nan")])
+def test_non_finite_drain_timeout_is_rejected_before_seal(
+    tmp_path: Path,
+    timeout: float,
+) -> None:
+    admission = _open_admission(tmp_path)
+
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        admission.seal_and_drain(
+            authority=_apply_authority(),
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            sealed_at=T1,
+            completed_at=T2,
+            expected_revision=0,
+            timeout=timeout,
+        )
+
+    assert admission.snapshot().state.kind == "open"
+
+
+def test_deletion_seal_uses_same_content_free_ordinary_refusal(tmp_path: Path) -> None:
+    from exomem.governance import consolidation_admission, consolidation_seal
+
+    store = consolidation_seal.ConsolidationSealStore(tmp_path)
+    opened = store.initialize_open(vault_binding_digest=VAULT_BINDING, recorded_at=T0)
+    store.seal_for_deletion(
+        vault_binding_digest=VAULT_BINDING,
+        checkpoint_digest=hashlib.sha256(b"checkpoint").hexdigest(),
+        sealed_at=T1,
+        expected_revision=opened.revision,
+    )
+    restarted = consolidation_admission.ConsolidationAdmission(
+        tmp_path,
+        vault_binding_digest=VAULT_BINDING,
+    )
+    assert restarted.snapshot().state.kind == "deletion-sealed"
+    with _assert_admission_error("CONSOLIDATION_SEALED"):
+        with restarted.admit_read():
+            pass
+
+
+def test_background_stop_failure_keeps_durable_seal_intent(tmp_path: Path) -> None:
+    from exomem.governance import consolidation_seal
+
+    admission = _open_admission(tmp_path)
+
+    def fail() -> None:
+        raise RuntimeError("private worker detail")
+
+    with _assert_admission_error("CONSOLIDATION_DRAIN_FAILED"):
+        admission.seal_and_drain(
+            authority=_apply_authority(),
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            sealed_at=T1,
+            completed_at=T2,
+            expected_revision=0,
+            timeout=1.0,
+            stoppers=(fail,),
+        )
+    durable = consolidation_seal.ConsolidationSealStore(tmp_path).load(
+        vault_binding_digest=VAULT_BINDING
+    )
+    assert durable.phase == "sealing"
+
+
+def test_untrusted_authority_cannot_create_denial_of_service_seal(tmp_path: Path) -> None:
+    admission = _open_admission(tmp_path)
+    with _assert_admission_error("CONSOLIDATION_AUTHORITY_UNAVAILABLE"):
+        admission.seal_and_drain(
+            authority=object(),
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            sealed_at=T1,
+            completed_at=T2,
+            expected_revision=0,
+            timeout=1.0,
+        )
+    assert admission.snapshot().state.kind == "open"
+    with admission.admit_read():
+        pass
+
+
+def test_hung_background_stopper_is_bounded_and_keeps_seal_intent(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import consolidation_seal
+
+    admission = _open_admission(tmp_path)
+    release = threading.Event()
+
+    def hang() -> None:
+        release.wait(5.0)
+
+    started = time.monotonic()
+    with _assert_admission_error("CONSOLIDATION_DRAIN_TIMEOUT"):
+        admission.seal_and_drain(
+            authority=_apply_authority(),
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            sealed_at=T1,
+            completed_at=T2,
+            expected_revision=0,
+            timeout=0.05,
+            stoppers=(hang,),
+        )
+    elapsed = time.monotonic() - started
+    release.set()
+    assert elapsed < 0.5
+    durable = consolidation_seal.ConsolidationSealStore(tmp_path).load(
+        vault_binding_digest=VAULT_BINDING
+    )
+    assert durable.phase == "sealing"


### PR DESCRIPTION
## Summary

- add a process-safe admission primitive for reads, mutations, transfers, and background work
- persist seal intent before draining durable participant records held by OS-backed locks
- recover same-domain crashed participants while preserving foreign-domain evidence and failing closed
- reject late admission consistently across sibling instances and spawned processes

Stacked after #927. This is a non-serving foundation: it does not wire public surfaces, touch a live vault, or mark OpenSpec tasks 6.4/6.5 complete.

## Verification

- red-first admission regressions before implementation
- admission and seal suites: 29 passed
- independent adversarial review: GO, no P0/P1/P2 findings; independent 29-test rerun
- Ruff on both changed files
- mypy on the admission module
- OpenSpec strict validation
- uv lock check
- public repository artifact validation: 3420 files / 3488 text payloads
- source distribution and wheel build; wheel contains the new admission module
- git diff check