### PR TITLE
feat(governance): prepare consolidation apply preimage

### DIFF
--- a/src/exomem/governance/consolidation_admission.py
+++ b/src/exomem/governance/consolidation_admission.py
@@ -921,7 +921,103 @@ class ConsolidationAdmission:
         # cross-replica lifecycle/fencing layer to resolve the configuration.
         _fail("CONSOLIDATION_ADMISSION_DOMAIN_CONFLICT")
 
-    def seal_and_drain(
+    def begin_seal(
+        self,
+        *,
+        control: object,
+        authority: object,
+        run_id: str,
+        operation_id: str,
+        journal_digest: str,
+        sealed_at: str,
+        expected_revision: int,
+        timeout: float = 5.0,
+    ) -> ConsolidationAdmissionSnapshot:
+        """Persist the exact seal intent before any participant is drained."""
+
+        if (
+            not isinstance(timeout, (int, float))
+            or isinstance(timeout, bool)
+            or not math.isfinite(float(timeout))
+            or timeout < 0
+        ):
+            raise ValueError("consolidation seal timeout must be finite and non-negative")
+
+        try:
+            consolidation_authority.require_authority(
+                authority,
+                vault_binding_digest=self.vault_binding_digest,
+                run_id=run_id,
+                operation_id=operation_id,
+                journal_digest=journal_digest,
+                phase="sealing",
+                action="apply",
+            )
+        except consolidation_authority.ConsolidationAuthorityUnavailable:
+            _fail("CONSOLIDATION_AUTHORITY_UNAVAILABLE")
+        control_participant = self._require_control(
+            control,
+            run_id=run_id,
+            operation_id=operation_id,
+            journal_digest=journal_digest,
+        )
+        if (
+            type(expected_revision) is not int
+            or expected_revision < 0
+            or expected_revision > _MAX_SAFE_INTEGER
+        ):
+            _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
+        deadline = time.monotonic() + float(timeout)
+        control_id = operation_id.replace("-", "")
+        try:
+            with self._coordinator(
+                "control",
+                control_id,
+                timeout=self._remaining(deadline),
+            ).hold(
+                request_id=control_id,
+                operation="seal_intent",
+                holder_kind="reserved-state",
+                publish_holder_metadata=False,
+            ):
+                with self._gate(timeout=self._remaining(deadline)).hold(
+                    request_id=control_id,
+                    operation="seal_intent",
+                    holder_kind="reserved-state",
+                    publish_holder_metadata=False,
+                ):
+                    self._require_durable_control(control_participant)
+                    current = self._load_state()
+                    if current.kind == "consolidation-sealed":
+                        if (
+                            current.phase == "sealing"
+                            and current.run_id == run_id
+                            and current.operation_id == operation_id
+                            and current.journal_digest == journal_digest
+                            and current.sealed_at == sealed_at
+                            and current.revision == expected_revision + 1
+                        ):
+                            return self._snapshot_from(
+                                current,
+                                self._load_participants(),
+                            )
+                        _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
+                    try:
+                        state = self._store.begin_consolidation(
+                            vault_binding_digest=self.vault_binding_digest,
+                            run_id=run_id,
+                            operation_id=operation_id,
+                            journal_digest=journal_digest,
+                            sealed_at=sealed_at,
+                            expected_revision=expected_revision,
+                        )
+                    except consolidation_seal.ConsolidationSealUnavailable:
+                        _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
+                    return self._snapshot_from(state, self._load_participants())
+        except OpError:
+            _fail("CONSOLIDATION_DRAIN_BUSY")
+
+    def drain_and_seal(
         self,
         *,
         control: object,
@@ -935,7 +1031,7 @@ class ConsolidationAdmission:
         timeout: float,
         stoppers: Sequence[Callable[[], object]] = (),
     ) -> ConsolidationAdmissionSnapshot:
-        """Persist intent, close admission, drain every process, then seal."""
+        """Drain every non-control participant, then persist the sealed terminal."""
 
         if (
             not isinstance(timeout, (int, float))
@@ -958,7 +1054,6 @@ class ConsolidationAdmission:
             )
         except consolidation_authority.ConsolidationAuthorityUnavailable:
             _fail("CONSOLIDATION_AUTHORITY_UNAVAILABLE")
-
         control_participant = self._require_control(
             control,
             run_id=run_id,
@@ -971,7 +1066,6 @@ class ConsolidationAdmission:
             or expected_revision > _MAX_SAFE_INTEGER
         ):
             _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
-
         deadline = time.monotonic() + float(timeout)
         control_id = operation_id.replace("-", "")
         try:
@@ -981,44 +1075,35 @@ class ConsolidationAdmission:
                 timeout=self._remaining(deadline),
             ).hold(
                 request_id=control_id,
-                operation="seal_and_drain",
+                operation="seal_drain",
                 holder_kind="reserved-state",
                 publish_holder_metadata=False,
             ):
-                with self._gate(timeout=self._remaining(deadline)).hold(
-                    request_id=control_id,
-                    operation="seal_intent",
-                    holder_kind="reserved-state",
-                    publish_holder_metadata=False,
+                current = self._load_state()
+                if current.kind == "consolidation-sealed" and current.phase == "sealed":
+                    if (
+                        current.run_id == run_id
+                        and current.operation_id == operation_id
+                        and current.journal_digest == journal_digest
+                        and current.sealed_at == sealed_at
+                        and current.recorded_at == completed_at
+                        and current.revision == expected_revision + 1
+                    ):
+                        return self._snapshot_from(current, ())
+                    _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
+                if (
+                    current.kind != "consolidation-sealed"
+                    or current.phase != "sealing"
+                    or current.run_id != run_id
+                    or current.operation_id != operation_id
+                    or current.journal_digest != journal_digest
+                    or current.sealed_at != sealed_at
+                    or current.revision != expected_revision
                 ):
-                    self._require_durable_control(control_participant)
-                    current = self._load_state()
-                    if current.kind == "consolidation-sealed" and current.phase == "sealed":
-                        if (
-                            current.run_id == run_id
-                            and current.operation_id == operation_id
-                            and current.journal_digest == journal_digest
-                            and current.sealed_at == sealed_at
-                            and current.recorded_at == completed_at
-                            and current.revision == expected_revision + 2
-                        ):
-                            return self._snapshot_from(current, ())
-                        _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
-                    try:
-                        state = self._store.begin_consolidation(
-                            vault_binding_digest=self.vault_binding_digest,
-                            run_id=run_id,
-                            operation_id=operation_id,
-                            journal_digest=journal_digest,
-                            sealed_at=sealed_at,
-                            expected_revision=expected_revision,
-                        )
-                    except consolidation_seal.ConsolidationSealUnavailable:
-                        _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
+                    _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
 
                 for stopper in tuple(stoppers):
                     self._stop_background(stopper, deadline=deadline)
-
                 while True:
                     participants = tuple(
                         participant
@@ -1038,7 +1123,8 @@ class ConsolidationAdmission:
                 ):
                     self._require_durable_control(control_participant)
                     if any(
-                        participant.kind != "control" for participant in self._load_participants()
+                        participant.kind != "control"
+                        for participant in self._load_participants()
                     ):
                         _fail("CONSOLIDATION_DRAIN_BUSY")
                     try:
@@ -1048,7 +1134,7 @@ class ConsolidationAdmission:
                             action="apply",
                             target_phase="sealed",
                             recorded_at=completed_at,
-                            expected_revision=state.revision,
+                            expected_revision=expected_revision,
                         )
                     except consolidation_seal.ConsolidationSealUnavailable:
                         _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
@@ -1057,6 +1143,74 @@ class ConsolidationAdmission:
                 _fail("CONSOLIDATION_DRAIN_TIMEOUT")
             _fail("CONSOLIDATION_DRAIN_BUSY")
         return self._snapshot_from(state, ())
+
+    def seal_and_drain(
+        self,
+        *,
+        control: object,
+        authority: object,
+        run_id: str,
+        operation_id: str,
+        journal_digest: str,
+        sealed_at: str,
+        completed_at: str,
+        expected_revision: int,
+        timeout: float,
+        stoppers: Sequence[Callable[[], object]] = (),
+    ) -> ConsolidationAdmissionSnapshot:
+        """Persist intent, close admission, drain every process, then seal."""
+        if (
+            not isinstance(timeout, (int, float))
+            or isinstance(timeout, bool)
+            or not math.isfinite(float(timeout))
+            or timeout < 0
+        ):
+            raise ValueError("consolidation drain timeout must be finite and non-negative")
+        if not all(callable(stopper) for stopper in stoppers):
+            raise TypeError("consolidation background stoppers must be callable")
+        if (
+            type(expected_revision) is not int
+            or expected_revision < 0
+            or expected_revision > _MAX_SAFE_INTEGER
+        ):
+            _fail("CONSOLIDATION_SEAL_UNAVAILABLE")
+        deadline = time.monotonic() + float(timeout)
+        current = self._load_state()
+        if current.kind == "consolidation-sealed" and current.phase == "sealed":
+            return self.drain_and_seal(
+                control=control,
+                authority=authority,
+                run_id=run_id,
+                operation_id=operation_id,
+                journal_digest=journal_digest,
+                sealed_at=sealed_at,
+                completed_at=completed_at,
+                expected_revision=expected_revision + 1,
+                timeout=self._remaining(deadline),
+                stoppers=stoppers,
+            )
+        sealing = self.begin_seal(
+            control=control,
+            authority=authority,
+            run_id=run_id,
+            operation_id=operation_id,
+            journal_digest=journal_digest,
+            sealed_at=sealed_at,
+            expected_revision=expected_revision,
+            timeout=self._remaining(deadline),
+        )
+        return self.drain_and_seal(
+            control=control,
+            authority=authority,
+            run_id=run_id,
+            operation_id=operation_id,
+            journal_digest=journal_digest,
+            sealed_at=sealed_at,
+            completed_at=completed_at,
+            expected_revision=sealing.state.revision,
+            timeout=self._remaining(deadline),
+            stoppers=stoppers,
+        )
 
 
 __all__ = [

--- a/src/exomem/governance/consolidation_apply_coordinator.py
+++ b/src/exomem/governance/consolidation_apply_coordinator.py
@@ -1,0 +1,674 @@
+"""Receipt-first apply preparation through a verified destination preimage.
+
+This coordinator begins at the already committed cutover token reservation and
+stops before policy or content publication.  Each durable transition has its
+own receipt and effect journal so restart can distinguish prior, prepared,
+target, and mixed state without repeating an effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NoReturn
+
+from . import (
+    consolidation_admission,
+    consolidation_authority,
+    consolidation_effect_coordinator,
+    consolidation_intake,
+    consolidation_plan,
+    consolidation_plan_store,
+    consolidation_preimage,
+    consolidation_receipts,
+    consolidation_seal,
+)
+
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_COMMITTED_EVENT = re.compile(r"[0-9a-f]{64}:committed\Z")
+_UUID4 = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
+)
+_EFFECT_SCHEMA = "exomem.consolidation-apply-preparation-effect/v1"
+
+__all__ = [
+    "ApplyPreparationResult",
+    "ConsolidationApplyPreparationUnavailable",
+    "prepare_apply_through_preimage",
+]
+
+
+class ConsolidationApplyPreparationUnavailable(RuntimeError):
+    """Content-free refusal for invalid or ambiguous apply preparation state."""
+
+    code = "CONSOLIDATION_APPLY_PREPARATION_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True, slots=True)
+class ApplyPreparationResult:
+    seal_intent: consolidation_effect_coordinator.EffectExecutionResult
+    seal_drained: consolidation_effect_coordinator.EffectExecutionResult
+    preimage_effect: consolidation_effect_coordinator.EffectExecutionResult
+    preimage_plan: consolidation_preimage.DestinationPreimagePlan
+    preimage: consolidation_preimage.DestinationPreimage
+    seal_state: consolidation_seal.ConsolidationSealState
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationApplyPreparationUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _uuid4(value: object) -> str:
+    if not isinstance(value, str) or _UUID4.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _effect_digest(kind: str, state: str, facts: dict[str, object]) -> str:
+    try:
+        raw = consolidation_plan.canonical_closed_jcs(
+            {
+                "schema": _EFFECT_SCHEMA,
+                "kind": kind,
+                "state": state,
+                "facts": facts,
+            }
+        )
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    domain = _EFFECT_SCHEMA.encode("ascii")
+    framed = (
+        len(domain).to_bytes(4, "big")
+        + domain
+        + len(raw).to_bytes(8, "big")
+        + raw
+    )
+    return hashlib.sha256(framed).hexdigest()
+
+
+def _observation(
+    state: str,
+    digest: str,
+) -> consolidation_effect_coordinator.EffectObservation:
+    return consolidation_effect_coordinator.EffectObservation(  # type: ignore[arg-type]
+        state=state,
+        digest=digest,
+    )
+
+
+def _committed_token_parent(
+    vault_root: Path,
+    *,
+    event_id: str,
+    payload_digest: str,
+    run_id: str,
+    operation_id: str,
+    request_digest: str,
+    plan_digest: str,
+) -> tuple[int, str, str]:
+    if not isinstance(event_id, str) or _COMMITTED_EVENT.fullmatch(event_id) is None:
+        _fail()
+    expected_payload = _digest(payload_digest)
+    matches = [
+        record
+        for record in consolidation_receipts._active_records(vault_root)  # noqa: SLF001
+        if record.get("event_type") == "consolidation"
+        and record.get("phase") == "committed"
+        and record.get("event_id") == event_id
+    ]
+    if len(matches) != 1:
+        _fail()
+    try:
+        nested = consolidation_receipts.validate_nested(
+            matches[0].get("consolidation_event"),
+            outer_phase="committed",
+        )
+    except consolidation_receipts.ConsolidationReceiptUnavailable:
+        _fail()
+    if (
+        nested["kind"] != "token-reservation"
+        or nested["run_id"] != run_id
+        or nested["operation_id"] != operation_id
+        or nested["request_digest"] != request_digest
+        or nested["payload_digest"] != expected_payload
+        or nested["evidence"]["plan_digest"] != plan_digest
+    ):
+        _fail()
+    return int(nested["effect_ordinal"]), event_id, expected_payload
+
+
+def _seal_matches(
+    state: consolidation_seal.ConsolidationSealState,
+    *,
+    phase: str,
+    revision: int,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+    sealed_at: str,
+    recorded_at: str,
+) -> bool:
+    return (
+        state.kind == "consolidation-sealed"
+        and state.phase == phase
+        and state.revision == revision
+        and state.vault_binding_digest == vault_binding_digest
+        and state.run_id == run_id
+        and state.operation_id == operation_id
+        and state.journal_digest == journal_digest
+        and state.sealed_at == sealed_at
+        and state.recorded_at == recorded_at
+    )
+
+
+def _apply_lineage_matches(
+    state: consolidation_seal.ConsolidationSealState,
+    *,
+    minimum_phase: str,
+    base_revision: int,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+    sealed_at: str,
+) -> bool:
+    revisions: dict[str, int] = {}
+    phase = "sealing"
+    revision = 1
+    while phase not in revisions:
+        revisions[phase] = revision
+        successor = consolidation_seal._PHASE_SUCCESSORS.get(phase)  # noqa: SLF001
+        if successor is None:
+            break
+        phase = successor
+        revision += 1
+    current_revision = revisions.get(str(state.phase))
+    minimum_revision = revisions.get(minimum_phase)
+    if current_revision is None or minimum_revision is None:
+        return False
+    return (
+        current_revision >= minimum_revision
+        and state.kind == "consolidation-sealed"
+        and state.revision == base_revision + current_revision
+        and state.vault_binding_digest == vault_binding_digest
+        and state.run_id == run_id
+        and state.operation_id == operation_id
+        and state.journal_digest == journal_digest
+        and state.sealed_at == sealed_at
+    )
+
+
+def _apply_base_revision(
+    state: consolidation_seal.ConsolidationSealState,
+    *,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+    sealed_at: str,
+) -> int:
+    if state.kind == "open" and state.vault_binding_digest == vault_binding_digest:
+        return state.revision
+    if (
+        state.kind != "consolidation-sealed"
+        or state.vault_binding_digest != vault_binding_digest
+        or state.run_id != run_id
+        or state.operation_id != operation_id
+        or state.journal_digest != journal_digest
+        or state.sealed_at != sealed_at
+    ):
+        _fail()
+    phase = "sealing"
+    increment = 1
+    while True:
+        if state.phase == phase:
+            base = state.revision - increment
+            if base < 0:
+                _fail()
+            return base
+        successor = consolidation_seal._PHASE_SUCCESSORS.get(phase)  # noqa: SLF001
+        if successor is None:
+            _fail()
+        phase = successor
+        increment += 1
+
+
+def prepare_apply_through_preimage(
+    *,
+    vault_root: Path | str,
+    admission: consolidation_admission.ConsolidationAdmission,
+    control: consolidation_admission.ConsolidationControlAdmission,
+    artifact_store: consolidation_intake.PrivateConsolidationArtifactStore,
+    token_reservation_event_id: str,
+    token_reservation_payload_digest: str,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+    request_digest: str,
+    plan_digest: str,
+    sealed_at: str,
+    drained_at: str,
+    preimage_ready_at: str,
+    now: int,
+    timeout: float,
+) -> ApplyPreparationResult:
+    """Seal, drain, and prove the exact preimage; publish no policy or content."""
+
+    root = Path(vault_root).absolute()
+    if (
+        not isinstance(admission, consolidation_admission.ConsolidationAdmission)
+        or admission.vault_root != root
+        or not isinstance(
+            control,
+            consolidation_admission.ConsolidationControlAdmission,
+        )
+        or not isinstance(
+            artifact_store,
+            consolidation_intake.PrivateConsolidationArtifactStore,
+        )
+    ):
+        _fail()
+    checked_run = _uuid4(run_id)
+    checked_operation = _uuid4(operation_id)
+    checked_vault = _digest(vault_binding_digest)
+    checked_journal = _digest(journal_digest)
+    checked_request = _digest(request_digest)
+    checked_plan = _digest(plan_digest)
+    if (
+        admission.vault_binding_digest != checked_vault
+        or type(now) is not int
+        or now < 0
+        or not isinstance(timeout, (int, float))
+        or isinstance(timeout, bool)
+        or not math.isfinite(float(timeout))
+        or timeout < 0
+    ):
+        _fail()
+    try:
+        _sealed_text, sealed_time = consolidation_plan._timestamp(  # noqa: SLF001
+            sealed_at
+        )
+        _drained_text, drained_time = consolidation_plan._timestamp(  # noqa: SLF001
+            drained_at
+        )
+        _ready_text, ready_time = consolidation_plan._timestamp(  # noqa: SLF001
+            preimage_ready_at
+        )
+        if not sealed_time < drained_time < ready_time:
+            _fail()
+        stored_plan = consolidation_plan_store.ConsolidationPlanStore(root).load(
+            checked_run,
+            plan_kind="cutover",
+            plan_digest=checked_plan,
+        )
+        if (
+            stored_plan.digest != checked_plan
+            or stored_plan.preimage["run_id"] != checked_run
+            or stored_plan.preimage["plan_kind"] != "cutover"
+        ):
+            _fail()
+        checked_basis = _digest(stored_plan.control_basis.digest)
+        checked_snapshot = _digest(
+            stored_plan.preimage["destination_snapshot_fingerprint"]
+        )
+        checked_census = _digest(
+            stored_plan.preimage["expected_destination_preimage_census_digest"]
+        )
+        parent_ordinal, parent_id, parent_digest = _committed_token_parent(
+            root,
+            event_id=token_reservation_event_id,
+            payload_digest=token_reservation_payload_digest,
+            run_id=checked_run,
+            operation_id=checked_operation,
+            request_digest=checked_request,
+            plan_digest=checked_plan,
+        )
+        sealing_authority = consolidation_authority.issue_authority(
+            vault_binding_digest=checked_vault,
+            run_id=checked_run,
+            operation_id=checked_operation,
+            journal_digest=checked_journal,
+            phase="sealing",
+            action="apply",
+        )
+        base_revision = _apply_base_revision(
+            admission.reload().state,
+            vault_binding_digest=checked_vault,
+            run_id=checked_run,
+            operation_id=checked_operation,
+            journal_digest=checked_journal,
+            sealed_at=sealed_at,
+        )
+        seal_facts = {
+            "vault_binding_digest": checked_vault,
+            "run_id": checked_run,
+            "operation_id": checked_operation,
+            "journal_digest": checked_journal,
+            "sealed_at": sealed_at,
+            "expected_revision": base_revision,
+        }
+        seal_prior = _effect_digest("seal-intent", "prior", seal_facts)
+        seal_target = _effect_digest("seal-intent", "target", seal_facts)
+        seal_basis = _effect_digest("seal-intent", "basis", seal_facts)
+
+        def classify_seal_intent() -> consolidation_effect_coordinator.EffectObservation:
+            state = admission.reload().state
+            if (
+                state.kind == "open"
+                and state.revision == base_revision
+                and state.vault_binding_digest == checked_vault
+            ):
+                return _observation("prior", seal_prior)
+            if _apply_lineage_matches(
+                state,
+                minimum_phase="sealing",
+                base_revision=base_revision,
+                vault_binding_digest=checked_vault,
+                run_id=checked_run,
+                operation_id=checked_operation,
+                journal_digest=checked_journal,
+                sealed_at=sealed_at,
+            ):
+                return _observation("target", seal_target)
+            return _observation("mixed", state.state_digest)
+
+        seal_intent_event = consolidation_receipts.build_intent(
+            kind="seal-intent",
+            run_id=checked_run,
+            operation_id=checked_operation,
+            phase="sealing",
+            effect_ordinal=parent_ordinal + 1,
+            request_digest=checked_request,
+            prior_digest=seal_prior,
+            target_digest=seal_target,
+            evidence=consolidation_receipts.build_evidence(
+                kind="seal-intent",
+                digests={"seal_basis_digest": seal_basis},
+            ),
+            semantic_parent_event_id=parent_id,
+            semantic_parent_payload_digest=parent_digest,
+        )
+        seal_intent = consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=root,
+            event=seal_intent_event,
+            journal=consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+                root,
+                run_id=checked_run,
+                effect_ordinal=parent_ordinal + 1,
+            ),
+            classify=classify_seal_intent,
+            apply_effect=lambda: admission.begin_seal(
+                control=control,
+                authority=sealing_authority,
+                run_id=checked_run,
+                operation_id=checked_operation,
+                journal_digest=checked_journal,
+                sealed_at=sealed_at,
+                expected_revision=base_revision,
+                timeout=timeout,
+            ),
+            timestamp=sealed_at,
+        )
+
+        drain_facts = {**seal_facts, "drained_at": drained_at}
+        drain_prior = _effect_digest("seal-drained", "prior", drain_facts)
+        drain_target = _effect_digest("seal-drained", "target", drain_facts)
+        drain_digest = _effect_digest("seal-drained", "drain", drain_facts)
+
+        def classify_drained() -> consolidation_effect_coordinator.EffectObservation:
+            state = admission.reload().state
+            if _seal_matches(
+                state,
+                phase="sealing",
+                revision=base_revision + 1,
+                vault_binding_digest=checked_vault,
+                run_id=checked_run,
+                operation_id=checked_operation,
+                journal_digest=checked_journal,
+                sealed_at=sealed_at,
+                recorded_at=sealed_at,
+            ):
+                return _observation("prior", drain_prior)
+            if _apply_lineage_matches(
+                state,
+                minimum_phase="sealed",
+                base_revision=base_revision,
+                vault_binding_digest=checked_vault,
+                run_id=checked_run,
+                operation_id=checked_operation,
+                journal_digest=checked_journal,
+                sealed_at=sealed_at,
+            ):
+                return _observation("target", drain_target)
+            return _observation("mixed", state.state_digest)
+
+        drain_event = consolidation_receipts.build_intent(
+            kind="seal-drained",
+            run_id=checked_run,
+            operation_id=checked_operation,
+            phase="sealed",
+            effect_ordinal=parent_ordinal + 2,
+            request_digest=checked_request,
+            prior_digest=drain_prior,
+            target_digest=drain_target,
+            evidence=consolidation_receipts.build_evidence(
+                kind="seal-drained",
+                digests={
+                    "drain_digest": drain_digest,
+                    "seal_basis_digest": seal_basis,
+                },
+            ),
+            semantic_parent_event_id=seal_intent.terminal.event_id,
+            semantic_parent_payload_digest=seal_intent.terminal.payload_digest,
+        )
+        seal_drained = consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=root,
+            event=drain_event,
+            journal=consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+                root,
+                run_id=checked_run,
+                effect_ordinal=parent_ordinal + 2,
+            ),
+            classify=classify_drained,
+            apply_effect=lambda: admission.drain_and_seal(
+                control=control,
+                authority=sealing_authority,
+                run_id=checked_run,
+                operation_id=checked_operation,
+                journal_digest=checked_journal,
+                sealed_at=sealed_at,
+                completed_at=drained_at,
+                expected_revision=base_revision + 1,
+                timeout=timeout,
+            ),
+            timestamp=drained_at,
+        )
+
+        binding = consolidation_preimage.DestinationPreimageBinding(
+            run_id=checked_run,
+            operation_id=checked_operation,
+            plan_digest=checked_plan,
+            control_basis_digest=checked_basis,
+            semantic_predecessor_event_id=seal_drained.terminal.event_id,
+            semantic_predecessor_digest=seal_drained.terminal.payload_digest,
+            destination_snapshot_fingerprint=checked_snapshot,
+            destination_census_digest=checked_census,
+        )
+        preimage_plan = consolidation_preimage.plan_local_destination_preimage(
+            root,
+            binding=binding,
+            artifact_store=artifact_store,
+            now=now,
+        )
+        preimage_facts = {
+            "manifest_digest": preimage_plan.manifest_digest,
+            "seal_drained_effect_digest": drain_target,
+            "preimage_ready_at": preimage_ready_at,
+        }
+        preimage_prior = _effect_digest("preimage", "prior", preimage_facts)
+        preimage_prepared = _effect_digest("preimage", "prepared", preimage_facts)
+        preimage_target = _effect_digest("preimage", "target", preimage_facts)
+        manifest_ref = (
+            "exomem-consolidation-preimage://sha256/"
+            f"{preimage_plan.manifest_digest}"
+        )
+        manifest_path = (
+            artifact_store.root / "preimages" / f"{preimage_plan.manifest_digest}.json"
+        )
+
+        def manifest_is_absent() -> bool:
+            try:
+                manifest_path.lstat()
+            except FileNotFoundError:
+                return True
+            except OSError:
+                return False
+            return False
+
+        def verified_preimage() -> consolidation_preimage.DestinationPreimage | None:
+            try:
+                return consolidation_preimage.verify_destination_preimage(
+                    manifest_ref,
+                    binding=binding,
+                    artifact_store=artifact_store,
+                )
+            except consolidation_preimage.ConsolidationPreimageUnavailable:
+                return None
+
+        def classify_preimage() -> consolidation_effect_coordinator.EffectObservation:
+            state = admission.reload().state
+            verified = verified_preimage()
+            if _seal_matches(
+                state,
+                phase="sealed",
+                revision=base_revision + 2,
+                vault_binding_digest=checked_vault,
+                run_id=checked_run,
+                operation_id=checked_operation,
+                journal_digest=checked_journal,
+                sealed_at=sealed_at,
+                recorded_at=drained_at,
+            ):
+                if verified is not None:
+                    return _observation("prepared", preimage_prepared)
+                if manifest_is_absent():
+                    return _observation("prior", preimage_prior)
+            if _seal_matches(
+                state,
+                phase="preimage-ready",
+                revision=base_revision + 3,
+                vault_binding_digest=checked_vault,
+                run_id=checked_run,
+                operation_id=checked_operation,
+                journal_digest=checked_journal,
+                sealed_at=sealed_at,
+                recorded_at=preimage_ready_at,
+            ) and verified is not None:
+                return _observation("target", preimage_target)
+            return _observation("mixed", state.state_digest)
+
+        sealed_authority = consolidation_authority.issue_authority(
+            vault_binding_digest=checked_vault,
+            run_id=checked_run,
+            operation_id=checked_operation,
+            journal_digest=checked_journal,
+            phase="sealed",
+            action="apply",
+        )
+
+        def advance_preimage_ready() -> None:
+            consolidation_seal.ConsolidationSealStore(root).advance_consolidation(
+                sealed_authority,
+                vault_binding_digest=checked_vault,
+                action="apply",
+                target_phase="preimage-ready",
+                recorded_at=preimage_ready_at,
+                expected_revision=base_revision + 2,
+            )
+
+        def materialize_and_advance() -> None:
+            consolidation_preimage.materialize_planned_destination_preimage(
+                root,
+                plan=preimage_plan,
+                artifact_store=artifact_store,
+                now=now,
+            )
+            advance_preimage_ready()
+
+        preimage_event = consolidation_receipts.build_intent(
+            kind="preimage",
+            run_id=checked_run,
+            operation_id=checked_operation,
+            phase="preimage",
+            effect_ordinal=parent_ordinal + 3,
+            request_digest=checked_request,
+            prior_digest=preimage_prior,
+            prepared_digest=preimage_prepared,
+            target_digest=preimage_target,
+            evidence=consolidation_receipts.build_evidence(
+                kind="preimage",
+                digests={"preimage_manifest_digest": preimage_plan.manifest_digest},
+            ),
+            semantic_parent_event_id=seal_drained.terminal.event_id,
+            semantic_parent_payload_digest=seal_drained.terminal.payload_digest,
+        )
+        preimage_effect = consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=root,
+            event=preimage_event,
+            journal=consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+                root,
+                run_id=checked_run,
+                effect_ordinal=parent_ordinal + 3,
+            ),
+            classify=classify_preimage,
+            apply_effect=materialize_and_advance,
+            resume_effect=advance_preimage_ready,
+            timestamp=preimage_ready_at,
+        )
+        preimage = consolidation_preimage.verify_destination_preimage(
+            manifest_ref,
+            binding=binding,
+            artifact_store=artifact_store,
+        )
+        seal_state = admission.reload().state
+        if seal_state.phase != "preimage-ready":
+            _fail()
+        return ApplyPreparationResult(
+            seal_intent=seal_intent,
+            seal_drained=seal_drained,
+            preimage_effect=preimage_effect,
+            preimage_plan=preimage_plan,
+            preimage=preimage,
+            seal_state=seal_state,
+        )
+    except ConsolidationApplyPreparationUnavailable:
+        raise
+    except (
+        consolidation_admission.ConsolidationAdmissionUnavailable,
+        consolidation_authority.ConsolidationAuthorityUnavailable,
+        consolidation_effect_coordinator.ConsolidationEffectUnavailable,
+        consolidation_intake.ConsolidationIntakeUnavailable,
+        consolidation_plan_store.ConsolidationPlanStoreUnavailable,
+        consolidation_preimage.ConsolidationPreimageUnavailable,
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        consolidation_seal.ConsolidationSealUnavailable,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ):
+        _fail()

--- a/src/exomem/governance/consolidation_preimage.py
+++ b/src/exomem/governance/consolidation_preimage.py
@@ -61,7 +61,10 @@ __all__ = [
     "DestinationPreimageBinding",
     "DestinationPreimageEntry",
     "DestinationPreimageLimits",
+    "DestinationPreimagePlan",
     "materialize_local_destination_preimage",
+    "materialize_planned_destination_preimage",
+    "plan_local_destination_preimage",
     "verify_destination_preimage",
 ]
 
@@ -112,6 +115,17 @@ class DestinationPreimage:
     entries: tuple[DestinationPreimageEntry, ...]
     manifest_digest: str
     manifest_ref: str
+
+
+@dataclass(frozen=True, slots=True)
+class DestinationPreimagePlan:
+    binding: DestinationPreimageBinding
+    limits: DestinationPreimageLimits
+    entry_count: int
+    total_bytes: int
+    entries: tuple[DestinationPreimageEntry, ...]
+    manifest_bytes: bytes
+    manifest_digest: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -247,6 +261,82 @@ def _manifest_value(
         "total_bytes": total,
         "entries": [_entry_dict(item) for item in entries],
     }
+
+
+def _planned_entries(
+    materials: tuple[_MaterialSource, ...],
+) -> tuple[DestinationPreimageEntry, ...]:
+    return tuple(
+        DestinationPreimageEntry(
+            path=item.entry.path,
+            size=item.entry.size,
+            sha256=item.entry.sha256,
+            artifact_ref=(
+                "exomem-consolidation-object://sha256/" f"{item.entry.sha256}"
+            ),
+        )
+        for item in materials
+    )
+
+
+def _plan(value: object) -> DestinationPreimagePlan:
+    if not isinstance(value, DestinationPreimagePlan):
+        _fail()
+    binding = _binding(value.binding)
+    limits = _limits(value.limits)
+    if not isinstance(value.entries, tuple) or not all(
+        isinstance(item, DestinationPreimageEntry) for item in value.entries
+    ):
+        _fail()
+    checked_entries: list[DestinationPreimageEntry] = []
+    for item in value.entries:
+        path = _path(item.path)
+        size = _integer(item.size)
+        digest = _digest(item.sha256)
+        artifact_ref = item.artifact_ref
+        match = (
+            _OBJECT_REF.fullmatch(artifact_ref)
+            if isinstance(artifact_ref, str)
+            else None
+        )
+        if match is None or match.group(1) != digest:
+            _fail()
+        checked_entries.append(
+            DestinationPreimageEntry(
+                path=path,
+                size=size,
+                sha256=digest,
+                artifact_ref=artifact_ref,
+            )
+        )
+    entries = tuple(checked_entries)
+    manifest_bytes = _canonical(_manifest_value(binding, entries))
+    if (
+        not isinstance(value.manifest_bytes, bytes)
+        or value.manifest_bytes != manifest_bytes
+        or len(manifest_bytes) > _MAX_MANIFEST_BYTES
+        or _digest(value.manifest_digest) != hashlib.sha256(manifest_bytes).hexdigest()
+        or _integer(value.entry_count) != len(entries)
+        or _integer(value.total_bytes) != sum(item.size for item in entries)
+    ):
+        _fail()
+    parsed = json.loads(manifest_bytes)
+    checked = _result_from_value(
+        parsed,
+        manifest_digest=value.manifest_digest,
+        manifest_ref=f"exomem-consolidation-preimage://sha256/{value.manifest_digest}",
+    )
+    if checked.binding != binding or checked.entries != entries:
+        _fail()
+    return DestinationPreimagePlan(
+        binding=binding,
+        limits=limits,
+        entry_count=checked.entry_count,
+        total_bytes=checked.total_bytes,
+        entries=checked.entries,
+        manifest_bytes=manifest_bytes,
+        manifest_digest=value.manifest_digest,
+    )
 
 
 def _available_bytes(path: Path) -> int:
@@ -463,7 +553,7 @@ def _result_from_value(
     )
 
 
-def materialize_local_destination_preimage(
+def plan_local_destination_preimage(
     vault_root: Path | str,
     *,
     binding: DestinationPreimageBinding,
@@ -471,8 +561,8 @@ def materialize_local_destination_preimage(
     now: int,
     portability_limits: hosted_portability.PortabilityLimits | None = None,
     resource_limits: DestinationPreimageLimits | None = None,
-) -> DestinationPreimage:
-    """Copy and publish one complete plan-bound destination preimage."""
+) -> DestinationPreimagePlan:
+    """Plan exact preimage bytes without creating or changing private artifacts."""
 
     checked_binding = _binding(binding)
     checked_limits = _limits(resource_limits or DestinationPreimageLimits())
@@ -480,13 +570,13 @@ def materialize_local_destination_preimage(
         _fail()
     root = Path(vault_root)
     try:
-        first_snapshot, census, materials = _sample_material(
+        snapshot, census, materials = _sample_material(
             root,
             now=now,
             portability_limits=portability_limits,
         )
         if (
-            first_snapshot.digest != checked_binding.destination_snapshot_fingerprint
+            snapshot.digest != checked_binding.destination_snapshot_fingerprint
             or census.digest != checked_binding.destination_census_digest
             or len(materials) > checked_limits.max_files
         ):
@@ -494,56 +584,21 @@ def materialize_local_destination_preimage(
         total_bytes = sum(item.entry.size for item in materials)
         if total_bytes > checked_limits.max_total_bytes:
             _fail()
-        planned_entries = tuple(
-            DestinationPreimageEntry(
-                path=item.entry.path,
-                size=item.entry.size,
-                sha256=item.entry.sha256,
-                artifact_ref=(
-                    "exomem-consolidation-object://sha256/"
-                    f"{item.entry.sha256}"
-                ),
-            )
-            for item in materials
-        )
+        planned_entries = _planned_entries(materials)
         manifest_bytes = _canonical(_manifest_value(checked_binding, planned_entries))
         if len(manifest_bytes) > _MAX_MANIFEST_BYTES:
             _fail()
         required = total_bytes + len(manifest_bytes) + checked_limits.minimum_free_bytes
         if required > _MAX_SAFE_INTEGER or _available_bytes(artifact_store.root) < required:
             _fail()
-
-        artifact_store._ensure()  # noqa: SLF001 - shared private-store boundary
-        transaction = Path(tempfile.mkdtemp(prefix=".preimage-build-", dir=artifact_store.root))
-        os.chmod(transaction, 0o700)
-        try:
-            for ordinal, (material, planned) in enumerate(
-                zip(materials, planned_entries, strict=True)
-            ):
-                staged = transaction / f"{ordinal:06d}.object"
-                _write_material(material, staged)
-                artifact_ref = artifact_store.install_object_file(
-                    staged,
-                    expected_digest=material.entry.sha256,
-                )
-                if artifact_ref != planned.artifact_ref:
-                    _fail()
-                staged.unlink(missing_ok=True)
-
-            final_snapshot, final_census, _final_material = _sample_material(
-                root,
-                now=now,
-                portability_limits=portability_limits,
-            )
-            if final_snapshot != first_snapshot or final_census != census:
-                _fail()
-            manifest_ref = artifact_store.install_preimage_bytes(manifest_bytes)
-        finally:
-            shutil.rmtree(transaction, ignore_errors=True)
-        return verify_destination_preimage(
-            manifest_ref,
+        return DestinationPreimagePlan(
             binding=checked_binding,
-            artifact_store=artifact_store,
+            limits=checked_limits,
+            entry_count=len(planned_entries),
+            total_bytes=total_bytes,
+            entries=planned_entries,
+            manifest_bytes=manifest_bytes,
+            manifest_digest=hashlib.sha256(manifest_bytes).hexdigest(),
         )
     except ConsolidationPreimageUnavailable:
         raise
@@ -557,6 +612,127 @@ def materialize_local_destination_preimage(
         ValueError,
     ):
         _fail()
+
+
+def materialize_planned_destination_preimage(
+    vault_root: Path | str,
+    *,
+    plan: DestinationPreimagePlan,
+    artifact_store: consolidation_intake.PrivateConsolidationArtifactStore,
+    now: int,
+    portability_limits: hosted_portability.PortabilityLimits | None = None,
+) -> DestinationPreimage:
+    """Publish only the exact bytes committed by a read-only preimage plan."""
+
+    checked_plan = _plan(plan)
+    if not isinstance(artifact_store, consolidation_intake.PrivateConsolidationArtifactStore):
+        _fail()
+    root = Path(vault_root)
+    try:
+        first_snapshot, census, materials = _sample_material(
+            root,
+            now=now,
+            portability_limits=portability_limits,
+        )
+        if (
+            first_snapshot.digest
+            != checked_plan.binding.destination_snapshot_fingerprint
+            or census.digest != checked_plan.binding.destination_census_digest
+            or _planned_entries(materials) != checked_plan.entries
+            or len(materials) > checked_plan.limits.max_files
+            or sum(item.entry.size for item in materials)
+            > checked_plan.limits.max_total_bytes
+        ):
+            _fail()
+        required = (
+            checked_plan.total_bytes
+            + len(checked_plan.manifest_bytes)
+            + checked_plan.limits.minimum_free_bytes
+        )
+        if required > _MAX_SAFE_INTEGER or _available_bytes(artifact_store.root) < required:
+            _fail()
+
+        artifact_store._ensure()  # noqa: SLF001 - shared private-store boundary
+        transaction = Path(tempfile.mkdtemp(prefix=".preimage-build-", dir=artifact_store.root))
+        os.chmod(transaction, 0o700)
+        try:
+            for ordinal, (material, planned) in enumerate(
+                zip(materials, checked_plan.entries, strict=True)
+            ):
+                staged = transaction / f"{ordinal:06d}.object"
+                _write_material(material, staged)
+                artifact_ref = artifact_store.install_object_file(
+                    staged,
+                    expected_digest=material.entry.sha256,
+                )
+                if artifact_ref != planned.artifact_ref:
+                    _fail()
+                staged.unlink(missing_ok=True)
+
+            final_snapshot, final_census, final_materials = _sample_material(
+                root,
+                now=now,
+                portability_limits=portability_limits,
+            )
+            if (
+                final_snapshot != first_snapshot
+                or final_census != census
+                or _planned_entries(final_materials) != checked_plan.entries
+            ):
+                _fail()
+            manifest_ref = artifact_store.install_preimage_bytes(
+                checked_plan.manifest_bytes
+            )
+        finally:
+            shutil.rmtree(transaction, ignore_errors=True)
+        result = verify_destination_preimage(
+            manifest_ref,
+            binding=checked_plan.binding,
+            artifact_store=artifact_store,
+        )
+        if result.manifest_digest != checked_plan.manifest_digest:
+            _fail()
+        return result
+    except ConsolidationPreimageUnavailable:
+        raise
+    except (
+        consolidation_fingerprints.ConsolidationFingerprintUnavailable,
+        consolidation_intake.ConsolidationIntakeUnavailable,
+        hosted_portability.PortabilityError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ):
+        _fail()
+
+
+def materialize_local_destination_preimage(
+    vault_root: Path | str,
+    *,
+    binding: DestinationPreimageBinding,
+    artifact_store: consolidation_intake.PrivateConsolidationArtifactStore,
+    now: int,
+    portability_limits: hosted_portability.PortabilityLimits | None = None,
+    resource_limits: DestinationPreimageLimits | None = None,
+) -> DestinationPreimage:
+    """Plan, copy, and publish one complete destination preimage."""
+
+    plan = plan_local_destination_preimage(
+        vault_root,
+        binding=binding,
+        artifact_store=artifact_store,
+        now=now,
+        portability_limits=portability_limits,
+        resource_limits=resource_limits,
+    )
+    return materialize_planned_destination_preimage(
+        vault_root,
+        plan=plan,
+        artifact_store=artifact_store,
+        now=now,
+        portability_limits=portability_limits,
+    )
 
 
 def verify_destination_preimage(

--- a/src/exomem/governance/consolidation_receipts.py
+++ b/src/exomem/governance/consolidation_receipts.py
@@ -102,7 +102,9 @@ _ORDINAL_FIELD = {
     "render-page": "page_ordinal",
     "render-ack": "page_ordinal",
 }
-_PREPARED_KINDS = frozenset({"content-batch", "rollback-restore-batch"})
+_PREPARED_KINDS = frozenset(
+    {"preimage", "content-batch", "rollback-restore-batch"}
+)
 _CONDITIONAL_SUCCESSOR_KINDS = frozenset({"reconcile", "repair-terminal"})
 _REQUIRED_SUCCESSOR_KINDS = frozenset(
     {

--- a/tests/test_consolidation_apply_coordinator.py
+++ b/tests/test_consolidation_apply_coordinator.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from exomem.governance import consolidation_fingerprints, consolidation_receipts
+from exomem.governance.consolidation_identity import ConsolidationCellIdentity
+
+RUN_ID = "00000000-0000-4000-8000-0000000000d1"
+OPERATION_ID = "00000000-0000-4000-8000-0000000000d2"
+PRIOR_RUN_ID = "00000000-0000-4000-8000-0000000000e1"
+PRIOR_OPERATION_ID = "00000000-0000-4000-8000-0000000000e2"
+VAULT_BINDING = hashlib.sha256(b"apply-preparation-vault").hexdigest()
+JOURNAL_DIGEST = hashlib.sha256(b"apply-preparation-journal").hexdigest()
+PRIOR_JOURNAL_DIGEST = hashlib.sha256(b"prior-apply-journal").hexdigest()
+REQUEST_DIGEST = hashlib.sha256(b"apply-preparation-request").hexdigest()
+PLAN_DIGEST = hashlib.sha256(b"apply-preparation-plan").hexdigest()
+CONTROL_BASIS_DIGEST = hashlib.sha256(b"apply-preparation-control").hexdigest()
+T0 = "2026-08-30T12:00:00.000Z"
+T1 = "2026-08-30T12:00:01.000Z"
+T2 = "2026-08-30T12:00:02.000Z"
+T3 = "2026-08-30T12:00:03.000Z"
+
+
+class SimulatedProcessCrash(BaseException):
+    pass
+
+
+def _identity(tmp_path: Path) -> ConsolidationCellIdentity:
+    def digest(value: bytes) -> str:
+        return hashlib.sha256(value).hexdigest()
+
+    return ConsolidationCellIdentity(
+        schema="exomem.consolidation-cell-identity/v1",
+        cell_id="cell-apply-preparation",
+        vault_id="vault-apply-preparation",
+        installation_id="installation-apply-preparation",
+        installation_generation=2,
+        active_fence_digest=digest(b"fence"),
+        root_binding_id="attachment-apply-preparation",
+        root_binding_digest=digest(b"root"),
+        machine_key_id="key-apply-preparation",
+        adoption_census_digest=digest(b"adoption"),
+        clone_of_vault_id=None,
+        clone_of_installation_id=None,
+        clone_of_snapshot_digest=None,
+        created_at=1_777_777_777,
+        authentication_algorithm="HMAC-SHA256",
+        record_digest=digest(b"identity"),
+        identity_path=tmp_path / "identity.json",
+    )
+
+
+def _destination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Path, object]:
+    from exomem.governance import consolidation_intake
+
+    vault = tmp_path / "vault"
+    files = {
+        "Knowledge Base/Notes/destination.md": b"destination before apply\n",
+        "Knowledge Base/Sources/source.md": b"preserved source\n",
+        "Knowledge Base/Evidence/proof.bin": b"proof\x00bytes",
+        "Knowledge Base/_access.yaml": b"readonly: []\n",
+        "Knowledge Base/.review-state.json": b'{"version":2,"records":{}}',
+    }
+    for relative, content in files.items():
+        path = vault / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+    monkeypatch.setattr(
+        consolidation_fingerprints,
+        "load_local_identity",
+        lambda *_args, **_kwargs: _identity(tmp_path),
+    )
+    monkeypatch.setattr(
+        consolidation_fingerprints,
+        "_load_active_policy_snapshot",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            active=SimpleNamespace(
+                logical_vault_id="vault-apply-preparation",
+                policy_fingerprint=hashlib.sha256(b"policy").hexdigest(),
+            ),
+            source_documents=(("rules/default.yaml", b"governance_version: 1\n"),),
+        ),
+    )
+    return vault, consolidation_intake.PrivateConsolidationArtifactStore(
+        tmp_path / "private-artifacts",
+        active_vault_roots=(vault,),
+    )
+
+
+def _append_token_reservation(vault: Path) -> dict[str, object]:
+    chain = (
+        ("start", "intake", None),
+        ("intake", "intake", None),
+        ("snapshot-source", "snapshot", None),
+        ("snapshot-destination", "snapshot", None),
+        ("reconcile", "reconciliation", None),
+        ("plan-cutover", "plan", None),
+        ("render-begin", "rendering", None),
+        ("render-page", "rendering", 0),
+        ("render-ack", "rendering", 0),
+        ("render-complete", "rendering", None),
+        ("approval", "approval", None),
+        ("token-reservation", "authorization", None),
+    )
+    parent_id, parent_digest = consolidation_receipts.semantic_root()
+    terminal: dict[str, object] | None = None
+    for ordinal, (kind, phase, page_ordinal) in enumerate(chain):
+        event = consolidation_receipts.build_intent(
+            kind=kind,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            phase=phase,
+            effect_ordinal=ordinal,
+            request_digest=REQUEST_DIGEST,
+            prior_digest=hashlib.sha256(f"{kind}:prior".encode()).hexdigest(),
+            target_digest=hashlib.sha256(f"{kind}:target".encode()).hexdigest(),
+            evidence=consolidation_receipts.build_evidence(
+                kind=kind,
+                digests={
+                    field: (
+                        PLAN_DIGEST
+                        if kind == "token-reservation" and field == "plan_digest"
+                        else hashlib.sha256(f"{kind}:{field}".encode()).hexdigest()
+                    )
+                    for field in consolidation_receipts._EVIDENCE_FIELDS[kind]  # noqa: SLF001
+                },
+            ),
+            semantic_parent_event_id=parent_id,
+            semantic_parent_payload_digest=parent_digest,
+            page_ordinal=page_ordinal,
+        )
+        intent = consolidation_receipts.append_intent(vault, event, timestamp=T0)
+        terminal = consolidation_receipts.append_terminal(
+            vault,
+            intent_event_id=str(intent["event_id"]),
+            role="committed",
+            observed_digest=str(event.payload["target_digest"]),
+            timestamp=T0,
+        )
+        parent_id = str(terminal["event_id"])
+        parent_digest = str(terminal["consolidation_event"]["payload_digest"])
+    assert terminal is not None
+    return terminal
+
+
+def _reopen_after_prior_apply(seal_store) -> None:
+    from exomem.governance import consolidation_authority, consolidation_seal
+
+    current = seal_store.begin_consolidation(
+        vault_binding_digest=VAULT_BINDING,
+        run_id=PRIOR_RUN_ID,
+        operation_id=PRIOR_OPERATION_ID,
+        journal_digest=PRIOR_JOURNAL_DIGEST,
+        sealed_at=T0,
+        expected_revision=0,
+    )
+    while current.phase != "complete":
+        assert current.phase is not None
+        authority = consolidation_authority.issue_authority(
+            vault_binding_digest=VAULT_BINDING,
+            run_id=PRIOR_RUN_ID,
+            operation_id=PRIOR_OPERATION_ID,
+            journal_digest=PRIOR_JOURNAL_DIGEST,
+            phase=current.phase,
+            action="apply",
+        )
+        current = seal_store.advance_consolidation(
+            authority,
+            vault_binding_digest=VAULT_BINDING,
+            action="apply",
+            target_phase=consolidation_seal._PHASE_SUCCESSORS[current.phase],  # noqa: SLF001
+            recorded_at=T0,
+            expected_revision=current.revision,
+        )
+    opened = seal_store.unseal_consolidation(
+        consolidation_authority.issue_authority(
+            vault_binding_digest=VAULT_BINDING,
+            run_id=PRIOR_RUN_ID,
+            operation_id=PRIOR_OPERATION_ID,
+            journal_digest=PRIOR_JOURNAL_DIGEST,
+            phase="complete",
+            action="apply",
+        ),
+        vault_binding_digest=VAULT_BINDING,
+        action="apply",
+        recorded_at=T0,
+        expected_revision=current.revision,
+    )
+    assert opened.kind == "open"
+    assert opened.revision == 14
+
+
+@pytest.mark.parametrize("crash_before_preimage_ready", [False, True])
+@pytest.mark.parametrize("reopened_after_prior_apply", [False, True])
+def test_apply_preparation_receipt_chains_seal_drain_and_exact_preimage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    crash_before_preimage_ready: bool,
+    reopened_after_prior_apply: bool,
+) -> None:
+    from exomem.governance import (
+        consolidation_admission,
+        consolidation_apply_coordinator,
+        consolidation_authority,
+        consolidation_plan_store,
+        consolidation_seal,
+        receipts,
+    )
+
+    vault, artifact_store = _destination(tmp_path, monkeypatch)
+    predecessor = _append_token_reservation(vault)
+    snapshot = consolidation_fingerprints.load_local_destination_snapshot(vault, now=123)
+    loaded_plans: list[tuple[str, str, str]] = []
+
+    def load_plan(_store, run_id, *, plan_kind, plan_digest):
+        loaded_plans.append((run_id, plan_kind, plan_digest))
+        return SimpleNamespace(
+            digest=PLAN_DIGEST,
+            control_basis=SimpleNamespace(digest=CONTROL_BASIS_DIGEST),
+            preimage={
+                "run_id": RUN_ID,
+                "plan_kind": "cutover",
+                "destination_snapshot_fingerprint": snapshot.digest,
+                "expected_destination_preimage_census_digest": (
+                    snapshot.canonical_census_digest
+                ),
+            },
+        )
+
+    monkeypatch.setattr(
+        consolidation_plan_store.ConsolidationPlanStore,
+        "load",
+        load_plan,
+    )
+    seal_store = consolidation_seal.ConsolidationSealStore(vault)
+    seal_store.initialize_open(vault_binding_digest=VAULT_BINDING, recorded_at=T0)
+    if reopened_after_prior_apply:
+        _reopen_after_prior_apply(seal_store)
+    admission = consolidation_admission.ConsolidationAdmission(
+        vault,
+        vault_binding_digest=VAULT_BINDING,
+    )
+    authority = consolidation_authority.issue_authority(
+        vault_binding_digest=VAULT_BINDING,
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        phase="sealing",
+        action="apply",
+    )
+    before = (vault / "Knowledge Base/Notes/destination.md").read_bytes()
+    arguments = {
+        "vault_root": vault,
+        "admission": admission,
+        "artifact_store": artifact_store,
+        "token_reservation_event_id": str(predecessor["event_id"]),
+        "token_reservation_payload_digest": str(
+            predecessor["consolidation_event"]["payload_digest"]
+        ),
+        "vault_binding_digest": VAULT_BINDING,
+        "run_id": RUN_ID,
+        "operation_id": OPERATION_ID,
+        "journal_digest": JOURNAL_DIGEST,
+        "request_digest": REQUEST_DIGEST,
+        "plan_digest": PLAN_DIGEST,
+        "sealed_at": T1,
+        "drained_at": T2,
+        "preimage_ready_at": T3,
+        "now": 123,
+        "timeout": 2.0,
+    }
+    original_advance = consolidation_seal.ConsolidationSealStore.advance_consolidation
+    crashed = False
+
+    def crash_once(self, *args, **kwargs):
+        nonlocal crashed
+        if (
+            crash_before_preimage_ready
+            and not crashed
+            and kwargs.get("target_phase") == "preimage-ready"
+        ):
+            crashed = True
+            raise SimulatedProcessCrash
+        return original_advance(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        consolidation_seal.ConsolidationSealStore,
+        "advance_consolidation",
+        crash_once,
+    )
+
+    result = None
+    with admission.admit_mutation() as mutation:
+        control = admission.convert_control_mutation(
+            mutation,
+            authority=authority,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            request_digest=REQUEST_DIGEST,
+            phase="sealing",
+            action="apply",
+        )
+        if crash_before_preimage_ready:
+            with pytest.raises(SimulatedProcessCrash):
+                consolidation_apply_coordinator.prepare_apply_through_preimage(
+                    control=control,
+                    **arguments,
+                )
+        else:
+            result = consolidation_apply_coordinator.prepare_apply_through_preimage(
+                control=control,
+                **arguments,
+            )
+
+    if crash_before_preimage_ready:
+        assert seal_store.load(vault_binding_digest=VAULT_BINDING).phase == "sealed"
+        assert list((artifact_store.root / "preimages").glob("*.json"))
+        assert receipts.event_records(vault)[-1]["phase"] == "intent"
+        with admission.resume_control_mutation(
+            authority=authority,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            request_digest=REQUEST_DIGEST,
+            phase="sealing",
+            action="apply",
+        ) as recovered:
+            result = consolidation_apply_coordinator.prepare_apply_through_preimage(
+                control=recovered,
+                **arguments,
+            )
+
+    assert result is not None
+    assert loaded_plans
+    assert set(loaded_plans) == {(RUN_ID, "cutover", PLAN_DIGEST)}
+    assert result.seal_state.phase == "preimage-ready"
+    assert result.preimage.manifest_digest == result.preimage_plan.manifest_digest
+    assert result.preimage.binding.semantic_predecessor_event_id == (
+        result.seal_drained.terminal.event_id
+    )
+    assert (vault / "Knowledge Base/Notes/destination.md").read_bytes() == before
+    assert [
+        record["consolidation_event"]["kind"]
+        for record in receipts.event_records(vault)[-6:]
+    ] == [
+        "seal-intent",
+        "seal-intent",
+        "seal-drained",
+        "seal-drained",
+        "preimage",
+        "preimage",
+    ]
+    assert [record["phase"] for record in receipts.event_records(vault)[-6:]] == [
+        "intent",
+        "committed",
+        "intent",
+        "committed",
+        "intent",
+        "committed",
+    ]
+    record_count = len(receipts.event_records(vault))
+    with admission.resume_control_mutation(
+        authority=authority,
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        request_digest=REQUEST_DIGEST,
+        phase="sealing",
+        action="apply",
+    ) as recovered:
+        replay = consolidation_apply_coordinator.prepare_apply_through_preimage(
+            control=recovered,
+            **arguments,
+        )
+    assert replay == result
+    assert len(receipts.event_records(vault)) == record_count
+    for changed in (
+        {"request_digest": hashlib.sha256(b"changed-request").hexdigest()},
+        {"plan_digest": hashlib.sha256(b"changed-plan").hexdigest()},
+        {"drained_at": T0},
+    ):
+        with admission.resume_control_mutation(
+            authority=authority,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            request_digest=REQUEST_DIGEST,
+            phase="sealing",
+            action="apply",
+        ) as recovered:
+            with pytest.raises(
+                consolidation_apply_coordinator.ConsolidationApplyPreparationUnavailable,
+                match="^CONSOLIDATION_APPLY_PREPARATION_UNAVAILABLE$",
+            ):
+                consolidation_apply_coordinator.prepare_apply_through_preimage(
+                    control=recovered,
+                    **{**arguments, **changed},
+                )
+    assert len(receipts.event_records(vault)) == record_count
+
+    if not crash_before_preimage_ready:
+        artifact_store.resolve_preimage(result.preimage.manifest_ref).write_bytes(b"{}")
+        with admission.resume_control_mutation(
+            authority=authority,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            request_digest=REQUEST_DIGEST,
+            phase="sealing",
+            action="apply",
+        ) as recovered:
+            with pytest.raises(
+                consolidation_apply_coordinator.ConsolidationApplyPreparationUnavailable,
+                match="^CONSOLIDATION_APPLY_PREPARATION_UNAVAILABLE$",
+            ):
+                consolidation_apply_coordinator.prepare_apply_through_preimage(
+                    control=recovered,
+                    **arguments,
+                )
+        assert len(receipts.event_records(vault)) == record_count

--- a/tests/test_consolidation_control_admission.py
+++ b/tests/test_consolidation_control_admission.py
@@ -989,3 +989,95 @@ def test_control_record_must_survive_until_seal_terminal(tmp_path: Path) -> None
         vault_binding_digest=VAULT_BINDING
     )
     assert durable.phase == "sealing"
+
+
+def test_receipt_first_seal_can_persist_intent_then_drain_as_two_exact_effects(
+    tmp_path: Path,
+) -> None:
+    admission = _open_admission(tmp_path)
+    ordinary, control = _convert_apply(admission)
+    authority = _apply_authority()
+    try:
+        sealing = admission.begin_seal(
+            control=control,
+            authority=authority,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            sealed_at=T1,
+            expected_revision=0,
+        )
+        assert sealing.state.phase == "sealing"
+        assert sealing.state.revision == 1
+        assert admission.begin_seal(
+            control=control,
+            authority=authority,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            sealed_at=T1,
+            expected_revision=0,
+        ) == sealing
+
+        with _assert_admission_error("CONSOLIDATION_SEALED"):
+            with admission.admit_read():
+                pass
+
+        sealed = admission.drain_and_seal(
+            control=control,
+            authority=authority,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            sealed_at=T1,
+            completed_at=T2,
+            expected_revision=1,
+            timeout=1.0,
+        )
+        assert sealed.state.phase == "sealed"
+        assert sealed.state.revision == 2
+        assert admission.drain_and_seal(
+            control=control,
+            authority=authority,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            sealed_at=T1,
+            completed_at=T2,
+            expected_revision=1,
+            timeout=1.0,
+        ) == sealed
+    finally:
+        ordinary.__exit__(None, None, None)
+
+
+def test_split_seal_rejects_changed_identity_without_advancing(
+    tmp_path: Path,
+) -> None:
+    admission = _open_admission(tmp_path)
+    ordinary, control = _convert_apply(admission)
+    try:
+        sealing = admission.begin_seal(
+            control=control,
+            authority=_apply_authority(),
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            sealed_at=T1,
+            expected_revision=0,
+        )
+        with _assert_admission_error("CONSOLIDATION_SEAL_UNAVAILABLE"):
+            admission.drain_and_seal(
+                control=control,
+                authority=_apply_authority(),
+                run_id=RUN_ID,
+                operation_id=OPERATION_ID,
+                journal_digest=JOURNAL_DIGEST,
+                sealed_at=T1,
+                completed_at=T2,
+                expected_revision=0,
+                timeout=1.0,
+            )
+        assert admission.reload().state == sealing.state
+    finally:
+        ordinary.__exit__(None, None, None)

--- a/tests/test_consolidation_effect_coordinator.py
+++ b/tests/test_consolidation_effect_coordinator.py
@@ -135,6 +135,11 @@ def _append_policy_active_parent(vault: Path) -> dict[str, object]:
             request_digest=REQUEST_DIGEST,
             prior_digest=hashlib.sha256(f"{kind}:prior".encode()).hexdigest(),
             target_digest=hashlib.sha256(f"{kind}:target".encode()).hexdigest(),
+            prepared_digest=(
+                hashlib.sha256(b"preimage:prepared").hexdigest()
+                if kind == "preimage"
+                else None
+            ),
             evidence=consolidation_receipts.build_evidence(
                 kind=kind,
                 digests={

--- a/tests/test_consolidation_preimage.py
+++ b/tests/test_consolidation_preimage.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import importlib
 import importlib.util
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -165,7 +166,6 @@ def test_materializes_every_canonical_destination_byte_and_publishes_manifest_la
     assert all("_Consolidation/" not in path for path in paths)
     assert all(".graph-commit-receipts/" not in path for path in paths)
     assert "Knowledge Base/.graph.sqlite" not in paths
-
     policy = next(
         entry
         for entry in result.entries
@@ -175,6 +175,64 @@ def test_materializes_every_canonical_destination_byte_and_publishes_manifest_la
     assert result.entry_count == len(result.entries)
     assert result.total_bytes == sum(entry.size for entry in result.entries)
 
+
+def test_preimage_plan_is_read_only_then_materializes_only_its_exact_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, vault, store, binding = _prepared(tmp_path, monkeypatch)
+
+    planned = module.plan_local_destination_preimage(
+        vault,
+        binding=binding,
+        artifact_store=store,
+        now=123,
+    )
+
+    assert planned.binding == binding
+    assert planned.manifest_digest == hashlib.sha256(planned.manifest_bytes).hexdigest()
+    assert not store.root.exists()
+
+    result = module.materialize_planned_destination_preimage(
+        vault,
+        plan=planned,
+        artifact_store=store,
+        now=123,
+    )
+    assert result.manifest_digest == planned.manifest_digest
+    assert result.entries == planned.entries
+    assert module.verify_destination_preimage(
+        result.manifest_ref,
+        binding=binding,
+        artifact_store=store,
+    ) == result
+
+
+def test_malformed_preimage_plan_refuses_before_private_artifact_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, vault, store, binding = _prepared(tmp_path, monkeypatch)
+    planned = module.plan_local_destination_preimage(
+        vault,
+        binding=binding,
+        artifact_store=store,
+        now=123,
+    )
+    malformed = replace(
+        planned,
+        entries=(replace(planned.entries[0], size=True), *planned.entries[1:]),
+    )
+
+    with pytest.raises(module.ConsolidationPreimageUnavailable):
+        module.materialize_planned_destination_preimage(
+            vault,
+            plan=malformed,
+            artifact_store=store,
+            now=123,
+        )
+
+    assert not store.root.exists()
 
 def test_preimage_objects_are_independent_of_later_destination_mutation(
     tmp_path: Path,

--- a/tests/test_consolidation_receipts.py
+++ b/tests/test_consolidation_receipts.py
@@ -39,6 +39,7 @@ def vault(tmp_path: Path) -> Path:
 _EVIDENCE_FIELDS = {
     "start": ("identity_binding_digest", "run_request_digest"),
     "intake": ("archive_attestation_digest", "intake_manifest_digest"),
+    "preimage": ("preimage_manifest_digest",),
     "content-batch": ("batch_manifest_digest", "classification_digest"),
     "complete": ("completion_digest", "verification_basis_digest"),
     "render-page": (
@@ -199,6 +200,28 @@ def test_intent_identity_and_payload_digest_are_exact_framed_jcs_vectors() -> No
     )
     assert event.phase == "intent"
     assert _intent() == event
+
+
+def test_preimage_receipt_requires_its_distinct_prepared_manifest_state() -> None:
+    from exomem.governance import consolidation_receipts
+
+    event = _intent(
+        kind="preimage",
+        phase="preimage",
+        batch_ordinal=None,
+    )
+
+    assert event.payload["prepared_digest"] == PREPARED_DIGEST
+    with pytest.raises(
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        match="^CONSOLIDATION_RECEIPT_UNAVAILABLE$",
+    ):
+        _intent(
+            kind="preimage",
+            phase="preimage",
+            batch_ordinal=None,
+            prepared_digest=None,
+        )
 
 
 def test_every_kind_binds_its_owner_protected_evidence_bundle() -> None:


### PR DESCRIPTION
## What this adds

Coordinates the first apply effects after a committed cutover token reservation:

- records seal intent before draining mutation participants
- records the completed drain before producing a destination preimage
- loads the exact stored cutover plan and derives all preimage facts from it
- resumes safely from a published preimage whose seal phase was not yet advanced
- supports later consolidation lifecycles after a completed seal and unseal

The boundary stops at preimage-ready. It does not publish policy or content and does not touch a live vault.

Stacked after #981.

## Verification

- 145 focused governance tests passed
- independent recheck: 98 related tests passed; 4/4 fresh/reopened crash matrix passed; GO
- OpenSpec strict validation: 168 passed
- Ruff and git diff check passed
- uv lock check passed
- public artifact validation: 3437 files / 3505 text payloads clean