### PR TITLE
feat(governance): publish consolidation content batches

### DIFF
--- a/src/exomem/governance/consolidation_batch_journal.py
+++ b/src/exomem/governance/consolidation_batch_journal.py
@@ -538,7 +538,19 @@ class ConsolidationBatchJournalStore:
             current = _parse_state(existing)
             if current.run_id != self.run_id:
                 _fail()
-            if current == target:
+            if (
+                current.schema == target.schema
+                and current.operation_id == target.operation_id
+                and current.request_digest == target.request_digest
+                and current.partition_digest == target.partition_digest
+                and current.binding_digest == target.binding_digest
+                and current.publication_boundary_ordinal
+                == target.publication_boundary_ordinal
+                and tuple(
+                    replace(entry, status="prior") for entry in current.batches
+                )
+                == target.batches
+            ):
                 return current
             _fail()
 

--- a/src/exomem/governance/consolidation_content_publication.py
+++ b/src/exomem/governance/consolidation_content_publication.py
@@ -1,0 +1,598 @@
+"""Publish one stored consolidation plan's canonical content batches.
+
+The coordinator joins the already committed restrictive policy terminal to the
+receipt-first batch executor. Planned bytes are resolved only from the private
+content-addressed artifact store by their approved final digest; request data
+never supplies publication content.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from contextlib import ExitStack
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path, PurePosixPath
+from typing import NoReturn
+
+from .. import reserved_paths, vault
+from . import (
+    consolidation_admission,
+    consolidation_authority,
+    consolidation_batch_journal,
+    consolidation_effect_coordinator,
+    consolidation_intake,
+    consolidation_plan,
+    consolidation_plan_store,
+    consolidation_receipts,
+    consolidation_saga,
+    consolidation_seal,
+)
+
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_UUID4 = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z")
+_ALLOWED_ENTRY_PHASES = frozenset({"policy-active", "publishing", "rebuilding"})
+
+__all__ = [
+    "ConsolidationContentPublicationResult",
+    "ConsolidationContentPublicationUnavailable",
+    "publish_stored_content_batches",
+]
+
+
+class ConsolidationContentPublicationUnavailable(RuntimeError):
+    """Content-free refusal for changed, corrupt, or ambiguous publication state."""
+
+    code = "CONSOLIDATION_CONTENT_PUBLICATION_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationContentPublicationResult:
+    partition_digest: str
+    publication_boundary_ordinal: int
+    committed_batch_ordinals: tuple[int, ...]
+    batch_effects: tuple[consolidation_effect_coordinator.EffectExecutionResult, ...]
+    batch_journal: consolidation_batch_journal.ConsolidationBatchJournalState
+    seal_state: consolidation_seal.ConsolidationSealState
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationContentPublicationUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _uuid4(value: object) -> str:
+    if not isinstance(value, str) or _UUID4.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _timestamp(value: object) -> str:
+    try:
+        checked, _parsed = consolidation_plan._timestamp(value)  # noqa: SLF001
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    return checked
+
+
+def _paths_overlap(left: Path, right: Path) -> bool:
+    try:
+        left.relative_to(right)
+        return True
+    except ValueError:
+        pass
+    try:
+        right.relative_to(left)
+        return True
+    except ValueError:
+        return False
+
+
+def _require_seal(
+    state: consolidation_seal.ConsolidationSealState,
+    *,
+    phases: frozenset[str],
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+) -> consolidation_seal.ConsolidationSealState:
+    if (
+        not isinstance(state, consolidation_seal.ConsolidationSealState)
+        or state.kind != "consolidation-sealed"
+        or state.phase not in phases
+        or state.vault_binding_digest != vault_binding_digest
+        or state.run_id != run_id
+        or state.operation_id != operation_id
+        or state.journal_digest != journal_digest
+    ):
+        _fail()
+    return state
+
+
+def _advance(
+    *,
+    admission: consolidation_admission.ConsolidationAdmission,
+    vault_root: Path,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+    source_phase: str,
+    target_phase: str,
+    recorded_at: str,
+) -> consolidation_seal.ConsolidationSealState:
+    current = _require_seal(
+        admission.reload().state,
+        phases=frozenset({source_phase, target_phase}),
+        vault_binding_digest=vault_binding_digest,
+        run_id=run_id,
+        operation_id=operation_id,
+        journal_digest=journal_digest,
+    )
+    if current.phase == target_phase:
+        if current.recorded_at != recorded_at:
+            _fail()
+        return current
+    authority = consolidation_authority.issue_authority(
+        vault_binding_digest=vault_binding_digest,
+        run_id=run_id,
+        operation_id=operation_id,
+        journal_digest=journal_digest,
+        phase=source_phase,
+        action="apply",
+    )
+    return consolidation_seal.ConsolidationSealStore(vault_root).advance_consolidation(
+        authority,
+        vault_binding_digest=vault_binding_digest,
+        action="apply",
+        target_phase=target_phase,
+        recorded_at=recorded_at,
+        expected_revision=current.revision,
+    )
+
+
+def _policy_parent(
+    vault_root: Path,
+    terminal: consolidation_saga.PolicyActivationTerminal,
+) -> tuple[int, str, str]:
+    try:
+        records = consolidation_receipts._active_records(vault_root)  # noqa: SLF001
+        nested = consolidation_saga._consolidation_receipt_event(  # noqa: SLF001
+            records,
+            event_id=terminal.terminal_event_id,
+            phase="committed",
+        )
+    except (
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        consolidation_saga.PolicyFirstPublicationUnavailable,
+    ):
+        _fail()
+    if (
+        nested["kind"] != "policy-active"
+        or nested["observed_digest"] != terminal.active_fingerprint
+    ):
+        _fail()
+    ordinal = nested["effect_ordinal"]
+    if type(ordinal) is not int or ordinal < 0:
+        _fail()
+    return ordinal, terminal.terminal_event_id, _digest(nested["payload_digest"])
+
+
+def _artifact_writes(
+    *,
+    vault_root: Path,
+    artifact_store: consolidation_intake.PrivateConsolidationArtifactStore,
+    actions: tuple[Mapping[str, object], ...],
+    stack: ExitStack,
+) -> tuple[vault.PlannedWrite, ...]:
+    writes: list[vault.PlannedWrite] = []
+    for action in actions:
+        before = action["expected_before_state"]
+        after = action["planned_after_state"]
+        before_digest = _digest(action["expected_before_sha256"])
+        after_digest = _digest(action["planned_after_sha256"])
+        if after != "present" or (before == after and before_digest == after_digest):
+            continue
+        reference = f"exomem-consolidation-object://sha256/{after_digest}"
+        source = artifact_store.resolve_object(reference)
+        relative = PurePosixPath(str(action["destination_path"]))
+        try:
+            if relative.suffix.casefold() == ".md":
+                content: str | vault.PreparedBinaryContent = source.read_bytes().decode("utf-8")
+            else:
+                size = source.stat().st_size
+                stream = stack.enter_context(source.open("rb"))
+                content = vault.PreparedBinaryContent(
+                    stream=stream,
+                    size=size,
+                    sha256=after_digest,
+                )
+        except (OSError, UnicodeDecodeError):
+            _fail()
+        writes.append(
+            vault.PlannedWrite(
+                path=vault_root.joinpath(*relative.parts),
+                content=content,
+                create_only=before == "absent",
+                expected_hash=(vault.MISSING_CONTENT_HASH if before == "absent" else before_digest),
+            )
+        )
+    return tuple(writes)
+
+
+def _batch_event(
+    *,
+    batch: consolidation_saga.ContentBatch,
+    run_id: str,
+    operation_id: str,
+    request_digest: str,
+    effect_ordinal: int,
+    parent_event_id: str,
+    parent_payload_digest: str,
+) -> consolidation_receipts.ConsolidationEvent:
+    return consolidation_receipts.build_intent(
+        kind="content-batch",
+        run_id=run_id,
+        operation_id=operation_id,
+        phase="publishing",
+        effect_ordinal=effect_ordinal,
+        batch_ordinal=batch.ordinal,
+        request_digest=request_digest,
+        prior_digest=batch.prior_fingerprint,
+        prepared_digest=batch.prepared_fingerprint,
+        target_digest=batch.final_fingerprint,
+        evidence=consolidation_receipts.build_evidence(
+            kind="content-batch",
+            digests={
+                "batch_manifest_digest": batch.action_set_digest,
+                "classification_digest": (
+                    consolidation_saga._content_batch_classification_digest(  # noqa: SLF001
+                        batch
+                    )
+                ),
+            },
+        ),
+        semantic_parent_event_id=parent_event_id,
+        semantic_parent_payload_digest=parent_payload_digest,
+    )
+
+
+def _materialize_approved_batch(
+    selected: consolidation_saga.ContentBatch,
+    *,
+    batch: consolidation_saga.ContentBatch,
+    batch_store: consolidation_batch_journal.ConsolidationBatchJournalStore,
+    actions: tuple[Mapping[str, object], ...],
+    vault_root: Path,
+    artifact_store: consolidation_intake.PrivateConsolidationArtifactStore,
+    stack: ExitStack,
+) -> tuple[vault.PlannedWrite, ...]:
+    if selected != batch:
+        _fail()
+    status = batch_store.batch_status(batch)
+    if status == "prior":
+        batch_store.prepare_batch(batch)
+    elif status != "prepared":
+        _fail()
+    selected_actions = tuple(
+        action for action in actions if action["batch_ordinal"] == batch.ordinal
+    )
+    return _artifact_writes(
+        vault_root=vault_root,
+        artifact_store=artifact_store,
+        actions=selected_actions,
+        stack=stack,
+    )
+
+
+def _rehydrate_completed_batches(
+    *,
+    vault_root: Path,
+    actions: tuple[Mapping[str, object], ...],
+    batches: tuple[consolidation_saga.ContentBatch, ...],
+    batch_state: consolidation_batch_journal.ConsolidationBatchJournalState,
+    run_id: str,
+    operation_id: str,
+    request_digest: str,
+    parent_ordinal: int,
+    parent_id: str,
+    parent_digest: str,
+) -> tuple[consolidation_effect_coordinator.EffectExecutionResult, ...]:
+    if not batch_state.publication_boundary_committed or any(
+        item.status != "final" for item in batch_state.batches
+    ):
+        _fail()
+    effects: list[consolidation_effect_coordinator.EffectExecutionResult] = []
+    for batch in batches:
+        effect_ordinal = parent_ordinal + batch.ordinal + 1
+        event = _batch_event(
+            batch=batch,
+            run_id=run_id,
+            operation_id=operation_id,
+            request_digest=request_digest,
+            effect_ordinal=effect_ordinal,
+            parent_event_id=parent_id,
+            parent_payload_digest=parent_digest,
+        )
+        state = consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+            vault_root,
+            run_id=run_id,
+            effect_ordinal=effect_ordinal,
+        ).load()
+        if (
+            state.status != "final"
+            or state.kind != "content-batch"
+            or state.operation_id != operation_id
+            or state.intent.event_id != event.event_id
+            or state.intent.payload_digest != event.payload_digest
+            or dict(state.intent_payload) != dict(event.payload)
+            or state.terminal is None
+            or state.terminal.event_id != f"{event.event_id}:committed"
+            or state.observed_state != "target"
+            or state.observed_digest != batch.final_fingerprint
+        ):
+            _fail()
+        observation = consolidation_saga.classify_content_batch_state(
+            vault_root=vault_root,
+            content_actions=actions,
+            batch=batch,
+        )
+        if observation.state not in {"final", "equivalent"}:
+            _fail()
+        effect = consolidation_effect_coordinator._result(state)  # noqa: SLF001
+        effects.append(effect)
+        parent_id = effect.terminal.event_id
+        parent_digest = effect.terminal.payload_digest
+    return tuple(effects)
+
+
+def publish_stored_content_batches(
+    *,
+    vault_root: Path | str,
+    admission: consolidation_admission.ConsolidationAdmission,
+    artifact_store: consolidation_intake.PrivateConsolidationArtifactStore,
+    policy_terminal: consolidation_saga.PolicyActivationTerminal,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+    request_digest: str,
+    plan_digest: str,
+    publishing_at: str,
+    rebuilding_at: str,
+) -> ConsolidationContentPublicationResult:
+    """Publish exact private artifacts after policy activation, then enter rebuild."""
+
+    root = Path(vault_root).absolute()
+    checked_vault = _digest(vault_binding_digest)
+    checked_run = _uuid4(run_id)
+    checked_operation = _uuid4(operation_id)
+    checked_journal = _digest(journal_digest)
+    checked_request = _digest(request_digest)
+    checked_plan = _digest(plan_digest)
+    publishing_time = _timestamp(publishing_at)
+    rebuilding_time = _timestamp(rebuilding_at)
+    if (
+        not isinstance(admission, consolidation_admission.ConsolidationAdmission)
+        or admission.vault_root != root
+        or admission.vault_binding_digest != checked_vault
+        or not isinstance(
+            artifact_store,
+            consolidation_intake.PrivateConsolidationArtifactStore,
+        )
+        or publishing_time >= rebuilding_time
+    ):
+        _fail()
+    try:
+        resolved_root = root.resolve(strict=False)
+        resolved_artifact_root = artifact_store.root.resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        _fail()
+    if _paths_overlap(resolved_root, resolved_artifact_root):
+        _fail()
+    try:
+        stored = consolidation_plan_store.ConsolidationPlanStore(root).load(
+            checked_run,
+            plan_kind="cutover",
+            plan_digest=checked_plan,
+        )
+        preimage = stored.preimage
+        if (
+            stored.digest != checked_plan
+            or not isinstance(preimage, Mapping)
+            or preimage.get("run_id") != checked_run
+            or preimage.get("plan_kind") != "cutover"
+        ):
+            _fail()
+        actions = consolidation_plan.validate_content_actions(preimage.get("content_actions"))
+        partition = consolidation_plan.derive_journal_batch_partition(actions)
+        if partition.digest != _digest(preimage.get("journal_batch_partition_digest")):
+            _fail()
+        expected_policy = _digest(preimage.get("prospective_policy_fingerprint"))
+        terminal = consolidation_saga._verify_policy_terminal_receipt(  # noqa: SLF001
+            vault_root=root,
+            vault_binding_digest=checked_vault,
+            terminal=policy_terminal,
+            expected_policy_fingerprint=expected_policy,
+            allowed_seal_phases=_ALLOWED_ENTRY_PHASES,
+        )
+        parent_ordinal, parent_id, parent_digest = _policy_parent(root, terminal)
+        current = _require_seal(
+            admission.reload().state,
+            phases=_ALLOWED_ENTRY_PHASES,
+            vault_binding_digest=checked_vault,
+            run_id=checked_run,
+            operation_id=checked_operation,
+            journal_digest=checked_journal,
+        )
+        batch_store = consolidation_batch_journal.ConsolidationBatchJournalStore(
+            root,
+            run_id=checked_run,
+        )
+        if current.phase != "policy-active":
+            batch_store.load()
+        batch_store.create(
+            operation_id=checked_operation,
+            request_digest=checked_request,
+            partition=partition,
+        )
+        batches = consolidation_saga._content_batches(partition)  # noqa: SLF001
+        if current.phase == "rebuilding":
+            if current.recorded_at != rebuilding_time:
+                _fail()
+            batch_state = batch_store.load()
+            effects = _rehydrate_completed_batches(
+                vault_root=root,
+                actions=actions,
+                batches=batches,
+                batch_state=batch_state,
+                run_id=checked_run,
+                operation_id=checked_operation,
+                request_digest=checked_request,
+                parent_ordinal=parent_ordinal,
+                parent_id=parent_id,
+                parent_digest=parent_digest,
+            )
+            return ConsolidationContentPublicationResult(
+                partition_digest=partition.digest,
+                publication_boundary_ordinal=batch_state.publication_boundary_ordinal,
+                committed_batch_ordinals=tuple(batch.ordinal for batch in batches),
+                batch_effects=effects,
+                batch_journal=batch_state,
+                seal_state=current,
+            )
+        if current.phase == "policy-active":
+            _advance(
+                admission=admission,
+                vault_root=root,
+                vault_binding_digest=checked_vault,
+                run_id=checked_run,
+                operation_id=checked_operation,
+                journal_digest=checked_journal,
+                source_phase="policy-active",
+                target_phase="publishing",
+                recorded_at=publishing_time,
+            )
+        elif current.phase == "publishing":
+            if current.recorded_at != publishing_time:
+                _fail()
+        else:
+            _fail()
+
+        effects: list[consolidation_effect_coordinator.EffectExecutionResult] = []
+        committed: list[int] = []
+        for batch in batches:
+            effect_ordinal = parent_ordinal + batch.ordinal + 1
+            event = _batch_event(
+                batch=batch,
+                run_id=checked_run,
+                operation_id=checked_operation,
+                request_digest=checked_request,
+                effect_ordinal=effect_ordinal,
+                parent_event_id=parent_id,
+                parent_payload_digest=parent_digest,
+            )
+            effect_store = consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+                root,
+                run_id=checked_run,
+                effect_ordinal=effect_ordinal,
+            )
+            coarse_status = batch_store.batch_status(batch)
+            if coarse_status in {"prepared", "final"}:
+                existing_effect = effect_store.load()
+                if existing_effect.kind != "content-batch" or existing_effect.status not in (
+                    {"prepared", "final"} if coarse_status == "prepared" else {"final"}
+                ):
+                    _fail()
+            with ExitStack() as stack:
+                effect = consolidation_saga.publish_content_batch_receipt_first(
+                    content_actions=actions,
+                    batch=batch,
+                    event=event,
+                    journal=effect_store,
+                    vault_root=root,
+                    materialize_batch=partial(
+                        _materialize_approved_batch,
+                        batch=batch,
+                        batch_store=batch_store,
+                        actions=actions,
+                        vault_root=root,
+                        artifact_store=artifact_store,
+                        stack=stack,
+                    ),
+                    timestamp=publishing_time,
+                )
+            if (
+                effect.role != "committed"
+                or effect.observed_state != "target"
+                or effect.observed_digest != batch.final_fingerprint
+                or effect.intent.event_id != event.event_id
+            ):
+                _fail()
+            status = batch_store.batch_status(batch)
+            if status == "prior":
+                batch_store.prepare_batch(batch)
+                status = "prepared"
+            if status == "prepared":
+                batch_store.commit_batch(batch)
+            elif status != "final":
+                _fail()
+            effects.append(effect)
+            committed.append(batch.ordinal)
+            parent_id = effect.terminal.event_id
+            parent_digest = effect.terminal.payload_digest
+
+        batch_state = batch_store.load()
+        if not batch_state.publication_boundary_committed or any(
+            item.status != "final" for item in batch_state.batches
+        ):
+            _fail()
+        seal_state = _advance(
+            admission=admission,
+            vault_root=root,
+            vault_binding_digest=checked_vault,
+            run_id=checked_run,
+            operation_id=checked_operation,
+            journal_digest=checked_journal,
+            source_phase="publishing",
+            target_phase="rebuilding",
+            recorded_at=rebuilding_time,
+        )
+        return ConsolidationContentPublicationResult(
+            partition_digest=partition.digest,
+            publication_boundary_ordinal=batch_state.publication_boundary_ordinal,
+            committed_batch_ordinals=tuple(committed),
+            batch_effects=tuple(effects),
+            batch_journal=batch_state,
+            seal_state=seal_state,
+        )
+    except ConsolidationContentPublicationUnavailable:
+        raise
+    except (
+        consolidation_admission.ConsolidationAdmissionUnavailable,
+        consolidation_authority.ConsolidationAuthorityUnavailable,
+        consolidation_batch_journal.ConsolidationBatchJournalUnavailable,
+        consolidation_effect_coordinator.ConsolidationEffectUnavailable,
+        consolidation_intake.ConsolidationIntakeUnavailable,
+        consolidation_plan.ConsolidationPlanUnavailable,
+        consolidation_plan_store.ConsolidationPlanStoreUnavailable,
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        consolidation_saga.PolicyFirstPublicationUnavailable,
+        consolidation_seal.ConsolidationSealUnavailable,
+        reserved_paths.ReservedPathLeafError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ):
+        _fail()

--- a/src/exomem/governance/consolidation_saga.py
+++ b/src/exomem/governance/consolidation_saga.py
@@ -36,6 +36,8 @@ POLICY_ACTIVATION_TERMINAL_SCHEMA = (
 
 _DIGEST = re.compile(r"[0-9a-f]{64}\Z")
 _COMMITTED_EVENT = re.compile(r"([0-9a-f]{64}):committed\Z")
+_POLICY_GATE_PHASES = frozenset({"policy-active", "publishing", "rebuilding"})
+_DEFAULT_POLICY_GATE_PHASES = frozenset({"policy-active", "publishing"})
 _BATCH_FIELDS = frozenset(
     {
         "batch_ordinal",
@@ -196,9 +198,16 @@ def _verify_policy_terminal_receipt(
     vault_binding_digest: str,
     terminal: object,
     expected_policy_fingerprint: str,
+    allowed_seal_phases: frozenset[str] = _DEFAULT_POLICY_GATE_PHASES,
 ) -> PolicyActivationTerminal:
     """Bind the content gate to the exact durable policy receipt chain."""
 
+    if (
+        not isinstance(allowed_seal_phases, frozenset)
+        or not allowed_seal_phases
+        or not allowed_seal_phases <= _POLICY_GATE_PHASES
+    ):
+        _fail()
     checked = _policy_terminal(
         terminal,
         expected_policy_fingerprint=expected_policy_fingerprint,
@@ -280,7 +289,7 @@ def _verify_policy_terminal_receipt(
         _fail()
     if (
         seal.kind != "consolidation-sealed"
-        or seal.phase not in {"policy-active", "publishing"}
+        or seal.phase not in allowed_seal_phases
         or seal.run_id != active_intent["run_id"]
         or seal.operation_id != active_intent["operation_id"]
         or active_snapshot.active.policy_fingerprint

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -4519,13 +4519,31 @@ def _batch_atomic_write_locked(
         if any(part.startswith(_BATCH_RESIDUE_PREFIX) for part in absolute_parts):
             raise _batch_residue_error("BATCH_RESIDUE_UNSAFE")
         if isinstance(write.content, PreparedBinaryContent):
-            if not write.create_only or write.expected_hash != MISSING_CONTENT_HASH:
+            if write.expected_hash is None or (
+                write.create_only != (write.expected_hash == MISSING_CONTENT_HASH)
+            ):
                 raise PathGuardError(
                     "PATH_GUARD_INVALID",
-                    "binary batch content requires an exact missing destination",
+                    "binary batch content requires an exact destination state",
                 )
-            if os.path.lexists(write.path):
-                raise CreateOnlyConflict(_safe_write_target(write.path, vault_root))
+            if write.create_only:
+                if os.path.lexists(write.path):
+                    raise CreateOnlyConflict(_safe_write_target(write.path, vault_root))
+            else:
+                try:
+                    with write.path.open("rb") as current_stream:
+                        current_digest = hashlib.file_digest(
+                            current_stream,
+                            "sha256",
+                        ).hexdigest()
+                except FileNotFoundError:
+                    current_digest = None
+                if current_digest != write.expected_hash:
+                    raise ContentHashMismatchError(
+                        write.path,
+                        write.expected_hash,
+                        current_digest,
+                    )
             continue
         if write.expected_hash is not None:
             try:
@@ -4662,10 +4680,12 @@ def _batch_atomic_write_locked(
                     f"stage-{index}.tmp", write.content.encode("utf-8")
                 )
             elif isinstance(write.content, PreparedBinaryContent):
-                if not write.create_only or write.expected_hash != MISSING_CONTENT_HASH:
+                if write.expected_hash is None or (
+                    write.create_only != (write.expected_hash == MISSING_CONTENT_HASH)
+                ):
                     raise PathGuardError(
                         "PATH_GUARD_INVALID",
-                        "binary batch content requires an exact missing destination",
+                        "binary batch content requires an exact destination state",
                     )
                 artifact = workspace.create_stream_artifact(
                     f"stage-{index}.tmp",

--- a/tests/test_consolidation_content_publication.py
+++ b/tests/test_consolidation_content_publication.py
@@ -1,0 +1,654 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from exomem.governance import consolidation_receipts
+from tests.test_consolidation_effect_coordinator import (
+    OPERATION_ID,
+    REQUEST_DIGEST,
+    RUN_ID,
+    _append_policy_active_parent,
+)
+
+VAULT_BINDING = hashlib.sha256(b"content-publication-vault").hexdigest()
+JOURNAL_DIGEST = hashlib.sha256(b"content-publication-journal").hexdigest()
+PLAN_DIGEST = hashlib.sha256(b"content-publication-plan").hexdigest()
+POLICY_FINGERPRINT = hashlib.sha256(b"content-publication-policy").hexdigest()
+T0 = "2026-08-30T12:00:00.000Z"
+T1 = "2026-08-30T12:00:01.000Z"
+T2 = "2026-08-30T12:00:02.000Z"
+T3 = "2026-08-30T12:00:03.000Z"
+T4 = "2026-08-30T12:00:04.000Z"
+T5 = "2026-08-30T12:00:05.000Z"
+
+
+class SimulatedPublicationCrash(BaseException):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _private_writer_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR",
+        str(tmp_path / "writer-state"),
+    )
+
+
+def _action(
+    ordinal: int,
+    *,
+    batch_ordinal: int,
+    destination_path: str,
+    before: bytes | None,
+    after: bytes,
+) -> dict[str, object]:
+    return {
+        "ordinal": ordinal,
+        "batch_ordinal": batch_ordinal,
+        "action": "add" if before is None else "overwrite",
+        "object_ref": f"approved-object-{ordinal}",
+        "source_path": f"Knowledge Base/Notes/source-{ordinal}.bin",
+        "destination_path": destination_path,
+        "expected_before_state": "absent" if before is None else "present",
+        "expected_before_sha256": (
+            "0" * 64 if before is None else hashlib.sha256(before).hexdigest()
+        ),
+        "planned_after_state": "present",
+        "planned_after_sha256": hashlib.sha256(after).hexdigest(),
+    }
+
+
+def _policy_terminal(vault: Path):
+    from exomem.governance import consolidation_saga
+
+    _append_policy_active_parent(vault)
+    records = consolidation_receipts._active_records(vault)  # noqa: SLF001
+    prepare_terminal = consolidation_receipts.validate_nested(
+        records[-3]["consolidation_event"],
+        outer_phase="committed",
+    )
+    consolidation_receipts.validate_nested(
+        records[-2]["consolidation_event"],
+        outer_phase="intent",
+    )
+    active_terminal = consolidation_receipts.validate_nested(
+        records[-1]["consolidation_event"],
+        outer_phase="committed",
+    )
+    return consolidation_saga.PolicyActivationTerminal(
+        schema=consolidation_saga.POLICY_ACTIVATION_TERMINAL_SCHEMA,
+        policy_fingerprint=POLICY_FINGERPRINT,
+        intent_event_id=str(records[-2]["event_id"]),
+        prepared_fingerprint=str(prepare_terminal["observed_digest"]),
+        active_fingerprint=str(active_terminal["observed_digest"]),
+        terminal_event_id=str(records[-1]["event_id"]),
+    )
+
+
+def _policy_active_vault(vault: Path) -> None:
+    from exomem.governance import consolidation_authority, consolidation_seal
+
+    store = consolidation_seal.ConsolidationSealStore(vault)
+    store.initialize_open(vault_binding_digest=VAULT_BINDING, recorded_at=T0)
+    current = store.begin_consolidation(
+        vault_binding_digest=VAULT_BINDING,
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        sealed_at=T0,
+        expected_revision=0,
+    )
+    for target, timestamp in (
+        ("sealed", T1),
+        ("preimage-ready", T2),
+        ("policy-active", T3),
+    ):
+        assert current.phase is not None
+        authority = consolidation_authority.issue_authority(
+            vault_binding_digest=VAULT_BINDING,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            phase=current.phase,
+            action="apply",
+        )
+        current = store.advance_consolidation(
+            authority,
+            vault_binding_digest=VAULT_BINDING,
+            action="apply",
+            target_phase=target,
+            recorded_at=timestamp,
+            expected_revision=current.revision,
+        )
+    assert current.phase == "policy-active"
+
+
+def _install_object(artifact_store, tmp_path: Path, content: bytes) -> None:
+    digest = hashlib.sha256(content).hexdigest()
+    staged = tmp_path / f"staged-{digest}"
+    staged.write_bytes(content)
+    assert (
+        artifact_store.install_object_file(
+            staged,
+            expected_digest=digest,
+        )
+        == f"exomem-consolidation-object://sha256/{digest}"
+    )
+
+
+def _setup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    actions: tuple[dict[str, object], ...],
+    after_values: tuple[bytes, ...],
+):
+    from exomem.governance import (
+        consolidation_admission,
+        consolidation_content_publication,
+        consolidation_intake,
+        consolidation_plan,
+        consolidation_plan_store,
+        consolidation_saga,
+    )
+
+    vault = tmp_path / "vault"
+    (vault / "Knowledge Base" / "Notes").mkdir(parents=True)
+    _policy_active_vault(vault)
+    terminal = _policy_terminal(vault)
+    partition = consolidation_plan.derive_journal_batch_partition(actions)
+    plan = SimpleNamespace(
+        digest=PLAN_DIGEST,
+        preimage={
+            "run_id": RUN_ID,
+            "plan_kind": "cutover",
+            "content_actions": actions,
+            "journal_batch_partition_digest": partition.digest,
+            "prospective_policy_fingerprint": POLICY_FINGERPRINT,
+        },
+    )
+    loads: list[tuple[object, object, object]] = []
+
+    def load_plan(_store, run_id, *, plan_kind, plan_digest):
+        loads.append((run_id, plan_kind, plan_digest))
+        return plan
+
+    monkeypatch.setattr(
+        consolidation_plan_store.ConsolidationPlanStore,
+        "load",
+        load_plan,
+    )
+
+    def verify_terminal(**kwargs):
+        assert kwargs["vault_root"] == vault
+        assert kwargs["vault_binding_digest"] == VAULT_BINDING
+        assert kwargs["allowed_seal_phases"] == frozenset(
+            {"policy-active", "publishing", "rebuilding"}
+        )
+        return consolidation_saga._policy_terminal(  # noqa: SLF001
+            kwargs["terminal"],
+            expected_policy_fingerprint=kwargs["expected_policy_fingerprint"],
+        )
+
+    monkeypatch.setattr(
+        consolidation_saga,
+        "_verify_policy_terminal_receipt",
+        verify_terminal,
+    )
+    artifact_store = consolidation_intake.PrivateConsolidationArtifactStore(
+        tmp_path / "private-artifacts",
+        active_vault_roots=(vault,),
+    )
+    for content in after_values:
+        _install_object(artifact_store, tmp_path, content)
+    admission = consolidation_admission.ConsolidationAdmission(
+        vault,
+        vault_binding_digest=VAULT_BINDING,
+    )
+    arguments = {
+        "vault_root": vault,
+        "admission": admission,
+        "artifact_store": artifact_store,
+        "policy_terminal": terminal,
+        "vault_binding_digest": VAULT_BINDING,
+        "run_id": RUN_ID,
+        "operation_id": OPERATION_ID,
+        "journal_digest": JOURNAL_DIGEST,
+        "request_digest": REQUEST_DIGEST,
+        "plan_digest": PLAN_DIGEST,
+        "publishing_at": T4,
+        "rebuilding_at": T5,
+    }
+    assert consolidation_content_publication is not None
+    return vault, partition, loads, arguments
+
+
+def _content_records(vault: Path) -> list[dict[str, object]]:
+    return [
+        record
+        for record in consolidation_receipts._active_records(vault)  # noqa: SLF001
+        if record.get("event_type") == "consolidation"
+        and isinstance(record.get("consolidation_event"), dict)
+        and record["consolidation_event"].get("kind") == "content-batch"
+    ]
+
+
+def test_policy_active_run_publishes_stored_batches_then_reaches_rebuilding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_batch_journal,
+        consolidation_content_publication,
+        consolidation_effect_coordinator,
+        consolidation_seal,
+    )
+
+    before = b"destination before\n"
+    first_after = b"destination after\n"
+    second_after = b"\x00private attachment\xff"
+    actions = (
+        _action(
+            0,
+            batch_ordinal=0,
+            destination_path="Knowledge Base/Notes/destination.md",
+            before=before,
+            after=first_after,
+        ),
+        _action(
+            1,
+            batch_ordinal=1,
+            destination_path="Knowledge Base/Notes/attachment.bin",
+            before=None,
+            after=second_after,
+        ),
+    )
+    vault, partition, loads, arguments = _setup(
+        tmp_path,
+        monkeypatch,
+        actions,
+        (first_after, second_after),
+    )
+    target = vault / "Knowledge Base" / "Notes" / "destination.md"
+    target.write_bytes(before)
+
+    result = consolidation_content_publication.publish_stored_content_batches(**arguments)
+
+    assert target.read_bytes() == first_after
+    assert (vault / "Knowledge Base" / "Notes" / "attachment.bin").read_bytes() == second_after
+    assert result.partition_digest == partition.digest
+    assert result.committed_batch_ordinals == (0, 1)
+    assert result.publication_boundary_ordinal == 0
+    assert result.seal_state.phase == "rebuilding"
+    assert loads == [(RUN_ID, "cutover", PLAN_DIGEST)]
+    state = consolidation_batch_journal.ConsolidationBatchJournalStore(
+        vault,
+        run_id=RUN_ID,
+    ).load()
+    assert tuple(item.status for item in state.batches) == ("final", "final")
+    assert state.publication_boundary_committed is True
+    assert (
+        consolidation_seal.ConsolidationSealStore(vault)
+        .load(vault_binding_digest=VAULT_BINDING)
+        .phase
+        == "rebuilding"
+    )
+    records = _content_records(vault)
+    assert [record["phase"] for record in records] == [
+        "intent",
+        "committed",
+        "intent",
+        "committed",
+    ]
+    first_intent = consolidation_receipts.validate_nested(
+        records[0]["consolidation_event"],
+        outer_phase="intent",
+    )
+    second_intent = consolidation_receipts.validate_nested(
+        records[2]["consolidation_event"],
+        outer_phase="intent",
+    )
+    assert (
+        first_intent["semantic_parent_event_id"] == arguments["policy_terminal"].terminal_event_id
+    )
+    assert second_intent["semantic_parent_event_id"] == records[1]["event_id"]
+    for effect_ordinal in (17, 18):
+        journal = consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+            vault,
+            run_id=RUN_ID,
+            effect_ordinal=effect_ordinal,
+        ).load()
+        assert journal.status == "final"
+        assert journal.observed_state == "target"
+
+
+def test_retry_after_batch_terminal_does_not_rewrite_approved_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import vault as vault_module
+    from exomem.governance import (
+        consolidation_batch_journal,
+        consolidation_content_publication,
+        consolidation_effect_coordinator,
+        consolidation_seal,
+    )
+
+    before = b"\x00binary before\xfe"
+    after = b"\x00binary after\xff"
+    actions = (
+        _action(
+            0,
+            batch_ordinal=0,
+            destination_path="Knowledge Base/Notes/destination.bin",
+            before=before,
+            after=after,
+        ),
+    )
+    vault, _partition, _loads, arguments = _setup(
+        tmp_path,
+        monkeypatch,
+        actions,
+        (after,),
+    )
+    target = vault / "Knowledge Base" / "Notes" / "destination.bin"
+    target.write_bytes(before)
+    writes = 0
+    real_write = vault_module.batch_atomic_write
+
+    def observed_write(*args: object, **kwargs: object):
+        nonlocal writes
+        writes += 1
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(vault_module, "batch_atomic_write", observed_write)
+    crashed = False
+
+    def crash_once(point: str) -> None:
+        nonlocal crashed
+        if point == "after-terminal" and not crashed:
+            crashed = True
+            raise SimulatedPublicationCrash
+
+    monkeypatch.setattr(
+        consolidation_effect_coordinator,
+        "_crash_point",
+        crash_once,
+    )
+    with pytest.raises(SimulatedPublicationCrash):
+        consolidation_content_publication.publish_stored_content_batches(**arguments)
+
+    assert target.read_bytes() == after
+    assert writes == 1
+    assert (
+        consolidation_seal.ConsolidationSealStore(vault)
+        .load(vault_binding_digest=VAULT_BINDING)
+        .phase
+        == "publishing"
+    )
+    batch_store = consolidation_batch_journal.ConsolidationBatchJournalStore(
+        vault,
+        run_id=RUN_ID,
+    )
+    assert batch_store.load().batches[0].status == "prepared"
+    assert (
+        consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+            vault,
+            run_id=RUN_ID,
+            effect_ordinal=17,
+        )
+        .load()
+        .status
+        == "prepared"
+    )
+
+    result = consolidation_content_publication.publish_stored_content_batches(**arguments)
+
+    assert result.seal_state.phase == "rebuilding"
+    assert target.read_bytes() == after
+    assert writes == 1
+    assert batch_store.load().batches[0].status == "final"
+    assert batch_store.load().publication_boundary_committed is True
+    assert [record["phase"] for record in _content_records(vault)] == [
+        "intent",
+        "committed",
+    ]
+
+    replayed = consolidation_content_publication.publish_stored_content_batches(
+        **arguments
+    )
+
+    assert replayed.seal_state.phase == "rebuilding"
+    assert replayed.committed_batch_ordinals == (0,)
+    assert target.read_bytes() == after
+    assert writes == 1
+    assert [record["phase"] for record in _content_records(vault)] == [
+        "intent",
+        "committed",
+    ]
+
+
+def test_publishing_phase_refuses_a_missing_batch_journal_without_recreating_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_authority,
+        consolidation_batch_journal,
+        consolidation_content_publication,
+        consolidation_seal,
+    )
+
+    after = b"approved"
+    actions = (
+        _action(
+            0,
+            batch_ordinal=0,
+            destination_path="Knowledge Base/Notes/new.bin",
+            before=None,
+            after=after,
+        ),
+    )
+    vault, _partition, _loads, arguments = _setup(
+        tmp_path,
+        monkeypatch,
+        actions,
+        (after,),
+    )
+    store = consolidation_seal.ConsolidationSealStore(vault)
+    current = store.load(vault_binding_digest=VAULT_BINDING)
+    store.advance_consolidation(
+        consolidation_authority.issue_authority(
+            vault_binding_digest=VAULT_BINDING,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            phase="policy-active",
+            action="apply",
+        ),
+        vault_binding_digest=VAULT_BINDING,
+        action="apply",
+        target_phase="publishing",
+        recorded_at=T4,
+        expected_revision=current.revision,
+    )
+    batch_store = consolidation_batch_journal.ConsolidationBatchJournalStore(
+        vault,
+        run_id=RUN_ID,
+    )
+    assert not batch_store.path.exists()
+
+    with pytest.raises(
+        consolidation_content_publication.ConsolidationContentPublicationUnavailable
+    ):
+        consolidation_content_publication.publish_stored_content_batches(**arguments)
+
+    assert not batch_store.path.exists()
+    assert not (vault / "Knowledge Base" / "Notes" / "new.bin").exists()
+
+
+def test_rebuilding_phase_refuses_an_incomplete_batch_journal_before_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_authority,
+        consolidation_batch_journal,
+        consolidation_content_publication,
+        consolidation_seal,
+    )
+
+    after = b"approved"
+    actions = (
+        _action(
+            0,
+            batch_ordinal=0,
+            destination_path="Knowledge Base/Notes/new.bin",
+            before=None,
+            after=after,
+        ),
+    )
+    vault, partition, _loads, arguments = _setup(
+        tmp_path,
+        monkeypatch,
+        actions,
+        (after,),
+    )
+    batch_store = consolidation_batch_journal.ConsolidationBatchJournalStore(
+        vault,
+        run_id=RUN_ID,
+    )
+    assert (
+        batch_store.create(
+            operation_id=OPERATION_ID,
+            request_digest=REQUEST_DIGEST,
+            partition=partition,
+        )
+        .batches[0]
+        .status
+        == "prior"
+    )
+    seal_store = consolidation_seal.ConsolidationSealStore(vault)
+    current = seal_store.load(vault_binding_digest=VAULT_BINDING)
+    for source, target, recorded_at in (
+        ("policy-active", "publishing", T4),
+        ("publishing", "rebuilding", T5),
+    ):
+        current = seal_store.advance_consolidation(
+            consolidation_authority.issue_authority(
+                vault_binding_digest=VAULT_BINDING,
+                run_id=RUN_ID,
+                operation_id=OPERATION_ID,
+                journal_digest=JOURNAL_DIGEST,
+                phase=source,
+                action="apply",
+            ),
+            vault_binding_digest=VAULT_BINDING,
+            action="apply",
+            target_phase=target,
+            recorded_at=recorded_at,
+            expected_revision=current.revision,
+        )
+
+    with pytest.raises(
+        consolidation_content_publication.ConsolidationContentPublicationUnavailable
+    ):
+        consolidation_content_publication.publish_stored_content_batches(**arguments)
+
+    assert batch_store.load().batches[0].status == "prior"
+    assert not (vault / "Knowledge Base" / "Notes" / "new.bin").exists()
+    assert _content_records(vault) == []
+
+
+def test_publication_refuses_an_artifact_store_inside_the_destination_vault(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_content_publication,
+        consolidation_intake,
+    )
+
+    after = b"approved"
+    actions = (
+        _action(
+            0,
+            batch_ordinal=0,
+            destination_path="Knowledge Base/Notes/new.bin",
+            before=None,
+            after=after,
+        ),
+    )
+    vault, _partition, _loads, arguments = _setup(
+        tmp_path,
+        monkeypatch,
+        actions,
+        (after,),
+    )
+    nested_store = consolidation_intake.PrivateConsolidationArtifactStore(
+        vault / "private-artifacts",
+        active_vault_roots=(),
+    )
+    _install_object(nested_store, tmp_path, after)
+    arguments["artifact_store"] = nested_store
+
+    with pytest.raises(
+        consolidation_content_publication.ConsolidationContentPublicationUnavailable
+    ):
+        consolidation_content_publication.publish_stored_content_batches(**arguments)
+
+    assert not (vault / "Knowledge Base" / "Notes" / "new.bin").exists()
+
+
+def test_removal_identity_race_is_normalized_to_content_free_refusal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import reserved_paths
+    from exomem.governance import consolidation_content_publication
+
+    before = b"reviewed removal"
+    actions = (
+        {
+            "ordinal": 0,
+            "batch_ordinal": 0,
+            "action": "remove",
+            "object_ref": "approved-removal",
+            "source_path": "Knowledge Base/Notes/source.md",
+            "destination_path": "Knowledge Base/Notes/remove.md",
+            "expected_before_state": "present",
+            "expected_before_sha256": hashlib.sha256(before).hexdigest(),
+            "planned_after_state": "absent",
+            "planned_after_sha256": "0" * 64,
+        },
+    )
+    vault, _partition, _loads, arguments = _setup(
+        tmp_path,
+        monkeypatch,
+        actions,
+        (),
+    )
+    target = vault / "Knowledge Base" / "Notes" / "remove.md"
+    target.write_bytes(before)
+
+    def changed_identity(*_args: object, **_kwargs: object) -> None:
+        raise reserved_paths.ReservedPathLeafError("IDENTITY_CHANGED")
+
+    monkeypatch.setattr(
+        reserved_paths,
+        "unlink_generic_file",
+        changed_identity,
+    )
+
+    with pytest.raises(
+        consolidation_content_publication.ConsolidationContentPublicationUnavailable
+    ):
+        consolidation_content_publication.publish_stored_content_batches(**arguments)
+
+    assert target.read_bytes() == before

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -206,6 +206,58 @@ def test_batch_binary_create_only_refuses_existing_non_utf8_leaf(
     assert target.read_bytes() == b"\xffexisting"
 
 
+def test_batch_binary_overwrite_requires_and_replaces_exact_prior_bytes(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "Evidence" / "artifact.bin"
+    target.parent.mkdir(parents=True)
+    before = b"\xffexisting"
+    after = b"\x00replacement\xfe"
+    target.write_bytes(before)
+
+    vault.batch_atomic_write(
+        [
+            vault.PlannedWrite(
+                target,
+                vault.PreparedBinaryContent(
+                    io.BytesIO(after),
+                    len(after),
+                    hashlib.sha256(after).hexdigest(),
+                ),
+                expected_hash=hashlib.sha256(before).hexdigest(),
+            )
+        ],
+        vault_root=tmp_path,
+    )
+
+    assert target.read_bytes() == after
+
+
+def test_batch_binary_overwrite_refuses_changed_prior_bytes(tmp_path: Path) -> None:
+    target = tmp_path / "Evidence" / "artifact.bin"
+    target.parent.mkdir(parents=True)
+    reviewed = b"reviewed"
+    target.write_bytes(b"changed")
+
+    with pytest.raises(vault.ContentHashMismatchError):
+        vault.batch_atomic_write(
+            [
+                vault.PlannedWrite(
+                    target,
+                    vault.PreparedBinaryContent(
+                        io.BytesIO(b"replacement"),
+                        len(b"replacement"),
+                        hashlib.sha256(b"replacement").hexdigest(),
+                    ),
+                    expected_hash=hashlib.sha256(reviewed).hexdigest(),
+                )
+            ],
+            vault_root=tmp_path,
+        )
+
+    assert target.read_bytes() == b"changed"
+
+
 def test_batch_write_rejects_changed_binary_stream_before_publication(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- load the exact stored cutover plan and deterministic content-batch partition before publication
- resolve approved bytes only from the private content-addressed artifact store, refusing any store that overlaps the destination vault
- advance policy-active through receipt-first batch publication to rebuilding, with exact coarse/effect journal recovery and no late publication after rebuilding begins
- support compare-and-swap binary overwrites and normalize removal races to the same content-free refusal

This is stacked on #998. It does not touch a live vault unless the coordinator is explicitly invoked against its bound, sealed destination.

## Verification

- 91 passed, 3 existing Windows-only skips across content publication, batch journals, effect recovery, policy-first saga, and vault writes
- 16 passed across policy activation and apply coordination regressions
- independent code review: no remaining findings after three fail-closed fixes
- independent verifier: exact six-file scope; Ruff 0.16.5, py_compile, and tracked/untracked diff checks passed
- openspec validate --all --strict: 168 passed, 0 failed
- uv lock --check
- public repository artifact validation: 3442 files, 3510 text payloads clean