### PR TITLE
feat(bootstrap): trim compact and admit the destination-choice clause

### DIFF
--- a/openspec/changes/archive/2026-08-29-trim-compact-bootstrap-and-admit-destination-choice/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-29-trim-compact-bootstrap-and-admit-destination-choice/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/archive/2026-08-29-trim-compact-bootstrap-and-admit-destination-choice/design.md
+++ b/openspec/changes/archive/2026-08-29-trim-compact-bootstrap-and-admit-destination-choice/design.md
@@ -1,0 +1,60 @@
+# Design — compact trim + destination-choice admission
+
+## D1 — The margin, argued once
+
+Target: after the clause is admitted, compact ≤ 60,888 bytes (61,400 − 512).
+The number is not invented here: `HEADROOM_WARNING_BYTES = 512` is already the
+codified line below which "the ceiling stops being a budget and becomes a
+cliff", added after compact reached 70 bytes of headroom silently. Landing
+under it clears the warning and gives the next contract change real budget.
+The ceiling itself does not move; neither does the 0.15 saving ratio.
+
+## D2 — Trim method (precedent-bound)
+
+The budget test's running log records two prior trims and their rule: bytes
+come back from REDUNDANCY — text repeating what the payload already says
+(e.g. `advanced` entries duplicating an action's primary route) — and "no rule
+left the payload, and the pins moved WITH the text rather than being loosened
+around it." This change binds itself to the same rule:
+
+1. Candidate cuts are passages whose content is stated elsewhere in the same
+   payload, connective prose, and adjectives that carry no pin.
+2. Never cut: a rule, a landing, a consequence, a named non-outcome, a route,
+   a command name reachable nowhere else, or a teaching the canonical spec
+   names.
+3. Every cut is argued in a new dated entry appended to the budget test's `#:`
+   log, and any content test pinned to trimmed wording moves with the text —
+   pins are never deleted or loosened to make a cut fit.
+
+Ruling (orchestrator, recorded before review): a cut passage that is shared
+prose leaves every profile that carried it. That is within this method — both
+precedent trims cut shared text, and rule 1's definition ("stated elsewhere in
+the same payload") only ever matches shared text — provided the passage is
+restated in substance elsewhere in the same payload, so no profile loses teaching.
+
+## D3 — Clause admission
+
+Compact gains the destination-choice teaching under the same key the full
+contract uses (`destination_choice`), condensed wording allowed; the RULE must
+survive condensation: destination choice happens at write time (search for an
+existing focused destination or create-and-link a child) and post-write
+advisories are the safety net, not the mechanism. Full's wording is untouched.
+
+## D4 — Red-first
+
+1. A compact-carriage test (compact payload teaches destination choice) fails
+   on the untouched base — captured verbatim before any commands.py edit.
+2. The existing compact byte-identical pin (from the S4 delivery) is expected
+   to flip: it is replaced by the carriage pin in the same delivery, with the
+   replacement named in the test file, not silently deleted.
+3. The budget test with the headroom warning promoted to error
+   (`-W error::UserWarning`) fails on base (24 bytes headroom) and passes
+   after — the measured proof the trim happened, not just the admission.
+
+## D5 — What the reviewer should attack
+
+Whether any cut removed a pinned rule or a spec-named teaching (diff every cut
+against the canonical specs); whether pins were loosened instead of moved;
+whether the condensed clause still states both halves of the rule; whether the
+saving ratio and diagnostics/full profiles are untouched; the arithmetic of
+the final sizes (paste `_size` for all three profiles).

--- a/openspec/changes/archive/2026-08-29-trim-compact-bootstrap-and-admit-destination-choice/proposal.md
+++ b/openspec/changes/archive/2026-08-29-trim-compact-bootstrap-and-admit-destination-choice/proposal.md
@@ -1,0 +1,51 @@
+# Trim the compact bootstrap and admit the destination-choice clause
+
+## Why
+
+Compact bootstrap is 61,376 bytes against its 61,400 ceiling — 24 bytes of
+headroom, which the budget test's own history pre-commits is "not headroom: the
+next addition trims or argues". Two deliveries have already recorded deferrals
+against this queue: route-lifecycle ("compact-bootstrap trim is still its own
+queued change") and the semantic scope-divergence sensor (design D8: the
+destination-choice teaching landed in the FULL contract only, with compact
+carriage "that work's acceptance concern"). The canonical
+`agent-bootstrap-contract` spec states the hook explicitly: "the compact payload
+remains byte-identical until the queued compact-bootstrap trim admits the
+clause." This is that change.
+
+## What Changes
+
+- **Trim compact below the warning line.** Recover bytes from the compact
+  payload by the method the budget test's log already established: redundancy
+  first — text that repeats what the payload says elsewhere — never a rule, a
+  landing, a consequence, or a named non-outcome. Every trimmed passage is
+  argued in the budget test's running log, following its convention. The
+  ceiling (61,400) does not move.
+- **Admit the destination-choice clause into compact.** Compact then carries
+  the pre-write destination-choice teaching (route an emerging out-of-scope
+  durable thread at write time; post-write advisories are the safety net),
+  condensed wording allowed, same rule as full.
+- **Land with real headroom.** After admission, compact finishes at or below
+  61,400 − 512 bytes — under `HEADROOM_WARNING_BYTES`, the line the test
+  already codifies as where the budget becomes a cliff — so the next contract
+  change starts with spendable budget instead of inheriting this queue.
+
+## Non-goals
+
+- No ceiling movement, no weakening of `MINIMUM_SAVING_RATIO`, and no change
+  to the full or diagnostics TEACHING beyond what clause admission requires.
+  Because the method cuts redundancy in shared prose, full and diagnostics
+  lose the same redundant bytes — as both precedent trims did — but no
+  teaching leaves any profile, and full's destination-choice wording stays
+  byte-identical.
+- No new teaching content beyond the already-specified destination-choice
+  clause; no tool-surface changes.
+
+## Impact
+
+- Affected specs: `agent-bootstrap-contract` (MODIFIED: destination-choice
+  requirement gains compact carriage).
+- Affected code: `src/exomem/commands.py` (`op_bootstrap` compact prose),
+  `tests/test_bootstrap_compact_budget.py` (log entry; pins that move with
+  text), `tests/test_epistemic_bootstrap_contract.py` (the compact
+  byte-identical pin flips to a compact-carriage pin).

--- a/openspec/changes/archive/2026-08-29-trim-compact-bootstrap-and-admit-destination-choice/specs/agent-bootstrap-contract/spec.md
+++ b/openspec/changes/archive/2026-08-29-trim-compact-bootstrap-and-admit-destination-choice/specs/agent-bootstrap-contract/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: The agent contract teaches pre-write destination choice
+
+The bootstrap contract SHALL teach, in both the full and compact profiles, that
+choosing the destination is part of writing, not a reaction to advisories: when
+a coherent durable thread emerges in conversation that sits outside the current
+page's declared scope, the agent searches for a focused existing destination or
+creates and links a focused child note, rather than letting the current page
+accumulate structural debt until a detector fires. The compact profile MAY
+carry a condensed wording, but SHALL state both halves of the rule: routing
+happens at write time, and post-write structural advisories are the safety
+net for missed routing, not the primary mechanism.
+
+#### Scenario: A divergent thread gets a home before the detector must speak
+
+- **WHEN** the bootstrap contract teaches capture routing in any profile that carries teaching
+- **THEN** it states that an emerging coherent durable thread outside the current page's declared scope is routed to a focused existing or new destination at write time
+- **AND** it states that post-write structural advisories are the safety net for missed routing, not the primary mechanism
+
+#### Scenario: Admission is paid for by trimming, not by the ceiling
+
+- **WHEN** the compact payload carries the destination-choice teaching
+- **THEN** the compact payload remains at or below its unchanged byte ceiling with at least the codified warning headroom to spare
+- **AND** the compact profile remains measurably smaller than full under the existing saving-ratio floor

--- a/openspec/changes/archive/2026-08-29-trim-compact-bootstrap-and-admit-destination-choice/tasks.md
+++ b/openspec/changes/archive/2026-08-29-trim-compact-bootstrap-and-admit-destination-choice/tasks.md
@@ -1,0 +1,37 @@
+# Tasks — trim-compact-bootstrap-and-admit-destination-choice
+
+## 1. Red-first
+
+- [x] 1.1 Compact-carriage test written and captured failing verbatim on the
+      untouched base; budget test with `-W error::UserWarning` captured failing
+      on base (24-byte headroom) as the trim's red evidence.
+
+## 2. Trim
+
+- [x] 2.1 Redundancy-first cuts in `op_bootstrap` compact prose per design D2;
+      every cut argued in a new dated `#:` log entry in
+      `tests/test_bootstrap_compact_budget.py`; pins moved with text, none
+      loosened or deleted.
+
+## 3. Admission
+
+- [x] 3.1 `destination_choice` teaching present in the compact payload
+      (condensed allowed, both halves of the rule intact per D3); full and
+      diagnostics wording untouched; the S4 compact byte-identical pin
+      replaced by the carriage pin in the same delivery.
+
+## 4. Gates
+
+- [x] 4.1 `tests/test_bootstrap_compact_budget.py` green UNMODIFIED in its
+      constants (ceiling 61,400, ratio 0.15, warning 512) and green under
+      `-W error::UserWarning`; paste `_size` for compact/full/diagnostics —
+      compact ≤ 60,888.
+- [x] 4.2 `tests/test_epistemic_bootstrap_contract.py` and every bootstrap /
+      prominence / scaffold suite that reads the payload green; scaffold
+      no-leak suite green.
+- [x] 4.3 `uvx ruff check src/exomem --select F`; `npm exec --yes
+      @fission-ai/openspec@1.10.0 -- validate --all --strict`; `git status`
+      proof of no tool-surface pin movement.
+- [x] 4.4 Mutation proof in a scratch copy under /tmp/claude-1000/**: reverting
+      the trim (restoring any one cut passage) while keeping the clause trips
+      the promoted-warning budget run — the margin is load-bearing.

--- a/openspec/specs/agent-bootstrap-contract/spec.md
+++ b/openspec/specs/agent-bootstrap-contract/spec.md
@@ -608,18 +608,27 @@ The bootstrap engagement guidance SHALL teach that a dismissal carries a reason 
 
 ### Requirement: The agent contract teaches pre-write destination choice
 
-The full bootstrap contract SHALL teach that choosing the destination is part of writing,
-not a reaction to advisories: when a coherent durable thread emerges in conversation
-that sits outside the current page's declared scope, the agent searches for a focused
-existing destination or creates and links a focused child note, rather than letting
-the current page accumulate structural debt until a detector fires.
+The bootstrap contract SHALL teach, in both the full and compact profiles, that
+choosing the destination is part of writing, not a reaction to advisories: when
+a coherent durable thread emerges in conversation that sits outside the current
+page's declared scope, the agent searches for a focused existing destination or
+creates and links a focused child note, rather than letting the current page
+accumulate structural debt until a detector fires. The compact profile MAY
+carry a condensed wording, but SHALL state both halves of the rule: routing
+happens at write time, and post-write structural advisories are the safety
+net for missed routing, not the primary mechanism.
 
 #### Scenario: A divergent thread gets a home before the detector must speak
 
-- **WHEN** the full bootstrap contract teaches capture routing
+- **WHEN** the bootstrap contract teaches capture routing in any profile that carries teaching
 - **THEN** it states that an emerging coherent durable thread outside the current page's declared scope is routed to a focused existing or new destination at write time
 - **AND** it states that post-write structural advisories are the safety net for missed routing, not the primary mechanism
-- **AND** the compact payload remains byte-identical until the queued compact-bootstrap trim admits the clause
+
+#### Scenario: Admission is paid for by trimming, not by the ceiling
+
+- **WHEN** the compact payload carries the destination-choice teaching
+- **THEN** the compact payload remains at or below its unchanged byte ceiling with at least the codified warning headroom to spare
+- **AND** the compact profile remains measurably smaller than full under the existing saving-ratio floor
 
 ### Requirement: The capture predicate covers stated intent and observed outcomes
 

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -770,11 +770,9 @@ def op_bootstrap(
                     "title-first citation"
                 ),
                 "reason in the agent",
-                "use connect_memory(operation='suggest-links' or 'suggest-relations') before important compiled writes",
-                "remember or replace_memory for page-level conclusions; observe_memory for one semantic unit; edit_memory for other small page corrections",
                 (
-                    "read the returned warnings and follow up on unresolved links "
-                    "or duplicate warnings; write_feedback needs "
+                    "after a write, read the returned warnings and follow up on "
+                    "unresolved links or duplicate warnings; write_feedback needs "
                     "response_detail='full', and suggestions additionally need "
                     "remember(suggestions=true)"
                 ),
@@ -843,27 +841,29 @@ def op_bootstrap(
                 "review_reason": "every review decision records WHY as a closed code: lead the `why` with intentional:, false_positive:, handled:, deferred:, or too_frequent: followed by the free text. Anything else records unspecified",
                 "family_disposition": "when the user asks to stop hearing about a KIND of signal, quiet that family rather than lowering prominence, which silences everything: triage_memory(ref='exomem://review/family/<family>', action='quiet'|'off'|'normal', why='<code>: ...'). quiet drops it from the default review union and every carrier; off also drops it from explicit category review; normal restores it",
                 "family_disposition_reading": "a quiet family is silent, not clean. It stays reviewable on request, review_memory(mode='dispositions') lists what is quiet and why, and the audit still measures it — so a due-state block that omits a family is never evidence that family has nothing due",
-                # FULL only, and the omission from compact is a decision, not an
-                # oversight: compact sits 24 bytes under a ceiling whose own
-                # docstring pre-commits the next addition to TRIMMING compact
-                # rather than raising it. Carrying this clause in compact is the
-                # queued compact-bootstrap trim's to spend, so the byte-identical
-                # compact payload is pinned by test rather than left to drift.
-                **(
-                    {
-                        "destination_choice": (
-                            "choosing the destination is part of writing, not a reaction to an "
-                            "advisory. When a coherent durable thread emerges in conversation that "
-                            "sits outside the current page's declared scope, search for a focused "
-                            "existing destination and link it, or create one, at write time. "
-                            "Post-write structural advisories are the safety net for routing that "
-                            "was missed, never the primary mechanism: a page left to accumulate "
-                            "structural debt until a detector speaks has already cost the reader "
-                            "what the routing would have given them."
-                        )
-                    }
-                    if profile != "compact"
-                    else {}
+                # Carried by EVERY profile. It was full-only while compact sat 24
+                # bytes under its ceiling; the queued compact-bootstrap trim has
+                # since paid for it out of redundancy elsewhere in the payload, and
+                # compact is the payload a hookless client receives, which is the
+                # surface with no detector-aware skill behind it. Compact states
+                # the same rule in fewer words -- both halves, the write-time
+                # routing act and the advisory as the net rather than the
+                # mechanism; full keeps its own wording unchanged.
+                "destination_choice": (
+                    "choose the destination at write time: when a coherent durable thread "
+                    "emerges outside the current page's declared scope, search for a focused "
+                    "existing destination, or create one, and link it. Post-write structural "
+                    "advisories are the safety net for missed routing, never the primary "
+                    "mechanism"
+                    if profile == "compact"
+                    else "choosing the destination is part of writing, not a reaction to an "
+                    "advisory. When a coherent durable thread emerges in conversation that "
+                    "sits outside the current page's declared scope, search for a focused "
+                    "existing destination and link it, or create one, at write time. "
+                    "Post-write structural advisories are the safety net for routing that "
+                    "was missed, never the primary mechanism: a page left to accumulate "
+                    "structural debt until a detector speaks has already cost the reader "
+                    "what the routing would have given them."
                 ),
             },
             "note_type_recipes": {
@@ -969,14 +969,10 @@ def op_bootstrap(
                 "args": {"detail": "compact", "rerank": False},
                 "when": "normal cheap product recall",
             },
-            "metadata_lookup": {
-                "tool": "ask_memory",
-                "args": {"detail": "compact", "rerank": False},
-                "when": "caller needs the richer find filters or compact stubs",
-            },
             "reasoning_lookup": {
                 "tool": "ask_memory",
                 "args": {"deep": True},
+                "when": "synthesis over bounded context",
             },
             "adopt_existing_vault": {
                 "tool": "adopt_vault",
@@ -1018,14 +1014,6 @@ def op_bootstrap(
             },
         },
         "performance_profiles": {
-            "normal": {
-                "ask_memory_args": {"detail": "compact", "rerank": False},
-                "interpretation": "cheap product recall; follow with read_memory if needed",
-            },
-            "reasoning": {
-                "ask_memory_args": {"deep": True},
-                "interpretation": "bounded context assembly for synthesis",
-            },
             "diagnostics": {
                 "ask_memory_args": {"include_timings": True, "rerank": True},
                 "interpretation": (
@@ -1073,11 +1061,7 @@ def op_bootstrap(
                 },
             },
             "retry_examples": [
-                "try synonyms and singular/plural forms",
-                "try adjacent domain terms",
-                "try scope='vault' if Knowledge Base recall is sparse",
                 "use adopt_vault(mode='scan-only') before proposing migration/copy actions",
-                "try ask_memory(deep=true) for synthesis instead of many read_memory calls",
             ],
         },
         "product_commands": product_tool_catalog(

--- a/tests/test_bootstrap_compact_budget.py
+++ b/tests/test_bootstrap_compact_budget.py
@@ -184,6 +184,105 @@ from exomem import commands
 #:
 #: 24 bytes is not headroom. The next addition trims or argues, and this branch
 #: has no claim on the argument: it spent 79 of the 103 bytes main left.
+#:
+#: TRIMMED, and this time the trim is the whole change rather than the price of
+#: one. The pre-write destination-choice clause landed in the FULL contract only
+#: and the canonical spec recorded the hook in as many words -- "the compact
+#: payload remains byte-identical until the queued compact-bootstrap trim admits
+#: the clause" -- with a test pinning that absence so it could not drift. This is
+#: that trim. The clause is now carried by every profile, and the ceiling did not
+#: move.
+#:
+#: Method is the one the two entries above set, and nothing here departs from it:
+#: bytes come back from REDUNDANCY -- text the payload already states somewhere
+#: else -- and pins moved WITH their text rather than being loosened around it.
+#: Six passages, 864 bytes, each measured on the final tree by restoring it alone:
+#:
+#:   workflow.loop suggest-links step       105  the same call is
+#:                                               `authoring_contract.canonical_loop`
+#:                                               step 5 on the draft, and
+#:                                               `preflight.connect_memory` names it
+#:                                               as the standard pre-write check
+#:   workflow.loop write-routing step       141  the four routes it listed ARE
+#:                                               `authoring_contract.route_by_intent`,
+#:                                               and each of the four is separately
+#:                                               pinned there
+#:   three retry_examples                   127  synonyms, adjacent terms and
+#:                                               scope='vault' are `workflow.miss_rule`,
+#:                                               which states all three as the rule
+#:                                               rather than as examples of it. One
+#:                                               fragment went with them that miss_rule
+#:                                               does NOT restate -- see below
+#:   one retry_example                       77  deep=true for synthesis is
+#:                                               canonical_loop step 2 and
+#:                                               `tool_defaults.reasoning_lookup`
+#:   tool_defaults.metadata_lookup          156  the same tool with byte-identical args
+#:                                               as `normal_lookup`; the richer filters
+#:                                               it pointed at are spelled out in
+#:                                               `search_guidance.semantic_recall`
+#:   performance_profiles normal, reasoning 258  each repeated one `tool_defaults`
+#:                                               row's args. `normal` also restated
+#:                                               that row's `when`; `reasoning` did
+#:                                               not, because that row carried no
+#:                                               `when` at all -- its interpretation
+#:                                               survives in canonical_loop step 2,
+#:                                               and this delivery ADDS the missing
+#:                                               `when` to the row itself so the
+#:                                               spec's three-lookup scenario still
+#:                                               reads all three from `tool_defaults`
+#:                                               (+42 B). The diagnostics profile stays
+#:
+#: One fragment left the payload UNRESTATED, and the ruling is deliberate rather
+#: than an oversight. "try synonyms and singular/plural forms" went out with the
+#: three retry examples, and miss_rule covers "synonyms" but not the morphological
+#: half: a plural is not a synonym. It is dropped as a sub-case of the synonym
+#: retry tactic, not as a rule -- the shipped skill scaffold still teaches
+#: morphological retry in references/operations.md, so the tactic is not lost to
+#: the product, only to this payload. Restoring it means widening miss_rule, which
+#: costs bytes this change does not have; it is the FIRST candidate to restore when
+#: a future trim frees them.
+#:
+#: What did NOT leave: no rule, no landing, no consequence, no named non-outcome,
+#: no route, and no command name reachable nowhere else. connect_memory, remember,
+#: replace_memory, observe_memory and edit_memory all keep their routes. The fifth
+#: retry example survives on the same test: scan-only BEFORE proposing a migration
+#: or copy is a guard, and nothing else in the payload states it.
+#:
+#: The clause costs compact 316 bytes in a condensed wording, 290 characters
+#: against full's 512, and both halves of the rule survive the condensation --
+#: destination choice happens at write time, by finding a focused existing
+#: destination or creating one; the post-write advisory is the safety net for
+#: missed routing, never the primary mechanism. Full's wording is untouched.
+#:
+#: Two of the cuts left a seam, and closing them is part of the same delivery
+#: rather than a later patch: the reasoning row's missing `when` above (+42 B),
+#: and the loop's last step, which said "read the returned warnings" after the
+#: step naming the write had gone. It now opens "after a write" (+15 B), which
+#: supplies the antecedent the cut removed.
+#:
+#: 61,376 - 864 + 316 + 57 = 60,885, measured. That is 515 bytes of headroom and
+#: the first time since the fourth raise that this payload has sat clear of
+#: HEADROOM_WARNING_BYTES. The margin is load-bearing in both directions:
+#: restoring any ONE of the six passages while keeping the clause puts compact
+#: back inside the warning band -- 410, 374, 388, 438, 359 and 257 bytes of
+#: headroom respectively -- so nothing here was cut for margin that was not
+#: needed. `MINIMUM_SAVING_RATIO` is untouched; the saving moved 35.32% -> 35.29%,
+#: because the redundant passages were shared text and full lost them too.
+#:
+#: Two larger redundancies were found and NOT taken. They are recorded here so
+#: the next trim starts from them instead of rediscovering them.
+#: `authoring_contract.semantic_units.contract` is the top-level
+#: `semantic_authoring` projection repeated in full -- 9,042 bytes, the single
+#: largest duplication in this payload -- and `tool_catalog` is `product_commands`
+#: repeated, 1,602 more. Neither is prose. Both are published payload KEYS a
+#: client may read, and the nested projection is pinned by name in
+#: test_bootstrap.py, so taking either means deleting a pin or withdrawing a key:
+#: a surface decision, not a trim. `records.software_rule` was rejected on a
+#: different ground -- it does restate `planning.execution_truth_boundary`, but it
+#: is that boundary stated INSIDE the Records contract, and it is pinned there.
+#:
+#: 515 bytes is spendable budget, not licence. The next addition of this size
+#: argues for itself the way the raises above had to.
 COMPACT_BYTE_CEILING = 61_400
 
 #: The defect was compact and full being near-identical. A profile that does not

--- a/tests/test_epistemic_bootstrap_contract.py
+++ b/tests/test_epistemic_bootstrap_contract.py
@@ -453,20 +453,30 @@ def test_destination_choice_names_no_tool(vault: Path) -> None:
     assert "(" not in clause and "_memory" not in clause
 
 
-def test_compact_payload_stays_byte_identical_without_the_clause(vault: Path) -> None:
-    """The clause is FULL-only, and that is a budget decision with a paper trail.
+def test_compact_payload_carries_the_destination_choice_clause(vault: Path) -> None:
+    """Named replacement for `test_compact_payload_stays_byte_identical_without_the_clause`.
 
-    Compact sits 24 bytes under a ceiling whose own docstring pre-commits the next
-    addition to TRIMMING compact rather than raising it. Carrying this clause in
-    compact belongs to the queued compact-bootstrap trim; until then compact must
-    not grow by a single byte on its account.
+    That pin held the clause out of compact and named its own successor: compact
+    sat 24 bytes under a ceiling whose docstring pre-commits the next addition to
+    TRIMMING compact rather than raising it, so carriage "belongs to the queued
+    compact-bootstrap trim". This is that delivery. The clause is now paid for out
+    of trimmed redundancy rather than deferred, so the pin flips from absence to
+    carriage rather than being deleted: compact carries the teaching, condensed
+    wording allowed, and both halves of the rule must survive the condensation.
     """
-    compact = commands.op_bootstrap(vault, profile="compact")
-    assert "destination_choice" not in compact["authoring_contract"]["post_write"]
+    clause = _post_write(vault, "compact")["destination_choice"]
 
-    without = json.dumps(compact)
-    # Full and diagnostics DO carry it, so the omission is a profile decision
-    # rather than the clause having been dropped altogether.
+    # Half one -- the routing act, at write time, against the declared scope.
+    assert "at write time" in clause
+    assert "declared scope" in clause
+    assert "existing destination" in clause and "create one" in clause
+    # Half two -- the detector is the net, never the mechanism.
+    assert "safety net" in clause
+    assert "never the primary mechanism" in clause
+    # Compact is the payload a hookless surface receives, which is exactly where
+    # `_filter_bootstrap_payload` deletes a string naming an unavailable command.
+    assert "(" not in clause and "_memory" not in clause
+
+    # Admission is not a move: full and diagnostics still carry it too.
     for profile in ("full", "diagnostics"):
         assert "destination_choice" in _post_write(vault, profile)
-    assert "destination_choice" not in without


### PR DESCRIPTION
## What

Closes the queued compact-bootstrap trim that two deliveries recorded deferrals against (route-lifecycle: "compact-bootstrap trim is still its own queued change"; semantic scope-divergence D8: clause "in the FULL contract only"). The canonical spec's own hook — "the compact payload remains byte-identical **until the queued compact-bootstrap trim admits the clause**" — is retired by this change.

- **Six redundancy-only cuts, 864 bytes**, each argued in the budget test's `#:` running log per its established method (bytes come back from text the payload already states elsewhere; pins move with text, none loosened or deleted; the budget-test diff is comment-only).
- **`destination_choice` admitted to compact** (316 bytes condensed, both halves of the rule intact: routing happens at write time; post-write advisories are the safety net). Full's 512-char wording byte-identical to before.
- **Review-round hardening (+57 bytes):** a `when` on `tool_defaults.reasoning_lookup` (closes the spec's three-lookup performance scenario, which the trim had left interpretation-less) and a restored antecedent on the loop's warnings step.

## Numbers

| | before | after |
|---|---|---|
| compact | 61,376 (24 headroom) | **60,885** (515 headroom, clear of the 512 warning band) |
| ceiling / ratio / warning | 61,400 / 0.15 / 512 | unchanged |
| saving vs full | 35.32% | 35.29% |
| tool-surface sha | `f12c6997…` | identical |

Margin is load-bearing both ways: restoring any single cut passage puts compact back inside the warning band (359–438 bytes headroom), mutation-verified. Two larger duplications (9,042-byte `semantic_units.contract`, 1,602-byte `tool_catalog`) were found, diagnosed as published-surface decisions, and recorded in the log for the next trim instead of being taken.

## Review

Fresh zero-context adversarial review reproduced **every** byte figure exactly (all six per-passage costs and all six restore-one headroom figures), verified each cut against its claimed restatement, pin integrity (S4's byte-identical pin replaced by a named successor asserting strictly more), and clause condensation against the spec delta: **APPROVE WITH NITS**; the three MEDIUM nits are closed in this delivery and re-gated.

## Verification

- Red-first: compact-carriage test failed on base (`KeyError: 'destination_choice'`); budget test with `-W error::UserWarning` failed on base (24-byte headroom).
- Budget suite 11/11 plain and with the warning promoted to error; bootstrap-contract suites 51 passed; 17 payload-reading suites + scaffold no-leak: 412 passed.
- `openspec validate --all --strict` 167/0 → archive → 166/0; archive-discipline check OK (archived in the same delivery).
