### PR TITLE
fix(timings): attribute the three stages that wrote no interval

### DIFF
--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -1390,38 +1390,39 @@ def find(
                 failed_out=failed,
             )
     else:
-        hits = _find_semantic(
-            vault_root,
-            query=query,
-            query_norm=query_norm,
-            types=types,
-            projects=projects,
-            tags=tags,
-            speakers=speakers,
-            file_types=file_types,
-            exclude_file_types=exclude_file_types,
-            limit=limit,
-            scope=walk_scope,
-            mode=mode,
-            graph=graph,
-            rerank=rerank,
-            rerank_max_candidates=rerank_max_candidates,
-            auto_rerank=auto_rerank,
-            temporal=temporal,
-            intent=intent,
-            prefer_compiled=prefer_compiled,
-            prefer_active=prefer_active,
-            prefer_used=prefer_used,
-            config=resolved_config,
-            timings=timings,
-            snapshot=snapshot,
-            page_memo=page_memo,
-            degraded_out=degraded,
-            failed_out=failed,
-            eligible_paths=eligible_paths,
-            recall_scope="kb" if scope == "kb-only" else "vault",
-            retrieval_trace=retrieval_trace,
-        )
+        with _span(timings, "semantic.search"):
+            hits = _find_semantic(
+                vault_root,
+                query=query,
+                query_norm=query_norm,
+                types=types,
+                projects=projects,
+                tags=tags,
+                speakers=speakers,
+                file_types=file_types,
+                exclude_file_types=exclude_file_types,
+                limit=limit,
+                scope=walk_scope,
+                mode=mode,
+                graph=graph,
+                rerank=rerank,
+                rerank_max_candidates=rerank_max_candidates,
+                auto_rerank=auto_rerank,
+                temporal=temporal,
+                intent=intent,
+                prefer_compiled=prefer_compiled,
+                prefer_active=prefer_active,
+                prefer_used=prefer_used,
+                config=resolved_config,
+                timings=timings,
+                snapshot=snapshot,
+                page_memo=page_memo,
+                degraded_out=degraded,
+                failed_out=failed,
+                eligible_paths=eligible_paths,
+                recall_scope="kb" if scope == "kb-only" else "vault",
+                retrieval_trace=retrieval_trace,
+            )
 
     if retrieval_trace is not None and (mode == "keyword" or not query_norm):
         retrieval_trace.record_keyword_hits(hits, filter_only=not query_norm)
@@ -1888,6 +1889,7 @@ def _vector_unit_candidates(
     allowed_parent_paths: set[str],
     degraded_out: list[str] | None,
     failed_out: list[str] | None,
+    timings: FindTimings | None,
 ) -> tuple[list[Any], dict[str, Any], str]:
     """Return bounded vector candidates without opening every Markdown parent."""
     model_name = "BAAI/bge-base-en-v1.5"
@@ -1908,7 +1910,8 @@ def _vector_unit_candidates(
         from . import embeddings
 
         index = embeddings.get_embedding_index(vault_root)
-        query_vector = embeddings.embed_texts([query], is_query=True)[0]
+        with _span(timings, "vector.unit.embed"):
+            query_vector = embeddings.embed_texts([query], is_query=True)[0]
         hits = index.search_semantic_units(
             query_vector,
             k=candidate_limit,
@@ -2173,6 +2176,7 @@ def _find_semantic_units(
             allowed_parent_paths=snapshot.recall_paths(scope),
             degraded_out=degraded_out,
             failed_out=failed_out,
+            timings=timings,
         )
         if (
             vector_allowed_refs is not None
@@ -3274,136 +3278,132 @@ def _find_semantic(
     )
     hits: list[Hit] = []
     seen: set[str] = set()
-    _filter_t0 = time.perf_counter()
-    for rel_path, _score in fused:
-        if rel_path in seen:
-            continue
-        seen.add(rel_path)
-        if rel_path.rsplit("/", 1)[-1].lower() in _NAVIGATION_BASENAMES:
-            continue
-        # Final egress guard: stale/non-projected sidecars can nominate paths,
-        # but they must not cause a raw Record to be hydrated even transiently.
-        if not recall_policy.is_recall_candidate(vault_root, vault_root / rel_path):
-            continue
-        page = _page_of(rel_path)
-        if page is None:
-            continue
-        if eligible_paths is not None and rel_path not in eligible_paths:
-            continue
-        if not _passes_filters(
-            page,
-            vault_root=vault_root,
-            types=types,
-            projects=projects,
-            tags=tags,
-            speakers=speakers,
-            file_types=file_types,
-            exclude_file_types=exclude_file_types,
-        ):
-            continue
-        keyword_excerpt = _make_excerpt(page, query_norm)
-        if (
-            rel_path not in vector_paths
-            and rel_path not in graph_set
-            and rel_path not in keyword_set
-            and rel_path not in clip_set
-            and rel_path not in frame_attribution
-            and keyword_excerpt is None
-        ):
-            # No literal match, not a graph hop, not vector-ranked, not in
-            # the keyword scan. Try stem match before dropping — recovers
-            # morphology ("regulation" matching a "regulator" page). With the
-            # semantic lanes absent (see flag above) the gate relaxes from
-            # all-stems to a strict majority of the query's words anchored by
-            # at least one content word, so BM25's own top-ranked evidence
-            # survives interrogative phrasing without function-word overlap
-            # alone retaining junk.
-            if semantic_lanes_absent:
-                present, total, content_present = _stem_word_coverage(
-                    page, degraded_query_words
-                )
-                stems_ok = 2 * present > total and content_present > 0
-            else:
-                stems_ok = _stem_tokens_present(page, query_norm)
-            if not stems_ok:
+    with _span(timings, "filter_hits"):
+        for rel_path, _score in fused:
+            if rel_path in seen:
                 continue
-            keyword_excerpt = _stem_anchored_excerpt(page, query_norm)
-        elif (
-            rel_path in graph_set or rel_path in clip_set or rel_path in frame_attribution
-        ) and keyword_excerpt is None:
-            # Graph-hop neighbour, CLIP visual match, or frame-collapsed parent:
-            # no all-tokens-present requirement (the reason for surfacing is
-            # connectivity / visual similarity / a child frame's text, not this
-            # page's lexical overlap). Prefer the matched frame's OCR text as the
-            # "why", else the sidecar's leading body.
-            attr = frame_attribution.get(rel_path)
-            if attr is not None:
-                fpage = _CACHE.get(vault_root / (attr[0] + ".md"), vault_root)
-                if fpage is not None:
-                    keyword_excerpt = _make_excerpt(fpage, query_norm)
-            if keyword_excerpt is None:
-                body = page.body.strip()
-                keyword_excerpt = _collapse(body[:EXCERPT_MAX_LEN]) if body else ""
-        chunk = chunk_text_by_path.get(rel_path)
-        excerpt = _semantic_excerpt(page, query_norm, chunk, keyword_excerpt)
-        is_graph_only = (
-            rel_path in graph_set
-            and rel_path not in vector_rank_by_path
-            and rel_path not in bm25_rank_by_path
-        )
-        hit_activation: float | None = None
-        hit_usage_mult: float | None = None
-        if usage_map:
-            from . import usage as usage_module
+            seen.add(rel_path)
+            if rel_path.rsplit("/", 1)[-1].lower() in _NAVIGATION_BASENAMES:
+                continue
+            # Final egress guard: stale/non-projected sidecars can nominate paths,
+            # but they must not cause a raw Record to be hydrated even transiently.
+            if not recall_policy.is_recall_candidate(vault_root, vault_root / rel_path):
+                continue
+            page = _page_of(rel_path)
+            if page is None:
+                continue
+            if eligible_paths is not None and rel_path not in eligible_paths:
+                continue
+            if not _passes_filters(
+                page,
+                vault_root=vault_root,
+                types=types,
+                projects=projects,
+                tags=tags,
+                speakers=speakers,
+                file_types=file_types,
+                exclude_file_types=exclude_file_types,
+            ):
+                continue
+            keyword_excerpt = _make_excerpt(page, query_norm)
+            if (
+                rel_path not in vector_paths
+                and rel_path not in graph_set
+                and rel_path not in keyword_set
+                and rel_path not in clip_set
+                and rel_path not in frame_attribution
+                and keyword_excerpt is None
+            ):
+                # No literal match, not a graph hop, not vector-ranked, not in
+                # the keyword scan. Try stem match before dropping — recovers
+                # morphology ("regulation" matching a "regulator" page). With the
+                # semantic lanes absent (see flag above) the gate relaxes from
+                # all-stems to a strict majority of the query's words anchored by
+                # at least one content word, so BM25's own top-ranked evidence
+                # survives interrogative phrasing without function-word overlap
+                # alone retaining junk.
+                if semantic_lanes_absent:
+                    present, total, content_present = _stem_word_coverage(
+                        page, degraded_query_words
+                    )
+                    stems_ok = 2 * present > total and content_present > 0
+                else:
+                    stems_ok = _stem_tokens_present(page, query_norm)
+                if not stems_ok:
+                    continue
+                keyword_excerpt = _stem_anchored_excerpt(page, query_norm)
+            elif (
+                rel_path in graph_set or rel_path in clip_set or rel_path in frame_attribution
+            ) and keyword_excerpt is None:
+                # Graph-hop neighbour, CLIP visual match, or frame-collapsed parent:
+                # no all-tokens-present requirement (the reason for surfacing is
+                # connectivity / visual similarity / a child frame's text, not this
+                # page's lexical overlap). Prefer the matched frame's OCR text as the
+                # "why", else the sidecar's leading body.
+                attr = frame_attribution.get(rel_path)
+                if attr is not None:
+                    fpage = _CACHE.get(vault_root / (attr[0] + ".md"), vault_root)
+                    if fpage is not None:
+                        keyword_excerpt = _make_excerpt(fpage, query_norm)
+                if keyword_excerpt is None:
+                    body = page.body.strip()
+                    keyword_excerpt = _collapse(body[:EXCERPT_MAX_LEN]) if body else ""
+            chunk = chunk_text_by_path.get(rel_path)
+            excerpt = _semantic_excerpt(page, query_norm, chunk, keyword_excerpt)
+            is_graph_only = (
+                rel_path in graph_set
+                and rel_path not in vector_rank_by_path
+                and rel_path not in bm25_rank_by_path
+            )
+            hit_activation: float | None = None
+            hit_usage_mult: float | None = None
+            if usage_map:
+                from . import usage as usage_module
 
-            hit_activation = usage_map.get(usage_module.canon(rel_path))
-            if hit_activation is not None:
-                hit_usage_mult = usage_module.usage_multiplier(hit_activation, config)
-        attr = frame_attribution.get(rel_path)
-        hit = Hit(
-            path=page.rel_path,
-            type=page.page_type,
-            scope=page.scope,
-            title=page.title,
-            updated=page.updated,
-            excerpt=excerpt or "",
-            media_type=page.media_type,
-            media_file=page.media_file,
-            status=page.status,
-            superseded_by=page.superseded_by,
-            bm25_rank=bm25_rank_by_path.get(rel_path),
-            vector_rank=vector_rank_by_path.get(rel_path),
-            vector_score=vector_score_by_path.get(rel_path),
-            clip_rank=clip_rank_by_path.get(rel_path),
-            clip_score=clip_score_by_path.get(rel_path),
-            clip_frame_ts=clip_frame_ts_by_path.get(rel_path),
-            graph_hop=is_graph_only,
-            graph_in_degree=graph_in_degree_by_path.get(rel_path, 0),
-            graph_provenance=graph_provenance_by_path.get(rel_path),
-            keyword_rank=keyword_rank_by_path.get(rel_path),
-            activation=hit_activation,
-            usage_boost_applied=hit_usage_mult,
-            scene_frame=attr[0] if attr else None,
-            scene_frame_ts=attr[1] if attr else None,
-            snapshot_hash=page.snapshot_hash,
-        )
-        hit.transcript_ts = _transcript_ts_for_hit(page, chunk, query_norm)
-        if hit.scene_frame is None and page.media_type == "video" and page.media_file:
-            # A localized match on a video — CLIP keyframe first (existing), else a
-            # timed-transcript match — attaches the nearest PERSISTED frame so the
-            # moment is viewable, not just timestamped.
-            anchor_ts = hit.clip_frame_ts if hit.clip_frame_ts is not None else hit.transcript_ts
-            if anchor_ts is not None:
-                nf = scene_frames.nearest_frame(vault_root, page.media_file, anchor_ts)
-                if nf is not None:
-                    hit.scene_frame, hit.scene_frame_ts = nf
-        hits.append(hit)
-        if len(hits) >= target_n:
-            break
-    if timings is not None:
-        timings.stages.setdefault("filter_hits", {})["ms"] = round(
-            (time.perf_counter() - _filter_t0) * 1000.0, 3
-        )
+                hit_activation = usage_map.get(usage_module.canon(rel_path))
+                if hit_activation is not None:
+                    hit_usage_mult = usage_module.usage_multiplier(hit_activation, config)
+            attr = frame_attribution.get(rel_path)
+            hit = Hit(
+                path=page.rel_path,
+                type=page.page_type,
+                scope=page.scope,
+                title=page.title,
+                updated=page.updated,
+                excerpt=excerpt or "",
+                media_type=page.media_type,
+                media_file=page.media_file,
+                status=page.status,
+                superseded_by=page.superseded_by,
+                bm25_rank=bm25_rank_by_path.get(rel_path),
+                vector_rank=vector_rank_by_path.get(rel_path),
+                vector_score=vector_score_by_path.get(rel_path),
+                clip_rank=clip_rank_by_path.get(rel_path),
+                clip_score=clip_score_by_path.get(rel_path),
+                clip_frame_ts=clip_frame_ts_by_path.get(rel_path),
+                graph_hop=is_graph_only,
+                graph_in_degree=graph_in_degree_by_path.get(rel_path, 0),
+                graph_provenance=graph_provenance_by_path.get(rel_path),
+                keyword_rank=keyword_rank_by_path.get(rel_path),
+                activation=hit_activation,
+                usage_boost_applied=hit_usage_mult,
+                scene_frame=attr[0] if attr else None,
+                scene_frame_ts=attr[1] if attr else None,
+                snapshot_hash=page.snapshot_hash,
+            )
+            hit.transcript_ts = _transcript_ts_for_hit(page, chunk, query_norm)
+            if hit.scene_frame is None and page.media_type == "video" and page.media_file:
+                # A localized match on a video — CLIP keyframe first (existing), else a
+                # timed-transcript match — attaches the nearest PERSISTED frame so the
+                # moment is viewable, not just timestamped.
+                anchor_ts = hit.clip_frame_ts if hit.clip_frame_ts is not None else hit.transcript_ts
+                if anchor_ts is not None:
+                    nf = scene_frames.nearest_frame(vault_root, page.media_file, anchor_ts)
+                    if nf is not None:
+                        hit.scene_frame, hit.scene_frame_ts = nf
+            hits.append(hit)
+            if len(hits) >= target_n:
+                break
 
     # Resolve the rerank decision. An explicit rerank=True/False always wins;
     # otherwise (rerank is None) auto_rerank consults should_rerank on the built
@@ -3450,113 +3450,108 @@ def _find_semantic(
     scorer_input_count = 0
     unscored_tail_count = max(0, len(hits) - rerank_candidate_limit)
     if do_rerank and hits:
-        _rerank_t0 = time.perf_counter()
-        rerank_prefix = hits[:rerank_candidate_limit]
-        scorer_input_count = len(rerank_prefix)
-        try:
-            from . import embeddings as emb
+        with _span(timings, "rerank"):
+            rerank_prefix = hits[:rerank_candidate_limit]
+            scorer_input_count = len(rerank_prefix)
+            try:
+                from . import embeddings as emb
 
-            # Best passage for each hit: the matched chunk when we have one,
-            # else the leading body slice.
-            passages: list[str] = []
-            for h in rerank_prefix:
-                ctext = chunk_text_by_path.get(h.path)
-                if ctext:
-                    passages.append(ctext)
-                else:
-                    pg = _page_of(h.path)
-                    body = (pg.body if pg else "") or h.excerpt
-                    passages.append(body[:1500])  # CrossEncoder caps at 512 tokens
-            scores = emb.rerank_pairs(query, passages)
-            if len(scores) != len(rerank_prefix):
-                raise ValueError("reranker returned a score count that does not match its inputs")
-            score_updates: list[
-                tuple[
-                    Hit,
-                    int,
-                    float,
-                    float,
-                    list[dict[str, float | str]] | None,
-                ]
-            ] = []
-            for input_rank, (h, s) in enumerate(zip(rerank_prefix, scores, strict=True), start=1):
-                raw_score = float(s)
-                adjusted = raw_score
-                chain: list[dict[str, float | str]] | None = (
-                    [] if retrieval_trace is not None else None
+                # Best passage for each hit: the matched chunk when we have one,
+                # else the leading body slice.
+                passages: list[str] = []
+                for h in rerank_prefix:
+                    ctext = chunk_text_by_path.get(h.path)
+                    if ctext:
+                        passages.append(ctext)
+                    else:
+                        pg = _page_of(h.path)
+                        body = (pg.body if pg else "") or h.excerpt
+                        passages.append(body[:1500])  # CrossEncoder caps at 512 tokens
+                scores = emb.rerank_pairs(query, passages)
+                if len(scores) != len(rerank_prefix):
+                    raise ValueError("reranker returned a score count that does not match its inputs")
+                score_updates: list[
+                    tuple[
+                        Hit,
+                        int,
+                        float,
+                        float,
+                        list[dict[str, float | str]] | None,
+                    ]
+                ] = []
+                for input_rank, (h, s) in enumerate(zip(rerank_prefix, scores, strict=True), start=1):
+                    raw_score = float(s)
+                    adjusted = raw_score
+                    chain: list[dict[str, float | str]] | None = (
+                        [] if retrieval_trace is not None else None
+                    )
+                    if prefer_compiled:
+                        factor = _type_multiplier(h.type, config)
+                        before = adjusted
+                        adjusted *= factor
+                        if chain is not None:
+                            chain.append(
+                                {
+                                    "name": "type",
+                                    "factor": factor,
+                                    "before": before,
+                                    "after": adjusted,
+                                }
+                            )
+                    if prefer_active:
+                        factor = _status_multiplier(h.status, config)
+                        before = adjusted
+                        adjusted *= factor
+                        if chain is not None:
+                            chain.append(
+                                {
+                                    "name": "status",
+                                    "factor": factor,
+                                    "before": before,
+                                    "after": adjusted,
+                                }
+                            )
+                    if usage_map and h.usage_boost_applied:
+                        factor = h.usage_boost_applied
+                        before = adjusted
+                        adjusted *= factor
+                        if chain is not None:
+                            chain.append(
+                                {
+                                    "name": "usage",
+                                    "factor": factor,
+                                    "before": before,
+                                    "after": adjusted,
+                                }
+                            )
+                    score_updates.append((h, input_rank, raw_score, adjusted, chain))
+                # Commit annotations only after every returned score and multiplier
+                # has been validated. A late conversion/application failure must
+                # leave the fused fallback free of partial reranker evidence.
+                for h, input_rank, raw_score, adjusted, chain in score_updates:
+                    h.rerank_input_rank = input_rank
+                    h.rerank_raw_score = raw_score
+                    h.rerank_score = adjusted
+                    if chain is not None:
+                        h.rerank_multiplier_chain = chain
+                hits = _order_reranked_prefix(
+                    hits,
+                    prefix_count=len(rerank_prefix),
                 )
-                if prefer_compiled:
-                    factor = _type_multiplier(h.type, config)
-                    before = adjusted
-                    adjusted *= factor
-                    if chain is not None:
-                        chain.append(
-                            {
-                                "name": "type",
-                                "factor": factor,
-                                "before": before,
-                                "after": adjusted,
-                            }
-                        )
-                if prefer_active:
-                    factor = _status_multiplier(h.status, config)
-                    before = adjusted
-                    adjusted *= factor
-                    if chain is not None:
-                        chain.append(
-                            {
-                                "name": "status",
-                                "factor": factor,
-                                "before": before,
-                                "after": adjusted,
-                            }
-                        )
-                if usage_map and h.usage_boost_applied:
-                    factor = h.usage_boost_applied
-                    before = adjusted
-                    adjusted *= factor
-                    if chain is not None:
-                        chain.append(
-                            {
-                                "name": "usage",
-                                "factor": factor,
-                                "before": before,
-                                "after": adjusted,
-                            }
-                        )
-                score_updates.append((h, input_rank, raw_score, adjusted, chain))
-            # Commit annotations only after every returned score and multiplier
-            # has been validated. A late conversion/application failure must
-            # leave the fused fallback free of partial reranker evidence.
-            for h, input_rank, raw_score, adjusted, chain in score_updates:
-                h.rerank_input_rank = input_rank
-                h.rerank_raw_score = raw_score
-                h.rerank_score = adjusted
-                if chain is not None:
-                    h.rerank_multiplier_chain = chain
-            hits = _order_reranked_prefix(
-                hits,
-                prefix_count=len(rerank_prefix),
-            )
-            rerank_outcome = {"decision": "ran", "reason": "ran"}
-        except ImportError as e:
-            log.warning("rerank requested but reranker unavailable: %s", e)
-            if timings is not None:
-                timings.error("rerank", e)
-            rerank_outcome = {
-                "decision": "unavailable",
-                "reason": "dependency_unavailable",
-            }
-        except Exception as e:  # noqa: BLE001 - optional reranker must soft-fail.
-            log.warning("rerank failed: %s; returning fused order", e)
-            if timings is not None:
-                timings.error("rerank", e)
-            rerank_outcome = {"decision": "failed", "reason": "runtime_failure"}
-        finally:
-            if timings is not None:
-                timings.stages.setdefault("rerank", {})["ms"] = round(
-                    (time.perf_counter() - _rerank_t0) * 1000.0, 3
-                )
+                rerank_outcome = {"decision": "ran", "reason": "ran"}
+            except ImportError as e:
+                log.warning("rerank requested but reranker unavailable: %s", e)
+                if timings is not None:
+                    timings.error("rerank", e)
+                rerank_outcome = {
+                    "decision": "unavailable",
+                    "reason": "dependency_unavailable",
+                }
+            except Exception as e:  # noqa: BLE001 - optional reranker must soft-fail.
+                log.warning("rerank failed: %s; returning fused order", e)
+                if timings is not None:
+                    timings.error("rerank", e)
+                rerank_outcome = {"decision": "failed", "reason": "runtime_failure"}
 
     _set_rerank_timing_profile(
         timings,

--- a/src/exomem/find_candidates.py
+++ b/src/exomem/find_candidates.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-import time
 from collections.abc import Callable
 from collections.abc import Set as AbstractSet
 from dataclasses import dataclass
@@ -213,13 +212,16 @@ def collect_candidates(
     else:
         try:
             with _span(timings, "vector"):
-                idx = embeddings.get_embedding_index(vault_root)
-                query_vec = embeddings.embed_texts([query], is_query=True)[0]
-                chunk_hits = idx.search(
-                    query_vec,
-                    k=candidate_k * 3,
-                    allowed_paths=semantic_paths,
-                )
+                with _span(timings, "vector.index"):
+                    idx = embeddings.get_embedding_index(vault_root)
+                with _span(timings, "vector.embed"):
+                    query_vec = embeddings.embed_texts([query], is_query=True)[0]
+                with _span(timings, "vector.search"):
+                    chunk_hits = idx.search(
+                        query_vec,
+                        k=candidate_k * 3,
+                        allowed_paths=semantic_paths,
+                    )
                 best_per_file: dict[str, tuple[float, str]] = {}
                 for fp, _idx, ctext, score in chunk_hits:
                     existing = best_per_file.get(fp)
@@ -499,182 +501,161 @@ def collect_candidates(
                 "status": "non_applicable",
                 "reason": "request_disabled",
             }
-    graph_t0 = time.perf_counter()
     if graph:
-        primary_set: set[str] = set(vector_ranking) | set(bm25_ranking)
-        vector_set: set[str] = set(vector_ranking)
-        graph_seeds: list[str] = []
-        seen_seed: set[str] = set()
-        for r in (vector_ranking, bm25_ranking):
-            for p in r[:config.graph_seed_cap]:
-                if p in seen_seed:
-                    continue
-                seen_seed.add(p)
-                if p in vector_set:
-                    graph_seeds.append(p)
-                    continue
-                page = page_of(p)
-                if page is None:
-                    continue
-                if (
-                    find_results.make_excerpt(page, query_norm) is not None
-                    or find_results.stem_tokens_present(page, query_norm)
-                ):
-                    graph_seeds.append(p)
-        graph_t_seeds = time.perf_counter()
-        graph_index = epistemic_graph.EpistemicGraphIndex(vault_root)
-        if graph_index.available():
-            # Hybrid: seeds with a sidecar file node get typed expansion; seeds
-            # outside the indexed scope (e.g. an out-of-KB page under
-            # scope="vault" — rebuild_all only walks the KB tree) have no node
-            # at all, so typed expansion alone would silently drop them. Those
-            # seeds fall back to the legacy 1-hop wikilink expansion instead,
-            # preserving pre-change recall for out-of-KB seeds.
-            indexed = graph_index.indexed_paths(graph_seeds)
-            typed_seeds = [s for s in graph_seeds if s in indexed]
-            legacy_seeds = [s for s in graph_seeds if s not in indexed]
-            neighbors = graph_index.neighbors_for(typed_seeds) if typed_seeds else []
-            graph_t_sidecar = time.perf_counter()
+        with _span(timings, "graph"):
+            primary_set: set[str] = set(vector_ranking) | set(bm25_ranking)
+            vector_set: set[str] = set(vector_ranking)
+            graph_seeds: list[str] = []
+            seen_seed: set[str] = set()
+            with _span(timings, "graph.seeds"):
+                for r in (vector_ranking, bm25_ranking):
+                    for p in r[:config.graph_seed_cap]:
+                        if p in seen_seed:
+                            continue
+                        seen_seed.add(p)
+                        if p in vector_set:
+                            graph_seeds.append(p)
+                            continue
+                        page = page_of(p)
+                        if page is None:
+                            continue
+                        if (
+                            find_results.make_excerpt(page, query_norm) is not None
+                            or find_results.stem_tokens_present(page, query_norm)
+                        ):
+                            graph_seeds.append(p)
+            graph_index = epistemic_graph.EpistemicGraphIndex(vault_root)
+            if graph_index.available():
+                # Hybrid: seeds with a sidecar file node get typed expansion; seeds
+                # outside the indexed scope (e.g. an out-of-KB page under
+                # scope="vault" — rebuild_all only walks the KB tree) have no node
+                # at all, so typed expansion alone would silently drop them. Those
+                # seeds fall back to the legacy 1-hop wikilink expansion instead,
+                # preserving pre-change recall for out-of-KB seeds.
+                with _span(timings, "graph.sidecar"):
+                    indexed = graph_index.indexed_paths(graph_seeds)
+                    typed_seeds = [s for s in graph_seeds if s in indexed]
+                    legacy_seeds = [s for s in graph_seeds if s not in indexed]
+                    neighbors = graph_index.neighbors_for(typed_seeds) if typed_seeds else []
 
-            # Family precedence MUST be decided BEFORE target dedup: when a
-            # target is reached by both a typed relation and a plain
-            # links_to/unregistered edge, first-seen-wins would let arbitrary
-            # edge order misclassify the target's tier and provenance. Group
-            # every edge touching a target, then keep the highest-precedence
-            # (lowest tier) edge as the surfacing/provenance edge. in-degree is
-            # still tallied for EVERY edge, matching the existing invariant.
-            best_tier_for_target: dict[str, int] = {}
-            best_neighbor_for_target: dict[str, epistemic_graph.GraphNeighbor] = {}
-            first_pos_for_target: dict[str, int] = {}
-            for pos, neighbor in enumerate(neighbors):
-                target_rel = neighbor.other_rel
-                if target_rel not in recall_paths:
-                    continue
-                graph_in_degree_by_path[target_rel] = (
-                    graph_in_degree_by_path.get(target_rel, 0) + 1
-                )
-                if target_rel in primary_set:
-                    continue
-                if eligible_paths is not None and target_rel not in eligible_paths:
-                    continue
-                family = neighbor.family
-                tier = 0 if (neighbor.relation_type and family and family != "link") else 1
-                current_best = best_tier_for_target.get(target_rel)
-                if current_best is None or tier < current_best:
-                    best_tier_for_target[target_rel] = tier
-                    best_neighbor_for_target[target_rel] = neighbor
-                    first_pos_for_target[target_rel] = pos
-            typed_targets = sorted(
-                best_tier_for_target,
-                key=lambda t: (best_tier_for_target[t], first_pos_for_target[t]),
-            )
-            for target_rel in typed_targets:
-                neighbor = best_neighbor_for_target[target_rel]
-                graph_provenance_by_path[target_rel] = GraphProvenance(
-                    relation_type=neighbor.relation_type,
-                    direction=neighbor.direction,
-                    seed=neighbor.seed_rel,
-                )
-            seen_target = set(typed_targets)
-
-            legacy_targets: list[str] = []
-            if legacy_seeds:
-                resolver = get_query_resolver(
-                    vault_root, freshness=snapshot.projection_key("vault")
-                )
-                for seed_rel in legacy_seeds:
-                    page = page_of(seed_rel)
-                    if page is None:
-                        continue
-                    for target_rel in outbound_wikilink_paths(
-                        page,
-                        vault_root,
-                        resolver=resolver,
-                        allowed_paths=recall_paths,
-                    ):
+                # Family precedence MUST be decided BEFORE target dedup: when a
+                # target is reached by both a typed relation and a plain
+                # links_to/unregistered edge, first-seen-wins would let arbitrary
+                # edge order misclassify the target's tier and provenance. Group
+                # every edge touching a target, then keep the highest-precedence
+                # (lowest tier) edge as the surfacing/provenance edge. in-degree is
+                # still tallied for EVERY edge, matching the existing invariant.
+                with _span(timings, "graph.expand"):
+                    best_tier_for_target: dict[str, int] = {}
+                    best_neighbor_for_target: dict[str, epistemic_graph.GraphNeighbor] = {}
+                    first_pos_for_target: dict[str, int] = {}
+                    for pos, neighbor in enumerate(neighbors):
+                        target_rel = neighbor.other_rel
                         if target_rel not in recall_paths:
                             continue
                         graph_in_degree_by_path[target_rel] = (
                             graph_in_degree_by_path.get(target_rel, 0) + 1
                         )
-                        if target_rel in primary_set or target_rel in seen_target:
+                        if target_rel in primary_set:
                             continue
                         if eligible_paths is not None and target_rel not in eligible_paths:
                             continue
-                        seen_target.add(target_rel)
-                        legacy_targets.append(target_rel)
-
-            graph_ranking = typed_targets + legacy_targets
-            if capture_trace:
-                lane_statuses["graph"] = {
-                    "status": "participated" if graph_ranking else "available_nonmatching",
-                    "backend": "epistemic_graph",
-                    "metric": {"name": "rank", "direction": "lower", "rounding": "none"},
-                }
-            if graph_ranking:
-                rankings.append(graph_ranking)
-            if timings is not None:
-                graph_t_end = time.perf_counter()
-                timings.stages.setdefault("graph", {})["ms"] = round(
-                    (graph_t_end - graph_t0) * 1000.0, 3
-                )
-                for name, t0, t1 in (
-                    ("graph.seeds", graph_t0, graph_t_seeds),
-                    ("graph.sidecar", graph_t_seeds, graph_t_sidecar),
-                    ("graph.expand", graph_t_sidecar, graph_t_end),
-                ):
-                    timings.stages[name] = {"ms": round((t1 - t0) * 1000.0, 3)}
-        else:
-            # Fallback: the pre-existing 1-hop outbound-wikilink expansion,
-            # byte-identical to the pre-change ordering. Do not refactor.
-            resolver = (
-                get_query_resolver(
-                    vault_root, freshness=snapshot.projection_key("vault")
-                )
-                if graph_seeds else None
-            )
-            graph_t_resolver = time.perf_counter()
-            seen_target = set()
-            for seed_rel in graph_seeds:
-                page = page_of(seed_rel)
-                if page is None:
-                    continue
-                for target_rel in outbound_wikilink_paths(
-                    page,
-                    vault_root,
-                    resolver=resolver,
-                    allowed_paths=recall_paths,
-                ):
-                    if target_rel not in recall_paths:
-                        continue
-                    graph_in_degree_by_path[target_rel] = (
-                        graph_in_degree_by_path.get(target_rel, 0) + 1
+                        family = neighbor.family
+                        tier = 0 if (neighbor.relation_type and family and family != "link") else 1
+                        current_best = best_tier_for_target.get(target_rel)
+                        if current_best is None or tier < current_best:
+                            best_tier_for_target[target_rel] = tier
+                            best_neighbor_for_target[target_rel] = neighbor
+                            first_pos_for_target[target_rel] = pos
+                    typed_targets = sorted(
+                        best_tier_for_target,
+                        key=lambda t: (best_tier_for_target[t], first_pos_for_target[t]),
                     )
-                    if target_rel in primary_set or target_rel in seen_target:
-                        continue
-                    if eligible_paths is not None and target_rel not in eligible_paths:
-                        continue
-                    seen_target.add(target_rel)
-                    graph_ranking.append(target_rel)
-            if graph_ranking:
-                rankings.append(graph_ranking)
-            if capture_trace:
-                lane_statuses["graph"] = {
-                    "status": "participated" if graph_ranking else "available_nonmatching",
-                    "backend": "wikilink_fallback",
-                    "metric": {"name": "rank", "direction": "lower", "rounding": "none"},
-                }
-            if timings is not None:
-                graph_t_end = time.perf_counter()
-                timings.stages.setdefault("graph", {})["ms"] = round(
-                    (graph_t_end - graph_t0) * 1000.0, 3
-                )
-                for name, t0, t1 in (
-                    ("graph.seeds", graph_t0, graph_t_seeds),
-                    ("graph.resolver", graph_t_seeds, graph_t_resolver),
-                    ("graph.expand", graph_t_resolver, graph_t_end),
-                ):
-                    timings.stages[name] = {"ms": round((t1 - t0) * 1000.0, 3)}
+                    for target_rel in typed_targets:
+                        neighbor = best_neighbor_for_target[target_rel]
+                        graph_provenance_by_path[target_rel] = GraphProvenance(
+                            relation_type=neighbor.relation_type,
+                            direction=neighbor.direction,
+                            seed=neighbor.seed_rel,
+                        )
+                    seen_target = set(typed_targets)
+
+                    legacy_targets: list[str] = []
+                    if legacy_seeds:
+                        resolver = get_query_resolver(
+                            vault_root, freshness=snapshot.projection_key("vault")
+                        )
+                        for seed_rel in legacy_seeds:
+                            page = page_of(seed_rel)
+                            if page is None:
+                                continue
+                            for target_rel in outbound_wikilink_paths(
+                                page,
+                                vault_root,
+                                resolver=resolver,
+                                allowed_paths=recall_paths,
+                            ):
+                                if target_rel not in recall_paths:
+                                    continue
+                                graph_in_degree_by_path[target_rel] = (
+                                    graph_in_degree_by_path.get(target_rel, 0) + 1
+                                )
+                                if target_rel in primary_set or target_rel in seen_target:
+                                    continue
+                                if eligible_paths is not None and target_rel not in eligible_paths:
+                                    continue
+                                seen_target.add(target_rel)
+                                legacy_targets.append(target_rel)
+
+                    graph_ranking = typed_targets + legacy_targets
+                if capture_trace:
+                    lane_statuses["graph"] = {
+                        "status": "participated" if graph_ranking else "available_nonmatching",
+                        "backend": "epistemic_graph",
+                        "metric": {"name": "rank", "direction": "lower", "rounding": "none"},
+                    }
+                if graph_ranking:
+                    rankings.append(graph_ranking)
+            else:
+                # Fallback: the pre-existing 1-hop outbound-wikilink expansion,
+                # byte-identical to the pre-change ordering. Do not refactor.
+                with _span(timings, "graph.resolver"):
+                    resolver = (
+                        get_query_resolver(
+                            vault_root, freshness=snapshot.projection_key("vault")
+                        )
+                        if graph_seeds else None
+                    )
+                    seen_target = set()
+                    for seed_rel in graph_seeds:
+                        page = page_of(seed_rel)
+                        if page is None:
+                            continue
+                        for target_rel in outbound_wikilink_paths(
+                            page,
+                            vault_root,
+                            resolver=resolver,
+                            allowed_paths=recall_paths,
+                        ):
+                            if target_rel not in recall_paths:
+                                continue
+                            graph_in_degree_by_path[target_rel] = (
+                                graph_in_degree_by_path.get(target_rel, 0) + 1
+                            )
+                            if target_rel in primary_set or target_rel in seen_target:
+                                continue
+                            if eligible_paths is not None and target_rel not in eligible_paths:
+                                continue
+                            seen_target.add(target_rel)
+                            graph_ranking.append(target_rel)
+                if graph_ranking:
+                    rankings.append(graph_ranking)
+                if capture_trace:
+                    lane_statuses["graph"] = {
+                        "status": "participated" if graph_ranking else "available_nonmatching",
+                        "backend": "wikilink_fallback",
+                        "metric": {"name": "rank", "direction": "lower", "rounding": "none"},
+                    }
 
     if not rankings:
         return empty_bundle(

--- a/src/exomem/find_candidates.py
+++ b/src/exomem/find_candidates.py
@@ -619,6 +619,12 @@ def collect_candidates(
             else:
                 # Fallback: the pre-existing 1-hop outbound-wikilink expansion,
                 # byte-identical to the pre-change ordering. Do not refactor.
+                # `graph.expand` is reported by BOTH branches, and the manual
+                # timers this replaced split the fallback at exactly this point:
+                # `graph.resolver` was resolver construction only, and everything
+                # after it was `graph.expand`. Wrapping the whole branch in one
+                # `graph.resolver` span both drops a stage other code reads and
+                # bills the expansion loop as resolver time.
                 with _span(timings, "graph.resolver"):
                     resolver = (
                         get_query_resolver(
@@ -626,6 +632,7 @@ def collect_candidates(
                         )
                         if graph_seeds else None
                     )
+                with _span(timings, "graph.expand"):
                     seen_target = set()
                     for seed_rel in graph_seeds:
                         page = page_of(seed_rel)

--- a/tests/test_read_path_timing_attribution.py
+++ b/tests/test_read_path_timing_attribution.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
-from exomem import commands, recall_policy
+from exomem import commands, embeddings, readiness, recall_policy
+from exomem import find as find_module
 from exomem.find_types import FindTimings
 
 
@@ -122,6 +123,60 @@ def test_the_query_log_projection_carries_the_unattributed_term() -> None:
 
 def test_the_query_log_projection_tolerates_no_timings() -> None:
     assert commands._timing_log_summary(None) is None
+
+
+def test_real_find_attributes_graph_materialization_and_reranking(
+    vault: Path, monkeypatch
+) -> None:
+    """A live find call must not report its major stages as unattributed."""
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    monkeypatch.setattr(embeddings, "ranking_enabled", lambda: True)
+    monkeypatch.setattr(readiness, "should_defer", lambda _component: False)
+
+    real_outbound_wikilinks = find_module._outbound_wikilink_paths
+
+    def slow_outbound_wikilinks(*args, **kwargs):
+        time.sleep(0.04)
+        return real_outbound_wikilinks(*args, **kwargs)
+
+    real_passes_filters = find_module._passes_filters
+
+    def slow_passes_filters(*args, **kwargs):
+        time.sleep(0.04)
+        return real_passes_filters(*args, **kwargs)
+
+    def slow_rerank(_query, passages):
+        time.sleep(0.04)
+        return [float(index) for index, _ in enumerate(passages)]
+
+    monkeypatch.setattr(find_module, "_outbound_wikilink_paths", slow_outbound_wikilinks)
+    monkeypatch.setattr(find_module, "_passes_filters", slow_passes_filters)
+    monkeypatch.setattr(
+        embeddings,
+        "rerank_pairs",
+        slow_rerank,
+    )
+
+    result = commands.op_find(
+        vault,
+        query="metabolism",
+        mode="hybrid",
+        graph=True,
+        rerank=True,
+        include_timings=True,
+    )
+
+    timings = result["timings"]
+    assert {"graph", "filter_hits", "rerank"} <= set(timings["stages"])
+    assert timings["unattributed_ms"] <= 0.15 * timings["total_ms"]
+
+    top_level_ms = sum(
+        stage["ms"]
+        for name, stage in timings["stages"].items()
+        if "." not in name and "ms" in stage
+    )
+    covered_ms = timings["total_ms"] - timings["unattributed_ms"]
+    assert abs(top_level_ms - covered_ms) <= 0.15 * timings["total_ms"]
 
 
 def _kb_page(vault: Path, name: str) -> Path:


### PR DESCRIPTION
Closes #983.

A novel hybrid recall reported `total_ms` ~1136 with `unattributed_ms` ~798 — **70% of the request claimed by no span**. That number was not merely incomplete, it was wrong in a way that made budget arithmetic unsound, and the cause was structural.

`unattributed_ms` is a union-of-intervals merge (`find_types.py:529-542`) that only sees intervals appended by `FindTimings.span`. Three major regions timed themselves with a manual `t0` and wrote straight into `timings.stages[...]`, never registering an interval — so their milliseconds appeared in the stages table **and simultaneously counted as unattributed**. Double-reported. The stages table was not a partition of the total, and anything computed against it was measuring noise.

## What changed

Instrumentation only. No retrieval logic moved.

- `find_candidates.py` — graph's manual timing writes become nested `graph`, `graph.seeds`, `graph.sidecar`, `graph.resolver`, `graph.expand` spans. The existing `vector` span splits into `vector.index` / `vector.embed` / `vector.search`, which previously wrapped `get_embedding_index()`, `embed_texts()` and `idx.search()` in one number.
- `find.py` — manual `filter_hits` and `rerank` writes become spans, keeping rerank's error reporting. Adds the `semantic.search` outer span. Threads `timings` into the unit vector lane, which took no collector at all, and records `vector.unit.embed`.
- `tests/test_read_path_timing_attribution.py` — a real `commands.op_find(..., include_timings=True)` test with graph and reranking on.

## Result

On a real `op_find`:

| | `unattributed_ms` | `total_ms` | share |
|---|---|---|---|
| before | 655.8 | 2771.8 | **23.7%** |
| after | 22.5 | 2485.5 | **0.9%** |

## Why the test is the deliverable

This was already a spec requirement with nothing behind it. `openspec/specs/find-recall-efficiency/spec.md:987` says material time "MUST NOT appear only as `unattributed_ms`". Every existing test in `tests/test_read_path_timing_attribution.py` built a `FindTimings` **by hand** and drove it with `time.sleep` — none ever called `find()`, which is exactly why three unspanned regions survived.

The new test calls the real thing and was shown **red on the pre-change code** before the fix went in.

It asserts over **top-level** stages only (names containing no `.`). Sub-stages nest inside their parents by design — `graph.seeds` inside `graph` — so a naive sum over every stage double-counts and would have baked the original confusion into the guard.

## Reviewing the diff

`find.py` shows 527 changed lines and `find_candidates.py` 327, which is alarming for an instrumentation change. Whitespace-insensitive it is **17 and 35 real lines**; the rest is re-indentation from wrapping blocks in `with`.

The one hazard in that kind of edit is silently re-binding an `else` or changing what a `try` covers. Checked by AST rather than by eye: the graph lane's `else` still binds to `if graph_index.available():`, and `rankings.append(graph_ranking)` remains in the true branch. The rerank change replaces a `finally:` with the span's context exit, which records on the error path identically since `FindTimings.span` is a `try/finally` generator.

`_vector_unit_candidates` gains a `timings` parameter. Both tests that monkeypatch it (`test_bounded_retrieval.py`, `test_category_candidate_algebra.py`) absorb it — one via `**_kwargs`, one via `lambda *_args, **_kwargs`.

## Known limitation, deliberately not addressed

Work after `timings.as_dict()` (`commands.py:1693`) is structurally outside the collector: `query_log.log_find_call`, envelope construction, `_with_due_state` (`commands.py:4623`), and the entire dispatcher terminal egress (`writer_lease.py:4331-4338` — `scrubber.scrub_value`, `gate_payload`, `gate_artifact_references`). That time is real and appears when measuring at the MCP tool boundary, but `FindTimings` cannot attribute it without moving where the timer stops. Left alone.

## Coverage gap worth naming

The new test sets `EXOMEM_DISABLE_EMBEDDINGS=1`, so the `vector.embed` / `vector.search` split is implemented but not exercised by it. That split is the number that decides whether #984 (the double embed) is worth doing at all, so it needs a measurement on a cell with embeddings live.
