### PR TITLE
fix(semantic): preserve compiled destinations for exempt notes

### DIFF
--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -750,25 +750,38 @@ def _path_parts(path: str) -> tuple[str, ...]:
     return tuple(part.casefold() for part in PurePosixPath(path.replace("\\", "/")).parts)
 
 
-def _path_excluded_from_semantic_minimum(path: str) -> bool:
+def _path_excluded_from_compiled_destination(path: str) -> bool:
     parts = _path_parts(path)
     if any(part in _SEMANTIC_UNIT_EXEMPT_PARTS for part in parts):
         return True
     name = parts[-1] if parts else ""
-    if name in {"hub.md", "index.md", "log.md"}:
+    return name in {"hub.md", "index.md", "log.md"}
+
+
+def _path_excluded_from_semantic_minimum(path: str) -> bool:
+    if _path_excluded_from_compiled_destination(path):
         return True
+    parts = _path_parts(path)
+    name = parts[-1] if parts else ""
     stem = PurePosixPath(name).stem
     return any(stem.endswith(suffix) for suffix in _SEMANTIC_UNIT_EXEMPT_SUFFIXES)
+
+
+def _structural_compiled_destination(path: str) -> str | None:
+    """Return a compiled route without applying minimum-unit-only exemptions."""
+    if _path_excluded_from_compiled_destination(path):
+        return None
+    parts = _path_parts(path)
+    if len(parts) < 3 or parts[:2] != ("knowledge base", "notes"):
+        return None
+    return _COMPILED_ROOT_TYPES.get(parts[2])
 
 
 def canonical_compiled_destination(path: str) -> str | None:
     """Return the compiled type selected by one canonical destination, if any."""
     if _path_excluded_from_semantic_minimum(path):
         return None
-    parts = _path_parts(path)
-    if len(parts) < 3 or parts[:2] != ("knowledge base", "notes"):
-        return None
-    return _COMPILED_ROOT_TYPES.get(parts[2])
+    return _structural_compiled_destination(path)
 
 
 def _frontmatter_tags(page: SemanticPageState) -> frozenset[str]:
@@ -799,8 +812,10 @@ def compiled_intent(page: SemanticPageState) -> bool:
 
 def compiled_structure_finding(page: SemanticPageState) -> ContractFinding | None:
     """Return a deterministic path/type mismatch before semantic applicability."""
-    destination_type = canonical_compiled_destination(page.path)
+    destination_type = _structural_compiled_destination(page.path)
     page_type = normalized_compiled_type(page.page_type)
+    if _path_excluded_from_semantic_minimum(page.path) and page_type not in COMPILED_TYPES:
+        return None
     if destination_type is not None and page_type != destination_type:
         return ContractFinding(
             code="COMPILED_TYPE_MISMATCH",

--- a/tests/test_edit_surgical_replace.py
+++ b/tests/test_edit_surgical_replace.py
@@ -32,6 +32,39 @@ def _make_page(vault: Path, body: str) -> str:
     return rel
 
 
+@pytest.mark.parametrize(
+    "address",
+    (
+        "Knowledge Base/Notes/Research/Records/personal-archive-architecture.md",
+        "Notes/Research/Records/personal-archive-architecture.md",
+    ),
+)
+def test_surgical_replace_accepts_exempt_research_hub(
+    vault: Path, address: str
+) -> None:
+    rel = "Knowledge Base/Notes/Research/Records/personal-archive-architecture.md"
+    page = vault / rel
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text(
+        "---\ntype: research-note\nproject: records\nstatus: active\n"
+        "created: 2026-05-18\nupdated: 2026-05-18\ntags: [hub]\n---\n"
+        "# Personal Archive\n\nBefore.\n",
+        encoding="utf-8",
+    )
+
+    result = edit_module.edit(
+        vault,
+        path=address,
+        why="refresh archive hub",
+        old_string="Before.",
+        new_string="After.",
+        today=TODAY,
+    )
+
+    assert result.path == rel
+    assert "After." in page.read_text(encoding="utf-8")
+
+
 def test_surgical_replace_fills_a_take(vault: Path) -> None:
     rel = _make_page(
         vault,

--- a/tests/test_semantic_contract.py
+++ b/tests/test_semantic_contract.py
@@ -207,6 +207,41 @@ def test_compiled_type_normalization_drives_eligibility_for_all_types(
 
 
 @pytest.mark.parametrize(
+    ("path", "extra"),
+    (
+        ("Knowledge Base/Notes/Research/Records/archive-architecture.md", ""),
+        ("Knowledge Base/Notes/Research/Records/archive.md", "tags: [hub]"),
+        ("Knowledge Base/Notes/Research/Records/archive-snapshot.md", ""),
+    ),
+)
+def test_exempt_compiled_page_keeps_valid_destination_structure(
+    tmp_path: Path, path: str, extra: str
+) -> None:
+    state = _state(
+        tmp_path,
+        path,
+        _source(page_type="research-note", project="records", extra=extra),
+    )
+
+    assert semantic_contract.compiled_intent(state) is True
+    assert semantic_contract.compiled_structure_finding(state) is None
+    assert semantic_contract.requires_semantic_unit(state) is False
+
+
+def test_tag_only_exemption_cannot_hide_noncompiled_type(tmp_path: Path) -> None:
+    state = _state(
+        tmp_path,
+        "Knowledge Base/Notes/Insights/ordinary.md",
+        _source(page_type="memo", extra="tags: [hub]"),
+    )
+
+    finding = semantic_contract.compiled_structure_finding(state)
+
+    assert finding is not None
+    assert finding.code == "COMPILED_TYPE_MISMATCH"
+
+
+@pytest.mark.parametrize(
     ("path", "page_type", "code"),
     (
         ("Knowledge Base/Notes/Insights/missing.md", "memo", "COMPILED_TYPE_MISMATCH"),


### PR DESCRIPTION
## Why

`edit_memory` treated descriptive `*-architecture` and `*-snapshot` notes as if they had no canonical compiled destination. A correctly typed research hub could therefore fail with `COMPILED_DESTINATION_MISMATCH`, even though it already lived under `Notes/Research`.

## What changed

- Separate paths that are structurally outside compiled destinations from filename exemptions that only waive the semantic-unit minimum.
- Validate exempt descriptive notes against their real compiled destination while preserving the minimum-unit exemption.
- Keep literal `hub.md`, `index.md`, `log.md`, administrative subtrees, wrong compiled types, and tag-only type mismatches strict.
- Cover both full and Knowledge-Base-relative `edit_memory` addresses.

## Verification

- `147 passed`: semantic contract, surgical edit, and get/edit round-trip suites.
- `206 passed`: semantic authoring, creation writers, and lifecycle writers.
- `uvx ruff check . --select F`
- `uv run python scripts/validate-public-artifacts.py --repository`
- Independent review passed after the tag-only adversarial regression was added.

A raw full-corpus attempt on Windows stopped on two unchanged platform cases: Kubernetes projected-volume `dir_fd` handling and reading an actively held writer-lease lock. The failing test and implementation blobs match `origin/main`; the maintained Linux PR shards provide the full branch gate.

Fixes #988