### PR TITLE
test: keep higher-scoped fixtures inside the injected state root

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -432,6 +432,42 @@ def _state_root_shallow_snapshot(root: Path) -> tuple:
     return ("present", info.st_mtime_ns, children)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _isolate_state_root_for_session(tmp_path_factory: pytest.TempPathFactory):
+    """A higher-scoped fixture must not write the real user state root either.
+
+    `_isolate_state_root` below is function-scoped, so it is simply not in
+    effect while a module- or session-scoped fixture *body* runs. One that
+    builds a vault there resolves `state_paths.state_store_root()` with no
+    override and writes the REAL platform root:
+    `tests/test_graph_value_benchmark.py`'s module-scoped `perfect_fixture`
+    did exactly that, leaving `<slug>-<digest>/.graph.sqlite` behind for the
+    rest of the session. Nothing failed at the point of the write, because no
+    function-scoped guard bracketed it; a later test that touched the same
+    directory inherited the assertion and was reported as the culprit.
+
+    Injecting at session scope also closes the window *between* tests. The
+    function-scoped guard's `undo()` now restores this session value instead
+    of unsetting the variable, so a write from a worker that outlived the test
+    that started it lands in a tmpdir rather than the user's real state root.
+
+    Deliberately a PRIVATE MonkeyPatch, for the reason the function-scoped
+    fixture documents: the shared `monkeypatch` object is function-scoped and
+    cannot hold a session-scoped patch anyway.
+    """
+    private = pytest.MonkeyPatch()
+    session_root = tmp_path_factory.mktemp("exomem-session-state-root")
+    private.setenv("EXOMEM_STATE_ROOT", str(session_root))
+    private.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR",
+        str(session_root / "writer-lease"),
+    )
+    try:
+        yield
+    finally:
+        private.undo()
+
+
 @pytest.fixture(autouse=True)
 def _isolate_state_root(tmp_path: Path):
     """No test writes the real user state root (task 1.5 of

--- a/tests/test_state_root_placement.py
+++ b/tests/test_state_root_placement.py
@@ -700,3 +700,31 @@ def test_shipped_guidance_does_not_name_relocated_state_as_in_vault() -> None:
         for path in shipped
     }
     assert not {path: tokens for path, tokens in violations.items() if tokens}
+
+
+@pytest.fixture(scope="module")
+def _state_root_seen_by_a_module_scoped_fixture() -> Path:
+    """Resolve the seam from inside a MODULE-scoped fixture body.
+
+    `_isolate_state_root` in `conftest.py` is function-scoped, so it is not in
+    effect here. Without the session-scoped injection beside it, this returns
+    the REAL per-user platform root -- which is exactly how
+    `test_graph_value_benchmark.py`'s module-scoped `perfect_fixture` came to
+    write `.graph.sqlite` and `.lexical.sqlite` into the developer's own state
+    directory, and then to be blamed on whichever later test next touched it.
+    """
+    from exomem import state_paths
+
+    return state_paths.state_store_root()
+
+
+def test_higher_scoped_fixtures_resolve_inside_the_injected_state_root(
+    _state_root_seen_by_a_module_scoped_fixture: Path,
+) -> None:
+    """The injection covers every fixture scope, not just function scope."""
+    from exomem import state_paths
+
+    assert (
+        _state_root_seen_by_a_module_scoped_fixture
+        != state_paths.platform_default_state_root()
+    )


### PR DESCRIPTION
## What changed

`tests/conftest.py` now injects `EXOMEM_STATE_ROOT` at **session** scope as well as function scope, and `tests/test_state_root_placement.py` gains a pin that resolves the seam from inside a module-scoped fixture body.

## Why

`_isolate_state_root` is function-scoped, so it is not in effect while a module- or session-scoped fixture *body* runs. Such a fixture resolves `state_paths.state_store_root()` with no override and writes the real per-user platform root. `test_graph_value_benchmark.py`'s module-scoped `perfect_fixture` did exactly this, leaving `<slug>-<digest>/.graph.sqlite` and `.lexical.sqlite` in the developer's own `~/.local/state/exomem/state` for the rest of the session.

Nothing failed where the write happened, because no function-scoped guard bracketed it. The next test to touch that directory inherited the assertion, so CI blamed `test_never_enrolled_provisioning_refuses_existing_governance_authority` — a test that neither creates nor uses it. That is why the reported culprit moved between runs while the escape itself was constant.

Session-scope injection also closes the window *between* tests: the function-scoped guard's `undo()` now restores the session value rather than unsetting the variable, so a write from a worker that outlived its test also lands in a tmpdir.

The suite has 38 higher-scoped fixtures, so this is fixed at the seam rather than per fixture.

## Verification

Core shard 3/8 run twice under identical conditions with `XDG_STATE_HOME` redirected at a scratch directory, so the "real" root could be observed directly:

| | before | after |
|---|---|---|
| shard 3/8 | 1507 passed, 21 skipped | 1507 passed, 21 skipped |
| residue in the real root | `exomem-b85b54adb3d21e19/{.graph.sqlite,.lexical.sqlite}` | none |
| real-root resolutions of the seam | 361, all `MainThread` inside `call_fixture_func`, all from `perfect_fixture` | — |

- The added pin fails without the conftest change (`assert PosixPath('~/.local/state/exomem/state') != PosixPath('~/.local/state/exomem/state')`) and passes with it.
- `tests/test_state_root_placement.py`: 23 passed.

## Context

`core tests (py3.13, shard 3/8)` is red on `main` at `9bf3d804` — three of three runs, including the dispatched full run required by the `release evidence` gate. That gate blocks cutting the next release.