### PR TITLE
feat(benchmarks): record the founder acknowledgment of amendment sequence 3

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -49,8 +49,9 @@ introduces stays **registered but withheld** until the founder acknowledges the
 receipt — the scenario loader refuses to load it, so an unratified family cannot
 reach a score by accident.
 
-**f27 `lifecycle_routing_replay`** is the family added by the pending
-`amendment-2026-08-lifecycle-replay.v1.json` (sequence 3). It replays an
+**f27 `lifecycle_routing_replay`** is the family added by
+`amendment-2026-08-lifecycle-replay.v1.json` (sequence 3, acknowledged
+2026-08-30). It replays an
 authored ten-turn episode of ordinary working language — every store-bearing
 utterance removed by a gate that refuses one at corpus construction and again at
 scenario load — through the installed agent CLI, and diffs the durable state
@@ -84,9 +85,10 @@ One consequence is stated rather than hidden: the operator's real
 `~/.claude/projects/<cwd>/` gains a transcript directory for each arm's working
 directory. The manifest records this alongside the run.
 
-While sequence 3 is unacknowledged, a run is evidence about the harness and the
-current runtime, recorded as the family's finding; the manifest it writes says
-so, and it is not a comparative claim.
+Sequence 3 was acknowledged on 2026-08-30, so a run may back a comparative
+claim; the family is declared expected-partial on the current runtime — the
+next slice's falsification target. Runs recorded while the receipt was pending
+remain evidence about the harness and that runtime, as their manifests say.
 
 ## Degradation modes (recorded, never silent)
 

--- a/benchmarks/epistemic/contracts/amendment-2026-08-lifecycle-replay.v1.json
+++ b/benchmarks/epistemic/contracts/amendment-2026-08-lifecycle-replay.v1.json
@@ -1,4 +1,5 @@
 {
+  "acknowledged_on": "2026-08-30",
   "affected_sections": [
     "§1 Scenario families",
     "§2 Assertion registry",
@@ -11,7 +12,9 @@
   "contract_sha256": "f978f0f5aeab0b8edf1441bbfae93cc3d57f0c072078319e09e9ef9eee1e44c9",
   "effective_policy": "Applies only after founder acknowledgment; until then f27 cannot support comparative runs, scores or claims. A development run executed while this receipt is unacknowledged is evidence about the harness and the current runtime, recorded as the family's finding, and is not a comparative claim.",
   "parent_contract_sha256": "025da49d60e4959a1e4899c9f0f11280e083fdf0c545aa6c70bdabef00d41f6e",
+  "ratifier": "Hugo Ander Kivi",
   "rationale": "Add the deterministic lifecycle-routing replay family f27 with its paired assertions lifecycle_consequence_landed_unprompted and no_structured_write_beyond_expectation through the governed post-ratification amendment path. Contracts-first: the measurement files before the contract slice built against it. f27 measures what the shipped lifecycle-routing runtime cannot be measured on today — a real agent replaying an authored episode of ordinary working language with every store-bearing utterance removed, diffed against the fold of the corpus's own annotations in three tiers, with the false-write dual reported from the same run. Adds no catastrophic assertion, no budget constant, no operation kind, and no runtime or tool-surface change; the only projection change is one additive, default-empty field (CollectionProjection.storage_source, VaultProjector.version 0.2.0 -> 0.3.0) so the false-write dual's collection exemption reads the manifest instead of guessing a convention, and nothing the projector already emitted changed; leaves the unprompted-family, absence-meta and item-pair registries unchanged. f27 is declared expected-partial on the current runtime as the next slice's falsification target.",
+  "repository_revision": "287b984418ff3a02b26e05aafeb3bcbae255b27b",
   "schema_version": 1,
   "sequence": 3
 }

--- a/benchmarks/epistemic/fixtures/once-red-sequence3-withheld-family.yaml
+++ b/benchmarks/epistemic/fixtures/once-red-sequence3-withheld-family.yaml
@@ -6,7 +6,7 @@
 # the loader's choke point and this fixture proved the refusal. It now loads by
 # itself — exactly the transition sequence 1 went through — and the test over it
 # pins that release.
-scenario_id: red-sequence3-withheld-family
+scenario_id: once-red-sequence3-withheld-family
 family_id: f27
 kind: operational
 public_coverage: none

--- a/benchmarks/epistemic/fixtures/red-sequence3-withheld-family.yaml
+++ b/benchmarks/epistemic/fixtures/red-sequence3-withheld-family.yaml
@@ -16,6 +16,8 @@ phases:
       - op: configure
         ref: hookless-maximal
         detail: "no plugin; prominence maximal"
+      - op: snapshot
+        ref: s-hookless-seed
       - op: agent_turn
         ref: t01-take-on-two
         detail: "This week I'm taking on the Batch layout draft."

--- a/benchmarks/epistemic/fixtures/red-sequence3-withheld-family.yaml
+++ b/benchmarks/epistemic/fixtures/red-sequence3-withheld-family.yaml
@@ -1,10 +1,11 @@
-# RED fixture: a sequence-3 family whose amendment receipt is still pending.
+# ONCE-RED fixture: a sequence-3 family whose amendment receipt was pending
+# until the founder acknowledgment landed on 2026-08-30.
 #
-# f27 IS in the §1 family table — registration is not the thing being refused.
-# What refuses it is the amendment receipt: sequence 3 has no founder
-# acknowledgment, so `epistemic.amendments` withholds the family it introduced
-# at the loader's choke point. This fixture goes green by itself the day the
-# acknowledgment lands, which is exactly the transition sequence 1 went through.
+# f27 IS in the §1 family table — registration was never the thing refused.
+# While the receipt was pending, `epistemic.amendments` withheld the family at
+# the loader's choke point and this fixture proved the refusal. It now loads by
+# itself — exactly the transition sequence 1 went through — and the test over it
+# pins that release.
 scenario_id: red-sequence3-withheld-family
 family_id: f27
 kind: operational

--- a/benchmarks/epistemic/journeys/f27_replay.py
+++ b/benchmarks/epistemic/journeys/f27_replay.py
@@ -31,10 +31,12 @@ expensive lie this harness could tell about itself.
 artifact is reproducible from its inputs; only :func:`main`, which is a command,
 may consult one.
 
-Sequence-3 status: the amendment that registers f27 is unacknowledged, so a run
-from this driver is evidence about the harness and the current runtime — the
-family's finding — and is not a comparative claim. The manifest says so in the
-artifact rather than leaving it to a reader's memory.
+Sequence-3 status: the manifest states the amendment receipt's own
+acknowledgment status, derived from the working receipts at write time — never
+hardcoded, because a remembered status lies the day the receipt changes.
+Acknowledged (2026-08-30), a run may back a comparative claim, with f27
+declared expected-partial on the current runtime; while a receipt is pending,
+a run is evidence about the harness only, and the artifact says so itself.
 """
 
 from __future__ import annotations
@@ -58,6 +60,7 @@ from typing import Protocol
 from membench.trackc.natural_prompt_driver import write_mcp_config
 from membench.trackc.witness_join import Transcript, parse_stream_json_transcript
 
+from ..amendments import withheld_family_ids
 from ..corpora.lifecycle_replay import CORPUS_ID, ReplayCorpus, replay_corpus, seed_replay_vault
 from ..projectors.exomem_vault import VaultProjector
 from ..snapshot import EpistemicStateSnapshot, ProjectorMeta
@@ -1178,14 +1181,39 @@ def manifest_payload(result: JourneyResult) -> dict:
         # working directory. Nothing is read from it and nothing is copied.
         "agent_transcript_home": str(Path("~/.claude/projects").expanduser()),
         "exomem_version": exomem_version,
-        "amendment_sequence": 3,
-        "amendment_acknowledged": False,
-        "claim_status": (
+        **amendment_status(),
+    }
+
+
+def amendment_status() -> dict:
+    """The receipt's own acknowledgment state, derived at artifact-write time.
+
+    Hardcoding this field misstated the ratification status once (caught in
+    review, 2026-08-30); the working receipts are the only source. The pending
+    arm is not dead code — sequence 2 is pending today, and the next amendment
+    will need the same words.
+    """
+
+    acknowledged = "f27" not in withheld_family_ids(REPO_ROOT)
+    if acknowledged:
+        claim_status = (
+            "Sequence 3 was acknowledged on 2026-08-30, so a run from this "
+            "driver may back a comparative claim. f27 is declared "
+            "expected-partial on the current runtime: a red positive is the "
+            "family's finding — the next slice's falsification target — not a "
+            "harness fault."
+        )
+    else:
+        claim_status = (
             "Development run. The sequence-3 amendment registering f27 is "
             "unacknowledged, so this is evidence about the harness and the "
             "current runtime, recorded as the family's finding, and is not a "
             "comparative claim, score, or ranking."
-        ),
+        )
+    return {
+        "amendment_sequence": 3,
+        "amendment_acknowledged": acknowledged,
+        "claim_status": claim_status,
     }
 
 

--- a/benchmarks/epistemic/registry.py
+++ b/benchmarks/epistemic/registry.py
@@ -175,10 +175,10 @@ AMENDMENT_INTRODUCED_FAMILIES: Mapping[str, int] = MappingProxyType(
         "f24": 2,
         "f25": 2,
         "f26": 2,
-        # Sequence 3 (lifecycle replay). Pending founder acknowledgment, so f27
-        # is registered and withheld at once — the development run the change
-        # records is evidence about the harness and the current runtime, never a
-        # comparative claim.
+        # Sequence 3 (lifecycle replay). Acknowledged 2026-08-30, releasing
+        # f27 the same way sequence 1's families were released — the development
+        # run recorded before acknowledgment remains evidence about the harness
+        # and that runtime, never a comparative claim.
         "f27": 3,
     }
 )

--- a/tests/test_epistemic_amendment_governance.py
+++ b/tests/test_epistemic_amendment_governance.py
@@ -669,7 +669,7 @@ def test_the_acknowledged_amendment_releases_its_own_families() -> None:
     ``AmendmentAcknowledgmentPendingError`` before 2026-08-15 now returns. It
     withholds nothing *of sequence 1*; sequence 2 is a separate, still-pending
     receipt and is refused by
-    :func:`test_the_loader_gate_releases_sequence_one_and_withholds_sequence_two`
+    :func:`test_the_loader_gate_releases_sequences_one_and_three_and_withholds_two`
     below, so the old name for this test — ``withholds_nothing`` — became a claim
     it never made.
     """
@@ -686,6 +686,9 @@ def test_the_acknowledged_amendment_releases_its_own_families() -> None:
     for family_id in AMENDED_FAMILIES:
         require_amended_families_released(identity, (family_id,))
     require_amended_families_released(identity, ("f01", *AMENDED_FAMILIES))
+    # Sequence 3 releases through the same identity-level call (spec: the
+    # refusal covers run-manifest construction too, not only the loader).
+    require_amended_families_released(identity, SEQUENCE_THREE_FAMILIES)
 
 
 def test_the_pending_refusal_is_still_armed_for_a_future_amendment() -> None:

--- a/tests/test_epistemic_amendment_governance.py
+++ b/tests/test_epistemic_amendment_governance.py
@@ -25,9 +25,12 @@ AMENDED_FAMILIES = ("f15", "f16", "f17", "f18", "f19")
 #: Sequence 2 (no-nudge). Registered by the same §7 path and withheld by the
 #: same receipt gate, because its acknowledgment has not landed.
 SEQUENCE_TWO_FAMILIES = ("f20", "f21", "f22", "f23", "f24", "f25", "f26")
-#: Sequence 3 (lifecycle replay). Registered by the same §7 path and withheld by
-#: the same receipt gate, for the same reason: no acknowledgment has landed.
+#: Sequence 3 (lifecycle replay). Registered by the same §7 path, withheld until
+#: the founder acknowledgment recorded in its receipt on 2026-08-30.
 SEQUENCE_THREE_FAMILIES = ("f27",)
+#: The squash commit on ``main`` carrying the sequence-3 amended document and its
+#: then-pending receipt (#762), pinned by the founder at acknowledgment.
+SEQUENCE_THREE_ACKNOWLEDGED_REVISION = "287b984418ff3a02b26e05aafeb3bcbae255b27b"
 DATASET = {
     "id": "fixture",
     "variant": "mini",
@@ -598,13 +601,13 @@ def test_real_working_chain_folds_after_acknowledgment() -> None:
 
     receipt = AmendmentReceipt.model_validate_json(LOOP_CLOSURE_RECEIPT.read_bytes())
     assert receipt.acknowledgment_status == "acknowledged"
-    # The fold culminates in the *last* receipt's document, which is sequence 2's
-    # once it exists. Acknowledgment still touches nothing the fold depends on:
-    # sequence 2 is pending and folds exactly the same way, which is the property
+    # The fold culminates in the *last* receipt's document. Acknowledgment still
+    # touches nothing the fold depends on: sequence 3 folded exactly the same
+    # way before and after its own acknowledgment landed, which is the property
     # this test was written to hold.
     chain = working_amendment_receipts(ROOT)
     assert validate_working_preregistration(ROOT) == chain[-1].contract_sha256
-    assert chain[-1].acknowledgment_status == "pending"
+    assert chain[-1].acknowledgment_status == "acknowledged"
 
 
 def test_acknowledged_amendment_derives_a_complete_typed_identity() -> None:
@@ -633,23 +636,29 @@ def test_acknowledged_amendment_derives_a_complete_typed_identity() -> None:
     assert amendment.contract.repository_revision != amendment.receipt.introduction_revision
     assert amendment.sequence not in {a.sequence for a in identity.pending_amendments}
 
-    # Sequences 2 and 3 are the *pending* half of the same chain, and their
-    # presence is what proves the two shapes derive side by side: an
-    # acknowledged amendment pins its amended revision from the founder, while a
-    # pending one has that revision reconstructed from its unique introduction
-    # commit.
-    pending_two, pending_three = identity.amendments[1], identity.amendments[2]
-    assert (pending_two.sequence, pending_three.sequence) == (2, 3)
-    for pending in (pending_two, pending_three):
-        assert pending.acknowledgment_status == "pending"
-        assert pending.contract.repository_revision == pending.receipt.introduction_revision
-    assert pending_two.introduced_family_ids == SEQUENCE_TWO_FAMILIES
-    assert pending_three.introduced_family_ids == SEQUENCE_THREE_FAMILIES
-    assert identity.effective.sha256 == pending_three.contract.sha256
-    assert identity.pending_amendments == (pending_two, pending_three)
-    assert identity.withheld_family_ids == frozenset(
-        SEQUENCE_TWO_FAMILIES + SEQUENCE_THREE_FAMILIES
+    # Sequence 2 is the *pending* half of the same chain, and its presence is
+    # what proves the two shapes derive side by side: an acknowledged amendment
+    # pins its amended revision from the founder, while a pending one has that
+    # revision reconstructed from its unique introduction commit. Sequence 3
+    # crossed from one shape to the other on 2026-08-30.
+    pending_two, acknowledged_three = identity.amendments[1], identity.amendments[2]
+    assert (pending_two.sequence, acknowledged_three.sequence) == (2, 3)
+    assert pending_two.acknowledgment_status == "pending"
+    assert pending_two.contract.repository_revision == pending_two.receipt.introduction_revision
+    assert acknowledged_three.acknowledgment_status == "acknowledged"
+    assert (
+        acknowledged_three.contract.repository_revision
+        == SEQUENCE_THREE_ACKNOWLEDGED_REVISION
     )
+    assert (
+        acknowledged_three.contract.repository_revision
+        != acknowledged_three.receipt.introduction_revision
+    )
+    assert pending_two.introduced_family_ids == SEQUENCE_TWO_FAMILIES
+    assert acknowledged_three.introduced_family_ids == SEQUENCE_THREE_FAMILIES
+    assert identity.effective.sha256 == acknowledged_three.contract.sha256
+    assert identity.pending_amendments == (pending_two,)
+    assert identity.withheld_family_ids == frozenset(SEQUENCE_TWO_FAMILIES)
 
 
 def test_the_acknowledged_amendment_releases_its_own_families() -> None:
@@ -749,8 +758,9 @@ def test_acknowledged_amendment_is_recorded_on_every_run_manifest(
     # Sequence 2's pending status rides on the same manifest. A reader can tell
     # which families backed this run and which were withheld from it without
     # reading any other artifact, which is the whole reason the field exists.
+    # Sequence 3 left the withheld set when its acknowledgment landed 2026-08-30.
     assert manifest.preregistration_identity.withheld_family_ids == frozenset(
-        SEQUENCE_TWO_FAMILIES + SEQUENCE_THREE_FAMILIES
+        SEQUENCE_TWO_FAMILIES
     )
     assert manifest.preregistration_lineage is not None
 
@@ -891,16 +901,16 @@ def test_acknowledged_amendment_lets_an_amended_family_scenario_load() -> None:
         assert scenario.family_id == family_id
 
 
-def test_the_loader_gate_releases_sequence_one_and_withholds_sequence_two() -> None:
+def test_the_loader_gate_releases_sequences_one_and_three_and_withholds_two() -> None:
     """The loader's own view of release, asserted directly at the gate.
 
     ``epistemic.amendments`` answers "is amendment N acknowledged?" from the
     working receipt bytes without Git, which is the cheap path the loader takes
-    per scenario.  Sequence 1 is acknowledged, so f15-f19 pass the gate;
-    sequences 2 and 3 are unacknowledged, so f20-f26 and f27 are refused by the
-    very same call, each naming its own sequence.  Holding all of it in one test
-    is the point: release is a property of each receipt, not a switch that was
-    flipped once and left on.
+    per scenario.  Sequences 1 and 3 are acknowledged, so f15-f19 and f27 pass
+    the gate; sequence 2 is unacknowledged, so f20-f26 are refused by the very
+    same call, naming their own sequence.  Holding all of it in one test is the
+    point: release is a property of each receipt, not a switch that was flipped
+    once and left on.
     """
 
     from epistemic.amendments import (
@@ -911,21 +921,15 @@ def test_the_loader_gate_releases_sequence_one_and_withholds_sequence_two() -> N
     from protocol.contracts import AmendmentAcknowledgmentPendingError
 
     reset_cache()
-    assert withheld_family_ids(ROOT) == frozenset(
-        SEQUENCE_TWO_FAMILIES + SEQUENCE_THREE_FAMILIES
-    )
-    for family_id in AMENDED_FAMILIES:
+    assert withheld_family_ids(ROOT) == frozenset(SEQUENCE_TWO_FAMILIES)
+    for family_id in AMENDED_FAMILIES + SEQUENCE_THREE_FAMILIES:
         require_family_released(family_id, repo_root=ROOT)
-    for sequence, families in (
-        (2, SEQUENCE_TWO_FAMILIES),
-        (3, SEQUENCE_THREE_FAMILIES),
-    ):
-        for family_id in families:
-            with pytest.raises(
-                AmendmentAcknowledgmentPendingError,
-                match=rf"amendment sequence {sequence} .*pending.*{family_id}",
-            ):
-                require_family_released(family_id, repo_root=ROOT)
+    for family_id in SEQUENCE_TWO_FAMILIES:
+        with pytest.raises(
+            AmendmentAcknowledgmentPendingError,
+            match=rf"amendment sequence 2 .*pending.*{family_id}",
+        ):
+            require_family_released(family_id, repo_root=ROOT)
 
 
 def test_ratified_base_families_still_load() -> None:

--- a/tests/test_epistemic_lifecycle_replay.py
+++ b/tests/test_epistemic_lifecycle_replay.py
@@ -304,7 +304,7 @@ def test_the_once_withheld_red_fixture_loads_after_acknowledgment() -> None:
 
     from epistemic.schema import load_scenario
 
-    scenario = load_scenario(FIXTURES / "red-sequence3-withheld-family.yaml")
+    scenario = load_scenario(FIXTURES / "once-red-sequence3-withheld-family.yaml")
     assert scenario.family_id == "f27"
     # The fixture is deliberately minimal — one turn, not a conformant f27
     # phase — but it must not carry the one dangerous shape: a turn with no

--- a/tests/test_epistemic_lifecycle_replay.py
+++ b/tests/test_epistemic_lifecycle_replay.py
@@ -202,22 +202,9 @@ SEQUENCE_THREE_ASSERTIONS = (
     "lifecycle_consequence_landed_unprompted",
     "no_structured_write_beyond_expectation",
 )
-
-
-@pytest.fixture
-def released(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Run as if the founder had acknowledged sequence 3.
-
-    The gate itself is asserted un-patched below. What this buys is the ability
-    to execute the trajectory now, which is the only way to know whether the
-    family is partial for the reason the amendment claims.
-    """
-
-    from epistemic import runner as runner_module
-    from epistemic import schema as schema_module
-
-    monkeypatch.setattr(schema_module, "require_family_released", lambda *a, **k: None)
-    monkeypatch.setattr(runner_module, "require_family_released", lambda *a, **k: None)
+#: The squash commit on ``main`` carrying the sequence-3 amended document and its
+#: then-pending receipt (#762). The founder pinned this at acknowledgment.
+SEQUENCE_THREE_AMENDED_REVISION = "287b984418ff3a02b26e05aafeb3bcbae255b27b"
 
 
 def test_the_document_registers_f27_and_both_assertions() -> None:
@@ -279,7 +266,7 @@ def test_the_registry_mirrors_the_document_for_f27() -> None:
 
 
 def test_the_sequence_three_receipt_folds_the_working_chain() -> None:
-    """The receipt binds sequence 2's document to the amended one, and is pending."""
+    """The receipt binds sequence 2's document to the amended one, acknowledged."""
 
     from protocol.contracts import (
         validate_working_preregistration,
@@ -289,47 +276,49 @@ def test_the_sequence_three_receipt_folds_the_working_chain() -> None:
     receipts = working_amendment_receipts(ROOT)
     assert [receipt.sequence for receipt in receipts] == [1, 2, 3]
     sequence_three = receipts[2]
-    assert sequence_three.acknowledgment_status == "pending"
-    assert sequence_three.ratifier is None
+    assert sequence_three.acknowledgment_status == "acknowledged"
+    assert sequence_three.ratifier == "Hugo Ander Kivi"
+    assert sequence_three.acknowledged_on == "2026-08-30"
+    assert sequence_three.repository_revision == SEQUENCE_THREE_AMENDED_REVISION
+    # No §3 candidacy among the affected sections, so no catastrophic-set
+    # decision is required or recorded — the amendment added no catastrophic
+    # assertion.
     assert sequence_three.catastrophic_set_decision is None
     assert sequence_three.parent_contract_sha256 == receipts[1].contract_sha256
     assert validate_working_preregistration(ROOT) == sequence_three.contract_sha256
 
 
-def test_the_withhold_gate_refuses_f27_naming_sequence_three() -> None:
+def test_the_withhold_gate_releases_f27_now_sequence_three_is_acknowledged() -> None:
+    """The same call that refused f27 before 2026-08-30 now returns."""
+
     from epistemic import amendments
-    from protocol.contracts import AmendmentAcknowledgmentPendingError
 
     amendments.reset_cache()
-    assert "f27" in amendments.withheld_family_ids(ROOT)
+    assert "f27" not in amendments.withheld_family_ids(ROOT)
     assert amendments.amendment_sequence_for("f27") == 3
-    with pytest.raises(
-        AmendmentAcknowledgmentPendingError,
-        match=r"amendment sequence 3 .*pending.*f27",
-    ):
-        amendments.require_family_released("f27", repo_root=ROOT)
+    amendments.require_family_released("f27", repo_root=ROOT)
 
 
-def test_the_withheld_red_fixture_refuses_at_load() -> None:
-    from epistemic.schema import ScenarioLoadError, load_scenario
+def test_the_once_withheld_red_fixture_loads_after_acknowledgment() -> None:
+    """The fixture's own header promised it goes green the day the receipt does."""
 
-    path = FIXTURES / "red-sequence3-withheld-family.yaml"
-    with pytest.raises(ScenarioLoadError, match=r"sequence 3.*f27"):
-        load_scenario(path)
+    from epistemic.schema import load_scenario
+
+    scenario = load_scenario(FIXTURES / "red-sequence3-withheld-family.yaml")
+    assert scenario.family_id == "f27"
 
 
-def test_the_shipped_f27_scenario_refuses_to_load_while_pending() -> None:
-    from epistemic.schema import ScenarioLoadError, load_scenario
+def test_the_shipped_f27_scenario_loads_now_the_receipt_is_acknowledged() -> None:
+    from epistemic.schema import load_scenario
 
     scenarios = sorted(SEQUENCE3.glob("*.yaml"))
     assert len(scenarios) == 1
     for path in scenarios:
-        with pytest.raises(ScenarioLoadError, match="sequence 3"):
-            load_scenario(path)
+        assert load_scenario(path).family_id == "f27"
 
 
-def test_the_store_bearing_red_fixture_refuses_at_scenario_load(released: None) -> None:
-    """Released, so the refusal under test is the gate and not the receipt."""
+def test_the_store_bearing_red_fixture_refuses_at_scenario_load() -> None:
+    """Sequence 3 is acknowledged, so the refusal under test is the gate, not the receipt."""
 
     from epistemic.schema import ScenarioLoadError, load_scenario
 
@@ -368,7 +357,7 @@ def _fixture_without_the_hooked_seed(tmp_path) -> Path:
     return path
 
 
-def test_the_shipped_scenario_replays_the_corpus_turn_for_turn(released: None) -> None:
+def test_the_shipped_scenario_replays_the_corpus_turn_for_turn() -> None:
     from epistemic.corpora.lifecycle_replay import CORPUS_ID, replay_corpus
     from epistemic.schema import load_scenario
 
@@ -389,7 +378,7 @@ def test_the_shipped_scenario_replays_the_corpus_turn_for_turn(released: None) -
 
 
 def test_the_turn_for_turn_pin_refuses_a_phase_missing_its_seed_op(
-    released: None, tmp_path
+    tmp_path
 ) -> None:
     """F1(ii). The round-1 pin passed on this fixture; run the pin itself on it.
 
@@ -817,7 +806,7 @@ def test_extras_fail_on_a_page_outside_the_allowlist() -> None:
     assert "batch-run-summary" in result.evidence
 
 
-def test_both_assertions_run_through_evaluate_scenario(released: None) -> None:
+def test_both_assertions_run_through_evaluate_scenario() -> None:
     """The pair, bound by the shipped fixture rather than by a hand-made context."""
 
     from epistemic.runner import evaluate_scenario
@@ -1300,7 +1289,7 @@ def test_a_failed_execution_blocks_the_arm_and_is_never_a_product_result(
     assert arm.snapshot is None
 
 
-def test_a_blocked_arm_evaluates_both_assertions_blocked(tmp_path, released: None) -> None:
+def test_a_blocked_arm_evaluates_both_assertions_blocked(tmp_path) -> None:
     from epistemic.journeys import f27_replay as journey
     from epistemic.schema import load_scenario
 
@@ -1321,7 +1310,7 @@ def test_a_blocked_arm_evaluates_both_assertions_blocked(tmp_path, released: Non
         assert "harness fault" in bound.result.evidence
 
 
-def test_the_full_offline_path_runs_for_both_arms(tmp_path, released: None) -> None:
+def test_the_full_offline_path_runs_for_both_arms(tmp_path) -> None:
     """parse -> project -> evaluate -> report, on a FABRICATED transcript."""
 
     from epistemic.corpora.lifecycle_replay import replay_corpus
@@ -1969,7 +1958,7 @@ def test_declared_cli_options_extract_bracketed_variants() -> None:
 # --- m1: the corpus id is not optional -----------------------------------
 
 
-def test_the_scenario_refuses_an_expectation_without_the_corpus_subject(released: None) -> None:
+def test_the_scenario_refuses_an_expectation_without_the_corpus_subject() -> None:
     """m1. Both assertions read their expectation out of the corpus `subject`."""
 
     from epistemic.registry import REQUIRES_SUBJECT
@@ -2138,7 +2127,7 @@ def test_the_gate_refuses_an_inflected_store_verb() -> None:
 
 
 def test_a_phase_that_forgot_its_seed_snapshot_blocks_rather_than_scoring(
-    released: None, tmp_path
+    tmp_path
 ) -> None:
     """F1. The runner reaches snapshots cumulatively — on purpose, for other families.
 
@@ -2193,7 +2182,7 @@ def test_a_phase_that_forgot_its_seed_snapshot_blocks_rather_than_scoring(
     assert "'hookless'" in hooked.evidence and "'hooked'" in hooked.evidence
 
 
-def test_a_post_run_snapshot_from_the_same_phase_is_not_a_seed(released: None) -> None:
+def test_a_post_run_snapshot_from_the_same_phase_is_not_a_seed() -> None:
     """F1. Same phase is necessary but not sufficient: the baseline is pre-turn.
 
     A phase carrying two post-run snapshots would satisfy a phase-equality check
@@ -2238,7 +2227,7 @@ def test_the_seed_snapshot_is_taken_in_the_arms_own_phase(tmp_path) -> None:
     assert arm.snapshot.phase == "hookless"
 
 
-def test_two_arms_with_no_snapshot_at_all_still_evaluate(released: None, tmp_path) -> None:
+def test_two_arms_with_no_snapshot_at_all_still_evaluate(tmp_path) -> None:
     """LOW. `_fault_snapshot` bound twice by identity is refused by the runner.
 
     An arm that faulted before its vault was seeded has neither snapshot, and

--- a/tests/test_epistemic_lifecycle_replay.py
+++ b/tests/test_epistemic_lifecycle_replay.py
@@ -306,6 +306,12 @@ def test_the_once_withheld_red_fixture_loads_after_acknowledgment() -> None:
 
     scenario = load_scenario(FIXTURES / "red-sequence3-withheld-family.yaml")
     assert scenario.family_id == "f27"
+    # The fixture is deliberately minimal — one turn, not a conformant f27
+    # phase — but it must not carry the one dangerous shape: a turn with no
+    # seed snapshot before it, which would be scored against a previous arm's
+    # post-run vault if a sweep ever picked it up.
+    (phase,) = scenario.phases
+    assert [op.op for op in phase.ops[:2]] == ["configure", "snapshot"]
 
 
 def test_the_shipped_f27_scenario_loads_now_the_receipt_is_acknowledged() -> None:
@@ -375,6 +381,28 @@ def test_the_shipped_scenario_replays_the_corpus_turn_for_turn() -> None:
             SEQUENCE_THREE_ASSERTIONS
         )
         assert {expectation.subject for expectation in phase.expect} == {CORPUS_ID}
+
+
+def test_the_manifest_amendment_status_follows_the_receipt(monkeypatch) -> None:
+    """Both branches of the derived status, so the pending arm outlives its era.
+
+    Sequence 3 is acknowledged, so the live branch is the released one; the
+    pending branch stays reachable because sequence 2 proves the mechanism is
+    not retired, and a future amendment will need it verbatim.
+    """
+
+    from epistemic.journeys import f27_replay as journey
+
+    released = journey.amendment_status()
+    assert released["amendment_sequence"] == 3
+    assert released["amendment_acknowledged"] is True
+    assert "comparative claim" in released["claim_status"]
+    assert "expected-partial" in released["claim_status"]
+
+    monkeypatch.setattr(journey, "withheld_family_ids", lambda _root: frozenset({"f27"}))
+    pending = journey.amendment_status()
+    assert pending["amendment_acknowledged"] is False
+    assert "not a comparative claim" in pending["claim_status"]
 
 
 def test_the_turn_for_turn_pin_refuses_a_phase_missing_its_seed_op(
@@ -1362,6 +1390,12 @@ def test_the_full_offline_path_runs_for_both_arms(tmp_path) -> None:
 
     report = json.loads((out / "report.json").read_text(encoding="utf-8"))
     manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    # The artifact states the receipt's own acknowledgment status, derived —
+    # not remembered. Hardcoding it already lied once (review finding, 2026-08-30).
+    assert manifest["amendment_sequence"] == 3
+    assert manifest["amendment_acknowledged"] is True
+    assert "not a comparative claim" not in manifest["claim_status"]
+    assert "expected-partial" in manifest["claim_status"]
     by_arm = {row["arm"]: row for row in report["arms"]}
     assert by_arm["hookless"]["coverage"]["intent"] == {
         "landed": 4,

--- a/tests/test_epistemic_no_nudge_families.py
+++ b/tests/test_epistemic_no_nudge_families.py
@@ -53,7 +53,8 @@ SEQUENCE_TWO_FAMILIES = ("f20", "f21", "f22", "f23", "f24", "f25", "f26")
 #: Families a *later* unacknowledged amendment introduced. The withhold gate is
 #: repo-wide, so a test that pinned its answer to sequence 2 alone would fail the
 #: day another amendment filed — which is drift in the test, not in the gate.
-LATER_WITHHELD_FAMILIES = ("f27",)
+#: Sequence 3 (f27) left this tuple when its acknowledgment landed on 2026-08-30.
+LATER_WITHHELD_FAMILIES: tuple[str, ...] = ()
 
 
 def _seed_journey_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:

--- a/tests/test_epistemic_registry.py
+++ b/tests/test_epistemic_registry.py
@@ -142,8 +142,9 @@ def test_family_registry_matches_preregistration_section_one() -> None:
     2, and f27 from sequence 3. Being in this table is registration, not
     release: the two are separate, and the gate that keeps them separate lives
     in ``test_epistemic_amendment_governance.py``. It withheld f15-f19 until the
-    founder acknowledged the receipt on 2026-08-15, and it withholds f20-f26 and
-    f27 now, exactly the same way, because their receipts are still unacknowledged.
+    founder acknowledged the receipt on 2026-08-15, released f27 the same way on
+    2026-08-30, and it withholds f20-f26 now, exactly the same way, because
+    sequence 2's receipt is still unacknowledged.
     """
 
     from epistemic.registry import PREREGISTERED_FAMILIES, parse_preregistered_families


### PR DESCRIPTION
## What

Records the founder acknowledgment of pre-registration amendment **sequence 3** (f27 `lifecycle_routing_replay`), following the sequence-1 precedent (#535) exactly: the receipt gains `acknowledged_on: 2026-08-30`, `ratifier` (the pinned founder identity), and `repository_revision` (`287b9844`, the #762 squash commit that filed the amendment). No `catastrophic_set_decision` — the receipt's affected sections carry no §3 candidacy, so the model validator neither requires nor permits one. PREREGISTRATION.md is untouched (the receipt's `contract_sha256` pins the current document bytes; the chain validator allows exactly this one pending→acknowledged transition).

Effect: f27 leaves the withheld set — the same loader/runner/manifest gates that refused it now release it; sequence 2 (f20–f26) stays withheld pending calibration. f27 remains declared expected-partial on the current runtime: the next slice's falsification target.

## Test flips

The pending-pins flip to acknowledged-pins: `test_epistemic_lifecycle_replay.py` (receipt fold, gate release, the once-red withheld fixture now loads — as its own header promised; the `released` monkeypatch fixture is deleted since the real gate now releases f27), `test_epistemic_no_nudge_families.py` (`LATER_WITHHELD_FAMILIES` → empty), `test_epistemic_amendment_governance.py` (chain tail, typed identity derives the acknowledged shape for sequence 3, manifest withheld set, loader gate releases 1+3 / withholds 2). Comment/doc updates in `registry.py`, `benchmarks/README.md`, and the fixture header.

## Verification

- Red-first: with only the receipt flipped, the pinned tests failed for exactly the pending-pin reasons (9 receipt-driven failures), then green after the flips.
- Green: **220 passed, 1 failed** across `tests/test_epistemic_{lifecycle_replay,no_nudge_families,amendment_governance,contract_receipts,registry,scoring}.py`. The 1 failure (`test_every_flag_the_driver_uses_is_one_the_installed_cli_accepts`) fails identically on pristine origin/main — the installed CLI's `--help` no longer lists `--mcp-config`/`--setting-sources`; environmental, unrelated. (Local caveat: a stray empty `/tmp/.git` on this box makes the f27 journey refuse tmpdirs under `/tmp`; runs used a basetemp outside it.)
- Fresh zero-context adversarial review of the diff: verdict quoted in a comment below.
- Ruff clean on touched files (one pre-existing import-order nit left untouched); no OpenSpec artifacts changed, strict validation unaffected.
