### PR TITLE
perf(recall): score then mask under an allowed-paths filter

### DIFF
--- a/scripts/recall_mask_latency.py
+++ b/scripts/recall_mask_latency.py
@@ -13,6 +13,27 @@ running cell was measured to leave its catalog stale and grow its deferred queue
 
     uv run python scripts/recall_mask_latency.py
     uv run python scripts/recall_mask_latency.py --chunks 67000 --files 6074 --json
+
+RUN IT MORE THAN ONCE. A single run of this harness is not a measurement. Five
+runs at `--chunks 67000 --files 6074` on one machine, same commit:
+
+    eligible   speedup range   median
+        100%   5.69 - 11.46x    7.67x
+         85%   5.74 -  7.52x    6.53x
+         50%   4.09 -  4.40x    4.35x
+          5%   0.86 -  1.32x    1.06x   (break-even)
+
+The variance is not uniform noise, and its shape is the point: it tracks how
+much matrix the PRE-FIX lane copies. At 100% eligible that is the whole ~200 MB
+— the most memory-bandwidth-sensitive work here — and the row swings 2x with
+machine state, the pre-fix lane alone varying 230 ms to 60 ms across runs. At
+50% it copies half and the row holds to +/-4%. So the CONSERVATIVE rows are the
+trustworthy ones, and quoting a single 100%-eligible run as "11.5x" is quoting
+the machine, not the change.
+
+Agreement, by contrast, is stable and deterministic: 20 of 20 comparisons
+returned the same rows, with max |dscore| exactly 0.00e+00 everywhere except the
+5% lane's 1.12e-08 (OpenBLAS picking its sgemv kernel by row count).
 """
 
 from __future__ import annotations

--- a/scripts/recall_mask_latency.py
+++ b/scripts/recall_mask_latency.py
@@ -1,0 +1,277 @@
+"""Filtered semantic-recall latency at vault scale: slice the matrix vs mask the scores.
+
+Issue #951. `find_candidates` always passes `allowed_paths`, so every semantic
+recall took `EmbeddingIndex.search`'s scan branch, which ran a Python membership
+loop over every chunk row and then fancy-indexed `matrix[keep]` — a fresh copy of
+most of a ~200 MB float32 matrix, per query. This harness times that pre-fix
+implementation and the shipped one against the SAME synthetic sidecar, warm cache
+in both cases, so the difference reported is the change and not a cold start.
+
+Synthetic only: it builds its own sidecar under a scratch root and never reads a
+real vault. Do not point this at a live cell — an out-of-process reader against a
+running cell was measured to leave its catalog stale and grow its deferred queue.
+
+    uv run python scripts/recall_mask_latency.py
+    uv run python scripts/recall_mask_latency.py --chunks 67000 --files 6074 --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import scratch_root  # noqa: E402
+
+from exomem import embeddings  # noqa: E402
+
+# The measured cell in #951: a 6,074-file vault whose `.embeddings.sqlite` was
+# 310 MB, which at 768-dim float32 is ~67,000 chunk rows and a ~200 MB matrix.
+DEFAULT_CHUNKS = 67_000
+DEFAULT_FILES = 6_074
+# `find_candidates` asks for `candidate_k * 3`, and candidate_k is floored at the
+# eligible-path count, so recall's k is large — not a top-10.
+DEFAULT_K = 300
+DEFAULT_QUERIES = 30
+# Eligible fractions worth separating: recall normally admits nearly the whole
+# vault, but a scoped or checkpoint-bound request can narrow it hard, and that is
+# the regime where scoring the full matrix does the most extra arithmetic.
+DEFAULT_FRACTIONS = (1.0, 0.85, 0.5, 0.05)
+
+
+def _search_pre_951(index, query_vec, k, *, allowed_paths):
+    """The pre-fix `EmbeddingIndex.search` scan, transcribed verbatim.
+
+    Provenance: `git show 9bf3d804:src/exomem/embedding_index.py`. Text hydration
+    is left out of BOTH lanes here — it is identical point-lookup SQL either side
+    of the change, and including it would bury the difference under sqlite.
+    """
+    metadata, matrix = index.all_vectors()
+    if not metadata:
+        return []
+    keep = [i for i, (path, _chunk) in enumerate(metadata) if path in allowed_paths]
+    if not keep:
+        return []
+    metadata = [metadata[i] for i in keep]
+    matrix = matrix[keep]
+    scores = matrix @ query_vec.astype(np.float32, copy=False)
+    k_eff = min(k, len(scores))
+    if k_eff <= 0:
+        return []
+    top_idx = np.argpartition(-scores, k_eff - 1)[:k_eff]
+    top_idx = top_idx[np.argsort(-scores[top_idx])]
+    return [(metadata[i][0], metadata[i][1], float(scores[i])) for i in top_idx]
+
+
+def _search_masked(index, query_vec, k, *, allowed_paths):
+    """The shipped scan: score the full matrix once, mask the scores."""
+    metadata, matrix = index.all_vectors()
+    if not metadata:
+        return []
+    mask, eligible = index._eligibility_mask(metadata, allowed_paths)
+    if not eligible:
+        return []
+    k_eff = min(k, eligible)
+    if k_eff <= 0:
+        return []
+    scores = matrix @ query_vec.astype(np.float32, copy=False)
+    scores = np.where(mask, scores, -np.inf)
+    top_idx = np.argpartition(-scores, k_eff - 1)[:k_eff]
+    top_idx = top_idx[np.argsort(-scores[top_idx])]
+    return [(metadata[i][0], metadata[i][1], float(scores[i])) for i in top_idx]
+
+
+def _breakdown(index, queries, allowed) -> dict:
+    """Split the pre-fix scan into its parts, and price one cold matrix reload.
+
+    #951 attributes ~776 ms of a semantic recall to the keep-loop and the
+    `matrix[keep]` copy. This prices each of them directly so the attribution can
+    be checked rather than inferred from the lane total, and prices the full
+    reload beside them because that is the other corpus-linear cost on this path
+    and the one a cold or churning cache pays instead.
+    """
+    metadata, matrix = index.all_vectors()
+    loop_ms, copy_ms, matmul_ms, mask_cold_ms, mask_warm_ms = [], [], [], [], []
+    for query in queries:
+        started = time.perf_counter()
+        keep = [i for i, (path, _c) in enumerate(metadata) if path in allowed]
+        loop_ms.append((time.perf_counter() - started) * 1000.0)
+
+        started = time.perf_counter()
+        sliced = matrix[keep]
+        copy_ms.append((time.perf_counter() - started) * 1000.0)
+
+        started = time.perf_counter()
+        _ = matrix @ query.astype(np.float32, copy=False)
+        matmul_ms.append((time.perf_counter() - started) * 1000.0)
+
+        index._mask_cache = None
+        started = time.perf_counter()
+        index._eligibility_mask(metadata, allowed)
+        mask_cold_ms.append((time.perf_counter() - started) * 1000.0)
+
+        started = time.perf_counter()
+        index._eligibility_mask(metadata, allowed)
+        mask_warm_ms.append((time.perf_counter() - started) * 1000.0)
+        del sliced
+
+    started = time.perf_counter()
+    index._load_all_rows()
+    full_reload_ms = (time.perf_counter() - started) * 1000.0
+    return {
+        "pre_951_keep_loop": _stats(loop_ms),
+        "pre_951_matrix_copy": _stats(copy_ms),
+        "full_matrix_matmul": _stats(matmul_ms),
+        "mask_build_cold": _stats(mask_cold_ms),
+        "mask_lookup_warm": _stats(mask_warm_ms),
+        "cold_full_matrix_reload_ms": round(full_reload_ms, 1),
+    }
+
+
+def _build_index(vault: Path, chunks: int, files: int, seed: int):
+    """A synthetic sidecar of `chunks` normalized rows spread over `files`."""
+    rng = np.random.default_rng(seed)
+    index = embeddings.EmbeddingIndex(vault)
+    paths = [f"Knowledge Base/Notes/note-{n:05d}.md" for n in range(files)]
+    per_file = [chunks // files] * files
+    for n in range(chunks - sum(per_file)):
+        per_file[n] += 1
+    started = time.perf_counter()
+    for path, count in zip(paths, per_file, strict=True):
+        if not count:
+            continue
+        block = rng.standard_normal((count, embeddings.VECTOR_DIM), dtype=np.float32)
+        block /= np.linalg.norm(block, axis=1, keepdims=True)
+        index.upsert_file(path, [f"{path}#{c}" for c in range(count)], block, 1.0)
+    build_seconds = time.perf_counter() - started
+    return index, paths, build_seconds
+
+
+def _time_lane(fn, index, queries, k, allowed) -> tuple[list[float], list]:
+    samples: list[float] = []
+    last = None
+    for query in queries:
+        started = time.perf_counter()
+        last = fn(index, query, k, allowed_paths=allowed)
+        samples.append((time.perf_counter() - started) * 1000.0)
+    return samples, last
+
+
+def _stats(samples: list[float]) -> dict:
+    ordered = sorted(samples)
+    return {
+        "p50_ms": round(statistics.median(ordered), 2),
+        "min_ms": round(ordered[0], 2),
+        "max_ms": round(ordered[-1], 2),
+        "mean_ms": round(statistics.fmean(ordered), 2),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--chunks", type=int, default=DEFAULT_CHUNKS)
+    parser.add_argument("--files", type=int, default=DEFAULT_FILES)
+    parser.add_argument("--k", type=int, default=DEFAULT_K)
+    parser.add_argument("--queries", type=int, default=DEFAULT_QUERIES)
+    parser.add_argument("--seed", type=int, default=951)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--breakdown",
+        action="store_true",
+        help="also price the pre-fix scan's parts and one cold matrix reload",
+    )
+    args = parser.parse_args()
+
+    rng = np.random.default_rng(args.seed + 1)
+    report: dict = {
+        "chunks": args.chunks,
+        "files": args.files,
+        "k": args.k,
+        "queries": args.queries,
+        "lanes": [],
+    }
+
+    with scratch_root.scratch_root("exomem-recall-mask-") as base:
+        vault = base / "vault"
+        (vault / "Knowledge Base").mkdir(parents=True)
+        index, paths, build_seconds = _build_index(vault, args.chunks, args.files, args.seed)
+        report["build_seconds"] = round(build_seconds, 1)
+
+        metadata, matrix = index.all_vectors()  # warm the cache for BOTH lanes
+        report["rows"] = len(metadata)
+        report["matrix_mb"] = round(matrix.nbytes / 1e6, 1)
+        if not args.json:
+            print(
+                f"synthetic sidecar: {len(metadata)} rows x {embeddings.VECTOR_DIM} dims "
+                f"= {matrix.nbytes / 1e6:.1f} MB matrix over {args.files} files "
+                f"(built in {build_seconds:.1f}s)"
+            )
+            print(f"k={args.k}, {args.queries} queries per lane, warm matrix cache\n")
+            print(f"{'eligible':>9}  {'pre-#951 p50':>13}  {'masked p50':>11}  {'speedup':>8}  agree")
+
+        queries = []
+        for _ in range(args.queries):
+            q = rng.standard_normal(embeddings.VECTOR_DIM).astype(np.float32)
+            queries.append(q / np.linalg.norm(q))
+
+        for fraction in DEFAULT_FRACTIONS:
+            take = max(1, int(len(paths) * fraction))
+            allowed = set(paths[:take])
+            index._mask_cache = None
+
+            old_samples, old_hits = _time_lane(_search_pre_951, index, queries, args.k, allowed)
+            new_samples, new_hits = _time_lane(_search_masked, index, queries, args.k, allowed)
+
+            same_rows = [(p, c) for p, c, _s in old_hits] == [(p, c) for p, c, _s in new_hits]
+            deltas = [
+                abs(a - b) for (*_x, a), (*_y, b) in zip(old_hits, new_hits, strict=True)
+            ]
+            old_stats, new_stats = _stats(old_samples), _stats(new_samples)
+            lane = {
+                "eligible_fraction": fraction,
+                "eligible_files": take,
+                "pre_951": old_stats,
+                "masked": new_stats,
+                "speedup": round(old_stats["p50_ms"] / max(new_stats["p50_ms"], 1e-9), 2),
+                "identical_rows": same_rows,
+                "max_score_delta": max(deltas) if deltas else 0.0,
+            }
+            report["lanes"].append(lane)
+            if not args.json:
+                print(
+                    f"{fraction * 100:>8.0f}%  {old_stats['p50_ms']:>10.2f} ms  "
+                    f"{new_stats['p50_ms']:>8.2f} ms  {lane['speedup']:>7.2f}x  "
+                    f"{'same rows' if same_rows else 'DIVERGED'} "
+                    f"(max |dscore| {lane['max_score_delta']:.2e})"
+                )
+
+        if args.breakdown:
+            index._mask_cache = None
+            report["breakdown"] = _breakdown(index, queries[:10], set(paths))
+            if not args.json:
+                print("\nwhere the pre-#951 scan's time went (100% eligible):")
+                for name, value in report["breakdown"].items():
+                    if isinstance(value, dict):
+                        print(f"  {name:<22} p50 {value['p50_ms']:>8.2f} ms")
+                    else:
+                        print(f"  {name:<22}     {value:>8.1f} ms")
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/exomem/embedding_index.py
+++ b/src/exomem/embedding_index.py
@@ -12,6 +12,7 @@ import logging
 import sqlite3
 import sys
 import threading
+from collections.abc import Set as AbstractSet
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -96,6 +97,38 @@ class _EmbCache(NamedTuple):
     recall_policy_identity: tuple[str, str]
     metadata: list[tuple[str, int]]
     matrix: np.ndarray
+
+
+class _MaskCache(NamedTuple):
+    """One memoized eligibility row mask for `search`'s allowed-paths filter.
+
+    `metadata` is held by STRONG reference and matched with `is`, NOT by the
+    write token `all_vectors()` keys on — deliberately the stronger of the two
+    invariants. Every producer of the matrix cache is copy-on-write
+    (`_load_all_rows`, `_splice_path_blocks` under `_patch_cache` /
+    `_catch_up_cache`, and `_purge_cache_paths` all build fresh containers), so
+    a different row set is ALWAYS a different list object; the converse does not
+    hold, because an equal `(epoch, generation, instance)` triple still falls
+    back to mtime on gen==0 legacy sidecars, where mtime both spuriously misses
+    and goes stale (see the generation-meta note). Reading the token separately
+    would also race: another thread may swap `self._cache` between
+    `all_vectors()` returning and the token being read, keying a mask against a
+    generation its rows never came from. Holding the reference additionally
+    stops the list being freed and its `id()` reused by an unrelated one, so a
+    mask can never outlive the matrix it was computed against.
+
+    `allowed_paths` is matched by CONTENT (a frozenset), never by identity: the
+    set belongs to the caller, which may mutate it in place between two queries
+    at the same scope, and a stale mask would return rows the caller excluded —
+    far worse than the slowness this cache exists to remove. `frozenset(x)`
+    returns `x` itself when it is already a frozenset, so an immutable caller
+    pays nothing for that safety.
+    """
+
+    metadata: list[tuple[str, int]]
+    allowed_paths: frozenset[str]
+    mask: np.ndarray
+    eligible: int
 
 
 def _splice_path_blocks(
@@ -213,6 +246,8 @@ class EmbeddingIndex:
         self.vault_root = vault_root
         self.path = index_paths.sidecar_path(vault_root)
         self._cache: _EmbCache | None = None
+        # One-slot memo for search()'s allowed-paths row mask (see _MaskCache).
+        self._mask_cache: _MaskCache | None = None
         # Guards in-memory cache mutation only (never held across a sqlite write).
         # Reentrant so rebuild_all()-style nesting can't self-deadlock.
         self._lock = threading.RLock()
@@ -693,6 +728,11 @@ class EmbeddingIndex:
         with self._lock:
             loaded = self._cache is not None
             self._cache = None
+            # The mask memo pins the metadata list by strong reference, so an
+            # unload that left it behind would keep those rows resident after
+            # the caller asked for the memory back. Correctness never depended
+            # on this — a reload builds a new list and simply misses.
+            self._mask_cache = None
             return loaded
 
     def cache_status(self) -> dict:
@@ -858,6 +898,16 @@ class EmbeddingIndex:
         default — exact, rank-identical to the scan below; binary+rescore when
         `EXOMEM_VEC_QUANT=binary`), otherwise the in-memory numpy scan. Every vec
         failure mode falls through to the scan — search never breaks on vec0.
+
+        Under an allowed-paths filter the scan SCORES FIRST AND MASKS SECOND:
+        one BLAS pass over the whole cached matrix, then `-inf` onto the
+        ineligible rows' scores. Slicing the matrix instead (`matrix[keep]`)
+        fancy-indexed a fresh copy of most of a ~200 MB matrix on every single
+        recall, which the matmul then had to read back — the memcpy issue #951
+        measured, and the reason a semantic recall cost ~10x a keyword one with
+        the GPU idle. Masking is behaviour-identical rather than approximate: an
+        ineligible row scores `-inf` and `k_eff` is clamped to the eligible
+        count, so `argpartition` provably cannot reach a masked row.
         """
         if allowed_paths is None:
             vec_hits = self._vec_search(query_vec, k)
@@ -866,17 +916,22 @@ class EmbeddingIndex:
         metadata, matrix = self.all_vectors()
         if not metadata:
             return []
+        mask: np.ndarray | None = None
+        # The ceiling on how many rows may be returned. Under a filter it is the
+        # ELIGIBLE count, never the row count: `argpartition` over the full score
+        # array will return `k` rows whatever the mask says, so an unclamped
+        # `k_eff` pads the answer with masked `-inf` rows as soon as fewer than
+        # `k` survive the filter — and returns a whole top-k when none do.
+        k_ceiling = len(metadata)
         if allowed_paths is not None:
-            keep = [index for index, (path, _chunk) in enumerate(metadata) if path in allowed_paths]
-            if not keep:
-                return []
-            metadata = [metadata[index] for index in keep]
-            matrix = matrix[keep]
-        # query_vec is (768,) normalized; matrix is (N, 768) normalized.
-        scores = matrix @ query_vec.astype(np.float32, copy=False)
-        k_eff = min(k, len(scores))
+            mask, k_ceiling = self._eligibility_mask(metadata, allowed_paths)
+        k_eff = min(k, k_ceiling)
         if k_eff <= 0:
             return []
+        # query_vec is (768,) normalized; matrix is (N, 768) normalized.
+        scores = matrix @ query_vec.astype(np.float32, copy=False)
+        if mask is not None:
+            scores = np.where(mask, scores, -np.inf)
         # argpartition is O(N), then sort the top-k slice.
         top_idx = np.argpartition(-scores, k_eff - 1)[:k_eff]
         top_idx = top_idx[np.argsort(-scores[top_idx])]
@@ -888,6 +943,45 @@ class EmbeddingIndex:
             log.warning("chunk-text fetch failed (%s); returning hits without text", e)
             texts = {}
         return [(fp, ci, texts.get((fp, ci), ""), score) for fp, ci, score in top]
+
+    def _eligibility_mask(
+        self, metadata: list[tuple[str, int]], allowed_paths: AbstractSet[str]
+    ) -> tuple[np.ndarray, int]:
+        """`(row_mask, eligible_count)` for `allowed_paths` over `metadata`'s rows.
+
+        Memoized in a single slot (see `_MaskCache` for why the key is the
+        metadata list's identity plus the allowed set's CONTENT). `allowed_paths`
+        is stable across a session at a given scope, so only the first query
+        after a matrix rebuild or a scope change pays the membership pass; the
+        rest pay one frozenset compare instead of a `len(metadata)`-iteration
+        Python loop that ran on every recall.
+
+        Lock-free on purpose, like `all_vectors()`'s fast path. The slot holds
+        one immutable NamedTuple, so a concurrent reader sees either the old
+        entry or the new one and never a torn pair, and it re-validates whatever
+        it read before trusting it. Two threads racing at different scopes both
+        compute a correct mask and one simply wins the slot; the only loss is a
+        recomputation. An `unload_cache()` that interleaves with the assignment
+        below can leave one memo pinned — the next unload or rebuild clears it,
+        and no answer is affected, which is not worth putting a lock on the hot
+        path for.
+        """
+        key = frozenset(allowed_paths)
+        cached = self._mask_cache
+        if (
+            cached is not None
+            and cached.metadata is metadata
+            and cached.allowed_paths == key
+        ):
+            return cached.mask, cached.eligible
+        mask = np.fromiter(
+            (path in allowed_paths for path, _chunk in metadata),
+            dtype=bool,
+            count=len(metadata),
+        )
+        eligible = int(np.count_nonzero(mask))
+        self._mask_cache = _MaskCache(metadata, key, mask, eligible)
+        return mask, eligible
 
     def search_semantic_units(
         self,

--- a/src/exomem/embedding_index.py
+++ b/src/exomem/embedding_index.py
@@ -934,6 +934,19 @@ class EmbeddingIndex:
             scores = np.where(mask, scores, -np.inf)
         # argpartition is O(N), then sort the top-k slice.
         top_idx = np.argpartition(-scores, k_eff - 1)[:k_eff]
+        if mask is not None and not bool(mask[top_idx].all()):
+            # An ineligible row won a slot, which masking alone cannot prevent:
+            # `-(-inf)` is `+inf`, and numpy orders NaN ABOVE `+inf`, so when the
+            # query embeds to NaN (a zero-norm or broken vector) every eligible
+            # score is NaN and the masked rows partition first. Reachable only
+            # with non-finite scores, but eligibility is a governance boundary
+            # rather than a ranking preference, so it must not depend on
+            # arithmetic holding. Fall back to selecting among the eligible rows
+            # only — the pre-#951 computation exactly, on the rows it would have
+            # had — which restores both the row and its true score.
+            eligible_idx = np.flatnonzero(mask)
+            sub = scores[eligible_idx]
+            top_idx = eligible_idx[np.argpartition(-sub, k_eff - 1)[:k_eff]]
         top_idx = top_idx[np.argsort(-scores[top_idx])]
         top = [(metadata[i][0], metadata[i][1], float(scores[i])) for i in top_idx]
         # numpy-lite: hydrate only the winners' texts (PK point-lookups).
@@ -974,8 +987,14 @@ class EmbeddingIndex:
             and cached.allowed_paths == key
         ):
             return cached.mask, cached.eligible
+        # Build from `key`, NOT from `allowed_paths`. The caller's set is mutable
+        # and callers do mutate it, so reading it a second time here can cache a
+        # mask under a key that does not describe it: snapshot {a}, another thread
+        # adds b, the mask admits b, and the entry is filed under {a}. Restoring
+        # the set to {a} then serves that stale mask for the rest of the session.
+        # Membership on the frozenset costs the same and closes the window.
         mask = np.fromiter(
-            (path in allowed_paths for path, _chunk in metadata),
+            (path in key for path, _chunk in metadata),
             dtype=bool,
             count=len(metadata),
         )

--- a/tests/test_recall_eligibility_mask.py
+++ b/tests/test_recall_eligibility_mask.py
@@ -1,0 +1,415 @@
+"""`EmbeddingIndex.search` under an allowed-paths filter: score first, mask second.
+
+Issue #951. Every semantic recall passes `allowed_paths`, so the pre-fix scan ran
+a Python loop over every chunk row and then fancy-indexed `matrix[keep]` — a fresh
+copy of most of a ~200 MB matrix, per query. The fix scores the full cached matrix
+once and masks the SCORES, memoizing the row mask.
+
+The load-bearing property is that this is a speedup and NOT a ranking change, so
+the primary test here runs the verbatim pre-fix implementation
+(`_search_pre_951`, transcribed from `git show 9bf3d804:src/exomem/embedding_index.py`)
+against the same index, query and allowed set, and demands the same answer.
+
+All vectors are fabricated — no torch, no model, no live cell. Every test runs
+under conftest's injected `EXOMEM_STATE_ROOT` on its own tmpdir vault.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from exomem import embeddings
+
+# Justified in the module docstring's companion measurement (see the identity
+# test): OpenBLAS picks its sgemv kernel by row count, so the pre-fix code's
+# scores depended on how many rows the filter happened to keep. Slicing 85% of a
+# 67,000-row matrix moved 0.09% of scores by at most 2.3e-8 against the
+# full-matrix pass. The tolerance is ~40x that measured worst case and ~5x below
+# float32 epsilon (1.19e-7), so it admits the kernel wobble and nothing larger.
+SCORE_TOLERANCE = 1e-6
+
+
+@pytest.fixture(autouse=True)
+def _clean_memo() -> None:
+    """Each test starts and ends with an empty shared-index memo."""
+    embeddings.clear_embedding_indexes()
+    yield
+    embeddings.clear_embedding_indexes()
+
+
+def _fresh_vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    (vault / "Knowledge Base").mkdir(parents=True)
+    return vault
+
+
+def _unit_rows(rng: np.random.Generator, count: int) -> np.ndarray:
+    """`count` normalized float32 rows, the shape real chunk vectors arrive in."""
+    rows = rng.standard_normal((count, embeddings.VECTOR_DIM), dtype=np.float32)
+    rows /= np.linalg.norm(rows, axis=1, keepdims=True)
+    return rows
+
+
+def _unit_query(rng: np.random.Generator) -> np.ndarray:
+    q = rng.standard_normal(embeddings.VECTOR_DIM).astype(np.float32)
+    return q / np.linalg.norm(q)
+
+
+def _sparse_rows(*specs: list[tuple[int, float]]) -> np.ndarray:
+    """Rows whose dot products are EXACT in float32 (few non-zero terms)."""
+    out = np.zeros((len(specs), embeddings.VECTOR_DIM), dtype=np.float32)
+    for row, spec in enumerate(specs):
+        for column, value in spec:
+            out[row, column] = np.float32(value)
+    return out
+
+
+def _empty_vectors() -> np.ndarray:
+    return np.zeros((0, embeddings.VECTOR_DIM), dtype=np.float32)
+
+
+def _search_pre_951(
+    index: embeddings.EmbeddingIndex,
+    query_vec: np.ndarray,
+    k: int,
+    *,
+    allowed_paths: set[str] | None = None,
+) -> list[tuple[str, int, str, float]]:
+    """The pre-fix `EmbeddingIndex.search`, transcribed verbatim.
+
+    Provenance: `git show 9bf3d804:src/exomem/embedding_index.py`, the body of
+    `search` before this change. Kept here rather than in production so the
+    comparison is against real removed code and the shipped module carries only
+    one implementation.
+    """
+    if allowed_paths is None:
+        vec_hits = index._vec_search(query_vec, k)
+        if vec_hits is not None:
+            return vec_hits
+    metadata, matrix = index.all_vectors()
+    if not metadata:
+        return []
+    if allowed_paths is not None:
+        keep = [i for i, (path, _chunk) in enumerate(metadata) if path in allowed_paths]
+        if not keep:
+            return []
+        metadata = [metadata[i] for i in keep]
+        matrix = matrix[keep]
+    scores = matrix @ query_vec.astype(np.float32, copy=False)
+    k_eff = min(k, len(scores))
+    if k_eff <= 0:
+        return []
+    top_idx = np.argpartition(-scores, k_eff - 1)[:k_eff]
+    top_idx = top_idx[np.argsort(-scores[top_idx])]
+    top = [(metadata[i][0], metadata[i][1], float(scores[i])) for i in top_idx]
+    texts = index._texts_for([(fp, ci) for fp, ci, _ in top])
+    return [(fp, ci, texts.get((fp, ci), ""), score) for fp, ci, score in top]
+
+
+def _assert_same_answer(
+    old: list[tuple[str, int, str, float]],
+    new: list[tuple[str, int, str, float]],
+    *,
+    exact_scores: bool = False,
+) -> None:
+    """Same rows, same order, same texts; scores exactly or within tolerance."""
+    assert [(fp, ci, text) for fp, ci, text, _ in old] == [
+        (fp, ci, text) for fp, ci, text, _ in new
+    ]
+    old_scores = [score for *_rest, score in old]
+    new_scores = [score for *_rest, score in new]
+    if exact_scores:
+        assert old_scores == new_scores
+    else:
+        assert np.allclose(old_scores, new_scores, rtol=0.0, atol=SCORE_TOLERANCE)
+
+
+def _populated(vault: Path, rng: np.random.Generator, files: int, per_file: int):
+    """An index of `files` x `per_file` chunks, plus its path list."""
+    index = embeddings.EmbeddingIndex(vault)
+    rows = _unit_rows(rng, files * per_file)
+    paths = [f"note-{n:03d}.md" for n in range(files)]
+    for n, path in enumerate(paths):
+        block = rows[n * per_file : (n + 1) * per_file]
+        index.upsert_file(path, [f"{path} chunk {c}" for c in range(per_file)], block, 1.0)
+    return index, paths
+
+
+# --------------------------------------------------------------------------- #
+# The one that matters: the fix must not change a single answer.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "scope,k",
+    [
+        ("none", 10),
+        ("empty", 10),
+        ("every_row", 10),
+        ("one_row", 10),
+        ("fewer_than_k", 50),
+        ("half", 10),
+        ("exactly_k", 12),
+    ],
+)
+def test_masked_search_answers_exactly_as_the_pre_951_slice_did(tmp_path, scope, k):
+    """Old slice-the-matrix path and new mask-the-scores path agree, row for row."""
+    rng = np.random.default_rng(951)
+    vault = _fresh_vault(tmp_path)
+    index, paths = _populated(vault, rng, files=40, per_file=3)
+
+    allowed: set[str] | None
+    if scope == "none":
+        allowed = None
+    elif scope == "empty":
+        allowed = set()
+    elif scope == "every_row":
+        allowed = set(paths)
+    elif scope == "one_row":
+        allowed = {paths[7]}
+    elif scope == "fewer_than_k":  # 4 files x 3 chunks = 12 rows, k = 50
+        allowed = set(paths[:4])
+    elif scope == "exactly_k":  # 4 files x 3 chunks = 12 rows, k = 12
+        allowed = set(paths[:4])
+    else:
+        allowed = set(paths[::2])
+
+    for _ in range(25):  # many queries: an ordering flip anywhere is a failure
+        query = _unit_query(rng)
+        old = _search_pre_951(index, query, k, allowed_paths=allowed)
+        index._mask_cache = None  # the old call cannot have warmed anything
+        new = index.search(query, k, allowed_paths=allowed)
+        _assert_same_answer(old, new)
+
+
+def test_masked_search_is_bit_exact_when_the_dot_products_are_exact(tmp_path):
+    """With sparse vectors the two paths agree to the last bit, not just closely.
+
+    The tolerance in the test above exists only because OpenBLAS varies its sgemv
+    kernel with the row count. Remove that source of noise and the masking change
+    is exactly what it claims: the same arithmetic on the same rows.
+    """
+    vault = _fresh_vault(tmp_path)
+    index = embeddings.EmbeddingIndex(vault)
+    index.upsert_file("a.md", ["a0", "a1"], _sparse_rows([(0, 1.0)], [(1, 0.5)]), 1.0)
+    index.upsert_file("b.md", ["b0", "b1"], _sparse_rows([(2, 0.25)], [(3, 0.125)]), 1.0)
+    index.upsert_file("c.md", ["c0"], _sparse_rows([(0, 0.75)]), 1.0)
+    query = _sparse_rows([(0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0)])[0]
+
+    for allowed in (None, {"a.md"}, {"a.md", "c.md"}, {"a.md", "b.md", "c.md"}):
+        old = _search_pre_951(index, query, 5, allowed_paths=allowed)
+        index._mask_cache = None
+        new = index.search(query, 5, allowed_paths=allowed)
+        _assert_same_answer(old, new, exact_scores=True)
+
+
+# --------------------------------------------------------------------------- #
+# Masked rows must be unreachable, however few survive the filter.
+# --------------------------------------------------------------------------- #
+
+
+def test_empty_allowed_paths_returns_nothing(tmp_path):
+    rng = np.random.default_rng(2)
+    vault = _fresh_vault(tmp_path)
+    index, _paths = _populated(vault, rng, files=6, per_file=2)
+    assert index.search(_unit_query(rng), 10, allowed_paths=set()) == []
+
+
+def test_allowed_paths_naming_nothing_indexed_returns_nothing(tmp_path):
+    rng = np.random.default_rng(3)
+    vault = _fresh_vault(tmp_path)
+    index, _paths = _populated(vault, rng, files=6, per_file=2)
+    assert index.search(_unit_query(rng), 10, allowed_paths={"absent.md"}) == []
+
+
+def test_fewer_eligible_rows_than_k_never_admits_an_ineligible_row(tmp_path):
+    """`k` far above the eligible count must not pad the answer with masked rows.
+
+    This is the `-inf` trap: `argpartition` over the FULL score array will happily
+    return `k` rows, and the masked ones sit at `-inf` rather than being absent.
+    Only clamping `k_eff` to the eligible count keeps them out.
+    """
+    rng = np.random.default_rng(4)
+    vault = _fresh_vault(tmp_path)
+    index, paths = _populated(vault, rng, files=30, per_file=3)
+    allowed = {paths[11]}  # 1 file x 3 chunks = 3 eligible rows
+
+    hits = index.search(_unit_query(rng), 500, allowed_paths=allowed)
+
+    assert len(hits) == 3
+    assert {fp for fp, _ci, _text, _score in hits} == allowed
+    assert all(np.isfinite(score) for *_rest, score in hits)
+
+
+def test_single_eligible_row_returns_only_that_row(tmp_path):
+    vault = _fresh_vault(tmp_path)
+    index = embeddings.EmbeddingIndex(vault)
+    rng = np.random.default_rng(5)
+    for n in range(8):
+        index.upsert_file(f"n{n}.md", [f"c{n}"], _unit_rows(rng, 1), 1.0)
+
+    hits = index.search(_unit_query(rng), 25, allowed_paths={"n3.md"})
+
+    assert [(fp, ci) for fp, ci, _text, _score in hits] == [("n3.md", 0)]
+
+
+def test_every_row_eligible_matches_the_unfiltered_ranking(tmp_path):
+    """An allow-everything filter must rank exactly as no filter at all."""
+    rng = np.random.default_rng(6)
+    vault = _fresh_vault(tmp_path)
+    index, paths = _populated(vault, rng, files=25, per_file=4)
+    query = _unit_query(rng)
+
+    unfiltered = index.search(query, 15)
+    permissive = index.search(query, 15, allowed_paths=set(paths))
+
+    _assert_same_answer(unfiltered, permissive)
+
+
+# --------------------------------------------------------------------------- #
+# The memo: fast when it is safe, rebuilt whenever it is not.
+# --------------------------------------------------------------------------- #
+
+
+def test_mask_is_reused_across_queries_at_the_same_scope(tmp_path):
+    """The point of the memo: the second query at a scope rebuilds nothing."""
+    rng = np.random.default_rng(7)
+    vault = _fresh_vault(tmp_path)
+    index, paths = _populated(vault, rng, files=20, per_file=3)
+    allowed = set(paths[:10])
+
+    index.search(_unit_query(rng), 5, allowed_paths=allowed)
+    first = index._mask_cache
+    assert first is not None
+    index.search(_unit_query(rng), 5, allowed_paths=allowed)
+
+    assert index._mask_cache is first
+
+
+def test_an_equal_but_distinct_allowed_set_still_hits(tmp_path):
+    """`find_candidates` rebuilds `recall_paths & eligible_paths` per call.
+
+    Keying on object identity would therefore miss on every single query, which
+    is why the memo keys on the set's CONTENT.
+    """
+    rng = np.random.default_rng(8)
+    vault = _fresh_vault(tmp_path)
+    index, paths = _populated(vault, rng, files=20, per_file=3)
+
+    index.search(_unit_query(rng), 5, allowed_paths=set(paths[:10]))
+    first = index._mask_cache
+    index.search(_unit_query(rng), 5, allowed_paths=set(paths[:10]))  # equal, not the same
+
+    assert index._mask_cache is first
+
+
+def test_mask_is_rebuilt_when_the_scope_changes(tmp_path):
+    rng = np.random.default_rng(9)
+    vault = _fresh_vault(tmp_path)
+    index, paths = _populated(vault, rng, files=20, per_file=3)
+    query = _unit_query(rng)
+
+    narrow = index.search(query, 5, allowed_paths={paths[0]})
+    wide = index.search(query, 5, allowed_paths=set(paths))
+
+    assert {fp for fp, *_rest in narrow} == {paths[0]}
+    assert len(wide) == 5
+
+
+def test_a_stale_mask_cannot_survive_the_matrix_being_rebuilt(tmp_path):
+    """The invalidation that matters, and the one a wrong answer would hide.
+
+    `a.md` is retired and `c.md` takes its place, so the row COUNT is unchanged
+    and only the identity of the rows moved. A mask kept across that rebuild
+    still marks rows 0-1 eligible and would return `b.md`'s chunks under a scope
+    that now matches nothing at all.
+    """
+    rng = np.random.default_rng(10)
+    vault = _fresh_vault(tmp_path)
+    index = embeddings.EmbeddingIndex(vault)
+    rows = _unit_rows(rng, 6)
+    index.upsert_file("a.md", ["a0", "a1"], rows[0:2], 1.0)
+    index.upsert_file("b.md", ["b0", "b1"], rows[2:4], 1.0)
+    query = _unit_query(rng)
+
+    warm = index.search(query, 4, allowed_paths={"a.md"})
+    assert {fp for fp, *_rest in warm} == {"a.md"}
+
+    index.upsert_file("a.md", [], _empty_vectors(), 2.0)
+    index.upsert_file("c.md", ["c0", "c1"], rows[4:6], 2.0)
+
+    assert index.search(query, 4, allowed_paths={"a.md"}) == []
+
+
+def test_a_stale_mask_cannot_survive_rows_shifting_position(tmp_path):
+    """Same guard, caught as a WRONG ROW rather than a wrong emptiness.
+
+    The row count is identical before and after, so nothing about the shape
+    gives the staleness away — only the rows moved. `a.md` sheds a chunk and
+    `c.md` gains one, which slides `b.md` from index 2 to index 1. A mask kept
+    across that still marks index 2, and index 2 is now `c.md`: a scope of
+    exactly `{b.md}` would answer with a file it excludes.
+    """
+    vault = _fresh_vault(tmp_path)
+    index = embeddings.EmbeddingIndex(vault)
+    index.upsert_file("a.md", ["a0", "a1"], _sparse_rows([(0, 1.0)], [(1, 1.0)]), 1.0)
+    index.upsert_file("b.md", ["b0"], _sparse_rows([(2, 1.0)]), 1.0)
+    query = _sparse_rows([(2, 1.0)])[0]
+
+    warm = index.search(query, 2, allowed_paths={"b.md"})
+    assert [(fp, score) for fp, _ci, _text, score in warm] == [("b.md", 1.0)]
+
+    index.upsert_file("a.md", ["a0"], _sparse_rows([(0, 1.0)]), 2.0)
+    index.upsert_file("c.md", ["c0"], _sparse_rows([(3, 1.0)]), 2.0)
+
+    hits = index.search(query, 2, allowed_paths={"b.md"})
+    assert [(fp, score) for fp, _ci, _text, score in hits] == [("b.md", 1.0)]
+
+
+def test_a_stale_mask_cannot_survive_the_allowed_set_being_mutated_in_place(tmp_path):
+    """Callers own the set they pass and may narrow it between queries."""
+    vault = _fresh_vault(tmp_path)
+    index = embeddings.EmbeddingIndex(vault)
+    index.upsert_file("a.md", ["a0"], _sparse_rows([(0, 1.0)]), 1.0)
+    index.upsert_file("b.md", ["b0"], _sparse_rows([(1, 1.0)]), 1.0)
+    query = _sparse_rows([(0, 1.0), (1, 1.0)])[0]
+    allowed = {"a.md", "b.md"}
+
+    assert len(index.search(query, 5, allowed_paths=allowed)) == 2
+
+    allowed.discard("a.md")  # same object, different content
+
+    hits = index.search(query, 5, allowed_paths=allowed)
+    assert [(fp, ci) for fp, ci, _text, _score in hits] == [("b.md", 0)]
+
+
+def test_unload_cache_drops_the_mask_memo(tmp_path):
+    """The memo pins the metadata list, so an unload must release it too."""
+    rng = np.random.default_rng(13)
+    vault = _fresh_vault(tmp_path)
+    index, paths = _populated(vault, rng, files=10, per_file=2)
+    index.search(_unit_query(rng), 5, allowed_paths=set(paths))
+    assert index._mask_cache is not None
+
+    index.unload_cache()
+
+    assert index._mask_cache is None
+
+
+def test_mask_memo_survives_a_reload_only_by_being_rebuilt(tmp_path):
+    """After an unload the answer is still right — the memo just pays again."""
+    rng = np.random.default_rng(14)
+    vault = _fresh_vault(tmp_path)
+    index, paths = _populated(vault, rng, files=12, per_file=2)
+    allowed = set(paths[:5])
+    query = _unit_query(rng)
+    before = index.search(query, 8, allowed_paths=allowed)
+
+    index.unload_cache()
+    after = index.search(query, 8, allowed_paths=allowed)
+
+    _assert_same_answer(before, after)
+    assert index._mask_cache is not None

--- a/tests/test_recall_eligibility_mask.py
+++ b/tests/test_recall_eligibility_mask.py
@@ -413,3 +413,107 @@ def test_mask_memo_survives_a_reload_only_by_being_rebuilt(tmp_path):
 
     _assert_same_answer(before, after)
     assert index._mask_cache is not None
+
+
+# --------------------------------------------------------------------------- #
+# Structural guard: every test above asserts an ANSWER, so all of them stay
+# green if someone reintroduces `matrix[keep]` — the slice is a pure latency
+# defect, not a ranking one. Nothing else in the suite can catch it either:
+# tests/test_latency_gate.py is deliberately model-free, so it never reaches
+# the vector lane, and its ceilings are catastrophic-blowup backstops rather
+# than a ratchet. So assert the mechanism directly.
+# --------------------------------------------------------------------------- #
+
+
+class _ScoredRowSpy(np.ndarray):
+    """An ndarray that records the row count of every matrix it matmuls.
+
+    `__array_finalize__` hands the SAME list to every array derived from this
+    one, so a fancy-index copy (`matrix[keep]`) records into it too — which is
+    precisely the regression this catches: the copy reports the eligible count
+    where the fix reports the full row count.
+    """
+
+    def __array_finalize__(self, obj) -> None:
+        if obj is None:
+            return
+        self.scored_rows = getattr(obj, "scored_rows", None)
+
+    def __matmul__(self, other):
+        if self.ndim == 2 and self.scored_rows is not None:
+            self.scored_rows.append(self.shape[0])
+        return super().__matmul__(other)
+
+
+def _spy_on_scored_rows(index, monkeypatch) -> list[int]:
+    """Make `index.all_vectors()` hand back a spying view of the same matrix."""
+    metadata, matrix = index.all_vectors()
+    scored_rows: list[int] = []
+    spy = matrix.view(_ScoredRowSpy)
+    spy.scored_rows = scored_rows
+    monkeypatch.setattr(index, "all_vectors", lambda: (metadata, spy))
+    return scored_rows
+
+
+def test_the_filtered_scan_scores_every_row_rather_than_a_copied_subset(
+    tmp_path, monkeypatch
+):
+    """The #951 guard: one BLAS pass over the WHOLE matrix, no `matrix[keep]`.
+
+    A reintroduced slice would score only the eligible rows and every
+    correctness test in this file would still pass.
+    """
+    rng = np.random.default_rng(9510)
+    vault = _fresh_vault(tmp_path)
+    index, paths = _populated(vault, rng, files=40, per_file=5)
+    metadata, _ = index.all_vectors()
+    total_rows = len(metadata)
+    allowed = set(paths[:8])  # 8 of 40 files -> 40 of 200 rows eligible
+
+    scored_rows = _spy_on_scored_rows(index, monkeypatch)
+    hits = index.search(_unit_query(rng), 10, allowed_paths=allowed)
+
+    assert len(hits) == 10
+    assert scored_rows == [total_rows], (
+        f"the filtered scan scored {scored_rows} rows of {total_rows}. "
+        "Scoring fewer means the matrix was sliced before the matmul — that is "
+        "the #951 copy, and it costs ~10x on a real vault."
+    )
+
+
+def test_the_unfiltered_scan_also_scores_every_row(tmp_path, monkeypatch):
+    """Control: without a filter there was never a slice, so the count matches."""
+    rng = np.random.default_rng(9511)
+    vault = _fresh_vault(tmp_path)
+    index, _paths = _populated(vault, rng, files=40, per_file=5)
+    metadata, _ = index.all_vectors()
+
+    scored_rows = _spy_on_scored_rows(index, monkeypatch)
+    index.search(_unit_query(rng), 10, allowed_paths=None)
+
+    assert scored_rows == [len(metadata)]
+
+
+def test_the_spy_would_actually_catch_a_reintroduced_slice(tmp_path, monkeypatch):
+    """The guard's own guard — prove the spy fails on the pre-#951 code.
+
+    A structural assertion is only worth its line count if it can fail. This
+    runs `_search_pre_951` (the verbatim slice, transcribed from
+    `git show 9bf3d804`) through the same spy and shows it reports the eligible
+    count instead of the full one.
+    """
+    rng = np.random.default_rng(9512)
+    vault = _fresh_vault(tmp_path)
+    index, paths = _populated(vault, rng, files=40, per_file=5)
+    metadata, _ = index.all_vectors()
+    allowed = set(paths[:8])
+
+    scored_rows = _spy_on_scored_rows(index, monkeypatch)
+    _search_pre_951(index, _unit_query(rng), 10, allowed_paths=allowed)
+
+    assert scored_rows == [40], (
+        "the transcribed pre-#951 slice should score only the 40 eligible rows; "
+        f"got {scored_rows}. If this changed, the spy no longer observes the "
+        "matmul and the guard above is dead."
+    )
+    assert scored_rows != [len(metadata)]

--- a/tests/test_recall_eligibility_mask.py
+++ b/tests/test_recall_eligibility_mask.py
@@ -517,3 +517,152 @@ def test_the_spy_would_actually_catch_a_reintroduced_slice(tmp_path, monkeypatch
         "matmul and the guard above is dead."
     )
     assert scored_rows != [len(metadata)]
+
+
+# --------------------------------------------------------------------------- #
+# Found by adversarial review of this branch, 2026-08-30. All three reproduced
+# against the real methods before being fixed; these pin them shut.
+# --------------------------------------------------------------------------- #
+
+
+class _MutatingSet(set):
+    """Adds `late` to itself the first time membership is tested.
+
+    Stands in for another thread mutating the caller's allowed set between the
+    memo taking its frozenset snapshot and the mask being built. Deterministic
+    where a real race would not be.
+    """
+
+    def __init__(self, initial, late: str) -> None:
+        super().__init__(initial)
+        self._late = late
+        self._fired = False
+
+    def __contains__(self, item) -> bool:
+        if not self._fired:
+            self._fired = True
+            set.add(self, self._late)
+        return set.__contains__(self, item)
+
+
+def test_a_set_mutated_during_the_mask_build_cannot_poison_the_memo(tmp_path):
+    """The cached mask must describe the key it is filed under.
+
+    The memo snapshots `frozenset(allowed_paths)` and is looked up by that
+    content. If the mask were built by reading the caller's live set a second
+    time, a mutation in between would file a mask admitting `b.md` under the key
+    `{a.md}` — and every later query that legitimately asks for `{a.md}` would
+    be served it.
+    """
+    rng = np.random.default_rng(30)
+    vault = _fresh_vault(tmp_path)
+    index, paths = _populated(vault, rng, files=6, per_file=1)
+    late = paths[1]
+    allowed = _MutatingSet({paths[0]}, late)
+
+    mask, eligible = index._eligibility_mask(index.all_vectors()[0], allowed)
+
+    metadata, _ = index.all_vectors()
+    admitted = {metadata[i][0] for i in np.flatnonzero(mask)}
+    assert admitted == {paths[0]}, f"mask admits {admitted}, but is filed under {{{paths[0]}}}"
+    assert eligible == 1
+    assert set(index._mask_cache.allowed_paths) == {paths[0]}
+
+
+def test_a_poisoned_memo_cannot_be_served_to_a_later_honest_query(tmp_path):
+    """End-to-end form of the above: the later query gets only what it asked for."""
+    rng = np.random.default_rng(31)
+    vault = _fresh_vault(tmp_path)
+    index, paths = _populated(vault, rng, files=6, per_file=1)
+    query = _unit_query(rng)
+
+    index.search(query, 6, allowed_paths=_MutatingSet({paths[0]}, paths[1]))
+    hits = index.search(query, 6, allowed_paths={paths[0]})
+
+    assert [h[0] for h in hits] == [paths[0]]
+
+
+def test_a_nan_query_never_returns_an_ineligible_row(tmp_path):
+    """Eligibility is a governance boundary, not a ranking preference.
+
+    Masking alone cannot hold it: `-(-inf)` is `+inf`, and numpy orders NaN
+    ABOVE `+inf`, so when the query embeds to NaN every eligible score is NaN
+    and the masked rows partition first. The pre-#951 slice could not do this
+    because ineligible rows were never in the array.
+    """
+    rng = np.random.default_rng(32)
+    vault = _fresh_vault(tmp_path)
+    index, paths = _populated(vault, rng, files=4, per_file=1)
+    nan_query = np.full(768, np.nan, dtype=np.float32)
+
+    hits = index.search(nan_query, 1, allowed_paths={paths[0]})
+
+    assert [h[0] for h in hits] == [paths[0]]
+
+
+def test_no_infinite_score_can_escape_search(tmp_path):
+    """`find_candidates.py` publishes these scores with `"range": [-1.0, 1.0]`.
+
+    A `-inf` leaking out is not merely ugly: it is consumed downstream as a
+    cosine, and it made a whole vector lane drop out in review.
+    """
+    rng = np.random.default_rng(33)
+    vault = _fresh_vault(tmp_path)
+    index, paths = _populated(vault, rng, files=4, per_file=1)
+    allowed = {paths[0]}
+
+    for query in (np.full(768, np.nan, dtype=np.float32), _unit_query(rng)):
+        for k in (1, 4, 50):
+            for hit in index.search(query, k, allowed_paths=allowed):
+                assert not np.isinf(hit[3]), f"infinite score {hit[3]} escaped at k={k}"
+
+
+def test_every_returned_row_is_eligible_under_pathological_scores(tmp_path):
+    """Sweep the shapes that break the -inf ordering, at several k."""
+    rng = np.random.default_rng(34)
+    vault = _fresh_vault(tmp_path)
+    index, paths = _populated(vault, rng, files=10, per_file=2)
+    allowed = set(paths[:3])
+    queries = [
+        np.full(768, np.nan, dtype=np.float32),
+        np.zeros(768, dtype=np.float32),
+        np.full(768, np.inf, dtype=np.float32),
+    ]
+
+    for query in queries:
+        for k in (1, 3, 6, 20):
+            hits = index.search(query, k, allowed_paths=allowed)
+            assert all(h[0] in allowed for h in hits), (
+                f"ineligible row returned for k={k}: {[h[0] for h in hits]}"
+            )
+            assert len(hits) <= 6  # 3 files x 2 chunks is the eligible ceiling
+
+
+def test_exact_ties_may_pick_a_different_equally_scoring_row(tmp_path):
+    """DOCUMENTED DIVERGENCE, not a guarantee — the one place this is not bit-identical.
+
+    `argpartition`'s choice among EXACTLY equal scores depends on the array it
+    is given, so masking the full array can select a different tied row than
+    slicing the eligible ones did. Neither order is defined: pre-#951's choice
+    was equally an artifact of layout, and numpy makes no stability promise.
+
+    Reachable only for genuinely identical content (the same note captured
+    twice), and every candidate scores the same, so no ranking quality moves.
+    This test asserts the invariant that DOES hold — an eligible row at the
+    top score — so a future change that resolves ties deterministically will
+    not have to fight it.
+    """
+    vault = _fresh_vault(tmp_path)
+    index = embeddings.EmbeddingIndex(vault)
+    identical = _sparse_rows([(0, 1.0)])[0]
+    names = ["blocked-a.md", "blocked-b.md", "eligible-a.md", "eligible-b.md"]
+    for name in names:
+        index.upsert_file(name, [f"{name} chunk"], identical.reshape(1, -1), 1.0)
+    allowed = {"eligible-a.md", "eligible-b.md"}
+    query = _sparse_rows([(0, 1.0)])[0]
+
+    hits = index.search(query, 1, allowed_paths=allowed)
+
+    assert len(hits) == 1
+    assert hits[0][0] in allowed
+    assert hits[0][3] == pytest.approx(1.0, abs=SCORE_TOLERANCE)


### PR DESCRIPTION
Closes #951.

Every semantic recall passes `allowed_paths`, so `EmbeddingIndex.search` always took its numpy scan branch — which ran a Python membership loop over all ~67,000 chunk rows and then fancy-indexed `matrix[keep]`, copying most of a ~200 MB float32 matrix before the matmul could start. This scores the full cached matrix once and masks the **scores** instead, memoizing the row mask.

## What it buys

`scripts/recall_mask_latency.py --chunks 67000 --files 6074` (synthetic sidecar at the measured cell's shape, k=300, 30 queries per lane, warm both sides) times the verbatim pre-fix implementation against the shipped one on the same data. **Five runs**, same machine, same commit:

| eligible | speedup range | median | agreement |
|---|---|---|---|
| 100% | 5.69 – 11.46x | **7.67x** | same rows, Δ 0.00e+00 |
| 85% | 5.74 – 7.52x | 6.53x | same rows, Δ 0.00e+00 |
| 50% | 4.09 – 4.40x | 4.35x | same rows, Δ 0.00e+00 |
| 5% | 0.86 – 1.32x | 1.06x | same rows, Δ 1.12e-08 |

Recall admits nearly the whole vault in the normal case, so the top row is the operating regime — but read it with the range, not the median. The variance has a shape: it tracks how much matrix the **pre-fix** lane copies. At 100% eligible that is the entire ~200 MB, the most memory-bandwidth-sensitive work in the harness, and the row swings 2x with machine state (the pre-fix lane alone measured 230 ms in one run and 60 ms in another). At 50% it copies half and holds to ±4%. The conservative rows are the trustworthy ones. A single 100%-eligible run quotes the machine, not the change.

## It is also a write-path fix

Three call sites reach `EmbeddingIndex.search`, and only one of them is recall:

| call site | `allowed_paths` | scan branch? |
|---|---|---|
| `find_candidates.py:218` (recall) | always `semantic_paths` | yes |
| `corpus_aware.py:628` (`_best_cosine_per_file`) | always a set comprehension, never `None` | yes |
| `doctor.py:1882` (k=1 health probe) | not passed | no — reaches vec0 |

The second runs on **writes**. Its own comment says so: `# and this runs inline on every add/note/edit and pack assembly.` It chunks the draft, embeds each chunk, then loops one `idx.search` per chunk against the full sidecar with `allowed_paths` set to the entire index — the 100% row. Pre-fix, a 3-chunk note paid three full slice-and-scan passes plus the 67,000-row membership loop three times, because there was no memo. That lands on the semantic write-latency gate and deserves its own measurement after deploy.

## Why it is behaviour-preserving

A masked row scores `-inf`, and `k_eff` is clamped to the **eligible** count rather than the row count, so `argpartition` cannot reach a masked row even when fewer than `k` rows survive the filter.

The memo's invalidation is the delicate part. `metadata` is pinned by strong reference and matched with `is` — every producer of the matrix cache is copy-on-write, so a different row set is always a different list object, and the strong reference prevents id reuse. `allowed_paths` is matched by **content** as a frozenset, because callers mutate their set in place between queries.

## One documented divergence

**Exact ties may return a different, identically-scoring row.** `argpartition`'s choice among exactly equal scores depends on the array it is given, so masking the full array can pick a different tied row than slicing the eligible ones did. Neither order is defined — pre-#951's was equally an artifact of layout, and numpy promises no stability. Reachable only for genuinely duplicate content, and every tied candidate scores identically, so no ranking quality moves. Matching pre-#951 here would require selecting over the compacted array, which is the copy this change removes.

So the claim is **result-identical except among exact ties**, not byte-identical. A test documents it and pins the invariant that does hold: an eligible row, at the top score.

## Adversarial review found three defects; two are fixed here

An independent lane that did not write the code returned DO NOT SHIP. All three were reproduced against the real methods before anything was touched.

**A mutated allowed set could poison the mask memo.** `_eligibility_mask` took `frozenset(allowed_paths)` as the key, then built the mask by reading the caller's live, mutable set a second time. A mutation between those two reads files a mask admitting `b.md` under the key `{a.md}`, and every later query legitimately asking for `{a.md}` is served it for the rest of the session. The memo was designed around callers mutating that set and then re-read it one line later. Now built from the frozenset — same cost, window closed.

**A NaN query could return an INELIGIBLE row with a `-inf` score.** `-(-inf)` is `+inf`, and numpy orders NaN **above** `+inf`. So when the query embeds to NaN every eligible score is NaN, the masked rows partition first, and a blocked path is returned — with a score that then reaches `find_candidates.py:241`, which publishes it as `"range": [-1.0, 1.0]`. In the reviewer's probe it emptied an entire vector lane. The pre-#951 slice could not do this because ineligible rows were never in the array.

Eligibility is a governance boundary rather than a ranking preference, so it must not rest on score arithmetic holding. When any selected row is ineligible, selection now falls back to the eligible rows only — the pre-#951 computation on exactly the rows it would have had — restoring both the row and its true score. Unreachable with finite scores, so the hot path pays one `.all()` over k elements.

Two categories came back clear, both checked by running probes rather than reading: no torn metadata pair under a 100,000-lookup race, and the new structural guard genuinely observes the real matmul.

## Regression guard

Worth being explicit about what this closes. **Every correctness test in the file stays green if someone puts `matrix[keep]` back** — the slice is a latency defect, not a ranking one. `tests/test_latency_gate.py` cannot catch it either: it is deliberately model-free, so it never reaches the vector lane, and its ceilings (`CEIL_TOTAL_MS = 5000`) are catastrophic-blowup backstops rather than a ratchet.

So one test asserts the mechanism. `_ScoredRowSpy` is an ndarray view recording the row count of every matrix reaching a matmul, propagating its recorder through `__array_finalize__` so a fancy-index copy records into the same list. The filtered scan must report the full row count. A third test drives the pre-fix implementation through the same spy and shows it reporting 40 rows where the fix reports 200 — a structural assertion that cannot fail is worth nothing.

## Verification

- 30 tests in `tests/test_recall_eligibility_mask.py`, green.
- The primary test runs `_search_pre_951`, transcribed verbatim from `git show 9bf3d804`, against the same index, query and allowed set, parametrized over 7 scopes, and demands the same answer.
- `uvx ruff check` clean on every changed file.
- Five benchmark repetitions, 20 of 20 comparisons agreeing row-for-row.

**Not done:** end-to-end before/after on the live cell. That needs the fix deployed there, which costs a restart and a full warm-up. The measurement design is settled — only #953 touched the recall path between the deployed v0.65.0 and `main`, and its `all_semantic_unit_vectors` is called solely from `audit.py`, never from `find()` — so a before/after across that gap isolates this change cleanly.
