### PR TITLE
fix(mutation-lock): guard the contention deque against concurrent mutation

### DIFF
--- a/src/exomem/mutation_lock.py
+++ b/src/exomem/mutation_lock.py
@@ -1700,11 +1700,10 @@ class _LocalLockState:
     acquired_at: float | None = None
     long_holder_seconds: float = _DEFAULT_LONG_HOLDER_SECONDS
     long_warning_emitted: bool = False
-    # Contention attribution.  These are *measurement only* — nothing in the
+    # Contention attribution. These are *measurement only* — nothing in the
     # acquire path reads them, so no fairness or timeout behaviour depends on
-    # them.  They are deliberately maintained without taking any new lock:
-    # `int` increments and `deque.append` are cheap, and losing a count under
-    # extreme thread contention degrades a diagnostic rather than a decision.
+    # them. They share ``metadata_guard`` with the holder fields so a published
+    # view has a coherent snapshot and a bounded deque cannot mutate mid-view.
     # They are also strictly PROCESS-LOCAL: a second exomem process holding the
     # same OS boundary contributes nothing here, which is why the published
     # block carries `scope: "process_local"`.
@@ -1728,10 +1727,11 @@ _LOCAL_STATES_GUARD = threading.Lock()
 def _note_acquire_attempt(state: _LocalLockState) -> None:
     """Count one `hold()` entry, including re-entrant ones (they never contend).
 
-    No lock: this is a diagnostic counter, and taking one would add an
-    acquisition to the hot path the counter exists to measure.
+    The counter is published alongside the rest of the contention view, so it
+    is updated under the same narrow publication guard.
     """
-    state.acquire_attempts += 1
+    with state.metadata_guard:
+        state.acquire_attempts += 1
 
 
 def _note_busy_refusal(
@@ -1744,21 +1744,22 @@ def _note_busy_refusal(
     increments the counters; `last_holder` keeps the previous observation
     because it is the *last known* holder, not the currently-observed one.
     """
-    state.busy_refusals += 1
-    # Window arithmetic on the monotonic clock; display timestamp on the wall
-    # clock.  They are not interchangeable and must not be mixed.
-    state.busy_refusal_monotonic.append(time.monotonic())
-    if snapshot is not None and snapshot.get("state") == "held":
-        state.last_holder = {
-            # A refusal can observe another process's holder, whose pid this
-            # process never learns; the sidecar record is content-free labels.
-            "pid": None,
-            "request_id": _safe_label(snapshot.get("request_id"), fallback="untracked"),
-            "operation": _safe_label(snapshot.get("operation"), fallback="unknown"),
-            "holder_kind": _safe_label(snapshot.get("holder_kind"), fallback="unknown"),
-            "observed_at": time.time(),
-            "source": "refusal",
-        }
+    with state.metadata_guard:
+        state.busy_refusals += 1
+        # Window arithmetic on the monotonic clock; display timestamp on the wall
+        # clock.  They are not interchangeable and must not be mixed.
+        state.busy_refusal_monotonic.append(time.monotonic())
+        if snapshot is not None and snapshot.get("state") == "held":
+            state.last_holder = {
+                # A refusal can observe another process's holder, whose pid this
+                # process never learns; the sidecar record is content-free labels.
+                "pid": None,
+                "request_id": _safe_label(snapshot.get("request_id"), fallback="untracked"),
+                "operation": _safe_label(snapshot.get("operation"), fallback="unknown"),
+                "holder_kind": _safe_label(snapshot.get("holder_kind"), fallback="unknown"),
+                "observed_at": time.time(),
+                "source": "refusal",
+            }
 
 
 def _note_release(
@@ -1769,31 +1770,38 @@ def _note_release(
     holder_kind: str | None,
 ) -> None:
     """Record the hold this process just released as the last-known holder."""
-    state.last_holder = {
-        "pid": os.getpid(),
-        "request_id": _safe_label(request_id, fallback="untracked"),
-        "operation": _safe_label(operation, fallback="unknown"),
-        "holder_kind": _safe_label(holder_kind, fallback="unknown"),
-        "observed_at": time.time(),
-        "source": "release",
-    }
+    with state.metadata_guard:
+        state.last_holder = {
+            "pid": os.getpid(),
+            "request_id": _safe_label(request_id, fallback="untracked"),
+            "operation": _safe_label(operation, fallback="unknown"),
+            "holder_kind": _safe_label(holder_kind, fallback="unknown"),
+            "observed_at": time.time(),
+            "source": "release",
+        }
 
 
 def _contention_view(state: _LocalLockState) -> dict[str, object]:
     """Project the process-local contention counters into a content-free block."""
+    with state.metadata_guard:
+        recent_samples = tuple(state.busy_refusal_monotonic)
+        acquire_attempts = state.acquire_attempts
+        busy_refusals = state.busy_refusals
+        last_holder = (
+            dict(state.last_holder) if state.last_holder is not None else None
+        )
     horizon = time.monotonic() - _CONTENTION_RECENT_WINDOW_SECONDS
-    recent = sum(1 for at in tuple(state.busy_refusal_monotonic) if at >= horizon)
-    last_holder = state.last_holder
+    recent = sum(1 for at in recent_samples if at >= horizon)
     return {
-        "acquire_attempts": state.acquire_attempts,
-        "busy_refusals": state.busy_refusals,
+        "acquire_attempts": acquire_attempts,
+        "busy_refusals": busy_refusals,
         "busy_refusals_recent": recent,
         "recent_window_seconds": _CONTENTION_RECENT_WINDOW_SECONDS,
         # Cross-process caveat: these counts describe this process only.  A
         # concurrent writer in another process is invisible here, so a zero
         # refusal count is not evidence that the boundary is uncontended.
         "scope": "process_local",
-        "last_holder": dict(last_holder) if last_holder is not None else None,
+        "last_holder": last_holder,
     }
 
 

--- a/tests/test_mutation_lock.py
+++ b/tests/test_mutation_lock.py
@@ -8,6 +8,7 @@ import os
 import stat
 import threading
 import time
+from collections import deque
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -30,6 +31,52 @@ def _boundary(snapshot: dict) -> dict:
     boundary state keys, which the stats block must never disturb.
     """
     return {key: value for key, value in snapshot.items() if key != "contention"}
+
+
+def test_contention_view_snapshots_busy_refusals_while_recording_a_refusal() -> None:
+    """A full recent-refusal deque may be evicted while a view is built."""
+
+    entered_iteration = threading.Event()
+    resume_iteration = threading.Event()
+
+    class _PausingDeque(deque[float]):
+        def __iter__(self):
+            iterator = super().__iter__()
+            yield next(iterator)
+            entered_iteration.set()
+            assert resume_iteration.wait(timeout=1)
+            yield from iterator
+
+    state = mutation_lock_module._LocalLockState(
+        busy_refusal_monotonic=_PausingDeque(
+            [time.monotonic()] * mutation_lock_module._CONTENTION_RECENT_SAMPLES,
+            maxlen=mutation_lock_module._CONTENTION_RECENT_SAMPLES,
+        )
+    )
+    failures: list[BaseException] = []
+
+    def view() -> None:
+        try:
+            mutation_lock_module._contention_view(state)
+        except BaseException as error:
+            failures.append(error)
+
+    reader = threading.Thread(target=view)
+    reader.start()
+    assert entered_iteration.wait(timeout=1)
+
+    writer = threading.Thread(
+        target=mutation_lock_module._note_busy_refusal,
+        args=(state, None),
+    )
+    writer.start()
+    resume_iteration.set()
+    reader.join(timeout=1)
+    writer.join(timeout=1)
+
+    assert not reader.is_alive()
+    assert not writer.is_alive()
+    assert failures == []
 
 
 #: How long a holder keeps the mutation boundary, and how long a test will

--- a/tests/test_mutation_lock.py
+++ b/tests/test_mutation_lock.py
@@ -33,6 +33,15 @@ def _boundary(snapshot: dict) -> dict:
     return {key: value for key, value in snapshot.items() if key != "contention"}
 
 
+#: How long a holder keeps the mutation boundary, and how long a test will
+#: wait to observe a contender being refused. The gap between them is the
+#: whole discriminating power of the contention assertions: a contender that
+#: waited for the holder instead of honouring its own timeout blows straight
+#: through the observation window.
+_HOLD_SECONDS = 45.0
+_OBSERVE_SECONDS = 15.0
+
+
 def test_contention_view_snapshots_busy_refusals_while_recording_a_refusal() -> None:
     """A full recent-refusal deque may be evicted while a view is built."""
 
@@ -44,7 +53,7 @@ def test_contention_view_snapshots_busy_refusals_while_recording_a_refusal() -> 
             iterator = super().__iter__()
             yield next(iterator)
             entered_iteration.set()
-            assert resume_iteration.wait(timeout=1)
+            assert resume_iteration.wait(timeout=_OBSERVE_SECONDS)
             yield from iterator
 
     state = mutation_lock_module._LocalLockState(
@@ -63,7 +72,7 @@ def test_contention_view_snapshots_busy_refusals_while_recording_a_refusal() -> 
 
     reader = threading.Thread(target=view)
     reader.start()
-    assert entered_iteration.wait(timeout=1)
+    assert entered_iteration.wait(timeout=_OBSERVE_SECONDS)
 
     writer = threading.Thread(
         target=mutation_lock_module._note_busy_refusal,
@@ -71,21 +80,13 @@ def test_contention_view_snapshots_busy_refusals_while_recording_a_refusal() -> 
     )
     writer.start()
     resume_iteration.set()
-    reader.join(timeout=1)
-    writer.join(timeout=1)
+    reader.join(timeout=_OBSERVE_SECONDS)
+    writer.join(timeout=_OBSERVE_SECONDS)
 
     assert not reader.is_alive()
     assert not writer.is_alive()
     assert failures == []
 
-
-#: How long a holder keeps the mutation boundary, and how long a test will
-#: wait to observe a contender being refused. The gap between them is the
-#: whole discriminating power of the contention assertions: a contender that
-#: waited for the holder instead of honouring its own timeout blows straight
-#: through the observation window.
-_HOLD_SECONDS = 45.0
-_OBSERVE_SECONDS = 15.0
 
 #: A NEGATIVE observation -- how long the test waits to prove something has NOT
 #: happened yet -- is a different animal and stays short. Widening one does not


### PR DESCRIPTION
`_contention_view` read a **bounded** deque without a lock:

```python
recent = sum(1 for at in tuple(state.busy_refusal_monotonic) if at >= horizon)
```

`tuple()` on a deque iterates; it is not an atomic snapshot. Because
`busy_refusal_monotonic` is `deque(maxlen=_CONTENTION_RECENT_SAMPLES)`, a
concurrent `append` on a full deque simultaneously evicts from the left, which
invalidates the in-progress iteration:

```
RuntimeError: deque mutated during iteration
src/exomem/mutation_lock.py:1785
```

`_note_busy_refusal` did the appending, also unlocked. `_LocalLockState` already
carried a `metadata_guard` for exactly this class of field; these two functions
simply were not using it.

This is not only a CI flake. `_contention_view` feeds the mutation boundary's
diagnostics, so under concurrent writes it can raise inside a real mutation.

## How it surfaced

A full CI run on `main` at the 0.67.1 release base failed here:

```
FAILED tests/test_mutation_concurrency.py::test_twenty_concurrent_real_captures_leave_complete_vault_state
  - RuntimeError: deque mutated during iteration
1 failed, 1531 passed, 14 skipped, 10871 deselected
```

## What changed

`metadata_guard` now covers every read and write of `busy_refusal_monotonic`
and `last_holder`. The critical section is deliberately narrow: the deque
snapshot, two integer reads, and the `last_holder` copy. Horizon arithmetic,
counting, and response construction stay outside it, so the diagnostics do not
serialize under the contention they exist to measure.

One behavioural nuance, stated rather than buried: the recent-window cutoff is
now sampled after the snapshot rather than before it, making "recent" relative
to publication time. Counts, key ordering, scope, and `last_holder` shape are
unchanged.

## Evidence

Red-first: a deterministic test drives a reader into the iteration and releases
a writer mid-iterate. It fails on the unmodified base and passes 10x after.

Mutation proof: bypassing only the reader-side guard while the writer keeps the
real lock reproduces `RuntimeError: deque mutated during iteration`; the
committed test kills that mutant 2000/2000.

Gates: `tests/test_mutation_lock.py` gives 69 passed, 11 skipped, 10 errors.
All 10 errors are the state-root guard in `tests/conftest.py` observing the
live exomem and POLLY services writing to the real machine-local state root
while the suite runs; the guard's own message names the interfering pids. They
reproduce on the base commit and are unrelated to this change. `ruff` reports 2
pre-existing B009 findings at lines 87 and 91, outside the changed region.

Reviewed adversarially by a lane that did not write it, which verified there is
no unguarded access path repo-wide, proved the non-reentrant `metadata_guard`
cannot be taken twice across `_snapshot_state`, `snapshot`, `_probe`,
`_refused`, both `_acquire_boundary` refusal paths, `_note_release` and nested
`hold()` (runtime sentinel: `max_depth=1`), and ran its own mutation rather
than trusting the table above.

## Deliberately not fixed

The same CI run previously failed on a different concurrency defect:

```
FAILED tests/test_authorization_session_wire_reconnect.py::test_stateless_mcp_grant_is_bound_across_serving_content_route_families
  - AssertionError: ('read_media', '... "authorization session is unavailable" ...')
```

That remains open. It is not #980 — that change only touches provisioner
annotations, which this in-process test does not import. The next step is to
rerun the py3.11 sequence with temporary, bearer-free instrumentation around
custody loading, database opening and `resume_session()`, so the broad
exception mapping in `governance/authorization_request.py:263` cannot erase the
cause. Both failures are pre-existing on `main` and neither comes from the
commits 0.67.1 carries.
