### PR TITLE
feat(governance): coordinate consolidation rebuilds

### DIFF
--- a/src/exomem/governance/consolidation_effect_coordinator.py
+++ b/src/exomem/governance/consolidation_effect_coordinator.py
@@ -38,6 +38,9 @@ _MAX_SAFE_INTEGER = (1 << 53) - 1
 _MAX_JOURNAL_BYTES = 512 * 1024
 _STATES = frozenset({"prior", "prepared", "target", "mixed"})
 _TERMINAL_ROLES = frozenset({"committed", "aborted"})
+_LEARNED_RESULT_KINDS = frozenset(
+    {"rebuild-kind", "abort-rebuild-kind", "rollback-rebuild-kind"}
+)
 _REFERENCE_FIELDS = frozenset(
     {
         "event_id",
@@ -494,7 +497,11 @@ def _observation(value: object, *, event: consolidation_receipts.ConsolidationEv
     }.get(value.state)
     if expected_field is not None:
         expected = event.payload.get(expected_field)
-        if expected is None or digest != expected:
+        learned_result = (
+            value.state == "target"
+            and event.payload.get("kind") in _LEARNED_RESULT_KINDS
+        )
+        if expected is None or (digest != expected and not learned_result):
             _fail()
     return EffectObservation(state=value.state, digest=digest)
 

--- a/src/exomem/governance/consolidation_rebuild_coordinator.py
+++ b/src/exomem/governance/consolidation_rebuild_coordinator.py
@@ -1,0 +1,630 @@
+"""Durably coordinate the post-publication derivative rebuild.
+
+The coordinator proves the exact content publication chain is final before it
+samples the destination's post-publication canonical census.  It then rebuilds
+the closed derivative set through one learned-result receipt per component.
+Actual artifact fingerprints are persisted before their terminal receipts, so
+a retry can finish receipt evidence without rerunning a completed component.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NoReturn
+
+from . import (
+    consolidation_admission,
+    consolidation_authority,
+    consolidation_batch_journal,
+    consolidation_content_publication,
+    consolidation_effect_coordinator,
+    consolidation_fingerprints,
+    consolidation_plan,
+    consolidation_plan_store,
+    consolidation_rebuild,
+    consolidation_rebuild_adapters,
+    consolidation_rebuild_journal,
+    consolidation_receipts,
+    consolidation_saga,
+    consolidation_seal,
+)
+
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_UUID4 = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z")
+_ALLOWED_ENTRY_PHASES = frozenset({"rebuilding", "verifying"})
+_CONTENT_EFFECTS_SCHEMA = "exomem.consolidation-content-effects/v1"
+_CONTENT_EFFECTS_DOMAIN = _CONTENT_EFFECTS_SCHEMA.encode("ascii")
+_REBUILD_BASIS_SCHEMA = "exomem.consolidation-rebuild-basis/v1"
+_REBUILD_BASIS_DOMAIN = _REBUILD_BASIS_SCHEMA.encode("ascii")
+_REBUILD_PRIOR_SCHEMA = "exomem.consolidation-rebuild-prior/v1"
+_REBUILD_PRIOR_DOMAIN = _REBUILD_PRIOR_SCHEMA.encode("ascii")
+_REBUILD_TARGET_SCHEMA = "exomem.consolidation-rebuild-target/v1"
+_REBUILD_TARGET_DOMAIN = _REBUILD_TARGET_SCHEMA.encode("ascii")
+
+__all__ = [
+    "ConsolidationRebuildCoordinatorResult",
+    "ConsolidationRebuildCoordinatorUnavailable",
+    "rebuild_published_destination",
+]
+
+
+class ConsolidationRebuildCoordinatorUnavailable(RuntimeError):
+    """Content-free refusal for an incomplete or contradictory rebuild."""
+
+    code = "CONSOLIDATION_REBUILD_COORDINATOR_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationRebuildCoordinatorResult:
+    canonical_census_digest: str
+    completed_components: tuple[str, ...]
+    rebuild_effects: tuple[consolidation_effect_coordinator.EffectExecutionResult, ...]
+    rebuild_journal: consolidation_rebuild_journal.ConsolidationRebuildJournalState
+    seal_state: consolidation_seal.ConsolidationSealState
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationRebuildCoordinatorUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if type(value) is not str or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _uuid4(value: object) -> str:
+    if type(value) is not str or _UUID4.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _timestamp(value: object) -> str:
+    try:
+        checked, _parsed = consolidation_plan._timestamp(value)  # noqa: SLF001
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    return checked
+
+
+def _framed_digest(domain: bytes, value: object) -> str:
+    try:
+        payload = consolidation_plan.canonical_closed_jcs(value)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    framed = len(domain).to_bytes(4, "big") + domain + len(payload).to_bytes(8, "big") + payload
+    return hashlib.sha256(framed).hexdigest()
+
+
+def _snapshot_census(vault_root: Path) -> str:
+    now = int(time.time())
+    if now < 0:
+        _fail()
+    return _digest(
+        consolidation_fingerprints.load_local_destination_snapshot(
+            vault_root,
+            now=now,
+        ).canonical_census_digest
+    )
+
+
+def _component_rebuilder():
+    return consolidation_rebuild_adapters.destination_component_rebuilder()
+
+
+def _crash_point(_point: str) -> None:
+    """Narrow test seam after durable rebuild completion and before phase advance."""
+
+
+def _require_seal(
+    state: consolidation_seal.ConsolidationSealState,
+    *,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+) -> consolidation_seal.ConsolidationSealState:
+    if (
+        not isinstance(state, consolidation_seal.ConsolidationSealState)
+        or state.kind != "consolidation-sealed"
+        or state.phase not in _ALLOWED_ENTRY_PHASES
+        or state.vault_binding_digest != vault_binding_digest
+        or state.run_id != run_id
+        or state.operation_id != operation_id
+        or state.journal_digest != journal_digest
+    ):
+        _fail()
+    return state
+
+
+def _advance_to_verifying(
+    *,
+    admission: consolidation_admission.ConsolidationAdmission,
+    vault_root: Path,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+    recorded_at: str,
+) -> consolidation_seal.ConsolidationSealState:
+    current = _require_seal(
+        admission.reload().state,
+        vault_binding_digest=vault_binding_digest,
+        run_id=run_id,
+        operation_id=operation_id,
+        journal_digest=journal_digest,
+    )
+    if current.phase == "verifying":
+        if current.recorded_at != recorded_at:
+            _fail()
+        return current
+    authority = consolidation_authority.issue_authority(
+        vault_binding_digest=vault_binding_digest,
+        run_id=run_id,
+        operation_id=operation_id,
+        journal_digest=journal_digest,
+        phase="rebuilding",
+        action="apply",
+    )
+    return consolidation_seal.ConsolidationSealStore(vault_root).advance_consolidation(
+        authority,
+        vault_binding_digest=vault_binding_digest,
+        action="apply",
+        target_phase="verifying",
+        recorded_at=recorded_at,
+        expected_revision=current.revision,
+    )
+
+
+def _content_effects_digest(
+    effects: tuple[consolidation_effect_coordinator.EffectExecutionResult, ...],
+) -> str:
+    if not effects:
+        _fail()
+    rows: list[dict[str, object]] = []
+    for effect in effects:
+        if (
+            not isinstance(
+                effect,
+                consolidation_effect_coordinator.EffectExecutionResult,
+            )
+            or effect.role != "committed"
+            or effect.observed_state != "target"
+        ):
+            _fail()
+        rows.append(
+            {
+                "intent_event_id": effect.intent.event_id,
+                "intent_payload_digest": _digest(effect.intent.payload_digest),
+                "terminal_event_id": effect.terminal.event_id,
+                "terminal_payload_digest": _digest(effect.terminal.payload_digest),
+                "observed_digest": _digest(effect.observed_digest),
+                "effect_journal_digest": _digest(effect.journal_digest),
+            }
+        )
+    return _framed_digest(
+        _CONTENT_EFFECTS_DOMAIN,
+        {"schema": _CONTENT_EFFECTS_SCHEMA, "effects": rows},
+    )
+
+
+def _rebuild_digests(
+    *,
+    state: consolidation_rebuild_journal.ConsolidationRebuildJournalState,
+    component: str,
+    rebuild_ordinal: int,
+) -> tuple[str, str, str]:
+    basis = _framed_digest(
+        _REBUILD_BASIS_DOMAIN,
+        {
+            "schema": _REBUILD_BASIS_SCHEMA,
+            "rebuild_journal_binding_digest": state.binding_digest,
+            "canonical_census_digest": state.canonical_census_digest,
+            "component": component,
+            "rebuild_ordinal": rebuild_ordinal,
+        },
+    )
+    prior = _framed_digest(
+        _REBUILD_PRIOR_DOMAIN,
+        {"schema": _REBUILD_PRIOR_SCHEMA, "rebuild_basis_digest": basis},
+    )
+    target = _framed_digest(
+        _REBUILD_TARGET_DOMAIN,
+        {"schema": _REBUILD_TARGET_SCHEMA, "rebuild_basis_digest": basis},
+    )
+    return basis, prior, target
+
+
+def _rebuild_event(
+    *,
+    state: consolidation_rebuild_journal.ConsolidationRebuildJournalState,
+    component: str,
+    rebuild_ordinal: int,
+    effect_ordinal: int,
+    parent_event_id: str,
+    parent_payload_digest: str,
+) -> consolidation_receipts.ConsolidationEvent:
+    basis, prior, target = _rebuild_digests(
+        state=state,
+        component=component,
+        rebuild_ordinal=rebuild_ordinal,
+    )
+    return consolidation_receipts.build_intent(
+        kind="rebuild-kind",
+        run_id=state.run_id,
+        operation_id=state.operation_id,
+        phase="rebuilding",
+        effect_ordinal=effect_ordinal,
+        rebuild_ordinal=rebuild_ordinal,
+        request_digest=state.request_digest,
+        prior_digest=prior,
+        target_digest=target,
+        evidence=consolidation_receipts.build_evidence(
+            kind="rebuild-kind",
+            digests={"rebuild_basis_digest": basis},
+        ),
+        semantic_parent_event_id=parent_event_id,
+        semantic_parent_payload_digest=parent_payload_digest,
+    )
+
+
+def _validate_existing_effect(
+    *,
+    entry: consolidation_rebuild_journal.ConsolidationRebuildJournalEntry,
+    event: consolidation_receipts.ConsolidationEvent,
+    store: consolidation_effect_coordinator.ConsolidationEffectJournalStore,
+) -> None:
+    current = store.load_optional()
+    if entry.status == "prior":
+        if current is not None:
+            _fail()
+        return
+    if current is None or (
+        current.kind != "rebuild-kind"
+        or current.intent.event_id != event.event_id
+        or current.intent.payload_digest != event.payload_digest
+        or dict(current.intent_payload) != dict(event.payload)
+    ):
+        _fail()
+    if entry.status == "prepared":
+        if current.status not in {"prepared", "final"}:
+            _fail()
+        if current.status == "final" and (
+            current.terminal is None
+            or current.terminal.event_id.rpartition(":")[2] != "committed"
+            or current.observed_state != "target"
+            or current.observed_digest != entry.artifact_fingerprint
+        ):
+            _fail()
+        return
+    if (
+        entry.status != "final"
+        or current.status != "final"
+        or current.terminal is None
+        or current.observed_state != "target"
+        or current.observed_digest != entry.artifact_fingerprint
+        or current.terminal.event_id != entry.terminal_event_id
+        or current.terminal.payload_digest != entry.terminal_payload_digest
+        or current.state_digest != entry.effect_journal_digest
+    ):
+        _fail()
+
+
+def _execute_rebuilds(
+    *,
+    vault_root: Path,
+    store: consolidation_rebuild_journal.ConsolidationRebuildJournalStore,
+    last_content_effect_ordinal: int,
+    timestamp: str,
+    expected_batch_count: int,
+    committed_batch_ordinals: tuple[int, ...],
+) -> tuple[
+    consolidation_rebuild.DerivativeRebuildResult,
+    tuple[consolidation_effect_coordinator.EffectExecutionResult, ...],
+]:
+    rebuild_component = _component_rebuilder()
+    effects: list[consolidation_effect_coordinator.EffectExecutionResult] = []
+
+    def execute(
+        component: str,
+        context: consolidation_rebuild.DerivativeRebuildContext,
+    ) -> consolidation_rebuild.DerivativeRebuildTerminal:
+        try:
+            ordinal = consolidation_rebuild.DERIVATIVE_COMPONENTS.index(component)
+        except ValueError:
+            _fail()
+        state = store.load()
+        if ordinal == 0:
+            parent_event_id = state.last_content_terminal_event_id
+            parent_payload_digest = state.last_content_terminal_payload_digest
+        else:
+            parent = state.components[ordinal - 1]
+            if (
+                parent.status != "final"
+                or parent.terminal_event_id is None
+                or parent.terminal_payload_digest is None
+            ):
+                _fail()
+            parent_event_id = parent.terminal_event_id
+            parent_payload_digest = parent.terminal_payload_digest
+        event = _rebuild_event(
+            state=state,
+            component=component,
+            rebuild_ordinal=ordinal,
+            effect_ordinal=last_content_effect_ordinal + ordinal + 1,
+            parent_event_id=parent_event_id,
+            parent_payload_digest=parent_payload_digest,
+        )
+        effect_store = consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+            vault_root,
+            run_id=state.run_id,
+            effect_ordinal=last_content_effect_ordinal + ordinal + 1,
+        )
+        entry = state.components[ordinal]
+        _validate_existing_effect(entry=entry, event=event, store=effect_store)
+        _basis, prior_digest, _target_digest = _rebuild_digests(
+            state=state,
+            component=component,
+            rebuild_ordinal=ordinal,
+        )
+
+        def classify() -> consolidation_effect_coordinator.EffectObservation:
+            current = store.load().components[ordinal]
+            if current.status == "prior":
+                return consolidation_effect_coordinator.EffectObservation(
+                    state="prior",
+                    digest=prior_digest,
+                )
+            if current.status not in {"prepared", "final"}:
+                _fail()
+            return consolidation_effect_coordinator.EffectObservation(
+                state="target",
+                digest=_digest(current.artifact_fingerprint),
+            )
+
+        def apply() -> None:
+            terminal = consolidation_rebuild._terminal(  # noqa: SLF001
+                rebuild_component(component, context),
+                component=component,
+                canonical_census_digest=context.canonical_census_digest,
+            )
+            store.record_component_result(component, terminal.artifact_fingerprint)
+
+        effect = consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=vault_root,
+            event=event,
+            journal=effect_store,
+            classify=classify,
+            apply_effect=apply,
+            timestamp=timestamp,
+        )
+        if (
+            effect.role != "committed"
+            or effect.observed_state != "target"
+            or effect.intent.event_id != event.event_id
+        ):
+            _fail()
+        current = store.load().components[ordinal]
+        if (
+            current.status not in {"prepared", "final"}
+            or current.artifact_fingerprint != effect.observed_digest
+        ):
+            _fail()
+        store.finalize_component(
+            component,
+            effect.observed_digest,
+            terminal_event_id=effect.terminal.event_id,
+            terminal_payload_digest=effect.terminal.payload_digest,
+            effect_journal_digest=effect.journal_digest,
+        )
+        effects.append(effect)
+        return consolidation_rebuild.DerivativeRebuildTerminal(
+            schema=consolidation_rebuild.DERIVATIVE_REBUILD_TERMINAL_SCHEMA,
+            component=component,
+            canonical_census_digest=context.canonical_census_digest,
+            artifact_fingerprint=effect.observed_digest,
+        )
+
+    state = store.load()
+    result = consolidation_rebuild.rebuild_destination_derivatives(
+        vault_root=vault_root,
+        expected_canonical_census_digest=state.canonical_census_digest,
+        expected_batch_count=expected_batch_count,
+        committed_batch_ordinals=committed_batch_ordinals,
+        snapshot_census=_snapshot_census,
+        rebuild_component=execute,
+    )
+    return result, tuple(effects)
+
+
+def rebuild_published_destination(
+    *,
+    vault_root: Path | str,
+    admission: consolidation_admission.ConsolidationAdmission,
+    policy_terminal: consolidation_saga.PolicyActivationTerminal,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+    request_digest: str,
+    plan_digest: str,
+    verifying_at: str,
+) -> ConsolidationRebuildCoordinatorResult:
+    """Rebuild every destination derivative and enter the verifying phase."""
+
+    root = Path(vault_root).absolute()
+    checked_vault = _digest(vault_binding_digest)
+    checked_run = _uuid4(run_id)
+    checked_operation = _uuid4(operation_id)
+    checked_journal = _digest(journal_digest)
+    checked_request = _digest(request_digest)
+    checked_plan = _digest(plan_digest)
+    verifying_time = _timestamp(verifying_at)
+    if (
+        not isinstance(admission, consolidation_admission.ConsolidationAdmission)
+        or admission.vault_root != root
+        or admission.vault_binding_digest != checked_vault
+    ):
+        _fail()
+    try:
+        stored = consolidation_plan_store.ConsolidationPlanStore(root).load(
+            checked_run,
+            plan_kind="cutover",
+            plan_digest=checked_plan,
+        )
+        preimage = stored.preimage
+        if (
+            stored.digest != checked_plan
+            or not isinstance(preimage, Mapping)
+            or preimage.get("run_id") != checked_run
+            or preimage.get("plan_kind") != "cutover"
+        ):
+            _fail()
+        actions = consolidation_plan.validate_content_actions(preimage.get("content_actions"))
+        partition = consolidation_plan.derive_journal_batch_partition(actions)
+        if partition.digest != _digest(preimage.get("journal_batch_partition_digest")):
+            _fail()
+        terminal = consolidation_saga._verify_policy_terminal_receipt(  # noqa: SLF001
+            vault_root=root,
+            vault_binding_digest=checked_vault,
+            terminal=policy_terminal,
+            expected_policy_fingerprint=_digest(preimage.get("prospective_policy_fingerprint")),
+            allowed_seal_phases=_ALLOWED_ENTRY_PHASES,
+        )
+        parent_ordinal, parent_id, parent_digest = consolidation_content_publication._policy_parent(  # noqa: SLF001
+            root,
+            terminal,
+        )
+        current = _require_seal(
+            admission.reload().state,
+            vault_binding_digest=checked_vault,
+            run_id=checked_run,
+            operation_id=checked_operation,
+            journal_digest=checked_journal,
+        )
+        if current.phase == "verifying":
+            if current.recorded_at != verifying_time:
+                _fail()
+        elif current.recorded_at >= verifying_time:
+            _fail()
+        batch_state = consolidation_batch_journal.ConsolidationBatchJournalStore(
+            root,
+            run_id=checked_run,
+        ).load()
+        if (
+            batch_state.operation_id != checked_operation
+            or batch_state.request_digest != checked_request
+            or batch_state.partition_digest != partition.digest
+        ):
+            _fail()
+        batches = consolidation_saga._content_batches(partition)  # noqa: SLF001
+        content_effects = consolidation_content_publication._rehydrate_completed_batches(  # noqa: SLF001
+            vault_root=root,
+            actions=actions,
+            batches=batches,
+            batch_state=batch_state,
+            run_id=checked_run,
+            operation_id=checked_operation,
+            request_digest=checked_request,
+            parent_ordinal=parent_ordinal,
+            parent_id=parent_id,
+            parent_digest=parent_digest,
+        )
+        if len(content_effects) != len(batches) or not content_effects:
+            _fail()
+        content_effects_digest = _content_effects_digest(content_effects)
+        last_content = content_effects[-1]
+        rebuild_store = consolidation_rebuild_journal.ConsolidationRebuildJournalStore(
+            root,
+            run_id=checked_run,
+        )
+        if current.phase == "rebuilding":
+            canonical_census_digest = _snapshot_census(root)
+            rebuild_state = rebuild_store.create(
+                operation_id=checked_operation,
+                request_digest=checked_request,
+                plan_digest=checked_plan,
+                partition_digest=partition.digest,
+                content_batch_journal_digest=batch_state.state_digest,
+                content_effects_digest=content_effects_digest,
+                last_content_terminal_event_id=last_content.terminal.event_id,
+                last_content_terminal_payload_digest=(last_content.terminal.payload_digest),
+                canonical_census_digest=canonical_census_digest,
+            )
+        else:
+            rebuild_state = rebuild_store.load()
+            if (
+                rebuild_state.operation_id != checked_operation
+                or rebuild_state.request_digest != checked_request
+                or rebuild_state.plan_digest != checked_plan
+                or rebuild_state.partition_digest != partition.digest
+                or rebuild_state.content_batch_journal_digest != batch_state.state_digest
+                or rebuild_state.content_effects_digest != content_effects_digest
+                or rebuild_state.last_content_terminal_event_id != last_content.terminal.event_id
+                or rebuild_state.last_content_terminal_payload_digest
+                != last_content.terminal.payload_digest
+            ):
+                _fail()
+        rebuilt, effects = _execute_rebuilds(
+            vault_root=root,
+            store=rebuild_store,
+            last_content_effect_ordinal=parent_ordinal + len(batches),
+            timestamp=verifying_time,
+            expected_batch_count=len(batches),
+            committed_batch_ordinals=tuple(batch.ordinal for batch in batches),
+        )
+        final_journal = rebuild_store.load()
+        if (
+            rebuilt.canonical_census_digest != final_journal.canonical_census_digest
+            or rebuilt.completed_components != consolidation_rebuild.DERIVATIVE_COMPONENTS
+            or len(effects) != len(consolidation_rebuild.DERIVATIVE_COMPONENTS)
+            or any(entry.status != "final" for entry in final_journal.components)
+        ):
+            _fail()
+        _crash_point("before-verifying")
+        seal_state = _advance_to_verifying(
+            admission=admission,
+            vault_root=root,
+            vault_binding_digest=checked_vault,
+            run_id=checked_run,
+            operation_id=checked_operation,
+            journal_digest=checked_journal,
+            recorded_at=verifying_time,
+        )
+        return ConsolidationRebuildCoordinatorResult(
+            canonical_census_digest=rebuilt.canonical_census_digest,
+            completed_components=rebuilt.completed_components,
+            rebuild_effects=effects,
+            rebuild_journal=final_journal,
+            seal_state=seal_state,
+        )
+    except ConsolidationRebuildCoordinatorUnavailable:
+        raise
+    except (
+        consolidation_admission.ConsolidationAdmissionUnavailable,
+        consolidation_authority.ConsolidationAuthorityUnavailable,
+        consolidation_batch_journal.ConsolidationBatchJournalUnavailable,
+        consolidation_content_publication.ConsolidationContentPublicationUnavailable,
+        consolidation_effect_coordinator.ConsolidationEffectUnavailable,
+        consolidation_fingerprints.ConsolidationFingerprintUnavailable,
+        consolidation_plan.ConsolidationPlanUnavailable,
+        consolidation_plan_store.ConsolidationPlanStoreUnavailable,
+        consolidation_rebuild.DerivativeRebuildUnavailable,
+        consolidation_rebuild_journal.ConsolidationRebuildJournalUnavailable,
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        consolidation_saga.PolicyFirstPublicationUnavailable,
+        consolidation_seal.ConsolidationSealUnavailable,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ):
+        _fail()

--- a/src/exomem/governance/consolidation_rebuild_journal.py
+++ b/src/exomem/governance/consolidation_rebuild_journal.py
@@ -1,0 +1,541 @@
+"""Durable exact-state journal for consolidation derivative rebuilds."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import NoReturn
+
+from .. import reserved_paths
+from ..kbdir import kb_dirname
+from . import consolidation_plan, consolidation_rebuild
+
+JOURNAL_SCHEMA = "exomem.consolidation-rebuild-journal/v1"
+
+_DESCRIPTOR_ID = "consolidation-tree"
+_OWNER = "consolidation.run"
+_BINDING_SCHEMA = "exomem.consolidation-rebuild-journal-binding/v1"
+_BINDING_DOMAIN = _BINDING_SCHEMA.encode("ascii")
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_EVENT_ID = re.compile(r"[0-9a-f]{64}:committed\Z")
+_UUID4 = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z")
+_MAX_JOURNAL_BYTES = 512 * 1024
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_STATUSES = frozenset({"prior", "prepared", "final"})
+_BASIS_FIELDS = frozenset(
+    {
+        "run_id",
+        "operation_id",
+        "request_digest",
+        "plan_digest",
+        "partition_digest",
+        "content_batch_journal_digest",
+        "content_effects_digest",
+        "last_content_terminal_event_id",
+        "last_content_terminal_payload_digest",
+        "canonical_census_digest",
+    }
+)
+_RECORD_FIELDS = _BASIS_FIELDS | frozenset({"schema", "binding_digest", "revision", "components"})
+_PRIOR_FIELDS = frozenset({"component", "status"})
+_PREPARED_FIELDS = _PRIOR_FIELDS | frozenset({"artifact_fingerprint"})
+_FINAL_FIELDS = _PREPARED_FIELDS | frozenset(
+    {"terminal_event_id", "terminal_payload_digest", "effect_journal_digest"}
+)
+
+__all__ = [
+    "JOURNAL_SCHEMA",
+    "ConsolidationRebuildJournalEntry",
+    "ConsolidationRebuildJournalState",
+    "ConsolidationRebuildJournalStore",
+    "ConsolidationRebuildJournalUnavailable",
+]
+
+
+class ConsolidationRebuildJournalUnavailable(RuntimeError):
+    """Stable content-free refusal for a missing, changed, or corrupt journal."""
+
+    code = "CONSOLIDATION_REBUILD_JOURNAL_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__("consolidation rebuild journal is unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationRebuildJournalEntry:
+    component: str
+    status: str
+    artifact_fingerprint: str | None
+    terminal_event_id: str | None
+    terminal_payload_digest: str | None
+    effect_journal_digest: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationRebuildJournalState:
+    schema: str
+    run_id: str
+    operation_id: str
+    request_digest: str
+    plan_digest: str
+    partition_digest: str
+    content_batch_journal_digest: str
+    content_effects_digest: str
+    last_content_terminal_event_id: str
+    last_content_terminal_payload_digest: str
+    canonical_census_digest: str
+    binding_digest: str
+    revision: int
+    components: tuple[ConsolidationRebuildJournalEntry, ...]
+    state_digest: str
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationRebuildJournalUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if type(value) is not str or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _event_id(value: object) -> str:
+    if type(value) is not str or _EVENT_ID.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _uuid4(value: object) -> str:
+    if type(value) is not str or _UUID4.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _integer(value: object, *, minimum: int = 0) -> int:
+    if type(value) is not int or not minimum <= value <= _MAX_SAFE_INTEGER:
+        _fail()
+    return value
+
+
+def _mapping(value: object, fields: frozenset[str]) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or frozenset(value) != fields:
+        _fail()
+    return value
+
+
+def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            _fail()
+        value[key] = item
+    return value
+
+
+def _reject_number(_value: str) -> NoReturn:
+    _fail()
+
+
+def _parse_integer(value: str) -> int:
+    if value.startswith("-"):
+        _fail()
+    try:
+        parsed = int(value)
+    except ValueError:
+        _fail()
+    return _integer(parsed)
+
+
+def _decode(raw: bytes) -> Mapping[str, object]:
+    if not isinstance(raw, bytes) or not raw or len(raw) > _MAX_JOURNAL_BYTES:
+        _fail()
+    try:
+        value = json.loads(
+            raw,
+            object_pairs_hook=_pairs,
+            parse_int=_parse_integer,
+            parse_float=_reject_number,
+            parse_constant=_reject_number,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ConsolidationRebuildJournalUnavailable):
+        _fail()
+    if not isinstance(value, Mapping):
+        _fail()
+    try:
+        canonical = consolidation_plan.canonical_closed_jcs(value)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    if canonical != raw:
+        _fail()
+    return value
+
+
+def _basis_value(state: ConsolidationRebuildJournalState) -> dict[str, object]:
+    return {
+        "run_id": state.run_id,
+        "operation_id": state.operation_id,
+        "request_digest": state.request_digest,
+        "plan_digest": state.plan_digest,
+        "partition_digest": state.partition_digest,
+        "content_batch_journal_digest": state.content_batch_journal_digest,
+        "content_effects_digest": state.content_effects_digest,
+        "last_content_terminal_event_id": state.last_content_terminal_event_id,
+        "last_content_terminal_payload_digest": state.last_content_terminal_payload_digest,
+        "canonical_census_digest": state.canonical_census_digest,
+    }
+
+
+def _binding_digest(state: ConsolidationRebuildJournalState) -> str:
+    try:
+        payload = consolidation_plan.canonical_closed_jcs(
+            {"schema": _BINDING_SCHEMA, **_basis_value(state)}
+        )
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    framed = (
+        len(_BINDING_DOMAIN).to_bytes(4, "big")
+        + _BINDING_DOMAIN
+        + len(payload).to_bytes(8, "big")
+        + payload
+    )
+    return hashlib.sha256(framed).hexdigest()
+
+
+def _entry_value(entry: ConsolidationRebuildJournalEntry) -> dict[str, object]:
+    value: dict[str, object] = {"component": entry.component, "status": entry.status}
+    if entry.status in {"prepared", "final"}:
+        value["artifact_fingerprint"] = entry.artifact_fingerprint
+    if entry.status == "final":
+        value["terminal_event_id"] = entry.terminal_event_id
+        value["terminal_payload_digest"] = entry.terminal_payload_digest
+        value["effect_journal_digest"] = entry.effect_journal_digest
+    return value
+
+
+def _state_value(state: ConsolidationRebuildJournalState) -> dict[str, object]:
+    return {
+        "schema": state.schema,
+        **_basis_value(state),
+        "binding_digest": state.binding_digest,
+        "revision": state.revision,
+        "components": tuple(_entry_value(entry) for entry in state.components),
+    }
+
+
+def _state_bytes(state: ConsolidationRebuildJournalState) -> bytes:
+    try:
+        return consolidation_plan.canonical_closed_jcs(_state_value(state))
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+
+
+def _parse_entry(value: object, *, component: str) -> ConsolidationRebuildJournalEntry:
+    if not isinstance(value, Mapping):
+        _fail()
+    status = value.get("status")
+    if status not in _STATUSES:
+        _fail()
+    fields = {
+        "prior": _PRIOR_FIELDS,
+        "prepared": _PREPARED_FIELDS,
+        "final": _FINAL_FIELDS,
+    }[status]
+    row = _mapping(value, fields)
+    if row["component"] != component:
+        _fail()
+    if status == "prior":
+        return ConsolidationRebuildJournalEntry(
+            component=component,
+            status=status,
+            artifact_fingerprint=None,
+            terminal_event_id=None,
+            terminal_payload_digest=None,
+            effect_journal_digest=None,
+        )
+    artifact = _digest(row["artifact_fingerprint"])
+    if status == "prepared":
+        return ConsolidationRebuildJournalEntry(
+            component=component,
+            status=status,
+            artifact_fingerprint=artifact,
+            terminal_event_id=None,
+            terminal_payload_digest=None,
+            effect_journal_digest=None,
+        )
+    return ConsolidationRebuildJournalEntry(
+        component=component,
+        status=status,
+        artifact_fingerprint=artifact,
+        terminal_event_id=_event_id(row["terminal_event_id"]),
+        terminal_payload_digest=_digest(row["terminal_payload_digest"]),
+        effect_journal_digest=_digest(row["effect_journal_digest"]),
+    )
+
+
+def _parse_state(raw: bytes) -> ConsolidationRebuildJournalState:
+    value = _mapping(_decode(raw), _RECORD_FIELDS)
+    if value["schema"] != JOURNAL_SCHEMA:
+        _fail()
+    rows = value["components"]
+    if isinstance(rows, (str, bytes)) or not isinstance(rows, Sequence):
+        _fail()
+    if len(rows) != len(consolidation_rebuild.DERIVATIVE_COMPONENTS):
+        _fail()
+    entries = tuple(
+        _parse_entry(row, component=component)
+        for row, component in zip(rows, consolidation_rebuild.DERIVATIVE_COMPONENTS, strict=True)
+    )
+    status_rank = {"final": 0, "prepared": 1, "prior": 2}
+    ranks = tuple(status_rank[entry.status] for entry in entries)
+    if tuple(sorted(ranks)) != ranks or ranks.count(1) > 1:
+        _fail()
+    expected_revision = 1 + sum(
+        2 if entry.status == "final" else 1 if entry.status == "prepared" else 0
+        for entry in entries
+    )
+    state = ConsolidationRebuildJournalState(
+        schema=JOURNAL_SCHEMA,
+        run_id=_uuid4(value["run_id"]),
+        operation_id=_uuid4(value["operation_id"]),
+        request_digest=_digest(value["request_digest"]),
+        plan_digest=_digest(value["plan_digest"]),
+        partition_digest=_digest(value["partition_digest"]),
+        content_batch_journal_digest=_digest(value["content_batch_journal_digest"]),
+        content_effects_digest=_digest(value["content_effects_digest"]),
+        last_content_terminal_event_id=_event_id(value["last_content_terminal_event_id"]),
+        last_content_terminal_payload_digest=_digest(value["last_content_terminal_payload_digest"]),
+        canonical_census_digest=_digest(value["canonical_census_digest"]),
+        binding_digest=_digest(value["binding_digest"]),
+        revision=_integer(value["revision"], minimum=expected_revision),
+        components=entries,
+        state_digest=hashlib.sha256(raw).hexdigest(),
+    )
+    if state.revision != expected_revision or state.binding_digest != _binding_digest(state):
+        _fail()
+    return state
+
+
+@contextmanager
+def _authority(vault_root: Path, *, mutation: bool) -> Iterator[None]:
+    try:
+        with reserved_paths._subsystem_authority_scope(_OWNER):  # noqa: SLF001
+            with reserved_paths._identity_coordination_scope(  # noqa: SLF001
+                vault_root,
+                descriptor_ids=(_DESCRIPTOR_ID,),
+                identity_may_change=mutation,
+            ):
+                yield
+    except ConsolidationRebuildJournalUnavailable:
+        raise
+    except (OSError, RuntimeError, ValueError):
+        _fail()
+
+
+class ConsolidationRebuildJournalStore:
+    """CAS-persist one rebuild's immutable basis and component terminals."""
+
+    def __init__(self, vault_root: Path | str, *, run_id: str):
+        self.vault_root = Path(vault_root).absolute()
+        self.run_id = _uuid4(run_id)
+        self.path = (
+            self.vault_root
+            / kb_dirname()
+            / "_Consolidation"
+            / "runs"
+            / self.run_id
+            / "rebuild.json"
+        )
+
+    def _read(self) -> bytes:
+        return reserved_paths._read_owner_bytes(  # noqa: SLF001
+            self.vault_root,
+            self.path,
+            _DESCRIPTOR_ID,
+            limit=_MAX_JOURNAL_BYTES,
+        )
+
+    def _read_optional(self) -> bytes | None:
+        try:
+            return self._read()
+        except FileNotFoundError:
+            return None
+
+    def _publish(
+        self,
+        raw: bytes,
+        *,
+        expected_sha256: str | None = None,
+        require_missing: bool = False,
+    ) -> None:
+        reserved_paths._publish_owner_bytes(  # noqa: SLF001
+            self.vault_root,
+            self.path,
+            _DESCRIPTOR_ID,
+            raw,
+            expected_sha256=expected_sha256,
+            require_missing=require_missing,
+        )
+
+    def _load_locked(self) -> tuple[ConsolidationRebuildJournalState, bytes]:
+        try:
+            raw = self._read()
+        except FileNotFoundError:
+            _fail()
+        state = _parse_state(raw)
+        if state.run_id != self.run_id:
+            _fail()
+        return state, raw
+
+    def create(
+        self,
+        *,
+        operation_id: str,
+        request_digest: str,
+        plan_digest: str,
+        partition_digest: str,
+        content_batch_journal_digest: str,
+        content_effects_digest: str,
+        last_content_terminal_event_id: str,
+        last_content_terminal_payload_digest: str,
+        canonical_census_digest: str,
+    ) -> ConsolidationRebuildJournalState:
+        candidate = ConsolidationRebuildJournalState(
+            schema=JOURNAL_SCHEMA,
+            run_id=self.run_id,
+            operation_id=_uuid4(operation_id),
+            request_digest=_digest(request_digest),
+            plan_digest=_digest(plan_digest),
+            partition_digest=_digest(partition_digest),
+            content_batch_journal_digest=_digest(content_batch_journal_digest),
+            content_effects_digest=_digest(content_effects_digest),
+            last_content_terminal_event_id=_event_id(last_content_terminal_event_id),
+            last_content_terminal_payload_digest=_digest(last_content_terminal_payload_digest),
+            canonical_census_digest=_digest(canonical_census_digest),
+            binding_digest="0" * 64,
+            revision=1,
+            components=tuple(
+                ConsolidationRebuildJournalEntry(
+                    component=component,
+                    status="prior",
+                    artifact_fingerprint=None,
+                    terminal_event_id=None,
+                    terminal_payload_digest=None,
+                    effect_journal_digest=None,
+                )
+                for component in consolidation_rebuild.DERIVATIVE_COMPONENTS
+            ),
+            state_digest="0" * 64,
+        )
+        candidate = replace(candidate, binding_digest=_binding_digest(candidate))
+        raw = _state_bytes(candidate)
+        target = replace(candidate, state_digest=hashlib.sha256(raw).hexdigest())
+        with _authority(self.vault_root, mutation=True):
+            existing = self._read_optional()
+            if existing is None:
+                self._publish(raw, require_missing=True)
+                return target
+            current = _parse_state(existing)
+            if current.run_id == self.run_id and _basis_value(current) == _basis_value(target):
+                return current
+            _fail()
+
+    def load(self) -> ConsolidationRebuildJournalState:
+        with _authority(self.vault_root, mutation=False):
+            state, _raw = self._load_locked()
+            return state
+
+    def _component_index(self, component: object) -> int:
+        if type(component) is not str:
+            _fail()
+        try:
+            return consolidation_rebuild.DERIVATIVE_COMPONENTS.index(component)
+        except ValueError:
+            _fail()
+
+    def record_component_result(
+        self,
+        component: str,
+        artifact_fingerprint: str,
+    ) -> ConsolidationRebuildJournalState:
+        ordinal = self._component_index(component)
+        fingerprint = _digest(artifact_fingerprint)
+        with _authority(self.vault_root, mutation=True):
+            current, raw = self._load_locked()
+            entry = current.components[ordinal]
+            if entry.status in {"prepared", "final"}:
+                if entry.artifact_fingerprint == fingerprint:
+                    return current
+                _fail()
+            if entry.status != "prior" or any(
+                prior.status != "final" for prior in current.components[:ordinal]
+            ):
+                _fail()
+            entries = list(current.components)
+            entries[ordinal] = replace(
+                entry,
+                status="prepared",
+                artifact_fingerprint=fingerprint,
+            )
+            return self._replace_locked(current, raw, components=tuple(entries))
+
+    def finalize_component(
+        self,
+        component: str,
+        artifact_fingerprint: str,
+        *,
+        terminal_event_id: str,
+        terminal_payload_digest: str,
+        effect_journal_digest: str,
+    ) -> ConsolidationRebuildJournalState:
+        ordinal = self._component_index(component)
+        fingerprint = _digest(artifact_fingerprint)
+        event_id = _event_id(terminal_event_id)
+        payload_digest = _digest(terminal_payload_digest)
+        journal_digest = _digest(effect_journal_digest)
+        with _authority(self.vault_root, mutation=True):
+            current, raw = self._load_locked()
+            entry = current.components[ordinal]
+            if entry.status == "final":
+                if (
+                    entry.artifact_fingerprint == fingerprint
+                    and entry.terminal_event_id == event_id
+                    and entry.terminal_payload_digest == payload_digest
+                    and entry.effect_journal_digest == journal_digest
+                ):
+                    return current
+                _fail()
+            if entry.status != "prepared" or entry.artifact_fingerprint != fingerprint:
+                _fail()
+            entries = list(current.components)
+            entries[ordinal] = replace(
+                entry,
+                status="final",
+                terminal_event_id=event_id,
+                terminal_payload_digest=payload_digest,
+                effect_journal_digest=journal_digest,
+            )
+            return self._replace_locked(current, raw, components=tuple(entries))
+
+    def _replace_locked(
+        self,
+        current: ConsolidationRebuildJournalState,
+        raw: bytes,
+        *,
+        components: tuple[ConsolidationRebuildJournalEntry, ...],
+    ) -> ConsolidationRebuildJournalState:
+        candidate = replace(
+            current,
+            revision=current.revision + 1,
+            components=components,
+            state_digest="0" * 64,
+        )
+        target_raw = _state_bytes(candidate)
+        target = replace(candidate, state_digest=hashlib.sha256(target_raw).hexdigest())
+        self._publish(target_raw, expected_sha256=hashlib.sha256(raw).hexdigest())
+        return target

--- a/src/exomem/governance/consolidation_receipts.py
+++ b/src/exomem/governance/consolidation_receipts.py
@@ -438,6 +438,13 @@ _EVIDENCE_FIELDS: Mapping[str, frozenset[str]] = MappingProxyType(
         ),
     }
 )
+_LEARNED_RESULT_FIELDS: Mapping[str, str] = MappingProxyType(
+    {
+        "rebuild-kind": "rebuild_result_digest",
+        "abort-rebuild-kind": "rebuild_result_digest",
+        "rollback-rebuild-kind": "rebuild_result_digest",
+    }
+)
 _SPECIALIZED_ORDINALS = frozenset(
     {"batch_ordinal", "rebuild_ordinal", "probe_ordinal", "page_ordinal"}
 )
@@ -567,15 +574,24 @@ def _evidence_schema(kind: str) -> str:
     return f"exomem.consolidation-event-evidence/{kind}/v1"
 
 
-def build_evidence(
+def _evidence_fields(kind: str, *, role: str) -> frozenset[str]:
+    expected = _EVIDENCE_FIELDS.get(kind)
+    if expected is None or role not in _ROLES:
+        _fail()
+    learned = _LEARNED_RESULT_FIELDS.get(kind)
+    if learned is not None and role in {"intent", "aborted"}:
+        return expected - {learned}
+    return expected
+
+
+def _build_evidence(
     *,
     kind: str,
     digests: Mapping[str, object],
+    role: str,
 ) -> Mapping[str, object]:
-    """Build one closed digest-only evidence object for an effect kind."""
-
-    expected = _EVIDENCE_FIELDS.get(kind)
-    if expected is None or not isinstance(digests, Mapping):
+    expected = _evidence_fields(kind, role=role)
+    if not isinstance(digests, Mapping):
         _fail()
     try:
         supplied = dict(digests)
@@ -596,7 +612,22 @@ def build_evidence(
     return MappingProxyType(evidence)
 
 
-def _validated_evidence(value: object, *, kind: str) -> Mapping[str, object]:
+def build_evidence(
+    *,
+    kind: str,
+    digests: Mapping[str, object],
+) -> Mapping[str, object]:
+    """Build the closed digest-only evidence declared before an effect."""
+
+    return _build_evidence(kind=kind, digests=digests, role="intent")
+
+
+def _validated_evidence(
+    value: object,
+    *,
+    kind: str,
+    role: str,
+) -> Mapping[str, object]:
     if not isinstance(value, Mapping):
         _fail()
     try:
@@ -608,7 +639,7 @@ def _validated_evidence(value: object, *, kind: str) -> Mapping[str, object]:
     digests = dict(snapshot)
     digests.pop("schema")
     digests.pop("kind")
-    return build_evidence(kind=kind, digests=digests)
+    return _build_evidence(kind=kind, digests=digests, role=role)
 
 
 def _evidence_digest(evidence: Mapping[str, object], *, kind: str) -> str:
@@ -678,7 +709,11 @@ def validate_nested(
     _digest(snapshot["request_digest"])
     _digest(snapshot["prior_digest"])
     _digest(snapshot["target_digest"])
-    evidence = _validated_evidence(snapshot["evidence"], kind=kind)
+    evidence = _validated_evidence(
+        snapshot["evidence"],
+        kind=kind,
+        role=role,
+    )
     snapshot["evidence"] = dict(evidence)
     if _digest(snapshot["evidence_digest"]) != _evidence_digest(
         evidence,
@@ -716,7 +751,14 @@ def validate_nested(
         if "observed_digest" in snapshot:
             _fail()
     else:
-        _digest(snapshot["observed_digest"])
+        observed_digest = _digest(snapshot["observed_digest"])
+        learned_result = _LEARNED_RESULT_FIELDS.get(kind)
+        if (
+            role == "committed"
+            and learned_result is not None
+            and evidence[learned_result] != observed_digest
+        ):
+            _fail()
     if has_seed:
         _digest(snapshot["successor_context_seed_digest"])
     supplied_digest = _digest(snapshot["payload_digest"])
@@ -788,7 +830,11 @@ def build_intent(
             semantic_parent_payload_digest
         ),
     }
-    checked_evidence = _validated_evidence(evidence, kind=kind)
+    checked_evidence = _validated_evidence(
+        evidence,
+        kind=kind,
+        role="intent",
+    )
     payload["evidence"] = dict(checked_evidence)
     payload["evidence_digest"] = _evidence_digest(checked_evidence, kind=kind)
     optional = {
@@ -835,8 +881,26 @@ def build_terminal(
     payload["semantic_parent_event_id"] = intent.event_id
     payload["semantic_parent_payload_digest"] = intent.payload_digest
     payload["observed_digest"] = _digest(observed_digest)
-    payload.pop("payload_digest")
     kind = str(payload["kind"])
+    learned_result = _LEARNED_RESULT_FIELDS.get(kind)
+    if learned_result is not None and role == "committed":
+        evidence = dict(payload["evidence"])
+        evidence[learned_result] = payload["observed_digest"]
+        checked_evidence = _build_evidence(
+            kind=kind,
+            digests={
+                key: value
+                for key, value in evidence.items()
+                if key not in {"schema", "kind"}
+            },
+            role=role,
+        )
+        payload["evidence"] = dict(checked_evidence)
+        payload["evidence_digest"] = _evidence_digest(
+            checked_evidence,
+            kind=kind,
+        )
+    payload.pop("payload_digest")
     payload["payload_digest"] = _framed_digest(
         f"exomem.consolidation-event-payload/{kind}/{role}/v1".encode("ascii"),
         payload,

--- a/src/exomem/governance/consolidation_saga.py
+++ b/src/exomem/governance/consolidation_saga.py
@@ -36,7 +36,9 @@ POLICY_ACTIVATION_TERMINAL_SCHEMA = (
 
 _DIGEST = re.compile(r"[0-9a-f]{64}\Z")
 _COMMITTED_EVENT = re.compile(r"([0-9a-f]{64}):committed\Z")
-_POLICY_GATE_PHASES = frozenset({"policy-active", "publishing", "rebuilding"})
+_POLICY_GATE_PHASES = frozenset(
+    {"policy-active", "publishing", "rebuilding", "verifying"}
+)
 _DEFAULT_POLICY_GATE_PHASES = frozenset({"policy-active", "publishing"})
 _BATCH_FIELDS = frozenset(
     {

--- a/tests/test_consolidation_effect_coordinator.py
+++ b/tests/test_consolidation_effect_coordinator.py
@@ -215,6 +215,124 @@ def _content_batch_event(
     return batch, event, journal
 
 
+def _rebuild_event(vault: Path, *, effect_ordinal: int = 18):
+    from exomem.governance import consolidation_effect_coordinator
+
+    parent = _append_policy_active_parent(vault)
+    content = consolidation_receipts.build_intent(
+        kind="content-batch",
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        phase="publishing",
+        effect_ordinal=effect_ordinal - 1,
+        batch_ordinal=0,
+        request_digest=REQUEST_DIGEST,
+        prior_digest=hashlib.sha256(b"batch-prior").hexdigest(),
+        prepared_digest=hashlib.sha256(b"batch-prepared").hexdigest(),
+        target_digest=hashlib.sha256(b"batch-target").hexdigest(),
+        evidence=consolidation_receipts.build_evidence(
+            kind="content-batch",
+            digests={
+                "batch_manifest_digest": hashlib.sha256(b"batch-manifest").hexdigest(),
+                "classification_digest": hashlib.sha256(b"classification").hexdigest(),
+            },
+        ),
+        semantic_parent_event_id=str(parent["event_id"]),
+        semantic_parent_payload_digest=str(parent["consolidation_event"]["payload_digest"]),
+    )
+    content_intent = consolidation_receipts.append_intent(vault, content, timestamp=T0)
+    content_terminal = consolidation_receipts.append_terminal(
+        vault,
+        intent_event_id=str(content_intent["event_id"]),
+        role="committed",
+        observed_digest=str(content.payload["target_digest"]),
+        timestamp=T0,
+    )
+    event = consolidation_receipts.build_intent(
+        kind="rebuild-kind",
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        phase="rebuilding",
+        effect_ordinal=effect_ordinal,
+        rebuild_ordinal=0,
+        request_digest=REQUEST_DIGEST,
+        prior_digest=PRIOR_DIGEST,
+        target_digest=TARGET_DIGEST,
+        evidence=consolidation_receipts.build_evidence(
+            kind="rebuild-kind",
+            digests={"rebuild_basis_digest": hashlib.sha256(b"rebuild-basis").hexdigest()},
+        ),
+        semantic_parent_event_id=str(content_terminal["event_id"]),
+        semantic_parent_payload_digest=str(
+            content_terminal["consolidation_event"]["payload_digest"]
+        ),
+    )
+    journal = consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+        vault,
+        run_id=RUN_ID,
+        effect_ordinal=effect_ordinal,
+    )
+    return event, journal
+
+
+def test_rebuild_effect_commits_a_learned_result_and_replays_without_rerun(
+    vault: Path,
+) -> None:
+    from exomem.governance import consolidation_effect_coordinator
+
+    event, journal = _rebuild_event(vault)
+    artifact_fingerprint = hashlib.sha256(b"rebuilt-artifact").hexdigest()
+    recorded: str | None = None
+    rebuilds = 0
+
+    def classify() -> consolidation_effect_coordinator.EffectObservation:
+        return consolidation_effect_coordinator.EffectObservation(
+            state="prior" if recorded is None else "target",
+            digest=PRIOR_DIGEST if recorded is None else recorded,
+        )
+
+    def rebuild() -> None:
+        nonlocal rebuilds, recorded
+        rebuilds += 1
+        recorded = artifact_fingerprint
+
+    result = consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+        vault_root=vault,
+        event=event,
+        journal=journal,
+        classify=classify,
+        apply_effect=rebuild,
+        timestamp=T0,
+    )
+
+    assert result.role == "committed"
+    assert result.observed_digest == artifact_fingerprint
+    assert result.observed_digest != event.payload["target_digest"]
+    assert rebuilds == 1
+    terminal_records = [
+        record
+        for record in consolidation_receipts._active_records(vault)  # noqa: SLF001
+        if record.get("event_id") == result.terminal.event_id
+    ]
+    assert len(terminal_records) == 1
+    assert (
+        terminal_records[0]["consolidation_event"]["evidence"]["rebuild_result_digest"]
+        == artifact_fingerprint
+    )
+
+    replayed = consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+        vault_root=vault,
+        event=event,
+        journal=journal,
+        classify=classify,
+        apply_effect=lambda: pytest.fail("final rebuild must not rerun"),
+        timestamp=T0,
+    )
+
+    assert replayed == result
+    assert rebuilds == 1
+
+
 def test_effect_uses_exact_receipt_first_order_and_persists_references(
     vault: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_consolidation_rebuild_coordinator.py
+++ b/tests/test_consolidation_rebuild_coordinator.py
@@ -1,0 +1,385 @@
+"""Coordinator integration contract for post-publication derivative rebuilds."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from exomem.governance import consolidation_receipts
+
+_tests_package = ModuleType("tests")
+_tests_package.__path__ = [str(Path(__file__).parent)]
+sys.modules.setdefault("tests", _tests_package)
+
+from tests.test_consolidation_content_publication import (  # noqa: E402
+    RUN_ID,
+    _action,
+    _setup,
+)
+
+VERIFYING_AT = "2026-08-30T12:00:06.000Z"
+POST_PUBLICATION_CENSUS = hashlib.sha256(b"post-publication-census").hexdigest()
+DRIFTED_CENSUS = hashlib.sha256(b"drifted-census").hexdigest()
+
+
+class SimulatedRebuildCrash(BaseException):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _private_writer_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR",
+        str(tmp_path / "writer-state"),
+    )
+
+
+def _published_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Path, dict[str, object], bytes]:
+    from exomem.governance import (
+        consolidation_content_publication,
+        consolidation_saga,
+    )
+
+    after = b"published canonical destination bytes\n"
+    actions = (
+        _action(
+            0,
+            batch_ordinal=0,
+            destination_path="Knowledge Base/Notes/destination.md",
+            before=None,
+            after=after,
+        ),
+    )
+    vault, _partition, _loads, arguments = _setup(
+        tmp_path,
+        monkeypatch,
+        actions,
+        (after,),
+    )
+    publication = consolidation_content_publication.publish_stored_content_batches(**arguments)
+    assert publication.seal_state.phase == "rebuilding"
+
+    def verify_policy_terminal(**kwargs):
+        assert kwargs["vault_root"] == vault
+        assert kwargs["vault_binding_digest"] == arguments["vault_binding_digest"]
+        assert kwargs["allowed_seal_phases"] == frozenset({"rebuilding", "verifying"})
+        return consolidation_saga._policy_terminal(  # noqa: SLF001
+            kwargs["terminal"],
+            expected_policy_fingerprint=kwargs["expected_policy_fingerprint"],
+        )
+
+    monkeypatch.setattr(
+        consolidation_saga,
+        "_verify_policy_terminal_receipt",
+        verify_policy_terminal,
+    )
+    coordinator_arguments = {
+        key: arguments[key]
+        for key in (
+            "vault_root",
+            "admission",
+            "policy_terminal",
+            "vault_binding_digest",
+            "run_id",
+            "operation_id",
+            "journal_digest",
+            "request_digest",
+            "plan_digest",
+        )
+    }
+    coordinator_arguments["verifying_at"] = VERIFYING_AT
+    return vault, coordinator_arguments, after
+
+
+def _terminal(component: str, context):
+    from exomem.governance import consolidation_rebuild
+
+    return consolidation_rebuild.DerivativeRebuildTerminal(
+        schema=consolidation_rebuild.DERIVATIVE_REBUILD_TERMINAL_SCHEMA,
+        component=component,
+        canonical_census_digest=context.canonical_census_digest,
+        artifact_fingerprint=hashlib.sha256(f"rebuilt:{component}".encode()).hexdigest(),
+    )
+
+
+def _rebuild_records(vault: Path) -> list[dict[str, object]]:
+    return [
+        record
+        for record in consolidation_receipts._active_records(vault)  # noqa: SLF001
+        if record.get("event_type") == "consolidation"
+        and isinstance(record.get("consolidation_event"), dict)
+        and record["consolidation_event"].get("kind") == "rebuild-kind"
+    ]
+
+
+def test_rebuild_derives_a_post_publication_census_and_chains_all_components(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_rebuild,
+        consolidation_rebuild_coordinator,
+        consolidation_rebuild_journal,
+    )
+
+    vault, arguments, after = _published_run(tmp_path, monkeypatch)
+    census_roots: list[Path] = []
+    calls: list[tuple[str, Path, str]] = []
+
+    def snapshot(root: Path) -> str:
+        census_roots.append(root)
+        assert (root / "Knowledge Base/Notes/destination.md").read_bytes() == after
+        return POST_PUBLICATION_CENSUS
+
+    def rebuild(component: str, context):
+        calls.append((component, context.vault_root, context.canonical_census_digest))
+        return _terminal(component, context)
+
+    monkeypatch.setattr(consolidation_rebuild_coordinator, "_snapshot_census", snapshot)
+    monkeypatch.setattr(
+        consolidation_rebuild_coordinator,
+        "_component_rebuilder",
+        lambda: rebuild,
+    )
+
+    result = consolidation_rebuild_coordinator.rebuild_published_destination(**arguments)
+
+    assert result.canonical_census_digest == POST_PUBLICATION_CENSUS
+    assert result.completed_components == consolidation_rebuild.DERIVATIVE_COMPONENTS
+    assert [component for component, _root, _digest in calls] == list(
+        consolidation_rebuild.DERIVATIVE_COMPONENTS
+    )
+    assert all(root == vault and digest == POST_PUBLICATION_CENSUS for _name, root, digest in calls)
+    assert census_roots and all(root == vault for root in census_roots)
+    assert result.seal_state.phase == "verifying"
+    assert all(entry.status == "final" for entry in result.rebuild_journal.components)
+
+    stored = consolidation_rebuild_journal.ConsolidationRebuildJournalStore(
+        vault,
+        run_id=RUN_ID,
+    ).load()
+    assert stored == result.rebuild_journal
+    assert (
+        tuple(entry.component for entry in stored.components)
+        == consolidation_rebuild.DERIVATIVE_COMPONENTS
+    )
+
+    records = _rebuild_records(vault)
+    intents = [
+        consolidation_receipts.validate_nested(record["consolidation_event"], outer_phase="intent")
+        for record in records
+        if record["phase"] == "intent"
+    ]
+    terminals = [record for record in records if record["phase"] == "committed"]
+    assert [intent["rebuild_ordinal"] for intent in intents] == list(range(8))
+    assert [intent["effect_ordinal"] for intent in intents] == list(range(18, 26))
+    content_terminals = [
+        record
+        for record in consolidation_receipts._active_records(vault)  # noqa: SLF001
+        if record.get("event_type") == "consolidation"
+        and isinstance(record.get("consolidation_event"), dict)
+        and record["consolidation_event"].get("kind") == "content-batch"
+        and record["phase"] == "committed"
+    ]
+    assert intents[0]["semantic_parent_event_id"] == content_terminals[-1]["event_id"]
+    assert len(terminals) == 8
+    assert all(
+        later["semantic_parent_event_id"] == previous["event_id"]
+        for previous, later in zip(terminals[:-1], intents[1:], strict=True)
+    )
+
+
+def test_retry_after_all_rebuild_terminals_only_advances_the_seal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_rebuild_coordinator
+
+    vault, arguments, _after = _published_run(tmp_path, monkeypatch)
+    rebuilds: list[str] = []
+
+    monkeypatch.setattr(
+        consolidation_rebuild_coordinator,
+        "_snapshot_census",
+        lambda _root: POST_PUBLICATION_CENSUS,
+    )
+    monkeypatch.setattr(
+        consolidation_rebuild_coordinator,
+        "_component_rebuilder",
+        lambda: (
+            lambda component, context: rebuilds.append(component) or _terminal(component, context)
+        ),
+    )
+
+    def crash_before_verifying(point: str) -> None:
+        if point == "before-verifying":
+            raise SimulatedRebuildCrash
+
+    monkeypatch.setattr(
+        consolidation_rebuild_coordinator,
+        "_crash_point",
+        crash_before_verifying,
+    )
+
+    with pytest.raises(SimulatedRebuildCrash):
+        consolidation_rebuild_coordinator.rebuild_published_destination(**arguments)
+
+    assert len(rebuilds) == 8
+    monkeypatch.setattr(
+        consolidation_rebuild_coordinator,
+        "_crash_point",
+        lambda _point: None,
+    )
+    monkeypatch.setattr(
+        consolidation_rebuild_coordinator,
+        "_component_rebuilder",
+        lambda: lambda *_args: pytest.fail("final rebuilds must not run on retry"),
+    )
+
+    retried = consolidation_rebuild_coordinator.rebuild_published_destination(**arguments)
+
+    assert retried.seal_state.phase == "verifying"
+    assert len(rebuilds) == 8
+
+
+def test_retry_after_component_result_finishes_receipt_without_rerunning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_effect_coordinator,
+        consolidation_rebuild,
+        consolidation_rebuild_coordinator,
+        consolidation_rebuild_journal,
+    )
+
+    vault, arguments, _after = _published_run(tmp_path, monkeypatch)
+    rebuilds: list[str] = []
+
+    monkeypatch.setattr(
+        consolidation_rebuild_coordinator,
+        "_snapshot_census",
+        lambda _root: POST_PUBLICATION_CENSUS,
+    )
+    monkeypatch.setattr(
+        consolidation_rebuild_coordinator,
+        "_component_rebuilder",
+        lambda: (
+            lambda component, context: rebuilds.append(component)
+            or _terminal(component, context)
+        ),
+    )
+    crashed = False
+
+    def crash_after_component_result(point: str) -> None:
+        nonlocal crashed
+        if point == "after-effect" and not crashed:
+            crashed = True
+            raise SimulatedRebuildCrash
+
+    monkeypatch.setattr(
+        consolidation_effect_coordinator,
+        "_crash_point",
+        crash_after_component_result,
+    )
+    with pytest.raises(SimulatedRebuildCrash):
+        consolidation_rebuild_coordinator.rebuild_published_destination(**arguments)
+
+    assert rebuilds == ["media"]
+    rebuild_state = consolidation_rebuild_journal.ConsolidationRebuildJournalStore(
+        vault,
+        run_id=RUN_ID,
+    ).load()
+    assert rebuild_state.components[0].status == "prepared"
+    assert (
+        consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+            vault,
+            run_id=RUN_ID,
+            effect_ordinal=18,
+        )
+        .load()
+        .status
+        == "prepared"
+    )
+
+    monkeypatch.setattr(
+        consolidation_effect_coordinator,
+        "_crash_point",
+        lambda _point: None,
+    )
+    retried = consolidation_rebuild_coordinator.rebuild_published_destination(
+        **arguments
+    )
+
+    assert rebuilds == list(consolidation_rebuild.DERIVATIVE_COMPONENTS)
+    assert rebuilds.count("media") == 1
+    assert retried.seal_state.phase == "verifying"
+
+
+def test_canonical_census_drift_refuses_before_the_next_component(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_rebuild_coordinator
+
+    _vault, arguments, _after = _published_run(tmp_path, monkeypatch)
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        consolidation_rebuild_coordinator,
+        "_snapshot_census",
+        lambda _root: POST_PUBLICATION_CENSUS if not calls else DRIFTED_CENSUS,
+    )
+    monkeypatch.setattr(
+        consolidation_rebuild_coordinator,
+        "_component_rebuilder",
+        lambda: lambda component, context: calls.append(component) or _terminal(component, context),
+    )
+
+    with pytest.raises(
+        consolidation_rebuild_coordinator.ConsolidationRebuildCoordinatorUnavailable
+    ):
+        consolidation_rebuild_coordinator.rebuild_published_destination(**arguments)
+
+    assert calls == ["media"]
+
+
+def test_verifying_replay_does_not_rebuild_final_components(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_rebuild_coordinator
+
+    _vault, arguments, _after = _published_run(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        consolidation_rebuild_coordinator,
+        "_snapshot_census",
+        lambda _root: POST_PUBLICATION_CENSUS,
+    )
+    monkeypatch.setattr(
+        consolidation_rebuild_coordinator,
+        "_component_rebuilder",
+        lambda: _terminal,
+    )
+
+    first = consolidation_rebuild_coordinator.rebuild_published_destination(**arguments)
+    assert first.seal_state.phase == "verifying"
+    monkeypatch.setattr(
+        consolidation_rebuild_coordinator,
+        "_component_rebuilder",
+        lambda: lambda *_args: pytest.fail("verifying replay must not rebuild"),
+    )
+
+    replayed = consolidation_rebuild_coordinator.rebuild_published_destination(**arguments)
+
+    assert replayed == first

--- a/tests/test_consolidation_rebuild_journal.py
+++ b/tests/test_consolidation_rebuild_journal.py
@@ -1,0 +1,190 @@
+"""Exact-state persistence for the consolidation derivative rebuild."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from exomem import writer_lease
+
+RUN_ID = "00000000-0000-4000-8000-000000000091"
+OPERATION_ID = "00000000-0000-4000-8000-000000000092"
+
+
+@pytest.fixture(autouse=True)
+def _private_writer_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = writer_lease.LeaseManager(
+        writer_lease.LeaseConfig(state_dir=tmp_path / "writer-state")
+    )
+    monkeypatch.setattr(writer_lease, "active_manager", lambda: manager)
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode()).hexdigest()
+
+
+def _store(vault: Path):
+    from exomem.governance import consolidation_rebuild_journal
+
+    return consolidation_rebuild_journal.ConsolidationRebuildJournalStore(
+        vault,
+        run_id=RUN_ID,
+    )
+
+
+def _create(store):
+    return store.create(
+        operation_id=OPERATION_ID,
+        request_digest=_digest("request"),
+        plan_digest=_digest("plan"),
+        partition_digest=_digest("partition"),
+        content_batch_journal_digest=_digest("batch-journal"),
+        content_effects_digest=_digest("content-effects"),
+        last_content_terminal_event_id=_digest("last-terminal") + ":committed",
+        last_content_terminal_payload_digest=_digest("last-payload"),
+        canonical_census_digest=_digest("post-publication-census"),
+    )
+
+
+def _path(vault: Path) -> Path:
+    return vault / "Knowledge Base" / "_Consolidation" / "runs" / RUN_ID / "rebuild.json"
+
+
+def test_create_persists_exact_prior_state_and_restarts(tmp_path: Path) -> None:
+    from exomem.governance import consolidation_rebuild
+
+    vault = tmp_path / "vault"
+    created = _create(_store(vault))
+
+    assert created.schema == "exomem.consolidation-rebuild-journal/v1"
+    assert created.revision == 1
+    assert tuple(entry.component for entry in created.components) == (
+        consolidation_rebuild.DERIVATIVE_COMPONENTS
+    )
+    assert tuple(entry.status for entry in created.components) == ("prior",) * len(
+        consolidation_rebuild.DERIVATIVE_COMPONENTS
+    )
+    assert _store(vault).load() == created
+
+
+def test_ordered_result_and_terminal_transitions_finish_all_components(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import consolidation_rebuild
+
+    store = _store(tmp_path / "vault")
+    initial = _create(store)
+
+    for ordinal, component in enumerate(consolidation_rebuild.DERIVATIVE_COMPONENTS):
+        fingerprint = _digest(f"artifact:{component}")
+        prepared = store.record_component_result(component, fingerprint)
+        assert prepared.revision == initial.revision + 1
+        assert prepared.components[ordinal].status == "prepared"
+        assert prepared.components[ordinal].artifact_fingerprint == fingerprint
+        assert store.record_component_result(component, fingerprint) == prepared
+
+        final = store.finalize_component(
+            component,
+            fingerprint,
+            terminal_event_id=_digest(f"terminal:{component}") + ":committed",
+            terminal_payload_digest=_digest(f"payload:{component}"),
+            effect_journal_digest=_digest(f"effect:{component}"),
+        )
+        assert final.revision == prepared.revision + 1
+        assert final.components[ordinal].status == "final"
+        assert final.components[ordinal].terminal_event_id == (
+            _digest(f"terminal:{component}") + ":committed"
+        )
+        assert (
+            store.finalize_component(
+                component,
+                fingerprint,
+                terminal_event_id=_digest(f"terminal:{component}") + ":committed",
+                terminal_payload_digest=_digest(f"payload:{component}"),
+                effect_journal_digest=_digest(f"effect:{component}"),
+            )
+            == final
+        )
+        initial = final
+
+    assert all(entry.status == "final" for entry in store.load().components)
+
+
+def test_create_adopts_progressed_same_basis_but_refuses_changed_basis(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import consolidation_rebuild_journal
+
+    vault = tmp_path / "vault"
+    store = _store(vault)
+    _create(store)
+    progressed = store.record_component_result("media", _digest("artifact:media"))
+    assert _create(_store(vault)) == progressed
+
+    with pytest.raises(consolidation_rebuild_journal.ConsolidationRebuildJournalUnavailable):
+        store.create(
+            operation_id=OPERATION_ID,
+            request_digest=_digest("changed-request"),
+            plan_digest=_digest("plan"),
+            partition_digest=_digest("partition"),
+            content_batch_journal_digest=_digest("batch-journal"),
+            content_effects_digest=_digest("content-effects"),
+            last_content_terminal_event_id=_digest("last-terminal") + ":committed",
+            last_content_terminal_payload_digest=_digest("last-payload"),
+            canonical_census_digest=_digest("post-publication-census"),
+        )
+    assert store.load() == progressed
+
+
+def test_changed_fingerprint_or_out_of_order_component_refuses(tmp_path: Path) -> None:
+    from exomem.governance import consolidation_rebuild_journal
+
+    store = _store(tmp_path / "vault")
+    initial = _create(store)
+    with pytest.raises(consolidation_rebuild_journal.ConsolidationRebuildJournalUnavailable):
+        store.record_component_result("lexical", _digest("artifact:lexical"))
+    with pytest.raises(consolidation_rebuild_journal.ConsolidationRebuildJournalUnavailable):
+        store.finalize_component(
+            "media",
+            _digest("artifact:media"),
+            terminal_event_id=_digest("terminal:media") + ":committed",
+            terminal_payload_digest=_digest("payload:media"),
+            effect_journal_digest=_digest("effect:media"),
+        )
+    prepared = store.record_component_result("media", _digest("artifact:media"))
+    with pytest.raises(consolidation_rebuild_journal.ConsolidationRebuildJournalUnavailable):
+        store.record_component_result("media", _digest("different-artifact:media"))
+    with pytest.raises(consolidation_rebuild_journal.ConsolidationRebuildJournalUnavailable):
+        store.finalize_component(
+            "media",
+            _digest("different-artifact:media"),
+            terminal_event_id=_digest("terminal:media") + ":committed",
+            terminal_payload_digest=_digest("payload:media"),
+            effect_journal_digest=_digest("effect:media"),
+        )
+    assert store.load() == prepared
+    assert initial.components[0].status == "prior"
+
+
+@pytest.mark.parametrize("mutation", ("missing", "tamper"))
+def test_missing_or_tampered_journal_refuses(tmp_path: Path, mutation: str) -> None:
+    from exomem.governance import consolidation_rebuild_journal
+
+    vault = tmp_path / "vault"
+    _create(_store(vault))
+    path = _path(vault)
+    if mutation == "missing":
+        path.unlink()
+    else:
+        value = json.loads(path.read_bytes())
+        value["revision"] = 2
+        path.write_bytes(json.dumps(value, sort_keys=True, separators=(",", ":")).encode())
+
+    with pytest.raises(consolidation_rebuild_journal.ConsolidationRebuildJournalUnavailable):
+        _store(vault).load()

--- a/tests/test_consolidation_receipts.py
+++ b/tests/test_consolidation_receipts.py
@@ -75,7 +75,7 @@ _EVIDENCE_FIELDS = {
         "source_consume_event_digest",
         "source_receipt_head_digest",
     ),
-    "rebuild-kind": ("rebuild_basis_digest", "rebuild_result_digest"),
+    "rebuild-kind": ("rebuild_basis_digest",),
     "in-process-probe": (
         "probe_digest",
         "probe_result_digest",
@@ -586,6 +586,166 @@ def test_kind_specific_evidence_is_closed_and_hashed_by_the_builder() -> None:
         consolidation_receipts.build_evidence(
             kind="content-batch",
             digests={"batch_manifest_digest": "a" * 64},
+        )
+
+
+def test_rebuild_receipt_learns_the_actual_result_only_after_commit() -> None:
+    from exomem.governance import consolidation_receipts
+
+    basis = hashlib.sha256(b"rebuild-basis").hexdigest()
+    intent = consolidation_receipts.build_intent(
+        kind="rebuild-kind",
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        phase="rebuilding",
+        effect_ordinal=8,
+        rebuild_ordinal=0,
+        request_digest=REQUEST_DIGEST,
+        prior_digest=PRIOR_DIGEST,
+        target_digest=TARGET_DIGEST,
+        evidence=consolidation_receipts.build_evidence(
+            kind="rebuild-kind",
+            digests={"rebuild_basis_digest": basis},
+        ),
+        semantic_parent_event_id=PARENT_EVENT_ID,
+        semantic_parent_payload_digest=PARENT_PAYLOAD_DIGEST,
+    )
+
+    assert intent.payload["evidence"] == {
+        "schema": "exomem.consolidation-event-evidence/rebuild-kind/v1",
+        "kind": "rebuild-kind",
+        "rebuild_basis_digest": basis,
+    }
+    terminal = consolidation_receipts.build_terminal(
+        intent,
+        role="committed",
+        observed_digest=OBSERVED_DIGEST,
+    )
+    assert terminal.payload["target_digest"] == TARGET_DIGEST
+    assert terminal.payload["observed_digest"] == OBSERVED_DIGEST
+    assert terminal.payload["evidence"] == {
+        "schema": "exomem.consolidation-event-evidence/rebuild-kind/v1",
+        "kind": "rebuild-kind",
+        "rebuild_basis_digest": basis,
+        "rebuild_result_digest": OBSERVED_DIGEST,
+    }
+    assert (
+        consolidation_receipts.validate_nested(
+            terminal.payload,
+            outer_phase="committed",
+        )["payload_digest"]
+        == terminal.payload_digest
+    )
+    aborted = consolidation_receipts.build_terminal(
+        intent,
+        role="aborted",
+        observed_digest=PRIOR_DIGEST,
+    )
+    assert "rebuild_result_digest" not in aborted.payload["evidence"]
+    assert (
+        consolidation_receipts.validate_nested(
+            aborted.payload,
+            outer_phase="aborted",
+        )["payload_digest"]
+        == aborted.payload_digest
+    )
+
+
+@pytest.mark.parametrize(
+    ("kind", "basis_field"),
+    (
+        ("abort-rebuild-kind", "abort_basis_digest"),
+        ("rollback-rebuild-kind", "rebuild_basis_digest"),
+    ),
+)
+def test_every_rebuild_branch_learns_its_result_only_at_commit(
+    kind: str,
+    basis_field: str,
+) -> None:
+    from exomem.governance import consolidation_receipts
+
+    basis = hashlib.sha256(f"{kind}:basis".encode()).hexdigest()
+    evidence = consolidation_receipts.build_evidence(
+        kind=kind,
+        digests={basis_field: basis},
+    )
+    assert "rebuild_result_digest" not in evidence
+    intent = consolidation_receipts.build_intent(
+        kind=kind,
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        phase="rebuilding",
+        effect_ordinal=8,
+        rebuild_ordinal=0,
+        request_digest=REQUEST_DIGEST,
+        prior_digest=PRIOR_DIGEST,
+        target_digest=TARGET_DIGEST,
+        evidence=evidence,
+        semantic_parent_event_id=PARENT_EVENT_ID,
+        semantic_parent_payload_digest=PARENT_PAYLOAD_DIGEST,
+    )
+
+    terminal = consolidation_receipts.build_terminal(
+        intent,
+        role="committed",
+        observed_digest=OBSERVED_DIGEST,
+    )
+
+    assert terminal.payload["evidence"][basis_field] == basis
+    assert (
+        terminal.payload["evidence"]["rebuild_result_digest"]
+        == OBSERVED_DIGEST
+    )
+
+
+def test_rebuild_intent_refuses_a_fabricated_future_result() -> None:
+    from exomem.governance import consolidation_receipts
+
+    with pytest.raises(
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        match="^CONSOLIDATION_RECEIPT_UNAVAILABLE$",
+    ):
+        consolidation_receipts.build_evidence(
+            kind="rebuild-kind",
+            digests={
+                "rebuild_basis_digest": "a" * 64,
+                "rebuild_result_digest": "b" * 64,
+            },
+        )
+
+
+def test_rebuild_terminal_refuses_a_result_different_from_observation() -> None:
+    from exomem.governance import consolidation_receipts
+
+    event = consolidation_receipts.build_intent(
+        kind="rebuild-kind",
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        phase="rebuilding",
+        effect_ordinal=8,
+        rebuild_ordinal=0,
+        request_digest=REQUEST_DIGEST,
+        prior_digest=PRIOR_DIGEST,
+        target_digest=TARGET_DIGEST,
+        evidence=_evidence("rebuild-kind"),
+        semantic_parent_event_id=PARENT_EVENT_ID,
+        semantic_parent_payload_digest=PARENT_PAYLOAD_DIGEST,
+    )
+    terminal = consolidation_receipts.build_terminal(
+        event,
+        role="committed",
+        observed_digest=OBSERVED_DIGEST,
+    )
+    changed = copy.deepcopy(dict(terminal.payload))
+    changed["evidence"]["rebuild_result_digest"] = "f" * 64
+
+    with pytest.raises(
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        match="^CONSOLIDATION_RECEIPT_UNAVAILABLE$",
+    ):
+        consolidation_receipts.validate_nested(
+            changed,
+            outer_phase="committed",
         )
 
 


### PR DESCRIPTION
## Summary

- verify the exact final content-batch journal and receipt chain before sampling the post-publication destination census
- rebuild the closed eight-component derivative set from destination canonical bytes, with learned artifact fingerprints and ordered receipt-first effects
- persist crash-recoverable aggregate progress so retries finish evidence without rerunning completed components, then advance rebuilding to verifying

Stacked on #1001. This does not merge or touch a live vault.

## Verification

- focused governance/rebuild/publication suites: 82 passed
- production derivative adapter suite: 10 passed
- rebuild coordinator crash/retry integration: 5 passed
- Ruff on all changed files and repository F rules
- Python bytecode compilation and git diff --check
- uv lock --check
- openspec validate --all --strict: 168 passed
- public repository privacy validation: 3446 files, 3514 text payloads clean