### PR TITLE
feat(governance): recover exact consolidation batches

### DIFF
--- a/src/exomem/_held_fs_posix.py
+++ b/src/exomem/_held_fs_posix.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ctypes
 import errno
+import hashlib
 import os
 import posix as _native
 import secrets
@@ -414,6 +415,27 @@ class PosixHeldFilesystem(HeldFilesystem):
             while chunk := _read(checked.descriptor, 65536):
                 chunks.append(chunk)
             return HeldResult(value=b"".join(chunks))
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def sha256(self, file: HeldFile) -> HeldResult[str]:
+        try:
+            checked = self._check_file(file)
+            before = _fstat(checked.descriptor)
+            _lseek(checked.descriptor, 0, os.SEEK_SET)
+            digest = hashlib.sha256()
+            while chunk := _read(checked.descriptor, 65536):
+                digest.update(chunk)
+            after = _fstat(checked.descriptor)
+            if (
+                _identity(before) != _identity(after)
+                or before.st_size != after.st_size
+                or before.st_mtime_ns != after.st_mtime_ns
+                or before.st_ctime_ns != after.st_ctime_ns
+            ):
+                raise OSError(errno.ESTALE, "held file changed while hashing")
+            checked.check()
+            return HeldResult(value=digest.hexdigest())
         except OSError as error:
             return HeldResult(error=_error(error))
 

--- a/src/exomem/_held_fs_windows.py
+++ b/src/exomem/_held_fs_windows.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import ctypes
 import errno
+import hashlib
 import os
 import secrets
 from ctypes import (
@@ -745,6 +746,27 @@ class WindowsHeldFilesystem(HeldFilesystem):
             while chunk := os.read(checked.descriptor, 65536):
                 chunks.append(chunk)
             return HeldResult(value=b"".join(chunks))
+        except OSError as error:
+            return HeldResult(error=_error(error))
+
+    def sha256(self, file: HeldFile) -> HeldResult[str]:
+        try:
+            checked = self._check_file(file)
+            before = os.fstat(checked.descriptor)
+            os.lseek(checked.descriptor, 0, os.SEEK_SET)
+            digest = hashlib.sha256()
+            while chunk := os.read(checked.descriptor, 65536):
+                digest.update(chunk)
+            after = os.fstat(checked.descriptor)
+            if (
+                _identity(_native(checked.descriptor)) != checked.identity
+                or before.st_size != after.st_size
+                or before.st_mtime_ns != after.st_mtime_ns
+                or before.st_ctime_ns != after.st_ctime_ns
+            ):
+                raise OSError(errno.ESTALE, "held file changed while hashing")
+            checked.check()
+            return HeldResult(value=digest.hexdigest())
         except OSError as error:
             return HeldResult(error=_error(error))
 

--- a/src/exomem/governance/consolidation_batch_journal.py
+++ b/src/exomem/governance/consolidation_batch_journal.py
@@ -547,6 +547,17 @@ class ConsolidationBatchJournalStore:
             state, _raw = self._load_locked()
             return state
 
+    def batch_status(self, batch_value: consolidation_saga.ContentBatch) -> str:
+        batch = _content_batch(batch_value)
+        with _authority(self.vault_root, mutation=False):
+            current, _raw = self._load_locked()
+            if not 0 <= batch.ordinal < len(current.batches):
+                _fail()
+            entry = current.batches[batch.ordinal]
+            if not _entry_matches_batch(entry, batch):
+                _fail()
+            return entry.status
+
     def _transition(
         self,
         batch_value: consolidation_saga.ContentBatch,

--- a/src/exomem/governance/consolidation_plan.py
+++ b/src/exomem/governance/consolidation_plan.py
@@ -459,10 +459,16 @@ def _validate_content_actions(value: object) -> tuple[Mapping[str, object], ...]
     return tuple(normalized)
 
 
+def validate_content_actions(value: object) -> tuple[Mapping[str, object], ...]:
+    """Return the exact validated action sequence used by plan fingerprints."""
+
+    return _validate_content_actions(value)
+
+
 def derive_journal_batch_partition(value: object) -> CanonicalObject:
     """Derive the only approved content-batch partition and state fingerprints."""
 
-    actions = _validate_content_actions(value)
+    actions = validate_content_actions(value)
     grouped: list[list[Mapping[str, object]]] = []
     expected_batch = 0
     for action in actions:

--- a/src/exomem/governance/consolidation_saga.py
+++ b/src/exomem/governance/consolidation_saga.py
@@ -9,13 +9,16 @@ remain separate layers built on these immutable batch descriptors.
 
 from __future__ import annotations
 
+import hashlib
+import os
 import re
 from collections.abc import Callable, Iterable, Mapping
+from contextlib import ExitStack
 from dataclasses import dataclass
-from pathlib import Path
-from typing import NoReturn, Protocol
+from pathlib import Path, PurePosixPath
+from typing import Literal, NoReturn, Protocol
 
-from .. import vault
+from .. import held_fs, vault
 from . import consolidation_plan
 
 POLICY_ACTIVATION_TERMINAL_SCHEMA = (
@@ -41,10 +44,12 @@ _BATCH_FIELDS = frozenset(
 __all__ = [
     "POLICY_ACTIVATION_TERMINAL_SCHEMA",
     "BatchJournal",
+    "BatchStateObservation",
     "ContentBatch",
     "PolicyActivationTerminal",
     "PolicyFirstPublicationResult",
     "PolicyFirstPublicationUnavailable",
+    "classify_content_batch_state",
     "publish_policy_first",
 ]
 
@@ -82,6 +87,15 @@ class ContentBatch:
 
 
 @dataclass(frozen=True, slots=True)
+class BatchStateObservation:
+    """Content-free exact-state classification for one canonical batch."""
+
+    batch_ordinal: int
+    action_count: int
+    state: Literal["prior", "final", "equivalent", "mixed"]
+
+
+@dataclass(frozen=True, slots=True)
 class PolicyFirstPublicationResult:
     policy_terminal: PolicyActivationTerminal
     partition_digest: str
@@ -91,6 +105,9 @@ class PolicyFirstPublicationResult:
 
 class BatchJournal(Protocol):
     """Durable receipt-first journal boundary supplied by the full coordinator."""
+
+    def batch_status(self, batch: ContentBatch) -> str:
+        """Return the exact durable status for this immutable batch."""
 
     def prepare_batch(self, batch: ContentBatch) -> object:
         """Persist the exact intent/prepared transition before publication."""
@@ -175,6 +192,154 @@ def _content_batches(
     return tuple(batches)
 
 
+def _observed_file_state(
+    filesystem: held_fs.HeldFilesystem,
+    stack: ExitStack,
+    destination_path: str,
+) -> tuple[str, str]:
+    path = PurePosixPath(destination_path)
+    parent_path = path.parent.as_posix()
+    parent_result = filesystem.parent(parent_path)
+    if parent_result.error is not None:
+        if parent_result.error.code == "MISSING":
+            return "absent", "0" * 64
+        _fail()
+    parent = stack.enter_context(parent_result.require())
+    file_result = filesystem.file(parent, path.name)
+    if file_result.error is not None:
+        if file_result.error.code == "MISSING":
+            return "absent", "0" * 64
+        _fail()
+    file = stack.enter_context(file_result.require())
+    if file.identity.kind != "file" or file.identity.link_count != 1:
+        _fail()
+    return "present", _digest(filesystem.sha256(file).require())
+
+
+def _matches_action_state(
+    action: Mapping[str, object],
+    observed: tuple[str, str],
+    *,
+    prefix: Literal["expected_before", "planned_after"],
+) -> bool:
+    return observed == (action[f"{prefix}_state"], action[f"{prefix}_sha256"])
+
+
+def _validated_batch_writes(
+    *,
+    vault_root: Path,
+    actions: tuple[Mapping[str, object], ...],
+    writes: Iterable[vault.PlannedWrite],
+) -> tuple[vault.PlannedWrite, ...]:
+    root = Path(os.path.abspath(vault_root))
+    required = {
+        str(action["destination_path"]): action
+        for action in actions
+        if (
+            action["planned_after_state"] == "present"
+            and (
+                action["expected_before_state"] != action["planned_after_state"]
+                or action["expected_before_sha256"] != action["planned_after_sha256"]
+            )
+        )
+    }
+    checked: dict[str, vault.PlannedWrite] = {}
+    for write in writes:
+        if not isinstance(write, vault.PlannedWrite):
+            _fail()
+        try:
+            relative = Path(os.path.abspath(write.path)).relative_to(root).as_posix()
+        except ValueError:
+            _fail()
+        action = required.get(relative)
+        if action is None or relative in checked:
+            _fail()
+        if isinstance(write.content, str):
+            content_digest = hashlib.sha256(write.content.encode("utf-8")).hexdigest()
+        elif isinstance(write.content, vault.PreparedBinaryContent):
+            content_digest = _digest(write.content.sha256)
+        else:  # pragma: no cover - PlannedWrite carries the closed content union
+            _fail()
+        expected_missing = action["expected_before_state"] == "absent"
+        expected_hash = (
+            vault.MISSING_CONTENT_HASH
+            if expected_missing
+            else action["expected_before_sha256"]
+        )
+        if (
+            content_digest != action["planned_after_sha256"]
+            or write.expected_hash != expected_hash
+            or write.create_only is not expected_missing
+        ):
+            _fail()
+        checked[relative] = write
+    if frozenset(checked) != frozenset(required):
+        _fail()
+    return tuple(checked[path] for path in required)
+
+
+def classify_content_batch_state(
+    *,
+    vault_root: Path,
+    content_actions: object,
+    batch: ContentBatch,
+) -> BatchStateObservation:
+    """Classify canonical destinations as exact prior/final or unsafe mixed state."""
+
+    try:
+        actions = consolidation_plan.validate_content_actions(content_actions)
+        partition = consolidation_plan.derive_journal_batch_partition(actions)
+        batches = _content_batches(partition)
+        if not 0 <= batch.ordinal < len(batches) or batches[batch.ordinal] != batch:
+            _fail()
+        selected = tuple(
+            action for action in actions if action["batch_ordinal"] == batch.ordinal
+        )
+        if (
+            len(selected) != batch.action_count
+            or selected[0]["ordinal"] != batch.first_action_ordinal
+            or selected[-1]["ordinal"] != batch.last_action_ordinal
+            or len({action["destination_path"] for action in selected}) != len(selected)
+        ):
+            _fail()
+        with ExitStack() as stack:
+            filesystem = stack.enter_context(held_fs.acquire(Path(vault_root)).require())
+            observed = tuple(
+                _observed_file_state(
+                    filesystem,
+                    stack,
+                    str(action["destination_path"]),
+                )
+                for action in selected
+            )
+            prior = all(
+                _matches_action_state(action, state, prefix="expected_before")
+                for action, state in zip(selected, observed, strict=True)
+            )
+            final = all(
+                _matches_action_state(action, state, prefix="planned_after")
+                for action, state in zip(selected, observed, strict=True)
+            )
+    except PolicyFirstPublicationUnavailable:
+        raise
+    except (held_fs.HeldFsError, OSError, ValueError):
+        _fail()
+    state: Literal["prior", "final", "equivalent", "mixed"]
+    if prior and final:
+        state = "equivalent"
+    elif prior:
+        state = "prior"
+    elif final:
+        state = "final"
+    else:
+        state = "mixed"
+    return BatchStateObservation(
+        batch_ordinal=batch.ordinal,
+        action_count=batch.action_count,
+        state=state,
+    )
+
+
 def publish_policy_first(
     *,
     content_actions: object,
@@ -197,14 +362,49 @@ def publish_policy_first(
     )
     committed: list[int] = []
     for batch in batches:
-        journal.prepare_batch(batch)
-        writes = tuple(materialize_batch(batch))
-        vault.batch_atomic_write(
-            writes,
+        status = journal.batch_status(batch)
+        if status not in {"prior", "prepared", "final"}:
+            _fail()
+        observation = classify_content_batch_state(
             vault_root=Path(vault_root),
-            post_commit_fanout=False,
+            content_actions=content_actions,
+            batch=batch,
         )
-        journal.commit_batch(batch)
+        if status == "final":
+            if observation.state not in {"final", "equivalent"}:
+                _fail()
+        elif status == "prepared" and observation.state in {"final", "equivalent"}:
+            journal.commit_batch(batch)
+        else:
+            if observation.state not in {"prior", "equivalent"}:
+                _fail()
+            if status == "prior":
+                journal.prepare_batch(batch)
+            if observation.state != "equivalent":
+                actions = consolidation_plan.validate_content_actions(content_actions)
+                selected = tuple(
+                    action
+                    for action in actions
+                    if action["batch_ordinal"] == batch.ordinal
+                )
+                writes = _validated_batch_writes(
+                    vault_root=Path(vault_root),
+                    actions=selected,
+                    writes=materialize_batch(batch),
+                )
+                vault.batch_atomic_write(
+                    writes,
+                    vault_root=Path(vault_root),
+                    post_commit_fanout=False,
+                )
+                observation = classify_content_batch_state(
+                    vault_root=Path(vault_root),
+                    content_actions=content_actions,
+                    batch=batch,
+                )
+                if observation.state not in {"final", "equivalent"}:
+                    _fail()
+            journal.commit_batch(batch)
         committed.append(batch.ordinal)
     return PolicyFirstPublicationResult(
         policy_terminal=terminal,

--- a/src/exomem/held_fs.py
+++ b/src/exomem/held_fs.py
@@ -173,6 +173,11 @@ class HeldFilesystem:
     def read(self, file: HeldFile) -> HeldResult[bytes]:
         raise NotImplementedError
 
+    def sha256(self, file: HeldFile) -> HeldResult[str]:
+        """Hash one retained regular file without materializing it in memory."""
+
+        raise NotImplementedError
+
     def write(self, file: HeldFile, data: bytes) -> HeldResult[None]:
         raise NotImplementedError
 

--- a/tests/test_consolidation_batch_journal.py
+++ b/tests/test_consolidation_batch_journal.py
@@ -99,6 +99,7 @@ def test_create_persists_exact_prior_state_and_restarts(tmp_path: Path) -> None:
     assert created.publication_boundary_ordinal == 0
     assert created.publication_boundary_committed is False
     assert tuple(item.status for item in created.batches) == ("prior", "prior")
+    assert store.batch_status(_batch(0)) == "prior"
     assert _store(vault).load() == created
 
 
@@ -117,11 +118,13 @@ def test_prepare_and_commit_are_cas_revisioned_and_exactly_replayable(
     assert prepared.revision == initial.revision + 1
     assert tuple(item.status for item in prepared.batches) == ("prepared", "prior")
     assert store.prepare_batch(_batch(0)) == prepared
+    assert _store(vault).batch_status(_batch(0)) == "prepared"
 
     final = store.commit_batch(_batch(0))
     assert final.revision == prepared.revision + 1
     assert tuple(item.status for item in final.batches) == ("final", "prior")
     assert final.publication_boundary_committed is True
+    assert store.batch_status(_batch(0)) == "final"
     assert _store(vault).commit_batch(_batch(0)) == final
 
     second_prepared = _store(vault).prepare_batch(_batch(1))

--- a/tests/test_consolidation_saga.py
+++ b/tests/test_consolidation_saga.py
@@ -342,6 +342,10 @@ def test_policy_terminal_precedes_every_content_batch(
     actions = (_content_action(0, 0), _content_action(1, 1))
     partition = consolidation_plan.derive_journal_batch_partition(actions)
     events: list[str] = []
+    for action in actions:
+        target = tmp_path / str(action["destination_path"])
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(f"before-{action['ordinal']}".encode())
 
     def activate_policy() -> consolidation_saga.PolicyActivationTerminal:
         events.extend(("policy-intent", "policy-prepare", "policy-activate", "policy-terminal"))
@@ -356,6 +360,9 @@ def test_policy_terminal_precedes_every_content_batch(
         )
 
     class Journal:
+        def batch_status(self, batch: consolidation_saga.ContentBatch) -> str:
+            return "prior"
+
         def prepare_batch(self, batch: consolidation_saga.ContentBatch) -> None:
             expected = partition.preimage["batches"][batch.ordinal]
             assert batch.action_set_digest == expected["action_set_digest"]
@@ -374,12 +381,14 @@ def test_policy_terminal_precedes_every_content_batch(
         vault_root: Path,
         post_commit_fanout: bool,
     ) -> list[Path]:
-        assert tuple(writes) == ()  # type: ignore[arg-type]
+        planned = tuple(writes)  # type: ignore[arg-type]
+        assert len(planned) == 1
         assert vault_root == tmp_path
         assert post_commit_fanout is False
         batch_ordinal = sum(event.startswith("batch_atomic_write:") for event in events)
         events.append(f"batch_atomic_write:{batch_ordinal}")
-        return []
+        planned[0].path.write_bytes(f"after-{batch_ordinal}".encode())
+        return [planned[0].path]
 
     monkeypatch.setattr(consolidation_saga.vault, "batch_atomic_write", batch_atomic_write)
 
@@ -390,7 +399,16 @@ def test_policy_terminal_precedes_every_content_batch(
         activate_policy=activate_policy,
         journal=Journal(),
         vault_root=tmp_path,
-        materialize_batch=lambda batch: (),
+        materialize_batch=lambda batch: (
+            consolidation_saga.vault.PlannedWrite(
+                path=tmp_path
+                / str(actions[batch.first_action_ordinal]["destination_path"]),
+                content=f"after-{batch.first_action_ordinal}",
+                expected_hash=str(
+                    actions[batch.first_action_ordinal]["expected_before_sha256"]
+                ),
+            ),
+        ),
     )
 
     assert events == [
@@ -422,6 +440,9 @@ def test_policy_activation_failure_never_reaches_content_publication() -> None:
         raise RuntimeError("activation did not reach its critical terminal")
 
     class Journal:
+        def batch_status(self, batch: consolidation_saga.ContentBatch) -> str:
+            return "prior"
+
         def prepare_batch(self, batch: consolidation_saga.ContentBatch) -> None:
             events.append(f"journal-prepare:{batch.ordinal}")
 
@@ -489,3 +510,453 @@ def test_noncommitted_policy_terminal_never_reaches_batch_journal() -> None:
         )
 
     assert effects == []
+
+
+def _publication_terminal():
+    from exomem.governance import consolidation_saga
+
+    intent_id = hashlib.sha256(b"policy-intent").hexdigest()
+    return consolidation_saga.PolicyActivationTerminal(
+        schema="exomem.consolidation-policy-activation-terminal/v1",
+        policy_fingerprint=POLICY_FINGERPRINT,
+        intent_event_id=intent_id,
+        prepared_fingerprint=hashlib.sha256(b"policy-prepared").hexdigest(),
+        active_fingerprint=hashlib.sha256(b"policy-active").hexdigest(),
+        terminal_event_id=f"{intent_id}:committed",
+    )
+
+
+def _state_action(
+    *,
+    ordinal: int,
+    batch_ordinal: int,
+    destination_path: str,
+    before: bytes | None,
+    after: bytes | None,
+) -> dict[str, object]:
+    return {
+        "ordinal": ordinal,
+        "batch_ordinal": batch_ordinal,
+        "action": "add" if before is None else "overwrite",
+        "object_ref": f"source-object-{ordinal}",
+        "source_path": f"Knowledge Base/Notes/source-{ordinal}.md",
+        "destination_path": destination_path,
+        "expected_before_state": "absent" if before is None else "present",
+        "expected_before_sha256": (
+            "0" * 64 if before is None else hashlib.sha256(before).hexdigest()
+        ),
+        "planned_after_state": "absent" if after is None else "present",
+        "planned_after_sha256": (
+            "0" * 64 if after is None else hashlib.sha256(after).hexdigest()
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    ("payloads", "expected"),
+    [
+        ((b"before-a", b"before-b"), "prior"),
+        ((b"after-a", b"after-b"), "final"),
+        ((b"before-a", b"after-b"), "mixed"),
+        ((b"third", b"after-b"), "mixed"),
+    ],
+)
+def test_content_batch_classifier_accepts_only_exact_prior_or_final(
+    tmp_path: Path,
+    payloads: tuple[bytes, bytes],
+    expected: str,
+) -> None:
+    from exomem.governance import consolidation_plan, consolidation_saga
+
+    root = tmp_path / "vault"
+    targets = (
+        "Knowledge Base/Notes/a.md",
+        "Knowledge Base/Notes/b.md",
+    )
+    actions = tuple(
+        _state_action(
+            ordinal=ordinal,
+            batch_ordinal=0,
+            destination_path=target,
+            before=f"before-{target[-4]}".encode(),
+            after=f"after-{target[-4]}".encode(),
+        )
+        for ordinal, target in enumerate(targets)
+    )
+    for target, payload in zip(targets, payloads, strict=True):
+        path = root / target
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(payload)
+    partition = consolidation_plan.derive_journal_batch_partition(actions)
+    batch = consolidation_saga._content_batches(partition)[0]
+
+    observation = consolidation_saga.classify_content_batch_state(
+        vault_root=root,
+        content_actions=actions,
+        batch=batch,
+    )
+
+    assert observation.state == expected
+    assert observation.batch_ordinal == 0
+
+
+def test_content_batch_classifier_handles_absent_and_equivalent_rows(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import consolidation_plan, consolidation_saga
+
+    root = tmp_path / "vault"
+    root.mkdir()
+    absent_action = _state_action(
+        ordinal=0,
+        batch_ordinal=0,
+        destination_path="Knowledge Base/Notes/new.md",
+        before=None,
+        after=b"new",
+    )
+    same_action = _state_action(
+        ordinal=0,
+        batch_ordinal=0,
+        destination_path="Knowledge Base/Notes/same.md",
+        before=b"same",
+        after=b"same",
+    )
+    same_path = root / str(same_action["destination_path"])
+    same_path.parent.mkdir(parents=True)
+    same_path.write_bytes(b"same")
+
+    absent_partition = consolidation_plan.derive_journal_batch_partition(
+        (absent_action,)
+    )
+    same_partition = consolidation_plan.derive_journal_batch_partition((same_action,))
+
+    assert consolidation_saga.classify_content_batch_state(
+        vault_root=root,
+        content_actions=(absent_action,),
+        batch=consolidation_saga._content_batches(absent_partition)[0],
+    ).state == "prior"
+    assert consolidation_saga.classify_content_batch_state(
+        vault_root=root,
+        content_actions=(same_action,),
+        batch=consolidation_saga._content_batches(same_partition)[0],
+    ).state == "equivalent"
+
+
+@pytest.mark.parametrize(
+    ("journal_status", "live_payload", "expected_events"),
+    [
+        (
+            "prior",
+            b"before",
+            ("status", "prepare", "materialize", "publish", "commit"),
+        ),
+        ("prepared", b"before", ("status", "materialize", "publish", "commit")),
+        ("prepared", b"after", ("status", "commit")),
+        ("final", b"after", ("status",)),
+    ],
+)
+def test_policy_first_retry_performs_only_the_missing_batch_effect(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    journal_status: str,
+    live_payload: bytes,
+    expected_events: tuple[str, ...],
+) -> None:
+    from exomem import vault, writer_lease
+    from exomem.governance import consolidation_plan, consolidation_saga
+
+    root = tmp_path / "vault"
+    target = root / "Knowledge Base/Notes/target.md"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(live_payload)
+    actions = (
+        _state_action(
+            ordinal=0,
+            batch_ordinal=0,
+            destination_path="Knowledge Base/Notes/target.md",
+            before=b"before",
+            after=b"after",
+        ),
+    )
+    partition = consolidation_plan.derive_journal_batch_partition(actions)
+    events: list[str] = []
+    manager = writer_lease.LeaseManager(
+        writer_lease.LeaseConfig(state_dir=tmp_path / "writer-state")
+    )
+    monkeypatch.setattr(writer_lease, "active_manager", lambda: manager)
+
+    class Journal:
+        def batch_status(self, batch: consolidation_saga.ContentBatch) -> str:
+            events.append("status")
+            return journal_status
+
+        def prepare_batch(self, batch: consolidation_saga.ContentBatch) -> object:
+            events.append("prepare")
+            return object()
+
+        def commit_batch(self, batch: consolidation_saga.ContentBatch) -> object:
+            events.append("commit")
+            return object()
+
+    real_batch_atomic_write = vault.batch_atomic_write
+
+    def observed_batch_atomic_write(*args: object, **kwargs: object) -> list[Path]:
+        events.append("publish")
+        return real_batch_atomic_write(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        consolidation_saga.vault,
+        "batch_atomic_write",
+        observed_batch_atomic_write,
+    )
+
+    def materialize(_batch: consolidation_saga.ContentBatch):
+        events.append("materialize")
+        return (
+            vault.PlannedWrite(
+                path=target,
+                content="after",
+                expected_hash=hashlib.sha256(b"before").hexdigest(),
+            ),
+        )
+
+    result = consolidation_saga.publish_policy_first(
+        content_actions=actions,
+        approved_partition_digest=partition.digest,
+        expected_policy_fingerprint=POLICY_FINGERPRINT,
+        activate_policy=_publication_terminal,
+        journal=Journal(),
+        vault_root=root,
+        materialize_batch=materialize,
+    )
+
+    assert tuple(events) == expected_events
+    assert target.read_bytes() == b"after"
+    assert result.committed_batch_ordinals == (0,)
+
+
+@pytest.mark.parametrize(
+    ("journal_status", "live_payload"),
+    [("prior", b"after"), ("prepared", b"third"), ("final", b"before")],
+)
+def test_policy_first_retry_refuses_inconsistent_journal_and_live_bytes(
+    tmp_path: Path,
+    journal_status: str,
+    live_payload: bytes,
+) -> None:
+    from exomem.governance import consolidation_plan, consolidation_saga
+
+    root = tmp_path / "vault"
+    target = root / "Knowledge Base/Notes/target.md"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(live_payload)
+    actions = (
+        _state_action(
+            ordinal=0,
+            batch_ordinal=0,
+            destination_path="Knowledge Base/Notes/target.md",
+            before=b"before",
+            after=b"after",
+        ),
+    )
+    partition = consolidation_plan.derive_journal_batch_partition(actions)
+    effects: list[str] = []
+
+    class Journal:
+        def batch_status(self, batch: consolidation_saga.ContentBatch) -> str:
+            return journal_status
+
+        def prepare_batch(self, batch: consolidation_saga.ContentBatch) -> object:
+            effects.append("prepare")
+            return object()
+
+        def commit_batch(self, batch: consolidation_saga.ContentBatch) -> object:
+            effects.append("commit")
+            return object()
+
+    with pytest.raises(consolidation_saga.PolicyFirstPublicationUnavailable):
+        consolidation_saga.publish_policy_first(
+            content_actions=actions,
+            approved_partition_digest=partition.digest,
+            expected_policy_fingerprint=POLICY_FINGERPRINT,
+            activate_policy=_publication_terminal,
+            journal=Journal(),
+            vault_root=root,
+            materialize_batch=lambda batch: effects.append("materialize") or (),
+        )
+
+    assert effects == []
+
+
+def test_persisted_multi_batch_retry_skips_final_and_resumes_prepared(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import vault, writer_lease
+    from exomem.governance import (
+        consolidation_batch_journal,
+        consolidation_plan,
+        consolidation_saga,
+    )
+
+    root = tmp_path / "vault"
+    targets = (
+        root / "Knowledge Base/Notes/first.md",
+        root / "Knowledge Base/Notes/second.md",
+    )
+    for ordinal, target in enumerate(targets):
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(f"before-{ordinal}".encode())
+    actions = tuple(
+        _state_action(
+            ordinal=ordinal,
+            batch_ordinal=ordinal,
+            destination_path=target.relative_to(root).as_posix(),
+            before=f"before-{ordinal}".encode(),
+            after=f"after-{ordinal}".encode(),
+        )
+        for ordinal, target in enumerate(targets)
+    )
+    partition = consolidation_plan.derive_journal_batch_partition(actions)
+    batches = consolidation_saga._content_batches(partition)
+    manager = writer_lease.LeaseManager(
+        writer_lease.LeaseConfig(state_dir=tmp_path / "writer-state")
+    )
+    monkeypatch.setattr(writer_lease, "active_manager", lambda: manager)
+    store = consolidation_batch_journal.ConsolidationBatchJournalStore(
+        root,
+        run_id="00000000-0000-4000-8000-000000000091",
+    )
+    store.create(
+        operation_id="00000000-0000-4000-8000-000000000092",
+        request_digest=hashlib.sha256(b"multi-batch-retry").hexdigest(),
+        partition=partition,
+    )
+    store.prepare_batch(batches[0])
+    targets[0].write_bytes(b"after-0")
+    store.commit_batch(batches[0])
+    store.prepare_batch(batches[1])
+    materialized: list[int] = []
+
+    def materialize(batch: consolidation_saga.ContentBatch):
+        materialized.append(batch.ordinal)
+        action = actions[batch.first_action_ordinal]
+        return (
+            vault.PlannedWrite(
+                path=root / str(action["destination_path"]),
+                content=f"after-{batch.ordinal}",
+                expected_hash=str(action["expected_before_sha256"]),
+            ),
+        )
+
+    result = consolidation_saga.publish_policy_first(
+        content_actions=actions,
+        approved_partition_digest=partition.digest,
+        expected_policy_fingerprint=POLICY_FINGERPRINT,
+        activate_policy=_publication_terminal,
+        journal=consolidation_batch_journal.ConsolidationBatchJournalStore(
+            root,
+            run_id="00000000-0000-4000-8000-000000000091",
+        ),
+        vault_root=root,
+        materialize_batch=materialize,
+    )
+
+    assert materialized == [1]
+    assert tuple(target.read_bytes() for target in targets) == (b"after-0", b"after-1")
+    assert result.committed_batch_ordinals == (0, 1)
+    assert tuple(entry.status for entry in store.load().batches) == ("final", "final")
+
+
+def test_content_batch_classifier_refuses_an_unsafe_leaf(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import consolidation_plan, consolidation_saga
+
+    root = tmp_path / "vault"
+    target = root / "Knowledge Base/Notes/target.md"
+    outside = tmp_path / "outside.md"
+    target.parent.mkdir(parents=True)
+    outside.write_bytes(b"before")
+    target.symlink_to(outside)
+    actions = (
+        _state_action(
+            ordinal=0,
+            batch_ordinal=0,
+            destination_path="Knowledge Base/Notes/target.md",
+            before=b"before",
+            after=b"after",
+        ),
+    )
+    partition = consolidation_plan.derive_journal_batch_partition(actions)
+
+    with pytest.raises(consolidation_saga.PolicyFirstPublicationUnavailable):
+        consolidation_saga.classify_content_batch_state(
+            vault_root=root,
+            content_actions=actions,
+            batch=consolidation_saga._content_batches(partition)[0],
+        )
+
+
+@pytest.mark.parametrize("changed", ["path", "content", "cas"])
+def test_policy_first_rejects_materialized_writes_outside_the_approved_action(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    changed: str,
+) -> None:
+    from exomem import vault
+    from exomem.governance import consolidation_plan, consolidation_saga
+
+    root = tmp_path / "vault"
+    target = root / "Knowledge Base/Notes/target.md"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"before")
+    action = _state_action(
+        ordinal=0,
+        batch_ordinal=0,
+        destination_path="Knowledge Base/Notes/target.md",
+        before=b"before",
+        after=b"after",
+    )
+    partition = consolidation_plan.derive_journal_batch_partition((action,))
+    effects: list[str] = []
+
+    class Journal:
+        def batch_status(self, batch: consolidation_saga.ContentBatch) -> str:
+            return "prior"
+
+        def prepare_batch(self, batch: consolidation_saga.ContentBatch) -> object:
+            effects.append("prepare")
+            return object()
+
+        def commit_batch(self, batch: consolidation_saga.ContentBatch) -> object:
+            effects.append("commit")
+            return object()
+
+    monkeypatch.setattr(
+        consolidation_saga.vault,
+        "batch_atomic_write",
+        lambda *args, **kwargs: effects.append("publish"),
+    )
+    write = vault.PlannedWrite(
+        path=(root / "Knowledge Base/Notes/extra.md") if changed == "path" else target,
+        content="different" if changed == "content" else "after",
+        expected_hash=(
+            hashlib.sha256(b"different-before").hexdigest()
+            if changed == "cas"
+            else hashlib.sha256(b"before").hexdigest()
+        ),
+    )
+
+    with pytest.raises(consolidation_saga.PolicyFirstPublicationUnavailable):
+        consolidation_saga.publish_policy_first(
+            content_actions=(action,),
+            approved_partition_digest=partition.digest,
+            expected_policy_fingerprint=POLICY_FINGERPRINT,
+            activate_policy=_publication_terminal,
+            journal=Journal(),
+            vault_root=root,
+            materialize_batch=lambda batch: (write,),
+        )
+
+    assert effects == ["prepare"]

--- a/tests/test_held_fs_contract.py
+++ b/tests/test_held_fs_contract.py
@@ -151,6 +151,9 @@ def test_relative_leaf_operations_use_held_parents_only(tmp_path: Path) -> None:
                 assert filesystem.write(source_file, b"source").ok
                 assert source_file.identity.kind == "file"
                 assert source_file.identity.link_count == 1
+                assert filesystem.sha256(source_file).require() == hashlib.sha256(
+                    b"source"
+                ).hexdigest()
 
             with filesystem.file(source, "source.txt", access="mutate").require() as source_file:
                 assert filesystem.read(source_file).require() == b"source"


### PR DESCRIPTION
## Summary

- classify every approved content batch from no-follow held handles as exact prior, exact final, equivalent, or unsafe mixed state
- bind retries to the persisted batch-journal status so final batches replay without publication and prepared+final batches repair only the missing terminal
- validate every materialized write against its approved destination, final SHA-256, and before-state CAS before `batch_atomic_write`
- add streaming SHA-256 to the POSIX and Windows held-file backends, including identity/metadata stability checks
- prove a persisted two-batch restart skips the final first batch and resumes only the prepared second batch

Stacked after #971. This is the live-byte/retry-classification slice of OpenSpec task 7.4; the later receipt/acknowledgement crash matrix remains separate. It does not merge or touch either real vault.

## Verification

- red-first: 12 expected classifier/retry failures, then 3 expected approved-write binding failures
- `tests/test_consolidation*.py tests/test_held_fs_contract.py tests/test_held_fs_posix.py`: 429 passed, 1 platform skip
- focused saga/journal/held-filesystem set: 59 passed, 1 platform skip
- native Windows module imports cleanly on Linux; the 20 NTFS-only cases remain delegated to Windows CI
- changed-file Ruff: clean
- `git diff --check`
- `openspec validate add-governed-vault-consolidation --strict`
- `uv lock --check`
- public repository artifact validation: 3426 files / 3494 text payloads
- `uv build`
