### PR TITLE
feat(governance): add consolidation receipt events

### DIFF
--- a/openspec/changes/add-governed-vault-consolidation/design.md
+++ b/openspec/changes/add-governed-vault-consolidation/design.md
@@ -1104,7 +1104,8 @@ The nested common fields are `schema`, `kind`, `run_id`, `operation_id`,
 `phase`, `record_role`, `effect_ordinal`, the applicable
 batch/rebuild/probe/page ordinal, canonical `request_digest`, exact
 `prior_digest`/`target_digest`, `prepared_digest` exactly when the kind defines a
-distinct prepared state, `semantic_parent_event_id`,
+distinct prepared state, required closed digest-only `evidence` plus its
+`evidence_digest`, `semantic_parent_event_id`,
 `semantic_parent_payload_digest`, and `payload_digest`; only terminal roles add
 required `observed_digest`. `payload_digest` is SHA-256 over the common frame
 with ASCII domain
@@ -1112,6 +1113,17 @@ with ASCII domain
 closed JCS object excluding `payload_digest`. Intent forbids
 `observed_digest`; committed/aborted requires it. Nested `record_role` equals
 outer `phase`, and every consolidation record is durable.
+
+Every kind's `evidence` is an exact closed object with schema
+`exomem.consolidation-event-evidence/<kind>/v1`, matching kind, and only the
+named 64-hex digest fields applicable to disposition, checkpoint, JTI,
+render/coverage/impact, verification basis, forward snapshot, surviving-copy
+ledger, or permanent fence. It contains no proof body, path, ref, principal,
+credential, token, timestamp, count, enum, or caller extension. Its
+`evidence_digest` is SHA-256 over the common frame with that schema's ASCII
+domain and the exact evidence bytes. Intent construction, append, verification,
+and recovery fail closed unless the kind-specific object is exact and its
+digest matches; underlying proof bodies stay owner-protected.
 
 For an intent whose committed target would produce a successor context, the
 intent and its matching committed or aborted terminal additionally require

--- a/openspec/changes/add-governed-vault-consolidation/specs/disclosure-evidence/spec.md
+++ b/openspec/changes/add-governed-vault-consolidation/specs/disclosure-evidence/spec.md
@@ -131,7 +131,8 @@ and one nested closed schema named
 `exomem.consolidation-event/<kind>/v1`. Every nested role SHALL require exactly
 `schema`, `kind`, `run_id`, `operation_id`, `phase`, `record_role`,
 `effect_ordinal`, `request_digest`, `prior_digest`, `target_digest`,
-`semantic_parent_event_id`, `semantic_parent_payload_digest`, and
+closed digest-only `evidence`, `evidence_digest`, `semantic_parent_event_id`,
+`semantic_parent_payload_digest`, and
 `payload_digest`; it SHALL require exactly the applicable one of
 `batch_ordinal`, `rebuild_ordinal`, `probe_ordinal`, or `page_ordinal`, require
 `prepared_digest` only for a kind with a distinct prepared state, and forbid
@@ -141,6 +142,21 @@ ordinal SHALL be an integer in `0..2^31-1`. An `intent` SHALL forbid
 lowercase hex and all ids SHALL follow the outer-id grammar below. Nested
 `record_role` SHALL equal outer `phase`; every consolidation record SHALL set
 outer `durable=true`, and any mismatch SHALL fail validation/recovery.
+
+`evidence` and `evidence_digest` SHALL be required for every kind. `evidence`
+SHALL be one exact closed object with schema
+`exomem.consolidation-event-evidence/<kind>/v1`, matching `kind`, and only the
+named 64-lowercase-hex digest fields applicable to that event's disposition,
+checkpoint, JTI, rendering/coverage, impact summary, verification basis,
+forward snapshot, surviving-copy ledger, or permanent fence. It SHALL contain
+no plaintext, path, ref, principal, credential, token, timestamp, count, enum,
+or caller extension. `evidence_digest` SHALL equal SHA-256 over
+the common length-framing contract with ASCII domain
+`exomem.consolidation-event-evidence/<kind>/v1` and those exact evidence bytes.
+The nested payload therefore exposes only field names and digests while the
+underlying proof bodies remain owner-protected. An unknown, missing,
+mismatched, or unvalidated kind-specific evidence object blocks intent
+construction, append, verification, and recovery.
 
 Exactly when an intent's committed target would create a successor context,
 that intent and its matching committed or aborted terminal SHALL additionally
@@ -160,7 +176,7 @@ nested object excluding `payload_digest`. The deterministic outer intent
 `exomem.consolidation-event-id/<kind>/v1` over the closed intent identity:
 `schema`, `kind`, `run_id`, `operation_id`, `phase`, `record_role=intent`, all
 applicable ordinals, `request_digest`, `prior_digest`, optional
-`prepared_digest`, `target_digest`, `semantic_parent_event_id`, and
+`prepared_digest`, `target_digest`, `evidence_digest`, `semantic_parent_event_id`, and
 `semantic_parent_payload_digest`. The physical receipt `prev`, outer sequence,
 timestamp, record hash, and nested `payload_digest` SHALL NOT enter this
 identity. The terminal outer id SHALL be exactly

--- a/openspec/changes/add-governed-vault-consolidation/tasks.md
+++ b/openspec/changes/add-governed-vault-consolidation/tasks.md
@@ -754,7 +754,12 @@ binds that reference and observed digest; no caller field selects K.
   and require its sole consolidation payload member to be one closed
   `exomem.consolidation-event/<kind>/v1` schema per effect, including disposition,
   forward-snapshot/surviving-copy-ledger, rendering/impact, and verification-basis
-  digests where applicable. Pin outer schema/event-type/phase/timestamp/instance/
+  digests where applicable through the required exact closed digest-only
+  `exomem.consolidation-event-evidence/<kind>/v1` object and its
+  `evidence_digest`; validate and hash the object at build, low-level append,
+  chain verification, and recovery boundaries rather than accepting a bare
+  caller digest.
+  Pin outer schema/event-type/phase/timestamp/instance/
   seq/physical-prev/durability/hash fields separately from the nested schema,
   require `successor_context_seed_digest` exactly on an intent whose target
   would create a context and its matching terminal, forbid it on every other
@@ -772,7 +777,8 @@ binds that reference and observed digest; no caller field selects K.
   `exomem.consolidation-event-id/<kind>/v1` over the exact closed intent identity:
   schema/kind/run/operation/phase/intent role, bounded effect and applicable
   batch/rebuild/probe/page ordinal, request/prior/optional-prepared/target digests,
-  plus non-caller-selected semantic-parent outer id/payload digest. Preserve the
+  required kind-specific evidence digest, plus non-caller-selected semantic-parent
+  outer id/payload digest. Preserve the
   outer terminal ids exactly as `<intent-id>:committed|aborted`; do not generate a
   second 64-hex terminal id. Make nested role branches closed: intent forbids
   observed digest; committed/aborted requires it and uses a distinct role payload

--- a/src/exomem/governance/consolidation_receipts.py
+++ b/src/exomem/governance/consolidation_receipts.py
@@ -1,0 +1,1127 @@
+"""Closed plaintext-free receipt payloads for consolidation effects.
+
+The common receipt writer owns physical append order and durability.  This
+module owns the nested consolidation schema, its semantic parent, and the
+deterministic intent/terminal identities.  It deliberately cannot accept
+paths, content, principals, policy documents, or caller-selected payload
+extensions.
+
+Each event also carries a closed digest-only evidence object plus its
+``evidence_digest``.  The object contains no paths, principals, content, or
+credentials; its named digests make every kind-specific retirement, rendering,
+and verification claim explicit and independently hashable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import NoReturn
+
+from . import consolidation_plan
+
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_EVENT_ID = re.compile(r"[0-9a-f]{64}(?::(?:committed|aborted))?\Z")
+_UUID4 = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
+)
+_PHASE = re.compile(r"[a-z][a-z0-9-]{0,63}\Z")
+_MAX_ORDINAL = (1 << 31) - 1
+_ROLES = frozenset({"intent", "committed", "aborted"})
+
+_KINDS = frozenset(
+    {
+        "start",
+        "intake",
+        "snapshot-source",
+        "snapshot-destination",
+        "reconcile",
+        "plan-cutover",
+        "plan-rollback",
+        "plan-retirement",
+        "render-begin",
+        "render-page",
+        "render-ack",
+        "render-complete",
+        "approval",
+        "token-reservation",
+        "seal-intent",
+        "seal-drained",
+        "preimage",
+        "policy-prepare",
+        "policy-active",
+        "content-batch",
+        "rebuild-kind",
+        "in-process-probe",
+        "in-process-verified",
+        "transport-stop",
+        "transport-probe",
+        "transport-verified",
+        "routing-open",
+        "complete",
+        "abort-begin",
+        "abort-policy-restore",
+        "abort-candidate-cleanup",
+        "abort-rebuild-kind",
+        "abort-probe",
+        "abort-complete",
+        "rollback-nonterminal-contingency-begin",
+        "rollback-terminal-plan-begin",
+        "rollback-seal",
+        "rollback-revalidate",
+        "rollback-restore-batch",
+        "rollback-rebuild-kind",
+        "rollback-probe",
+        "rollback-complete",
+        "recover-classification",
+        "repair-terminal",
+        "forward-snapshot-verified",
+        "surviving-copy-ledger",
+        "retirement-pending-forward-only",
+        "retirement-clearance",
+        "retirement-pending-fence-release",
+        "retirement-consume",
+        "retirement-completion",
+        "retirement-finalize",
+    }
+)
+_ORDINAL_FIELD = {
+    "content-batch": "batch_ordinal",
+    "rollback-restore-batch": "batch_ordinal",
+    "rebuild-kind": "rebuild_ordinal",
+    "abort-rebuild-kind": "rebuild_ordinal",
+    "rollback-rebuild-kind": "rebuild_ordinal",
+    "in-process-probe": "probe_ordinal",
+    "transport-probe": "probe_ordinal",
+    "abort-probe": "probe_ordinal",
+    "rollback-probe": "probe_ordinal",
+    "render-page": "page_ordinal",
+    "render-ack": "page_ordinal",
+}
+_PREPARED_KINDS = frozenset({"content-batch", "rollback-restore-batch"})
+_CONDITIONAL_SUCCESSOR_KINDS = frozenset({"reconcile", "repair-terminal"})
+_REQUIRED_SUCCESSOR_KINDS = frozenset(
+    {
+        "complete",
+        "rollback-complete",
+        "retirement-pending-forward-only",
+        "retirement-finalize",
+    }
+)
+_SUCCESSOR_KINDS = _CONDITIONAL_SUCCESSOR_KINDS | _REQUIRED_SUCCESSOR_KINDS
+_EXTERNAL_PARENT_KINDS = frozenset(
+    {"retirement-consume", "retirement-completion"}
+)
+_LOCAL_PARENT_KINDS: Mapping[str, frozenset[str]] = MappingProxyType(
+    {
+        "intake": frozenset({"start"}),
+        "snapshot-source": frozenset({"intake"}),
+        "snapshot-destination": frozenset({"snapshot-source"}),
+        "reconcile": frozenset({"snapshot-destination"}),
+        "plan-cutover": frozenset({"reconcile", "repair-terminal"}),
+        "plan-rollback": frozenset(
+            {
+                "complete",
+                "rollback-complete",
+                "retirement-pending-forward-only",
+                "retirement-finalize",
+                "repair-terminal",
+            }
+        ),
+        "plan-retirement": frozenset({"complete", "repair-terminal"}),
+        "render-begin": frozenset(
+            {"plan-cutover", "plan-rollback", "plan-retirement"}
+        ),
+        "render-page": frozenset({"render-begin", "render-ack"}),
+        "render-ack": frozenset({"render-page"}),
+        "render-complete": frozenset({"render-ack"}),
+        "approval": frozenset({"render-complete"}),
+        "token-reservation": frozenset({"approval"}),
+        "seal-intent": frozenset({"token-reservation"}),
+        "seal-drained": frozenset({"seal-intent"}),
+        "preimage": frozenset({"seal-drained"}),
+        "policy-prepare": frozenset({"preimage"}),
+        "policy-active": frozenset({"policy-prepare"}),
+        "content-batch": frozenset({"policy-active", "content-batch"}),
+        "rebuild-kind": frozenset({"content-batch", "rebuild-kind"}),
+        "in-process-probe": frozenset(
+            {"rebuild-kind", "in-process-probe"}
+        ),
+        "in-process-verified": frozenset({"in-process-probe"}),
+        "transport-stop": frozenset({"in-process-verified"}),
+        "transport-probe": frozenset({"transport-stop", "transport-probe"}),
+        "transport-verified": frozenset({"transport-probe"}),
+        "routing-open": frozenset({"transport-verified"}),
+        "complete": frozenset({"routing-open"}),
+        "abort-begin": frozenset(
+            {
+                "token-reservation",
+                "seal-intent",
+                "seal-drained",
+                "preimage",
+                "policy-prepare",
+                "policy-active",
+            }
+        ),
+        "abort-policy-restore": frozenset({"abort-begin"}),
+        "abort-candidate-cleanup": frozenset(
+            {"abort-begin", "abort-policy-restore"}
+        ),
+        "abort-rebuild-kind": frozenset(
+            {"abort-candidate-cleanup", "abort-rebuild-kind"}
+        ),
+        "abort-probe": frozenset(
+            {"abort-candidate-cleanup", "abort-rebuild-kind", "abort-probe"}
+        ),
+        "abort-complete": frozenset(
+            {"abort-candidate-cleanup", "abort-rebuild-kind", "abort-probe"}
+        ),
+        "rollback-nonterminal-contingency-begin": frozenset(
+            {
+                "content-batch",
+                "rebuild-kind",
+                "in-process-probe",
+                "in-process-verified",
+                "transport-stop",
+                "transport-probe",
+                "transport-verified",
+                "routing-open",
+            }
+        ),
+        "rollback-terminal-plan-begin": frozenset({"token-reservation"}),
+        "rollback-seal": frozenset(
+            {
+                "rollback-nonterminal-contingency-begin",
+                "rollback-terminal-plan-begin",
+            }
+        ),
+        "rollback-revalidate": frozenset({"rollback-seal"}),
+        "rollback-restore-batch": frozenset(
+            {"rollback-revalidate", "rollback-restore-batch"}
+        ),
+        "rollback-rebuild-kind": frozenset(
+            {"rollback-restore-batch", "rollback-rebuild-kind"}
+        ),
+        "rollback-probe": frozenset(
+            {"rollback-rebuild-kind", "rollback-probe"}
+        ),
+        "rollback-complete": frozenset({"rollback-probe"}),
+        "repair-terminal": frozenset({"recover-classification"}),
+        "forward-snapshot-verified": frozenset({"token-reservation"}),
+        "surviving-copy-ledger": frozenset(
+            {
+                "token-reservation",
+                "forward-snapshot-verified",
+                "surviving-copy-ledger",
+            }
+        ),
+        "retirement-pending-forward-only": frozenset(
+            {"surviving-copy-ledger"}
+        ),
+        "retirement-clearance": frozenset(
+            {"surviving-copy-ledger", "retirement-pending-forward-only"}
+        ),
+        "retirement-pending-fence-release": frozenset(
+            {"recover-classification"}
+        ),
+        "retirement-finalize": frozenset({"retirement-completion"}),
+    }
+)
+_EVIDENCE_FIELDS: Mapping[str, frozenset[str]] = MappingProxyType(
+    {
+        "start": frozenset({"identity_binding_digest", "run_request_digest"}),
+        "intake": frozenset(
+            {"archive_attestation_digest", "intake_manifest_digest"}
+        ),
+        "snapshot-source": frozenset({"source_snapshot_digest"}),
+        "snapshot-destination": frozenset({"destination_snapshot_digest"}),
+        "reconcile": frozenset(
+            {"mapping_set_digest", "reconciliation_digest"}
+        ),
+        "plan-cutover": frozenset(
+            {"plan_digest", "plan_input_basis_digest"}
+        ),
+        "plan-rollback": frozenset(
+            {"plan_digest", "plan_input_basis_digest"}
+        ),
+        "plan-retirement": frozenset(
+            {"plan_digest", "plan_input_basis_digest"}
+        ),
+        "render-begin": frozenset(
+            {"impact_summary_digest", "plan_digest", "render_session_digest"}
+        ),
+        "render-page": frozenset(
+            {
+                "impact_summary_digest",
+                "page_digest",
+                "plan_digest",
+                "render_session_digest",
+            }
+        ),
+        "render-ack": frozenset(
+            {
+                "acknowledgement_digest",
+                "impact_summary_digest",
+                "page_digest",
+                "plan_digest",
+                "render_session_digest",
+            }
+        ),
+        "render-complete": frozenset(
+            {
+                "coverage_digest",
+                "impact_summary_digest",
+                "plan_digest",
+                "render_session_digest",
+            }
+        ),
+        "approval": frozenset(
+            {"confirmation_digest", "plan_digest", "rendering_completeness_digest"}
+        ),
+        "token-reservation": frozenset(
+            {"plan_digest", "token_jti_digest", "token_reservation_digest"}
+        ),
+        "seal-intent": frozenset({"seal_basis_digest"}),
+        "seal-drained": frozenset({"drain_digest", "seal_basis_digest"}),
+        "preimage": frozenset({"preimage_manifest_digest"}),
+        "policy-prepare": frozenset(
+            {"policy_bundle_digest", "policy_prepared_digest"}
+        ),
+        "policy-active": frozenset(
+            {"policy_active_digest", "policy_bundle_digest"}
+        ),
+        "content-batch": frozenset(
+            {"batch_manifest_digest", "classification_digest"}
+        ),
+        "rebuild-kind": frozenset(
+            {"rebuild_basis_digest", "rebuild_result_digest"}
+        ),
+        "in-process-probe": frozenset(
+            {"probe_digest", "probe_result_digest", "verification_basis_digest"}
+        ),
+        "in-process-verified": frozenset(
+            {"verification_basis_digest", "verification_result_digest"}
+        ),
+        "transport-stop": frozenset(
+            {"routing_stop_digest", "verification_basis_digest"}
+        ),
+        "transport-probe": frozenset(
+            {"probe_digest", "probe_result_digest", "verification_basis_digest"}
+        ),
+        "transport-verified": frozenset(
+            {"verification_basis_digest", "verification_result_digest"}
+        ),
+        "routing-open": frozenset(
+            {"routing_basis_digest", "routing_result_digest"}
+        ),
+        "complete": frozenset(
+            {"completion_digest", "verification_basis_digest"}
+        ),
+        "abort-begin": frozenset({"abort_basis_digest"}),
+        "abort-policy-restore": frozenset(
+            {"abort_basis_digest", "policy_restore_digest"}
+        ),
+        "abort-candidate-cleanup": frozenset(
+            {"abort_basis_digest", "cleanup_digest"}
+        ),
+        "abort-rebuild-kind": frozenset(
+            {"abort_basis_digest", "rebuild_result_digest"}
+        ),
+        "abort-probe": frozenset(
+            {"abort_basis_digest", "probe_digest", "probe_result_digest"}
+        ),
+        "abort-complete": frozenset(
+            {"abort_basis_digest", "abort_result_digest"}
+        ),
+        "rollback-nonterminal-contingency-begin": frozenset(
+            {"rollback_authority_digest", "rollback_basis_digest"}
+        ),
+        "rollback-terminal-plan-begin": frozenset(
+            {"rollback_plan_digest", "token_jti_digest"}
+        ),
+        "rollback-seal": frozenset(
+            {"rollback_basis_digest", "seal_basis_digest"}
+        ),
+        "rollback-revalidate": frozenset(
+            {"revalidation_digest", "rollback_basis_digest"}
+        ),
+        "rollback-restore-batch": frozenset(
+            {"batch_manifest_digest", "classification_digest"}
+        ),
+        "rollback-rebuild-kind": frozenset(
+            {"rebuild_basis_digest", "rebuild_result_digest"}
+        ),
+        "rollback-probe": frozenset(
+            {"probe_digest", "probe_result_digest", "verification_basis_digest"}
+        ),
+        "rollback-complete": frozenset(
+            {"rollback_result_digest", "verification_basis_digest"}
+        ),
+        "recover-classification": frozenset(
+            {"classification_digest", "recovery_basis_digest"}
+        ),
+        "repair-terminal": frozenset(
+            {"recovery_basis_digest", "repair_result_digest"}
+        ),
+        "forward-snapshot-verified": frozenset(
+            {"forward_snapshot_digest", "verification_result_digest"}
+        ),
+        "surviving-copy-ledger": frozenset(
+            {"surviving_copy_ledger_digest"}
+        ),
+        "retirement-pending-forward-only": frozenset(
+            {
+                "forward_snapshot_digest",
+                "pending_fence_digest",
+                "surviving_copy_ledger_digest",
+            }
+        ),
+        "retirement-clearance": frozenset(
+            {
+                "clearance_outcome_digest",
+                "destination_proof_digest",
+                "disposition_digest",
+                "retirement_plan_digest",
+                "source_checkpoint_digest",
+                "token_jti_digest",
+            }
+        ),
+        "retirement-pending-fence-release": frozenset(
+            {
+                "clearance_jti_digest",
+                "nonconsumption_digest",
+                "pending_fence_digest",
+                "source_survival_digest",
+            }
+        ),
+        "retirement-consume": frozenset(
+            {
+                "clearance_jti_digest",
+                "destination_proof_digest",
+                "disposition_digest",
+                "source_checkpoint_digest",
+                "source_fence_digest",
+                "verifier_decision_digest",
+            }
+        ),
+        "retirement-completion": frozenset(
+            {
+                "authentication_proof_digest",
+                "completion_attestation_digest",
+                "disposition_digest",
+                "source_consume_event_digest",
+                "source_receipt_head_digest",
+            }
+        ),
+        "retirement-finalize": frozenset(
+            {
+                "completion_attestation_digest",
+                "disposition_digest",
+                "permanent_fence_digest",
+            }
+        ),
+    }
+)
+_SPECIALIZED_ORDINALS = frozenset(
+    {"batch_ordinal", "rebuild_ordinal", "probe_ordinal", "page_ordinal"}
+)
+_BASE_FIELDS = frozenset(
+    {
+        "schema",
+        "kind",
+        "run_id",
+        "operation_id",
+        "phase",
+        "record_role",
+        "effect_ordinal",
+        "request_digest",
+        "prior_digest",
+        "target_digest",
+        "evidence",
+        "evidence_digest",
+        "semantic_parent_event_id",
+        "semantic_parent_payload_digest",
+        "payload_digest",
+    }
+)
+
+__all__ = [
+    "CONSOLIDATION_EVENT_KINDS",
+    "ConsolidationEvent",
+    "ConsolidationReceiptUnavailable",
+    "append_intent",
+    "append_terminal",
+    "build_evidence",
+    "build_intent",
+    "build_terminal",
+    "semantic_root",
+    "validate_nested",
+]
+
+CONSOLIDATION_EVENT_KINDS = _KINDS
+
+
+class ConsolidationReceiptUnavailable(RuntimeError):
+    """Stable content-free refusal for malformed or contradictory evidence."""
+
+    code = "CONSOLIDATION_RECEIPT_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationEvent:
+    event_id: str
+    phase: str
+    payload: Mapping[str, object]
+    payload_digest: str
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationReceiptUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _event_id(value: object, *, intent_only: bool = False) -> str:
+    if not isinstance(value, str) or _EVENT_ID.fullmatch(value) is None:
+        _fail()
+    if intent_only and ":" in value:
+        _fail()
+    return value
+
+
+def _uuid4(value: object) -> str:
+    if not isinstance(value, str) or _UUID4.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _phase(value: object) -> str:
+    if not isinstance(value, str) or _PHASE.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _ordinal(value: object) -> int:
+    if type(value) is not int or not 0 <= value <= _MAX_ORDINAL:
+        _fail()
+    return value
+
+
+def _frame(domain: bytes, payload: bytes) -> bytes:
+    return (
+        len(domain).to_bytes(4, "big")
+        + domain
+        + len(payload).to_bytes(8, "big")
+        + payload
+    )
+
+
+def _framed_digest(domain: bytes, value: Mapping[str, object]) -> str:
+    try:
+        canonical = consolidation_plan.canonical_closed_jcs(value)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    return hashlib.sha256(_frame(domain, canonical)).hexdigest()
+
+
+def semantic_root() -> tuple[str, str]:
+    """Return the fixed start-only semantic root id and payload digest."""
+
+    digest = _framed_digest(b"exomem.consolidation-semantic-root/v1", {})
+    return digest, digest
+
+
+def _schema(kind: str) -> str:
+    if kind not in _KINDS:
+        _fail()
+    return f"exomem.consolidation-event/{kind}/v1"
+
+
+def _evidence_schema(kind: str) -> str:
+    if kind not in _KINDS:
+        _fail()
+    return f"exomem.consolidation-event-evidence/{kind}/v1"
+
+
+def build_evidence(
+    *,
+    kind: str,
+    digests: Mapping[str, object],
+) -> Mapping[str, object]:
+    """Build one closed digest-only evidence object for an effect kind."""
+
+    expected = _EVIDENCE_FIELDS.get(kind)
+    if expected is None or not isinstance(digests, Mapping):
+        _fail()
+    try:
+        supplied = dict(digests)
+    except (TypeError, ValueError):
+        _fail()
+    if frozenset(supplied) != expected:
+        _fail()
+    evidence: dict[str, object] = {
+        "schema": _evidence_schema(kind),
+        "kind": kind,
+    }
+    for field in sorted(expected):
+        evidence[field] = _digest(supplied[field])
+    try:
+        consolidation_plan.canonical_closed_jcs(evidence)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    return MappingProxyType(evidence)
+
+
+def _validated_evidence(value: object, *, kind: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        _fail()
+    try:
+        snapshot = dict(value)
+    except (TypeError, ValueError):
+        _fail()
+    if snapshot.get("schema") != _evidence_schema(kind) or snapshot.get("kind") != kind:
+        _fail()
+    digests = dict(snapshot)
+    digests.pop("schema")
+    digests.pop("kind")
+    return build_evidence(kind=kind, digests=digests)
+
+
+def _evidence_digest(evidence: Mapping[str, object], *, kind: str) -> str:
+    return _framed_digest(
+        f"exomem.consolidation-event-evidence/{kind}/v1".encode("ascii"),
+        evidence,
+    )
+
+
+def _expected_fields(
+    kind: str,
+    role: str,
+    *,
+    has_successor_seed: bool,
+) -> frozenset[str]:
+    if kind not in _KINDS or role not in _ROLES:
+        _fail()
+    if kind in _REQUIRED_SUCCESSOR_KINDS and not has_successor_seed:
+        _fail()
+    if has_successor_seed and kind not in _SUCCESSOR_KINDS:
+        _fail()
+    fields = set(_BASE_FIELDS)
+    ordinal_field = _ORDINAL_FIELD.get(kind)
+    if ordinal_field is not None:
+        fields.add(ordinal_field)
+    if kind in _PREPARED_KINDS:
+        fields.add("prepared_digest")
+    if role != "intent":
+        fields.add("observed_digest")
+    if has_successor_seed:
+        fields.add("successor_context_seed_digest")
+    return frozenset(fields)
+
+
+def validate_nested(
+    value: object,
+    *,
+    outer_phase: str | None = None,
+) -> Mapping[str, object]:
+    """Validate one exact nested event and recompute its role payload digest."""
+
+    if not isinstance(value, Mapping):
+        _fail()
+    try:
+        snapshot = dict(value)
+    except (TypeError, ValueError):
+        _fail()
+    kind = snapshot.get("kind")
+    role = snapshot.get("record_role")
+    if not isinstance(kind, str) or not isinstance(role, str):
+        _fail()
+    has_seed = "successor_context_seed_digest" in snapshot
+    if frozenset(snapshot) != _expected_fields(
+        kind,
+        role,
+        has_successor_seed=has_seed,
+    ):
+        _fail()
+    if snapshot["schema"] != _schema(kind):
+        _fail()
+    if outer_phase is not None and role != outer_phase:
+        _fail()
+    _uuid4(snapshot["run_id"])
+    _uuid4(snapshot["operation_id"])
+    _phase(snapshot["phase"])
+    _ordinal(snapshot["effect_ordinal"])
+    _digest(snapshot["request_digest"])
+    _digest(snapshot["prior_digest"])
+    _digest(snapshot["target_digest"])
+    evidence = _validated_evidence(snapshot["evidence"], kind=kind)
+    snapshot["evidence"] = dict(evidence)
+    if _digest(snapshot["evidence_digest"]) != _evidence_digest(
+        evidence,
+        kind=kind,
+    ):
+        _fail()
+    semantic_parent_id = _event_id(snapshot["semantic_parent_event_id"])
+    semantic_parent_digest = _digest(snapshot["semantic_parent_payload_digest"])
+    root_id, root_digest = semantic_root()
+    if role == "intent":
+        if kind == "start":
+            if (
+                semantic_parent_id != root_id
+                or semantic_parent_digest != root_digest
+            ):
+                _fail()
+        elif kind == "recover-classification":
+            if semantic_parent_id == root_id:
+                _fail()
+        elif not semantic_parent_id.endswith(":committed"):
+            _fail()
+    elif ":" in semantic_parent_id:
+        _fail()
+    ordinal_field = _ORDINAL_FIELD.get(kind)
+    for field in _SPECIALIZED_ORDINALS:
+        if field == ordinal_field:
+            _ordinal(snapshot[field])
+        elif field in snapshot:
+            _fail()
+    if kind in _PREPARED_KINDS:
+        _digest(snapshot["prepared_digest"])
+    elif "prepared_digest" in snapshot:
+        _fail()
+    if role == "intent":
+        if "observed_digest" in snapshot:
+            _fail()
+    else:
+        _digest(snapshot["observed_digest"])
+    if has_seed:
+        _digest(snapshot["successor_context_seed_digest"])
+    supplied_digest = _digest(snapshot["payload_digest"])
+    preimage = dict(snapshot)
+    preimage.pop("payload_digest")
+    expected_digest = _framed_digest(
+        f"exomem.consolidation-event-payload/{kind}/{role}/v1".encode("ascii"),
+        preimage,
+    )
+    if supplied_digest != expected_digest:
+        _fail()
+    try:
+        canonical = consolidation_plan.canonical_closed_jcs(snapshot)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    # JCS rejects unsupported values after the one immutable snapshot above.
+    if not canonical:
+        _fail()
+    return MappingProxyType(snapshot)
+
+
+def _intent_identity(payload: Mapping[str, object]) -> str:
+    checked = validate_nested(payload, outer_phase="intent")
+    identity = dict(checked)
+    identity.pop("payload_digest")
+    identity.pop("evidence")
+    kind = str(checked["kind"])
+    return _framed_digest(
+        f"exomem.consolidation-event-id/{kind}/v1".encode("ascii"),
+        identity,
+    )
+
+
+def build_intent(
+    *,
+    kind: str,
+    run_id: str,
+    operation_id: str,
+    phase: str,
+    effect_ordinal: int,
+    request_digest: str,
+    prior_digest: str,
+    target_digest: str,
+    evidence: Mapping[str, object],
+    semantic_parent_event_id: str,
+    semantic_parent_payload_digest: str,
+    prepared_digest: str | None = None,
+    batch_ordinal: int | None = None,
+    rebuild_ordinal: int | None = None,
+    probe_ordinal: int | None = None,
+    page_ordinal: int | None = None,
+    successor_context_seed_digest: str | None = None,
+) -> ConsolidationEvent:
+    """Build one deterministic intent without accepting arbitrary payload data."""
+
+    payload: dict[str, object] = {
+        "schema": _schema(kind),
+        "kind": kind,
+        "run_id": _uuid4(run_id),
+        "operation_id": _uuid4(operation_id),
+        "phase": _phase(phase),
+        "record_role": "intent",
+        "effect_ordinal": _ordinal(effect_ordinal),
+        "request_digest": _digest(request_digest),
+        "prior_digest": _digest(prior_digest),
+        "target_digest": _digest(target_digest),
+        "semantic_parent_event_id": _event_id(semantic_parent_event_id),
+        "semantic_parent_payload_digest": _digest(
+            semantic_parent_payload_digest
+        ),
+    }
+    checked_evidence = _validated_evidence(evidence, kind=kind)
+    payload["evidence"] = dict(checked_evidence)
+    payload["evidence_digest"] = _evidence_digest(checked_evidence, kind=kind)
+    optional = {
+        "prepared_digest": prepared_digest,
+        "batch_ordinal": batch_ordinal,
+        "rebuild_ordinal": rebuild_ordinal,
+        "probe_ordinal": probe_ordinal,
+        "page_ordinal": page_ordinal,
+        "successor_context_seed_digest": successor_context_seed_digest,
+    }
+    payload.update({key: item for key, item in optional.items() if item is not None})
+    payload["payload_digest"] = _framed_digest(
+        f"exomem.consolidation-event-payload/{kind}/intent/v1".encode("ascii"),
+        payload,
+    )
+    checked = validate_nested(payload, outer_phase="intent")
+    event_id = _intent_identity(checked)
+    return ConsolidationEvent(
+        event_id=event_id,
+        phase="intent",
+        payload=checked,
+        payload_digest=str(checked["payload_digest"]),
+    )
+
+
+def build_terminal(
+    intent: ConsolidationEvent,
+    *,
+    role: str,
+    observed_digest: str,
+) -> ConsolidationEvent:
+    """Derive the one suffix terminal from an already validated intent."""
+
+    if not isinstance(intent, ConsolidationEvent) or intent.phase != "intent":
+        _fail()
+    _event_id(intent.event_id, intent_only=True)
+    if role not in {"committed", "aborted"}:
+        _fail()
+    checked_intent = validate_nested(intent.payload, outer_phase="intent")
+    if intent.event_id != _intent_identity(checked_intent):
+        _fail()
+    payload = dict(checked_intent)
+    payload["record_role"] = role
+    payload["semantic_parent_event_id"] = intent.event_id
+    payload["semantic_parent_payload_digest"] = intent.payload_digest
+    payload["observed_digest"] = _digest(observed_digest)
+    payload.pop("payload_digest")
+    kind = str(payload["kind"])
+    payload["payload_digest"] = _framed_digest(
+        f"exomem.consolidation-event-payload/{kind}/{role}/v1".encode("ascii"),
+        payload,
+    )
+    checked = validate_nested(payload, outer_phase=role)
+    return ConsolidationEvent(
+        event_id=f"{intent.event_id}:{role}",
+        phase=role,
+        payload=checked,
+        payload_digest=str(checked["payload_digest"]),
+    )
+
+
+def append_intent(
+    vault_root: Path,
+    event: ConsolidationEvent,
+    *,
+    timestamp: str | None = None,
+) -> dict[str, object]:
+    """Append or adopt one exact durable consolidation intent."""
+
+    from . import receipts
+
+    try:
+        if not isinstance(event, ConsolidationEvent) or event.phase != "intent":
+            _fail()
+        checked = validate_nested(event.payload, outer_phase="intent")
+        if (
+            event.payload_digest != checked["payload_digest"]
+            or event.event_id != _intent_identity(checked)
+        ):
+            _fail()
+        record = receipts.append_event(
+            Path(vault_root),
+            event_type="consolidation",
+            phase="intent",
+            event_id=_event_id(event.event_id, intent_only=True),
+            payload={"consolidation_event": dict(checked)},
+            timestamp=timestamp,
+            critical=True,
+        )
+        return {key: value for key, value in record.items() if not key.startswith("_")}
+    except ConsolidationReceiptUnavailable:
+        raise
+    except (OSError, RuntimeError, TypeError, ValueError):
+        _fail()
+
+
+def _active_records(vault_root: Path) -> list[dict[str, object]]:
+    from . import receipts
+
+    with receipts._receipt_connection(Path(vault_root)) as connection:  # noqa: SLF001
+        instance_id = receipts._instance_id(connection)  # noqa: SLF001
+        records, issues = receipts._chain_state(  # noqa: SLF001
+            receipts._instance_dir(Path(vault_root), instance_id)  # noqa: SLF001
+        )
+    if issues:
+        _fail()
+    return records
+
+
+def _consolidation_nested(
+    record: Mapping[str, object],
+) -> Mapping[str, object]:
+    phase = record.get("phase")
+    if not isinstance(phase, str) or phase not in _ROLES:
+        _fail()
+    return validate_nested(
+        record.get("consolidation_event"),
+        outer_phase=phase,
+    )
+
+
+def _validate_unique_effect_ordinal(
+    records: list[dict[str, object]],
+    *,
+    event_id: str,
+    checked: Mapping[str, object],
+) -> None:
+    for record in records:
+        if (
+            record.get("event_type") != "consolidation"
+            or record.get("phase") != "intent"
+        ):
+            continue
+        existing = _consolidation_nested(record)
+        if (
+            existing["run_id"] == checked["run_id"]
+            and existing["effect_ordinal"] == checked["effect_ordinal"]
+            and record.get("event_id") != event_id
+        ):
+            _fail()
+
+
+def _validate_specialized_parent(
+    checked: Mapping[str, object],
+    parent: Mapping[str, object],
+) -> None:
+    kind = str(checked["kind"])
+    field = _ORDINAL_FIELD.get(kind)
+    if field is None:
+        return
+    ordinal = int(checked[field])
+    parent_kind = str(parent["kind"])
+    if kind == "render-ack":
+        if parent_kind != "render-page" or ordinal != parent["page_ordinal"]:
+            _fail()
+        return
+    if kind == "render-page" and parent_kind == "render-ack":
+        if ordinal != int(parent["page_ordinal"]) + 1:
+            _fail()
+        return
+    if parent_kind == kind:
+        if ordinal != int(parent[field]) + 1:
+            _fail()
+        return
+    if ordinal != 0:
+        _fail()
+
+
+def _validate_local_intent_parent(
+    records: list[dict[str, object]],
+    checked: Mapping[str, object],
+) -> None:
+    kind = str(checked["kind"])
+    parent_id = str(checked["semantic_parent_event_id"])
+    parents = [
+        record
+        for record in records
+        if record.get("event_type") == "consolidation"
+        and record.get("event_id") == parent_id
+    ]
+    if len(parents) != 1:
+        _fail()
+    parent_record = parents[0]
+    parent_phase = str(parent_record.get("phase"))
+    if kind != "recover-classification" and parent_phase != "committed":
+        _fail()
+    parent = _consolidation_nested(parent_record)
+    if (
+        parent["run_id"] != checked["run_id"]
+        or parent["payload_digest"]
+        != checked["semantic_parent_payload_digest"]
+        or int(checked["effect_ordinal"])
+        != int(parent["effect_ordinal"]) + 1
+    ):
+        _fail()
+    if kind != "recover-classification":
+        allowed = _LOCAL_PARENT_KINDS.get(kind)
+        if allowed is None or parent["kind"] not in allowed:
+            _fail()
+        _validate_specialized_parent(checked, parent)
+
+
+def validate_outer_append(
+    records: list[dict[str, object]],
+    *,
+    event_id: object,
+    outer_phase: str,
+    nested: object,
+) -> None:
+    """Validate identity and local intent/terminal causality before append."""
+
+    checked = validate_nested(nested, outer_phase=outer_phase)
+    if outer_phase == "intent":
+        checked_event_id = _event_id(event_id, intent_only=True)
+        if checked_event_id != _intent_identity(checked):
+            _fail()
+        kind = str(checked["kind"])
+        _validate_unique_effect_ordinal(
+            records,
+            event_id=checked_event_id,
+            checked=checked,
+        )
+        if kind == "start":
+            if checked["effect_ordinal"] != 0:
+                _fail()
+            return
+        # Cross-chain retirement causality must enter through the later trusted
+        # source-lifecycle/control adapter.  The generic local writer cannot
+        # authenticate an external receipt head, so it refuses these events.
+        if kind in _EXTERNAL_PARENT_KINDS:
+            _fail()
+        _validate_local_intent_parent(records, checked)
+        return
+    if outer_phase not in {"committed", "aborted"}:
+        _fail()
+    supplied_id = _event_id(event_id)
+    intent_event_id = supplied_id.removesuffix(f":{outer_phase}")
+    if intent_event_id == supplied_id or not _DIGEST.fullmatch(intent_event_id):
+        _fail()
+    intents = [
+        record
+        for record in records
+        if record.get("event_type") == "consolidation"
+        and record.get("phase") == "intent"
+        and record.get("event_id") == intent_event_id
+    ]
+    if len(intents) != 1:
+        _fail()
+    intent_nested = validate_nested(
+        intents[0].get("consolidation_event"),
+        outer_phase="intent",
+    )
+    intent = ConsolidationEvent(
+        event_id=intent_event_id,
+        phase="intent",
+        payload=intent_nested,
+        payload_digest=str(intent_nested["payload_digest"]),
+    )
+    expected = build_terminal(
+        intent,
+        role=outer_phase,
+        observed_digest=str(checked["observed_digest"]),
+    )
+    if dict(expected.payload) != dict(checked) or expected.event_id != supplied_id:
+        _fail()
+    competing_ids = {
+        f"{intent_event_id}:committed",
+        f"{intent_event_id}:aborted",
+    }
+    if any(
+        record.get("event_id") in competing_ids
+        and record.get("event_id") != supplied_id
+        for record in records
+    ):
+        _fail()
+
+
+def append_terminal(
+    vault_root: Path,
+    *,
+    intent_event_id: str,
+    role: str,
+    observed_digest: str,
+    timestamp: str | None = None,
+) -> dict[str, object]:
+    """Append/adopt exactly one terminal for an intent on the active chain."""
+
+    from . import receipts
+
+    intent_event_id = _event_id(intent_event_id, intent_only=True)
+    if role not in {"committed", "aborted"}:
+        _fail()
+    try:
+        with receipts._receipt_lock(Path(vault_root)):  # noqa: SLF001
+            records = _active_records(Path(vault_root))
+            matching = [
+                record
+                for record in records
+                if record.get("event_type") == "consolidation"
+                and record.get("phase") == "intent"
+                and record.get("event_id") == intent_event_id
+            ]
+            if len(matching) != 1:
+                _fail()
+            intent_record = matching[0]
+            checked = validate_nested(
+                intent_record.get("consolidation_event"),
+                outer_phase="intent",
+            )
+            intent = ConsolidationEvent(
+                event_id=intent_event_id,
+                phase="intent",
+                payload=checked,
+                payload_digest=str(checked["payload_digest"]),
+            )
+            terminal = build_terminal(
+                intent,
+                role=role,
+                observed_digest=observed_digest,
+            )
+            competing = [
+                record
+                for record in records
+                if record.get("event_id")
+                in {
+                    f"{intent_event_id}:committed",
+                    f"{intent_event_id}:aborted",
+                }
+            ]
+            if competing and competing[-1].get("event_id") != terminal.event_id:
+                _fail()
+            record = receipts.append_event(
+                Path(vault_root),
+                event_type="consolidation",
+                phase=role,
+                event_id=terminal.event_id,
+                payload={"consolidation_event": dict(terminal.payload)},
+                timestamp=timestamp,
+                critical=True,
+            )
+            return {
+                key: value
+                for key, value in record.items()
+                if not key.startswith("_")
+            }
+    except ConsolidationReceiptUnavailable:
+        raise
+    except (OSError, RuntimeError, TypeError, ValueError):
+        _fail()

--- a/src/exomem/governance/receipts.py
+++ b/src/exomem/governance/receipts.py
@@ -72,6 +72,9 @@ _EVENT_PAYLOAD_FIELDS = {
     }),
     ("critical", "committed"): frozenset({"causation_id", "outcome"}),
     ("critical", "aborted"): frozenset({"causation_id", "outcome"}),
+    ("consolidation", "intent"): frozenset({"consolidation_event"}),
+    ("consolidation", "committed"): frozenset({"consolidation_event"}),
+    ("consolidation", "aborted"): frozenset({"consolidation_event"}),
 }
 _OUTCOME_FIELDS = frozenset({
     "ref", "content_hash", "size", "level", "decision", "redaction_count", "count",
@@ -773,7 +776,19 @@ def _validate_event(event_type: str, phase: str, payload: Mapping[str, Any]) -> 
         for field in ("principal", "audience", "purpose", "command"):
             if field in payload and not _identifier_value(payload[field]):
                 raise ReceiptError("credential identifier is invalid")
-    if phase == "intent":
+    if event_type == "consolidation":
+        if set(payload) != {"consolidation_event"}:
+            raise ReceiptError("consolidation receipt requires one nested event")
+        try:
+            from . import consolidation_receipts
+
+            consolidation_receipts.validate_nested(
+                payload["consolidation_event"],
+                outer_phase=phase,
+            )
+        except consolidation_receipts.ConsolidationReceiptUnavailable as exc:
+            raise ReceiptError("consolidation receipt event is invalid") from exc
+    if event_type == "critical" and phase == "intent":
         if not {"operation", "prior", "target"} <= set(payload):
             raise ReceiptError("critical intent requires operation, prior, and target")
         if not _identifier_value(payload["operation"]) or not _hex(payload["prior"]) or not _hex(payload["target"]):
@@ -788,7 +803,7 @@ def _validate_event(event_type: str, phase: str, payload: Mapping[str, Any]) -> 
             raise ReceiptError("critical parent causation id is invalid")
         if "intent_id" in payload and not _identifier_value(payload["intent_id"]):
             raise ReceiptError("critical child intent id is invalid")
-    if phase in {"committed", "aborted"}:
+    if event_type == "critical" and phase in {"committed", "aborted"}:
         if not _opaque_causation_id(payload.get("causation_id")):
             raise ReceiptError("critical terminal causation id is invalid")
         if "outcome" in payload and not _identifier_value(payload["outcome"]):
@@ -819,7 +834,7 @@ def _canonical_memory_ref(value: Any) -> bool:
 
 
 def _valid_event_id(event_type: str, phase: str, event_id: Any) -> bool:
-    if event_type != "critical":
+    if event_type not in {"critical", "consolidation"}:
         return _hex32(event_id)
     if phase == "intent":
         return _hex(event_id)
@@ -1258,8 +1273,10 @@ def append_event(
     _validate_event(event_type, phase, payload)
     if event_id is not None and not _valid_event_id(event_type, phase, event_id):
         raise ReceiptError("receipt event id is not opaque for its event phase")
-    if event_type == "critical" and event_id is None:
+    if event_type in {"critical", "consolidation"} and event_id is None:
         raise ReceiptError("critical receipts require a deterministic event id")
+    if event_type == "consolidation" and critical is not True:
+        raise ReceiptError("consolidation receipts must be durable")
     timestamp, _parsed = _timestamp(timestamp or _now())
     with _receipt_lock(vault_root):
         with _receipt_connection(vault_root, durable=critical) as conn:
@@ -1323,6 +1340,21 @@ def append_event(
                     conn.commit()
                     return tail
                 raise ReceiptError("receipt anchor is stale; reconcile before append")
+            if event_type == "consolidation":
+                try:
+                    from . import consolidation_receipts
+
+                    chain_records, chain_issues = _chain_state(instance_dir)
+                    if chain_issues:
+                        raise ReceiptError("receipt chain requires reconciliation")
+                    consolidation_receipts.validate_outer_append(
+                        chain_records,
+                        event_id=eid,
+                        outer_phase=phase,
+                        nested=payload["consolidation_event"],
+                    )
+                except consolidation_receipts.ConsolidationReceiptUnavailable as exc:
+                    raise ReceiptError("consolidation receipt causality is invalid") from exc
             if event_id is not None and critical:
                 existing = _matching_existing_event(instance_dir, eid, event_type, phase, payload)
                 if existing is not None:
@@ -1670,11 +1702,29 @@ def verify_chain(vault_root: Path) -> dict[str, Any]:
                     issues.append({"code": "sidecar_read_error", "path": str(instance_dir), "detail": str(exc)})
             if anchor is not None:
                 issues.extend(_anchor_issues(vault_root, instance_dir, records, anchor))
-            terminals = {str(item.get("causation_id")) for item in records if item.get("phase") in {"committed", "aborted"}}
+            terminals = {
+                str(
+                    item.get("consolidation_event", {}).get(
+                        "semantic_parent_event_id"
+                    )
+                    if item.get("event_type") == "consolidation"
+                    and isinstance(item.get("consolidation_event"), Mapping)
+                    else item.get("causation_id")
+                )
+                for item in records
+                if item.get("phase") in {"committed", "aborted"}
+            }
             terminal_phases: dict[str, set[str]] = {}
             for item in records:
                 if item.get("phase") in {"committed", "aborted"}:
-                    terminal_phases.setdefault(str(item.get("causation_id")), set()).add(str(item["phase"]))
+                    nested = item.get("consolidation_event")
+                    causation_id = (
+                        nested.get("semantic_parent_event_id")
+                        if item.get("event_type") == "consolidation"
+                        and isinstance(nested, Mapping)
+                        else item.get("causation_id")
+                    )
+                    terminal_phases.setdefault(str(causation_id), set()).add(str(item["phase"]))
             for causation_id, phases in terminal_phases.items():
                 if len(phases) > 1:
                     issues.append({"code": "competing_terminals", "path": str(instance_dir), "detail": causation_id})

--- a/tests/test_consolidation_receipts.py
+++ b/tests/test_consolidation_receipts.py
@@ -1,0 +1,714 @@
+"""Closed, deterministic receipt evidence for consolidation effects."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+from pathlib import Path
+
+import pytest
+
+RUN_ID = "00000000-0000-4000-8000-000000000091"
+OPERATION_ID = "00000000-0000-4000-8000-000000000092"
+REQUEST_DIGEST = hashlib.sha256(b"request").hexdigest()
+PRIOR_DIGEST = hashlib.sha256(b"prior").hexdigest()
+PREPARED_DIGEST = hashlib.sha256(b"prepared").hexdigest()
+TARGET_DIGEST = hashlib.sha256(b"target").hexdigest()
+OBSERVED_DIGEST = hashlib.sha256(b"observed").hexdigest()
+PARENT_EVENT_ID = f"{'d' * 64}:committed"
+PARENT_PAYLOAD_DIGEST = "e" * 64
+T0 = "2026-08-30T10:00:00Z"
+T1 = "2026-08-30T10:00:01Z"
+
+
+@pytest.fixture(autouse=True)
+def receipt_state_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR",
+        str(tmp_path / "writer-state"),
+    )
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    root = tmp_path / "vault"
+    (root / "Knowledge Base").mkdir(parents=True)
+    return root
+
+
+_EVIDENCE_FIELDS = {
+    "start": ("identity_binding_digest", "run_request_digest"),
+    "intake": ("archive_attestation_digest", "intake_manifest_digest"),
+    "content-batch": ("batch_manifest_digest", "classification_digest"),
+    "complete": ("completion_digest", "verification_basis_digest"),
+    "render-page": (
+        "impact_summary_digest",
+        "page_digest",
+        "plan_digest",
+        "render_session_digest",
+    ),
+    "render-ack": (
+        "acknowledgement_digest",
+        "impact_summary_digest",
+        "page_digest",
+        "plan_digest",
+        "render_session_digest",
+    ),
+    "retirement-consume": (
+        "clearance_jti_digest",
+        "destination_proof_digest",
+        "disposition_digest",
+        "source_checkpoint_digest",
+        "source_fence_digest",
+        "verifier_decision_digest",
+    ),
+    "retirement-completion": (
+        "authentication_proof_digest",
+        "completion_attestation_digest",
+        "disposition_digest",
+        "source_consume_event_digest",
+        "source_receipt_head_digest",
+    ),
+    "rebuild-kind": ("rebuild_basis_digest", "rebuild_result_digest"),
+    "in-process-probe": (
+        "probe_digest",
+        "probe_result_digest",
+        "verification_basis_digest",
+    ),
+}
+
+
+def _evidence(kind: str):
+    from exomem.governance import consolidation_receipts
+
+    return consolidation_receipts.build_evidence(
+        kind=kind,
+        digests={
+            field: hashlib.sha256(f"{kind}:{field}".encode()).hexdigest()
+            for field in _EVIDENCE_FIELDS[kind]
+        },
+    )
+
+
+def _intent(**overrides: object):
+    from exomem.governance import consolidation_receipts
+
+    values: dict[str, object] = {
+        "kind": "content-batch",
+        "run_id": RUN_ID,
+        "operation_id": OPERATION_ID,
+        "phase": "publishing",
+        "effect_ordinal": 7,
+        "batch_ordinal": 2,
+        "request_digest": REQUEST_DIGEST,
+        "prior_digest": PRIOR_DIGEST,
+        "prepared_digest": PREPARED_DIGEST,
+        "target_digest": TARGET_DIGEST,
+        "semantic_parent_event_id": PARENT_EVENT_ID,
+        "semantic_parent_payload_digest": PARENT_PAYLOAD_DIGEST,
+    }
+    values.update(overrides)
+    values.setdefault("evidence", _evidence(str(values["kind"])))
+    return consolidation_receipts.build_intent(**values)
+
+
+def _append_start(vault: Path):
+    from exomem.governance import consolidation_receipts
+
+    root_id, root_digest = consolidation_receipts.semantic_root()
+    start = consolidation_receipts.build_intent(
+        kind="start",
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        phase="intake",
+        effect_ordinal=0,
+        request_digest=REQUEST_DIGEST,
+        prior_digest=PRIOR_DIGEST,
+        target_digest=TARGET_DIGEST,
+        evidence=_evidence("start"),
+        semantic_parent_event_id=root_id,
+        semantic_parent_payload_digest=root_digest,
+    )
+    start_record = consolidation_receipts.append_intent(vault, start, timestamp=T0)
+    return consolidation_receipts.append_terminal(
+        vault,
+        intent_event_id=start_record["event_id"],
+        role="committed",
+        observed_digest=TARGET_DIGEST,
+        timestamp=T0,
+    )
+
+
+def _appendable_intent(vault: Path):
+    from exomem.governance import consolidation_receipts
+
+    parent = _append_start(vault)
+    return consolidation_receipts.build_intent(
+        kind="intake",
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        phase="intake",
+        effect_ordinal=1,
+        request_digest=REQUEST_DIGEST,
+        prior_digest=PRIOR_DIGEST,
+        target_digest=TARGET_DIGEST,
+        evidence=_evidence("intake"),
+        semantic_parent_event_id=parent["event_id"],
+        semantic_parent_payload_digest=parent["consolidation_event"][
+            "payload_digest"
+        ],
+    )
+
+
+def test_intent_identity_and_payload_digest_are_exact_framed_jcs_vectors() -> None:
+    from exomem.governance import consolidation_plan, consolidation_receipts
+
+    event = _intent()
+    payload_without_digest = dict(event.payload)
+    payload_without_digest.pop("payload_digest")
+    payload_bytes = consolidation_plan.canonical_closed_jcs(payload_without_digest)
+    payload_domain = b"exomem.consolidation-event-payload/content-batch/intent/v1"
+    expected_payload_digest = hashlib.sha256(
+        len(payload_domain).to_bytes(4, "big")
+        + payload_domain
+        + len(payload_bytes).to_bytes(8, "big")
+        + payload_bytes
+    ).hexdigest()
+    identity_preimage = dict(payload_without_digest)
+    identity_preimage.pop("evidence")
+    identity_bytes = consolidation_plan.canonical_closed_jcs(identity_preimage)
+    identity_domain = b"exomem.consolidation-event-id/content-batch/v1"
+    expected_event_id = hashlib.sha256(
+        len(identity_domain).to_bytes(4, "big")
+        + identity_domain
+        + len(identity_bytes).to_bytes(8, "big")
+        + identity_bytes
+    ).hexdigest()
+
+    assert event.payload_digest == expected_payload_digest
+    assert event.event_id == expected_event_id
+    assert event.payload_digest == (
+        "3aad76e3f306762c21781dc5d8f4d56e7265f3676d8d76dd80cf0557c7360138"
+    )
+    assert event.event_id == (
+        "23bfe075deeb12e20d8db33b9fcbcfd7ff2c817dd081048308da30e7db48ecf3"
+    )
+    assert consolidation_receipts.semantic_root() == (
+        "28db6cc424d3332bdfff97ecf3238eda5982c82c92a9d0d11bca1ec0e92fdd3d",
+        "28db6cc424d3332bdfff97ecf3238eda5982c82c92a9d0d11bca1ec0e92fdd3d",
+    )
+    assert event.phase == "intent"
+    assert _intent() == event
+
+
+def test_every_kind_binds_its_owner_protected_evidence_bundle() -> None:
+    from exomem.governance import consolidation_plan
+
+    event = _intent()
+    evidence = dict(_evidence("content-batch"))
+    domain = b"exomem.consolidation-event-evidence/content-batch/v1"
+    encoded = consolidation_plan.canonical_closed_jcs(evidence)
+    expected = hashlib.sha256(
+        len(domain).to_bytes(4, "big")
+        + domain
+        + len(encoded).to_bytes(8, "big")
+        + encoded
+    ).hexdigest()
+    assert event.payload["evidence"] == evidence
+    assert event.payload["evidence_digest"] == expected
+
+
+def test_terminal_suffix_ids_and_role_payload_digests_are_fixed_vectors() -> None:
+    from exomem.governance import consolidation_receipts
+
+    intent = _intent()
+    committed = consolidation_receipts.build_terminal(
+        intent,
+        role="committed",
+        observed_digest=OBSERVED_DIGEST,
+    )
+    aborted = consolidation_receipts.build_terminal(
+        intent,
+        role="aborted",
+        observed_digest=PRIOR_DIGEST,
+    )
+
+    assert committed.event_id == f"{intent.event_id}:committed"
+    assert committed.payload_digest == (
+        "18402f4c67a9a94278af2b05a7255033ae96628f1d02308e5c1224610da32e19"
+    )
+    assert aborted.event_id == f"{intent.event_id}:aborted"
+    assert aborted.payload_digest == (
+        "62649628fcea42657d6814fba771baaff0c1299a2fcb181d5f3793fee4b34eb8"
+    )
+
+
+def test_receipt_envelope_keeps_physical_prev_separate_from_semantic_parent(
+    vault: Path,
+) -> None:
+    from exomem.governance import consolidation_receipts, receipts
+
+    intent = consolidation_receipts.append_intent(
+        vault,
+        _appendable_intent(vault),
+        timestamp=T0,
+    )
+    unrelated = receipts.append_event(
+        vault,
+        event_type="disclosure",
+        payload={"outcomes": []},
+        timestamp=T0,
+    )
+    terminal = consolidation_receipts.append_terminal(
+        vault,
+        intent_event_id=intent["event_id"],
+        role="committed",
+        observed_digest=OBSERVED_DIGEST,
+        timestamp=T1,
+    )
+
+    nested = terminal["consolidation_event"]
+    assert terminal["schema"] == "receipt/v1"
+    assert terminal["event_type"] == "consolidation"
+    assert terminal["event_id"] == f"{intent['event_id']}:committed"
+    assert terminal["prev"] == unrelated["hash"]
+    assert nested["semantic_parent_event_id"] == intent["event_id"]
+    assert nested["semantic_parent_payload_digest"] == intent["consolidation_event"][
+        "payload_digest"
+    ]
+    assert nested["observed_digest"] == OBSERVED_DIGEST
+    assert receipts.verify_chain(vault)["valid"] is True
+
+
+def test_identical_intent_and_terminal_retries_adopt_the_same_records(
+    vault: Path,
+) -> None:
+    from exomem.governance import consolidation_receipts, receipts
+
+    event = _appendable_intent(vault)
+    first_intent = consolidation_receipts.append_intent(vault, event, timestamp=T0)
+    replayed_intent = consolidation_receipts.append_intent(vault, event, timestamp=T0)
+    first_terminal = consolidation_receipts.append_terminal(
+        vault,
+        intent_event_id=first_intent["event_id"],
+        role="committed",
+        observed_digest=OBSERVED_DIGEST,
+        timestamp=T1,
+    )
+    replayed_terminal = consolidation_receipts.append_terminal(
+        vault,
+        intent_event_id=first_intent["event_id"],
+        role="committed",
+        observed_digest=OBSERVED_DIGEST,
+        timestamp=T1,
+    )
+
+    assert replayed_intent == first_intent
+    assert replayed_terminal == first_terminal
+    assert len(receipts.event_records(vault)) == 4
+
+
+def test_terminal_requires_its_exact_intent_and_refuses_competing_outcome(
+    vault: Path,
+) -> None:
+    from exomem.governance import consolidation_receipts
+
+    with pytest.raises(
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        match="^CONSOLIDATION_RECEIPT_UNAVAILABLE$",
+    ):
+        consolidation_receipts.append_terminal(
+            vault,
+            intent_event_id="a" * 64,
+            role="committed",
+            observed_digest=OBSERVED_DIGEST,
+        )
+
+    intent = consolidation_receipts.append_intent(
+        vault,
+        _appendable_intent(vault),
+        timestamp=T0,
+    )
+    consolidation_receipts.append_terminal(
+        vault,
+        intent_event_id=intent["event_id"],
+        role="committed",
+        observed_digest=OBSERVED_DIGEST,
+        timestamp=T1,
+    )
+    with pytest.raises(
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        match="^CONSOLIDATION_RECEIPT_UNAVAILABLE$",
+    ):
+        consolidation_receipts.append_terminal(
+            vault,
+            intent_event_id=intent["event_id"],
+            role="aborted",
+            observed_digest=PRIOR_DIGEST,
+        )
+
+
+def test_low_level_writer_cannot_bypass_terminal_intent_causality(vault: Path) -> None:
+    from exomem.governance import consolidation_receipts, receipts
+
+    intent = _appendable_intent(vault)
+    terminal = consolidation_receipts.build_terminal(
+        intent,
+        role="committed",
+        observed_digest=OBSERVED_DIGEST,
+    )
+    with pytest.raises(receipts.ReceiptError):
+        receipts.append_event(
+            vault,
+            event_type="consolidation",
+            phase="committed",
+            event_id=terminal.event_id,
+            payload={"consolidation_event": dict(terminal.payload)},
+            critical=True,
+        )
+
+    consolidation_receipts.append_intent(vault, intent, timestamp=T0)
+    written = receipts.append_event(
+        vault,
+        event_type="consolidation",
+        phase="committed",
+        event_id=terminal.event_id,
+        payload={"consolidation_event": dict(terminal.payload)},
+        timestamp=T1,
+        critical=True,
+    )
+    assert written["event_id"] == terminal.event_id
+
+
+def test_low_level_writer_refuses_a_nondurable_consolidation_record(
+    vault: Path,
+) -> None:
+    from exomem.governance import receipts
+
+    intent = _intent()
+    with pytest.raises(receipts.ReceiptError):
+        receipts.append_event(
+            vault,
+            event_type="consolidation",
+            phase="intent",
+            event_id=intent.event_id,
+            payload={"consolidation_event": dict(intent.payload)},
+            critical=False,
+        )
+
+
+def test_nonstart_intent_requires_its_exact_local_semantic_parent(
+    vault: Path,
+) -> None:
+    from exomem.governance import consolidation_receipts
+
+    with pytest.raises(
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        match="^CONSOLIDATION_RECEIPT_UNAVAILABLE$",
+    ):
+        consolidation_receipts.append_intent(vault, _intent())
+
+
+def test_intent_append_recomputes_the_deterministic_outer_identity(vault: Path) -> None:
+    from exomem.governance import consolidation_receipts
+
+    event = _intent()
+    forged = consolidation_receipts.ConsolidationEvent(
+        event_id="a" * 64,
+        phase=event.phase,
+        payload=event.payload,
+        payload_digest=event.payload_digest,
+    )
+    with pytest.raises(
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        match="^CONSOLIDATION_RECEIPT_UNAVAILABLE$",
+    ):
+        consolidation_receipts.append_intent(vault, forged)
+
+
+def test_successor_seed_is_allowed_only_on_registered_producer_kinds() -> None:
+    from exomem.governance import consolidation_receipts
+
+    seed = hashlib.sha256(b"successor-seed").hexdigest()
+    producer = _intent(
+        kind="complete",
+        phase="complete",
+        batch_ordinal=None,
+        prepared_digest=None,
+        successor_context_seed_digest=seed,
+    )
+    terminal = consolidation_receipts.build_terminal(
+        producer,
+        role="committed",
+        observed_digest=OBSERVED_DIGEST,
+    )
+    assert producer.payload["successor_context_seed_digest"] == seed
+    assert terminal.payload["successor_context_seed_digest"] == seed
+
+    with pytest.raises(
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        match="^CONSOLIDATION_RECEIPT_UNAVAILABLE$",
+    ):
+        _intent(successor_context_seed_digest=seed)
+
+
+def test_complete_requires_a_successor_context_seed() -> None:
+    from exomem.governance import consolidation_receipts
+
+    with pytest.raises(
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        match="^CONSOLIDATION_RECEIPT_UNAVAILABLE$",
+    ):
+        _intent(
+            kind="complete",
+            phase="complete",
+            batch_ordinal=None,
+            prepared_digest=None,
+        )
+
+
+def test_render_page_after_matching_ack_advances_to_the_next_page() -> None:
+    from exomem.governance import consolidation_receipts
+
+    ack_intent = _intent(
+        kind="render-ack",
+        phase="rendering",
+        effect_ordinal=7,
+        batch_ordinal=None,
+        prepared_digest=None,
+        page_ordinal=0,
+    )
+    ack = consolidation_receipts.build_terminal(
+        ack_intent,
+        role="committed",
+        observed_digest=OBSERVED_DIGEST,
+    )
+    page = _intent(
+        kind="render-page",
+        phase="rendering",
+        effect_ordinal=8,
+        batch_ordinal=None,
+        prepared_digest=None,
+        page_ordinal=1,
+        semantic_parent_event_id=ack.event_id,
+        semantic_parent_payload_digest=ack.payload_digest,
+    )
+
+    consolidation_receipts.validate_outer_append(
+        [
+            {
+                "event_type": "consolidation",
+                "phase": "committed",
+                "event_id": ack.event_id,
+                "consolidation_event": dict(ack.payload),
+            }
+        ],
+        event_id=page.event_id,
+        outer_phase="intent",
+        nested=page.payload,
+    )
+
+
+def test_kind_specific_evidence_is_closed_and_hashed_by_the_builder() -> None:
+    from exomem.governance import consolidation_receipts
+
+    evidence = consolidation_receipts.build_evidence(
+        kind="content-batch",
+        digests={
+            "batch_manifest_digest": hashlib.sha256(b"batch-manifest").hexdigest(),
+            "classification_digest": hashlib.sha256(b"classification").hexdigest(),
+        },
+    )
+    assert evidence == {
+        "schema": "exomem.consolidation-event-evidence/content-batch/v1",
+        "kind": "content-batch",
+        "batch_manifest_digest": hashlib.sha256(b"batch-manifest").hexdigest(),
+        "classification_digest": hashlib.sha256(b"classification").hexdigest(),
+    }
+
+    with pytest.raises(
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        match="^CONSOLIDATION_RECEIPT_UNAVAILABLE$",
+    ):
+        consolidation_receipts.build_evidence(
+            kind="content-batch",
+            digests={"batch_manifest_digest": "a" * 64},
+        )
+
+
+def test_only_start_can_name_the_fixed_semantic_root() -> None:
+    from exomem.governance import consolidation_receipts
+
+    root_id, root_digest = consolidation_receipts.semantic_root()
+    start = consolidation_receipts.build_intent(
+        kind="start",
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        phase="intake",
+        effect_ordinal=0,
+        request_digest=REQUEST_DIGEST,
+        prior_digest=PRIOR_DIGEST,
+        target_digest=TARGET_DIGEST,
+        evidence=_evidence("start"),
+        semantic_parent_event_id=root_id,
+        semantic_parent_payload_digest=root_digest,
+    )
+    assert start.payload["semantic_parent_event_id"] == root_id
+
+    with pytest.raises(
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        match="^CONSOLIDATION_RECEIPT_UNAVAILABLE$",
+    ):
+        consolidation_receipts.build_intent(
+            kind="content-batch",
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            phase="publishing",
+            effect_ordinal=1,
+            batch_ordinal=0,
+            prepared_digest=PREPARED_DIGEST,
+            request_digest=REQUEST_DIGEST,
+            prior_digest=PRIOR_DIGEST,
+            target_digest=TARGET_DIGEST,
+            evidence=_evidence("content-batch"),
+            semantic_parent_event_id=root_id,
+            semantic_parent_payload_digest=root_digest,
+        )
+
+
+def test_content_batch_cannot_skip_policy_and_name_start_as_its_parent(
+    vault: Path,
+) -> None:
+    from exomem.governance import consolidation_receipts
+
+    parent = _append_start(vault)
+    event = _intent(
+        batch_ordinal=0,
+        effect_ordinal=1,
+        semantic_parent_event_id=parent["event_id"],
+        semantic_parent_payload_digest=parent["consolidation_event"][
+            "payload_digest"
+        ],
+    )
+    with pytest.raises(
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        match="^CONSOLIDATION_RECEIPT_UNAVAILABLE$",
+    ):
+        consolidation_receipts.append_intent(vault, event)
+
+
+@pytest.mark.parametrize("kind", ("retirement-consume", "retirement-completion"))
+def test_cross_chain_retirement_parent_needs_authenticated_intake_authority(
+    vault: Path,
+    kind: str,
+) -> None:
+    from exomem.governance import consolidation_receipts
+
+    event = consolidation_receipts.build_intent(
+        kind=kind,
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        phase="retirement",
+        effect_ordinal=1,
+        request_digest=REQUEST_DIGEST,
+        prior_digest=PRIOR_DIGEST,
+        target_digest=TARGET_DIGEST,
+        evidence=_evidence(kind),
+        semantic_parent_event_id=PARENT_EVENT_ID,
+        semantic_parent_payload_digest=PARENT_PAYLOAD_DIGEST,
+    )
+    with pytest.raises(
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        match="^CONSOLIDATION_RECEIPT_UNAVAILABLE$",
+    ):
+        consolidation_receipts.append_intent(vault, event)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        lambda value: value.update(path="Knowledge Base/Notes/private.md"),
+        lambda value: value.update(record_role="aborted"),
+        lambda value: value.pop("observed_digest", None),
+        lambda value: value.update(page_ordinal=0),
+        lambda value: value.update(batch_ordinal=-1),
+        lambda value: value.update(payload_digest="f" * 64),
+    ),
+)
+def test_nested_terminal_schema_rejects_unknown_role_ordinal_and_digest_changes(
+    mutation,
+) -> None:
+    from exomem.governance import consolidation_receipts
+
+    intent = _intent()
+    terminal = consolidation_receipts.build_terminal(
+        intent,
+        role="committed",
+        observed_digest=OBSERVED_DIGEST,
+    )
+    changed = copy.deepcopy(dict(terminal.payload))
+    mutation(changed)
+
+    with pytest.raises(
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        match="^CONSOLIDATION_RECEIPT_UNAVAILABLE$",
+    ):
+        consolidation_receipts.validate_nested(changed, outer_phase="committed")
+
+
+def test_receipt_writer_rejects_a_nested_schema_masquerading_as_the_envelope(
+    vault: Path,
+) -> None:
+    from exomem.governance import receipts
+
+    with pytest.raises(receipts.ReceiptError):
+        receipts.append_event(
+            vault,
+            event_type="consolidation",
+            phase="intent",
+            event_id="a" * 64,
+            payload={
+                "schema": "exomem.consolidation-event/start/v1",
+                "kind": "start",
+            },
+            critical=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("kind", "ordinal_name"),
+    (
+        ("content-batch", "batch_ordinal"),
+        ("rebuild-kind", "rebuild_ordinal"),
+        ("in-process-probe", "probe_ordinal"),
+        ("render-page", "page_ordinal"),
+    ),
+)
+def test_each_specialized_effect_requires_only_its_registered_ordinal(
+    kind: str,
+    ordinal_name: str,
+) -> None:
+    from exomem.governance import consolidation_receipts
+
+    values: dict[str, object] = {
+        "kind": kind,
+        "run_id": RUN_ID,
+        "operation_id": OPERATION_ID,
+        "phase": "publishing",
+        "effect_ordinal": 1,
+        ordinal_name: 0,
+        "request_digest": REQUEST_DIGEST,
+        "prior_digest": PRIOR_DIGEST,
+        "target_digest": TARGET_DIGEST,
+        "semantic_parent_event_id": PARENT_EVENT_ID,
+        "semantic_parent_payload_digest": PARENT_PAYLOAD_DIGEST,
+    }
+    values["evidence"] = _evidence(kind)
+    if kind == "content-batch":
+        values["prepared_digest"] = PREPARED_DIGEST
+    event = consolidation_receipts.build_intent(**values)
+    assert event.payload[ordinal_name] == 0
+    assert not (
+        {"batch_ordinal", "rebuild_ordinal", "probe_ordinal", "page_ordinal"}
+        - {ordinal_name}
+    ).intersection(event.payload)


### PR DESCRIPTION
## Summary

- add deterministic plaintext-free consolidation intent and terminal events under the existing `receipt/v1` envelope
- enforce the closed semantic-parent graph, contiguous effect/specialized ordinals, one terminal outcome, and mandatory successor-context seeds
- carry and hash exact digest-only evidence objects for all 52 consolidation effect kinds
- refuse cross-chain retirement consume/completion at the generic local writer until authenticated lifecycle intake is implemented
- update the active OpenSpec design, disclosure-evidence delta, and tasks contract to match the executable schema

This is a deliberately non-serving foundation stacked after #975. It does not add a product command, open a consolidation route, or touch any live vault. The next lane uses these receipts in the cross-store saga journal/coordinator.

## Security properties

- physical receipt `prev` remains separate from semantic causation
- event ids and role payload digests are framed-JCS fixed vectors
- low-level receipt append cannot bypass nested-schema, evidence, parent, ordinal, or terminal validation
- event evidence contains names and digests only: no paths, content, refs, principals, policy text, credentials, or token bytes
- source/destination cross-chain retirement causality stays fail-closed pending its authenticated adapter

## Verification

- red-first regressions for missing evidence binding, wrong parent/ordinal, optional completion seed, unauthenticated retirement parent, and multi-page render sequencing
- `323 passed` across consolidation receipts and adjacent governance receipt/store/policy/adoption suites
- independent focused security re-review: GO, no P0/P1/P2 findings
- Ruff on all changed Python files
- `openspec validate add-governed-vault-consolidation --strict`
- `uv lock --check`
- public repository artifact validation: 3433 files / 3501 text payloads clean
- `uv build`
- whitespace checks for tracked and new files

Stacked after #975. No live-vault action and no merge performed.