### PR TITLE
feat(governance): bind consolidation policy bundle

### DIFF
--- a/openspec/changes/add-governed-vault-consolidation/design.md
+++ b/openspec/changes/add-governed-vault-consolidation/design.md
@@ -796,7 +796,8 @@ preimage has these required fields:
 - exact content actions, expected before hashes, planned after hashes, and
   journal batch partition digest;
 - exact canonical policy documents, prospective policy fingerprint, bridge and
-  exact-release approval fingerprints;
+  exact-release approval fingerprints, plus the digest of the exact canonical
+  destination-policy bundle from which those values were reviewed;
 - fresh destination owner/principal attestation-set digest;
 - representative principal x purpose x item disclosure-matrix digest;
 - positive/negative verification-plan digest;
@@ -811,6 +812,27 @@ preimage has these required fields:
   change, batch, rollback consequence, surviving-copy obligation, and unresolved
   count; and
 - plan creation time, plan validity deadline, and a fresh plan nonce.
+
+For a cutover plan, the owner-only plan directory also contains immutable
+`policy-bundle.json`: the canonical bytes of
+`exomem.consolidation-destination-policy/v1`. The bundle carries the exact
+destination vault binding, prospective compile target and authoring snapshot,
+document edits and document-set digest, source-authority review records/digest,
+fresh principal attestations and attestation-set digest, principal requirements,
+and named principals. Its framed-JCS digest is outside those bytes; the cutover
+plan binds it as `policy_bundle_digest`. The bundle deliberately contains no
+`plan_digest`, avoiding a digest cycle. `plan.json`, `control-basis.json`, and
+`policy-bundle.json` are one immutable stored cutover-plan object: missing,
+partial, changed, non-canonical, digest-mismatched, or legacy unbound state is a
+closed refusal rather than authority reconstructed from caller fields.
+
+At apply and every recovery continuation, the server loads those exact stored
+bundle bytes, cross-checks their digest, destination binding, policy documents,
+prospective policy fingerprint, principal-attestation-set digest, and plan
+nonce against the stored plan, then reruns prospective compilation and fresh
+destination-principal/session attestation validation. This check completes
+before any governance policy mutation. A caller-supplied bundle, digest-only
+claim, or freshly reconstructed approximation cannot authorize publication.
 
 Every consolidation source-export claim, cutover, rollback, rendering,
 retirement, event, and fingerprint object uses one canonical encoding: RFC 8785 JSON Canonicalization
@@ -1018,16 +1040,17 @@ The exact order is:
    token-reservation event as the apply journal's
    separate current predecessor, acquire exclusive writer/lifecycle authority,
    revalidate that predecessor, then seal and drain the destination. Revalidate
-   the source artifact, both snapshots, principal attestations, conflict
-   decisions, and complete plan preimage without comparing the current global
-   receipt head/full mutable run control tree to their materialization-time
-   values.
+   the source artifact, both snapshots, the exact stored destination-policy
+   bundle and its fresh principal attestations, conflict decisions, and complete
+   plan preimage without comparing the current global receipt head/full mutable
+   run control tree to their materialization-time values. Missing, changed, or
+   unbound policy-bundle bytes refuse before governance mutation.
 2. Materialize a full content-addressed destination preimage in private artifact
    storage. Verify every entry and bind its manifest digest to the approved
    destination census before continuing.
-3. Activate the approved restrictive destination policy through the existing
-   governance journal/marker/critical-receipt protocol. The seal remains the
-   outer floor.
+3. Activate only the exact stored and revalidated restrictive destination-policy
+   bundle through the existing governance journal/marker/critical-receipt
+   protocol. The seal remains the outer floor.
 4. Publish exact content actions in bounded deterministic batches through
    `batch_atomic_write`. Each batch has prior/prepared/final fingerprints,
    receipt-first intent, a durable run-journal transition, and idempotent exact

--- a/openspec/changes/add-governed-vault-consolidation/specs/command-surface/spec.md
+++ b/openspec/changes/add-governed-vault-consolidation/specs/command-surface/spec.md
@@ -519,6 +519,12 @@ missing, inapplicable, or additional fields SHALL be refused:
 | `rollback_options` | `target_kind={pre-cutover,post-cutover-forward}`, `target_snapshot_ref`, `target_snapshot_digest`, `expected_current_census_digest`, `treatment_set_ref`, `treatment_set_digest`, `surviving_copy_ledger_digest`, `expected_retirement_state_digest` | none |
 | `retirement_options` | `archive_disposition={retain,transfer,external-destruction}`, `archive_artifact_ref`, `archive_artifact_digest`, `archive_terms_digest`, `post_retirement_rollback_mode={pre-cutover-reversible,forward-only}`, `source_retention_proof_ref`, `source_retention_proof_digest`, `surviving_copy_ledger_digest`, `retained_irrecoverable_statement_digest` | transfer requires `custodian_receipt_ref`,`custodian_receipt_digest`; forward-only requires `forward_snapshot_ref`,`forward_snapshot_digest` |
 
+For cutover, `expected_policy_bundle_digest` SHALL resolve to the exact
+owner-only canonical `policy-bundle.json` co-persisted with the immutable plan.
+The stored plan SHALL bind that digest and apply SHALL cross-check the bundle's
+destination, nonce, policy documents/fingerprint, and principal-attestation set;
+a caller-supplied digest without those exact stored bytes is not authority.
+
 Every digest/ref uses the common bounds above. For external destruction,
 source-retention proof describes the current copy only and SHALL not satisfy the
 post-effect ledger; for forward-only, the forward snapshot must. Inapplicable

--- a/openspec/changes/add-governed-vault-consolidation/specs/vault-consolidation/spec.md
+++ b/openspec/changes/add-governed-vault-consolidation/specs/vault-consolidation/spec.md
@@ -343,7 +343,9 @@ destination-mismatched, session-mismatched, or source-copied principal identity.
 - every exact content action with expected-before and planned-after hashes, plus
   the deterministic journal-batch partition digest;
 - every exact canonical prospective policy document and its compiled policy,
-  bridge, and exact-release approval fingerprints;
+  bridge, and exact-release approval fingerprints, plus
+  `policy_bundle_digest` for the exact canonical destination-policy bundle from
+  which those values were reviewed;
 - the fresh destination owner/principal attestation-set digest;
 - the representative principal-by-purpose-by-item disclosure-matrix digest;
 - positive/negative verification-plan and nonterminal apply rollback-contingency
@@ -359,6 +361,25 @@ destination-mismatched, session-mismatched, or source-copied principal identity.
   no-loss consequence, and unresolved count; and
 - plan creation time, validity deadline, and fresh plan nonce.
 
+For a cutover plan, the owner-only immutable plan object SHALL contain
+`policy-bundle.json` beside `plan.json` and `control-basis.json`. Its bytes SHALL
+be canonical `exomem.consolidation-destination-policy/v1` and SHALL carry the
+exact destination binding, prospective compile target and authoring snapshot,
+document edits/set digest, source-authority review records/digest, destination
+principal attestations/set digest, principal requirements, and named principals.
+Its framed-JCS digest SHALL remain outside those bytes and SHALL equal the
+cutover plan's `policy_bundle_digest`; the bundle SHALL NOT contain
+`plan_digest`. Persist/load SHALL treat the three files as one immutable object
+and refuse missing, partial, non-canonical, changed, digest-mismatched, or legacy
+cutover plans without a bundle binding.
+
+Before governance mutation, apply and recovery SHALL load the exact stored
+bundle bytes, cross-bind them to the plan's policy documents, prospective policy
+fingerprint, principal-attestation-set digest, nonce, and destination, then
+rerun prospective compilation and fresh destination-principal/session
+validation. Caller-supplied bundle bytes, a digest-only claim, or reconstructed
+equivalent values SHALL NOT substitute for the stored reviewed bundle.
+
 All source-export claim, cutover, rollback, retirement, rendering, event, and fingerprint preimages
 SHALL use RFC 8785 JCS over a closed value subset: NFC-valid strings; duplicate
 keys, including post-NFC duplicates, refused; JCS escaping/property ordering;
@@ -370,6 +391,12 @@ u64be(JCS byte length) || JCS bytes`. `plan_digest` SHALL be SHA-256 over that
 framing with domain `exomem.consolidation-plan/v1` and SHALL not occur inside its
 own preimage. Cross-runtime fixed vectors SHALL pin NFC, escaping, order,
 integer boundaries, framing, and digest.
+
+#### Scenario: Stored policy bundle is missing or changed
+
+- **WHEN** apply loads a cutover plan whose `policy-bundle.json` is absent, non-canonical, changed, digest-mismatched, destination-mismatched, nonce-mismatched, or inconsistent with the plan's policy documents, prospective fingerprint, or principal attestation set
+- **THEN** apply refuses before any governance policy mutation
+- **AND** no caller-supplied bytes or digest-only assertion can repair or replace that reviewed authority
 
 `control_basis_digest` SHALL be framed-JCS SHA-256 under exact domain
 `exomem.consolidation-control-basis/v1` over a closed object containing run,
@@ -585,8 +612,10 @@ routing-opening -> complete`. Before publication it SHALL verify the immutable
 control basis and exact allowed successor chain, reserve the approval JTI and
 operation id, persist/revalidate the separate apply-predecessor terminal, acquire exclusive writer/lifecycle authority,
 persist and drain a destination-wide seal, and revalidate source artifacts,
-both snapshots, principal attestations, conflict completeness, and the entire
-plan preimage.
+both snapshots, the exact stored destination-policy bundle and its fresh
+principal attestations, conflict completeness, and the entire plan preimage.
+Missing, changed, or unbound policy-bundle bytes SHALL refuse before governance
+policy mutation.
 
 While sealed, every normal content read and mutation surface SHALL return the
 same content-free sealed outcome for every ordinary principal, including the
@@ -598,8 +627,9 @@ not be serializable, persisted as a reusable credential, or accepted from any
 request field.
 
 After proving a complete content-addressed destination preimage, apply SHALL
-activate the exact approved restrictive policy through the existing governance
-journal/marker/critical-receipt protocol. Only then SHALL it publish exact
+activate only the exact stored and revalidated restrictive policy bundle
+through the existing governance journal/marker/critical-receipt protocol. Only
+then SHALL it publish exact
 content actions in bounded deterministic `batch_atomic_write` batches. Each
 batch SHALL record domain-separated prior, prepared, and final fingerprints,
 receipt-first intent, and a durable run-journal transition. The first committed

--- a/openspec/changes/add-governed-vault-consolidation/tasks.md
+++ b/openspec/changes/add-governed-vault-consolidation/tasks.md
@@ -305,6 +305,14 @@
   to equal the plan-time values.
 - [ ] 5.5 Implement canonical plan assembly over immutable run objects, persisting the
   complete preimage owner-only and returning bounded pages plus stable digests/counts.
+  For cutover, canonicalize and co-persist the exact reviewed
+  `exomem.consolidation-destination-policy/v1` as immutable
+  `policy-bundle.json`, bind its outside digest as `policy_bundle_digest` in the
+  plan/input basis, and make missing/partial/non-canonical/tampered/legacy-unbound
+  bundle state a closed refusal. Apply/recovery must load those exact bytes,
+  cross-bind destination/nonce/documents/policy/attestations to the stored plan,
+  and rerun prospective compile plus fresh principal-session validation before
+  governance mutation.
   Materialize `control_basis_digest` and the closed successor-automaton digest,
   persist every declared event predecessor, and bind the current executor
   predecessor separately at token reservation/apply without hashing mutable
@@ -562,6 +570,8 @@ binds that reference and observed digest; no caller field selects K.
 - [ ] 7.6 Implement the saga coordinator over the existing governance transaction,
   receipt-first critical-event, writer boundary, and bounded
   `batch_atomic_write` primitives. Persist phase/action fingerprints before effects,
+  activate only the exact stored and freshly revalidated destination-policy
+  bundle bound by the approved cutover plan,
   reserve the approval JTI/operation once, keep the typed consolidation seal
   throughout ordinary publication, use only the phase-bound routing-stopped
   suspension for exact-cell transport verification, and treat the first committed

--- a/src/exomem/governance/consolidation_apply_coordinator.py
+++ b/src/exomem/governance/consolidation_apply_coordinator.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 import hashlib
 import math
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import NoReturn
 
@@ -22,16 +24,16 @@ from . import (
     consolidation_intake,
     consolidation_plan,
     consolidation_plan_store,
+    consolidation_policy,
     consolidation_preimage,
     consolidation_receipts,
     consolidation_seal,
 )
+from .principal import RequestPrincipal
 
 _DIGEST = re.compile(r"[0-9a-f]{64}\Z")
 _COMMITTED_EVENT = re.compile(r"[0-9a-f]{64}:committed\Z")
-_UUID4 = re.compile(
-    r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
-)
+_UUID4 = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z")
 _EFFECT_SCHEMA = "exomem.consolidation-apply-preparation-effect/v1"
 
 __all__ = [
@@ -76,6 +78,14 @@ def _uuid4(value: object) -> str:
     return value
 
 
+def _policy_verification_timestamp() -> str:
+    """Return a server-current millisecond timestamp for fresh session checks."""
+
+    current = datetime.now(UTC)
+    current = current.replace(microsecond=(current.microsecond // 1000) * 1000)
+    return current.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
 def _effect_digest(kind: str, state: str, facts: dict[str, object]) -> str:
     try:
         raw = consolidation_plan.canonical_closed_jcs(
@@ -89,12 +99,7 @@ def _effect_digest(kind: str, state: str, facts: dict[str, object]) -> str:
     except consolidation_plan.ConsolidationPlanUnavailable:
         _fail()
     domain = _EFFECT_SCHEMA.encode("ascii")
-    framed = (
-        len(domain).to_bytes(4, "big")
-        + domain
-        + len(raw).to_bytes(8, "big")
-        + raw
-    )
+    framed = len(domain).to_bytes(4, "big") + domain + len(raw).to_bytes(8, "big") + raw
     return hashlib.sha256(framed).hexdigest()
 
 
@@ -260,6 +265,7 @@ def prepare_apply_through_preimage(
     journal_digest: str,
     request_digest: str,
     plan_digest: str,
+    principal_contexts: Sequence[RequestPrincipal],
     sealed_at: str,
     drained_at: str,
     preimage_ready_at: str,
@@ -310,7 +316,8 @@ def prepare_apply_through_preimage(
         )
         if not sealed_time < drained_time < ready_time:
             _fail()
-        stored_plan = consolidation_plan_store.ConsolidationPlanStore(root).load(
+        plan_store = consolidation_plan_store.ConsolidationPlanStore(root)
+        stored_plan = plan_store.load(
             checked_run,
             plan_kind="cutover",
             plan_digest=checked_plan,
@@ -322,11 +329,25 @@ def prepare_apply_through_preimage(
         ):
             _fail()
         checked_basis = _digest(stored_plan.control_basis.digest)
-        checked_snapshot = _digest(
-            stored_plan.preimage["destination_snapshot_fingerprint"]
-        )
+        checked_snapshot = _digest(stored_plan.preimage["destination_snapshot_fingerprint"])
         checked_census = _digest(
             stored_plan.preimage["expected_destination_preimage_census_digest"]
+        )
+        plan_nonce = stored_plan.preimage["nonce"]
+        if not isinstance(plan_nonce, str):
+            _fail()
+        stored_policy_bundle = plan_store.load_policy_bundle(
+            checked_run,
+            plan_kind="cutover",
+            plan_digest=checked_plan,
+        )
+        consolidation_policy.revalidate_destination_policy(
+            root,
+            stored_policy_bundle,
+            principal_contexts=principal_contexts,
+            destination_vault_id=stored_policy_bundle.destination_vault_id,
+            expected_nonce=plan_nonce,
+            verified_at=_policy_verification_timestamp(),
         )
         parent_ordinal, parent_id, parent_digest = _committed_token_parent(
             root,
@@ -522,13 +543,8 @@ def prepare_apply_through_preimage(
         preimage_prior = _effect_digest("preimage", "prior", preimage_facts)
         preimage_prepared = _effect_digest("preimage", "prepared", preimage_facts)
         preimage_target = _effect_digest("preimage", "target", preimage_facts)
-        manifest_ref = (
-            "exomem-consolidation-preimage://sha256/"
-            f"{preimage_plan.manifest_digest}"
-        )
-        manifest_path = (
-            artifact_store.root / "preimages" / f"{preimage_plan.manifest_digest}.json"
-        )
+        manifest_ref = f"exomem-consolidation-preimage://sha256/{preimage_plan.manifest_digest}"
+        manifest_path = artifact_store.root / "preimages" / f"{preimage_plan.manifest_digest}.json"
 
         def manifest_is_absent() -> bool:
             try:
@@ -567,17 +583,20 @@ def prepare_apply_through_preimage(
                     return _observation("prepared", preimage_prepared)
                 if manifest_is_absent():
                     return _observation("prior", preimage_prior)
-            if _seal_matches(
-                state,
-                phase="preimage-ready",
-                revision=base_revision + 3,
-                vault_binding_digest=checked_vault,
-                run_id=checked_run,
-                operation_id=checked_operation,
-                journal_digest=checked_journal,
-                sealed_at=sealed_at,
-                recorded_at=preimage_ready_at,
-            ) and verified is not None:
+            if (
+                _seal_matches(
+                    state,
+                    phase="preimage-ready",
+                    revision=base_revision + 3,
+                    vault_binding_digest=checked_vault,
+                    run_id=checked_run,
+                    operation_id=checked_operation,
+                    journal_digest=checked_journal,
+                    sealed_at=sealed_at,
+                    recorded_at=preimage_ready_at,
+                )
+                and verified is not None
+            ):
                 return _observation("target", preimage_target)
             return _observation("mixed", state.state_digest)
 
@@ -663,6 +682,7 @@ def prepare_apply_through_preimage(
         consolidation_effect_coordinator.ConsolidationEffectUnavailable,
         consolidation_intake.ConsolidationIntakeUnavailable,
         consolidation_plan_store.ConsolidationPlanStoreUnavailable,
+        consolidation_policy.DestinationPolicyUnavailable,
         consolidation_preimage.ConsolidationPreimageUnavailable,
         consolidation_receipts.ConsolidationReceiptUnavailable,
         consolidation_seal.ConsolidationSealUnavailable,

--- a/src/exomem/governance/consolidation_plan.py
+++ b/src/exomem/governance/consolidation_plan.py
@@ -92,6 +92,7 @@ _BASE_FIELDS = frozenset(
         "content_actions",
         "journal_batch_partition_digest",
         "policy_documents",
+        "policy_bundle_digest",
         "prospective_policy_fingerprint",
         "bridge_fingerprints",
         "exact_release_approval_fingerprints",
@@ -680,6 +681,7 @@ def _render_section_rows(
     )
     policy_fingerprints: Mapping[str, object] = {
         "row_kind": "policy-fingerprints",
+        "policy_bundle_digest": value["policy_bundle_digest"],
         "prospective_policy_fingerprint": value["prospective_policy_fingerprint"],
         "bridge_fingerprints": tuple(_sequence(value["bridge_fingerprints"], maximum=4096)),
         "exact_release_approval_fingerprints": tuple(
@@ -768,6 +770,7 @@ def derive_rendering_definition(
     _validate_verification(source["verification_plan"])
     _validate_rollback(source["rollback_contingency"])
     _validate_retention(source["source_retention"])
+    _digest(source["policy_bundle_digest"])
     _digest(source["prospective_policy_fingerprint"])
     source["content_actions"] = actions
     source["policy_documents"] = documents
@@ -831,6 +834,7 @@ def _validate_base(value: Mapping[str, object]) -> dict[str, object]:
         "path_map_digest",
         "dependency_map_digest",
         "journal_batch_partition_digest",
+        "policy_bundle_digest",
         "prospective_policy_fingerprint",
         "principal_attestation_set_digest",
         "disclosure_matrix_digest",
@@ -1208,13 +1212,16 @@ def parse_journal_batch_partition(raw: bytes) -> CanonicalObject:
             "final_fingerprint",
         ):
             _digest(batch[field])
-        if len(
-            {
-                batch["prior_fingerprint"],
-                batch["prepared_fingerprint"],
-                batch["final_fingerprint"],
-            }
-        ) != 3:
+        if (
+            len(
+                {
+                    batch["prior_fingerprint"],
+                    batch["prepared_fingerprint"],
+                    batch["final_fingerprint"],
+                }
+            )
+            != 3
+        ):
             _fail()
         seen_actions += count
     if seen_actions != action_count:

--- a/src/exomem/governance/consolidation_plan_store.py
+++ b/src/exomem/governance/consolidation_plan_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -9,7 +10,7 @@ from pathlib import Path
 from typing import NoReturn
 
 from .. import reserved_paths
-from . import consolidation_plan, consolidation_run_state
+from . import consolidation_plan, consolidation_policy, consolidation_run_state, policy
 
 _DESCRIPTOR_ID = "consolidation-tree"
 _OWNER = "consolidation.run"
@@ -19,6 +20,7 @@ _UUID4 = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-
 _MAX_SAFE_INTEGER = (1 << 53) - 1
 _MAX_PLAN_BYTES = 16 * 1024 * 1024
 _MAX_CONTROL_BYTES = 64 * 1024
+_MAX_POLICY_BUNDLE_BYTES = 16 * 1024 * 1024
 
 
 class ConsolidationPlanStoreUnavailable(RuntimeError):
@@ -123,10 +125,40 @@ class ConsolidationPlanStore:
         ):
             _fail("PLAN_RUN_MISMATCH")
 
+    @staticmethod
+    def _bind_policy_bundle(
+        record: consolidation_run_state.ConsolidationRunRecord,
+        plan: consolidation_plan.CanonicalConsolidationPlan,
+        bundle: consolidation_policy.DestinationPolicyPlan,
+    ) -> None:
+        documents = tuple(
+            {
+                "path": path,
+                "content": raw.decode("utf-8"),
+                "byte_size": len(raw),
+                "sha256": hashlib.sha256(raw).hexdigest(),
+            }
+            for path, raw in bundle.prospective.target_documents
+            if policy._document_kind(path) is not None  # noqa: SLF001
+        )
+        if (
+            plan.preimage["plan_kind"] != "cutover"
+            or plan.preimage["policy_bundle_digest"] != bundle.digest
+            or plan.preimage["policy_documents"] != documents
+            or plan.preimage["prospective_policy_fingerprint"]
+            != bundle.prospective.policy.fingerprint
+            or plan.preimage["principal_attestation_set_digest"]
+            != bundle.principal_attestation_set_digest
+            or plan.preimage["nonce"] != bundle.nonce
+            or record.identity.destination_vault_id != bundle.destination_vault_id
+        ):
+            _fail("PLAN_POLICY_BUNDLE_MISMATCH")
+
     def persist(
         self,
         plan: consolidation_plan.CanonicalConsolidationPlan,
         *,
+        policy_bundle: consolidation_policy.DestinationPolicyPlan | None = None,
         expected_run_revision: int,
     ) -> consolidation_plan.CanonicalConsolidationPlan:
         """Create or adopt one byte-identical immutable plan."""
@@ -150,40 +182,81 @@ class ConsolidationPlanStore:
             _fail("PLAN_RUN_REVISION_CONFLICT")
         directory = self._plan_dir(run_id, kind, digest)
         control_path = directory / "control-basis.json"
+        policy_bundle_path = directory / "policy-bundle.json"
         plan_path = directory / "plan.json"
+
+        policy_bundle_raw: bytes | None = None
+        if kind == "cutover":
+            if not isinstance(policy_bundle, consolidation_policy.DestinationPolicyPlan):
+                _fail("PLAN_POLICY_BUNDLE_REQUIRED")
+            try:
+                policy_bundle_raw = consolidation_policy.canonical_destination_policy_bundle(
+                    policy_bundle
+                )
+                if (
+                    consolidation_policy.parse_destination_policy_bundle(policy_bundle_raw)
+                    != policy_bundle
+                ):
+                    _fail("PLAN_STORE_INPUT_INVALID")
+            except consolidation_policy.DestinationPolicyUnavailable:
+                _fail("PLAN_STORE_INPUT_INVALID")
+        elif policy_bundle is not None:
+            _fail("PLAN_STORE_INPUT_INVALID")
 
         with _authority(self.vault_root, mutation=True):
             record, _inventory, _raw = self.run_store._load_locked(run_id)  # noqa: SLF001
             if record.revision != revision:
                 _fail("PLAN_RUN_REVISION_CONFLICT")
             self._bind_run(record, plan)
+            if policy_bundle is not None:
+                self._bind_policy_bundle(record, plan, policy_bundle)
             existing_control = self._read_optional(
                 control_path,
                 limit=_MAX_CONTROL_BYTES,
             )
+            existing_policy_bundle = self._read_optional(
+                policy_bundle_path,
+                limit=_MAX_POLICY_BUNDLE_BYTES,
+            )
             existing_plan = self._read_optional(plan_path, limit=_MAX_PLAN_BYTES)
-            if existing_control is None and existing_plan is not None:
+            if existing_control is None and (
+                existing_policy_bundle is not None or existing_plan is not None
+            ):
                 _fail("PLAN_STORE_CORRUPT")
             if (
-                existing_control is not None
-                and existing_control != plan.control_basis.canonical_bytes
-            ) or (existing_plan is not None and existing_plan != plan.canonical_bytes):
+                kind == "cutover" and existing_plan is not None and existing_policy_bundle is None
+            ) or (kind != "cutover" and existing_policy_bundle is not None):
+                _fail("PLAN_STORE_CORRUPT")
+            if (
+                (
+                    existing_control is not None
+                    and existing_control != plan.control_basis.canonical_bytes
+                )
+                or (
+                    existing_policy_bundle is not None
+                    and existing_policy_bundle != policy_bundle_raw
+                )
+                or (existing_plan is not None and existing_plan != plan.canonical_bytes)
+            ):
                 _fail("PLAN_STORE_CONFLICT")
             if existing_control is None:
                 self._publish_missing(control_path, plan.control_basis.canonical_bytes)
+            if existing_policy_bundle is None and policy_bundle_raw is not None:
+                self._publish_missing(policy_bundle_path, policy_bundle_raw)
             if existing_plan is None:
                 self._publish_missing(plan_path, plan.canonical_bytes)
         return plan
 
-    def load(
+    def _load_exact(
         self,
         run_id: str,
         *,
         plan_kind: str,
         plan_digest: str,
-    ) -> consolidation_plan.CanonicalConsolidationPlan:
-        """Load an exact stored plan by its opaque run/kind/digest key."""
-
+    ) -> tuple[
+        consolidation_plan.CanonicalConsolidationPlan,
+        consolidation_policy.DestinationPolicyPlan | None,
+    ]:
         run_id = _run_id(run_id)
         kind = _plan_kind(plan_kind)
         digest = _digest(plan_digest)
@@ -194,13 +267,19 @@ class ConsolidationPlanStore:
                 directory / "control-basis.json",
                 limit=_MAX_CONTROL_BYTES,
             )
+            policy_bundle_raw = self._read_optional(
+                directory / "policy-bundle.json",
+                limit=_MAX_POLICY_BUNDLE_BYTES,
+            )
             plan_raw = self._read_optional(
                 directory / "plan.json",
                 limit=_MAX_PLAN_BYTES,
             )
-            if control_raw is None and plan_raw is None:
+            if control_raw is None and policy_bundle_raw is None and plan_raw is None:
                 _fail("PLAN_NOT_FOUND")
             if control_raw is None or plan_raw is None:
+                _fail("PLAN_STORE_CORRUPT")
+            if (kind == "cutover") != (policy_bundle_raw is not None):
                 _fail("PLAN_STORE_CORRUPT")
             try:
                 control = consolidation_plan.parse_control_basis(control_raw)
@@ -208,7 +287,15 @@ class ConsolidationPlanStore:
                     plan_raw,
                     control_basis=control,
                 )
-            except consolidation_plan.ConsolidationPlanUnavailable:
+                bundle = (
+                    None
+                    if policy_bundle_raw is None
+                    else consolidation_policy.parse_destination_policy_bundle(policy_bundle_raw)
+                )
+            except (
+                consolidation_plan.ConsolidationPlanUnavailable,
+                consolidation_policy.DestinationPolicyUnavailable,
+            ):
                 _fail("PLAN_STORE_CORRUPT")
             if (
                 plan.digest != digest
@@ -217,7 +304,43 @@ class ConsolidationPlanStore:
             ):
                 _fail("PLAN_STORE_CORRUPT")
             self._bind_run(record, plan)
+            if bundle is not None:
+                self._bind_policy_bundle(record, plan, bundle)
+        return plan, bundle
+
+    def load(
+        self,
+        run_id: str,
+        *,
+        plan_kind: str,
+        plan_digest: str,
+    ) -> consolidation_plan.CanonicalConsolidationPlan:
+        """Load an exact stored plan by its opaque run/kind/digest key."""
+
+        plan, _bundle = self._load_exact(
+            run_id,
+            plan_kind=plan_kind,
+            plan_digest=plan_digest,
+        )
         return plan
+
+    def load_policy_bundle(
+        self,
+        run_id: str,
+        *,
+        plan_kind: str,
+        plan_digest: str,
+    ) -> consolidation_policy.DestinationPolicyPlan:
+        """Load the exact policy bundle bound by one stored cutover plan."""
+
+        _plan, bundle = self._load_exact(
+            run_id,
+            plan_kind=plan_kind,
+            plan_digest=plan_digest,
+        )
+        if bundle is None:
+            _fail("PLAN_POLICY_BUNDLE_REQUIRED")
+        return bundle
 
 
 __all__ = ["ConsolidationPlanStore", "ConsolidationPlanStoreUnavailable"]

--- a/src/exomem/governance/consolidation_policy.py
+++ b/src/exomem/governance/consolidation_policy.py
@@ -9,6 +9,7 @@ documents against the exact live authoring snapshot.
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 import secrets
 import unicodedata
@@ -33,7 +34,7 @@ _SOURCE_AUTHORITY_REVIEW_DOMAIN = b"exomem.source-authority-review/v1"
 _ATTESTATION_SET_DOMAIN = b"exomem.destination-principal-attestation-set/v1"
 _DOCUMENT_SET_DOMAIN = b"exomem.consolidation-destination-documents/v1"
 _AUTHORING_SNAPSHOT_DOMAIN = b"exomem.consolidation-authoring-snapshot/v1"
-_PLAN_DOMAIN = b"exomem.consolidation-destination-policy-plan/v1"
+_PLAN_DOMAIN = DESTINATION_POLICY_PLAN_SCHEMA.encode("ascii")
 
 _TRUSTED_SURFACES = frozenset({"cli", "hosted", "mcp", "rest"})
 _SOURCE_AUTHORITY_KINDS = frozenset(
@@ -61,6 +62,7 @@ _RFC3339_MILLISECONDS = re.compile(
 _MAX_SAFE_INTEGER = (1 << 53) - 1
 _MAX_DOCUMENTS = 1024
 _MAX_DOCUMENT_BYTES = 1 << 20
+_MAX_POLICY_BUNDLE_BYTES = 16 * 1024 * 1024
 
 __all__ = [
     "DESTINATION_POLICY_PLAN_SCHEMA",
@@ -71,7 +73,10 @@ __all__ = [
     "SourceAuthorityReviewArtifact",
     "VerifiedDestinationPrincipalAttestation",
     "compile_destination_policy",
+    "canonical_destination_policy_bundle",
+    "destination_policy_bundle_digest",
     "issue_destination_principal_attestation",
+    "parse_destination_policy_bundle",
     "principal_attestation_set_digest",
     "revalidate_destination_policy",
     "source_authority_review_digest",
@@ -124,6 +129,7 @@ class SourceAuthorityReviewArtifact:
 class DestinationPolicyPlan:
     schema: str
     destination_vault_id: str
+    nonce: str
     prospective: policy.ProspectiveCompile
     document_edits: tuple[tuple[str, str | None], ...]
     document_set_digest: str
@@ -528,6 +534,262 @@ def _authoring_snapshot_digest(snapshot: policy.AuthoringSnapshot) -> str:
     return _framed_digest(_AUTHORING_SNAPSHOT_DOMAIN, value)
 
 
+def _integer(value: object) -> int:
+    if type(value) is not int or not 0 <= value <= _MAX_SAFE_INTEGER:
+        _fail()
+    return value
+
+
+def _mapping(value: object, fields: frozenset[str]) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or frozenset(value) != fields:
+        _fail()
+    return value
+
+
+def _policy_path(value: object) -> str:
+    path = _text(value)
+    parsed = PurePosixPath(path)
+    if (
+        not path
+        or len(path.encode("utf-8")) > 4096
+        or "\\" in path
+        or parsed.is_absolute()
+        or parsed.as_posix() != path
+        or any(part in {"", ".", ".."} for part in parsed.parts)
+    ):
+        _fail()
+    return path
+
+
+def _document_rows(documents: Sequence[tuple[str, bytes]]) -> list[dict[str, object]]:
+    if len(documents) > _MAX_DOCUMENTS:
+        _fail()
+    rows: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for raw_path, raw in documents:
+        path = _policy_path(raw_path)
+        if path in seen or not isinstance(raw, bytes) or len(raw) > _MAX_DOCUMENT_BYTES:
+            _fail()
+        try:
+            content = _text(raw.decode("utf-8"))
+        except UnicodeDecodeError:
+            _fail()
+        if content.encode("utf-8") != raw:
+            _fail()
+        seen.add(path)
+        rows.append(
+            {
+                "path": path,
+                "content": content,
+                "byte_size": len(raw),
+                "sha256": hashlib.sha256(raw).hexdigest(),
+            }
+        )
+    if tuple(row["path"] for row in rows) != tuple(sorted(seen)):
+        _fail()
+    return rows
+
+
+def _parse_document_rows(value: object) -> tuple[tuple[str, bytes], ...]:
+    if not isinstance(value, list) or len(value) > _MAX_DOCUMENTS:
+        _fail()
+    documents: list[tuple[str, bytes]] = []
+    for raw in value:
+        item = _mapping(
+            raw,
+            frozenset({"path", "content", "byte_size", "sha256"}),
+        )
+        path = _policy_path(item["path"])
+        content = _text(item["content"])
+        encoded = content.encode("utf-8")
+        if (
+            len(encoded) > _MAX_DOCUMENT_BYTES
+            or _integer(item["byte_size"]) != len(encoded)
+            or _digest(item["sha256"]) != hashlib.sha256(encoded).hexdigest()
+        ):
+            _fail()
+        documents.append((path, encoded))
+    if tuple(path for path, _raw in documents) != tuple(sorted({path for path, _raw in documents})):
+        _fail()
+    return tuple(documents)
+
+
+def _stable_identity_from_value(value: object) -> StableIdentity:
+    item = _mapping(
+        value,
+        frozenset({"device", "inode", "kind", "link_count"}),
+    )
+    return StableIdentity(
+        device=_integer(item["device"]),
+        inode=_integer(item["inode"]),
+        kind=_identifier(item["kind"]),
+        link_count=_integer(item["link_count"]),
+    )
+
+
+def _authoring_snapshot_value(snapshot: policy.AuthoringSnapshot) -> dict[str, object]:
+    root: dict[str, object]
+    if snapshot.governance_root_identity is None:
+        root = {"state": "absent"}
+    else:
+        root = {
+            "state": "present",
+            "identity": _stable_identity_value(snapshot.governance_root_identity),
+        }
+    file_paths = tuple(_policy_path(item.path) for item in snapshot.file_identities)
+    directory_paths = tuple(_policy_path(path) for path, _identity in snapshot.directory_identities)
+    file_identities = [
+        {
+            "path": path,
+            "sha256": _digest(item.sha256),
+            "identity": _stable_identity_value(item.identity),
+        }
+        for path, item in zip(file_paths, snapshot.file_identities, strict=True)
+    ]
+    directory_identities = [
+        {
+            "path": checked_path,
+            "identity": _stable_identity_value(identity),
+        }
+        for checked_path, (_path, identity) in zip(
+            directory_paths,
+            snapshot.directory_identities,
+            strict=True,
+        )
+    ]
+    if file_paths != tuple(sorted(set(file_paths))) or directory_paths != tuple(
+        sorted(set(directory_paths))
+    ):
+        _fail()
+    return {
+        "documents": _document_rows(snapshot.documents),
+        "source_fingerprint": _digest(snapshot.source_fingerprint),
+        "conflict_set_digest": _digest(snapshot.conflict_set_digest),
+        "guard_generation": _text(snapshot.guard_generation),
+        "file_identities": file_identities,
+        "directory_identities": directory_identities,
+        "governance_root": root,
+    }
+
+
+def _parse_authoring_snapshot(value: object) -> policy.AuthoringSnapshot:
+    item = _mapping(
+        value,
+        frozenset(
+            {
+                "documents",
+                "source_fingerprint",
+                "conflict_set_digest",
+                "guard_generation",
+                "file_identities",
+                "directory_identities",
+                "governance_root",
+            }
+        ),
+    )
+    documents = _parse_document_rows(item["documents"])
+    raw_files = item["file_identities"]
+    raw_directories = item["directory_identities"]
+    if not isinstance(raw_files, list) or not isinstance(raw_directories, list):
+        _fail()
+    files: list[policy.AuthoringFileIdentity] = []
+    for raw in raw_files:
+        row = _mapping(raw, frozenset({"path", "sha256", "identity"}))
+        files.append(
+            policy.AuthoringFileIdentity(
+                path=_policy_path(row["path"]),
+                sha256=_digest(row["sha256"]),
+                identity=_stable_identity_from_value(row["identity"]),
+            )
+        )
+    directories: list[tuple[str, StableIdentity]] = []
+    for raw in raw_directories:
+        row = _mapping(raw, frozenset({"path", "identity"}))
+        directories.append(
+            (_policy_path(row["path"]), _stable_identity_from_value(row["identity"]))
+        )
+    if tuple(item.path for item in files) != tuple(sorted({item.path for item in files})) or tuple(
+        path for path, _identity in directories
+    ) != tuple(sorted({path for path, _identity in directories})):
+        _fail()
+    raw_root = item["governance_root"]
+    if raw_root == {"state": "absent"}:
+        root = None
+    else:
+        root_row = _mapping(raw_root, frozenset({"state", "identity"}))
+        if root_row["state"] != "present":
+            _fail()
+        root = _stable_identity_from_value(root_row["identity"])
+    snapshot = policy.AuthoringSnapshot(
+        documents=documents,
+        source_fingerprint=_digest(item["source_fingerprint"]),
+        conflict_set_digest=_digest(item["conflict_set_digest"]),
+        guard_generation=_text(item["guard_generation"]),
+        file_identities=tuple(files),
+        directory_identities=tuple(directories),
+        governance_root_identity=root,
+    )
+    if _authoring_snapshot_value(snapshot) != value:
+        _fail()
+    return snapshot
+
+
+def _document_edit_rows(
+    edits: Sequence[tuple[str, str | None]],
+) -> list[dict[str, object]]:
+    checked = _document_edits(dict(edits))
+    if tuple(edits) != checked:
+        _fail()
+    rows: list[dict[str, object]] = []
+    for path, content in checked:
+        if content is None:
+            rows.append({"path": path, "state": "absent"})
+        else:
+            encoded = content.encode("utf-8")
+            rows.append(
+                {
+                    "path": path,
+                    "state": "present",
+                    "content": content,
+                    "byte_size": len(encoded),
+                    "sha256": hashlib.sha256(encoded).hexdigest(),
+                }
+            )
+    return rows
+
+
+def _parse_document_edits(value: object) -> tuple[tuple[str, str | None], ...]:
+    if not isinstance(value, list) or len(value) > _MAX_DOCUMENTS:
+        _fail()
+    edits: dict[str, str | None] = {}
+    for raw in value:
+        if not isinstance(raw, Mapping) or raw.get("state") not in {"absent", "present"}:
+            _fail()
+        if raw["state"] == "absent":
+            row = _mapping(raw, frozenset({"path", "state"}))
+            content = None
+        else:
+            row = _mapping(
+                raw,
+                frozenset({"path", "state", "content", "byte_size", "sha256"}),
+            )
+            content = _text(row["content"])
+            encoded = content.encode("utf-8")
+            if (
+                _integer(row["byte_size"]) != len(encoded)
+                or _digest(row["sha256"]) != hashlib.sha256(encoded).hexdigest()
+            ):
+                _fail()
+        path = _policy_path(row["path"])
+        if path in edits:
+            _fail()
+        edits[path] = content
+    checked = _document_edits(edits)
+    if _document_edit_rows(checked) != value:
+        _fail()
+    return checked
+
+
 def _requirements(compiled: policy.Policy) -> dict[str, set[str]]:
     required: dict[str, set[str]] = {}
     for rule in compiled.rules:
@@ -570,6 +832,306 @@ def _requirements_tuple(
         (principal_id, tuple(sorted(purposes)))
         for principal_id, purposes in sorted(requirements.items())
     )
+
+
+def _policy_bundle_value(plan: DestinationPolicyPlan) -> dict[str, object]:
+    if (
+        not isinstance(plan, DestinationPolicyPlan)
+        or plan.schema != DESTINATION_POLICY_PLAN_SCHEMA
+        or not isinstance(plan.prospective, policy.ProspectiveCompile)
+        or not isinstance(plan.prospective.snapshot, policy.AuthoringSnapshot)
+    ):
+        _fail()
+    vault_id = _identifier(plan.destination_vault_id)
+    nonce = _identifier(plan.nonce)
+    snapshot = plan.prospective.snapshot
+    target_documents = plan.prospective.target_documents
+    compiled = policy.compile_documents(dict(target_documents))
+    requirements = {
+        _identifier(principal_id): set(_purposes(purposes))
+        for principal_id, purposes in plan.principal_requirements
+    }
+    attestations_by_principal = {
+        attestation.principal_id: attestation for attestation in plan.attestations
+    }
+    if (
+        plan.prospective.policy != compiled
+        or plan.document_edits != _document_edits(dict(plan.document_edits))
+        or plan.document_set_digest != _document_set_digest(target_documents)
+        or plan.authoring_snapshot_digest != _authoring_snapshot_digest(snapshot)
+        or plan.source_authority
+        != tuple(sorted(plan.source_authority, key=lambda item: item.object_ref))
+        or plan.source_authority_review_digest
+        != source_authority_review_digest(plan.source_authority)
+        or plan.attestations != tuple(sorted(plan.attestations, key=lambda item: item.principal_id))
+        or plan.principal_attestation_set_digest
+        != principal_attestation_set_digest(plan.attestations)
+        or len(attestations_by_principal) != len(plan.attestations)
+        or set(attestations_by_principal) != set(requirements)
+        or any(
+            attestation.destination_vault_id != vault_id
+            or attestation.nonce != nonce
+            or not requirements[principal_id] <= set(attestation.purposes)
+            for principal_id, attestation in attestations_by_principal.items()
+        )
+        or _requirements_tuple(requirements) != plan.principal_requirements
+        or any(
+            not purposes <= requirements.get(principal_id, set())
+            for principal_id, purposes in _requirements(compiled).items()
+        )
+        or tuple(sorted(requirements)) != plan.named_principals
+    ):
+        _fail()
+    return {
+        "schema": plan.schema,
+        "destination_vault_id": vault_id,
+        "nonce": nonce,
+        "prospective": {
+            "snapshot": _authoring_snapshot_value(snapshot),
+            "target_documents": _document_rows(target_documents),
+            "policy_fingerprint": _digest(compiled.fingerprint),
+        },
+        "document_edits": _document_edit_rows(plan.document_edits),
+        "document_set_digest": _digest(plan.document_set_digest),
+        "authoring_snapshot_digest": _digest(plan.authoring_snapshot_digest),
+        "source_authority": _source_authority_value(plan.source_authority),
+        "source_authority_review_digest": _digest(plan.source_authority_review_digest),
+        "attestations": _attestation_value(plan.attestations),
+        "principal_attestation_set_digest": _digest(plan.principal_attestation_set_digest),
+        "principal_requirements": [
+            {"principal_id": principal_id, "purposes": list(purposes)}
+            for principal_id, purposes in plan.principal_requirements
+        ],
+        "named_principals": list(plan.named_principals),
+    }
+
+
+def _source_authority_from_value(value: object) -> tuple[SourceAuthorityReviewArtifact, ...]:
+    if not isinstance(value, list) or len(value) > 4096:
+        _fail()
+    artifacts: list[SourceAuthorityReviewArtifact] = []
+    for raw in value:
+        item = _mapping(
+            raw,
+            frozenset(
+                {
+                    "object_ref",
+                    "object_kind",
+                    "object_sha256",
+                    "bundle_sha256",
+                    "provenance_ref",
+                }
+            ),
+        )
+        artifacts.append(
+            SourceAuthorityReviewArtifact(
+                object_ref=_reference(item["object_ref"]),
+                object_kind=_identifier(item["object_kind"]),
+                object_sha256=_digest(item["object_sha256"]),
+                bundle_sha256=_digest(item["bundle_sha256"]),
+                provenance_ref=_reference(item["provenance_ref"]),
+            )
+        )
+    ordered = tuple(sorted(artifacts, key=lambda item: item.object_ref))
+    if _source_authority_value(ordered) != value:
+        _fail()
+    return ordered
+
+
+def _attestations_from_value(
+    value: object,
+) -> tuple[DestinationPrincipalAttestation, ...]:
+    if not isinstance(value, list) or len(value) > 1024:
+        _fail()
+    attestations: list[DestinationPrincipalAttestation] = []
+    fields = frozenset(
+        {
+            "schema",
+            "destination_vault_id",
+            "issuer_family",
+            "surface",
+            "principal_id",
+            "purposes",
+            "issued_at",
+            "expires_at",
+            "authentication_binding_digest",
+            "nonce",
+            "fingerprint",
+        }
+    )
+    for raw in value:
+        item = _mapping(raw, fields)
+        purposes = item["purposes"]
+        if not isinstance(purposes, list):
+            _fail()
+        attestations.append(
+            DestinationPrincipalAttestation(
+                schema=_text(item["schema"]),
+                destination_vault_id=_identifier(item["destination_vault_id"]),
+                issuer_family=_identifier(item["issuer_family"]),
+                surface=_text(item["surface"]),
+                principal_id=_identifier(item["principal_id"]),
+                purposes=_purposes(purposes),
+                issued_at=_timestamp(item["issued_at"])[0],
+                expires_at=_timestamp(item["expires_at"])[0],
+                authentication_binding_digest=_digest(item["authentication_binding_digest"]),
+                nonce=_identifier(item["nonce"]),
+                fingerprint=_digest(item["fingerprint"]),
+            )
+        )
+    ordered = tuple(sorted(attestations, key=lambda item: item.principal_id))
+    if _attestation_value(ordered) != value:
+        _fail()
+    return ordered
+
+
+def _requirements_from_value(
+    value: object,
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    if not isinstance(value, list) or len(value) > 1024:
+        _fail()
+    rows: list[tuple[str, tuple[str, ...]]] = []
+    for raw in value:
+        item = _mapping(raw, frozenset({"principal_id", "purposes"}))
+        purposes = item["purposes"]
+        if not isinstance(purposes, list):
+            _fail()
+        rows.append((_identifier(item["principal_id"]), _purposes(purposes)))
+    requirements = tuple(rows)
+    if requirements != _requirements_tuple(
+        {principal_id: set(purposes) for principal_id, purposes in requirements}
+    ):
+        _fail()
+    return requirements
+
+
+def _policy_plan_from_value(value: object) -> DestinationPolicyPlan:
+    item = _mapping(
+        value,
+        frozenset(
+            {
+                "schema",
+                "destination_vault_id",
+                "nonce",
+                "prospective",
+                "document_edits",
+                "document_set_digest",
+                "authoring_snapshot_digest",
+                "source_authority",
+                "source_authority_review_digest",
+                "attestations",
+                "principal_attestation_set_digest",
+                "principal_requirements",
+                "named_principals",
+            }
+        ),
+    )
+    if item["schema"] != DESTINATION_POLICY_PLAN_SCHEMA:
+        _fail()
+    prospective_value = _mapping(
+        item["prospective"],
+        frozenset({"snapshot", "target_documents", "policy_fingerprint"}),
+    )
+    snapshot = _parse_authoring_snapshot(prospective_value["snapshot"])
+    target_documents = _parse_document_rows(prospective_value["target_documents"])
+    compiled = policy.compile_documents(dict(target_documents))
+    if compiled.fingerprint != _digest(prospective_value["policy_fingerprint"]):
+        _fail()
+    prospective = policy.ProspectiveCompile(
+        snapshot=snapshot,
+        target_documents=target_documents,
+        policy=compiled,
+    )
+    source_authority = _source_authority_from_value(item["source_authority"])
+    attestations = _attestations_from_value(item["attestations"])
+    requirements = _requirements_from_value(item["principal_requirements"])
+    named = item["named_principals"]
+    if not isinstance(named, list):
+        _fail()
+    named_principals = tuple(_identifier(principal_id) for principal_id in named)
+    preliminary = DestinationPolicyPlan(
+        schema=DESTINATION_POLICY_PLAN_SCHEMA,
+        destination_vault_id=_identifier(item["destination_vault_id"]),
+        nonce=_identifier(item["nonce"]),
+        prospective=prospective,
+        document_edits=_parse_document_edits(item["document_edits"]),
+        document_set_digest=_digest(item["document_set_digest"]),
+        authoring_snapshot_digest=_digest(item["authoring_snapshot_digest"]),
+        source_authority=source_authority,
+        source_authority_review_digest=_digest(item["source_authority_review_digest"]),
+        attestations=attestations,
+        principal_attestation_set_digest=_digest(item["principal_attestation_set_digest"]),
+        principal_requirements=requirements,
+        named_principals=named_principals,
+        digest="0" * 64,
+    )
+    if _policy_bundle_value(preliminary) != value:
+        _fail()
+    return DestinationPolicyPlan(
+        schema=preliminary.schema,
+        destination_vault_id=preliminary.destination_vault_id,
+        nonce=preliminary.nonce,
+        prospective=preliminary.prospective,
+        document_edits=preliminary.document_edits,
+        document_set_digest=preliminary.document_set_digest,
+        authoring_snapshot_digest=preliminary.authoring_snapshot_digest,
+        source_authority=preliminary.source_authority,
+        source_authority_review_digest=preliminary.source_authority_review_digest,
+        attestations=preliminary.attestations,
+        principal_attestation_set_digest=preliminary.principal_attestation_set_digest,
+        principal_requirements=preliminary.principal_requirements,
+        named_principals=preliminary.named_principals,
+        digest=_plan_digest(preliminary),
+    )
+
+
+def canonical_destination_policy_bundle(plan: DestinationPolicyPlan) -> bytes:
+    """Return the exact canonical bytes whose framed digest authorizes apply."""
+
+    value = _policy_bundle_value(plan)
+    if plan.digest != _framed_digest(_PLAN_DOMAIN, value):
+        _fail()
+    return _canonical(value)
+
+
+def destination_policy_bundle_digest(plan: DestinationPolicyPlan) -> str:
+    """Return the outside digest of one exact canonical policy bundle."""
+
+    canonical_destination_policy_bundle(plan)
+    return plan.digest
+
+
+def parse_destination_policy_bundle(raw: bytes) -> DestinationPolicyPlan:
+    """Parse only exact canonical stored destination-policy bundle bytes."""
+
+    if not isinstance(raw, bytes) or not 1 <= len(raw) <= _MAX_POLICY_BUNDLE_BYTES:
+        _fail()
+
+    def object_pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, item in pairs:
+            normalized = _text(key)
+            if normalized in result:
+                _fail()
+            result[normalized] = item
+        return result
+
+    def invalid_number(_value: str) -> NoReturn:
+        _fail()
+
+    try:
+        parsed = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=object_pairs,
+            parse_float=invalid_number,
+            parse_constant=invalid_number,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError):
+        _fail()
+    plan = _policy_plan_from_value(parsed)
+    if canonical_destination_policy_bundle(plan) != raw:
+        _fail()
+    return plan
 
 
 def _principal_map(principals: Sequence[RequestPrincipal]) -> dict[str, RequestPrincipal]:
@@ -619,25 +1181,7 @@ def _verify_attestation_set(
 
 
 def _plan_digest(plan: DestinationPolicyPlan) -> str:
-    snapshot = plan.prospective.snapshot
-    value = {
-        "schema": plan.schema,
-        "destination_vault_id": plan.destination_vault_id,
-        "source_fingerprint": snapshot.source_fingerprint,
-        "conflict_set_digest": snapshot.conflict_set_digest,
-        "guard_generation": snapshot.guard_generation,
-        "document_set_digest": plan.document_set_digest,
-        "authoring_snapshot_digest": plan.authoring_snapshot_digest,
-        "policy_fingerprint": plan.prospective.policy.fingerprint,
-        "source_authority_review_digest": plan.source_authority_review_digest,
-        "principal_attestation_set_digest": plan.principal_attestation_set_digest,
-        "principal_requirements": [
-            {"principal_id": principal_id, "purposes": list(purposes)}
-            for principal_id, purposes in plan.principal_requirements
-        ],
-        "named_principals": list(plan.named_principals),
-    }
-    return _framed_digest(_PLAN_DOMAIN, value)
+    return _framed_digest(_PLAN_DOMAIN, _policy_bundle_value(plan))
 
 
 def compile_destination_policy(
@@ -675,6 +1219,7 @@ def compile_destination_policy(
     plan = DestinationPolicyPlan(
         schema=DESTINATION_POLICY_PLAN_SCHEMA,
         destination_vault_id=vault_id,
+        nonce=_identifier(expected_nonce),
         prospective=prospective,
         document_edits=edits,
         document_set_digest=_document_set_digest(prospective.target_documents),
@@ -690,6 +1235,7 @@ def compile_destination_policy(
     return DestinationPolicyPlan(
         schema=plan.schema,
         destination_vault_id=plan.destination_vault_id,
+        nonce=plan.nonce,
         prospective=plan.prospective,
         document_edits=plan.document_edits,
         document_set_digest=plan.document_set_digest,
@@ -719,6 +1265,7 @@ def revalidate_destination_policy(
         not isinstance(plan, DestinationPolicyPlan)
         or plan.schema != DESTINATION_POLICY_PLAN_SCHEMA
         or plan.destination_vault_id != _identifier(destination_vault_id)
+        or plan.nonce != _identifier(expected_nonce)
         or plan.digest != _plan_digest(plan)
         or plan.source_authority_review_digest
         != source_authority_review_digest(plan.source_authority)

--- a/tests/test_consolidation_apply_coordinator.py
+++ b/tests/test_consolidation_apply_coordinator.py
@@ -197,6 +197,108 @@ def _reopen_after_prior_apply(seal_store) -> None:
     assert opened.revision == 14
 
 
+def test_apply_refuses_missing_policy_bundle_before_sealing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_admission,
+        consolidation_apply_coordinator,
+        consolidation_authority,
+        consolidation_plan_store,
+        consolidation_seal,
+        receipts,
+    )
+
+    vault, artifact_store = _destination(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        consolidation_apply_coordinator,
+        "_policy_verification_timestamp",
+        lambda: T1,
+    )
+    predecessor = _append_token_reservation(vault)
+    snapshot = consolidation_fingerprints.load_local_destination_snapshot(vault, now=123)
+
+    monkeypatch.setattr(
+        consolidation_plan_store.ConsolidationPlanStore,
+        "load",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            digest=PLAN_DIGEST,
+            control_basis=SimpleNamespace(digest=CONTROL_BASIS_DIGEST),
+            preimage={
+                "run_id": RUN_ID,
+                "plan_kind": "cutover",
+                "destination_snapshot_fingerprint": snapshot.digest,
+                "expected_destination_preimage_census_digest": (snapshot.canonical_census_digest),
+                "nonce": "apply-policy-bundle-nonce",
+            },
+        ),
+    )
+
+    def missing_bundle(*_args, **_kwargs):
+        raise consolidation_plan_store.ConsolidationPlanStoreUnavailable("PLAN_STORE_CORRUPT")
+
+    monkeypatch.setattr(
+        consolidation_plan_store.ConsolidationPlanStore,
+        "load_policy_bundle",
+        missing_bundle,
+    )
+    seal_store = consolidation_seal.ConsolidationSealStore(vault)
+    seal_store.initialize_open(vault_binding_digest=VAULT_BINDING, recorded_at=T0)
+    admission = consolidation_admission.ConsolidationAdmission(
+        vault,
+        vault_binding_digest=VAULT_BINDING,
+    )
+    authority = consolidation_authority.issue_authority(
+        vault_binding_digest=VAULT_BINDING,
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        phase="sealing",
+        action="apply",
+    )
+    record_count = len(receipts.event_records(vault))
+    with admission.admit_mutation() as mutation:
+        control = admission.convert_control_mutation(
+            mutation,
+            authority=authority,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            request_digest=REQUEST_DIGEST,
+            phase="sealing",
+            action="apply",
+        )
+        with pytest.raises(
+            consolidation_apply_coordinator.ConsolidationApplyPreparationUnavailable
+        ):
+            consolidation_apply_coordinator.prepare_apply_through_preimage(
+                vault_root=vault,
+                admission=admission,
+                control=control,
+                artifact_store=artifact_store,
+                token_reservation_event_id=str(predecessor["event_id"]),
+                token_reservation_payload_digest=str(
+                    predecessor["consolidation_event"]["payload_digest"]
+                ),
+                vault_binding_digest=VAULT_BINDING,
+                run_id=RUN_ID,
+                operation_id=OPERATION_ID,
+                journal_digest=JOURNAL_DIGEST,
+                request_digest=REQUEST_DIGEST,
+                plan_digest=PLAN_DIGEST,
+                principal_contexts=(),
+                sealed_at=T1,
+                drained_at=T2,
+                preimage_ready_at=T3,
+                now=123,
+                timeout=2.0,
+            )
+
+    assert seal_store.load(vault_binding_digest=VAULT_BINDING).kind == "open"
+    assert len(receipts.event_records(vault)) == record_count
+
+
 @pytest.mark.parametrize("crash_before_preimage_ready", [False, True])
 @pytest.mark.parametrize("reopened_after_prior_apply", [False, True])
 def test_apply_preparation_receipt_chains_seal_drain_and_exact_preimage(
@@ -210,14 +312,22 @@ def test_apply_preparation_receipt_chains_seal_drain_and_exact_preimage(
         consolidation_apply_coordinator,
         consolidation_authority,
         consolidation_plan_store,
+        consolidation_policy,
         consolidation_seal,
         receipts,
     )
 
     vault, artifact_store = _destination(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        consolidation_apply_coordinator,
+        "_policy_verification_timestamp",
+        lambda: T1,
+    )
     predecessor = _append_token_reservation(vault)
     snapshot = consolidation_fingerprints.load_local_destination_snapshot(vault, now=123)
     loaded_plans: list[tuple[str, str, str]] = []
+    loaded_bundles: list[tuple[str, str, str]] = []
+    revalidated_bundles: list[object] = []
 
     def load_plan(_store, run_id, *, plan_kind, plan_digest):
         loaded_plans.append((run_id, plan_kind, plan_digest))
@@ -228,16 +338,41 @@ def test_apply_preparation_receipt_chains_seal_drain_and_exact_preimage(
                 "run_id": RUN_ID,
                 "plan_kind": "cutover",
                 "destination_snapshot_fingerprint": snapshot.digest,
-                "expected_destination_preimage_census_digest": (
-                    snapshot.canonical_census_digest
-                ),
+                "expected_destination_preimage_census_digest": (snapshot.canonical_census_digest),
+                "nonce": "apply-policy-bundle-nonce",
             },
         )
+
+    policy_bundle = SimpleNamespace(destination_vault_id="vault-apply-preparation")
+
+    def load_policy_bundle(_store, run_id, *, plan_kind, plan_digest):
+        loaded_bundles.append((run_id, plan_kind, plan_digest))
+        return policy_bundle
+
+    def revalidate_policy(_vault, bundle, **kwargs):
+        assert kwargs == {
+            "principal_contexts": (),
+            "destination_vault_id": "vault-apply-preparation",
+            "expected_nonce": "apply-policy-bundle-nonce",
+            "verified_at": T1,
+        }
+        revalidated_bundles.append(bundle)
+        return bundle
 
     monkeypatch.setattr(
         consolidation_plan_store.ConsolidationPlanStore,
         "load",
         load_plan,
+    )
+    monkeypatch.setattr(
+        consolidation_plan_store.ConsolidationPlanStore,
+        "load_policy_bundle",
+        load_policy_bundle,
+    )
+    monkeypatch.setattr(
+        consolidation_policy,
+        "revalidate_destination_policy",
+        revalidate_policy,
     )
     seal_store = consolidation_seal.ConsolidationSealStore(vault)
     seal_store.initialize_open(vault_binding_digest=VAULT_BINDING, recorded_at=T0)
@@ -270,6 +405,7 @@ def test_apply_preparation_receipt_chains_seal_drain_and_exact_preimage(
         "journal_digest": JOURNAL_DIGEST,
         "request_digest": REQUEST_DIGEST,
         "plan_digest": PLAN_DIGEST,
+        "principal_contexts": (),
         "sealed_at": T1,
         "drained_at": T2,
         "preimage_ready_at": T3,
@@ -341,6 +477,8 @@ def test_apply_preparation_receipt_chains_seal_drain_and_exact_preimage(
     assert result is not None
     assert loaded_plans
     assert set(loaded_plans) == {(RUN_ID, "cutover", PLAN_DIGEST)}
+    assert set(loaded_bundles) == {(RUN_ID, "cutover", PLAN_DIGEST)}
+    assert revalidated_bundles and set(map(id, revalidated_bundles)) == {id(policy_bundle)}
     assert result.seal_state.phase == "preimage-ready"
     assert result.preimage.manifest_digest == result.preimage_plan.manifest_digest
     assert result.preimage.binding.semantic_predecessor_event_id == (
@@ -348,8 +486,7 @@ def test_apply_preparation_receipt_chains_seal_drain_and_exact_preimage(
     )
     assert (vault / "Knowledge Base/Notes/destination.md").read_bytes() == before
     assert [
-        record["consolidation_event"]["kind"]
-        for record in receipts.event_records(vault)[-6:]
+        record["consolidation_event"]["kind"] for record in receipts.event_records(vault)[-6:]
     ] == [
         "seal-intent",
         "seal-intent",

--- a/tests/test_consolidation_plan.py
+++ b/tests/test_consolidation_plan.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from exomem.governance import consolidation_plan, consolidation_review
+from exomem.governance import consolidation_plan, consolidation_policy, consolidation_review
 
 RUN_ID = "00000000-0000-4000-8000-000000000001"
 OPERATION_ID = "00000000-0000-4000-8000-000000000002"
@@ -40,11 +40,15 @@ def _policy_document() -> dict[str, object]:
     }
 
 
-def _plan_input() -> dict[str, object]:
+def _plan_input(
+    policy_bundle: consolidation_policy.DestinationPolicyPlan | None = None,
+    *,
+    plan_kind: str = "cutover",
+) -> dict[str, object]:
     value = {
         "schema": "exomem.consolidation-plan/v1",
         "protocol_version": 1,
-        "plan_kind": "cutover",
+        "plan_kind": plan_kind,
         "run_id": RUN_ID,
         "run_mode": "cloned-rehearsal",
         "source_snapshot_fingerprint": _digest("source-snapshot"),
@@ -72,6 +76,7 @@ def _plan_input() -> dict[str, object]:
         ],
         "journal_batch_partition_digest": _digest("batch-partition"),
         "policy_documents": [_policy_document()],
+        "policy_bundle_digest": _digest("policy-bundle"),
         "prospective_policy_fingerprint": _digest("prospective-policy"),
         "bridge_fingerprints": [_digest("bridge")],
         "exact_release_approval_fingerprints": [_digest("release")],
@@ -119,6 +124,11 @@ def _plan_input() -> dict[str, object]:
         "valid_until": VALID_UNTIL,
         "nonce": NONCE,
     }
+    if policy_bundle is not None:
+        value["policy_bundle_digest"] = policy_bundle.digest
+        value["prospective_policy_fingerprint"] = policy_bundle.prospective.policy.fingerprint
+        value["principal_attestation_set_digest"] = policy_bundle.principal_attestation_set_digest
+        value["nonce"] = policy_bundle.nonce
     value["rendering_definition"] = consolidation_plan.derive_rendering_definition(value)
     return value
 
@@ -135,9 +145,14 @@ def _materialization(
     )
 
 
-def _plan(*, basis_run_revision: int = 7) -> consolidation_plan.CanonicalConsolidationPlan:
+def _plan(
+    *,
+    basis_run_revision: int = 7,
+    policy_bundle: consolidation_policy.DestinationPolicyPlan | None = None,
+    plan_kind: str = "cutover",
+) -> consolidation_plan.CanonicalConsolidationPlan:
     return consolidation_plan.materialize_plan(
-        _plan_input(),
+        _plan_input(policy_bundle, plan_kind=plan_kind),
         materialization=_materialization(basis_run_revision=basis_run_revision),
     )
 
@@ -160,6 +175,7 @@ EXPECTED_TOP_LEVEL_FIELDS = {
     "content_actions",
     "journal_batch_partition_digest",
     "policy_documents",
+    "policy_bundle_digest",
     "prospective_policy_fingerprint",
     "bridge_fingerprints",
     "exact_release_approval_fingerprints",
@@ -198,26 +214,26 @@ def test_plan_has_one_closed_cross_runtime_canonical_vector() -> None:
 
     assert set(plan.preimage) == EXPECTED_TOP_LEVEL_FIELDS
     assert set(plan.control_basis.preimage) == EXPECTED_CONTROL_BASIS_FIELDS
-    assert plan.digest == "8a999da89e1ffea6fc39a5be071f11b697733674f98b383a2786a25bc52819e8"
+    assert plan.digest == "b6ae9ea26b3cd08ba4a96bee788bb7d9b73645aebe605db0d3d516a8d7d2602f"
     assert plan.plan_input_set_digest == (
-        "1c2498af2ee36226a2d8a2f492a4a701c26ec18a8b5d7ac0f2f8d5de19689b76"
+        "6b4a6d9c7dd1e7517accc478d7da79e7783157b8b002bdeadc09af174d53a201"
     )
     assert plan.control_basis.digest == (
-        "9d34ae072e4bb0a1210ed7b5ce64d112978d2f295af84bf38c2852a7c39aadb5"
+        "d26eaaeecbb6f8162cc72d8a483330c72144be8ca8ab5f8381e01f6bcd3c2726"
     )
     assert plan.impact_summary_digest == (
         "e6ec13c6d5a662678910a04d60d67cc095480b907cb8f30751399977ac6ec46f"
     )
     assert plan.rendering_definition_digest == (
-        "f156fef8cac9c177c52b17038bb16be32ee3e3cac680cf9d115c6f8c25dd6d57"
+        "aa0c600a14463a3a773ace9fa492cb067daa46ff091e75ea4f676ab435bee7eb"
     )
-    assert len(plan.canonical_bytes) == 5178
+    assert len(plan.canonical_bytes) == 5268
     assert hashlib.sha256(plan.canonical_bytes).hexdigest() == (
-        "863fbd64bc8ede83bea2cbc6a090bd5d448e177c6487ee5a20a553bb54305443"
+        "6f685f0f0436fdbbc995ff6476c2b7e33b2af91734771e705682d4ca38683529"
     )
-    assert len(plan.framed_bytes) == 5218
+    assert len(plan.framed_bytes) == 5308
     assert plan.framed_bytes[:40].hex() == (
-        "0000001c65786f6d656d2e636f6e736f6c69646174696f6e2d706c616e2f7631000000000000143a"
+        "0000001c65786f6d656d2e636f6e736f6c69646174696f6e2d706c616e2f76310000000000001494"
     )
     assert b"plan_digest" not in plan.canonical_bytes
     assert b"control_basis_digest" in plan.canonical_bytes
@@ -440,6 +456,7 @@ def _mutate_rendering(value: dict[str, object]) -> None:
         _mutate_action,
         _replace_digest("journal_batch_partition_digest"),
         _mutate_policy,
+        _replace_digest("policy_bundle_digest"),
         _replace_digest("prospective_policy_fingerprint"),
         lambda value: value["bridge_fingerprints"].append(_digest("bridge-2")),
         lambda value: value["exact_release_approval_fingerprints"].append(_digest("release-2")),
@@ -510,7 +527,7 @@ def test_rendering_definition_is_derived_from_the_exact_plan_rows() -> None:
         plan.preimage["rendering_definition"]
     ) == consolidation_plan.canonical_closed_jcs(definition)
     assert consolidation_plan.render_plan_page(plan, page_ordinal=0).digest == (
-        "2b001af5360c42fcbf94f1d6003d77c32961aea966be4e9815ec820f020a857a"
+        "8bf88aeab633924885b5a995f3d131f5cf15c3af80f6c03d9168a94f475b65cf"
     )
 
     injected = copy.deepcopy(draft)
@@ -600,6 +617,25 @@ def _create_run(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     consolidation_run_state.ConsolidationRunStore(vault).create(identity, (item,))
 
 
+def _policy_bundle(
+    vault: Path,
+    *,
+    name: str = 'Résumé "review"',
+) -> consolidation_policy.DestinationPolicyPlan:
+    document = _policy_document()
+    content = str(document["content"]).replace('Résumé "review"', name)
+    return consolidation_policy.compile_destination_policy(
+        vault,
+        documents={str(document["path"]): content},
+        source_authority=(),
+        attestations=(),
+        principal_contexts=(),
+        destination_vault_id="vault-destination-01",
+        expected_nonce=NONCE,
+        verified_at=CREATED_AT,
+    )
+
+
 def test_owner_only_plan_store_reloads_exact_bytes_and_replays_idempotently(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -608,12 +644,35 @@ def test_owner_only_plan_store_reloads_exact_bytes_and_replays_idempotently(
 
     vault = tmp_path / "vault"
     _create_run(vault, monkeypatch)
-    plan = _plan(basis_run_revision=1)
+    policy_bundle = _policy_bundle(vault)
+    plan = _plan(basis_run_revision=1, policy_bundle=policy_bundle)
     store = consolidation_plan_store.ConsolidationPlanStore(vault)
 
-    first = store.persist(plan, expected_run_revision=1)
-    assert store.persist(plan, expected_run_revision=1) == first
+    with pytest.raises(consolidation_plan_store.ConsolidationPlanStoreUnavailable):
+        store.persist(
+            plan,
+            policy_bundle=_policy_bundle(vault, name="Changed review"),
+            expected_run_revision=1,
+        )
+
+    first = store.persist(
+        plan,
+        policy_bundle=policy_bundle,
+        expected_run_revision=1,
+    )
+    assert (
+        store.persist(
+            plan,
+            policy_bundle=policy_bundle,
+            expected_run_revision=1,
+        )
+        == first
+    )
     assert store.load(RUN_ID, plan_kind="cutover", plan_digest=plan.digest) == plan
+    assert (
+        store.load_policy_bundle(RUN_ID, plan_kind="cutover", plan_digest=plan.digest)
+        == policy_bundle
+    )
     plan_dir = (
         vault
         / "Knowledge Base"
@@ -627,6 +686,7 @@ def test_owner_only_plan_store_reloads_exact_bytes_and_replays_idempotently(
     assert sorted(path.name for path in plan_dir.iterdir()) == [
         "control-basis.json",
         "plan.json",
+        "policy-bundle.json",
     ]
     if os.name != "nt":
         assert plan_dir.stat().st_mode & 0o777 == 0o700
@@ -634,6 +694,10 @@ def test_owner_only_plan_store_reloads_exact_bytes_and_replays_idempotently(
 
     restarted = consolidation_plan_store.ConsolidationPlanStore(vault)
     assert restarted.load(RUN_ID, plan_kind="cutover", plan_digest=plan.digest) == plan
+    assert (
+        restarted.load_policy_bundle(RUN_ID, plan_kind="cutover", plan_digest=plan.digest)
+        == policy_bundle
+    )
 
 
 def test_plan_store_refuses_wrong_run_revision_or_partial_state(
@@ -644,12 +708,23 @@ def test_plan_store_refuses_wrong_run_revision_or_partial_state(
 
     vault = tmp_path / "vault"
     _create_run(vault, monkeypatch)
-    plan = _plan(basis_run_revision=1)
+    policy_bundle = _policy_bundle(vault)
+    plan = _plan(basis_run_revision=1, policy_bundle=policy_bundle)
     store = consolidation_plan_store.ConsolidationPlanStore(vault)
 
     with pytest.raises(consolidation_plan_store.ConsolidationPlanStoreUnavailable):
-        store.persist(plan, expected_run_revision=2)
-    store.persist(plan, expected_run_revision=1)
+        store.persist(
+            plan,
+            policy_bundle=policy_bundle,
+            expected_run_revision=2,
+        )
+    with pytest.raises(consolidation_plan_store.ConsolidationPlanStoreUnavailable):
+        store.persist(plan, expected_run_revision=1)
+    store.persist(
+        plan,
+        policy_bundle=policy_bundle,
+        expected_run_revision=1,
+    )
     control_path = (
         vault
         / "Knowledge Base"
@@ -674,7 +749,8 @@ def test_plan_store_recovers_control_first_crash_without_changing_plan(
 
     vault = tmp_path / "vault"
     _create_run(vault, monkeypatch)
-    plan = _plan(basis_run_revision=1)
+    policy_bundle = _policy_bundle(vault)
+    plan = _plan(basis_run_revision=1, policy_bundle=policy_bundle)
     store = consolidation_plan_store.ConsolidationPlanStore(vault)
     original_publish = store._publish_missing
 
@@ -685,11 +761,104 @@ def test_plan_store_recovers_control_first_crash_without_changing_plan(
 
     monkeypatch.setattr(store, "_publish_missing", crash_before_plan)
     with pytest.raises(consolidation_plan_store.ConsolidationPlanStoreUnavailable):
-        store.persist(plan, expected_run_revision=1)
+        store.persist(
+            plan,
+            policy_bundle=policy_bundle,
+            expected_run_revision=1,
+        )
 
     monkeypatch.setattr(store, "_publish_missing", original_publish)
-    assert store.persist(plan, expected_run_revision=1) == plan
+    assert (
+        store.persist(
+            plan,
+            policy_bundle=policy_bundle,
+            expected_run_revision=1,
+        )
+        == plan
+    )
     assert store.load(RUN_ID, plan_kind="cutover", plan_digest=plan.digest) == plan
+
+
+@pytest.mark.parametrize("replacement", [None, b"{}"])
+def test_plan_store_refuses_missing_or_changed_policy_bundle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replacement: bytes | None,
+) -> None:
+    from exomem.governance import consolidation_plan_store
+
+    vault = tmp_path / "vault"
+    _create_run(vault, monkeypatch)
+    policy_bundle = _policy_bundle(vault)
+    plan = _plan(basis_run_revision=1, policy_bundle=policy_bundle)
+    store = consolidation_plan_store.ConsolidationPlanStore(vault)
+    store.persist(
+        plan,
+        policy_bundle=policy_bundle,
+        expected_run_revision=1,
+    )
+    path = (
+        vault
+        / "Knowledge Base"
+        / "_Consolidation"
+        / "runs"
+        / RUN_ID
+        / "plans"
+        / "cutover"
+        / plan.digest
+        / "policy-bundle.json"
+    )
+    if replacement is None:
+        path.unlink()
+    else:
+        path.write_bytes(replacement)
+
+    with pytest.raises(consolidation_plan_store.ConsolidationPlanStoreUnavailable):
+        store.load(RUN_ID, plan_kind="cutover", plan_digest=plan.digest)
+
+
+def test_plan_store_binds_only_executable_policy_documents(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_plan_store
+
+    vault = tmp_path / "vault"
+    _create_run(vault, monkeypatch)
+    governance = vault / "Knowledge Base" / "_Governance"
+    governance.mkdir(parents=True)
+    (governance / "README.md").write_text("Authoring guidance only.\n", encoding="utf-8")
+    policy_bundle = _policy_bundle(vault)
+    plan = _plan(basis_run_revision=1, policy_bundle=policy_bundle)
+    store = consolidation_plan_store.ConsolidationPlanStore(vault)
+
+    assert (
+        store.persist(
+            plan,
+            policy_bundle=policy_bundle,
+            expected_run_revision=1,
+        )
+        == plan
+    )
+    assert store.load(RUN_ID, plan_kind="cutover", plan_digest=plan.digest) == plan
+
+
+@pytest.mark.parametrize("plan_kind", ["rollback", "retirement"])
+def test_non_cutover_plan_store_replay_does_not_require_policy_bundle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    plan_kind: str,
+) -> None:
+    from exomem.governance import consolidation_plan_store
+
+    vault = tmp_path / "vault"
+    _create_run(vault, monkeypatch)
+    plan = _plan(basis_run_revision=1, plan_kind=plan_kind)
+    store = consolidation_plan_store.ConsolidationPlanStore(vault)
+
+    assert store.persist(plan, expected_run_revision=1) == plan
+    assert store.persist(plan, expected_run_revision=1) == plan
+    assert store.load(RUN_ID, plan_kind=plan_kind, plan_digest=plan.digest) == plan
 
 
 def _trusted_renderer() -> consolidation_review.TrustedRenderIdentity:
@@ -735,7 +904,7 @@ def test_render_session_is_bound_to_stored_plan_and_trusted_surface() -> None:
         "nonce",
     }
     assert review.session.digest == (
-        "355cb885118f2794eedb193ca260b8a8811753cfefec77a53b2e3b9ff9bfe768"
+        "d5b0891f67fe6db97c60f5fc0cbc650aa281a0c921abac2574e14b7226cb103c"
     )
     assert review.state.preimage["next_page_ordinal"] == 0
     assert b"governance_version" not in review.state.canonical_bytes
@@ -966,9 +1135,11 @@ def _stored_review(
 
     vault = tmp_path / "vault"
     _create_run(vault, monkeypatch)
-    plan = _plan(basis_run_revision=1)
+    policy_bundle = _policy_bundle(vault)
+    plan = _plan(basis_run_revision=1, policy_bundle=policy_bundle)
     consolidation_plan_store.ConsolidationPlanStore(vault).persist(
         plan,
+        policy_bundle=policy_bundle,
         expected_run_revision=1,
     )
     review = consolidation_review.begin_review(
@@ -1286,7 +1457,7 @@ def test_approval_token_binds_exact_plan_completeness_and_confirmation() -> None
         "expires_at": "2026-08-28T12:30:00.000Z",
         "signing_key_id": "approval-key-01",
     }
-    assert token.digest == "49fe7fa8efb483f4eaee44a24bbad09ed8139dac1ee17da3ba9edca00393d522"
+    assert token.digest == "acf440d4b21fbe930d2e782d6c1b9b305a2ce36a4fb176278a402848eae668a0"
     assert (
         consolidation_approval.verify_approval(
             token.wire,

--- a/tests/test_consolidation_policy.py
+++ b/tests/test_consolidation_policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from dataclasses import replace
 from pathlib import Path
 
@@ -136,6 +137,38 @@ def test_destination_principal_attestation_has_one_fixed_vector() -> None:
     )
     assert verified.attestation == attestation
     assert verified.verified_at == VERIFIED_AT
+
+
+def test_destination_policy_bundle_is_one_exact_canonical_round_trip(tmp_path: Path) -> None:
+    plan = consolidation_policy.compile_destination_policy(
+        _vault(tmp_path),
+        documents=_documents(),
+        source_authority=(_review(),),
+        attestations=(_attestation(),),
+        principal_contexts=(_principal(),),
+        destination_vault_id=DESTINATION_VAULT_ID,
+        expected_nonce=NONCE,
+        verified_at=VERIFIED_AT,
+    )
+
+    raw = consolidation_policy.canonical_destination_policy_bundle(plan)
+    parsed = json.loads(raw)
+
+    assert parsed["schema"] == "exomem.consolidation-destination-policy/v1"
+    assert parsed["nonce"] == NONCE
+    assert "digest" not in parsed
+    assert "plan_digest" not in parsed
+    assert len(raw) == 3330
+    assert hashlib.sha256(raw).hexdigest() == (
+        "1e6c6476b332f65fed44c2a1088518b14debcd713dcb9961b7de25e3b90d7b7e"
+    )
+    assert plan.digest == "3194d49690ff9e7c924077323f99f766641a157afee28850bda65cc1cd72cde6"
+    assert consolidation_policy.parse_destination_policy_bundle(raw) == plan
+    assert consolidation_policy.destination_policy_bundle_digest(plan) == plan.digest
+
+    changed = raw.replace(b'"destination-vault"', b'"destination-other"')
+    with pytest.raises(consolidation_policy.DestinationPolicyUnavailable):
+        consolidation_policy.parse_destination_policy_bundle(changed)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Persist the exact canonical destination-policy bundle alongside each consolidation cutover plan, bind its digest into the plan and control basis, and require apply preparation to load and freshly revalidate those stored bytes.

Malformed, missing, tampered, stale, or cross-run bundles now fail closed before sealing or any governance mutation. Rollback and retirement plan replay remain compatible.

This tranche stops at `preimage-ready`: it does not activate policy, publish content, or touch a live vault.

Stacked after #993.

## Verification

- focused consolidation policy/plan/apply suites: 121 passed
- exact missing/tampered/canonical-bundle regressions: 4 passed
- `openspec validate add-governed-vault-consolidation --strict`
- Ruff on all changed Python files
- targeted mypy on changed governance modules
- `uv lock --check`
- public repository artifact validation
- `git diff --check`
- independent adversarial review: GO, no findings
- independent verification with isolated `/tmp` state: passed
