### PR TITLE
docs(openspec): propose due-state carriage on the operation leaves (S6 bulk-carrier)

### DIFF
--- a/openspec/changes/extend-due-state-to-bulk-carriers/design.md
+++ b/openspec/changes/extend-due-state-to-bulk-carriers/design.md
@@ -1,0 +1,93 @@
+# Design — due-state carriage on the operation leaves
+
+## D1. Carriage rides the committed terminal, so the no-write case is out
+
+The block is admitted inside the terminal projection, which exists only when
+the invocation committed a governed write (`mark_active_mutation_committed`
+fires on a real replacement; the projection short-circuits otherwise). All
+five leaves reach that path when they write. When they do not write — a
+clean-vault `fix` pass, already-valid media, `process_media` `retry` (which
+re-enqueues in the machine-local job store and commits nothing) — there is no
+committed terminal to carry a block, and the leaf's raw payload passes
+through untouched. The requirement therefore scopes carriage to invocations
+that commit at least one governed write, honestly: a first-qualifying
+no-write maintenance pass stays silent even when the projection has open
+items. Closing that would be a response-contract change to non-committing
+responses — named future work, not implied.
+
+## D2. The invocation list is enumerated, not gestured at
+
+- `adoption_studio`: `apply` and `apply-proposal` only. The other six
+  registry mutations (`start`, `select`, `plan`, `cancel`, `finish`,
+  `propose`) are run bookkeeping or previews; letting a `plan` preview carry
+  would burn the session's single change-only emission before the real apply
+  — the exact failure the terminal's admission logic records having fixed
+  once.
+- `maintain_memory`: `fix` with `dry_run=false` (the mode DEFAULTS to a
+  dry-run preview, which is read-only), `reconcile` (mutating by default),
+  `backfill-ids` with `dry_run=false` (already batch-scoped), and
+  `structured-files` with `apply=true` — the one maintenance mode that
+  already produces a canonical terminal and the only one exempt from the
+  remote-surface refusal.
+- `adopt_vault`: mutating modes (scan-only stays clean).
+- `preserve_artifacts` and `process_media` mutating operations, subject to
+  D1's committed-write scoping.
+
+## D3. Per-leaf projection reality
+
+Two different value propositions, stated so nobody expects the wrong one:
+
+| Leaf | Its writes move projected categories? | Delta path |
+|---|---|---|
+| `adopt_vault`, `adoption_studio` applies | Yes — compiled pages | already wired (`_apply_batch_deltas`) |
+| `maintain_memory` mutating modes | Sometimes — repairs touch compiled pages | settle in tasks 1.5: wire the batch-delta path or prove the reconcile rebuild covers it before carriage lands |
+| `preserve_artifacts`, `process_media` | No — binary Evidence blobs and transcript sidecars author no predictions, questions, experiments, or supersession pointers | none needed; carriage value is the session channel (first qualifying response and change-only deltas from elsewhere) |
+
+Either way the served block SHALL reflect the post-batch projection — a block
+computed from a stale projection is the bug tasks 1.5 exists to prevent.
+
+## D4. Surface reality
+
+Mutating `maintain_memory` (except `structured-files`) is refused on every
+request-bound remote surface, so its carriage serves the local operator.
+Hosted and MCP invocations of the other leaves flow through the same terminal
+projection — no hosted-specific machinery, no per-surface emission rules.
+
+## D5. Bench adjudication (the D10 precedent)
+
+f23 was built to measure the missing carrier: its journey docstring records
+zero carrier reach for four of these five leaves, the canonical f23 scenario
+pins "on this runtime it reports `unsupported`", and two tests in
+`tests/test_due_state_emission_capture.py` are documented tripwires ("the day
+this leaf commits through `semantic_writes` … this test says so"). This
+change flips them on purpose:
+
+- The MODIFIED requirement rewrites the f23 scenario's runtime-outcome lines:
+  the emission assertion is now decided (one block, twelve writes) and the
+  measured-zero clause is retired. The evaluation rule itself — decided only
+  for a batch that delivered a block, `unsupported` otherwise — is unchanged.
+- The tripwire tests are **inverted, not deleted**: their red run against the
+  old expectation is the red-first evidence for tasks 2.1.
+- No §7 amendment is needed: a preregistered assertion moving from
+  `unsupported` to evaluated is the anticipated consequence the family was
+  built to detect — the runtime gained the capability; no family, assertion,
+  predicate, gate, or OpKind changes, and the deterministic evaluation rule
+  stands. This is the same adjudication the structured-collection carrier
+  change recorded in its D10.
+- f26 (`hookless_episode_carrier`) is withheld with amendment sequence 2; its
+  measured world changes too, and its before/after is recorded when sequence
+  2 activates — nothing publishes meanwhile.
+
+## D6. Rollout, partial failure, and the payload check
+
+Per-leaf wiring is independently shippable behind its own red-first test —
+no all-five-or-none coupling; a leaf that stalls ships later without
+un-shipping the others. A partially failed invocation that committed at
+least one governed write still carries under the change-only rule; a wholly
+failed or wholly-refused one has no committed terminal and carries nothing.
+Before wiring each leaf, tasks 1.6 verifies the terminal's compact rebuild
+preserves that leaf's response payload (the adoption-run document, maintain
+summaries, the media job payload — including the media `state` key that
+would collide with the envelope's) — a payload the terminal would gut is a
+pre-existing defect escalated as its own change, never silently worked
+around.

--- a/openspec/changes/extend-due-state-to-bulk-carriers/proposal.md
+++ b/openspec/changes/extend-due-state-to-bulk-carriers/proposal.md
@@ -1,46 +1,76 @@
-# Extend due-state carriage to the bulk-operation leaves
+# Extend due-state carriage to the operation leaves
 
 ## Why
 
-The due-state block is the one accumulation signal that reaches every client
+The due-state block is the accumulation signal that reaches an agent
 mid-conversation — the channel the no-nudge architecture report made
-load-bearing precisely because structural drift accumulates *during* work, not
-at session boundaries. Today the carriers are the compact page-write and
-recall responses plus the structured-collection mutations (`command-surface`,
-"Structured-collection mutations are due-state carriers"). The bulk-operation
-leaves — vault adoption, Adoption Studio applies, maintenance fix passes,
-artifact preservation, media processing — are not carriers, yet they are the
-product's largest write bursts: exactly where the projection moves most and
-the agent currently hears nothing until the next ordinary write.
+load-bearing because structural drift accumulates *during* work, not at
+session boundaries. Today the carriers are the compact page-write and recall
+responses plus the structured-collection mutations. The operation leaves —
+vault adoption, Adoption Studio applies, maintenance repair, artifact
+preservation, media processing — are not carriers. For adoption and applies
+that gap sits exactly on the product's largest write bursts, where the
+projection moves most; for artifact preservation and media processing the
+leaves' own writes do not move the projected categories, but a carrying
+response is still the session's channel for counts that changed since the
+last delivery. One honest bound up front: mutating `maintain_memory` (other
+than `structured-files`) is refused on every remote surface, so maintenance
+carriage reaches the local CLI operator only — the mid-conversation claim for
+remote clients rests on the other leaves and on ordinary writes.
 
-The batch-once emission discipline already exists canonically: the emission
-ledger requires a multi-write invocation to emit "at most once, at the end of
-the invocation, under the unchanged change-only rule", and the
-cannot-nag requirement pins "a bulk import does not emit forty blocks". What
-is missing is only carriage. The founder decision (2026-08-30, S6
-bulk-carrier question from the report's open decisions): the bulk leaves carry
-the block, batch-once. This change adds carriage, not machinery.
+The batch-once emission discipline already exists canonically (the emission
+ledger's "at most once, at the end of the invocation, under the unchanged
+change-only rule", and the cannot-nag bulk rule). The f23 bench family was
+deliberately built to measure the absence this change removes: its journey
+records that "no product leaf reaches the write carrier" and reports the
+emission assertion `unsupported`, and two tripwire tests in
+`tests/test_due_state_emission_capture.py` pin the measured zero so that the
+day a leaf commits through the carrier, they say so. This change flips those
+artifacts deliberately and says so (design D5), rather than leaving them to
+go red as a surprise.
+
+The founder decision (2026-08-30, the S6 bulk-carrier question from the
+architecture report's open decisions, recorded in the wave's KB milestone
+note): the operation leaves carry the block, batch-once. This change adds
+carriage, not machinery.
 
 ## What Changes
 
-- **`command-surface` delta (one added requirement).** The bulk-operation
-  leaves' mutating invocations — `adopt_vault` mutating modes,
-  `adoption_studio` mutating actions, `maintain_memory` fix and reconcile
-  modes, `preserve_artifacts`, and `process_media` mutating operations — carry
-  the bounded advisory due-state block under the same carrier contract and
-  emission governance as page writes, reusing the shared due-state helpers;
-  one invocation is one batch scope (at most one block, at its end).
-- **No new machinery.** No tool input schema changes; no projection, ledger,
-  or governance changes — the existing batch-once and change-only rules apply
-  as written. If the recorded response contract or packaged digest moves for
-  any of the five leaves, the documented two-phase response-contract rollout
-  applies.
+- **`command-surface` delta — one ADDED requirement.** The enumerated
+  mutating invocations of the five operation leaves (see the requirement for
+  the exact `dry_run`/action/mode qualifications) carry the bounded advisory
+  due-state block when — and only when — the invocation commits at least one
+  governed write, under the same carrier contract as page writes, reusing the
+  shared due-state helpers behind the terminal projection. Emission follows
+  the canonical governance and ledger requirements unchanged. The no-write
+  case (clean-vault repair, already-valid media, a re-enqueue) carries no
+  block: it has no committed terminal to carry one, and closing that gap is a
+  response-contract change explicitly out of scope.
+- **`command-surface` delta — one MODIFIED requirement.** "The f23 family
+  runs against the real runtime": the emission assertion's recorded outcome
+  moves from `unsupported` (measured zero carrier) to decided — one block
+  against twelve writes in the bulk batch. No family, assertion, predicate,
+  gate, or schema changes; design D5 adjudicates why this needs no §7
+  amendment.
+- **No new machinery.** No tool input schema changes, no projection or ledger
+  changes, no new emission rules.
 
 ## Impact
 
-- Affected specs: `command-surface` (one added requirement).
+- Affected specs: `command-surface` (one added requirement, one modified
+  requirement).
 - Affected code (implementation slice, after approval): the five leaf
-  responders call the shared due-state release-plane helpers; tests per leaf.
+  responders reach the shared due-state terminal projection; the
+  projection-delta path for the newly carrying leaves is settled per design
+  D3; the f23 driver docstring updated.
+- Affected tests, named: `tests/test_due_state_emission_capture.py` — the two
+  tripwire pins (`test_a_multi_write_command_carries_one_block`-adjacent
+  zero-carrier assertions) are **inverted, not deleted** (tasks 2.1).
+- Affected benchmarks: f23's recorded emission-assertion outcome flips
+  `unsupported` → decided and is recorded in tasks; f26
+  (`hookless_episode_carrier`, withheld with amendment sequence 2) has its
+  measured world change recorded when sequence 2 activates.
 - Not affected: due-state projection and ledger semantics, emission
   governance, family dispositions, tool input schemas, the legacy response
-  detail (which continues to omit the block).
+  detail. If any leaf's recorded response contract or packaged digest moves,
+  the documented two-phase response-contract rollout applies.

--- a/openspec/changes/extend-due-state-to-bulk-carriers/proposal.md
+++ b/openspec/changes/extend-due-state-to-bulk-carriers/proposal.md
@@ -64,8 +64,9 @@ carriage, not machinery.
   projection-delta path for the newly carrying leaves is settled per design
   D3; the f23 driver docstring updated.
 - Affected tests, named: `tests/test_due_state_emission_capture.py` — the two
-  tripwire pins (`test_a_multi_write_command_carries_one_block`-adjacent
-  zero-carrier assertions) are **inverted, not deleted** (tasks 2.1).
+  tripwire pins (`test_a_multi_write_command_carries_one_block` and
+  `test_the_batch_scope_on_this_leaf_suppresses_nothing_today`) are
+  **inverted, not deleted** (tasks 2.1).
 - Affected benchmarks: f23's recorded emission-assertion outcome flips
   `unsupported` → decided and is recorded in tasks; f26
   (`hookless_episode_carrier`, withheld with amendment sequence 2) has its

--- a/openspec/changes/extend-due-state-to-bulk-carriers/proposal.md
+++ b/openspec/changes/extend-due-state-to-bulk-carriers/proposal.md
@@ -1,0 +1,46 @@
+# Extend due-state carriage to the bulk-operation leaves
+
+## Why
+
+The due-state block is the one accumulation signal that reaches every client
+mid-conversation — the channel the no-nudge architecture report made
+load-bearing precisely because structural drift accumulates *during* work, not
+at session boundaries. Today the carriers are the compact page-write and
+recall responses plus the structured-collection mutations (`command-surface`,
+"Structured-collection mutations are due-state carriers"). The bulk-operation
+leaves — vault adoption, Adoption Studio applies, maintenance fix passes,
+artifact preservation, media processing — are not carriers, yet they are the
+product's largest write bursts: exactly where the projection moves most and
+the agent currently hears nothing until the next ordinary write.
+
+The batch-once emission discipline already exists canonically: the emission
+ledger requires a multi-write invocation to emit "at most once, at the end of
+the invocation, under the unchanged change-only rule", and the
+cannot-nag requirement pins "a bulk import does not emit forty blocks". What
+is missing is only carriage. The founder decision (2026-08-30, S6
+bulk-carrier question from the report's open decisions): the bulk leaves carry
+the block, batch-once. This change adds carriage, not machinery.
+
+## What Changes
+
+- **`command-surface` delta (one added requirement).** The bulk-operation
+  leaves' mutating invocations — `adopt_vault` mutating modes,
+  `adoption_studio` mutating actions, `maintain_memory` fix and reconcile
+  modes, `preserve_artifacts`, and `process_media` mutating operations — carry
+  the bounded advisory due-state block under the same carrier contract and
+  emission governance as page writes, reusing the shared due-state helpers;
+  one invocation is one batch scope (at most one block, at its end).
+- **No new machinery.** No tool input schema changes; no projection, ledger,
+  or governance changes — the existing batch-once and change-only rules apply
+  as written. If the recorded response contract or packaged digest moves for
+  any of the five leaves, the documented two-phase response-contract rollout
+  applies.
+
+## Impact
+
+- Affected specs: `command-surface` (one added requirement).
+- Affected code (implementation slice, after approval): the five leaf
+  responders call the shared due-state release-plane helpers; tests per leaf.
+- Not affected: due-state projection and ledger semantics, emission
+  governance, family dispositions, tool input schemas, the legacy response
+  detail (which continues to omit the block).

--- a/openspec/changes/extend-due-state-to-bulk-carriers/specs/command-surface/spec.md
+++ b/openspec/changes/extend-due-state-to-bulk-carriers/specs/command-surface/spec.md
@@ -24,7 +24,7 @@ outside this requirement. A partially failed invocation that committed at
 least one governed write SHALL still carry under the change-only rule.
 Read-only and dry-run invocations of these leaves SHALL NOT carry the block.
 The leaves SHALL reuse the shared due-state projection helpers (the
-`due_state.block_for_write` family behind the terminal's
+`due_state.block_for_write` family behind the due-state helpers'
 `due_state_advisory` disclosure boundary) rather than re-deriving any of it,
 and tool input schemas SHALL NOT change.
 

--- a/openspec/changes/extend-due-state-to-bulk-carriers/specs/command-surface/spec.md
+++ b/openspec/changes/extend-due-state-to-bulk-carriers/specs/command-surface/spec.md
@@ -1,38 +1,83 @@
 ## ADDED Requirements
 
-### Requirement: Bulk-operation leaves are due-state carriers
+### Requirement: Operation leaves are due-state carriers
 
-Mutating invocations of the bulk-operation leaves — `adopt_vault` mutating
-modes, `adoption_studio` mutating actions, `maintain_memory` fix and
-reconcile modes, `preserve_artifacts`, and `process_media` mutating
-operations — SHALL carry the bounded advisory due-state block under the same
-carrier contract and emission governance as page writes: the block is served
-through the release plane, validated and bounded, never a key a client
-branches on for operation outcome, emission is recorded once per delivered
-block, family dispositions apply, and an unreadable review state yields no
-block while the operation still completes. One invocation SHALL be one batch
-scope: at most one block, at the end of the invocation, under the unchanged
-change-only rule. Read-only invocations of the same leaves SHALL NOT carry
-the block. The leaves SHALL reuse the shared due-state helpers rather than
-re-deriving any of it, and tool input schemas SHALL NOT change.
+An invocation of the operation leaves — `adopt_vault` mutating modes,
+`adoption_studio` `apply` and `apply-proposal`, `maintain_memory` in `fix`
+with `dry_run=false`, `reconcile`, `backfill-ids` with `dry_run=false`, or
+`structured-files` with `apply=true`, `preserve_artifacts`, and
+`process_media` mutating operations — that commits at least one governed
+write SHALL carry the bounded advisory due-state block under the same
+carrier contract as page writes: served from the committed terminal
+projection, validated and bounded, never a key a client branches on for
+operation outcome, family dispositions applied, emission recorded in the
+ledger once per delivered block, and an unreadable review state yielding no
+block while the operation still completes. Emission SHALL follow the
+canonical emission-governance and emission-ledger requirements unchanged —
+the invocation is one batch scope, change-only, delivered at the end.
 
-#### Scenario: A bulk apply reports accumulation once, at the end
+An invocation that commits no governed write — a clean-vault repair pass,
+already-valid media, a `retry` re-enqueue — SHALL carry no block even when
+the projection has open items: it produces no committed terminal, and
+extending carriage to non-committing responses is a response-contract change
+outside this requirement. A partially failed invocation that committed at
+least one governed write SHALL still carry under the change-only rule.
+Read-only and dry-run invocations of these leaves SHALL NOT carry the block.
+The leaves SHALL reuse the shared due-state projection helpers (the
+`due_state.block_for_write` family behind the terminal's
+`due_state_advisory` disclosure boundary) rather than re-deriving any of it,
+and tool input schemas SHALL NOT change.
 
-- **WHEN** an `adoption_studio` apply commits many governed writes whose
+#### Scenario: A bulk apply reports accumulation exactly once, at the end
+
+- **WHEN** an `adoption_studio` `apply` commits twelve governed writes whose
   deltas change the due-state counts
-- **THEN** the invocation's response carries at most one `due_state` block,
+- **THEN** the invocation's response carries exactly one `due_state` block
   reflecting the projection after the batch
 - **AND** the operation outcome keys are byte-identical to a projection-free
   response apart from the advisory block
 
-#### Scenario: A read-only invocation stays clean
+#### Scenario: Unchanged totals stay quiet on a carrying leaf
 
-- **WHEN** `adopt_vault` runs in scan-only mode
+- **WHEN** a `preserve_artifacts` invocation commits its artifacts while no
+  category count differs from the last delivered block
 - **THEN** the response carries no `due_state` block
 
-#### Scenario: Unreadable review state never blocks the bulk operation
+#### Scenario: A committing-nothing invocation carries nothing
+
+- **WHEN** `maintain_memory` in `fix` with `dry_run=false` runs over a clean
+  vault and commits no write, while the projection holds open items
+- **THEN** the response carries no `due_state` block and the operation's
+  existing terminal is unchanged
+
+#### Scenario: Previews and scans stay clean
+
+- **WHEN** `adopt_vault` runs in scan-only mode, or `maintain_memory` `fix`
+  runs with its default dry-run preview
+- **THEN** the response carries no `due_state` block
+
+#### Scenario: Unreadable review state never blocks the operation
 
 - **WHEN** the review state cannot be read while a `process_media` processing
-  invocation completes
+  invocation commits a transcript sidecar
 - **THEN** the invocation completes with its existing terminal unchanged and
   no `due_state` block
+
+## MODIFIED Requirements
+
+### Requirement: The f23 family runs against the real runtime
+
+A journey driver SHALL execute the f23 scenario's operations against an installed envelope — seed, maintenance passes, a triage dismissal, an engine restart, prominence reconfiguration across the full level range, and one bulk ingest — and SHALL project the resulting review state and emission ledger into the snapshot pair the family's assertions evaluate. The vault projector SHALL declare `due_state_counters` available through the projection file. The driver SHALL refuse to run rather than fall back when no envelope is installed.
+
+#### Scenario: f23 reports what this runtime can decide, and no more
+
+- **WHEN** the f23 journey runs against the current runtime
+- **THEN** `dismissal_respected_across_passes` passes for the dismissed subject
+- **AND** `counter_emission_not_repeated_per_write` is evaluated on the emission delta between the two snapshots, so it is decided only for a batch that delivered at least one block, and otherwise reports `unsupported` rather than passing vacuously or inheriting an earlier batch's delivery
+- **AND** on this runtime it is decided: the bulk ingest commits through a carrying operation leaf, the batch delivers exactly one block, and the assertion passes on an emission delta of one against a write delta of twelve
+- **AND** the batch-once requirement is proven where it is decidable: twelve write carriers inside one batch scope emit at most one block
+
+#### Scenario: Removing the batch scope turns the counter assertion red
+
+- **WHEN** the batch scope is disabled and twelve write carriers run over one vault
+- **THEN** `counter_emission_not_repeated_per_write` fails with twelve emissions for twelve writes

--- a/openspec/changes/extend-due-state-to-bulk-carriers/specs/command-surface/spec.md
+++ b/openspec/changes/extend-due-state-to-bulk-carriers/specs/command-surface/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Bulk-operation leaves are due-state carriers
+
+Mutating invocations of the bulk-operation leaves — `adopt_vault` mutating
+modes, `adoption_studio` mutating actions, `maintain_memory` fix and
+reconcile modes, `preserve_artifacts`, and `process_media` mutating
+operations — SHALL carry the bounded advisory due-state block under the same
+carrier contract and emission governance as page writes: the block is served
+through the release plane, validated and bounded, never a key a client
+branches on for operation outcome, emission is recorded once per delivered
+block, family dispositions apply, and an unreadable review state yields no
+block while the operation still completes. One invocation SHALL be one batch
+scope: at most one block, at the end of the invocation, under the unchanged
+change-only rule. Read-only invocations of the same leaves SHALL NOT carry
+the block. The leaves SHALL reuse the shared due-state helpers rather than
+re-deriving any of it, and tool input schemas SHALL NOT change.
+
+#### Scenario: A bulk apply reports accumulation once, at the end
+
+- **WHEN** an `adoption_studio` apply commits many governed writes whose
+  deltas change the due-state counts
+- **THEN** the invocation's response carries at most one `due_state` block,
+  reflecting the projection after the batch
+- **AND** the operation outcome keys are byte-identical to a projection-free
+  response apart from the advisory block
+
+#### Scenario: A read-only invocation stays clean
+
+- **WHEN** `adopt_vault` runs in scan-only mode
+- **THEN** the response carries no `due_state` block
+
+#### Scenario: Unreadable review state never blocks the bulk operation
+
+- **WHEN** the review state cannot be read while a `process_media` processing
+  invocation completes
+- **THEN** the invocation completes with its existing terminal unchanged and
+  no `due_state` block

--- a/openspec/changes/extend-due-state-to-bulk-carriers/tasks.md
+++ b/openspec/changes/extend-due-state-to-bulk-carriers/tasks.md
@@ -1,30 +1,52 @@
-# Tasks — extend due-state carriage to the bulk-operation leaves
+# Tasks — extend due-state carriage to the operation leaves
 
 Every test lands red first (verbatim failing output recorded before the
 implementation, then green).
 
 ## 1. Carriage
 
-- [ ] 1.1 Wire the shared due-state release-plane helpers into the five leaf
-  responders (`adopt_vault` mutating modes, `adoption_studio` mutating
-  actions, `maintain_memory` fix/reconcile, `preserve_artifacts`,
-  `process_media` mutating operations). Red-first per leaf: a mutating
-  invocation whose writes change the counts carries exactly one block at the
-  end; outcome keys byte-identical otherwise.
-- [ ] 1.2 Batch-once and change-only pins: a multi-write apply emits at most
-  one block; an invocation with unchanged totals emits none; the emission
-  ledger records one delivery per block. Red-first against the ledger.
-- [ ] 1.3 Read-only invocations (scan-only adopt, status/work-item actions,
-  audit-only maintain, media status) carry no block; the legacy response
-  detail omits it. Red-first.
-- [ ] 1.4 Failure isolation: unreadable review state yields no block, the
-  operation completes with its terminal unchanged. Red-first.
+- [ ] 1.1 Wire the terminal's due-state admission for each enumerated
+  invocation (design D2), reusing the `due_state.block_for_write` family
+  behind the `due_state_advisory` disclosure boundary. Red-first per leaf: a
+  committing invocation whose writes change the counts carries EXACTLY ONE
+  block reflecting the post-batch projection; outcome keys byte-identical
+  otherwise. Each leaf is independently shippable behind its own test.
+- [ ] 1.2 Batch-once, change-only, and ledger pins: a multi-write apply
+  emits one block recorded once in the emission ledger; a committing
+  invocation with unchanged totals emits none. Red-first against the ledger.
+- [ ] 1.3 Negative pins: no-commit invocations (clean-vault `fix
+  dry_run=false`, already-valid media, `process_media` `retry`), read-only
+  and dry-run invocations (scan-only adopt, default dry-run `fix`, status
+  and preview actions), and the legacy response detail all carry no block.
+  Red-first.
+- [ ] 1.4 Failure isolation: unreadable review state yields no block while
+  the operation completes with its terminal unchanged; a partially failed
+  invocation that committed at least one write still carries under
+  change-only. Red-first both halves.
+- [ ] 1.5 Projection-delta settlement per design D3: wire the batch-delta
+  path for `maintain_memory` mutating modes or record evidence that the
+  rebuild path covers them; pin that the served block reflects the
+  post-batch projection, not a stale read. Red-first with a
+  mid-batch-changing fixture.
+- [ ] 1.6 Pre-wiring payload check per leaf: the terminal's compact rebuild
+  preserves the leaf's response payload (adoption-run document, maintain
+  summaries, media job payload including the `state` key collision). A
+  payload the terminal would drop is a BLOCKER escalated as its own change —
+  never silently worked around. Record the per-leaf result here.
 
-## 2. Acceptance
+## 2. Bench and contract closure
 
-- [ ] 2.1 Response-contract check: if any of the five leaves' recorded
+- [ ] 2.1 Invert — do not delete — the two zero-carrier tripwire pins in
+  `tests/test_due_state_emission_capture.py` (their red run against the old
+  expectation is this task's red-first evidence); update the f23 driver
+  docstring's zero-carrier inventory; record the f23
+  `counter_emission_not_repeated_per_write` flip `unsupported` → decided in
+  this file. Record f26's before/after when amendment sequence 2 activates
+  (nothing publishes meanwhile). No family, assertion, predicate, gate, or
+  OpKind changes (design D5).
+- [ ] 2.2 Response-contract check: if any of the five leaves' recorded
   contract or packaged digest moves, follow the documented two-phase rollout
   and record it here; otherwise record that no contract moved.
-- [ ] 2.2 `openspec validate --all --strict` green; scoped suites green; full
+- [ ] 2.3 `openspec validate --all --strict` green; scoped suites green; full
   suite at the completion boundary attributed against the origin/main
   baseline.

--- a/openspec/changes/extend-due-state-to-bulk-carriers/tasks.md
+++ b/openspec/changes/extend-due-state-to-bulk-carriers/tasks.md
@@ -1,0 +1,30 @@
+# Tasks — extend due-state carriage to the bulk-operation leaves
+
+Every test lands red first (verbatim failing output recorded before the
+implementation, then green).
+
+## 1. Carriage
+
+- [ ] 1.1 Wire the shared due-state release-plane helpers into the five leaf
+  responders (`adopt_vault` mutating modes, `adoption_studio` mutating
+  actions, `maintain_memory` fix/reconcile, `preserve_artifacts`,
+  `process_media` mutating operations). Red-first per leaf: a mutating
+  invocation whose writes change the counts carries exactly one block at the
+  end; outcome keys byte-identical otherwise.
+- [ ] 1.2 Batch-once and change-only pins: a multi-write apply emits at most
+  one block; an invocation with unchanged totals emits none; the emission
+  ledger records one delivery per block. Red-first against the ledger.
+- [ ] 1.3 Read-only invocations (scan-only adopt, status/work-item actions,
+  audit-only maintain, media status) carry no block; the legacy response
+  detail omits it. Red-first.
+- [ ] 1.4 Failure isolation: unreadable review state yields no block, the
+  operation completes with its terminal unchanged. Red-first.
+
+## 2. Acceptance
+
+- [ ] 2.1 Response-contract check: if any of the five leaves' recorded
+  contract or packaged digest moves, follow the documented two-phase rollout
+  and record it here; otherwise record that no contract moved.
+- [ ] 2.2 `openspec validate --all --strict` green; scoped suites green; full
+  suite at the completion boundary attributed against the origin/main
+  baseline.


### PR DESCRIPTION
## What

Proposes **due-state carriage on the operation leaves** (OpenSpec change `extend-due-state-to-bulk-carriers`; spec artifacts only, no code) — the S6 bulk-carrier founder decision (2026-08-30): the operation leaves carry the bounded advisory due-state block, batch-once.

One ADDED `command-surface` requirement: enumerated mutating invocations of `adopt_vault`, `adoption_studio` (`apply`/`apply-proposal` only — previews would burn the session's single change-only emission), `maintain_memory` (`fix` with `dry_run=false`, `reconcile`, `backfill-ids` with `dry_run=false`, `structured-files` with `apply=true`), `preserve_artifacts`, and `process_media` carry the block **when the invocation commits at least one governed write**, under the existing carrier contract and unchanged canonical emission governance. The no-write case (clean-vault repair, already-valid media, a retry re-enqueue) carries nothing — it has no committed terminal — and that limitation is stated, not papered over, as is the remote-surface bound (mutating maintenance other than structured-files is local-CLI-only).

One MODIFIED `command-surface` requirement: "The f23 family runs against the real runtime" — the emission assertion's recorded outcome moves from `unsupported` (measured zero carrier) to decided (one block against twelve writes). The two zero-carrier tripwire tests in `tests/test_due_state_emission_capture.py` are named for **inversion, not deletion**; design D5 adjudicates on the recorded precedent why an assertion flipping `unsupported` → decided needs no §7 bench amendment (no family, assertion, predicate, gate, or OpKind changes). f26 stays withheld with sequence 2 and gets recorded at activation.

## Verification

- `openspec validate --all --strict`: 169 passed, 0 failed.
- Two adversarial review rounds by a fresh zero-context reviewer over the actual diff and shipped code (65 tool uses, tracing the terminal path, the leaf registries, the bench journeys, and the tripwire tests). Round 1: REQUEST CHANGES — 1 CRITICAL (the change silently invalidated the f23 bench scenario and two deliberately-built tripwire tests with no MODIFIED block), 7 MAJOR (dry-run defaults, omitted maintenance modes, the no-write case, projection reality for two leaves, remote-surface bound, tautological scenario). Round 2 verdict: **APPROVE** — quoted in a comment below.
