### PR TITLE
docs(openspec): propose the delegation envelope (S7)

### DIFF
--- a/openspec/changes/add-delegation-envelope/design.md
+++ b/openspec/changes/add-delegation-envelope/design.md
@@ -1,0 +1,90 @@
+# Design — the delegation envelope
+
+## D1. Ceilings are product law; the envelope moves only below them
+
+The v1 table, from the architecture report §8, adjusted where the shipped
+product is already more specific:
+
+| Action class (v1 id) | Ceiling | Envelope range below the ceiling | v1 default by prominence |
+|---|---|---|---|
+| `hygiene_writes` (index/log/backrefs riding a governed write) | silent | silent only | silent at every level |
+| `proactive_capture` (agent-initiated capture/record/plan writes) | silent-capable | off → advisory → silent | off / off / silent / silent |
+| `link_acceptance` (relation-queue acceptance) | confirm | off → advisory → confirm-shortcut | off / advisory / advisory / advisory |
+| `structural_suggestions` (review-plane surfacing) | advisory (surface only) | off → advisory | off / advisory / advisory / advisory |
+| `restructure_execution` (also supersession commit, entity creation, deletion) | **confirm-required, always in v1** | confirmation UX only | confirm at every level |
+| `disclosure` (cross-boundary) | governed by the governance plane | not envelope-configurable | refused with a named error |
+
+Two deliberate deltas from the report's draft table, both because shipped
+behaviour is the authority the spec must not silently regress:
+
+- **`proactive_capture` at `balanced` stays autonomous.** The report reserved
+  "silent" for maximal; but `balanced` has captured stepping-stones on its own,
+  with a one-line report, since the prominence contract shipped. The envelope's
+  `silent` disposition means "acts without asking"; *narration* stays the
+  prominence axis it already is. Tightening `balanced` to advisory would turn
+  every routine capture into a question — a nag increase inside the no-nudge
+  programme.
+- **`structural_suggestions` has no separate `family-quiet` disposition.** The
+  S6 family-disposition store already IS that state, per family. The envelope
+  class disposition composes with it: class `off` empties the plane wholesale;
+  family `quiet` mutes one family. One mechanism per scope, no duplicate state.
+
+## D2. Configuration model
+
+The envelope lives in the same shared config file as `mode` and `prominence`
+(`mode.config_path()`), for the same reason: the MCP server and the CLI are
+often different OS users, and bootstrap serves the active envelope from the
+server. Shape: an `envelope` object mapping class id → disposition. An absent
+key means "derived from prominence"; a present key is an explicit override that
+persists across prominence changes and restarts until reset. Unknown class ids
+and dispositions outside the class's range are refused with a named error —
+the same refusal discipline the family-disposition store uses.
+
+Derivation is a pure function `derive_envelope(prominence_level) -> dict` in
+`prominence.py`'s import-cheap tier: no I/O, pinned by test against the table
+above, so the served envelope is always attributable to (level, overrides).
+
+## D3. The closed class set
+
+Six ids, a closed enum. New action classes arrive only through a spec change —
+an unclassified future behaviour has no envelope cell and therefore no
+authority (fail-closed, matching the matrix's posture). `restructure_execution`
+covers the adoption/curation apply surfaces, supersession commits, entity
+creation and deletion because they share one property: hard-to-reverse
+mutation of canon; v1 keeps them behind explicit confirmation regardless of
+any other setting.
+
+## D4. Adaptation: deterministic, consent-shaped, once
+
+Only explicit triage history moves anything, and only by offering:
+
+- A plain-language request ("stop suggesting projects") maps to the existing
+  S6 surface: `triage_memory(ref="exomem://review/family/<family>",
+  action="quiet")`. The envelope adds no second quieting mechanism.
+- Three dismissals of items in one family — counted from the review-state
+  records that already exist, not from any usage signal — make the *next*
+  surfacing of that family carry exactly one quiet-offer annotation. The offer
+  is recorded in the family's review-state entry (`quiet_offered_at`), so it is
+  made once per family, survives restarts, and is never repeated after a
+  decline. Nothing is auto-quieted, ever.
+- No behavioural inference from reads, queries or engagement; the spec bans the
+  input, not just the current implementation.
+
+## D5. The agent contract and its budget
+
+The decider protocol the bootstrap teaches, per action the agent is about to
+take: name the class → ceiling check (above-ceiling intent becomes a proposal,
+never an act) → disposition check (off: don't; advisory: surface in domain
+language; silent: act, narrate per prominence; confirm: ask first) → record the
+outcome through triage. The teaching must fit the compact envelope: the target
+is ≤ ~50 lines across all carriers, measured in tasks against
+`COMPACT_BYTE_CEILING` with before/after bytes recorded — the S1/S6 pattern.
+
+## D6. Explicitly out of v1
+
+Standing delegation of restructure execution ("do this kind of thing from now
+on") is a founder decision (report §16.2). The spec pins the refusal so the
+capability cannot drift in as a convenience. Also out: any hosted-side
+enforcement changes (the envelope is served and taught; hosted profiles read
+the same config), and any new tool surface (inspection rides
+`review_memory(mode="dispositions")` and `bootstrap`).

--- a/openspec/changes/add-delegation-envelope/design.md
+++ b/openspec/changes/add-delegation-envelope/design.md
@@ -5,14 +5,18 @@
 The v1 table, from the architecture report §8, adjusted where the shipped
 product is already more specific:
 
-| Action class (v1 id) | Ceiling | Envelope range below the ceiling | v1 default by prominence |
+| Action class (v1 id) | Ceiling | Disposition | v1 default by prominence (off/light/balanced/maximal) |
 |---|---|---|---|
-| `hygiene_writes` (index/log/backrefs riding a governed write) | silent | silent only | silent at every level |
-| `proactive_capture` (agent-initiated capture/record/plan writes) | silent-capable | off → advisory → silent | off / off / silent / silent |
-| `link_acceptance` (relation-queue acceptance) | confirm | off → advisory → confirm-shortcut | off / advisory / advisory / advisory |
-| `structural_suggestions` (review-plane surfacing) | advisory (surface only) | off → advisory | off / advisory / advisory / advisory |
-| `restructure_execution` (also supersession commit, entity creation, deletion) | **confirm-required, always in v1** | confirmation UX only | confirm at every level |
-| `disclosure` (cross-boundary) | governed by the governance plane | not envelope-configurable | refused with a named error |
+| `hygiene_writes` (index/log/backrefs riding a governed write) | silent | fixed: silent | silent at every level |
+| `proactive_capture` (agent-initiated capture/record/plan writes) | silent-capable | ranged: off → advisory → silent | off / off / silent / silent |
+| `link_acceptance` (relation-queue acceptance) | confirm | ranged: off → advisory → confirm-shortcut | off / advisory / advisory / advisory |
+| `structural_suggestions` (structural advice on every channel: the review/attention plane's structural categories and the write-response structure advisory) | advisory (surface only) | ranged: off → advisory | off / advisory / advisory / advisory |
+| `restructure_execution` (restructure apply, supersession commit, entity creation, deletion) | **confirm-required, always in v1** | fixed: confirm — any change request hits the founder-gate refusal | confirm at every level |
+| `disclosure` (cross-boundary) | governance plane owns it | none — served marked governance-owned | refused with a named error |
+
+Six classes; three carry ranges. `confirm-shortcut` is an inline single-action
+confirmation rendered with the surfaced item — the confirmation step itself is
+never skipped, which is why it sits below the `confirm` ceiling.
 
 Two deliberate deltas from the report's draft table, both because shipped
 behaviour is the authority the spec must not silently regress:
@@ -26,8 +30,20 @@ behaviour is the authority the spec must not silently regress:
   programme.
 - **`structural_suggestions` has no separate `family-quiet` disposition.** The
   S6 family-disposition store already IS that state, per family. The envelope
-  class disposition composes with it: class `off` empties the plane wholesale;
-  family `quiet` mutes one family. One mechanism per scope, no duplicate state.
+  class disposition composes with it: class `off` stops agent-initiated
+  structural advice wholesale; family `quiet` mutes one family. One mechanism
+  per scope, no duplicate state. Class `off` never blocks an explicitly
+  requested review — dispositions govern agent-initiated engagement only,
+  mirroring S6's "quiet is silent, not clean".
+
+**Confirm-required enforcement is tiered, stated plainly.** The served
+envelope marks the class; the agent contract requires in-conversation
+confirmation; and the server-side gates that exist today stay mandatory —
+deletion's explicit `confirm` parameter and the adoption apply surface's
+preview-first default. Supersession and entity creation have no server-side
+confirm parameter today; v1 does not add one (that is a tool-schema change
+behind the documented rollout, named as future work), and the served contract
+says so instead of implying a gate that does not exist.
 
 ## D2. Configuration model
 
@@ -36,9 +52,22 @@ The envelope lives in the same shared config file as `mode` and `prominence`
 often different OS users, and bootstrap serves the active envelope from the
 server. Shape: an `envelope` object mapping class id → disposition. An absent
 key means "derived from prominence"; a present key is an explicit override that
-persists across prominence changes and restarts until reset. Unknown class ids
-and dispositions outside the class's range are refused with a named error —
-the same refusal discipline the family-disposition store uses.
+persists across prominence changes and restarts until reset.
+
+**Per-machine by design.** Prominence itself is machine posture in this same
+file; the envelope derives from it and inherits that scope deliberately. What
+travels with the vault is the family-disposition store (S6, portable review
+state). The spec states the split so nobody discovers it as a surprise:
+machine posture in the config file, vault decisions in review state.
+
+**Write-time strictness, read-time tolerance.** Unknown class ids and
+out-of-range dispositions are refused at write with a named error. An unknown
+id or value found in the *stored* file (e.g. written by a newer runtime) is
+reported and ignored at read — reading the envelope never breaks bootstrap.
+
+**Rollback is the absent key.** Deleting the `envelope` object restores pure
+derivation, which is today's shipped behaviour; no migration is needed in
+either direction.
 
 Derivation is a pure function `derive_envelope(prominence_level) -> dict` in
 `prominence.py`'s import-cheap tier: no I/O, pinned by test against the table
@@ -51,22 +80,27 @@ an unclassified future behaviour has no envelope cell and therefore no
 authority (fail-closed, matching the matrix's posture). `restructure_execution`
 covers the adoption/curation apply surfaces, supersession commits, entity
 creation and deletion because they share one property: hard-to-reverse
-mutation of canon; v1 keeps them behind explicit confirmation regardless of
-any other setting.
+mutation of canon.
 
 ## D4. Adaptation: deterministic, consent-shaped, once
 
 Only explicit triage history moves anything, and only by offering:
 
-- A plain-language request ("stop suggesting projects") maps to the existing
-  S6 surface: `triage_memory(ref="exomem://review/family/<family>",
-  action="quiet")`. The envelope adds no second quieting mechanism.
-- Three dismissals of items in one family — counted from the review-state
-  records that already exist, not from any usage signal — make the *next*
-  surfacing of that family carry exactly one quiet-offer annotation. The offer
-  is recorded in the family's review-state entry (`quiet_offered_at`), so it is
-  made once per family, survives restarts, and is never repeated after a
-  decline. Nothing is auto-quieted, ever.
+- A plain-language request ("stop suggesting projects") is mapped by the agent
+  to a registered family and lands through the existing S6 surface:
+  `triage_memory(ref="exomem://review/family/<family>", action="quiet")`. The
+  envelope adds no second quieting mechanism and no server-side language
+  resolver — the mapping is the decider's judgment, which is where the
+  constitution puts it.
+- Three **manual-origin dismissal events** in one family arm the next surfacing
+  of that family with exactly one quiet-offer annotation. Events are counted
+  from the durable review-state records themselves — not from the live surface
+  index — so the count never decreases when items later vanish, and
+  automatic-origin decisions never count. The offer is recorded durably
+  against the family (`quiet_offered_at`), written through the review-state
+  store's existing concurrent-write discipline. It is cleared only by an
+  explicit reset of the family to `normal` (which clears the family's slate);
+  a decline without a reset never re-offers.
 - No behavioural inference from reads, queries or engagement; the spec bans the
   input, not just the current implementation.
 
@@ -74,17 +108,21 @@ Only explicit triage history moves anything, and only by offering:
 
 The decider protocol the bootstrap teaches, per action the agent is about to
 take: name the class → ceiling check (above-ceiling intent becomes a proposal,
-never an act) → disposition check (off: don't; advisory: surface in domain
-language; silent: act, narrate per prominence; confirm: ask first) → record the
-outcome through triage. The teaching must fit the compact envelope: the target
-is ≤ ~50 lines across all carriers, measured in tasks against
-`COMPACT_BYTE_CEILING` with before/after bytes recorded — the S1/S6 pattern.
+never an act) → disposition check (off: don't initiate; advisory: surface in
+domain language; silent: act, narrate per prominence; confirm /
+confirm-shortcut: get the confirmation first) → record the outcome through
+triage. Budget: **at most fifty lines per carrier** (compact bootstrap,
+scaffold SKILL.md, plugin SKILL.md, hookless custom-instructions block), with
+compact bootstrap's share additionally byte-measured against
+`COMPACT_BYTE_CEILING` and before/after sizes recorded — the S1/S6 pattern.
+Fifty total across four carriers was arithmetic that could not hold six
+classes, four dispositions and a protocol; per-carrier is the honest budget.
 
 ## D6. Explicitly out of v1
 
 Standing delegation of restructure execution ("do this kind of thing from now
 on") is a founder decision (report §16.2). The spec pins the refusal so the
-capability cannot drift in as a convenience. Also out: any hosted-side
-enforcement changes (the envelope is served and taught; hosted profiles read
-the same config), and any new tool surface (inspection rides
-`review_memory(mode="dispositions")` and `bootstrap`).
+capability cannot drift in as a convenience — and makes that refusal the sole
+specified error for the class, so it cannot be shadowed by a generic
+range-refusal message. Also out: new server-side confirmation parameters (see
+D1), hosted-side enforcement changes, and any new tool schema.

--- a/openspec/changes/add-delegation-envelope/proposal.md
+++ b/openspec/changes/add-delegation-envelope/proposal.md
@@ -74,7 +74,14 @@ class wiring are re-reviewed against the landed text before implementation.
   SKILL.md copies, tests. If the recorded dispositions-view response contract
   or packaged digest moves, the documented two-phase response-contract rollout
   applies.
-- Not affected: review-state schema (dispositions are reused as-is), hooks
+- Review-state schema IS affected: adaptation counts dismissal events "from
+  the records themselves", which requires family attribution on dismissal
+  records, and `quiet_offered_at` needs a durable slot that exists even while
+  the family's disposition is `normal` (today `normal` is represented by the
+  absence of a record). Both land as one versioned schema migration under the
+  attention-queue migration discipline (previous-schema files migrate on load;
+  a newer schema refuses on an older runtime).
+- Not affected: hooks
   (presets unchanged), governance plane (cross-boundary disclosure stays
   where it is), tool input schemas (no new commands, no new parameters —
   inspection rides `review_memory(mode="dispositions")` and `bootstrap`), and

--- a/openspec/changes/add-delegation-envelope/proposal.md
+++ b/openspec/changes/add-delegation-envelope/proposal.md
@@ -29,20 +29,35 @@ Gating that has cleared: the authority-and-effects matrix is ratified
 (2026-08-30) as the constitution's restated model clause; S1 and S6 are merged.
 This slice is S7 of the programme (report §17).
 
+Gating that has not: `add-prominence-levels` and
+`add-relation-acceptance-queue` are active changes touching the prominence
+contract and the relation-queue surface this envelope composes with. This
+change binds to their **merged** state; if either lands differently than its
+current delta, the envelope's derivation table and the `link_acceptance`
+class wiring are re-reviewed against the landed text before implementation.
+
 ## What Changes
 
-- **New capability `delegation-envelope`.** The v1 ceilings table; an envelope
-  configuration deriving per-action-class dispositions from the prominence
-  level with explicit per-class overrides; deterministic, consent-shaped
-  adaptation (plain-language family quieting stays the S6 surface; three
-  dismissals of one family prompt exactly one offer to quiet it); inspection,
-  durability and reset. Standing delegation of restructure execution is
-  explicitly out of v1 — it would be an envelope cell above the current
-  ceiling, and only a deliberate founder ratification may ever create one.
+- **New capability `delegation-envelope`.** The v1 ceilings table (six classes:
+  three ranged, `hygiene_writes` and `restructure_execution` fixed,
+  `disclosure` governance-owned); an envelope configuration deriving
+  per-action-class dispositions from the prominence level with explicit
+  per-class overrides, stored in the shared per-machine config file;
+  deterministic, consent-shaped adaptation (plain-language family quieting
+  stays the S6 surface; three manual-origin dismissal events in one family arm
+  exactly one offer to quiet it, cleared only by an explicit family reset);
+  inspection, durability and reset. Standing delegation of restructure
+  execution is explicitly out of v1 — it would be an envelope cell above the
+  current ceiling, and only a deliberate founder ratification may ever create
+  one; its refusal is the sole specified error for that class.
 - **`agent-bootstrap-contract` delta.** The agent contract teaches the
-  envelope: how the decider reads ceilings and dispositions before acting or
-  asking, and how due-state counters are read under it — bounded to a compact
-  budget (target ≤ ~50 lines across all carriers, measured in tasks).
+  envelope: served classes with provenance, the decider protocol, the
+  founder-gate refusal — at most fifty measured lines per carrier, compact
+  bootstrap within its existing byte ceiling.
+- **`command-surface` delta.** The dispositions view
+  (`review_memory(mode="dispositions")`) carries the envelope beside the
+  family dispositions as a structurally separate block — one added
+  requirement; no tool input schema changes.
 - **No new sensor, no new queue, no model.** The envelope composes the S6
   disposition store and the existing confirmation surfaces; it adds authority
   arithmetic, not machinery.
@@ -50,12 +65,17 @@ This slice is S7 of the programme (report §17).
 ## Impact
 
 - Affected specs: `delegation-envelope` (new), `agent-bootstrap-contract`
-  (one added requirement).
+  (one added requirement), `command-surface` (one added requirement: the
+  dispositions-view envelope block).
 - Affected code (implementation slice, after this change is approved):
   `src/exomem/prominence.py` (envelope derivation), a small envelope module
   reusing the shared config file, `commands.op_bootstrap` (contract lines,
-  compact budget re-measured), scaffold/plugin SKILL.md copies, tests.
+  compact budget re-measured), the dispositions-view renderer, scaffold/plugin
+  SKILL.md copies, tests. If the recorded dispositions-view response contract
+  or packaged digest moves, the documented two-phase response-contract rollout
+  applies.
 - Not affected: review-state schema (dispositions are reused as-is), hooks
   (presets unchanged), governance plane (cross-boundary disclosure stays
-  where it is), tool surface (no new commands — inspection rides
-  `review_memory(mode="dispositions")` and `bootstrap`).
+  where it is), tool input schemas (no new commands, no new parameters —
+  inspection rides `review_memory(mode="dispositions")` and `bootstrap`), and
+  server-side confirmation parameters (v1 adds none; existing gates stand).

--- a/openspec/changes/add-delegation-envelope/proposal.md
+++ b/openspec/changes/add-delegation-envelope/proposal.md
@@ -1,0 +1,61 @@
+# Add the delegation envelope
+
+## Why
+
+Prominence is today the only dial a user has over how much Exomem does on its
+own: one level (`off`/`light`/`balanced`/`maximal`) moving recall, capture and
+narration together (`src/exomem/prominence.py`). The no-nudge programme has
+since shipped the pieces around it: per-family signal dispositions with reason
+codes, origin tags and a first-surfaced ledger (S6, `attention-queue` spec
+"Signal families carry a durable disposition"), due-state counters on every
+carrier (S1), and a sensor set that emits into the review plane rather than
+acting (S4/S5). What is missing is the layer the no-nudge architecture report
+(§8, KB `^authority-effects-matrix` note) specifies between prominence and the
+dispositions: **per-action-class authority under hard ceilings that prominence
+cannot exceed**.
+
+Without it, the product has two failure directions. Upward: a future capability
+(curation lane S8, standing sweeps) could inherit `maximal` prominence as
+permission to act, which the report's review round showed becomes an envelope
+that grants and revokes the same authority in adjacent paragraphs. Downward: a
+user who wants less has only prominence (which silences everything, including
+recall they still want) or per-family quieting (which is reactive, one family
+at a time, and unknown to most users). The envelope resolves both with a small,
+deterministic model: ceilings are hard product law; the envelope chooses a
+disposition *below* the ceiling per action class; prominence only sets the
+defaults.
+
+Gating that has cleared: the authority-and-effects matrix is ratified
+(2026-08-30) as the constitution's restated model clause; S1 and S6 are merged.
+This slice is S7 of the programme (report §17).
+
+## What Changes
+
+- **New capability `delegation-envelope`.** The v1 ceilings table; an envelope
+  configuration deriving per-action-class dispositions from the prominence
+  level with explicit per-class overrides; deterministic, consent-shaped
+  adaptation (plain-language family quieting stays the S6 surface; three
+  dismissals of one family prompt exactly one offer to quiet it); inspection,
+  durability and reset. Standing delegation of restructure execution is
+  explicitly out of v1 — it would be an envelope cell above the current
+  ceiling, and only a deliberate founder ratification may ever create one.
+- **`agent-bootstrap-contract` delta.** The agent contract teaches the
+  envelope: how the decider reads ceilings and dispositions before acting or
+  asking, and how due-state counters are read under it — bounded to a compact
+  budget (target ≤ ~50 lines across all carriers, measured in tasks).
+- **No new sensor, no new queue, no model.** The envelope composes the S6
+  disposition store and the existing confirmation surfaces; it adds authority
+  arithmetic, not machinery.
+
+## Impact
+
+- Affected specs: `delegation-envelope` (new), `agent-bootstrap-contract`
+  (one added requirement).
+- Affected code (implementation slice, after this change is approved):
+  `src/exomem/prominence.py` (envelope derivation), a small envelope module
+  reusing the shared config file, `commands.op_bootstrap` (contract lines,
+  compact budget re-measured), scaffold/plugin SKILL.md copies, tests.
+- Not affected: review-state schema (dispositions are reused as-is), hooks
+  (presets unchanged), governance plane (cross-boundary disclosure stays
+  where it is), tool surface (no new commands — inspection rides
+  `review_memory(mode="dispositions")` and `bootstrap`).

--- a/openspec/changes/add-delegation-envelope/specs/agent-bootstrap-contract/spec.md
+++ b/openspec/changes/add-delegation-envelope/specs/agent-bootstrap-contract/spec.md
@@ -2,29 +2,32 @@
 
 ### Requirement: The agent contract teaches the delegation envelope compactly
 
-Bootstrap SHALL serve the active envelope — each v1 action class with its
-ceiling and current disposition, marked derived or overridden — and SHALL teach
-the decider protocol: name the class before acting; treat an above-ceiling
-intent as a proposal, never an act; honour the disposition (`off` — do not do
-it; `advisory` — surface in domain language and stop; `silent` — act, with
-narration governed by prominence; `confirm` — ask before executing); and record
-outcomes through triage. The teaching SHALL name the standing-delegation
-refusal so the agent does not improvise one. Across every carrier — compact
-bootstrap, scaffold and plugin skill copies, and the hookless
-custom-instructions block — the envelope teaching SHALL fit a measured budget
-of at most fifty lines in total, and compact bootstrap SHALL stay within its
-existing byte ceiling, with before and after sizes recorded when the
-implementation lands.
+Bootstrap SHALL serve the active envelope: the five disposition-bearing v1
+action classes each with ceiling, current disposition, and
+fixed/derived/overridden provenance, and the `disclosure` class marked
+governance-owned with no disposition. It SHALL teach the decider protocol —
+name the class before acting; treat an above-ceiling intent as a proposal,
+never an act; honour the disposition (`off`: do not initiate, though an
+explicit user request is never blocked; `advisory`: surface in domain language
+and stop; `silent`: act, narration governed by prominence; `confirm` /
+`confirm-shortcut`: obtain the confirmation first); record outcomes through
+triage — and SHALL name the founder-gate refusal for `restructure_execution`
+so the agent does not improvise one. The same teaching SHALL land on every
+carrier (compact bootstrap, scaffold and plugin skill copies, the hookless
+custom-instructions block) within a measured budget of at most fifty lines per
+carrier, with compact bootstrap additionally within its existing byte ceiling
+and before/after sizes recorded when the implementation lands.
 
 #### Scenario: The contract names every class and the protocol
 
 - **WHEN** compact bootstrap is served at any prominence level
-- **THEN** the engagement guidance names all six v1 action classes with their
-  ceilings and current dispositions and states the four-step decider protocol
+- **THEN** the engagement guidance names all six v1 action classes — five with
+  ceiling, disposition, and provenance, and `disclosure` as governance-owned —
+  and states the decider protocol including the founder-gate refusal
 
 #### Scenario: A hookless client receives the same teaching
 
 - **WHEN** the hookless custom-instructions block is generated
-- **THEN** it carries the envelope teaching within the shared fifty-line
-  budget, and its instructions match the served envelope rather than
+- **THEN** it carries the envelope teaching within its per-carrier fifty-line
+  budget, and its instructions defer to the served envelope rather than
   restating a hardcoded table

--- a/openspec/changes/add-delegation-envelope/specs/agent-bootstrap-contract/spec.md
+++ b/openspec/changes/add-delegation-envelope/specs/agent-bootstrap-contract/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: The agent contract teaches the delegation envelope compactly
+
+Bootstrap SHALL serve the active envelope — each v1 action class with its
+ceiling and current disposition, marked derived or overridden — and SHALL teach
+the decider protocol: name the class before acting; treat an above-ceiling
+intent as a proposal, never an act; honour the disposition (`off` — do not do
+it; `advisory` — surface in domain language and stop; `silent` — act, with
+narration governed by prominence; `confirm` — ask before executing); and record
+outcomes through triage. The teaching SHALL name the standing-delegation
+refusal so the agent does not improvise one. Across every carrier — compact
+bootstrap, scaffold and plugin skill copies, and the hookless
+custom-instructions block — the envelope teaching SHALL fit a measured budget
+of at most fifty lines in total, and compact bootstrap SHALL stay within its
+existing byte ceiling, with before and after sizes recorded when the
+implementation lands.
+
+#### Scenario: The contract names every class and the protocol
+
+- **WHEN** compact bootstrap is served at any prominence level
+- **THEN** the engagement guidance names all six v1 action classes with their
+  ceilings and current dispositions and states the four-step decider protocol
+
+#### Scenario: A hookless client receives the same teaching
+
+- **WHEN** the hookless custom-instructions block is generated
+- **THEN** it carries the envelope teaching within the shared fifty-line
+  budget, and its instructions match the served envelope rather than
+  restating a hardcoded table

--- a/openspec/changes/add-delegation-envelope/specs/command-surface/spec.md
+++ b/openspec/changes/add-delegation-envelope/specs/command-surface/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: The dispositions view carries the envelope beside the families
+
+The dispositions review mode SHALL list the envelope's action classes in a
+block structurally separate from the signal-family rows, so the two
+vocabularies never share a column and the word `off` is never ambiguous
+between them: a family `off` is annotated review-state, an envelope `off` is
+"the agent does not initiate this class". Each envelope row SHALL carry the
+class, its ceiling, its disposition or governance-owned marker, and whether the
+disposition is fixed, derived, or overridden. If landing this changes a
+recorded response contract or moves the packaged tool-surface digest, the
+documented two-phase rollout SHALL be followed; no tool schema changes.
+
+#### Scenario: One view, two clearly separated vocabularies
+
+- **WHEN** the dispositions view is read while one family is `quiet` and one
+  envelope class is overridden
+- **THEN** the family appears in the family block with its review-state
+  disposition, the class appears in the envelope block with its ceiling and
+  override marker, and neither block contains rows of the other kind

--- a/openspec/changes/add-delegation-envelope/specs/delegation-envelope/spec.md
+++ b/openspec/changes/add-delegation-envelope/specs/delegation-envelope/spec.md
@@ -1,0 +1,125 @@
+## ADDED Requirements
+
+### Requirement: Hard authority ceilings bound every action class
+
+The product SHALL define a closed v1 set of envelope action classes —
+`hygiene_writes`, `proactive_capture`, `link_acceptance`,
+`structural_suggestions`, `restructure_execution`, `disclosure` — each with a
+hard ceiling: `hygiene_writes` silent; `proactive_capture` silent-capable;
+`link_acceptance` confirm; `structural_suggestions` advisory (surface only);
+`restructure_execution` — covering restructure application, supersession
+commit, entity creation, and deletion — confirm-required; `disclosure` governed
+exclusively by the governance plane. No prominence level, envelope setting,
+disposition, configuration value, or adaptation SHALL authorize behaviour above
+a class's ceiling. An unknown class id, and any attempt to configure
+`disclosure` through the envelope, SHALL be refused with a named error and no
+state change.
+
+#### Scenario: Maximal prominence cannot lift a ceiling
+
+- **WHEN** prominence is `maximal` and every envelope override is set as
+  permissive as its range allows
+- **THEN** restructure application, supersession commit, entity creation, and
+  deletion still each require explicit confirmation before executing
+
+#### Scenario: An unknown class is refused
+
+- **WHEN** an envelope disposition is requested for a class id outside the
+  closed v1 set
+- **THEN** the request is refused with a class-specific error and no state
+  changes
+
+#### Scenario: Disclosure is not envelope-configurable
+
+- **WHEN** an envelope disposition is requested for `disclosure`
+- **THEN** the request is refused naming the governance plane as the owner
+
+### Requirement: The envelope derives from prominence with explicit overrides
+
+Each action class SHALL carry a disposition drawn from its class range:
+`hygiene_writes` {silent}; `proactive_capture` {off, advisory, silent};
+`link_acceptance` {off, advisory, confirm-shortcut}; `structural_suggestions`
+{off, advisory}; `restructure_execution` {confirm}. Absent an explicit
+override, the disposition SHALL be a pure derivation from the active prominence
+level: `hygiene_writes` silent at every level; `proactive_capture` off/off/
+silent/silent for off/light/balanced/maximal; `link_acceptance` and
+`structural_suggestions` off at prominence `off` and advisory otherwise;
+`restructure_execution` confirm at every level. An explicit override SHALL
+persist across engine restarts and prominence changes until reset, SHALL be
+stored in the shared engagement configuration, and SHALL be refused when
+outside the class range. The active envelope — every class, its disposition,
+and whether it is derived or overridden — SHALL be inspectable from the same
+surface that lists family dispositions and SHALL be served to the agent by
+bootstrap. A reset SHALL restore pure derivation for the named class.
+
+#### Scenario: An override outlives a prominence change and a restart
+
+- **WHEN** `proactive_capture` is explicitly set `advisory` while prominence is
+  `maximal`, prominence is then changed to `balanced`, and the engine restarts
+- **THEN** the served envelope still carries `proactive_capture: advisory`,
+  marked as an override, and every other class re-derives from `balanced`
+
+#### Scenario: Out-of-range dispositions are refused
+
+- **WHEN** `structural_suggestions` is set to `silent`, or
+  `restructure_execution` to anything but `confirm`
+- **THEN** each request is refused naming the class's range and nothing changes
+
+#### Scenario: Reset restores derivation
+
+- **WHEN** the `proactive_capture` override is reset at prominence `balanced`
+- **THEN** the served disposition returns to `silent` and is marked derived
+
+### Requirement: Envelope adaptation is deterministic and consent-shaped
+
+Envelope and family-disposition adaptation SHALL derive only from explicit
+triage decisions. When review-state records show three dismissals of items in
+one registered family with no intervening quiet offer, the next surfacing of
+that family SHALL carry exactly one offer to quiet it; the offer SHALL be
+recorded durably against the family, made at most once per family until the
+family is reset to `normal`, and SHALL change nothing by itself. Usage logs,
+query history, read counts, and any engagement measure SHALL NOT be inputs to
+any adaptation. Nothing SHALL be quieted, turned off, or made more permissive
+except by an explicit decision.
+
+#### Scenario: Three dismissals earn one offer, once
+
+- **WHEN** a user dismisses three items of one family and then dismisses two
+  more without acting on the offer
+- **THEN** the family's next surfacing after the third dismissal carried the
+  quiet offer, and no later surfacing repeats it
+
+#### Scenario: Nothing adapts on its own
+
+- **WHEN** a family's items are repeatedly surfaced and ignored without triage
+- **THEN** the family's disposition and every envelope cell are unchanged
+
+### Requirement: Standing delegation is not a v1 envelope cell
+
+The envelope SHALL NOT offer, accept, or store a standing delegation of
+`restructure_execution` — any request shaped as "always allow" or "do this kind
+of thing from now on" for that class SHALL be refused with a named error
+stating that standing delegation is gated on an explicit founder ratification
+and does not exist in v1.
+
+#### Scenario: A standing-delegation request is refused by name
+
+- **WHEN** any surface attempts to set `restructure_execution` to a
+  non-confirm disposition, however phrased
+- **THEN** the refusal names the founder gate and the envelope is unchanged
+
+### Requirement: The envelope round-trips on a hookless client
+
+On a client with no hooks installed, a plain-language request to stop a kind of
+suggestion SHALL durably quiet exactly the named family through the existing
+family-disposition surface; the change SHALL be inspectable with its reason and
+origin, SHALL persist across sessions and engine restarts, and SHALL reset on
+request — with the envelope's class dispositions unaffected throughout.
+
+#### Scenario: "Stop suggesting projects" sticks, is visible, and resets
+
+- **WHEN** a hookless session asks to stop project-structure suggestions, a new
+  session starts, and the dispositions view is read
+- **THEN** the structural family the request named is `quiet` with the recorded
+  reason and origin, other families are untouched, and a reset request restores
+  `normal`

--- a/openspec/changes/add-delegation-envelope/specs/delegation-envelope/spec.md
+++ b/openspec/changes/add-delegation-envelope/specs/delegation-envelope/spec.md
@@ -11,23 +11,39 @@ hard ceiling: `hygiene_writes` silent; `proactive_capture` silent-capable;
 commit, entity creation, and deletion — confirm-required; `disclosure` governed
 exclusively by the governance plane. No prominence level, envelope setting,
 disposition, configuration value, or adaptation SHALL authorize behaviour above
-a class's ceiling. An unknown class id, and any attempt to configure
-`disclosure` through the envelope, SHALL be refused with a named error and no
-state change.
+a class's ceiling.
+
+Confirm-required SHALL bind at three tiers: the served envelope marks the class
+confirm-required; the agent contract requires explicit in-conversation user
+confirmation before any surface of the class is invoked; and every server-side
+confirmation or preview-first gate that exists today — deletion's explicit
+confirm parameter, the adoption apply surface's preview-first default — SHALL
+remain required. v1 SHALL add no new server-side confirmation parameter and no
+tool-schema change; a server-side confirm for supersession and entity creation
+is named future work behind the documented tool-surface rollout, and its
+absence today SHALL be stated in the served contract rather than implied away.
+
+A request to set a disposition for an unknown class id SHALL be refused with a
+class-specific error and no state change. A request to configure `disclosure`
+through the envelope SHALL be refused naming the governance plane as the owner.
+An unknown class id or disposition found in the STORED configuration (for
+example, written by a newer runtime) SHALL be reported and ignored at read
+time, never refused — reading the envelope never breaks bootstrap.
 
 #### Scenario: Maximal prominence cannot lift a ceiling
 
 - **WHEN** prominence is `maximal` and every envelope override is set as
   permissive as its range allows
-- **THEN** restructure application, supersession commit, entity creation, and
-  deletion still each require explicit confirmation before executing
+- **THEN** the served envelope still marks `restructure_execution`
+  confirm-required, deletion still requires its explicit confirm parameter, and
+  the adoption apply surface still defaults to preview-first
 
-#### Scenario: An unknown class is refused
+#### Scenario: An unknown class is refused at write and tolerated at read
 
 - **WHEN** an envelope disposition is requested for a class id outside the
-  closed v1 set
-- **THEN** the request is refused with a class-specific error and no state
-  changes
+  closed v1 set, and separately a stored configuration carries an unknown id
+- **THEN** the write is refused with a class-specific error and no state
+  change, while the read serves the known classes and reports the unknown id
 
 #### Scenario: Disclosure is not envelope-configurable
 
@@ -36,33 +52,50 @@ state change.
 
 ### Requirement: The envelope derives from prominence with explicit overrides
 
-Each action class SHALL carry a disposition drawn from its class range:
-`hygiene_writes` {silent}; `proactive_capture` {off, advisory, silent};
-`link_acceptance` {off, advisory, confirm-shortcut}; `structural_suggestions`
-{off, advisory}; `restructure_execution` {confirm}. Absent an explicit
-override, the disposition SHALL be a pure derivation from the active prominence
-level: `hygiene_writes` silent at every level; `proactive_capture` off/off/
-silent/silent for off/light/balanced/maximal; `link_acceptance` and
-`structural_suggestions` off at prominence `off` and advisory otherwise;
-`restructure_execution` confirm at every level. An explicit override SHALL
-persist across engine restarts and prominence changes until reset, SHALL be
-stored in the shared engagement configuration, and SHALL be refused when
-outside the class range. The active envelope — every class, its disposition,
-and whether it is derived or overridden — SHALL be inspectable from the same
-surface that lists family dispositions and SHALL be served to the agent by
-bootstrap. A reset SHALL restore pure derivation for the named class.
+Three classes SHALL carry a configurable disposition drawn from a class range:
+`proactive_capture` {off, advisory, silent}; `link_acceptance` {off, advisory,
+confirm-shortcut}; `structural_suggestions` {off, advisory}. Two SHALL be
+fixed: `hygiene_writes` silent and `restructure_execution` confirm — any
+attempt to change `restructure_execution` is governed solely by the
+standing-delegation refusal below. `disclosure` SHALL carry no disposition and
+SHALL be served marked governance-owned.
+
+`confirm-shortcut` SHALL mean an inline single-action confirmation rendered
+with the surfaced item — one action approving that one named acceptance. The
+confirmation step itself is never skipped, so `confirm-shortcut` sits below the
+`confirm` ceiling.
+
+A disposition SHALL govern agent-initiated behaviour only: an explicitly
+requested read or review is always served, matching the family-disposition
+rule that quiet is silent, not clean.
+
+Absent an explicit override, each configurable disposition SHALL be a pure
+derivation from the active prominence level: `proactive_capture`
+off/off/silent/silent for off/light/balanced/maximal; `link_acceptance` and
+`structural_suggestions` off at prominence `off` and advisory otherwise. An
+explicit override SHALL persist across engine restarts and prominence changes
+until reset, SHALL be stored in the shared engagement configuration (the same
+per-machine file prominence lives in — the envelope is machine posture by
+design, while family dispositions travel with the vault), and SHALL be refused
+when outside the class range. The active envelope — every class, its
+disposition or governance-owned marker, and whether a disposition is fixed,
+derived, or overridden — SHALL be served by bootstrap and SHALL be inspectable
+from the same surface that lists family dispositions, structurally separated
+from the family rows so the two vocabularies never share a column. A reset
+SHALL restore pure derivation for the named class.
 
 #### Scenario: An override outlives a prominence change and a restart
 
 - **WHEN** `proactive_capture` is explicitly set `advisory` while prominence is
   `maximal`, prominence is then changed to `balanced`, and the engine restarts
 - **THEN** the served envelope still carries `proactive_capture: advisory`,
-  marked as an override, and every other class re-derives from `balanced`
+  marked as an override, and every other configurable class re-derives from
+  `balanced`
 
 #### Scenario: Out-of-range dispositions are refused
 
-- **WHEN** `structural_suggestions` is set to `silent`, or
-  `restructure_execution` to anything but `confirm`
+- **WHEN** `link_acceptance` is set to `silent`, or `structural_suggestions`
+  to `confirm-shortcut`
 - **THEN** each request is refused naming the class's range and nothing changes
 
 #### Scenario: Reset restores derivation
@@ -70,17 +103,26 @@ bootstrap. A reset SHALL restore pure derivation for the named class.
 - **WHEN** the `proactive_capture` override is reset at prominence `balanced`
 - **THEN** the served disposition returns to `silent` and is marked derived
 
+#### Scenario: Class off never blocks an explicit request
+
+- **WHEN** `structural_suggestions` is `off` and the user explicitly requests a
+  structural review
+- **THEN** the review is served, and only agent-initiated surfacing is absent
+
 ### Requirement: Envelope adaptation is deterministic and consent-shaped
 
 Envelope and family-disposition adaptation SHALL derive only from explicit
-triage decisions. When review-state records show three dismissals of items in
-one registered family with no intervening quiet offer, the next surfacing of
-that family SHALL carry exactly one offer to quiet it; the offer SHALL be
-recorded durably against the family, made at most once per family until the
-family is reset to `normal`, and SHALL change nothing by itself. Usage logs,
-query history, read counts, and any engagement measure SHALL NOT be inputs to
-any adaptation. Nothing SHALL be quieted, turned off, or made more permissive
-except by an explicit decision.
+triage decisions. When the durable review-state records hold three
+manual-origin dismissal events in one registered family — dismissal events,
+counted from the records themselves so the count never decreases when items
+later vanish, with automatic-origin decisions excluded — the next surfacing of
+that family SHALL carry exactly one offer to quiet it. The offer SHALL be
+recorded durably against the family, SHALL change nothing by itself, and SHALL
+be made at most once: it is cleared only when the family is explicitly reset to
+`normal`, which clears the family's slate; a decline without a reset never
+re-offers. Usage logs, query history, read counts, and any engagement measure
+SHALL NOT be inputs to any adaptation. Nothing SHALL be quieted, turned off, or
+made more permissive except by an explicit decision.
 
 #### Scenario: Three dismissals earn one offer, once
 
@@ -89,6 +131,13 @@ except by an explicit decision.
 - **THEN** the family's next surfacing after the third dismissal carried the
   quiet offer, and no later surfacing repeats it
 
+#### Scenario: A decline is durable until an explicit reset
+
+- **WHEN** the user declines the offer, later quiets and then resets the family
+  to `normal`, and dismisses three more items
+- **THEN** no offer appeared between the decline and the reset, and exactly one
+  new offer may appear after the post-reset third dismissal
+
 #### Scenario: Nothing adapts on its own
 
 - **WHEN** a family's items are repeatedly surfaced and ignored without triage
@@ -96,11 +145,13 @@ except by an explicit decision.
 
 ### Requirement: Standing delegation is not a v1 envelope cell
 
-The envelope SHALL NOT offer, accept, or store a standing delegation of
-`restructure_execution` — any request shaped as "always allow" or "do this kind
-of thing from now on" for that class SHALL be refused with a named error
-stating that standing delegation is gated on an explicit founder ratification
-and does not exist in v1.
+The envelope SHALL NOT offer, accept, or store any non-confirm disposition for
+`restructure_execution`, however the request is phrased — including "always
+allow" and "do this kind of thing from now on". The refusal SHALL name the
+founder gate: standing delegation would be an envelope cell above the current
+ceiling, does not exist in v1, and only a deliberate founder ratification may
+ever create one. This refusal is the sole specified error for the class; the
+range-refusal rule above does not apply to it.
 
 #### Scenario: A standing-delegation request is refused by name
 
@@ -108,18 +159,31 @@ and does not exist in v1.
   non-confirm disposition, however phrased
 - **THEN** the refusal names the founder gate and the envelope is unchanged
 
-### Requirement: The envelope round-trips on a hookless client
+### Requirement: The envelope teaching closes the hookless quiet loop
 
-On a client with no hooks installed, a plain-language request to stop a kind of
-suggestion SHALL durably quiet exactly the named family through the existing
-family-disposition surface; the change SHALL be inspectable with its reason and
-origin, SHALL persist across sessions and engine restarts, and SHALL reset on
-request — with the envelope's class dispositions unaffected throughout.
+The served contract SHALL teach a hookless client how to route a
+plain-language request to stop a kind of suggestion: the registered-family
+vocabulary is discoverable from the served surfaces, the mapping from the
+user's words to a registered family is the agent's judgment, and the resulting
+decision lands through the existing family-disposition surface. The
+server-side half of the loop — the quiet persisting with reason and origin
+across sessions and engine restarts, inspection, and reset — is the
+family-disposition requirement of the attention queue and SHALL hold unchanged
+with the envelope present; the envelope's class dispositions SHALL be
+unaffected by any family decision.
 
-#### Scenario: "Stop suggesting projects" sticks, is visible, and resets
+#### Scenario: A taught mapping quiets a real family and the envelope stands
 
-- **WHEN** a hookless session asks to stop project-structure suggestions, a new
-  session starts, and the dispositions view is read
-- **THEN** the structural family the request named is `quiet` with the recorded
-  reason and origin, other families are untouched, and a reset request restores
-  `normal`
+- **WHEN** a hookless session, following the served contract, quiets the
+  registered structural family (for example `scope_divergence_semantic`) with a
+  reason, a new session starts, and the dispositions view is read
+- **THEN** that family is `quiet` with the recorded reason and origin, other
+  families are untouched, every envelope class disposition is unchanged, and a
+  reset restores `normal`
+
+#### Scenario: The vocabulary is discoverable without hooks
+
+- **WHEN** the hookless custom-instructions block and compact bootstrap are
+  generated
+- **THEN** each names the family-disposition surface and how to list the
+  registered families, rather than hardcoding a family table

--- a/openspec/changes/add-delegation-envelope/tasks.md
+++ b/openspec/changes/add-delegation-envelope/tasks.md
@@ -45,6 +45,12 @@ the task is ticked, not estimated.
   pin (the derivation reads review-state records only).
 - [ ] 3.2 The offer changes nothing by itself: disposition unchanged until an
   explicit decision lands. Red-first.
+- [ ] 3.3 Review-state schema migration: dismissal records gain family
+  attribution and the family slate gains a durable `quiet_offered_at` slot
+  that survives a `normal` disposition; one version bump, previous-schema
+  files migrated on load and rewritten on next write, newer schema refused by
+  an older runtime with a named error. Red-first on all three behaviours over
+  fixture files at both versions.
 
 ## 4. The dispositions view and the agent contract (design D5; command-surface delta)
 

--- a/openspec/changes/add-delegation-envelope/tasks.md
+++ b/openspec/changes/add-delegation-envelope/tasks.md
@@ -1,0 +1,59 @@
+# Tasks — add the delegation envelope
+
+Every test lands red first (verbatim failing output recorded before the
+implementation, then green). Measured budgets are written into this file when
+the task is ticked, not estimated.
+
+## 1. Envelope core (design D1–D3)
+
+- [ ] 1.1 `src/exomem/envelope.py` (import-cheap, torch-free): the closed class
+  enum, per-class ranges, ceilings, `derive_envelope(level)` pinned by test
+  against the design table; refusal errors for unknown class, out-of-range
+  disposition, and `disclosure`.
+- [ ] 1.2 Shared-config storage: `envelope` object in `mode.config_path()`;
+  overrides persist across restarts and prominence changes; reset per class.
+  Red-first tests over a temp config root (no real state root — fixture
+  discipline per `tests/conftest.py`).
+- [ ] 1.3 Serve the envelope: bootstrap engagement block carries every class,
+  disposition, and derived/override marker; the dispositions view lists the
+  envelope beside family dispositions. Red-first pins on both surfaces.
+
+## 2. Ceiling enforcement (design D1, D6)
+
+- [ ] 2.1 Confirmation invariant test over the four confirm-required surfaces
+  (restructure apply, supersession commit, entity creation, deletion): with the
+  most permissive envelope and `maximal` prominence, each still requires the
+  explicit confirmation its surface defines today. Mechanism-removal proof: a
+  scratch mutant that consults the envelope above the ceiling fails the test.
+- [ ] 2.2 Standing-delegation refusal: any non-confirm disposition request for
+  `restructure_execution` refuses naming the founder gate. Red-first.
+
+## 3. Adaptation (design D4)
+
+- [ ] 3.1 Quiet-offer derivation from existing review-state dismissal records:
+  third dismissal arms exactly one offer; `quiet_offered_at` recorded on the
+  family; no repeat until the family resets to `normal`. Red-first through the
+  review-state store, plus a no-usage-signals pin (the derivation function's
+  inputs are review-state records only — asserted structurally, not by prose).
+- [ ] 3.2 The offer changes nothing by itself: disposition unchanged until an
+  explicit decision lands. Red-first.
+
+## 4. The agent contract (design D5)
+
+- [ ] 4.1 Bootstrap + scaffold/plugin SKILL.md copies + hookless
+  custom-instructions block teach the decider protocol; ≤ 50 lines total
+  across carriers, counted by test; compact payload measured before/after and
+  recorded here; `COMPACT_BYTE_CEILING` respected without being raised past
+  its current headroom discipline.
+- [ ] 4.2 Scaffold no-leak and skill-sync tests stay green.
+
+## 5. Acceptance (spec round-trip)
+
+- [ ] 5.1 Hookless round-trip test: a scripted hookless session issues the
+  plain-language quiet request; assert the named family is quiet with reason
+  and origin, other families untouched, persistence across a fresh engine, and
+  reset. Uses the installed CLI journey pattern only if a deterministic
+  in-process equivalent cannot express it; otherwise in-process.
+- [ ] 5.2 `openspec validate --all --strict` green; lean scoped suites green;
+  full-suite at the completion boundary with failures attributed against the
+  origin/main baseline.

--- a/openspec/changes/add-delegation-envelope/tasks.md
+++ b/openspec/changes/add-delegation-envelope/tasks.md
@@ -7,53 +7,67 @@ the task is ticked, not estimated.
 ## 1. Envelope core (design D1–D3)
 
 - [ ] 1.1 `src/exomem/envelope.py` (import-cheap, torch-free): the closed class
-  enum, per-class ranges, ceilings, `derive_envelope(level)` pinned by test
-  against the design table; refusal errors for unknown class, out-of-range
-  disposition, and `disclosure`.
+  enum; per-class ranges incl. the `confirm-shortcut` definition; ceilings;
+  `derive_envelope(level)` pinned by test against the design table; write-time
+  refusals for unknown class, out-of-range disposition, and `disclosure`;
+  read-time report-and-ignore for unknown stored ids (red-first: a config with
+  a future class id still serves and names it).
 - [ ] 1.2 Shared-config storage: `envelope` object in `mode.config_path()`;
-  overrides persist across restarts and prominence changes; reset per class.
-  Red-first tests over a temp config root (no real state root — fixture
-  discipline per `tests/conftest.py`).
-- [ ] 1.3 Serve the envelope: bootstrap engagement block carries every class,
-  disposition, and derived/override marker; the dispositions view lists the
-  envelope beside family dispositions. Red-first pins on both surfaces.
+  overrides persist across restarts and prominence changes; reset per class;
+  absent key = derivation (rollback pin). Red-first over a temp config root
+  (no real state root — fixture discipline per `tests/conftest.py`).
+- [ ] 1.3 Serve the envelope: bootstrap engagement block carries every class
+  with ceiling, disposition or governance-owned marker, and
+  fixed/derived/override provenance. Red-first pin on the payload.
 
 ## 2. Ceiling enforcement (design D1, D6)
 
-- [ ] 2.1 Confirmation invariant test over the four confirm-required surfaces
-  (restructure apply, supersession commit, entity creation, deletion): with the
-  most permissive envelope and `maximal` prominence, each still requires the
-  explicit confirmation its surface defines today. Mechanism-removal proof: a
-  scratch mutant that consults the envelope above the ceiling fails the test.
-- [ ] 2.2 Standing-delegation refusal: any non-confirm disposition request for
-  `restructure_execution` refuses naming the founder gate. Red-first.
+- [ ] 2.1 Tiered confirm-required test: with the most permissive envelope and
+  `maximal` prominence — (a) the served envelope still marks
+  `restructure_execution` confirm-required, (b) `op_delete` still requires its
+  explicit `confirm` parameter, (c) the adoption apply surface still defaults
+  preview-first. Mechanism-removal proof: a scratch mutant that lets the
+  envelope override the served confirm-required marker fails (a). No new
+  server-side confirm parameters; the served contract names the
+  supersession/entity-creation gap as future work.
+- [ ] 2.2 Founder-gate refusal is the sole error for `restructure_execution`:
+  any non-confirm disposition request refuses naming the gate; the generic
+  range refusal never fires for this class. Red-first both halves.
 
 ## 3. Adaptation (design D4)
 
-- [ ] 3.1 Quiet-offer derivation from existing review-state dismissal records:
-  third dismissal arms exactly one offer; `quiet_offered_at` recorded on the
-  family; no repeat until the family resets to `normal`. Red-first through the
-  review-state store, plus a no-usage-signals pin (the derivation function's
-  inputs are review-state records only — asserted structurally, not by prose).
+- [ ] 3.1 Quiet-offer derivation from durable manual-origin dismissal records
+  (event count, monotonic, automatic origin excluded): third event arms exactly
+  one offer; `quiet_offered_at` recorded; cleared only by explicit family reset
+  to `normal`; a decline without reset never re-offers. Red-first through the
+  review-state store, incl. a records-not-live-index pin (deleting the
+  dismissed items does not disarm the offer) and a no-usage-signals structural
+  pin (the derivation reads review-state records only).
 - [ ] 3.2 The offer changes nothing by itself: disposition unchanged until an
   explicit decision lands. Red-first.
 
-## 4. The agent contract (design D5)
+## 4. The dispositions view and the agent contract (design D5; command-surface delta)
 
-- [ ] 4.1 Bootstrap + scaffold/plugin SKILL.md copies + hookless
-  custom-instructions block teach the decider protocol; ≤ 50 lines total
-  across carriers, counted by test; compact payload measured before/after and
-  recorded here; `COMPACT_BYTE_CEILING` respected without being raised past
-  its current headroom discipline.
-- [ ] 4.2 Scaffold no-leak and skill-sync tests stay green.
+- [ ] 4.1 `review_memory(mode="dispositions")` gains the structurally separate
+  envelope block (class, ceiling, disposition/marker, provenance). If the
+  recorded response contract or packaged digest moves, follow the documented
+  two-phase rollout and record it here. Red-first pin on the two-block shape.
+- [ ] 4.2 Bootstrap + scaffold/plugin SKILL.md copies + hookless
+  custom-instructions block teach the decider protocol and how to discover the
+  registered family vocabulary; ≤ 50 lines per carrier, counted by test;
+  compact payload measured before/after and recorded here within the
+  `COMPACT_BYTE_CEILING` discipline. Scaffold no-leak and skill-sync tests
+  stay green.
 
 ## 5. Acceptance (spec round-trip)
 
-- [ ] 5.1 Hookless round-trip test: a scripted hookless session issues the
-  plain-language quiet request; assert the named family is quiet with reason
-  and origin, other families untouched, persistence across a fresh engine, and
-  reset. Uses the installed CLI journey pattern only if a deterministic
-  in-process equivalent cannot express it; otherwise in-process.
+- [ ] 5.1 Hookless quiet-loop test over a REAL registered family (e.g.
+  `scope_divergence_semantic`): quiet with reason lands through
+  `triage_memory`, persists across a fresh engine, is listed with origin in the
+  dispositions view, resets to `normal` — with every envelope class disposition
+  unchanged throughout; plus a pin that the hookless custom-instructions block
+  and compact bootstrap name the family-disposition surface and the vocabulary
+  discovery path rather than a hardcoded family table.
 - [ ] 5.2 `openspec validate --all --strict` green; lean scoped suites green;
   full-suite at the completion boundary with failures attributed against the
   origin/main baseline.


### PR DESCRIPTION
## What

Proposes **S7 of the no-nudge programme — the delegation envelope** (OpenSpec change `add-delegation-envelope`; spec artifacts only, no code). Per-action-class authority under hard ceilings prominence cannot exceed: six closed v1 classes — three ranged (proactive capture, link acceptance, structural suggestions), two fixed (hygiene writes silent, restructure execution confirm-required always), and disclosure governance-owned with no disposition. Dispositions derive from the prominence level as a pure function, with explicit persistent per-class overrides in the shared per-machine config file (machine posture by design; family dispositions travel with the vault). Confirm-required binds at three tiers — the served envelope, the agent contract, and the existing server gates (`op_delete`'s confirm parameter, adoption preview-first); v1 adds no new server-side confirmation parameter, and the supersession/entity-creation gap is stated in the served contract as future work rather than implied away. Standing delegation of restructure execution is pinned OUT of v1 behind a named founder-gate refusal — the sole specified error for that class (report §16.2).

Adaptation is deterministic and consent-shaped: three manual-origin dismissal EVENTS counted from durable review-state records (monotonic — deleting items never disarms; automatic origin excluded) arm exactly one recorded quiet offer, cleared only by an explicit family reset; no usage or engagement inputs — the spec bans the input, not just the implementation. Class `off` never blocks an explicit user request. Acceptance round-trips over the real registered family `scope_divergence_semantic` on a hookless client.

Deltas: new `delegation-envelope` capability; `agent-bootstrap-contract` (the contract teaches classes, protocol and the founder-gate refusal at ≤50 measured lines per carrier); `command-surface` (the dispositions view carries the envelope beside the families as a structurally separate block — no tool input-schema changes). One named review-state schema migration: family attribution on dismissal records and a durable `quiet_offered_at` slot. Gating: binds to the merged state of `add-prominence-levels` and `add-relation-acceptance-queue`; the matrix-ratification sibling PR merges first.

## Verification

- `openspec validate --all --strict`: 167 passed, 0 failed (new change included).
- Two adversarial review rounds by a fresh zero-context reviewer (contradiction walk of ceilings/derivation/scenarios, shipped-behaviour check against `prominence.py` and the attention-queue disposition spec). Round 1: REQUEST CHANGES (5 HIGH, 7 MEDIUM); v2 resolved all HIGHs and six of seven MEDIUMs, round 2 verdict: **APPROVE**, with one residual (a stale Impact line + missing migration task) fixed in the follow-up commit exactly as prescribed. Verdicts quoted in a comment below.
