### PR TITLE
feat(governance): rebuild consolidation derivatives

### DIFF
--- a/openspec/changes/add-governed-vault-consolidation/tasks.md
+++ b/openspec/changes/add-governed-vault-consolidation/tasks.md
@@ -555,7 +555,7 @@ binds that reference and observed digest; no caller field selects K.
   metadata, journal, receipt, and acknowledgement seam. State may be prior,
   prepared, or final only; a mixed/third state stays sealed and never produces a
   false whole-saga atomicity claim.
-- [ ] 7.5 Add red rebuild tests proving lexical, embedding, semantic-unit, graph,
+- [x] 7.5 Add red rebuild tests proving lexical, embedding, semantic-unit, graph,
   media, freshness, identity, and review derivatives are recreated only from
   canonical destination bytes after all content batches, source-derived databases
   are never installed, and canonical bytes cannot be changed by rebuild.

--- a/src/exomem/governance/consolidation_rebuild.py
+++ b/src/exomem/governance/consolidation_rebuild.py
@@ -20,11 +20,14 @@ DERIVATIVE_REBUILD_TERMINAL_SCHEMA = (
     "exomem.consolidation-derivative-rebuild-terminal/v1"
 )
 DERIVATIVE_COMPONENTS = (
+    # Media comes first because rebuilding configured scene-frame derivatives can
+    # fan out incremental text/graph updates.  The complete rebuilds below replace
+    # that incidental state from the final destination corpus.
+    "media",
     "lexical",
     "embedding",
     "semantic-unit",
     "graph",
-    "media",
     "freshness",
     "identity",
     "review",

--- a/src/exomem/governance/consolidation_rebuild_adapters.py
+++ b/src/exomem/governance/consolidation_rebuild_adapters.py
@@ -1,0 +1,524 @@
+"""Destination-only derivative adapters for governed consolidation."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import stat
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NoReturn
+
+import numpy as np
+
+from .. import (
+    access,
+    claims,
+    due_state,
+    embeddings,
+    epistemic_graph,
+    extract,
+    freshness,
+    index_paths,
+    lexstore,
+    media_worker,
+    memory_refs,
+    recall_policy,
+    scene_frames,
+    semantic_index,
+)
+from ..kbdir import kb_dirname
+from . import consolidation_rebuild, projections
+
+DERIVATIVE_ARTIFACT_SCHEMA = "exomem.consolidation-derivative-artifact/v1"
+MEDIA_REBUILD_TIMEOUT_SECONDS = 900.0
+
+_ARTIFACT_DOMAIN = DERIVATIVE_ARTIFACT_SCHEMA.encode("ascii")
+_PARENT_MEDIA = re.compile(r"(?m)^parent_media\s*:")
+
+RebuildService = Callable[[Path], Mapping[str, object]]
+
+__all__ = [
+    "DERIVATIVE_ARTIFACT_SCHEMA",
+    "MEDIA_REBUILD_TIMEOUT_SECONDS",
+    "DestinationRebuildServices",
+    "MediaCandidate",
+    "destination_component_rebuilder",
+    "production_destination_rebuild_services",
+]
+
+
+def _fail() -> NoReturn:
+    raise consolidation_rebuild.DerivativeRebuildUnavailable from None
+
+
+def _matrix_sha256(matrix: object) -> str:
+    try:
+        values = np.ascontiguousarray(matrix, dtype="<f4")
+    except (TypeError, ValueError):
+        _fail()
+    return hashlib.sha256(values.tobytes()).hexdigest()
+
+
+def _file_sha256(path: Path) -> str:
+    """Hash one stable regular file without following a final symlink."""
+
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, flags)
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            _fail()
+        digest = hashlib.sha256()
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+        after = os.fstat(descriptor)
+        def identity(value: os.stat_result) -> tuple[int, int, int, int, int]:
+            return (
+                value.st_dev,
+                value.st_ino,
+                value.st_size,
+                value.st_mtime_ns,
+                value.st_ctime_ns,
+            )
+        if identity(before) != identity(after):
+            _fail()
+        return digest.hexdigest()
+    except consolidation_rebuild.DerivativeRebuildUnavailable:
+        raise
+    except OSError:
+        _fail()
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _artifact_fingerprint(
+    *,
+    component: str,
+    canonical_census_digest: str,
+    observation: Mapping[str, object],
+) -> str:
+    if type(observation) is not dict or any(type(key) is not str for key in observation):
+        _fail()
+    try:
+        payload = projections.canonical_jcs(
+            {
+                "schema": DERIVATIVE_ARTIFACT_SCHEMA,
+                "component": component,
+                "canonical_census_digest": canonical_census_digest,
+                "observation": observation,
+            }
+        )
+    except Exception:  # noqa: BLE001 - one stable rebuild refusal
+        _fail()
+    framed = (
+        len(_ARTIFACT_DOMAIN).to_bytes(4, "big")
+        + _ARTIFACT_DOMAIN
+        + len(payload).to_bytes(8, "big")
+        + payload
+    )
+    return hashlib.sha256(framed).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class MediaCandidate:
+    binary_path: Path
+    sidecar_path: Path
+    relative_path: str
+    media_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class DestinationRebuildServices:
+    media: RebuildService
+    lexical: RebuildService
+    embedding: RebuildService
+    semantic_unit: RebuildService
+    graph: RebuildService
+    freshness: RebuildService
+    identity: RebuildService
+    review: RebuildService
+
+
+def _service_for(
+    services: DestinationRebuildServices,
+    component: str,
+) -> RebuildService:
+    values = {
+        "media": services.media,
+        "lexical": services.lexical,
+        "embedding": services.embedding,
+        "semantic-unit": services.semantic_unit,
+        "graph": services.graph,
+        "freshness": services.freshness,
+        "identity": services.identity,
+        "review": services.review,
+    }
+    selected = values.get(component)
+    if selected is None:
+        _fail()
+    return selected
+
+
+def destination_component_rebuilder(
+    *,
+    services: DestinationRebuildServices | None = None,
+) -> Callable[
+    [str, consolidation_rebuild.DerivativeRebuildContext],
+    consolidation_rebuild.DerivativeRebuildTerminal,
+]:
+    """Return the closed destination-only adapter used by the saga coordinator."""
+
+    selected_services = services or production_destination_rebuild_services()
+
+    def rebuild(
+        component: str,
+        context: consolidation_rebuild.DerivativeRebuildContext,
+    ) -> consolidation_rebuild.DerivativeRebuildTerminal:
+        if component not in consolidation_rebuild.DERIVATIVE_COMPONENTS:
+            _fail()
+        try:
+            observation = _service_for(selected_services, component)(context.vault_root)
+            fingerprint = _artifact_fingerprint(
+                component=component,
+                canonical_census_digest=context.canonical_census_digest,
+                observation=observation,
+            )
+        except consolidation_rebuild.DerivativeRebuildUnavailable:
+            raise
+        except Exception:  # noqa: BLE001 - do not disclose component internals
+            _fail()
+        return consolidation_rebuild.DerivativeRebuildTerminal(
+            schema=consolidation_rebuild.DERIVATIVE_REBUILD_TERMINAL_SCHEMA,
+            component=component,
+            canonical_census_digest=context.canonical_census_digest,
+            artifact_fingerprint=fingerprint,
+        )
+
+    return rebuild
+
+
+def _rebuild_lexical(vault_root: Path) -> dict[str, object]:
+    index = lexstore.LexicalStore(vault_root)
+    if index.rebuild_atomic() is not True:
+        _fail()
+    path = lexstore.lexical_path(vault_root)
+    if not path.is_file():
+        _fail()
+    return {"database_sha256": _file_sha256(path), "published": True}
+
+
+def _embedding_paths(metadata: object) -> list[str]:
+    if not isinstance(metadata, list):
+        _fail()
+    values: list[str] = []
+    for row in metadata:
+        if (
+            not isinstance(row, tuple)
+            or len(row) != 2
+            or type(row[0]) is not str
+            or type(row[1]) is not int
+            or row[1] < 0
+        ):
+            _fail()
+        values.append(f"{row[0]}#{row[1]}")
+    return values
+
+
+def _rebuild_embedding(vault_root: Path) -> dict[str, object]:
+    if os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
+        _fail()
+    index = embeddings.get_embedding_index(vault_root)
+    prior_metadata, _prior_matrix = index.all_vectors()
+    prior_paths = sorted({row[0] for row in prior_metadata})
+    if prior_paths:
+        index.purge_paths_if_present(prior_paths)
+    rebuilt = index.rebuild_all()
+    metadata, matrix = index.all_vectors()
+    paths = _embedding_paths(metadata)
+    if type(rebuilt) is not int or rebuilt < 0 or rebuilt != len(paths):
+        _fail()
+    return {
+        "chunk_rows": len(paths),
+        "matrix_sha256": _matrix_sha256(matrix),
+        "paths": paths,
+        "rebuilt_rows": rebuilt,
+    }
+
+
+def _semantic_states(vault_root: Path) -> dict[str, semantic_index.SemanticParentIndexState]:
+    states: dict[str, semantic_index.SemanticParentIndexState] = {}
+    for path in index_paths.iter_index_markdown(vault_root):
+        if not index_paths.is_embeddable_path(path):
+            continue
+        relative = index_paths.rel_to_vault(vault_root, path)
+        if relative is None or not access.is_indexable(vault_root, relative):
+            continue
+        try:
+            state = semantic_index.build_parent_index_state(vault_root, path)
+        except (OSError, UnicodeError, ValueError):
+            _fail()
+        if state.path in states:
+            _fail()
+        states[state.path] = state
+    return states
+
+
+def _rebuild_semantic_units(vault_root: Path) -> dict[str, object]:
+    states = _semantic_states(vault_root)
+    drift = semantic_index.audit_semantic_unit_sidecars(
+        vault_root,
+        states,
+        include_lexical=True,
+        include_vectors=True,
+        include_graph=False,
+    )
+    if drift:
+        _fail()
+    parent_generations = sorted(
+        f"{path}:{state.parent_generation}" for path, state in states.items()
+    )
+    unit_count = sum(
+        unit.unit_ref is not None
+        for state in states.values()
+        for unit in state.document.units
+    )
+    return {
+        "parent_generations": parent_generations,
+        "parents": len(states),
+        "semantic_units": unit_count,
+    }
+
+
+def _normalized_graph_value(value: object) -> object:
+    if value is None:
+        return {"none": True}
+    if type(value) in {bool, int, str}:
+        return value
+    if type(value) is float:
+        return {"binary64": value.hex()}
+    if isinstance(value, bytes):
+        return {"bytes_sha256": hashlib.sha256(value).hexdigest()}
+    if isinstance(value, (list, tuple)):
+        return [_normalized_graph_value(item) for item in value]
+    if isinstance(value, dict) and all(type(key) is str for key in value):
+        return {key: _normalized_graph_value(value[key]) for key in sorted(value)}
+    _fail()
+
+
+def _rebuild_graph(vault_root: Path) -> dict[str, object]:
+    if not epistemic_graph.graph_enabled():
+        _fail()
+    index = epistemic_graph.EpistemicGraphIndex(vault_root)
+    report = index.rebuild_all()
+    if type(report) is not dict or set(report) != {"indexed_files", "nodes", "edges"}:
+        _fail()
+    if any(type(report[key]) is not int or report[key] < 0 for key in report):
+        _fail()
+    topology = projections.canonical_jcs(
+        {
+            "nodes": _normalized_graph_value(index.nodes()),
+            "edges": _normalized_graph_value(index.edges()),
+        }
+    )
+    return {
+        "edges": report["edges"],
+        "indexed_files": report["indexed_files"],
+        "nodes": report["nodes"],
+        "topology_sha256": hashlib.sha256(topology).hexdigest(),
+    }
+
+
+def _media_candidates(vault_root: Path) -> tuple[MediaCandidate, ...]:
+    kb = vault_root / kb_dirname()
+    if not kb.is_dir():
+        return ()
+    candidates: list[MediaCandidate] = []
+    for binary in media_worker.iter_kb_files(kb):
+        media_type = extract.media_type_for(binary)
+        if media_type not in {"image", "video"}:
+            continue
+        sidecar = binary.with_name(binary.name + ".md")
+        if binary.is_symlink() or sidecar.is_symlink():
+            _fail()
+        if (
+            not sidecar.is_file()
+            or recall_policy.is_structured_only_path(vault_root, sidecar)
+            or not recall_policy.is_recall_candidate(vault_root, sidecar)
+        ):
+            continue
+        try:
+            header = sidecar.read_text(encoding="utf-8")[:4096]
+            relative = binary.resolve().relative_to(vault_root.resolve()).as_posix()
+        except (OSError, UnicodeError, ValueError):
+            _fail()
+        if _PARENT_MEDIA.search(header):
+            continue
+        candidates.append(
+            MediaCandidate(binary, sidecar, relative, media_type)
+        )
+    return tuple(sorted(candidates, key=lambda item: item.relative_path))
+
+
+def _scene_file_observation(
+    vault_root: Path,
+    candidates: tuple[MediaCandidate, ...],
+) -> list[dict[str, object]]:
+    values: list[dict[str, object]] = []
+    for candidate in candidates:
+        if candidate.media_type != "video":
+            continue
+        directory = scene_frames.frames_dir_for(candidate.binary_path)
+        if not directory.exists():
+            continue
+        if not directory.is_dir() or directory.is_symlink():
+            _fail()
+        for path in sorted(directory.iterdir(), key=lambda item: item.name):
+            if path.is_symlink() or not path.is_file():
+                _fail()
+            frame_name = path.name.removesuffix(".md")
+            if scene_frames.parse_frame_ts(frame_name) is None:
+                _fail()
+            try:
+                relative = path.relative_to(vault_root).as_posix()
+                size = path.stat().st_size
+            except OSError:
+                _fail()
+            values.append(
+                {"path": relative, "sha256": _file_sha256(path), "size": size}
+            )
+    return values
+
+
+def _rebuild_media(vault_root: Path) -> dict[str, object]:
+    candidates = _media_candidates(vault_root)
+    index = embeddings.get_clip_index(vault_root)
+    old_paths, _old_timestamps, _old_matrix = index.all_vectors()
+    if old_paths:
+        index.purge_paths_if_present(sorted(set(old_paths)))
+    cleared = sum(
+        scene_frames.clear_scene_frames(vault_root, item.binary_path)
+        for item in candidates
+        if item.media_type == "video"
+    )
+    if candidates and not embeddings.clip_enabled():
+        _fail()
+    if candidates:
+        worker = media_worker.MediaWorker(vault_root, execution_mode="inline")
+        worker.start()
+        try:
+            for item in candidates:
+                worker.enqueue(
+                    binary_path=item.binary_path,
+                    sidecar_path=item.sidecar_path,
+                    media_type=item.media_type,
+                    do_ocr=False,
+                    do_clip=True,
+                )
+            worker.join(timeout=MEDIA_REBUILD_TIMEOUT_SECONDS)
+        finally:
+            worker.stop()
+    for item in candidates:
+        ready = (
+            index.has_frames(item.relative_path)
+            if item.media_type == "video"
+            else index.has(item.relative_path)
+        )
+        if not ready:
+            _fail()
+    paths, timestamps, matrix = index.all_vectors()
+    expected = {item.relative_path for item in candidates}
+    if set(paths) != expected or len(paths) != len(timestamps):
+        _fail()
+    frame_keys = [
+        f"{path}#{'image' if timestamp is None else scene_frames.frame_timestamp_ms(timestamp)}"
+        for path, timestamp in zip(paths, timestamps, strict=True)
+    ]
+    return {
+        "candidate_paths": sorted(expected),
+        "cleared_scene_files": cleared,
+        "clip_rows": len(paths),
+        "frame_keys": frame_keys,
+        "matrix_sha256": _matrix_sha256(matrix),
+        "scene_files": _scene_file_observation(vault_root, candidates),
+    }
+
+
+def _rebuild_freshness(vault_root: Path) -> dict[str, object]:
+    result = freshness.rebaseline(vault_root)
+    if type(result) is not dict or not result or any(
+        type(scope) is not str or status is not True for scope, status in result.items()
+    ):
+        _fail()
+    return {"scopes": sorted(result)}
+
+
+def _rebuild_identity(vault_root: Path) -> dict[str, object]:
+    result = memory_refs.ReferenceIndex(vault_root).rebuild_all()
+    if (
+        type(result) is not dict
+        or set(result) != {"indexed", "duplicates", "malformed"}
+        or any(type(result[key]) is not int or result[key] < 0 for key in result)
+        or result["duplicates"]
+        or result["malformed"]
+    ):
+        _fail()
+    return dict(result)
+
+
+def _rebuild_review(vault_root: Path) -> dict[str, object]:
+    payload = due_state.reconcile(vault_root)
+    if due_state.load(vault_root) != payload:
+        _fail()
+    due_path = due_state.state_path(vault_root)
+    if not due_path.is_file():
+        _fail()
+    due_digest = _file_sha256(due_path)
+    if not claims.claim_level_enabled():
+        index = claims.get_claim_index(vault_root)
+        index.replace_all(
+            [],
+            identity=recall_policy.recall_policy_identity(vault_root),
+        )
+        return {
+            "claim_index": "not-configured-cleared",
+            "due_state_sha256": due_digest,
+        }
+    if os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
+        _fail()
+    index = claims.get_claim_index(vault_root)
+    rebuilt = index.rebuild_all()
+    metadata, matrix = index.all_claims()
+    if type(rebuilt) is not int or rebuilt < 0 or rebuilt != len(metadata):
+        _fail()
+    paths: list[str] = []
+    for row in metadata:
+        if not isinstance(row, tuple) or len(row) != 4 or type(row[0]) is not str:
+            _fail()
+        paths.append(row[0])
+    return {
+        "claim_rows": len(paths),
+        "due_state_sha256": due_digest,
+        "matrix_sha256": _matrix_sha256(matrix),
+        "paths": paths,
+    }
+
+
+def production_destination_rebuild_services() -> DestinationRebuildServices:
+    return DestinationRebuildServices(
+        media=_rebuild_media,
+        lexical=_rebuild_lexical,
+        embedding=_rebuild_embedding,
+        semantic_unit=_rebuild_semantic_units,
+        graph=_rebuild_graph,
+        freshness=_rebuild_freshness,
+        identity=_rebuild_identity,
+        review=_rebuild_review,
+    )

--- a/src/exomem/media_worker.py
+++ b/src/exomem/media_worker.py
@@ -1006,6 +1006,8 @@ def _join_with_timeout(q: queue.Queue, timeout: float) -> None:
     deadline = time.monotonic() + timeout
     while q.unfinished_tasks and time.monotonic() < deadline:
         time.sleep(0.02)
+    if q.unfinished_tasks:
+        raise TimeoutError("media worker queue did not drain")
 
 
 def _idle_seconds() -> float:

--- a/tests/test_consolidation_rebuild.py
+++ b/tests/test_consolidation_rebuild.py
@@ -57,11 +57,11 @@ def test_rebuild_runs_the_closed_component_set_after_every_batch_is_final(
     )
 
     assert tuple(component for component, _root, _digest in calls) == (
+        "media",
         "lexical",
         "embedding",
         "semantic-unit",
         "graph",
-        "media",
         "freshness",
         "identity",
         "review",
@@ -129,7 +129,7 @@ def test_rebuild_stops_on_the_first_canonical_byte_change(tmp_path: Path) -> Non
             rebuild_component=rebuild,
         )
 
-    assert calls == ["lexical", "embedding", "semantic-unit"]
+    assert calls == ["media", "lexical", "embedding", "semantic-unit"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_consolidation_rebuild_adapters.py
+++ b/tests/test_consolidation_rebuild_adapters.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from exomem.governance import consolidation_rebuild
+from exomem.governance import consolidation_rebuild_adapters as adapters
+
+
+def _context(vault: Path) -> consolidation_rebuild.DerivativeRebuildContext:
+    return consolidation_rebuild.DerivativeRebuildContext(
+        vault_root=vault,
+        canonical_census_digest="a" * 64,
+    )
+
+
+def test_closed_adapter_set_receives_only_the_destination_root(tmp_path: Path) -> None:
+    calls: list[tuple[str, Path]] = []
+
+    def service(component: str):
+        def rebuild(vault_root: Path) -> dict[str, object]:
+            calls.append((component, vault_root))
+            return {"component": component, "rows": 1}
+
+        return rebuild
+
+    services = adapters.DestinationRebuildServices(
+        media=service("media"),
+        lexical=service("lexical"),
+        embedding=service("embedding"),
+        semantic_unit=service("semantic-unit"),
+        graph=service("graph"),
+        freshness=service("freshness"),
+        identity=service("identity"),
+        review=service("review"),
+    )
+    rebuild = adapters.destination_component_rebuilder(services=services)
+    context = _context(tmp_path / "destination")
+
+    terminals = [rebuild(component, context) for component in consolidation_rebuild.DERIVATIVE_COMPONENTS]
+
+    assert calls == [
+        (component, context.vault_root)
+        for component in consolidation_rebuild.DERIVATIVE_COMPONENTS
+    ]
+    assert [terminal.component for terminal in terminals] == list(
+        consolidation_rebuild.DERIVATIVE_COMPONENTS
+    )
+    assert all(terminal.canonical_census_digest == "a" * 64 for terminal in terminals)
+    assert len({terminal.artifact_fingerprint for terminal in terminals}) == len(terminals)
+    assert not hasattr(services, "source_root")
+    assert not hasattr(services, "source_database")
+
+
+def test_evidence_fingerprint_binds_component_census_and_observation(tmp_path: Path) -> None:
+    services = adapters.DestinationRebuildServices(
+        **{
+            field: (lambda _root: {"rows": 1})
+            for field in (
+                "media",
+                "lexical",
+                "embedding",
+                "semantic_unit",
+                "graph",
+                "freshness",
+                "identity",
+                "review",
+            )
+        }
+    )
+    rebuild = adapters.destination_component_rebuilder(services=services)
+    first = rebuild("lexical", _context(tmp_path))
+    second = rebuild(
+        "lexical",
+        consolidation_rebuild.DerivativeRebuildContext(tmp_path, "b" * 64),
+    )
+
+    assert first.artifact_fingerprint != second.artifact_fingerprint
+    with pytest.raises(consolidation_rebuild.DerivativeRebuildUnavailable):
+        rebuild("unknown", _context(tmp_path))
+
+
+def test_embedding_rebuild_replaces_rows_and_binds_vector_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class Index:
+        def __init__(self) -> None:
+            self.purged: list[str] = []
+
+        def all_vectors(self):
+            if not self.purged:
+                return [
+                    ("Knowledge Base/old.md", 0),
+                ], np.asarray([[0.0, 1.0]], dtype=np.float32)
+            return [
+                ("Knowledge Base/new.md", 0),
+            ], np.asarray([[1.0, 2.0]], dtype=np.float32)
+
+        def purge_paths_if_present(self, paths: list[str]) -> int:
+            self.purged.extend(paths)
+            return len(paths)
+
+        def rebuild_all(self) -> int:
+            return 1
+
+    index = Index()
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setattr(adapters.embeddings, "get_embedding_index", lambda _root: index)
+
+    evidence = adapters._rebuild_embedding(tmp_path)
+
+    assert index.purged == ["Knowledge Base/old.md"]
+    assert evidence == {
+        "chunk_rows": 1,
+        "matrix_sha256": hashlib.sha256(
+            np.asarray([[1.0, 2.0]], dtype=np.float32).tobytes()
+        ).hexdigest(),
+        "paths": ["Knowledge Base/new.md#0"],
+        "rebuilt_rows": 1,
+    }
+
+
+def test_embedding_rebuild_refuses_when_the_model_lane_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+
+    with pytest.raises(consolidation_rebuild.DerivativeRebuildUnavailable):
+        adapters._rebuild_embedding(tmp_path)
+
+
+def test_semantic_unit_adapter_refuses_any_sidecar_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(adapters, "_semantic_states", lambda _root: {"a.md": object()})
+    monkeypatch.setattr(
+        adapters.semantic_index,
+        "audit_semantic_unit_sidecars",
+        lambda *_args, **_kwargs: (object(),),
+    )
+
+    with pytest.raises(consolidation_rebuild.DerivativeRebuildUnavailable):
+        adapters._rebuild_semantic_units(tmp_path)
+
+
+def test_identity_adapter_refuses_duplicate_or_malformed_ids(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class Index:
+        def rebuild_all(self) -> dict[str, int]:
+            return {"indexed": 2, "duplicates": 1, "malformed": 0}
+
+    monkeypatch.setattr(adapters.memory_refs, "ReferenceIndex", lambda _root: Index())
+
+    with pytest.raises(consolidation_rebuild.DerivativeRebuildUnavailable):
+        adapters._rebuild_identity(tmp_path)
+
+
+def test_media_rebuild_purges_old_rows_then_requires_every_destination_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    image = adapters.MediaCandidate(
+        binary_path=tmp_path / "Knowledge Base/photo.jpg",
+        sidecar_path=tmp_path / "Knowledge Base/photo.jpg.md",
+        relative_path="Knowledge Base/photo.jpg",
+        media_type="image",
+    )
+    video = adapters.MediaCandidate(
+        binary_path=tmp_path / "Knowledge Base/talk.mp4",
+        sidecar_path=tmp_path / "Knowledge Base/talk.mp4.md",
+        relative_path="Knowledge Base/talk.mp4",
+        media_type="video",
+    )
+
+    class Clip:
+        def __init__(self) -> None:
+            self.purged: list[str] = []
+
+        def all_vectors(self):
+            paths = ["Knowledge Base/stale.png"] if not self.purged else [
+                image.relative_path,
+                video.relative_path,
+            ]
+            frames = [None] if not self.purged else [None, 1.0]
+            return paths, frames, np.ones((len(paths), 2), dtype=np.float32)
+
+        def purge_paths_if_present(self, paths: list[str]) -> int:
+            self.purged.extend(paths)
+            return len(paths)
+
+        def has(self, path: str) -> bool:
+            return path == image.relative_path
+
+        def has_frames(self, path: str) -> bool:
+            return path == video.relative_path
+
+    class Worker:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self.enqueued: list[tuple[Path, str]] = []
+
+        def start(self) -> None:
+            pass
+
+        def enqueue(self, *, binary_path: Path, media_type: str, **_kwargs) -> None:
+            self.enqueued.append((binary_path, media_type))
+
+        def join(self, timeout: float) -> None:
+            assert timeout == adapters.MEDIA_REBUILD_TIMEOUT_SECONDS
+
+        def stop(self) -> None:
+            pass
+
+    clip = Clip()
+    worker = Worker()
+    cleared: list[Path] = []
+    monkeypatch.setattr(adapters, "_media_candidates", lambda _root: (image, video))
+    monkeypatch.setattr(adapters.embeddings, "clip_enabled", lambda: True)
+    monkeypatch.setattr(adapters.embeddings, "get_clip_index", lambda _root: clip)
+    monkeypatch.setattr(adapters.media_worker, "MediaWorker", lambda *_a, **_kw: worker)
+    monkeypatch.setattr(
+        adapters.scene_frames,
+        "clear_scene_frames",
+        lambda _root, path: cleared.append(path) or 2,
+    )
+
+    evidence = adapters._rebuild_media(tmp_path)
+
+    assert clip.purged == ["Knowledge Base/stale.png"]
+    assert worker.enqueued == [
+        (image.binary_path, "image"),
+        (video.binary_path, "video"),
+    ]
+    assert cleared == [video.binary_path]
+    assert evidence["candidate_paths"] == [image.relative_path, video.relative_path]
+    assert evidence["cleared_scene_files"] == 2
+    assert evidence["clip_rows"] == 2
+    assert evidence["scene_files"] == []
+
+
+def test_freshness_and_review_respect_their_configured_lanes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    due_path = tmp_path / "Knowledge Base/.due-state.json"
+    due_path.parent.mkdir(parents=True)
+    due_path.write_bytes(b'{"version":1}\n')
+
+    class ClaimIndex:
+        def replace_all(self, rows: list[object], *, identity: tuple[str, str]) -> None:
+            assert rows == []
+            assert identity == ("policy", "access")
+
+    monkeypatch.setattr(
+        adapters.freshness,
+        "rebaseline",
+        lambda _root: {"kb": True, "vault": True},
+    )
+    monkeypatch.setattr(adapters.claims, "claim_level_enabled", lambda: False)
+    monkeypatch.setattr(adapters.claims, "get_claim_index", lambda _root: ClaimIndex())
+    monkeypatch.setattr(
+        adapters.recall_policy,
+        "recall_policy_identity",
+        lambda _root: ("policy", "access"),
+    )
+    monkeypatch.setattr(
+        adapters.due_state,
+        "reconcile",
+        lambda _root: {"version": 1},
+    )
+    monkeypatch.setattr(adapters.due_state, "load", lambda _root: {"version": 1})
+    monkeypatch.setattr(adapters.due_state, "state_path", lambda _root: due_path)
+
+    assert adapters._rebuild_freshness(tmp_path) == {"scopes": ["kb", "vault"]}
+    assert adapters._rebuild_review(tmp_path) == {
+        "claim_index": "not-configured-cleared",
+        "due_state_sha256": hashlib.sha256(b'{"version":1}\n').hexdigest(),
+    }
+
+
+def test_review_rebuild_refuses_when_due_state_did_not_persist(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(adapters.claims, "claim_level_enabled", lambda: False)
+    monkeypatch.setattr(
+        adapters.claims,
+        "get_claim_index",
+        lambda _root: type(
+            "Index",
+            (),
+            {"replace_all": lambda _self, _rows, *, identity: None},
+        )(),
+    )
+    monkeypatch.setattr(
+        adapters.recall_policy,
+        "recall_policy_identity",
+        lambda _root: ("policy", "access"),
+    )
+    monkeypatch.setattr(adapters.due_state, "reconcile", lambda _root: {"version": 1})
+    monkeypatch.setattr(adapters.due_state, "load", lambda _root: None)
+
+    with pytest.raises(consolidation_rebuild.DerivativeRebuildUnavailable):
+        adapters._rebuild_review(tmp_path)
+
+
+def test_real_model_free_adapters_rebuild_from_one_destination_vault(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "destination"
+    kb = vault / "Knowledge Base"
+    kb.mkdir(parents=True)
+    (kb / "note.md").write_text(
+        "---\n"
+        "exomem_id: 11111111-1111-4111-8111-111111111111\n"
+        "type: insight\n"
+        "status: active\n"
+        "---\n"
+        "# Note\n\nDestination canonical bytes.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_CLIP", "1")
+    monkeypatch.delenv("EXOMEM_DISABLE_GRAPH_INDEX", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_FRESHNESS_INDEX", raising=False)
+
+    assert adapters._rebuild_media(vault)["candidate_paths"] == []
+    assert adapters._rebuild_lexical(vault)["published"] is True
+    assert adapters._rebuild_graph(vault)["indexed_files"] == 1
+    assert adapters._rebuild_freshness(vault) == {"scopes": ["kb", "vault"]}
+    assert adapters._rebuild_identity(vault) == {
+        "indexed": 1,
+        "duplicates": 0,
+        "malformed": 0,
+    }
+    review = adapters._rebuild_review(vault)
+    assert review["claim_index"] == "not-configured-cleared"
+    assert len(str(review["due_state_sha256"])) == 64

--- a/tests/test_media_worker.py
+++ b/tests/test_media_worker.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import os
+import queue
 import threading
 import time
 from contextlib import contextmanager
@@ -1944,6 +1945,14 @@ def test_process_worker_drains_and_exits_after_idle(vault, monkeypatch: pytest.M
         assert media_jobs.status(vault)["worker_active"] is False
     finally:
         w.stop()
+
+
+def test_inline_join_timeout_refuses_an_undrained_queue() -> None:
+    pending: queue.Queue[object] = queue.Queue()
+    pending.put(object())
+
+    with pytest.raises(TimeoutError, match="media worker queue did not drain"):
+        media_worker._join_with_timeout(pending, timeout=0)
 
 
 def test_child_defers_transient_writer_failure_without_poisoning_job(


### PR DESCRIPTION
## Summary

- add the closed destination-only adapter set for media, lexical, embedding, semantic-unit, graph, freshness, identity, and review rebuilds
- bind every terminal to the approved canonical census plus deterministic observed derivative evidence; fail closed on model disablement, semantic drift, malformed identities, incomplete media, or unpersisted review projection
- run media first so optional scene-frame fanout is replaced by the subsequent complete text/vector/graph rebuilds, and make bounded inline media joins actually refuse on timeout

Stacked after #974. This does not merge or touch any live vault.

## Verification

- red-first: adapter module import failed; media timeout regression did not raise
- `tests/test_consolidation_rebuild.py tests/test_consolidation_rebuild_adapters.py`: 22 passed
- all consolidation tests: 435 passed
- focused inline/process media join tests: 2 passed
- real disposable-vault probes: lexical, graph, media-empty, freshness, identity, and review derivatives rebuilt successfully
- Ruff on all changed Python files
- `openspec validate add-governed-vault-consolidation --strict`
- public repository artifact validation
- `uv lock --check`
- `uv build`
- `git diff --check`

## Scope note

OpenSpec task 7.5 is complete here. The saga coordinator, receipt-first rebuild events/recovery, probes, and installed rehearsal remain later stack entries; this PR does not claim production cutover readiness by itself.
