### PR TITLE
fix: name the offending arguments in Planning and Records refusals

### DIFF
--- a/src/exomem/plan_memory.py
+++ b/src/exomem/plan_memory.py
@@ -331,20 +331,31 @@ def _validate_arguments(action: object, values: dict[str, Any]) -> None:
     if not isinstance(action, str) or action not in ACTIONS:
         _invalid_arguments()
     supplied = {name for name, value in values.items() if value is not None}
-    if not _REQUIRED_FIELDS[action] <= supplied or not supplied <= _ACTION_FIELDS[action]:
-        _invalid_arguments()
+    missing = _REQUIRED_FIELDS[action] - supplied
+    surplus = supplied - _ACTION_FIELDS[action]
+    if missing or surplus:
+        parts = []
+        if surplus:
+            parts.append(f"unexpected for {action}: " + ", ".join(sorted(surplus)))
+        if missing:
+            parts.append(f"missing for {action}: " + ", ".join(sorted(missing)))
+        _invalid_arguments("; ".join(parts))
     if action == "query" and values["view"] is not None and supplied & _VIEW_SHAPING_FIELDS:
-        _invalid_arguments()
+        offending = sorted(supplied & _VIEW_SHAPING_FIELDS)
+        _invalid_arguments("view excludes shaping fields: " + ", ".join(offending))
     if action == "validate" and (
         (values["collection"] is None) == (values["manifest_path"] is None)
     ):
-        _invalid_arguments()
+        _invalid_arguments("validate requires exactly one of: collection, manifest_path")
     if action == "update" and values["changes"] is None and values["body"] is None:
-        _invalid_arguments()
+        _invalid_arguments("update requires at least one of: changes, body")
 
 
-def _invalid_arguments() -> Never:
-    raise OpError("INVALID_PLAN_ARGUMENTS", "arguments do not match the selected Planning action")
+def _invalid_arguments(detail: str | None = None) -> Never:
+    message = "arguments do not match the selected Planning action"
+    if detail:
+        message = f"{message}: {detail}"
+    raise OpError("INVALID_PLAN_ARGUMENTS", message)
 
 
 def _public_error_code(error: CollectionError) -> str:

--- a/src/exomem/record_memory.py
+++ b/src/exomem/record_memory.py
@@ -378,24 +378,35 @@ def _validate_arguments(action: object, values: dict[str, Any]) -> None:
     if not isinstance(action, str) or action not in ACTIONS:
         _invalid_arguments()
     supplied = {name for name, value in values.items() if value is not None}
-    if not _REQUIRED_FIELDS[action] <= supplied or not supplied <= _ACTION_FIELDS[action]:
-        _invalid_arguments()
+    missing = _REQUIRED_FIELDS[action] - supplied
+    surplus = supplied - _ACTION_FIELDS[action]
+    if missing or surplus:
+        parts = []
+        if surplus:
+            parts.append(f"unexpected for {action}: " + ", ".join(sorted(surplus)))
+        if missing:
+            parts.append(f"missing for {action}: " + ", ".join(sorted(missing)))
+        _invalid_arguments("; ".join(parts))
     if action == "update" and values["changes"] is None and values["refresh_presentation"] is not True:
-        _invalid_arguments()
+        _invalid_arguments("update requires changes or refresh_presentation=true")
     if action == "update" and values["refresh_presentation"] not in {None, True}:
-        _invalid_arguments()
+        _invalid_arguments("refresh_presentation must be true when supplied")
     if action == "validate" and ((values["collection"] is None) == (values["manifest_path"] is None)):
-        _invalid_arguments()
+        _invalid_arguments("validate requires exactly one of: collection, manifest_path")
     if action == "validate" and values["collection"] is not None and values["scaffold"] is not None:
-        _invalid_arguments()
+        _invalid_arguments("scaffold is not accepted when collection is supplied")
     if action == "query" and values["view"] is not None and supplied & _QUERY_SHAPING_FIELDS:
-        _invalid_arguments()
+        offending = sorted(supplied & _QUERY_SHAPING_FIELDS)
+        _invalid_arguments("view excludes shaping fields: " + ", ".join(offending))
     if action == "query" and values["expand_children"] is True and values["expand_child"] is not None:
-        _invalid_arguments()
+        _invalid_arguments("expand_children and expand_child are mutually exclusive")
 
 
-def _invalid_arguments() -> Never:
-    raise OpError("INVALID_RECORD_ARGUMENTS", "arguments do not match the selected record action")
+def _invalid_arguments(detail: str | None = None) -> Never:
+    message = "arguments do not match the selected record action"
+    if detail:
+        message = f"{message}: {detail}"
+    raise OpError("INVALID_RECORD_ARGUMENTS", message)
 
 
 def _is_direct_legacy_tracker_selector(collection: str) -> bool:

--- a/tests/test_plan_memory_command.py
+++ b/tests/test_plan_memory_command.py
@@ -246,3 +246,60 @@ def test_collection_dependent_actions_reject_a_missing_selector(
         plan_memory(tmp_path, action, **arguments)
 
     assert raised.value.code == "INVALID_PLAN_ARGUMENTS"
+
+
+def test_plan_memory_update_names_the_unexpected_argument(tmp_path: Path) -> None:
+    from exomem.plan_memory import plan_memory
+
+    with pytest.raises(OpError) as raised:
+        plan_memory(
+            tmp_path,
+            "update",
+            collection="Knowledge Base/Planning/Work/_collection.md",
+            plan_id="991acdd4-16b9-4396-8220-2cb37b7e8516",
+            expected_container_hash="a" * 64,
+            expected_item_version="b" * 64,
+            why="update",
+            changes={"status": "done"},
+            item={"title": "not allowed here"},
+        )
+
+    assert raised.value.code == "INVALID_PLAN_ARGUMENTS"
+    assert "unexpected for update: item" in raised.value.message
+    assert "not allowed here" not in raised.value.message
+
+
+def test_plan_memory_update_names_the_missing_argument(tmp_path: Path) -> None:
+    from exomem.plan_memory import plan_memory
+
+    with pytest.raises(OpError) as raised:
+        plan_memory(
+            tmp_path,
+            "update",
+            collection="Knowledge Base/Planning/Work/_collection.md",
+            plan_id="991acdd4-16b9-4396-8220-2cb37b7e8516",
+            expected_container_hash="a" * 64,
+            why="update",
+            changes={"status": "done"},
+        )
+
+    assert raised.value.code == "INVALID_PLAN_ARGUMENTS"
+    assert "missing for update: expected_item_version" in raised.value.message
+    assert "991acdd4-16b9-4396-8220-2cb37b7e8516" not in raised.value.message
+
+
+def test_plan_memory_query_view_names_the_excluded_shaping_field(tmp_path: Path) -> None:
+    from exomem.plan_memory import plan_memory
+
+    with pytest.raises(OpError) as raised:
+        plan_memory(
+            tmp_path,
+            "query",
+            collection="Knowledge Base/Planning/Work/_collection.md",
+            view="inbox",
+            columns=["title"],
+        )
+
+    assert raised.value.code == "INVALID_PLAN_ARGUMENTS"
+    assert "view excludes shaping fields: columns" in raised.value.message
+    assert "inbox" not in raised.value.message

--- a/tests/test_record_memory_command.py
+++ b/tests/test_record_memory_command.py
@@ -148,6 +148,50 @@ def test_record_memory_rejects_cross_action_arguments_before_defaults(
         record_memory(tmp_path, **kwargs)
 
 
+def test_record_memory_update_names_the_unexpected_argument(tmp_path: Path) -> None:
+    """Twin of plan_memory's update-surplus refusal: name the offending field."""
+    from exomem.cli_ops import OpError
+    from exomem.record_memory import record_memory
+
+    with pytest.raises(OpError) as raised:
+        record_memory(
+            tmp_path,
+            action="update",
+            collection="Knowledge Base/Records/New/_collection.md",
+            item_key="991acdd4-16b9-4396-8220-2cb37b7e8516",
+            expected_container_hash="a" * 64,
+            expected_item_version="b" * 64,
+            why="update",
+            changes={"status": "done"},
+            item={"title": "not allowed here"},
+        )
+
+    assert raised.value.code == "INVALID_RECORD_ARGUMENTS"
+    assert "unexpected for update: item" in raised.value.message
+    assert "not allowed here" not in raised.value.message
+
+
+def test_record_memory_update_names_the_missing_argument(tmp_path: Path) -> None:
+    """Twin of plan_memory's update-missing refusal: name the missing field."""
+    from exomem.cli_ops import OpError
+    from exomem.record_memory import record_memory
+
+    with pytest.raises(OpError) as raised:
+        record_memory(
+            tmp_path,
+            action="update",
+            collection="Knowledge Base/Records/New/_collection.md",
+            item_key="991acdd4-16b9-4396-8220-2cb37b7e8516",
+            expected_container_hash="a" * 64,
+            expected_item_version="b" * 64,
+            changes={"status": "done"},
+        )
+
+    assert raised.value.code == "INVALID_RECORD_ARGUMENTS"
+    assert "missing for update: why" in raised.value.message
+    assert "991acdd4-16b9-4396-8220-2cb37b7e8516" not in raised.value.message
+
+
 def test_record_memory_preserves_explicit_false_and_routes_append(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes the first f27 dogfood finding: `plan_memory` and `record_memory` refused invalid argument shapes with a generic message that named nothing, so an agent had to rediscover the offending field by trial.

## What changed

Every argument-validation refusal in both commands now says what is wrong, using argument **names only — never values**:

- `arguments do not match the selected Planning action: unexpected for update: item; missing for update: expected_item_version`
- `arguments do not match the selected Planning action: view excludes shaping fields: columns`
- `arguments do not match the selected record action: missing for update: why`
- exactly-one-of (`validate`: collection XOR manifest_path) and at-least-one-of (`update`: changes or body) rules are stated in the message.

Error codes (`INVALID_PLAN_ARGUMENTS` / `INVALID_RECORD_ARGUMENTS`), the code-stable message prefixes, and the remediation registry are unchanged; the detail is additive after the prefix. Name lists are sorted, so refusals are deterministic.

Value leakage is structurally impossible: the detail is built from set arithmetic over the commands' declared parameter names (a closed set fixed in source), never from caller input. No tool descriptions or generated surfaces changed — the tool-surface fingerprint is untouched.

## Verification

- Red-first: all 5 new tests fail against the previous sources with the generic message; green after.
- Tests pin the composed phrases and additionally assert planted sentinel values (`"not allowed here"`, an item-key UUID, `"inbox"`) never appear in the public message; a deliberate value-echo mutation is caught by exactly those asserts.
- Independent review: a 23,390-shape differential probe against main confirmed no refusal decision or error code changed — message text only; a 14-branch sentinel probe found zero value leaks; approved after one test-hardening round.
- Gates: `pytest tests/test_plan_memory_command.py tests/test_planning_query.py tests/test_record_mutation.py tests/test_record_memory_command.py -q` → 84 passed; `ruff check --select F` clean; no drift under `tool_surface_contract.json`, `plugins/`, or `tests/fixtures/mcp_tool_schemas.json`.
