### PR TITLE
feat(governance): guard consolidation derivative rebuilds

### DIFF
--- a/src/exomem/governance/consolidation_rebuild.py
+++ b/src/exomem/governance/consolidation_rebuild.py
@@ -1,0 +1,177 @@
+"""Closed derivative-rebuild boundary for governed vault consolidation.
+
+The complete apply coordinator supplies the concrete component rebuilders.  This
+module owns the invariant around them: all approved content batches are final,
+each component is bound to the same canonical destination census, and canonical
+bytes remain unchanged after every component.  Source/archive paths are
+deliberately absent from the rebuild context.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NoReturn
+
+DERIVATIVE_REBUILD_TERMINAL_SCHEMA = (
+    "exomem.consolidation-derivative-rebuild-terminal/v1"
+)
+DERIVATIVE_COMPONENTS = (
+    "lexical",
+    "embedding",
+    "semantic-unit",
+    "graph",
+    "media",
+    "freshness",
+    "identity",
+    "review",
+)
+
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
+
+__all__ = [
+    "DERIVATIVE_COMPONENTS",
+    "DERIVATIVE_REBUILD_TERMINAL_SCHEMA",
+    "DerivativeRebuildContext",
+    "DerivativeRebuildResult",
+    "DerivativeRebuildTerminal",
+    "DerivativeRebuildUnavailable",
+    "rebuild_destination_derivatives",
+]
+
+
+class DerivativeRebuildUnavailable(RuntimeError):
+    """Content-free refusal for an untrusted or incomplete rebuild state."""
+
+    code = "CONSOLIDATION_DERIVATIVE_REBUILD_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__("consolidation derivative rebuild is unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class DerivativeRebuildContext:
+    vault_root: Path
+    canonical_census_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class DerivativeRebuildTerminal:
+    schema: str
+    component: str
+    canonical_census_digest: str
+    artifact_fingerprint: str
+
+
+@dataclass(frozen=True, slots=True)
+class DerivativeRebuildResult:
+    canonical_census_digest: str
+    completed_components: tuple[str, ...]
+    terminals: tuple[DerivativeRebuildTerminal, ...]
+
+
+def _fail() -> NoReturn:
+    raise DerivativeRebuildUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if type(value) is not str or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _snapshot(
+    snapshot_census: Callable[[Path], str],
+    vault_root: Path,
+) -> str:
+    try:
+        return _digest(snapshot_census(vault_root))
+    except DerivativeRebuildUnavailable:
+        raise
+    except Exception:  # noqa: BLE001 - expose only the stable sealed refusal
+        _fail()
+
+
+def _terminal(
+    value: object,
+    *,
+    component: str,
+    canonical_census_digest: str,
+) -> DerivativeRebuildTerminal:
+    if type(value) is not DerivativeRebuildTerminal:
+        _fail()
+    if (
+        value.schema != DERIVATIVE_REBUILD_TERMINAL_SCHEMA
+        or value.component != component
+        or value.canonical_census_digest != canonical_census_digest
+    ):
+        _fail()
+    return DerivativeRebuildTerminal(
+        schema=value.schema,
+        component=value.component,
+        canonical_census_digest=_digest(value.canonical_census_digest),
+        artifact_fingerprint=_digest(value.artifact_fingerprint),
+    )
+
+
+def rebuild_destination_derivatives(
+    *,
+    vault_root: Path,
+    expected_canonical_census_digest: str,
+    expected_batch_count: int,
+    committed_batch_ordinals: tuple[int, ...],
+    snapshot_census: Callable[[Path], str],
+    rebuild_component: Callable[
+        [str, DerivativeRebuildContext], DerivativeRebuildTerminal
+    ],
+) -> DerivativeRebuildResult:
+    """Run the closed rebuild set without permitting canonical-byte drift.
+
+    The caller cannot start this boundary until the complete deterministic
+    content partition is final.  Every component receives only the destination
+    root and its approved canonical census digest; no source/archive/database
+    input exists.  Abrupt ``BaseException`` interruption remains visible to the
+    saga recovery layer, while ordinary component failures become one stable,
+    content-free refusal.
+    """
+
+    if type(expected_batch_count) is not int or expected_batch_count <= 0:
+        _fail()
+    if (
+        type(committed_batch_ordinals) is not tuple
+        or committed_batch_ordinals != tuple(range(expected_batch_count))
+        or any(type(value) is not int for value in committed_batch_ordinals)
+    ):
+        _fail()
+    expected = _digest(expected_canonical_census_digest)
+    root = Path(os.path.abspath(vault_root))
+    if _snapshot(snapshot_census, root) != expected:
+        _fail()
+    context = DerivativeRebuildContext(
+        vault_root=root,
+        canonical_census_digest=expected,
+    )
+    terminals: list[DerivativeRebuildTerminal] = []
+    for component in DERIVATIVE_COMPONENTS:
+        try:
+            rebuilt = rebuild_component(component, context)
+        except DerivativeRebuildUnavailable:
+            raise
+        except Exception:  # noqa: BLE001 - component details cannot cross the boundary
+            _fail()
+        terminal = _terminal(
+            rebuilt,
+            component=component,
+            canonical_census_digest=expected,
+        )
+        if _snapshot(snapshot_census, root) != expected:
+            _fail()
+        terminals.append(terminal)
+    return DerivativeRebuildResult(
+        canonical_census_digest=expected,
+        completed_components=DERIVATIVE_COMPONENTS,
+        terminals=tuple(terminals),
+    )

--- a/tests/test_consolidation_rebuild.py
+++ b/tests/test_consolidation_rebuild.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from exomem.governance import consolidation_rebuild
+
+CANONICAL = "Knowledge Base/Notes/canonical.md"
+
+
+def _sha(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _snapshot(vault_root: Path) -> str:
+    return _sha((vault_root / CANONICAL).read_bytes())
+
+
+def _terminal(
+    component: str,
+    context: consolidation_rebuild.DerivativeRebuildContext,
+) -> consolidation_rebuild.DerivativeRebuildTerminal:
+    return consolidation_rebuild.DerivativeRebuildTerminal(
+        schema=consolidation_rebuild.DERIVATIVE_REBUILD_TERMINAL_SCHEMA,
+        component=component,
+        canonical_census_digest=context.canonical_census_digest,
+        artifact_fingerprint=_sha(f"rebuilt:{component}".encode()),
+    )
+
+
+def test_rebuild_runs_the_closed_component_set_after_every_batch_is_final(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "destination"
+    canonical = vault / CANONICAL
+    canonical.parent.mkdir(parents=True)
+    canonical.write_bytes(b"destination canonical bytes")
+    expected = _snapshot(vault)
+    calls: list[tuple[str, Path, str]] = []
+
+    def rebuild(
+        component: str,
+        context: consolidation_rebuild.DerivativeRebuildContext,
+    ) -> consolidation_rebuild.DerivativeRebuildTerminal:
+        calls.append((component, context.vault_root, context.canonical_census_digest))
+        return _terminal(component, context)
+
+    result = consolidation_rebuild.rebuild_destination_derivatives(
+        vault_root=vault,
+        expected_canonical_census_digest=expected,
+        expected_batch_count=3,
+        committed_batch_ordinals=(0, 1, 2),
+        snapshot_census=_snapshot,
+        rebuild_component=rebuild,
+    )
+
+    assert tuple(component for component, _root, _digest in calls) == (
+        "lexical",
+        "embedding",
+        "semantic-unit",
+        "graph",
+        "media",
+        "freshness",
+        "identity",
+        "review",
+    )
+    assert all(root == vault and digest == expected for _component, root, digest in calls)
+    assert result.canonical_census_digest == expected
+    assert result.completed_components == tuple(component for component, *_ in calls)
+    assert canonical.read_bytes() == b"destination canonical bytes"
+
+
+@pytest.mark.parametrize(
+    "committed",
+    ((), (0,), (0, 2), (1, 0), (0, 1, 2, 3)),
+)
+def test_rebuild_refuses_before_the_exact_content_partition_is_final(
+    tmp_path: Path,
+    committed: tuple[int, ...],
+) -> None:
+    vault = tmp_path / "destination"
+    canonical = vault / CANONICAL
+    canonical.parent.mkdir(parents=True)
+    canonical.write_bytes(b"destination canonical bytes")
+    calls: list[str] = []
+
+    with pytest.raises(
+        consolidation_rebuild.DerivativeRebuildUnavailable,
+        match="consolidation derivative rebuild is unavailable",
+    ):
+        consolidation_rebuild.rebuild_destination_derivatives(
+            vault_root=vault,
+            expected_canonical_census_digest=_snapshot(vault),
+            expected_batch_count=3,
+            committed_batch_ordinals=committed,
+            snapshot_census=_snapshot,
+            rebuild_component=lambda component, _context: calls.append(component),
+        )
+
+    assert calls == []
+
+
+def test_rebuild_stops_on_the_first_canonical_byte_change(tmp_path: Path) -> None:
+    vault = tmp_path / "destination"
+    canonical = vault / CANONICAL
+    canonical.parent.mkdir(parents=True)
+    canonical.write_bytes(b"destination canonical bytes")
+    expected = _snapshot(vault)
+    calls: list[str] = []
+
+    def rebuild(
+        component: str,
+        context: consolidation_rebuild.DerivativeRebuildContext,
+    ) -> consolidation_rebuild.DerivativeRebuildTerminal:
+        calls.append(component)
+        if component == "semantic-unit":
+            canonical.write_bytes(b"mutated by a broken rebuild")
+        return _terminal(component, context)
+
+    with pytest.raises(consolidation_rebuild.DerivativeRebuildUnavailable):
+        consolidation_rebuild.rebuild_destination_derivatives(
+            vault_root=vault,
+            expected_canonical_census_digest=expected,
+            expected_batch_count=1,
+            committed_batch_ordinals=(0,),
+            snapshot_census=_snapshot,
+            rebuild_component=rebuild,
+        )
+
+    assert calls == ["lexical", "embedding", "semantic-unit"]
+
+
+@pytest.mark.parametrize(
+    "changed_field",
+    ("schema", "component", "canonical_census_digest", "artifact_fingerprint"),
+)
+def test_rebuild_rejects_a_malformed_or_unbound_component_terminal(
+    tmp_path: Path,
+    changed_field: str,
+) -> None:
+    vault = tmp_path / "destination"
+    canonical = vault / CANONICAL
+    canonical.parent.mkdir(parents=True)
+    canonical.write_bytes(b"destination canonical bytes")
+    expected = _snapshot(vault)
+
+    def rebuild(
+        component: str,
+        context: consolidation_rebuild.DerivativeRebuildContext,
+    ) -> consolidation_rebuild.DerivativeRebuildTerminal:
+        values = {
+            "schema": consolidation_rebuild.DERIVATIVE_REBUILD_TERMINAL_SCHEMA,
+            "component": component,
+            "canonical_census_digest": context.canonical_census_digest,
+            "artifact_fingerprint": _sha(component.encode()),
+        }
+        values[changed_field] = {
+            "schema": "wrong/v1",
+            "component": "wrong",
+            "canonical_census_digest": "f" * 64,
+            "artifact_fingerprint": "not-a-digest",
+        }[changed_field]
+        return consolidation_rebuild.DerivativeRebuildTerminal(**values)
+
+    with pytest.raises(consolidation_rebuild.DerivativeRebuildUnavailable):
+        consolidation_rebuild.rebuild_destination_derivatives(
+            vault_root=vault,
+            expected_canonical_census_digest=expected,
+            expected_batch_count=1,
+            committed_batch_ordinals=(0,),
+            snapshot_census=_snapshot,
+            rebuild_component=rebuild,
+        )
+
+
+def test_rebuild_has_no_source_database_installation_input(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source_database = source / "Knowledge Base/.lexical.sqlite"
+    source_database.parent.mkdir(parents=True)
+    source_database.write_bytes(b"source database sentinel")
+    canonical = destination / CANONICAL
+    canonical.parent.mkdir(parents=True)
+    canonical.write_bytes(b"destination canonical bytes")
+    expected = _snapshot(destination)
+
+    def rebuild(
+        component: str,
+        context: consolidation_rebuild.DerivativeRebuildContext,
+    ) -> consolidation_rebuild.DerivativeRebuildTerminal:
+        assert not hasattr(context, "source_root")
+        assert not hasattr(context, "source_database")
+        derived = destination / "Knowledge Base" / f".{component}.derived"
+        derived.write_bytes(canonical.read_bytes() + component.encode())
+        return consolidation_rebuild.DerivativeRebuildTerminal(
+            schema=consolidation_rebuild.DERIVATIVE_REBUILD_TERMINAL_SCHEMA,
+            component=component,
+            canonical_census_digest=context.canonical_census_digest,
+            artifact_fingerprint=_sha(derived.read_bytes()),
+        )
+
+    consolidation_rebuild.rebuild_destination_derivatives(
+        vault_root=destination,
+        expected_canonical_census_digest=expected,
+        expected_batch_count=1,
+        committed_batch_ordinals=(0,),
+        snapshot_census=_snapshot,
+        rebuild_component=rebuild,
+    )
+
+    assert source_database.read_bytes() == b"source database sentinel"
+    assert not (destination / "Knowledge Base/.lexical.sqlite").exists()


### PR DESCRIPTION
## Summary

- add a closed lexical/embedding/semantic-unit/graph/media/freshness/identity/review rebuild boundary
- refuse rebuild until the complete deterministic content-batch partition is final
- bind every component terminal to the approved canonical destination census and recheck canonical bytes after every component
- omit source/archive/database inputs entirely so source-derived stores cannot be installed through this boundary

Stacked after #973. This establishes the invariant boundary for OpenSpec task 7.5; the next stacked change supplies the concrete destination-only rebuild adapters. It does not merge or touch any live vault.

## Verification

- red-first: new suite initially failed at import because the boundary did not exist
- `uv run --frozen python -m pytest -q tests/test_consolidation_rebuild.py tests/test_consolidation_saga.py tests/test_consolidation_batch_journal.py tests/test_consolidation_batch_crash_matrix.py` — 59 passed
- `uv run --frozen python -m pytest -q tests/test_consolidation*.py` — 425 passed
- Ruff on both changed files
- `git diff --check`
- `openspec validate add-governed-vault-consolidation --strict`
- `uv lock --check`
- `uv build`
