### PR TITLE
fix(state): bound the cross-principal machine-local state root

### DIFF
--- a/openspec/changes/bound-cross-principal-state-access/design.md
+++ b/openspec/changes/bound-cross-principal-state-access/design.md
@@ -1,0 +1,102 @@
+## Context
+
+The private-DACL validator is token-relative. Measured on the affected host:
+
+```
+user trustees   : ('S-1-5-21-...-1001', 'SY', 'BA')
+SYSTEM trustees : ('SY', 'BA')
+```
+
+`_windows_private_dacl_trustees(sid)` returns `(sid, "SY", "BA")`, which collapses to
+`("SY","BA")` when the caller is LocalSystem. So the phrase "the DACL the service
+validates" has no fixed value — it is a function of the runtime account. Any fix for
+requirement 1 of #933 must first answer *which principal's DACL a user-token flow
+should write*, and the issue does not answer it.
+
+## Decision: resolve the runtime principal from the service registry
+
+A user-token flow reads the installed service's account from the SCM hive and writes
+that principal's private DACL. With no service install, the runtime principal is the
+current token and nothing changes.
+
+Why this over the alternatives that were on the table:
+
+- **Hardcode SY/BA.** Rejected. It is correct only for a LocalSystem service and
+  breaks every user-mode install, where the runtime principal is the operator. It
+  would trade one cross-principal failure for another.
+- **Declare a two-principal root** admitting `{service account, operator, SY, BA}`.
+  This is the only option that also fixes existing SYSTEM-owned children going
+  forward, because they would inherit a descriptor admitting the operator. Rejected
+  because it relaxes the expected trustee set, which is the invariant the private-DACL
+  validator exists to enforce — the state root is meant to be private to one
+  principal, and widening it to make maintenance convenient defeats that.
+- **Service-mediated maintenance**, routing CLI operations through the running
+  server. This is the cleanest long-term answer and the only one that can recover an
+  *existing* SYSTEM-owned WAL. Rejected for this change as scope: it requires a
+  maintenance endpoint and client path, making it a new capability rather than a
+  repair of a shipped defect. The refusal path below makes the current behaviour safe
+  in the meantime, and does not foreclose this later.
+
+Feasibility was verified rather than assumed: a non-elevated user token *can* apply
+`D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)` to a directory it owns, and can undo it, because
+the owner retains `WRITE_DAC`.
+
+The precedent for reading the SCM hive already exists in-tree:
+`scripts/_service-common.ps1` reads
+`HKLM\SYSTEM\CurrentControlSet\Services\<name>\Parameters\Application` non-elevated and
+describes it as the single source of truth for the service's interpreter. `ObjectName`
+sits beside it. A Python-side reader is new surface, and is acceptable only because
+the refusal path below catches every user-token flow that gets it wrong.
+
+## Why placement and access are separate checks
+
+During the incident `state.placement` reported "pass — migration completed" while the
+cell was completely dead. Placement asks *where* state lives; access asks *whether
+this principal can open it*. Conflating them produced a doctor that was confidently
+wrong precisely when it was needed. They are now two checks, and the access check is
+allowed to FAIL beside a passing placement check.
+
+## Un-evaluated is not a pass
+
+A descriptor that could not be read, and a scan root that could not be listed, each
+report their own state. `is_dir()` does not screen out an unlistable directory —
+`stat` succeeds through the parent's traverse while `iterdir` is refused — so a check
+that only guarded on existence reported a confident "no orphans found" derived from an
+inspection that never ran. Absence must be proven before it is acted on.
+
+## Accepted consequence: a manual doctor run can now fail where it previously passed
+
+`state.dacl` FAILs on a locally-unsafe DACL, not only on a cross-principal one. A
+manual `exomem doctor` therefore reports a failure on a root it previously passed, and
+any caller gating on doctor's exit code stops.
+
+The originally-stated version of this consequence — "upgrades that previously
+proceeded will now be blocked" — was over-claimed and is corrected here.
+`scripts/upgrade.ps1` runs `maintain --migrate-state --offline` (line 196) *before*
+the doctor gate (line 203), and that migration already reaches
+`state_paths.ensure_vault_state_dir`, which raises `WindowsRuntimeDaclError` on a
+locally-unsafe DACL. So that upgrade path already stopped one step earlier, both
+before and after this change. The new consequence is real for a manual doctor
+invocation and for future gate callers, not for `upgrade.ps1` as currently ordered.
+
+The trade is still the intended one: the remediation is printed with the finding, and
+failing loudly beats deploying into the infinite-refusal loop.
+
+## Open risk to settle before this ships
+
+The trustee set is evaluated for the calling token. On a correctly-configured
+LocalSystem service install, an operator running `doctor` compares expected
+`{operator, SY, BA}` against an observed `{SY, BA}` and gets `unsafe` — a FAIL on a
+cell that is healthy from the service's point of view. If that holds, `exomem doctor`
+is red-by-construction on every Windows service install until the runtime-principal
+resolution in section 4 lands, which would make the check unactionable rather than
+diagnostic. This must be confirmed against a real service cell in a stop window, and
+is a further argument for landing section 4 in the same change rather than deferring
+it.
+
+## Residual risk
+
+An already-existing SYSTEM-owned WAL under SY/BA-only inheritance cannot be recovered
+by a user token at all — the operator is not its owner, so `icacls /grant /t` fails on
+exactly that file. Only elevation or the service itself clears it. This change stops
+that state from being created and names it clearly when found; it does not repair it.

--- a/openspec/changes/bound-cross-principal-state-access/proposal.md
+++ b/openspec/changes/bound-cross-principal-state-access/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+The 2026-08-29 incident cost two days of a dead personal cell. The cause was not a
+retrieval defect: a user-token flow created the external state root carrying the
+creating token's ACE, and the LocalSystem service then fail-closed every catalog
+proof, lexical repair and graph recovery with `WindowsRuntimeDaclError`, refusing
+`catalog_proof_incomplete` forever at ~0 CPU. Nothing in `doctor` said why —
+`state.placement` reported a healthy "migration completed" the whole time, because
+placement and *access* were never separated.
+
+Issue #933 records four measured manifestations. Two more were found while fixing
+it: `_check_rebuild_temp_orphans` crashes on an unlistable root one check after the
+cause is correctly reported, and `is_dir()` does not screen that case out because
+stat succeeds through the parent's traverse while `iterdir` is refused.
+
+The underlying rule is that the private-DACL validator is **token-relative**:
+`_windows_private_dacl_trustees(sid)` yields `(current-token-SID, "SY", "BA")`, which
+collapses to `("SY","BA")` for LocalSystem. So a user-token flow cannot know what to
+write without an authority for the runtime principal, and hardcoding SY/BA would
+break every user-mode install, where the runtime principal *is* the user.
+
+## What Changes
+
+- **A user-token flow that creates or recreates the state root resolves the runtime
+  principal first**, and applies that principal's private DACL rather than its own
+  token's default. The authority is the service account recorded in the SCM hive
+  (`HKLM\SYSTEM\CurrentControlSet\Services\<name>`, whose `ObjectName` sits beside
+  the `Parameters\Application` value `scripts/_service-common.ps1` already reads
+  non-elevated and calls the single source of truth). With no service install, the
+  runtime principal is the current token and behaviour is unchanged.
+- **`doctor` gains a `state.dacl` check** that is separate from `state.placement`,
+  because place and access are different questions and conflating them is what hid
+  the incident. It FAILs with a named finding — never a traceback — on a root the
+  runtime principal cannot open, and reports "could not evaluate" as its own state
+  rather than as a pass.
+- **`doctor` degrades gracefully on unreadable state**, reporting a finding instead
+  of raising, across the lexical sidecar, the deferred-index backlog, and the
+  rebuild-temp orphan scan.
+- **CLI maintenance detects the cross-principal case up front** and refuses with a
+  stable `STATE_ROOT_CROSS_PRINCIPAL` error carrying the observed descriptor, the
+  required trustees, and an exact `icacls` remediation — before taking the mutation
+  hold, rather than crashing mid-operation as `maintain --reconcile --rebuild-graph`
+  previously did in `census_unavailable_graph_lineage`.
+
+## Impact
+
+A manual `exomem doctor` run now FAILs on a locally-unsafe DACL where it previously
+passed, and any caller gating on its exit code stops. This is deliberate and
+accepted: failing with an actionable remediation beats proceeding into the
+infinite-refusal loop that caused the incident. Note `scripts/upgrade.ps1` is not
+newly affected — it runs `maintain --migrate-state --offline` before its doctor
+gate, and that step already raised on this condition.
+
+Windows-only in effect; the POSIX branch no-ops and must not begin refusing.
+
+Out of scope: recovering an *already existing* SYSTEM-owned WAL under SY/BA-only
+inheritance. The user is not its owner, so `icacls /grant /t` fails on exactly that
+file; only elevation or the service itself can clear it. This change prevents the
+state from being created and reports it clearly when found.

--- a/openspec/changes/bound-cross-principal-state-access/specs/machine-local-state-placement/spec.md
+++ b/openspec/changes/bound-cross-principal-state-access/specs/machine-local-state-placement/spec.md
@@ -1,0 +1,158 @@
+## ADDED Requirements
+
+### Requirement: State-root access is proven against the runtime principal, not the creating token
+
+The private-DACL trustee set is token-relative, so a flow that creates or recreates
+the machine-local state root SHALL resolve the **runtime principal** — the account
+the server will run as — and apply that principal's private DACL, rather than the
+DACL implied by the creating token. Where a service install exists, the runtime
+principal SHALL be read from the platform service registry; where none exists, the
+runtime principal is the current token and behaviour is unchanged. The system SHALL
+NOT relax the expected trustee set, make the validator advisory, broadly grant the
+operator on a live root, or silently rewrite the DACL of a root the process does not
+own.
+
+#### Scenario: A user-token creation leaves a root the service can open
+
+- **WHEN** a flow running under the operator's token creates or recreates the state root on a host where the server is installed as a service under a different account
+- **THEN** the resulting root satisfies the private-DACL validator evaluated for the service account
+- **AND** the service opens it without a runtime DACL error
+
+#### Scenario: No service install leaves current-token behaviour unchanged
+
+- **WHEN** the same flow runs on a host with no service install
+- **THEN** the runtime principal is the current token
+- **AND** the root carries that token's private DACL exactly as before
+
+#### Scenario: A failed registry read is not treated as an absent service
+
+- **WHEN** the platform service registry cannot be read, as distinct from naming no service
+- **THEN** the runtime principal degrades with the read failure recorded as its reason
+- **AND** it does not present as a clean current-token resolution, which would fail a correctly sealed root and prescribe a repair that breaks the service
+
+#### Scenario: A root owned by another principal is never silently re-ACLed
+
+- **WHEN** a process encounters a state root governed by a principal it is not
+- **THEN** it does not modify that root's descriptor
+- **AND** it refuses with an actionable finding instead
+
+#### Scenario: Only the state root the service is bound to is sealed
+
+- **WHEN** a flow prepares a state root for a vault the installed service is not bound to
+- **THEN** it does not apply the service principal's DACL to that root
+- **AND** the operator retains access to the state root of a vault they created
+- **AND** the presence of an unrelated service registration on the machine does not by itself authorise a re-ACL
+
+#### Scenario: Sealing protects the state, not merely the directory entry
+
+- **WHEN** a state root is sealed to the runtime principal after its state has been migrated in
+- **THEN** the files already inside it are not left readable or writable by a principal the seal excludes
+- **AND** the access check does not report the root as private while its contents remain accessible to an excluded principal
+
+#### Scenario: A seal that did not take is not reported as success
+
+- **WHEN** the seal writes a descriptor and the post-write read does not satisfy the runtime principal's own validator
+- **THEN** the operation reports that the seal did not take
+- **AND** it does not log or return a successful seal for that root
+
+### Requirement: Doctor separates state placement from state access
+
+`doctor` SHALL report state **access** as a check distinct from state **placement**,
+because a correctly-placed root can still be unopenable and reporting only placement
+hides that. The access check SHALL FAIL with a named, actionable finding — never an
+unhandled exception — when the runtime principal cannot open the root, and SHALL
+report a descriptor it could not evaluate as its own state rather than as a pass.
+Checks that read state artifacts SHALL degrade to a finding rather than raising when
+an artifact cannot be read, and SHALL name what was not evaluated.
+
+#### Scenario: Cross-principal root fails with a finding, not a traceback
+
+- **WHEN** `doctor` runs against a state root governed by a principal that is not the runtime principal the server will run as
+- **THEN** the access check reports FAIL with the observed descriptor, the required trustees, and an exact remediation
+- **AND** the process exits with a failing status rather than raising
+
+#### Scenario: An unresolved runtime principal does not prescribe a token-relative repair
+
+- **WHEN** the runtime principal could not be resolved and has degraded to the calling token
+- **THEN** the finding says the runtime principal is unresolved
+- **AND** it does not print an `icacls` command that would grant the calling token, because on a service install that repair breaks the principal the server actually runs as
+
+#### Scenario: Placement passing does not imply access passing
+
+- **WHEN** the state root is correctly placed outside the vault but unopenable by the runtime principal
+- **THEN** the placement check may pass
+- **AND** the access check independently reports FAIL
+
+#### Scenario: A healthy service-owned root is not failed for the caller's sake
+
+- **WHEN** `doctor` runs under an operator token against a root that is correct for the service account the server runs as
+- **THEN** the access check PASSES, because the descriptor is judged against the runtime principal rather than the calling token
+- **AND** the caller's own inability to open it is reported as expected detail, not as a failure
+
+#### Scenario: A passing access check says when the contents were not evaluated
+
+- **WHEN** the access check passes on a root whose listing this process is denied, so no child was examined
+- **THEN** the finding states that the contents were not evaluated and that the verdict covers the directory entry only
+- **AND** the sampled-child count is reported, so a reader can tell an unexamined root from a verified one
+
+#### Scenario: An unreadable state artifact is reported, not fatal
+
+- **WHEN** `doctor` cannot read the lexical sidecar, the deferred-index backlog, or list the rebuild-temp scan root
+- **THEN** each affected check reports a finding naming the path it could not evaluate
+- **AND** no check reports a confident negative result derived from an inspection that did not happen
+
+#### Scenario: Access evaluation is a no-op off Windows
+
+- **WHEN** `doctor` runs on a platform without Windows discretionary access control
+- **THEN** the access check does not refuse
+- **AND** it reports that the posture was not applicable rather than claiming the root is private
+
+### Requirement: Maintenance refuses an unusable state root before taking any hold
+
+A CLI maintenance operation against a state root the running process cannot work
+with SHALL detect that condition up front and refuse, before acquiring the mutation
+hold or performing partial work. Two distinct conditions qualify and BOTH SHALL
+refuse: the process cannot open the root at all, and the process can open the root
+but its own private-DACL validator rejects the trustee set. The second is not a
+lesser case — it is how the failure presents to a LocalSystem service, which holds
+an `SY` full-access ACE on an operator-created root and so opens it successfully
+before failing closed at every private-state boundary behind it.
+
+The refusal SHALL carry a stable machine-readable error code, the observed security
+descriptor, the trustees the process requires, and an exact remediation command. A
+maintenance operation SHALL NOT fail part-way through with a raw operating-system
+error, and the pre-flight SHALL NOT itself raise one when its own inspection fails.
+
+An unopenable root SHALL be distinguished by cause. Only an access denial is a
+cross-principal condition with an ACL remediation; a reparse point or a wrong entry
+type SHALL be reported as the path problem it is, without offering an ACL repair
+that cannot fix it.
+
+#### Scenario: Reconcile refuses before the mutation hold
+
+- **WHEN** `maintain --reconcile --rebuild-graph` runs against a root owned by another principal
+- **THEN** it exits non-zero with the stable cross-principal error code and remediation
+- **AND** it has not taken the mutation hold or mutated any state
+
+#### Scenario: An openable root the validator rejects refuses the same way
+
+- **WHEN** maintenance runs as a principal that can open the root but whose private-DACL validator rejects its trustee set
+- **THEN** it refuses up front with the same stable error code and remediation
+- **AND** it does not proceed into state creation and fail there with a raw runtime DACL error
+
+#### Scenario: An alias root is not reported as a principal problem
+
+- **WHEN** the state root is a reparse point rather than a real directory
+- **THEN** it is not classified as cross-principal
+- **AND** the finding does not offer an ACL repair
+
+#### Scenario: Offline state migration refuses the same way
+
+- **WHEN** an offline state migration targets a root the current token cannot open
+- **THEN** it refuses with the same error code and remediation before migrating any family
+
+#### Scenario: A healthy same-principal root is not refused
+
+- **WHEN** maintenance runs against a state root the current process can open normally
+- **THEN** no cross-principal refusal occurs
+- **AND** the operation proceeds exactly as before

--- a/openspec/changes/bound-cross-principal-state-access/tasks.md
+++ b/openspec/changes/bound-cross-principal-state-access/tasks.md
@@ -1,0 +1,45 @@
+## 1. Read-only posture inspection
+
+- [x] 1.1 `mutation_lock.WindowsDirectoryPosture` + `inspect_windows_private_directory`: read the descriptor and report a verdict without raising, without repairing, and without modifying the root
+- [x] 1.2 `state_paths.StateRootPosture`, `StateRootAccessDenied(OSError)`, `inspect_state_root`, `assert_state_root_accessible`
+- [x] 1.3 POSIX branch no-ops and never refuses
+
+## 2. Doctor separates placement from access and degrades gracefully
+
+- [x] 2.1 New `state.dacl` check, distinct from `state.placement`, wired into the ordered report
+- [x] 2.2 FAILs with observed descriptor, required trustees, and exact remediation — never a traceback
+- [x] 2.3 Reports an un-evaluated descriptor as its own state, not as a pass
+- [x] 2.4 `_check_lexical` reports an unreadable sidecar instead of raising
+- [x] 2.5 `_check_deferred_index_backlog` survives an unreadable sidecar
+- [x] 2.6 `_check_rebuild_temp_orphans` reports an unlistable scan root instead of raising, and does not claim "no orphans found" from a scan that did not run
+
+## 3. Maintenance refuses up front
+
+- [x] 3.1 `commands._assert_state_root_usable`, called first in `op_maintain_memory`, before the mutation hold
+- [x] 3.2 `state_migration` preflight before the lock in `migrate_vault_state_offline`
+- [x] 3.3 Stable `STATE_ROOT_CROSS_PRINCIPAL` error code carrying descriptor, required trustees, and remediation
+- [x] 3.4 Happy path proven unaffected: a same-principal root is never refused
+
+## 4. Runtime-principal resolution (requirement 1)
+
+- [x] 4.1 Resolve the runtime principal from the platform service registry (`ObjectName` beside the `Parameters\Application` value `scripts/_service-common.ps1` already reads); fall back to the current token when no service install exists
+- [x] 4.2 Apply the runtime principal's private DACL when a user-token flow creates or recreates the state root — as the LAST act of the migration, never at creation: the creating token has to write the state in first, so a root sealed up front locks its own migrator out
+- [x] 4.3 Never widen the trustee set, never make the validator advisory, never re-ACL a root this process does not own
+- [x] 4.4 Red-first test: a user-token creation leaves a root that satisfies the validator evaluated **for the service account**, asserted with the validator itself rather than a restated SDDL literal
+- [x] 4.5 Test: no service install leaves current-token behaviour byte-identical
+- [x] 4.6 Test: an unreadable or absent service registry entry degrades to the current token with a named reason, never a crash and never a guessed principal
+- [x] 4.7 `state.dacl` judges the descriptor against the RUNTIME principal, not the calling token. Forced by measurement, not preference: a correct LocalSystem root reads `unsafe` and unopenable to every operator token, so judging by the caller FAILs every healthy Windows service install — including inside `upgrade.ps1`'s own doctor gate, which runs as the operator
+- [x] 4.8 `EXOMEM_RUNTIME_PRINCIPAL` pins the principal (`current-token`, or a literal SID) for stop-window maintenance, and keeps the suite's verdict a property of the code rather than of whether the developer's machine happens to have a service registered
+- [x] 4.9 The seal fires only for the vault the machine's service is BOUND to, read from the service's managed dotenv the way `upgrade.ps1` reads it. A machine merely having a service registered says nothing about an unrelated vault: without this, `exomem init` of a brand-new vault handed its state root to LocalSystem and locked the operator out of the directory it had just made. An unreadable binding refuses rather than sealing
+- [x] 4.10 The seal protects the STATE, not merely the directory entry. Protecting a DACL converts children's inherited ACEs to explicit ones, so a root sealed with `SetFileSecurityW` reported private over files the old principal still read and wrote; the seal applies through `SetNamedSecurityInfoW` so inheritance is recomputed across the tree
+- [x] 4.11 `state.dacl` samples children rather than trusting the root descriptor alone, and FAILs when the state inside a private-looking root is not private
+- [x] 4.12 An unresolved runtime principal withholds the token-relative `icacls` entirely, rather than prescribing the ACL ping-pong the incident is about
+
+## 5. Verification
+
+- [x] 5.1 Mutation proof: deleting each guard fails a named test (round 1: 9/9; round 2: 17/18 — the seal's post-write validation SURVIVED and was mis-reported as proven; round 3: 21/21, that guard included)
+- [x] 5.2 Targeted suite green with no new failures against an untouched-main baseline
+- [x] 5.3 `uvx ruff check` clean on changed files
+- [x] 5.4 Re-run 5.1–5.3 after section 4 lands
+- [x] 5.5 `openspec validate --all --strict`
+- [ ] 5.6 Independent adversarial review by a lane that did not author the change, running the reproduction rather than trusting the report

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -2981,7 +2981,16 @@ def _simple_maintain_main(argv: list[str]) -> int:
             )
         except (OSError, RuntimeError, ValueError) as error:
             if args.json:
-                print(json.dumps({"success": False, "error": {"message": str(error)}}))
+                # `upgrade.ps1` consumes this envelope, and a message-only one
+                # cannot be branched on. Errors that carry a stable code emit it.
+                payload: dict[str, object] = {"message": str(error)}
+                code = getattr(error, "code", None)
+                if isinstance(code, str) and code:
+                    payload["code"] = code
+                remediation = getattr(error, "remediation", None)
+                if isinstance(remediation, str) and remediation:
+                    payload["remediation"] = remediation
+                print(json.dumps({"success": False, "error": payload}))
             else:
                 print(f"Error: {error}", file=sys.stderr)
             return 1

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -6668,6 +6668,54 @@ def op_adoption_studio(
         raise
 
 
+def _assert_state_root_usable(vault_root: Path) -> None:
+    """Refuse an unusable state root before any maintenance work starts.
+
+    Every maintenance mode reads or writes machine-local state, so a root this
+    token cannot work with is fatal to all of them -- the only question is how
+    far in it gets before saying so. `maintain --reconcile --rebuild-graph`
+    under the operator's token against a LocalSystem-owned root took the
+    mutation hold and reached `census_unavailable_graph_lineage` before dying on
+    `[Errno 5] cannot safely open .graph.sqlite-wal`, leaving the operator with
+    a half-run repair and no statement of the actual problem. The structured
+    code is what lets the CLI and the MCP envelope both carry the remediation.
+
+    Both halves refuse, not just "cannot open". A LocalSystem service opens an
+    operator-created root through its own `SY` ACE and only then rejects the
+    trustee set, so gating on openability alone let the SERVICE -- the principal
+    the incident was actually about -- walk straight past this into
+    `ensure_vault_state_dir` and die there with a raw `WindowsRuntimeDaclError`.
+    """
+    from . import state_paths
+    from .cli_ops import OpError
+
+    try:
+        state_paths.assert_state_root_accessible(vault_root)
+    except state_paths.StateRootAccessDenied as error:
+        raise OpError(
+            error.code,
+            str(error),
+            (
+                "Run this as the principal that owns the machine-local state root "
+                "(for a service install, the service account), or re-ACL the root "
+                "with: " + (error.remediation or "")
+            ),
+            details={"state_root": str(error.posture.directory)},
+        ) from error
+    except (OSError, ValueError) as error:
+        # The pre-flight's OWN inspection can fail: a relative or in-vault
+        # `EXOMEM_STATE_ROOT` raises `ValueError` out of `vault_state_dir`, and
+        # an unestablishable token identity raises `OSError`. Letting those
+        # through would have this guard emit exactly the kind of raw error it
+        # exists to replace.
+        raise OpError(
+            "STATE_ROOT_UNREADABLE",
+            f"the machine-local state root could not be inspected: {error}",
+            "Check EXOMEM_STATE_ROOT resolves to an absolute path outside the "
+            "vault, then rerun as the principal that owns the state root.",
+        ) from error
+
+
 def op_maintain_memory(
     vault_root: Path,
     mode: str = "audit",
@@ -6731,6 +6779,7 @@ def op_maintain_memory(
     """
     if rebuild_graph and mode != "reconcile":
         raise ValueError("INVALID_MODE: rebuild_graph is valid only for reconcile")
+    _assert_state_root_usable(vault_root)
     if mode == "structured-files":
         if (
             not isinstance(collection, str)

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -774,7 +774,25 @@ def _check_lexical(vault_root: Path | None) -> DoctorCheck:
     if vault_root is None:
         return _check("dep.fts5-lexical", "pass", "FTS5 + trigram are available.")
     side = lexstore.lexical_path(vault_root)
-    if not side.exists():
+    try:
+        present = side.exists()
+    except OSError as error:
+        # `Path.exists` re-raises `PermissionError` rather than swallowing it
+        # (only ENOENT/ENOTDIR-class errors are ignored), and a sidecar under a
+        # state root owned by another principal raises exactly that -- which
+        # crashed the whole of `exomem doctor` during the 2026-08 incident, at
+        # the moment its diagnosis was most needed. Reporting it as a finding is
+        # the fix; `os.path.exists`, which returns a confident False here, is
+        # not -- an inaccessible sidecar is not an absent one.
+        return _check(
+            "dep.fts5-lexical",
+            "warn",
+            f"The lexical sidecar could not be inspected ({error.strerror or error}); "
+            "lanes fall back to the in-process paths.",
+            "Rerun as the principal that owns the machine-local state root — see "
+            "the `state.dacl` check for the exact posture and repair.",
+        )
+    if not present:
         return _check(
             "dep.fts5-lexical",
             "pass",
@@ -825,12 +843,14 @@ def _check_deferred_index_backlog(vault_root: Path | None) -> DoctorCheck:
     from . import index_sync, lexstore
 
     sidecar = lexstore.lexical_path(vault_root)
-    if sidecar.exists():
-        try:
+    try:
+        # `exists()` itself raises under a state root owned by another
+        # principal, so the probe has to sit inside the same guard as the read.
+        if sidecar.exists():
             details["indexed_pages"] = _lexical_page_count(sidecar)
-        except (OSError, sqlite3.Error):
-            # The lexical health check owns the unreadable-sidecar diagnostic.
-            pass
+    except (OSError, sqlite3.Error):
+        # The lexical health check owns the unreadable-sidecar diagnostic.
+        pass
     status = index_sync.deferred_work_status(vault_root)
     for queue in ("semantic_upserts", "full_upserts"):
         details[queue] = int(status.get(queue, {}).get("count", 0))
@@ -1106,6 +1126,231 @@ def _check_state_placement(vault_root: Path | None) -> DoctorCheck:
     )
 
 
+def _check_state_root_dacl(vault_root: Path | None) -> DoctorCheck:
+    """FAIL when the state root's DACL is wrong for the principal that RUNS it.
+
+    `state.placement` answers "is state in the right PLACE"; this answers "will
+    the principal that runs against it accept it". They came apart during the
+    2026-08 rollout: an offline migration under the operator's token left the
+    root carrying the user's ACE, the LocalSystem service then rejected it as
+    `unsafe` on every catalog proof, lexical repair and graph recovery, and
+    doctor -- which saw a correctly-placed, migration-complete root -- reported
+    nothing wrong for the whole outage.
+
+    Judged against the RUNTIME principal, not the calling token. That is not a
+    refinement, it is the difference between shipping and not: the private-DACL
+    model is token-relative, so a correct LocalSystem root
+    (`D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)`) reads as `unsafe` to every operator
+    who inspects it -- measured, not assumed. Judging by the caller would make
+    this check FAIL on every healthy Windows service install, including inside
+    `upgrade.ps1`'s own doctor gate, which runs as the operator.
+
+    The calling token's own access is reported too, but as detail rather than as
+    a verdict: an operator who cannot open a service-owned root is looking at
+    normal, and the maintenance pre-flight is what refuses their work.
+
+    Read-only and never repairing: silently rewriting a DACL is exactly what the
+    private-state model exists to prevent.
+    """
+    from . import state_paths
+
+    if vault_root is None:
+        return _check(
+            "state.dacl",
+            "pass",
+            "No vault configured; the machine-local state root was not inspected.",
+        )
+    try:
+        posture = state_paths.inspect_state_root(vault_root)
+    except (OSError, ValueError) as error:
+        # `state_root` deliberately included even here: a finding that cannot
+        # name the path it failed on is not actionable from a remote report.
+        try:
+            location = str(state_paths.vault_state_dir(vault_root))
+        except (OSError, ValueError):
+            location = "unresolved"
+        return _check(
+            "state.dacl",
+            "fail",
+            "The machine-local state root's access posture could not be determined.",
+            "Rerun `exomem doctor` as the principal that owns the state root; do "
+            "not adopt, re-ACL or delete state while the posture is unknown.",
+            details={"state_root": location, "error": type(error).__name__},
+        )
+    details: dict[str, object] = {
+        "state_root": str(posture.directory),
+        "present": posture.present,
+        "accessible": posture.accessible,
+        "unopenable_reason": posture.unopenable_reason,
+        "dacl_verdict": posture.verdict,
+        "runtime_dacl_verdict": posture.runtime_verdict,
+        "child_dacl_verdict": posture.child_verdict,
+        "child_sampled": posture.child_sampled,
+        "expected_trustees": list(posture.expected),
+        "runtime_expected_trustees": list(posture.runtime_expected),
+        "runtime_principal": posture.runtime_principal_source,
+        "observed": posture.observed,
+    }
+    # A repair rendered for THIS token is worse than none when the principal
+    # that will run against the root is unknown: following it re-introduces the
+    # ACL ping-pong that cost most of a day.
+    unresolved_note = (
+        " The principal that runs against this root could not be established "
+        f"({posture.runtime_principal_source}), so no ACL repair is offered — "
+        "establish the service account first."
+    )
+    repair = (
+        unresolved_note
+        if posture.runtime_principal_unresolved
+        else (posture.remediation or "")
+    )
+    if not posture.present:
+        return _check(
+            "state.dacl",
+            "pass",
+            f"No machine-local state root yet at {posture.directory}; it is created "
+            "private to the principal that will run against it.",
+            details=details,
+        )
+    if posture.alias_path:
+        # A junction, or a file where the root should be. Real, and refused at
+        # the private-state boundary -- but no ACL repairs it, so reporting it
+        # as a principal problem hands the operator a useless `icacls`.
+        return _check(
+            "state.dacl",
+            "fail",
+            (
+                f"The machine-local state root ({posture.directory}) is a "
+                f"{(posture.unopenable_reason or '').replace('-', ' ')} rather than a "
+                "real directory; the private-state boundary refuses to open it."
+            ),
+            "Replace the alias with a real directory (or repoint EXOMEM_STATE_ROOT); "
+            "this is not repairable with an ACL change.",
+            details=details,
+        )
+    if posture.unopenable_for_unknown_reason:
+        # Neither a principal nor an alias explains it -- a sharing violation, a
+        # not-ready device. Un-evaluated is its own state, never a pass.
+        return _check(
+            "state.dacl",
+            "fail",
+            (
+                f"The machine-local state root ({posture.directory}) could not be "
+                f"opened ({posture.unopenable_reason}), so its posture is unverified "
+                "and maintenance against it is refused."
+            ),
+            "Resolve what is holding the directory (a running writer, a "
+            "disconnected device), then rerun `exomem doctor`.",
+            details=details,
+        )
+    # Derived from the validator's own vocabulary, never restated here: a
+    # literal would keep passing if the verdict names ever changed.
+    from .mutation_lock import _WINDOWS_DACL_UNSAFE
+
+    if posture.child_verdict == _WINDOWS_DACL_UNSAFE:
+        # The root can read `private` over state that is not. Protecting a
+        # directory converts its children's inherited ACEs to explicit ones, so
+        # a seal that only wrote the entry leaves every file the migration just
+        # moved in readable and writable by the old principal -- reported as a
+        # pass, which is worse than an honest "unsealed".
+        return _check(
+            "state.dacl",
+            "fail",
+            (
+                f"The machine-local state root ({posture.directory}) is private, but "
+                "state INSIDE it is not: sampled children carry ACEs the principal "
+                f"that runs against it ({posture.runtime_principal_source}) rejects."
+            ),
+            (
+                unresolved_note
+                if posture.runtime_principal_unresolved
+                else (
+                    "Re-apply the private DACL so inheritance is recomputed across "
+                    "the tree, in a stop window: " + repair
+                )
+            ),
+            details=details,
+        )
+    if posture.runtime_verdict == _WINDOWS_DACL_UNSAFE:
+        return _check(
+            "state.dacl",
+            "fail",
+            (
+                f"The machine-local state root ({posture.directory}) carries a DACL "
+                "the principal that runs against it "
+                f"({posture.runtime_principal_source}) rejects, so every "
+                "private-state boundary behind it fails closed: catalog proofs, "
+                "lexical repair and graph recovery all refuse, with no progress."
+            ),
+            # Rendered for the RUNTIME principal, so following it does not flip
+            # the other principal into failure the way the incident's manual
+            # toggling did. It does end this process's own access when the
+            # runtime principal is a service account — that is the intended end
+            # state, so say so rather than let it read as a surprise.
+            unresolved_note
+            if posture.runtime_principal_unresolved
+            else (
+                "Do this in a stop window: stop the service, re-ACL the root with "
+                + repair
+                + ", then start it. The root is then private to the service account, "
+                "so run later maintenance as that account rather than re-ACLing back "
+                "and forth."
+            ),
+            details=details,
+        )
+    if posture.runtime_verdict is None and posture.runtime_expected:
+        # The descriptor could not be read, so the trustee set is UNKNOWN, not
+        # proven good. An un-evaluated item is not a pass.
+        return _check(
+            "state.dacl",
+            "warn",
+            f"The machine-local state root ({posture.directory}) could not have its "
+            "security descriptor read, so its trustees are unverified.",
+            "Rerun `exomem doctor` as the principal that owns the state root.",
+            details=details,
+        )
+    if not posture.runtime_expected:
+        # No DACL model evaluated (POSIX). Saying "private to this principal"
+        # here would report an un-evaluated item as a proven one, which is the
+        # failure mode this check exists to end.
+        return _check(
+            "state.dacl",
+            "pass",
+            f"The machine-local state root ({posture.directory}) is reachable; this "
+            "platform has no cross-principal DACL model to evaluate.",
+            details=details,
+        )
+    caller_note = (
+        ""
+        if posture.accessible
+        else (
+            " This process cannot open it, which is expected when the service runs "
+            "as a different principal; run maintenance as that principal."
+        )
+    )
+    # Say what was NOT checked. Once a root is sealed the operator's listing is
+    # denied, so the sampler examines nothing and the verdict describes the
+    # directory entry alone. A pass that reads as "this is private" while the
+    # contents were never looked at is the confidently-green report that cost a
+    # day in the original incident.
+    contents_note = (
+        f" Contents verified across {posture.child_sampled} sampled child(ren)."
+        if posture.child_sampled
+        else (
+            " Contents were NOT evaluated (this process cannot list the root), so "
+            "this verdict covers the directory entry only."
+        )
+    )
+    return _check(
+        "state.dacl",
+        "pass",
+        f"The machine-local state root ({posture.directory}) is private to the "
+        f"principal that runs against it ({posture.runtime_principal_source}; "
+        f"verdict: {posture.runtime_verdict}).{caller_note}{contents_note}",
+        details=details,
+    )
+
+
 def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
     """Leaked rebuild-temporary files from interrupted background rebuilds.
 
@@ -1177,10 +1422,23 @@ def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
     )
     graph_orphans: list[Path] = []
     lexical_orphans: list[Path] = []
+    unreadable: list[Path] = []
     for scan_root in scan_roots:
-        if not scan_root.is_dir():
+        try:
+            if not scan_root.is_dir():
+                continue
+            entries = list(scan_root.iterdir())
+        except OSError:
+            # A state root governed by another principal denies the listing
+            # outright, and `is_dir()` does not screen it out -- stat succeeds
+            # through the parent's traverse while `iterdir` is refused. Left
+            # unguarded this crashed `exomem doctor` one check after the
+            # `state.dacl` finding that named the cause. An un-scanned root is
+            # not an empty one, so it is collected and reported rather than
+            # skipped into a confident "no orphans found".
+            unreadable.append(scan_root)
             continue
-        for entry in scan_root.iterdir():
+        for entry in entries:
             try:
                 if not entry.is_file():
                     continue
@@ -1226,26 +1484,58 @@ def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
     details["total_bytes"] = total_bytes
     details["stale_count"] = stale_count
     details["stale_bytes"] = stale_bytes
+    details["unreadable_roots"] = [str(path) for path in unreadable]
     mb = total_bytes / (1024 * 1024)
     stale_mb = stale_bytes / (1024 * 1024)
     age_minutes = vault_module.REBUILD_TEMP_STALE_AGE_SECONDS // 60
 
-    if count == 0:
+    def _with_unreadable(verdict: DoctorCheck) -> DoctorCheck:
+        """Merge the un-scanned roots into a verdict computed from what WAS scanned.
+
+        Never downgrades. Short-circuiting on `unreadable` before computing the
+        verdict turned a real leak into a warn -- 5+ stale orphans in the vault
+        plus an unlistable state root reported `warn`, and `DoctorReport.success`
+        gates on `fail`, so the leak stopped failing the run. The un-scanned root
+        makes a finding LESS certain, not less severe.
+        """
+        if not unreadable:
+            return verdict
+        roots = ", ".join(str(path) for path in unreadable)
+        suffix = (
+            f" Rebuild temporaries could not be inspected under {roots}; any orphans "
+            "there are uncounted, so this count is a floor."
+        )
+        remediation = verdict.remediation or ""
+        joiner = " " if remediation else ""
         return _check(
+            verdict.id,
+            "warn" if verdict.status == "pass" else verdict.status,
+            verdict.message + suffix,
+            remediation
+            + joiner
+            + (
+                "Rerun as the principal that owns the machine-local state root — see "
+                "the `state.dacl` check for the exact posture and repair."
+            ),
+            details=verdict.details,
+        )
+
+    if count == 0:
+        return _with_unreadable(_check(
             "rebuild_temp.orphans",
             "pass",
             "No orphaned rebuild temporaries found.",
             details=details,
-        )
+        ))
     if stale_count == 0:
-        return _check(
+        return _with_unreadable(_check(
             "rebuild_temp.orphans",
             "pass",
             f"{count} rebuild temporary file(s) totaling {mb:.1f} MB present, none "
             f"older than {age_minutes} minutes — likely an in-flight rebuild, not "
             "an orphan.",
             details=details,
-        )
+        ))
     remediation = (
         f"Stop the exomem service, then run `{_REBUILD_VECTORS_CMD}` "
         "out-of-process (it reads the vault from EXOMEM_VAULT_PATH, not "
@@ -1261,7 +1551,7 @@ def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
         stale_count > _REBUILD_TEMP_ORPHAN_FAIL_COUNT
         or stale_bytes > _REBUILD_TEMP_ORPHAN_FAIL_BYTES
     ):
-        return _check(
+        return _with_unreadable(_check(
             "rebuild_temp.orphans",
             "fail",
             f"{stale_count} rebuild temporary file(s) older than {age_minutes} "
@@ -1269,23 +1559,23 @@ def _check_rebuild_temp_orphans(vault_root: Path | None) -> DoctorCheck:
             f"interrupted rebuilds ({summary}).",
             remediation,
             details=details,
-        )
+        ))
     if stale_count > 1:
-        return _check(
+        return _with_unreadable(_check(
             "rebuild_temp.orphans",
             "warn",
             f"{stale_count} rebuild temporary file(s) older than {age_minutes} "
             f"minutes, totaling {stale_mb:.1f} MB ({summary}).",
             remediation,
             details=details,
-        )
-    return _check(
+        ))
+    return _with_unreadable(_check(
         "rebuild_temp.orphans",
         "pass",
         f"{stale_count} rebuild temporary file older than {age_minutes} minutes, "
         f"totaling {stale_mb:.1f} MB (below the warn threshold).",
         details=details,
-    )
+    ))
 
 
 def _check_write_path_env_flags(vault_root: Path | None) -> DoctorCheck:
@@ -3056,6 +3346,7 @@ def doctor(
         _check_deferred_index_backlog(vault_root),
         _check_graph_sync_state(vault_root),
         _check_state_placement(vault_root),
+        _check_state_root_dacl(vault_root),
         _check_rebuild_temp_orphans(vault_root),
         _check_write_path_env_flags(vault_root),
         check_graph_recovery_age(vault_root),

--- a/src/exomem/mutation_lock.py
+++ b/src/exomem/mutation_lock.py
@@ -376,6 +376,22 @@ class _SecureDirectory:
             self._close_windows_handle(self.windows_handles.pop())
 
 
+class WindowsReparsePointError(OSError):
+    """The opened entry is a reparse point (symlink/junction), which is refused.
+
+    An `OSError` subclass so every existing `except OSError` keeps catching it.
+    It exists so a caller can tell "this path is an alias" from "another
+    principal denied me": both used to surface as a bare `OSError` here, and a
+    junction standing in for the state root was then diagnosed as a
+    cross-principal DACL problem with an `icacls` remediation that cannot fix
+    it.
+    """
+
+
+class WindowsPathTypeError(OSError):
+    """The entry exists but is a file where a directory was required, or vice versa."""
+
+
 def _windows_open_path(
     path: Path,
     *,
@@ -424,9 +440,9 @@ def _windows_open_path(
         if not get_info(handle, 9, ctypes.byref(info), ctypes.sizeof(info)):
             raise OSError(_windows_last_error(ctypes), f"cannot inspect {path.name}")
         if info.attributes & 0x400:  # FILE_ATTRIBUTE_REPARSE_POINT
-            raise OSError("reparse points are not allowed")
+            raise WindowsReparsePointError("reparse points are not allowed")
         if bool(info.attributes & 0x10) != directory:
-            raise OSError("unexpected path type")
+            raise WindowsPathTypeError("unexpected path type")
     except BaseException:
         kernel32.CloseHandle(handle)
         raise
@@ -684,8 +700,26 @@ def _windows_private_dacl_sddl(sid: str) -> str:
     )
 
 
-def _windows_apply_dacl_sddl(path: Path, sddl: str) -> None:
-    """Apply one native SDDL DACL without shelling out through a localized tool."""
+def _windows_apply_dacl_sddl(path: Path, sddl: str, *, propagate: bool = False) -> None:
+    """Apply one native SDDL DACL without shelling out through a localized tool.
+
+    ``propagate`` picks the API, and the choice is load-bearing for any entry
+    that already has children. ``SetFileSecurityW`` writes the one object and
+    leaves existing children alone -- and because protecting a DACL strips the
+    parent's inheritance, Windows CONVERTS each child's previously-inherited
+    ACEs into explicit ones so they survive. Measured on a state root sealed to
+    SYSTEM: the child went from ``(A;ID;FA;;;<user>)`` to ``(A;;FA;;;<user>)``
+    and stayed fully readable and writable by the operator, while the directory
+    itself refused a listing -- a root that LOOKS sealed over state that is not.
+
+    ``SetNamedSecurityInfoW`` recomputes inheritance across the tree instead, so
+    the same child became ``AI(A;ID;FA;;;SY)(A;ID;FA;;;BA)`` and every operator
+    read, write and create was denied.
+
+    Creation paths keep the cheaper call deliberately: the directory their own
+    ``mkdir`` just made has no children to propagate to, and they are the
+    long-tested idempotency and writer-lease paths.
+    """
     import ctypes
     from ctypes import wintypes
 
@@ -698,19 +732,43 @@ def _windows_apply_dacl_sddl(path: Path, sddl: str) -> None:
     if not convert(sddl, 1, ctypes.byref(descriptor), None):
         raise OSError(_windows_last_error(ctypes), "cannot build Windows runtime DACL")
     try:
-        set_security = advapi32.SetFileSecurityW
-        set_security.argtypes = [wintypes.LPCWSTR, wintypes.DWORD, wintypes.LPVOID]
-        set_security.restype = wintypes.BOOL
+        # DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION
         dacl_information = 0x00000004 | 0x80000000
-        if not set_security(str(path), dacl_information, descriptor):
-            raise OSError(_windows_last_error(ctypes), "cannot protect Windows runtime DACL")
+        if not propagate:
+            set_security = advapi32.SetFileSecurityW
+            set_security.argtypes = [wintypes.LPCWSTR, wintypes.DWORD, wintypes.LPVOID]
+            set_security.restype = wintypes.BOOL
+            if not set_security(str(path), dacl_information, descriptor):
+                raise OSError(_windows_last_error(ctypes), "cannot protect Windows runtime DACL")
+            return
+        dacl = wintypes.LPVOID()
+        present = wintypes.BOOL()
+        defaulted = wintypes.BOOL()
+        get_dacl = advapi32.GetSecurityDescriptorDacl
+        get_dacl.argtypes = [
+            wintypes.LPVOID, ctypes.POINTER(wintypes.BOOL),
+            ctypes.POINTER(wintypes.LPVOID), ctypes.POINTER(wintypes.BOOL),
+        ]
+        get_dacl.restype = wintypes.BOOL
+        if not get_dacl(descriptor, ctypes.byref(present), ctypes.byref(dacl),
+                        ctypes.byref(defaulted)):
+            raise OSError(_windows_last_error(ctypes), "cannot read Windows runtime DACL")
+        set_named = advapi32.SetNamedSecurityInfoW
+        set_named.argtypes = [
+            wintypes.LPWSTR, ctypes.c_int, wintypes.DWORD, wintypes.LPVOID,
+            wintypes.LPVOID, wintypes.LPVOID, wintypes.LPVOID,
+        ]
+        set_named.restype = wintypes.DWORD
+        result = set_named(str(path), 1, dacl_information, None, None, dacl, None)
+        if result:
+            raise OSError(result, "cannot protect Windows runtime DACL tree")
     finally:
         kernel32.LocalFree(descriptor)
 
 
-def _windows_apply_private_dacl(path: Path, sid: str) -> None:
+def _windows_apply_private_dacl(path: Path, sid: str, *, propagate: bool = False) -> None:
     """Set a protected inheritable DACL on a newly-created runtime directory."""
-    _windows_apply_dacl_sddl(path, _windows_private_dacl_sddl(sid))
+    _windows_apply_dacl_sddl(path, _windows_private_dacl_sddl(sid), propagate=propagate)
 
 
 def _windows_tighten_private_directory(
@@ -949,6 +1007,648 @@ def _validate_windows_runtime_entry(
     finally:
         if opened_here:
             _windows_close_handle(handle)
+
+
+#: Service names to try, in order, when resolving the runtime principal. Mirrors
+#: `$script:ExomemServiceNames` in `scripts/_service-common.ps1`; `kb-mcp` is the
+#: pre-rename name still registered on boxes provisioned before the rename.
+_WINDOWS_SERVICE_NAMES = ("exomem", "kb-mcp")
+
+#: Account names the SCM accepts for the built-in service principals, casefolded.
+#: `LookupAccountName` resolves most of these, but `LocalSystem` -- the spelling
+#: the SCM itself stores for SYSTEM -- is not an account name it knows, so the
+#: fixed map is the authority for these and lookup is only the fallback.
+_WINDOWS_SERVICE_ACCOUNT_SIDS = {
+    "localsystem": "S-1-5-18",
+    ".\\localsystem": "S-1-5-18",
+    "nt authority\\system": "S-1-5-18",
+    "nt authority\\localservice": "S-1-5-19",
+    "nt authority\\local service": "S-1-5-19",
+    "nt authority\\networkservice": "S-1-5-20",
+    "nt authority\\network service": "S-1-5-20",
+}
+
+
+@dataclass(frozen=True)
+class WindowsRuntimePrincipal:
+    """The principal whose private DACL the machine-local state root should carry.
+
+    Not the calling token. The private-DACL model is token-relative, so a state
+    root written by an operator's offline migration is `unsafe` to the
+    LocalSystem service that then has to read it -- which is manifestation 1 of
+    #933, and cost a day of toggling ACLs back and forth. The runtime principal
+    is whoever will actually RUN against this root, and it is a fact about the
+    machine, not about whoever happens to be typing.
+
+    Resolved from the SCM registry, the same hive and the same non-elevated read
+    `scripts/_service-common.ps1` already documents as "the single source of
+    truth" for the service's interpreter. `ObjectName` sits beside the
+    `Parameters\\Application` value it reads.
+
+    With no service installed the runtime principal IS the current token, and
+    every path stays byte-identical to the single-principal behaviour. An
+    unreadable or unrecognised entry degrades to the current token and SAYS so
+    through `source`: a guessed principal would trade one cross-principal
+    failure for another, silently.
+    """
+
+    sid: str
+    #: `service:<name>` when the SCM answered; `current-token` when no service is
+    #: installed; `current-token (<why>)` when a service exists but its principal
+    #: could not be established. Never omitted -- it is what makes a degraded
+    #: resolution visible instead of indistinguishable from a clean one.
+    source: str
+    #: The vault this principal's service is configured to serve, when one could
+    #: be established. `None` for a pinned or current-token principal, and also
+    #: when the service exists but its binding is unreadable -- callers must read
+    #: that as "do not act", never as "no binding exists".
+    bound_vault: str | None = None
+
+    @property
+    def authoritative(self) -> bool:
+        """True only for a principal established from an authority, not inferred.
+
+        Gates the seal. A principal that merely defaulted to the current token --
+        including one that defaulted BECAUSE the registry was unreadable -- must
+        never authorise re-ACLing anything, or an unreadable hive would quietly
+        rewrite the root to the wrong principal.
+
+        Named for what it asserts. It was `resolved_from_service`, which was
+        untrue for the `pinned:` case it also admits.
+        """
+        return self.source.startswith(("service:", "pinned:"))
+
+    def seals_vault(self, vault_root: str | os.PathLike[str]) -> bool:
+        """Whether this principal may seal *vault_root*'s state root.
+
+        The seal's whole justification is a user-token flow preparing the root
+        THE SERVICE WILL RUN AGAINST. A machine that merely has a service
+        registered says nothing about an unrelated vault, and sealing on that
+        basis handed a brand-new `exomem init` vault to LocalSystem and locked
+        the operator out of the state root it had just made for them.
+
+        An explicitly pinned principal is an operator instruction about this
+        invocation, so it needs no binding. A service principal needs one, and
+        an unreadable binding refuses.
+        """
+        if not self.authoritative:
+            return False
+        if self.source.startswith("pinned:"):
+            return True
+        return self.bound_vault is not None and _same_vault(self.bound_vault, vault_root)
+
+
+#: `ERROR_FILE_NOT_FOUND` / `ERROR_PATH_NOT_FOUND`. The registry raises these for
+#: a key that is not there, which is the ordinary "no service installed" answer.
+#: Every other error means the read FAILED, which is a different fact.
+_WINDOWS_REGISTRY_ABSENT = frozenset({2, 3})
+
+
+def _windows_service_object_name(name: str) -> str | None:
+    """Read one service's configured account from the SCM hive.
+
+    Returns None only when the service is genuinely ABSENT. A read that FAILED
+    -- permissions, a corrupt hive, a redirected view -- raises instead, because
+    the two are different facts and collapsing them is how a correctly sealed
+    root got a `current-token` principal, a FAIL, and an `icacls` that would
+    have granted the operator and broken the service.
+    """
+    import winreg
+
+    try:
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE,
+            f"SYSTEM\\CurrentControlSet\\Services\\{name}",
+        ) as key:
+            value, _kind = winreg.QueryValueEx(key, "ObjectName")
+    except OSError as error:
+        if getattr(error, "winerror", None) in _WINDOWS_REGISTRY_ABSENT:
+            return None
+        raise
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _windows_service_bound_vault(name: str) -> str | None:
+    r"""The vault path one installed service is configured to serve, or None.
+
+    Resolution mirrors `scripts/upgrade.ps1` (~:120) exactly, because the two
+    have to agree about which cell is which: the managed dotenv in the service's
+    NSSM `AppDirectory` first, then the `AppEnvironmentExtra` NSSM injects. The
+    dotenv wins because python-dotenv loads it with `override=True` before
+    readiness, so it is what the running service actually reads.
+
+    Never raises, and never returns a value it had to guess at. `None` means
+    "this service's vault could not be established", which callers must treat as
+    "do not act", not as "no binding exists".
+    """
+    import winreg
+
+    try:
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE,
+            f"SYSTEM\\CurrentControlSet\\Services\\{name}\\Parameters",
+        ) as key:
+            try:
+                app_directory, _kind = winreg.QueryValueEx(key, "AppDirectory")
+            except OSError:
+                app_directory = None
+            try:
+                extra, _kind = winreg.QueryValueEx(key, "AppEnvironmentExtra")
+            except OSError:
+                extra = None
+    except OSError:
+        return None
+    if isinstance(app_directory, str) and app_directory.strip():
+        dotenv = Path(app_directory.strip()) / ".env"
+        try:
+            lines = dotenv.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            lines = []
+        for line in reversed(lines):
+            match = re.match(r"\s*EXOMEM_VAULT_PATH\s*=\s*(.*?)\s*$", line)
+            if match:
+                value = match.group(1).strip().strip("\"'")
+                if value:
+                    return value
+    # NSSM stores this as REG_MULTI_SZ; only ever read the one key out of it.
+    # The rest of that block carries service secrets and must not be surfaced.
+    if isinstance(extra, list):
+        for item in extra:
+            if isinstance(item, str) and item.startswith("EXOMEM_VAULT_PATH="):
+                value = item.split("=", 1)[1].strip().strip("\"'")
+                if value:
+                    return value
+    return None
+
+
+def _same_vault(left: str | os.PathLike[str], right: str | os.PathLike[str]) -> bool:
+    """Whether two spellings name the same vault, by the state key's own rule.
+
+    Derived from `state_paths.vault_state_key`'s normalization rather than
+    restated: two paths that map to the same state key ARE the same vault by
+    definition, so comparing keys cannot drift from the placement seam.
+    """
+    from .state_paths import vault_state_key
+
+    try:
+        return vault_state_key(Path(left)) == vault_state_key(Path(right))
+    except (OSError, ValueError):
+        return False
+
+
+def _windows_sid_for_account(account: str) -> str | None:
+    """Resolve one account name to its SID string, or None when unresolvable."""
+    fixed = _WINDOWS_SERVICE_ACCOUNT_SIDS.get(account.casefold())
+    if fixed is not None:
+        return fixed
+    import ctypes
+    from ctypes import wintypes
+
+    advapi32 = _windows_library(ctypes, "advapi32")
+    lookup = advapi32.LookupAccountNameW
+    lookup.argtypes = [
+        wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.LPVOID,
+        ctypes.POINTER(wintypes.DWORD), wintypes.LPWSTR,
+        ctypes.POINTER(wintypes.DWORD), ctypes.POINTER(wintypes.DWORD),
+    ]
+    lookup.restype = wintypes.BOOL
+    sid_size = wintypes.DWORD(0)
+    domain_size = wintypes.DWORD(0)
+    use = wintypes.DWORD(0)
+    lookup(None, account, None, ctypes.byref(sid_size), None,
+           ctypes.byref(domain_size), ctypes.byref(use))
+    if not sid_size.value:
+        return None
+    sid_buffer = ctypes.create_string_buffer(sid_size.value)
+    domain_buffer = ctypes.create_unicode_buffer(domain_size.value)
+    if not lookup(None, account, sid_buffer, ctypes.byref(sid_size), domain_buffer,
+                  ctypes.byref(domain_size), ctypes.byref(use)):
+        return None
+    convert = advapi32.ConvertSidToStringSidW
+    convert.argtypes = [wintypes.LPVOID, ctypes.POINTER(wintypes.LPWSTR)]
+    convert.restype = wintypes.BOOL
+    text = wintypes.LPWSTR()
+    if not convert(sid_buffer, ctypes.byref(text)):
+        return None
+    try:
+        return str(text.value)
+    finally:
+        _windows_library(ctypes, "kernel32").LocalFree(text)
+
+
+#: Explicit override for the runtime principal. `current-token` pins the
+#: single-principal behaviour; anything else must be a literal SID. Two callers
+#: need it and neither is exotic: an operator doing maintenance inside a stop
+#: window with the service disabled, and the test suite -- which must not change
+#: behaviour based on whether the developer's machine happens to have an
+#: `exomem` service registered, since that would make the suite's verdict a
+#: property of the box rather than of the code.
+ENV_RUNTIME_PRINCIPAL = "EXOMEM_RUNTIME_PRINCIPAL"
+
+
+def resolve_windows_runtime_principal(
+    *, service_names: tuple[str, ...] = _WINDOWS_SERVICE_NAMES
+) -> WindowsRuntimePrincipal:
+    """Whose private DACL the state root should carry on this machine.
+
+    Never guesses. Every failure to establish a SERVICE principal degrades to
+    the current token with the reason recorded in `source`, because a wrong
+    principal is worse than a conservative one: it would lock out the operator
+    AND fail the service.
+
+    It can still raise `OSError` from `_windows_current_user_sid`, which is the
+    one question with no honest fallback -- a process that cannot establish its
+    own identity has nothing to degrade TO. Callers that must not fail catch it.
+    """
+    current = _windows_current_user_sid()
+    override = os.environ.get(ENV_RUNTIME_PRINCIPAL, "").strip()
+    if override:
+        if override.casefold() == "current-token":
+            # `pinned:` and NOT `current-token (...)`: the parenthesised form is
+            # reserved for a principal that DEGRADED to this token, and callers
+            # withhold the token-relative repair on seeing it. A deliberate pin
+            # is the opposite of a degradation and must not read as one.
+            return WindowsRuntimePrincipal(sid=current, source="pinned:current-token")
+        if re.fullmatch(r"S-1-[0-9-]+", override):
+            return WindowsRuntimePrincipal(sid=override, source=f"pinned:{override}")
+        return WindowsRuntimePrincipal(
+            sid=current,
+            source=f"current-token ({ENV_RUNTIME_PRINCIPAL}={override!r} is not a SID)",
+        )
+    degraded: str | None = None
+    for name in service_names:
+        try:
+            account = _windows_service_object_name(name)
+        except OSError as error:
+            # A read that FAILED, not an absent service. Degrading silently here
+            # made a correctly-sealed cell look misconfigured and prescribed the
+            # repair that breaks it.
+            degraded = f"service {name!r} registry read failed ({error})"
+            continue
+        if account is None:
+            continue
+        try:
+            sid = _windows_sid_for_account(account)
+        except OSError:
+            sid = None
+        if sid is None:
+            degraded = f"service {name!r} account {account!r} is unresolvable"
+            continue
+        return WindowsRuntimePrincipal(
+            sid=sid,
+            source=f"service:{name}",
+            bound_vault=_windows_service_bound_vault(name),
+        )
+    if degraded is not None:
+        return WindowsRuntimePrincipal(sid=current, source=f"current-token ({degraded})")
+    return WindowsRuntimePrincipal(sid=current, source="current-token")
+
+
+@dataclass(frozen=True)
+class WindowsDirectoryPosture:
+    """What the CURRENT process token can do with one private directory.
+
+    The private-DACL model is relative to the calling token
+    (`_windows_private_dacl_trustees` puts that token's own SID first), so the
+    same directory is `private` to the principal that created it and `unsafe`
+    to any other. That is correct for a single-principal install and is exactly
+    the cross-principal defect when a LocalSystem service and an operator's CLI
+    share one machine-local state root: whichever principal did not create it
+    fails, and until now it failed as a traceback from deep inside whatever
+    operation happened to touch state first.
+
+    This type is the read-only vocabulary for reporting that condition instead
+    of raising it. It never repairs and never opens anything for write.
+
+    It carries TWO verdicts because the two questions operators actually ask are
+    different. "Can I work here?" is about the calling token. "Is this cell
+    configured correctly?" is about the RUNTIME principal -- and answering the
+    second with the first makes a healthy LocalSystem install permanently red to
+    every operator, since a correct `D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)` root is
+    `unsafe` to anyone who is not SYSTEM. Measured, not assumed.
+    """
+
+    path: Path
+    #: This token can open the directory itself.
+    accessible: bool
+    #: Why the open failed, when it did: `access-denied` (the cross-principal
+    #: case), `reparse-point`, `unexpected-path-type`, `missing`, `unopenable`.
+    #: None when it succeeded. Collapsing these lost the difference between "a
+    #: principal denied me" and "this is a junction" -- and only the first has an
+    #: `icacls` repair.
+    unopenable_reason: str | None
+    #: `private` / `inherited` / `unsafe` as THIS TOKEN's validator judges it,
+    #: or None when the descriptor could not be read at all.
+    verdict: str | None
+    #: The same judgement made for the runtime principal. Equal to `verdict`
+    #: whenever they are the same principal.
+    runtime_verdict: str | None
+    #: The worst verdict among a sample of the root's CHILDREN, judged for the
+    #: runtime principal, or None when there was nothing readable to judge. The
+    #: root's own descriptor cannot answer whether the state inside it is
+    #: private, and a sealed-looking root over readable state is worse than an
+    #: honestly unsealed one.
+    child_verdict: str | None
+    #: How many children that verdict is based on. 0 with a None verdict means
+    #: the contents were NOT EVALUATED, which callers must say out loud rather
+    #: than report as privacy.
+    child_sampled: int
+    #: The observed SDDL, when readable. An object's OWNER keeps READ_CONTROL,
+    #: so a root this user created but re-ACLed to SY/BA still reports its
+    #: descriptor -- which is what makes a remote report actionable.
+    observed: str | None
+    #: The full-access trustees THIS TOKEN's validator requires.
+    expected: tuple[str, ...]
+    #: The full-access trustees the RUNTIME principal's validator requires.
+    runtime_expected: tuple[str, ...]
+    #: The runtime principal, and how it was established.
+    runtime_principal: WindowsRuntimePrincipal
+    #: The exact non-recursive repair, rendered for the RUNTIME principal -- the
+    #: DACL this root is supposed to end up carrying. Rendering it for the
+    #: calling token instead is what produced #933's day of toggling: following
+    #: it on a service install writes a root the service then rejects forever.
+    remediation: str
+
+
+def inspect_windows_private_directory(
+    path: Path, *, runtime_principal: WindowsRuntimePrincipal | None = None
+) -> WindowsDirectoryPosture | None:
+    """Describe one private directory's posture. Read-only; does not repair.
+
+    Returns None off Windows (the POSIX branch has no DACL model) and None when
+    the entry is absent -- an absent root is not a cross-principal root, and
+    conflating them would make every fresh install look like the defect.
+
+    Raises only if the CURRENT TOKEN's own identity cannot be established
+    (`_windows_current_user_sid`, or an invalid SID reaching
+    `_windows_private_dacl_trustees`). Everything about the directory itself is
+    reported rather than raised; it is only the question "who am I" that has no
+    honest answer to report.
+    """
+    if os.name != "nt":
+        return None
+    target = Path(path)
+    if not os.path.lexists(target):
+        return None
+    sid = _windows_current_user_sid()
+    principal = runtime_principal or resolve_windows_runtime_principal()
+    expected = _windows_private_dacl_trustees(sid)
+    runtime_expected = _windows_private_dacl_trustees(principal.sid)
+    remediation = _windows_private_dacl_repair_command(
+        target, principal.sid, directory=True
+    )
+    # Read the descriptor by path first: it survives the loss of directory
+    # access that makes the handle open fail, so the two probes answer
+    # different questions and the descriptor one must not be skipped when the
+    # other fails.
+    try:
+        observed: str | None = _windows_dacl_sddl(target)
+    except OSError:
+        observed = None
+
+    def _verdict(for_sid: str) -> str | None:
+        if observed is None:
+            return None
+        return _windows_private_dacl_verdict(observed, for_sid, directory=True)
+
+    accessible = True
+    unopenable_reason: str | None = None
+    try:
+        handle = _windows_open_path(target, directory=True)
+    except WindowsReparsePointError:
+        accessible, unopenable_reason = False, "reparse-point"
+    except WindowsPathTypeError:
+        accessible, unopenable_reason = False, "unexpected-path-type"
+    except FileNotFoundError:
+        accessible, unopenable_reason = False, "missing"
+    except OSError as error:
+        accessible = False
+        # `_windows_open_path` passes the raw Windows error through as `errno`,
+        # so ACCESS_DENIED arrives as 5 rather than as EACCES.
+        unopenable_reason = (
+            "access-denied" if error.errno in {5, errno.EACCES} else "unopenable"
+        )
+    else:
+        _windows_close_handle(handle)
+    child_verdict, child_sampled = _windows_child_dacl_verdict(target, principal.sid)
+    return WindowsDirectoryPosture(
+        path=target,
+        accessible=accessible,
+        unopenable_reason=unopenable_reason,
+        verdict=_verdict(sid),
+        runtime_verdict=_verdict(principal.sid),
+        child_verdict=child_verdict,
+        child_sampled=child_sampled,
+        observed=observed,
+        expected=expected,
+        runtime_expected=runtime_expected,
+        runtime_principal=principal,
+        remediation=remediation,
+    )
+
+
+#: How many children to sample when asking whether the state INSIDE a private
+#: root is private too. A sample, not a sweep: this runs inside `doctor`, the
+#: root can hold thousands of index pages, and one foreign ACE is as damning as
+#: a hundred. `sorted` so the sample is the same set run to run rather than
+#: whatever order the filesystem happened to hand back.
+_WINDOWS_CHILD_DACL_SAMPLE = 16
+
+
+def _windows_sample_children(directory: Path) -> list[Path] | None:
+    """A stable sample of one directory's children, or None when unlistable.
+
+    `sorted` so the sample is the same set run to run rather than whatever order
+    the filesystem happened to hand back. None and [] are different answers:
+    None means the listing was refused, [] means there is genuinely nothing
+    there, and only the second licenses a claim about the contents.
+    """
+    if os.name != "nt":
+        return None
+    try:
+        return sorted(Path(directory).iterdir())[:_WINDOWS_CHILD_DACL_SAMPLE]
+    except OSError:
+        return None
+
+
+def _windows_child_dacl_verdict(
+    directory: Path, sid: str, *, children: list[Path] | None = None
+) -> tuple[str | None, int]:
+    """Worst verdict among a sample of the directory's children, and its size.
+
+    The root's own descriptor cannot answer whether the STATE is private.
+    Protecting a directory converts its children's inherited ACEs to explicit
+    ones, so a root that reports `private` can sit over files any other
+    principal still reads and writes -- which is the exact hazard this module's
+    placement docstring opens with, and it read as `pass`.
+
+    The count is returned, not implied. A `None` verdict with 0 sampled means
+    the contents were NOT EVALUATED -- the normal case for an operator looking
+    at a service-owned root, whose listing is denied -- and a caller that
+    reports privacy without saying so is making exactly the confidently-green
+    claim this check exists to stop.
+
+    `children` lets a caller supply paths it enumerated earlier. The seal needs
+    that: after it writes, its own listing is denied, but child DESCRIPTORS stay
+    readable by path because the owner keeps `READ_CONTROL`.
+    """
+    if os.name != "nt":
+        return (None, 0)
+    sample = children if children is not None else _windows_sample_children(directory)
+    if sample is None:
+        return (None, 0)
+    seen: list[str] = []
+    for child in sample:
+        try:
+            child_sddl = _windows_dacl_sddl(child)
+            # Inside the guard: `Path.is_dir` SWALLOWS `OSError`, so a denied
+            # child directory would silently be judged with the file flag-set.
+            is_directory = child.is_dir()
+        except OSError:
+            continue
+        seen.append(_windows_private_dacl_verdict(child_sddl, sid, directory=is_directory))
+    if not seen:
+        return (None, 0)
+    # One rule, ordered worst-first. This was a short-circuit on `unsafe` plus an
+    # accumulator, and the accumulator only ever escalated to `inherited` -- so
+    # with the short-circuit removed an `unsafe` child that did not sort first
+    # was silently dropped. A single ranking cannot develop that seam.
+    for verdict in (
+        _WINDOWS_DACL_UNSAFE,
+        _WINDOWS_DACL_INHERITED,
+        _WINDOWS_DACL_PRIVATE,
+    ):
+        if verdict in seen:
+            return (verdict, len(seen))
+    return (seen[0], len(seen))
+
+
+class WindowsRuntimePrincipalUnresolved(RuntimeError):
+    """The runtime principal could not be established, so nothing was re-ACLed.
+
+    Deliberately not a silent no-op. Sealing to a GUESSED principal is the one
+    outcome worse than not sealing: it locks the operator out AND leaves the
+    service failing closed, which is the pair of failures #933 is about.
+    """
+
+
+def seal_windows_state_root_for_runtime_principal(
+    state_dir: Path,
+    *,
+    vault_root: Path | None = None,
+    runtime_principal: WindowsRuntimePrincipal | None = None,
+) -> WindowsRuntimePrincipal | None:
+    """Leave one state root carrying the RUNTIME principal's private DACL.
+
+    Called at the END of a user-token flow that created or recreated the root,
+    never at creation: the creating token has to be able to write the state into
+    it first, and a root sealed to LocalSystem up front is one its own migrator
+    can no longer open.
+
+    Returns the principal it sealed for, or None when there was nothing to do:
+    POSIX, an absent root, a runtime principal that IS the current token, or --
+    the case that matters -- a vault this machine's service is not bound to.
+    That last one is not a nicety. Resolving a principal from the machine's
+    service registry says nothing about WHICH vault that service serves, so
+    without the binding check an `exomem init` of a brand-new unrelated vault
+    handed its state root to LocalSystem and locked the operator out of the
+    directory it had just made for them.
+
+    Refuses rather than guessing when the principal is unresolved, refuses to
+    touch a root this process does not own, and refuses an aliased root: the
+    seal is the one DACL write that never opened a handle, so without its own
+    check it would happily protect a junction and leave the real root untouched
+    while reporting success.
+    """
+    if os.name != "nt":
+        return None
+    target = Path(state_dir)
+    if not os.path.lexists(target):
+        return None
+    principal = runtime_principal or resolve_windows_runtime_principal()
+    current = _windows_current_user_sid()
+    if principal.sid.casefold() == current.casefold():
+        return None
+    if not principal.authoritative:
+        raise WindowsRuntimePrincipalUnresolved(principal.source)
+    if vault_root is not None and not principal.seals_vault(vault_root):
+        # Two very different skips, and they must not look alike in a log. One
+        # is correct and expected; the other is a SILENT MISS on the upgrade
+        # path -- the service's own vault going unsealed because its binding
+        # could not be read.
+        if principal.bound_vault is None:
+            logger.warning(
+                "not sealing %s: the %s binding could not be read, so this vault "
+                "cannot be confirmed as the one it serves",
+                target, principal.source,
+            )
+        else:
+            logger.info(
+                "not sealing %s: %s is bound to a different vault (%s)",
+                target, principal.source, principal.bound_vault,
+            )
+        return None
+    # Open it the way every other private-state boundary does, so a reparse
+    # point or a non-directory is refused here too rather than silently sealed.
+    try:
+        _windows_close_handle(_windows_open_path(target, directory=True))
+    except (WindowsReparsePointError, WindowsPathTypeError):
+        raise
+    except OSError:
+        # Unopenable. If it is ALREADY exactly what this call would write, that
+        # is a repeat call on a sealed root, and a seal has to be idempotent:
+        # the first version raised a raw `[Errno 5]` from here on the second
+        # call. Anything else is a real failure and still propagates.
+        try:
+            already = _windows_private_dacl_is_valid(
+                _windows_dacl_sddl(target), principal.sid, directory=True
+            )
+        except OSError:
+            already = False
+        if already:
+            return None
+        raise
+    observed = _windows_dacl_sddl(target)
+    if not _windows_owner_admits_current_user(_windows_sddl_owner(observed), current):
+        raise WindowsRuntimePrincipalUnresolved(
+            f"this process does not own {target}; refusing to re-ACL it"
+        )
+    # Enumerate BEFORE the write, while the listing is still permitted. After
+    # the seal this token cannot list the root, but child descriptors stay
+    # readable by path because the owner keeps `READ_CONTROL` -- so this is the
+    # only moment at which the contents can be named for later verification.
+    children = _windows_sample_children(target)
+    # `propagate` is load-bearing, not a flag. Protecting the entry alone makes
+    # Windows convert each child's inherited ACEs into explicit ones, so every
+    # file the migration just moved in stays readable and writable by this token
+    # behind a directory that merely LOOKS sealed.
+    _windows_apply_private_dacl(target, principal.sid, propagate=True)
+    # Prove the write took, judged by the same validator the runtime principal
+    # will use. Read by path: the seal has just removed this token's own access,
+    # so a fresh handle open would fail on a root that is now exactly correct.
+    sealed = _windows_dacl_sddl(target)
+    if not _windows_private_dacl_is_valid(sealed, principal.sid, directory=True):
+        raise WindowsRuntimeDaclError(
+            target,
+            _windows_private_dacl_repair_command(target, principal.sid, directory=True),
+            observed=sealed,
+            expected=_windows_private_dacl_trustees(principal.sid),
+        )
+    # And prove it took on the CONTENTS, which is what the seal actually claims
+    # to have fixed. Checking only the entry would report success over a partial
+    # propagation -- a child directory carrying its own protected DACL stays
+    # `unsafe` for the runtime principal and inheritance never reaches it.
+    child_verdict, _sampled = _windows_child_dacl_verdict(
+        target, principal.sid, children=children
+    )
+    if child_verdict == _WINDOWS_DACL_UNSAFE:
+        raise WindowsRuntimeDaclError(
+            target,
+            _windows_private_dacl_repair_command(target, principal.sid, directory=True),
+            observed=f"root sealed, but contents remain {child_verdict}",
+            expected=_windows_private_dacl_trustees(principal.sid),
+        )
+    return principal
 
 
 def prepare_windows_idempotency_runtime_paths(state_dir: Path, owners_dir: Path) -> None:

--- a/src/exomem/state_migration.py
+++ b/src/exomem/state_migration.py
@@ -467,6 +467,12 @@ def migrate_vault_state_offline(
     if adopt is not None and adopt not in (*_ADOPT_CHOICES, _GOVERNANCE_VAULT_ADOPTION):
         raise ValueError(f"--adopt-state must be one of {_ADOPT_CHOICES}")
     vault_root = Path(vault_root)
+    # Before the lock, before any adoption, before `ensure_vault_state_dir`: an
+    # offline migration under the operator's token against a root the service
+    # owns cannot succeed, and `scripts/upgrade.ps1` learned that as `[Errno 5]
+    # cannot safely open Obsidian-<key>` part-way through an upgrade whose
+    # service was already stopped.
+    state_paths.assert_state_root_accessible(vault_root)
     state_dir = state_paths.vault_state_dir(vault_root)
     if adopt == _GOVERNANCE_VAULT_ADOPTION:
         return _adopt_governance_store_from_vault_offline(vault_root)
@@ -491,7 +497,45 @@ def migrate_vault_state_offline(
             "a complete manifest has legacy in-vault duplicates",
         )
     require_vault_state_ready(vault_root)
+    _seal_state_root_for_runtime_principal(vault_root)
     return resolution
+
+
+def _seal_state_root_for_runtime_principal(vault_root: Path) -> None:
+    """Leave the migrated root carrying the DACL its RUNTIME principal validates.
+
+    The last act of the migration, deliberately after `require_vault_state_ready`:
+    the migrating token has to be able to read and write the root right up to
+    here, and sealing it to LocalSystem any earlier locks the migration out of
+    its own destination.
+
+    This is what closes manifestation 1. `upgrade.ps1` runs this step under the
+    operator's token; without the seal the root keeps the operator's ACE, and the
+    LocalSystem service that starts immediately afterwards rejects it as `unsafe`
+    on every catalog proof, lexical repair and graph recovery -- refusing forever
+    at ~0 CPU, which is the outage.
+
+    A no-op when the runtime principal IS the current token, so a machine with no
+    service installed behaves exactly as it did before. Never guesses: an
+    unresolved principal leaves the DACL alone and logs why, because sealing to
+    the wrong principal locks out the operator AND the service at once.
+    """
+    try:
+        sealed = state_paths.seal_state_root_for_runtime_principal(vault_root)
+    except Exception as error:  # noqa: BLE001 - the migration itself has succeeded
+        # Never fatal here. The state is migrated and readable by the migrating
+        # token; a failed seal is a posture the `state.dacl` doctor check reports
+        # and an operator can repair, not a reason to unwind a completed move.
+        log.warning(
+            "machine-local state root not sealed to the runtime principal: %s", error
+        )
+        return
+    if sealed is not None:
+        log.info(
+            "machine-local state root sealed to runtime principal %s (%s)",
+            sealed.sid,
+            sealed.source,
+        )
 
 
 def _resolve_locked(vault_root: Path, state_dir: Path) -> StateResolution:

--- a/src/exomem/state_paths.py
+++ b/src/exomem/state_paths.py
@@ -29,7 +29,12 @@ from __future__ import annotations
 import hashlib
 import os
 import unicodedata
+from dataclasses import dataclass, replace
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .mutation_lock import WindowsRuntimePrincipal
 
 ENV_STATE_ROOT = "EXOMEM_STATE_ROOT"
 ENV_HOSTED_STATE_ROOT = "EXOMEM_HOSTED_STATE_ROOT"
@@ -227,6 +232,284 @@ def _ensure_hosted_state_directory(directory: Path) -> bool:
             except ValueError as error:
                 raise OSError("hosted state anchor escaped its private root") from error
     return True
+
+
+def _unsafe_verdict() -> str:
+    """The validator's own name for "a principal outside the private set may hold access".
+
+    Read from the validator rather than restated here, so a rename there cannot
+    leave this silently matching nothing and quietly stop refusing.
+    """
+    from .mutation_lock import _WINDOWS_DACL_UNSAFE
+
+    return _WINDOWS_DACL_UNSAFE
+
+
+@dataclass(frozen=True)
+class StateRootPosture:
+    """How one vault's state root stands, for BOTH principals that touch it.
+
+    The Windows private-DACL model is relative to the calling token, so a state
+    root created by a LocalSystem service is `unsafe` -- and unopenable -- to the
+    operator's CLI, and vice versa. Two different questions follow from that, and
+    answering one with the other is a defect in each direction:
+
+    * "Can I work here?" is about the CURRENT token (`blocks_current_token`).
+    * "Is this cell configured correctly?" is about the RUNTIME principal
+      (`runtime_verdict`). A correct LocalSystem root is `unsafe` to every
+      operator, so judging cell health by the caller's token makes a healthy
+      service install permanently red.
+    """
+
+    directory: Path
+    #: The root exists on disk. An absent root is a fresh install, not a defect.
+    present: bool
+    #: This token can open the root.
+    accessible: bool
+    #: Why the open failed, when it did. `access-denied` is the cross-principal
+    #: case; `reparse-point` and `unexpected-path-type` are alias problems with
+    #: no `icacls` repair, and must not be reported as principal problems.
+    unopenable_reason: str | None
+    verdict: str | None
+    runtime_verdict: str | None
+    #: Worst verdict among a sample of the root's children, judged for the
+    #: runtime principal. The root's own descriptor cannot say whether the STATE
+    #: inside it is private.
+    child_verdict: str | None
+    #: How many children that verdict rests on. 0 means the contents were NOT
+    #: EVALUATED -- the normal case once a root is sealed, since the operator's
+    #: listing is then denied. Reporting privacy without saying so is the
+    #: confidently-green claim this whole check exists to stop.
+    child_sampled: int
+    observed: str | None
+    expected: tuple[str, ...]
+    runtime_expected: tuple[str, ...]
+    #: How the runtime principal was established, or None off Windows.
+    runtime_principal_source: str | None
+    remediation: str | None
+
+    @property
+    def cross_principal(self) -> bool:
+        """Present, openable by nobody but another principal. Repairable by ACL."""
+        return self.present and not self.accessible and (
+            self.unopenable_reason == "access-denied"
+        )
+
+    @property
+    def contents_unevaluated(self) -> bool:
+        """The root is present but nothing inside it was examined."""
+        return self.present and self.child_sampled == 0
+
+    @property
+    def runtime_principal_unresolved(self) -> bool:
+        """The runtime principal fell back to this token instead of being established.
+
+        A remediation rendered for THIS token would then re-introduce the exact
+        ping-pong #933 is about, so callers withhold it rather than print it.
+        """
+        source = self.runtime_principal_source
+        return source is not None and source.startswith("current-token (")
+
+    @property
+    def unopenable_for_unknown_reason(self) -> bool:
+        """Unopenable, and neither a principal nor an alias explains it.
+
+        A sharing violation, a not-ready device, anything outside the causes
+        this module names. Narrowing `cross_principal` to `access-denied` was
+        right, but it must not leave a residual bucket that simply passes: an
+        un-evaluated state is not a safe one, and maintenance that proceeds into
+        it fails somewhere further in with a raw error.
+        """
+        return (
+            self.present
+            and not self.accessible
+            and self.unopenable_reason
+            not in {"access-denied", "reparse-point", "unexpected-path-type"}
+        )
+
+    @property
+    def locally_unsafe(self) -> bool:
+        """Openable, but this token's own validator rejects the trustee set.
+
+        The half the first pre-flight missed, and the half the incident's
+        service was actually on: LocalSystem holds an `SY` full-access ACE on a
+        `user+SY+BA` root, so it opens the root fine and then fails closed on
+        every private-state boundary behind it.
+        """
+        return self.present and self.verdict == _unsafe_verdict()
+
+    @property
+    def blocks_current_token(self) -> bool:
+        """Any half. Work started here dies; the only question is how far in."""
+        return (
+            self.cross_principal
+            or self.locally_unsafe
+            or self.unopenable_for_unknown_reason
+        )
+
+    @property
+    def alias_path(self) -> bool:
+        """The root is a reparse point or the wrong entry type -- not a DACL problem."""
+        return self.unopenable_reason in {"reparse-point", "unexpected-path-type"}
+
+
+class StateRootAccessDenied(OSError):
+    """This token cannot do machine-local state work against this root.
+
+    An `OSError` deliberately: every caller that already fails closed on state
+    it cannot reach keeps doing so, and the CLI paths that catch `OSError` to
+    print a clean error keep catching it -- they just get an actionable message
+    instead of a traceback from somewhere further in.
+    """
+
+    #: Stable, machine-readable. `upgrade.ps1` consumes the JSON envelope this
+    #: reaches, and a message-only envelope cannot be branched on.
+    code = "STATE_ROOT_CROSS_PRINCIPAL"
+
+    def __init__(self, posture: StateRootPosture) -> None:
+        self.posture = posture
+        self.remediation = posture.remediation
+        detail = f"; observed {posture.observed!r}" if posture.observed else ""
+        if posture.expected:
+            detail += (
+                "; this process requires full-access trustees "
+                + ", ".join(posture.expected)
+            )
+        # Both halves can hold at once — a SY/BA-only root is unopenable to the
+        # operator AND `unsafe` to them. Report the stronger, more concrete fact
+        # first: "cannot open it" is checkable, "the validator rejects it" needs
+        # the reader to know what the validator is.
+        if posture.cross_principal:
+            lead = (
+                f"the machine-local state root {posture.directory} is owned by another "
+                f"principal and cannot be opened by this process{detail}."
+            )
+        elif posture.unopenable_for_unknown_reason:
+            lead = (
+                f"the machine-local state root {posture.directory} could not be opened "
+                f"({posture.unopenable_reason}), so its posture is unverified{detail}."
+            )
+        else:
+            lead = (
+                f"the machine-local state root {posture.directory} carries a DACL this "
+                "process's own private-state validator rejects, so every boundary "
+                f"behind it fails closed{detail}."
+            )
+        if posture.runtime_principal_unresolved:
+            # Withhold the repair. It renders THIS token's trustees, and the
+            # principal that will actually run against the root is unknown --
+            # so following it is how #933's day of ACL ping-pong starts.
+            super().__init__(
+                lead
+                + " The principal that runs against this root could not be established "
+                f"({posture.runtime_principal_source}), so no repair is offered: "
+                "re-ACLing to this token would be a guess that breaks the other "
+                "principal. Establish the service account first."
+            )
+            return
+        super().__init__(
+            lead
+            + " Run it as the principal that owns the root (the service account), "
+            "or re-ACL the root with: " + (posture.remediation or "")
+        )
+
+
+def _posture_off_windows(directory: Path) -> StateRootPosture:
+    # POSIX privacy is mode-based and the mutation-lock branch no-ops there, so
+    # there is no cross-principal DACL condition to report. An unreadable root
+    # still fails at its own boundary, as it always has.
+    return StateRootPosture(
+        directory=directory,
+        present=os.path.lexists(directory),
+        accessible=True,
+        unopenable_reason=None,
+        verdict=None,
+        runtime_verdict=None,
+        child_verdict=None,
+        child_sampled=0,
+        observed=None,
+        expected=(),
+        runtime_expected=(),
+        runtime_principal_source=None,
+        remediation=None,
+    )
+
+
+def inspect_state_root(vault_root: Path) -> StateRootPosture:
+    """Read-only posture of one vault's state root. Repairs nothing.
+
+    Reports everything about the directory rather than raising it. It can still
+    raise for questions that have no honest answer to report: an
+    `EXOMEM_STATE_ROOT` that is relative or inside the vault (`ValueError` from
+    :func:`vault_state_dir`), or a current-token identity that cannot be
+    established (`OSError`). Callers that must not fail on those catch them --
+    doctor turns them into a finding, and the maintenance pre-flight refuses.
+    """
+    directory = vault_state_dir(vault_root)
+    if not _is_windows():
+        return _posture_off_windows(directory)
+
+    from .mutation_lock import inspect_windows_private_directory
+
+    posture = inspect_windows_private_directory(directory)
+    if posture is None:
+        return replace(_posture_off_windows(directory), present=False)
+    return StateRootPosture(
+        directory=directory,
+        present=True,
+        accessible=posture.accessible,
+        unopenable_reason=posture.unopenable_reason,
+        verdict=posture.verdict,
+        runtime_verdict=posture.runtime_verdict,
+        child_verdict=posture.child_verdict,
+        child_sampled=posture.child_sampled,
+        observed=posture.observed,
+        expected=posture.expected,
+        runtime_expected=posture.runtime_expected,
+        runtime_principal_source=posture.runtime_principal.source,
+        remediation=posture.remediation,
+    )
+
+
+def assert_state_root_accessible(vault_root: Path) -> None:
+    """Refuse an unusable state root BEFORE an operation does any work.
+
+    Refuses on BOTH halves. The first version gated only on "cannot open",
+    which is the operator's failure; the service's failure is the other one --
+    it opens a `user+SY+BA` root through its `SY` ACE and then rejects the
+    trustee set, which is manifestation 1 of #933. Gating on one half let
+    `maintain` proceed into `ensure_vault_state_dir` and die there with a raw
+    `WindowsRuntimeDaclError`, which is the exact failure this exists to remove.
+
+    The alternative is what the incident produced: `maintain --reconcile
+    --rebuild-graph` ran far enough to take the mutation hold and census the
+    graph lineage, then died on `[Errno 5] cannot safely open .graph.sqlite-wal`
+    with the operation half-done and no statement of what to do about it.
+    """
+    posture = inspect_state_root(vault_root)
+    if posture.blocks_current_token:
+        raise StateRootAccessDenied(posture)
+
+
+def seal_state_root_for_runtime_principal(
+    vault_root: Path,
+) -> WindowsRuntimePrincipal | None:
+    """Leave the state root carrying the DACL the RUNTIME principal validates.
+
+    The last act of a user-token flow that created or recreated the root, never
+    part of creating it: the creating token must be able to write the state in
+    first. A no-op returning None whenever the runtime principal is the current
+    token, so a machine with no service install behaves exactly as before -- and
+    also whenever this vault is not the one that machine's service is bound to.
+    """
+    if not _is_windows():
+        return None
+
+    from .mutation_lock import seal_windows_state_root_for_runtime_principal
+
+    return seal_windows_state_root_for_runtime_principal(
+        vault_state_dir(vault_root), vault_root=Path(vault_root)
+    )
 
 
 def ensure_vault_state_dir(vault_root: Path) -> Path:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -458,6 +458,13 @@ def _isolate_state_root(tmp_path: Path):
         "EXOMEM_WRITER_LEASE_STATE_DIR",
         str(state_root / "writer-lease"),
     )
+    # Pin the runtime principal to the calling token. Without this the suite's
+    # behaviour depends on whether the developer's machine happens to have an
+    # `exomem`/`kb-mcp` service registered: the offline migration seals the state
+    # root to that service's account, which would lock every test — and tmpdir
+    # teardown — out of its own fixture. A test that asserts on cross-principal
+    # behaviour sets this itself (tests/test_cross_principal_state_root.py).
+    private.setenv("EXOMEM_RUNTIME_PRINCIPAL", "current-token")
     writer_lease_module = None
     try:
         try:

--- a/tests/test_cross_principal_state_root.py
+++ b/tests/test_cross_principal_state_root.py
@@ -1,0 +1,1560 @@
+"""Cross-principal machine-local state root (issue #933).
+
+The service runs as LocalSystem and the operator's CLI runs as the user, but
+the private-DACL model is relative to the CALLING token: a root created by one
+principal is `unsafe` to the other. Every operator flow against a service-owned
+root therefore fails, and it fails as a traceback rather than as a finding.
+
+These tests pin the three behaviours the issue requires that do not depend on a
+deployment decision: a posture inspector that names the cross-principal case, a
+doctor that reports it (and unreadable state) as findings rather than crashing,
+and CLI maintenance ops that refuse up front instead of part-way through.
+
+Every fixture writes a tmpdir; `conftest._isolate_state_root` injects
+`EXOMEM_STATE_ROOT` so nothing here can reach the real user state root.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from exomem.doctor import _REBUILD_TEMP_ORPHAN_FAIL_COUNT
+from exomem.kbdir import kb_dirname
+
+windows_only = pytest.mark.skipif(
+    os.name != "nt", reason="the private-DACL model is Windows-only"
+)
+
+#: The DACL a LocalSystem service writes and validates: SYSTEM + Administrators
+#: and nobody else. Applied to a directory the test user owns, this reproduces
+#: the incident's root exactly -- the user keeps ownership (so it can be undone)
+#: but loses every access the operator flows need.
+_SERVICE_PRIVATE_SDDL = "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    root = tmp_path / "vault"
+    (root / kb_dirname()).mkdir(parents=True)
+    return root
+
+
+def _posture(directory: Path, **overrides):
+    """A synthetic posture with healthy defaults; override exactly one axis.
+
+    Synthetic on purpose. Every branch of `state.dacl` has to be reachable from
+    a test that does not depend on the developer's box being elevated, having a
+    service registered, or being Windows at all -- two of these branches
+    survived mutation to `"pass"` with zero failures because every test drove
+    the same one.
+    """
+    from exomem import state_paths
+
+    fields = {
+        "directory": directory,
+        "present": True,
+        "accessible": True,
+        "unopenable_reason": None,
+        "verdict": "private",
+        "runtime_verdict": "private",
+        "child_verdict": "private",
+        "child_sampled": 3,
+        "observed": "O:SYD:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)",
+        "expected": ("S-1-5-21-1-2-3-1001", "SY", "BA"),
+        "runtime_expected": ("SY", "BA"),
+        "runtime_principal_source": "service:exomem",
+        "remediation": "icacls.exe 'X' /reset",
+    }
+    fields.update(overrides)
+    return state_paths.StateRootPosture(**fields)
+
+
+def _make_service_owned(directory: Path) -> None:
+    """Re-ACL *directory* to the SY/BA-only posture a LocalSystem service writes.
+
+    Skips when the calling token can still open the result. That is not a
+    workaround: an ELEVATED token is a member of `BUILTIN\\Administrators`, so
+    the `BA` ACE genuinely admits it and the cross-principal scenario does not
+    exist for that caller. Asserting inaccessibility anyway would make these
+    tests pass or fail on whether the runner happened to be elevated. The
+    synthetic-posture tests cover the same branches unconditionally.
+    """
+    from exomem import mutation_lock
+
+    mutation_lock._windows_apply_dacl_sddl(directory, _SERVICE_PRIVATE_SDDL)
+    try:
+        handle = mutation_lock._windows_open_path(directory, directory=True)
+    except OSError:
+        return
+    mutation_lock._windows_close_handle(handle)
+    _restore(directory)
+    pytest.skip(
+        "running elevated: the BA ACE admits this token, so a SY/BA-only root is "
+        "not cross-principal for it"
+    )
+
+
+def _restore(directory: Path) -> None:
+    """Give the test user its access back so tmpdir teardown can remove the tree."""
+    from exomem import mutation_lock
+
+    mutation_lock._windows_apply_private_dacl(
+        directory, mutation_lock._windows_current_user_sid()
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 1. The posture inspector names the cross-principal case
+# --------------------------------------------------------------------------- #
+
+
+def test_state_root_posture_accepts_a_root_this_token_created(vault: Path) -> None:
+    from exomem import state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+
+    posture = state_paths.inspect_state_root(vault)
+
+    assert posture.directory == directory
+    assert posture.present is True
+    assert posture.accessible is True
+    assert posture.cross_principal is False
+
+
+def test_state_root_posture_reports_an_absent_root_as_not_cross_principal(
+    vault: Path,
+) -> None:
+    from exomem import state_paths
+
+    posture = state_paths.inspect_state_root(vault)
+
+    assert posture.present is False
+    assert posture.cross_principal is False
+
+
+@windows_only
+def test_windows_state_root_posture_reports_a_service_owned_root_as_cross_principal(
+    vault: Path,
+) -> None:
+    from exomem import state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    _make_service_owned(directory)
+    try:
+        posture = state_paths.inspect_state_root(vault)
+
+        assert posture.present is True
+        assert posture.accessible is False
+        assert posture.cross_principal is True
+        # The observed descriptor and the trustees THIS token requires, so a
+        # report from another host is actionable without logging into it.
+        assert posture.observed is not None
+        assert "(A;OICI;FA;;;SY)" in posture.observed
+        assert posture.expected
+        assert posture.remediation is not None
+        assert "icacls" in posture.remediation
+        assert str(directory) in posture.remediation
+    finally:
+        _restore(directory)
+
+
+@windows_only
+def test_windows_a_junction_state_root_is_not_reported_as_cross_principal(
+    tmp_path: Path,
+) -> None:
+    """A reparse point is unopenable for a reason no `icacls` can repair.
+
+    Collapsing every open failure into one state diagnosed a junction as
+    "owned by another principal" and handed over an ACL repair that cannot work.
+    """
+    import subprocess
+
+    from exomem import mutation_lock
+
+    target = tmp_path / "real-target"
+    target.mkdir()
+    link = tmp_path / "junction"
+    # `mklink` is a cmd builtin, so it needs cmd; argv list, never a shell string.
+    created = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+        capture_output=True, check=False,
+    )
+    if created.returncode != 0 or not os.path.lexists(link):
+        pytest.skip("could not create a junction on this filesystem")
+
+    posture = mutation_lock.inspect_windows_private_directory(link)
+
+    assert posture is not None
+    assert posture.accessible is False
+    assert posture.unopenable_reason == "reparse-point"
+
+
+# --------------------------------------------------------------------------- #
+# 2a. Doctor FAILs on a root DACL the running principal will reject
+# --------------------------------------------------------------------------- #
+
+
+def test_doctor_state_dacl_passes_on_a_root_this_token_owns(vault: Path) -> None:
+    from exomem import doctor, state_paths
+
+    state_paths.ensure_vault_state_dir(vault)
+
+    check = doctor._check_state_root_dacl(vault)
+
+    assert check.id == "state.dacl"
+    assert check.status == "pass"
+
+
+def _pin_posture(monkeypatch: pytest.MonkeyPatch, directory: Path, **overrides):
+    from exomem import state_paths
+
+    monkeypatch.setattr(
+        state_paths, "inspect_state_root", lambda _root: _posture(directory, **overrides)
+    )
+
+
+def test_doctor_state_dacl_fails_when_the_runtime_principal_rejects_the_dacl(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Manifestation 1, seen from the side that matters: the SERVICE's.
+
+    Pins the branch that a mutation to `"pass"` survived with zero failures,
+    because every other `state.dacl` test drove the cross-principal branch.
+    """
+    from exomem import doctor, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    _pin_posture(monkeypatch, directory, verdict="private", runtime_verdict="unsafe")
+
+    check = doctor._check_state_root_dacl(vault)
+
+    assert check.id == "state.dacl"
+    assert check.status == "fail"
+    assert check.remediation is not None and "icacls" in check.remediation
+    assert check.details is not None
+    assert check.details["state_root"] == str(directory)
+    assert check.details["runtime_dacl_verdict"] == "unsafe"
+
+
+def test_doctor_state_dacl_warns_when_the_descriptor_could_not_be_read(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An un-evaluated trustee set is its own state, never a pass.
+
+    The second branch that survived mutation to `"pass"`.
+    """
+    from exomem import doctor, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    _pin_posture(
+        monkeypatch, directory, verdict=None, runtime_verdict=None, observed=None
+    )
+
+    check = doctor._check_state_root_dacl(vault)
+
+    assert check.status == "warn"
+    assert "unverified" in check.message
+    assert check.details is not None
+    assert check.details["runtime_dacl_verdict"] is None
+
+
+def test_doctor_state_dacl_passes_on_a_healthy_service_root_the_caller_cannot_open(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The ship blocker: a correct LocalSystem root must not be red to operators.
+
+    Measured, not assumed — a real `D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)` root
+    reads `verdict=unsafe, accessible=False` from any operator token. Judging
+    cell health by the caller would FAIL every healthy Windows service install,
+    including inside `upgrade.ps1`'s own doctor gate, which runs as the operator.
+    """
+    from exomem import doctor, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    _pin_posture(
+        monkeypatch,
+        directory,
+        accessible=False,
+        unopenable_reason="access-denied",
+        verdict="unsafe",          # the operator's view of a healthy root
+        runtime_verdict="private",  # the service's view of the same root
+    )
+
+    check = doctor._check_state_root_dacl(vault)
+
+    assert check.status == "pass"
+    assert "cannot open it" in check.message
+    assert check.details is not None
+    assert check.details["accessible"] is False
+
+
+def test_doctor_state_dacl_fails_on_an_alias_root_without_offering_an_acl_repair(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A junction is a real refusal with no ACL that fixes it."""
+    from exomem import doctor, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    _pin_posture(
+        monkeypatch, directory, accessible=False, unopenable_reason="reparse-point"
+    )
+
+    check = doctor._check_state_root_dacl(vault)
+
+    assert check.status == "fail"
+    assert "reparse point" in check.message
+    assert check.remediation is not None
+    assert "icacls" not in check.remediation
+    assert "not repairable with an ACL change" in check.remediation
+
+
+def test_doctor_state_dacl_names_the_path_even_when_the_posture_is_undeterminable(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import doctor, state_paths
+
+    directory = state_paths.vault_state_dir(vault)
+    monkeypatch.setattr(
+        state_paths,
+        "inspect_state_root",
+        lambda _root: (_ for _ in ()).throw(OSError("token identity unavailable")),
+    )
+
+    check = doctor._check_state_root_dacl(vault)
+
+    assert check.status == "fail"
+    assert check.details is not None
+    # A finding that cannot name its path is not actionable from a remote report.
+    assert check.details["state_root"] == str(directory)
+
+
+@windows_only
+def test_windows_doctor_state_dacl_fails_on_a_service_owned_root_without_raising(
+    vault: Path,
+) -> None:
+    from exomem import doctor, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    _make_service_owned(directory)
+    try:
+        check = doctor._check_state_root_dacl(vault)
+
+        assert check.id == "state.dacl"
+        assert check.status == "fail"
+        assert check.details is not None
+        assert check.details["accessible"] is False
+        assert check.remediation is not None and "icacls" in check.remediation
+    finally:
+        _restore(directory)
+
+
+def test_doctor_reports_state_dacl_in_its_check_set(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import doctor
+
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(vault))
+    report = doctor.doctor(profile="lean")
+
+    assert "state.dacl" in {check.id for check in report.checks}
+
+
+# --------------------------------------------------------------------------- #
+# 2b. Doctor degrades to a finding on state it cannot read
+# --------------------------------------------------------------------------- #
+
+
+class _DeniedPath(type(Path())):  # type: ignore[misc]
+    """A path whose stat-backed probes fail the way a foreign DACL makes them."""
+
+    def exists(self, *args: object, **kwargs: object) -> bool:
+        raise PermissionError(13, "Access is denied", str(self))
+
+    def stat(self, *args: object, **kwargs: object) -> os.stat_result:
+        raise PermissionError(13, "Access is denied", str(self))
+
+
+def test_doctor_lexical_check_reports_an_unreadable_sidecar_instead_of_raising(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import doctor, lexstore
+
+    denied = _DeniedPath(lexstore.lexical_path(vault))
+    monkeypatch.setattr(lexstore, "backend", lambda: "fts5")
+    monkeypatch.setattr(lexstore, "fts5_available", lambda: True)
+    monkeypatch.setattr(lexstore, "lexical_path", lambda _root: denied)
+
+    check = doctor._check_lexical(vault)
+
+    # Not a crash, and not a confident "the sidecar will be built on first
+    # search" either: an inaccessible sidecar is not an absent one, and
+    # `os.path.exists` would have reported exactly that false absence.
+    assert check.status in {"warn", "fail"}
+    assert "could not be inspected" in check.message
+    assert "will be built" not in check.message
+    assert check.remediation is not None and "state.dacl" in check.remediation
+
+
+def test_doctor_deferred_backlog_check_survives_an_unreadable_sidecar(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import doctor, lexstore
+
+    denied = _DeniedPath(lexstore.lexical_path(vault))
+    monkeypatch.setattr(lexstore, "lexical_path", lambda _root: denied)
+
+    check = doctor._check_deferred_index_backlog(vault)
+
+    assert check.id == "deferred_index_backlog"
+    assert check.status in {"pass", "warn", "fail"}
+
+
+@windows_only
+def test_windows_doctor_completes_end_to_end_against_a_service_owned_root(
+    vault: Path,
+) -> None:
+    """No check may crash the run on a root another principal governs.
+
+    Found by driving the real CLI rather than the units: `state.dacl` reported
+    the cause correctly and then `rebuild_temp.orphans` killed the process one
+    check later on `iterdir`. Hardening only the sites the issue named leaves
+    doctor just as unusable during the incident it is meant to diagnose.
+    """
+    from exomem import doctor, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    _make_service_owned(directory)
+    try:
+        report = doctor.doctor(vault=str(vault), profile="lean")
+    finally:
+        _restore(directory)
+
+    ids = {check.id for check in report.checks}
+    assert "state.dacl" in ids
+    assert "rebuild_temp.orphans" in ids
+    dacl = next(c for c in report.checks if c.id == "state.dacl")
+    assert dacl.status == "fail"
+    orphans = next(c for c in report.checks if c.id == "rebuild_temp.orphans")
+    # Not a confident "no orphans found" over a directory it could not list.
+    assert orphans.status == "warn"
+    assert "could not be inspected" in orphans.message
+
+
+def test_doctor_rebuild_temp_orphans_reports_an_unlistable_state_root(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import doctor, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+
+    class _UnlistablePath(type(Path())):  # type: ignore[misc]
+        def iterdir(self):
+            raise PermissionError(13, "Access is denied", str(self))
+
+    monkeypatch.setattr(
+        state_paths, "vault_state_dir", lambda _root: _UnlistablePath(directory)
+    )
+
+    check = doctor._check_rebuild_temp_orphans(vault)
+
+    assert check.status == "warn"
+    assert "could not be inspected" in check.message
+    assert check.details is not None
+    assert check.details["unreadable_roots"] == [str(directory)]
+
+
+def test_doctor_rebuild_temp_orphans_never_downgrades_a_real_leak_to_warn(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An un-scanned root makes a finding less CERTAIN, not less severe.
+
+    Short-circuiting on the unreadable root turned a genuine leak into a warn,
+    and `DoctorReport.success` gates on `fail` — so the leak stopped failing the
+    run at exactly the moment state was hardest to inspect.
+    """
+    import time
+
+    from exomem import doctor, state_paths
+    from exomem import vault as vault_module
+    from exomem.kbdir import kb_dirname
+
+    state_paths.ensure_vault_state_dir(vault)
+    stale = time.time() - vault_module.REBUILD_TEMP_STALE_AGE_SECONDS - 60
+    kb = vault / kb_dirname()
+    for index in range(_REBUILD_TEMP_ORPHAN_FAIL_COUNT + 1):
+        name = f".graph-rebuild-{index:064x}-{index:024x}.sqlite"
+        # Asserted against the canonical matcher rather than trusting the shape:
+        # a name this check does not recognise would make the test vacuous.
+        assert vault_module.is_graph_rebuild_runtime_file_name(name)
+        orphan = kb / name
+        orphan.write_bytes(b"x" * (12 * 1024 * 1024))
+        os.utime(orphan, (stale, stale))
+
+    class _UnlistablePath(type(Path())):  # type: ignore[misc]
+        def iterdir(self):
+            raise PermissionError(13, "Access is denied", str(self))
+
+    unlistable = _UnlistablePath(state_paths.vault_state_dir(vault))
+    monkeypatch.setattr(state_paths, "vault_state_dir", lambda _root: unlistable)
+
+    check = doctor._check_rebuild_temp_orphans(vault)
+
+    assert check.status == "fail", "an unreadable root must not mask a real leak"
+    assert "could not be inspected" in check.message
+    assert "this count is a floor" in check.message
+
+
+# --------------------------------------------------------------------------- #
+# 3. CLI maintenance refuses up front instead of crashing part-way through
+# --------------------------------------------------------------------------- #
+
+
+def _cross_principal_posture(directory: Path):
+    return _posture(
+        directory,
+        accessible=False,
+        unopenable_reason="access-denied",
+        verdict="unsafe",
+        runtime_verdict="private",
+    )
+
+
+def _openable_but_unsafe_posture(directory: Path):
+    """The half the first pre-flight missed — and the half the service was on.
+
+    LocalSystem holds an `SY` full-access ACE on a `user+SY+BA` root, so it OPENS
+    the root fine and then rejects the trustee set at every private-state
+    boundary behind it.
+    """
+    return _posture(directory, accessible=True, verdict="unsafe", runtime_verdict="unsafe")
+
+
+def test_maintain_refuses_a_cross_principal_state_root_before_any_work(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import commands, state_paths
+    from exomem.cli_ops import OpError
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    monkeypatch.setattr(
+        state_paths, "inspect_state_root", lambda _root: _cross_principal_posture(directory)
+    )
+    reached = []
+    monkeypatch.setattr(
+        commands,
+        "op_reconcile",
+        lambda *a, **k: reached.append(True),
+    )
+
+    with pytest.raises(OpError) as raised:
+        commands.op_maintain_memory(vault, mode="reconcile", rebuild_graph=True)
+
+    assert raised.value.code == "STATE_ROOT_CROSS_PRINCIPAL"
+    assert raised.value.remediation is not None
+    assert "icacls" in raised.value.remediation
+    assert reached == [], "the refusal must precede every unit of maintenance work"
+
+
+def test_maintain_refuses_an_openable_but_unsafe_state_root_before_any_work(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """H1: gating only on "cannot open" let the SERVICE's failure straight through.
+
+    A LocalSystem service opens a `user+SY+BA` root through its own `SY` ACE, so
+    `cross_principal` is False — and `maintain` then proceeded into
+    `ensure_vault_state_dir` and died there with a raw `WindowsRuntimeDaclError`,
+    which is the exact failure this pre-flight exists to remove.
+    """
+    from exomem import commands, state_paths
+    from exomem.cli_ops import OpError
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    monkeypatch.setattr(
+        state_paths,
+        "inspect_state_root",
+        lambda _root: _openable_but_unsafe_posture(directory),
+    )
+    reached = []
+    monkeypatch.setattr(commands, "op_reconcile", lambda *a, **k: reached.append(True))
+
+    with pytest.raises(OpError) as raised:
+        commands.op_maintain_memory(vault, mode="reconcile", rebuild_graph=True)
+
+    assert raised.value.code == "STATE_ROOT_CROSS_PRINCIPAL"
+    assert "private-state validator rejects" in str(raised.value)
+    assert reached == [], "the refusal must precede every unit of maintenance work"
+
+
+def test_maintain_does_not_call_an_alias_root_a_cross_principal_one(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A junction is unopenable, but not by a principal — and no `icacls` fixes it.
+
+    Pins `cross_principal` to the access-denied reason specifically. Widening it
+    back to "any open failure" hands the operator an ACL repair for a path
+    problem, which is the shape medium finding 2 describes.
+    """
+    from exomem import commands, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    monkeypatch.setattr(
+        state_paths,
+        "inspect_state_root",
+        lambda _root: _posture(
+            directory, accessible=False, unopenable_reason="reparse-point"
+        ),
+    )
+    monkeypatch.setattr(commands, "op_audit", lambda *a, **k: {"ran": True})
+
+    posture = state_paths.inspect_state_root(vault)
+    assert posture.cross_principal is False
+    assert posture.blocks_current_token is False
+    # And so the DACL pre-flight stays silent: the alias is refused at the
+    # private-state boundary that can actually describe it, and `state.dacl`
+    # reports it without offering an ACL repair.
+    assert commands.op_maintain_memory(vault, mode="audit") == {"ran": True}
+
+
+def test_maintain_reports_a_stable_code_when_its_own_preflight_cannot_inspect(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard must not emit the kind of raw error it exists to replace."""
+    from exomem import commands, state_paths
+    from exomem.cli_ops import OpError
+
+    monkeypatch.setattr(
+        state_paths,
+        "inspect_state_root",
+        lambda _root: (_ for _ in ()).throw(
+            ValueError("EXOMEM_STATE_ROOT must be an absolute path")
+        ),
+    )
+
+    with pytest.raises(OpError) as raised:
+        commands.op_maintain_memory(vault, mode="audit")
+
+    assert raised.value.code == "STATE_ROOT_UNREADABLE"
+
+
+def test_maintain_audit_also_refuses_a_cross_principal_state_root(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import commands, state_paths
+    from exomem.cli_ops import OpError
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    monkeypatch.setattr(
+        state_paths, "inspect_state_root", lambda _root: _cross_principal_posture(directory)
+    )
+
+    with pytest.raises(OpError) as raised:
+        commands.op_maintain_memory(vault, mode="audit")
+
+    assert raised.value.code == "STATE_ROOT_CROSS_PRINCIPAL"
+
+
+def test_maintain_runs_normally_when_the_state_root_is_this_token_s(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import commands, state_paths
+
+    state_paths.ensure_vault_state_dir(vault)
+    monkeypatch.setattr(commands, "op_reconcile", lambda *a, **k: {"ran": True})
+
+    assert commands.op_maintain_memory(vault, mode="reconcile") == {"ran": True}
+
+
+def test_offline_state_migration_refuses_a_cross_principal_state_root(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import state_migration, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    monkeypatch.setattr(
+        state_paths, "inspect_state_root", lambda _root: _cross_principal_posture(directory)
+    )
+    monkeypatch.setattr(
+        state_migration,
+        "_resolve_locked",
+        lambda *a, **k: pytest.fail("migration must refuse before taking the lock"),
+    )
+
+    authority = state_migration.assert_offline_migration_authority(source="test")
+    with pytest.raises(state_paths.StateRootAccessDenied) as raised:
+        state_migration.migrate_vault_state_offline(vault, authority=authority)
+
+    # The stable code, not a substring of the prose: `upgrade.ps1` consumes the
+    # JSON envelope this reaches, and a message-only envelope cannot be branched on.
+    assert raised.value.code == "STATE_ROOT_CROSS_PRINCIPAL"
+    assert "icacls" in (raised.value.remediation or "")
+
+
+def test_offline_migration_json_envelope_carries_the_stable_code(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    import json
+
+    from exomem import __main__ as main_module
+    from exomem import state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    monkeypatch.setattr(
+        main_module,
+        "_run_offline_state_migration",
+        lambda **_k: (_ for _ in ()).throw(
+            state_paths.StateRootAccessDenied(_cross_principal_posture(directory))
+        ),
+    )
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(vault))
+
+    exit_code = main_module._simple_maintain_main(["--migrate-state", "--offline", "--json"])
+
+    assert exit_code == 1
+    envelope = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert envelope["success"] is False
+    assert envelope["error"]["code"] == "STATE_ROOT_CROSS_PRINCIPAL"
+
+
+# --------------------------------------------------------------------------- #
+# 4. Runtime-principal resolution (requirement 1)
+# --------------------------------------------------------------------------- #
+
+
+@windows_only
+def test_runtime_principal_is_the_current_token_without_a_service_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No service install leaves single-principal behaviour byte-identical."""
+    from exomem import mutation_lock
+
+    monkeypatch.delenv("EXOMEM_RUNTIME_PRINCIPAL", raising=False)
+    monkeypatch.setattr(mutation_lock, "_windows_service_object_name", lambda _n: None)
+
+    principal = mutation_lock.resolve_windows_runtime_principal()
+
+    assert principal.sid == mutation_lock._windows_current_user_sid()
+    assert principal.source == "current-token"
+    assert principal.authoritative is False
+
+
+@windows_only
+def test_runtime_principal_reads_the_service_account_from_the_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import mutation_lock
+
+    monkeypatch.delenv("EXOMEM_RUNTIME_PRINCIPAL", raising=False)
+    monkeypatch.setattr(
+        mutation_lock,
+        "_windows_service_object_name",
+        lambda name: "LocalSystem" if name == "exomem" else None,
+    )
+
+    principal = mutation_lock.resolve_windows_runtime_principal()
+
+    assert principal.sid == "S-1-5-18"
+    assert principal.source == "service:exomem"
+    assert principal.authoritative is True
+
+
+@windows_only
+def test_runtime_principal_degrades_with_a_named_reason_when_unresolvable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unresolvable account must never become a guessed principal.
+
+    Sealing to the wrong principal locks out the operator AND the service at
+    once, which is strictly worse than not sealing at all.
+    """
+    from exomem import mutation_lock
+
+    monkeypatch.delenv("EXOMEM_RUNTIME_PRINCIPAL", raising=False)
+    monkeypatch.setattr(
+        mutation_lock, "_windows_service_object_name", lambda _n: "NoSuchAccount"
+    )
+    monkeypatch.setattr(mutation_lock, "_windows_sid_for_account", lambda _a: None)
+
+    principal = mutation_lock.resolve_windows_runtime_principal()
+
+    assert principal.sid == mutation_lock._windows_current_user_sid()
+    assert principal.source.startswith("current-token (")
+    assert "unresolvable" in principal.source
+    # Load-bearing: a degraded principal must not authorise re-ACLing anything.
+    assert principal.authoritative is False
+
+
+@windows_only
+def test_seal_is_a_noop_when_the_runtime_principal_is_the_current_token(
+    vault: Path,
+) -> None:
+    from exomem import mutation_lock, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    before = mutation_lock._windows_dacl_sddl(directory)
+
+    assert state_paths.seal_state_root_for_runtime_principal(vault) is None
+    assert mutation_lock._windows_dacl_sddl(directory) == before
+
+
+@windows_only
+def test_an_unresolvable_principal_leaves_the_dacl_completely_untouched(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Degrade, never guess. A garbage override falls back to the current token,
+    which makes the seal a no-op rather than a rewrite to the wrong principal."""
+    from exomem import mutation_lock, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    before = mutation_lock._windows_dacl_sddl(directory)
+    monkeypatch.setenv("EXOMEM_RUNTIME_PRINCIPAL", "not-a-sid")
+
+    assert state_paths.seal_state_root_for_runtime_principal(vault) is None
+    assert mutation_lock._windows_dacl_sddl(directory) == before
+    # And the degradation is visible rather than indistinguishable from clean.
+    principal = mutation_lock.resolve_windows_runtime_principal()
+    assert "is not a SID" in principal.source
+    assert principal.authoritative is False
+
+
+@windows_only
+def test_seal_refuses_a_degraded_principal_rather_than_re_acling_on_a_guess(
+    vault: Path,
+) -> None:
+    """The guard for a caller that hands in a principal it could not establish."""
+    from exomem import mutation_lock, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    before = mutation_lock._windows_dacl_sddl(directory)
+    degraded = mutation_lock.WindowsRuntimePrincipal(
+        sid="S-1-5-18", source="current-token (registry unreadable)"
+    )
+
+    with pytest.raises(mutation_lock.WindowsRuntimePrincipalUnresolved):
+        mutation_lock.seal_windows_state_root_for_runtime_principal(
+            directory, runtime_principal=degraded
+        )
+
+    assert mutation_lock._windows_dacl_sddl(directory) == before
+
+
+@windows_only
+def test_seal_refuses_to_re_acl_a_root_this_process_does_not_own(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Never re-ACL a root you do not own — an explicit invariant of #933."""
+    from exomem import mutation_lock, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    monkeypatch.setattr(
+        mutation_lock, "_windows_owner_admits_current_user", lambda _o, _s: False
+    )
+    before = mutation_lock._windows_dacl_sddl(directory)
+
+    with pytest.raises(mutation_lock.WindowsRuntimePrincipalUnresolved) as raised:
+        mutation_lock.seal_windows_state_root_for_runtime_principal(
+            directory,
+            runtime_principal=mutation_lock.WindowsRuntimePrincipal(
+                sid="S-1-5-18", source="service:exomem"
+            ),
+        )
+
+    assert "does not own" in str(raised.value)
+    assert mutation_lock._windows_dacl_sddl(directory) == before
+
+
+@windows_only
+def test_seal_leaves_a_root_the_runtime_principals_own_validator_accepts(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Requirement 1, asserted with the validator itself rather than an SDDL literal.
+
+    The seal is caught rather than allowed to propagate. `conftest` converts a
+    `WindowsRuntimeDaclError` into a SKIP (it is in
+    `_HOSTED_POSIX_OWNERSHIP_REFUSAL`), so letting the fail-closed path raise
+    out of here would turn a real regression in this Windows-only code into a
+    silent skip on the only platform that runs it.
+    """
+    from exomem import mutation_lock, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    monkeypatch.setenv("EXOMEM_RUNTIME_PRINCIPAL", "S-1-5-18")
+    try:
+        sealed = None
+        raised: str | None = None
+        try:
+            sealed = state_paths.seal_state_root_for_runtime_principal(vault)
+        except Exception as error:  # noqa: BLE001 - see the docstring
+            raised = repr(error)
+        # Outside the handler on purpose: raising inside it would leave the
+        # refusal as this failure's `__context__`, and conftest's skip walker
+        # follows that chain -- which is how the mutant first came back "skipped".
+        if raised is not None:
+            pytest.fail(f"seal did not apply the runtime principal's DACL: {raised}")
+
+        assert sealed is not None and sealed.sid == "S-1-5-18"
+        observed = mutation_lock._windows_dacl_sddl(directory)
+        assert mutation_lock._windows_private_dacl_is_valid(
+            observed, "S-1-5-18", directory=True
+        ), observed
+        # And it is genuinely no longer this token's: the two views disagree,
+        # which is the whole point of resolving a runtime principal.
+        assert not mutation_lock._windows_private_dacl_is_valid(
+            observed, mutation_lock._windows_current_user_sid(), directory=True
+        )
+    finally:
+        _restore(directory)
+
+
+@windows_only
+def test_offline_migration_seals_the_root_for_the_service_principal(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End of requirement 1: the migration is what leaves the root correct."""
+    from exomem import mutation_lock, state_migration, state_paths
+
+    directory = state_paths.vault_state_dir(vault)
+    monkeypatch.setenv("EXOMEM_RUNTIME_PRINCIPAL", "S-1-5-18")
+    try:
+        authority = state_migration.assert_offline_migration_authority(source="test")
+        state_migration.migrate_vault_state_offline(vault, authority=authority)
+
+        observed = mutation_lock._windows_dacl_sddl(directory)
+        assert mutation_lock._windows_private_dacl_is_valid(
+            observed, "S-1-5-18", directory=True
+        ), observed
+    finally:
+        _restore(directory)
+
+
+@windows_only
+def test_windows_maintain_refuses_a_real_service_owned_state_root(vault: Path) -> None:
+    from exomem import commands, state_paths
+    from exomem.cli_ops import OpError
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    _make_service_owned(directory)
+    try:
+        with pytest.raises(OpError) as raised:
+            commands.op_maintain_memory(vault, mode="reconcile", rebuild_graph=True)
+
+        assert raised.value.code == "STATE_ROOT_CROSS_PRINCIPAL"
+        assert str(directory) in (raised.value.remediation or "")
+    finally:
+        _restore(directory)
+
+
+# --------------------------------------------------------------------------- #
+# Round 3: the seal's scope, its reach, and its proof
+# --------------------------------------------------------------------------- #
+
+
+@windows_only
+def test_seal_refuses_a_vault_the_service_is_not_bound_to(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """H1. A machine having a service says nothing about an unrelated vault.
+
+    Without this, `exomem init` of a brand-new vault on a box that happens to
+    have a service registered handed its state root to LocalSystem and locked
+    the operator out of the directory it had just made for them.
+    """
+    from exomem import mutation_lock, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    before = mutation_lock._windows_dacl_sddl(directory)
+    monkeypatch.delenv("EXOMEM_RUNTIME_PRINCIPAL", raising=False)
+    monkeypatch.setattr(
+        mutation_lock, "_windows_service_object_name",
+        lambda name: "LocalSystem" if name == "exomem" else None,
+    )
+    monkeypatch.setattr(
+        mutation_lock, "_windows_service_bound_vault",
+        lambda _name: str(vault.parent / "some-other-vault"),
+    )
+
+    assert state_paths.seal_state_root_for_runtime_principal(vault) is None
+    assert mutation_lock._windows_dacl_sddl(directory) == before
+    # The operator keeps the access they had before, which is the whole point.
+    assert os.listdir(directory) is not None
+
+
+@windows_only
+def test_seal_accepts_the_vault_the_service_is_bound_to(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other side of H1: the upgrade path must still seal."""
+    from exomem import mutation_lock, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    monkeypatch.delenv("EXOMEM_RUNTIME_PRINCIPAL", raising=False)
+    monkeypatch.setattr(
+        mutation_lock, "_windows_service_object_name",
+        lambda name: "LocalSystem" if name == "exomem" else None,
+    )
+    # A different spelling of the same vault, to prove the comparison normalises
+    # rather than string-matches.
+    monkeypatch.setattr(
+        mutation_lock, "_windows_service_bound_vault",
+        lambda _name: str(vault).upper(),
+    )
+    try:
+        sealed = state_paths.seal_state_root_for_runtime_principal(vault)
+        assert sealed is not None and sealed.sid == "S-1-5-18"
+    finally:
+        _restore(directory)
+
+
+@windows_only
+def test_seal_refuses_a_binding_it_could_not_read(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreadable binding is "do not act", never "no binding exists"."""
+    from exomem import mutation_lock, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    before = mutation_lock._windows_dacl_sddl(directory)
+    monkeypatch.delenv("EXOMEM_RUNTIME_PRINCIPAL", raising=False)
+    monkeypatch.setattr(
+        mutation_lock, "_windows_service_object_name",
+        lambda name: "LocalSystem" if name == "exomem" else None,
+    )
+    monkeypatch.setattr(mutation_lock, "_windows_service_bound_vault", lambda _n: None)
+
+    assert state_paths.seal_state_root_for_runtime_principal(vault) is None
+    assert mutation_lock._windows_dacl_sddl(directory) == before
+
+
+@windows_only
+def test_seal_protects_the_state_inside_the_root_not_just_the_entry(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """H2. A root that merely LOOKS sealed is worse than an honestly unsealed one.
+
+    Protecting the directory alone makes Windows convert each child's inherited
+    ACEs into explicit ones, so every file the migration just moved in stayed
+    readable and writable by the operator behind a directory that refused a
+    listing -- and `state.dacl` reported pass.
+    """
+    from exomem import mutation_lock, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    child = directory / "state.sqlite"
+    child.write_bytes(b"PRE-EXISTING SECRET STATE")
+    monkeypatch.setenv("EXOMEM_RUNTIME_PRINCIPAL", "S-1-5-18")
+    seal_error = None
+    reachable = []
+    try:
+        try:
+            sealed = state_paths.seal_state_root_for_runtime_principal(vault)
+        except Exception as error:  # noqa: BLE001 - conftest skips on this type
+            seal_error, sealed = type(error).__name__, None
+        for name, probe in (
+            ("read", lambda: child.read_bytes()),
+            ("write", lambda: child.open("ab").close()),
+            ("stat", lambda: child.stat()),
+        ):
+            try:
+                probe()
+                reachable.append(name)
+            except PermissionError:
+                pass
+        observed = mutation_lock._windows_dacl_sddl(child)
+    finally:
+        mutation_lock._windows_apply_private_dacl(
+            directory, mutation_lock._windows_current_user_sid(), propagate=True
+        )
+    # Asserted outside every handler: conftest converts `WindowsRuntimeDaclError`
+    # into a SKIP and follows `__context__` to do it (issue #952), so a raise in
+    # here would hide a regression instead of failing on it.
+    assert seal_error is None, f"seal raised {seal_error}"
+    assert sealed is not None
+    assert reachable == [], f"operator can still {reachable} inside a sealed root"
+    # The child's own DACL no longer grants this token. Compared against the DACL
+    # section only: the owner field still names the creating account, and
+    # ownership is not access.
+    assert mutation_lock._windows_current_user_sid() not in observed.split("D:", 1)[1]
+
+
+def test_doctor_state_dacl_fails_when_children_are_not_private(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reporting half of H2: a private root over non-private state is a FAIL."""
+    from exomem import doctor, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    _pin_posture(monkeypatch, directory, runtime_verdict="private",
+                 child_verdict="unsafe")
+
+    check = doctor._check_state_root_dacl(vault)
+
+    assert check.status == "fail"
+    assert "state INSIDE it is not" in check.message
+    assert check.details is not None
+    assert check.details["child_dacl_verdict"] == "unsafe"
+
+
+@windows_only
+def test_seal_refuses_an_aliased_state_root(tmp_path: Path) -> None:
+    """Item 4. The seal is the only DACL write that never opened a handle."""
+    import subprocess
+
+    from exomem import mutation_lock
+
+    target = tmp_path / "real-target"
+    target.mkdir()
+    link = tmp_path / "junction"
+    created = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+        capture_output=True, check=False,
+    )
+    if created.returncode != 0 or not os.path.lexists(link):
+        pytest.skip("could not create a junction on this filesystem")
+    before = mutation_lock._windows_dacl_sddl(target)
+
+    with pytest.raises(mutation_lock.WindowsReparsePointError):
+        mutation_lock.seal_windows_state_root_for_runtime_principal(
+            link,
+            runtime_principal=mutation_lock.WindowsRuntimePrincipal(
+                sid="S-1-5-18", source="pinned:S-1-5-18"
+            ),
+        )
+
+    # The real root behind the junction was never touched.
+    assert mutation_lock._windows_dacl_sddl(target) == before
+
+
+@windows_only
+def test_seal_proves_the_write_took(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """M1. The seal's own fail-closed proof, which survived round 2's mutation.
+
+    A seal that reports success without checking is how a root gets recorded as
+    sealed while carrying whatever the write actually left behind.
+    """
+    from exomem import mutation_lock, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    monkeypatch.setenv("EXOMEM_RUNTIME_PRINCIPAL", "S-1-5-18")
+    # The write silently does nothing; only the post-write validation can catch it.
+    monkeypatch.setattr(
+        mutation_lock, "_windows_apply_private_dacl", lambda *a, **k: None
+    )
+    raised = None
+    try:
+        state_paths.seal_state_root_for_runtime_principal(vault)
+    except Exception as error:  # noqa: BLE001 - conftest skips on this type
+        raised = type(error).__name__
+    finally:
+        _restore(directory)
+    # Asserted outside the handler: conftest's skip walker follows __context__
+    # and would turn this failure into a silent skip (issue #952).
+    assert raised == "WindowsRuntimeDaclError", raised
+
+
+def test_maintain_refuses_an_unopenable_root_of_unknown_cause(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Item 3. Narrowing `cross_principal` must not leave a passable residual.
+
+    A sharing violation or a not-ready device is un-evaluated, and un-evaluated
+    is not safe: round 1 refused on any `accessible=False` and that floor holds.
+    """
+    from exomem import commands, state_paths
+    from exomem.cli_ops import OpError
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    monkeypatch.setattr(
+        state_paths, "inspect_state_root",
+        lambda _root: _posture(
+            directory, accessible=False, unopenable_reason="unopenable"
+        ),
+    )
+
+    posture = state_paths.inspect_state_root(vault)
+    assert posture.cross_principal is False
+    assert posture.blocks_current_token is True
+
+    with pytest.raises(OpError) as raised:
+        commands.op_maintain_memory(vault, mode="audit")
+    assert raised.value.code == "STATE_ROOT_CROSS_PRINCIPAL"
+    assert "unverified" in str(raised.value)
+
+
+def test_doctor_withholds_a_token_relative_repair_when_the_principal_is_unresolved(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Item 2. A repair for the wrong principal restarts the ACL ping-pong."""
+    from exomem import doctor, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    _pin_posture(
+        monkeypatch, directory,
+        runtime_verdict="unsafe",
+        runtime_principal_source="current-token (service 'exomem' account is unresolvable)",
+    )
+
+    check = doctor._check_state_root_dacl(vault)
+
+    assert check.status == "fail"
+    assert check.remediation is not None
+    assert "icacls" not in check.remediation
+    assert "could not be established" in check.remediation
+
+
+def test_a_pinned_current_token_is_not_read_as_a_degraded_principal(
+    vault: Path,
+) -> None:
+    """`pinned:` and `current-token (...)` must stay distinguishable.
+
+    The conftest pins `current-token` for isolation; if that read as a
+    degradation, every test would exercise the withheld-repair path instead of
+    the real one.
+    """
+    from exomem import state_paths
+
+    state_paths.ensure_vault_state_dir(vault)
+    posture = state_paths.inspect_state_root(vault)
+
+    assert posture.runtime_principal_unresolved is False
+
+
+@windows_only
+def test_the_real_registry_readers_answer_in_the_expected_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise the real SCM readers, asserting only on shape.
+
+    Box-independent by construction: this machine may or may not have a service
+    registered, and either answer is valid. What must hold is that the readers
+    run against the real registry without raising and produce a `source` this
+    module's own consumers can branch on.
+    """
+    from exomem import mutation_lock
+
+    # The conftest pins this for isolation; drop it so the REAL readers run.
+    monkeypatch.delenv("EXOMEM_RUNTIME_PRINCIPAL", raising=False)
+    principal = mutation_lock.resolve_windows_runtime_principal()
+
+    assert principal.sid.startswith("S-1-")
+    # The degraded form is admitted too: on a box whose service account is
+    # unresolvable, `current-token (...)` is the CORRECT answer, and a test
+    # that rejects it is exactly the box-dependency it was written to avoid.
+    assert (
+        principal.source.startswith("service:")
+        or principal.source == "current-token"
+        or principal.source.startswith("current-token (")
+    ), principal.source
+    if principal.source.startswith("service:"):
+        assert principal.bound_vault is None or isinstance(principal.bound_vault, str)
+    else:
+        assert principal.bound_vault is None
+
+
+@windows_only
+def test_the_child_sampler_reports_a_foreign_ace_on_a_private_root(
+    tmp_path: Path,
+) -> None:
+    """H2's detector, exercised for real rather than through a synthetic posture.
+
+    A root can be `private` while a single child inside it admits a foreign
+    trustee, which is exactly the shape a non-propagating seal leaves behind.
+    """
+    from exomem import mutation_lock
+
+    sid = mutation_lock._windows_current_user_sid()
+    root = tmp_path / "root"
+    root.mkdir()
+    mutation_lock._windows_apply_private_dacl(root, sid)
+    (root / "good.sqlite").write_bytes(b"x")
+
+    assert mutation_lock._windows_child_dacl_verdict(root, sid) == ("private", 1)
+
+    # `WD` is Everyone: a trustee outside the private set, on one child only.
+    # Named to sort AFTER the clean one deliberately -- an aggregation that only
+    # escalates on the first child it sees would miss exactly this.
+    bad = root / "zzz-bad.sqlite"
+    bad.write_bytes(b"x")
+    mutation_lock._windows_apply_dacl_sddl(
+        bad, f"D:P(A;;FA;;;{sid})(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;WD)"
+    )
+
+    assert mutation_lock._windows_child_dacl_verdict(root, sid)[0] == "unsafe"
+    # The root itself still reads clean -- which is why the root descriptor
+    # alone cannot answer whether the state inside it is private.
+    assert mutation_lock._windows_private_dacl_verdict(
+        mutation_lock._windows_dacl_sddl(root), sid, directory=True
+    ) == "private"
+
+
+# --------------------------------------------------------------------------- #
+# Round 4: say what was not checked, prove what was claimed, degrade honestly
+# --------------------------------------------------------------------------- #
+
+
+def test_doctor_pass_says_so_when_the_contents_were_not_evaluated(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """MEDIUM 1. A sealed root denies the operator's listing, so nothing inside
+    it is examined -- and a PASS that asserts privacy unqualified is exactly the
+    confidently-green report that cost a day in the original incident."""
+    from exomem import doctor, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    _pin_posture(
+        monkeypatch, directory,
+        accessible=False, unopenable_reason="access-denied",
+        verdict="unsafe", runtime_verdict="private",
+        child_verdict=None, child_sampled=0,
+    )
+
+    check = doctor._check_state_root_dacl(vault)
+
+    assert check.status == "pass"
+    assert "Contents were NOT evaluated" in check.message
+    assert check.details is not None
+    assert check.details["child_sampled"] == 0
+
+
+def test_doctor_pass_names_the_sample_size_when_contents_were_evaluated(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import doctor, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    _pin_posture(monkeypatch, directory, child_verdict="private", child_sampled=4)
+
+    check = doctor._check_state_root_dacl(vault)
+
+    assert check.status == "pass"
+    assert "Contents verified across 4 sampled child(ren)" in check.message
+    assert "NOT evaluated" not in check.message
+
+
+@windows_only
+def test_seal_fails_when_a_child_resists_the_propagation(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """MEDIUM 2. The seal's proof must cover the contents it claims to have fixed.
+
+    A child directory carrying its own PROTECTED DACL does not inherit, so the
+    propagation genuinely does not reach it. Checking only the root reported
+    success over exactly that.
+    """
+    from exomem import mutation_lock, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    stubborn = directory / "stubborn"
+    stubborn.mkdir()
+    # Protected against inheritance and naming a trustee SYSTEM's validator
+    # rejects, so propagation cannot reach it and it stays `unsafe`.
+    mutation_lock._windows_apply_dacl_sddl(
+        stubborn,
+        f"D:P(A;OICI;FA;;;{mutation_lock._windows_current_user_sid()})"
+        "(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)",
+    )
+    monkeypatch.setenv("EXOMEM_RUNTIME_PRINCIPAL", "S-1-5-18")
+
+    raised = None
+    try:
+        state_paths.seal_state_root_for_runtime_principal(vault)
+    except Exception as error:  # noqa: BLE001 - conftest skips on this type
+        raised = (type(error).__name__, str(error))
+    finally:
+        mutation_lock._windows_apply_private_dacl(
+            directory, mutation_lock._windows_current_user_sid(), propagate=True
+        )
+    # Asserted outside the handler: conftest's skip walker follows __context__
+    # and would turn this failure into a silent skip (issue #952).
+    assert raised is not None, "the seal reported success over unsealed contents"
+    assert raised[0] == "WindowsRuntimeDaclError"
+    assert "contents remain" in raised[1]
+
+
+@windows_only
+def test_a_failed_registry_read_degrades_rather_than_reading_as_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MEDIUM 3. "Read failed" and "no service installed" are different facts.
+
+    Collapsed, a correctly-sealed root gets a `current-token` principal, a FAIL,
+    and an `icacls` that grants the operator and breaks the service.
+    """
+    from exomem import mutation_lock
+
+    monkeypatch.delenv("EXOMEM_RUNTIME_PRINCIPAL", raising=False)
+
+    def _denied(_name):
+        raise PermissionError(5, "Access is denied")
+
+    monkeypatch.setattr(mutation_lock, "_windows_service_object_name", _denied)
+
+    principal = mutation_lock.resolve_windows_runtime_principal()
+
+    assert principal.source.startswith("current-token (")
+    assert "registry read failed" in principal.source
+    assert principal.authoritative is False
+
+
+@windows_only
+def test_an_absent_service_is_not_reported_as_a_failed_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The other side of MEDIUM 3: a genuinely absent service stays clean."""
+    import winreg
+
+    from exomem import mutation_lock
+
+    monkeypatch.delenv("EXOMEM_RUNTIME_PRINCIPAL", raising=False)
+
+    def _absent(*_args, **_kwargs):
+        error = OSError(2, "The system cannot find the file specified")
+        error.winerror = 2  # ERROR_FILE_NOT_FOUND
+        raise error
+
+    monkeypatch.setattr(winreg, "OpenKey", _absent)
+
+    principal = mutation_lock.resolve_windows_runtime_principal()
+
+    # Clean `current-token`, with no parenthesised degradation reason: nothing
+    # failed, there is simply no service here.
+    assert principal.source == "current-token"
+    assert principal.authoritative is False
+
+
+@windows_only
+def test_sealing_an_already_sealed_root_is_a_no_op(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """LOW. A seal has to be idempotent; the alias guard made the second call
+    raise a raw `[Errno 5]`."""
+    from exomem import mutation_lock, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    monkeypatch.setenv("EXOMEM_RUNTIME_PRINCIPAL", "S-1-5-18")
+    try:
+        assert state_paths.seal_state_root_for_runtime_principal(vault) is not None
+        sealed = mutation_lock._windows_dacl_sddl(directory)
+
+        # Second call: no exception, no change.
+        assert state_paths.seal_state_root_for_runtime_principal(vault) is None
+        assert mutation_lock._windows_dacl_sddl(directory) == sealed
+    finally:
+        mutation_lock._windows_apply_private_dacl(
+            directory, mutation_lock._windows_current_user_sid(), propagate=True
+        )
+
+
+@windows_only
+def test_a_skipped_seal_distinguishes_wrong_vault_from_unreadable_binding(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, caplog
+) -> None:
+    """LOW. "Bound elsewhere" is correct and expected; "binding unreadable" is a
+    silent miss on the upgrade path. They must not look alike in a log."""
+    import logging
+
+    from exomem import mutation_lock, state_paths
+
+    state_paths.ensure_vault_state_dir(vault)
+    monkeypatch.delenv("EXOMEM_RUNTIME_PRINCIPAL", raising=False)
+    monkeypatch.setattr(
+        mutation_lock, "_windows_service_object_name",
+        lambda name: "LocalSystem" if name == "exomem" else None,
+    )
+
+    monkeypatch.setattr(
+        mutation_lock, "_windows_service_bound_vault",
+        lambda _n: str(vault.parent / "elsewhere"),
+    )
+    with caplog.at_level(logging.INFO, logger="exomem.mutation_lock"):
+        assert state_paths.seal_state_root_for_runtime_principal(vault) is None
+    assert any("bound to a different vault" in r.message for r in caplog.records)
+    assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+
+    caplog.clear()
+    monkeypatch.setattr(mutation_lock, "_windows_service_bound_vault", lambda _n: None)
+    with caplog.at_level(logging.INFO, logger="exomem.mutation_lock"):
+        assert state_paths.seal_state_root_for_runtime_principal(vault) is None
+    assert any("could not be read" in r.message for r in caplog.records)
+    # A silent miss on the upgrade path warrants a WARNING, not an INFO.
+    assert any(r.levelno >= logging.WARNING for r in caplog.records)
+
+
+@windows_only
+def test_the_real_object_name_reader_distinguishes_absent_from_denied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MEDIUM 3 at the reader itself, not through a stubbed caller.
+
+    The degrade test monkeypatches `_windows_service_object_name`, so it never
+    executes the branch that tells the two apart. This one does.
+    """
+    import winreg
+
+    from exomem import mutation_lock
+
+    def _raising(winerror: int):
+        def _open(*_args, **_kwargs):
+            error = OSError(winerror, "synthetic")
+            error.winerror = winerror
+            raise error
+
+        return _open
+
+    # ERROR_FILE_NOT_FOUND: the service is genuinely absent -> None, no raise.
+    monkeypatch.setattr(winreg, "OpenKey", _raising(2))
+    assert mutation_lock._windows_service_object_name("exomem") is None
+
+    # ERROR_ACCESS_DENIED: the read FAILED -> raises, so the caller can degrade.
+    monkeypatch.setattr(winreg, "OpenKey", _raising(5))
+    with pytest.raises(OSError):
+        mutation_lock._windows_service_object_name("exomem")
+
+
+@windows_only
+def test_the_child_sampler_judges_a_subdirectory_with_the_directory_flag_set(
+    tmp_path: Path,
+) -> None:
+    """LOW. `Path.is_dir()` swallows `OSError`, so it belongs inside the guard —
+    and a child DIRECTORY must be judged as one.
+
+    An INHERITING subdirectory is the distinguishing shape, and the ordinary one:
+    its `OICIID` flags read `inherited` under the directory flag-set and `unsafe`
+    under the file one. (A subdirectory with its own protected `OICI` DACL is
+    `private` either way, so it cannot tell the two apart.)
+    """
+    from exomem import mutation_lock
+
+    sid = mutation_lock._windows_current_user_sid()
+    root = tmp_path / "root"
+    root.mkdir()
+    mutation_lock._windows_apply_private_dacl(root, sid)
+    child_dir = root / "subdir"
+    child_dir.mkdir()  # inherits the root's ACEs, as every real one does
+
+    verdict, sampled = mutation_lock._windows_child_dacl_verdict(root, sid)
+
+    assert sampled == 1
+    assert verdict == "inherited", (
+        "a child directory judged with the file flag-set reads unsafe"
+    )
+
+
+def test_doctor_pass_message_names_the_unevaluated_contents_verbatim(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """MEDIUM 1, pinned on the sentence rather than only on the detail field.
+
+    The details carried the count before this round; what was missing was the
+    message SAYING so, which is what an operator actually reads.
+    """
+    from exomem import doctor, state_paths
+
+    directory = state_paths.ensure_vault_state_dir(vault)
+    _pin_posture(monkeypatch, directory, child_verdict=None, child_sampled=0)
+
+    check = doctor._check_state_root_dacl(vault)
+
+    assert check.status == "pass"
+    assert "verdict covers the directory entry only" in check.message

--- a/tests/test_doctor_write_path.py
+++ b/tests/test_doctor_write_path.py
@@ -596,9 +596,12 @@ def test_new_checks_are_wired_into_the_ordered_report(
     assert "rebuild_temp.orphans" in ids
     assert "write_path.env_flags" in ids
     i = ids.index("deferred_index_backlog")
-    assert ids[i + 1 : i + 5] == [
+    # `state.dacl` sits immediately after `state.placement`: place first, then
+    # whether the principal running this can actually reach that place.
+    assert ids[i + 1 : i + 6] == [
         "graph_sync.state",
         "state.placement",
+        "state.dacl",
         "rebuild_temp.orphans",
         "write_path.env_flags",
     ]


### PR DESCRIPTION
Complete delivery of #933: all three of its required behaviours are implemented and verified. OpenSpec change: `bound-cross-principal-state-access` (archives after merge).

## The defect

The Windows private-DACL trustee set is relative to the **calling token** — `_windows_private_dacl_trustees` puts that token's own SID first. So the same state root is `private` to whichever principal created it and `unsafe` to the other:

| root written by | operator's view | LocalSystem's view |
|---|---|---|
| operator (`user+SY+BA`) | `private`, openable | `unsafe` — opens it via its `SY` ACE, then fails closed |
| service (`SY+BA`) | `unsafe`, not openable | `private` |

That single fact produced all four manifestations in the issue: the service refusing `catalog_proof_incomplete` forever at ~0 CPU, `upgrade.ps1` dying mid-migration, `doctor` crashing on a `.lexical.sqlite` stat, and `maintain --reconcile --rebuild-graph` dying inside `census_unavailable_graph_lineage` with the operation half-done.

## What changed

**1. A runtime principal, resolved rather than guessed.** `resolve_windows_runtime_principal()` reads the service account from the SCM hive — the same non-elevated read `scripts/_service-common.ps1` documents as "the single source of truth". No service installed → the runtime principal is the current token and behaviour is byte-identical. A registry read that *fails* is distinguished from a service that is *absent*, because collapsing them makes a correctly-sealed cell look misconfigured. Nothing is ever guessed: a degraded principal can never authorise a DACL write.

**2. The migration seals the root for that principal — and only for the right vault.** Sealing is the last act of `migrate_vault_state_offline`, never part of creating the root (the migrator has to write the state in first). It fires only when the vault being migrated is the one the machine's service is bound to, read from the service's managed dotenv exactly as `upgrade.ps1` reads it. Without that gate, `exomem init` of an unrelated vault on a service-registered box handed its state root to LocalSystem and locked the operator out of the directory it had just made.

The seal applies through `SetNamedSecurityInfoW` so inheritance is recomputed across the tree. `SetFileSecurityW` protects only the entry, and Windows then converts each child's inherited ACEs into explicit ones — leaving every file the migration just moved in readable and writable by the excluded principal behind a directory that merely *looks* sealed.

**3. `doctor` separates placement from access.** A new `state.dacl` check, judged against the **runtime principal**, not the caller. This is the difference between shipping and not: a correct LocalSystem root reads `unsafe` to every operator, so judging by the caller would FAIL every healthy Windows service install — including inside `upgrade.ps1`'s own doctor gate, which runs as the operator. `_check_lexical`, `_check_deferred_index_backlog` and `_check_rebuild_temp_orphans` now report unreadable state as findings instead of raising, and never report a confident result from an inspection that did not run.

**4. Maintenance refuses up front.** `maintain` and `--migrate-state` detect an unusable root before taking the mutation hold, with the stable code `STATE_ROOT_CROSS_PRINCIPAL`, the observed descriptor, the required trustees and an exact remediation. Both halves refuse: "cannot open" *and* "opens it but the validator rejects the trustee set" — the second is how the failure presents to the service, which is the principal the incident was actually about.

## Verification

- Targeted suite: **588 passed, 6 failed, 265 errors** against an `origin/main` baseline of **534 passed, 6 failed, 239 errors** for the same selection — **identical failure sets in both directions, no new failures**. The 6 failures and the errors are pre-existing on untouched main (Linux installer scripts under Git Bash; `ContentHashMismatchError` in `structured_files`; a concurrently-running local cell writing its own state root during teardown).
- **30/30 mutation proofs**: deleting each guard fails a named test, proven in a scratch copy with its import path verified.
- `uvx ruff check` clean on every changed file (3 findings remain, all reproduced on untouched main under the same ruff version).
- `openspec validate --all --strict` → 170 passed, 0 failed.
- Windows-only paths verified end-to-end against a real service registration and real ACLs, in temporary directories throughout.

## Residual risk

**Contents are unverifiable by the operator once a root is sealed.** After sealing, this process's listing of the root is denied, so `state.dacl` examines no children and its verdict covers the directory entry alone. The check now says so explicitly and reports `child_sampled: 0` rather than asserting privacy it did not establish — a confidently-green report over unexamined state is the failure mode that cost a day in the original incident. Verification of the contents is performed by the seal itself, which enumerates children before writing and re-checks them afterwards by path; a reader inspecting later gets an honest "not evaluated" instead.

Two consequences worth stating plainly:

- `state.dacl` FAILs on a root whose DACL the runtime principal rejects. That is intended, and it can newly **block an upgrade** that previously proceeded into the infinite-refusal loop — the better of the two outcomes, but a behaviour change.
- On a service install the sealed root is private to the service account, so later maintenance must run as that account. The remediation is rendered for the runtime principal (not the caller) precisely so following it does not restart the ACL ping-pong the incident is about, and it is withheld entirely when the principal could not be established.

Mutation counts in earlier review rounds were reported as 18/18; that was wrong — one guard (the seal's own post-write validation) survived and is corrected here. The accurate figures are 17/18 for that round and 30/30 now.

## Scope not taken

`exomem index --scope vault` and the server's startup path have no pre-flight; #933 scopes the requirement to CLI maintenance ops and widening further looked like scope creep. Flagging rather than deciding.
