### PR TITLE
docs(openspec): propose frozen stance verification (S9)

### DIFF
--- a/openspec/changes/add-frozen-stance-verification/design.md
+++ b/openspec/changes/add-frozen-stance-verification/design.md
@@ -1,0 +1,69 @@
+# Design — frozen stance verification
+
+## D1. The admission rule is code, not posture
+
+A verifier is admitted by a registry entry pinning four things: the model name,
+the sha256 digest of its resolved weights, the label-map version it was
+verified against, and the fixture set that verified it. At load, the resolved
+weights are hashed and compared to the pin; a mismatch, a missing model, or an
+unverified (name, label-map) pair refuses the verifier. Refusal degrades to
+**absence** — the entry simply carries no stance — never to the lexical
+heuristic wearing the verifier's `method` label. The heuristic remains what it
+is today (a differently-labelled, unprivileged measurement) and is not part of
+this slice's queue enrichment.
+
+## D2. Stance is enrichment, not a new entry kind
+
+`meta.provenance` keeps its closed set (`asserted` / `proximity`). A proximity
+entry gains an optional `meta.stance` block: `label`, `method: "nli"`,
+`model_digest`, `label_map_version`, and the score as a measurement (precedent:
+the cosine already rides the entry). Three invariants keep it inside the
+matrix: attaching or changing a stance never changes `signal_version` (no
+dismissal resurfaces because labelling arrived — the same guarantee the
+provenance-labelling requirement made); ranking is untouched (asserted above
+proximity stands; stance never reorders); and canon, decisions, retrieval and
+policy never read it — it exists for the reader and the decider on the review
+surface.
+
+## D3. Invocation point: the audit's contradiction pass
+
+Enrichment runs where the queue is already assembled — the asynchronous
+audit/sweep path — bounded per pass and failure-isolated per entry (an
+exception leaves that entry unenriched and recorded as degraded, mirroring the
+existing soft-fail discipline). Nothing runs at write time: `corpus_aware`'s
+`_refine_contradictions` call is removed, not capped. The default write path is
+byte-identical (the `EXOMEM_CLAIM_LEVEL` gate is off today); the opt-in
+write-time sharpening clause is retired deliberately — a stance verdict
+belongs on the queue entry a reader triages, not in a write response emitted
+under latency budget. This is a stated behaviour change for gate-on users, not
+a silent one.
+
+## D4. The label map is a versioned artifact
+
+The current logit-threshold logic in `_nli_polarity` becomes **label map v1**:
+an in-repo, versioned mapping from cross-encoder logits to the closed label
+set. Changing a threshold, the label set, or the direction convention bumps the
+version and requires re-verification against the fixture set before the
+(digest, label-map) pair is admitted again. The map is data reviewed in diff,
+not arithmetic buried in code.
+
+## D5. No vault text in instruction position, by construction
+
+The verifier is a cross-encoder: two claim texts enter as the classification
+pair and logits come out. There is no prompt assembly, no instruction template,
+and no generation. The spec pins the input shape so a future "better" verifier
+cannot quietly become a prompted generative model behind the same seam.
+
+## D6. Verification fixture set
+
+Golden claim pairs with expected labels — drawn from the f22 corpus shapes
+(genuine contradiction, concordant evidence, restatement, unrelated) plus the
+heuristic's known failure cases — checked at admission time and in CI with the
+extra installed. The slice's precision claim is made against these fixtures
+only; comparative bench claims stay withheld with sequence 2.
+
+## D7. Out of scope
+
+Hosted activation; any second verifier slot (alias NN remains S5-adjacent
+future work); ranking or attention changes; any write-path latency budget
+change (the path gets shorter, and the latency gates simply keep holding).

--- a/openspec/changes/add-frozen-stance-verification/design.md
+++ b/openspec/changes/add-frozen-stance-verification/design.md
@@ -4,48 +4,70 @@
 
 A verifier is admitted by a registry entry pinning four things: the model name,
 the sha256 digest of its resolved weights, the label-map version it was
-verified against, and the fixture set that verified it. At load, the resolved
-weights are hashed and compared to the pin; a mismatch, a missing model, or an
-unverified (name, label-map) pair refuses the verifier. Refusal degrades to
-**absence** — the entry simply carries no stance — never to the lexical
-heuristic wearing the verifier's `method` label. The heuristic remains what it
-is today (a differently-labelled, unprivileged measurement) and is not part of
-this slice's queue enrichment.
+verified against, and the fixture set that verified it. The registry is a
+**repository artifact** — reviewed in diff, versioned with the code; no
+runtime configuration, environment knob, or vault content can add or alter a
+pin (`EXOMEM_CLAIM_NLI_MODEL`, the free-form override, is retired). At load,
+the resolved weights are hashed once per process and the digest cached;
+a mismatch, a missing model, a missing dependency, an unverified
+(name, label-map) pair, or the opt-in gate (`EXOMEM_CLAIM_POLARITY_NLI`,
+default off) being unset refuses the verifier. Refusal degrades to
+**absence** — the entry simply carries no label — never to the lexical
+heuristic wearing the verifier's `method` name. The heuristic itself is
+retired from queue enrichment: it had no admission control, which is exactly
+the seam the ratified matrix names non-compliant. This satisfies the
+`epistemic-graph` requirement "Model-Backed Graph Suggestions Respect Pure
+Substrate" by construction rather than by configuration.
 
-## D2. Stance is enrichment, not a new entry kind
+## D2. The label is enrichment on the existing channel, not a new one
 
-`meta.provenance` keeps its closed set (`asserted` / `proximity`). A proximity
-entry gains an optional `meta.stance` block: `label`, `method: "nli"`,
-`model_digest`, `label_map_version`, and the score as a measurement (precedent:
-the cosine already rides the entry). Three invariants keep it inside the
-matrix: attaching or changing a stance never changes `signal_version` (no
-dismissal resurfaces because labelling arrived — the same guarantee the
-provenance-labelling requirement made); ranking is untouched (asserted above
-proximity stands; stance never reorders); and canon, decisions, retrieval and
-policy never read it — it exists for the reader and the decider on the review
-surface.
+`meta.provenance` keeps its closed set (`asserted` / `proximity`). The
+shipped enrichment keys stay: a proximity entry MAY carry `meta.polarity`
+(closed set `contradict` / `refine` / `duplicate` / `unrelated`),
+`meta.polarity_score`, and `meta.polarity_method` — after this change always
+`"nli"` — joined by `meta.polarity_model_digest` and
+`meta.polarity_label_map_version`, and by the `signal_version` the label was
+computed against. Four invariants keep it inside the matrix: attaching or
+changing a label never changes `signal_version` (no dismissal resurfaces
+because labelling arrived); a label whose recorded signal_version no longer
+matches the entry's is stale and is dropped, never served against changed
+content; ranking is untouched (asserted above proximity stands; the label
+never reorders); and canon, decisions, retrieval and policy never read it — it
+exists for the reader and the decider on the review surface. The model
+polarity label is not the reader's competing-alternatives pair stance: that
+stance is a recorded triage disposition with its own contract (it moves queue
+position by design) and this change does not touch it.
 
-## D3. Invocation point: the audit's contradiction pass
+## D3. One channel: the audit's contradiction pass, modified in place
 
-Enrichment runs where the queue is already assembled — the asynchronous
-audit/sweep path — bounded per pass and failure-isolated per entry (an
-exception leaves that entry unenriched and recorded as degraded, mirroring the
-existing soft-fail discipline). Nothing runs at write time: `corpus_aware`'s
-`_refine_contradictions` call is removed, not capped. The default write path is
-byte-identical (the `EXOMEM_CLAIM_LEVEL` gate is off today); the opt-in
-write-time sharpening clause is retired deliberately — a stance verdict
-belongs on the queue entry a reader triages, not in a write response emitted
-under latency budget. This is a stated behaviour change for gate-on users, not
-a silent one.
+Two invocation paths exist today, both behind `EXOMEM_CLAIM_LEVEL`. The
+synchronous one (`corpus_aware._refine_contradictions`) is removed, not
+capped — along with `_POLARITY_CLAUSE`, the `contradiction-band` advisory
+partition, and the `DupCandidate.polarity*` fields that exist only to carry
+its result. The asynchronous one (`audit._pair_polarity` and its rendering)
+is **modified in place** to become the sole channel: it enriches only through
+the admitted verifier, and the heuristic fallback inside
+`claims.classify_polarity` no longer reaches queue metadata. Enrichment is
+bounded by construction — it runs over the surfaced set, already capped at
+`EXOMEM_CONTRADICTION_TOP_N` — and failure-isolated per entry (an exception
+leaves that entry unenriched and recorded as degraded, mirroring the existing
+soft-fail discipline). The rendered polarity note keeps naming the label and
+method. The default write path is byte-identical (the gate is off today and
+the contradiction-band kind never fired without it); for gate-on users this
+is a stated behaviour change, not a silent one: no write-time polarity, and
+heuristic-method queue labels replaced by admitted-verifier labels or absence.
 
 ## D4. The label map is a versioned artifact
 
 The current logit-threshold logic in `_nli_polarity` becomes **label map v1**:
 an in-repo, versioned mapping from cross-encoder logits to the closed label
-set. Changing a threshold, the label set, or the direction convention bumps the
-version and requires re-verification against the fixture set before the
-(digest, label-map) pair is admitted again. The map is data reviewed in diff,
-not arithmetic buried in code.
+set. The map declares the logit column semantics and their order — a model
+whose head orders entailment/contradiction differently is a different
+(digest, label-map) pair and needs its own verified version. Changing a
+threshold, the label set, the column order, or the direction convention bumps
+the version and requires re-verification against the fixture set before the
+pair is admitted again. The map is data reviewed in diff, not arithmetic
+buried in code.
 
 ## D5. No vault text in instruction position, by construction
 
@@ -65,5 +87,6 @@ only; comparative bench claims stay withheld with sequence 2.
 ## D7. Out of scope
 
 Hosted activation; any second verifier slot (alias NN remains S5-adjacent
-future work); ranking or attention changes; any write-path latency budget
-change (the path gets shorter, and the latency gates simply keep holding).
+future work); ranking or attention changes; the competing-alternatives stance
+contract; any write-path latency budget change (the path gets shorter, and
+the latency gates simply keep holding).

--- a/openspec/changes/add-frozen-stance-verification/proposal.md
+++ b/openspec/changes/add-frozen-stance-verification/proposal.md
@@ -1,0 +1,61 @@
+# Add frozen stance verification
+
+## Why
+
+The contradiction queue is stance-blind by its own admission. The cosine band
+`[0.82, 0.90)` is a proximity measurement; the claim-level polarity heuristic in
+`src/exomem/claims.py` self-describes as "a lexical stand-in for a real NLI
+model"; and the NLI cross-encoder backend is marked **WIRED BUT UNVERIFIED**,
+selected by an unpinned environment knob (`EXOMEM_CLAIM_NLI_MODEL`), with its
+one invocation path (`_refine_contradictions`) sitting inside synchronous
+write-time warning generation (`corpus_aware.py`). The cost of stance-blindness
+is precision: concordant-evidence pairs surface beside genuine conflicts,
+burning reader trust and agent tokens — the exact failure the (withheld,
+sequence-2) bench family f22 makes a red line with its concordant twin.
+
+The authority-and-effects matrix, ratified 2026-08-30 as the constitution's
+model clause, admits a frozen verifier under a strict rule: **pinned model
+digest, versioned label map, output restricted to provenance-marked review-queue
+labels, off the synchronous write path, no vault text in instruction position** —
+never entering canon, decisions, retrieval, ranking, or policy. The
+`epistemic-graph` spec already requires any model-backed polarity path to be
+optional, default-off, soft-failing, measurement-labelled and propose-only;
+today those properties hold by configuration accident. This slice (S9 of the
+no-nudge programme, report §17) makes them hold by construction, and makes the
+verifier tier real with its first occupant.
+
+## What Changes
+
+- **New capability `frozen-verifiers`.** The admission rule as spec: a verifier
+  runs only under a pinned weights digest, a versioned label map, and a green
+  verification fixture set; anything else degrades to *absence* (no label),
+  never to a differently-produced label wearing the verifier's name. Output is
+  provenance-marked review-queue enrichment only.
+- **`contradiction-queue` delta.** Proximity pair entries may carry a model
+  stance label (`contradict` / `refine` / `duplicate` / `unrelated`) as
+  asynchronous enrichment with full identity (method, model digest, label-map
+  version). Stance never changes an entry's `signal_version`, never moves
+  ranking, and never appears on the synchronous write path.
+- **The write path loses the in-path call.** `_refine_contradictions` leaves
+  write-time warning generation entirely. The default path is byte-identical
+  today (the gate is off); the opt-in `EXOMEM_CLAIM_LEVEL` write-time
+  sharpening is retired, and stance appears on the queue entry instead.
+- **`nli` optional extra.** The cross-encoder dependency ships as a default-off
+  extra; the model weights are pinned by digest through the existing offline
+  model cache; the label map (the current threshold logic, promoted to a
+  versioned in-repo artifact) is label map v1.
+- **Local-only in v1.** Hosted activation (an int8 classifier fits the cell
+  envelope) is a separate decision and out of scope here.
+
+## Impact
+
+- Affected specs: `frozen-verifiers` (new), `contradiction-queue` (one added
+  requirement).
+- Affected code (implementation slice, after approval): `src/exomem/claims.py`
+  (pinning, label map, fixture verification), `src/exomem/corpus_aware.py`
+  (remove the in-path invocation), the audit/sweep contradiction pass
+  (enrichment), `pyproject.toml` (`nli` extra), doctor (verifier status line),
+  tests including the verification fixture set.
+- Bench linkage, stated honestly: f22 is withheld until sequence 2 is
+  acknowledged; this slice claims precision improvement on its *verification
+  fixtures* only, and gate-off behaviour stays byte-identical.

--- a/openspec/changes/add-frozen-stance-verification/proposal.md
+++ b/openspec/changes/add-frozen-stance-verification/proposal.md
@@ -6,56 +6,89 @@ The contradiction queue is stance-blind by its own admission. The cosine band
 `[0.82, 0.90)` is a proximity measurement; the claim-level polarity heuristic in
 `src/exomem/claims.py` self-describes as "a lexical stand-in for a real NLI
 model"; and the NLI cross-encoder backend is marked **WIRED BUT UNVERIFIED**,
-selected by an unpinned environment knob (`EXOMEM_CLAIM_NLI_MODEL`), with its
-one invocation path (`_refine_contradictions`) sitting inside synchronous
-write-time warning generation (`corpus_aware.py`). The cost of stance-blindness
-is precision: concordant-evidence pairs surface beside genuine conflicts,
-burning reader trust and agent tokens — the exact failure the (withheld,
-sequence-2) bench family f22 makes a red line with its concordant twin.
+selected by an unpinned environment knob (`EXOMEM_CLAIM_NLI_MODEL`). Claim
+polarity reaches the product on **two paths today**, both behind the
+`EXOMEM_CLAIM_LEVEL` master gate (default off): the synchronous write path
+(`corpus_aware._refine_contradictions`), which sharpens warning text and mints
+the `contradiction-band` advisory kind; and the asynchronous audit sweep
+(`audit._pair_polarity`), which already writes `meta.polarity`,
+`meta.polarity_score`, and `meta.polarity_method` onto `corpus_contradictions`
+entries plus a rendered polarity note. On both, the method silently falls back
+to the lexical heuristic unless `EXOMEM_CLAIM_POLARITY_NLI` is also set. The
+cost of stance-blindness is precision: concordant-evidence pairs surface beside
+genuine conflicts — the exact failure the (withheld, sequence-2) bench family
+f22 makes a red line with its concordant twin.
 
 The authority-and-effects matrix, ratified 2026-08-30 as the constitution's
-model clause, admits a frozen verifier under a strict rule: **pinned model
-digest, versioned label map, output restricted to provenance-marked review-queue
-labels, off the synchronous write path, no vault text in instruction position** —
-never entering canon, decisions, retrieval, ranking, or policy. The
-`epistemic-graph` spec already requires any model-backed polarity path to be
-optional, default-off, soft-failing, measurement-labelled and propose-only;
-today those properties hold by configuration accident. This slice (S9 of the
-no-nudge programme, report §17) makes them hold by construction, and makes the
-verifier tier real with its first occupant.
+model clause, names this claim-polarity seam non-compliant until re-laned or
+removed, and admits a frozen verifier under a strict rule: **pinned model
+digest, versioned label map, output restricted to provenance-marked
+review-queue labels, off the synchronous write path, no vault text in
+instruction position**. The `epistemic-graph` requirement "Model-Backed Graph
+Suggestions Respect Pure Substrate" already demands optional, default-off,
+soft-failing, measurement-labelled, propose-only; today those properties hold
+by configuration accident. This slice (S9 of the no-nudge programme, report
+§17) is the re-laning: it makes them hold by construction, consolidates the
+two paths into one admitted channel, and makes the verifier tier real with its
+first occupant.
 
 ## What Changes
 
 - **New capability `frozen-verifiers`.** The admission rule as spec: a verifier
-  runs only under a pinned weights digest, a versioned label map, and a green
-  verification fixture set; anything else degrades to *absence* (no label),
-  never to a differently-produced label wearing the verifier's name. Output is
-  provenance-marked review-queue enrichment only.
-- **`contradiction-queue` delta.** Proximity pair entries may carry a model
-  stance label (`contradict` / `refine` / `duplicate` / `unrelated`) as
-  asynchronous enrichment with full identity (method, model digest, label-map
-  version). Stance never changes an entry's `signal_version`, never moves
-  ranking, and never appears on the synchronous write path.
-- **The write path loses the in-path call.** `_refine_contradictions` leaves
-  write-time warning generation entirely. The default path is byte-identical
-  today (the gate is off); the opt-in `EXOMEM_CLAIM_LEVEL` write-time
-  sharpening is retired, and stance appears on the queue entry instead.
+  runs only under a pinned weights digest, a versioned label map, a green
+  verification fixture set, and its opt-in gate; anything else degrades to
+  *absence* (no label), never to a differently-produced label wearing the
+  verifier's name. The pin registry is a repository artifact — no runtime
+  configuration adds or alters a pin. Output is provenance-marked review-queue
+  enrichment only.
+- **`contradiction-queue` delta.** The existing `meta.polarity` enrichment is
+  re-laned: after this change it is produced only by the admitted verifier
+  (`polarity_method: "nli"`), gains `polarity_model_digest` and
+  `polarity_label_map_version`, and is bound to the `signal_version` it was
+  computed against. Heuristic-method queue labels are retired — the lexical
+  stand-in had no admission control. A model polarity label never changes an
+  entry's `signal_version`, never moves ranking, and is distinct from the
+  reader-recorded competing-alternatives pair stance, which is a triage
+  disposition and is untouched.
+- **`command-surface` delta.** The write path loses the in-path call:
+  `_refine_contradictions` leaves write-time warning generation, retiring the
+  `contradiction-band` advisory kind with it (its only producer was that call).
+  The canonical write-path-advisory requirement is modified to two kinds
+  (near-duplicate, overlap). A dismissal recorded against a retired
+  contradiction-band identity does not transfer: the pair may resurface once
+  under the overlap identity — a stated one-time cost borne only by gate-on
+  users, since the kind never fired on the default path.
+- **Knob fate.** `EXOMEM_CLAIM_LEVEL` keeps gating the claim subsystem;
+  `EXOMEM_CLAIM_POLARITY_NLI` (default off) remains the verifier's opt-in
+  gate, now additionally requiring admission; `EXOMEM_CLAIM_NLI_MODEL` is
+  retired — model identity comes only from the in-repo pin registry, and a
+  set-but-ignored value is reported.
 - **`nli` optional extra.** The cross-encoder dependency ships as a default-off
-  extra; the model weights are pinned by digest through the existing offline
-  model cache; the label map (the current threshold logic, promoted to a
-  versioned in-repo artifact) is label map v1.
+  extra; weights are pinned by digest through the existing offline model
+  cache; the label map (the current threshold logic, promoted to a versioned
+  in-repo artifact) is label map v1.
 - **Local-only in v1.** Hosted activation (an int8 classifier fits the cell
   envelope) is a separate decision and out of scope here.
 
 ## Impact
 
 - Affected specs: `frozen-verifiers` (new), `contradiction-queue` (one added
-  requirement).
+  requirement), `command-surface` (one modified requirement: write-path
+  advisory kinds).
 - Affected code (implementation slice, after approval): `src/exomem/claims.py`
-  (pinning, label map, fixture verification), `src/exomem/corpus_aware.py`
-  (remove the in-path invocation), the audit/sweep contradiction pass
-  (enrichment), `pyproject.toml` (`nli` extra), doctor (verifier status line),
-  tests including the verification fixture set.
+  (pin registry, label map, fixture verification, knob retirement),
+  `src/exomem/corpus_aware.py` (remove `_refine_contradictions` and its
+  invocation, the `contradiction-band` partition, `_POLARITY_CLAUSE`, and the
+  now-dead `DupCandidate.polarity` / `polarity_score` / `polarity_method`
+  fields), `src/exomem/audit.py` (`_pair_polarity` and its rendering become
+  the single admitted channel), `pyproject.toml` (`nli` extra), doctor
+  (verifier status line), tests including the verification fixture set.
+- Affected tests, named: `tests/test_write_advisory_suppression.py`
+  (contradiction-band suppression cases) and `tests/test_claims.py` (gate-on
+  polarity pins) assert the retired behaviour and are updated red-first with
+  the change, not deleted around it.
 - Bench linkage, stated honestly: f22 is withheld until sequence 2 is
   acknowledged; this slice claims precision improvement on its *verification
-  fixtures* only, and gate-off behaviour stays byte-identical.
+  fixtures* only. Byte-identity claims are scoped to the default gate-off
+  path; gate-on users get two stated changes (no write-time polarity, admitted
+  verifier or absence on the queue).

--- a/openspec/changes/add-frozen-stance-verification/specs/command-surface/spec.md
+++ b/openspec/changes/add-frozen-stance-verification/specs/command-surface/spec.md
@@ -1,0 +1,57 @@
+## MODIFIED Requirements
+
+### Requirement: Write-path advisories are suppressed for exactly-dismissed fingerprints
+
+Each write-path advisory — the near-duplicate warning and the overlap
+warning — SHALL carry a stable review reference and a signal fingerprint
+derived from the advisory's endpoints and their content signal versions.
+Before emitting an advisory, the system SHALL consult the portable review
+state: an advisory whose exact `(review identity, fingerprint)` pair was
+dismissed SHALL NOT be emitted; a snoozed pair SHALL NOT be emitted before its
+expiry.
+
+The `contradiction-band` advisory kind is retired: write-time warning
+generation SHALL invoke no polarity classification, so no advisory
+distinguishes a proximity pair by claimed stance. A dismissal recorded against
+a retired contradiction-band identity SHALL NOT suppress the same pair's
+overlap advisory; such a pair may resurface once under the overlap identity.
+
+A material change to the counterpart endpoint SHALL produce a different
+fingerprint, and the advisory SHALL then be emitted again. A change to the
+written page itself SHALL resurface a dismissed advisory only when it changes
+the detected signal class for the pair. Ranking drift, unrelated writes, the
+triggering write's own change to the written page, and repeated identical page
+states SHALL NOT change the fingerprint.
+
+Suppression SHALL be failure-isolated in the emitting direction: review state
+that cannot be read or parsed SHALL cause the advisory to be emitted, and
+SHALL NOT fail, delay, or alter the committed mutation.
+
+#### Scenario: A dismissed duplicate warning stays quiet on the next write
+
+- **WHEN** a near-duplicate advisory for a page pair is dismissed through triage, and a further write commits to the same page with the counterpart materially unchanged and the detected signal class unchanged
+- **THEN** the committed result carries no near-duplicate advisory for that pair
+- **AND** the mutation outcome, status, and path are unchanged from an emission-free write
+
+#### Scenario: A material change resurfaces the advisory
+
+- **WHEN** a previously dismissed advisory's counterpart page is materially edited, and a further write commits to the original page
+- **THEN** the advisory is emitted again with a new fingerprint
+- **AND** the earlier dismissal record does not suppress it
+
+#### Scenario: Unreadable review state fails open to emission
+
+- **WHEN** the portable review state cannot be read during a compiled write that would emit an advisory
+- **THEN** the advisory is emitted
+- **AND** the write commits with its existing terminal unchanged
+
+#### Scenario: A declared rival pair produces no duplicate advisory
+
+- **WHEN** a page pair carries a recorded competing-alternatives stance and a further write commits to either page
+- **THEN** no near-duplicate advisory is emitted for that pair
+- **AND** the suppression follows from the stance contract, not from a dismissal record
+
+#### Scenario: The claim-level gate no longer changes write-path advisories
+
+- **WHEN** the claim-level subsystem is enabled and a draft lands in the proximity band against an active note
+- **THEN** the advisory emitted is the overlap kind with no polarity clause, exactly as on the default path

--- a/openspec/changes/add-frozen-stance-verification/specs/contradiction-queue/spec.md
+++ b/openspec/changes/add-frozen-stance-verification/specs/contradiction-queue/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Model stance labels are asynchronous provenance-marked enrichment
+
+A `corpus_contradictions` proximity pair MAY carry a model stance label —
+`contradict`, `refine`, `duplicate`, or `unrelated` — produced by an admitted
+frozen verifier, attached as entry metadata naming the method, model digest,
+and label-map version. Stance SHALL be produced only on the asynchronous
+audit/sweep path; the synchronous write path SHALL invoke no stance
+classification, and write-time warnings SHALL carry no stance clause. Attaching
+or changing a stance SHALL NOT change the entry's `meta.signal_version`, its
+`meta.provenance`, its position under the queue's ordering rules, or the cap
+and omitted-count accounting; a recorded triage decision SHALL NOT resurface
+because a stance arrived or changed. Asserted pairs SHALL NOT be
+stance-labelled — the author's stance already outranks a model's.
+
+#### Scenario: Stance arrives on the sweep, not the write
+
+- **WHEN** a write lands a proximity pair and the next audit pass runs with the
+  verifier admitted
+- **THEN** the write response carried no stance, and after the pass the queue
+  entry carries the label with its digest and label-map version
+
+#### Scenario: Labelling alone resurfaces nothing and moves nothing
+
+- **WHEN** a dismissed proximity entry gains a `contradict` stance
+- **THEN** the dismissal stands, `signal_version` is unchanged, and the
+  entry's rank relative to every other entry is unchanged
+
+#### Scenario: The write path is stance-free even when the verifier is admitted
+
+- **WHEN** the verifier is installed, pinned, and admitted and a draft overlaps
+  an active note
+- **THEN** the write-time overlap warning is exactly the proximity text, with
+  no claim-level clause

--- a/openspec/changes/add-frozen-stance-verification/specs/contradiction-queue/spec.md
+++ b/openspec/changes/add-frozen-stance-verification/specs/contradiction-queue/spec.md
@@ -1,35 +1,50 @@
 ## ADDED Requirements
 
-### Requirement: Model stance labels are asynchronous provenance-marked enrichment
+### Requirement: Model polarity labels are admitted asynchronous enrichment
 
-A `corpus_contradictions` proximity pair MAY carry a model stance label —
-`contradict`, `refine`, `duplicate`, or `unrelated` — produced by an admitted
-frozen verifier, attached as entry metadata naming the method, model digest,
-and label-map version. Stance SHALL be produced only on the asynchronous
-audit/sweep path; the synchronous write path SHALL invoke no stance
-classification, and write-time warnings SHALL carry no stance clause. Attaching
-or changing a stance SHALL NOT change the entry's `meta.signal_version`, its
-`meta.provenance`, its position under the queue's ordering rules, or the cap
-and omitted-count accounting; a recorded triage decision SHALL NOT resurface
-because a stance arrived or changed. Asserted pairs SHALL NOT be
-stance-labelled — the author's stance already outranks a model's.
+A `corpus_contradictions` proximity pair MAY carry a model polarity label —
+`meta.polarity` from the closed set `contradict` / `refine` / `duplicate` /
+`unrelated`, with `meta.polarity_score`, `meta.polarity_method: "nli"`,
+`meta.polarity_model_digest`, and `meta.polarity_label_map_version` — produced
+only by an admitted frozen verifier. The lexical heuristic SHALL NOT produce
+queue polarity metadata. The label SHALL be produced only on the asynchronous
+audit/sweep path; the synchronous write path SHALL invoke no polarity
+classification, and write-time warnings SHALL carry no polarity clause.
 
-#### Scenario: Stance arrives on the sweep, not the write
+The label SHALL record the `signal_version` it was computed against; a label
+whose recorded signal_version differs from the entry's SHALL be dropped, not
+served. Attaching, changing, or dropping a label SHALL NOT change the entry's
+`meta.signal_version`, its `meta.provenance`, its position under the queue's
+ordering rules, or the cap and omitted-count accounting; a recorded triage
+decision SHALL NOT resurface because a label arrived, changed, or was dropped.
+Asserted pairs SHALL NOT carry a model polarity label — the author's assertion
+outranks a model's guess. The model polarity label is distinct from the
+reader-recorded competing-alternatives pair stance, which remains a triage
+disposition under its own contract and is unaffected by this requirement.
+
+#### Scenario: The label arrives on the sweep, not the write
 
 - **WHEN** a write lands a proximity pair and the next audit pass runs with the
   verifier admitted
-- **THEN** the write response carried no stance, and after the pass the queue
+- **THEN** the write response carried no polarity, and after the pass the queue
   entry carries the label with its digest and label-map version
 
 #### Scenario: Labelling alone resurfaces nothing and moves nothing
 
-- **WHEN** a dismissed proximity entry gains a `contradict` stance
+- **WHEN** a dismissed proximity entry gains a `contradict` label
 - **THEN** the dismissal stands, `signal_version` is unchanged, and the
   entry's rank relative to every other entry is unchanged
 
-#### Scenario: The write path is stance-free even when the verifier is admitted
+#### Scenario: A stale label is dropped, not served
 
-- **WHEN** the verifier is installed, pinned, and admitted and a draft overlaps
-  an active note
-- **THEN** the write-time overlap warning is exactly the proximity text, with
-  no claim-level clause
+- **WHEN** an entry's content changes so its `signal_version` no longer
+  matches the one its label was computed against
+- **THEN** the entry is served without the label until the verifier labels the
+  new content
+
+#### Scenario: The heuristic never wears the verifier's name
+
+- **WHEN** the verifier is refused and the audit contradiction pass runs with
+  the claim subsystem enabled
+- **THEN** entries carry no `meta.polarity` at all — no heuristic-method
+  label is written

--- a/openspec/changes/add-frozen-stance-verification/specs/frozen-verifiers/spec.md
+++ b/openspec/changes/add-frozen-stance-verification/specs/frozen-verifiers/spec.md
@@ -2,19 +2,22 @@
 
 ### Requirement: A frozen verifier runs only under a pinned identity
 
-A model-backed verifier SHALL run only when its resolved weights match a pinned
-sha256 digest, its label map carries the version the pin names, and that
-(digest, label-map version) pair has a green verification fixture set. A digest
-mismatch, missing weights, missing dependency, or unverified pair SHALL refuse
-the verifier for the process. The verifier's input SHALL be a fixed
-classification shape over the texts it compares — never an assembled prompt,
-never vault text in instruction position — and its output SHALL be drawn from
-the label map's closed set.
+A model-backed verifier SHALL run only when its opt-in gate is set
+(`EXOMEM_CLAIM_POLARITY_NLI`, default off), its resolved weights match a
+pinned sha256 digest, its label map carries the version the pin names, and
+that (digest, label-map version) pair has a green verification fixture set.
+The pin registry SHALL be a repository artifact: no runtime configuration,
+environment value, or vault content may add, select, or alter a pin. The gate
+being unset, a digest mismatch, missing weights, a missing dependency, or an
+unverified pair SHALL refuse the verifier for the process. The verifier's
+input SHALL be a fixed classification shape over the texts it compares —
+never an assembled prompt, never vault text in instruction position — and its
+output SHALL be drawn from the label map's closed set.
 
 #### Scenario: An unpinned model never labels
 
 - **WHEN** the configured weights resolve to a digest other than the pinned one
-- **THEN** the verifier refuses, the affected entries carry no stance, and the
+- **THEN** the verifier refuses, the affected entries carry no label, and the
   refusal is recorded as a degradation — no label is produced by any fallback
   under the verifier's method name
 
@@ -23,6 +26,13 @@ the label map's closed set.
 - **WHEN** the label map's thresholds or label set change without a version
   bump and fixture re-verification
 - **THEN** the verifier refuses to run against the stale pair
+
+#### Scenario: Runtime configuration cannot supply a model
+
+- **WHEN** an environment value names a model absent from the repository pin
+  registry
+- **THEN** no verifier runs under that name, and the ignored value is reported
+  on the diagnostic surface
 
 ### Requirement: Verifier output is provenance-marked queue enrichment only
 
@@ -40,17 +50,19 @@ any page, relation, or proposal.
 
 ### Requirement: Verifier absence degrades to byte-identical silence
 
-With the verifier's extra uninstalled, its gate off, or its pin unsatisfied,
-every product surface SHALL behave byte-identically to a build that has no
-verifier tier at all, apart from an explicit degradation record on the
-diagnostic surface. A per-entry failure during an enrichment pass SHALL leave
-that entry unenriched and recorded, and SHALL NOT abort the pass.
+With the verifier's extra uninstalled, its opt-in gate off (the default), or
+its pin unsatisfied, every product surface SHALL behave byte-identically to a
+build that has no verifier tier at all, apart from an explicit degradation
+record on the diagnostic surface. A per-entry failure during an enrichment
+pass SHALL leave that entry unenriched and recorded, and SHALL NOT abort the
+pass.
 
 #### Scenario: Uninstalled means invisible
 
 - **WHEN** the extra is not installed and a full audit and write cycle runs
 - **THEN** queue entries, write responses, and rankings are byte-identical to
-  today's, and only the diagnostic surface names the absent verifier
+  a no-verifier build's, and only the diagnostic surface names the absent
+  verifier
 
 #### Scenario: One bad entry does not take down the pass
 

--- a/openspec/changes/add-frozen-stance-verification/specs/frozen-verifiers/spec.md
+++ b/openspec/changes/add-frozen-stance-verification/specs/frozen-verifiers/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: A frozen verifier runs only under a pinned identity
+
+A model-backed verifier SHALL run only when its resolved weights match a pinned
+sha256 digest, its label map carries the version the pin names, and that
+(digest, label-map version) pair has a green verification fixture set. A digest
+mismatch, missing weights, missing dependency, or unverified pair SHALL refuse
+the verifier for the process. The verifier's input SHALL be a fixed
+classification shape over the texts it compares — never an assembled prompt,
+never vault text in instruction position — and its output SHALL be drawn from
+the label map's closed set.
+
+#### Scenario: An unpinned model never labels
+
+- **WHEN** the configured weights resolve to a digest other than the pinned one
+- **THEN** the verifier refuses, the affected entries carry no stance, and the
+  refusal is recorded as a degradation — no label is produced by any fallback
+  under the verifier's method name
+
+#### Scenario: A label-map change demands re-verification
+
+- **WHEN** the label map's thresholds or label set change without a version
+  bump and fixture re-verification
+- **THEN** the verifier refuses to run against the stale pair
+
+### Requirement: Verifier output is provenance-marked queue enrichment only
+
+A frozen verifier's labels SHALL attach only to review-queue entries, carrying
+the method, model digest, and label-map version that produced them. Verifier
+output SHALL NOT enter note canon, decisions, retrieval, ranking, policy, or
+any synchronous write path, and SHALL NOT create, mutate, accept, or supersede
+any page, relation, or proposal.
+
+#### Scenario: The label stays on the review surface
+
+- **WHEN** a verifier labels a queue entry
+- **THEN** no page, relation, ranking position, or write response changes, and
+  the entry's label names its producing digest and label-map version
+
+### Requirement: Verifier absence degrades to byte-identical silence
+
+With the verifier's extra uninstalled, its gate off, or its pin unsatisfied,
+every product surface SHALL behave byte-identically to a build that has no
+verifier tier at all, apart from an explicit degradation record on the
+diagnostic surface. A per-entry failure during an enrichment pass SHALL leave
+that entry unenriched and recorded, and SHALL NOT abort the pass.
+
+#### Scenario: Uninstalled means invisible
+
+- **WHEN** the extra is not installed and a full audit and write cycle runs
+- **THEN** queue entries, write responses, and rankings are byte-identical to
+  today's, and only the diagnostic surface names the absent verifier
+
+#### Scenario: One bad entry does not take down the pass
+
+- **WHEN** the model raises on one claim pair mid-pass
+- **THEN** that entry is unenriched and recorded as degraded, and every other
+  entry's enrichment completes

--- a/openspec/changes/add-frozen-stance-verification/tasks.md
+++ b/openspec/changes/add-frozen-stance-verification/tasks.md
@@ -7,41 +7,62 @@ the task is ticked, not estimated.
 ## 1. Admission machinery (design D1, D4, D5)
 
 - [ ] 1.1 Label map v1: promote the `_nli_polarity` threshold logic to a
-  versioned in-repo artifact; loading an unknown or unversioned map refuses.
-  Red-first.
-- [ ] 1.2 Weights pinning: resolve-and-hash at load against the pinned digest
-  through the offline model cache; mismatch/missing refuses to absence with a
-  degradation record; the lexical heuristic never carries `method: "nli"`.
-  Red-first with a wrong-digest fixture.
-- [ ] 1.3 Verification fixture set: golden pairs (contradiction, concordant,
+  versioned in-repo artifact declaring the logit column semantics and order;
+  loading an unknown or unversioned map refuses. Red-first.
+- [ ] 1.2 Pin registry as repository artifact: model name, weights digest,
+  label-map version, fixture set; resolve-and-hash at load (hashed once per
+  process, cached) against the pinned digest through the offline model cache;
+  gate-off, mismatch, or missing refuses to absence with a degradation
+  record; the lexical heuristic never carries `method: "nli"`. Red-first with
+  a wrong-digest fixture AND a runtime-configuration pin-injection attempt
+  that must not admit.
+- [ ] 1.3 Knob fate: `EXOMEM_CLAIM_POLARITY_NLI` default-off pin;
+  `EXOMEM_CLAIM_NLI_MODEL` retired — a set value selects nothing and is
+  reported on the diagnostic surface. Red-first.
+- [ ] 1.4 Verification fixture set: golden pairs (contradiction, concordant,
   restatement, unrelated, plus known heuristic failures); admission requires
   green at the pinned (digest, label-map) pair; CI job runs it with the extra
   installed.
-- [ ] 1.4 Input-shape pin: the verifier accepts exactly a claim-text pair;
+- [ ] 1.5 Input-shape pin: the verifier accepts exactly a claim-text pair;
   structural test that no prompt/template path exists behind the seam.
 
-## 2. Write path (design D3)
+## 2. Write path (design D3; command-surface delta)
 
-- [ ] 2.1 Remove the `_refine_contradictions` invocation from write-time
-  warning generation; delete the write-time polarity clause. Red-first:
-  gate-off byte-identity pin on warnings, then a gate-on test asserting no
-  stance clause; write-latency gates unchanged.
+- [ ] 2.1 Remove the `_refine_contradictions` invocation and function, the
+  `contradiction-band` partition, `_POLARITY_CLAUSE`, and the dead
+  `DupCandidate.polarity` / `polarity_score` / `polarity_method` fields from
+  `corpus_aware.py`. Red-first: gate-off byte-identity pin on warnings, then
+  a gate-on pin that the advisory kind set is {near-duplicate, overlap} with
+  no polarity clause; write-latency gates unchanged.
+- [ ] 2.2 Update the named suites with the change, red-first:
+  `tests/test_write_advisory_suppression.py` contradiction-band suppression
+  cases become retired-kind cases (old dismissal does not suppress the
+  overlap identity — the stated one-time resurfacing), and
+  `tests/test_claims.py` gate-on write-path pins move to the queue channel.
 
 ## 3. Queue enrichment (design D2, D3)
 
-- [ ] 3.1 Audit/sweep contradiction pass enriches proximity entries with
-  stance via the admitted verifier; bounded per pass; per-entry soft-fail
-  recorded. Red-first with an injected fake verifier.
+- [ ] 3.1 Modify `audit._pair_polarity` and its rendering in place: enrichment
+  only through the admitted verifier (`polarity_method: "nli"` plus digest and
+  label-map version keys); the heuristic fallback never reaches queue
+  metadata; bounded by the surfaced set (`EXOMEM_CONTRADICTION_TOP_N`);
+  per-entry soft-fail recorded. Red-first with an injected fake verifier, plus
+  a refused-verifier pin that no heuristic-method label is written.
 - [ ] 3.2 Invariance pins: `signal_version`, provenance, ordering, cap and
-  omitted count unchanged by stance arrival; a dismissed entry stays dismissed.
+  omitted count unchanged by label arrival; a dismissed entry stays dismissed.
   Mechanism-removal proof for each pin on a scratch mutant.
-- [ ] 3.3 Asserted pairs are never stance-labelled. Red-first.
+- [ ] 3.3 Staleness binding: the label records the `signal_version` it was
+  computed against and is dropped, not served, on mismatch. Red-first.
+- [ ] 3.4 Asserted pairs carry no model polarity label; the recorded
+  competing-alternatives stance contract is untouched by enrichment.
+  Red-first.
 
 ## 4. Packaging and diagnostics
 
 - [ ] 4.1 `nli` optional extra in `pyproject.toml`; uninstalled degrades
   byte-identically; doctor reports the verifier tier's status (absent /
-  admitted / refused-with-reason) without failing warm.
+  admitted / refused-with-reason, including an ignored
+  `EXOMEM_CLAIM_NLI_MODEL`) without failing warm.
 - [ ] 4.2 Docs: README degradation-modes table gains the verifier row; the
   hosted-inference-boundary doc cross-references the admission rule.
 

--- a/openspec/changes/add-frozen-stance-verification/tasks.md
+++ b/openspec/changes/add-frozen-stance-verification/tasks.md
@@ -1,0 +1,54 @@
+# Tasks — add frozen stance verification
+
+Every test lands red first (verbatim failing output recorded before the
+implementation, then green). Measured budgets are written into this file when
+the task is ticked, not estimated.
+
+## 1. Admission machinery (design D1, D4, D5)
+
+- [ ] 1.1 Label map v1: promote the `_nli_polarity` threshold logic to a
+  versioned in-repo artifact; loading an unknown or unversioned map refuses.
+  Red-first.
+- [ ] 1.2 Weights pinning: resolve-and-hash at load against the pinned digest
+  through the offline model cache; mismatch/missing refuses to absence with a
+  degradation record; the lexical heuristic never carries `method: "nli"`.
+  Red-first with a wrong-digest fixture.
+- [ ] 1.3 Verification fixture set: golden pairs (contradiction, concordant,
+  restatement, unrelated, plus known heuristic failures); admission requires
+  green at the pinned (digest, label-map) pair; CI job runs it with the extra
+  installed.
+- [ ] 1.4 Input-shape pin: the verifier accepts exactly a claim-text pair;
+  structural test that no prompt/template path exists behind the seam.
+
+## 2. Write path (design D3)
+
+- [ ] 2.1 Remove the `_refine_contradictions` invocation from write-time
+  warning generation; delete the write-time polarity clause. Red-first:
+  gate-off byte-identity pin on warnings, then a gate-on test asserting no
+  stance clause; write-latency gates unchanged.
+
+## 3. Queue enrichment (design D2, D3)
+
+- [ ] 3.1 Audit/sweep contradiction pass enriches proximity entries with
+  stance via the admitted verifier; bounded per pass; per-entry soft-fail
+  recorded. Red-first with an injected fake verifier.
+- [ ] 3.2 Invariance pins: `signal_version`, provenance, ordering, cap and
+  omitted count unchanged by stance arrival; a dismissed entry stays dismissed.
+  Mechanism-removal proof for each pin on a scratch mutant.
+- [ ] 3.3 Asserted pairs are never stance-labelled. Red-first.
+
+## 4. Packaging and diagnostics
+
+- [ ] 4.1 `nli` optional extra in `pyproject.toml`; uninstalled degrades
+  byte-identically; doctor reports the verifier tier's status (absent /
+  admitted / refused-with-reason) without failing warm.
+- [ ] 4.2 Docs: README degradation-modes table gains the verifier row; the
+  hosted-inference-boundary doc cross-references the admission rule.
+
+## 5. Acceptance
+
+- [ ] 5.1 Fixture-set precision table recorded here (heuristic vs verifier on
+  the golden pairs), claimed against fixtures only; no f22 bench claim while
+  sequence 2 is withheld.
+- [ ] 5.2 `openspec validate --all --strict` green; scoped suites green; full
+  suite at the completion boundary attributed against the origin/main baseline.


### PR DESCRIPTION
## What

Proposes **S9 of the no-nudge programme — frozen stance verification** (OpenSpec change `add-frozen-stance-verification`; spec artifacts only, no code). First occupant of the verifier tier the ratified authority-and-effects matrix admits, and the re-laning of the claim-polarity seam the constitution names non-compliant.

Claim polarity reaches the product on two paths today, both behind `EXOMEM_CLAIM_LEVEL` (default off): the synchronous write path (`corpus_aware._refine_contradictions`, which sharpens warning text and mints the `contradiction-band` advisory kind) and the asynchronous audit sweep (`audit._pair_polarity`, which already writes `meta.polarity*` enrichment) — with silent fallback to a lexical heuristic that self-describes as a stand-in, and a model chosen by an unpinned env knob. This change consolidates to ONE admitted channel:

- **New `frozen-verifiers` capability**: a verifier runs only under its opt-in gate (`EXOMEM_CLAIM_POLARITY_NLI`, default off) plus a repository pin registry (weights digest, versioned label map, green verification fixture set — no runtime configuration can add or alter a pin); anything else refuses to absence, never to a fallback wearing the verifier's name; classification-shaped input only, no vault text in instruction position; output is provenance-marked review-queue enrichment only; byte-identical degradation when absent.
- **`contradiction-queue` delta**: the shipped `meta.polarity` enrichment is re-laned — produced only by the admitted verifier (`polarity_method: "nli"`), gaining `polarity_model_digest` + `polarity_label_map_version`, bound to the `signal_version` it was computed against (stale labels drop, never serve). Heuristic-method queue labels are retired. The label never changes `signal_version`, ranking, caps, or recorded triage; it is explicitly distinct from the reader-recorded competing-alternatives pair stance.
- **`command-surface` MODIFIED delta**: the write path loses the in-path call entirely; the `contradiction-band` advisory kind is retired (its only producer was that call — it never fired on the default path), the canonical write-path-advisory requirement shrinks to two kinds, and the fate of stranded gate-on dismissals is stated (one-time resurfacing under the overlap identity).
- **Knob fate**: `EXOMEM_CLAIM_LEVEL` keeps gating the claim subsystem; `EXOMEM_CLAIM_NLI_MODEL` is retired (a set value selects nothing and is reported). Ships as a default-off `nli` extra, local-only in v1. Bench honesty: f22 stays withheld with sequence 2; precision is claimed against the verification fixtures only; byte-identity claims are scoped to the default gate-off path.

Merge after #963 (matrix ratification) — this change executes the constitution clause that PR ratifies.

## Verification

- `openspec validate --all --strict`: 167 passed, 0 failed (new change included).
- Two adversarial review rounds by a fresh zero-context reviewer over the actual diff and the shipped code. Round 1: REQUEST CHANGES (9 findings, including two HIGHs the first draft missed: the audit sweep already writes `meta.polarity` on the same path, and removing the write-path call silently retired an advisory kind named by a canonical SHALL). Round 2 verdict: **APPROVE** — quoted in a comment below.
