### PR TITLE
fix(hosted): align provisioned namespace with authorization session contract

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -442,6 +442,9 @@ class KubernetesProviderRegistry:
                 "exomem.io/resource-name": metadata.resource_name,
                 "exomem.io/pvc-name": metadata.resource_name + "-data",
                 "exomem.io/credentials-secret-name": "exomem-cell-credentials",
+                "exomem.io/authorization-session-secret-name": (
+                    "exomem-authorization-session"
+                ),
                 "exomem.io/init-request-configmap-name": metadata.resource_name + "-init-request",
                 "exomem.io/provision-mode": provision_mode,
             }

--- a/infra/provisioner/tests/test_live_provider.py
+++ b/infra/provisioner/tests/test_live_provider.py
@@ -511,6 +511,7 @@ async def test_live_plane_namespace_carries_the_fixed_helm_contract_annotations(
         "exomem.io/lifecycle-actions-enabled": "false",
         "exomem.io/browser-origin": "https://substratesystems.io",
         "exomem.io/transfer-hostname": "transfer.example.invalid",
+        "exomem.io/authorization-session-secret-name": "exomem-authorization-session",
     }
     annotations = core.namespace_body["metadata"]["annotations"]
     assert {key: annotations.get(key) for key in expected} == expected


### PR DESCRIPTION
The 0.66 platform admission policy requires every tenant namespace to name its authorization-session secret. The live provisioner omitted that fixed annotation, so Kubernetes rejected new cell namespaces before provisioning could begin.

This adds the required fixed annotation to provisioner-created namespaces and pins the behavior in the live-provider test.

Verification:
- 525 provisioner tests passed; 17 skipped
- 28 live-provider tests passed
- hosted Helm contract: 5 passed; 54 environment-dependent renders skipped
- Ruff passed on changed Python files
- public artifact privacy gate passed