### PR TITLE
feat(governance): add consolidation control admission

### DIFF
--- a/src/exomem/governance/consolidation_admission.py
+++ b/src/exomem/governance/consolidation_admission.py
@@ -14,7 +14,7 @@ from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from threading import Event, Thread
-from typing import NoReturn
+from typing import NoReturn, cast
 
 from .. import held_fs, reserved_paths, writer_lease
 from ..cli_ops import OpError
@@ -24,12 +24,29 @@ from . import consolidation_authority, consolidation_plan, consolidation_seal
 _DESCRIPTOR_ID = "consolidation-tree"
 _OWNER = "consolidation.run"
 _PARTICIPANT_SCHEMA = "exomem.consolidation-admission-participant/v1"
+_CONTROL_SCHEMA = "exomem.consolidation-control-participant/v1"
 _PARTICIPANT_KINDS = frozenset({"read", "mutation", "transfer", "background"})
-_PARTICIPANT_FIELDS = frozenset(
-    {"schema", "participant_id", "kind", "state_domain_digest"}
+_PARTICIPANT_FIELDS = frozenset({"schema", "participant_id", "kind", "state_domain_digest"})
+_CONTROL_FIELDS = frozenset(
+    {
+        "schema",
+        "participant_id",
+        "kind",
+        "state_domain_digest",
+        "run_id",
+        "operation_id",
+        "journal_digest",
+        "request_digest",
+        "phase",
+        "action",
+    }
 )
 _PARTICIPANT_NAME = re.compile(r"([0-9a-f]{32})\.json\Z")
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_UUID4 = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z")
 _MAX_PARTICIPANT_BYTES = 1024
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_HANDLE_SEAL = object()
 
 
 class ConsolidationAdmissionUnavailable(RuntimeError):
@@ -70,6 +87,101 @@ class _Participant:
     participant_id: str
     kind: str
     state_domain_digest: str
+    run_id: str | None = None
+    operation_id: str | None = None
+    journal_digest: str | None = None
+    request_digest: str | None = None
+    phase: str | None = None
+    action: str | None = None
+
+
+@dataclass(slots=True)
+class _HandleLease:
+    active: bool = True
+
+
+class ConsolidationMutationAdmission:
+    """Opaque process-local handle for one ordinary mutation admission."""
+
+    __slots__ = ("__converted", "__lease", "__owner", "__participant_id", "__seal")
+
+    def __init__(
+        self,
+        owner: object,
+        participant_id: str,
+        lease: _HandleLease,
+        seal: object,
+    ) -> None:
+        self.__owner = owner
+        self.__participant_id = participant_id
+        self.__lease = lease
+        self.__seal = seal
+        self.__converted = False
+
+    def _matches(self, owner: object, participant_id: str) -> bool:
+        return (
+            self.__seal is _HANDLE_SEAL
+            and self.__owner is owner
+            and self.__participant_id == participant_id
+            and self.__lease.active
+        )
+
+    def _participant(self, owner: object) -> str:
+        if not self._matches(owner, self.__participant_id):
+            _fail("CONSOLIDATION_CONTROL_UNAVAILABLE")
+        return self.__participant_id
+
+    def _convert(self) -> None:
+        self.__converted = True
+
+    def _is_converted(self) -> bool:
+        return self.__converted
+
+    def _lease(self) -> _HandleLease:
+        return self.__lease
+
+    def _finish(self) -> None:
+        self.__lease.active = False
+
+    def __reduce__(self) -> NoReturn:
+        raise TypeError("consolidation mutation admission is process-local")
+
+
+class ConsolidationControlAdmission:
+    """Opaque process-local handle for one exact durable control participant."""
+
+    __slots__ = ("__lease", "__owner", "__participant", "__seal")
+
+    def __init__(
+        self,
+        owner: object,
+        participant: _Participant,
+        lease: _HandleLease,
+        seal: object,
+    ) -> None:
+        self.__owner = owner
+        self.__participant = participant
+        self.__lease = lease
+        self.__seal = seal
+
+    def _matches(self, owner: object, participant: _Participant) -> bool:
+        return (
+            self.__seal is _HANDLE_SEAL
+            and self.__owner is owner
+            and self.__participant == participant
+            and self.__lease.active
+        )
+
+    def _participant_for(self, owner: object) -> _Participant:
+        if not self._matches(owner, self.__participant):
+            _fail("CONSOLIDATION_CONTROL_UNAVAILABLE")
+        return self.__participant
+
+    def _finish(self) -> None:
+        self.__lease.active = False
+
+    def __reduce__(self) -> NoReturn:
+        raise TypeError("consolidation control admission is process-local")
 
 
 @contextmanager
@@ -108,16 +220,14 @@ class ConsolidationAdmission:
         self.vault_binding_digest = vault_binding_digest
         self._store = store or consolidation_seal.ConsolidationSealStore(self.vault_root)
         self._participants = (
-            self.vault_root
-            / "Knowledge Base"
-            / "_Consolidation"
-            / "admission"
-            / "participants"
+            self.vault_root / "Knowledge Base" / "_Consolidation" / "admission" / "participants"
         )
         try:
-            self._state_root = Path(
-                writer_lease.active_manager().config.state_dir
-            ).expanduser().resolve(strict=False)
+            self._state_root = (
+                Path(writer_lease.active_manager().config.state_dir)
+                .expanduser()
+                .resolve(strict=False)
+            )
             self._store.load(vault_binding_digest=vault_binding_digest)
         except consolidation_seal.ConsolidationSealUnavailable:
             _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
@@ -157,10 +267,7 @@ class ConsolidationAdmission:
         timeout: float,
         state_root: Path | None = None,
     ) -> VaultMutationCoordinator:
-        boundary = (
-            "consolidation-admission:"
-            f"{self.vault_binding_digest}:{namespace}:{identity}"
-        )
+        boundary = f"consolidation-admission:{self.vault_binding_digest}:{namespace}:{identity}"
         return VaultMutationCoordinator(
             self._state_root if state_root is None else state_root,
             boundary,
@@ -180,14 +287,29 @@ class ConsolidationAdmission:
 
     @staticmethod
     def _participant_bytes(participant: _Participant) -> bytes:
-        return consolidation_plan.canonical_closed_jcs(
-            {
+        if participant.kind in _PARTICIPANT_KINDS:
+            value: dict[str, object] = {
                 "schema": _PARTICIPANT_SCHEMA,
                 "participant_id": participant.participant_id,
                 "kind": participant.kind,
                 "state_domain_digest": participant.state_domain_digest,
             }
-        )
+        elif participant.kind == "control":
+            value = {
+                "schema": _CONTROL_SCHEMA,
+                "participant_id": participant.participant_id,
+                "kind": participant.kind,
+                "state_domain_digest": participant.state_domain_digest,
+                "run_id": participant.run_id,
+                "operation_id": participant.operation_id,
+                "journal_digest": participant.journal_digest,
+                "request_digest": participant.request_digest,
+                "phase": participant.phase,
+                "action": participant.action,
+            }
+        else:
+            _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
+        return consolidation_plan.canonical_closed_jcs(value)
 
     @staticmethod
     def _parse_participant(raw: bytes, *, expected_id: str) -> _Participant:
@@ -196,30 +318,71 @@ class ConsolidationAdmission:
                 raw,
                 maximum=_MAX_PARTICIPANT_BYTES,
             )
-            if frozenset(parsed) != _PARTICIPANT_FIELDS:
-                raise ValueError
             if consolidation_plan.canonical_closed_jcs(parsed) != raw:
                 raise ValueError
+            schema = parsed["schema"]
             participant_id = parsed["participant_id"]
             kind = parsed["kind"]
             state_domain_digest = parsed["state_domain_digest"]
             if participant_id != expected_id:
-                raise ValueError
-            if not isinstance(kind, str) or kind not in _PARTICIPANT_KINDS:
                 raise ValueError
             if (
                 not isinstance(state_domain_digest, str)
                 or re.fullmatch(r"[0-9a-f]{64}", state_domain_digest) is None
             ):
                 raise ValueError
+            if schema == _PARTICIPANT_SCHEMA:
+                if frozenset(parsed) != _PARTICIPANT_FIELDS or kind not in _PARTICIPANT_KINDS:
+                    raise ValueError
+                return _Participant(participant_id, kind, state_domain_digest)
+            if (
+                schema != _CONTROL_SCHEMA
+                or frozenset(parsed) != _CONTROL_FIELDS
+                or kind != "control"
+            ):
+                raise ValueError
+            run_id = parsed["run_id"]
+            operation_id = parsed["operation_id"]
+            journal_digest = parsed["journal_digest"]
+            request_digest = parsed["request_digest"]
+            phase = parsed["phase"]
+            action = parsed["action"]
+            if (
+                not isinstance(run_id, str)
+                or _UUID4.fullmatch(run_id) is None
+                or not isinstance(operation_id, str)
+                or _UUID4.fullmatch(operation_id) is None
+                or not isinstance(journal_digest, str)
+                or _DIGEST.fullmatch(journal_digest) is None
+                or not isinstance(request_digest, str)
+                or _DIGEST.fullmatch(request_digest) is None
+                or phase != "sealing"
+                or action != "apply"
+            ):
+                raise ValueError
         except (KeyError, TypeError, ValueError, consolidation_plan.ConsolidationPlanUnavailable):
             _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
-        return _Participant(participant_id, kind, state_domain_digest)
+        return _Participant(
+            participant_id,
+            kind,
+            state_domain_digest,
+            run_id,
+            operation_id,
+            journal_digest,
+            request_digest,
+            phase,
+            action,
+        )
 
     def _participant_path(self, participant_id: str) -> Path:
         return self._participants / f"{participant_id}.json"
 
-    def _publish_participant(self, participant: _Participant) -> None:
+    def _publish_participant(
+        self,
+        participant: _Participant,
+        *,
+        expected_raw: bytes | None = None,
+    ) -> None:
         try:
             with _authority(self.vault_root, mutation=True):
                 reserved_paths._publish_owner_bytes(  # noqa: SLF001
@@ -227,7 +390,12 @@ class ConsolidationAdmission:
                     self._participant_path(participant.participant_id),
                     _DESCRIPTOR_ID,
                     self._participant_bytes(participant),
-                    require_missing=True,
+                    expected_sha256=(
+                        hashlib.sha256(expected_raw).hexdigest()
+                        if expected_raw is not None
+                        else None
+                    ),
+                    require_missing=expected_raw is None,
                 )
         except ConsolidationAdmissionUnavailable:
             raise
@@ -318,7 +486,8 @@ class ConsolidationAdmission:
     ) -> ConsolidationAdmissionSnapshot:
         counts = {kind: 0 for kind in _PARTICIPANT_KINDS}
         for participant in participants:
-            counts[participant.kind] += 1
+            if participant.kind in counts:
+                counts[participant.kind] += 1
         return ConsolidationAdmissionSnapshot(
             state=state,
             active_reads=counts["read"],
@@ -345,11 +514,17 @@ class ConsolidationAdmission:
         return self.snapshot()
 
     @contextmanager
-    def _admit(self, kind: str) -> Iterator[None]:
+    def _admit(self, kind: str) -> Iterator[ConsolidationMutationAdmission | None]:
         if kind not in _PARTICIPANT_KINDS:
             raise ValueError("unknown consolidation admission participant")
         participant_id = uuid.uuid4().hex
         participant = _Participant(participant_id, kind, self._state_domain_digest)
+        lease = _HandleLease()
+        mutation = (
+            ConsolidationMutationAdmission(self, participant_id, lease, _HANDLE_SEAL)
+            if kind == "mutation"
+            else None
+        )
         lock = self._participant_lock(participant_id, timeout=5.0)
         published = False
         try:
@@ -368,6 +543,8 @@ class ConsolidationAdmission:
                     ):
                         if self._load_state().kind != "open":
                             _fail("CONSOLIDATION_SEALED")
+                        if any(current.kind == "control" for current in self._load_participants()):
+                            _fail("CONSOLIDATION_CONTROL_PENDING")
                         self._publish_participant(participant)
                         published = True
                     # Another configured coordination root cannot share this
@@ -376,24 +553,317 @@ class ConsolidationAdmission:
                         self._remove_participant(participant_id)
                         published = False
                         _fail("CONSOLIDATION_SEALED")
-                    yield
+                    yield mutation
                 finally:
-                    if published:
+                    if published and (mutation is None or not mutation._is_converted()):
                         self._remove_participant(participant_id)
+                    if mutation is not None:
+                        mutation._finish()
         except OpError:
             _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
 
     def admit_read(self) -> AbstractContextManager[None]:
-        return self._admit("read")
+        return cast(AbstractContextManager[None], self._admit("read"))
 
-    def admit_mutation(self) -> AbstractContextManager[None]:
-        return self._admit("mutation")
+    def admit_mutation(self) -> AbstractContextManager[ConsolidationMutationAdmission]:
+        return cast(
+            AbstractContextManager[ConsolidationMutationAdmission],
+            self._admit("mutation"),
+        )
 
     def admit_transfer(self) -> AbstractContextManager[None]:
-        return self._admit("transfer")
+        return cast(AbstractContextManager[None], self._admit("transfer"))
 
     def admit_background(self) -> AbstractContextManager[None]:
-        return self._admit("background")
+        return cast(AbstractContextManager[None], self._admit("background"))
+
+    @staticmethod
+    def _control_participant(
+        participant_id: str,
+        state_domain_digest: str,
+        *,
+        run_id: str,
+        operation_id: str,
+        journal_digest: str,
+        request_digest: str,
+        phase: str,
+        action: str,
+    ) -> _Participant:
+        if not isinstance(request_digest, str) or _DIGEST.fullmatch(request_digest) is None:
+            _fail("CONSOLIDATION_CONTROL_UNAVAILABLE")
+        if phase != "sealing" or action != "apply":
+            _fail("CONSOLIDATION_CONTROL_UNAVAILABLE")
+        return _Participant(
+            participant_id,
+            "control",
+            state_domain_digest,
+            run_id,
+            operation_id,
+            journal_digest,
+            request_digest,
+            phase,
+            action,
+        )
+
+    @staticmethod
+    def _require_control_authority(
+        authority: object,
+        *,
+        vault_binding_digest: str,
+        run_id: str,
+        operation_id: str,
+        journal_digest: str,
+        phase: str,
+        action: str,
+    ) -> None:
+        try:
+            consolidation_authority.require_authority(
+                authority,
+                vault_binding_digest=vault_binding_digest,
+                run_id=run_id,
+                operation_id=operation_id,
+                journal_digest=journal_digest,
+                phase=phase,
+                action=action,
+            )
+        except consolidation_authority.ConsolidationAuthorityUnavailable:
+            _fail("CONSOLIDATION_AUTHORITY_UNAVAILABLE")
+
+    def convert_control_mutation(
+        self,
+        mutation: object,
+        *,
+        authority: object,
+        run_id: str,
+        operation_id: str,
+        journal_digest: str,
+        request_digest: str,
+        phase: str,
+        action: str,
+    ) -> ConsolidationControlAdmission:
+        """Atomically replace this operation's ordinary count with durable control."""
+
+        self._require_control_authority(
+            authority,
+            vault_binding_digest=self.vault_binding_digest,
+            run_id=run_id,
+            operation_id=operation_id,
+            journal_digest=journal_digest,
+            phase=phase,
+            action=action,
+        )
+        if type(mutation) is not ConsolidationMutationAdmission:
+            _fail("CONSOLIDATION_CONTROL_UNAVAILABLE")
+        participant_id = mutation._participant(self)
+        ordinary = _Participant(participant_id, "mutation", self._state_domain_digest)
+        control = self._control_participant(
+            participant_id,
+            self._state_domain_digest,
+            run_id=run_id,
+            operation_id=operation_id,
+            journal_digest=journal_digest,
+            request_digest=request_digest,
+            phase=phase,
+            action=action,
+        )
+        try:
+            with self._gate().hold(
+                request_id=participant_id,
+                operation="convert_control_mutation",
+                holder_kind="reserved-state",
+                publish_holder_metadata=False,
+            ):
+                if self._load_state().kind != "open":
+                    _fail("CONSOLIDATION_SEALED")
+                participants = self._load_participants()
+                if ordinary not in participants:
+                    _fail("CONSOLIDATION_CONTROL_UNAVAILABLE")
+                if any(current.kind == "control" for current in participants):
+                    _fail("CONSOLIDATION_CONTROL_CONFLICT")
+                try:
+                    self._publish_participant(
+                        control,
+                        expected_raw=self._participant_bytes(ordinary),
+                    )
+                except ConsolidationAdmissionUnavailable:
+                    # Publication is durable before its catalogue bookkeeping.
+                    # Adopt an exact committed control after a lost acknowledgement;
+                    # otherwise retain ambiguous evidence rather than deleting a
+                    # possibly committed control in the admission context cleanup.
+                    try:
+                        current = self._load_participant(participant_id)
+                    except ConsolidationAdmissionUnavailable:
+                        mutation._convert()
+                        raise
+                    if current == control:
+                        mutation._convert()
+                    elif current == ordinary:
+                        raise
+                    else:
+                        mutation._convert()
+                        _fail("CONSOLIDATION_CONTROL_CONFLICT")
+                else:
+                    mutation._convert()
+        except OpError:
+            _fail("CONSOLIDATION_ADMISSION_UNAVAILABLE")
+        return ConsolidationControlAdmission(
+            self,
+            control,
+            mutation._lease(),
+            _HANDLE_SEAL,
+        )
+
+    def _matching_control(
+        self,
+        *,
+        run_id: str,
+        operation_id: str,
+        journal_digest: str,
+        request_digest: str,
+        phase: str,
+        action: str,
+    ) -> _Participant:
+        controls = tuple(
+            participant
+            for participant in self._load_participants()
+            if participant.kind == "control"
+        )
+        if len(controls) != 1:
+            _fail("CONSOLIDATION_CONTROL_UNAVAILABLE")
+        current = controls[0]
+        if current.state_domain_digest != self._state_domain_digest:
+            _fail("CONSOLIDATION_ADMISSION_DOMAIN_CONFLICT")
+        expected = self._control_participant(
+            current.participant_id,
+            current.state_domain_digest,
+            run_id=run_id,
+            operation_id=operation_id,
+            journal_digest=journal_digest,
+            request_digest=request_digest,
+            phase=phase,
+            action=action,
+        )
+        if current != expected:
+            _fail("CONSOLIDATION_CONTROL_CONFLICT")
+        return current
+
+    def _require_durable_control(self, expected: _Participant) -> None:
+        controls = tuple(
+            participant
+            for participant in self._load_participants()
+            if participant.kind == "control"
+        )
+        if not controls:
+            _fail("CONSOLIDATION_CONTROL_UNAVAILABLE")
+        if len(controls) != 1 or controls[0] != expected:
+            _fail("CONSOLIDATION_CONTROL_CONFLICT")
+        if controls[0].state_domain_digest != self._state_domain_digest:
+            _fail("CONSOLIDATION_ADMISSION_DOMAIN_CONFLICT")
+
+    @contextmanager
+    def resume_control_mutation(
+        self,
+        *,
+        authority: object,
+        run_id: str,
+        operation_id: str,
+        journal_digest: str,
+        request_digest: str,
+        phase: str,
+        action: str,
+    ) -> Iterator[ConsolidationControlAdmission]:
+        """Recover one exact converted operation without reopening ordinary work."""
+
+        self._require_control_authority(
+            authority,
+            vault_binding_digest=self.vault_binding_digest,
+            run_id=run_id,
+            operation_id=operation_id,
+            journal_digest=journal_digest,
+            phase=phase,
+            action=action,
+        )
+        try:
+            with self._gate().hold(
+                operation="resume_control_lookup",
+                holder_kind="reserved-state",
+                publish_holder_metadata=False,
+            ):
+                current = self._matching_control(
+                    run_id=run_id,
+                    operation_id=operation_id,
+                    journal_digest=journal_digest,
+                    request_digest=request_digest,
+                    phase=phase,
+                    action=action,
+                )
+                state = self._load_state()
+                if state.kind == "deletion-sealed":
+                    _fail("CONSOLIDATION_CONTROL_UNAVAILABLE")
+                if state.kind == "consolidation-sealed" and (
+                    state.run_id != run_id
+                    or state.operation_id != operation_id
+                    or state.journal_digest != journal_digest
+                ):
+                    _fail("CONSOLIDATION_CONTROL_CONFLICT")
+            with self._participant_lock(current.participant_id, timeout=5.0).hold(
+                request_id=current.participant_id,
+                operation="resume_control_mutation",
+                holder_kind="reserved-state",
+                publish_holder_metadata=False,
+            ):
+                with self._gate().hold(
+                    request_id=current.participant_id,
+                    operation="resume_control_recheck",
+                    holder_kind="reserved-state",
+                    publish_holder_metadata=False,
+                ):
+                    current = self._matching_control(
+                        run_id=run_id,
+                        operation_id=operation_id,
+                        journal_digest=journal_digest,
+                        request_digest=request_digest,
+                        phase=phase,
+                        action=action,
+                    )
+                lease = _HandleLease()
+                control = ConsolidationControlAdmission(
+                    self,
+                    current,
+                    lease,
+                    _HANDLE_SEAL,
+                )
+                try:
+                    yield control
+                finally:
+                    control._finish()
+        except OpError:
+            _fail("CONSOLIDATION_CONTROL_BUSY")
+
+    def _require_control(
+        self,
+        control: object,
+        *,
+        run_id: str,
+        operation_id: str,
+        journal_digest: str,
+    ) -> _Participant:
+        if type(control) is not ConsolidationControlAdmission:
+            _fail("CONSOLIDATION_CONTROL_UNAVAILABLE")
+        bound = control._participant_for(self)
+        if bound.request_digest is None:
+            _fail("CONSOLIDATION_CONTROL_UNAVAILABLE")
+        current = self._matching_control(
+            run_id=run_id,
+            operation_id=operation_id,
+            journal_digest=journal_digest,
+            request_digest=bound.request_digest,
+            phase="sealing",
+            action="apply",
+        )
+        if not control._matches(self, current):
+            _fail("CONSOLIDATION_CONTROL_UNAVAILABLE")
+        return current
 
     @staticmethod
     def _remaining(deadline: float) -> float:
@@ -454,6 +924,7 @@ class ConsolidationAdmission:
     def seal_and_drain(
         self,
         *,
+        control: object,
         authority: object,
         run_id: str,
         operation_id: str,
@@ -488,6 +959,19 @@ class ConsolidationAdmission:
         except consolidation_authority.ConsolidationAuthorityUnavailable:
             _fail("CONSOLIDATION_AUTHORITY_UNAVAILABLE")
 
+        control_participant = self._require_control(
+            control,
+            run_id=run_id,
+            operation_id=operation_id,
+            journal_digest=journal_digest,
+        )
+        if (
+            type(expected_revision) is not int
+            or expected_revision < 0
+            or expected_revision > _MAX_SAFE_INTEGER
+        ):
+            _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
+
         deadline = time.monotonic() + float(timeout)
         control_id = operation_id.replace("-", "")
         try:
@@ -507,6 +991,19 @@ class ConsolidationAdmission:
                     holder_kind="reserved-state",
                     publish_holder_metadata=False,
                 ):
+                    self._require_durable_control(control_participant)
+                    current = self._load_state()
+                    if current.kind == "consolidation-sealed" and current.phase == "sealed":
+                        if (
+                            current.run_id == run_id
+                            and current.operation_id == operation_id
+                            and current.journal_digest == journal_digest
+                            and current.sealed_at == sealed_at
+                            and current.recorded_at == completed_at
+                            and current.revision == expected_revision + 2
+                        ):
+                            return self._snapshot_from(current, ())
+                        _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
                     try:
                         state = self._store.begin_consolidation(
                             vault_binding_digest=self.vault_binding_digest,
@@ -523,7 +1020,11 @@ class ConsolidationAdmission:
                     self._stop_background(stopper, deadline=deadline)
 
                 while True:
-                    participants = self._load_participants()
+                    participants = tuple(
+                        participant
+                        for participant in self._load_participants()
+                        if participant != control_participant
+                    )
                     if not participants:
                         break
                     for participant in participants:
@@ -535,7 +1036,10 @@ class ConsolidationAdmission:
                     holder_kind="reserved-state",
                     publish_holder_metadata=False,
                 ):
-                    if self._load_participants():
+                    self._require_durable_control(control_participant)
+                    if any(
+                        participant.kind != "control" for participant in self._load_participants()
+                    ):
                         _fail("CONSOLIDATION_DRAIN_BUSY")
                     try:
                         state = self._store.advance_consolidation(
@@ -559,4 +1063,6 @@ __all__ = [
     "ConsolidationAdmission",
     "ConsolidationAdmissionSnapshot",
     "ConsolidationAdmissionUnavailable",
+    "ConsolidationControlAdmission",
+    "ConsolidationMutationAdmission",
 ]

--- a/tests/test_consolidation_control_admission.py
+++ b/tests/test_consolidation_control_admission.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import multiprocessing
 import os
+import sys
 import threading
 import time
 from contextlib import ExitStack
@@ -16,6 +17,8 @@ OTHER_VAULT_BINDING = hashlib.sha256(b"other-admission-vault").hexdigest()
 RUN_ID = "00000000-0000-4000-8000-000000000061"
 OPERATION_ID = "00000000-0000-4000-8000-000000000062"
 JOURNAL_DIGEST = hashlib.sha256(b"admission-journal").hexdigest()
+REQUEST_DIGEST = hashlib.sha256(b"admission-request").hexdigest()
+OTHER_REQUEST_DIGEST = hashlib.sha256(b"other-admission-request").hexdigest()
 T0 = "2026-08-28T16:00:00.000Z"
 T1 = "2026-08-28T16:00:01.000Z"
 T2 = "2026-08-28T16:00:02.000Z"
@@ -43,6 +46,82 @@ def _apply_authority():
         phase="sealing",
         action="apply",
     )
+
+
+def _convert_apply(admission):
+    ordinary = admission.admit_mutation()
+    mutation = ordinary.__enter__()
+    try:
+        control = admission.convert_control_mutation(
+            mutation,
+            authority=_apply_authority(),
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            request_digest=REQUEST_DIGEST,
+            phase="sealing",
+            action="apply",
+        )
+    except BaseException:
+        ordinary.__exit__(*sys.exc_info())
+        raise
+    return ordinary, control
+
+
+def _seal_with_new_control(
+    admission,
+    *,
+    authority=None,
+    timeout: float = 2.0,
+    stoppers=(),
+):
+    exact_authority = _apply_authority() if authority is None else authority
+    with admission.admit_mutation() as mutation:
+        control = admission.convert_control_mutation(
+            mutation,
+            authority=exact_authority,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            request_digest=REQUEST_DIGEST,
+            phase="sealing",
+            action="apply",
+        )
+        return admission.seal_and_drain(
+            control=control,
+            authority=exact_authority,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            sealed_at=T1,
+            completed_at=T2,
+            expected_revision=0,
+            timeout=timeout,
+            stoppers=stoppers,
+        )
+
+
+def _seal_with_recovered_control(admission, *, timeout: float = 2.0):
+    with admission.resume_control_mutation(
+        authority=_apply_authority(),
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        request_digest=REQUEST_DIGEST,
+        phase="sealing",
+        action="apply",
+    ) as control:
+        return admission.seal_and_drain(
+            control=control,
+            authority=_apply_authority(),
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            sealed_at=T1,
+            completed_at=T2,
+            expected_revision=0,
+            timeout=timeout,
+        )
 
 
 def _assert_admission_error(code: str):
@@ -116,14 +195,8 @@ def test_seal_intent_precedes_stop_and_new_work_while_admitted_read_drains(
 
     def seal() -> None:
         try:
-            controller.seal_and_drain(
-                authority=_apply_authority(),
-                run_id=RUN_ID,
-                operation_id=OPERATION_ID,
-                journal_digest=JOURNAL_DIGEST,
-                sealed_at=T1,
-                completed_at=T2,
-                expected_revision=0,
+            _seal_with_new_control(
+                controller,
                 timeout=2.0,
                 stoppers=(stop_background,),
             )
@@ -167,14 +240,8 @@ def test_seal_drains_participant_admitted_by_another_process(tmp_path: Path) -> 
 
     def seal() -> None:
         try:
-            admission.seal_and_drain(
-                authority=_apply_authority(),
-                run_id=RUN_ID,
-                operation_id=OPERATION_ID,
-                journal_digest=JOURNAL_DIGEST,
-                sealed_at=T1,
-                completed_at=T2,
-                expected_revision=0,
+            _seal_with_new_control(
+                admission,
                 timeout=4.0,
             )
         except Exception as error:  # noqa: BLE001  # pragma: no cover - asserted below
@@ -223,16 +290,7 @@ def test_seal_reclaims_same_domain_record_after_participant_process_crash(
     assert participant.exitcode == 0
     assert admission.snapshot().active_reads == 1
 
-    sealed = admission.seal_and_drain(
-        authority=_apply_authority(),
-        run_id=RUN_ID,
-        operation_id=OPERATION_ID,
-        journal_digest=JOURNAL_DIGEST,
-        sealed_at=T1,
-        completed_at=T2,
-        expected_revision=0,
-        timeout=2.0,
-    )
+    sealed = _seal_with_new_control(admission, timeout=2.0)
 
     assert sealed.state.phase == "sealed"
     assert sealed.active_total == 0
@@ -256,16 +314,7 @@ def test_foreign_state_domain_fails_immediately_without_deleting_evidence(
 
     started = time.monotonic()
     with _assert_admission_error("CONSOLIDATION_ADMISSION_DOMAIN_CONFLICT"):
-        admission.seal_and_drain(
-            authority=_apply_authority(),
-            run_id=RUN_ID,
-            operation_id=OPERATION_ID,
-            journal_digest=JOURNAL_DIGEST,
-            sealed_at=T1,
-            completed_at=T2,
-            expected_revision=0,
-            timeout=2.0,
-        )
+        _seal_with_new_control(admission, timeout=2.0)
     assert time.monotonic() - started < 0.5
 
     durable = consolidation_seal.ConsolidationSealStore(tmp_path).load(
@@ -292,16 +341,7 @@ def test_drain_timeout_leaves_recoverable_durable_sealing_state(tmp_path: Path) 
     participant.start()
     assert entered.wait(1.0)
     with _assert_admission_error("CONSOLIDATION_DRAIN_TIMEOUT"):
-        admission.seal_and_drain(
-            authority=_apply_authority(),
-            run_id=RUN_ID,
-            operation_id=OPERATION_ID,
-            journal_digest=JOURNAL_DIGEST,
-            sealed_at=T1,
-            completed_at=T2,
-            expected_revision=0,
-            timeout=0.05,
-        )
+        _seal_with_new_control(admission, timeout=0.05)
     release.set()
     participant.join(2.0)
     assert not participant.is_alive()
@@ -316,16 +356,7 @@ def test_drain_timeout_leaves_recoverable_durable_sealing_state(tmp_path: Path) 
         with admission.admit_mutation():
             pass
 
-    recovered = admission.seal_and_drain(
-        authority=_apply_authority(),
-        run_id=RUN_ID,
-        operation_id=OPERATION_ID,
-        journal_digest=JOURNAL_DIGEST,
-        sealed_at=T1,
-        completed_at=T2,
-        expected_revision=0,
-        timeout=1.0,
-    )
+    recovered = _seal_with_recovered_control(admission, timeout=1.0)
     assert recovered.state.phase == "sealed"
     assert recovered.draining is False
 
@@ -401,16 +432,7 @@ def test_other_canonical_vault_remains_independently_open(tmp_path: Path) -> Non
             release.wait(2.0)
 
     def seal_first() -> None:
-        first.seal_and_drain(
-            authority=_apply_authority(),
-            run_id=RUN_ID,
-            operation_id=OPERATION_ID,
-            journal_digest=JOURNAL_DIGEST,
-            sealed_at=T1,
-            completed_at=T2,
-            expected_revision=0,
-            timeout=2.0,
-        )
+        _seal_with_new_control(first, timeout=2.0)
         finished.set()
 
     participant = threading.Thread(target=hold_first)
@@ -444,6 +466,7 @@ def test_non_finite_drain_timeout_is_rejected_before_seal(
 
     with pytest.raises(ValueError, match="finite and non-negative"):
         admission.seal_and_drain(
+            control=object(),
             authority=_apply_authority(),
             run_id=RUN_ID,
             operation_id=OPERATION_ID,
@@ -487,14 +510,8 @@ def test_background_stop_failure_keeps_durable_seal_intent(tmp_path: Path) -> No
         raise RuntimeError("private worker detail")
 
     with _assert_admission_error("CONSOLIDATION_DRAIN_FAILED"):
-        admission.seal_and_drain(
-            authority=_apply_authority(),
-            run_id=RUN_ID,
-            operation_id=OPERATION_ID,
-            journal_digest=JOURNAL_DIGEST,
-            sealed_at=T1,
-            completed_at=T2,
-            expected_revision=0,
+        _seal_with_new_control(
+            admission,
             timeout=1.0,
             stoppers=(fail,),
         )
@@ -507,16 +524,7 @@ def test_background_stop_failure_keeps_durable_seal_intent(tmp_path: Path) -> No
 def test_untrusted_authority_cannot_create_denial_of_service_seal(tmp_path: Path) -> None:
     admission = _open_admission(tmp_path)
     with _assert_admission_error("CONSOLIDATION_AUTHORITY_UNAVAILABLE"):
-        admission.seal_and_drain(
-            authority=object(),
-            run_id=RUN_ID,
-            operation_id=OPERATION_ID,
-            journal_digest=JOURNAL_DIGEST,
-            sealed_at=T1,
-            completed_at=T2,
-            expected_revision=0,
-            timeout=1.0,
-        )
+        _seal_with_new_control(admission, authority=object(), timeout=1.0)
     assert admission.snapshot().state.kind == "open"
     with admission.admit_read():
         pass
@@ -535,7 +543,124 @@ def test_hung_background_stopper_is_bounded_and_keeps_seal_intent(
 
     started = time.monotonic()
     with _assert_admission_error("CONSOLIDATION_DRAIN_TIMEOUT"):
-        admission.seal_and_drain(
+        _seal_with_new_control(
+            admission,
+            timeout=0.05,
+            stoppers=(hang,),
+        )
+    elapsed = time.monotonic() - started
+    release.set()
+    assert elapsed < 0.5
+    durable = consolidation_seal.ConsolidationSealStore(tmp_path).load(
+        vault_binding_digest=VAULT_BINDING
+    )
+    assert durable.phase == "sealing"
+
+
+def test_control_conversion_excludes_only_itself_before_seal_drain(
+    tmp_path: Path,
+) -> None:
+    admission = _open_admission(tmp_path)
+    other = admission.admit_mutation()
+    other.__enter__()
+    ordinary, control = _convert_apply(admission)
+    finished = threading.Event()
+    failures: list[Exception] = []
+
+    assert admission.snapshot().active_mutations == 1
+
+    def seal() -> None:
+        try:
+            admission.seal_and_drain(
+                control=control,
+                authority=_apply_authority(),
+                run_id=RUN_ID,
+                operation_id=OPERATION_ID,
+                journal_digest=JOURNAL_DIGEST,
+                sealed_at=T1,
+                completed_at=T2,
+                expected_revision=0,
+                timeout=2.0,
+            )
+        except Exception as error:  # noqa: BLE001  # pragma: no cover - asserted below
+            failures.append(error)
+        finally:
+            finished.set()
+
+    controller = threading.Thread(target=seal)
+    controller.start()
+    deadline = time.monotonic() + 1.0
+    while admission.reload().state.phase != "sealing" and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert admission.reload().state.phase == "sealing"
+    assert not finished.wait(0.05)
+
+    other.__exit__(None, None, None)
+    controller.join(2.0)
+    ordinary.__exit__(None, None, None)
+    assert not controller.is_alive()
+    assert failures == []
+    assert admission.snapshot().state.phase == "sealed"
+    assert admission.snapshot().active_total == 0
+
+
+def test_converted_control_blocks_late_ordinary_admission_before_seal_intent(
+    tmp_path: Path,
+) -> None:
+    admission = _open_admission(tmp_path)
+    ordinary, _control = _convert_apply(admission)
+    try:
+        assert admission.snapshot().state.kind == "open"
+        assert admission.snapshot().active_mutations == 0
+        for enter in (
+            admission.admit_read,
+            admission.admit_mutation,
+            admission.admit_transfer,
+            admission.admit_background,
+        ):
+            with _assert_admission_error("CONSOLIDATION_CONTROL_PENDING"):
+                with enter():
+                    pass
+    finally:
+        ordinary.__exit__(None, None, None)
+
+
+def test_restart_recovers_only_exact_converted_control_operation(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import consolidation_admission
+
+    admission = _open_admission(tmp_path)
+    ordinary, _control = _convert_apply(admission)
+    ordinary.__exit__(None, None, None)
+
+    restarted = consolidation_admission.ConsolidationAdmission(
+        tmp_path,
+        vault_binding_digest=VAULT_BINDING,
+    )
+    with _assert_admission_error("CONSOLIDATION_CONTROL_CONFLICT"):
+        with restarted.resume_control_mutation(
+            authority=_apply_authority(),
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            request_digest=OTHER_REQUEST_DIGEST,
+            phase="sealing",
+            action="apply",
+        ):
+            pass
+
+    with restarted.resume_control_mutation(
+        authority=_apply_authority(),
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        request_digest=REQUEST_DIGEST,
+        phase="sealing",
+        action="apply",
+    ) as recovered:
+        sealed = restarted.seal_and_drain(
+            control=recovered,
             authority=_apply_authority(),
             run_id=RUN_ID,
             operation_id=OPERATION_ID,
@@ -543,12 +668,323 @@ def test_hung_background_stopper_is_bounded_and_keeps_seal_intent(
             sealed_at=T1,
             completed_at=T2,
             expected_revision=0,
-            timeout=0.05,
-            stoppers=(hang,),
+            timeout=1.0,
         )
-    elapsed = time.monotonic() - started
-    release.set()
-    assert elapsed < 0.5
+    assert sealed.state.phase == "sealed"
+
+
+def test_forged_control_handle_cannot_exclude_itself_from_drain(tmp_path: Path) -> None:
+    admission = _open_admission(tmp_path)
+
+    with _assert_admission_error("CONSOLIDATION_CONTROL_UNAVAILABLE"):
+        admission.seal_and_drain(
+            control=object(),
+            authority=_apply_authority(),
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            sealed_at=T1,
+            completed_at=T2,
+            expected_revision=0,
+            timeout=1.0,
+        )
+    assert admission.snapshot().state.kind == "open"
+
+
+def test_control_handle_expires_when_its_admission_scope_exits(tmp_path: Path) -> None:
+    admission = _open_admission(tmp_path)
+    ordinary, control = _convert_apply(admission)
+    ordinary.__exit__(None, None, None)
+
+    with _assert_admission_error("CONSOLIDATION_CONTROL_UNAVAILABLE"):
+        admission.seal_and_drain(
+            control=control,
+            authority=_apply_authority(),
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            sealed_at=T1,
+            completed_at=T2,
+            expected_revision=0,
+            timeout=1.0,
+        )
+    assert admission.snapshot().state.kind == "open"
+
+
+def test_foreign_domain_control_is_preserved_and_never_recovered_locally(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import consolidation_admission
+
+    admission = _open_admission(tmp_path)
+    participant_id = "b" * 32
+    admission._publish_participant(  # noqa: SLF001 - adversarial stored-state fixture
+        consolidation_admission._Participant(  # noqa: SLF001
+            participant_id,
+            "control",
+            hashlib.sha256(b"foreign-control-domain").hexdigest(),
+            RUN_ID,
+            OPERATION_ID,
+            JOURNAL_DIGEST,
+            REQUEST_DIGEST,
+            "sealing",
+            "apply",
+        )
+    )
+
+    with _assert_admission_error("CONSOLIDATION_ADMISSION_DOMAIN_CONFLICT"):
+        with admission.resume_control_mutation(
+            authority=_apply_authority(),
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            request_digest=REQUEST_DIGEST,
+            phase="sealing",
+            action="apply",
+        ):
+            pass
+    assert admission._load_participant(participant_id) is not None  # noqa: SLF001
+
+
+def test_control_record_is_revalidated_inside_seal_intent_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    admission = _open_admission(tmp_path)
+    ordinary, control = _convert_apply(admission)
+    original = admission._require_control  # noqa: SLF001
+
+    def remove_after_validation(*args, **kwargs):
+        participant = original(*args, **kwargs)
+        admission._remove_participant(participant.participant_id)  # noqa: SLF001
+        return participant
+
+    monkeypatch.setattr(admission, "_require_control", remove_after_validation)
+    try:
+        with _assert_admission_error("CONSOLIDATION_CONTROL_UNAVAILABLE"):
+            admission.seal_and_drain(
+                control=control,
+                authority=_apply_authority(),
+                run_id=RUN_ID,
+                operation_id=OPERATION_ID,
+                journal_digest=JOURNAL_DIGEST,
+                sealed_at=T1,
+                completed_at=T2,
+                expected_revision=0,
+                timeout=1.0,
+            )
+    finally:
+        ordinary.__exit__(None, None, None)
+    assert admission.snapshot().state.kind == "open"
+
+
+def test_two_pre_admitted_mutations_cannot_both_convert_to_control(
+    tmp_path: Path,
+) -> None:
+    admission = _open_admission(tmp_path)
+    first_scope = admission.admit_mutation()
+    second_scope = admission.admit_mutation()
+    first = first_scope.__enter__()
+    second = second_scope.__enter__()
+    try:
+        admission.convert_control_mutation(
+            first,
+            authority=_apply_authority(),
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            request_digest=REQUEST_DIGEST,
+            phase="sealing",
+            action="apply",
+        )
+        with _assert_admission_error("CONSOLIDATION_CONTROL_CONFLICT"):
+            admission.convert_control_mutation(
+                second,
+                authority=_apply_authority(),
+                run_id=RUN_ID,
+                operation_id=OPERATION_ID,
+                journal_digest=JOURNAL_DIGEST,
+                request_digest=OTHER_REQUEST_DIGEST,
+                phase="sealing",
+                action="apply",
+            )
+        assert admission.snapshot().active_mutations == 1
+    finally:
+        second_scope.__exit__(None, None, None)
+        first_scope.__exit__(None, None, None)
+    assert admission.snapshot().active_mutations == 0
+
+
+def test_lost_control_conversion_ack_adopts_the_durable_control(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_admission
+
+    admission = _open_admission(tmp_path)
+    publish = admission._publish_participant  # noqa: SLF001
+
+    def publish_then_lose_ack(participant, **kwargs) -> None:
+        publish(participant, **kwargs)
+        if participant.kind == "control":
+            raise consolidation_admission.ConsolidationAdmissionUnavailable(
+                "CONSOLIDATION_ADMISSION_UNAVAILABLE"
+            )
+
+    monkeypatch.setattr(admission, "_publish_participant", publish_then_lose_ack)
+    with admission.admit_mutation() as mutation:
+        control = admission.convert_control_mutation(
+            mutation,
+            authority=_apply_authority(),
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            request_digest=REQUEST_DIGEST,
+            phase="sealing",
+            action="apply",
+        )
+        assert control is not None
+
+    persisted = admission._matching_control(  # noqa: SLF001
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        request_digest=REQUEST_DIGEST,
+        phase="sealing",
+        action="apply",
+    )
+    assert persisted.kind == "control"
+    with _assert_admission_error("CONSOLIDATION_CONTROL_PENDING"):
+        with admission.admit_read():
+            pass
+
+
+def test_lost_seal_terminal_ack_replays_the_exact_durable_terminal(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import consolidation_admission
+
+    admission = _open_admission(tmp_path)
+    sealed = _seal_with_new_control(admission)
+    restarted = consolidation_admission.ConsolidationAdmission(
+        tmp_path,
+        vault_binding_digest=VAULT_BINDING,
+    )
+
+    replayed = _seal_with_recovered_control(restarted)
+
+    assert replayed == sealed
+
+
+@pytest.mark.parametrize(
+    ("sealed_at", "completed_at", "expected_revision"),
+    ((T0, T2, 0), (T1, T0, 0), (T1, T2, 1)),
+)
+def test_seal_terminal_replay_rejects_changed_request_facts(
+    tmp_path: Path,
+    sealed_at: str,
+    completed_at: str,
+    expected_revision: int,
+) -> None:
+    from exomem.governance import consolidation_admission
+
+    admission = _open_admission(tmp_path)
+    _seal_with_new_control(admission)
+    restarted = consolidation_admission.ConsolidationAdmission(
+        tmp_path,
+        vault_binding_digest=VAULT_BINDING,
+    )
+
+    with restarted.resume_control_mutation(
+        authority=_apply_authority(),
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        request_digest=REQUEST_DIGEST,
+        phase="sealing",
+        action="apply",
+    ) as control:
+        with _assert_admission_error("CONSOLIDATION_SEAL_UNAVAILABLE"):
+            restarted.seal_and_drain(
+                control=control,
+                authority=_apply_authority(),
+                run_id=RUN_ID,
+                operation_id=OPERATION_ID,
+                journal_digest=JOURNAL_DIGEST,
+                sealed_at=sealed_at,
+                completed_at=completed_at,
+                expected_revision=expected_revision,
+                timeout=1.0,
+            )
+
+
+@pytest.mark.parametrize("expected_revision", (False, 0.0))
+def test_seal_terminal_replay_rejects_non_integer_revision(
+    tmp_path: Path,
+    expected_revision: object,
+) -> None:
+    from exomem.governance import consolidation_admission
+
+    admission = _open_admission(tmp_path)
+    _seal_with_new_control(admission)
+    restarted = consolidation_admission.ConsolidationAdmission(
+        tmp_path,
+        vault_binding_digest=VAULT_BINDING,
+    )
+
+    with restarted.resume_control_mutation(
+        authority=_apply_authority(),
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        request_digest=REQUEST_DIGEST,
+        phase="sealing",
+        action="apply",
+    ) as control:
+        with _assert_admission_error("CONSOLIDATION_SEAL_UNAVAILABLE"):
+            restarted.seal_and_drain(
+                control=control,
+                authority=_apply_authority(),
+                run_id=RUN_ID,
+                operation_id=OPERATION_ID,
+                journal_digest=JOURNAL_DIGEST,
+                sealed_at=T1,
+                completed_at=T2,
+                expected_revision=expected_revision,  # type: ignore[arg-type]
+                timeout=1.0,
+            )
+
+
+def test_control_record_must_survive_until_seal_terminal(tmp_path: Path) -> None:
+    from exomem.governance import consolidation_seal
+
+    admission = _open_admission(tmp_path)
+    ordinary, control = _convert_apply(admission)
+
+    def remove_control() -> None:
+        participant = next(
+            item
+            for item in admission._load_participants()
+            if item.kind == "control"  # noqa: SLF001
+        )
+        admission._remove_participant(participant.participant_id)  # noqa: SLF001
+
+    try:
+        with _assert_admission_error("CONSOLIDATION_CONTROL_UNAVAILABLE"):
+            admission.seal_and_drain(
+                control=control,
+                authority=_apply_authority(),
+                run_id=RUN_ID,
+                operation_id=OPERATION_ID,
+                journal_digest=JOURNAL_DIGEST,
+                sealed_at=T1,
+                completed_at=T2,
+                expected_revision=0,
+                timeout=1.0,
+                stoppers=(remove_control,),
+            )
+    finally:
+        ordinary.__exit__(None, None, None)
     durable = consolidation_seal.ConsolidationSealStore(tmp_path).load(
         vault_binding_digest=VAULT_BINDING
     )


### PR DESCRIPTION
## Summary

- convert one admitted mutation into a durable, journal-bound consolidation control participant without self-deadlocking the drain
- block late ordinary admissions, drain every other process participant, and keep deletion seals distinct
- recover exact control operations and exact sealed terminals across crashes and lost acknowledgements while rejecting forged, stale, foreign-domain, or changed retries

Stacked after #928. This is an internal consolidation foundation slice; it does not expose a public command or touch any live vault. OpenSpec tasks 6.6–6.7 remain incomplete until the later orchestration and transport slices land.

## Verification

- red-first regressions for self-drain, exclusive conversion, process restart, durable-control loss, lost conversion acknowledgement, exact terminal replay, and changed retry facts
- `45 passed` — `tests/test_consolidation_control_admission.py` + `tests/test_consolidation_seal.py`
- Ruff format/check on both changed files
- targeted mypy on `consolidation_admission.py`
- `openspec validate add-governed-vault-consolidation --strict`
- public repository artifact validation
- `uv build --no-sources`
- `git diff --check`
- independent reviewer: GO, no P0/P1/P2 findings
