### PR TITLE
feat(audit): add the entity recurrence sensor

### DIFF
--- a/openspec/changes/archive/2026-08-30-add-entity-recurrence-sensor/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-30-add-entity-recurrence-sensor/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/archive/2026-08-30-add-entity-recurrence-sensor/design.md
+++ b/openspec/changes/archive/2026-08-30-add-entity-recurrence-sensor/design.md
@@ -1,0 +1,160 @@
+# Design — entity recurrence sensor (unresolved-identity v1)
+
+Authority order: source+tests > active/accepted OpenSpec > the no-nudge
+architecture report (KB, S5) > older notes.
+
+## D1 — Evidence source
+
+The only evidence is what pages already say: for each parsed page in the audit's
+existing page list, the body's wikilinks (`vault.find_body_wikilinks`) whose
+target does not exist in the vault. No new I/O beyond the bodies the audit
+already holds; no embedding; no model. An identity is the NFKC-normalised form
+of the link target via `entity_candidates.identity_key` — imported, never
+reimplemented. Pages whose body is unavailable are not counted (absence is
+never evidence).
+
+## D2 — Gates
+
+A candidate fires only when ALL hold:
+
+1. **Spread**: unresolved wikilinks to the identity appear in at least
+   `SPREAD_MIN_PAGES` distinct pages (PROVISIONAL, 3 — f21's "three distinct
+   sources" precedent).
+2. **Unresolved as a page**: no vault page exists at the link target, and none
+   exists at the NAME the target ends in either. `[[Some/Wrong/Path/Marin Osk]]`
+   while `Notes/Marin Osk.md` exists is a misfiled link to a page that exists —
+   the audit already reports it as one — not evidence that nobody has written
+   the identity down. An AMBIGUOUS bare name counts as existence for the same
+   reason: a name the vault wrote down twice is emphatically not one it never
+   wrote down.
+3. **Unresolved as an entity**: the identity does not NFKC-resolve against the
+   entity registry's titles or aliases (`entity_candidates` machinery reused).
+   A resolved identity is the registry's business, not a candidate.
+4. **Self-links excluded**: a page linking to itself, and links inside
+   `Entities/`, count nothing.
+5. **Present attention only**: a page whose status is `superseded`, `archived`
+   or `draft`, and a page whose tree is `excluded` in `_access.yaml`, supplies
+   no spread and can never be the anchor. A retired note's links record what the
+   vault USED to reach for, and a retired page often sorts early, so without
+   this a finding both crosses the gate on history and names it. This is the
+   status half of `audit._is_active_compiled_rw` and DELIBERATELY only that
+   half: a Source or an Evidence page IS the corpus reaching for a name, so the
+   template's compiled-and-read-write restriction would discard exactly the
+   evidence this sensor exists to count.
+
+Counting is per page (a page mentioning the identity five times contributes
+one), so frequency inside one note never substitutes for spread — the
+incidental-mention discipline made mechanical.
+
+**A dot in a name is punctuation until a file proves otherwise.** A wikilink
+target carrying an extension is an attachment only when `_ordinary_file_exists`
+confirms a file at it — the rule `_check_wikilinks` already applies, and the
+reason it probes the filesystem instead of reading the suffix. Deciding from the
+dot alone silences `SomeProduct 2.0` (`Path.suffix` is `.0`), `Dr. Ines Roth`,
+`U.S. Navy` and `Node.js`. The probe runs AFTER spread and the registry have
+narrowed the set, so it costs at most one existence check per distinct suffixed
+target per surviving candidate, never one per link.
+
+## D3 — Identity assist (lexical only)
+
+The finding carries up to `MAX_NEAR_MATCHES` (PROVISIONAL, 3) registry entries
+sharing at least one identity token with the candidate, ordered
+deterministically (shared-token count desc, then path asc). This is advice for
+the agent's own existing check-before-create judgment. No fuzzy-distance
+algorithm, no embedding — no entity-title vector index exists and this change
+may not add one.
+
+## D4 — Placement, fingerprint, anchor
+
+Category `entity_recurrence`, reason `unresolved_identity_recurs`, registered
+in `EPISTEMIC_REVIEW_CATEGORIES` (opt-in; same argument as
+`scope_divergence_semantic`). Findings ride the existing review composer:
+`meta["signal_version"] = content_hash(identity_key)[:16]` — the identity IS
+the signal, so a dismissal binds to the candidate and survives every
+incidental edit; v1 defines no material-change reopen (growth in spread does
+not re-raise a dismissed candidate — PROVISIONAL, revisit with calibration).
+The finding anchors to the lexicographically smallest mentioning page
+(deterministic; the full sorted page list rides `meta`), accepting that if
+that page stops mentioning the identity the anchor moves and a dismissal can
+orphan — recorded here as a known v1 trade rather than hidden.
+
+The page list rides `meta` and NOT the `paths` group field, and that is the
+dismissal contract rather than a formatting choice: `review_state.fingerprint`
+folds a finding's `paths` into the item identity, so a list that grows every
+time somebody links the name again would move the fingerprint on exactly the
+event this design says must not re-raise a settled candidate. Because `paths` is
+therefore empty, `review_context` draws this category's related-page evidence
+from `meta["pages"]`, so a reader opening the item still sees the pages the
+count is about.
+
+`meta["review_partition"]` is the identity, for the same reason the signal
+version is. Two identities recurring across one corpus routinely share an
+anchor — the page that sorts smallest mentions both — and without a partition
+`attention` fuses them onto ONE review id: a single dismissal puts down several
+unrelated candidates, and a third identity arriving on that anchor changes the
+fused fingerprint and reopens the settled decision. Same mechanism
+`prediction_window`, `question_aging`, `bridge_review` and
+`unreflected_outcomes` already use.
+
+**No cap on findings, deliberately.** One finding per qualifying identity, with
+no per-sweep ceiling — the `scope_divergence_semantic` precedent. A cap would
+make which candidates a reader sees depend on how many others qualified, and the
+first-run backlog is exactly what the opt-in registration already handles: the
+category is registered and triageable but stays out of the default attention
+union, so a large first sweep never displaces the daily surface.
+
+## D5 — Resolution by state change
+
+Quiet when: the target page is created (link no longer unresolved), or an
+entity page whose title or alias NFKC-resolves the identity exists. Deleting
+either brings the finding back. Never resolved by time or by the runtime
+editing anything.
+
+## D6 — Acceptance fixtures
+
+1. Three pages link `[[Unresolved Name]]` → one finding: candidate, three
+   pages sorted, near-matches listed. RED on base (unknown category).
+2. Plain-text mentions at matched frequency, no wikilinks → quiet (the
+   deferred stream, asserted so the v1 scope is pinned, not implied).
+3. Registry-resolved identity (alias match) linked from five pages → quiet.
+4. Two-page spread → quiet.
+5. State change both directions: create entity page → quiet; delete it →
+   finding returns; create the target page itself → quiet.
+6. S6: family `off` silences; a dismissed candidate stays dismissed across
+   incidental edits.
+7. Determinism: identical findings across page-insertion orders.
+
+## D7 — What the reviewer should attack
+
+The identity normalisation (aliasing collisions two distinct names into one
+candidate), the anchor-movement trade in D4, registry-resolution correctness
+(subpath/heading links, `[[a|display]]` forms), cost on large vaults (the
+sweep must stay one pass over already-parsed bodies), and whether the
+near-match ordering is genuinely deterministic.
+
+Known follow-ups, named rather than hidden:
+
+- **The skill scaffold's `audit-checks.md` does not list this category.** That
+  gap is pre-existing and general: `scope_divergence_semantic` (this change's
+  own template), `unreflected_outcomes` and `entity_type_unregistered` are all
+  registered and all absent from that file too. `src/exomem/_scaffold/**` is out
+  of scope for this change.
+  A separate change should reconcile the scaffold with the registry once, for
+  every category, rather than each sensor patching it on the way past.
+- **Vault-root spelling.** The resolution-entry walk derives a relative path the
+  same way `ParsedPage` and `WikilinkResolver._build` do (through `resolve()`),
+  so one file can never reach the resolver under two spellings. The divergence
+  this prevents is currently unreachable and therefore unpinned by a test: the
+  only vector is a symlinked vault root, and `_parse_all` refuses one upstream
+  (`reserved identity catalogue could not acquire the vault`) on the untouched
+  base too. The alignment is kept as defence, not as a fix for a live bug.
+
+## D8 — Measured cost (recorded at delivery)
+
+10,300-page synthetic vault (two wikilinks per page, 300 registry entities),
+quiesced WSL box: sweep 0.70 s ≈ 69 µs per page over already-parsed pages —
+about a fifth of the `_parse_all` it rides on. Exactly one path-only vault walk
+and one file open (`entity-types.yaml`, digest-cached) per sweep, plus at most
+two existence probes per gate-crossing dotted identity and none below the gate.
+Near-match assist ≈ 35 µs per surviving candidate against a 300-entry registry
+(O(candidates × registry), in-memory).

--- a/openspec/changes/archive/2026-08-30-add-entity-recurrence-sensor/proposal.md
+++ b/openspec/changes/archive/2026-08-30-add-entity-recurrence-sensor/proposal.md
@@ -1,0 +1,63 @@
+# Add the entity recurrence sensor (unresolved-identity v1)
+
+## Why
+
+Entity emergence is a flagship no-nudge commitment and a pre-registered
+falsification family (f21 `entity_emergence`: an identity recurring with
+reusable facts across at least three distinct sources SHALL surface an
+entity-candidate signal). Today no recurrence signal exists anywhere:
+`resolve_entity_candidate` is exact NFKC title/alias matching, the audit
+detects unresolved wikilinks per page (`forward_reference`) but never counts
+recurrence across pages, and an identity a user links five times from five
+notes accumulates no candidate anywhere. The agent can only notice by luck.
+
+## What Changes
+
+- **A corpus-recurrence sensor over unresolved wikilinks.** A new audit
+  category `entity_recurrence` counts, per NFKC-normalised identity, the
+  distinct pages whose bodies carry an unresolved wikilink to it. An identity
+  reaching the spread gate — and NOT resolving against the entity registry's
+  titles and aliases — produces one finding carrying reason
+  `unresolved_identity_recurs`, the candidate name, the sorted mentioning
+  pages, and up to three registry near-matches (shared identity tokens,
+  deterministic) so the agent checks before creating.
+- **Advice, never creation.** The finding proposes that the agent consider the
+  conservative-capture judgment it already owns (`proactive-entity-capture`:
+  creation stays agent-side; a single mention never justifies it — and this
+  sensor's spread gate is that rule made mechanical). The runtime creates
+  nothing.
+- **Resolution stays state-change-only.** Creating an entity page whose title
+  or alias NFKC-resolves the identity silences it; so does creating the linked
+  page itself (the link stops being unresolved). Deleting either brings the
+  finding back. No dismissal memory beyond S6.
+- **Delivery through existing machinery.** Registered in
+  `EPISTEMIC_REVIEW_CATEGORIES` (opt-in — same posture as
+  `scope_divergence_semantic`: a recurrence sensor meets an existing corpus
+  where every candidate it will name is already linked). Findings are
+  fingerprint-bound review items under S2 suppression and S6 family
+  dispositions; attention-queue admission and family registration follow
+  derivationally from the category registries, so no delta is filed for them.
+
+## Non-goals
+
+- **The proper-n-gram stream is deliberately deferred.** The architecture
+  report named plain-text recurring proper n-grams as a second evidence
+  stream; it is exactly the incidental-mention false-positive surface whose
+  budgets f21 freezes behind the three-expert calibration study. v1 ships the
+  explicit, high-precision stream only; the n-gram stream is a future change
+  once calibration lands.
+- No embedding, no model call, no new index, no write-time work: identity
+  assist is lexical (NFKC identity tokens), because no entity-title embedding
+  index exists and the sensor may not add one.
+- No bootstrap-contract change: the active `harden-write-and-entity-capture`
+  change owns entity-capture teaching.
+- No bench-constant changes; f21 stays withheld and calibration-owned.
+
+## Impact
+
+- Affected specs: `action-first-audit` (new category).
+- Affected code: new `entity_recurrence.py` (or a sibling section), `audit.py`
+  category registration and sweep, tests.
+- Falsification: f21 `entity_emergence` (registered, withheld); the
+  frequency-matched incidental-mention twin maps to this sensor's
+  out-of-scope plain-text stream and the below-spread twin.

--- a/openspec/changes/archive/2026-08-30-add-entity-recurrence-sensor/specs/action-first-audit/spec.md
+++ b/openspec/changes/archive/2026-08-30-add-entity-recurrence-sensor/specs/action-first-audit/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: The audit detects recurring unresolved entity identities
+
+The audit SHALL provide an `entity_recurrence` category that counts, per
+NFKC-normalised identity, the distinct pages whose bodies carry an unresolved
+wikilink to it, and SHALL produce one finding per identity that reaches the
+spread gate while resolving against neither an existing vault page nor the
+entity registry's titles and aliases. The finding SHALL carry reason
+`unresolved_identity_recurs`, the candidate identity, the sorted mentioning
+pages, and a bounded deterministic list of registry near-matches. The category
+SHALL add no write-time work, no embedding, no model call, and SHALL never
+create any page.
+
+#### Scenario: A recurring unresolved identity becomes a candidate
+
+- **GIVEN** three distinct pages whose bodies link an identity that exists neither as a page nor as a registry title or alias
+- **WHEN** the audit sweeps the category
+- **THEN** one `entity_recurrence` finding is produced carrying reason `unresolved_identity_recurs`, the candidate, the three pages sorted, and the near-match list
+
+#### Scenario: Frequency inside one page is not spread
+
+- **GIVEN** one page linking the same unresolved identity five times and one other page linking it once
+- **WHEN** the audit sweeps the category
+- **THEN** zero findings are produced for that identity
+
+#### Scenario: Plain-text mentions are out of scope for this stream
+
+- **GIVEN** an identity mentioned in body text of many pages with no wikilink anywhere
+- **WHEN** the audit sweeps the category
+- **THEN** zero findings are produced for it
+
+#### Scenario: A registry-resolved identity is never a candidate
+
+- **GIVEN** an entity page whose alias NFKC-matches an identity linked from five pages
+- **WHEN** the audit sweeps the category
+- **THEN** zero findings are produced for that identity
+
+#### Scenario: Retired and excluded pages are not evidence
+
+- **GIVEN** an identity linked from two eligible pages and from one page that is superseded, archived, draft, or in an excluded access tier
+- **WHEN** the audit sweeps the category
+- **THEN** zero findings are produced for that identity
+- **AND** a finding never anchors on a retired or excluded page
+
+#### Scenario: Acting on the advice resolves it by state change
+
+- **GIVEN** a firing candidate
+- **WHEN** an entity page whose title or alias resolves the identity is created, or the linked target page itself is created
+- **THEN** the finding is not produced on the next sweep
+- **AND** deleting that page brings the finding back without any recorded dismissal
+
+#### Scenario: Findings ride the existing review machinery
+
+- **GIVEN** an `entity_recurrence` finding
+- **WHEN** it is delivered
+- **THEN** it is a fingerprint-bound review item keyed on the identity, honouring family dispositions and dismissal suppression

--- a/openspec/changes/archive/2026-08-30-add-entity-recurrence-sensor/tasks.md
+++ b/openspec/changes/archive/2026-08-30-add-entity-recurrence-sensor/tasks.md
@@ -1,0 +1,47 @@
+# Tasks — add-entity-recurrence-sensor
+
+## 1. Red-first fixtures
+
+- [x] 1.1 Acceptance fixture (D6.1): three pages carrying `[[Unresolved Name]]`
+      → RED on the untouched base with verbatim output captured before any
+      sensor code.
+- [x] 1.2 The three quiet twins (D6.2–D6.4): plain-text mentions, registry-
+      resolved alias, below-spread — zero findings asserted positively.
+
+## 2. Sensor
+
+- [x] 2.1 Recurrence collection: one pass over the audit's parsed pages,
+      `vault.find_body_wikilinks` per body, `entity_candidates.identity_key`
+      normalisation (imported), per-page dedup, spread gate
+      `SPREAD_MIN_PAGES` (PROVISIONAL), self-link and `Entities/` exclusions,
+      wikilink display/heading forms (`[[a|b]]`, `[[a#h]]`) normalised to the
+      target page identity.
+- [x] 2.2 Registry resolution + near-match assist: candidate excluded when it
+      NFKC-resolves against titles/aliases; near-matches by shared identity
+      tokens, `MAX_NEAR_MATCHES` cap, deterministic order.
+- [x] 2.3 Finding composition: reason `unresolved_identity_recurs`,
+      `meta["signal_version"] = content_hash(identity_key)[:16]`, anchor =
+      lexicographically smallest mentioning page, sorted page list in meta.
+
+## 3. Delivery through existing machinery
+
+- [x] 3.1 Category `entity_recurrence` in `EPISTEMIC_REVIEW_CATEGORIES` and the
+      sweep wired in `audit.py` (scope_divergence_semantic is the template);
+      family registration and attention admission verified derivational (no
+      registry restated).
+- [x] 3.2 Resolution by state change (D6.5) and S6 integration (D6.6) tested:
+      entity page create/delete both directions; target-page create; family
+      `off`; dismissal survives incidental edits.
+
+## 4. Gates
+
+- [x] 4.1 Focused suites: the new sensor tests, audit suites, review-state and
+      attention suites. Mutation proofs in a scratch copy under
+      /tmp/claude-1000/** (never the worktree): every gate constant and
+      exclusion rule names a test that fails when deleted.
+- [x] 4.2 Cost bound measured and recorded: one pass over already-parsed
+      bodies; no second corpus scan; number for a large synthetic vault.
+- [x] 4.3 `uvx ruff check src/exomem --select F`; `openspec validate --all
+      --strict` (npm exec @fission-ai/openspec@1.10.0); no tool-surface pin
+      move (`git status` proof).
+- [x] 4.4 Determinism across page-insertion orders (D6.7).

--- a/openspec/specs/action-first-audit/spec.md
+++ b/openspec/specs/action-first-audit/spec.md
@@ -101,3 +101,59 @@ The category SHALL add no write-time embedding, no model call, and no new index.
 - **GIVEN** a `scope_divergence_semantic` finding
 - **WHEN** it is delivered
 - **THEN** it is a fingerprint-bound review item keyed by page identity and the sorted label terms, honouring family dispositions, dismissal suppression, and material-change reopen when the label set changes
+
+### Requirement: The audit detects recurring unresolved entity identities
+
+The audit SHALL provide an `entity_recurrence` category that counts, per
+NFKC-normalised identity, the distinct pages whose bodies carry an unresolved
+wikilink to it, and SHALL produce one finding per identity that reaches the
+spread gate while resolving against neither an existing vault page nor the
+entity registry's titles and aliases. The finding SHALL carry reason
+`unresolved_identity_recurs`, the candidate identity, the sorted mentioning
+pages, and a bounded deterministic list of registry near-matches. The category
+SHALL add no write-time work, no embedding, no model call, and SHALL never
+create any page.
+
+#### Scenario: A recurring unresolved identity becomes a candidate
+
+- **GIVEN** three distinct pages whose bodies link an identity that exists neither as a page nor as a registry title or alias
+- **WHEN** the audit sweeps the category
+- **THEN** one `entity_recurrence` finding is produced carrying reason `unresolved_identity_recurs`, the candidate, the three pages sorted, and the near-match list
+
+#### Scenario: Frequency inside one page is not spread
+
+- **GIVEN** one page linking the same unresolved identity five times and one other page linking it once
+- **WHEN** the audit sweeps the category
+- **THEN** zero findings are produced for that identity
+
+#### Scenario: Plain-text mentions are out of scope for this stream
+
+- **GIVEN** an identity mentioned in body text of many pages with no wikilink anywhere
+- **WHEN** the audit sweeps the category
+- **THEN** zero findings are produced for it
+
+#### Scenario: A registry-resolved identity is never a candidate
+
+- **GIVEN** an entity page whose alias NFKC-matches an identity linked from five pages
+- **WHEN** the audit sweeps the category
+- **THEN** zero findings are produced for that identity
+
+#### Scenario: Retired and excluded pages are not evidence
+
+- **GIVEN** an identity linked from two eligible pages and from one page that is superseded, archived, draft, or in an excluded access tier
+- **WHEN** the audit sweeps the category
+- **THEN** zero findings are produced for that identity
+- **AND** a finding never anchors on a retired or excluded page
+
+#### Scenario: Acting on the advice resolves it by state change
+
+- **GIVEN** a firing candidate
+- **WHEN** an entity page whose title or alias resolves the identity is created, or the linked target page itself is created
+- **THEN** the finding is not produced on the next sweep
+- **AND** deleting that page brings the finding back without any recorded dismissal
+
+#### Scenario: Findings ride the existing review machinery
+
+- **GIVEN** an `entity_recurrence` finding
+- **WHEN** it is delivered
+- **THEN** it is a fingerprint-bound review item keyed on the identity, honouring family dispositions and dismissal suppression

--- a/src/exomem/audit.py
+++ b/src/exomem/audit.py
@@ -105,6 +105,7 @@ from . import (
     source_closure,
     temporal,
 )
+from . import entity_recurrence as entity_recurrence_module
 from . import entity_types as entity_types_module
 from . import find as find_module
 from . import vault as vault_module
@@ -148,6 +149,7 @@ ALL_CATEGORIES: tuple[str, ...] = (
     "entity_type_unregistered",
     "unreflected_outcomes",
     "scope_divergence_semantic",
+    "entity_recurrence",
 )
 OPTIONAL_CATEGORIES: tuple[str, ...] = (
     "relation_registry",
@@ -202,6 +204,15 @@ EPISTEMIC_REVIEW_CATEGORIES: tuple[str, ...] = (
     # surface; a queue that fires on a number the product picked has not, and
     # admitting one would let a tuning decision quietly displace authored work.
     "question_aging",
+    # A third reason for the same exclusion, and the one this tuple's BACKLOG
+    # PROFILE gate was written for. A recurrence sensor meets an existing corpus
+    # in which every candidate it will ever name is ALREADY linked — the whole
+    # grandfathered population arrives on the first run. It is registered,
+    # selectable and triageable from that run; it simply does not displace a
+    # surface someone already relies on. Whether it graduates into the default
+    # union is a calibration decision, on evidence this change deliberately does
+    # not yet have (f21 stays withheld).
+    "entity_recurrence",
 )
 _SEMANTIC_AUDIT_CATEGORIES = frozenset({"semantic_contract_drift", *TYPED_SEMANTIC_CATEGORIES})
 _LEGACY_BACKLOG_CODE = "RELATION_DISPOSITION_MISSING"
@@ -516,6 +527,8 @@ def audit(
         findings.extend(_check_corpus_contradictions(vault_root, pages, today=today))
     if "scope_divergence_semantic" in selected:
         findings.extend(_check_scope_divergence_semantic(vault_root, pages))
+    if "entity_recurrence" in selected:
+        findings.extend(_check_entity_recurrence(vault_root, pages))
     if "relation_registry" in selected:
         findings.extend(_check_relation_registry(vault_root))
     if "relation_debt" in selected:
@@ -5304,6 +5317,160 @@ def _check_scope_divergence_semantic(
         if advisory is not None:
             findings.append(_scope_divergence_semantic_finding(rel_path, advisory))
     return findings
+
+
+def _entity_recurrence_finding(
+    candidate: entity_recurrence_module.Candidate,
+) -> AuditFinding:
+    """One recurring identity -> one finding, with the ONE signal version it uses.
+
+    The fingerprint a review decision binds to is composed by `review_state` from
+    the finding's category, path and `signal_version`; this is the only place the
+    latter is chosen, and it is composed over the IDENTITY rather than over any
+    page's bytes. That is the whole dismissal contract for this family: the
+    identity IS the signal, so "I have decided not to create this entity" survives
+    every incidental edit to every page that mentions it, and a different identity
+    can never inherit that decision. v1 deliberately defines no material-change
+    reopen — a candidate that grows from three mentioning pages to nine does not
+    re-raise a dismissal (design D4, PROVISIONAL, revisit with calibration).
+    """
+    near = [match["title"] for match in candidate.near_matches]
+    return AuditFinding(
+        category=entity_recurrence_module.KIND,
+        severity="info",
+        path=candidate.anchor,
+        # The mentioning pages ride `meta`, NOT the `paths` group field, and that
+        # is the dismissal contract rather than a stylistic choice (design D4).
+        # `review_state.fingerprint` folds a finding's `paths` into the item
+        # identity, so putting a list that grows every time somebody links the
+        # name again there would move the fingerprint on exactly the event v1
+        # says must not re-raise a settled candidate. `attention` carries `meta`
+        # into the reason payload, so the reader still sees every page.
+        detail=(
+            f"[[{candidate.candidate}]] is linked from {len(candidate.pages)} distinct "
+            "pages and resolves to neither a page nor a registry entity"
+            + (f" (nearest registry names: {', '.join(near)})" if near else "")
+        ),
+        proposed_fix=(
+            "Surfaced for REVIEW only — a count of how often the corpus reaches for "
+            "this name, not a judgment that an entity is missing. Check the "
+            "near-matches first: a recurring name is often one the registry already "
+            "holds under a different spelling, and an alias belongs on that page "
+            "rather than on a new one. If it is genuinely a new entity, creating it "
+            "is your call, as is creating the linked page itself. Nothing is "
+            "auto-created."
+        ),
+        meta={
+            "reasons": [entity_recurrence_module.REASON_UNRESOLVED_IDENTITY_RECURS],
+            "candidate": candidate.candidate,
+            "identity": candidate.identity,
+            # Two identities recurring across the same corpus routinely share an
+            # anchor — whichever page sorts smallest mentions both. Without a
+            # partition `attention` fuses them onto one review id, so ONE
+            # dismissal puts down several unrelated candidates and a THIRD
+            # identity arriving on that anchor changes the fused fingerprint and
+            # REOPENS the settled decision. The identity is the partition for the
+            # same reason it is the signal version: it is what a decision here is
+            # about. Same mechanism `prediction_window`, `question_aging`,
+            # `bridge_review` and `unreflected_outcomes` already use.
+            "review_partition": candidate.identity,
+            "pages": list(candidate.pages),
+            "page_count": len(candidate.pages),
+            "near_matches": [dict(match) for match in candidate.near_matches],
+            "signal_version": content_hash(candidate.identity)[:16],
+        },
+    )
+
+
+def _entity_recurrence_resolution_entries(
+    vault_root: Path,
+    pages: list[find_module.ParsedPage],
+) -> dict[str, str | None]:
+    """Path + title entries for an I/O-FREE wikilink resolver.
+
+    `WikilinkResolver(vault_root)` would re-read and YAML-parse every Markdown
+    file in the vault, which is precisely the second corpus scan this sweep must
+    not pay. Titles come from the pages the audit already parsed (`parse_page`
+    and the resolver derive a title through the same `resolve_display_title`, so
+    the title edges are the ones a full build would have produced); the walk adds
+    PATHS ONLY, opening no file, so links into curated sibling trees outside the
+    Knowledge Base resolve instead of reading as unwritten identities.
+
+    The residual gap is recorded rather than hidden: a page OUTSIDE the Knowledge
+    Base that is reachable only by its frontmatter title contributes no title
+    edge, so a bare-title link to it reads as unresolved. Closing it costs a read
+    of every file in the vault, which is the cost this sweep exists to avoid.
+    """
+    entries: dict[str, str | None] = {}
+    # `ParsedPage.rel_path` is derived through `resolve()`, and so is
+    # `WikilinkResolver._build`'s. The walk must agree with them or one file
+    # reaches the resolver under two spellings — two stem edges, two title
+    # candidates, and a bare name that looks ambiguous because of how it was
+    # enumerated rather than because of what the vault holds.
+    vault_resolved = vault_root.resolve()
+    for md_path in _walk_vault_md(vault_root):
+        try:
+            entries[md_path.resolve().relative_to(vault_resolved).as_posix()] = None
+        except (OSError, ValueError):
+            continue
+    for page in pages:
+        entries[str(page.rel_path)] = page.title
+    return entries
+
+
+def _check_entity_recurrence(
+    vault_root: Path,
+    pages: list[find_module.ParsedPage],
+) -> list[AuditFinding]:
+    """Corpus sweep for identities the vault keeps reaching for and never wrote.
+
+    The per-page link check (`forward_reference`) says "this page points at
+    something that does not exist"; it has never been able to say "and so do four
+    others". This counts across pages, which is the only place that arithmetic can
+    happen, and it runs here rather than at write time for one reason: this is
+    where the parsed bodies already are.
+
+    Cost is bounded by construction: EXACTLY ONE path-only vault walk per sweep
+    for the existence set, one registry index built from those same parsed pages,
+    and then one pass over the bodies. Nothing is embedded, no model is called,
+    and no `Entities/` glob runs per candidate. The sweep opens exactly one file —
+    the digest-cached entity-type registry — plus, for each identity that has
+    ALREADY cleared spread and the registry and whose name carries a dot, one
+    existence probe per distinct suffixed target. That probe is what stops the
+    sensor deciding from punctuation that `Node.js` or `Dr. Ines Roth` is a file.
+    """
+    if not pages:
+        return []
+    resolver = vault_module.WikilinkResolver.from_entries(
+        vault_root, _entity_recurrence_resolution_entries(vault_root, pages).items()
+    )
+    registry = entity_recurrence_module.registry_index(
+        pages, entity_types=entity_types_module.load_entity_types(vault_root)
+    )
+
+    def attachment_probe(target: str) -> bool:
+        """Is an ordinary file standing at this suffixed target?
+
+        The same two spellings `_check_wikilinks` probes — vault-rooted and
+        KB-relative — through the same `_ordinary_file_exists`, so the two agree
+        on what an attachment is.
+        """
+        normalized = target.removeprefix(kb_prefix()).lstrip("/")
+        return _ordinary_file_exists(
+            vault_root, vault_root / target.lstrip("/")
+        ) or _ordinary_file_exists(vault_root, vault_root / kb_dirname() / normalized)
+
+    return [
+        _entity_recurrence_finding(candidate)
+        for candidate in entity_recurrence_module.collect(
+            pages,
+            vault_root=vault_root,
+            resolver=resolver,
+            registry=registry,
+            indexable=lambda rel_path: access.is_indexable(vault_root, rel_path),
+            attachment_probe=attachment_probe,
+        )
+    ]
 
 
 def _check_corpus_contradictions(

--- a/src/exomem/entity_recurrence.py
+++ b/src/exomem/entity_recurrence.py
@@ -1,0 +1,411 @@
+"""Advisory detection that one identity keeps recurring with nothing to resolve it.
+
+Entity emergence is a flagship no-nudge commitment, and until now nothing in the
+corpus counted it. `entity_candidates.resolve_entity_candidate` answers "does the
+registry already know this name?" one name at a time. The audit reports an
+unresolved wikilink page by page (`forward_reference`) and never looks across
+pages. So an identity a person reaches for from five separate notes accumulates
+no signal anywhere, and the agent can only notice by luck.
+
+This module counts. The evidence is what pages already say — the wikilinks in
+bodies the audit has already parsed — and the arithmetic is spread: how many
+DISTINCT pages reach for one NFKC-normalised identity that resolves to neither a
+vault page nor a registry entity. Frequency inside one note contributes exactly
+one, which is the conservative-capture rule (`proactive-entity-capture`: a single
+mention never justifies creating anything) made mechanical rather than remembered.
+
+Everything here is advice. The runtime creates no page, edits nothing, and
+proposes only that the agent run the check-before-create judgment it already
+owns — which is why the finding carries registry near-matches: the most likely
+correct action on a recurring name is often "this is the entity you already have,
+spelt differently", and the sensor should hand over the evidence for that rather
+than push toward a new page.
+
+Determinism is a hard requirement: no clock, no RNG, no I/O, and no result that
+can depend on the order pages were read in. Absence is never evidence — a page
+whose body the audit does not hold is not counted at all.
+
+Two known v1 trades, recorded rather than hidden:
+
+* **Name aliasing.** The identity of `[[Notes/Marin]]` and `[[People/Marin]]` is
+  the same, because the registry resolves on a NAME and the name is what a
+  candidate would be created under. Two genuinely distinct people who share a
+  name therefore collapse into one candidate. The near-match list is what makes
+  that visible to the agent rather than silent.
+* **Anchor movement.** The finding anchors to the lexicographically smallest
+  mentioning page (design D4). If that page stops mentioning the identity the
+  anchor moves, and a dismissal bound to the old anchor can orphan.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .entity_candidates import _aliases as alias_values
+from .entity_candidates import identity_key
+from .entity_types import EntityTypeRegistry
+from .kbdir import kb_prefix
+from .vault import (
+    AmbiguousWikilinkError,
+    UnresolvedWikilinkError,
+    WikilinkResolver,
+    find_body_wikilinks,
+    normalize_wikilink,
+)
+
+#: The audit category this sensor feeds. Defined here, imported by the composer;
+#: `audit.ALL_CATEGORIES` and the sweep's own dispatch name it as a literal, in
+#: the same shape every other registered category uses.
+KIND = "entity_recurrence"
+REASON_UNRESOLVED_IDENTITY_RECURS = "unresolved_identity_recurs"
+
+# ---------------------------------------------------------------------------
+# PROVISIONAL thresholds.
+#
+# PRODUCT constants, not the frozen falsification-bench budgets: moving one is a
+# code change with its own evidence, never a §7 amendment. f21's "three distinct
+# sources" is the precedent the spread gate starts from; it is unvalidated at
+# corpus scale, so the tests pin behaviour AT the constant rather than at a
+# literal, and a threshold can move without rewriting what a test means.
+# ---------------------------------------------------------------------------
+
+#: How many DISTINCT pages must reach for one identity before it is a candidate.
+#: Distinct pages, never mentions: frequency inside one note is emphasis, not
+#: recurrence, and treating it as recurrence is exactly the incidental-mention
+#: false positive f21 freezes budgets against.
+SPREAD_MIN_PAGES = 3  # PROVISIONAL
+
+#: How many registry near-matches ride one finding. A bounded, ordered list is
+#: advice; an unbounded one is a second search result the agent has to triage.
+MAX_NEAR_MATCHES = 3  # PROVISIONAL
+
+#: Statuses whose pages are no longer the corpus paying attention to a name.
+#: The status half of `audit._is_active_compiled_rw`, reused rather than
+#: re-invented: a superseded note's links are a record of what the vault USED to
+#: reach for, and letting them supply spread — or, worse, anchor the finding,
+#: since a retired page often sorts early — measures history rather than
+#: attention. Deliberately only the status half: a Source or an Evidence page IS
+#: the corpus reaching for a name, so the template's compiled-and-read-write
+#: restriction would discard exactly the evidence this sensor exists to count.
+INELIGIBLE_STATUSES = frozenset({"superseded", "archived", "draft"})
+
+
+def entities_prefix() -> str:
+    """The subtree whose own links say nothing about recurrence (design D2.4).
+
+    Entity pages link each other as a matter of form — a hub listing every
+    person, a profile naming its own affiliations — so counting those links
+    would measure the registry's shape rather than the corpus's attention.
+    """
+    return f"{kb_prefix()}Entities/"
+
+
+@dataclass(frozen=True, slots=True)
+class Wikilink:
+    """One body wikilink, split into what resolves and what names an identity.
+
+    `target` is the whole link as written (minus display alias, heading anchor
+    and `.md`), because THAT is what decides whether a page already exists.
+    `name` is its last path segment, because that is what a registry resolves on
+    and what a candidate would be created under. `suffix` is the extension the
+    target carries, and it is carried rather than acted on: a dot in a name is
+    not evidence of a file (design D2).
+    """
+
+    target: str
+    name: str
+    suffix: str
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryEntry:
+    """One active registry entity, reduced to what resolution and assist need."""
+
+    path: str
+    title: str
+    #: Every name this entry answers to, NFKC-normalised: title plus aliases.
+    identities: frozenset[str]
+    #: The identity tokens of all of those names, for the lexical assist.
+    tokens: frozenset[str]
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryIndex:
+    """The registry's resolution surface, built once per sweep."""
+
+    entries: tuple[RegistryEntry, ...]
+    identities: frozenset[str]
+
+    def resolves(self, identity: str) -> bool:
+        """Whether the registry already answers to this identity (design D2.3)."""
+        return identity in self.identities
+
+    def near_matches(self, identity: str) -> tuple[dict[str, Any], ...]:
+        """Bounded, deterministic registry entries sharing an identity token.
+
+        Lexical only, and deliberately so: no entity-title vector index exists
+        and this change may not add one (design D3). Ordering is shared-token
+        count descending, then path ascending — a total order over distinct
+        paths, so it cannot depend on how the corpus was walked.
+        """
+        wanted = identity_tokens(identity)
+        if not wanted:
+            return ()
+        scored = [
+            (len(shared), entry)
+            for entry in self.entries
+            if (shared := entry.tokens & wanted)
+        ]
+        scored.sort(key=lambda item: (-item[0], item[1].path))
+        return tuple(
+            {
+                "path": entry.path,
+                "title": entry.title,
+                "shared_tokens": sorted(entry.tokens & wanted),
+            }
+            for _count, entry in scored[:MAX_NEAR_MATCHES]
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Candidate:
+    """One identity that cleared every gate, ready for the review composer."""
+
+    identity: str
+    #: The name as a body actually wrote it, taken from the anchor page.
+    candidate: str
+    pages: tuple[str, ...]
+    near_matches: tuple[dict[str, Any], ...]
+
+    @property
+    def anchor(self) -> str:
+        """Lexicographically smallest mentioning page (design D4)."""
+        return self.pages[0]
+
+
+def identity_tokens(value: str) -> frozenset[str]:
+    """The comparison tokens of one identity, through the ONE normaliser."""
+    return frozenset(identity_key(value).split())
+
+
+def parse_link(raw_target: str) -> Wikilink | None:
+    """Reduce one raw wikilink target to the page identity it names, or None.
+
+    `None` means "this link names no page identity", and there are exactly two
+    ways that happens: a folder-hub link (`[[Notes/Patterns/]]`) is not a page
+    link, and an empty target names nothing.
+
+    An extension is NOT one of them. A trailing `.something` is read as a
+    filename only when a file is actually there, which is the rule
+    `_check_wikilinks` already applies (audit.py — it probes the filesystem with
+    `_ordinary_file_exists` before calling a suffixed link an attachment). The
+    probe is the caller's job because it costs I/O; `suffix` is carried here so
+    the caller knows which candidates are worth probing at all.
+
+    Deciding from the dot alone was measured wrong: `Path("SomeProduct 2.0")`
+    has suffix `.0`, and so do `Dr. Ines Roth`, `U.S. Navy` and `Node.js` — four
+    of five reviewer probes produced zero findings for names a vault genuinely
+    reaches for. The dot is punctuation far more often than it is a file.
+    """
+    cleaned = str(raw_target or "").strip()
+    if not cleaned or cleaned.endswith("/"):
+        return None
+    cleaned = cleaned.split("#", 1)[0].strip()
+    if not cleaned:
+        return None
+    # Read BEFORE `.md` is stripped, exactly as `_check_wikilinks` reads it, so
+    # the two agree on which links are even candidates for the file probe.
+    suffix = PurePosixPath(cleaned).suffix.lower()
+    target = cleaned.removesuffix(".md").strip().strip("/")
+    if not target:
+        return None
+    return Wikilink(
+        target=target,
+        name=target.rsplit("/", 1)[-1],
+        suffix="" if suffix == ".md" else suffix,
+    )
+
+
+def page_exists(target: str, vault_root: Path, resolver: WikilinkResolver) -> bool:
+    """Whether a page already stands at `target` (design D2.2).
+
+    Resolution is the vault's own, not a second opinion about it: `strict=True`
+    turns every outcome into a distinguishable one, and AMBIGUITY counts as
+    existence. A bare name matching two files is a link to a page that exists
+    and needs disambiguating — the audit already calls that a broken link rather
+    than a forward reference, and an identity the vault has written down twice is
+    emphatically not one it has never written down.
+    """
+    try:
+        normalize_wikilink(target, vault_root, resolver=resolver, strict=True)
+    except AmbiguousWikilinkError:
+        return True
+    except UnresolvedWikilinkError:
+        return False
+    return True
+
+
+def registry_index(
+    pages: Iterable[Any], *, entity_types: EntityTypeRegistry
+) -> RegistryIndex:
+    """Build the registry's resolution surface from already-parsed pages.
+
+    Mirrors `resolve_entity_candidate`'s predicate — active entity pages sitting
+    directly in a registered kind's folder — but reads the bodies the audit
+    already holds instead of re-globbing `Entities/` from disk. One sweep must
+    not pay a directory walk per candidate.
+    """
+    folders = {definition.folder for definition in entity_types.active_definitions}
+    prefix = entities_prefix()
+    entries: list[RegistryEntry] = []
+    for page in pages:
+        rel_path = str(page.rel_path)
+        if not rel_path.startswith(prefix):
+            continue
+        remainder = rel_path[len(prefix) :]
+        folder, separator, name = remainder.partition("/")
+        if not separator or folder not in folders or "/" in name:
+            continue
+        if name.casefold() == "index.md":
+            continue
+        frontmatter = page.frontmatter
+        if str(frontmatter.get("type") or "").casefold() != "entity":
+            continue
+        if str(frontmatter.get("status") or "").casefold() != "active":
+            continue
+        if entity_types.resolve(str(frontmatter.get("entity_type") or "")) is None:
+            continue
+        title = str(frontmatter.get("title") or Path(rel_path).stem).strip()
+        names = (title, *alias_values(frontmatter.get("aliases")))
+        identities = frozenset(key for name_ in names if (key := identity_key(name_)))
+        if not identities:
+            continue
+        entries.append(
+            RegistryEntry(
+                path=rel_path,
+                title=title,
+                identities=identities,
+                tokens=frozenset().union(*(identity_tokens(n) for n in names)),
+            )
+        )
+    entries.sort(key=lambda entry: entry.path)
+    return RegistryIndex(
+        entries=tuple(entries),
+        identities=frozenset().union(*(e.identities for e in entries)) if entries else frozenset(),
+    )
+
+
+def counts_as_evidence(page: Any, *, indexable: bool) -> bool:
+    """Whether one page's links are the corpus reaching for a name (design D2.5).
+
+    Two ways a page is present in the corpus without its links being evidence of
+    present attention: it has been retired (`INELIGIBLE_STATUSES`), or its tree
+    is `excluded` in `_access.yaml` and therefore outside every read surface. An
+    excluded page must not supply spread and must never become the anchor — the
+    finding would name a path the reader has told the system not to surface.
+    """
+    if not indexable:
+        return False
+    return (page.status or "").casefold() not in INELIGIBLE_STATUSES
+
+
+def collect(
+    pages: Iterable[Any],
+    *,
+    vault_root: Path,
+    resolver: WikilinkResolver,
+    registry: RegistryIndex,
+    indexable: Callable[[str], bool],
+    attachment_probe: Callable[[str], bool],
+) -> list[Candidate]:
+    """One pass over already-parsed bodies; every gate of design D2 applied.
+
+    Deterministic, and I/O-free in itself: the two things that genuinely need the
+    filesystem are INJECTED rather than reached for, so this function stays unit
+    testable and the cost of each stays visible at the call site. `indexable`
+    answers the access tier of one path (cached policy state, no read).
+    `attachment_probe` answers whether an ordinary file stands at one suffixed
+    target, and it is called ONLY for identities that already cleared spread and
+    the registry — a stat for the handful of dotted names that got that far,
+    never a stat per link.
+
+    Nothing can depend on the order `pages` arrives in: the per-page map is keyed
+    by path and every emitted sequence is sorted.
+
+    Absence is never evidence, and it is enforced upstream: a page the corpus
+    parser could not read never becomes a `ParsedPage` and so never reaches this
+    function, rather than arriving as a page that appears to mention nothing.
+    """
+    entities = entities_prefix()
+    mentions: dict[str, dict[str, str]] = {}
+    #: identity -> the distinct suffixed targets written for it, kept so the
+    #: file probe can run once per surviving candidate instead of once per link.
+    suffixed: dict[str, set[str]] = {}
+    for page in pages:
+        rel_path = str(page.rel_path)
+        # D2.4 — the registry's own cross-links measure the registry, not attention.
+        if rel_path.startswith(entities):
+            continue
+        # D2.5 — retired and excluded pages are not present attention.
+        if not counts_as_evidence(page, indexable=indexable(rel_path)):
+            continue
+        self_identities = {
+            identity_key(page.title),
+            identity_key(Path(rel_path).stem),
+        }
+        for match in find_body_wikilinks(page.body):
+            link = parse_link(match.group(1))
+            if link is None:
+                continue
+            identity = identity_key(link.name)
+            # D2.4 — a page reaching for its own name has recurred with nobody.
+            if not identity or identity in self_identities:
+                continue
+            # D2.2 — a written-down page is not an unwritten identity. The link as
+            # written decides first; failing that, the NAME it ends in, because
+            # `[[Some/Wrong/Path/Marin Osk]]` is a misfiled link to a page that
+            # exists, not evidence that nobody has written Marin Osk down.
+            if page_exists(link.target, vault_root, resolver):
+                continue
+            if link.name != link.target and page_exists(link.name, vault_root, resolver):
+                continue
+            seen = mentions.setdefault(identity, {})
+            written = seen.get(rel_path)
+            # Per-page dedup: five mentions on one page contribute one page, and
+            # the form kept is the smallest, so the display name cannot depend on
+            # which mention the scanner reached first.
+            if written is None or link.name < written:
+                seen[rel_path] = link.name
+            if link.suffix:
+                suffixed.setdefault(identity, set()).add(link.target)
+
+    candidates: list[Candidate] = []
+    for identity in sorted(mentions):
+        by_page = mentions[identity]
+        # D2.1 — spread, the whole arithmetic of this sensor.
+        if len(by_page) < SPREAD_MIN_PAGES:
+            continue
+        # D2.3 — a resolved identity is the registry's business, not a candidate.
+        # The TITLE half is largely subsumed by the page gate above (an entity
+        # page's title is in the resolver too); what this uniquely answers for is
+        # ALIASES, which no wikilink resolver indexes.
+        if registry.resolves(identity):
+            continue
+        # D2.2, the attachment half — last, because it is the only gate that
+        # touches the filesystem, and by here at most a handful of identities
+        # remain. A dotted name is a file only when a file is actually there.
+        if any(attachment_probe(target) for target in sorted(suffixed.get(identity, ()))):
+            continue
+        ordered = tuple(sorted(by_page))
+        candidates.append(
+            Candidate(
+                identity=identity,
+                candidate=by_page[ordered[0]],
+                pages=ordered,
+                near_matches=registry.near_matches(identity),
+            )
+        )
+    return candidates

--- a/src/exomem/review_context.py
+++ b/src/exomem/review_context.py
@@ -345,6 +345,15 @@ def _related_section(
     candidates: list[str] = []
     for reason in item.reasons:
         candidates.extend(str(path) for path in reason.get("related_paths", []))
+        # A finding whose evidence is a GROUP of pages, but whose group must stay
+        # out of the fingerprint-bearing `related_paths`, carries it in `meta`
+        # instead (`entity_recurrence`: the mentioning pages grow as the corpus
+        # links a name again, and folding that into the item identity would
+        # reopen settled decisions). Those pages are still the evidence a reader
+        # opening the item needs to see.
+        candidates.extend(
+            str(path) for path in (reason.get("meta") or {}).get("pages", []) or []
+        )
     candidates.extend(
         str(node.get("path"))
         for node in graph.get("nodes", [])

--- a/tests/test_entity_recurrence.py
+++ b/tests/test_entity_recurrence.py
@@ -1,0 +1,1047 @@
+"""Entity recurrence sensor: an identity that recurs across notes is a candidate.
+
+The corpus already records who and what a vault keeps coming back to — in the
+wikilinks its notes carry. Nothing counts them. `resolve_entity_candidate` is
+exact-match resolution against the registry, the audit reports an unresolved
+wikilink page by page (`forward_reference`), and an identity linked from five
+separate notes accumulates no signal anywhere.
+
+These fixtures build the evidence the way a vault actually produces it: real
+Markdown bodies with real wikilinks, swept through the real audit. Every gate
+is exercised AT the module's own constant rather than at a literal restated
+here, so moving a PROVISIONAL threshold moves the fixtures with it and the test
+intent survives (design D2).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from exomem import audit as audit_module
+from exomem import find as find_module
+
+CATEGORY = "entity_recurrence"
+
+
+# ------------------------------------------------------------------ vault fixtures
+
+
+def _write(root: Path, rel: str, text: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    find_module.clear_cache()
+    return path
+
+
+def _note(root: Path, rel: str, *, title: str, body: str) -> Path:
+    """A compiled note whose body is the only evidence this sensor reads."""
+    return _write(
+        root,
+        rel,
+        f"---\ntype: insight\ntitle: {title}\nstatus: active\n---\n# {title}\n\n{body}\n",
+    )
+
+
+def _entity(
+    root: Path,
+    rel: str,
+    *,
+    title: str,
+    aliases: list[str] | None = None,
+    entity_type: str = "person",
+    status: str = "active",
+) -> Path:
+    alias_line = f"aliases: [{', '.join(aliases)}]\n" if aliases else ""
+    return _write(
+        root,
+        rel,
+        f"---\ntype: entity\ntitle: {title}\nentity_type: {entity_type}\n"
+        f"status: {status}\n{alias_line}---\n# {title}\n",
+    )
+
+
+def _findings(root: Path) -> list:
+    report = audit_module.audit(root, categories=[CATEGORY])
+    return [f for f in report.findings if f.category == CATEGORY]
+
+
+#: The D6.1 corpus: three distinct notes reaching for one identity the vault has
+#: never written down. Three is the spec scenario's own number, not a restatement
+#: of the spread constant — `test_spread_gate_fires_exactly_at_the_constant`
+#: below is what pins behaviour AT `SPREAD_MIN_PAGES`.
+_RECURRING = "Marin Osk"
+_MENTIONING = (
+    "Knowledge Base/Notes/harbour-review.md",
+    "Knowledge Base/Notes/interviews.md",
+    "Knowledge Base/Notes/Patterns/handover.md",
+)
+
+
+def _recurring_vault(root: Path, *, target: str = _RECURRING) -> None:
+    """Three notes link one identity; the registry holds two lexical neighbours."""
+    for index, rel in enumerate(_MENTIONING):
+        _note(
+            root,
+            rel,
+            title=f"Note {index}",
+            body=f"The handover went through [[{target}]] again.",
+        )
+    _entity(root, "Knowledge Base/Entities/People/marin-vale.md", title="Marin Vale")
+    _entity(
+        root,
+        "Knowledge Base/Entities/Organizations/osk-yard.md",
+        title="Osk Yard",
+        entity_type="organization",
+    )
+
+
+# ------------------------------------------------------- 1.1 the acceptance fixture
+
+
+def test_recurring_unresolved_identity_becomes_one_candidate(tmp_path: Path) -> None:
+    """D6.1 — the whole point: three notes, one identity, one candidate finding."""
+    _recurring_vault(tmp_path)
+
+    findings = _findings(tmp_path)
+
+    from exomem import entity_recurrence as sensor
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.category == CATEGORY
+    assert finding.severity == "info"
+    # Anchored on the lexicographically smallest mentioning page (design D4).
+    assert finding.path == min(_MENTIONING)
+    assert finding.meta["reasons"] == [sensor.REASON_UNRESOLVED_IDENTITY_RECURS]
+    assert finding.meta["candidate"] == _RECURRING
+    assert finding.meta["identity"] == sensor.identity_key(_RECURRING)
+    assert finding.meta["pages"] == sorted(_MENTIONING)
+    # The page list rides `meta` and NOT the fingerprint-bearing `paths` group
+    # field, so spread growth cannot re-raise a settled candidate (design D4).
+    assert finding.paths is None
+    # The check-before-create assist: registry entries sharing an identity token.
+    # One shared token each, so the tie breaks on path (design D3).
+    assert [match["path"] for match in finding.meta["near_matches"]] == [
+        "Knowledge Base/Entities/Organizations/osk-yard.md",
+        "Knowledge Base/Entities/People/marin-vale.md",
+    ]
+    assert [match["shared_tokens"] for match in finding.meta["near_matches"]] == [
+        ["osk"],
+        ["marin"],
+    ]
+
+
+# ------------------------------------------------------------- 1.2 the quiet twins
+
+
+def test_plain_text_mentions_at_matched_frequency_stay_quiet(tmp_path: Path) -> None:
+    """D6.2 — the deferred stream, asserted so v1's scope is pinned, not implied.
+
+    Same identity, same page count, same sentence — the wikilinks removed. The
+    proper-n-gram stream is exactly the incidental-mention false-positive surface
+    f21's budgets freeze behind calibration, so it must produce nothing here.
+    """
+    for index, rel in enumerate(_MENTIONING):
+        _note(
+            tmp_path,
+            rel,
+            title=f"Note {index}",
+            body=f"The handover went through {_RECURRING} again.",
+        )
+    _entity(tmp_path, "Knowledge Base/Entities/People/marin-vale.md", title="Marin Vale")
+
+    assert _findings(tmp_path) == []
+
+
+def test_registry_resolved_alias_stays_quiet_at_five_pages(tmp_path: Path) -> None:
+    """D6.3 — a resolved identity is the registry's business, not a candidate.
+
+    Five pages, comfortably past the spread gate, linking a name the registry
+    already answers to through an ALIAS rather than a title.
+    """
+    for index in range(5):
+        _note(
+            tmp_path,
+            f"Knowledge Base/Notes/note-{index}.md",
+            title=f"Note {index}",
+            body=f"Reviewed with [[{_RECURRING}]] on Tuesday.",
+        )
+    _entity(
+        tmp_path,
+        "Knowledge Base/Entities/People/marin.md",
+        title="Marin Oskarsdottir",
+        aliases=[_RECURRING],
+    )
+
+    assert _findings(tmp_path) == []
+
+
+def test_below_spread_stays_quiet(tmp_path: Path) -> None:
+    """D6.4 — one page short of the gate says nothing, however emphatic it is."""
+    from exomem import entity_recurrence as sensor
+
+    for index in range(sensor.SPREAD_MIN_PAGES - 1):
+        _note(
+            tmp_path,
+            f"Knowledge Base/Notes/note-{index}.md",
+            title=f"Note {index}",
+            body=f"[[{_RECURRING}]] again, and [[{_RECURRING}]] once more.",
+        )
+
+    assert _findings(tmp_path) == []
+
+
+def test_spread_gate_fires_exactly_at_the_constant(tmp_path: Path) -> None:
+    """The gate is pinned AT `SPREAD_MIN_PAGES`, in both directions.
+
+    Frequency inside one page is never spread (the spec's second scenario): the
+    below-gate corpus links the identity repeatedly on every page it has and is
+    still silent, so only the page COUNT can be what flips this.
+    """
+    from exomem import entity_recurrence as sensor
+
+    def corpus(pages: int) -> Path:
+        root = tmp_path / f"vault-{pages}"
+        for index in range(pages):
+            _note(
+                root,
+                f"Knowledge Base/Notes/note-{index}.md",
+                title=f"Note {index}",
+                body=f"[[{_RECURRING}]] and again [[{_RECURRING}]].",
+            )
+        return root
+
+    assert _findings(corpus(sensor.SPREAD_MIN_PAGES - 1)) == []
+    assert len(_findings(corpus(sensor.SPREAD_MIN_PAGES))) == 1
+
+
+def test_frequency_inside_one_page_is_not_spread(tmp_path: Path) -> None:
+    """The spec's second scenario, and the per-page dedup rule it exists for.
+
+    Five links on one page and one on another is six mentions and TWO pages. If
+    dedup is what is holding this quiet rather than the spread gate, deleting it
+    makes six clear a gate of three and this fires.
+    """
+    _note(
+        tmp_path,
+        "Knowledge Base/Notes/emphatic.md",
+        title="Emphatic",
+        body=" ".join(f"[[{_RECURRING}]]" for _ in range(5)),
+    )
+    _note(
+        tmp_path,
+        "Knowledge Base/Notes/passing.md",
+        title="Passing",
+        body=f"Also [[{_RECURRING}]].",
+    )
+
+    assert _findings(tmp_path) == []
+
+
+# --------------------------------------------------- 2.1 what a wikilink identity is
+
+
+def test_display_heading_extension_and_path_forms_are_one_identity(tmp_path: Path) -> None:
+    """2.1 — `[[a|b]]`, `[[a#h]]`, `[[a.md]]` and `[[dir/a]]` name the same page.
+
+    Four spellings, four pages, one candidate — and the display name is taken
+    from the anchor page rather than from whichever form was scanned first.
+    """
+    forms = {
+        "Knowledge Base/Notes/n0.md": f"[[{_RECURRING}|the harbourmaster]]",
+        "Knowledge Base/Notes/n1.md": f"[[{_RECURRING}#history]]",
+        "Knowledge Base/Notes/n2.md": f"[[{_RECURRING}.md]]",
+        "Knowledge Base/Notes/n3.md": f"[[Knowledge Base/Entities/People/{_RECURRING}]]",
+    }
+    for index, (rel, body) in enumerate(sorted(forms.items())):
+        _note(tmp_path, rel, title=f"Note {index}", body=body)
+
+    findings = _findings(tmp_path)
+    assert len(findings) == 1
+    assert findings[0].meta["candidate"] == _RECURRING
+    assert findings[0].meta["pages"] == sorted(forms)
+
+
+def test_wikilinks_inside_code_are_not_evidence(tmp_path: Path) -> None:
+    """A regex in a fenced block is not somebody reaching for a name."""
+    for index in range(5):
+        _note(
+            tmp_path,
+            f"Knowledge Base/Notes/note-{index}.md",
+            title=f"Note {index}",
+            body=f"Inline `[[{_RECURRING}]]` and\n\n```\n[[{_RECURRING}]]\n```\n",
+        )
+
+    assert _findings(tmp_path) == []
+
+
+def test_folder_hubs_are_not_identities(tmp_path: Path) -> None:
+    """A folder link names no page identity (design D1)."""
+    for index in range(5):
+        _note(
+            tmp_path,
+            f"Knowledge Base/Notes/note-{index}.md",
+            title=f"Note {index}",
+            body="[[Knowledge Base/Notes/Patterns/]]",
+        )
+
+    assert _findings(tmp_path) == []
+
+
+def test_a_link_to_a_file_that_exists_is_an_attachment_not_an_identity(
+    tmp_path: Path,
+) -> None:
+    """D2.2 — the FILE is what makes a suffixed link an attachment, not the dot.
+
+    `_check_wikilinks` probes the filesystem before calling a suffixed link an
+    attachment, and so does this. The scan is really there, so five notes
+    reaching for it are reaching for a document, not for an unwritten identity.
+    """
+    scan = tmp_path / "Reference" / "scan-2026.pdf"
+    scan.parent.mkdir(parents=True, exist_ok=True)
+    scan.write_bytes(b"%PDF-1.4 fixture\n")
+    for index in range(5):
+        _note(
+            tmp_path,
+            f"Knowledge Base/Notes/note-{index}.md",
+            title=f"Note {index}",
+            body="[[Reference/scan-2026.pdf]]",
+        )
+
+    assert _findings(tmp_path) == []
+
+
+def test_a_dot_in_a_name_is_punctuation_when_no_file_is_there(tmp_path: Path) -> None:
+    """D2.2, the half a suffix heuristic got wrong.
+
+    `Path("SomeProduct 2.0").suffix` is `.0`, and the same accident silenced
+    `Dr. Ines Roth`, `U.S. Navy` and `Node.js` — four names a vault genuinely
+    recurs on, each producing zero findings while the shipped link audit
+    reported every one of them. Nothing stands at any of these paths, so each is
+    a page identity and each recurs.
+    """
+    dotted = ["SomeProduct 2.0", "Dr. Ines Roth", "U.S. Navy", "Node.js"]
+    for name in dotted:
+        root = tmp_path / name.replace(" ", "-").replace("/", "-")
+        for index in range(3):
+            _note(
+                root,
+                f"Knowledge Base/Notes/note-{index}.md",
+                title=f"Note {index}",
+                body=f"Shipped with [[{name}]].",
+            )
+        findings = _findings(root)
+        assert len(findings) == 1, f"{name!r} produced no candidate"
+        assert findings[0].meta["candidate"] == name
+
+
+# ------------------------------------------------------------ 2.1 the two exclusions
+
+
+def test_links_from_inside_entities_count_nothing(tmp_path: Path) -> None:
+    """D2.4 — the registry's own cross-links measure the registry, not attention.
+
+    Two notes and one entity profile reach for the same unwritten name. Only the
+    notes are the corpus paying attention, so this stays one page short of the
+    gate; counting the profile would push it over.
+    """
+    for index in range(2):
+        _note(
+            tmp_path,
+            f"Knowledge Base/Notes/note-{index}.md",
+            title=f"Note {index}",
+            body=f"Introduced by [[{_RECURRING}]].",
+        )
+    _write(
+        tmp_path,
+        "Knowledge Base/Entities/People/ines.md",
+        "---\ntype: entity\ntitle: Ines Roth\nentity_type: person\nstatus: active\n"
+        f"---\n# Ines Roth\n\nWorked with [[{_RECURRING}]].\n",
+    )
+
+    assert _findings(tmp_path) == []
+
+
+def test_a_page_reaching_for_its_own_name_counts_nothing(tmp_path: Path) -> None:
+    """D2.4 — a self-link has recurred with nobody.
+
+    The link is the full-width spelling of the page's own title. NFKC folds the
+    two together, so it IS the page's own identity; the resolver's exact-title
+    map does not fold, so the link is genuinely unresolved and would otherwise be
+    counted. Two ordinary notes carry the same spelling, leaving the corpus one
+    page short of the gate unless the self-link is counted too.
+    """
+    wide = "Ｚｅｔａ"  # "Zeta", full-width
+    _note(tmp_path, "Knowledge Base/Notes/zeta-note.md", title="Zeta",
+          body=f"See [[{wide}]].")
+    for index in range(2):
+        _note(
+            tmp_path,
+            f"Knowledge Base/Notes/other-{index}.md",
+            title=f"Other {index}",
+            body=f"See [[{wide}]].",
+        )
+
+    assert _findings(tmp_path) == []
+
+
+# -------------------------------------------------- 2.2 registry resolution and assist
+
+
+def test_only_an_active_registered_entity_page_resolves_an_identity(tmp_path: Path) -> None:
+    """2.2 — each half of the registry predicate is load-bearing.
+
+    Every variant below answers to the alias `Marin Osk` on paper and must not
+    silence the sensor: a superseded profile, a page that is not an entity, a
+    kind the registry does not know, a folder no registered kind owns, and the
+    folder's index. Deleting any one of those checks admits that variant to the
+    registry index and the candidate goes quiet.
+    """
+    variants = {
+        "superseded": ("Knowledge Base/Entities/People/a.md",
+                       "type: entity\nentity_type: person\nstatus: superseded\n"),
+        "not an entity": ("Knowledge Base/Entities/People/b.md",
+                          "type: insight\nentity_type: person\nstatus: active\n"),
+        "unregistered kind": ("Knowledge Base/Entities/People/c.md",
+                              "type: entity\nentity_type: spaceship\nstatus: active\n"),
+        "unregistered folder": ("Knowledge Base/Entities/Vessels/d.md",
+                                "type: entity\nentity_type: person\nstatus: active\n"),
+        "folder index": ("Knowledge Base/Entities/People/index.md",
+                         "type: entity\nentity_type: person\nstatus: active\n"),
+    }
+    for label, (rel, header) in variants.items():
+        root = tmp_path / label.replace(" ", "-")
+        for index in range(3):
+            _note(
+                root,
+                f"Knowledge Base/Notes/note-{index}.md",
+                title=f"Note {index}",
+                body=f"Reviewed with [[{_RECURRING}]].",
+            )
+        _write(
+            root,
+            rel,
+            f"---\n{header}title: Marin Oskarsdottir\naliases: [{_RECURRING}]\n"
+            "---\n# Marin Oskarsdottir\n",
+        )
+        assert len(_findings(root)) == 1, f"{label} must not resolve the identity"
+
+
+def test_a_registry_alias_silences_a_path_form_candidate(tmp_path: Path) -> None:
+    """D2.3 — the half of the registry gate no wikilink resolver can reach.
+
+    An entity page's TITLE is indexed by the resolver, so once the name-fallback
+    exists the page gate silences a title match on its own. An ALIAS is indexed
+    nowhere, which is what this gate uniquely answers for — asserted through a
+    path form, so the link resolves to nothing either as written or by name.
+    """
+    for index in range(4):
+        _note(
+            tmp_path,
+            f"Knowledge Base/Notes/note-{index}.md",
+            title=f"Note {index}",
+            body=f"Reviewed with [[Knowledge Base/People/{_RECURRING}]].",
+        )
+
+    assert len(_findings(tmp_path)) == 1
+
+    _entity(
+        tmp_path,
+        "Knowledge Base/Entities/People/marin.md",
+        title="Marin Oskarsdottir",
+        aliases=[_RECURRING],
+    )
+    assert _findings(tmp_path) == []
+
+
+def test_a_misfiled_path_form_does_not_invent_an_unwritten_identity(
+    tmp_path: Path,
+) -> None:
+    """D2.2 — the link as written misses, but the NAME it ends in does not.
+
+    `[[Knowledge Base/People/Marin Osk]]` while `Notes/Marin Osk.md` exists is a
+    link filed under the wrong folder, and the audit already reports it as one.
+    Reading it as "this identity is written down nowhere" would put a false
+    sentence in front of the reader about a page they can see.
+    """
+    _note(tmp_path, f"Knowledge Base/Notes/{_RECURRING}.md",
+          title=_RECURRING, body="The real page.")
+    for index in range(3):
+        _note(
+            tmp_path,
+            f"Knowledge Base/Notes/n{index}.md",
+            title=f"N{index}",
+            body=f"See [[Knowledge Base/People/{_RECURRING}]].",
+        )
+
+    assert _findings(tmp_path) == []
+
+
+def test_near_matches_are_capped_and_ordered_by_shared_tokens(tmp_path: Path) -> None:
+    """D3 — bounded advice, ordered deterministically, strongest first."""
+    from exomem import entity_recurrence as sensor
+
+    for index in range(3):
+        _note(
+            tmp_path,
+            f"Knowledge Base/Notes/note-{index}.md",
+            title=f"Note {index}",
+            body="Handled by [[Marin Osk Trust]].",
+        )
+    # Two shared tokens, then three with one each — more than the cap admits.
+    _entity(tmp_path, "Knowledge Base/Entities/People/z-two.md", title="Marin Osk")
+    _entity(tmp_path, "Knowledge Base/Entities/People/a-one.md", title="Marin Vale")
+    _entity(tmp_path, "Knowledge Base/Entities/People/b-one.md", title="Osk Reyn")
+    _entity(tmp_path, "Knowledge Base/Entities/People/c-one.md", title="Trust Board")
+
+    matches = _findings(tmp_path)[0].meta["near_matches"]
+    assert len(matches) == sensor.MAX_NEAR_MATCHES
+    # Two shared tokens outrank one however late the path sorts; the rest tie on
+    # count and fall back to path order.
+    assert [match["path"] for match in matches] == [
+        "Knowledge Base/Entities/People/z-two.md",
+        "Knowledge Base/Entities/People/a-one.md",
+        "Knowledge Base/Entities/People/b-one.md",
+    ]
+
+
+def test_an_ambiguous_bare_name_is_a_page_that_exists(tmp_path: Path) -> None:
+    """D2.2 — a name the vault wrote down TWICE is not one it never wrote down.
+
+    Two files share the stem, so the link resolves to a page that exists and
+    merely needs disambiguating — which the audit already reports as a broken
+    link rather than a forward reference. Treating ambiguity as absence would
+    turn every colliding basename into an entity candidate.
+    """
+    _note(tmp_path, "Knowledge Base/Notes/a/Ghost.md", title="Ghost A", body="one")
+    _note(tmp_path, "Knowledge Base/Notes/b/Ghost.md", title="Ghost B", body="two")
+    for index in range(3):
+        _note(
+            tmp_path,
+            f"Knowledge Base/Notes/note-{index}.md",
+            title=f"Note {index}",
+            body="See [[Ghost]].",
+        )
+
+    assert _findings(tmp_path) == []
+
+
+# --------------------------------------------------- 3.2 resolution by state change
+
+
+def test_creating_the_entity_page_silences_it_and_deleting_it_brings_it_back(
+    tmp_path: Path,
+) -> None:
+    """D6.5 — acting on the advice resolves it; undoing the act restores it."""
+    _recurring_vault(tmp_path)
+    assert len(_findings(tmp_path)) == 1
+
+    profile = _entity(
+        tmp_path,
+        "Knowledge Base/Entities/People/marin.md",
+        title="Marin Oskarsdottir",
+        aliases=[_RECURRING],
+    )
+    assert _findings(tmp_path) == []
+
+    profile.unlink()
+    find_module.clear_cache()
+    assert len(_findings(tmp_path)) == 1, "no dismissal was recorded, so it returns"
+
+
+def test_creating_the_linked_page_itself_silences_it_and_deleting_it_brings_it_back(
+    tmp_path: Path,
+) -> None:
+    """D6.5, the other half — the link stops being unresolved at all."""
+    _recurring_vault(tmp_path)
+    assert len(_findings(tmp_path)) == 1
+
+    target = _note(
+        tmp_path,
+        "Knowledge Base/Notes/marin-osk.md",
+        title=_RECURRING,
+        body="Notes on the handover.",
+    )
+    assert _findings(tmp_path) == []
+
+    target.unlink()
+    find_module.clear_cache()
+    assert len(_findings(tmp_path)) == 1
+
+
+def test_the_sweep_writes_nothing_at_all(tmp_path: Path) -> None:
+    """"Advice, never creation" — the flagship no-nudge property, measured."""
+    _recurring_vault(tmp_path)
+
+    def snapshot() -> dict[str, bytes]:
+        return {
+            path.relative_to(tmp_path).as_posix(): path.read_bytes()
+            for path in sorted(tmp_path.rglob("*.md"))
+        }
+
+    before = snapshot()
+    assert len(_findings(tmp_path)) == 1
+    assert snapshot() == before
+
+
+# ------------------------------------------------------------------ 3.x delivery
+
+
+def test_category_is_registered_and_triageable(tmp_path: Path) -> None:
+    """3.1 — registered, selectable, disposable against; derivationally, not restated."""
+    from exomem import attention as attention_module
+    from exomem import review_state as review_state_module
+
+    assert CATEGORY in audit_module.ALL_CATEGORIES
+    assert CATEGORY in audit_module.EPISTEMIC_REVIEW_CATEGORIES
+    assert CATEGORY in attention_module.ATTENTION_CATEGORIES
+    assert CATEGORY in review_state_module.registered_families()
+    # Opt-in: every candidate this sensor will ever name is already linked, so the
+    # whole backlog arrives on the first run and must not displace the daily surface.
+    assert CATEGORY not in attention_module.DEFAULT_ATTENTION_CATEGORIES
+
+
+def test_fingerprint_binds_to_the_identity_not_to_any_page(tmp_path: Path) -> None:
+    """D4 — the identity IS the signal.
+
+    Editing a mentioning page, and even adding another one, leaves the signal
+    version alone; a different identity gets a different one.
+    """
+    from exomem import entity_recurrence as sensor
+    from exomem.vault import content_hash
+
+    _recurring_vault(tmp_path)
+    before = _findings(tmp_path)[0].meta["signal_version"]
+    assert before == content_hash(sensor.identity_key(_RECURRING))[:16]
+
+    _note(
+        tmp_path,
+        _MENTIONING[0],
+        title="Note 0",
+        body=f"The handover went through [[{_RECURRING}]] again, revised.",
+    )
+    _note(
+        tmp_path,
+        "Knowledge Base/Notes/fourth.md",
+        title="Fourth",
+        body=f"And again with [[{_RECURRING}]].",
+    )
+    after = _findings(tmp_path)[0]
+    assert after.meta["page_count"] == 4
+    assert after.meta["signal_version"] == before
+
+    _recurring_vault(tmp_path / "other", target="Halle Berg")
+    assert _findings(tmp_path / "other")[0].meta["signal_version"] != before
+
+
+# -------------------------------------------------------------- 3.2 S6 integration
+
+
+def _items(root: Path, *, state: str = "open") -> list:
+    from exomem import attention as attention_module
+
+    report = attention_module.attention(
+        root, categories=[CATEGORY], limit=0, state=state, record_surfacing=False
+    )
+    return list(report.items)
+
+
+def test_family_disposition_off_silences_the_queue(tmp_path: Path) -> None:
+    """D6.6 — "stop suggesting entities at me" is obeyed."""
+    from exomem import review_state as review_state_module
+
+    _recurring_vault(tmp_path)
+    assert len(_items(tmp_path)) == 1
+
+    review_state_module.ReviewStateStore(tmp_path).set_disposition(
+        CATEGORY, "off", why="intentional: I name entities when I choose to"
+    )
+    assert _items(tmp_path) == []
+
+
+def test_a_dismissed_candidate_stays_dismissed_across_incidental_edits(
+    tmp_path: Path,
+) -> None:
+    """D6.6 — the dismissal contract, end to end.
+
+    "I have decided not to create this entity" binds to the identity, so editing a
+    mentioning page must not resurrect it, and neither must a fourth page linking
+    the same name: v1 defines no material-change reopen for spread growth (design
+    D4, PROVISIONAL). A DIFFERENT identity is a different signal and still speaks.
+    """
+    from exomem import review_state as review_state_module
+
+    _recurring_vault(tmp_path)
+    item = _items(tmp_path)[0]
+    review_state_module.apply_for_item(
+        tmp_path, item, action="dismiss", why="intentional: a supplier, not an entity"
+    )
+    assert _items(tmp_path) == []
+
+    _note(
+        tmp_path,
+        _MENTIONING[0],
+        title="Note 0",
+        body=f"The handover went through [[{_RECURRING}]] again, revised.",
+    )
+    assert _items(tmp_path) == [], "an incidental edit must not reopen a dismissal"
+
+    _note(
+        tmp_path,
+        "Knowledge Base/Notes/fourth.md",
+        title="Fourth",
+        body=f"And again with [[{_RECURRING}]].",
+    )
+    assert _items(tmp_path) == [], "spread growth does not re-raise in v1"
+
+    for index in range(3):
+        _note(
+            tmp_path,
+            f"Knowledge Base/Notes/halle-{index}.md",
+            title=f"Halle {index}",
+            body="Introduced by [[Halle Berg]].",
+        )
+    assert len(_items(tmp_path)) == 1, "a different identity is a different signal"
+
+
+# ------------------------------------------- 2.1 what counts as present attention
+
+
+def test_a_retired_page_neither_supplies_spread_nor_anchors(tmp_path: Path) -> None:
+    """D2.5 — a superseded note records what the vault USED to reach for.
+
+    Two live notes and one superseded one, and the superseded one sorts first, so
+    without the rule it would both push the corpus over the gate AND become the
+    page the finding names.
+    """
+    for index in range(2):
+        _note(
+            tmp_path,
+            f"Knowledge Base/Notes/n{index}.md",
+            title=f"N{index}",
+            body=f"Met [[{_RECURRING}]].",
+        )
+    _write(
+        tmp_path,
+        "Knowledge Base/Notes/aaa-old.md",
+        f"---\ntype: insight\ntitle: Old\nstatus: superseded\n---\n# Old\n\n"
+        f"Met [[{_RECURRING}]].\n",
+    )
+
+    assert _findings(tmp_path) == []
+
+    # ...and the same page, live again, is evidence like any other.
+    _note(tmp_path, "Knowledge Base/Notes/aaa-old.md", title="Old",
+          body=f"Met [[{_RECURRING}]].")
+    findings = _findings(tmp_path)
+    assert len(findings) == 1
+    assert findings[0].path == "Knowledge Base/Notes/aaa-old.md"
+
+
+def test_an_excluded_page_neither_supplies_spread_nor_anchors(tmp_path: Path) -> None:
+    """D2.5 — `excluded` means excluded, and anchoring is a surface too.
+
+    The diary is placed so it sorts FIRST among the mentioning pages: while
+    excluded it must neither push the corpus over the gate nor be nameable,
+    and the moment it stops being excluded the anchor must land on it --
+    pinning the spread half and the anchor half separately.
+    """
+    _write(tmp_path, "Knowledge Base/_access.yaml", "excluded:\n  - Aaa-private\n")
+    for index in range(2):
+        _note(
+            tmp_path,
+            f"Knowledge Base/Notes/n{index}.md",
+            title=f"N{index}",
+            body=f"Met [[{_RECURRING}]].",
+        )
+    _note(tmp_path, "Knowledge Base/Aaa-private/aaa-diary.md", title="Diary",
+          body=f"Met [[{_RECURRING}]] again.")
+
+    assert _findings(tmp_path) == []
+
+    # ...and the same page, no longer excluded, is evidence AND the anchor.
+    _write(tmp_path, "Knowledge Base/_access.yaml", "excluded: []\n")
+    findings = _findings(tmp_path)
+    assert len(findings) == 1
+    assert findings[0].path == "Knowledge Base/Aaa-private/aaa-diary.md"
+
+
+# ------------------------------------------ 3.2 one review item per identity
+
+
+def test_two_identities_sharing_an_anchor_are_triaged_independently(
+    tmp_path: Path,
+) -> None:
+    """D4 — the identity partitions the review item, not just the fingerprint.
+
+    Two identities recurring across one corpus routinely share an anchor: the
+    page that sorts smallest mentions both. Fused onto one review id, a single
+    dismissal puts down BOTH, and a third identity landing on that anchor changes
+    the fused fingerprint and reopens the decision the reader already made. All
+    three failures are measured here, in the order they bite.
+    """
+    _note(tmp_path, "Knowledge Base/Notes/aaa.md", title="AAA",
+          body="[[Alpha One]] and [[Beta Two]]")
+    for index in range(2):
+        _note(tmp_path, f"Knowledge Base/Notes/b{index}.md", title=f"B{index}",
+              body="[[Alpha One]]")
+        _note(tmp_path, f"Knowledge Base/Notes/c{index}.md", title=f"C{index}",
+              body="[[Beta Two]]")
+
+    findings = _findings(tmp_path)
+    assert {f.path for f in findings} == {"Knowledge Base/Notes/aaa.md"}
+    assert sorted(f.meta["candidate"] for f in findings) == ["Alpha One", "Beta Two"]
+
+    items = _items(tmp_path)
+    assert len(items) == 2, "one anchor, two identities, two decisions to make"
+    assert len({item.item_id for item in items}) == 2
+
+    from exomem import review_state as review_state_module
+
+    alpha = next(i for i in items if i.reasons[0]["meta"]["candidate"] == "Alpha One")
+    review_state_module.apply_for_item(
+        tmp_path, alpha, action="dismiss", why="intentional: a supplier, not an entity"
+    )
+    remaining = _items(tmp_path)
+    assert [i.reasons[0]["meta"]["candidate"] for i in remaining] == ["Beta Two"], (
+        "dismissing one identity must not put down the other"
+    )
+
+    # A third identity on the same anchor must not disturb either decision.
+    _note(tmp_path, "Knowledge Base/Notes/aaa.md", title="AAA",
+          body="[[Alpha One]] and [[Beta Two]] and [[Gamma Three]]")
+    for index in range(2):
+        _note(tmp_path, f"Knowledge Base/Notes/d{index}.md", title=f"D{index}",
+              body="[[Gamma Three]]")
+    after = sorted(i.reasons[0]["meta"]["candidate"] for i in _items(tmp_path))
+    assert after == ["Beta Two", "Gamma Three"], (
+        "an unrelated third identity reopened a settled dismissal"
+    )
+
+
+def test_opening_the_review_item_shows_the_mentioning_pages(tmp_path: Path) -> None:
+    """The evidence a reader needs is the pages, and `meta` is where they live.
+
+    Keeping the group out of `related_paths` protects the dismissal contract
+    (design D4) but would otherwise leave the reviewer an item with no excerpts
+    at all — the sentence "linked from three pages" and no way to see them.
+    `review_context` draws group evidence from `meta["pages"]` for exactly this.
+    """
+    from exomem import review_context as review_context_module
+
+    _recurring_vault(tmp_path)
+    item = _items(tmp_path)[0]
+
+    context = review_context_module.assemble(tmp_path, ref=item.ref)
+    shown = [row["path"] for row in context["related"]["items"]]
+    assert shown == sorted(_MENTIONING)[1:], "every mentioning page but the anchor"
+
+
+def test_the_identity_key_helper_is_the_one_entity_candidates_owns(tmp_path: Path) -> None:
+    """The two names this module borrows from `entity_candidates` are ITS names.
+
+    `identity_key` is the shared normaliser and `_aliases` is the shared reader of
+    the `aliases` frontmatter field. Both are imported rather than reimplemented,
+    and `_aliases` is private — so a rename there must fail loudly here rather
+    than leave this module quietly resolving no aliases at all.
+    """
+    from exomem import entity_candidates as entity_candidates_module
+    from exomem import entity_recurrence as sensor
+
+    assert sensor.identity_key is entity_candidates_module.identity_key
+    assert sensor.alias_values is entity_candidates_module._aliases
+    assert sensor.alias_values(["Ari", 3, "Vale"]) == ("Ari", "Vale")
+    assert sensor.alias_values("Solo") == ("Solo",)
+    assert tmp_path.exists()
+
+
+# ------------------------------------------------------------- 4.4 determinism
+
+
+_IDENTITIES = ("Marin Osk", "Halle Berg", "Ines Roth")
+
+
+def _multi_identity_corpus(root: Path, *, reverse: bool = False) -> None:
+    """Six notes, three recurring identities, several names per note."""
+    plan = [
+        (f"Knowledge Base/Notes/note-{index}.md", _IDENTITIES[index % 3], _IDENTITIES[(index + 1) % 3])
+        for index in range(6)
+    ]
+    for rel, first, second in reversed(plan) if reverse else plan:
+        _note(root, rel, title=rel, body=f"[[{first}]] met [[{second}]].")
+    _entity(root, "Knowledge Base/Entities/People/marin-vale.md", title="Marin Vale")
+
+
+def _shape(findings: list) -> list[tuple]:
+    return [(f.category, f.severity, f.path, f.detail, f.meta) for f in findings]
+
+
+def test_findings_are_identical_across_page_insertion_orders(tmp_path: Path) -> None:
+    """D6.7 — nothing may depend on the order the corpus was written or walked."""
+    from exomem import vault as vault_module
+
+    forward_root, backward_root = tmp_path / "forward", tmp_path / "backward"
+    _multi_identity_corpus(forward_root)
+    _multi_identity_corpus(backward_root, reverse=True)
+    assert _shape(_findings(forward_root)) == _shape(_findings(backward_root))
+    assert len(_findings(forward_root)) == len(_IDENTITIES)
+
+    # And the sweep itself, fed the same pages in the opposite order.
+    pages = audit_module._parse_all(vault_module.kb_root(forward_root), forward_root)
+    assert _shape(audit_module._check_entity_recurrence(forward_root, pages)) == _shape(
+        audit_module._check_entity_recurrence(forward_root, list(reversed(pages)))
+    )
+
+
+# ------------------------------------------------------------------ 4.2 cost bound
+
+
+def test_the_sweep_walks_the_vault_once(tmp_path: Path, monkeypatch) -> None:
+    """4.2 — one path-only walk per sweep, whatever the corpus costs.
+
+    The shape being prevented is a per-page existence walk, which would turn one
+    sweep into a corpus scan per page. Counting the walk across a multi-page
+    corpus is what makes "exactly one" provable rather than asserted — a per-page
+    walk would track the page count. The other half, that the walk opens nothing,
+    is `test_the_sweep_opens_only_the_files_it_can_name` below.
+    """
+    from exomem import vault as vault_module
+
+    _recurring_vault(tmp_path)
+    for index in range(12):
+        _note(
+            tmp_path,
+            f"Knowledge Base/Notes/filler-{index}.md",
+            title=f"Filler {index}",
+            body=f"Nothing to see, and [[{_RECURRING}]].",
+        )
+
+    walks: list[int] = []
+    original_walk = audit_module._walk_vault_md
+
+    def counted(vault_root):
+        walks.append(1)
+        return original_walk(vault_root)
+
+    def forbidden_resolver(self, vault_root):
+        raise AssertionError("the sweep must not build a resolver from disk")
+
+    monkeypatch.setattr(audit_module, "_walk_vault_md", counted)
+    # The I/O-free `from_entries` seam is the whole point: `WikilinkResolver(root)`
+    # re-reads and YAML-parses every Markdown file in the vault.
+    monkeypatch.setattr(vault_module.WikilinkResolver, "__init__", forbidden_resolver)
+
+    findings = _findings(tmp_path)
+    assert len(findings) == 1
+    assert findings[0].meta["page_count"] == 15, "every page must actually be counted"
+    assert len(walks) == 1, f"one vault walk per sweep, got {len(walks)}"
+
+
+def _sweep_opens(tmp_path: Path, monkeypatch, root: Path) -> list[str]:
+    """Every path the sweep itself opens, with the shared page parse excluded."""
+    import builtins
+
+    from exomem import vault as vault_module
+
+    pages = audit_module._parse_all(vault_module.kb_root(root), root)
+    opened: list[str] = []
+    for owner, name in ((builtins, "open"), (Path, "read_text"), (Path, "read_bytes")):
+        original = getattr(owner, name)
+
+        def counting(first, *args, _original=original, **kwargs):
+            opened.append(str(first))
+            return _original(first, *args, **kwargs)
+
+        monkeypatch.setattr(owner, name, counting)
+    audit_module._check_entity_recurrence(root, pages)
+    return opened
+
+
+def test_the_sweep_opens_only_the_files_it_can_name(tmp_path: Path, monkeypatch) -> None:
+    """4.2 — the sweep reads no page, and the files it DOES open are countable.
+
+    The whole cost argument is that recurrence is counted over bodies the audit
+    has already parsed. So the honest pin is not "zero I/O" — it is that every
+    open is one this design can name. There is exactly one: the digest-cached
+    entity-type registry. No page, no `Entities/` glob, no second corpus read.
+    """
+    root = tmp_path / "v"
+    for index in range(8):
+        _note(root, f"Knowledge Base/Notes/n{index}.md", title=f"N{index}",
+              body=f"[[{_RECURRING}]]")
+
+    opened = _sweep_opens(tmp_path, monkeypatch, root)
+
+    assert [Path(path).name for path in opened] == ["entity-types.yaml"], opened
+
+
+def test_a_dotted_candidate_costs_one_existence_probe_and_no_read(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """4.2 — the file probe added for dotted names is bounded and post-gate.
+
+    It runs only for identities that already cleared spread and the registry, and
+    it asks whether a file is there without reading one. Below the gate it never
+    runs at all, which is what keeps a corpus full of `v1.2` mentions cheap.
+    """
+    from exomem import entity_recurrence as sensor
+
+    root = tmp_path / "v"
+    for index in range(sensor.SPREAD_MIN_PAGES):
+        _note(root, f"Knowledge Base/Notes/n{index}.md", title=f"N{index}",
+              body="Shipped [[Node.js]] and [[Some Plain Name]].")
+
+    probed: list[str] = []
+    original = audit_module._ordinary_file_exists
+
+    def counting(vault_root, candidate):
+        probed.append(str(candidate))
+        return original(vault_root, candidate)
+
+    monkeypatch.setattr(audit_module, "_ordinary_file_exists", counting)
+    opened = _sweep_opens(tmp_path, monkeypatch, root)
+
+    assert [Path(path).name for path in opened] == ["entity-types.yaml"], opened
+    # Two spellings probed for the ONE dotted identity; the plain name costs none.
+    assert [Path(path).name for path in probed] == ["Node.js", "Node.js"], probed
+
+
+def test_a_below_gate_dotted_name_is_never_probed(tmp_path: Path, monkeypatch) -> None:
+    """The probe is post-gate, so a name nobody recurred on costs nothing."""
+    from exomem import entity_recurrence as sensor
+    from exomem import vault as vault_module
+
+    root = tmp_path / "v"
+    for index in range(sensor.SPREAD_MIN_PAGES - 1):
+        _note(root, f"Knowledge Base/Notes/n{index}.md", title=f"N{index}",
+              body="Shipped [[Node.js]].")
+    pages = audit_module._parse_all(vault_module.kb_root(root), root)
+
+    probed: list[str] = []
+    monkeypatch.setattr(
+        audit_module,
+        "_ordinary_file_exists",
+        lambda vault_root, candidate: probed.append(str(candidate)) or False,
+    )
+    assert audit_module._check_entity_recurrence(root, pages) == []
+    assert probed == []
+
+
+def test_the_displayed_candidate_comes_from_the_anchor_page(tmp_path: Path) -> None:
+    """D4 — the anchor decides the name shown, and nothing else does.
+
+    Three pages write the same identity three ways, and the anchor page writes it
+    twice. The name that reaches the reader is the smallest form on the
+    lexicographically smallest mentioning page: no part of it may depend on which
+    page or which mention the scanner reached first.
+    """
+    _note(tmp_path, "Knowledge Base/Notes/a.md", title="A",
+          body="[[Marin Osk]] and later [[MARIN OSK]]")
+    _note(tmp_path, "Knowledge Base/Notes/b.md", title="B", body="[[marin osk]]")
+    _note(tmp_path, "Knowledge Base/Notes/c.md", title="C", body="[[Marin  Osk]]")
+
+    finding = _findings(tmp_path)[0]
+    assert finding.path == "Knowledge Base/Notes/a.md"
+    assert finding.meta["candidate"] == "MARIN OSK"
+    assert finding.meta["page_count"] == 3


### PR DESCRIPTION
## What

Slice S5 of the no-nudge programme: a new opt-in audit category **`entity_recurrence`** — the first recurrence signal for entity emergence (today `resolve-entity` is exact match only; an identity linked from five notes accumulates no candidate anywhere).

- Counts, per NFKC identity (`entity_candidates.identity_key`, imported), the **distinct eligible pages** whose bodies carry an unresolved wikilink to it; fires at spread ≥ 3 (`SPREAD_MIN_PAGES`, PROVISIONAL) when the target resolves to **neither a vault page nor a registry title/alias**. Per-page dedup: frequency inside one note never substitutes for spread.
- Finding carries reason `unresolved_identity_recurs`, the sorted mentioning pages (in `meta` — deliberately not in `paths`, so the fingerprint binds to the identity and a dismissal survives new mentions), and up to 3 deterministic lexical near-matches for check-before-create.
- **Advice, never creation** (conservative-capture conformance); resolution is state-change-only (create the entity page or the target page → quiet; delete → returns).
- v1 scope pinned by test: plain-text mentions are out of scope — the n-gram stream stays deferred behind the f21 calibration study.

## Hardening from the adversarial review rounds (all measured)

- **Dotted names are identities**: `[[SomeProduct 2.0]]`, `[[Dr. Ines Roth]]`, `[[Node.js]]` fire; a dotted target is an attachment only when `_ordinary_file_exists` confirms a real file — the same probe `_check_wikilinks` uses, applied only after the spread+registry gates (pinned I/O: at most two existence probes per gate-crossing dotted identity, none below the gate).
- **`review_partition` = the identity**: candidates sharing an anchor page are independently triageable; dismissing one never covers another, and a third identity never reopens a settled dismissal (in-repo precedent: prediction_window, question_aging, bridge_review).
- **Corpus eligibility**: superseded/archived/draft and excluded-tier pages neither supply spread nor anchor (status half only — Sources and Evidence ARE the corpus reaching for a name; recorded in design D2.5 and a spec scenario).
- **Name fallback**: a path-form link to a page that exists elsewhere repairs links instead of inventing an entity.
- Review items surface excerpts from the mentioning pages (`review_context` reads `meta["pages"]`, +9 lines).

## Verification

- Red-first: acceptance fixture failed on base with `unknown audit categories: ['entity_recurrence']`; all quiet twins asserted positively.
- **Mutation matrix: 29 rows, 28 caught** (the one unproven row — rel-path spelling agreement — is unreachable today because a symlinked vault root is refused upstream; recorded in D7, independently confirmed pre-existing).
- Cost, measured at 10,300 pages: sweep 0.70 s ≈ 69 µs/page over already-parsed pages; exactly one path-only vault walk and one file open per sweep; near-matches ≈ 35 µs/candidate. Delivery is fully derivational — `EPISTEMIC_REVIEW_CATEGORIES` membership alone buys attention, triage, and family registration.
- Fresh zero-context review (REQUEST CHANGES: 2 HIGH, 2 MEDIUM, all measured) → correction round → targeted recheck: **APPROVE** — "both HIGHs and both MEDIUMs are genuinely fixed with mechanism-level evidence and killing mutations; 97/97 focused tests"; its two LOW nits (cost number in the artifact; excluded-tier anchor-half fixture) folded in before this PR.
- Focused suites green (sensor 36/36; audit, attention, review-state, review-context, due-state); `openspec validate --all --strict` 167/0 → archive → 166/0; archive-discipline OK (change archived in this delivery). No tool-surface pin movement.
