### PR TITLE
feat(governance): add consolidation destination preimages

### DIFF
--- a/src/exomem/governance/consolidation_intake.py
+++ b/src/exomem/governance/consolidation_intake.py
@@ -35,6 +35,9 @@ _PRIVATE_PROOF_REF = re.compile(
 _PRIVATE_OBJECT_REF = re.compile(
     r"exomem-consolidation-object://sha256/([0-9a-f]{64})\Z"
 )
+_PRIVATE_PREIMAGE_REF = re.compile(
+    r"exomem-consolidation-preimage://sha256/([0-9a-f]{64})\Z"
+)
 
 
 class ConsolidationIntakeUnavailable(RuntimeError):
@@ -251,7 +254,7 @@ class PrivateConsolidationArtifactStore:
 
     def _ensure(self) -> None:
         _ensure_private_directory(self.root)
-        for name in ("archives", "proofs", "objects"):
+        for name in ("archives", "proofs", "objects", "preimages"):
             _ensure_private_directory(self.root / name)
 
     def _object_path(self, digest: str) -> Path:
@@ -312,6 +315,14 @@ class PrivateConsolidationArtifactStore:
             suffix=".json",
         )
 
+    def resolve_preimage(self, reference: str) -> Path:
+        return self._resolve(
+            reference,
+            pattern=_PRIVATE_PREIMAGE_REF,
+            directory="preimages",
+            suffix=".json",
+        )
+
     def _install(self, staged: Path, destination: Path, expected_digest: str) -> None:
         _ensure_private_directory(destination.parent)
         try:
@@ -338,6 +349,46 @@ class PrivateConsolidationArtifactStore:
             raise
         except OSError:
             raise ConsolidationIntakeUnavailable from None
+
+    def install_object_file(self, staged: Path, *, expected_digest: str) -> str:
+        """Install one independently staged immutable object and return its opaque ref."""
+
+        if not isinstance(staged, Path) or _PRIVATE_OBJECT_REF.fullmatch(
+            f"exomem-consolidation-object://sha256/{expected_digest}"
+        ) is None:
+            raise ConsolidationIntakeUnavailable
+        self._ensure()
+        self._install(staged, self._object_path(expected_digest), expected_digest)
+        return f"exomem-consolidation-object://sha256/{expected_digest}"
+
+    def install_preimage_bytes(self, payload: bytes) -> str:
+        """Publish one canonical preimage manifest after all objects are durable."""
+
+        if not isinstance(payload, bytes) or not payload:
+            raise ConsolidationIntakeUnavailable
+        self._ensure()
+        digest = hashlib.sha256(payload).hexdigest()
+        temporary: Path | None = None
+        try:
+            descriptor, raw_path = tempfile.mkstemp(prefix=".preimage-", dir=self.root)
+            temporary = Path(raw_path)
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            self._install(
+                temporary,
+                self.root / "preimages" / f"{digest}.json",
+                digest,
+            )
+        except ConsolidationIntakeUnavailable:
+            raise
+        except OSError:
+            raise ConsolidationIntakeUnavailable from None
+        finally:
+            if temporary is not None:
+                temporary.unlink(missing_ok=True)
+        return f"exomem-consolidation-preimage://sha256/{digest}"
 
 
 def _request_refs(request: ConsolidationIntakeRequest) -> tuple[str, str]:

--- a/src/exomem/governance/consolidation_preimage.py
+++ b/src/exomem/governance/consolidation_preimage.py
@@ -1,0 +1,612 @@
+"""Complete private destination preimages for governed vault consolidation.
+
+The manifest is published only after every approved canonical byte has been
+copied into independent content-addressed storage and the live destination has
+revalidated against the plan-bound snapshot.  Run, receipt, seal, and journal
+state remain outside the byte census; their semantic bindings are explicit
+manifest fields instead.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import tempfile
+import unicodedata
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import NoReturn
+
+from .. import hosted_portability
+from ..kbdir import kb_dirname
+from . import consolidation_fingerprints, consolidation_intake
+from .projections import ProjectionCanonicalizationError, canonical_jcs
+
+DESTINATION_PREIMAGE_SCHEMA = "exomem.consolidation-destination-preimage/v1"
+
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_EVENT_ID = re.compile(r"[0-9a-f]{64}:committed\Z")
+_OBJECT_REF = re.compile(r"exomem-consolidation-object://sha256/([0-9a-f]{64})\Z")
+_PREIMAGE_REF = re.compile(r"exomem-consolidation-preimage://sha256/([0-9a-f]{64})\Z")
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_MAX_MANIFEST_BYTES = 64 * 1024 * 1024
+_MANIFEST_FIELDS = frozenset(
+    {
+        "schema",
+        "run_id",
+        "operation_id",
+        "plan_digest",
+        "control_basis_digest",
+        "semantic_predecessor_event_id",
+        "semantic_predecessor_digest",
+        "destination_snapshot_fingerprint",
+        "destination_census_digest",
+        "entry_count",
+        "total_bytes",
+        "entries",
+    }
+)
+_ENTRY_FIELDS = frozenset({"path", "size", "sha256", "artifact_ref"})
+
+__all__ = [
+    "DESTINATION_PREIMAGE_SCHEMA",
+    "ConsolidationPreimageUnavailable",
+    "DestinationPreimage",
+    "DestinationPreimageBinding",
+    "DestinationPreimageEntry",
+    "DestinationPreimageLimits",
+    "materialize_local_destination_preimage",
+    "verify_destination_preimage",
+]
+
+
+class ConsolidationPreimageUnavailable(RuntimeError):
+    """Stable, content-free refusal for incomplete or stale preimage state."""
+
+    code = "CONSOLIDATION_PREIMAGE_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__("consolidation preimage is unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class DestinationPreimageBinding:
+    run_id: str
+    operation_id: str
+    plan_digest: str
+    control_basis_digest: str
+    semantic_predecessor_event_id: str
+    semantic_predecessor_digest: str
+    destination_snapshot_fingerprint: str
+    destination_census_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class DestinationPreimageLimits:
+    max_files: int = 100_000
+    max_total_bytes: int = _MAX_SAFE_INTEGER
+    minimum_free_bytes: int = 64 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class DestinationPreimageEntry:
+    path: str
+    size: int
+    sha256: str
+    artifact_ref: str
+
+
+@dataclass(frozen=True, slots=True)
+class DestinationPreimage:
+    schema: str
+    binding: DestinationPreimageBinding
+    destination_census_digest: str
+    entry_count: int
+    total_bytes: int
+    entries: tuple[DestinationPreimageEntry, ...]
+    manifest_digest: str
+    manifest_ref: str
+
+
+@dataclass(frozen=True, slots=True)
+class _MaterialSource:
+    entry: consolidation_fingerprints.CanonicalCensusEntry
+    source_path: Path | None
+    source_signature: tuple[int, int, int, int, int, int] | None
+    content: bytes | None
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationPreimageUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _uuid4(value: object) -> str:
+    if not isinstance(value, str) or value != value.lower():
+        _fail()
+    try:
+        parsed = uuid.UUID(value)
+    except (AttributeError, ValueError):
+        _fail()
+    if parsed.version != 4 or str(parsed) != value:
+        _fail()
+    return value
+
+
+def _integer(value: object, *, minimum: int = 0) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < minimum
+        or value > _MAX_SAFE_INTEGER
+    ):
+        _fail()
+    return value
+
+
+def _path(value: object) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value or "\\" in value:
+        _fail()
+    normalized = unicodedata.normalize("NFC", value)
+    parsed = PurePosixPath(value)
+    if (
+        normalized != value
+        or parsed.is_absolute()
+        or parsed.as_posix() != value
+        or any(part in {"", ".", ".."} for part in parsed.parts)
+    ):
+        _fail()
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        _fail()
+    return value
+
+
+def _binding(value: object) -> DestinationPreimageBinding:
+    if not isinstance(value, DestinationPreimageBinding):
+        _fail()
+    return DestinationPreimageBinding(
+        run_id=_uuid4(value.run_id),
+        operation_id=_uuid4(value.operation_id),
+        plan_digest=_digest(value.plan_digest),
+        control_basis_digest=_digest(value.control_basis_digest),
+        semantic_predecessor_event_id=(
+            value.semantic_predecessor_event_id
+            if isinstance(value.semantic_predecessor_event_id, str)
+            and _EVENT_ID.fullmatch(value.semantic_predecessor_event_id) is not None
+            else _fail()
+        ),
+        semantic_predecessor_digest=_digest(value.semantic_predecessor_digest),
+        destination_snapshot_fingerprint=_digest(
+            value.destination_snapshot_fingerprint
+        ),
+        destination_census_digest=_digest(value.destination_census_digest),
+    )
+
+
+def _limits(value: object) -> DestinationPreimageLimits:
+    if not isinstance(value, DestinationPreimageLimits):
+        _fail()
+    return DestinationPreimageLimits(
+        max_files=_integer(value.max_files, minimum=1),
+        max_total_bytes=_integer(value.max_total_bytes),
+        minimum_free_bytes=_integer(value.minimum_free_bytes),
+    )
+
+
+def _binding_dict(value: DestinationPreimageBinding) -> dict[str, str]:
+    return {
+        "run_id": value.run_id,
+        "operation_id": value.operation_id,
+        "plan_digest": value.plan_digest,
+        "control_basis_digest": value.control_basis_digest,
+        "semantic_predecessor_event_id": value.semantic_predecessor_event_id,
+        "semantic_predecessor_digest": value.semantic_predecessor_digest,
+        "destination_snapshot_fingerprint": value.destination_snapshot_fingerprint,
+        "destination_census_digest": value.destination_census_digest,
+    }
+
+
+def _entry_dict(value: DestinationPreimageEntry) -> dict[str, str | int]:
+    return {
+        "path": value.path,
+        "size": value.size,
+        "sha256": value.sha256,
+        "artifact_ref": value.artifact_ref,
+    }
+
+
+def _canonical(value: object) -> bytes:
+    try:
+        return canonical_jcs(value)
+    except ProjectionCanonicalizationError:
+        _fail()
+
+
+def _manifest_value(
+    binding: DestinationPreimageBinding,
+    entries: tuple[DestinationPreimageEntry, ...],
+) -> dict[str, object]:
+    total = sum(item.size for item in entries)
+    return {
+        "schema": DESTINATION_PREIMAGE_SCHEMA,
+        **_binding_dict(binding),
+        "entry_count": len(entries),
+        "total_bytes": total,
+        "entries": [_entry_dict(item) for item in entries],
+    }
+
+
+def _available_bytes(path: Path) -> int:
+    candidate = Path(path).absolute()
+    while not candidate.exists() and candidate != candidate.parent:
+        candidate = candidate.parent
+    try:
+        return shutil.disk_usage(candidate).free
+    except OSError:
+        _fail()
+
+
+def _review_state_path() -> str:
+    return f"{kb_dirname()}/.review-state.json"
+
+
+def _policy_path(relative: str) -> str:
+    return _path(f"{kb_dirname()}/_Governance/{relative}")
+
+
+def _sample_material(
+    vault_root: Path,
+    *,
+    now: int,
+    portability_limits: hosted_portability.PortabilityLimits | None,
+) -> tuple[
+    consolidation_fingerprints.DestinationSnapshot,
+    consolidation_fingerprints.CanonicalCensus,
+    tuple[_MaterialSource, ...],
+]:
+    effective = portability_limits or hosted_portability.PortabilityLimits()
+    hosted_portability._validate_limits(effective)  # noqa: SLF001
+    snapshot = consolidation_fingerprints.load_local_destination_snapshot(
+        vault_root,
+        now=now,
+        limits=effective,
+    )
+    active = consolidation_fingerprints._load_active_policy_snapshot(  # noqa: SLF001
+        vault_root,
+        now=now,
+    )
+    snapshots = hosted_portability._enumerate_source(vault_root, effective)  # noqa: SLF001
+    materials: list[_MaterialSource] = []
+    for item in snapshots:
+        if not (
+            item.classification == hosted_portability.ArtifactClass.CANONICAL.value
+            or item.path == _review_state_path()
+        ):
+            continue
+        materials.append(
+            _MaterialSource(
+                entry=consolidation_fingerprints.CanonicalCensusEntry(
+                    path=item.path,
+                    entry_type="file",
+                    size=item.size,
+                    sha256=item.sha256,
+                ),
+                source_path=item.source_path,
+                source_signature=item.source_signature,
+                content=None,
+            )
+        )
+    for relative, content in active.source_documents:
+        if not isinstance(relative, str) or not isinstance(content, bytes):
+            _fail()
+        materials.append(
+            _MaterialSource(
+                entry=consolidation_fingerprints.CanonicalCensusEntry(
+                    path=_policy_path(relative),
+                    entry_type="file",
+                    size=len(content),
+                    sha256=hashlib.sha256(content).hexdigest(),
+                ),
+                source_path=None,
+                source_signature=None,
+                content=content,
+            )
+        )
+    census = consolidation_fingerprints.canonical_content_census(
+        tuple(item.entry for item in materials)
+    )
+    by_path = {item.entry.path: item for item in materials}
+    if len(by_path) != len(materials) or census.digest != snapshot.canonical_census_digest:
+        _fail()
+    return snapshot, census, tuple(by_path[item.path] for item in census.entries)
+
+
+def _copy_live_source(source: _MaterialSource, staged: Path) -> None:
+    if source.source_path is None or source.source_signature is None:
+        _fail()
+    descriptor: int | None = None
+    try:
+        descriptor, signature = hosted_portability._open_regular_source(  # noqa: SLF001
+            source.source_path,
+            expected_signature=source.source_signature,
+        )
+        digest = hashlib.sha256()
+        size = 0
+        with staged.open("xb") as output:
+            while chunk := os.read(descriptor, 1024 * 1024):
+                output.write(chunk)
+                digest.update(chunk)
+                size += len(chunk)
+            output.flush()
+            os.fsync(output.fileno())
+        after = hosted_portability._source_signature(os.fstat(descriptor))  # noqa: SLF001
+        if (
+            after != signature
+            or size != source.entry.size
+            or digest.hexdigest() != source.entry.sha256
+        ):
+            _fail()
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _write_material(source: _MaterialSource, staged: Path) -> None:
+    if source.content is None:
+        _copy_live_source(source, staged)
+        return
+    try:
+        with staged.open("xb") as output:
+            output.write(source.content)
+            output.flush()
+            os.fsync(output.fileno())
+    except OSError:
+        _fail()
+    if (
+        len(source.content) != source.entry.size
+        or hashlib.sha256(source.content).hexdigest() != source.entry.sha256
+    ):
+        _fail()
+
+
+def _result_from_value(
+    value: Mapping[str, object],
+    *,
+    manifest_digest: str,
+    manifest_ref: str,
+) -> DestinationPreimage:
+    if set(value) != _MANIFEST_FIELDS or value.get("schema") != DESTINATION_PREIMAGE_SCHEMA:
+        _fail()
+    binding = _binding(
+        DestinationPreimageBinding(
+            run_id=value.get("run_id"),  # type: ignore[arg-type]
+            operation_id=value.get("operation_id"),  # type: ignore[arg-type]
+            plan_digest=value.get("plan_digest"),  # type: ignore[arg-type]
+            control_basis_digest=value.get("control_basis_digest"),  # type: ignore[arg-type]
+            semantic_predecessor_event_id=value.get("semantic_predecessor_event_id"),  # type: ignore[arg-type]
+            semantic_predecessor_digest=value.get("semantic_predecessor_digest"),  # type: ignore[arg-type]
+            destination_snapshot_fingerprint=value.get("destination_snapshot_fingerprint"),  # type: ignore[arg-type]
+            destination_census_digest=value.get("destination_census_digest"),  # type: ignore[arg-type]
+        )
+    )
+    raw_entries = value.get("entries")
+    if not isinstance(raw_entries, list):
+        _fail()
+    entries: list[DestinationPreimageEntry] = []
+    seen: set[str] = set()
+    folded: set[str] = set()
+    for raw in raw_entries:
+        if not isinstance(raw, dict) or set(raw) != _ENTRY_FIELDS:
+            _fail()
+        path = _path(raw["path"])
+        digest = _digest(raw["sha256"])
+        size = _integer(raw["size"])
+        artifact_ref = raw["artifact_ref"]
+        match = _OBJECT_REF.fullmatch(artifact_ref) if isinstance(artifact_ref, str) else None
+        if match is None or match.group(1) != digest:
+            _fail()
+        collision = path.casefold()
+        if path in seen or collision in folded:
+            _fail()
+        seen.add(path)
+        folded.add(collision)
+        entries.append(
+            DestinationPreimageEntry(
+                path=path,
+                size=size,
+                sha256=digest,
+                artifact_ref=artifact_ref,
+            )
+        )
+    ordered = tuple(sorted(entries, key=lambda item: item.path))
+    if tuple(entries) != ordered:
+        _fail()
+    count = _integer(value.get("entry_count"))
+    total = _integer(value.get("total_bytes"))
+    if count != len(ordered) or total != sum(item.size for item in ordered):
+        _fail()
+    census = consolidation_fingerprints.canonical_content_census(
+        tuple(
+            consolidation_fingerprints.CanonicalCensusEntry(
+                path=item.path,
+                entry_type="file",
+                size=item.size,
+                sha256=item.sha256,
+            )
+            for item in ordered
+        )
+    )
+    if census.digest != binding.destination_census_digest:
+        _fail()
+    return DestinationPreimage(
+        schema=DESTINATION_PREIMAGE_SCHEMA,
+        binding=binding,
+        destination_census_digest=binding.destination_census_digest,
+        entry_count=count,
+        total_bytes=total,
+        entries=ordered,
+        manifest_digest=_digest(manifest_digest),
+        manifest_ref=manifest_ref,
+    )
+
+
+def materialize_local_destination_preimage(
+    vault_root: Path | str,
+    *,
+    binding: DestinationPreimageBinding,
+    artifact_store: consolidation_intake.PrivateConsolidationArtifactStore,
+    now: int,
+    portability_limits: hosted_portability.PortabilityLimits | None = None,
+    resource_limits: DestinationPreimageLimits | None = None,
+) -> DestinationPreimage:
+    """Copy and publish one complete plan-bound destination preimage."""
+
+    checked_binding = _binding(binding)
+    checked_limits = _limits(resource_limits or DestinationPreimageLimits())
+    if not isinstance(artifact_store, consolidation_intake.PrivateConsolidationArtifactStore):
+        _fail()
+    root = Path(vault_root)
+    try:
+        first_snapshot, census, materials = _sample_material(
+            root,
+            now=now,
+            portability_limits=portability_limits,
+        )
+        if (
+            first_snapshot.digest != checked_binding.destination_snapshot_fingerprint
+            or census.digest != checked_binding.destination_census_digest
+            or len(materials) > checked_limits.max_files
+        ):
+            _fail()
+        total_bytes = sum(item.entry.size for item in materials)
+        if total_bytes > checked_limits.max_total_bytes:
+            _fail()
+        planned_entries = tuple(
+            DestinationPreimageEntry(
+                path=item.entry.path,
+                size=item.entry.size,
+                sha256=item.entry.sha256,
+                artifact_ref=(
+                    "exomem-consolidation-object://sha256/"
+                    f"{item.entry.sha256}"
+                ),
+            )
+            for item in materials
+        )
+        manifest_bytes = _canonical(_manifest_value(checked_binding, planned_entries))
+        if len(manifest_bytes) > _MAX_MANIFEST_BYTES:
+            _fail()
+        required = total_bytes + len(manifest_bytes) + checked_limits.minimum_free_bytes
+        if required > _MAX_SAFE_INTEGER or _available_bytes(artifact_store.root) < required:
+            _fail()
+
+        artifact_store._ensure()  # noqa: SLF001 - shared private-store boundary
+        transaction = Path(tempfile.mkdtemp(prefix=".preimage-build-", dir=artifact_store.root))
+        os.chmod(transaction, 0o700)
+        try:
+            for ordinal, (material, planned) in enumerate(
+                zip(materials, planned_entries, strict=True)
+            ):
+                staged = transaction / f"{ordinal:06d}.object"
+                _write_material(material, staged)
+                artifact_ref = artifact_store.install_object_file(
+                    staged,
+                    expected_digest=material.entry.sha256,
+                )
+                if artifact_ref != planned.artifact_ref:
+                    _fail()
+                staged.unlink(missing_ok=True)
+
+            final_snapshot, final_census, _final_material = _sample_material(
+                root,
+                now=now,
+                portability_limits=portability_limits,
+            )
+            if final_snapshot != first_snapshot or final_census != census:
+                _fail()
+            manifest_ref = artifact_store.install_preimage_bytes(manifest_bytes)
+        finally:
+            shutil.rmtree(transaction, ignore_errors=True)
+        return verify_destination_preimage(
+            manifest_ref,
+            binding=checked_binding,
+            artifact_store=artifact_store,
+        )
+    except ConsolidationPreimageUnavailable:
+        raise
+    except (
+        consolidation_fingerprints.ConsolidationFingerprintUnavailable,
+        consolidation_intake.ConsolidationIntakeUnavailable,
+        hosted_portability.PortabilityError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ):
+        _fail()
+
+
+def verify_destination_preimage(
+    manifest_ref: str,
+    *,
+    binding: DestinationPreimageBinding,
+    artifact_store: consolidation_intake.PrivateConsolidationArtifactStore,
+) -> DestinationPreimage:
+    """Re-read one manifest and every object before any publication may begin."""
+
+    checked_binding = _binding(binding)
+    if not isinstance(artifact_store, consolidation_intake.PrivateConsolidationArtifactStore):
+        _fail()
+    match = _PREIMAGE_REF.fullmatch(manifest_ref) if isinstance(manifest_ref, str) else None
+    if match is None:
+        _fail()
+    try:
+        manifest_path = artifact_store.resolve_preimage(manifest_ref)
+        raw = manifest_path.read_bytes()
+        if len(raw) > _MAX_MANIFEST_BYTES or hashlib.sha256(raw).hexdigest() != match.group(1):
+            _fail()
+        parsed = json.loads(raw)
+        if not isinstance(parsed, Mapping) or _canonical(parsed) != raw:
+            _fail()
+        result = _result_from_value(
+            parsed,
+            manifest_digest=match.group(1),
+            manifest_ref=manifest_ref,
+        )
+        if result.binding != checked_binding:
+            _fail()
+        for entry in result.entries:
+            object_path = artifact_store.resolve_object(entry.artifact_ref)
+            info = object_path.lstat()
+            if (
+                stat.S_ISLNK(info.st_mode)
+                or not stat.S_ISREG(info.st_mode)
+                or info.st_size != entry.size
+            ):
+                _fail()
+        return result
+    except ConsolidationPreimageUnavailable:
+        raise
+    except (
+        consolidation_fingerprints.ConsolidationFingerprintUnavailable,
+        consolidation_intake.ConsolidationIntakeUnavailable,
+        json.JSONDecodeError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ):
+        _fail()

--- a/tests/test_consolidation_preimage.py
+++ b/tests/test_consolidation_preimage.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import hashlib
+import importlib
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from exomem.governance import consolidation_fingerprints, consolidation_intake
+from exomem.governance.consolidation_identity import ConsolidationCellIdentity
+
+RUN_ID = "00000000-0000-4000-8000-000000000081"
+OPERATION_ID = "00000000-0000-4000-8000-000000000082"
+_D1 = hashlib.sha256(b"preimage-one").hexdigest()
+_D2 = hashlib.sha256(b"preimage-two").hexdigest()
+_D3 = hashlib.sha256(b"preimage-three").hexdigest()
+_D4 = hashlib.sha256(b"preimage-four").hexdigest()
+_ACTIVE_POLICY = b"governance_version: 1\n"
+
+
+def _module():
+    name = "exomem.governance.consolidation_preimage"
+    assert importlib.util.find_spec(name) is not None, "destination preimage module is missing"
+    return importlib.import_module(name)
+
+
+def _identity(tmp_path: Path) -> ConsolidationCellIdentity:
+    return ConsolidationCellIdentity(
+        schema="exomem.consolidation-cell-identity/v1",
+        cell_id="cell-destination-01",
+        vault_id="vault-destination-01",
+        installation_id="installation-destination-01",
+        installation_generation=3,
+        active_fence_digest=_D1,
+        root_binding_id="attachment-destination-01",
+        root_binding_digest=_D2,
+        machine_key_id="key-destination-01",
+        adoption_census_digest=_D3,
+        clone_of_vault_id=None,
+        clone_of_installation_id=None,
+        clone_of_snapshot_digest=None,
+        created_at=1_777_777_777,
+        authentication_algorithm="HMAC-SHA256",
+        record_digest=_D4,
+        identity_path=tmp_path / "identity.json",
+    )
+
+
+def _write_destination(vault: Path) -> None:
+    files: dict[str, bytes] = {
+        "Knowledge Base/Notes/insight.md": (
+            b"---\ntype: insight\nid: insight-1\n"
+            b"citations:\n  - '[[Knowledge Base/Sources/raw]]'\n"
+            b"relations:\n  supports:\n    - '[[Knowledge Base/Evidence/case.bin]]'\n"
+            b"history:\n  - created\n---\n# Insight\nCanonical metadata survives.\n"
+        ),
+        "Knowledge Base/Notes/caf\u00e9.md": b"NFC path\n",
+        "Knowledge Base/Notes/empty.bin": b"",
+        "Knowledge Base/Notes/blob.bin": b"\x00\xffbinary\r\n",
+        "Knowledge Base/Sources/raw.md": b"raw source\n",
+        "Knowledge Base/Evidence/case.bin": b"evidence\x00bytes",
+        "Knowledge Base/Records/events/item.json": b'{"id":"event-1"}',
+        "Knowledge Base/Media/image.png": b"\x89PNG\r\n\x1a\n",
+        "Knowledge Base/Media/image.png.md": b"---\ntype: source\n---\nmedia sidecar\n",
+        "Knowledge Base/_access.yaml": b"readonly: []\n",
+        "Knowledge Base/.review-state.json": b'{"version":2,"records":{}}',
+        # These are control/derived state and must never enter the preimage.
+        "Knowledge Base/_Consolidation/runs/older/state.json": b"older run",
+        "Knowledge Base/_Governance/pending.yaml": b"unapproved pending policy",
+        "Knowledge Base/.graph-commit-receipts/0123456789abcdef01234567.json": b"receipt",
+        "Knowledge Base/.graph.sqlite": b"derived graph",
+    }
+    for relative, content in files.items():
+        target = vault / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
+
+def _patch_destination(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        consolidation_fingerprints,
+        "load_local_identity",
+        lambda *_args, **_kwargs: _identity(tmp_path),
+    )
+    monkeypatch.setattr(
+        consolidation_fingerprints,
+        "_load_active_policy_snapshot",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            active=SimpleNamespace(
+                logical_vault_id="vault-destination-01",
+                policy_fingerprint=_D1,
+            ),
+            source_documents=(("rules/default.yaml", _ACTIVE_POLICY),),
+        ),
+    )
+
+
+def _prepared(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _module()
+    vault = tmp_path / "vault"
+    _write_destination(vault)
+    _patch_destination(monkeypatch, tmp_path)
+    snapshot = consolidation_fingerprints.load_local_destination_snapshot(vault, now=123)
+    store = consolidation_intake.PrivateConsolidationArtifactStore(
+        tmp_path / "private-artifacts",
+        active_vault_roots=(vault,),
+    )
+    binding = module.DestinationPreimageBinding(
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        plan_digest=_D2,
+        control_basis_digest=_D3,
+        semantic_predecessor_event_id=f"{_D4}:committed",
+        semantic_predecessor_digest=_D1,
+        destination_snapshot_fingerprint=snapshot.digest,
+        destination_census_digest=snapshot.canonical_census_digest,
+    )
+    return module, vault, store, binding
+
+
+def test_materializes_every_canonical_destination_byte_and_publishes_manifest_last(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, vault, store, binding = _prepared(tmp_path, monkeypatch)
+
+    result = module.materialize_local_destination_preimage(
+        vault,
+        binding=binding,
+        artifact_store=store,
+        now=123,
+    )
+    verified = module.verify_destination_preimage(
+        result.manifest_ref,
+        binding=binding,
+        artifact_store=store,
+    )
+
+    assert verified == result
+    assert result.schema == "exomem.consolidation-destination-preimage/v1"
+    assert result.destination_census_digest == binding.destination_census_digest
+    paths = {entry.path for entry in result.entries}
+    assert {
+        "Knowledge Base/Notes/insight.md",
+        "Knowledge Base/Notes/empty.bin",
+        "Knowledge Base/Notes/blob.bin",
+        "Knowledge Base/Notes/caf\u00e9.md",
+        "Knowledge Base/Sources/raw.md",
+        "Knowledge Base/Evidence/case.bin",
+        "Knowledge Base/Records/events/item.json",
+        "Knowledge Base/Media/image.png",
+        "Knowledge Base/Media/image.png.md",
+        "Knowledge Base/_access.yaml",
+        "Knowledge Base/.review-state.json",
+        "Knowledge Base/_Governance/rules/default.yaml",
+    } <= paths
+    assert all("_Consolidation/" not in path for path in paths)
+    assert all(".graph-commit-receipts/" not in path for path in paths)
+    assert "Knowledge Base/.graph.sqlite" not in paths
+
+    policy = next(
+        entry
+        for entry in result.entries
+        if entry.path == "Knowledge Base/_Governance/rules/default.yaml"
+    )
+    assert store.resolve_object(policy.artifact_ref).read_bytes() == _ACTIVE_POLICY
+    assert result.entry_count == len(result.entries)
+    assert result.total_bytes == sum(entry.size for entry in result.entries)
+
+
+def test_preimage_objects_are_independent_of_later_destination_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, vault, store, binding = _prepared(tmp_path, monkeypatch)
+    original = (vault / "Knowledge Base/Notes/insight.md").read_bytes()
+    result = module.materialize_local_destination_preimage(
+        vault,
+        binding=binding,
+        artifact_store=store,
+        now=123,
+    )
+    entry = next(
+        item for item in result.entries if item.path == "Knowledge Base/Notes/insight.md"
+    )
+
+    (vault / entry.path).write_bytes(b"changed after materialization")
+
+    assert store.resolve_object(entry.artifact_ref).read_bytes() == original
+    assert module.verify_destination_preimage(
+        result.manifest_ref,
+        binding=binding,
+        artifact_store=store,
+    ) == result
+
+
+def test_stale_snapshot_refuses_before_private_artifact_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, vault, store, binding = _prepared(tmp_path, monkeypatch)
+    (vault / "Knowledge Base/Notes/insight.md").write_bytes(b"drifted")
+
+    with pytest.raises(module.ConsolidationPreimageUnavailable):
+        module.materialize_local_destination_preimage(
+            vault,
+            binding=binding,
+            artifact_store=store,
+            now=123,
+        )
+
+    assert not store.root.exists()
+
+
+@pytest.mark.parametrize("resource_case", ["quota", "space"])
+def test_capacity_refusal_precedes_copy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    resource_case: str,
+) -> None:
+    module, vault, store, binding = _prepared(tmp_path, monkeypatch)
+    limits = module.DestinationPreimageLimits(
+        max_files=100_000,
+        max_total_bytes=1 if resource_case == "quota" else (1 << 40),
+        minimum_free_bytes=0,
+    )
+    if resource_case == "space":
+        monkeypatch.setattr(module, "_available_bytes", lambda _path: 0)
+
+    with pytest.raises(module.ConsolidationPreimageUnavailable):
+        module.materialize_local_destination_preimage(
+            vault,
+            binding=binding,
+            artifact_store=store,
+            now=123,
+            resource_limits=limits,
+        )
+
+    assert not store.root.exists()
+
+
+def test_unsafe_link_or_changed_path_refuses_without_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, vault, store, binding = _prepared(tmp_path, monkeypatch)
+    target = vault / "Knowledge Base/Notes/insight.md"
+    target.unlink()
+    target.symlink_to(vault / "Knowledge Base/Sources/raw.md")
+
+    with pytest.raises(module.ConsolidationPreimageUnavailable):
+        module.materialize_local_destination_preimage(
+            vault,
+            binding=binding,
+            artifact_store=store,
+            now=123,
+        )
+
+    assert not (store.root / "preimages").exists()
+
+
+@pytest.mark.parametrize("damage", ["missing-object", "changed-object", "manifest"])
+def test_verification_refuses_lost_partial_or_mismatched_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    damage: str,
+) -> None:
+    module, vault, store, binding = _prepared(tmp_path, monkeypatch)
+    result = module.materialize_local_destination_preimage(
+        vault,
+        binding=binding,
+        artifact_store=store,
+        now=123,
+    )
+    if damage == "manifest":
+        store.resolve_preimage(result.manifest_ref).write_bytes(b"{}")
+    else:
+        object_path = store.resolve_object(result.entries[0].artifact_ref)
+        if damage == "missing-object":
+            object_path.unlink()
+        else:
+            original = object_path.read_bytes()
+            replacement = (b"x" if original[:1] != b"x" else b"y") + original[1:]
+            object_path.write_bytes(replacement)
+
+    with pytest.raises(module.ConsolidationPreimageUnavailable):
+        module.verify_destination_preimage(
+            result.manifest_ref,
+            binding=binding,
+            artifact_store=store,
+        )
+
+
+def test_control_and_receipt_churn_does_not_change_preimage_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, vault, store, binding = _prepared(tmp_path, monkeypatch)
+    first = module.materialize_local_destination_preimage(
+        vault,
+        binding=binding,
+        artifact_store=store,
+        now=123,
+    )
+    (vault / "Knowledge Base/_Consolidation/runs/older/state.json").write_bytes(
+        b"new control state"
+    )
+    (vault / "Knowledge Base/.graph-commit-receipts/0123456789abcdef01234567.json").write_bytes(
+        b"new physical receipt head"
+    )
+
+    replay = module.materialize_local_destination_preimage(
+        vault,
+        binding=binding,
+        artifact_store=store,
+        now=123,
+    )
+
+    assert replay == first


### PR DESCRIPTION
## Summary

- materialize every approved canonical destination byte into independent content-addressed private storage
- bind the preimage manifest to the plan, immutable control basis, semantic predecessor, destination snapshot, and canonical census
- refuse stale snapshots, unsafe links, resource exhaustion, missing/corrupt objects, and non-canonical manifests before publication
- exclude consolidation control, receipt, and derived state while preserving active policy, access/review state, Sources, Evidence, Records, media, empty files, and binary bytes

Stacked after #930. This adds the verified preimage substrate only; it does not expose a product command, perform cutover, or touch any live vault.

## Verification

- red-first: missing preimage module failed before implementation
- destination preimage suite: 10 passed
- all consolidation suites: 374 passed
- Ruff on all changed Python files
- targeted MyPy on both changed source modules
- strict OpenSpec validation
- repository and built-artifact privacy validation
- sdist and wheel build
- git diff --check