### PR TITLE
feat(governance): enforce policy-first consolidation batches

### DIFF
--- a/openspec/changes/add-governed-vault-consolidation/tasks.md
+++ b/openspec/changes/add-governed-vault-consolidation/tasks.md
@@ -546,7 +546,7 @@ binds that reference and observed digest; no caller field selects K.
   predecessor/outer receipt references separately; prove no restore touches an
   older or concurrent run/evidence subtree and no unrelated physical-head append
   changes the canonical preimage.
-- [ ] 7.3 Add a red ordering test that instruments the existing governance
+- [x] 7.3 Add a red ordering test that instruments the existing governance
   transaction and `batch_atomic_write`: restrictive policy intent/prepare/activate/
   critical terminal must finish before the first content batch call. Assert the
   approved deterministic partition and each batch's prior/prepared/final/action

--- a/src/exomem/governance/consolidation_plan.py
+++ b/src/exomem/governance/consolidation_plan.py
@@ -25,11 +25,18 @@ PLAN_SCHEMA = "exomem.consolidation-plan/v1"
 CONTROL_BASIS_SCHEMA = "exomem.consolidation-control-basis/v1"
 PLAN_INPUT_SET_SCHEMA = "exomem.consolidation-plan-input-set/v1"
 PLAN_SUCCESSOR_AUTOMATON_SCHEMA = "exomem.consolidation-plan-successor-automaton/v1"
+JOURNAL_BATCH_PARTITION_SCHEMA = "exomem.consolidation-journal-batch-partition/v1"
+MAX_CONTENT_BATCH_ACTIONS = 128
 
 _PLAN_DOMAIN = PLAN_SCHEMA.encode("ascii")
 _CONTROL_BASIS_DOMAIN = CONTROL_BASIS_SCHEMA.encode("ascii")
 _PLAN_INPUT_SET_DOMAIN = PLAN_INPUT_SET_SCHEMA.encode("ascii")
 _AUTOMATON_DOMAIN = PLAN_SUCCESSOR_AUTOMATON_SCHEMA.encode("ascii")
+_JOURNAL_BATCH_PARTITION_DOMAIN = JOURNAL_BATCH_PARTITION_SCHEMA.encode("ascii")
+_BATCH_ACTION_SET_DOMAIN = b"exomem.consolidation-content-batch-actions/v1"
+_BATCH_PRIOR_DOMAIN = b"exomem.consolidation-content-batch-prior/v1"
+_BATCH_PREPARED_DOMAIN = b"exomem.consolidation-content-batch-prepared/v1"
+_BATCH_FINAL_DOMAIN = b"exomem.consolidation-content-batch-final/v1"
 _IMPACT_SUMMARY_DOMAIN = b"exomem.consolidation-impact-summary/v1"
 _RENDERING_DEFINITION_DOMAIN = b"exomem.consolidation-rendering-definition/v1"
 _RENDER_SECTION_DOMAIN = b"exomem.consolidation-render-section/v1"
@@ -186,6 +193,8 @@ _SECTION_FIELDS = frozenset(
 
 __all__ = [
     "CONTROL_BASIS_SCHEMA",
+    "JOURNAL_BATCH_PARTITION_SCHEMA",
+    "MAX_CONTENT_BATCH_ACTIONS",
     "PLAN_INPUT_SET_SCHEMA",
     "PLAN_SCHEMA",
     "PLAN_SUCCESSOR_AUTOMATON_SCHEMA",
@@ -197,10 +206,12 @@ __all__ = [
     "RENDER_PAGE_SIZE",
     "RENDER_SECTION_IDS",
     "canonical_closed_jcs",
+    "derive_journal_batch_partition",
     "derive_rendering_definition",
     "materialize_plan",
     "parse_canonical_plan",
     "parse_control_basis",
+    "parse_journal_batch_partition",
     "plan_successor_automaton",
     "render_plan_page",
 ]
@@ -446,6 +457,102 @@ def _validate_content_actions(value: object) -> tuple[Mapping[str, object], ...]
             _fail()
         normalized.append(item)
     return tuple(normalized)
+
+
+def derive_journal_batch_partition(value: object) -> CanonicalObject:
+    """Derive the only approved content-batch partition and state fingerprints."""
+
+    actions = _validate_content_actions(value)
+    grouped: list[list[Mapping[str, object]]] = []
+    expected_batch = 0
+    for action in actions:
+        batch_ordinal = _integer(action["batch_ordinal"], maximum=(1 << 31) - 1)
+        if batch_ordinal == expected_batch:
+            grouped.append([action])
+            expected_batch += 1
+        elif batch_ordinal == expected_batch - 1 and grouped:
+            grouped[-1].append(action)
+        else:
+            _fail()
+
+    batches: list[dict[str, object]] = []
+    for batch_ordinal, batch_actions in enumerate(grouped):
+        if len(batch_actions) > MAX_CONTENT_BATCH_ACTIONS:
+            _fail()
+        action_set = _canonical_object(
+            {
+                "schema": "exomem.consolidation-content-batch-actions/v1",
+                "batch_ordinal": batch_ordinal,
+                "actions": tuple(batch_actions),
+            },
+            _BATCH_ACTION_SET_DOMAIN,
+        )
+        prior_rows = tuple(
+            {
+                "ordinal": action["ordinal"],
+                "object_ref": action["object_ref"],
+                "destination_path": action["destination_path"],
+                "state": action["expected_before_state"],
+                "sha256": action["expected_before_sha256"],
+            }
+            for action in batch_actions
+        )
+        final_rows = tuple(
+            {
+                "ordinal": action["ordinal"],
+                "object_ref": action["object_ref"],
+                "destination_path": action["destination_path"],
+                "state": action["planned_after_state"],
+                "sha256": action["planned_after_sha256"],
+            }
+            for action in batch_actions
+        )
+        prior = _canonical_object(
+            {
+                "schema": "exomem.consolidation-content-batch-prior/v1",
+                "batch_ordinal": batch_ordinal,
+                "entries": prior_rows,
+            },
+            _BATCH_PRIOR_DOMAIN,
+        )
+        prepared = _canonical_object(
+            {
+                "schema": "exomem.consolidation-content-batch-prepared/v1",
+                "batch_ordinal": batch_ordinal,
+                "entries": final_rows,
+            },
+            _BATCH_PREPARED_DOMAIN,
+        )
+        final = _canonical_object(
+            {
+                "schema": "exomem.consolidation-content-batch-final/v1",
+                "batch_ordinal": batch_ordinal,
+                "entries": final_rows,
+            },
+            _BATCH_FINAL_DOMAIN,
+        )
+        batches.append(
+            {
+                "batch_ordinal": batch_ordinal,
+                "first_action_ordinal": batch_actions[0]["ordinal"],
+                "last_action_ordinal": batch_actions[-1]["ordinal"],
+                "action_count": len(batch_actions),
+                "publication_boundary": batch_ordinal == 0,
+                "action_set_digest": action_set.digest,
+                "prior_fingerprint": prior.digest,
+                "prepared_fingerprint": prepared.digest,
+                "final_fingerprint": final.digest,
+            }
+        )
+    return _canonical_object(
+        {
+            "schema": JOURNAL_BATCH_PARTITION_SCHEMA,
+            "action_count": len(actions),
+            "batch_count": len(batches),
+            "batches": tuple(batches),
+        },
+        _JOURNAL_BATCH_PARTITION_DOMAIN,
+    )
 
 
 def _validate_policy_documents(value: object) -> tuple[Mapping[str, object], ...]:
@@ -1043,6 +1150,73 @@ def parse_control_basis(raw: bytes) -> CanonicalObject:
     if control.canonical_bytes != raw:
         _fail()
     return control
+
+
+def parse_journal_batch_partition(raw: bytes) -> CanonicalObject:
+    """Parse one exact canonical batch partition and recompute its framed digest."""
+
+    parsed = _parse_canonical_mapping(raw, maximum=16 * 1024 * 1024)
+    if frozenset(parsed) != {"schema", "action_count", "batch_count", "batches"}:
+        _fail()
+    if parsed["schema"] != JOURNAL_BATCH_PARTITION_SCHEMA:
+        _fail()
+    action_count = _integer(parsed["action_count"], minimum=1)
+    batch_count = _integer(parsed["batch_count"], minimum=1)
+    batches = _sequence(parsed["batches"])
+    fields = frozenset(
+        {
+            "batch_ordinal",
+            "first_action_ordinal",
+            "last_action_ordinal",
+            "action_count",
+            "publication_boundary",
+            "action_set_digest",
+            "prior_fingerprint",
+            "prepared_fingerprint",
+            "final_fingerprint",
+        }
+    )
+    if len(batches) != batch_count:
+        _fail()
+    seen_actions = 0
+    for ordinal, raw_batch in enumerate(batches):
+        batch = _mapping(raw_batch, fields)
+        count = _integer(
+            batch["action_count"],
+            minimum=1,
+            maximum=MAX_CONTENT_BATCH_ACTIONS,
+        )
+        first = _integer(batch["first_action_ordinal"])
+        last = _integer(batch["last_action_ordinal"])
+        if (
+            _integer(batch["batch_ordinal"]) != ordinal
+            or batch["publication_boundary"] is not (ordinal == 0)
+            or first != seen_actions
+            or last != first + count - 1
+        ):
+            _fail()
+        for field in (
+            "action_set_digest",
+            "prior_fingerprint",
+            "prepared_fingerprint",
+            "final_fingerprint",
+        ):
+            _digest(batch[field])
+        if len(
+            {
+                batch["prior_fingerprint"],
+                batch["prepared_fingerprint"],
+                batch["final_fingerprint"],
+            }
+        ) != 3:
+            _fail()
+        seen_actions += count
+    if seen_actions != action_count:
+        _fail()
+    result = _canonical_object(parsed, _JOURNAL_BATCH_PARTITION_DOMAIN)
+    if result.canonical_bytes != raw:
+        _fail()
+    return result
 
 
 def parse_canonical_plan(

--- a/src/exomem/governance/consolidation_saga.py
+++ b/src/exomem/governance/consolidation_saga.py
@@ -1,0 +1,214 @@
+"""Policy-first publication ordering for governed vault consolidation.
+
+This module is deliberately narrower than the complete apply coordinator.  It
+binds the approved deterministic content partition and will not invoke a batch
+publisher until the existing governance transaction returns its exact committed
+policy terminal.  Crash classification, content materialization, and recovery
+remain separate layers built on these immutable batch descriptors.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NoReturn, Protocol
+
+from .. import vault
+from . import consolidation_plan
+
+POLICY_ACTIVATION_TERMINAL_SCHEMA = (
+    "exomem.consolidation-policy-activation-terminal/v1"
+)
+
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_COMMITTED_EVENT = re.compile(r"([0-9a-f]{64}):committed\Z")
+_BATCH_FIELDS = frozenset(
+    {
+        "batch_ordinal",
+        "first_action_ordinal",
+        "last_action_ordinal",
+        "action_count",
+        "publication_boundary",
+        "action_set_digest",
+        "prior_fingerprint",
+        "prepared_fingerprint",
+        "final_fingerprint",
+    }
+)
+
+__all__ = [
+    "POLICY_ACTIVATION_TERMINAL_SCHEMA",
+    "BatchJournal",
+    "ContentBatch",
+    "PolicyActivationTerminal",
+    "PolicyFirstPublicationResult",
+    "PolicyFirstPublicationUnavailable",
+    "publish_policy_first",
+]
+
+
+class PolicyFirstPublicationUnavailable(RuntimeError):
+    """Stable refusal for malformed policy terminals or batch partitions."""
+
+    code = "CONSOLIDATION_PUBLICATION_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__("consolidation publication is unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyActivationTerminal:
+    schema: str
+    policy_fingerprint: str
+    intent_event_id: str
+    prepared_fingerprint: str
+    active_fingerprint: str
+    terminal_event_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ContentBatch:
+    ordinal: int
+    first_action_ordinal: int
+    last_action_ordinal: int
+    action_count: int
+    publication_boundary: bool
+    action_set_digest: str
+    prior_fingerprint: str
+    prepared_fingerprint: str
+    final_fingerprint: str
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyFirstPublicationResult:
+    policy_terminal: PolicyActivationTerminal
+    partition_digest: str
+    publication_boundary_ordinal: int
+    committed_batch_ordinals: tuple[int, ...]
+
+
+class BatchJournal(Protocol):
+    """Durable receipt-first journal boundary supplied by the full coordinator."""
+
+    def prepare_batch(self, batch: ContentBatch) -> None:
+        """Persist the exact intent/prepared transition before publication."""
+
+    def commit_batch(self, batch: ContentBatch) -> None:
+        """Persist the exact final/terminal transition after publication."""
+
+
+def _fail() -> NoReturn:
+    raise PolicyFirstPublicationUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _policy_terminal(
+    value: object,
+    *,
+    expected_policy_fingerprint: str,
+) -> PolicyActivationTerminal:
+    if not isinstance(value, PolicyActivationTerminal):
+        _fail()
+    intent_id = _digest(value.intent_event_id)
+    terminal_match = (
+        _COMMITTED_EVENT.fullmatch(value.terminal_event_id)
+        if isinstance(value.terminal_event_id, str)
+        else None
+    )
+    if (
+        value.schema != POLICY_ACTIVATION_TERMINAL_SCHEMA
+        or value.policy_fingerprint != _digest(expected_policy_fingerprint)
+        or terminal_match is None
+        or terminal_match.group(1) != intent_id
+    ):
+        _fail()
+    return PolicyActivationTerminal(
+        schema=value.schema,
+        policy_fingerprint=value.policy_fingerprint,
+        intent_event_id=intent_id,
+        prepared_fingerprint=_digest(value.prepared_fingerprint),
+        active_fingerprint=_digest(value.active_fingerprint),
+        terminal_event_id=value.terminal_event_id,
+    )
+
+
+def _content_batches(
+    partition: consolidation_plan.CanonicalObject,
+) -> tuple[ContentBatch, ...]:
+    if not isinstance(partition, consolidation_plan.CanonicalObject):
+        _fail()
+    try:
+        checked = consolidation_plan.parse_journal_batch_partition(
+            partition.canonical_bytes
+        )
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    if checked != partition:
+        _fail()
+    raw_batches = checked.preimage["batches"]
+    if not isinstance(raw_batches, tuple):
+        _fail()
+    batches: list[ContentBatch] = []
+    for ordinal, raw in enumerate(raw_batches):
+        if not isinstance(raw, Mapping) or frozenset(raw) != _BATCH_FIELDS:
+            _fail()
+        batches.append(
+            ContentBatch(
+                ordinal=ordinal,
+                first_action_ordinal=int(raw["first_action_ordinal"]),
+                last_action_ordinal=int(raw["last_action_ordinal"]),
+                action_count=int(raw["action_count"]),
+                publication_boundary=raw["publication_boundary"] is True,
+                action_set_digest=_digest(raw["action_set_digest"]),
+                prior_fingerprint=_digest(raw["prior_fingerprint"]),
+                prepared_fingerprint=_digest(raw["prepared_fingerprint"]),
+                final_fingerprint=_digest(raw["final_fingerprint"]),
+            )
+        )
+    return tuple(batches)
+
+
+def publish_policy_first(
+    *,
+    content_actions: object,
+    approved_partition_digest: str,
+    expected_policy_fingerprint: str,
+    activate_policy: Callable[[], PolicyActivationTerminal],
+    journal: BatchJournal,
+    vault_root: Path,
+    materialize_batch: Callable[[ContentBatch], Iterable[vault.PlannedWrite]],
+) -> PolicyFirstPublicationResult:
+    """Activate the reviewed policy terminal before invoking any content batch."""
+
+    partition = consolidation_plan.derive_journal_batch_partition(content_actions)
+    batches = _content_batches(partition)
+    if partition.digest != _digest(approved_partition_digest):
+        _fail()
+    terminal = _policy_terminal(
+        activate_policy(),
+        expected_policy_fingerprint=expected_policy_fingerprint,
+    )
+    committed: list[int] = []
+    for batch in batches:
+        journal.prepare_batch(batch)
+        writes = tuple(materialize_batch(batch))
+        vault.batch_atomic_write(
+            writes,
+            vault_root=Path(vault_root),
+            post_commit_fanout=False,
+        )
+        journal.commit_batch(batch)
+        committed.append(batch.ordinal)
+    return PolicyFirstPublicationResult(
+        policy_terminal=terminal,
+        partition_digest=partition.digest,
+        publication_boundary_ordinal=batches[0].ordinal,
+        committed_batch_ordinals=tuple(committed),
+    )

--- a/tests/test_consolidation_saga.py
+++ b/tests/test_consolidation_saga.py
@@ -9,6 +9,7 @@ VAULT_BINDING = hashlib.sha256(b"saga-vault-binding").hexdigest()
 RUN_ID = "00000000-0000-4000-8000-000000000071"
 OPERATION_ID = "00000000-0000-4000-8000-000000000072"
 JOURNAL_DIGEST = hashlib.sha256(b"saga-journal").hexdigest()
+POLICY_FINGERPRINT = hashlib.sha256(b"saga-policy").hexdigest()
 T0 = "2026-08-28T17:00:00.000Z"
 T1 = "2026-08-28T17:00:01.000Z"
 T2 = "2026-08-28T17:00:02.000Z"
@@ -233,3 +234,258 @@ def test_apply_transition_replay_rejects_a_changed_action(tmp_path: Path) -> Non
             expected_revision=sealing.revision,
         )
     assert store.load(vault_binding_digest=VAULT_BINDING) == sealed
+
+
+def _content_action(
+    ordinal: int,
+    batch_ordinal: int,
+    *,
+    before: str = "present",
+    after: str = "present",
+) -> dict[str, object]:
+    return {
+        "ordinal": ordinal,
+        "batch_ordinal": batch_ordinal,
+        "action": "overwrite",
+        "object_ref": f"source-object-{ordinal}",
+        "source_path": f"Knowledge Base/Notes/source-{ordinal}.md",
+        "destination_path": f"Knowledge Base/Notes/destination-{ordinal}.md",
+        "expected_before_state": before,
+        "expected_before_sha256": (
+            hashlib.sha256(f"before-{ordinal}".encode()).hexdigest()
+            if before == "present"
+            else "0" * 64
+        ),
+        "planned_after_state": after,
+        "planned_after_sha256": (
+            hashlib.sha256(f"after-{ordinal}".encode()).hexdigest()
+            if after == "present"
+            else "0" * 64
+        ),
+    }
+
+
+def test_journal_batch_partition_is_deterministic_and_binds_each_state() -> None:
+    from exomem.governance import consolidation_plan
+
+    actions = (
+        _content_action(0, 0),
+        _content_action(1, 0, before="absent"),
+        _content_action(2, 1, after="absent"),
+    )
+
+    first = consolidation_plan.derive_journal_batch_partition(actions)
+    second = consolidation_plan.derive_journal_batch_partition(
+        tuple(dict(row) for row in actions)
+    )
+
+    assert first == second
+    assert first.digest == "0159532ea78c3e08be2803c955b2f78d03092a049371a1e4611a2078c2db20d2"
+    assert consolidation_plan.parse_journal_batch_partition(first.canonical_bytes) == first
+    assert first.preimage["schema"] == "exomem.consolidation-journal-batch-partition/v1"
+    assert first.preimage["action_count"] == 3
+    assert first.preimage["batch_count"] == 2
+    batches = first.preimage["batches"]
+    assert isinstance(batches, tuple)
+    assert [batch["batch_ordinal"] for batch in batches] == [0, 1]
+    assert [batch["publication_boundary"] for batch in batches] == [True, False]
+    for batch in batches:
+        assert batch["action_set_digest"] not in {
+            batch["prior_fingerprint"],
+            batch["prepared_fingerprint"],
+            batch["final_fingerprint"],
+        }
+        assert len(
+            {
+                batch["prior_fingerprint"],
+                batch["prepared_fingerprint"],
+                batch["final_fingerprint"],
+            }
+        ) == 3
+
+
+@pytest.mark.parametrize(
+    "actions",
+    [
+        (_content_action(0, 1),),
+        (_content_action(0, 0), _content_action(1, 2)),
+        (_content_action(0, 0), _content_action(1, 1), _content_action(2, 0)),
+    ],
+)
+def test_journal_batch_partition_rejects_noncanonical_batch_ordinals(
+    actions: tuple[dict[str, object], ...],
+) -> None:
+    from exomem.governance import consolidation_plan
+
+    with pytest.raises(consolidation_plan.ConsolidationPlanUnavailable):
+        consolidation_plan.derive_journal_batch_partition(actions)
+
+
+def test_journal_batch_partition_has_a_fixed_action_bound() -> None:
+    from exomem.governance import consolidation_plan
+
+    actions = tuple(
+        _content_action(ordinal, 0)
+        for ordinal in range(consolidation_plan.MAX_CONTENT_BATCH_ACTIONS + 1)
+    )
+
+    with pytest.raises(consolidation_plan.ConsolidationPlanUnavailable):
+        consolidation_plan.derive_journal_batch_partition(actions)
+
+
+def test_policy_terminal_precedes_every_content_batch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_plan, consolidation_saga
+
+    actions = (_content_action(0, 0), _content_action(1, 1))
+    partition = consolidation_plan.derive_journal_batch_partition(actions)
+    events: list[str] = []
+
+    def activate_policy() -> consolidation_saga.PolicyActivationTerminal:
+        events.extend(("policy-intent", "policy-prepare", "policy-activate", "policy-terminal"))
+        intent_id = hashlib.sha256(b"policy-intent").hexdigest()
+        return consolidation_saga.PolicyActivationTerminal(
+            schema="exomem.consolidation-policy-activation-terminal/v1",
+            policy_fingerprint=POLICY_FINGERPRINT,
+            intent_event_id=intent_id,
+            prepared_fingerprint=hashlib.sha256(b"policy-prepared").hexdigest(),
+            active_fingerprint=hashlib.sha256(b"policy-active").hexdigest(),
+            terminal_event_id=f"{intent_id}:committed",
+        )
+
+    class Journal:
+        def prepare_batch(self, batch: consolidation_saga.ContentBatch) -> None:
+            expected = partition.preimage["batches"][batch.ordinal]
+            assert batch.action_set_digest == expected["action_set_digest"]
+            assert batch.prior_fingerprint == expected["prior_fingerprint"]
+            assert batch.prepared_fingerprint == expected["prepared_fingerprint"]
+            assert batch.final_fingerprint == expected["final_fingerprint"]
+            assert batch.publication_boundary is (batch.ordinal == 0)
+            events.append(f"journal-prepare:{batch.ordinal}")
+
+        def commit_batch(self, batch: consolidation_saga.ContentBatch) -> None:
+            events.append(f"journal-final:{batch.ordinal}")
+
+    def batch_atomic_write(
+        writes: object,
+        *,
+        vault_root: Path,
+        post_commit_fanout: bool,
+    ) -> list[Path]:
+        assert tuple(writes) == ()  # type: ignore[arg-type]
+        assert vault_root == tmp_path
+        assert post_commit_fanout is False
+        batch_ordinal = sum(event.startswith("batch_atomic_write:") for event in events)
+        events.append(f"batch_atomic_write:{batch_ordinal}")
+        return []
+
+    monkeypatch.setattr(consolidation_saga.vault, "batch_atomic_write", batch_atomic_write)
+
+    result = consolidation_saga.publish_policy_first(
+        content_actions=actions,
+        approved_partition_digest=partition.digest,
+        expected_policy_fingerprint=POLICY_FINGERPRINT,
+        activate_policy=activate_policy,
+        journal=Journal(),
+        vault_root=tmp_path,
+        materialize_batch=lambda batch: (),
+    )
+
+    assert events == [
+        "policy-intent",
+        "policy-prepare",
+        "policy-activate",
+        "policy-terminal",
+        "journal-prepare:0",
+        "batch_atomic_write:0",
+        "journal-final:0",
+        "journal-prepare:1",
+        "batch_atomic_write:1",
+        "journal-final:1",
+    ]
+    assert result.policy_terminal.policy_fingerprint == POLICY_FINGERPRINT
+    assert result.publication_boundary_ordinal == 0
+    assert result.committed_batch_ordinals == (0, 1)
+
+
+def test_policy_activation_failure_never_reaches_content_publication() -> None:
+    from exomem.governance import consolidation_plan, consolidation_saga
+
+    actions = (_content_action(0, 0),)
+    partition = consolidation_plan.derive_journal_batch_partition(actions)
+    events: list[str] = []
+
+    def activate_policy() -> consolidation_saga.PolicyActivationTerminal:
+        events.append("policy-refused")
+        raise RuntimeError("activation did not reach its critical terminal")
+
+    class Journal:
+        def prepare_batch(self, batch: consolidation_saga.ContentBatch) -> None:
+            events.append(f"journal-prepare:{batch.ordinal}")
+
+        def commit_batch(self, batch: consolidation_saga.ContentBatch) -> None:
+            events.append(f"journal-final:{batch.ordinal}")
+
+    with pytest.raises(RuntimeError, match="critical terminal"):
+        consolidation_saga.publish_policy_first(
+            content_actions=actions,
+            approved_partition_digest=partition.digest,
+            expected_policy_fingerprint=POLICY_FINGERPRINT,
+            activate_policy=activate_policy,
+            journal=Journal(),
+            vault_root=Path("unused"),
+            materialize_batch=lambda batch: (),
+        )
+
+    assert events == ["policy-refused"]
+
+
+def test_changed_approved_batch_partition_refuses_before_policy_activation() -> None:
+    from exomem.governance import consolidation_saga
+
+    actions = (_content_action(0, 0),)
+    effects: list[str] = []
+
+    with pytest.raises(consolidation_saga.PolicyFirstPublicationUnavailable):
+        consolidation_saga.publish_policy_first(
+            content_actions=actions,
+            approved_partition_digest=hashlib.sha256(b"different-partition").hexdigest(),
+            expected_policy_fingerprint=POLICY_FINGERPRINT,
+            activate_policy=lambda: effects.append("policy") or None,  # type: ignore[arg-type,return-value]
+            journal=None,  # type: ignore[arg-type]
+            vault_root=Path("unused"),
+            materialize_batch=lambda batch: effects.append(f"batch:{batch.ordinal}") or (),
+        )
+
+    assert effects == []
+
+
+def test_noncommitted_policy_terminal_never_reaches_batch_journal() -> None:
+    from exomem.governance import consolidation_plan, consolidation_saga
+
+    actions = (_content_action(0, 0),)
+    partition = consolidation_plan.derive_journal_batch_partition(actions)
+    effects: list[str] = []
+    intent_id = hashlib.sha256(b"policy-intent").hexdigest()
+
+    with pytest.raises(consolidation_saga.PolicyFirstPublicationUnavailable):
+        consolidation_saga.publish_policy_first(
+            content_actions=actions,
+            approved_partition_digest=partition.digest,
+            expected_policy_fingerprint=POLICY_FINGERPRINT,
+            activate_policy=lambda: consolidation_saga.PolicyActivationTerminal(
+                schema="exomem.consolidation-policy-activation-terminal/v1",
+                policy_fingerprint=POLICY_FINGERPRINT,
+                intent_event_id=intent_id,
+                prepared_fingerprint=hashlib.sha256(b"policy-prepared").hexdigest(),
+                active_fingerprint=hashlib.sha256(b"policy-active").hexdigest(),
+                terminal_event_id=f"{intent_id}:aborted",
+            ),
+            journal=None,  # type: ignore[arg-type]
+            vault_root=Path("unused"),
+            materialize_batch=lambda batch: effects.append(f"batch:{batch.ordinal}") or (),
+        )
+
+    assert effects == []


### PR DESCRIPTION
## Summary

- derive a canonical, fixed-vector journal batch partition from the approved content actions
- bind each bounded batch to domain-separated action-set and prior/prepared/final fingerprints
- require the exact committed restrictive-policy terminal before invoking the real `batch_atomic_write` boundary
- journal prepare/final transitions around each batch and mark the first committed batch as the publication boundary
- mark OpenSpec task 7.3 complete

Stacked after #967. This does not merge the stack or touch any live vault.

## Verification

- red-first: 6 expected ordering/partition failures before implementation; later concrete `batch_atomic_write` instrumentation failed before wiring
- `uv run python -m pytest -q tests/test_consolidation*.py` — 383 passed
- `uvx ruff check` on changed Python files — passed
- `openspec validate add-governed-vault-consolidation --strict` — valid
- `uv lock --check` — passed
- `uv run python scripts/validate-public-artifacts.py --repository` — 3424 files / 3492 text payloads clean
- `uv build` — sdist and wheel built
- `git diff --check` — clean