### PR TITLE
feat(governance): persist consolidation batch journal

### DIFF
--- a/src/exomem/governance/consolidation_batch_journal.py
+++ b/src/exomem/governance/consolidation_batch_journal.py
@@ -1,0 +1,612 @@
+"""Durable exact-state journal for consolidation content batches."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import NoReturn
+
+from .. import reserved_paths
+from ..kbdir import kb_dirname
+from . import consolidation_plan, consolidation_saga
+
+JOURNAL_SCHEMA = "exomem.consolidation-content-batch-journal/v1"
+
+_DESCRIPTOR_ID = "consolidation-tree"
+_OWNER = "consolidation.run"
+_BINDING_SCHEMA = "exomem.consolidation-content-batch-journal-binding/v1"
+_BINDING_DOMAIN = _BINDING_SCHEMA.encode("ascii")
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_UUID4 = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
+)
+_STATUSES = frozenset({"prior", "prepared", "final"})
+_MAX_JOURNAL_BYTES = 16 * 1024 * 1024
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_BATCH_FIELDS = frozenset(
+    {
+        "batch_ordinal",
+        "first_action_ordinal",
+        "last_action_ordinal",
+        "action_count",
+        "publication_boundary",
+        "action_set_digest",
+        "prior_fingerprint",
+        "prepared_fingerprint",
+        "final_fingerprint",
+        "status",
+    }
+)
+_RECORD_FIELDS = frozenset(
+    {
+        "schema",
+        "run_id",
+        "operation_id",
+        "request_digest",
+        "partition_digest",
+        "binding_digest",
+        "revision",
+        "publication_boundary_ordinal",
+        "publication_boundary_committed",
+        "batches",
+    }
+)
+
+__all__ = [
+    "JOURNAL_SCHEMA",
+    "ConsolidationBatchJournalEntry",
+    "ConsolidationBatchJournalState",
+    "ConsolidationBatchJournalStore",
+    "ConsolidationBatchJournalUnavailable",
+]
+
+
+class ConsolidationBatchJournalUnavailable(RuntimeError):
+    """Stable content-free refusal for a missing, changed, or corrupt journal."""
+
+    code = "CONSOLIDATION_BATCH_JOURNAL_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__("consolidation batch journal is unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationBatchJournalEntry:
+    ordinal: int
+    first_action_ordinal: int
+    last_action_ordinal: int
+    action_count: int
+    publication_boundary: bool
+    action_set_digest: str
+    prior_fingerprint: str
+    prepared_fingerprint: str
+    final_fingerprint: str
+    status: str
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationBatchJournalState:
+    schema: str
+    run_id: str
+    operation_id: str
+    request_digest: str
+    partition_digest: str
+    binding_digest: str
+    revision: int
+    publication_boundary_ordinal: int
+    publication_boundary_committed: bool
+    batches: tuple[ConsolidationBatchJournalEntry, ...]
+    state_digest: str
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationBatchJournalUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _uuid4(value: object) -> str:
+    if not isinstance(value, str) or _UUID4.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _integer(
+    value: object,
+    *,
+    minimum: int = 0,
+    maximum: int = _MAX_SAFE_INTEGER,
+) -> int:
+    if type(value) is not int or not minimum <= value <= maximum:
+        _fail()
+    return value
+
+
+def _mapping(value: object, fields: frozenset[str]) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or frozenset(value) != fields:
+        _fail()
+    return value
+
+
+def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            _fail()
+        value[key] = item
+    return value
+
+
+def _reject_number(_value: str) -> NoReturn:
+    _fail()
+
+
+def _parse_integer(value: str) -> int:
+    if value.startswith("-"):
+        _fail()
+    try:
+        parsed = int(value)
+    except ValueError:
+        _fail()
+    return _integer(parsed)
+
+
+def _decode(raw: bytes) -> Mapping[str, object]:
+    if not isinstance(raw, bytes) or not raw or len(raw) > _MAX_JOURNAL_BYTES:
+        _fail()
+    try:
+        value = json.loads(
+            raw,
+            object_pairs_hook=_pairs,
+            parse_int=_parse_integer,
+            parse_float=_reject_number,
+            parse_constant=_reject_number,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ConsolidationBatchJournalUnavailable):
+        _fail()
+    if not isinstance(value, Mapping):
+        _fail()
+    try:
+        canonical = consolidation_plan.canonical_closed_jcs(value)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    if canonical != raw:
+        _fail()
+    return value
+
+
+def _binding_digest(
+    *,
+    run_id: str,
+    operation_id: str,
+    request_digest: str,
+    partition_digest: str,
+) -> str:
+    payload = consolidation_plan.canonical_closed_jcs(
+        {
+            "schema": _BINDING_SCHEMA,
+            "run_id": _uuid4(run_id),
+            "operation_id": _uuid4(operation_id),
+            "request_digest": _digest(request_digest),
+            "partition_digest": _digest(partition_digest),
+        }
+    )
+    framed = (
+        len(_BINDING_DOMAIN).to_bytes(4, "big")
+        + _BINDING_DOMAIN
+        + len(payload).to_bytes(8, "big")
+        + payload
+    )
+    return hashlib.sha256(framed).hexdigest()
+
+
+def _entry_value(entry: ConsolidationBatchJournalEntry) -> dict[str, object]:
+    return {
+        "batch_ordinal": entry.ordinal,
+        "first_action_ordinal": entry.first_action_ordinal,
+        "last_action_ordinal": entry.last_action_ordinal,
+        "action_count": entry.action_count,
+        "publication_boundary": entry.publication_boundary,
+        "action_set_digest": entry.action_set_digest,
+        "prior_fingerprint": entry.prior_fingerprint,
+        "prepared_fingerprint": entry.prepared_fingerprint,
+        "final_fingerprint": entry.final_fingerprint,
+        "status": entry.status,
+    }
+
+
+def _partition_value(
+    entries: Sequence[ConsolidationBatchJournalEntry],
+) -> dict[str, object]:
+    return {
+        "schema": consolidation_plan.JOURNAL_BATCH_PARTITION_SCHEMA,
+        "action_count": sum(entry.action_count for entry in entries),
+        "batch_count": len(entries),
+        "batches": tuple(
+            {
+                key: value
+                for key, value in _entry_value(entry).items()
+                if key != "status"
+            }
+            for entry in entries
+        ),
+    }
+
+
+def _state_value(state: ConsolidationBatchJournalState) -> dict[str, object]:
+    return {
+        "schema": state.schema,
+        "run_id": state.run_id,
+        "operation_id": state.operation_id,
+        "request_digest": state.request_digest,
+        "partition_digest": state.partition_digest,
+        "binding_digest": state.binding_digest,
+        "revision": state.revision,
+        "publication_boundary_ordinal": state.publication_boundary_ordinal,
+        "publication_boundary_committed": state.publication_boundary_committed,
+        "batches": tuple(_entry_value(entry) for entry in state.batches),
+    }
+
+
+def _state_bytes(state: ConsolidationBatchJournalState) -> bytes:
+    try:
+        return consolidation_plan.canonical_closed_jcs(_state_value(state))
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+
+
+def _entries_from_partition(
+    partition: consolidation_plan.CanonicalObject,
+) -> tuple[ConsolidationBatchJournalEntry, ...]:
+    if not isinstance(partition, consolidation_plan.CanonicalObject):
+        _fail()
+    try:
+        checked = consolidation_plan.parse_journal_batch_partition(
+            partition.canonical_bytes
+        )
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    if checked != partition:
+        _fail()
+    rows = checked.preimage["batches"]
+    if not isinstance(rows, tuple):
+        _fail()
+    return tuple(
+        ConsolidationBatchJournalEntry(
+            ordinal=_integer(row["batch_ordinal"]),
+            first_action_ordinal=_integer(row["first_action_ordinal"]),
+            last_action_ordinal=_integer(row["last_action_ordinal"]),
+            action_count=_integer(
+                row["action_count"],
+                minimum=1,
+                maximum=consolidation_plan.MAX_CONTENT_BATCH_ACTIONS,
+            ),
+            publication_boundary=row["publication_boundary"] is True,
+            action_set_digest=_digest(row["action_set_digest"]),
+            prior_fingerprint=_digest(row["prior_fingerprint"]),
+            prepared_fingerprint=_digest(row["prepared_fingerprint"]),
+            final_fingerprint=_digest(row["final_fingerprint"]),
+            status="prior",
+        )
+        for row in rows
+        if isinstance(row, Mapping)
+    )
+
+
+def _parse_entry(value: object, *, expected_ordinal: int) -> ConsolidationBatchJournalEntry:
+    row = _mapping(value, _BATCH_FIELDS)
+    ordinal = _integer(row["batch_ordinal"])
+    count = _integer(
+        row["action_count"],
+        minimum=1,
+        maximum=consolidation_plan.MAX_CONTENT_BATCH_ACTIONS,
+    )
+    first = _integer(row["first_action_ordinal"])
+    last = _integer(row["last_action_ordinal"])
+    status = row["status"]
+    if (
+        ordinal != expected_ordinal
+        or first > last
+        or last != first + count - 1
+        or row["publication_boundary"] is not (ordinal == 0)
+        or not isinstance(status, str)
+        or status not in _STATUSES
+    ):
+        _fail()
+    return ConsolidationBatchJournalEntry(
+        ordinal=ordinal,
+        first_action_ordinal=first,
+        last_action_ordinal=last,
+        action_count=count,
+        publication_boundary=row["publication_boundary"] is True,
+        action_set_digest=_digest(row["action_set_digest"]),
+        prior_fingerprint=_digest(row["prior_fingerprint"]),
+        prepared_fingerprint=_digest(row["prepared_fingerprint"]),
+        final_fingerprint=_digest(row["final_fingerprint"]),
+        status=status,
+    )
+
+
+def _parse_state(raw: bytes) -> ConsolidationBatchJournalState:
+    value = _mapping(_decode(raw), _RECORD_FIELDS)
+    if value["schema"] != JOURNAL_SCHEMA:
+        _fail()
+    rows = value["batches"]
+    if isinstance(rows, (str, bytes)) or not isinstance(rows, Sequence) or not rows:
+        _fail()
+    entries = tuple(
+        _parse_entry(row, expected_ordinal=ordinal)
+        for ordinal, row in enumerate(rows)
+    )
+    if any(
+        entry.first_action_ordinal
+        != (0 if index == 0 else entries[index - 1].last_action_ordinal + 1)
+        for index, entry in enumerate(entries)
+    ):
+        _fail()
+    status_rank = {"final": 0, "prepared": 1, "prior": 2}
+    ranks = tuple(status_rank[entry.status] for entry in entries)
+    if tuple(sorted(ranks)) != ranks or ranks.count(1) > 1:
+        _fail()
+    expected_revision = 1 + sum(
+        2 if entry.status == "final" else 1 if entry.status == "prepared" else 0
+        for entry in entries
+    )
+    run_id = _uuid4(value["run_id"])
+    operation_id = _uuid4(value["operation_id"])
+    request_digest = _digest(value["request_digest"])
+    partition_digest = _digest(value["partition_digest"])
+    try:
+        partition = consolidation_plan.parse_journal_batch_partition(
+            consolidation_plan.canonical_closed_jcs(_partition_value(entries))
+        )
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    if partition.digest != partition_digest:
+        _fail()
+    binding_digest = _binding_digest(
+        run_id=run_id,
+        operation_id=operation_id,
+        request_digest=request_digest,
+        partition_digest=partition_digest,
+    )
+    boundary_ordinal = _integer(value["publication_boundary_ordinal"])
+    boundary_committed = value["publication_boundary_committed"]
+    if (
+        value["binding_digest"] != binding_digest
+        or boundary_ordinal != 0
+        or type(boundary_committed) is not bool
+        or boundary_committed is not (entries[0].status == "final")
+    ):
+        _fail()
+    return ConsolidationBatchJournalState(
+        schema=JOURNAL_SCHEMA,
+        run_id=run_id,
+        operation_id=operation_id,
+        request_digest=request_digest,
+        partition_digest=partition_digest,
+        binding_digest=binding_digest,
+        revision=_integer(value["revision"], minimum=expected_revision, maximum=expected_revision),
+        publication_boundary_ordinal=boundary_ordinal,
+        publication_boundary_committed=boundary_committed,
+        batches=entries,
+        state_digest=hashlib.sha256(raw).hexdigest(),
+    )
+
+
+def _content_batch(value: object) -> consolidation_saga.ContentBatch:
+    if not isinstance(value, consolidation_saga.ContentBatch):
+        _fail()
+    return value
+
+
+def _entry_matches_batch(
+    entry: ConsolidationBatchJournalEntry,
+    batch: consolidation_saga.ContentBatch,
+) -> bool:
+    return (
+        entry.ordinal == batch.ordinal
+        and entry.first_action_ordinal == batch.first_action_ordinal
+        and entry.last_action_ordinal == batch.last_action_ordinal
+        and entry.action_count == batch.action_count
+        and entry.publication_boundary is batch.publication_boundary
+        and entry.action_set_digest == batch.action_set_digest
+        and entry.prior_fingerprint == batch.prior_fingerprint
+        and entry.prepared_fingerprint == batch.prepared_fingerprint
+        and entry.final_fingerprint == batch.final_fingerprint
+    )
+
+
+@contextmanager
+def _authority(vault_root: Path, *, mutation: bool) -> Iterator[None]:
+    try:
+        with reserved_paths._subsystem_authority_scope(_OWNER):  # noqa: SLF001
+            with reserved_paths._identity_coordination_scope(  # noqa: SLF001
+                vault_root,
+                descriptor_ids=(_DESCRIPTOR_ID,),
+                identity_may_change=mutation,
+            ):
+                yield
+    except ConsolidationBatchJournalUnavailable:
+        raise
+    except (OSError, RuntimeError, ValueError):
+        _fail()
+
+
+class ConsolidationBatchJournalStore:
+    """CAS-persist one run's immutable batch plan and exact transition states."""
+
+    def __init__(self, vault_root: Path | str, *, run_id: str):
+        self.vault_root = Path(vault_root).absolute()
+        self.run_id = _uuid4(run_id)
+        self.path = (
+            self.vault_root
+            / kb_dirname()
+            / "_Consolidation"
+            / "runs"
+            / self.run_id
+            / "content-batches.json"
+        )
+
+    def _read(self) -> bytes:
+        return reserved_paths._read_owner_bytes(  # noqa: SLF001
+            self.vault_root,
+            self.path,
+            _DESCRIPTOR_ID,
+            limit=_MAX_JOURNAL_BYTES,
+        )
+
+    def _read_optional(self) -> bytes | None:
+        try:
+            return self._read()
+        except FileNotFoundError:
+            return None
+
+    def _publish(
+        self,
+        raw: bytes,
+        *,
+        expected_sha256: str | None = None,
+        require_missing: bool = False,
+    ) -> None:
+        reserved_paths._publish_owner_bytes(  # noqa: SLF001
+            self.vault_root,
+            self.path,
+            _DESCRIPTOR_ID,
+            raw,
+            expected_sha256=expected_sha256,
+            require_missing=require_missing,
+        )
+
+    def _load_locked(self) -> tuple[ConsolidationBatchJournalState, bytes]:
+        try:
+            raw = self._read()
+        except FileNotFoundError:
+            _fail()
+        state = _parse_state(raw)
+        if state.run_id != self.run_id:
+            _fail()
+        return state, raw
+
+    def create(
+        self,
+        *,
+        operation_id: str,
+        request_digest: str,
+        partition: consolidation_plan.CanonicalObject,
+    ) -> ConsolidationBatchJournalState:
+        operation_id = _uuid4(operation_id)
+        request_digest = _digest(request_digest)
+        entries = _entries_from_partition(partition)
+        if not entries:
+            _fail()
+        binding_digest = _binding_digest(
+            run_id=self.run_id,
+            operation_id=operation_id,
+            request_digest=request_digest,
+            partition_digest=partition.digest,
+        )
+        candidate = ConsolidationBatchJournalState(
+            schema=JOURNAL_SCHEMA,
+            run_id=self.run_id,
+            operation_id=operation_id,
+            request_digest=request_digest,
+            partition_digest=partition.digest,
+            binding_digest=binding_digest,
+            revision=1,
+            publication_boundary_ordinal=0,
+            publication_boundary_committed=False,
+            batches=entries,
+            state_digest="0" * 64,
+        )
+        raw = _state_bytes(candidate)
+        target = replace(candidate, state_digest=hashlib.sha256(raw).hexdigest())
+        with _authority(self.vault_root, mutation=True):
+            existing = self._read_optional()
+            if existing is None:
+                self._publish(raw, require_missing=True)
+                return target
+            current = _parse_state(existing)
+            if current.run_id != self.run_id:
+                _fail()
+            if current == target:
+                return current
+            _fail()
+
+    def load(self) -> ConsolidationBatchJournalState:
+        with _authority(self.vault_root, mutation=False):
+            state, _raw = self._load_locked()
+            return state
+
+    def _transition(
+        self,
+        batch_value: consolidation_saga.ContentBatch,
+        *,
+        target_status: str,
+    ) -> ConsolidationBatchJournalState:
+        batch = _content_batch(batch_value)
+        with _authority(self.vault_root, mutation=True):
+            current, raw = self._load_locked()
+            if not 0 <= batch.ordinal < len(current.batches):
+                _fail()
+            entry = current.batches[batch.ordinal]
+            if not _entry_matches_batch(entry, batch):
+                _fail()
+            if entry.status == target_status:
+                return current
+            if target_status == "prepared":
+                if entry.status == "final":
+                    return current
+                if entry.status != "prior" or any(
+                    prior.status != "final"
+                    for prior in current.batches[: batch.ordinal]
+                ):
+                    _fail()
+            elif target_status == "final":
+                if entry.status != "prepared":
+                    _fail()
+            else:  # pragma: no cover - the public methods use the closed pair
+                _fail()
+            entries = list(current.batches)
+            entries[batch.ordinal] = replace(entry, status=target_status)
+            candidate = replace(
+                current,
+                revision=current.revision + 1,
+                publication_boundary_committed=(
+                    current.publication_boundary_committed
+                    or (batch.publication_boundary and target_status == "final")
+                ),
+                batches=tuple(entries),
+                state_digest="0" * 64,
+            )
+            target_raw = _state_bytes(candidate)
+            target = replace(
+                candidate,
+                state_digest=hashlib.sha256(target_raw).hexdigest(),
+            )
+            self._publish(
+                target_raw,
+                expected_sha256=hashlib.sha256(raw).hexdigest(),
+            )
+            return target
+
+    def prepare_batch(
+        self,
+        batch: consolidation_saga.ContentBatch,
+    ) -> ConsolidationBatchJournalState:
+        return self._transition(batch, target_status="prepared")
+
+    def commit_batch(
+        self,
+        batch: consolidation_saga.ContentBatch,
+    ) -> ConsolidationBatchJournalState:
+        return self._transition(batch, target_status="final")

--- a/src/exomem/governance/consolidation_saga.py
+++ b/src/exomem/governance/consolidation_saga.py
@@ -92,10 +92,10 @@ class PolicyFirstPublicationResult:
 class BatchJournal(Protocol):
     """Durable receipt-first journal boundary supplied by the full coordinator."""
 
-    def prepare_batch(self, batch: ContentBatch) -> None:
+    def prepare_batch(self, batch: ContentBatch) -> object:
         """Persist the exact intent/prepared transition before publication."""
 
-    def commit_batch(self, batch: ContentBatch) -> None:
+    def commit_batch(self, batch: ContentBatch) -> object:
         """Persist the exact final/terminal transition after publication."""
 
 

--- a/tests/test_consolidation_batch_journal.py
+++ b/tests/test_consolidation_batch_journal.py
@@ -1,0 +1,236 @@
+"""Durable exact-state journal for consolidation content batches."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from exomem import writer_lease
+from exomem.governance import consolidation_plan, consolidation_saga
+
+RUN_ID = "00000000-0000-4000-8000-000000000081"
+OPERATION_ID = "00000000-0000-4000-8000-000000000082"
+REQUEST_DIGEST = hashlib.sha256(b"batch-request").hexdigest()
+
+
+@pytest.fixture(autouse=True)
+def _private_writer_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = writer_lease.LeaseManager(
+        writer_lease.LeaseConfig(state_dir=tmp_path / "writer-state")
+    )
+    monkeypatch.setattr(writer_lease, "active_manager", lambda: manager)
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode()).hexdigest()
+
+
+def _action(ordinal: int, batch_ordinal: int) -> dict[str, object]:
+    return {
+        "ordinal": ordinal,
+        "batch_ordinal": batch_ordinal,
+        "action": "overwrite",
+        "object_ref": f"source-object-{ordinal}",
+        "source_path": f"Knowledge Base/Notes/source-{ordinal}.md",
+        "destination_path": f"Knowledge Base/Notes/destination-{ordinal}.md",
+        "expected_before_state": "present",
+        "expected_before_sha256": _digest(f"before-{ordinal}"),
+        "planned_after_state": "present",
+        "planned_after_sha256": _digest(f"after-{ordinal}"),
+    }
+
+
+def _partition() -> consolidation_plan.CanonicalObject:
+    return consolidation_plan.derive_journal_batch_partition(
+        (_action(0, 0), _action(1, 0), _action(2, 1))
+    )
+
+
+def _batch(ordinal: int) -> consolidation_saga.ContentBatch:
+    row = _partition().preimage["batches"][ordinal]
+    return consolidation_saga.ContentBatch(
+        ordinal=ordinal,
+        first_action_ordinal=row["first_action_ordinal"],
+        last_action_ordinal=row["last_action_ordinal"],
+        action_count=row["action_count"],
+        publication_boundary=row["publication_boundary"],
+        action_set_digest=row["action_set_digest"],
+        prior_fingerprint=row["prior_fingerprint"],
+        prepared_fingerprint=row["prepared_fingerprint"],
+        final_fingerprint=row["final_fingerprint"],
+    )
+
+
+def _store(vault: Path):
+    from exomem.governance import consolidation_batch_journal
+
+    return consolidation_batch_journal.ConsolidationBatchJournalStore(
+        vault,
+        run_id=RUN_ID,
+    )
+
+
+def test_create_persists_exact_prior_state_and_restarts(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    store = _store(vault)
+
+    created = store.create(
+        operation_id=OPERATION_ID,
+        request_digest=REQUEST_DIGEST,
+        partition=_partition(),
+    )
+
+    assert created.schema == "exomem.consolidation-content-batch-journal/v1"
+    assert created.revision == 1
+    assert created.partition_digest == _partition().digest
+    assert created.binding_digest == (
+        "3744d28927cdbe78a647a55dbf124b5377da557cc3e83961720105fcf4760870"
+    )
+    assert created.state_digest == (
+        "bd8e47e2ffdd3f3363cc590ec8358caa76f3f83461e2bd58c7832439762bf0d1"
+    )
+    assert created.publication_boundary_ordinal == 0
+    assert created.publication_boundary_committed is False
+    assert tuple(item.status for item in created.batches) == ("prior", "prior")
+    assert _store(vault).load() == created
+
+
+def test_prepare_and_commit_are_cas_revisioned_and_exactly_replayable(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    store = _store(vault)
+    initial = store.create(
+        operation_id=OPERATION_ID,
+        request_digest=REQUEST_DIGEST,
+        partition=_partition(),
+    )
+
+    prepared = store.prepare_batch(_batch(0))
+    assert prepared.revision == initial.revision + 1
+    assert tuple(item.status for item in prepared.batches) == ("prepared", "prior")
+    assert store.prepare_batch(_batch(0)) == prepared
+
+    final = store.commit_batch(_batch(0))
+    assert final.revision == prepared.revision + 1
+    assert tuple(item.status for item in final.batches) == ("final", "prior")
+    assert final.publication_boundary_committed is True
+    assert _store(vault).commit_batch(_batch(0)) == final
+
+    second_prepared = _store(vault).prepare_batch(_batch(1))
+    assert tuple(item.status for item in second_prepared.batches) == (
+        "final",
+        "prepared",
+    )
+
+
+def test_out_of_order_or_changed_batch_never_advances_the_journal(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import consolidation_batch_journal
+
+    vault = tmp_path / "vault"
+    store = _store(vault)
+    initial = store.create(
+        operation_id=OPERATION_ID,
+        request_digest=REQUEST_DIGEST,
+        partition=_partition(),
+    )
+
+    for operation in (
+        lambda: store.prepare_batch(_batch(1)),
+        lambda: store.commit_batch(_batch(0)),
+        lambda: store.prepare_batch(
+            replace(_batch(0), final_fingerprint=_digest("changed-final"))
+        ),
+    ):
+        with pytest.raises(
+            consolidation_batch_journal.ConsolidationBatchJournalUnavailable
+        ):
+            operation()
+        assert store.load() == initial
+
+
+def test_create_replay_rejects_changed_operation_request_or_partition(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import consolidation_batch_journal
+
+    vault = tmp_path / "vault"
+    store = _store(vault)
+    created = store.create(
+        operation_id=OPERATION_ID,
+        request_digest=REQUEST_DIGEST,
+        partition=_partition(),
+    )
+    assert store.create(
+        operation_id=OPERATION_ID,
+        request_digest=REQUEST_DIGEST,
+        partition=_partition(),
+    ) == created
+
+    changed = (
+        {"operation_id": "00000000-0000-4000-8000-000000000083"},
+        {"request_digest": _digest("changed-request")},
+        {
+            "partition": consolidation_plan.derive_journal_batch_partition(
+                (_action(0, 0),)
+            )
+        },
+    )
+    for override in changed:
+        kwargs = {
+            "operation_id": OPERATION_ID,
+            "request_digest": REQUEST_DIGEST,
+            "partition": _partition(),
+            **override,
+        }
+        with pytest.raises(
+            consolidation_batch_journal.ConsolidationBatchJournalUnavailable
+        ):
+            store.create(**kwargs)
+        assert store.load() == created
+
+
+def test_corrupt_or_revision_inconsistent_journal_is_never_recreated(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import consolidation_batch_journal
+
+    vault = tmp_path / "vault"
+    store = _store(vault)
+    created = store.create(
+        operation_id=OPERATION_ID,
+        request_digest=REQUEST_DIGEST,
+        partition=_partition(),
+    )
+    path = (
+        vault
+        / "Knowledge Base"
+        / "_Consolidation"
+        / "runs"
+        / RUN_ID
+        / "content-batches.json"
+    )
+    value = json.loads(path.read_bytes())
+    value["revision"] = created.revision + 1
+    changed = consolidation_plan.canonical_closed_jcs(value)
+    path.write_bytes(changed)
+
+    with pytest.raises(
+        consolidation_batch_journal.ConsolidationBatchJournalUnavailable
+    ):
+        store.create(
+            operation_id=OPERATION_ID,
+            request_digest=REQUEST_DIGEST,
+            partition=_partition(),
+        )
+
+    assert path.read_bytes() == changed


### PR DESCRIPTION
## Summary

- persist one owner-only, reserved consolidation batch journal per run
- bind run, operation, request, and the approved batch partition in a fixed cross-runtime identity
- CAS-revision exact prior → prepared → final transitions and make identical retries idempotent
- mark the publication boundary only when the first batch reaches final
- fail closed on corruption, changed batches, skipped batches, changed requests, and revision inconsistencies

Stacked after #970. This is the durable journal substrate for OpenSpec 7.4; the live-byte crash classifier remains a follow-on, so 7.4 is not marked complete here. No live vault is touched.

## Verification

- red-first: 4 expected missing-store failures
- `uv run python -m pytest -q tests/test_consolidation*.py tests/test_reserved_admin_paths.py` — 578 passed
- changed-file Ruff (`E,F,I,B,UP,BLE`) — passed
- `openspec validate add-governed-vault-consolidation --strict` — valid
- `uv lock --check` — passed
- public repository artifact validation — 3426 files / 3494 text payloads clean
- `git diff --check` — clean