### PR TITLE
feat(governance): coordinate consolidation effects

### DIFF
--- a/src/exomem/governance/consolidation_effect_coordinator.py
+++ b/src/exomem/governance/consolidation_effect_coordinator.py
@@ -1,0 +1,1013 @@
+"""Crash-recoverable receipt-first execution for consolidation effects.
+
+The receipt chain, effect journal, and mutated state are separate durable stores.
+This module therefore never infers one store from another: it binds the exact
+receipt records into an owner-only prepared journal, classifies the effect, and
+only then appends a terminal and finalizes the journal.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Literal, NoReturn
+
+from .. import mutation_lock, reserved_paths, writer_lease
+from ..cli_ops import OpError
+from ..kbdir import kb_dirname
+from . import consolidation_plan, consolidation_receipts, receipts
+
+JOURNAL_SCHEMA = "exomem.consolidation-effect-journal/v1"
+
+_OWNER = "consolidation.run"
+_DESCRIPTOR_ID = "consolidation-tree"
+_BINDING_SCHEMA = "exomem.consolidation-effect-journal-binding/v1"
+_BINDING_DOMAIN = _BINDING_SCHEMA.encode("ascii")
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_EVENT_ID = re.compile(r"[0-9a-f]{64}(?::(?:committed|aborted))?\Z")
+_INSTANCE_ID = re.compile(r"[0-9a-f]{32}\Z")
+_UUID4 = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
+)
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_MAX_JOURNAL_BYTES = 512 * 1024
+_STATES = frozenset({"prior", "prepared", "target", "mixed"})
+_TERMINAL_ROLES = frozenset({"committed", "aborted"})
+_REFERENCE_FIELDS = frozenset(
+    {
+        "event_id",
+        "instance_id",
+        "payload_digest",
+        "receipt_head_digest",
+        "record_hash",
+        "sequence",
+    }
+)
+_PREPARED_FIELDS = frozenset(
+    {
+        "binding_digest",
+        "effect_ordinal",
+        "intent",
+        "intent_payload",
+        "kind",
+        "operation_id",
+        "revision",
+        "run_id",
+        "schema",
+        "status",
+    }
+)
+_FINAL_FIELDS = _PREPARED_FIELDS | frozenset(
+    {"observed_digest", "observed_state", "terminal"}
+)
+
+__all__ = [
+    "JOURNAL_SCHEMA",
+    "ConsolidationEffectJournalState",
+    "ConsolidationEffectJournalStore",
+    "ConsolidationEffectUnavailable",
+    "EffectExecutionResult",
+    "EffectObservation",
+    "ReceiptReference",
+]
+
+
+class ConsolidationEffectUnavailable(RuntimeError):
+    """Stable content-free refusal for ambiguous or contradictory effect state."""
+
+    code = "CONSOLIDATION_EFFECT_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True, slots=True)
+class ReceiptReference:
+    event_id: str
+    instance_id: str
+    payload_digest: str
+    receipt_head_digest: str
+    record_hash: str
+    sequence: int
+
+
+@dataclass(frozen=True, slots=True)
+class EffectObservation:
+    state: Literal["prior", "prepared", "target", "mixed"]
+    digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationEffectJournalState:
+    schema: str
+    run_id: str
+    operation_id: str
+    kind: str
+    effect_ordinal: int
+    binding_digest: str
+    revision: int
+    status: Literal["prepared", "final"]
+    intent: ReceiptReference
+    intent_payload: Mapping[str, object]
+    terminal: ReceiptReference | None
+    observed_state: str | None
+    observed_digest: str | None
+    state_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class EffectExecutionResult:
+    role: Literal["committed", "aborted"]
+    observed_state: str
+    observed_digest: str
+    intent: ReceiptReference
+    terminal: ReceiptReference
+    journal_digest: str
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationEffectUnavailable from None
+
+
+def _crash_point(_point: str) -> None:
+    """Narrow test seam for the six durable cross-store boundaries."""
+
+
+def _digest(value: object) -> str:
+    if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _event_id(value: object) -> str:
+    if not isinstance(value, str) or _EVENT_ID.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _uuid4(value: object) -> str:
+    if not isinstance(value, str) or _UUID4.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _integer(value: object, *, minimum: int = 0) -> int:
+    if type(value) is not int or not minimum <= value <= _MAX_SAFE_INTEGER:
+        _fail()
+    return value
+
+
+def _mapping(value: object, fields: frozenset[str]) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or frozenset(value) != fields:
+        _fail()
+    return value
+
+
+def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            _fail()
+        value[key] = item
+    return value
+
+
+def _reject_number(_value: str) -> NoReturn:
+    _fail()
+
+
+def _parse_integer(value: str) -> int:
+    if value.startswith("-"):
+        _fail()
+    try:
+        return _integer(int(value))
+    except ValueError:
+        _fail()
+
+
+def _decode(raw: bytes) -> Mapping[str, object]:
+    if not isinstance(raw, bytes) or not raw or len(raw) > _MAX_JOURNAL_BYTES:
+        _fail()
+    try:
+        value = json.loads(
+            raw,
+            object_pairs_hook=_pairs,
+            parse_int=_parse_integer,
+            parse_float=_reject_number,
+            parse_constant=_reject_number,
+        )
+    except (
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        ConsolidationEffectUnavailable,
+    ):
+        _fail()
+    if not isinstance(value, Mapping):
+        _fail()
+    try:
+        canonical = consolidation_plan.canonical_closed_jcs(value)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    if canonical != raw:
+        _fail()
+    return value
+
+
+def _frame(domain: bytes, payload: bytes) -> bytes:
+    return (
+        len(domain).to_bytes(4, "big")
+        + domain
+        + len(payload).to_bytes(8, "big")
+        + payload
+    )
+
+
+def _binding_digest(payload: Mapping[str, object]) -> str:
+    try:
+        encoded = consolidation_plan.canonical_closed_jcs(payload)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    return hashlib.sha256(_frame(_BINDING_DOMAIN, encoded)).hexdigest()
+
+
+def _reference_value(reference: ReceiptReference) -> dict[str, object]:
+    return {
+        "event_id": reference.event_id,
+        "instance_id": reference.instance_id,
+        "payload_digest": reference.payload_digest,
+        "receipt_head_digest": reference.receipt_head_digest,
+        "record_hash": reference.record_hash,
+        "sequence": reference.sequence,
+    }
+
+
+def _parse_reference(value: object) -> ReceiptReference:
+    row = _mapping(value, _REFERENCE_FIELDS)
+    instance_id = row["instance_id"]
+    if not isinstance(instance_id, str) or _INSTANCE_ID.fullmatch(instance_id) is None:
+        _fail()
+    record_hash = _digest(row["record_hash"])
+    head = _digest(row["receipt_head_digest"])
+    if record_hash != head:
+        _fail()
+    return ReceiptReference(
+        event_id=_event_id(row["event_id"]),
+        instance_id=instance_id,
+        payload_digest=_digest(row["payload_digest"]),
+        receipt_head_digest=head,
+        record_hash=record_hash,
+        sequence=_integer(row["sequence"], minimum=1),
+    )
+
+
+def _intent_from_payload(
+    payload: object,
+    *,
+    event_id: str,
+) -> consolidation_receipts.ConsolidationEvent:
+    try:
+        checked = consolidation_receipts.validate_nested(
+            payload,
+            outer_phase="intent",
+        )
+        expected_id = consolidation_receipts._intent_identity(checked)  # noqa: SLF001
+    except consolidation_receipts.ConsolidationReceiptUnavailable:
+        _fail()
+    if event_id != expected_id:
+        _fail()
+    return consolidation_receipts.ConsolidationEvent(
+        event_id=event_id,
+        phase="intent",
+        payload=checked,
+        payload_digest=_digest(checked["payload_digest"]),
+    )
+
+
+def _state_value(state: ConsolidationEffectJournalState) -> dict[str, object]:
+    value: dict[str, object] = {
+        "schema": state.schema,
+        "run_id": state.run_id,
+        "operation_id": state.operation_id,
+        "kind": state.kind,
+        "effect_ordinal": state.effect_ordinal,
+        "binding_digest": state.binding_digest,
+        "revision": state.revision,
+        "status": state.status,
+        "intent": _reference_value(state.intent),
+        "intent_payload": dict(state.intent_payload),
+    }
+    if state.status == "final":
+        if (
+            state.terminal is None
+            or state.observed_state is None
+            or state.observed_digest is None
+        ):
+            _fail()
+        value.update(
+            {
+                "terminal": _reference_value(state.terminal),
+                "observed_state": state.observed_state,
+                "observed_digest": state.observed_digest,
+            }
+        )
+    elif any(
+        item is not None
+        for item in (state.terminal, state.observed_state, state.observed_digest)
+    ):
+        _fail()
+    return value
+
+
+def _state_bytes(state: ConsolidationEffectJournalState) -> bytes:
+    try:
+        return consolidation_plan.canonical_closed_jcs(_state_value(state))
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+
+
+def _parse_state(raw: bytes) -> ConsolidationEffectJournalState:
+    value = _decode(raw)
+    status = value.get("status")
+    fields = _FINAL_FIELDS if status == "final" else _PREPARED_FIELDS
+    row = _mapping(value, fields)
+    if row["schema"] != JOURNAL_SCHEMA or status not in {"prepared", "final"}:
+        _fail()
+    intent_ref = _parse_reference(row["intent"])
+    intent = _intent_from_payload(
+        row["intent_payload"],
+        event_id=intent_ref.event_id,
+    )
+    if intent_ref.payload_digest != intent.payload_digest:
+        _fail()
+    payload = intent.payload
+    run_id = _uuid4(row["run_id"])
+    operation_id = _uuid4(row["operation_id"])
+    ordinal = _integer(row["effect_ordinal"])
+    kind = row["kind"]
+    if (
+        not isinstance(kind, str)
+        or payload["run_id"] != run_id
+        or payload["operation_id"] != operation_id
+        or payload["effect_ordinal"] != ordinal
+        or payload["kind"] != kind
+    ):
+        _fail()
+    binding_payload = {
+        "schema": _BINDING_SCHEMA,
+        "run_id": run_id,
+        "operation_id": operation_id,
+        "kind": kind,
+        "effect_ordinal": ordinal,
+        "intent_event_id": intent.event_id,
+        "intent_payload_digest": intent.payload_digest,
+    }
+    binding_digest = _binding_digest(binding_payload)
+    if row["binding_digest"] != binding_digest:
+        _fail()
+    terminal: ReceiptReference | None = None
+    observed_state: str | None = None
+    observed_digest: str | None = None
+    revision = _integer(row["revision"], minimum=1)
+    if status == "prepared":
+        if revision != 1:
+            _fail()
+    else:
+        terminal = _parse_reference(row["terminal"])
+        observed_state = row["observed_state"]
+        if not isinstance(observed_state, str) or observed_state not in _STATES:
+            _fail()
+        observed_digest = _digest(row["observed_digest"])
+        terminal_role = terminal.event_id.rpartition(":")[2]
+        if (
+            terminal_role not in _TERMINAL_ROLES
+            or terminal.event_id != f"{intent.event_id}:{terminal_role}"
+            or (terminal_role == "committed" and observed_state != "target")
+            or (terminal_role == "aborted" and observed_state != "prior")
+            or (terminal_role == "committed" and revision != 2)
+            or (terminal_role == "aborted" and revision not in {1, 2})
+        ):
+            _fail()
+        expected = consolidation_receipts.build_terminal(
+            intent,
+            role=terminal_role,
+            observed_digest=observed_digest,
+        )
+        if terminal.payload_digest != expected.payload_digest:
+            _fail()
+    return ConsolidationEffectJournalState(
+        schema=JOURNAL_SCHEMA,
+        run_id=run_id,
+        operation_id=operation_id,
+        kind=kind,
+        effect_ordinal=ordinal,
+        binding_digest=binding_digest,
+        revision=revision,
+        status=status,
+        intent=intent_ref,
+        intent_payload=intent.payload,
+        terminal=terminal,
+        observed_state=observed_state,
+        observed_digest=observed_digest,
+        state_digest=hashlib.sha256(raw).hexdigest(),
+    )
+
+
+def _reference_from_record(
+    record: Mapping[str, object],
+    *,
+    expected_event_id: str,
+    expected_payload_digest: str,
+    expected_phase: str,
+) -> ReceiptReference:
+    try:
+        nested = consolidation_receipts.validate_nested(
+            record.get("consolidation_event"),
+            outer_phase=expected_phase,
+        )
+    except consolidation_receipts.ConsolidationReceiptUnavailable:
+        _fail()
+    if (
+        record.get("schema") != "receipt/v1"
+        or record.get("event_type") != "consolidation"
+        or record.get("phase") != expected_phase
+        or record.get("event_id") != expected_event_id
+        or record.get("durable") is not True
+        or nested["payload_digest"] != expected_payload_digest
+    ):
+        _fail()
+    instance_id = record.get("instance_id")
+    if not isinstance(instance_id, str) or _INSTANCE_ID.fullmatch(instance_id) is None:
+        _fail()
+    record_hash = _digest(record.get("hash"))
+    return ReceiptReference(
+        event_id=expected_event_id,
+        instance_id=instance_id,
+        payload_digest=expected_payload_digest,
+        receipt_head_digest=record_hash,
+        record_hash=record_hash,
+        sequence=_integer(record.get("seq"), minimum=1),
+    )
+
+
+def _verify_reference(
+    vault_root: Path,
+    reference: ReceiptReference,
+    *,
+    expected_phase: str,
+) -> Mapping[str, object]:
+    try:
+        candidates = [
+            record
+            for record in receipts.event_records(vault_root)
+            if record.get("instance_id") == reference.instance_id
+            and record.get("seq") == reference.sequence
+        ]
+    except (OSError, RuntimeError, ValueError):
+        _fail()
+    if len(candidates) != 1:
+        _fail()
+    record = candidates[0]
+    checked = _reference_from_record(
+        record,
+        expected_event_id=reference.event_id,
+        expected_payload_digest=reference.payload_digest,
+        expected_phase=expected_phase,
+    )
+    if checked != reference:
+        _fail()
+    return record
+
+
+def _observation(value: object, *, event: consolidation_receipts.ConsolidationEvent) -> EffectObservation:
+    if not isinstance(value, EffectObservation) or value.state not in _STATES:
+        _fail()
+    digest = _digest(value.digest)
+    expected_field = {
+        "prior": "prior_digest",
+        "prepared": "prepared_digest",
+        "target": "target_digest",
+    }.get(value.state)
+    if expected_field is not None:
+        expected = event.payload.get(expected_field)
+        if expected is None or digest != expected:
+            _fail()
+    return EffectObservation(state=value.state, digest=digest)
+
+
+@contextmanager
+def _authority(vault_root: Path, *, mutation: bool) -> Iterator[None]:
+    try:
+        with reserved_paths._subsystem_authority_scope(_OWNER):  # noqa: SLF001
+            with reserved_paths._identity_coordination_scope(  # noqa: SLF001
+                vault_root,
+                descriptor_ids=(_DESCRIPTOR_ID,),
+                identity_may_change=mutation,
+            ):
+                yield
+    except ConsolidationEffectUnavailable:
+        raise
+    except (OSError, RuntimeError, ValueError):
+        _fail()
+
+
+@contextmanager
+def _execution_lock(
+    vault_root: Path,
+    *,
+    effect_ordinal: int,
+) -> Iterator[None]:
+    """Serialize one effect across threads and processes without holding receipts."""
+
+    try:
+        manager = writer_lease.active_manager()
+        coordinator = mutation_lock.VaultMutationCoordinator(
+            manager.config.state_dir,
+            Path(vault_root),
+        )
+        with coordinator.hold(
+            request_id=f"effect-{effect_ordinal}",
+            operation="consolidation-effect",
+            holder_kind="consolidation-control",
+        ):
+            yield
+    except ConsolidationEffectUnavailable:
+        raise
+    except (OSError, OpError, RuntimeError, TypeError, ValueError):
+        _fail()
+
+
+class ConsolidationEffectJournalStore:
+    """Persist one effect's exact prepared and final cross-store references."""
+
+    def __init__(
+        self,
+        vault_root: Path | str,
+        *,
+        run_id: str,
+        effect_ordinal: int,
+    ) -> None:
+        self.vault_root = Path(vault_root).absolute()
+        self.run_id = _uuid4(run_id)
+        self.effect_ordinal = _integer(effect_ordinal)
+        self.path = (
+            self.vault_root
+            / kb_dirname()
+            / "_Consolidation"
+            / "runs"
+            / self.run_id
+            / "effects"
+            / f"effect-{self.effect_ordinal:010d}.json"
+        )
+
+    def _read(self) -> bytes:
+        return reserved_paths._read_owner_bytes(  # noqa: SLF001
+            self.vault_root,
+            self.path,
+            _DESCRIPTOR_ID,
+            limit=_MAX_JOURNAL_BYTES,
+        )
+
+    def _read_optional(self) -> bytes | None:
+        try:
+            return self._read()
+        except FileNotFoundError:
+            return None
+
+    def _publish(
+        self,
+        raw: bytes,
+        *,
+        expected_sha256: str | None = None,
+        require_missing: bool = False,
+    ) -> None:
+        reserved_paths._publish_owner_bytes(  # noqa: SLF001
+            self.vault_root,
+            self.path,
+            _DESCRIPTOR_ID,
+            raw,
+            expected_sha256=expected_sha256,
+            require_missing=require_missing,
+        )
+
+    def load(self) -> ConsolidationEffectJournalState:
+        with _authority(self.vault_root, mutation=False):
+            try:
+                state = _parse_state(self._read())
+            except FileNotFoundError:
+                _fail()
+            self._validate_identity(state)
+            self._verify_receipts(state)
+            return state
+
+    def load_optional(self) -> ConsolidationEffectJournalState | None:
+        with _authority(self.vault_root, mutation=False):
+            raw = self._read_optional()
+            if raw is None:
+                return None
+            state = _parse_state(raw)
+            self._validate_identity(state)
+            self._verify_receipts(state)
+            return state
+
+    def _validate_identity(self, state: ConsolidationEffectJournalState) -> None:
+        if (
+            state.run_id != self.run_id
+            or state.effect_ordinal != self.effect_ordinal
+        ):
+            _fail()
+
+    def _verify_receipts(self, state: ConsolidationEffectJournalState) -> None:
+        _verify_reference(self.vault_root, state.intent, expected_phase="intent")
+        if state.status == "final":
+            if state.terminal is None:
+                _fail()
+            role = state.terminal.event_id.rpartition(":")[2]
+            _verify_reference(
+                self.vault_root,
+                state.terminal,
+                expected_phase=role,
+            )
+
+    def prepare(
+        self,
+        event: consolidation_receipts.ConsolidationEvent,
+        intent_record: Mapping[str, object],
+    ) -> ConsolidationEffectJournalState:
+        intent = _intent_from_payload(event.payload, event_id=event.event_id)
+        if event != intent or intent.payload["run_id"] != self.run_id:
+            _fail()
+        if intent.payload["effect_ordinal"] != self.effect_ordinal:
+            _fail()
+        reference = _reference_from_record(
+            intent_record,
+            expected_event_id=intent.event_id,
+            expected_payload_digest=intent.payload_digest,
+            expected_phase="intent",
+        )
+        _verify_reference(self.vault_root, reference, expected_phase="intent")
+        binding_payload = {
+            "schema": _BINDING_SCHEMA,
+            "run_id": self.run_id,
+            "operation_id": intent.payload["operation_id"],
+            "kind": intent.payload["kind"],
+            "effect_ordinal": self.effect_ordinal,
+            "intent_event_id": intent.event_id,
+            "intent_payload_digest": intent.payload_digest,
+        }
+        candidate = ConsolidationEffectJournalState(
+            schema=JOURNAL_SCHEMA,
+            run_id=self.run_id,
+            operation_id=str(intent.payload["operation_id"]),
+            kind=str(intent.payload["kind"]),
+            effect_ordinal=self.effect_ordinal,
+            binding_digest=_binding_digest(binding_payload),
+            revision=1,
+            status="prepared",
+            intent=reference,
+            intent_payload=intent.payload,
+            terminal=None,
+            observed_state=None,
+            observed_digest=None,
+            state_digest="0" * 64,
+        )
+        raw = _state_bytes(candidate)
+        target = replace(candidate, state_digest=hashlib.sha256(raw).hexdigest())
+        with _authority(self.vault_root, mutation=True):
+            existing_raw = self._read_optional()
+            if existing_raw is None:
+                self._publish(raw, require_missing=True)
+                return target
+            existing = _parse_state(existing_raw)
+            self._validate_identity(existing)
+            if existing.status == "prepared" and existing == target:
+                return existing
+            if (
+                existing.status == "final"
+                and existing.binding_digest == target.binding_digest
+                and existing.intent == target.intent
+                and dict(existing.intent_payload) == dict(target.intent_payload)
+            ):
+                self._verify_receipts(existing)
+                return existing
+            _fail()
+
+    def finalize(
+        self,
+        event: consolidation_receipts.ConsolidationEvent,
+        terminal_record: Mapping[str, object],
+        *,
+        observed_state: str,
+        observed_digest: str,
+    ) -> ConsolidationEffectJournalState:
+        intent = _intent_from_payload(event.payload, event_id=event.event_id)
+        if observed_state not in _STATES:
+            _fail()
+        observed = _observation(
+            EffectObservation(
+                state=observed_state,
+                digest=observed_digest,
+            ),
+            event=intent,
+        )
+        role = terminal_record.get("phase")
+        if not isinstance(role, str) or role not in _TERMINAL_ROLES:
+            _fail()
+        if (role == "committed" and observed.state != "target") or (
+            role == "aborted" and observed.state != "prior"
+        ):
+            _fail()
+        expected_terminal = consolidation_receipts.build_terminal(
+            intent,
+            role=role,
+            observed_digest=observed.digest,
+        )
+        reference = _reference_from_record(
+            terminal_record,
+            expected_event_id=expected_terminal.event_id,
+            expected_payload_digest=expected_terminal.payload_digest,
+            expected_phase=role,
+        )
+        _verify_reference(self.vault_root, reference, expected_phase=role)
+        with _authority(self.vault_root, mutation=True):
+            try:
+                raw = self._read()
+            except FileNotFoundError:
+                _fail()
+            current = _parse_state(raw)
+            self._validate_identity(current)
+            if current.status == "final":
+                if (
+                    current.terminal == reference
+                    and current.observed_state == observed.state
+                    and current.observed_digest == observed.digest
+                ):
+                    self._verify_receipts(current)
+                    return current
+                _fail()
+            if (
+                current.intent.event_id != intent.event_id
+                or current.intent.payload_digest != intent.payload_digest
+                or dict(current.intent_payload) != dict(intent.payload)
+            ):
+                _fail()
+            candidate = replace(
+                current,
+                revision=2,
+                status="final",
+                terminal=reference,
+                observed_state=observed.state,
+                observed_digest=observed.digest,
+                state_digest="0" * 64,
+            )
+            target_raw = _state_bytes(candidate)
+            target = replace(
+                candidate,
+                state_digest=hashlib.sha256(target_raw).hexdigest(),
+            )
+            self._publish(
+                target_raw,
+                expected_sha256=hashlib.sha256(raw).hexdigest(),
+            )
+            return target
+
+    def finalize_unprepared_abort(
+        self,
+        event: consolidation_receipts.ConsolidationEvent,
+        intent_record: Mapping[str, object],
+        terminal_record: Mapping[str, object],
+    ) -> ConsolidationEffectJournalState:
+        """Record the only valid intent-without-prepared recovery: abort on prior."""
+
+        intent = _intent_from_payload(event.payload, event_id=event.event_id)
+        if (
+            intent.payload["run_id"] != self.run_id
+            or intent.payload["effect_ordinal"] != self.effect_ordinal
+            or terminal_record.get("phase") != "aborted"
+        ):
+            _fail()
+        intent_reference = _reference_from_record(
+            intent_record,
+            expected_event_id=intent.event_id,
+            expected_payload_digest=intent.payload_digest,
+            expected_phase="intent",
+        )
+        terminal = consolidation_receipts.build_terminal(
+            intent,
+            role="aborted",
+            observed_digest=str(intent.payload["prior_digest"]),
+        )
+        terminal_reference = _reference_from_record(
+            terminal_record,
+            expected_event_id=terminal.event_id,
+            expected_payload_digest=terminal.payload_digest,
+            expected_phase="aborted",
+        )
+        _verify_reference(self.vault_root, intent_reference, expected_phase="intent")
+        _verify_reference(
+            self.vault_root,
+            terminal_reference,
+            expected_phase="aborted",
+        )
+        binding_payload = {
+            "schema": _BINDING_SCHEMA,
+            "run_id": self.run_id,
+            "operation_id": intent.payload["operation_id"],
+            "kind": intent.payload["kind"],
+            "effect_ordinal": self.effect_ordinal,
+            "intent_event_id": intent.event_id,
+            "intent_payload_digest": intent.payload_digest,
+        }
+        candidate = ConsolidationEffectJournalState(
+            schema=JOURNAL_SCHEMA,
+            run_id=self.run_id,
+            operation_id=str(intent.payload["operation_id"]),
+            kind=str(intent.payload["kind"]),
+            effect_ordinal=self.effect_ordinal,
+            binding_digest=_binding_digest(binding_payload),
+            revision=1,
+            status="final",
+            intent=intent_reference,
+            intent_payload=intent.payload,
+            terminal=terminal_reference,
+            observed_state="prior",
+            observed_digest=str(intent.payload["prior_digest"]),
+            state_digest="0" * 64,
+        )
+        raw = _state_bytes(candidate)
+        target = replace(candidate, state_digest=hashlib.sha256(raw).hexdigest())
+        with _authority(self.vault_root, mutation=True):
+            existing_raw = self._read_optional()
+            if existing_raw is None:
+                self._publish(raw, require_missing=True)
+                return target
+            existing = _parse_state(existing_raw)
+            self._validate_identity(existing)
+            self._verify_receipts(existing)
+            if existing == target:
+                return existing
+            _fail()
+
+
+def _result(
+    state: ConsolidationEffectJournalState,
+) -> EffectExecutionResult:
+    if (
+        state.status != "final"
+        or state.terminal is None
+        or state.observed_state is None
+        or state.observed_digest is None
+    ):
+        _fail()
+    role = state.terminal.event_id.rpartition(":")[2]
+    if role not in _TERMINAL_ROLES:
+        _fail()
+    return EffectExecutionResult(
+        role=role,
+        observed_state=state.observed_state,
+        observed_digest=state.observed_digest,
+        intent=state.intent,
+        terminal=state.terminal,
+        journal_digest=state.state_digest,
+    )
+
+
+def _execute_effect(
+    *,
+    vault_root: Path,
+    event: consolidation_receipts.ConsolidationEvent,
+    journal: ConsolidationEffectJournalStore,
+    classify: Callable[[], EffectObservation],
+    classify_unprepared: Callable[[], EffectObservation] | None = None,
+    apply_effect: Callable[[], None],
+    resume_effect: Callable[[], None] | None = None,
+    timestamp: str | None = None,
+) -> EffectExecutionResult:
+    """Execute or recover one non-successor consolidation effect exactly once."""
+
+    if not isinstance(journal, ConsolidationEffectJournalStore):
+        _fail()
+    with _execution_lock(
+        Path(vault_root),
+        effect_ordinal=journal.effect_ordinal,
+    ):
+        return _execute_effect_locked(
+            vault_root=Path(vault_root),
+            event=event,
+            journal=journal,
+            classify=classify,
+            classify_unprepared=classify_unprepared,
+            apply_effect=apply_effect,
+            resume_effect=resume_effect,
+            timestamp=timestamp,
+        )
+
+
+def _execute_effect_locked(
+    *,
+    vault_root: Path,
+    event: consolidation_receipts.ConsolidationEvent,
+    journal: ConsolidationEffectJournalStore,
+    classify: Callable[[], EffectObservation],
+    classify_unprepared: Callable[[], EffectObservation] | None,
+    apply_effect: Callable[[], None],
+    resume_effect: Callable[[], None] | None,
+    timestamp: str | None,
+) -> EffectExecutionResult:
+    try:
+        intent = _intent_from_payload(event.payload, event_id=event.event_id)
+        if (
+            event != intent
+            or Path(vault_root).absolute() != journal.vault_root
+            or intent.payload["run_id"] != journal.run_id
+            or intent.payload["effect_ordinal"] != journal.effect_ordinal
+            or "successor_context_seed_digest" in intent.payload
+        ):
+            _fail()
+        intent_record, adopted_intent = (
+            consolidation_receipts.append_intent_with_status(
+            vault_root,
+            intent,
+            timestamp=timestamp,
+            )
+        )
+        _crash_point("after-intent")
+        existing = journal.load_optional()
+        if existing is None:
+            unprepared = _observation(
+                (classify_unprepared or classify)(),
+                event=intent,
+            )
+            if unprepared.state != "prior":
+                _fail()
+        if existing is None and adopted_intent:
+            terminal_record = consolidation_receipts.append_terminal(
+                vault_root,
+                intent_event_id=intent.event_id,
+                role="aborted",
+                observed_digest=unprepared.digest,
+                timestamp=timestamp,
+            )
+            _crash_point("after-terminal")
+            journal.finalize_unprepared_abort(
+                intent,
+                intent_record,
+                terminal_record,
+            )
+            _crash_point("after-final")
+            _fail()
+        prepared = journal.prepare(intent, intent_record)
+        if prepared.status == "final":
+            observation = _observation(classify(), event=intent)
+            if (
+                prepared.terminal is None
+                or prepared.terminal.event_id.rpartition(":")[2] != "committed"
+                or observation.state != "target"
+                or observation.digest != prepared.observed_digest
+            ):
+                _fail()
+            return _result(prepared)
+        _crash_point("after-prepared")
+        before = _observation(classify(), event=intent)
+        if before.state == "mixed":
+            _fail()
+        if before.state == "target":
+            after = before
+        else:
+            if before.state == "prepared":
+                if resume_effect is None:
+                    _fail()
+                resume_effect()
+            else:
+                apply_effect()
+            _crash_point("after-effect")
+            after = _observation(classify(), event=intent)
+            if after.state != "target":
+                _fail()
+        _crash_point("after-classification")
+        terminal_record = consolidation_receipts.append_terminal(
+            vault_root,
+            intent_event_id=intent.event_id,
+            role="committed",
+            observed_digest=after.digest,
+            timestamp=timestamp,
+        )
+        _crash_point("after-terminal")
+        final = journal.finalize(
+            intent,
+            terminal_record,
+            observed_state=after.state,
+            observed_digest=after.digest,
+        )
+        _crash_point("after-final")
+        return _result(final)
+    except ConsolidationEffectUnavailable:
+        raise
+    except consolidation_receipts.ConsolidationReceiptUnavailable:
+        _fail()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        _fail()

--- a/src/exomem/governance/consolidation_receipts.py
+++ b/src/exomem/governance/consolidation_receipts.py
@@ -454,6 +454,7 @@ __all__ = [
     "ConsolidationEvent",
     "ConsolidationReceiptUnavailable",
     "append_intent",
+    "append_intent_with_status",
     "append_terminal",
     "build_evidence",
     "build_intent",
@@ -845,6 +846,22 @@ def append_intent(
 ) -> dict[str, object]:
     """Append or adopt one exact durable consolidation intent."""
 
+    record, _adopted = append_intent_with_status(
+        vault_root,
+        event,
+        timestamp=timestamp,
+    )
+    return record
+
+
+def append_intent_with_status(
+    vault_root: Path,
+    event: ConsolidationEvent,
+    *,
+    timestamp: str | None = None,
+) -> tuple[dict[str, object], bool]:
+    """Append/adopt an intent and report whether its durable record pre-existed."""
+
     from . import receipts
 
     try:
@@ -864,8 +881,15 @@ def append_intent(
             payload={"consolidation_event": dict(checked)},
             timestamp=timestamp,
             critical=True,
+            _report_adoption=True,
         )
-        return {key: value for key, value in record.items() if not key.startswith("_")}
+        adopted = record.get("_adopted")
+        if type(adopted) is not bool:
+            _fail()
+        return (
+            {key: value for key, value in record.items() if not key.startswith("_")},
+            adopted,
+        )
     except ConsolidationReceiptUnavailable:
         raise
     except (OSError, RuntimeError, TypeError, ValueError):

--- a/src/exomem/governance/consolidation_saga.py
+++ b/src/exomem/governance/consolidation_saga.py
@@ -16,10 +16,13 @@ from collections.abc import Callable, Iterable, Mapping
 from contextlib import ExitStack
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Literal, NoReturn, Protocol
+from typing import TYPE_CHECKING, Literal, NoReturn, Protocol
 
-from .. import held_fs, vault
-from . import consolidation_plan
+from .. import held_fs, reserved_paths, vault
+from . import consolidation_plan, consolidation_receipts
+
+if TYPE_CHECKING:
+    from . import consolidation_effect_coordinator
 
 POLICY_ACTIVATION_TERMINAL_SCHEMA = (
     "exomem.consolidation-policy-activation-terminal/v1"
@@ -51,6 +54,7 @@ __all__ = [
     "PolicyFirstPublicationUnavailable",
     "classify_content_batch_state",
     "publish_policy_first",
+    "publish_content_batch_receipt_first",
 ]
 
 
@@ -278,6 +282,32 @@ def _validated_batch_writes(
     return tuple(checked[path] for path in required)
 
 
+def _validated_batch_removals(
+    *,
+    vault_root: Path,
+    actions: tuple[Mapping[str, object], ...],
+) -> tuple[tuple[str, held_fs.StableIdentity, str], ...]:
+    removals: list[tuple[str, held_fs.StableIdentity, str]] = []
+    for action in actions:
+        before = action["expected_before_state"]
+        after = action["planned_after_state"]
+        kind = action["action"]
+        if after == "absent":
+            if before != "present" or kind != "remove":
+                _fail()
+            relative = str(action["destination_path"])
+            try:
+                identity = reserved_paths.inspect_generic_file(vault_root, relative)
+            except reserved_paths.ReservedPathLeafError:
+                _fail()
+            removals.append(
+                (relative, identity, _digest(action["expected_before_sha256"]))
+            )
+        elif kind == "remove":
+            _fail()
+    return tuple(removals)
+
+
 def classify_content_batch_state(
     *,
     vault_root: Path,
@@ -411,4 +441,139 @@ def publish_policy_first(
         partition_digest=partition.digest,
         publication_boundary_ordinal=batches[0].ordinal,
         committed_batch_ordinals=tuple(committed),
+    )
+
+
+def _content_batch_classification_digest(batch: ContentBatch) -> str:
+    value = {
+        "schema": "exomem.consolidation-content-batch-classification/v1",
+        "batch_ordinal": batch.ordinal,
+        "action_set_digest": batch.action_set_digest,
+        "prior_fingerprint": batch.prior_fingerprint,
+        "prepared_fingerprint": batch.prepared_fingerprint,
+        "final_fingerprint": batch.final_fingerprint,
+    }
+    encoded = consolidation_plan.canonical_closed_jcs(value)
+    domain = b"exomem.consolidation-content-batch-classification/v1"
+    framed = (
+        len(domain).to_bytes(4, "big")
+        + domain
+        + len(encoded).to_bytes(8, "big")
+        + encoded
+    )
+    return hashlib.sha256(framed).hexdigest()
+
+
+def publish_content_batch_receipt_first(
+    *,
+    content_actions: object,
+    batch: ContentBatch,
+    event: consolidation_receipts.ConsolidationEvent,
+    journal: consolidation_effect_coordinator.ConsolidationEffectJournalStore,
+    vault_root: Path,
+    materialize_batch: Callable[[ContentBatch], Iterable[vault.PlannedWrite]],
+    timestamp: str | None = None,
+) -> consolidation_effect_coordinator.EffectExecutionResult:
+    """Publish one real content batch through the receipt-first effect engine."""
+
+    from . import consolidation_effect_coordinator
+
+    partition = consolidation_plan.derive_journal_batch_partition(content_actions)
+    batches = _content_batches(partition)
+    if (
+        not isinstance(batch, ContentBatch)
+        or not 0 <= batch.ordinal < len(batches)
+        or batches[batch.ordinal] != batch
+        or not isinstance(event, consolidation_receipts.ConsolidationEvent)
+    ):
+        _fail()
+    try:
+        payload = consolidation_receipts.validate_nested(
+            event.payload,
+            outer_phase="intent",
+        )
+    except consolidation_receipts.ConsolidationReceiptUnavailable:
+        _fail()
+    evidence = payload.get("evidence")
+    if (
+        payload.get("kind") != "content-batch"
+        or payload.get("phase") != "publishing"
+        or payload.get("batch_ordinal") != batch.ordinal
+        or payload.get("prior_digest") != batch.prior_fingerprint
+        or payload.get("prepared_digest") != batch.prepared_fingerprint
+        or payload.get("target_digest") != batch.final_fingerprint
+        or not isinstance(evidence, Mapping)
+        or evidence.get("batch_manifest_digest") != batch.action_set_digest
+        or evidence.get("classification_digest")
+        != _content_batch_classification_digest(batch)
+    ):
+        _fail()
+
+    def classify_observation(
+        *,
+        equivalent_as: Literal["prior", "target"],
+    ) -> consolidation_effect_coordinator.EffectObservation:
+        observed = classify_content_batch_state(
+            vault_root=Path(vault_root),
+            content_actions=content_actions,
+            batch=batch,
+        )
+        if observed.state == "prior" or (
+            observed.state == "equivalent" and equivalent_as == "prior"
+        ):
+            return consolidation_effect_coordinator.EffectObservation(
+                state="prior",
+                digest=batch.prior_fingerprint,
+            )
+        if observed.state in {"final", "equivalent"}:
+            return consolidation_effect_coordinator.EffectObservation(
+                state="target",
+                digest=batch.final_fingerprint,
+            )
+        return consolidation_effect_coordinator.EffectObservation(
+            state="mixed",
+            digest=_content_batch_classification_digest(batch),
+        )
+
+    def classify() -> consolidation_effect_coordinator.EffectObservation:
+        return classify_observation(equivalent_as="target")
+
+    def classify_unprepared() -> consolidation_effect_coordinator.EffectObservation:
+        return classify_observation(equivalent_as="prior")
+
+    def apply() -> None:
+        actions = consolidation_plan.validate_content_actions(content_actions)
+        selected = tuple(
+            action for action in actions if action["batch_ordinal"] == batch.ordinal
+        )
+        writes = _validated_batch_writes(
+            vault_root=Path(vault_root),
+            actions=selected,
+            writes=materialize_batch(batch),
+        )
+        removals = _validated_batch_removals(
+            vault_root=Path(vault_root),
+            actions=selected,
+        )
+        vault.batch_atomic_write(
+            writes,
+            vault_root=Path(vault_root),
+            post_commit_fanout=False,
+        )
+        for relative, identity, expected_sha256 in removals:
+            reserved_paths.unlink_generic_file(
+                Path(vault_root),
+                relative,
+                expected_identity=identity,
+                expected_sha256=expected_sha256,
+            )
+
+    return consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+        vault_root=Path(vault_root),
+        event=event,
+        journal=journal,
+        classify=classify,
+        classify_unprepared=classify_unprepared,
+        apply_effect=apply,
+        timestamp=timestamp,
     )

--- a/src/exomem/governance/receipts.py
+++ b/src/exomem/governance/receipts.py
@@ -1268,8 +1268,18 @@ def append_event(
     event_id: str | None = None,
     timestamp: str | None = None,
     critical: bool = False,
+    _report_adoption: bool = False,
 ) -> dict[str, Any]:
     """Append one validated receipt, failing closed if its anchor is stale."""
+    if type(_report_adoption) is not bool:
+        raise ReceiptError("receipt adoption-report flag must be boolean")
+
+    def result(record: Mapping[str, Any], *, adopted: bool) -> dict[str, Any]:
+        returned = dict(record)
+        if _report_adoption:
+            returned["_adopted"] = adopted
+        return returned
+
     _validate_event(event_type, phase, payload)
     if event_id is not None and not _valid_event_id(event_type, phase, event_id):
         raise ReceiptError("receipt event id is not opaque for its event phase")
@@ -1338,7 +1348,7 @@ def append_event(
                             (actual_seq, actual_hash, instance_id),
                         )
                     conn.commit()
-                    return tail
+                    return result(tail, adopted=True)
                 raise ReceiptError("receipt anchor is stale; reconcile before append")
             if event_type == "consolidation":
                 try:
@@ -1358,7 +1368,7 @@ def append_event(
             if event_id is not None and critical:
                 existing = _matching_existing_event(instance_dir, eid, event_type, phase, payload)
                 if existing is not None:
-                    return existing
+                    return result(existing, adopted=True)
             path = _month_path(vault_root, instance_id, timestamp)
             if tail is not None and path.name < Path(tail["_path"]).name:
                 raise ReceiptError("backdated receipt month rotation is refused")
@@ -1405,7 +1415,7 @@ def append_event(
             _crash_point("after_sidecar_commit")
             if event_type == "critical" and phase in {"committed", "aborted"}:
                 _crash_point("after_terminal_append")
-            return record
+            return result(record, adopted=False)
 
 
 def critical_event_id(operation_identity: Any) -> str:

--- a/src/exomem/reserved_paths.py
+++ b/src/exomem/reserved_paths.py
@@ -47,6 +47,7 @@ _HELD_PUBLICATION_RE = re.compile(
     re.ASCII,
 )
 _DRIVE_RE = re.compile(r"^[a-zA-Z]:")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$", re.ASCII)
 
 
 class PathDisposition(StrEnum):
@@ -966,9 +967,21 @@ def unlink_generic_file(
     value: object,
     *,
     expected_identity: held_fs.StableIdentity | None = None,
+    expected_sha256: str | None = None,
     identities: IdentityCatalogue | None = None,
 ) -> None:
-    """Remove one exact ordinary file through its retained parent and leaf."""
+    """Remove one exact ordinary file through its retained parent and leaf.
+
+    When supplied, ``expected_sha256`` is checked on the same retained file
+    handle that is consumed by the unlink.  This closes the in-place rewrite
+    race that an identity-only guard cannot detect.
+    """
+
+    if expected_sha256 is not None and (
+        not isinstance(expected_sha256, str)
+        or _SHA256_RE.fullmatch(expected_sha256) is None
+    ):
+        raise ReservedPathLeafError("CONTENT_CHANGED")
 
     with _generic_identity_catalogue_scope(
         vault_root, value, identities=identities
@@ -977,6 +990,7 @@ def unlink_generic_file(
             vault_root,
             value,
             expected_identity=expected_identity,
+            expected_sha256=expected_sha256,
             identities=current,
         )
 
@@ -986,6 +1000,7 @@ def _unlink_generic_file_held(
     value: object,
     *,
     expected_identity: held_fs.StableIdentity | None,
+    expected_sha256: str | None,
     identities: IdentityCatalogue,
 ) -> None:
 
@@ -994,7 +1009,7 @@ def _unlink_generic_file_held(
     if not acquired.ok:
         raise ReservedPathLeafError("CAPABILITY_UNAVAILABLE")
     with acquired.require() as filesystem:
-        parent_result = filesystem.parent(parent_path)
+        parent_result = filesystem.parent(parent_path, access="flush")
         if not parent_result.ok:
             code = (
                 parent_result.error.code
@@ -1017,6 +1032,12 @@ def _unlink_generic_file_held(
                 _refuse_private_identity(file.identity, identities)
                 if expected_identity is not None and file.identity != expected_identity:
                     raise ReservedPathLeafError("IDENTITY_CHANGED")
+                if expected_sha256 is not None:
+                    observed_sha256 = filesystem.sha256(file)
+                    if not observed_sha256.ok:
+                        raise ReservedPathLeafError("IO_REFUSED")
+                    if observed_sha256.require() != expected_sha256:
+                        raise ReservedPathLeafError("CONTENT_CHANGED")
                 removed = filesystem.unlink(file)
                 if not removed.ok:
                     code = (
@@ -1025,6 +1046,14 @@ def _unlink_generic_file_held(
                         else "IO_REFUSED"
                     )
                     raise ReservedPathLeafError(code)
+            flushed = filesystem.flush_directory(parent)
+            if not flushed.ok:
+                code = (
+                    flushed.error.code
+                    if flushed.error is not None
+                    else "IO_REFUSED"
+                )
+                raise ReservedPathLeafError(code)
             missing = filesystem.file(parent, leaf)
             if missing.ok:
                 missing.require().close()

--- a/tests/test_consolidation_effect_coordinator.py
+++ b/tests/test_consolidation_effect_coordinator.py
@@ -1,0 +1,860 @@
+"""Receipt-first execution and recovery for one consolidation effect."""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from exomem.governance import consolidation_receipts
+
+RUN_ID = "00000000-0000-4000-8000-0000000000b1"
+OPERATION_ID = "00000000-0000-4000-8000-0000000000b2"
+REQUEST_DIGEST = hashlib.sha256(b"effect-request").hexdigest()
+PRIOR_DIGEST = hashlib.sha256(b"effect-prior").hexdigest()
+TARGET_DIGEST = hashlib.sha256(b"effect-target").hexdigest()
+MIXED_DIGEST = hashlib.sha256(b"effect-mixed").hexdigest()
+T0 = "2026-08-30T12:00:00Z"
+
+
+class SimulatedProcessCrash(BaseException):
+    """Bypass ordinary exception recovery like abrupt process loss."""
+
+
+@pytest.fixture(autouse=True)
+def _private_writer_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR",
+        str(tmp_path / "writer-state"),
+    )
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    root = tmp_path / "vault"
+    (root / "Knowledge Base").mkdir(parents=True)
+    return root
+
+
+def _start_event() -> consolidation_receipts.ConsolidationEvent:
+    root_id, root_digest = consolidation_receipts.semantic_root()
+    return consolidation_receipts.build_intent(
+        kind="start",
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        phase="intake",
+        effect_ordinal=0,
+        request_digest=REQUEST_DIGEST,
+        prior_digest=PRIOR_DIGEST,
+        target_digest=TARGET_DIGEST,
+        evidence=consolidation_receipts.build_evidence(
+            kind="start",
+            digests={
+                "identity_binding_digest": hashlib.sha256(b"identity").hexdigest(),
+                "run_request_digest": REQUEST_DIGEST,
+            },
+        ),
+        semantic_parent_event_id=root_id,
+        semantic_parent_payload_digest=root_digest,
+    )
+
+
+def _engine(vault: Path):
+    from exomem.governance import consolidation_effect_coordinator
+
+    return consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+        vault,
+        run_id=RUN_ID,
+        effect_ordinal=0,
+    )
+
+
+def _journal(vault: Path, effect_ordinal: int):
+    from exomem.governance import consolidation_effect_coordinator
+
+    return consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+        vault,
+        run_id=RUN_ID,
+        effect_ordinal=effect_ordinal,
+    )
+
+
+def _observation(state: str):
+    from exomem.governance import consolidation_effect_coordinator
+
+    digest = {
+        "prior": PRIOR_DIGEST,
+        "target": TARGET_DIGEST,
+        "mixed": MIXED_DIGEST,
+    }[state]
+    return consolidation_effect_coordinator.EffectObservation(
+        state=state,
+        digest=digest,
+    )
+
+
+def _append_policy_active_parent(vault: Path) -> dict[str, object]:
+    chain = (
+        ("start", "intake", None),
+        ("intake", "intake", None),
+        ("snapshot-source", "snapshot", None),
+        ("snapshot-destination", "snapshot", None),
+        ("reconcile", "reconciliation", None),
+        ("plan-cutover", "plan", None),
+        ("render-begin", "rendering", None),
+        ("render-page", "rendering", 0),
+        ("render-ack", "rendering", 0),
+        ("render-complete", "rendering", None),
+        ("approval", "approval", None),
+        ("token-reservation", "authorization", None),
+        ("seal-intent", "sealing", None),
+        ("seal-drained", "sealed", None),
+        ("preimage", "preimage", None),
+        ("policy-prepare", "policy", None),
+        ("policy-active", "policy", None),
+    )
+    root_id, root_digest = consolidation_receipts.semantic_root()
+    parent_id = root_id
+    parent_digest = root_digest
+    terminal: dict[str, object] | None = None
+    for ordinal, (kind, phase, page_ordinal) in enumerate(chain):
+        fields = consolidation_receipts._EVIDENCE_FIELDS[kind]  # noqa: SLF001
+        event = consolidation_receipts.build_intent(
+            kind=kind,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            phase=phase,
+            effect_ordinal=ordinal,
+            request_digest=REQUEST_DIGEST,
+            prior_digest=hashlib.sha256(f"{kind}:prior".encode()).hexdigest(),
+            target_digest=hashlib.sha256(f"{kind}:target".encode()).hexdigest(),
+            evidence=consolidation_receipts.build_evidence(
+                kind=kind,
+                digests={
+                    field: hashlib.sha256(f"{kind}:{field}".encode()).hexdigest()
+                    for field in fields
+                },
+            ),
+            semantic_parent_event_id=parent_id,
+            semantic_parent_payload_digest=parent_digest,
+            page_ordinal=page_ordinal,
+        )
+        intent = consolidation_receipts.append_intent(vault, event, timestamp=T0)
+        terminal = consolidation_receipts.append_terminal(
+            vault,
+            intent_event_id=str(intent["event_id"]),
+            role="committed",
+            observed_digest=str(event.payload["target_digest"]),
+            timestamp=T0,
+        )
+        parent_id = str(terminal["event_id"])
+        parent_digest = str(terminal["consolidation_event"]["payload_digest"])
+    assert terminal is not None
+    return terminal
+
+
+def _content_batch_event(
+    vault: Path,
+    actions: tuple[dict[str, object], ...],
+    *,
+    effect_ordinal: int = 17,
+):
+    from exomem.governance import (
+        consolidation_effect_coordinator,
+        consolidation_plan,
+        consolidation_saga,
+    )
+
+    parent = _append_policy_active_parent(vault)
+    partition = consolidation_plan.derive_journal_batch_partition(actions)
+    batch = consolidation_saga._content_batches(partition)[0]  # noqa: SLF001
+    event = consolidation_receipts.build_intent(
+        kind="content-batch",
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        phase="publishing",
+        effect_ordinal=effect_ordinal,
+        batch_ordinal=0,
+        request_digest=REQUEST_DIGEST,
+        prior_digest=batch.prior_fingerprint,
+        prepared_digest=batch.prepared_fingerprint,
+        target_digest=batch.final_fingerprint,
+        evidence=consolidation_receipts.build_evidence(
+            kind="content-batch",
+            digests={
+                "batch_manifest_digest": batch.action_set_digest,
+                "classification_digest": (
+                    consolidation_saga._content_batch_classification_digest(  # noqa: SLF001
+                        batch
+                    )
+                ),
+            },
+        ),
+        semantic_parent_event_id=str(parent["event_id"]),
+        semantic_parent_payload_digest=str(
+            parent["consolidation_event"]["payload_digest"]
+        ),
+    )
+    journal = consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+        vault,
+        run_id=RUN_ID,
+        effect_ordinal=effect_ordinal,
+    )
+    return batch, event, journal
+
+
+def test_effect_uses_exact_receipt_first_order_and_persists_references(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_effect_coordinator, receipts
+
+    live = {"state": "prior"}
+    order: list[str] = []
+    monkeypatch.setattr(
+        consolidation_effect_coordinator,
+        "_crash_point",
+        order.append,
+    )
+
+    result = consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+        vault_root=vault,
+        event=_start_event(),
+        journal=_engine(vault),
+        classify=lambda: _observation(live["state"]),
+        apply_effect=lambda: live.__setitem__("state", "target"),
+        timestamp=T0,
+    )
+
+    assert order == [
+        "after-intent",
+        "after-prepared",
+        "after-effect",
+        "after-classification",
+        "after-terminal",
+        "after-final",
+    ]
+    assert result.role == "committed"
+    assert result.observed_digest == TARGET_DIGEST
+    state = _engine(vault).load()
+    assert state.status == "final"
+    assert state.intent.event_id == _start_event().event_id
+    assert state.intent.record_hash == state.intent.receipt_head_digest
+    assert state.terminal is not None
+    assert state.terminal.event_id == f"{_start_event().event_id}:committed"
+    assert state.terminal.record_hash == state.terminal.receipt_head_digest
+    assert state.observed_state == "target"
+    assert state.observed_digest == TARGET_DIGEST
+    assert [record["phase"] for record in receipts.event_records(vault)] == [
+        "intent",
+        "committed",
+    ]
+
+
+@pytest.mark.parametrize(
+    "crash_seam",
+    (
+        "after-prepared",
+        "after-effect",
+        "after-classification",
+        "after-terminal",
+        "after-final",
+    ),
+)
+def test_restart_repairs_each_cross_store_gap_without_repeating_effect(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    crash_seam: str,
+) -> None:
+    from exomem.governance import consolidation_effect_coordinator, receipts
+
+    live = {"state": "prior"}
+    effects = 0
+
+    def apply() -> None:
+        nonlocal effects
+        effects += 1
+        live["state"] = "target"
+
+    def crash(point: str) -> None:
+        if point == crash_seam:
+            raise SimulatedProcessCrash
+
+    monkeypatch.setattr(consolidation_effect_coordinator, "_crash_point", crash)
+    with pytest.raises(SimulatedProcessCrash):
+        consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=vault,
+            event=_start_event(),
+            journal=_engine(vault),
+            classify=lambda: _observation(live["state"]),
+            apply_effect=apply,
+            timestamp=T0,
+        )
+
+    monkeypatch.setattr(
+        consolidation_effect_coordinator,
+        "_crash_point",
+        lambda _point: None,
+    )
+    result = consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+        vault_root=vault,
+        event=_start_event(),
+        journal=_engine(vault),
+        classify=lambda: _observation(live["state"]),
+        apply_effect=apply,
+        timestamp=T0,
+    )
+
+    assert effects == 1
+    assert result.role == "committed"
+    assert _engine(vault).load().status == "final"
+    assert len(receipts.event_records(vault)) == 2
+
+
+def test_intent_without_prepared_journal_aborts_on_prior_without_effect(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_effect_coordinator, receipts
+
+    live = {"state": "prior"}
+    effects = 0
+
+    def apply() -> None:
+        nonlocal effects
+        effects += 1
+        live["state"] = "target"
+
+    def crash(point: str) -> None:
+        if point == "after-intent":
+            raise SimulatedProcessCrash
+
+    monkeypatch.setattr(consolidation_effect_coordinator, "_crash_point", crash)
+    with pytest.raises(SimulatedProcessCrash):
+        consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=vault,
+            event=_start_event(),
+            journal=_engine(vault),
+            classify=lambda: _observation(live["state"]),
+            apply_effect=apply,
+            timestamp=T0,
+        )
+
+    monkeypatch.setattr(
+        consolidation_effect_coordinator,
+        "_crash_point",
+        lambda _point: None,
+    )
+    with pytest.raises(
+        consolidation_effect_coordinator.ConsolidationEffectUnavailable,
+        match="^CONSOLIDATION_EFFECT_UNAVAILABLE$",
+    ):
+        consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=vault,
+            event=_start_event(),
+            journal=_engine(vault),
+            classify=lambda: _observation(live["state"]),
+            apply_effect=apply,
+            timestamp=T0,
+        )
+
+    assert effects == 0
+    final = _engine(vault).load()
+    assert final.status == "final"
+    assert final.revision == 1
+    assert final.terminal is not None
+    assert final.terminal.event_id.endswith(":aborted")
+    assert final.observed_state == "prior"
+    assert [record["phase"] for record in receipts.event_records(vault)] == [
+        "intent",
+        "aborted",
+    ]
+
+
+def test_mixed_state_after_preparation_stays_blocked_without_terminal(
+    vault: Path,
+) -> None:
+    from exomem.governance import consolidation_effect_coordinator, receipts
+
+    states = iter((_observation("prior"), _observation("mixed")))
+    with pytest.raises(
+        consolidation_effect_coordinator.ConsolidationEffectUnavailable,
+        match="^CONSOLIDATION_EFFECT_UNAVAILABLE$",
+    ):
+        consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=vault,
+            event=_start_event(),
+            journal=_engine(vault),
+            classify=lambda: next(states),
+            apply_effect=lambda: None,
+            timestamp=T0,
+        )
+
+    assert _engine(vault).load().status == "prepared"
+    assert [record["phase"] for record in receipts.event_records(vault)] == ["intent"]
+
+
+def test_intent_without_prepared_journal_blocks_if_target_already_exists(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_effect_coordinator, receipts
+
+    def crash(point: str) -> None:
+        if point == "after-intent":
+            raise SimulatedProcessCrash
+
+    monkeypatch.setattr(consolidation_effect_coordinator, "_crash_point", crash)
+    with pytest.raises(SimulatedProcessCrash):
+        consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=vault,
+            event=_start_event(),
+            journal=_engine(vault),
+            classify=lambda: _observation("prior"),
+            apply_effect=lambda: None,
+            timestamp=T0,
+        )
+
+    monkeypatch.setattr(
+        consolidation_effect_coordinator,
+        "_crash_point",
+        lambda _point: None,
+    )
+    with pytest.raises(
+        consolidation_effect_coordinator.ConsolidationEffectUnavailable,
+        match="^CONSOLIDATION_EFFECT_UNAVAILABLE$",
+    ):
+        consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=vault,
+            event=_start_event(),
+            journal=_engine(vault),
+            classify=lambda: _observation("target"),
+            apply_effect=lambda: pytest.fail("target without journal must not replay"),
+            timestamp=T0,
+        )
+
+    assert not _engine(vault).path.exists()
+    assert [record["phase"] for record in receipts.event_records(vault)] == ["intent"]
+
+
+def test_new_intent_does_not_legalize_a_preexisting_target(vault: Path) -> None:
+    from exomem.governance import consolidation_effect_coordinator, receipts
+
+    effects = 0
+
+    def apply() -> None:
+        nonlocal effects
+        effects += 1
+
+    with pytest.raises(
+        consolidation_effect_coordinator.ConsolidationEffectUnavailable,
+        match="^CONSOLIDATION_EFFECT_UNAVAILABLE$",
+    ):
+        consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=vault,
+            event=_start_event(),
+            journal=_engine(vault),
+            classify=lambda: _observation("target"),
+            apply_effect=apply,
+            timestamp=T0,
+        )
+
+    assert effects == 0
+    assert not _engine(vault).path.exists()
+    assert [record["phase"] for record in receipts.event_records(vault)] == ["intent"]
+
+
+def test_final_journal_with_missing_or_changed_terminal_never_replays_success(
+    vault: Path,
+) -> None:
+    from exomem.governance import consolidation_effect_coordinator
+
+    live = {"state": "prior"}
+    consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+        vault_root=vault,
+        event=_start_event(),
+        journal=_engine(vault),
+        classify=lambda: _observation(live["state"]),
+        apply_effect=lambda: live.__setitem__("state", "target"),
+        timestamp=T0,
+    )
+    path = _engine(vault).path
+    raw = path.read_bytes()
+    terminal_id = f"{_start_event().event_id}:committed".encode()
+    path.write_bytes(raw.replace(terminal_id, b"f" * len(terminal_id)))
+
+    with pytest.raises(
+        consolidation_effect_coordinator.ConsolidationEffectUnavailable,
+        match="^CONSOLIDATION_EFFECT_UNAVAILABLE$",
+    ):
+        _engine(vault).load()
+
+
+def test_real_content_batch_uses_receipt_first_engine_and_held_batch_writer(
+    vault: Path,
+) -> None:
+    from exomem import vault as exomem_vault
+    from exomem.governance import (
+        consolidation_effect_coordinator,
+        consolidation_plan,
+        consolidation_saga,
+        receipts,
+    )
+
+    parent = _append_policy_active_parent(vault)
+    target = vault / "Knowledge Base" / "Notes" / "target.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("before", encoding="utf-8")
+    before_digest = hashlib.sha256(b"before").hexdigest()
+    after_digest = hashlib.sha256(b"after").hexdigest()
+    actions = (
+        {
+            "ordinal": 0,
+            "batch_ordinal": 0,
+            "action": "overwrite",
+            "object_ref": "source-object-0",
+            "source_path": "Knowledge Base/Notes/source.md",
+            "destination_path": "Knowledge Base/Notes/target.md",
+            "expected_before_state": "present",
+            "expected_before_sha256": before_digest,
+            "planned_after_state": "present",
+            "planned_after_sha256": after_digest,
+        },
+    )
+    partition = consolidation_plan.derive_journal_batch_partition(actions)
+    batch = consolidation_saga._content_batches(partition)[0]  # noqa: SLF001
+    classification_digest = consolidation_saga._content_batch_classification_digest(  # noqa: SLF001
+        batch
+    )
+    event = consolidation_receipts.build_intent(
+        kind="content-batch",
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        phase="publishing",
+        effect_ordinal=17,
+        batch_ordinal=0,
+        request_digest=REQUEST_DIGEST,
+        prior_digest=batch.prior_fingerprint,
+        prepared_digest=batch.prepared_fingerprint,
+        target_digest=batch.final_fingerprint,
+        evidence=consolidation_receipts.build_evidence(
+            kind="content-batch",
+            digests={
+                "batch_manifest_digest": batch.action_set_digest,
+                "classification_digest": classification_digest,
+            },
+        ),
+        semantic_parent_event_id=str(parent["event_id"]),
+        semantic_parent_payload_digest=str(
+            parent["consolidation_event"]["payload_digest"]
+        ),
+    )
+    journal = _journal(vault, 17)
+
+    result = consolidation_saga.publish_content_batch_receipt_first(
+        content_actions=actions,
+        batch=batch,
+        event=event,
+        journal=journal,
+        vault_root=vault,
+        materialize_batch=lambda _batch: (
+            exomem_vault.PlannedWrite(
+                path=target,
+                content="after",
+                expected_hash=before_digest,
+            ),
+        ),
+        timestamp=T0,
+    )
+
+    assert target.read_text(encoding="utf-8") == "after"
+    assert result.role == "committed"
+    assert result.observed_digest == batch.final_fingerprint
+    final = journal.load()
+    assert final.status == "final"
+    assert final.kind == "content-batch"
+    assert final.observed_state == "target"
+    assert [record["phase"] for record in receipts.event_records(vault)[-2:]] == [
+        "intent",
+        "committed",
+    ]
+    assert isinstance(
+        journal,
+        consolidation_effect_coordinator.ConsolidationEffectJournalStore,
+    )
+
+
+def test_equivalent_content_batch_commits_without_materialization(vault: Path) -> None:
+    from exomem.governance import consolidation_saga
+
+    target = vault / "Knowledge Base" / "Notes" / "same.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("same", encoding="utf-8")
+    digest = hashlib.sha256(b"same").hexdigest()
+    actions = (
+        {
+            "ordinal": 0,
+            "batch_ordinal": 0,
+            "action": "reuse_destination",
+            "object_ref": "source-object-same",
+            "source_path": "Knowledge Base/Notes/source-same.md",
+            "destination_path": "Knowledge Base/Notes/same.md",
+            "expected_before_state": "present",
+            "expected_before_sha256": digest,
+            "planned_after_state": "present",
+            "planned_after_sha256": digest,
+        },
+    )
+    batch, event, journal = _content_batch_event(vault, actions)
+
+    result = consolidation_saga.publish_content_batch_receipt_first(
+        content_actions=actions,
+        batch=batch,
+        event=event,
+        journal=journal,
+        vault_root=vault,
+        materialize_batch=lambda _batch: pytest.fail(
+            "equivalent batches must not materialize"
+        ),
+        timestamp=T0,
+    )
+
+    assert result.role == "committed"
+    assert result.observed_state == "target"
+    assert target.read_text(encoding="utf-8") == "same"
+
+
+def test_equivalent_batch_crash_after_intent_closes_aborted_without_effect(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_effect_coordinator, consolidation_saga
+
+    target = vault / "Knowledge Base" / "Notes" / "same.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("same", encoding="utf-8")
+    digest = hashlib.sha256(b"same").hexdigest()
+    actions = (
+        {
+            "ordinal": 0,
+            "batch_ordinal": 0,
+            "action": "reuse_destination",
+            "object_ref": "source-object-same",
+            "source_path": "Knowledge Base/Notes/source-same.md",
+            "destination_path": "Knowledge Base/Notes/same.md",
+            "expected_before_state": "present",
+            "expected_before_sha256": digest,
+            "planned_after_state": "present",
+            "planned_after_sha256": digest,
+        },
+    )
+    batch, event, journal = _content_batch_event(vault, actions)
+
+    monkeypatch.setattr(
+        consolidation_effect_coordinator,
+        "_crash_point",
+        lambda point: (_ for _ in ()).throw(SimulatedProcessCrash)
+        if point == "after-intent"
+        else None,
+    )
+    with pytest.raises(SimulatedProcessCrash):
+        consolidation_saga.publish_content_batch_receipt_first(
+            content_actions=actions,
+            batch=batch,
+            event=event,
+            journal=journal,
+            vault_root=vault,
+            materialize_batch=lambda _batch: pytest.fail(
+                "equivalent batches must not materialize"
+            ),
+            timestamp=T0,
+        )
+
+    monkeypatch.setattr(
+        consolidation_effect_coordinator,
+        "_crash_point",
+        lambda _point: None,
+    )
+    with pytest.raises(
+        consolidation_effect_coordinator.ConsolidationEffectUnavailable,
+        match="^CONSOLIDATION_EFFECT_UNAVAILABLE$",
+    ):
+        consolidation_saga.publish_content_batch_receipt_first(
+            content_actions=actions,
+            batch=batch,
+            event=event,
+            journal=journal,
+            vault_root=vault,
+            materialize_batch=lambda _batch: pytest.fail(
+                "unprepared equivalent recovery must not materialize"
+            ),
+            timestamp=T0,
+        )
+
+    final = journal.load()
+    assert final.status == "final"
+    assert final.observed_state == "prior"
+    assert final.terminal is not None
+    assert final.terminal.event_id.endswith(":aborted")
+
+
+def test_remove_content_action_is_applied_before_commit(vault: Path) -> None:
+    from exomem import held_fs
+    from exomem.governance import consolidation_saga
+
+    target = vault / "Knowledge Base" / "Notes" / "remove.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("remove me", encoding="utf-8")
+    digest = hashlib.sha256(b"remove me").hexdigest()
+    actions = (
+        {
+            "ordinal": 0,
+            "batch_ordinal": 0,
+            "action": "remove",
+            "object_ref": "destination-object-remove",
+            "source_path": "Knowledge Base/Notes/source-remove.md",
+            "destination_path": "Knowledge Base/Notes/remove.md",
+            "expected_before_state": "present",
+            "expected_before_sha256": digest,
+            "planned_after_state": "absent",
+            "planned_after_sha256": "0" * 64,
+        },
+    )
+    batch, event, journal = _content_batch_event(vault, actions)
+    flush_observations: list[bool] = []
+    with held_fs.acquire(vault).require() as filesystem:
+        filesystem_type = type(filesystem)
+    original_flush = filesystem_type.flush_directory
+
+    def observed_flush(filesystem, parent):
+        flush_observations.append(not target.exists())
+        return original_flush(filesystem, parent)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(filesystem_type, "flush_directory", observed_flush)
+
+        result = consolidation_saga.publish_content_batch_receipt_first(
+            content_actions=actions,
+            batch=batch,
+            event=event,
+            journal=journal,
+            vault_root=vault,
+            materialize_batch=lambda _batch: (),
+            timestamp=T0,
+        )
+
+    assert not target.exists()
+    assert flush_observations == [True]
+    assert result.role == "committed"
+    assert result.observed_state == "target"
+
+
+def test_remove_refuses_same_identity_with_changed_bytes(vault: Path) -> None:
+    from exomem import reserved_paths
+
+    target = vault / "Knowledge Base" / "Notes" / "changed.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("reviewed", encoding="utf-8")
+    identity = reserved_paths.inspect_generic_file(
+        vault,
+        "Knowledge Base/Notes/changed.md",
+    )
+    target.write_text("changed after review", encoding="utf-8")
+
+    with pytest.raises(reserved_paths.ReservedPathLeafError) as error:
+        reserved_paths.unlink_generic_file(
+            vault,
+            "Knowledge Base/Notes/changed.md",
+            expected_identity=identity,
+            expected_sha256=hashlib.sha256(b"reviewed").hexdigest(),
+        )
+
+    assert error.value.code == "CONTENT_CHANGED"
+    assert target.read_text(encoding="utf-8") == "changed after review"
+
+
+def test_mutation_lock_error_is_normalized_before_any_receipt(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import mutation_lock
+    from exomem.cli_ops import OpError
+    from exomem.governance import consolidation_effect_coordinator, receipts
+
+    class RefusingHold:
+        def __enter__(self):
+            raise OpError("MUTATION_BUSY", "busy")
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+    monkeypatch.setattr(
+        mutation_lock.VaultMutationCoordinator,
+        "hold",
+        lambda *_args, **_kwargs: RefusingHold(),
+    )
+
+    with pytest.raises(
+        consolidation_effect_coordinator.ConsolidationEffectUnavailable,
+        match="^CONSOLIDATION_EFFECT_UNAVAILABLE$",
+    ):
+        consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=vault,
+            event=_start_event(),
+            journal=_engine(vault),
+            classify=lambda: _observation("prior"),
+            apply_effect=lambda: pytest.fail("lock refusal must precede the effect"),
+            timestamp=T0,
+        )
+
+    assert receipts.event_records(vault) == []
+    assert not _engine(vault).path.exists()
+
+
+def test_two_same_effect_executors_cannot_both_enter_the_effect(
+    vault: Path,
+) -> None:
+    from exomem.governance import consolidation_effect_coordinator
+
+    live = {"state": "prior"}
+    entered = threading.Event()
+    release = threading.Event()
+    apply_count = 0
+    apply_guard = threading.Lock()
+
+    def apply() -> None:
+        nonlocal apply_count
+        with apply_guard:
+            apply_count += 1
+        entered.set()
+        assert release.wait(timeout=2.0)
+        live["state"] = "target"
+
+    def execute():
+        return consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=vault,
+            event=_start_event(),
+            journal=_engine(vault),
+            classify=lambda: _observation(live["state"]),
+            apply_effect=apply,
+            timestamp=T0,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(execute)
+        assert entered.wait(timeout=2.0)
+        second = pool.submit(execute)
+        time.sleep(0.1)
+        with apply_guard:
+            assert apply_count == 1
+        release.set()
+        assert first.result(timeout=2.0).role == "committed"
+        assert second.result(timeout=2.0).role == "committed"
+    assert apply_count == 1


### PR DESCRIPTION
## Summary

- add an owner-only prepared/final journal that binds exact receipt records around one consolidation effect
- recover intent, effect, terminal, and final-journal crash gaps without replaying ambiguous mutations
- route content batches through the coordinator, including exact no-op handling and held-handle, hash-guarded durable removals
- serialize effects across processes and normalize lock/tamper failures to one content-free refusal

Stacked after #979. This is a non-serving consolidation foundation slice and does not touch any live vault. OpenSpec task 9.2 remains incomplete until every effect kind uses the protocol.

## Verification

- red-first coordinator coverage for six crash seams, unprepared intent recovery, pre-existing target refusal, no-op recovery, delete durability, lock serialization, tamper, and exact receipt references
- 258 passed, 3 Windows-only skipped: coordinator, saga, batch journal/crash matrix, reserved paths, and alias guards
- 212 passed: coordinator plus consolidation/governance receipt suites
- independent re-review: GO, no P0/P1/P2 findings; reviewer focused suite 81 passed
- Ruff on all six changed files
- `openspec validate add-governed-vault-consolidation --strict`
- `uv lock --check`
- public repository artifact validation
- source distribution and wheel build
- `git diff --check`