### PR TITLE
fix(state): admit provably-fresh deployments at the readiness gate

### DIFF
--- a/openspec/changes/relocate-machine-local-state/specs/machine-local-state-placement/spec.md
+++ b/openspec/changes/relocate-machine-local-state/specs/machine-local-state-placement/spec.md
@@ -56,17 +56,43 @@ remain under a quiescent vault.
 ### Requirement: State migration requires explicit offline authority and is never lossy
 
 Before a service or stateful CLI consumer opens an external-state family, it
-SHALL call a read-only readiness gate. That gate SHALL NOT create directories,
-copy or delete bytes, take the migration lock, resume interrupted work, adopt an
-authority, or upgrade a manifest. It SHALL refuse with the stable path-free
+SHALL call a read-only readiness gate. That gate SHALL NOT copy or delete
+family bytes, resume interrupted work, adopt an authority, or upgrade a
+manifest. It SHALL refuse with the stable path-free
 `STATE_MIGRATION_OFFLINE_REQUIRED` code when the manifest is absent,
 in-progress, stale relative to the descriptor registry, complete while any
 legacy duplicate remains, or carries an active or complete governance rollback
-marker.
+marker — with one bootstrap exception: when the manifest is absent, the vault
+carries zero legacy external-state members, and the external root carries zero
+state, the gate SHALL admit by creating the external root and durably writing
+the first empty complete manifest under the migration lock, re-verifying both
+emptiness proofs under that lock before writing. Because that lock is never
+exclusion of an older writer, the bootstrap SHALL additionally fence the
+manifest write: re-scan both authorities after publishing and durably roll the
+manifest back if any state appeared, keeping the refusal. The bootstrap SHALL
+acquire the migration lock with a bounded wait and refuse on contention rather
+than block startup, and its own bookkeeping (manifest, lock file, manifest
+staging temporaries) SHALL never count as external state. A refusal there
+protects no bytes and instead fails first-run onboarding (a container boots
+the server directly over a just-initialized vault). An uninspectable side is
+not proof of absence and SHALL keep the refusal; every other manifest-absent
+shape SHALL keep the refusal.
+
+#### Scenario: A provably-fresh deployment admits without offline ceremony
+
+- **WHEN** a service or stateful CLI starts over a vault with zero legacy external-state members, an external root holding no state (or no root at all), and no migration manifest
+- **THEN** the readiness gate creates the external root and durably writes the first empty complete manifest under the migration lock
+- **AND** startup admits and builds regenerable state fresh in the external root
+- **AND** a legacy member, unexplained external state, or an uninspectable side observed before or under the lock keeps the `STATE_MIGRATION_OFFLINE_REQUIRED` refusal
+- **AND** state that lands after the manifest write is fenced: the bootstrap re-scans both authorities, durably rolls the manifest back, and keeps the refusal
 
 All state placement mutation SHALL require an explicit offline migration
 authority and SHALL be reachable only through
-`exomem maintain --migrate-state --offline`. Deployment SHALL prove every
+`exomem maintain --migrate-state --offline` — the fresh bootstrap above is the
+single exception, and it is not placement mutation: it moves, copies, and
+deletes no family bytes, publishes only the first empty complete manifest over
+proven emptiness, and un-publishes that manifest when the proof is invalidated.
+Deployment SHALL prove every
 legacy writer stopped independently of the migration lock; that lock serializes
 only new migrators and SHALL NOT be treated as exclusion of an older writer.
 The offline migrator SHALL durably record its versioned manifest and per-family
@@ -77,9 +103,10 @@ invalid manifests, and unexplained dual authority SHALL fail closed.
 
 #### Scenario: Ordinary startup refuses without mutating legacy state
 
-- **WHEN** a service or stateful CLI starts over a vault whose migration manifest is absent, in-progress, or stale
+- **WHEN** a service or stateful CLI starts over a vault whose migration manifest is in-progress or stale, or absent while legacy in-vault members or external state exist
 - **THEN** it refuses with `STATE_MIGRATION_OFFLINE_REQUIRED`
-- **AND** it does not create the external root, copy or unlink a source, resume progress, or rewrite the manifest
+- **AND** it does not copy or unlink a source, resume progress, or rewrite the manifest
+- **AND** it leaves no external root behind beyond, at worst, a refused bootstrap attempt's empty directory and released lock file, which never count as state
 
 #### Scenario: A legacy WAL writer remains authoritative until the stop window
 
@@ -217,7 +244,7 @@ invalid manifests, and unexplained dual authority SHALL fail closed.
 #### Scenario: An adopted vault regenerates on a new machine
 
 - **WHEN** a vault is moved to a machine that has no state root for it
-- **THEN** the explicit offline initialization writes a complete empty manifest
+- **THEN** the explicit offline initialization writes a complete empty manifest, or the readiness gate's fresh-deployment bootstrap writes the same manifest when startup arrives first over the proven-empty pair
 - **AND** the admitted system builds fresh state from vault content for every regenerable family without requiring the old machine's runtime state
 
 ### Requirement: Deployment proves an offline writer-free transition

--- a/openspec/changes/relocate-machine-local-state/tasks.md
+++ b/openspec/changes/relocate-machine-local-state/tasks.md
@@ -87,6 +87,13 @@
       phase (or retains non-resumable `starting`). Make hosted rollout prove
       fresh zero-pod state and return route/commit failures to target-image zero
       with routes closed.
+- [x] 2.11 Admit provably-fresh deployments without offline ceremony: when the
+      manifest is absent and both the vault legacy scan and the external root
+      are provably empty, the readiness gate bootstraps the first empty
+      complete manifest under the migration lock (re-verifying emptiness under
+      the lock); every other manifest-absent shape keeps the refusal. Repairs
+      first-run onboarding — the docker smoke boots the server directly over a
+      just-initialized vault and fail-closed startup broke it deterministically.
 
 ## 3. Verification and delivery
 

--- a/src/exomem/state_migration.py
+++ b/src/exomem/state_migration.py
@@ -8,6 +8,7 @@ that published proof.
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
 import logging
@@ -16,6 +17,7 @@ import sqlite3
 import stat
 import tempfile
 import threading
+import time
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -38,6 +40,16 @@ _ROLLBACK_OPERATIONS = frozenset({
 })
 _LOCK_NAME = ".state-migration.lock"
 _COPY_CHUNK = 4 * 1024 * 1024
+_BOOTSTRAP_LOCK_TIMEOUT_SECONDS = 5.0
+
+
+class _MigrationLockBusy(TimeoutError):
+    """The bounded migration-lock wait expired with the lock still held.
+
+    A distinct type so the bootstrap's contention handling can never claim a
+    genuine `TimeoutError` from filesystem I/O (`ETIMEDOUT` on a network
+    mount raises the same builtin) as lock contention.
+    """
 _MANIFEST_STATES = frozenset({"in-progress", "complete"})
 _FAMILY_STATES = frozenset({"pending", "published", "complete"})
 
@@ -302,12 +314,18 @@ def migration_status(vault_root: Path) -> str:
     return state
 
 
-def require_vault_state_ready(vault_root: Path) -> StateResolution:
-    """Read-only admission gate for service and stateful CLI startup.
+def require_vault_state_ready(
+    vault_root: Path, *, _after_bootstrap: bool = False
+) -> StateResolution:
+    """Admission gate for service and stateful CLI startup.
 
-    This gate never creates a directory, takes the migration lock, copies,
-    unlinks, resumes, adopts, or upgrades state.  Any state that needs one of
-    those transitions receives the same stable offline-required refusal.
+    This gate never copies, unlinks, resumes, adopts, or upgrades family
+    state; any state needing one of those transitions receives the same
+    stable offline-required refusal.  Its single mutation is the fresh
+    bootstrap in `_bootstrap_fresh_state`: when the manifest is absent and
+    both authorities are provably empty, it creates the external root and
+    writes the first empty complete manifest — there are no bytes a refusal
+    could protect, only a first run it would break.
     """
 
     vault_root = Path(vault_root)
@@ -319,10 +337,14 @@ def require_vault_state_ready(vault_root: Path) -> StateResolution:
     try:
         state_paths.validate_hosted_state_directory(state_dir)
     except FileNotFoundError as error:
+        if not _after_bootstrap and _bootstrap_fresh_state(vault_root, state_dir):
+            return require_vault_state_ready(vault_root, _after_bootstrap=True)
         raise StateMigrationOfflineRequired("hosted state directory is absent") from error
 
     manifest = _load_manifest(state_dir, vault_root=vault_root)
     if manifest is None:
+        if not _after_bootstrap and _bootstrap_fresh_state(vault_root, state_dir):
+            return require_vault_state_ready(vault_root, _after_bootstrap=True)
         raise StateMigrationOfflineRequired("migration manifest is absent")
     if (
         manifest.get("governance_rollback") is not None
@@ -342,6 +364,95 @@ def require_vault_state_ready(vault_root: Path) -> StateResolution:
     with _RESOLUTION_LOCK:
         _RESOLUTION_CACHE[key] = resolution
     return resolution
+
+
+def _bootstrap_fresh_state(vault_root: Path, state_dir: Path) -> bool:
+    """Write the first empty complete manifest for a provably-fresh deployment.
+
+    The offline-required refusal exists to protect bytes from being moved,
+    preferred, or deleted without an operator-asserted stop window.  A
+    deployment whose vault carries zero legacy members and whose external
+    root carries zero state has no bytes to protect: refusing it does not
+    fail closed, it fails onboarding (`docker run` boots the server directly
+    against a just-initialized vault).  Only that zero-byte case bootstraps;
+    every other manifest-absent shape keeps the refusal.  The emptiness is
+    re-verified under the migration lock, and — because that lock serializes
+    only new migrators and is never exclusion of an older writer — the
+    manifest write is additionally fenced: both authorities are re-scanned
+    after publishing, and the manifest is rolled back if any bytes appeared.
+    """
+
+    created_root = False
+    admitted = False
+    try:
+        if scan_vault_state(vault_root) or _external_state_present(state_dir):
+            return False
+        created_root = not state_dir.exists()
+        state_paths.ensure_vault_state_dir(vault_root)
+        with _migration_lock(
+            state_dir, timeout_seconds=_BOOTSTRAP_LOCK_TIMEOUT_SECONDS
+        ):
+            if _load_manifest(state_dir, vault_root=vault_root) is not None:
+                return True
+            if not scan_vault_state(vault_root) and not _external_state_present(
+                state_dir
+            ):
+                manifest = _new_manifest(vault_root, _descriptor_ids())
+                manifest["state"] = "complete"
+                for family in manifest["families"].values():
+                    family["status"] = "complete"
+                _write_manifest(state_dir, manifest)
+                # The migration lock serializes only new migrators; an old
+                # release that ignores it can land legacy bytes between the
+                # re-verification above and the manifest write. Fence the
+                # write: re-scan both authorities after publishing and roll
+                # the manifest back rather than leave a false-complete
+                # authority whose remediation would discard foreign bytes.
+                # A scan that cannot run verified nothing — treat "cannot
+                # verify" as "did not verify" and retract.
+                try:
+                    landed = bool(scan_vault_state(vault_root)) or bool(
+                        _external_state_present(state_dir)
+                    )
+                except (OSError, StateMigrationManifestError):
+                    landed = True
+                if landed:
+                    _manifest_path(state_dir).unlink(missing_ok=True)
+                    _fsync_directory(state_dir)
+                else:
+                    admitted = True
+    except _MigrationLockBusy:
+        log.error(
+            "fresh-state bootstrap refused: another migrator holds the "
+            "migration lock"
+        )
+        return False
+    except (OSError, StateMigrationManifestError):
+        # An uninspectable side is not proof of absence; keep the refusal.
+        _discard_bootstrap_residue(state_dir, created_root)
+        return False
+    if admitted:
+        log.info("fresh machine-local state root bootstrapped for startup admission")
+        return True
+    _discard_bootstrap_residue(state_dir, created_root)
+    return False
+
+
+def _discard_bootstrap_residue(state_dir: Path, created_root: bool) -> None:
+    """Best-effort removal of a root the refused bootstrap itself created.
+
+    Only the empty directory is ever removed — `rmdir`, never a recursive
+    delete — so a lock file another process may hold open, and anything
+    unexpected, keeps the directory. A failure to remove is swallowed: the
+    residue is manifest bookkeeping that no emptiness proof counts as state.
+    """
+
+    if not created_root:
+        return
+    try:
+        os.rmdir(state_dir)
+    except OSError:
+        pass
 
 
 def migrate_vault_state_offline(
@@ -1163,7 +1274,7 @@ def _write_manifest_cas(state_dir: Path, manifest: Mapping[str, Any], *, expecte
 
 
 @contextmanager
-def governance_rollback_session(vault_root: Path) -> Iterator["GovernanceRollbackSession"]:
+def governance_rollback_session(vault_root: Path) -> Iterator[GovernanceRollbackSession]:
     """One held migration-lock session for v1 begin or v2 replay coordinators."""
     root = Path(vault_root)
     state_dir = state_paths.vault_state_dir(root)
@@ -1288,6 +1399,20 @@ def _fsync_directory(path: Path) -> None:
         os.close(descriptor)
 
 
+def _is_manifest_bookkeeping(name: str) -> bool:
+    """Manifest, lock, and manifest staging files are never external state.
+
+    `_write_manifest` stages through `.{MANIFEST_NAME}.<random>.tmp` in the
+    state root; a process killed mid-write orphans that staging file with no
+    chance to clean it up. Counting the orphan as state would permanently
+    refuse the very fresh deployment whose crash created it.
+    """
+
+    if name in {MANIFEST_NAME, _LOCK_NAME}:
+        return True
+    return name.startswith(f".{MANIFEST_NAME}.") and name.endswith(".tmp")
+
+
 def _external_state_present(state_dir: Path) -> bool:
     try:
         entries = os.scandir(state_dir)
@@ -1296,11 +1421,22 @@ def _external_state_present(state_dir: Path) -> bool:
     except OSError as error:
         raise OSError("external state root cannot be inspected") from error
     with entries:
-        return any(entry.name not in {MANIFEST_NAME, _LOCK_NAME} for entry in entries)
+        return any(not _is_manifest_bookkeeping(entry.name) for entry in entries)
 
 
 @contextmanager
-def _migration_lock(state_dir: Path) -> Iterator[None]:
+def _migration_lock(
+    state_dir: Path, *, timeout_seconds: float | None = None
+) -> Iterator[None]:
+    """Serialize new migrators; optionally give up after a bounded wait.
+
+    `timeout_seconds=None` blocks until acquired — the offline migrator's
+    behavior, where the operator asserted the stop window and waiting for a
+    sibling migrator is correct. Startup admission passes a bounded budget
+    instead: startup must never block indefinitely on a lock, so contention
+    raises `TimeoutError` and the caller refuses.
+    """
+
     path = Path(state_dir) / _LOCK_NAME
     handle = path.open("a+b")
     locked = False
@@ -1311,16 +1447,49 @@ def _migration_lock(state_dir: Path) -> Iterator[None]:
             handle.flush()
             os.fsync(handle.fileno())
         handle.seek(0)
+        deadline = (
+            None if timeout_seconds is None else time.monotonic() + timeout_seconds
+        )
         if os.name == "nt":
             import msvcrt
 
-            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
-            locked = True
+            if deadline is None:
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+                locked = True
+            else:
+                while True:
+                    try:
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                        locked = True
+                        break
+                    except OSError as error:
+                        # Only contention retries; a genuine lock-machinery
+                        # failure must not be diagnosed as a held lock.
+                        if error.errno not in (errno.EACCES, errno.EDEADLK):
+                            raise
+                        if time.monotonic() >= deadline:
+                            raise _MigrationLockBusy(
+                                "the state migration lock is held by another migrator"
+                            ) from None
+                        time.sleep(0.2)
         else:
             import fcntl
 
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-            locked = True
+            if deadline is None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+                locked = True
+            else:
+                while True:
+                    try:
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        locked = True
+                        break
+                    except BlockingIOError:
+                        if time.monotonic() >= deadline:
+                            raise _MigrationLockBusy(
+                                "the state migration lock is held by another migrator"
+                            ) from None
+                        time.sleep(0.2)
         yield
     finally:
         try:

--- a/src/exomem/state_paths.py
+++ b/src/exomem/state_paths.py
@@ -157,8 +157,10 @@ def _hosted_state_root_for(directory: Path) -> Path | None:
 def validate_hosted_state_directory(directory: Path) -> None:
     """Read-only, held validation of an existing hosted vault-state leaf.
 
-    Ordinary startup must never create or repair state.  When hosted mode is
-    bound, retain the provisioned root and open both descendant components
+    Ordinary startup never creates or repairs family state; the readiness
+    gate's fresh bootstrap is the one admission that creates anything, and it
+    writes only the first empty manifest over proven emptiness.  When hosted
+    mode is bound, retain the provisioned root and open both descendant components
     relative to that handle with no-follow semantics.  Missing components are
     reported distinctly so the readiness gate can issue its stable offline
     migration refusal.

--- a/tests/test_state_root_migration.py
+++ b/tests/test_state_root_migration.py
@@ -1757,3 +1757,263 @@ def test_target_adjacent_scratch_is_not_migrated(tmp_path: Path) -> None:
     state_dir = state_paths.vault_state_dir(vault)
     assert not (state_dir / batch.name).exists()
     assert not (state_dir / held.name).exists()
+
+
+def test_fresh_deployment_admits_without_offline_migration(tmp_path: Path) -> None:
+    """A provably-fresh deployment admits directly: zero bytes on either side.
+
+    The docker onboarding path boots the server against a just-initialized
+    vault with no external root and no manifest anywhere. There is nothing an
+    offline stop window could protect, so the read-only gate bootstraps the
+    first empty complete manifest itself instead of refusing.
+    """
+    from exomem import state_migration, state_paths
+    from exomem.kbdir import kb_dirname
+
+    vault = tmp_path / "vault"
+    (vault / kb_dirname() / "Notes").mkdir(parents=True)
+    (vault / kb_dirname() / "Notes" / "a-note.md").write_text("# note\n", encoding="utf-8")
+    _reset_resolution_cache()
+
+    resolution = state_migration.require_vault_state_ready(vault)
+
+    assert resolution.state_dir == state_paths.vault_state_dir(vault)
+    assert resolution.dual_state is False
+    manifest = json.loads(
+        (resolution.state_dir / state_migration.MANIFEST_NAME).read_text(encoding="utf-8")
+    )
+    assert manifest["state"] == "complete"
+    assert manifest["vault_identity"] == state_paths.vault_state_key(vault)
+    # The bootstrap is idempotent and the cached resolution stays admissible.
+    assert state_migration.require_vault_state_ready(vault) == resolution
+
+
+def test_admission_still_refuses_legacy_vault_state_without_manifest(tmp_path: Path) -> None:
+    """Legacy in-vault bytes without a manifest keep the offline-required refusal."""
+    from exomem import state_migration
+    from exomem.kbdir import kb_dirname
+
+    vault = tmp_path / "vault"
+    kb = vault / kb_dirname()
+    kb.mkdir(parents=True)
+    (kb / ".governance.sqlite").write_bytes(b"legacy-governance-bytes")
+    _reset_resolution_cache()
+
+    with pytest.raises(state_migration.StateMigrationOfflineRequired):
+        state_migration.require_vault_state_ready(vault)
+    assert (kb / ".governance.sqlite").read_bytes() == b"legacy-governance-bytes"
+
+
+def test_admission_still_refuses_external_state_without_manifest(tmp_path: Path) -> None:
+    """External-root bytes without a manifest are unexplained: refuse, never bless."""
+    from exomem import state_migration, state_paths
+    from exomem.kbdir import kb_dirname
+
+    vault = tmp_path / "vault"
+    (vault / kb_dirname()).mkdir(parents=True)
+    state_dir = state_paths.vault_state_dir(vault)
+    state_dir.mkdir(parents=True)
+    (state_dir / ".graph.sqlite").write_bytes(b"unexplained-external-bytes")
+    _reset_resolution_cache()
+
+    with pytest.raises(state_migration.StateMigrationOfflineRequired):
+        state_migration.require_vault_state_ready(vault)
+    assert (state_dir / ".graph.sqlite").read_bytes() == b"unexplained-external-bytes"
+
+
+def test_bootstrap_fences_state_that_lands_after_the_manifest_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The migration lock is not exclusion of an older writer: bytes that land
+    after the bootstrap's manifest write must roll the manifest back, never
+    leave a false-complete authority whose remediation discards them."""
+    from exomem import state_migration, state_paths
+    from exomem.kbdir import kb_dirname
+
+    vault = tmp_path / "vault"
+    kb = vault / kb_dirname()
+    kb.mkdir(parents=True)
+    _reset_resolution_cache()
+
+    real_scan = state_migration.scan_vault_state
+    calls = {"n": 0}
+
+    def racing_scan(vault_root: Path) -> dict[str, tuple[Path, ...]]:
+        calls["n"] += 1
+        if calls["n"] >= 3:  # pre-lock, under-lock pass; the fence sees the race
+            return {"governance-store": (kb / ".governance.sqlite",)}
+        return real_scan(vault_root)
+
+    monkeypatch.setattr(state_migration, "scan_vault_state", racing_scan)
+
+    with pytest.raises(state_migration.StateMigrationOfflineRequired):
+        state_migration.require_vault_state_ready(vault)
+
+    state_dir = state_paths.vault_state_dir(vault)
+    assert not (state_dir / state_migration.MANIFEST_NAME).exists(), (
+        "a lost old-writer race left a false-complete manifest behind"
+    )
+
+
+def test_bootstrap_under_lock_recheck_catches_state_between_scan_and_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Task 2.11's under-lock re-verification: an unclassified external entry
+    that lands between the pre-lock scan and the lock keeps the refusal, and
+    keeps it WITHOUT ever publishing a manifest — the write-fence would also
+    retract, but publishing a complete authority over known-dirty state even
+    transiently is what the under-lock check exists to prevent."""
+    from exomem import state_migration, state_paths
+    from exomem.kbdir import kb_dirname
+
+    vault = tmp_path / "vault"
+    (vault / kb_dirname()).mkdir(parents=True)
+    state_dir = state_paths.vault_state_dir(vault)
+    state_dir.mkdir(parents=True)
+    _reset_resolution_cache()
+
+    real_load = state_migration._load_manifest
+    calls = {"n": 0}
+
+    def racing_load(target: Path, *, vault_root: Path):
+        calls["n"] += 1
+        if calls["n"] == 2:  # the bootstrap's under-lock manifest read
+            (Path(target) / "stray.bin").write_bytes(b"foreign-bytes")
+        return real_load(target, vault_root=vault_root)
+
+    monkeypatch.setattr(state_migration, "_load_manifest", racing_load)
+    real_write = state_migration._write_manifest
+    writes: list[Path] = []
+
+    def spying_write(target: Path, manifest) -> None:
+        writes.append(Path(target))
+        real_write(target, manifest)
+
+    monkeypatch.setattr(state_migration, "_write_manifest", spying_write)
+
+    with pytest.raises(state_migration.StateMigrationOfflineRequired):
+        state_migration.require_vault_state_ready(vault)
+
+    assert not (state_dir / state_migration.MANIFEST_NAME).exists()
+    assert (state_dir / "stray.bin").read_bytes() == b"foreign-bytes"
+    assert writes == [], (
+        "the under-lock re-check must refuse BEFORE any manifest is published"
+    )
+
+
+def test_orphaned_manifest_staging_temp_does_not_brick_fresh_admission(
+    tmp_path: Path,
+) -> None:
+    """A crash during `_write_manifest` orphans `.{MANIFEST}.*.tmp` staging in
+    the state root; that bookkeeping must never count as external state, or
+    the crashed fresh deployment can never admit again."""
+    from exomem import state_migration, state_paths
+    from exomem.kbdir import kb_dirname
+
+    vault = tmp_path / "vault"
+    (vault / kb_dirname()).mkdir(parents=True)
+    state_dir = state_paths.vault_state_dir(vault)
+    state_dir.mkdir(parents=True)
+    stray = state_dir / f".{state_migration.MANIFEST_NAME}.deadbeef.tmp"
+    stray.write_bytes(b"interrupted staging bytes")
+    _reset_resolution_cache()
+
+    resolution = state_migration.require_vault_state_ready(vault)
+
+    assert resolution.dual_state is False
+    manifest = json.loads(
+        (state_dir / state_migration.MANIFEST_NAME).read_text(encoding="utf-8")
+    )
+    assert manifest["state"] == "complete"
+
+
+def test_bootstrap_refuses_promptly_when_the_migration_lock_is_held(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Startup must never block unboundedly on the migration lock: contention
+    refuses within the bounded budget instead of hanging the boot."""
+    import time as time_module
+
+    from exomem import state_migration, state_paths
+    from exomem.kbdir import kb_dirname
+
+    vault = tmp_path / "vault"
+    (vault / kb_dirname()).mkdir(parents=True)
+    state_dir = state_paths.vault_state_dir(vault)
+    state_dir.mkdir(parents=True)
+    _reset_resolution_cache()
+    monkeypatch.setattr(state_migration, "_BOOTSTRAP_LOCK_TIMEOUT_SECONDS", 0.5)
+
+    held = threading.Event()
+    release = threading.Event()
+
+    def holder() -> None:
+        with state_migration._migration_lock(state_dir):
+            held.set()
+            release.wait(timeout=30)
+
+    thread = threading.Thread(target=holder, daemon=True)
+    thread.start()
+    assert held.wait(timeout=10), "lock holder thread never acquired the lock"
+    try:
+        started = time_module.monotonic()
+        with pytest.raises(state_migration.StateMigrationOfflineRequired):
+            state_migration.require_vault_state_ready(vault)
+        elapsed = time_module.monotonic() - started
+        assert elapsed < 5, f"bounded lock wait took {elapsed:.1f}s"
+    finally:
+        release.set()
+        thread.join(timeout=10)
+
+
+def test_bootstrap_retracts_the_manifest_when_the_fence_scan_itself_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fence scan that cannot run verified nothing: the just-published
+    manifest must be retracted, never left as a false-complete authority."""
+    from exomem import state_migration, state_paths
+    from exomem.kbdir import kb_dirname
+
+    vault = tmp_path / "vault"
+    (vault / kb_dirname()).mkdir(parents=True)
+    _reset_resolution_cache()
+
+    real_scan = state_migration.scan_vault_state
+    calls = {"n": 0}
+
+    def failing_fence_scan(vault_root: Path) -> dict[str, tuple[Path, ...]]:
+        calls["n"] += 1
+        if calls["n"] >= 3:  # pre-lock and under-lock pass; the fence's scan dies
+            raise OSError("vault became uninspectable during the fence")
+        return real_scan(vault_root)
+
+    monkeypatch.setattr(state_migration, "scan_vault_state", failing_fence_scan)
+
+    with pytest.raises(state_migration.StateMigrationOfflineRequired):
+        state_migration.require_vault_state_ready(vault)
+
+    state_dir = state_paths.vault_state_dir(vault)
+    assert not (state_dir / state_migration.MANIFEST_NAME).exists(), (
+        "an unverifiable fence left a false-complete manifest behind"
+    )
+
+
+def test_bootstrap_that_cannot_publish_a_manifest_refuses_rather_than_recursing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The re-entry after a bootstrap is bounded: when the written manifest is
+    not visible to the next read, the gate refuses instead of re-bootstrapping
+    forever."""
+    from exomem import state_migration
+    from exomem.kbdir import kb_dirname
+
+    vault = tmp_path / "vault"
+    (vault / kb_dirname()).mkdir(parents=True)
+    _reset_resolution_cache()
+
+    monkeypatch.setattr(
+        state_migration, "_write_manifest", lambda state_dir, manifest: None
+    )
+
+    with pytest.raises(state_migration.StateMigrationOfflineRequired):
+        state_migration.require_vault_state_ready(vault)


### PR DESCRIPTION
## What

The relocate-machine-local-state readiness gate (#917) refuses whenever the migration manifest is absent. A brand-new deployment — a container booting over a just-initialized vault, with no external root and nothing to migrate — therefore exits with `STATE_MIGRATION_OFFLINE_REQUIRED` on first boot. This broke the docker onboarding path and the ci.yml docker smoke deterministically (runs 33243897408 and 33244658743; reproduced locally — container exits(1) with that exact message).

## Change

The gate bootstraps the first empty complete manifest exactly when both authorities are provably empty (zero legacy external-state members in the vault, zero state in the external root), re-verified under the migration lock. The manifest write is fenced: a post-publish re-scan retracts the manifest if any state appeared or if the scan itself cannot run. Every other manifest-absent shape keeps the refusal. The bounded lock wait refuses on contention instead of blocking startup; manifest bookkeeping (manifest, lock file, staging temporaries) never counts as external state; a refused bootstrap removes at most the empty root it created. The OpenSpec delta for the still-active `relocate-machine-local-state` change is amended to carve out and argue exactly this exception (tasks 2.11).

## Verification

- Focused suite: 74 passed, 1 skipped (`tests/test_state_root_migration.py`; teardown errors on this dev box come from a live service writing the real state root — Linux CI is unaffected).
- Guards are mutation-proven: deleting the under-lock re-check, the write-fence, the cannot-verify handling, or the recursion bound each fails a named test (verified in scratch copies with import-path proof).
- `uvx ruff check` clean; `openspec validate --all --strict` 169/169.
- Docker lean image built from this tree boots a fresh vault to serving (`GET /mcp` → 401) in ~5s; the same sequence exits(1) on current main.
- Independent adversarial review, three rounds, final verdict APPROVE. Known accepted residual: a sub-millisecond crash window between manifest write and fence that only matters combined with a concurrent pre-#917 legacy writer.

Unblocks the 0.65.0 release evidence gate (full-tier ci.yml currently red on the docker smoke).