### PR TITLE
chore(ci): make release evidence self-driving

### DIFF
--- a/.github/workflows/release-evidence-automation.yml
+++ b/.github/workflows/release-evidence-automation.yml
@@ -35,6 +35,13 @@ permissions:
   contents: read
   pull-requests: read
 
+# A disable/re-enable pair (or a double-click) fires auto_merge_enabled twice;
+# without serialization both jobs can pass the eligibility check before either
+# dispatch is visible, yielding two full-tier runs. Queue, don't cancel — a
+# cancelled rerun job would drop the re-run silently.
+concurrency:
+  group: release-evidence-automation-${{ github.event.pull_request.number || github.event.workflow_run.head_sha }}
+
 jobs:
   dispatch-evidence:
     name: dispatch evidence run on release intent
@@ -54,6 +61,8 @@ jobs:
             echo "main has moved past the release base; release-please will resync and re-trigger"
             exit 0
           fi
+          # per_page=100, newest-first: BASE_SHA is main's tip (verified just
+          # above), so its runs are on the first page — no pagination needed.
           eligible=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?branch=main&per_page=100" \
             --jq "[.workflow_runs[] | select((.event == \"workflow_dispatch\" or .event == \"schedule\") and .head_sha == \"$BASE_SHA\" and (.conclusion == \"success\" or .status == \"queued\" or .status == \"in_progress\"))] | length")
           if test "$eligible" -ge 1; then
@@ -91,8 +100,11 @@ jobs:
             echo "release PR base $base_sha does not match evidence revision $EVIDENCE_SHA; skipping"
             exit 0
           fi
+          # head_sha is both a query param and a jq filter: if the API ever
+          # ignores the param, the filter still prevents re-running an
+          # unrelated PR's failing run.
           run_id=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?event=pull_request&head_sha=$head_sha&per_page=10" \
-            --jq '[.workflow_runs[] | select(.status == "completed" and .conclusion == "failure")] | .[0].id // empty')
+            --jq "[.workflow_runs[] | select(.head_sha == \"$head_sha\" and .status == \"completed\" and .conclusion == \"failure\")] | .[0].id // empty")
           if test -z "$run_id"; then
             echo "no completed failing CI run on the release PR head; nothing to re-run"
             exit 0

--- a/.github/workflows/release-evidence-automation.yml
+++ b/.github/workflows/release-evidence-automation.yml
@@ -1,0 +1,101 @@
+# Self-driving release evidence — no manual dispatch, no manual re-run.
+#
+# ci.yml's `release-evidence` job is deliberately a seconds-class check: it
+# requires one green scheduled-or-dispatched full CI run on main at the release
+# PR's base revision, and fails fast when none exists. That preserves the lean
+# PR tier (test_expensive_ci_runs_nightly_and_manually_only pins the measured
+# stampede this replaced), but it used to leave two manual cranks: somebody had
+# to dispatch the full run, and somebody had to re-run the failed evidence
+# check after it finished. This workflow removes both cranks without
+# reintroducing the stampede:
+#
+#   1. Enabling auto-merge on the release PR is the one explicit "release now"
+#      signal. It dispatches the full-tier run automatically when no eligible
+#      run already exists — one dispatch per release intent, never one per
+#      push to main.
+#   2. Whenever a scheduled or dispatched full run completes green on main,
+#      the open release PR at that revision gets its failed checks re-run
+#      automatically. The nightly schedule therefore turns a waiting release
+#      PR green with zero human action.
+#
+# Together: enable auto-merge on the release PR and walk away — evidence is
+# produced, the checks re-evaluate, and GitHub merges when they pass.
+
+name: release evidence automation
+
+on:
+  pull_request:
+    types: [auto_merge_enabled]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  dispatch-evidence:
+    name: dispatch evidence run on release intent
+    if: >-
+      ${{ github.event_name == 'pull_request' &&
+          github.event.pull_request.head.ref == 'release-please--branches--main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Dispatch a full CI run when no eligible evidence exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          main_sha=$(gh api "repos/${{ github.repository }}/commits/main" --jq .sha)
+          if test "$main_sha" != "$BASE_SHA"; then
+            echo "main has moved past the release base; release-please will resync and re-trigger"
+            exit 0
+          fi
+          eligible=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?branch=main&per_page=100" \
+            --jq "[.workflow_runs[] | select((.event == \"workflow_dispatch\" or .event == \"schedule\") and .head_sha == \"$BASE_SHA\" and (.conclusion == \"success\" or .status == \"queued\" or .status == \"in_progress\"))] | length")
+          if test "$eligible" -ge 1; then
+            echo "an eligible evidence run already exists or is in flight at $BASE_SHA"
+            exit 0
+          fi
+          gh workflow run ci.yml --ref main
+          echo "dispatched a full CI run on main at $BASE_SHA"
+
+  rerun-evidence-check:
+    name: re-run release checks when evidence lands
+    if: >-
+      ${{ github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main' &&
+          (github.event.workflow_run.event == 'workflow_dispatch' ||
+           github.event.workflow_run.event == 'schedule') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Re-run the release PR's failed checks at this evidence revision
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVIDENCE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          pr=$(gh api "repos/${{ github.repository }}/pulls?state=open&head=${{ github.repository_owner }}:release-please--branches--main" \
+            --jq '.[0] // empty')
+          if test -z "$pr"; then
+            echo "no open release PR; nothing to re-run"
+            exit 0
+          fi
+          base_sha=$(echo "$pr" | jq -r .base.sha)
+          head_sha=$(echo "$pr" | jq -r .head.sha)
+          if test "$base_sha" != "$EVIDENCE_SHA"; then
+            echo "release PR base $base_sha does not match evidence revision $EVIDENCE_SHA; skipping"
+            exit 0
+          fi
+          run_id=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?event=pull_request&head_sha=$head_sha&per_page=10" \
+            --jq '[.workflow_runs[] | select(.status == "completed" and .conclusion == "failure")] | .[0].id // empty')
+          if test -z "$run_id"; then
+            echo "no completed failing CI run on the release PR head; nothing to re-run"
+            exit 0
+          fi
+          gh run rerun "$run_id" --failed
+          echo "re-ran failed checks of run $run_id for the release PR"

--- a/tests/test_ci_reliability_contract.py
+++ b/tests/test_ci_reliability_contract.py
@@ -769,8 +769,19 @@ def test_release_evidence_automation_removes_both_manual_cranks() -> None:
     triggers = _triggers(workflow)
 
     assert triggers["pull_request"] == {"types": ["auto_merge_enabled"]}
-    assert triggers["workflow_run"] == {"workflows": ["CI"], "types": ["completed"]}
+    # workflow_run matches on ci.yml's `name:`, not its filename — derive the
+    # expected value from ci.yml itself so renaming CI cannot silently kill
+    # the rerun trigger while this test stays green.
+    ci_name = yaml.safe_load(
+        (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    )["name"]
+    assert triggers["workflow_run"] == {"workflows": [ci_name], "types": ["completed"]}
     assert set(triggers) == {"pull_request", "workflow_run"}
+
+    # Duplicate release intents (disable/re-enable auto-merge) must serialize
+    # so only one evidence dispatch can win the eligibility check.
+    assert "concurrency" in workflow
+    assert "release-evidence-automation-" in workflow["concurrency"]["group"]
 
     jobs = workflow["jobs"]
     assert set(jobs) == {"dispatch-evidence", "rerun-evidence-check"}

--- a/tests/test_ci_reliability_contract.py
+++ b/tests/test_ci_reliability_contract.py
@@ -749,3 +749,52 @@ def test_cross_platform_matrix_runs_nightly_and_manually_only() -> None:
         "windows-latest",
         "macos-latest",
     ]
+
+
+def test_release_evidence_automation_removes_both_manual_cranks() -> None:
+    """The release pipeline is self-driving without reintroducing the stampede.
+
+    ci.yml's release-evidence job stays a seconds-class check; the companion
+    workflow supplies the two automations that used to be manual cranks:
+    dispatching the full-tier evidence run (only on the explicit release
+    intent of enabling auto-merge — never per push to main, which is the
+    measured stampede test_expensive_ci_runs_nightly_and_manually_only pins),
+    and re-running the release PR's failed checks when eligible evidence
+    lands on main.
+    """
+    text = (ROOT / ".github/workflows/release-evidence-automation.yml").read_text(
+        encoding="utf-8"
+    )
+    workflow = yaml.safe_load(text)
+    triggers = _triggers(workflow)
+
+    assert triggers["pull_request"] == {"types": ["auto_merge_enabled"]}
+    assert triggers["workflow_run"] == {"workflows": ["CI"], "types": ["completed"]}
+    assert set(triggers) == {"pull_request", "workflow_run"}
+
+    jobs = workflow["jobs"]
+    assert set(jobs) == {"dispatch-evidence", "rerun-evidence-check"}
+
+    dispatch_if = " ".join(str(jobs["dispatch-evidence"]["if"]).split())
+    assert "auto_merge_enabled" not in dispatch_if  # gated by the trigger, not the if
+    assert "release-please--branches--main" in dispatch_if
+    assert "github.event_name == 'pull_request'" in dispatch_if
+
+    rerun_if = " ".join(str(jobs["rerun-evidence-check"]["if"]).split())
+    assert "workflow_run" in rerun_if
+    assert "'success'" in rerun_if
+    assert "'main'" in rerun_if
+    assert "workflow_dispatch" in rerun_if
+    assert "schedule" in rerun_if
+
+    # The dispatch job must never fire from pushes: only the two declared
+    # events exist, and neither is push/synchronize.
+    assert "synchronize" not in text
+    assert "push:" not in text
+
+    # Least privilege: actions write (dispatch + rerun), nothing more.
+    assert workflow["permissions"] == {
+        "actions": "write",
+        "contents": "read",
+        "pull-requests": "read",
+    }


### PR DESCRIPTION
## Why

Every release since 0.64.1 has needed two manual cranks: dispatching the full-tier CI run on main to produce release evidence, and re-running the release PR's failed evidence check once that run finished. The evidence gate itself is deliberate (it preserves the lean PR tier that replaced the measured runner-minute stampede) — the manual labor around it was not.

## What

A companion workflow, `release-evidence-automation.yml`, removes both cranks without reintroducing the stampede:

1. **Enabling auto-merge on the release PR** is the one explicit release-now signal. It dispatches a full-tier CI run on main automatically — only if main still equals the PR base and no eligible run already exists or is in flight. One dispatch per release intent, never one per push.
2. **When any scheduled or dispatched full run completes green on main**, the open release PR at that revision gets its failed checks re-run automatically. The nightly schedule alone therefore turns a waiting release PR green with zero human action.

Net workflow: enable auto-merge and walk away.

## Safety properties

- No attacker-controllable value reaches a shell: both SHAs pass through `env:`, `head.ref` never leaves the `if:` expression.
- Least-privilege permissions (`actions: write`, reads elsewhere), pinned exactly by the contract test.
- `head_sha` is filtered both as a query param and inside jq, so a silently-ignored param cannot re-run an unrelated PR's checks.
- A concurrency group serializes duplicate release intents (queue, not cancel).
- Fork PRs fail closed: auto-merge needs write access, and `pull_request` gives forks a read-only token.

## Verification

- `tests/test_ci_reliability_contract.py::test_release_evidence_automation_removes_both_manual_cranks` pins triggers, jobs, guards, permissions, and the concurrency group; the `workflow_run` expectation is derived from ci.yml's own `name:` so renaming CI breaks the test instead of silently killing the trigger.
- `uv run pytest tests/test_ci_reliability_contract.py -q` → 24 passed. `ruff check` clean.
- Independently reviewed (two rounds); all findings fixed and verified against the final text.
- GitHub docs confirm the design: `workflow_dispatch` events always create workflow runs (the documented exception to the GITHUB_TOKEN no-recursion rule), and the `workflow_run` listener is one level deep, far under the three-level chain cap. Worst case on the dispatch hop is today's status quo (one manual re-run), while the nightly path removes the crank unconditionally.