### PR TITLE
docs(openspec): ratify the authority-and-effects matrix as the constitution's model clause

### DIFF
--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -10,11 +10,21 @@ context: |
   search, MarkItDown for office docs. Optional extras: embeddings, media, diarization,
   vision. NSSM-managed Windows service; GitHub OAuth proxy; cloudflared tunnel.
 
-  THE CORE CONSTRAINT — "pure substrate": the server MEASURES, the brain (Claude/Max)
-  REASONS. Deterministic transduction (ASR, OCR, embeddings, CLIP, frozen captioners,
-  voice-embedding speaker-ID) is "measurement" and is IN bounds. A server-side reasoning
-  LLM is NEVER added. No confidence/authority floats on notes. Epistemic surfaces
-  (conflict, staleness) MEASURE and SURFACE for review; they never auto-decay or rank.
+  THE CORE CONSTRAINT — the authority-and-effects matrix (ratified 2026-08-30,
+  restating the older transducer-vs-reasoner line as OUTPUT AUTHORITY): the server
+  MEASURES, the brain (Claude/Max) REASONS. What a server-side model may do is bounded
+  by what its output is allowed to touch, not by its architecture class:
+  retrieval scorers (embeddings, rerankers) may RANK; content transducers (ASR, OCR,
+  CLIP, frozen captioners, voice-embedding speaker-ID) may TRANSCRIBE across
+  modalities; frozen verifiers (e.g. an NLI stance classifier) may LABEL into
+  provenance-marked review queues only — pinned model digest, versioned label map,
+  off the synchronous write path, no vault text in instruction position — and their
+  output never enters canon, decisions, retrieval, ranking, or policy. The agent
+  alone judges conversation and authors proposals; governed leaves alone mutate.
+  Same-modal text-to-text generation server-side stays banned: a server-side
+  reasoning LLM is NEVER added. No confidence/authority floats on notes. Epistemic
+  surfaces (conflict, staleness) MEASURE and SURFACE for review; they never
+  auto-decay or rank.
 
   Surface consistency (engraph/Endstate-style): every core operation should be reachable
   consistently across the MCP tools, the CLI (`python -m exomem <cmd>`), and the personal

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -10,21 +10,27 @@ context: |
   search, MarkItDown for office docs. Optional extras: embeddings, media, diarization,
   vision. NSSM-managed Windows service; GitHub OAuth proxy; cloudflared tunnel.
 
-  THE CORE CONSTRAINT — the authority-and-effects matrix (ratified 2026-08-30,
-  restating the older transducer-vs-reasoner line as OUTPUT AUTHORITY): the server
-  MEASURES, the brain (Claude/Max) REASONS. What a server-side model may do is bounded
-  by what its output is allowed to touch, not by its architecture class:
-  retrieval scorers (embeddings, rerankers) may RANK; content transducers (ASR, OCR,
-  CLIP, frozen captioners, voice-embedding speaker-ID) may TRANSCRIBE across
-  modalities; frozen verifiers (e.g. an NLI stance classifier) may LABEL into
-  provenance-marked review queues only — pinned model digest, versioned label map,
-  off the synchronous write path, no vault text in instruction position — and their
-  output never enters canon, decisions, retrieval, ranking, or policy. The agent
-  alone judges conversation and authors proposals; governed leaves alone mutate.
-  Same-modal text-to-text generation server-side stays banned: a server-side
-  reasoning LLM is NEVER added. No confidence/authority floats on notes. Epistemic
-  surfaces (conflict, staleness) MEASURE and SURFACE for review; they never
-  auto-decay or rank.
+  THE CORE CONSTRAINT — "pure substrate", restated as the authority-and-effects
+  matrix (ratified 2026-08-30, per the 2026-08 no-nudge architecture review): the
+  server MEASURES, the brain (Claude/Max) REASONS. What a server-side model may do
+  is bounded by what its output is allowed to touch, in addition to the class bans
+  below, which stand unchanged. Retrieval scorers (embeddings, rerankers) may RANK.
+  Frozen, deterministic content transducers (ASR, OCR, CLIP, pinned-weight frozen
+  captioners, voice-embedding speaker-ID) may TRANSCRIBE across modalities —
+  default-off wherever they emit prose, and an unpinned or instruction-following
+  generative model is out of bounds in EVERY modality pairing. Frozen verifiers
+  (e.g. an NLI stance classifier) may LABEL into provenance-marked review queues
+  only — pinned model digest, versioned label map, off the synchronous write path,
+  no vault text in instruction position — and their output never enters canon,
+  decisions, retrieval, ranking, or policy. A model serving two roles is bound by
+  each role's rule for that output. The one pre-existing claim-polarity seam
+  (default-off, wired-but-unverified) predates this lane and violates its guards;
+  it may not be enabled as a verifier until re-laned to meet them or removed.
+  The agent alone judges conversation and authors proposals; mutation happens only
+  through governed leaves. Same-modal text-to-text generation server-side stays
+  banned: a server-side reasoning LLM is NEVER added. No confidence/authority
+  floats on notes. Epistemic surfaces (conflict, staleness) MEASURE and SURFACE
+  for review; they never auto-decay notes or rank their authority.
 
   Surface consistency (engraph/Endstate-style): every core operation should be reachable
   consistently across the MCP tools, the CLI (`python -m exomem <cmd>`), and the personal


### PR DESCRIPTION
## What

Ratifies the **authority-and-effects matrix** as the constitution's model clause (`openspec/config.yaml` context block), restating the "pure substrate" line as output authority — in addition to the class bans, which stand unchanged. Retrieval scorers may rank; frozen, deterministic content transducers may transcribe across modalities (default-off wherever they emit prose; an unpinned or instruction-following generative model is out of bounds in EVERY modality pairing); frozen verifiers may label into provenance-marked review queues only — pinned model digest, versioned label map, off the synchronous write path, no vault text in instruction position — never entering canon, decisions, retrieval, ranking, or policy. A model serving two roles is bound by each role's rule for that output. The agent alone judges and authors proposals; mutation happens only through governed leaves. Same-modal text-to-text server-side generation stays banned; "a server-side reasoning LLM is NEVER added" stands verbatim. The one pre-existing claim-polarity seam (default-off, wired-but-unverified) is named non-compliant until re-laned (the S9 sibling PR) or removed.

This is the recorded verdict of the no-nudge architecture report (§6.1) and its KB note (`^authority-effects-matrix`), executed under the founder's direction to proceed on the open decisions. It gates S7 (delegation envelope) and S9 (frozen stance verification), both proposed in sibling PRs; merge this one first.

## Verification

- `openspec validate --all --strict`: 166 passed, 0 failed.
- Two adversarial review rounds by a fresh zero-context reviewer over the actual diff. Round 1 returned REQUEST CHANGES (the first draft weakened the constitution: dropped the determinism gate, re-based the generative ban onto modality, disarmed the class bans, left "pure substrate" dangling); v2 fixed every finding at the mechanism level. Round 2 verdict: **APPROVE** — quoted in a comment below.
