### PR TITLE
test: attribute state-root guard failures to drifted entries and concurrent processes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -405,9 +405,18 @@ def _stop_leaked_graph_drain():
 #: Captured before any test can instrument the filesystem primitives: the
 #: guard below runs in autouse teardown, after test-scoped patches of
 #: `os.scandir`/`os.lstat` may still be mid-unwind, and the guard's own probe
-#: of the REAL platform root must never route through them.
+#: of the REAL platform root must never route through them. The `/proc` scan
+#: below extends the same discipline to its own primitives -- deliberately
+#: plain `os` calls rather than `pathlib.Path` methods, so a test patching
+#: `Path.iterdir`/`Path.read_bytes`/`Path.is_dir` cannot pollute or stall the
+#: triage scan either.
 _REAL_SCANDIR = os.scandir
 _REAL_LSTAT = os.lstat
+_REAL_OS_OPEN = os.open
+_REAL_OS_READ = os.read
+_REAL_OS_CLOSE = os.close
+_REAL_OS_READLINK = os.readlink
+_REAL_OS_PATH_ISDIR = os.path.isdir
 
 
 def _state_root_shallow_snapshot(root: Path) -> tuple:
@@ -422,14 +431,248 @@ def _state_root_shallow_snapshot(root: Path) -> tuple:
         return ("absent",)
     try:
         children = tuple(
-            sorted(
-                (entry.name, entry.stat().st_mtime_ns)
-                for entry in _REAL_SCANDIR(root)
-            )
+            sorted((entry.name, entry.stat().st_mtime_ns) for entry in _REAL_SCANDIR(root))
         )
     except OSError:
         children = ("unreadable",)
     return ("present", info.st_mtime_ns, children)
+
+
+def _state_root_drift_summary(before: tuple, after: tuple) -> str:
+    """A legible description of what changed between two
+    :func:`_state_root_shallow_snapshot` results, by entry name.
+
+    Split out from the assert purely for testability -- this function makes
+    no pass/fail decision and the guard's own comparison stays `after ==
+    before`, unchanged, regardless of what this reports. Four incidents on
+    2026-08-29 alone showed a triager the raw snapshot tuples
+    (`before=('present', 1788012082470890197, ...)`) and nothing else; naming
+    the added/removed/mtime-shifted entries is the whole point.
+    """
+    if before == after:
+        return "no drift detected"
+    before_present = before[0] == "present"
+    after_present = after[0] == "present"
+    if before_present and not after_present:
+        return "the root existed before and is gone now"
+    if after_present and not before_present:
+        return "the root did not exist before and exists now"
+    if not before_present and not after_present:
+        # Both "absent" yet the tuples differ, or one/both is some other
+        # sentinel shape entirely -- say so rather than guessing.
+        return f"before={before!r} after={after!r}"
+    before_children = before[2]
+    after_children = after[2]
+    if before_children == ("unreadable",) or after_children == ("unreadable",):
+        return "the root's children became readable/unreadable between snapshots"
+    before_map = dict(before_children)
+    after_map = dict(after_children)
+    added = sorted(set(after_map) - set(before_map))
+    removed = sorted(set(before_map) - set(after_map))
+    changed = sorted(
+        name for name in set(before_map) & set(after_map) if before_map[name] != after_map[name]
+    )
+    parts = []
+    if added:
+        parts.append("added: " + ", ".join(added))
+    if removed:
+        parts.append("removed: " + ", ".join(removed))
+    if changed:
+        parts.append("changed: " + ", ".join(changed))
+    if not parts:
+        return "the root directory's own mtime changed with no child differences"
+    return "; ".join(parts)
+
+
+def _read_proc_file(path: str, max_bytes: int = 4096) -> bytes | None:
+    """Read a `/proc` pseudo-file through import-time-captured `os`
+    primitives only -- never `pathlib.Path`, per the module header note.
+
+    Never raises: any failure (process exited mid-read, permission denied,
+    the path never existed) reports as "nothing read" to the caller, which is
+    always a best-effort triage consumer.
+    """
+    fd = None
+    try:
+        fd = _REAL_OS_OPEN(path, os.O_RDONLY)
+        return _REAL_OS_READ(fd, max_bytes)
+    except OSError:
+        return None
+    finally:
+        if fd is not None:
+            try:
+                _REAL_OS_CLOSE(fd)
+            except OSError:
+                pass
+
+
+def _process_ancestor_pids(start_pid: int) -> frozenset[int]:
+    """Every pid from `start_pid`'s parent up to pid 1, via `/proc/<pid>/stat`.
+
+    CI always runs pytest under a wrapper (`uv run ... python -m pytest`), so
+    the running process's own ancestor chain matches "pytest"/"exomem" on
+    every single run -- without exclusion, `_concurrent_process_candidates`
+    would report a "concurrent" hit unconditionally and mislead every
+    triager, every run, regardless of whether anything is actually
+    interfering.
+
+    `stat`'s comm field (2nd column, in parens) can itself contain spaces or
+    parens, so ppid is located from the LAST ')' rather than by naive
+    whitespace-splitting (proc(5)): the whitespace-separated fields after it
+    are state, ppid, pgrp, ... -- ppid is the 2nd of those.
+
+    Best-effort like the scan it supports: any failure simply stops the walk
+    where it is, returning whatever ancestors were already found.
+    """
+    ancestors: set[int] = set()
+    seen = {start_pid}
+    pid = start_pid
+    for _ in range(4096):  # hard cap: never loop forever on a corrupt chain
+        raw = _read_proc_file(f"/proc/{pid}/stat")
+        if not raw:
+            break
+        text = raw.decode("utf-8", "replace")
+        close = text.rfind(")")
+        if close == -1:
+            break
+        fields = text[close + 1 :].split()
+        if len(fields) < 2:
+            break
+        try:
+            ppid = int(fields[1])
+        except ValueError:
+            break
+        if ppid <= 0 or ppid in seen:
+            break
+        ancestors.add(ppid)
+        seen.add(ppid)
+        if ppid == 1:
+            break
+        pid = ppid
+    return frozenset(ancestors)
+
+
+def _best_effort_proc_cwd(pid: int) -> str:
+    """The best-effort cwd of `pid` -- the actually-useful triage datum (which
+    worktree's run this is) -- never the full argv."""
+    try:
+        return _REAL_OS_READLINK(f"/proc/{pid}/cwd")
+    except OSError:
+        return "unknown"
+
+
+def _matching_processes(exclude: frozenset[int]) -> tuple[tuple[int, str], ...]:
+    """All ``(pid, cmdline)`` for live processes outside ``exclude`` whose
+    cmdline contains "pytest" or "exomem".
+
+    Uncapped and unredacted -- :func:`_concurrent_process_candidates` applies
+    the cap and redaction on top of this. Split out so ancestor-exclusion and
+    third-party-detection can be tested directly, without the cap's
+    iteration-order sensitivity (``/proc`` readdir order is not guaranteed,
+    so which matches survive a cap is not deterministic on a busy box).
+
+    Per-entry failures are caught individually so one uncooperative ``/proc``
+    entry does not discard matches already found; the directory iteration
+    itself is wrapped a second time for the same reason.
+    """
+    if os.name != "posix":
+        return ()
+    found: list[tuple[int, str]] = []
+    try:
+        if not _REAL_OS_PATH_ISDIR("/proc"):
+            return ()
+        for entry in _REAL_SCANDIR("/proc"):
+            try:
+                if not entry.name.isdigit():
+                    continue
+                pid = int(entry.name)
+                if pid in exclude:
+                    continue
+                raw = _read_proc_file(f"/proc/{pid}/cmdline")
+                if not raw:
+                    continue
+                cmdline = raw.replace(b"\x00", b" ").strip().decode("utf-8", "replace")
+                if not cmdline:
+                    continue
+                if "pytest" in cmdline or "exomem" in cmdline:
+                    found.append((pid, cmdline))
+            except Exception:  # noqa: BLE001 -- one entry's failure must not discard matches already found; this scan is best-effort triage, never load-bearing for the assert.
+                continue
+    except Exception:  # noqa: BLE001 -- the whole scan is best-effort triage; a failure here returns whatever was already collected rather than aborting the guard itself.
+        pass
+    return tuple(found)
+
+
+#: Redacted candidate lines are capped; overflow is summarized rather than
+#: silently truncated.
+_CONCURRENT_CANDIDATE_CAP = 5
+
+
+def _candidate_exclusion_pids() -> frozenset[int]:
+    """The pids the candidate scan must never report: this process and its
+    full ancestor chain. Extracted as a named seam so a test can pin the
+    exclusion-set CONSTRUCTION itself -- absence from a capped render proves
+    nothing, and a weakened set here is exactly the mutation review caught.
+    """
+    own_pid = os.getpid()
+    return frozenset(_process_ancestor_pids(own_pid) | {own_pid})
+
+
+def _concurrent_process_candidates() -> tuple[str, ...]:
+    """Best-effort `/proc` scan for other live pytest/exomem processes.
+
+    Purely diagnostic triage, never load-bearing for the assert: the state
+    root is machine-global, so another worktree's pytest, a stray `-x` run,
+    or a foreign tmpdir can all trip the guard on files this diff never
+    touched. Deliberately POSIX-only (`/proc` has no Windows analogue) and
+    never raises -- a scan that finds nothing and a scan that fails outright
+    are reported identically by the caller (as "unavailable"), so a bare
+    empty tuple is the right shape for both.
+
+    Redaction: only the pid, the basename of argv[0], and a best-effort cwd
+    are ever reported -- never the raw argv line, which can carry secrets (an
+    ssh private-key path was captured live in review off an earlier,
+    unredacted render). The scan's own ancestor chain
+    (:func:`_process_ancestor_pids`) is excluded so a run's own `uv run ...
+    python -m pytest` wrapper never reports itself as "concurrent".
+    """
+    if os.name != "posix":
+        return ()
+    matches = _matching_processes(_candidate_exclusion_pids())
+    found = []
+    for pid, cmdline in matches[:_CONCURRENT_CANDIDATE_CAP]:
+        argv0 = cmdline.split(" ", 1)[0]
+        basename = argv0.rsplit("/", 1)[-1] or argv0
+        cwd = _best_effort_proc_cwd(pid)
+        found.append(f"pid {pid}: {basename} (matched: pytest|exomem, cwd: {cwd})")
+    if len(matches) > _CONCURRENT_CANDIDATE_CAP:
+        found.append(f"(+{len(matches) - _CONCURRENT_CANDIDATE_CAP} more)")
+    return tuple(found)
+
+
+_STATE_ROOT_GUARD_TRIAGE_HINT = (
+    "this also fires for cross-process interference, not just this diff: "
+    "another worktree's pytest, a stray -x run, or a foreign tmpdir can "
+    "touch this same machine-global root; check for concurrent pytest/exomem "
+    "processes and rerun this file solo before attributing the failure to "
+    "the code under test."
+)
+
+
+def _state_root_guard_message(real_root: Path, before: tuple, after: tuple) -> str:
+    """The guard's full assertion message: legible attribution first, the
+    triage hint, best-effort concurrent-process candidates, then the raw
+    snapshot tuples last (kept available, but secondary)."""
+    drift = _state_root_drift_summary(before, after)
+    candidates = _concurrent_process_candidates()
+    candidates_text = "; ".join(candidates) if candidates else "unavailable"
+    return (
+        f"a test touched the real user state root {real_root} ({drift}); "
+        "every fixture must stay under the injected EXOMEM_STATE_ROOT tmpdir. "
+        f"{_STATE_ROOT_GUARD_TRIAGE_HINT} "
+        f"concurrent candidates: {candidates_text}. "
+        f"raw snapshot (before={before!r}, after={after!r})"
+    )
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -509,11 +752,7 @@ def _isolate_state_root(tmp_path: Path):
         before = _state_root_shallow_snapshot(real_root)
         yield
         after = _state_root_shallow_snapshot(real_root)
-        assert after == before, (
-            f"a test touched the real user state root {real_root} "
-            f"(before={before}, after={after}); every fixture must stay under the "
-            "injected EXOMEM_STATE_ROOT tmpdir"
-        )
+        assert after == before, _state_root_guard_message(real_root, before, after)
     finally:
         if writer_lease_module is not None:
             writer_lease_module.reset_managers_for_tests()

--- a/tests/test_state_root_guard.py
+++ b/tests/test_state_root_guard.py
@@ -1,0 +1,345 @@
+"""Attribution + triage hardening for the real-state-root guard (packet G).
+
+`_isolate_state_root` in conftest.py already asserts, correctly, that nothing
+in a test run touched the machine's real platform state root. What it did not
+do -- until this lane -- is say WHAT changed, or note that the failure is at
+least as often cross-process interference (another worktree's pytest, a stray
+``-x`` run, a foreign tmpdir touching this same machine-global root) as it is
+the diff under test. Four incidents on 2026-08-29 alone hit exactly this: an
+unrelated test ERRORs with "a test touched the real user state root" on files
+the diff never touched, and the message printed raw snapshot tuples a triager
+could not act on.
+
+These tests drive the actual fixture generator directly through its
+documented seam (``XDG_STATE_HOME``, mirroring how conftest.py itself derives
+the real root and how ``tests/test_state_root_placement.py`` already
+monkeypatches it) rather than reimplementing its comparison logic, so a red
+run here is truthful about what the shipped fixture actually says -- and a
+green run proves the enrichment without moving WHEN the assert fires. The
+assert condition itself (``after == before``) must never change; every test
+below aims at the *message*, never at weakening the comparison.
+
+Correction round (independent review, same day): the first pass leaked raw
+argv (including, live, an ssh private-key path) into the failure message, and
+its "concurrent candidates" scan matched the run's own ancestor chain
+unconditionally (CI always runs pytest under a wrapper, so that chain always
+matches "pytest"), which would have misattributed genuine diff failures to
+interference on every single run. Two mutation-proven gaps were also found: a
+`tmp*`-prefix allowlist and a lying drift summary (naming a file as both
+added and removed) both passed the original six tests. The tests below add
+coverage for all four; see `test_concurrent_scan_excludes_its_own_ancestor_chain_but_not_a_genuine_third_party`
+and the parametrization / negative asserts on the added- and removed-entry
+tests.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from conftest import (
+    _candidate_exclusion_pids,
+    _concurrent_process_candidates,
+    _isolate_state_root,
+    _matching_processes,
+    _process_ancestor_pids,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason=(
+        "drives the POSIX XDG_STATE_HOME branch of "
+        "state_paths.platform_default_state_root(), and the /proc-based "
+        "concurrent-process scan; Windows has neither"
+    ),
+)
+
+
+def _wrapped_fixture_function(fixture):
+    """The raw function a `@pytest.fixture` wraps.
+
+    `_get_wrapped_function()` is pytest 9.0.3's accessor for this (verified
+    against `_pytest.fixtures.FixtureFunctionDefinition`); `__wrapped__` is
+    kept as a fallback for other pytest versions this suite might run under.
+    """
+    getter = getattr(fixture, "_get_wrapped_function", None)
+    if getter is not None:
+        return getter()
+    return fixture.__wrapped__
+
+
+def _drive_guard(inner_tmp_path: Path):
+    """Start one raw instance of the real fixture body outside pytest's own
+    fixture machinery, wrapped in `contextlib.closing`.
+
+    Fixture-teardown assertions are otherwise invisible to the test they
+    wrap -- `_isolate_state_root` is autouse, so the only way to inspect its
+    own failure is to run its generator by hand. `inner_tmp_path` stands in
+    for the `tmp_path` pytest would normally inject; it must be a distinct
+    directory from the *outer* test's own `tmp_path` (used to control
+    `XDG_STATE_HOME` below) so this inner run's injected `EXOMEM_STATE_ROOT`
+    never collides with the outer autouse guard already wrapping this very
+    test.
+
+    `contextlib.closing` matters here: if a test raised between getting this
+    generator and calling `_finish` on it (its own manipulation of the fake
+    real root failing, say), the generator would otherwise sit suspended,
+    holding the fixture's private `EXOMEM_STATE_ROOT` monkeypatch open until
+    the GC eventually collects it. `with _drive_guard(...) as gen:` calls
+    `gen.close()` deterministically at block exit instead, which resumes the
+    fixture at its `yield` with `GeneratorExit` and runs its own
+    `finally: private.undo()` immediately. Calling `.close()` on an already
+    -exhausted generator (the normal path, via `_finish`) is a safe no-op.
+    """
+    inner_tmp_path.mkdir(parents=True, exist_ok=True)
+    raw = _wrapped_fixture_function(_isolate_state_root)
+    gen = raw(inner_tmp_path)
+    next(gen)  # run setup through `yield`: captures the "before" snapshot
+    return contextlib.closing(gen)
+
+
+def _finish(gen) -> str | None:
+    """Drive the generator past its `yield`.
+
+    Returns the guard's AssertionError message if it fired, or None if the
+    generator completed cleanly (no drift detected).
+    """
+    try:
+        next(gen)
+    except StopIteration:
+        return None
+    except AssertionError as exc:
+        return str(exc)
+    raise AssertionError(
+        "guard generator yielded a second time; _isolate_state_root's shape "
+        "changed and this harness no longer matches it"
+    )
+
+
+def _point_real_root_at(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Redirect `platform_default_state_root()` at a private tmp directory
+    for this test only, via the same `XDG_STATE_HOME` seam
+    `test_state_root_placement.py` already uses. Returns the resulting real
+    root (not yet created)."""
+    xdg_base = tmp_path / "xdg-home"
+    monkeypatch.setenv("XDG_STATE_HOME", str(xdg_base))
+    return xdg_base / "exomem" / "state"
+
+
+def _drift_clause(message: str) -> str:
+    """The `(...)` drift-summary clause right after "real user state root
+    <path> " in the guard message.
+
+    The raw snapshot tuples at the end of the message legitimately mention
+    every present filename, both unchanged and changed -- an untouched
+    sibling file's name is expected to appear there. Negative asserts about
+    "this name must not be listed as added/removed" must scope to the
+    drift-summary clause only, or they would false-fail against a correct
+    implementation.
+    """
+    return message.split("(", 1)[1].split(")", 1)[0]
+
+
+def test_guard_passes_when_nothing_changed(tmp_path, monkeypatch):
+    real_root = _point_real_root_at(monkeypatch, tmp_path)
+    real_root.mkdir(parents=True)
+    (real_root / "steady.txt").write_text("baseline")
+
+    with _drive_guard(tmp_path / "inner-untouched") as gen:
+        message = _finish(gen)
+
+    assert message is None
+
+
+@pytest.mark.parametrize(
+    "intruder_name",
+    [
+        "intruder-471fb58e.txt",
+        # The real 2026-08-29 incidents were named exactly like this
+        # (pytest's own tmp_path_factory prefix). A mutation that ignored
+        # `tmp*`-prefixed intruders (plausible-looking as "probably a
+        # pytest tmpdir, not a real change") would still pass every other
+        # test here while silently blinding the guard to the actual
+        # incident shape -- this parametrization closes that gap.
+        "tmp0cx8c0i9-abc",
+    ],
+)
+def test_guard_names_added_entry_and_carries_triage_hint(tmp_path, monkeypatch, intruder_name):
+    real_root = _point_real_root_at(monkeypatch, tmp_path)
+    real_root.mkdir(parents=True)
+    (real_root / "steady.txt").write_text("baseline")
+
+    with _drive_guard(tmp_path / "inner-added") as gen:
+        # Simulate exactly the cross-process interference the packet
+        # describes: something else writes into the real root mid-test.
+        (real_root / intruder_name).write_text("from another process")
+        message = _finish(gen)
+
+    assert message is not None, "guard did not fire on an added entry"
+    drift_clause = _drift_clause(message)
+    assert f"added: {intruder_name}" in drift_clause, message
+    # A lying drift summary that names every child as both added and removed
+    # would still satisfy the assertion above -- pin that the untouched
+    # sibling is not swept into the drift clause at all.
+    assert "steady.txt" not in drift_clause, message
+    assert "concurrent" in message.lower(), message
+    assert "rerun" in message.lower(), message
+
+
+def test_guard_names_removed_entry(tmp_path, monkeypatch):
+    real_root = _point_real_root_at(monkeypatch, tmp_path)
+    real_root.mkdir(parents=True)
+    (real_root / "keep.txt").write_text("baseline")
+    (real_root / "gone.txt").write_text("baseline")
+
+    with _drive_guard(tmp_path / "inner-removed") as gen:
+        (real_root / "gone.txt").unlink()
+        message = _finish(gen)
+
+    assert message is not None, "guard did not fire on a removed entry"
+    drift_clause = _drift_clause(message)
+    assert "removed: gone.txt" in drift_clause, message
+    assert "keep.txt" not in drift_clause, message
+
+
+def test_guard_names_mtime_shifted_entry(tmp_path, monkeypatch):
+    real_root = _point_real_root_at(monkeypatch, tmp_path)
+    real_root.mkdir(parents=True)
+    (real_root / "sibling.txt").write_text("baseline")
+    target = real_root / "vault-shifted.txt"
+    target.write_text("baseline")
+
+    with _drive_guard(tmp_path / "inner-mtime") as gen:
+        shifted = target.stat().st_mtime + 120
+        os.utime(target, (shifted, shifted))
+        message = _finish(gen)
+
+    assert message is not None, "guard did not fire on an mtime-only shift"
+    drift_clause = _drift_clause(message)
+    assert "changed: vault-shifted.txt" in drift_clause, message
+    assert "sibling.txt" not in drift_clause, message
+
+
+def test_guard_never_omits_the_concurrent_candidates_line(tmp_path, monkeypatch):
+    """The 'concurrent candidates' line must appear even when the best-effort
+    /proc scan finds nothing to report -- never silently omitted. This does
+    not assert the scan is empty: other processes are routinely running
+    concurrently on this box (that is the whole premise of packet G), so the
+    only safe assertion is that the label itself is always present.
+    """
+    real_root = _point_real_root_at(monkeypatch, tmp_path)
+    real_root.mkdir(parents=True)
+
+    with _drive_guard(tmp_path / "inner-candidates") as gen:
+        (real_root / "intruder.txt").write_text("x")
+        message = _finish(gen)
+
+    assert message is not None
+    assert "concurrent candidates:" in message, message
+
+
+def test_guard_keeps_raw_snapshot_tuples_available(tmp_path, monkeypatch):
+    """Raw tuples stay in the message -- secondary to the legible attribution,
+    never removed (packet requirement: 'Keep raw tuples available but
+    secondary')."""
+    real_root = _point_real_root_at(monkeypatch, tmp_path)
+    real_root.mkdir(parents=True)
+
+    with _drive_guard(tmp_path / "inner-raw") as gen:
+        (real_root / "intruder.txt").write_text("x")
+        message = _finish(gen)
+
+    assert message is not None
+    assert "before=" in message, message
+    assert "after=" in message, message
+
+
+def test_guard_never_prints_raw_argv_in_candidates(tmp_path, monkeypatch):
+    """Redaction: a candidate line names the pid, the basename of argv[0], and
+    a best-effort cwd -- never the raw argv, which can carry secrets (an ssh
+    private-key path was captured live in review off an earlier, unredacted
+    render). This is a real-box smoke check, not synthetic: it runs the
+    actual scan and pins the *shape* of whatever it finds rather than
+    asserting specific content, since this dev box always has several real
+    concurrent exomem/pytest processes to find.
+    """
+    candidates = _concurrent_process_candidates()
+    for line in candidates:
+        if line.startswith("(+") and line.endswith(" more)"):
+            continue  # the capped-overflow summary line, not a process line
+        assert line.startswith("pid "), line
+        assert "matched: pytest|exomem" in line, line
+        assert "cwd: " in line, line
+        # A raw cmdline would routinely contain "/", multiple words, and
+        # flags; the basename slot must not carry a full path.
+        basename_slot = line.split(": ", 1)[1].split(" (matched:", 1)[0]
+        assert "/" not in basename_slot, (
+            f"candidate line leaks a path instead of a basename: {line!r}"
+        )
+
+
+def test_concurrent_scan_excludes_its_own_ancestor_chain_but_not_a_genuine_third_party():
+    """CI always runs pytest under a wrapper (`uv run ... python -m
+    pytest`), so the scan's own ancestor chain would otherwise match
+    "pytest"/"exomem" on every single run, making "concurrent candidates"
+    permanently non-empty and actively misleading a triager into blaming
+    interference for a genuine diff failure -- reproduced live in review.
+
+    Proven two ways:
+
+    1. none of this process's real ancestor pids (nor itself) survive the
+       exclusion in the UNCAPPED `_matching_processes` scan. Checked against
+       the uncapped scan deliberately: on a busy box the cap can hide an
+       ancestor that sits late in `/proc` readdir order, so absence from the
+       capped render proves nothing. A precondition assert (this very pytest
+       process is visible to an unexcluded scan) keeps the check from going
+       vacuous on a quiet host.
+    2. a genuine third party -- this test's own CHILD process, never an
+       ancestor, with "pytest" in its argv[0] via the `sleep` argv-override
+       trick -- is still found by the underlying scan. Checked against the
+       uncapped `_matching_processes` rather than the public capped
+       function: this box routinely runs several concurrent exomem/pytest
+       sessions and `/proc` readdir order is not guaranteed, so the cap
+       could cut the marker before it through no fault of the exclusion
+       logic under test.
+
+    The marker is always reaped in `finally`, bounded to a 300s `sleep` that
+    is killed almost immediately.
+    """
+    own_pid = os.getpid()
+    ancestors = _process_ancestor_pids(own_pid)
+    assert ancestors, "expected at least one live ancestor pid for this test process"
+
+    excluded = ancestors | {own_pid}
+    assert _candidate_exclusion_pids() >= excluded, (
+        "the scan's own exclusion set must contain this process and its full "
+        "ancestor chain; a weaker set re-reports the run's own wrapper as "
+        "concurrent interference"
+    )
+    unexcluded_pids = {pid for pid, _cmdline in _matching_processes(frozenset())}
+    assert own_pid in unexcluded_pids, (
+        "precondition: an unexcluded scan must see this very pytest process, "
+        "or the exclusion assertion below has no content on this host"
+    )
+    excluded_scan_pids = {pid for pid, _cmdline in _matching_processes(excluded)}
+    leaked = sorted(excluded_scan_pids & excluded)
+    assert not leaked, f"self/ancestor pids leaked past the exclusion: {leaked}"
+
+    marker = subprocess.Popen(
+        ["fake-pytest-marker-should-be-reported", "300"],
+        executable="/bin/sleep",
+    )
+    try:
+        matches = _matching_processes(ancestors | {own_pid})
+        matched_pids = {pid for pid, _cmdline in matches}
+        assert marker.pid in matched_pids, (
+            f"genuine third-party marker process (pid {marker.pid}) was not "
+            f"reported; matched pids only (argv withheld): {sorted(matched_pids)!r}"
+        )
+    finally:
+        marker.kill()
+        marker.wait(timeout=5)


### PR DESCRIPTION
## What

The machine-global state-root guard in `tests/conftest.py` (`_isolate_state_root`) kept its exact detection strength but its failure message becomes actionable: it now names the added / removed / mtime-shifted entries, carries a cross-process triage hint (this root is shared by every concurrent pytest on the box — four incidents on 2026-08-29 alone, including CI main shard 3/8), and appends a best-effort `/proc` scan of other live pytest/exomem processes.

## Invariant

The assert condition `after == before` is byte-identical to base and every new helper is reachable only on the failure path — verified independently at the rewritten-AST level. No tolerance windows, no skip paths, no allowlists, no env kill-switch.

## Hardening from two review rounds

- **Redaction:** candidate lines carry only `pid`, `basename(argv[0])`, the matched token, and a best-effort cwd — never raw argv (an earlier render captured an ssh private-key path from an unrelated process). Capped at 5 with an overflow marker; pinned by a test.
- **Ancestor exclusion:** the scan excludes the run's own full ancestor chain (`/proc/<pid>/stat` ppid walk, comm-with-parens safe), so CI's `uv run … python -m pytest` wrapper never reports itself as "concurrent interference". The exclusion-set construction is a named seam (`_candidate_exclusion_pids`) pinned by a test; deleting the exclusion fails the suite (mutation-verified).
- **Mutation-proven test gaps closed:** the firing test is parametrized over the real incident shape (`tmp0cx8c0i9-…` names), and negative asserts catch a drift summary that names the wrong files.
- Best-effort discipline: partial scan results survive per-entry failures; `/proc` access uses import-time-captured os primitives (the file's existing `_REAL_SCANDIR` pattern); deterministic generator cleanup via `contextlib.closing`.

## Verification

- Red-first: 4/6 new tests failed on the untouched base for exactly the attribution gaps; the 2 green-on-base tests are the invariance pins.
- `tests/test_state_root_guard.py`: 9 passed (stable across repeated runs). Packet gates: guard + provisioning 67 passed; `tests/test_record_governance.py` 130 passed.
- `ruff check` clean under the repo's full select; `ruff format` deltas are pre-existing debt only.
- Scope: only `tests/conftest.py` and the new `tests/test_state_root_guard.py`; stdlib only; POSIX-guarded (`unavailable` on Windows).
