### PR TITLE
feat(governance): activate consolidation policy first

### DIFF
--- a/src/exomem/governance/consolidation_policy_activation.py
+++ b/src/exomem/governance/consolidation_policy_activation.py
@@ -1,0 +1,1560 @@
+"""Durable exact policy-publication inputs for consolidation recovery."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import NoReturn
+
+from .. import reserved_paths
+from ..kbdir import kb_dirname
+from . import (
+    consolidation_admission,
+    consolidation_apply_coordinator,
+    consolidation_authority,
+    consolidation_effect_coordinator,
+    consolidation_plan,
+    consolidation_plan_store,
+    consolidation_policy,
+    consolidation_receipts,
+    consolidation_saga,
+    consolidation_seal,
+    policy,
+    policy_publication,
+    receipts,
+    schema_v4,
+)
+from .principal import RequestPrincipal
+
+PUBLICATION_RECORD_SCHEMA = "exomem.consolidation-policy-publication/v1"
+
+_BINDING_SCHEMA = "exomem.consolidation-policy-publication-binding/v1"
+_BINDING_DOMAIN = _BINDING_SCHEMA.encode("ascii")
+_DESCRIPTOR_ID = "consolidation-tree"
+_OWNER = "consolidation.run"
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_COMMITTED_EVENT = re.compile(r"[0-9a-f]{64}:committed\Z")
+_UUID4 = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
+)
+_MAX_RECORD_BYTES = 16 * 1024 * 1024
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_CROCKFORD32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+_IDENTITY_SCHEMA = "exomem.consolidation-policy-publication-identity/v1"
+_IDENTITY_DOMAIN = _IDENTITY_SCHEMA.encode("ascii")
+_RFC3339_MILLISECONDS = re.compile(
+    r"[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])"
+    r"T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{3}Z\Z"
+)
+_RECORD_FIELDS = frozenset(
+    {
+        "schema",
+        "run_id",
+        "operation_id",
+        "effect_ordinal",
+        "request_digest",
+        "plan_digest",
+        "policy_bundle_digest",
+        "preimage_terminal_event_id",
+        "preimage_terminal_payload_digest",
+        "binding_digest",
+        "publication",
+    }
+)
+
+__all__ = [
+    "PUBLICATION_RECORD_SCHEMA",
+    "ConsolidationPolicyActivationUnavailable",
+    "ConsolidationPolicyPublicationIdentity",
+    "ConsolidationPolicyPublicationRecord",
+    "ConsolidationPolicyPublicationStore",
+    "ConsolidationPolicyActivationResult",
+    "activate_stored_destination_policy",
+    "derive_policy_publication_identity",
+]
+
+
+class ConsolidationPolicyActivationUnavailable(RuntimeError):
+    """Content-free refusal for missing, changed, or ambiguous activation state."""
+
+    code = "CONSOLIDATION_POLICY_ACTIVATION_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationPolicyActivationResult:
+    """Receipt-proven policy activation, before any content publication."""
+
+    policy_prepare: consolidation_effect_coordinator.EffectExecutionResult
+    policy_active: consolidation_effect_coordinator.EffectExecutionResult
+    terminal: consolidation_saga.PolicyActivationTerminal
+    seal_state: consolidation_seal.ConsolidationSealState
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationPolicyPublicationRecord:
+    schema: str
+    run_id: str
+    operation_id: str
+    effect_ordinal: int
+    request_digest: str
+    plan_digest: str
+    policy_bundle_digest: str
+    preimage_terminal_event_id: str
+    preimage_terminal_payload_digest: str
+    binding_digest: str
+    publication: policy_publication.PreparedPolicyPublication
+    state_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationPolicyPublicationIdentity:
+    generation_id: str
+    authoring_event_id: str
+    receipt_event_id: str
+    binding_digest: str
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationPolicyActivationUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _uuid4(value: object) -> str:
+    if not isinstance(value, str) or _UUID4.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _integer(value: object, *, minimum: int = 0) -> int:
+    if type(value) is not int or not minimum <= value <= _MAX_SAFE_INTEGER:
+        _fail()
+    return value
+
+
+def _text(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        _fail()
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        _fail()
+    return value
+
+
+def _timestamp(value: object) -> tuple[str, datetime]:
+    checked = _text(value)
+    if _RFC3339_MILLISECONDS.fullmatch(checked) is None:
+        _fail()
+    try:
+        parsed = datetime.fromisoformat(checked.removesuffix("Z") + "+00:00")
+    except ValueError:
+        _fail()
+    if parsed.tzinfo != UTC:
+        _fail()
+    return checked, parsed
+
+
+def derive_policy_publication_identity(
+    *,
+    destination_vault_id: str,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    request_digest: str,
+    plan_digest: str,
+    policy_bundle_digest: str,
+    preimage_terminal_event_id: str,
+    preimage_terminal_payload_digest: str,
+    policy_prepared_at: str,
+) -> ConsolidationPolicyPublicationIdentity:
+    """Derive stable publication identities without proposal-table semantics."""
+
+    prepared_at, parsed = _timestamp(policy_prepared_at)
+    if (
+        not isinstance(preimage_terminal_event_id, str)
+        or _COMMITTED_EVENT.fullmatch(preimage_terminal_event_id) is None
+    ):
+        _fail()
+    value = {
+        "schema": _IDENTITY_SCHEMA,
+        "destination_vault_id": _text(destination_vault_id),
+        "vault_binding_digest": _digest(vault_binding_digest),
+        "run_id": _uuid4(run_id),
+        "operation_id": _uuid4(operation_id),
+        "request_digest": _digest(request_digest),
+        "plan_digest": _digest(plan_digest),
+        "policy_bundle_digest": _digest(policy_bundle_digest),
+        "preimage_terminal_event_id": preimage_terminal_event_id,
+        "preimage_terminal_payload_digest": _digest(
+            preimage_terminal_payload_digest
+        ),
+        "policy_prepared_at": prepared_at,
+    }
+    try:
+        raw = consolidation_plan.canonical_closed_jcs(value)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    framed = (
+        len(_IDENTITY_DOMAIN).to_bytes(4, "big")
+        + _IDENTITY_DOMAIN
+        + len(raw).to_bytes(8, "big")
+        + raw
+    )
+    binding_digest = hashlib.sha256(framed).hexdigest()
+    milliseconds = int(parsed.timestamp() * 1000)
+    if not 0 <= milliseconds < (1 << 48):
+        _fail()
+    entropy = hashlib.sha256(_IDENTITY_DOMAIN + b"\0" + raw).digest()[:10]
+    ulid = (milliseconds << 80) | int.from_bytes(entropy, "big")
+    generation_id = "".join(
+        _CROCKFORD32[(ulid >> shift) & 31] for shift in range(125, -1, -5)
+    )
+    authoring_event_id = receipts.critical_event_id(
+        {
+            "operation": "consolidation_policy_authoring_review",
+            "binding_digest": binding_digest,
+            "generation_id": generation_id,
+        }
+    )
+    receipt_event_id = receipts.critical_event_id(
+        {
+            "operation": "governance_policy_publication",
+            "authoring_event_id": authoring_event_id,
+            "binding_digest": binding_digest,
+            "generation_id": generation_id,
+        }
+    )
+    return ConsolidationPolicyPublicationIdentity(
+        generation_id=generation_id,
+        authoring_event_id=authoring_event_id,
+        receipt_event_id=receipt_event_id,
+        binding_digest=binding_digest,
+    )
+
+
+def _mapping(value: object, fields: frozenset[str]) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or frozenset(value) != fields:
+        _fail()
+    return value
+
+
+def _encode_bytes(value: bytes) -> str:
+    if not isinstance(value, bytes):
+        _fail()
+    return base64.b64encode(value).decode("ascii")
+
+
+def _decode_bytes(value: object) -> bytes:
+    if not isinstance(value, str):
+        _fail()
+    try:
+        return base64.b64decode(value, validate=True)
+    except (TypeError, ValueError):
+        _fail()
+
+
+def _expected_value(value: schema_v4.VerifiedActiveGovernanceState) -> dict[str, object]:
+    if not isinstance(value, schema_v4.VerifiedActiveGovernanceState):
+        _fail()
+    return {
+        "logical_vault_id": _text(value.logical_vault_id),
+        "activation_store_id": _text(value.activation_store_id),
+        "activation_epoch": _integer(value.activation_epoch, minimum=1),
+        "activation_state_digest": _digest(value.activation_state_digest),
+        "policy_generation_id": _text(value.policy_generation_id),
+        "policy_fingerprint": _digest(value.policy_fingerprint),
+        "projector_schema_version": _integer(
+            value.projector_schema_version,
+            minimum=1,
+        ),
+        "catalog_generation": _integer(value.catalog_generation, minimum=1),
+        "projection_namespace_id": _text(value.projection_namespace_id),
+    }
+
+
+def _expected_from_value(value: object) -> schema_v4.VerifiedActiveGovernanceState:
+    item = _mapping(
+        value,
+        frozenset(
+            {
+                "logical_vault_id",
+                "activation_store_id",
+                "activation_epoch",
+                "activation_state_digest",
+                "policy_generation_id",
+                "policy_fingerprint",
+                "projector_schema_version",
+                "catalog_generation",
+                "projection_namespace_id",
+            }
+        ),
+    )
+    return schema_v4.VerifiedActiveGovernanceState(
+        logical_vault_id=_text(item["logical_vault_id"]),
+        activation_store_id=_text(item["activation_store_id"]),
+        activation_epoch=_integer(item["activation_epoch"], minimum=1),
+        activation_state_digest=_digest(item["activation_state_digest"]),
+        policy_generation_id=_text(item["policy_generation_id"]),
+        policy_fingerprint=_digest(item["policy_fingerprint"]),
+        projector_schema_version=_integer(
+            item["projector_schema_version"],
+            minimum=1,
+        ),
+        catalog_generation=_integer(item["catalog_generation"], minimum=1),
+        projection_namespace_id=_text(item["projection_namespace_id"]),
+    )
+
+
+def _policy_value(value: schema_v4.PolicyGenerationSeed) -> dict[str, object]:
+    if not isinstance(value, schema_v4.PolicyGenerationSeed):
+        _fail()
+    documents = [
+        {"path": _text(path), "bytes": _encode_bytes(raw)}
+        for path, raw in value.source_documents
+    ]
+    if tuple(row["path"] for row in documents) != tuple(
+        sorted({str(row["path"]) for row in documents})
+    ):
+        _fail()
+    compiled = policy.compile_documents(dict(value.source_documents))
+    if (
+        compiled.empty
+        or compiled.blocked
+        or compiled.conflicted
+        or value.source_fingerprint != compiled.fingerprint
+        or value.policy_fingerprint != compiled.fingerprint
+        or value.compiled_policy != policy.canonical_compiled_bytes(compiled)
+    ):
+        _fail()
+    return {
+        "generation_id": _text(value.generation_id),
+        "source_documents": documents,
+        "source_fingerprint": _digest(value.source_fingerprint),
+        "conflict_digest": _digest(value.conflict_digest),
+        "compiled_policy": _encode_bytes(value.compiled_policy),
+        "policy_fingerprint": _digest(value.policy_fingerprint),
+        "compiler_schema_version": _integer(
+            value.compiler_schema_version,
+            minimum=1,
+        ),
+        "projector_schema_version": _integer(
+            value.projector_schema_version,
+            minimum=1,
+        ),
+        "predecessor_generation": (
+            {"state": "absent"}
+            if value.predecessor_generation_id is None
+            else {
+                "state": "present",
+                "generation_id": _text(value.predecessor_generation_id),
+            }
+        ),
+        "authoring_event_id": _text(value.authoring_event_id),
+        "receipt_event_id": _digest(value.receipt_event_id),
+        "created_at": _integer(value.created_at),
+    }
+
+
+def _policy_from_value(value: object) -> schema_v4.PolicyGenerationSeed:
+    item = _mapping(
+        value,
+        frozenset(
+            {
+                "generation_id",
+                "source_documents",
+                "source_fingerprint",
+                "conflict_digest",
+                "compiled_policy",
+                "policy_fingerprint",
+                "compiler_schema_version",
+                "projector_schema_version",
+                "predecessor_generation",
+                "authoring_event_id",
+                "receipt_event_id",
+                "created_at",
+            }
+        ),
+    )
+    raw_documents = item["source_documents"]
+    if isinstance(raw_documents, (str, bytes)) or not isinstance(
+        raw_documents,
+        Sequence,
+    ):
+        _fail()
+    documents = tuple(
+        (
+            _text(row["path"]),
+            _decode_bytes(row["bytes"]),
+        )
+        for raw in raw_documents
+        for row in [_mapping(raw, frozenset({"path", "bytes"}))]
+    )
+    predecessor = item["predecessor_generation"]
+    if predecessor == {"state": "absent"}:
+        predecessor_generation_id = None
+    else:
+        predecessor_row = _mapping(
+            predecessor,
+            frozenset({"state", "generation_id"}),
+        )
+        if predecessor_row["state"] != "present":
+            _fail()
+        predecessor_generation_id = _text(predecessor_row["generation_id"])
+    seed = schema_v4.PolicyGenerationSeed(
+        generation_id=_text(item["generation_id"]),
+        source_documents=documents,
+        source_fingerprint=_digest(item["source_fingerprint"]),
+        conflict_digest=_digest(item["conflict_digest"]),
+        compiled_policy=_decode_bytes(item["compiled_policy"]),
+        policy_fingerprint=_digest(item["policy_fingerprint"]),
+        compiler_schema_version=_integer(
+            item["compiler_schema_version"],
+            minimum=1,
+        ),
+        projector_schema_version=_integer(
+            item["projector_schema_version"],
+            minimum=1,
+        ),
+        predecessor_generation_id=predecessor_generation_id,
+        authoring_event_id=_text(item["authoring_event_id"]),
+        receipt_event_id=_digest(item["receipt_event_id"]),
+        created_at=_integer(item["created_at"]),
+    )
+    _policy_value(seed)
+    return seed
+
+
+def _catalog_value(value: schema_v4.CatalogGenerationSeed | None) -> object:
+    if value is None:
+        return {"state": "absent"}
+    if not isinstance(value, schema_v4.CatalogGenerationSeed):
+        _fail()
+    return {
+        "state": "present",
+        "catalog_generation": _integer(value.catalog_generation, minimum=1),
+        "descriptor": _encode_bytes(value.descriptor),
+        "artifact_count": _integer(value.artifact_count),
+        "created_at": _integer(value.created_at),
+    }
+
+
+def _catalog_from_value(value: object) -> schema_v4.CatalogGenerationSeed | None:
+    if value == {"state": "absent"}:
+        return None
+    item = _mapping(
+        value,
+        frozenset(
+            {
+                "state",
+                "catalog_generation",
+                "descriptor",
+                "artifact_count",
+                "created_at",
+            }
+        ),
+    )
+    if item["state"] != "present":
+        _fail()
+    return schema_v4.CatalogGenerationSeed(
+        catalog_generation=_integer(item["catalog_generation"], minimum=1),
+        descriptor=_decode_bytes(item["descriptor"]),
+        artifact_count=_integer(item["artifact_count"]),
+        created_at=_integer(item["created_at"]),
+    )
+
+
+def _namespace_value(value: schema_v4.ProjectionNamespaceSeed) -> dict[str, object]:
+    if not isinstance(value, schema_v4.ProjectionNamespaceSeed):
+        _fail()
+    return {
+        "namespace_id": _text(value.namespace_id),
+        "evidence": _encode_bytes(value.evidence),
+        "ready_at": _integer(value.ready_at),
+    }
+
+
+def _namespace_from_value(value: object) -> schema_v4.ProjectionNamespaceSeed:
+    item = _mapping(value, frozenset({"namespace_id", "evidence", "ready_at"}))
+    return schema_v4.ProjectionNamespaceSeed(
+        namespace_id=_text(item["namespace_id"]),
+        evidence=_decode_bytes(item["evidence"]),
+        ready_at=_integer(item["ready_at"]),
+    )
+
+
+def _grant_value(value: schema_v4.DependentGrantTransition) -> dict[str, object]:
+    if not isinstance(value, schema_v4.DependentGrantTransition):
+        _fail()
+    if value.target_status not in {"review", "expired"}:
+        _fail()
+    return {
+        "grant_id": _text(value.grant_id),
+        "expected_policy_fingerprint": _digest(value.expected_policy_fingerprint),
+        "expected_membership_manifest": _text(value.expected_membership_manifest),
+        "target_status": value.target_status,
+        "target_policy_fingerprint": _digest(value.target_policy_fingerprint),
+        "target_membership_manifest": _text(value.target_membership_manifest),
+    }
+
+
+def _grant_from_value(value: object) -> schema_v4.DependentGrantTransition:
+    item = _mapping(
+        value,
+        frozenset(
+            {
+                "grant_id",
+                "expected_policy_fingerprint",
+                "expected_membership_manifest",
+                "target_status",
+                "target_policy_fingerprint",
+                "target_membership_manifest",
+            }
+        ),
+    )
+    transition = schema_v4.DependentGrantTransition(
+        grant_id=_text(item["grant_id"]),
+        expected_policy_fingerprint=_digest(item["expected_policy_fingerprint"]),
+        expected_membership_manifest=_text(item["expected_membership_manifest"]),
+        target_status=_text(item["target_status"]),
+        target_policy_fingerprint=_digest(item["target_policy_fingerprint"]),
+        target_membership_manifest=_text(item["target_membership_manifest"]),
+    )
+    _grant_value(transition)
+    return transition
+
+
+def _publication_value(
+    value: policy_publication.PreparedPolicyPublication,
+) -> dict[str, object]:
+    if not isinstance(value, policy_publication.PreparedPolicyPublication):
+        _fail()
+    grants = value.dependent_grants
+    grant_rows: object = (
+        {"state": "legacy-unbound"}
+        if grants is None
+        else {
+            "state": "bound",
+            "items": [_grant_value(item) for item in grants],
+        }
+    )
+    if grants is not None and tuple(item.grant_id for item in grants) != tuple(
+        sorted({item.grant_id for item in grants})
+    ):
+        _fail()
+    if (
+        value.identity.receipt_event_id != value.policy.receipt_event_id
+        or value.identity.policy_generation_id != value.policy.generation_id
+        or value.expected.policy_generation_id
+        != value.policy.predecessor_generation_id
+        or value.expected.projector_schema_version
+        != value.policy.projector_schema_version
+        or any(
+            item.expected_policy_fingerprint != value.expected.policy_fingerprint
+            or item.target_policy_fingerprint != value.policy.policy_fingerprint
+            for item in grants or ()
+        )
+    ):
+        _fail()
+    return {
+        "identity": {
+            "receipt_event_id": _digest(value.identity.receipt_event_id),
+            "policy_generation_id": _text(value.identity.policy_generation_id),
+        },
+        "expected": _expected_value(value.expected),
+        "policy": _policy_value(value.policy),
+        "catalog": _catalog_value(value.catalog),
+        "namespace": _namespace_value(value.namespace),
+        "dependent_grants": grant_rows,
+    }
+
+
+def _publication_from_value(
+    value: object,
+) -> policy_publication.PreparedPolicyPublication:
+    item = _mapping(
+        value,
+        frozenset(
+            {
+                "identity",
+                "expected",
+                "policy",
+                "catalog",
+                "namespace",
+                "dependent_grants",
+            }
+        ),
+    )
+    identity = _mapping(
+        item["identity"],
+        frozenset({"receipt_event_id", "policy_generation_id"}),
+    )
+    raw_grants = item["dependent_grants"]
+    grants: tuple[schema_v4.DependentGrantTransition, ...] | None
+    if raw_grants == {"state": "legacy-unbound"}:
+        grants = None
+    else:
+        grant_set = _mapping(raw_grants, frozenset({"state", "items"}))
+        raw_items = grant_set["items"]
+        if (
+            grant_set["state"] != "bound"
+            or isinstance(raw_items, (str, bytes))
+            or not isinstance(raw_items, Sequence)
+        ):
+            _fail()
+        grants = tuple(_grant_from_value(raw) for raw in raw_items)
+    publication = policy_publication.prepare_policy_publication(
+        expected=_expected_from_value(item["expected"]),
+        policy=_policy_from_value(item["policy"]),
+        catalog=_catalog_from_value(item["catalog"]),
+        namespace=_namespace_from_value(item["namespace"]),
+        dependent_grants=grants,
+    )
+    if (
+        publication.identity.receipt_event_id
+        != _digest(identity["receipt_event_id"])
+        or publication.identity.policy_generation_id
+        != _text(identity["policy_generation_id"])
+        or _publication_value(publication) != value
+    ):
+        _fail()
+    return publication
+
+
+def _binding_digest(
+    *,
+    run_id: str,
+    operation_id: str,
+    effect_ordinal: int,
+    request_digest: str,
+    plan_digest: str,
+    policy_bundle_digest: str,
+    preimage_terminal_event_id: str,
+    preimage_terminal_payload_digest: str,
+    publication: policy_publication.PreparedPolicyPublication,
+) -> str:
+    value = {
+        "schema": _BINDING_SCHEMA,
+        "run_id": _uuid4(run_id),
+        "operation_id": _uuid4(operation_id),
+        "effect_ordinal": _integer(effect_ordinal),
+        "request_digest": _digest(request_digest),
+        "plan_digest": _digest(plan_digest),
+        "policy_bundle_digest": _digest(policy_bundle_digest),
+        "preimage_terminal_event_id": (
+            preimage_terminal_event_id
+            if isinstance(preimage_terminal_event_id, str)
+            and _COMMITTED_EVENT.fullmatch(preimage_terminal_event_id) is not None
+            else _fail()
+        ),
+        "preimage_terminal_payload_digest": _digest(
+            preimage_terminal_payload_digest
+        ),
+        "publication": _publication_value(publication),
+    }
+    raw = consolidation_plan.canonical_closed_jcs(value)
+    framed = (
+        len(_BINDING_DOMAIN).to_bytes(4, "big")
+        + _BINDING_DOMAIN
+        + len(raw).to_bytes(8, "big")
+        + raw
+    )
+    return hashlib.sha256(framed).hexdigest()
+
+
+def _record_value(record: ConsolidationPolicyPublicationRecord) -> dict[str, object]:
+    return {
+        "schema": record.schema,
+        "run_id": record.run_id,
+        "operation_id": record.operation_id,
+        "effect_ordinal": record.effect_ordinal,
+        "request_digest": record.request_digest,
+        "plan_digest": record.plan_digest,
+        "policy_bundle_digest": record.policy_bundle_digest,
+        "preimage_terminal_event_id": record.preimage_terminal_event_id,
+        "preimage_terminal_payload_digest": record.preimage_terminal_payload_digest,
+        "binding_digest": record.binding_digest,
+        "publication": _publication_value(record.publication),
+    }
+
+
+def _record_bytes(record: ConsolidationPolicyPublicationRecord) -> bytes:
+    try:
+        return consolidation_plan.canonical_closed_jcs(_record_value(record))
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+
+
+def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            _fail()
+        value[key] = item
+    return value
+
+
+def _reject_number(_value: str) -> NoReturn:
+    _fail()
+
+
+def _parse_integer(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError:
+        _fail()
+    return _integer(parsed)
+
+
+def _parse_record(raw: bytes) -> ConsolidationPolicyPublicationRecord:
+    if not isinstance(raw, bytes) or not raw or len(raw) > _MAX_RECORD_BYTES:
+        _fail()
+    try:
+        value = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=_pairs,
+            parse_int=_parse_integer,
+            parse_float=_reject_number,
+            parse_constant=_reject_number,
+        )
+    except (
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        RecursionError,
+        ConsolidationPolicyActivationUnavailable,
+    ):
+        _fail()
+    item = _mapping(value, _RECORD_FIELDS)
+    if item["schema"] != PUBLICATION_RECORD_SCHEMA:
+        _fail()
+    publication = _publication_from_value(item["publication"])
+    event_id = item["preimage_terminal_event_id"]
+    if not isinstance(event_id, str) or _COMMITTED_EVENT.fullmatch(event_id) is None:
+        _fail()
+    record = ConsolidationPolicyPublicationRecord(
+        schema=PUBLICATION_RECORD_SCHEMA,
+        run_id=_uuid4(item["run_id"]),
+        operation_id=_uuid4(item["operation_id"]),
+        effect_ordinal=_integer(item["effect_ordinal"]),
+        request_digest=_digest(item["request_digest"]),
+        plan_digest=_digest(item["plan_digest"]),
+        policy_bundle_digest=_digest(item["policy_bundle_digest"]),
+        preimage_terminal_event_id=event_id,
+        preimage_terminal_payload_digest=_digest(
+            item["preimage_terminal_payload_digest"]
+        ),
+        binding_digest=_digest(item["binding_digest"]),
+        publication=publication,
+        state_digest=hashlib.sha256(raw).hexdigest(),
+    )
+    expected_binding = _binding_digest(
+        run_id=record.run_id,
+        operation_id=record.operation_id,
+        effect_ordinal=record.effect_ordinal,
+        request_digest=record.request_digest,
+        plan_digest=record.plan_digest,
+        policy_bundle_digest=record.policy_bundle_digest,
+        preimage_terminal_event_id=record.preimage_terminal_event_id,
+        preimage_terminal_payload_digest=record.preimage_terminal_payload_digest,
+        publication=record.publication,
+    )
+    if record.binding_digest != expected_binding or _record_bytes(record) != raw:
+        _fail()
+    return record
+
+
+@contextmanager
+def _authority(vault_root: Path, *, mutation: bool) -> Iterator[None]:
+    try:
+        with reserved_paths._subsystem_authority_scope(_OWNER):  # noqa: SLF001
+            with reserved_paths._identity_coordination_scope(  # noqa: SLF001
+                vault_root,
+                descriptor_ids=(_DESCRIPTOR_ID,),
+                identity_may_change=mutation,
+            ):
+                yield
+    except ConsolidationPolicyActivationUnavailable:
+        raise
+    except (OSError, RuntimeError, ValueError):
+        _fail()
+
+
+class ConsolidationPolicyPublicationStore:
+    """Persist the exact non-recomputable inputs needed after policy CAS."""
+
+    def __init__(
+        self,
+        vault_root: Path | str,
+        *,
+        run_id: str,
+        effect_ordinal: int,
+    ) -> None:
+        self.vault_root = Path(vault_root).absolute()
+        self.run_id = _uuid4(run_id)
+        self.effect_ordinal = _integer(effect_ordinal)
+        self.path = (
+            self.vault_root
+            / kb_dirname()
+            / "_Consolidation"
+            / "runs"
+            / self.run_id
+            / "effects"
+            / f"policy-publication-{self.effect_ordinal:010d}.json"
+        )
+
+    def _read_optional(self) -> bytes | None:
+        try:
+            return reserved_paths._read_owner_bytes(  # noqa: SLF001
+                self.vault_root,
+                self.path,
+                _DESCRIPTOR_ID,
+                limit=_MAX_RECORD_BYTES,
+            )
+        except FileNotFoundError:
+            return None
+
+    def load(self) -> ConsolidationPolicyPublicationRecord:
+        with _authority(self.vault_root, mutation=False):
+            raw = self._read_optional()
+            if raw is None:
+                _fail()
+            record = _parse_record(raw)
+            if (
+                record.run_id != self.run_id
+                or record.effect_ordinal != self.effect_ordinal
+            ):
+                _fail()
+            return record
+
+    def load_optional(self) -> ConsolidationPolicyPublicationRecord | None:
+        with _authority(self.vault_root, mutation=False):
+            raw = self._read_optional()
+            if raw is None:
+                return None
+            record = _parse_record(raw)
+            if (
+                record.run_id != self.run_id
+                or record.effect_ordinal != self.effect_ordinal
+            ):
+                _fail()
+            return record
+
+    def create(
+        self,
+        *,
+        operation_id: str,
+        request_digest: str,
+        plan_digest: str,
+        policy_bundle_digest: str,
+        preimage_terminal_event_id: str,
+        preimage_terminal_payload_digest: str,
+        publication: policy_publication.PreparedPolicyPublication,
+    ) -> ConsolidationPolicyPublicationRecord:
+        binding = _binding_digest(
+            run_id=self.run_id,
+            operation_id=operation_id,
+            effect_ordinal=self.effect_ordinal,
+            request_digest=request_digest,
+            plan_digest=plan_digest,
+            policy_bundle_digest=policy_bundle_digest,
+            preimage_terminal_event_id=preimage_terminal_event_id,
+            preimage_terminal_payload_digest=preimage_terminal_payload_digest,
+            publication=publication,
+        )
+        candidate = ConsolidationPolicyPublicationRecord(
+            schema=PUBLICATION_RECORD_SCHEMA,
+            run_id=self.run_id,
+            operation_id=_uuid4(operation_id),
+            effect_ordinal=self.effect_ordinal,
+            request_digest=_digest(request_digest),
+            plan_digest=_digest(plan_digest),
+            policy_bundle_digest=_digest(policy_bundle_digest),
+            preimage_terminal_event_id=preimage_terminal_event_id,
+            preimage_terminal_payload_digest=_digest(
+                preimage_terminal_payload_digest
+            ),
+            binding_digest=binding,
+            publication=publication,
+            state_digest="0" * 64,
+        )
+        raw = _record_bytes(candidate)
+        target = ConsolidationPolicyPublicationRecord(
+            **{
+                **{
+                    field: getattr(candidate, field)
+                    for field in candidate.__dataclass_fields__
+                    if field != "state_digest"
+                },
+                "state_digest": hashlib.sha256(raw).hexdigest(),
+            }
+        )
+        with _authority(self.vault_root, mutation=True):
+            existing = self._read_optional()
+            if existing is None:
+                reserved_paths._publish_owner_bytes(  # noqa: SLF001
+                    self.vault_root,
+                    self.path,
+                    _DESCRIPTOR_ID,
+                    raw,
+                    require_missing=True,
+                )
+                return target
+            current = _parse_record(existing)
+            if (
+                current.run_id != self.run_id
+                or current.effect_ordinal != self.effect_ordinal
+                or current != target
+            ):
+                _fail()
+            return current
+
+
+_EFFECT_SCHEMA = "exomem.consolidation-policy-activation-effect/v1"
+_MIRROR_SCHEMA = "exomem.consolidation-policy-workspace-mirror/v1"
+
+
+def _crash_point(_point: str) -> None:
+    """Narrow test seam around durable policy activation boundaries."""
+
+
+def _effect_digest(kind: str, state: str, facts: Mapping[str, object]) -> str:
+    try:
+        raw = consolidation_plan.canonical_closed_jcs(
+            {
+                "schema": _EFFECT_SCHEMA,
+                "kind": kind,
+                "state": state,
+                "facts": dict(facts),
+            }
+        )
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    domain = _EFFECT_SCHEMA.encode("ascii")
+    return hashlib.sha256(
+        len(domain).to_bytes(4, "big")
+        + domain
+        + len(raw).to_bytes(8, "big")
+        + raw
+    ).hexdigest()
+
+
+def _observation(
+    state: str,
+    digest: str,
+) -> consolidation_effect_coordinator.EffectObservation:
+    return consolidation_effect_coordinator.EffectObservation(  # type: ignore[arg-type]
+        state=state,
+        digest=digest,
+    )
+
+
+def _policy_receipt(
+    record: ConsolidationPolicyPublicationRecord,
+) -> policy_publication.CriticalReceipt:
+    publication = record.publication
+    grants = publication.dependent_grants or ()
+    prior = _effect_digest(
+        "governance-policy-publication",
+        "prior",
+        {
+            "activation_state_digest": publication.expected.activation_state_digest,
+            "policy_generation_id": publication.expected.policy_generation_id,
+            "dependent_grant_ids": [item.grant_id for item in grants],
+        },
+    )
+    prepared = _effect_digest(
+        "governance-policy-publication",
+        "prepared",
+        {
+            "policy_generation_id": publication.policy.generation_id,
+            "policy_fingerprint": publication.policy.policy_fingerprint,
+            "namespace_id": publication.namespace.namespace_id,
+            "dependent_grant_ids": [item.grant_id for item in grants],
+        },
+    )
+    target = _effect_digest(
+        "governance-policy-publication",
+        "target",
+        {"binding_digest": record.binding_digest},
+    )
+    affected = tuple(
+        sorted(
+            {
+                hashlib.sha256(
+                    f"policy_generation:{publication.policy.generation_id}".encode()
+                ).hexdigest(),
+                *(
+                    hashlib.sha256(
+                        f"dependent_grant:{item.grant_id}".encode()
+                    ).hexdigest()
+                    for item in grants
+                ),
+            }
+        )
+    )
+    return policy_publication.CriticalReceipt(
+        event_id=publication.identity.receipt_event_id,
+        operation="governance_policy_publication",
+        prior=prior,
+        prepared=prepared,
+        target=target,
+        affected_ids=affected,
+    )
+
+
+def _workspace_mirror(
+    record: ConsolidationPolicyPublicationRecord,
+) -> policy_publication.WorkspaceMirror:
+    publication = record.publication
+    event_id = receipts.critical_event_id(
+        {
+            "schema": _MIRROR_SCHEMA,
+            "policy_receipt_event_id": publication.identity.receipt_event_id,
+            "policy_generation_id": publication.identity.policy_generation_id,
+            "binding_digest": record.binding_digest,
+        }
+    )
+    source_documents = [
+        {
+            "path_digest": hashlib.sha256(relative.encode("utf-8")).hexdigest(),
+            "sha256": hashlib.sha256(content).hexdigest(),
+        }
+        for relative, content in publication.policy.source_documents
+    ]
+    receipt = policy_publication.CriticalReceipt(
+        event_id=event_id,
+        operation="governance_policy_workspace_mirror",
+        prior=_effect_digest(
+            "governance-policy-workspace-mirror",
+            "prior",
+            {
+                "policy_generation_id": publication.expected.policy_generation_id,
+                "authoring_snapshot_digest": record.binding_digest,
+            },
+        ),
+        prepared=_effect_digest(
+            "governance-policy-workspace-mirror",
+            "prepared",
+            {
+                "policy_generation_id": publication.policy.generation_id,
+                "policy_receipt_event_id": publication.identity.receipt_event_id,
+                "source_fingerprint": publication.policy.source_fingerprint,
+            },
+        ),
+        target=_effect_digest(
+            "governance-policy-workspace-mirror",
+            "target",
+            {
+                "policy_generation_id": publication.policy.generation_id,
+                "source_documents": source_documents,
+            },
+        ),
+        affected_ids=(
+            hashlib.sha256(
+                consolidation_plan.canonical_closed_jcs(
+                    sorted(relative for relative, _content in publication.policy.source_documents)
+                )
+            ).hexdigest(),
+        ),
+        parent_causation_id=publication.identity.receipt_event_id,
+    )
+    return policy_publication.WorkspaceMirror(
+        receipt=receipt,
+        outcomes=frozenset({"complete", "diverged"}),
+    )
+
+
+def _preimage_parent(
+    vault_root: Path,
+    *,
+    result: consolidation_apply_coordinator.ApplyPreparationResult,
+    run_id: str,
+    operation_id: str,
+    request_digest: str,
+) -> int:
+    terminal = result.preimage_effect.terminal
+    if terminal.event_id != result.preimage_effect.intent.event_id + ":committed":
+        _fail()
+    matches = [
+        row
+        for row in consolidation_receipts._active_records(vault_root)  # noqa: SLF001
+        if row.get("event_type") == "consolidation"
+        and row.get("phase") == "committed"
+        and row.get("event_id") == terminal.event_id
+    ]
+    if len(matches) != 1:
+        _fail()
+    try:
+        nested = consolidation_receipts.validate_nested(
+            matches[0].get("consolidation_event"),
+            outer_phase="committed",
+        )
+    except consolidation_receipts.ConsolidationReceiptUnavailable:
+        _fail()
+    if (
+        nested["kind"] != "preimage"
+        or nested["run_id"] != run_id
+        or nested["operation_id"] != operation_id
+        or nested["request_digest"] != request_digest
+        or nested["payload_digest"] != terminal.payload_digest
+    ):
+        _fail()
+    return int(nested["effect_ordinal"])
+
+
+def _timestamp_seconds(value: str) -> int:
+    try:
+        _text, parsed = consolidation_plan._timestamp(value)  # noqa: SLF001
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    timestamp = int(parsed.timestamp())
+    if timestamp < 0:
+        _fail()
+    return timestamp
+
+
+def _policy_verification_timestamp() -> str:
+    """Return server-current time for live destination-attestation checks."""
+
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace(
+        "+00:00",
+        "Z",
+    )
+
+
+def _authorization_now() -> int:
+    """Return server-current epoch time for custody and tuple publication."""
+
+    return int(datetime.now(UTC).timestamp())
+
+
+def _current_authorization_now() -> int:
+    """Sample and validate authorization time at the custody operation."""
+
+    current = _authorization_now()
+    if type(current) is not int or current < 0:
+        _fail()
+    return current
+
+
+def activate_stored_destination_policy(
+    *,
+    vault_root: Path | str,
+    admission: consolidation_admission.ConsolidationAdmission,
+    preparation: consolidation_apply_coordinator.ApplyPreparationResult,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+    request_digest: str,
+    plan_digest: str,
+    principal_contexts: Sequence[RequestPrincipal],
+    policy_prepare_at: str,
+    policy_active_at: str,
+    timeout: float,
+) -> ConsolidationPolicyActivationResult:
+    """Activate only the stored destination policy after the verified preimage."""
+
+    root = Path(vault_root).absolute()
+    checked_run = _uuid4(run_id)
+    checked_operation = _uuid4(operation_id)
+    checked_vault = _digest(vault_binding_digest)
+    checked_journal = _digest(journal_digest)
+    checked_request = _digest(request_digest)
+    checked_plan = _digest(plan_digest)
+    if (
+        not isinstance(admission, consolidation_admission.ConsolidationAdmission)
+        or admission.vault_root != root
+        or not isinstance(
+            preparation,
+            consolidation_apply_coordinator.ApplyPreparationResult,
+        )
+        or not isinstance(timeout, (int, float))
+        or isinstance(timeout, bool)
+        or timeout < 0
+    ):
+        _fail()
+    try:
+        _timestamp_seconds(policy_prepare_at)
+        _timestamp_seconds(policy_active_at)
+        parent_ordinal = _preimage_parent(
+            root,
+            result=preparation,
+            run_id=checked_run,
+            operation_id=checked_operation,
+            request_digest=checked_request,
+        )
+        plan_store = consolidation_plan_store.ConsolidationPlanStore(root)
+        stored_plan = plan_store.load(
+            checked_run,
+            plan_kind="cutover",
+            plan_digest=checked_plan,
+        )
+        bundle = plan_store.load_policy_bundle(
+            checked_run,
+            plan_kind="cutover",
+            plan_digest=checked_plan,
+        )
+        if (
+            stored_plan.preimage["policy_bundle_digest"] != bundle.digest
+            or stored_plan.preimage["nonce"] != bundle.nonce
+            or stored_plan.preimage["run_id"] != checked_run
+        ):
+            _fail()
+        prepare_store = ConsolidationPolicyPublicationStore(
+            root,
+            run_id=checked_run,
+            effect_ordinal=parent_ordinal + 1,
+        )
+        prepare_facts = {
+            "plan_digest": checked_plan,
+            "policy_bundle_digest": bundle.digest,
+            "preimage_terminal_event_id": preparation.preimage_effect.terminal.event_id,
+            "preimage_terminal_payload_digest": preparation.preimage_effect.terminal.payload_digest,
+        }
+        prepare_prior = _effect_digest("policy-prepare", "prior", prepare_facts)
+        prepare_target = _effect_digest("policy-prepare", "target", prepare_facts)
+        prepare_evidence = _effect_digest("policy-prepare", "prepared", prepare_facts)
+
+        def stored_record() -> ConsolidationPolicyPublicationRecord | None:
+            record = prepare_store.load_optional()
+            if record is None:
+                return None
+            if (
+                record.operation_id != checked_operation
+                or record.request_digest != checked_request
+                or record.plan_digest != checked_plan
+                or record.policy_bundle_digest != bundle.digest
+                or record.preimage_terminal_event_id
+                != preparation.preimage_effect.terminal.event_id
+                or record.preimage_terminal_payload_digest
+                != preparation.preimage_effect.terminal.payload_digest
+            ):
+                _fail()
+            return record
+
+        def classify_prepare() -> consolidation_effect_coordinator.EffectObservation:
+            record = stored_record()
+            if record is None:
+                return _observation("prior", prepare_prior)
+            terminal = policy_publication.receipt_terminal(root, _policy_receipt(record))
+            if terminal is None:
+                return _observation("prepared", prepare_evidence)
+            if terminal in {"pending", "committed"}:
+                return _observation("target", prepare_target)
+            _fail()
+
+        def fresh_revalidate() -> None:
+            consolidation_policy.revalidate_destination_policy(
+                root,
+                bundle,
+                principal_contexts=principal_contexts,
+                destination_vault_id=bundle.destination_vault_id,
+                expected_nonce=bundle.nonce,
+                verified_at=_policy_verification_timestamp(),
+            )
+
+        def prepare_policy() -> None:
+            fresh_revalidate()
+            identity = derive_policy_publication_identity(
+                destination_vault_id=bundle.destination_vault_id,
+                vault_binding_digest=checked_vault,
+                run_id=checked_run,
+                operation_id=checked_operation,
+                request_digest=checked_request,
+                plan_digest=checked_plan,
+                policy_bundle_digest=bundle.digest,
+                preimage_terminal_event_id=preparation.preimage_effect.terminal.event_id,
+                preimage_terminal_payload_digest=(
+                    preparation.preimage_effect.terminal.payload_digest
+                ),
+                policy_prepared_at=policy_prepare_at,
+            )
+            publication = policy_publication.prepare_destination_policy_publication(
+                root,
+                prospective=bundle.prospective,
+                document_edits=dict(bundle.document_edits),
+                generation_id=identity.generation_id,
+                authoring_event_id=identity.authoring_event_id,
+                receipt_event_id=identity.receipt_event_id,
+                ready_at=_timestamp_seconds(policy_prepare_at),
+                now=_current_authorization_now(),
+            )
+            record = prepare_store.create(
+                operation_id=checked_operation,
+                request_digest=checked_request,
+                plan_digest=checked_plan,
+                policy_bundle_digest=bundle.digest,
+                preimage_terminal_event_id=preparation.preimage_effect.terminal.event_id,
+                preimage_terminal_payload_digest=(
+                    preparation.preimage_effect.terminal.payload_digest
+                ),
+                publication=publication,
+            )
+            _crash_point("after-policy-record")
+            policy_publication.begin_receipt(root, _policy_receipt(record))
+            _crash_point("after-inner-receipt-intent")
+
+        def resume_prepare() -> None:
+            fresh_revalidate()
+            record = stored_record()
+            if record is None:
+                _fail()
+            policy_publication.begin_receipt(root, _policy_receipt(record))
+            _crash_point("after-inner-receipt-intent")
+
+        prepare_event = consolidation_receipts.build_intent(
+            kind="policy-prepare",
+            run_id=checked_run,
+            operation_id=checked_operation,
+            phase="policy-prepare",
+            effect_ordinal=parent_ordinal + 1,
+            request_digest=checked_request,
+            prior_digest=prepare_prior,
+            prepared_digest=prepare_evidence,
+            target_digest=prepare_target,
+            evidence=consolidation_receipts.build_evidence(
+                kind="policy-prepare",
+                digests={
+                    "policy_bundle_digest": bundle.digest,
+                    "policy_prepared_digest": prepare_evidence,
+                },
+            ),
+            semantic_parent_event_id=preparation.preimage_effect.terminal.event_id,
+            semantic_parent_payload_digest=(
+                preparation.preimage_effect.terminal.payload_digest
+            ),
+        )
+        policy_prepare = consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=root,
+            event=prepare_event,
+            journal=consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+                root,
+                run_id=checked_run,
+                effect_ordinal=parent_ordinal + 1,
+            ),
+            classify=classify_prepare,
+            apply_effect=prepare_policy,
+            resume_effect=resume_prepare,
+            timestamp=policy_prepare_at,
+        )
+        record = stored_record()
+        if record is None:
+            _fail()
+        active_facts = {
+            "policy_bundle_digest": bundle.digest,
+            "policy_prepared_digest": record.binding_digest,
+            "policy_prepare_terminal": policy_prepare.terminal.event_id,
+        }
+        active_prior = _effect_digest("policy-active", "prior", active_facts)
+        active_prepared = _effect_digest("policy-active", "prepared", active_facts)
+        active_target = _effect_digest("policy-active", "target", active_facts)
+
+        def seal_is_target() -> bool:
+            state = admission.reload().state
+            return (
+                state.kind == "consolidation-sealed"
+                and state.phase == "policy-active"
+                and state.vault_binding_digest == checked_vault
+                and state.run_id == checked_run
+                and state.operation_id == checked_operation
+                and state.journal_digest == checked_journal
+            )
+
+        def seal_is_preimage_ready() -> bool:
+            state = admission.reload().state
+            return (
+                state.kind == "consolidation-sealed"
+                and state.phase == "preimage-ready"
+                and state.vault_binding_digest == checked_vault
+                and state.run_id == checked_run
+                and state.operation_id == checked_operation
+                and state.journal_digest == checked_journal
+            )
+
+        def classify_active() -> consolidation_effect_coordinator.EffectObservation:
+            authority = policy_publication.classify_authority(
+                root,
+                record.publication,
+                now=_current_authorization_now(),
+            )
+            if authority.state == "mixed":
+                return _observation("mixed", record.binding_digest)
+            if authority.state == "prior":
+                return _observation("prior", active_prior)
+            if authority.state == "tuple-committed":
+                return _observation("prepared", active_prepared)
+            if authority.state != "active":
+                _fail()
+            if policy_publication.receipt_terminal(root, _policy_receipt(record)) != "committed":
+                return _observation("prepared", active_prepared)
+            mirror_terminal = policy_publication.workspace_mirror_terminal(
+                root,
+                _workspace_mirror(record),
+            )
+            if mirror_terminal == "diverged":
+                return _observation("mixed", record.binding_digest)
+            if mirror_terminal == "complete":
+                prepared_mirror = policy_publication.prepare_workspace_mirror(
+                    record.publication,
+                    mirror=_workspace_mirror(record),
+                    reviewed=bundle.prospective.snapshot,
+                )
+                if not policy_publication.prepared_workspace_mirror_matches(
+                    root,
+                    prepared_mirror,
+                ):
+                    return _observation("mixed", record.binding_digest)
+            if mirror_terminal == "complete" and seal_is_target():
+                return _observation("target", active_target)
+            if mirror_terminal in {None, "complete"}:
+                return _observation("prepared", active_prepared)
+            _fail()
+
+        def finish_active() -> None:
+            if not (seal_is_preimage_ready() or seal_is_target()):
+                _fail()
+            before = policy_publication.classify_authority(
+                root,
+                record.publication,
+                now=_current_authorization_now(),
+            )
+            if before.state == "mixed":
+                _fail()
+            if before.state == "prior":
+                # Until CAS commits the exact successor, authorization remains
+                # mutable authority and its attestations must still be fresh.
+                fresh_revalidate()
+            classification = policy_publication.activate_or_recover(
+                root,
+                record.publication,
+                now=_current_authorization_now(),
+            )
+            if classification.state == "stale" or classification.active is None:
+                _fail()
+            _crash_point("after-tuple-custody-activation")
+            receipt = _policy_receipt(record)
+            policy_publication.commit_receipt(root, receipt)
+            _crash_point("after-inner-terminal")
+            mirror = policy_publication.prepare_workspace_mirror(
+                record.publication,
+                mirror=_workspace_mirror(record),
+                reviewed=bundle.prospective.snapshot,
+            )
+            with reserved_paths._owner_authority_scope(  # noqa: SLF001
+                "govern_memory"
+            ):
+                outcome = policy_publication.run_prepared_workspace_mirror(
+                    root,
+                    mirror,
+                )
+            if outcome != "complete":
+                _fail()
+            if not policy_publication.prepared_workspace_mirror_matches(root, mirror):
+                _fail()
+            _crash_point("after-mirror")
+            state = admission.reload().state
+            if state.phase == "preimage-ready":
+                authority = consolidation_authority.issue_authority(
+                    vault_binding_digest=checked_vault,
+                    run_id=checked_run,
+                    operation_id=checked_operation,
+                    journal_digest=checked_journal,
+                    phase="preimage-ready",
+                    action="apply",
+                )
+                consolidation_seal.ConsolidationSealStore(root).advance_consolidation(
+                    authority,
+                    vault_binding_digest=checked_vault,
+                    action="apply",
+                    target_phase="policy-active",
+                    recorded_at=policy_active_at,
+                    expected_revision=state.revision,
+                )
+            elif not seal_is_target():
+                _fail()
+            _crash_point("after-seal-advance")
+
+        active_event = consolidation_receipts.build_intent(
+            kind="policy-active",
+            run_id=checked_run,
+            operation_id=checked_operation,
+            phase="policy-active",
+            effect_ordinal=parent_ordinal + 2,
+            request_digest=checked_request,
+            prior_digest=active_prior,
+            prepared_digest=active_prepared,
+            target_digest=active_target,
+            evidence=consolidation_receipts.build_evidence(
+                kind="policy-active",
+                digests={
+                    "policy_bundle_digest": bundle.digest,
+                    "policy_active_digest": active_target,
+                    "policy_fingerprint": (
+                        record.publication.policy.policy_fingerprint
+                    ),
+                },
+            ),
+            semantic_parent_event_id=policy_prepare.terminal.event_id,
+            semantic_parent_payload_digest=policy_prepare.terminal.payload_digest,
+        )
+        policy_active = consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=root,
+            event=active_event,
+            journal=consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+                root,
+                run_id=checked_run,
+                effect_ordinal=parent_ordinal + 2,
+            ),
+            classify=classify_active,
+            apply_effect=finish_active,
+            resume_effect=finish_active,
+            timestamp=policy_active_at,
+        )
+        state = admission.reload().state
+        if not seal_is_target():
+            _fail()
+        terminal = consolidation_saga.PolicyActivationTerminal(
+            schema=consolidation_saga.POLICY_ACTIVATION_TERMINAL_SCHEMA,
+            policy_fingerprint=record.publication.policy.policy_fingerprint,
+            intent_event_id=policy_active.intent.event_id,
+            prepared_fingerprint=policy_prepare.observed_digest,
+            active_fingerprint=policy_active.observed_digest,
+            terminal_event_id=policy_active.terminal.event_id,
+        )
+        return ConsolidationPolicyActivationResult(
+            policy_prepare=policy_prepare,
+            policy_active=policy_active,
+            terminal=terminal,
+            seal_state=state,
+        )
+    except ConsolidationPolicyActivationUnavailable:
+        raise
+    except (
+        consolidation_admission.ConsolidationAdmissionUnavailable,
+        consolidation_authority.ConsolidationAuthorityUnavailable,
+        consolidation_effect_coordinator.ConsolidationEffectUnavailable,
+        consolidation_plan_store.ConsolidationPlanStoreUnavailable,
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        consolidation_seal.ConsolidationSealUnavailable,
+        policy_publication.GovernanceError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ):
+        _fail()

--- a/src/exomem/governance/consolidation_receipts.py
+++ b/src/exomem/governance/consolidation_receipts.py
@@ -103,7 +103,13 @@ _ORDINAL_FIELD = {
     "render-ack": "page_ordinal",
 }
 _PREPARED_KINDS = frozenset(
-    {"preimage", "content-batch", "rollback-restore-batch"}
+    {
+        "preimage",
+        "policy-prepare",
+        "policy-active",
+        "content-batch",
+        "rollback-restore-batch",
+    }
 )
 _CONDITIONAL_SUCCESSOR_KINDS = frozenset({"reconcile", "repair-terminal"})
 _REQUIRED_SUCCESSOR_KINDS = frozenset(
@@ -294,7 +300,11 @@ _EVIDENCE_FIELDS: Mapping[str, frozenset[str]] = MappingProxyType(
             {"policy_bundle_digest", "policy_prepared_digest"}
         ),
         "policy-active": frozenset(
-            {"policy_active_digest", "policy_bundle_digest"}
+            {
+                "policy_active_digest",
+                "policy_bundle_digest",
+                "policy_fingerprint",
+            }
         ),
         "content-batch": frozenset(
             {"batch_manifest_digest", "classification_digest"}

--- a/src/exomem/governance/consolidation_saga.py
+++ b/src/exomem/governance/consolidation_saga.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import time
 from collections.abc import Callable, Iterable, Mapping
 from contextlib import ExitStack
 from dataclasses import dataclass
@@ -19,7 +20,12 @@ from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Literal, NoReturn, Protocol
 
 from .. import held_fs, reserved_paths, vault
-from . import consolidation_plan, consolidation_receipts
+from . import (
+    consolidation_plan,
+    consolidation_receipts,
+    consolidation_seal,
+    policy_publication,
+)
 
 if TYPE_CHECKING:
     from . import consolidation_effect_coordinator
@@ -158,6 +164,131 @@ def _policy_terminal(
         active_fingerprint=_digest(value.active_fingerprint),
         terminal_event_id=value.terminal_event_id,
     )
+
+
+def _consolidation_receipt_event(
+    records: list[dict[str, object]],
+    *,
+    event_id: str,
+    phase: Literal["intent", "committed"],
+) -> Mapping[str, object]:
+    matching = [
+        record
+        for record in records
+        if record.get("event_type") == "consolidation"
+        and record.get("phase") == phase
+        and record.get("event_id") == event_id
+    ]
+    if len(matching) != 1:
+        _fail()
+    try:
+        return consolidation_receipts.validate_nested(
+            matching[0].get("consolidation_event"),
+            outer_phase=phase,
+        )
+    except consolidation_receipts.ConsolidationReceiptUnavailable:
+        _fail()
+
+
+def _verify_policy_terminal_receipt(
+    *,
+    vault_root: Path,
+    vault_binding_digest: str,
+    terminal: object,
+    expected_policy_fingerprint: str,
+) -> PolicyActivationTerminal:
+    """Bind the content gate to the exact durable policy receipt chain."""
+
+    checked = _policy_terminal(
+        terminal,
+        expected_policy_fingerprint=expected_policy_fingerprint,
+    )
+    try:
+        records = consolidation_receipts._active_records(  # noqa: SLF001
+            Path(vault_root)
+        )
+    except consolidation_receipts.ConsolidationReceiptUnavailable:
+        _fail()
+    active_intent = _consolidation_receipt_event(
+        records,
+        event_id=checked.intent_event_id,
+        phase="intent",
+    )
+    active_terminal = _consolidation_receipt_event(
+        records,
+        event_id=checked.terminal_event_id,
+        phase="committed",
+    )
+    prepare_terminal = _consolidation_receipt_event(
+        records,
+        event_id=str(active_intent["semantic_parent_event_id"]),
+        phase="committed",
+    )
+    active_evidence = active_intent["evidence"]
+    terminal_evidence = active_terminal["evidence"]
+    if (
+        not isinstance(active_evidence, Mapping)
+        or not isinstance(terminal_evidence, Mapping)
+        or active_intent["kind"] != "policy-active"
+        or active_intent["target_digest"] != checked.active_fingerprint
+        or active_evidence.get("policy_active_digest")
+        != checked.active_fingerprint
+        or active_evidence.get("policy_fingerprint")
+        != checked.policy_fingerprint
+        or active_terminal["kind"] != "policy-active"
+        or active_terminal["target_digest"] != checked.active_fingerprint
+        or active_terminal["observed_digest"] != checked.active_fingerprint
+        or terminal_evidence != active_evidence
+        or active_terminal["semantic_parent_event_id"]
+        != checked.intent_event_id
+        or active_terminal["semantic_parent_payload_digest"]
+        != active_intent["payload_digest"]
+        or prepare_terminal["kind"] != "policy-prepare"
+        or prepare_terminal["target_digest"] != checked.prepared_fingerprint
+        or prepare_terminal["observed_digest"]
+        != checked.prepared_fingerprint
+        or prepare_terminal["payload_digest"]
+        != active_intent["semantic_parent_payload_digest"]
+        or prepare_terminal["run_id"] != active_intent["run_id"]
+        or prepare_terminal["operation_id"] != active_intent["operation_id"]
+        or prepare_terminal["request_digest"] != active_intent["request_digest"]
+        or int(prepare_terminal["effect_ordinal"]) + 1
+        != int(active_intent["effect_ordinal"])
+    ):
+        _fail()
+    try:
+        seal = consolidation_seal.ConsolidationSealStore(vault_root).load(
+            vault_binding_digest=_digest(vault_binding_digest),
+        )
+        current_now = int(time.time())
+        if current_now < 0:
+            _fail()
+        _custody, active_snapshot = (
+            policy_publication.load_active_authority_snapshot(
+                vault_root,
+                now=current_now,
+            )
+        )
+    except (
+        consolidation_seal.ConsolidationSealUnavailable,
+        policy_publication.GovernanceError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ):
+        _fail()
+    if (
+        seal.kind != "consolidation-sealed"
+        or seal.phase not in {"policy-active", "publishing"}
+        or seal.run_id != active_intent["run_id"]
+        or seal.operation_id != active_intent["operation_id"]
+        or active_snapshot.active.policy_fingerprint
+        != checked.policy_fingerprint
+        or active_snapshot.policy.fingerprint != checked.policy_fingerprint
+    ):
+        _fail()
+    return checked
 
 
 def _content_batches(
@@ -375,6 +506,7 @@ def publish_policy_first(
     content_actions: object,
     approved_partition_digest: str,
     expected_policy_fingerprint: str,
+    vault_binding_digest: str,
     activate_policy: Callable[[], PolicyActivationTerminal],
     journal: BatchJournal,
     vault_root: Path,
@@ -386,8 +518,10 @@ def publish_policy_first(
     batches = _content_batches(partition)
     if partition.digest != _digest(approved_partition_digest):
         _fail()
-    terminal = _policy_terminal(
-        activate_policy(),
+    terminal = _verify_policy_terminal_receipt(
+        vault_root=Path(vault_root),
+        vault_binding_digest=vault_binding_digest,
+        terminal=activate_policy(),
         expected_policy_fingerprint=expected_policy_fingerprint,
     )
     committed: list[int] = []

--- a/src/exomem/governance/policy_publication.py
+++ b/src/exomem/governance/policy_publication.py
@@ -1,0 +1,1212 @@
+"""Proposal-neutral exact publication of a reviewed schema-v4 policy tuple."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import sqlite3
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from .. import find_corpus, reserved_paths
+from . import (
+    authorization_custody,
+    authorization_session_authority,
+    authorization_session_lifecycle,
+    membership,
+    projection_store,
+    projections,
+    receipts,
+    schema_v4,
+    store,
+)
+from . import policy as policy_module
+from .transaction import GovernanceError
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyPublicationIdentity:
+    """The immutable identity shared by publication receipts and SQLite state."""
+
+    receipt_event_id: str
+    policy_generation_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedPolicyPublication:
+    """One exact reviewed v4 tuple, independent of its proposal lifecycle."""
+
+    identity: PolicyPublicationIdentity
+    expected: schema_v4.VerifiedActiveGovernanceState
+    policy: schema_v4.PolicyGenerationSeed
+    catalog: schema_v4.CatalogGenerationSeed | None
+    namespace: schema_v4.ProjectionNamespaceSeed
+    dependent_grants: tuple[schema_v4.DependentGrantTransition, ...] | None
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyPublicationClassification:
+    """The monotonic SQLite/custody classification of one exact publication."""
+
+    state: Literal["activated", "recovered", "stale"]
+    active: schema_v4.VerifiedActiveGovernanceState | None
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorityClassification:
+    """Read-only relation between custody and one exact reviewed tuple."""
+
+    state: Literal["prior", "tuple-committed", "active", "mixed"]
+    active: schema_v4.VerifiedActiveGovernanceState | None
+
+
+@dataclass(frozen=True, slots=True)
+class CriticalReceipt:
+    """Exact evidence for one receipt-first policy-publication effect."""
+
+    event_id: str
+    operation: str
+    prior: str
+    prepared: str
+    target: str
+    affected_ids: tuple[str, ...]
+    parent_causation_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceMirror:
+    """The exact receipt and terminal vocabulary of a non-authoritative mirror."""
+
+    receipt: CriticalReceipt
+    outcomes: frozenset[str]
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedWorkspaceMirror:
+    """Exact source/target bytes behind one receipt-first workspace mirror."""
+
+    publication: PreparedPolicyPublication
+    mirror: WorkspaceMirror
+    reviewed: policy_module.AuthoringSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class StagedTargetProjection:
+    """One exact inert target namespace derived from the active catalog."""
+
+    catalog: schema_v4.CatalogGenerationSeed | None
+    namespace: dict[str, object]
+    predecessor_items: tuple[projection_store.ProjectionItemVariants, ...]
+    items: tuple[projection_store.ProjectionItemVariants, ...]
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def load_active_authority_snapshot(
+    vault_root: Path,
+    *,
+    now: int,
+) -> tuple[
+    authorization_custody.AuthorizationCustody,
+    schema_v4.ActivePolicySnapshot,
+]:
+    """Load one custody-bound active v4 policy snapshot."""
+
+    connection: sqlite3.Connection | None = None
+    try:
+        custody = authorization_custody.load_authorization_custody(
+            vault_root,
+            now=now,
+        )
+        control = custody.control
+        if (
+            not control.governance_enrolled
+            or control.activation_store_id is None
+            or control.activation_epoch is None
+            or control.activation_state_digest is None
+        ):
+            raise schema_v4.SchemaV4Error(
+                "external activation authority is incomplete"
+            )
+        connection = store.open_authorization_session_connection(vault_root)
+        connection.execute("BEGIN")
+        snapshot = schema_v4.load_active_policy(
+            connection,
+            expected_logical_vault_id=control.logical_vault_id,
+            expected_activation_store_id=control.activation_store_id,
+            expected_activation_epoch=control.activation_epoch,
+            expected_activation_state_digest=control.activation_state_digest,
+        )
+        connection.commit()
+        return custody, snapshot
+    except (
+        authorization_custody.AuthorizationCustodyUnavailable,
+        schema_v4.SchemaV4Error,
+        store.UnsupportedGovernanceSchema,
+        FileNotFoundError,
+        OSError,
+        sqlite3.Error,
+        RuntimeError,
+        ValueError,
+    ):
+        if connection is not None and connection.in_transaction:
+            connection.rollback()
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "the active governance tuple cannot be verified",
+        ) from None
+    finally:
+        if connection is not None:
+            connection.close()
+
+
+def _full_search_fields(
+    item: projection_store.ProjectionItemVariants,
+) -> Mapping[str, str]:
+    candidates: list[Mapping[str, str]] = []
+    for variant in item.variants:
+        if variant.decision_level != policy_module.DISCLOSURE_MAX:
+            continue
+        try:
+            value = json.loads(variant.value_jcs)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if value.get("release_strip") == []:
+            candidates.append(variant.search_fields)
+    if not candidates:
+        raise GovernanceError(
+            "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
+            "the active catalog lacks an unstripped full projection",
+        )
+    canonical = {_canonical_json(dict(candidate)) for candidate in candidates}
+    if len(canonical) != 1:
+        raise GovernanceError(
+            "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
+            "the active catalog has ambiguous full projections",
+        )
+    return dict(candidates[0])
+
+
+def stage_target_projection_namespace(
+    vault_root: Path,
+    *,
+    active_snapshot: schema_v4.ActivePolicySnapshot,
+    target_policy: policy_module.Policy,
+    ready_at: int,
+) -> StagedTargetProjection:
+    """Stage and verify the exact target projection namespace without activation."""
+
+    try:
+        active_evidence = projection_store.namespace_evidence_from_snapshot(
+            active_snapshot
+        )
+        active_manifest, active_items = projection_store.load_projection_catalog(
+            vault_root,
+            key=active_evidence.manifest.namespace_key,
+            expected_rows_digest=active_evidence.manifest.rows_digest,
+        )
+        projection_store.bind_active_projection_namespace(
+            active_snapshot,
+            manifest=active_manifest,
+            items=active_items,
+        )
+        if active_evidence.required_measurement_roots:
+            raise GovernanceError(
+                "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
+                "the active model/graph lanes require a prepared measurement rebuild",
+            )
+        target_memberships: list[tuple[str, ...]] = []
+        for item in active_items:
+            snapshot = reserved_paths.read_generic_bytes(
+                vault_root,
+                item.item_identity,
+            )
+            if not __import__("hmac").compare_digest(
+                hashlib.sha256(snapshot.data).hexdigest(),
+                item.content_hash,
+            ):
+                raise GovernanceError(
+                    "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
+                    "the live corpus no longer matches the active catalog",
+                )
+            if Path(item.item_identity).suffix.casefold() == ".md":
+                page = find_corpus.parse_page(
+                    vault_root / item.item_identity,
+                    snapshot.mtime,
+                    vault_root,
+                    content=snapshot.data,
+                    resolved_relative=item.item_identity,
+                )
+                if page is None:
+                    raise GovernanceError(
+                        "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
+                        "the active Markdown catalog item cannot be classified",
+                    )
+                scope_ids = membership.evaluate(page, target_policy)
+            else:
+                scope_ids = membership.evaluate_path_only(
+                    vault_root,
+                    item.item_identity,
+                    target_policy,
+                ).require_classified()
+            target_memberships.append(tuple(sorted(scope_ids)))
+
+        membership_changed = any(
+            target_scope_ids != item.scope_ids
+            for item, target_scope_ids in zip(
+                active_items,
+                target_memberships,
+                strict=True,
+            )
+        )
+        target_catalog_generation = (
+            active_snapshot.active.catalog_generation + int(membership_changed)
+        )
+        key = projections.ProjectionNamespaceKey(
+            policy_fingerprint=target_policy.fingerprint,
+            projector_schema_version=(
+                active_snapshot.active.projector_schema_version
+            ),
+            catalog_generation=target_catalog_generation,
+        )
+        target_items = tuple(
+            projection_store.ProjectionItemVariants(
+                item_identity=item.item_identity,
+                content_hash=item.content_hash,
+                scope_ids=target_scope_ids,
+                variants=projections.enumerate_projection_variants(
+                    item_identity=item.item_identity,
+                    content_hash=item.content_hash,
+                    scope_ids=target_scope_ids,
+                    policy=target_policy,
+                    projector_schema_version=key.projector_schema_version,
+                    full_search_fields=_full_search_fields(item),
+                ),
+            )
+            for item, target_scope_ids in zip(
+                active_items,
+                target_memberships,
+                strict=True,
+            )
+        )
+        target_catalog_descriptor = projection_store.catalog_descriptor_bytes(
+            key,
+            target_items,
+        )
+        if not membership_changed and not __import__("hmac").compare_digest(
+            target_catalog_descriptor,
+            active_snapshot.catalog_descriptor,
+        ):
+            raise GovernanceError(
+                "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
+                "the prepared projection catalog does not match the reviewed catalog",
+            )
+        target_catalog = (
+            schema_v4.CatalogGenerationSeed(
+                catalog_generation=target_catalog_generation,
+                descriptor=target_catalog_descriptor,
+                artifact_count=len(target_items),
+                created_at=ready_at,
+            )
+            if membership_changed
+            else None
+        )
+        target_manifest = projection_store.stage_variant_store(
+            vault_root,
+            key=key,
+            items=target_items,
+        )
+        evidence = projection_store.projection_namespace_evidence_bytes(
+            target_manifest
+        )
+        connection = store.open_authorization_session_connection(vault_root)
+        try:
+            existing_namespace = connection.execute(
+                "SELECT namespace_id, evidence, ready_at "
+                "FROM governance_projection_namespaces "
+                "WHERE policy_fingerprint=? AND projector_schema_version=? "
+                "AND catalog_generation=?",
+                (
+                    key.policy_fingerprint,
+                    key.projector_schema_version,
+                    key.catalog_generation,
+                ),
+            ).fetchone()
+        finally:
+            connection.close()
+        if existing_namespace is not None:
+            if (
+                existing_namespace[0] != key.namespace_id
+                or bytes(existing_namespace[1]) != evidence
+            ):
+                raise GovernanceError(
+                    "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
+                    "the reusable projection namespace does not verify",
+                )
+            ready_at = int(existing_namespace[2])
+    except GovernanceError:
+        raise
+    except (
+        membership.MembershipUnresolved,
+        projection_store.ProjectionStoreError,
+        projections.ProjectionError,
+        reserved_paths.ReservedPathLeafError,
+        FileNotFoundError,
+        OSError,
+        sqlite3.Error,
+        TypeError,
+        ValueError,
+    ):
+        raise GovernanceError(
+            "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
+            "the target authorization-projection namespace is unavailable",
+        ) from None
+    return StagedTargetProjection(
+        catalog=target_catalog,
+        namespace={
+            "namespace_id": key.namespace_id,
+            "projector_schema_version": key.projector_schema_version,
+            "catalog_generation": key.catalog_generation,
+            "projection_rows_digest": target_manifest.rows_digest,
+            "evidence": base64.b64encode(evidence).decode("ascii"),
+            "ready_at": ready_at,
+        },
+        predecessor_items=active_items,
+        items=target_items,
+    )
+
+
+def dependent_grant_transitions(
+    vault_root: Path,
+    *,
+    current_policy: policy_module.Policy,
+    target_policy: policy_module.Policy,
+    predecessor_items: tuple[projection_store.ProjectionItemVariants, ...],
+    target_items: tuple[projection_store.ProjectionItemVariants, ...],
+) -> tuple[schema_v4.DependentGrantTransition, ...]:
+    """Bind every active dependent grant to an exact non-active successor."""
+
+    connection = store.open_authorization_session_connection(vault_root)
+    try:
+        rows = connection.execute(
+            "SELECT grant_id, paths, fingerprints, scope_ids, membership_manifest, "
+            "policy_fingerprint, prepared_event_id FROM governance_session_grants "
+            "WHERE status='active' ORDER BY grant_id"
+        ).fetchall()
+    except sqlite3.Error:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "dependent grant authority cannot be reviewed exactly",
+        ) from None
+    finally:
+        connection.close()
+    predecessor_by_path = {
+        item.item_identity: item for item in predecessor_items
+    }
+    target_by_path = {item.item_identity: item for item in target_items}
+    transitions: list[schema_v4.DependentGrantTransition] = []
+    for row in rows:
+        try:
+            grant_id = str(row[0])
+            paths = json.loads(str(row[1]))
+            fingerprints = json.loads(str(row[2]))
+            scope_ids = json.loads(str(row[3]))
+            expected_manifest = str(row[4])
+            stored_policy_fingerprint = str(row[5])
+            reviewed_membership = authorization_session_authority._load_membership(  # noqa: SLF001
+                expected_manifest
+            )
+            if (
+                not grant_id
+                or not isinstance(paths, list)
+                or not all(isinstance(path, str) and path for path in paths)
+                or not isinstance(fingerprints, list)
+                or not all(isinstance(value, str) for value in fingerprints)
+                or len(paths) != len(fingerprints)
+                or not isinstance(scope_ids, list)
+                or not scope_ids
+                or not all(
+                    isinstance(scope_id, str) and scope_id
+                    for scope_id in scope_ids
+                )
+                or scope_ids != sorted(set(scope_ids))
+                or tuple(paths)
+                != tuple(item.path for item in reviewed_membership)
+                or tuple(fingerprints)
+                != tuple(item.fingerprint for item in reviewed_membership)
+                or any(path not in predecessor_by_path for path in paths)
+                or not set(scope_ids).issubset(
+                    {
+                        scope_id
+                        for item in reviewed_membership
+                        for scope_id in item.scope_ids
+                    }
+                )
+                or stored_policy_fingerprint != current_policy.fingerprint
+                or row[6] is not None
+            ):
+                raise ValueError
+            target_membership = [
+                {
+                    "path": path,
+                    "fingerprint": target_by_path[path].content_hash,
+                    "scope_ids": list(target_by_path[path].scope_ids),
+                }
+                for path in paths
+                if path in target_by_path
+            ]
+            target_manifest = _canonical_json(target_membership)
+        except (
+            GovernanceError,
+            authorization_session_lifecycle.AuthorizationSessionUnavailable,
+            json.JSONDecodeError,
+            TypeError,
+            ValueError,
+        ):
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "dependent grant authority cannot be reviewed exactly",
+            ) from None
+        transitions.append(
+            schema_v4.DependentGrantTransition(
+                grant_id=grant_id,
+                expected_policy_fingerprint=stored_policy_fingerprint,
+                expected_membership_manifest=expected_manifest,
+                target_status=(
+                    "expired"
+                    if target_manifest != expected_manifest
+                    else "review"
+                ),
+                target_policy_fingerprint=target_policy.fingerprint,
+                target_membership_manifest=target_manifest,
+            )
+        )
+    return tuple(transitions)
+
+
+def prepare_destination_policy_publication(
+    vault_root: Path,
+    *,
+    prospective: policy_module.ProspectiveCompile,
+    document_edits: Mapping[str, str | None],
+    generation_id: str,
+    authoring_event_id: str,
+    receipt_event_id: str,
+    ready_at: int,
+    now: int,
+) -> PreparedPolicyPublication:
+    """Prepare exact v4 seeds from one freshly reviewed destination policy."""
+
+    _custody, active_snapshot = load_active_authority_snapshot(
+        vault_root,
+        now=now,
+    )
+    live = policy_module.compile_prospective(vault_root, dict(document_edits))
+    if (
+        not isinstance(prospective, policy_module.ProspectiveCompile)
+        or live is None
+        or live != prospective
+        or prospective.policy.empty
+        or prospective.policy.blocked
+        or prospective.policy.conflicted
+        or active_snapshot.active.policy_fingerprint
+        != active_snapshot.policy.fingerprint
+    ):
+        raise GovernanceError(
+            "STALE_GOVERNANCE_POLICY",
+            "the reviewed policy workspace changed",
+        )
+    staged = stage_target_projection_namespace(
+        vault_root,
+        active_snapshot=active_snapshot,
+        target_policy=prospective.policy,
+        ready_at=ready_at,
+    )
+    grants = dependent_grant_transitions(
+        vault_root,
+        current_policy=active_snapshot.policy,
+        target_policy=prospective.policy,
+        predecessor_items=staged.predecessor_items,
+        target_items=staged.items,
+    )
+    namespace = staged.namespace
+    try:
+        namespace_seed = schema_v4.ProjectionNamespaceSeed(
+            namespace_id=str(namespace["namespace_id"]),
+            evidence=base64.b64decode(str(namespace["evidence"]), validate=True),
+            ready_at=int(namespace["ready_at"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        raise GovernanceError(
+            "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
+            "the target authorization-projection namespace is unavailable",
+        ) from None
+    seed = schema_v4.PolicyGenerationSeed(
+        generation_id=generation_id,
+        source_documents=prospective.target_documents,
+        source_fingerprint=prospective.policy.fingerprint,
+        conflict_digest=prospective.snapshot.conflict_set_digest,
+        compiled_policy=policy_module.canonical_compiled_bytes(
+            prospective.policy
+        ),
+        policy_fingerprint=prospective.policy.fingerprint,
+        compiler_schema_version=1,
+        projector_schema_version=active_snapshot.active.projector_schema_version,
+        predecessor_generation_id=active_snapshot.active.policy_generation_id,
+        authoring_event_id=authoring_event_id,
+        receipt_event_id=receipt_event_id,
+        created_at=ready_at,
+    )
+    return prepare_policy_publication(
+        expected=active_snapshot.active,
+        policy=seed,
+        catalog=staged.catalog,
+        namespace=namespace_seed,
+        dependent_grants=grants,
+    )
+
+
+def receipt_terminal(vault_root: Path, receipt: CriticalReceipt) -> str | None:
+    """Classify one critical receipt without accepting substituted evidence."""
+
+    try:
+        records = receipts.event_records(vault_root)
+    except receipts.ReceiptError:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy publication receipt evidence cannot be verified",
+        ) from None
+    intents = [
+        record
+        for record in records
+        if record.get("event_id") == receipt.event_id and record.get("phase") == "intent"
+    ]
+    terminals = [
+        record
+        for record in records
+        if record.get("causation_id") == receipt.event_id
+        and record.get("phase") in {"committed", "aborted"}
+    ]
+    if not intents and not terminals:
+        return None
+    expected = {
+        "event_type": "critical",
+        "operation": receipt.operation,
+        "prior": receipt.prior,
+        "prepared": receipt.prepared,
+        "target": receipt.target,
+        "affected_ids": list(receipt.affected_ids),
+    }
+    if receipt.parent_causation_id is not None:
+        expected["parent_causation_id"] = receipt.parent_causation_id
+    if len(intents) != 1 or any(
+        intents[0].get(field) != value for field, value in expected.items()
+    ):
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy publication receipt intent is contradictory",
+        )
+    if not terminals:
+        return "pending"
+    if len(terminals) != 1:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy publication receipt terminal is contradictory",
+        )
+    phase = terminals[0].get("phase")
+    outcome = terminals[0].get("outcome")
+    if phase == "committed" and outcome == "committed":
+        return "committed"
+    if phase == "aborted" and isinstance(outcome, str) and outcome:
+        return "aborted"
+    raise GovernanceError(
+        "GOVERNANCE_BLOCKED",
+        "policy publication receipt terminal is contradictory",
+    )
+
+
+def begin_receipt(vault_root: Path, receipt: CriticalReceipt) -> None:
+    """Durably record the exact critical intent once."""
+
+    terminal = receipt_terminal(vault_root, receipt)
+    if terminal == "committed":
+        return
+    if terminal == "aborted":
+        raise GovernanceError(
+            "STALE_GOVERNANCE_POLICY",
+            "the reviewed policy publication was already refused",
+        )
+    if terminal == "pending":
+        return
+    try:
+        receipts.begin_event(
+            vault_root,
+            operation=receipt.operation,
+            prior=receipt.prior,
+            prepared=receipt.prepared,
+            target=receipt.target,
+            affected_ids=list(receipt.affected_ids),
+            event_id=receipt.event_id,
+            parent_causation_id=receipt.parent_causation_id,
+        )
+    except receipts.ReceiptError:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy publication receipt intent could not be recorded",
+        ) from None
+
+
+def commit_receipt(vault_root: Path, receipt: CriticalReceipt) -> None:
+    """Close an exact critical receipt only as committed."""
+
+    terminal = receipt_terminal(vault_root, receipt)
+    if terminal == "committed":
+        return
+    if terminal == "aborted":
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "committed policy publication has an aborted receipt",
+        )
+    if terminal is None:
+        begin_receipt(vault_root, receipt)
+    try:
+        receipts.commit_event(vault_root, receipt.event_id, outcome="committed")
+    except receipts.ReceiptError:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy publication receipt terminal could not be recorded",
+        ) from None
+
+
+def abort_receipt(vault_root: Path, receipt: CriticalReceipt) -> None:
+    """Close an in-flight exact receipt as a stale predecessor."""
+
+    terminal = receipt_terminal(vault_root, receipt)
+    if terminal in {None, "aborted"}:
+        return
+    if terminal == "committed":
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "committed policy publication cannot be expired as stale",
+        )
+    try:
+        receipts.abort_event(
+            vault_root,
+            receipt.event_id,
+            outcome="stale_predecessor",
+        )
+    except receipts.ReceiptError:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "stale policy publication receipt could not be closed",
+        ) from None
+
+
+def workspace_mirror_terminal(
+    vault_root: Path,
+    mirror: WorkspaceMirror,
+) -> str | None:
+    """Return only a receipt-proven mirror outcome from its closed vocabulary."""
+
+    receipt = mirror.receipt
+    try:
+        records = receipts.event_records(vault_root)
+    except receipts.ReceiptError:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy workspace mirror evidence cannot be verified",
+        ) from None
+    intents = [
+        record
+        for record in records
+        if record.get("event_id") == receipt.event_id and record.get("phase") == "intent"
+    ]
+    terminals = [
+        record
+        for record in records
+        if record.get("causation_id") == receipt.event_id
+        and record.get("phase") in {"committed", "aborted"}
+    ]
+    if not intents and not terminals:
+        return None
+    expected = {
+        "event_type": "critical",
+        "operation": receipt.operation,
+        "prior": receipt.prior,
+        "prepared": receipt.prepared,
+        "target": receipt.target,
+        "affected_ids": list(receipt.affected_ids),
+    }
+    if receipt.parent_causation_id is not None:
+        expected["parent_causation_id"] = receipt.parent_causation_id
+    if len(intents) != 1 or any(
+        intents[0].get(field) != value for field, value in expected.items()
+    ):
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy workspace mirror intent evidence is contradictory",
+        )
+    if not terminals:
+        return None
+    if len(terminals) != 1 or terminals[0].get("phase") != "committed":
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy workspace mirror evidence is contradictory",
+        )
+    outcome = terminals[0].get("outcome")
+    if outcome not in mirror.outcomes:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy workspace mirror evidence has an unknown outcome",
+        )
+    return str(outcome)
+
+
+def run_workspace_mirror(
+    vault_root: Path,
+    mirror: WorkspaceMirror,
+    apply: Callable[[], str],
+    *,
+    after_intent: Callable[[], None] | None = None,
+) -> str:
+    """Run one receipt-first non-authoritative workspace mirror exactly once."""
+
+    existing = workspace_mirror_terminal(vault_root, mirror)
+    if existing is not None:
+        return existing
+    receipt = mirror.receipt
+    try:
+        receipts.begin_event(
+            vault_root,
+            operation=receipt.operation,
+            prior=receipt.prior,
+            prepared=receipt.prepared,
+            target=receipt.target,
+            affected_ids=list(receipt.affected_ids),
+            event_id=receipt.event_id,
+            parent_causation_id=receipt.parent_causation_id,
+        )
+    except receipts.ReceiptError:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy workspace mirror intent could not be recorded",
+        ) from None
+    if after_intent is not None:
+        after_intent()
+    outcome = apply()
+    if outcome not in mirror.outcomes:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "the committed policy tuple is active but its workspace mirror needs retry",
+        )
+    try:
+        receipts.commit_event(vault_root, receipt.event_id, outcome=outcome)
+    except receipts.ReceiptError:
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "policy workspace mirror outcome could not be recorded",
+        ) from None
+    return outcome
+
+
+def prepare_workspace_mirror(
+    publication: PreparedPolicyPublication,
+    *,
+    mirror: WorkspaceMirror,
+    reviewed: policy_module.AuthoringSnapshot,
+) -> PreparedWorkspaceMirror:
+    """Bind a mirror receipt to the exact reviewed and published document sets."""
+
+    if (
+        not isinstance(publication, PreparedPolicyPublication)
+        or not isinstance(mirror, WorkspaceMirror)
+        or not isinstance(reviewed, policy_module.AuthoringSnapshot)
+    ):
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "the exact policy workspace mirror cannot be prepared",
+        )
+    compiled = policy_module.compile_documents(
+        dict(publication.policy.source_documents)
+    )
+    if (
+        compiled.empty
+        or compiled.blocked
+        or compiled.conflicted
+        or compiled.fingerprint != publication.policy.policy_fingerprint
+        or policy_module.canonical_compiled_bytes(compiled)
+        != publication.policy.compiled_policy
+        or mirror.receipt.parent_causation_id
+        != publication.identity.receipt_event_id
+    ):
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "the exact policy workspace mirror cannot be prepared",
+        )
+    return PreparedWorkspaceMirror(
+        publication=publication,
+        mirror=mirror,
+        reviewed=reviewed,
+    )
+
+
+def run_prepared_workspace_mirror(
+    vault_root: Path,
+    prepared: PreparedWorkspaceMirror,
+    *,
+    barrier: Callable[[str, str], None] | None = None,
+) -> str:
+    """Mirror exact published bytes through the shared receipt-first primitive."""
+
+    if not isinstance(prepared, PreparedWorkspaceMirror):
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "the exact policy workspace mirror is unavailable",
+        )
+    if not reserved_paths.owner_authorized("governance-tree"):
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "the exact policy workspace mirror lacks caller authority",
+        )
+
+    def apply() -> str:
+        return policy_module.mirror_authoring_workspace(
+            vault_root,
+            reviewed=prepared.reviewed,
+            target_documents=prepared.publication.policy.source_documents,
+            barrier=barrier,
+        )
+
+    return run_workspace_mirror(
+        vault_root,
+        prepared.mirror,
+        apply,
+    )
+
+
+def prepared_workspace_mirror_matches(
+    vault_root: Path,
+    prepared: PreparedWorkspaceMirror,
+) -> bool:
+    """Re-observe exact target bytes before trusting a completed mirror receipt."""
+
+    if not isinstance(prepared, PreparedWorkspaceMirror):
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "the exact policy workspace mirror is unavailable",
+        )
+    observed = policy_module.observe_authoring_snapshot(vault_root)
+    return (
+        observed is not None
+        and observed.documents == prepared.publication.policy.source_documents
+    )
+
+
+def prepare_policy_publication(
+    *,
+    expected: schema_v4.VerifiedActiveGovernanceState,
+    policy: schema_v4.PolicyGenerationSeed,
+    catalog: schema_v4.CatalogGenerationSeed | None,
+    namespace: schema_v4.ProjectionNamespaceSeed,
+    dependent_grants: tuple[schema_v4.DependentGrantTransition, ...] | None,
+) -> PreparedPolicyPublication:
+    """Bind reviewed v4 seeds to their durable publication identity."""
+
+    return PreparedPolicyPublication(
+        identity=PolicyPublicationIdentity(
+            receipt_event_id=policy.receipt_event_id,
+            policy_generation_id=policy.generation_id,
+        ),
+        expected=expected,
+        policy=policy,
+        catalog=catalog,
+        namespace=namespace,
+        dependent_grants=dependent_grants,
+    )
+
+
+def _control_matches_active(
+    control: authorization_custody.AuthorizationControlRecord,
+    active: schema_v4.VerifiedActiveGovernanceState,
+) -> bool:
+    return (
+        control.governance_enrolled
+        and control.logical_vault_id == active.logical_vault_id
+        and control.activation_store_id == active.activation_store_id
+        and control.activation_epoch == active.activation_epoch
+        and control.activation_state_digest == active.activation_state_digest
+    )
+
+
+def _committed_target(
+    connection: sqlite3.Connection,
+    prepared: PreparedPolicyPublication,
+) -> schema_v4.VerifiedActiveGovernanceState | None:
+    target_catalog_generation = (
+        prepared.expected.catalog_generation
+        if prepared.catalog is None
+        else prepared.catalog.catalog_generation
+    )
+    row = connection.execute(
+        "SELECT publication_kind, predecessor_activation_state_digest, "
+        "target_activation_state_digest, policy_generation_id, policy_fingerprint, "
+        "projector_schema_version, catalog_generation, activation_epoch, status "
+        "FROM governance_tuple_publications WHERE event_id=?",
+        (prepared.identity.receipt_event_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    target = schema_v4.load_active_tuple_pointer(connection)
+    if (
+        tuple(row)
+        != (
+            "policy",
+            prepared.expected.activation_state_digest,
+            target.activation_state_digest,
+            prepared.identity.policy_generation_id,
+            prepared.policy.policy_fingerprint,
+            prepared.policy.projector_schema_version,
+            target_catalog_generation,
+            prepared.expected.activation_epoch + 1,
+            "committed",
+        )
+        or target.logical_vault_id != prepared.expected.logical_vault_id
+        or target.activation_store_id != prepared.expected.activation_store_id
+        or target.activation_epoch != prepared.expected.activation_epoch + 1
+        or target.policy_generation_id != prepared.identity.policy_generation_id
+        or target.policy_fingerprint != prepared.policy.policy_fingerprint
+        or target.projector_schema_version != prepared.policy.projector_schema_version
+        or target.catalog_generation != target_catalog_generation
+        or target.projection_namespace_id != prepared.namespace.namespace_id
+    ):
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "committed policy publication does not match the reviewed proposal",
+        )
+    active_count = connection.execute(
+        "SELECT COUNT(*) FROM governance_session_grants WHERE status='active'"
+    ).fetchone()
+    if prepared.dependent_grants is not None:
+        committed_grants = (
+            connection.execute(
+                "SELECT grant_id, status, policy_fingerprint, membership_manifest, "
+                "prepared_event_id FROM governance_session_grants "
+                "WHERE grant_id IN ("
+                + ",".join("?" for _ in prepared.dependent_grants)
+                + ") ORDER BY grant_id",
+                tuple(transition.grant_id for transition in prepared.dependent_grants),
+            ).fetchall()
+            if prepared.dependent_grants
+            else []
+        )
+        expected_grants = [
+            (
+                transition.grant_id,
+                transition.target_status,
+                transition.target_policy_fingerprint,
+                transition.target_membership_manifest,
+                None,
+            )
+            for transition in prepared.dependent_grants
+        ]
+        if committed_grants != expected_grants or active_count != (0,):
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "committed dependent grants do not match the reviewed proposal",
+            )
+    elif active_count != (0,):
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "legacy policy publication did not bind the active dependent grants",
+        )
+    return target
+
+
+def classify_authority(
+    vault_root: Path,
+    prepared: PreparedPolicyPublication,
+    *,
+    now: int,
+) -> AuthorityClassification:
+    """Classify SQLite/custody state without repairing either side."""
+
+    connection = store.open_authorization_session_connection(vault_root)
+    try:
+        target = _committed_target(connection, prepared)
+        if target is None:
+            active = schema_v4.load_active_tuple_pointer(connection)
+            if active != prepared.expected:
+                return AuthorityClassification("mixed", active)
+            custody = authorization_custody.load_authorization_custody(
+                vault_root,
+                now=now,
+            )
+            state: Literal["prior", "tuple-committed", "active", "mixed"] = (
+                "prior"
+                if _control_matches_active(custody.control, prepared.expected)
+                else "mixed"
+            )
+            return AuthorityClassification(state, None)
+        custody = authorization_custody.load_authorization_custody(vault_root, now=now)
+        if _control_matches_active(custody.control, target):
+            return AuthorityClassification("active", target)
+        if _control_matches_active(custody.control, prepared.expected):
+            return AuthorityClassification("tuple-committed", target)
+        return AuthorityClassification("mixed", target)
+    except GovernanceError:
+        raise
+    except (
+        authorization_custody.AuthorizationCustodyUnavailable,
+        schema_v4.SchemaV4Error,
+        FileNotFoundError,
+        OSError,
+        sqlite3.Error,
+        RuntimeError,
+        ValueError,
+    ):
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "the committed policy tuple needs exact registry recovery",
+        ) from None
+    finally:
+        connection.close()
+
+
+def recover(
+    vault_root: Path,
+    *,
+    connection: sqlite3.Connection,
+    prepared: PreparedPolicyPublication,
+    now: int,
+) -> schema_v4.VerifiedActiveGovernanceState | None:
+    """Recover custody acknowledgement only for this exact committed tuple."""
+
+    try:
+        target = _committed_target(connection, prepared)
+        if target is None:
+            return None
+        custody = authorization_custody.load_authorization_custody(
+            vault_root,
+            now=now,
+        )
+        if _control_matches_active(custody.control, target):
+            verified = schema_v4.load_active_state(
+                connection,
+                expected_logical_vault_id=target.logical_vault_id,
+                expected_activation_store_id=target.activation_store_id,
+                expected_activation_epoch=target.activation_epoch,
+                expected_activation_state_digest=target.activation_state_digest,
+            )
+            if verified != target:
+                raise schema_v4.SchemaV4Error(
+                    "active tuple changed during policy recovery"
+                )
+            return target
+        if not _control_matches_active(custody.control, prepared.expected):
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "external activation authority names neither reviewed policy state",
+            )
+        recovered = schema_v4.recover_registry_acknowledgement(
+            connection,
+            expected=prepared.expected,
+            acknowledge_registry=lambda active: (
+                authorization_custody.acknowledge_activation_tuple(
+                    vault_root,
+                    expected_control=custody.control,
+                    target=active,
+                    now=now,
+                )
+            ),
+        )
+        if recovered.active != target:
+            raise schema_v4.SchemaV4Error(
+                "registry recovery selected an unexpected policy tuple"
+            )
+        return target
+    except GovernanceError:
+        raise
+    except (
+        authorization_custody.AuthorizationCustodyUnavailable,
+        schema_v4.SchemaV4Error,
+        FileNotFoundError,
+        OSError,
+        sqlite3.Error,
+        RuntimeError,
+        ValueError,
+    ):
+        raise GovernanceError(
+            "GOVERNANCE_BLOCKED",
+            "the committed policy tuple needs exact registry recovery",
+        ) from None
+
+
+def activate_or_recover(
+    vault_root: Path,
+    prepared: PreparedPolicyPublication,
+    *,
+    now: int,
+) -> PolicyPublicationClassification:
+    """Atomically activate a reviewed tuple or classify its exact CAS winner."""
+
+    connection = store.open_authorization_session_connection(vault_root)
+    try:
+        try:
+            custody = authorization_custody.load_authorization_custody(
+                vault_root,
+                now=now,
+            )
+            published = schema_v4.publish_policy_generation(
+                connection,
+                expected=prepared.expected,
+                policy=prepared.policy,
+                catalog=prepared.catalog,
+                namespace=prepared.namespace,
+                # A pre-v4 proposal did not bind grants. Passing an exact
+                # empty tuple makes the transaction prove there are none;
+                # it must never silently preserve unreviewed active rows.
+                dependent_grants=prepared.dependent_grants or (),
+                activated_at=now,
+                acknowledge_registry=lambda active: (
+                    authorization_custody.acknowledge_activation_tuple(
+                        vault_root,
+                        expected_control=custody.control,
+                        target=active,
+                        now=now,
+                    )
+                ),
+            )
+            return PolicyPublicationClassification("activated", published.active)
+        except schema_v4.ActiveTupleStale:
+            recovered = recover(
+                vault_root,
+                connection=connection,
+                prepared=prepared,
+                now=now,
+            )
+            if recovered is not None:
+                return PolicyPublicationClassification("recovered", recovered)
+            return PolicyPublicationClassification("stale", None)
+        except authorization_custody.AuthorizationCustodyUnavailable:
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "the committed policy tuple needs exact registry recovery",
+            ) from None
+        except (schema_v4.SchemaV4Error, OSError, sqlite3.Error):
+            raise GovernanceError(
+                "GOVERNANCE_BLOCKED",
+                "the reviewed policy tuple could not be published exactly",
+            ) from None
+    finally:
+        connection.close()

--- a/src/exomem/governance/tool.py
+++ b/src/exomem/governance/tool.py
@@ -49,6 +49,7 @@ from . import (
     decisions,
     graph_producer,
     membership,
+    policy_publication,
     projection_store,
     projections,
     receipts,
@@ -135,6 +136,18 @@ class _ValidatedV4PolicyProposal:
     decoded: _DecodedV4PolicyProposal
     custody: authorization_custody.AuthorizationCustody
 
+
+def _prepared_v4_policy_publication(
+    decoded: _DecodedV4PolicyProposal,
+) -> policy_publication.PreparedPolicyPublication:
+    return policy_publication.prepare_policy_publication(
+        expected=decoded.expected,
+        policy=decoded.policy,
+        catalog=decoded.catalog,
+        namespace=decoded.namespace,
+        dependent_grants=decoded.dependent_grants,
+    )
+
 __all__ = [
     "GovernanceCrash",
     "GovernanceError",
@@ -178,50 +191,7 @@ def _v4_active_authority_snapshot(
     authorization_custody.AuthorizationCustody,
     schema_v4.ActivePolicySnapshot,
 ]:
-    connection: sqlite3.Connection | None = None
-    try:
-        custody = authorization_custody.load_authorization_custody(
-            vault_root,
-            now=now,
-        )
-        control = custody.control
-        if (
-            not control.governance_enrolled
-            or control.activation_store_id is None
-            or control.activation_epoch is None
-            or control.activation_state_digest is None
-        ):
-            raise schema_v4.SchemaV4Error("external activation authority is incomplete")
-        connection = store.open_authorization_session_connection(vault_root)
-        connection.execute("BEGIN")
-        snapshot = schema_v4.load_active_policy(
-            connection,
-            expected_logical_vault_id=control.logical_vault_id,
-            expected_activation_store_id=control.activation_store_id,
-            expected_activation_epoch=control.activation_epoch,
-            expected_activation_state_digest=control.activation_state_digest,
-        )
-        connection.commit()
-        return custody, snapshot
-    except (
-        authorization_custody.AuthorizationCustodyUnavailable,
-        schema_v4.SchemaV4Error,
-        store.UnsupportedGovernanceSchema,
-        FileNotFoundError,
-        OSError,
-        sqlite3.Error,
-        RuntimeError,
-        ValueError,
-    ):
-        if connection is not None and connection.in_transaction:
-            connection.rollback()
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "the active governance tuple cannot be verified",
-        ) from None
-    finally:
-        if connection is not None:
-            connection.close()
+    return policy_publication.load_active_authority_snapshot(vault_root, now=now)
 
 
 def _v4_active_policy_snapshot(
@@ -354,28 +324,7 @@ def _policy_publication_identities(
 def _full_search_fields(
     item: projection_store.ProjectionItemVariants,
 ) -> Mapping[str, str]:
-    candidates: list[Mapping[str, str]] = []
-    for variant in item.variants:
-        if variant.decision_level != policy_module.DISCLOSURE_MAX:
-            continue
-        try:
-            value = json.loads(variant.value_jcs)
-        except (UnicodeDecodeError, json.JSONDecodeError):
-            continue
-        if value.get("release_strip") == []:
-            candidates.append(variant.search_fields)
-    if not candidates:
-        raise GovernanceError(
-            "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
-            "the active catalog lacks an unstripped full projection",
-        )
-    canonical = {_canonical_json(dict(candidate)) for candidate in candidates}
-    if len(canonical) != 1:
-        raise GovernanceError(
-            "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
-            "the active catalog has ambiguous full projections",
-        )
-    return dict(candidates[0])
+    return policy_publication._full_search_fields(item)  # noqa: SLF001
 
 
 def _stage_target_projection_namespace(
@@ -385,179 +334,17 @@ def _stage_target_projection_namespace(
     target_policy: policy_module.Policy,
     ready_at: int,
 ) -> _StagedTargetProjection:
-    try:
-        active_evidence = projection_store.namespace_evidence_from_snapshot(
-            active_snapshot
-        )
-        active_manifest, active_items = projection_store.load_projection_catalog(
-            vault_root,
-            key=active_evidence.manifest.namespace_key,
-            expected_rows_digest=active_evidence.manifest.rows_digest,
-        )
-        projection_store.bind_active_projection_namespace(
-            active_snapshot,
-            manifest=active_manifest,
-            items=active_items,
-        )
-        if active_evidence.required_measurement_roots:
-            raise GovernanceError(
-                "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
-                "the active model/graph lanes require a prepared measurement rebuild",
-            )
-        target_memberships: list[tuple[str, ...]] = []
-        for item in active_items:
-            snapshot = reserved_paths.read_generic_bytes(
-                vault_root,
-                item.item_identity,
-            )
-            if not __import__("hmac").compare_digest(
-                hashlib.sha256(snapshot.data).hexdigest(),
-                item.content_hash,
-            ):
-                raise GovernanceError(
-                    "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
-                    "the live corpus no longer matches the active catalog",
-                )
-            if Path(item.item_identity).suffix.casefold() == ".md":
-                page = find_corpus.parse_page(
-                    vault_root / item.item_identity,
-                    snapshot.mtime,
-                    vault_root,
-                    content=snapshot.data,
-                    resolved_relative=item.item_identity,
-                )
-                if page is None:
-                    raise GovernanceError(
-                        "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
-                        "the active Markdown catalog item cannot be classified",
-                    )
-                scope_ids = membership.evaluate(page, target_policy)
-            else:
-                scope_ids = membership.evaluate_path_only(
-                    vault_root,
-                    item.item_identity,
-                    target_policy,
-                ).require_classified()
-            target_memberships.append(tuple(sorted(scope_ids)))
-
-        membership_changed = any(
-            target_scope_ids != item.scope_ids
-            for item, target_scope_ids in zip(
-                active_items,
-                target_memberships,
-                strict=True,
-            )
-        )
-        target_catalog_generation = active_snapshot.active.catalog_generation + int(
-            membership_changed
-        )
-        key = projections.ProjectionNamespaceKey(
-            policy_fingerprint=target_policy.fingerprint,
-            projector_schema_version=active_snapshot.active.projector_schema_version,
-            catalog_generation=target_catalog_generation,
-        )
-        target_items = tuple(
-            projection_store.ProjectionItemVariants(
-                item_identity=item.item_identity,
-                content_hash=item.content_hash,
-                scope_ids=target_scope_ids,
-                variants=projections.enumerate_projection_variants(
-                    item_identity=item.item_identity,
-                    content_hash=item.content_hash,
-                    scope_ids=target_scope_ids,
-                    policy=target_policy,
-                    projector_schema_version=key.projector_schema_version,
-                    full_search_fields=_full_search_fields(item),
-                ),
-            )
-            for item, target_scope_ids in zip(
-                active_items,
-                target_memberships,
-                strict=True,
-            )
-        )
-        target_catalog_descriptor = projection_store.catalog_descriptor_bytes(
-            key,
-            target_items,
-        )
-        if not membership_changed and not __import__("hmac").compare_digest(
-            target_catalog_descriptor,
-            active_snapshot.catalog_descriptor,
-        ):
-            raise GovernanceError(
-                "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
-                "the prepared projection catalog does not match the reviewed catalog",
-            )
-        target_catalog = (
-            schema_v4.CatalogGenerationSeed(
-                catalog_generation=target_catalog_generation,
-                descriptor=target_catalog_descriptor,
-                artifact_count=len(target_items),
-                created_at=ready_at,
-            )
-            if membership_changed
-            else None
-        )
-        target_manifest = projection_store.stage_variant_store(
-            vault_root,
-            key=key,
-            items=target_items,
-        )
-        evidence = projection_store.projection_namespace_evidence_bytes(target_manifest)
-        connection = store.open_authorization_session_connection(vault_root)
-        try:
-            existing_namespace = connection.execute(
-                "SELECT namespace_id, evidence, ready_at "
-                "FROM governance_projection_namespaces "
-                "WHERE policy_fingerprint=? AND projector_schema_version=? "
-                "AND catalog_generation=?",
-                (
-                    key.policy_fingerprint,
-                    key.projector_schema_version,
-                    key.catalog_generation,
-                ),
-            ).fetchone()
-        finally:
-            connection.close()
-        if existing_namespace is not None:
-            if (
-                existing_namespace[0] != key.namespace_id
-                or bytes(existing_namespace[1]) != evidence
-            ):
-                raise GovernanceError(
-                    "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
-                    "the reusable projection namespace does not verify",
-                )
-            ready_at = int(existing_namespace[2])
-    except GovernanceError:
-        raise
-    except (
-        membership.MembershipUnresolved,
-        projection_store.ProjectionStoreError,
-        projections.ProjectionError,
-        reserved_paths.ReservedPathLeafError,
-        FileNotFoundError,
-        OSError,
-        sqlite3.Error,
-        TypeError,
-        ValueError,
-    ):
-        raise GovernanceError(
-            "GOVERNANCE_PROJECTION_REBUILD_REQUIRED",
-            "the target authorization-projection namespace is unavailable",
-        ) from None
+    staged = policy_publication.stage_target_projection_namespace(
+        vault_root,
+        active_snapshot=active_snapshot,
+        target_policy=target_policy,
+        ready_at=ready_at,
+    )
     return _StagedTargetProjection(
-        catalog=target_catalog,
-        namespace={
-            "namespace_id": key.namespace_id,
-            "projector_schema_version": key.projector_schema_version,
-            "catalog_generation": key.catalog_generation,
-            "projection_rows_digest": target_manifest.rows_digest,
-            "evidence": base64.b64encode(evidence).decode("ascii"),
-            "ready_at": ready_at,
-        },
-        predecessor_items=active_items,
-        items=target_items,
+        catalog=staged.catalog,
+        namespace=dict(staged.namespace),
+        predecessor_items=staged.predecessor_items,
+        items=staged.items,
     )
 
 
@@ -569,99 +356,13 @@ def _v4_dependent_grant_transitions(
     predecessor_items: tuple[projection_store.ProjectionItemVariants, ...],
     target_items: tuple[projection_store.ProjectionItemVariants, ...],
 ) -> tuple[schema_v4.DependentGrantTransition, ...]:
-    connection = store.open_authorization_session_connection(vault_root)
-    try:
-        rows = connection.execute(
-            "SELECT grant_id, paths, fingerprints, scope_ids, membership_manifest, "
-            "policy_fingerprint, prepared_event_id FROM governance_session_grants "
-            "WHERE status='active' ORDER BY grant_id"
-        ).fetchall()
-    except sqlite3.Error:
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "dependent grant authority cannot be reviewed exactly",
-        ) from None
-    finally:
-        connection.close()
-    predecessor_by_path = {item.item_identity: item for item in predecessor_items}
-    target_by_path = {item.item_identity: item for item in target_items}
-    transitions: list[schema_v4.DependentGrantTransition] = []
-    for row in rows:
-        try:
-            grant_id = str(row[0])
-            paths = json.loads(str(row[1]))
-            fingerprints = json.loads(str(row[2]))
-            scope_ids = json.loads(str(row[3]))
-            expected_manifest = str(row[4])
-            stored_policy_fingerprint = str(row[5])
-            reviewed_membership = authorization_session_authority._load_membership(
-                expected_manifest
-            )
-            if (
-                not grant_id
-                or not isinstance(paths, list)
-                or not all(isinstance(path, str) and path for path in paths)
-                or not isinstance(fingerprints, list)
-                or not all(isinstance(value, str) for value in fingerprints)
-                or len(paths) != len(fingerprints)
-                or not isinstance(scope_ids, list)
-                or not scope_ids
-                or not all(isinstance(scope_id, str) and scope_id for scope_id in scope_ids)
-                or scope_ids != sorted(set(scope_ids))
-                or tuple(paths) != tuple(item.path for item in reviewed_membership)
-                or tuple(fingerprints)
-                != tuple(item.fingerprint for item in reviewed_membership)
-                or any(
-                    path not in predecessor_by_path
-                    for path in paths
-                )
-                or not set(scope_ids).issubset(
-                    {
-                        scope_id
-                        for item in reviewed_membership
-                        for scope_id in item.scope_ids
-                    }
-                )
-                or stored_policy_fingerprint != current_policy.fingerprint
-                or row[6] is not None
-            ):
-                raise ValueError
-            target_membership = [
-                {
-                    "path": path,
-                    "fingerprint": target_by_path[path].content_hash,
-                    "scope_ids": list(target_by_path[path].scope_ids),
-                }
-                for path in paths
-                if path in target_by_path
-            ]
-            target_manifest = _canonical_json(target_membership)
-        except (
-            GovernanceError,
-            authorization_session_lifecycle.AuthorizationSessionUnavailable,
-            json.JSONDecodeError,
-            TypeError,
-            ValueError,
-        ):
-            raise GovernanceError(
-                "GOVERNANCE_BLOCKED",
-                "dependent grant authority cannot be reviewed exactly",
-            ) from None
-        transitions.append(
-            schema_v4.DependentGrantTransition(
-                grant_id=grant_id,
-                expected_policy_fingerprint=stored_policy_fingerprint,
-                expected_membership_manifest=expected_manifest,
-                target_status=(
-                    "expired"
-                    if target_manifest != expected_manifest
-                    else "review"
-                ),
-                target_policy_fingerprint=target_policy.fingerprint,
-                target_membership_manifest=target_manifest,
-            )
-        )
-    return tuple(transitions)
+    return policy_publication.dependent_grant_transitions(
+        vault_root,
+        current_policy=current_policy,
+        target_policy=target_policy,
+        predecessor_items=predecessor_items,
+        target_items=target_items,
+    )
 
 
 def _direction_with_dependent_grants(
@@ -4049,99 +3750,6 @@ def _validate_v4_proposal_binding(
     return _ValidatedV4PolicyProposal(decoded, custody)
 
 
-def _control_matches_active(
-    control: authorization_custody.AuthorizationControlRecord,
-    active: schema_v4.VerifiedActiveGovernanceState,
-) -> bool:
-    return (
-        control.governance_enrolled
-        and control.logical_vault_id == active.logical_vault_id
-        and control.activation_store_id == active.activation_store_id
-        and control.activation_epoch == active.activation_epoch
-        and control.activation_state_digest == active.activation_state_digest
-    )
-
-
-def _committed_v4_policy_target(
-    connection: sqlite3.Connection,
-    decoded: _DecodedV4PolicyProposal,
-) -> schema_v4.VerifiedActiveGovernanceState | None:
-    target_catalog_generation = (
-        decoded.expected.catalog_generation
-        if decoded.catalog is None
-        else decoded.catalog.catalog_generation
-    )
-    row = connection.execute(
-        "SELECT publication_kind, predecessor_activation_state_digest, "
-        "target_activation_state_digest, policy_generation_id, policy_fingerprint, "
-        "projector_schema_version, catalog_generation, activation_epoch, status "
-        "FROM governance_tuple_publications WHERE event_id=?",
-        (decoded.policy.receipt_event_id,),
-    ).fetchone()
-    if row is None:
-        return None
-    target = schema_v4.load_active_tuple_pointer(connection)
-    if (
-        tuple(row)
-        != (
-            "policy",
-            decoded.expected.activation_state_digest,
-            target.activation_state_digest,
-            decoded.policy.generation_id,
-            decoded.policy.policy_fingerprint,
-            decoded.policy.projector_schema_version,
-            target_catalog_generation,
-            decoded.expected.activation_epoch + 1,
-            "committed",
-        )
-        or target.logical_vault_id != decoded.expected.logical_vault_id
-        or target.activation_store_id != decoded.expected.activation_store_id
-        or target.activation_epoch != decoded.expected.activation_epoch + 1
-        or target.policy_generation_id != decoded.policy.generation_id
-        or target.policy_fingerprint != decoded.policy.policy_fingerprint
-        or target.projector_schema_version != decoded.policy.projector_schema_version
-        or target.catalog_generation != target_catalog_generation
-        or target.projection_namespace_id != decoded.namespace.namespace_id
-    ):
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "committed policy publication does not match the reviewed proposal",
-        )
-    active_count = connection.execute(
-        "SELECT COUNT(*) FROM governance_session_grants WHERE status='active'"
-    ).fetchone()
-    if decoded.dependent_grants is not None:
-        committed_grants = connection.execute(
-            "SELECT grant_id, status, policy_fingerprint, membership_manifest, "
-            "prepared_event_id FROM governance_session_grants "
-            "WHERE grant_id IN ("
-            + ",".join("?" for _ in decoded.dependent_grants)
-            + ") ORDER BY grant_id",
-            tuple(transition.grant_id for transition in decoded.dependent_grants),
-        ).fetchall() if decoded.dependent_grants else []
-        expected_grants = [
-            (
-                transition.grant_id,
-                transition.target_status,
-                transition.target_policy_fingerprint,
-                transition.target_membership_manifest,
-                None,
-            )
-            for transition in decoded.dependent_grants
-        ]
-        if committed_grants != expected_grants or active_count != (0,):
-            raise GovernanceError(
-                "GOVERNANCE_BLOCKED",
-                "committed dependent grants do not match the reviewed proposal",
-            )
-    elif active_count != (0,):
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "legacy policy publication did not bind the active dependent grants",
-        )
-    return target
-
-
 def _verify_recorded_v4_policy_terminal(
     vault_root: Path,
     decoded: _DecodedV4PolicyProposal,
@@ -4249,64 +3857,12 @@ def _recover_v4_policy_publication(
     decoded: _DecodedV4PolicyProposal,
     now: int,
 ) -> schema_v4.VerifiedActiveGovernanceState | None:
-    try:
-        target = _committed_v4_policy_target(connection, decoded)
-        if target is None:
-            return None
-        custody = authorization_custody.load_authorization_custody(
-            vault_root,
-            now=now,
-        )
-        if _control_matches_active(custody.control, target):
-            verified = schema_v4.load_active_state(
-                connection,
-                expected_logical_vault_id=target.logical_vault_id,
-                expected_activation_store_id=target.activation_store_id,
-                expected_activation_epoch=target.activation_epoch,
-                expected_activation_state_digest=target.activation_state_digest,
-            )
-            if verified != target:
-                raise schema_v4.SchemaV4Error(
-                    "active tuple changed during policy recovery"
-                )
-            return target
-        if not _control_matches_active(custody.control, decoded.expected):
-            raise GovernanceError(
-                "GOVERNANCE_BLOCKED",
-                "external activation authority names neither reviewed policy state",
-            )
-        recovered = schema_v4.recover_registry_acknowledgement(
-            connection,
-            expected=decoded.expected,
-            acknowledge_registry=lambda active: (
-                authorization_custody.acknowledge_activation_tuple(
-                    vault_root,
-                    expected_control=custody.control,
-                    target=active,
-                    now=now,
-                )
-            ),
-        )
-        if recovered.active != target:
-            raise schema_v4.SchemaV4Error(
-                "registry recovery selected an unexpected policy tuple"
-            )
-        return target
-    except GovernanceError:
-        raise
-    except (
-        authorization_custody.AuthorizationCustodyUnavailable,
-        schema_v4.SchemaV4Error,
-        FileNotFoundError,
-        OSError,
-        sqlite3.Error,
-        RuntimeError,
-        ValueError,
-    ):
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "the committed policy tuple needs exact registry recovery",
-        ) from None
+    return policy_publication.recover(
+        vault_root,
+        connection=connection,
+        prepared=_prepared_v4_policy_publication(decoded),
+        now=now,
+    )
 
 
 def _spend_v4_policy_proposal(
@@ -4470,61 +4026,25 @@ def _v4_policy_publication_receipt_terminal(
     vault_root: Path,
     decoded: _DecodedV4PolicyProposal,
 ) -> str | None:
+    return policy_publication.receipt_terminal(
+        vault_root,
+        _v4_policy_publication_receipt(decoded),
+    )
+
+
+def _v4_policy_publication_receipt(
+    decoded: _DecodedV4PolicyProposal,
+) -> policy_publication.CriticalReceipt:
     prior, prepared, target, affected = _v4_policy_publication_receipt_digests(
         decoded
     )
-    try:
-        records = receipts.event_records(vault_root)
-    except receipts.ReceiptError:
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "policy publication receipt evidence cannot be verified",
-        ) from None
-    intents = [
-        record
-        for record in records
-        if record.get("event_id") == decoded.policy.receipt_event_id
-        and record.get("phase") == "intent"
-    ]
-    terminals = [
-        record
-        for record in records
-        if record.get("causation_id") == decoded.policy.receipt_event_id
-        and record.get("phase") in {"committed", "aborted"}
-    ]
-    if not intents and not terminals:
-        return None
-    if len(intents) != 1 or any(
-        intents[0].get(field) != expected
-        for field, expected in {
-            "event_type": "critical",
-            "operation": _V4_POLICY_PUBLICATION_RECEIPT_OPERATION,
-            "prior": prior,
-            "prepared": prepared,
-            "target": target,
-            "affected_ids": affected,
-        }.items()
-    ):
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "policy publication receipt intent is contradictory",
-        )
-    if not terminals:
-        return "pending"
-    if len(terminals) != 1:
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "policy publication receipt terminal is contradictory",
-        )
-    phase = terminals[0].get("phase")
-    outcome = terminals[0].get("outcome")
-    if phase == "committed" and outcome == "committed":
-        return "committed"
-    if phase == "aborted" and isinstance(outcome, str) and outcome:
-        return "aborted"
-    raise GovernanceError(
-        "GOVERNANCE_BLOCKED",
-        "policy publication receipt terminal is contradictory",
+    return policy_publication.CriticalReceipt(
+        event_id=decoded.policy.receipt_event_id,
+        operation=_V4_POLICY_PUBLICATION_RECEIPT_OPERATION,
+        prior=prior,
+        prepared=prepared,
+        target=target,
+        affected_ids=tuple(affected),
     )
 
 
@@ -4532,86 +4052,21 @@ def _begin_v4_policy_publication_receipt(
     vault_root: Path,
     decoded: _DecodedV4PolicyProposal,
 ) -> None:
-    terminal = _v4_policy_publication_receipt_terminal(vault_root, decoded)
-    if terminal == "committed":
-        return
-    if terminal == "aborted":
-        raise GovernanceError(
-            "STALE_GOVERNANCE_POLICY",
-            "the reviewed policy publication was already refused",
-        )
-    if terminal == "pending":
-        return
-    prior, prepared, target, affected = _v4_policy_publication_receipt_digests(
-        decoded
-    )
-    try:
-        receipts.begin_event(
-            vault_root,
-            operation=_V4_POLICY_PUBLICATION_RECEIPT_OPERATION,
-            prior=prior,
-            prepared=prepared,
-            target=target,
-            affected_ids=affected,
-            event_id=decoded.policy.receipt_event_id,
-        )
-    except receipts.ReceiptError:
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "policy publication receipt intent could not be recorded",
-        ) from None
+    policy_publication.begin_receipt(vault_root, _v4_policy_publication_receipt(decoded))
 
 
 def _commit_v4_policy_publication_receipt(
     vault_root: Path,
     decoded: _DecodedV4PolicyProposal,
 ) -> None:
-    terminal = _v4_policy_publication_receipt_terminal(vault_root, decoded)
-    if terminal == "committed":
-        return
-    if terminal == "aborted":
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "committed policy publication has an aborted receipt",
-        )
-    if terminal is None:
-        _begin_v4_policy_publication_receipt(vault_root, decoded)
-    try:
-        receipts.commit_event(
-            vault_root,
-            decoded.policy.receipt_event_id,
-            outcome="committed",
-        )
-    except receipts.ReceiptError:
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "policy publication receipt terminal could not be recorded",
-        ) from None
+    policy_publication.commit_receipt(vault_root, _v4_policy_publication_receipt(decoded))
 
 
 def _abort_v4_policy_publication_receipt(
     vault_root: Path,
     decoded: _DecodedV4PolicyProposal,
 ) -> None:
-    terminal = _v4_policy_publication_receipt_terminal(vault_root, decoded)
-    if terminal in {None, "aborted"}:
-        return
-    if terminal == "committed":
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "committed policy publication cannot be expired as stale",
-        )
-    try:
-        receipts.abort_event(
-            vault_root,
-            decoded.policy.receipt_event_id,
-            outcome="stale_predecessor",
-        )
-    except receipts.ReceiptError:
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "stale policy publication receipt could not be closed",
-        ) from None
+    policy_publication.abort_receipt(vault_root, _v4_policy_publication_receipt(decoded))
 
 
 def _v4_workspace_mirror_barrier(_phase: str, _path: str | None = None) -> None:
@@ -4632,58 +4087,29 @@ def _v4_workspace_mirror_terminal(
     vault_root: Path,
     decoded: _DecodedV4PolicyProposal,
 ) -> str | None:
+    return policy_publication.workspace_mirror_terminal(
+        vault_root,
+        _v4_workspace_mirror(decoded),
+    )
+
+
+def _v4_workspace_mirror(
+    decoded: _DecodedV4PolicyProposal,
+) -> policy_publication.WorkspaceMirror:
     event_id = _v4_workspace_mirror_event_id(decoded)
     prior, prepared, target, affected = _v4_workspace_mirror_receipt_digests(decoded)
-    try:
-        event_records = receipts.event_records(vault_root)
-        intents = [
-            record
-            for record in event_records
-            if record.get("event_id") == event_id and record.get("phase") == "intent"
-        ]
-        terminals = [
-            record
-            for record in event_records
-            if record.get("causation_id") == event_id
-            and record.get("phase") in {"committed", "aborted"}
-        ]
-    except receipts.ReceiptError:
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "policy workspace mirror evidence cannot be verified",
-        ) from None
-    if not intents and not terminals:
-        return None
-    if len(intents) != 1 or any(
-        intents[0].get(field) != expected
-        for field, expected in {
-            "event_type": "critical",
-            "operation": _V4_POLICY_MIRROR_OPERATION,
-            "prior": prior,
-            "prepared": prepared,
-            "target": target,
-            "affected_ids": affected,
-            "parent_causation_id": decoded.policy.receipt_event_id,
-        }.items()
-    ):
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "policy workspace mirror intent evidence is contradictory",
-        )
-    if not terminals:
-        return None
-    if len(terminals) != 1 or terminals[0].get("phase") != "committed":
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "policy workspace mirror evidence is contradictory",
-        )
-    outcome = terminals[0].get("outcome")
-    if outcome not in _V4_POLICY_MIRROR_OUTCOMES:
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "policy workspace mirror evidence has an unknown outcome",
-        )
-    return str(outcome)
+    return policy_publication.WorkspaceMirror(
+        receipt=policy_publication.CriticalReceipt(
+            event_id=event_id,
+            operation=_V4_POLICY_MIRROR_OPERATION,
+            prior=prior,
+            prepared=prepared,
+            target=target,
+            affected_ids=tuple(affected),
+            parent_causation_id=decoded.policy.receipt_event_id,
+        ),
+        outcomes=_V4_POLICY_MIRROR_OUTCOMES,
+    )
 
 
 def _v4_workspace_mirror_receipt_digests(
@@ -4788,49 +4214,27 @@ def _mirror_v4_policy_workspace(
     *,
     crash_at: object,
 ) -> str:
-    event_id = _v4_workspace_mirror_event_id(decoded)
-    existing = _v4_workspace_mirror_terminal(vault_root, decoded)
-    if existing is not None:
-        return existing
-    prior, prepared, target, affected = _v4_workspace_mirror_receipt_digests(decoded)
-    try:
-        receipts.begin_event(
+    def after_intent() -> None:
+        _v4_workspace_mirror_barrier("after_intent")
+        if crash_at == "v4_after_mirror_intent":
+            raise GovernanceCrash("v4_after_mirror_intent")
+
+    def apply() -> str:
+        outcome = _apply_v4_workspace_mirror(
             vault_root,
-            operation=_V4_POLICY_MIRROR_OPERATION,
-            prior=prior,
-            prepared=prepared,
-            target=target,
-            affected_ids=affected,
-            event_id=event_id,
-            parent_causation_id=decoded.policy.receipt_event_id,
+            decoded,
+            crash_at=crash_at,
         )
-    except receipts.ReceiptError:
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "policy workspace mirror intent could not be recorded",
-        ) from None
-    _v4_workspace_mirror_barrier("after_intent")
-    if crash_at == "v4_after_mirror_intent":
-        raise GovernanceCrash("v4_after_mirror_intent")
-    outcome = _apply_v4_workspace_mirror(
+        if crash_at == "v4_after_mirror_effect":
+            raise GovernanceCrash("v4_after_mirror_effect")
+        return outcome
+
+    outcome = policy_publication.run_workspace_mirror(
         vault_root,
-        decoded,
-        crash_at=crash_at,
+        _v4_workspace_mirror(decoded),
+        apply,
+        after_intent=after_intent,
     )
-    if crash_at == "v4_after_mirror_effect":
-        raise GovernanceCrash("v4_after_mirror_effect")
-    if outcome == "pending":
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "the committed policy tuple is active but its workspace mirror needs retry",
-        )
-    try:
-        receipts.commit_event(vault_root, event_id, outcome=outcome)
-    except receipts.ReceiptError:
-        raise GovernanceError(
-            "GOVERNANCE_BLOCKED",
-            "policy workspace mirror outcome could not be recorded",
-        ) from None
     if crash_at == "v4_after_mirror_terminal":
         raise GovernanceCrash("v4_after_mirror_terminal")
     return outcome
@@ -4961,62 +4365,25 @@ def _commit(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
         )
         if kwargs.get("crash_at") == "v4_after_policy_receipt_intent":
             raise GovernanceCrash("v4_after_policy_receipt_intent")
-        connection = store.open_authorization_session_connection(vault_root)
-        try:
-            try:
-                schema_v4.publish_policy_generation(
-                    connection,
-                    expected=validated.decoded.expected,
-                    policy=validated.decoded.policy,
-                    catalog=validated.decoded.catalog,
-                    namespace=validated.decoded.namespace,
-                    # A pre-v4 proposal did not bind grants. Passing an exact
-                    # empty tuple makes the transaction prove there are none;
-                    # it must never silently preserve unreviewed active rows.
-                    dependent_grants=validated.decoded.dependent_grants or (),
-                    activated_at=int(now),
-                    acknowledge_registry=lambda active: (
-                        authorization_custody.acknowledge_activation_tuple(
-                            vault_root,
-                            expected_control=validated.custody.control,
-                            target=active,
-                            now=int(now),
-                        )
-                    ),
-                )
-            except schema_v4.ActiveTupleStale:
-                recovered = _recover_v4_policy_publication(
-                    vault_root,
-                    connection=connection,
-                    decoded=validated.decoded,
-                    now=int(now),
-                )
-                if recovered is None:
-                    _abort_v4_policy_publication_receipt(
-                        vault_root,
-                        validated.decoded,
-                    )
-                    _expire_v4_policy_proposal(
-                        vault_root,
-                        proposal_id=proposal_id,
-                        expired_at=int(now),
-                    )
-                    raise GovernanceError(
-                        "STALE_GOVERNANCE_POLICY",
-                        "the reviewed active policy tuple changed",
-                    ) from None
-            except authorization_custody.AuthorizationCustodyUnavailable:
-                raise GovernanceError(
-                    "GOVERNANCE_BLOCKED",
-                    "the committed policy tuple needs exact registry recovery",
-                ) from None
-            except (schema_v4.SchemaV4Error, OSError, sqlite3.Error):
-                raise GovernanceError(
-                    "GOVERNANCE_BLOCKED",
-                    "the reviewed policy tuple could not be published exactly",
-                ) from None
-        finally:
-            connection.close()
+        publication = policy_publication.activate_or_recover(
+            vault_root,
+            _prepared_v4_policy_publication(validated.decoded),
+            now=int(now),
+        )
+        if publication.state == "stale":
+            _abort_v4_policy_publication_receipt(
+                vault_root,
+                validated.decoded,
+            )
+            _expire_v4_policy_proposal(
+                vault_root,
+                proposal_id=proposal_id,
+                expired_at=int(now),
+            )
+            raise GovernanceError(
+                "STALE_GOVERNANCE_POLICY",
+                "the reviewed active policy tuple changed",
+            )
         if kwargs.get("crash_at") == "v4_after_registry_ack":
             raise GovernanceCrash("v4_after_registry_ack")
         _commit_v4_policy_publication_receipt(vault_root, validated.decoded)

--- a/tests/test_consolidation_batch_crash_matrix.py
+++ b/tests/test_consolidation_batch_crash_matrix.py
@@ -18,6 +18,7 @@ RUN_ID = "00000000-0000-4000-8000-0000000000a1"
 OPERATION_ID = "00000000-0000-4000-8000-0000000000a2"
 REQUEST_DIGEST = hashlib.sha256(b"batch-crash-matrix").hexdigest()
 POLICY_FINGERPRINT = hashlib.sha256(b"batch-crash-policy").hexdigest()
+VAULT_BINDING = hashlib.sha256(b"batch-crash-vault-binding").hexdigest()
 
 
 class SimulatedProcessCrash(BaseException):
@@ -33,6 +34,27 @@ def _private_writer_state(
         writer_lease.LeaseConfig(state_dir=tmp_path / "writer-state")
     )
     monkeypatch.setattr(writer_lease, "active_manager", lambda: manager)
+
+    def accept_synthetic_terminal(
+        *,
+        vault_root: Path,
+        terminal: consolidation_saga.PolicyActivationTerminal,
+        expected_policy_fingerprint: str,
+        vault_binding_digest: str,
+    ) -> consolidation_saga.PolicyActivationTerminal:
+        del vault_root
+        del vault_binding_digest
+        return consolidation_saga._policy_terminal(  # noqa: SLF001
+            terminal,
+            expected_policy_fingerprint=expected_policy_fingerprint,
+        )
+
+    monkeypatch.setattr(
+        consolidation_saga,
+        "_verify_policy_terminal_receipt",
+        accept_synthetic_terminal,
+        raising=False,
+    )
 
 
 def _action(ordinal: int, *, batch_ordinal: int = 0) -> dict[str, object]:
@@ -185,6 +207,7 @@ def test_restart_repairs_only_the_missing_effect_or_terminal(
             content_actions=actions,
             approved_partition_digest=partition.digest,
             expected_policy_fingerprint=POLICY_FINGERPRINT,
+            vault_binding_digest=VAULT_BINDING,
             activate_policy=_terminal,
             journal=FaultingJournal(store, seam),
             vault_root=root,
@@ -203,6 +226,7 @@ def test_restart_repairs_only_the_missing_effect_or_terminal(
         content_actions=actions,
         approved_partition_digest=partition.digest,
         expected_policy_fingerprint=POLICY_FINGERPRINT,
+        vault_binding_digest=VAULT_BINDING,
         activate_policy=_terminal,
         journal=_store(root),
         vault_root=root,
@@ -238,6 +262,7 @@ def test_crash_after_one_of_two_destination_renames_stays_mixed_and_cannot_advan
             content_actions=actions,
             approved_partition_digest=partition.digest,
             expected_policy_fingerprint=POLICY_FINGERPRINT,
+            vault_binding_digest=VAULT_BINDING,
             activate_policy=_terminal,
             journal=store,
             vault_root=root,
@@ -258,6 +283,7 @@ def test_crash_after_one_of_two_destination_renames_stays_mixed_and_cannot_advan
             content_actions=actions,
             approved_partition_digest=partition.digest,
             expected_policy_fingerprint=POLICY_FINGERPRINT,
+            vault_binding_digest=VAULT_BINDING,
             activate_policy=_terminal,
             journal=_store(root),
             vault_root=root,
@@ -288,6 +314,7 @@ def test_crash_after_last_destination_rename_repairs_only_the_final_terminal(
             content_actions=actions,
             approved_partition_digest=partition.digest,
             expected_policy_fingerprint=POLICY_FINGERPRINT,
+            vault_binding_digest=VAULT_BINDING,
             activate_policy=_terminal,
             journal=store,
             vault_root=root,
@@ -307,6 +334,7 @@ def test_crash_after_last_destination_rename_repairs_only_the_final_terminal(
         content_actions=actions,
         approved_partition_digest=partition.digest,
         expected_policy_fingerprint=POLICY_FINGERPRINT,
+        vault_binding_digest=VAULT_BINDING,
         activate_policy=_terminal,
         journal=_store(root),
         vault_root=root,

--- a/tests/test_consolidation_effect_coordinator.py
+++ b/tests/test_consolidation_effect_coordinator.py
@@ -136,8 +136,8 @@ def _append_policy_active_parent(vault: Path) -> dict[str, object]:
             prior_digest=hashlib.sha256(f"{kind}:prior".encode()).hexdigest(),
             target_digest=hashlib.sha256(f"{kind}:target".encode()).hexdigest(),
             prepared_digest=(
-                hashlib.sha256(b"preimage:prepared").hexdigest()
-                if kind == "preimage"
+                hashlib.sha256(f"{kind}:prepared".encode()).hexdigest()
+                if kind in {"preimage", "policy-prepare", "policy-active"}
                 else None
             ),
             evidence=consolidation_receipts.build_evidence(

--- a/tests/test_consolidation_policy_activation.py
+++ b/tests/test_consolidation_policy_activation.py
@@ -1,0 +1,715 @@
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import sqlite3
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+RUN_ID = "00000000-0000-4000-8000-0000000000f1"
+OPERATION_ID = "00000000-0000-4000-8000-0000000000f2"
+REQUEST_DIGEST = hashlib.sha256(b"policy-activation-request").hexdigest()
+PLAN_DIGEST = hashlib.sha256(b"policy-activation-plan").hexdigest()
+BUNDLE_DIGEST = hashlib.sha256(b"policy-activation-bundle").hexdigest()
+PREIMAGE_EVENT_ID = f"{hashlib.sha256(b'preimage-event').hexdigest()}:committed"
+PREIMAGE_PAYLOAD_DIGEST = hashlib.sha256(b"preimage-payload").hexdigest()
+VAULT_BINDING_DIGEST = hashlib.sha256(b"policy-activation-vault").hexdigest()
+POLICY_PREPARED_AT = "2026-08-31T10:11:12.345Z"
+
+
+class SimulatedActivationCrash(BaseException):
+    pass
+
+
+def _prepared_publication():
+    from exomem.governance import policy, policy_publication, schema_v4
+
+    documents = (
+        (
+            "scopes/private.yaml",
+            (
+                b"governance_version: 1\n"
+                b"id: 01ARZ3NDEKTSV4RRFFQ69G5FAV\n"
+                b"name: private\n"
+                b"paths:\n"
+                b"  - Knowledge Base/Notes/**\n"
+                b"default_deny: true\n"
+            ),
+        ),
+    )
+    compiled = policy.compile_documents(dict(documents))
+    expected = schema_v4.VerifiedActiveGovernanceState(
+        logical_vault_id="vault-policy-activation",
+        activation_store_id="activation-policy-activation",
+        activation_epoch=1,
+        activation_state_digest=hashlib.sha256(b"prior-state").hexdigest(),
+        policy_generation_id="01ARZ3NDEKTSV4RRFFQ69G5FAX",
+        policy_fingerprint=hashlib.sha256(b"prior-policy").hexdigest(),
+        projector_schema_version=1,
+        catalog_generation=1,
+        projection_namespace_id="namespace-prior",
+    )
+    seed = schema_v4.PolicyGenerationSeed(
+        generation_id="01ARZ3NDEKTSV4RRFFQ69G5FAY",
+        source_documents=documents,
+        source_fingerprint=compiled.fingerprint,
+        conflict_digest=hashlib.sha256(b"conflicts").hexdigest(),
+        compiled_policy=policy.canonical_compiled_bytes(compiled),
+        policy_fingerprint=compiled.fingerprint,
+        compiler_schema_version=1,
+        projector_schema_version=1,
+        predecessor_generation_id=expected.policy_generation_id,
+        authoring_event_id=hashlib.sha256(b"authoring-event").hexdigest(),
+        receipt_event_id=hashlib.sha256(b"publication-event").hexdigest(),
+        created_at=1_777_777_777,
+    )
+    return policy_publication.prepare_policy_publication(
+        expected=expected,
+        policy=seed,
+        catalog=None,
+        namespace=schema_v4.ProjectionNamespaceSeed(
+            namespace_id="namespace-target",
+            evidence=b'{"ready":true}',
+            ready_at=1_777_777_777,
+        ),
+        dependent_grants=(),
+    )
+
+
+def test_consolidation_publication_identity_is_exact_and_retry_stable() -> None:
+    from exomem.governance import consolidation_policy_activation
+
+    arguments = {
+        "destination_vault_id": "vault-policy-activation",
+        "vault_binding_digest": VAULT_BINDING_DIGEST,
+        "run_id": RUN_ID,
+        "operation_id": OPERATION_ID,
+        "request_digest": REQUEST_DIGEST,
+        "plan_digest": PLAN_DIGEST,
+        "policy_bundle_digest": BUNDLE_DIGEST,
+        "preimage_terminal_event_id": PREIMAGE_EVENT_ID,
+        "preimage_terminal_payload_digest": PREIMAGE_PAYLOAD_DIGEST,
+        "policy_prepared_at": POLICY_PREPARED_AT,
+    }
+
+    identity = consolidation_policy_activation.derive_policy_publication_identity(
+        **arguments
+    )
+
+    assert consolidation_policy_activation.derive_policy_publication_identity(
+        **arguments
+    ) == identity
+    assert len(identity.generation_id) == 26
+    assert len(identity.authoring_event_id) == 64
+    assert len(identity.receipt_event_id) == 64
+    assert len(identity.binding_digest) == 64
+    assert identity == consolidation_policy_activation.ConsolidationPolicyPublicationIdentity(
+        generation_id="01M1BMTCTS0VXP31FDD1YQ3EYC",
+        authoring_event_id=(
+            "f904db70565e61aa7dbfda2bdc8d13e0278167cb8bb1b9b7aacefe39e983ea5f"
+        ),
+        receipt_event_id=(
+            "cad18fd9fbebb0c521fd40e97d339a4355bf752e0ae1df778e5c82a03cf5e29e"
+        ),
+        binding_digest=(
+            "6ce93bde1b038422782c7c21252d845a5835d1d9b77cf45803d7bf34e13cba1b"
+        ),
+    )
+    assert identity != consolidation_policy_activation.derive_policy_publication_identity(
+        **{
+            **arguments,
+            "policy_bundle_digest": hashlib.sha256(b"changed-bundle").hexdigest(),
+        }
+    )
+
+
+def test_prepared_publication_record_round_trips_exact_recovery_inputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_policy_activation
+
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR",
+        str(tmp_path / "writer-state"),
+    )
+    vault = tmp_path / "vault"
+    (vault / "Knowledge Base").mkdir(parents=True)
+    prepared = _prepared_publication()
+    store = consolidation_policy_activation.ConsolidationPolicyPublicationStore(
+        vault,
+        run_id=RUN_ID,
+        effect_ordinal=16,
+    )
+
+    created = store.create(
+        operation_id=OPERATION_ID,
+        request_digest=REQUEST_DIGEST,
+        plan_digest=PLAN_DIGEST,
+        policy_bundle_digest=BUNDLE_DIGEST,
+        preimage_terminal_event_id=PREIMAGE_EVENT_ID,
+        preimage_terminal_payload_digest=PREIMAGE_PAYLOAD_DIGEST,
+        publication=prepared,
+    )
+
+    assert created.publication == prepared
+    assert store.load() == created
+    assert store.create(
+        operation_id=OPERATION_ID,
+        request_digest=REQUEST_DIGEST,
+        plan_digest=PLAN_DIGEST,
+        policy_bundle_digest=BUNDLE_DIGEST,
+        preimage_terminal_event_id=PREIMAGE_EVENT_ID,
+        preimage_terminal_payload_digest=PREIMAGE_PAYLOAD_DIGEST,
+        publication=prepared,
+    ) == created
+    with pytest.raises(
+        consolidation_policy_activation.ConsolidationPolicyActivationUnavailable,
+        match="^CONSOLIDATION_POLICY_ACTIVATION_UNAVAILABLE$",
+    ):
+        store.create(
+            operation_id=OPERATION_ID,
+            request_digest=hashlib.sha256(b"changed-request").hexdigest(),
+            plan_digest=PLAN_DIGEST,
+            policy_bundle_digest=BUNDLE_DIGEST,
+            preimage_terminal_event_id=PREIMAGE_EVENT_ID,
+            preimage_terminal_payload_digest=PREIMAGE_PAYLOAD_DIGEST,
+            publication=prepared,
+        )
+
+
+def test_policy_activation_exports_the_receipt_first_entrypoint() -> None:
+    from exomem.governance import consolidation_policy_activation
+
+    assert callable(
+        consolidation_policy_activation.activate_stored_destination_policy
+    )
+    assert (
+        consolidation_policy_activation.ConsolidationPolicyActivationResult
+        is not None
+    )
+
+
+def test_shared_workspace_mirror_requires_caller_owned_governance_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import policy, policy_publication, receipts
+
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR",
+        str(tmp_path / "writer-state"),
+    )
+    vault = tmp_path / "vault"
+    prepared = _prepared_publication()
+    governance = vault / "Knowledge Base" / "_Governance"
+    for relative, content in prepared.policy.source_documents:
+        target = governance / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+    reviewed = policy.observe_authoring_snapshot(vault)
+    assert reviewed is not None
+    mirror = policy_publication.WorkspaceMirror(
+        receipt=policy_publication.CriticalReceipt(
+            event_id=receipts.critical_event_id(
+                {"consolidation-workspace-mirror": "caller-authority"}
+            ),
+            operation="governance_policy_workspace_mirror",
+            prior="1" * 64,
+            prepared="2" * 64,
+            target="3" * 64,
+            affected_ids=("4" * 64,),
+            parent_causation_id=prepared.identity.receipt_event_id,
+        ),
+        outcomes=frozenset({"complete", "diverged"}),
+    )
+    bound = policy_publication.prepare_workspace_mirror(
+        prepared,
+        mirror=mirror,
+        reviewed=reviewed,
+    )
+
+    with pytest.raises(policy_publication.GovernanceError):
+        policy_publication.run_prepared_workspace_mirror(vault, bound)
+
+
+@pytest.mark.parametrize(
+    ("crash_point", "expected"),
+    (
+        (None, "success"),
+        ("authorization-clock-advance", "authorization-expiry-refusal"),
+        ("after-policy-record", "recovered-prior"),
+        ("after-inner-receipt-intent", "expired-prior-refusal"),
+        ("after-tuple-custody-activation", "recovered"),
+        ("after-inner-terminal", "recovered"),
+        ("after-mirror", "mirror-divergence-refusal"),
+    ),
+)
+def test_policy_activation_runs_the_real_preimage_chain_without_publishing_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    crash_point: str | None,
+    expected: str,
+) -> None:
+    from exomem import vault as vault_module
+    from exomem import writer_lease
+    from exomem.governance import (
+        consolidation_admission,
+        consolidation_apply_coordinator,
+        consolidation_authority,
+        consolidation_fingerprints,
+        consolidation_plan_store,
+        consolidation_policy,
+        consolidation_policy_activation,
+        consolidation_receipts,
+        consolidation_saga,
+        consolidation_seal,
+        policy,
+        receipts,
+        schema_v4,
+        store,
+    )
+    from tests.test_consolidation_apply_coordinator import (
+        JOURNAL_DIGEST as APPLY_JOURNAL_DIGEST,
+    )
+    from tests.test_consolidation_apply_coordinator import (
+        OPERATION_ID as APPLY_OPERATION_ID,
+    )
+    from tests.test_consolidation_apply_coordinator import (
+        PLAN_DIGEST as APPLY_PLAN_DIGEST,
+    )
+    from tests.test_consolidation_apply_coordinator import (
+        REQUEST_DIGEST as APPLY_REQUEST_DIGEST,
+    )
+    from tests.test_consolidation_apply_coordinator import RUN_ID as APPLY_RUN_ID
+    from tests.test_consolidation_apply_coordinator import (
+        T0,
+        T1,
+        T2,
+        T3,
+        VAULT_BINDING,
+        _append_token_reservation,
+        _identity,
+    )
+    from tests.test_consolidation_policy import _principal
+    from tests.test_governance_active_tuple import (
+        LOGICAL_VAULT_ID,
+        _configure_custody,
+        _documents,
+        _migrate_with_projection_item,
+        _write_workspace,
+    )
+
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR",
+        str(tmp_path / "writer-state"),
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    source = "---\ntype: note\n---\ndestination before activation\n"
+    content_path = vault / "Knowledge Base" / "Notes" / "destination.md"
+    content_path.parent.mkdir(parents=True)
+    content_path.write_text(source, encoding="utf-8")
+    (vault / "Knowledge Base" / "_access.yaml").write_text(
+        "readonly: []\n",
+        encoding="utf-8",
+    )
+    (vault / "Knowledge Base" / ".review-state.json").write_text(
+        '{"version":2,"records":{}}',
+        encoding="utf-8",
+    )
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_projection_item(
+        vault,
+        path="Knowledge Base/Notes/destination.md",
+        source=source,
+        now=now,
+    )
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    monkeypatch.setattr(
+        consolidation_fingerprints,
+        "load_local_identity",
+        lambda *_args, **_kwargs: dataclasses.replace(
+            _identity(tmp_path),
+            vault_id=LOGICAL_VAULT_ID,
+        ),
+    )
+    predecessor = _append_token_reservation(vault)
+    edits = {
+        "rules/external.yaml": dict(_documents(ceiling=1))[
+            "rules/external.yaml"
+        ].decode("utf-8")
+    }
+    principal = _principal(principal_id="external", vault_id=LOGICAL_VAULT_ID)
+    attestation = consolidation_policy.issue_destination_principal_attestation(
+        principal,
+        destination_vault_id=LOGICAL_VAULT_ID,
+        purposes=(),
+        issued_at="2026-08-30T11:59:00.000Z",
+        expires_at="2026-09-01T12:00:00.000Z",
+        nonce="policy-activation-nonce",
+    )
+    bundle = consolidation_policy.compile_destination_policy(
+        vault,
+        documents=edits,
+        source_authority=(),
+        attestations=(attestation,),
+        principal_contexts=(principal,),
+        destination_vault_id=LOGICAL_VAULT_ID,
+        expected_nonce="policy-activation-nonce",
+        verified_at=T1,
+    )
+    snapshot = consolidation_fingerprints.load_local_destination_snapshot(
+        vault,
+        now=now,
+    )
+    content_census_before = (
+        consolidation_fingerprints.load_local_source_content_census(vault).digest
+    )
+    plan = SimpleNamespace(
+        digest=APPLY_PLAN_DIGEST,
+        control_basis=SimpleNamespace(digest=hashlib.sha256(b"control").hexdigest()),
+        preimage={
+            "run_id": APPLY_RUN_ID,
+            "plan_kind": "cutover",
+            "destination_snapshot_fingerprint": snapshot.digest,
+            "expected_destination_preimage_census_digest": (
+                snapshot.canonical_census_digest
+            ),
+            "nonce": bundle.nonce,
+            "policy_bundle_digest": bundle.digest,
+        },
+    )
+    monkeypatch.setattr(
+        consolidation_plan_store.ConsolidationPlanStore,
+        "load",
+        lambda *_args, **_kwargs: plan,
+    )
+    monkeypatch.setattr(
+        consolidation_plan_store.ConsolidationPlanStore,
+        "load_policy_bundle",
+        lambda *_args, **_kwargs: bundle,
+    )
+    monkeypatch.setattr(
+        consolidation_apply_coordinator,
+        "_policy_verification_timestamp",
+        lambda: T1,
+    )
+
+    def refuse_content_write(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("policy activation invoked the content batch writer")
+
+    monkeypatch.setattr(vault_module, "batch_atomic_write", refuse_content_write)
+    live_prospective = policy.compile_prospective(vault, edits)
+    assert live_prospective == bundle.prospective
+    seal_store = consolidation_seal.ConsolidationSealStore(vault)
+    seal_store.initialize_open(vault_binding_digest=VAULT_BINDING, recorded_at=T0)
+    admission = consolidation_admission.ConsolidationAdmission(
+        vault,
+        vault_binding_digest=VAULT_BINDING,
+    )
+    authority = consolidation_authority.issue_authority(
+        vault_binding_digest=VAULT_BINDING,
+        run_id=APPLY_RUN_ID,
+        operation_id=APPLY_OPERATION_ID,
+        journal_digest=APPLY_JOURNAL_DIGEST,
+        phase="sealing",
+        action="apply",
+    )
+    content_before = content_path.read_bytes()
+    with admission.admit_mutation() as mutation:
+        control = admission.convert_control_mutation(
+            mutation,
+            authority=authority,
+            run_id=APPLY_RUN_ID,
+            operation_id=APPLY_OPERATION_ID,
+            journal_digest=APPLY_JOURNAL_DIGEST,
+            request_digest=APPLY_REQUEST_DIGEST,
+            phase="sealing",
+            action="apply",
+        )
+        preparation = consolidation_apply_coordinator.prepare_apply_through_preimage(
+            vault_root=vault,
+            admission=admission,
+            control=control,
+            artifact_store=__import__(
+                "exomem.governance.consolidation_intake",
+                fromlist=["PrivateConsolidationArtifactStore"],
+            ).PrivateConsolidationArtifactStore(
+                tmp_path / "private-artifacts",
+                active_vault_roots=(vault,),
+            ),
+            token_reservation_event_id=str(predecessor["event_id"]),
+            token_reservation_payload_digest=str(
+                predecessor["consolidation_event"]["payload_digest"]
+            ),
+            vault_binding_digest=VAULT_BINDING,
+            run_id=APPLY_RUN_ID,
+            operation_id=APPLY_OPERATION_ID,
+            journal_digest=APPLY_JOURNAL_DIGEST,
+            request_digest=APPLY_REQUEST_DIGEST,
+            plan_digest=APPLY_PLAN_DIGEST,
+            principal_contexts=(principal,),
+            sealed_at=T1,
+            drained_at=T2,
+            preimage_ready_at=T3,
+            now=now,
+            timeout=2.0,
+        )
+        activation_arguments = {
+            "vault_root": vault,
+            "admission": admission,
+            "preparation": preparation,
+            "vault_binding_digest": VAULT_BINDING,
+            "run_id": APPLY_RUN_ID,
+            "operation_id": APPLY_OPERATION_ID,
+            "journal_digest": APPLY_JOURNAL_DIGEST,
+            "request_digest": APPLY_REQUEST_DIGEST,
+            "plan_digest": APPLY_PLAN_DIGEST,
+            "principal_contexts": (principal,),
+            "policy_prepare_at": "2026-08-30T12:00:04.000Z",
+            "policy_active_at": "2026-08-30T12:00:05.000Z",
+            "timeout": 2.0,
+        }
+        authorization_clock_calls = 0
+
+        def authorization_now() -> int:
+            nonlocal authorization_clock_calls
+            authorization_clock_calls += 1
+            if expected == "authorization-expiry-refusal" and (
+                authorization_clock_calls > 1
+            ):
+                return now + 7_200
+            return now
+
+        monkeypatch.setattr(
+            consolidation_policy_activation,
+            "_authorization_now",
+            authorization_now,
+        )
+        monkeypatch.setattr(
+            consolidation_policy_activation,
+            "_policy_verification_timestamp",
+            lambda: "2026-08-30T12:00:04.000Z",
+            raising=False,
+        )
+        crashed = False
+
+        def crash_once(point: str) -> None:
+            nonlocal crashed
+            if point == crash_point and not crashed:
+                crashed = True
+                raise SimulatedActivationCrash
+
+        monkeypatch.setattr(
+            consolidation_policy_activation,
+            "_crash_point",
+            crash_once,
+        )
+        if expected == "authorization-expiry-refusal":
+            with pytest.raises(
+                consolidation_policy_activation.ConsolidationPolicyActivationUnavailable
+            ):
+                consolidation_policy_activation.activate_stored_destination_policy(
+                    **activation_arguments
+                )
+            result = None
+        elif crash_point is None:
+            result = consolidation_policy_activation.activate_stored_destination_policy(
+                **activation_arguments
+            )
+        else:
+            with pytest.raises(SimulatedActivationCrash):
+                consolidation_policy_activation.activate_stored_destination_policy(
+                    **activation_arguments
+                )
+            if expected != "recovered-prior":
+                monkeypatch.setattr(
+                    consolidation_policy_activation,
+                    "_policy_verification_timestamp",
+                    lambda: "2026-09-01T12:00:00.000Z",
+                    raising=False,
+                )
+            if expected == "mirror-divergence-refusal":
+                (vault / "Knowledge Base" / "_Governance" / "rules" / "external.yaml").write_bytes(
+                    dict(_documents(ceiling=0))["rules/external.yaml"]
+                )
+            if expected in {
+                "expired-prior-refusal",
+                "mirror-divergence-refusal",
+            }:
+                with pytest.raises(
+                    consolidation_policy_activation.ConsolidationPolicyActivationUnavailable
+                ):
+                    consolidation_policy_activation.activate_stored_destination_policy(
+                        **activation_arguments
+                    )
+                result = None
+            else:
+                result = (
+                    consolidation_policy_activation.activate_stored_destination_policy(
+                        **activation_arguments
+                    )
+                )
+                receipt_count = len(receipts.event_records(vault))
+                assert (
+                    consolidation_policy_activation.activate_stored_destination_policy(
+                        **activation_arguments
+                    )
+                    == result
+                )
+                assert len(receipts.event_records(vault)) == receipt_count
+
+    after = consolidation_fingerprints.load_local_destination_snapshot(vault, now=now)
+    if expected in {
+        "authorization-expiry-refusal",
+        "expired-prior-refusal",
+        "mirror-divergence-refusal",
+    }:
+        assert result is None
+        assert seal_store.load(vault_binding_digest=VAULT_BINDING).phase == "preimage-ready"
+        assert content_path.read_bytes() == content_before
+        with sqlite3.connect(store.sidecar_path(vault)) as connection:
+            active = schema_v4.load_active_tuple_pointer(connection)
+            assert active.activation_epoch == (
+                1
+                if expected
+                in {"authorization-expiry-refusal", "expired-prior-refusal"}
+                else 2
+            )
+            assert connection.execute(
+                "SELECT COUNT(*) FROM governance_tuple_publications "
+                "WHERE publication_kind='policy'"
+            ).fetchone() == (
+                (0,)
+                if expected
+                in {"authorization-expiry-refusal", "expired-prior-refusal"}
+                else (1,)
+            )
+        return
+
+    assert result is not None
+    assert result.seal_state.phase == "policy-active"
+    assert result.terminal.policy_fingerprint == bundle.prospective.policy.fingerprint
+    assert (
+        consolidation_saga._verify_policy_terminal_receipt(  # noqa: SLF001
+            vault_root=vault,
+            vault_binding_digest=VAULT_BINDING,
+            terminal=result.terminal,
+            expected_policy_fingerprint=bundle.prospective.policy.fingerprint,
+        )
+        == result.terminal
+    )
+    assert content_path.read_bytes() == content_before
+    assert (
+        consolidation_fingerprints.load_local_source_content_census(vault).digest
+        == content_census_before
+    )
+    assert after.canonical_census_digest != snapshot.canonical_census_digest
+    assert policy.load(vault).fingerprint == bundle.prospective.policy.fingerprint
+    with sqlite3.connect(store.sidecar_path(vault)) as connection:
+        active = schema_v4.load_active_tuple_pointer(connection)
+        assert active.activation_epoch == 2
+        assert connection.execute(
+            "SELECT COUNT(*) FROM governance_tuple_publications "
+            "WHERE publication_kind='policy'"
+        ).fetchone() == (1,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM governance_proposals"
+        ).fetchone() == (0,)
+
+    outer = [
+        row
+        for row in consolidation_receipts._active_records(vault)  # noqa: SLF001
+        if row.get("event_type") == "consolidation"
+    ]
+    assert [
+        (row["consolidation_event"]["kind"], row["phase"])
+        for row in outer[-4:]
+    ] == [
+        ("policy-prepare", "intent"),
+        ("policy-prepare", "committed"),
+        ("policy-active", "intent"),
+        ("policy-active", "committed"),
+    ]
+    record = consolidation_policy_activation.ConsolidationPolicyPublicationStore(
+        vault,
+        run_id=APPLY_RUN_ID,
+        effect_ordinal=15,
+    ).load()
+    policy_receipt = consolidation_policy_activation._policy_receipt(record)  # noqa: SLF001
+    mirror_receipt = consolidation_policy_activation._workspace_mirror(  # noqa: SLF001
+        record
+    ).receipt
+    all_receipts = receipts.event_records(vault)
+
+    def terminal_pair(event_id: str) -> list[tuple[object, object]]:
+        return [
+            (row.get("phase"), row.get("outcome"))
+            for row in all_receipts
+            if row.get("event_id") == event_id
+            or row.get("causation_id") == event_id
+        ]
+
+    assert terminal_pair(policy_receipt.event_id) == [
+        ("intent", None),
+        ("committed", "committed"),
+    ]
+    assert terminal_pair(mirror_receipt.event_id) == [
+        ("intent", None),
+        ("committed", "complete"),
+    ]
+    if crash_point is None:
+        predecessor_authority = record.publication.expected
+        with sqlite3.connect(store.sidecar_path(vault)) as connection:
+            connection.execute(
+                "UPDATE active_governance_tuple SET policy_generation_id=?, "
+                "policy_fingerprint=?, projector_schema_version=?, "
+                "catalog_generation=? WHERE singleton=1",
+                (
+                    predecessor_authority.policy_generation_id,
+                    predecessor_authority.policy_fingerprint,
+                    predecessor_authority.projector_schema_version,
+                    predecessor_authority.catalog_generation,
+                ),
+            )
+            connection.execute(
+                "UPDATE governance_activation_store SET activation_epoch=?, "
+                "activation_state_digest=? WHERE singleton=1",
+                (
+                    predecessor_authority.activation_epoch,
+                    predecessor_authority.activation_state_digest,
+                ),
+            )
+            connection.commit()
+        _configure_custody(
+            monkeypatch,
+            tmp_path / "custody",
+            activation_epoch=predecessor_authority.activation_epoch,
+            activation_state_digest=(
+                predecessor_authority.activation_state_digest
+            ),
+            now=now,
+        )
+
+        with pytest.raises(
+            consolidation_saga.PolicyFirstPublicationUnavailable
+        ):
+            consolidation_saga._verify_policy_terminal_receipt(  # noqa: SLF001
+                vault_root=vault,
+                vault_binding_digest=VAULT_BINDING,
+                terminal=result.terminal,
+                expected_policy_fingerprint=(
+                    bundle.prospective.policy.fingerprint
+                ),
+            )

--- a/tests/test_consolidation_receipts.py
+++ b/tests/test_consolidation_receipts.py
@@ -40,6 +40,11 @@ _EVIDENCE_FIELDS = {
     "start": ("identity_binding_digest", "run_request_digest"),
     "intake": ("archive_attestation_digest", "intake_manifest_digest"),
     "preimage": ("preimage_manifest_digest",),
+    "policy-active": (
+        "policy_active_digest",
+        "policy_bundle_digest",
+        "policy_fingerprint",
+    ),
     "content-batch": ("batch_manifest_digest", "classification_digest"),
     "complete": ("completion_digest", "verification_basis_digest"),
     "render-page": (
@@ -219,6 +224,31 @@ def test_preimage_receipt_requires_its_distinct_prepared_manifest_state() -> Non
         _intent(
             kind="preimage",
             phase="preimage",
+            batch_ordinal=None,
+            prepared_digest=None,
+        )
+
+
+def test_policy_active_receipt_requires_its_distinct_recovery_state() -> None:
+    from exomem.governance import consolidation_receipts
+
+    event = _intent(
+        kind="policy-active",
+        phase="policy",
+        batch_ordinal=None,
+    )
+
+    assert event.payload["prepared_digest"] == PREPARED_DIGEST
+    assert event.payload["evidence"]["policy_fingerprint"] == hashlib.sha256(
+        b"policy-active:policy_fingerprint"
+    ).hexdigest()
+    with pytest.raises(
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        match="^CONSOLIDATION_RECEIPT_UNAVAILABLE$",
+    ):
+        _intent(
+            kind="policy-active",
+            phase="policy",
             batch_ordinal=None,
             prepared_digest=None,
         )

--- a/tests/test_consolidation_saga.py
+++ b/tests/test_consolidation_saga.py
@@ -32,6 +32,39 @@ APPLY_PHASES = (
 )
 
 
+@pytest.fixture(autouse=True)
+def _allow_synthetic_policy_terminals_in_batch_unit_tests(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if request.node.name == (
+        "test_forged_committed_policy_terminal_never_reaches_batch_journal"
+    ):
+        return
+    from exomem.governance import consolidation_saga
+
+    def accept_synthetic_terminal(
+        *,
+        vault_root: Path,
+        terminal: consolidation_saga.PolicyActivationTerminal,
+        expected_policy_fingerprint: str,
+        vault_binding_digest: str,
+    ) -> consolidation_saga.PolicyActivationTerminal:
+        del vault_root
+        del vault_binding_digest
+        return consolidation_saga._policy_terminal(  # noqa: SLF001
+            terminal,
+            expected_policy_fingerprint=expected_policy_fingerprint,
+        )
+
+    monkeypatch.setattr(
+        consolidation_saga,
+        "_verify_policy_terminal_receipt",
+        accept_synthetic_terminal,
+        raising=False,
+    )
+
+
 def _authority(phase: str, *, action: str = "apply"):
     from exomem.governance import consolidation_authority
 
@@ -396,6 +429,7 @@ def test_policy_terminal_precedes_every_content_batch(
         content_actions=actions,
         approved_partition_digest=partition.digest,
         expected_policy_fingerprint=POLICY_FINGERPRINT,
+        vault_binding_digest=VAULT_BINDING,
         activate_policy=activate_policy,
         journal=Journal(),
         vault_root=tmp_path,
@@ -454,6 +488,7 @@ def test_policy_activation_failure_never_reaches_content_publication() -> None:
             content_actions=actions,
             approved_partition_digest=partition.digest,
             expected_policy_fingerprint=POLICY_FINGERPRINT,
+            vault_binding_digest=VAULT_BINDING,
             activate_policy=activate_policy,
             journal=Journal(),
             vault_root=Path("unused"),
@@ -474,6 +509,7 @@ def test_changed_approved_batch_partition_refuses_before_policy_activation() -> 
             content_actions=actions,
             approved_partition_digest=hashlib.sha256(b"different-partition").hexdigest(),
             expected_policy_fingerprint=POLICY_FINGERPRINT,
+            vault_binding_digest=VAULT_BINDING,
             activate_policy=lambda: effects.append("policy") or None,  # type: ignore[arg-type,return-value]
             journal=None,  # type: ignore[arg-type]
             vault_root=Path("unused"),
@@ -496,6 +532,7 @@ def test_noncommitted_policy_terminal_never_reaches_batch_journal() -> None:
             content_actions=actions,
             approved_partition_digest=partition.digest,
             expected_policy_fingerprint=POLICY_FINGERPRINT,
+            vault_binding_digest=VAULT_BINDING,
             activate_policy=lambda: consolidation_saga.PolicyActivationTerminal(
                 schema="exomem.consolidation-policy-activation-terminal/v1",
                 policy_fingerprint=POLICY_FINGERPRINT,
@@ -510,6 +547,45 @@ def test_noncommitted_policy_terminal_never_reaches_batch_journal() -> None:
         )
 
     assert effects == []
+
+
+def test_forged_committed_policy_terminal_never_reaches_batch_journal(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import consolidation_plan, consolidation_saga
+
+    actions = (_content_action(0, 0),)
+    target = tmp_path / str(actions[0]["destination_path"])
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"before-0")
+    partition = consolidation_plan.derive_journal_batch_partition(actions)
+    effects: list[str] = []
+
+    class Journal:
+        def batch_status(self, batch: consolidation_saga.ContentBatch) -> str:
+            effects.append(f"journal-status:{batch.ordinal}")
+            return "prior"
+
+        def prepare_batch(self, batch: consolidation_saga.ContentBatch) -> None:
+            effects.append(f"journal-prepare:{batch.ordinal}")
+
+        def commit_batch(self, batch: consolidation_saga.ContentBatch) -> None:
+            effects.append(f"journal-final:{batch.ordinal}")
+
+    with pytest.raises(consolidation_saga.PolicyFirstPublicationUnavailable):
+        consolidation_saga.publish_policy_first(
+            content_actions=actions,
+            approved_partition_digest=partition.digest,
+            expected_policy_fingerprint=POLICY_FINGERPRINT,
+            vault_binding_digest=VAULT_BINDING,
+            activate_policy=_publication_terminal,
+            journal=Journal(),
+            vault_root=tmp_path,
+            materialize_batch=lambda batch: (),
+        )
+
+    assert effects == []
+    assert target.read_bytes() == b"before-0"
 
 
 def _publication_terminal():
@@ -724,6 +800,7 @@ def test_policy_first_retry_performs_only_the_missing_batch_effect(
         content_actions=actions,
         approved_partition_digest=partition.digest,
         expected_policy_fingerprint=POLICY_FINGERPRINT,
+        vault_binding_digest=VAULT_BINDING,
         activate_policy=_publication_terminal,
         journal=Journal(),
         vault_root=root,
@@ -779,6 +856,7 @@ def test_policy_first_retry_refuses_inconsistent_journal_and_live_bytes(
             content_actions=actions,
             approved_partition_digest=partition.digest,
             expected_policy_fingerprint=POLICY_FINGERPRINT,
+            vault_binding_digest=VAULT_BINDING,
             activate_policy=_publication_terminal,
             journal=Journal(),
             vault_root=root,
@@ -853,6 +931,7 @@ def test_persisted_multi_batch_retry_skips_final_and_resumes_prepared(
         content_actions=actions,
         approved_partition_digest=partition.digest,
         expected_policy_fingerprint=POLICY_FINGERPRINT,
+        vault_binding_digest=VAULT_BINDING,
         activate_policy=_publication_terminal,
         journal=consolidation_batch_journal.ConsolidationBatchJournalStore(
             root,
@@ -953,6 +1032,7 @@ def test_policy_first_rejects_materialized_writes_outside_the_approved_action(
             content_actions=(action,),
             approved_partition_digest=partition.digest,
             expected_policy_fingerprint=POLICY_FINGERPRINT,
+            vault_binding_digest=VAULT_BINDING,
             activate_policy=_publication_terminal,
             journal=Journal(),
             vault_root=root,

--- a/tests/test_governance_active_tuple.py
+++ b/tests/test_governance_active_tuple.py
@@ -3358,6 +3358,221 @@ def test_govern_memory_v4_commit_adopts_its_exact_concurrent_cas_winner(
         ).fetchone() == (1,)
 
 
+def test_govern_memory_v4_commit_routes_exact_state_through_publication_adapter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import policy_publication
+    from exomem.governance import tool as governance_tool
+    from exomem.governance.tool import op_govern_memory
+
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR",
+        str(tmp_path / "publication-writer-state"),
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    _configure_custody(
+        monkeypatch,
+        tmp_path / "custody",
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        proposed = op_govern_memory(
+            vault,
+            operation="propose",
+            principal=owner_principal(),
+            intent="Lower the external ceiling",
+            documents={
+                relative: content.decode("utf-8")
+                for relative, content in _documents(ceiling=1)
+            },
+            target_ceiling=1,
+            now=now + 1,
+        )
+
+    observed: list[policy_publication.PreparedPolicyPublication] = []
+    activate_or_recover = policy_publication.activate_or_recover
+
+    def record(
+        vault_root: Path,
+        prepared: policy_publication.PreparedPolicyPublication,
+        *,
+        now: int,
+    ) -> policy_publication.PolicyPublicationClassification:
+        observed.append(prepared)
+        return activate_or_recover(vault_root, prepared, now=now)
+
+    monkeypatch.setattr(
+        governance_tool.policy_publication,
+        "activate_or_recover",
+        record,
+    )
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        committed = op_govern_memory(
+            vault,
+            operation="commit",
+            principal=owner_principal(),
+            proposal_id=proposed["proposal_id"],
+            now=now + 2,
+        )
+
+    assert committed["status"] == "committed"
+    assert len(observed) == 1
+    prepared = observed[0]
+    assert prepared.identity.receipt_event_id == committed["event_id"]
+    assert prepared.expected.activation_state_digest == migration.activation_state_digest
+    assert prepared.policy.policy_fingerprint == _compiled(_documents(ceiling=1)).fingerprint
+
+
+def test_policy_publication_classifies_a_third_sqlite_tuple_as_mixed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import policy_publication
+
+    now = int(time.time())
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR",
+        str(tmp_path / "publication-writer-state"),
+    )
+    writer_lease.reset_managers_for_tests()
+    vault = tmp_path / "vault"
+    _write_workspace(vault, _documents(ceiling=2))
+    migration = _migrate_with_empty_projection_catalog(vault, now=now)
+    custody_root = tmp_path / "custody"
+    _configure_custody(
+        monkeypatch,
+        custody_root,
+        activation_epoch=1,
+        activation_state_digest=migration.activation_state_digest,
+        now=now,
+    )
+
+    def prepare(
+        *,
+        ceiling: int,
+        generation_id: str,
+        event_suffix: str,
+    ) -> policy_publication.PreparedPolicyPublication:
+        edits = {
+            "rules/external.yaml": dict(_documents(ceiling=ceiling))[
+                "rules/external.yaml"
+            ].decode("utf-8")
+        }
+        prospective = policy.compile_prospective(vault, edits)
+        assert prospective is not None
+        return policy_publication.prepare_destination_policy_publication(
+            vault,
+            prospective=prospective,
+            document_edits=edits,
+            generation_id=generation_id,
+            authoring_event_id=hashlib.sha256(
+                f"authoring-{event_suffix}".encode()
+            ).hexdigest(),
+            receipt_event_id=hashlib.sha256(
+                f"receipt-{event_suffix}".encode()
+            ).hexdigest(),
+            ready_at=now + 1,
+            now=now,
+        )
+
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        reviewed = prepare(
+            ceiling=1,
+            generation_id=LOSING_GENERATION_ID,
+            event_suffix="reviewed",
+        )
+        third = prepare(
+            ceiling=0,
+            generation_id=SECOND_GENERATION_ID,
+            event_suffix="third",
+        )
+        published = policy_publication.activate_or_recover(
+            vault,
+            third,
+            now=now + 2,
+        )
+        assert published.state == "activated"
+
+        # Recreate the split-brain shape: external custody still names the
+        # reviewed predecessor while SQLite was won by an unrelated publication.
+        _configure_custody(
+            monkeypatch,
+            custody_root,
+            activation_epoch=1,
+            activation_state_digest=migration.activation_state_digest,
+            now=now + 3,
+        )
+        classification = policy_publication.classify_authority(
+            vault,
+            reviewed,
+            now=now + 3,
+        )
+
+    assert classification.state == "mixed"
+    assert classification.active is not None
+    assert classification.active.policy_generation_id == SECOND_GENERATION_ID
+
+
+def test_policy_publication_critical_receipt_replays_its_exact_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import policy_publication
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer"))
+    event_id = receipts.critical_event_id(
+        {"policy-publication-receipt": "exact-terminal"}
+    )
+    receipt = policy_publication.CriticalReceipt(
+        event_id=event_id,
+        operation="governance_policy_publication",
+        prior="1" * 64,
+        prepared="2" * 64,
+        target="3" * 64,
+        affected_ids=("4" * 64,),
+    )
+
+    assert policy_publication.receipt_terminal(vault, receipt) is None
+    policy_publication.begin_receipt(vault, receipt)
+    assert policy_publication.receipt_terminal(vault, receipt) == "pending"
+    policy_publication.commit_receipt(vault, receipt)
+    assert policy_publication.receipt_terminal(vault, receipt) == "committed"
+
+
+def test_policy_publication_workspace_mirror_records_exact_outcome(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import policy_publication
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer"))
+    mirror = policy_publication.WorkspaceMirror(
+        receipt=policy_publication.CriticalReceipt(
+            event_id=receipts.critical_event_id({"workspace-mirror": "complete"}),
+            operation="governance_policy_workspace_mirror",
+            prior="1" * 64,
+            prepared="2" * 64,
+            target="3" * 64,
+            affected_ids=("4" * 64,),
+        ),
+        outcomes=frozenset({"complete", "diverged"}),
+    )
+
+    assert policy_publication.run_workspace_mirror(vault, mirror, lambda: "complete") == "complete"
+    assert policy_publication.workspace_mirror_terminal(vault, mirror) == "complete"
+
+
 def test_govern_memory_v4_commit_refuses_reviewed_tuple_mismatch(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- extract proposal-neutral schema-v4 policy publication so normal governance commits and consolidation share the same tuple, custody, receipt, projection, and workspace-mirror implementation
- persist the exact prepared policy publication and drive `preimage-ready -> policy-active` through receipt-first, crash-recoverable effects without creating a synthetic governance proposal
- require the committed policy receipt, current consolidation seal, and current custody-bound active authority before any content-batch journal access
- fail closed on stale attestations before tuple publication, malformed or historical terminals, third-state authority, mirror divergence, and every covered cross-store crash seam

This is stacked on #997. It changes no live vault and performs no ordinary content writes.

## Verification

- `241 passed` across policy activation, apply coordination, receipts, effect recovery, policy-first saga, batch crash matrix, and active-tuple parity
- independent security recheck: all authorization/currentness findings closed
- independent code review and finding recheck: no remaining blockers
- independent verifier: same `241 passed` suite, Ruff over all 11 changed files, and `git diff --check`
- `openspec validate --all --strict`: `168 passed, 0 failed`
- `uv lock --check`
- public repository artifact validation: `3440 files, 3508 text payloads` clean
