### PR TITLE
feat(governance): bind consolidation verification probes

### DIFF
--- a/src/exomem/governance/consolidation_verification.py
+++ b/src/exomem/governance/consolidation_verification.py
@@ -1,0 +1,296 @@
+"""Closed, plan-bound in-process probes for governed consolidation.
+
+Probe definitions are owner-protected control data.  Receipts see only their
+digests and bounded outcome class; probe refs never cross the evidence boundary.
+The process-local consolidation authority is carried only in memory.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, NoReturn
+
+from . import consolidation_plan
+
+VERIFICATION_PROBE_SCHEMA = "exomem.consolidation-verification-probe/v1"
+VERIFICATION_PROBE_TERMINAL_SCHEMA = "exomem.consolidation-verification-probe-terminal/v1"
+POSITIVE_PROBE_SET_SCHEMA = "exomem.consolidation-positive-probes/v1"
+NEGATIVE_PROBE_SET_SCHEMA = "exomem.consolidation-negative-probes/v1"
+CANONICAL_SURFACE_EXECUTOR_ID = "canonical-governance-surface-v1"
+
+_PROBE_DOMAIN = VERIFICATION_PROBE_SCHEMA.encode("ascii")
+_POSITIVE_DOMAIN = POSITIVE_PROBE_SET_SCHEMA.encode("ascii")
+_NEGATIVE_DOMAIN = NEGATIVE_PROBE_SET_SCHEMA.encode("ascii")
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_IDENTIFIER = re.compile(r"[a-z][a-z0-9-]{0,127}\Z")
+_PROBE_FIELDS = frozenset({"probe_id", "executor_id", "contract_digest", "expected_result_digest"})
+_MAX_PROBES = 1024
+
+__all__ = [
+    "NEGATIVE_PROBE_SET_SCHEMA",
+    "POSITIVE_PROBE_SET_SCHEMA",
+    "CANONICAL_SURFACE_EXECUTOR_ID",
+    "VERIFICATION_PROBE_SCHEMA",
+    "VERIFICATION_PROBE_TERMINAL_SCHEMA",
+    "ConsolidationVerificationUnavailable",
+    "VerificationPlan",
+    "VerificationProbe",
+    "VerificationProbeContext",
+    "VerificationProbeTerminal",
+    "build_verification_plan",
+]
+
+
+class ConsolidationVerificationUnavailable(RuntimeError):
+    """Content-free refusal for an invalid plan, probe, or result."""
+
+    code = "CONSOLIDATION_VERIFICATION_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationProbe:
+    schema: str
+    ordinal: int
+    probe_kind: Literal["positive", "negative"]
+    probe_id: str
+    executor_id: str
+    contract_digest: str
+    expected_result_digest: str
+    probe_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationPlan:
+    positive_probes: tuple[VerificationProbe, ...]
+    negative_probes: tuple[VerificationProbe, ...]
+    positive_probe_digest: str
+    negative_probe_digest: str
+
+    @property
+    def probes(self) -> tuple[VerificationProbe, ...]:
+        return self.positive_probes + self.negative_probes
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationProbeContext:
+    vault_root: Path
+    canonical_census_digest: str
+    verification_basis_digest: str
+    authority: object
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationProbeTerminal:
+    schema: str
+    probe_id: str
+    probe_digest: str
+    result_digest: str
+    outcome: Literal["passed"]
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationVerificationUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if type(value) is not str or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _identifier(value: object) -> str:
+    if type(value) is not str or _IDENTIFIER.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _framed_digest(domain: bytes, value: object) -> str:
+    try:
+        encoded = consolidation_plan.canonical_closed_jcs(value)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    framed = len(domain).to_bytes(4, "big") + domain + len(encoded).to_bytes(8, "big") + encoded
+    return hashlib.sha256(framed).hexdigest()
+
+
+def _probe_value(probe: VerificationProbe) -> dict[str, object]:
+    return {
+        "schema": probe.schema,
+        "ordinal": probe.ordinal,
+        "probe_kind": probe.probe_kind,
+        "probe_id": probe.probe_id,
+        "executor_id": probe.executor_id,
+        "contract_digest": probe.contract_digest,
+        "expected_result_digest": probe.expected_result_digest,
+    }
+
+
+def _build_probe(
+    value: object,
+    *,
+    ordinal: int,
+    probe_kind: Literal["positive", "negative"],
+) -> VerificationProbe:
+    if not isinstance(value, Mapping) or frozenset(value) != _PROBE_FIELDS:
+        _fail()
+    candidate = VerificationProbe(
+        schema=VERIFICATION_PROBE_SCHEMA,
+        ordinal=ordinal,
+        probe_kind=probe_kind,
+        probe_id=_identifier(value["probe_id"]),
+        executor_id=_identifier(value["executor_id"]),
+        contract_digest=_digest(value["contract_digest"]),
+        expected_result_digest=_digest(value["expected_result_digest"]),
+        probe_digest="0" * 64,
+    )
+    if candidate.executor_id != CANONICAL_SURFACE_EXECUTOR_ID:
+        _fail()
+    return VerificationProbe(
+        schema=candidate.schema,
+        ordinal=candidate.ordinal,
+        probe_kind=candidate.probe_kind,
+        probe_id=candidate.probe_id,
+        executor_id=candidate.executor_id,
+        contract_digest=candidate.contract_digest,
+        expected_result_digest=candidate.expected_result_digest,
+        probe_digest=_framed_digest(_PROBE_DOMAIN, _probe_value(candidate)),
+    )
+
+
+def _sequence(value: object) -> Sequence[object]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        _fail()
+    if not 1 <= len(value) <= _MAX_PROBES:
+        _fail()
+    return value
+
+
+def _set_digest(
+    probes: tuple[VerificationProbe, ...],
+    *,
+    schema: str,
+    domain: bytes,
+) -> str:
+    return _framed_digest(
+        domain,
+        {
+            "schema": schema,
+            "probes": tuple(
+                {**_probe_value(probe), "probe_digest": probe.probe_digest} for probe in probes
+            ),
+        },
+    )
+
+
+def build_verification_plan(
+    *,
+    positive_probes: Sequence[Mapping[str, object]],
+    negative_probes: Sequence[Mapping[str, object]],
+) -> VerificationPlan:
+    """Build the exact positive/negative matrices bound by a cutover plan."""
+
+    positive_values = _sequence(positive_probes)
+    negative_values = _sequence(negative_probes)
+    if len(positive_values) + len(negative_values) > _MAX_PROBES:
+        _fail()
+    positive = tuple(
+        _build_probe(value, ordinal=ordinal, probe_kind="positive")
+        for ordinal, value in enumerate(positive_values)
+    )
+    negative = tuple(
+        _build_probe(
+            value,
+            ordinal=len(positive) + ordinal,
+            probe_kind="negative",
+        )
+        for ordinal, value in enumerate(negative_values)
+    )
+    ids = tuple(probe.probe_id for probe in positive + negative)
+    if len(set(ids)) != len(ids):
+        _fail()
+    return VerificationPlan(
+        positive_probes=positive,
+        negative_probes=negative,
+        positive_probe_digest=_set_digest(
+            positive,
+            schema=POSITIVE_PROBE_SET_SCHEMA,
+            domain=_POSITIVE_DOMAIN,
+        ),
+        negative_probe_digest=_set_digest(
+            negative,
+            schema=NEGATIVE_PROBE_SET_SCHEMA,
+            domain=_NEGATIVE_DOMAIN,
+        ),
+    )
+
+
+def _checked_plan(value: object) -> VerificationPlan:
+    if type(value) is not VerificationPlan:
+        _fail()
+    rebuilt = build_verification_plan(
+        positive_probes=tuple(
+            {
+                "probe_id": probe.probe_id,
+                "executor_id": probe.executor_id,
+                "contract_digest": probe.contract_digest,
+                "expected_result_digest": probe.expected_result_digest,
+            }
+            for probe in value.positive_probes
+        ),
+        negative_probes=tuple(
+            {
+                "probe_id": probe.probe_id,
+                "executor_id": probe.executor_id,
+                "contract_digest": probe.contract_digest,
+                "expected_result_digest": probe.expected_result_digest,
+            }
+            for probe in value.negative_probes
+        ),
+    )
+    if rebuilt != value:
+        _fail()
+    return rebuilt
+
+
+def _terminal(
+    value: object,
+    *,
+    probe: VerificationProbe,
+) -> VerificationProbeTerminal:
+    if type(value) is not VerificationProbeTerminal:
+        _fail()
+    if (
+        value.schema != VERIFICATION_PROBE_TERMINAL_SCHEMA
+        or value.probe_id != probe.probe_id
+        or value.probe_digest != probe.probe_digest
+        or value.result_digest != probe.expected_result_digest
+        or value.outcome != "passed"
+    ):
+        _fail()
+    return VerificationProbeTerminal(
+        schema=value.schema,
+        probe_id=value.probe_id,
+        probe_digest=_digest(value.probe_digest),
+        result_digest=_digest(value.result_digest),
+        outcome="passed",
+    )
+
+
+def _run_probe(
+    runner: Callable[[VerificationProbe, VerificationProbeContext], VerificationProbeTerminal],
+    probe: VerificationProbe,
+    context: VerificationProbeContext,
+) -> VerificationProbeTerminal:
+    try:
+        return _terminal(runner(probe, context), probe=probe)
+    except ConsolidationVerificationUnavailable:
+        raise
+    except Exception:  # noqa: BLE001 - never disclose probe failure details
+        _fail()

--- a/src/exomem/governance/consolidation_verification_coordinator.py
+++ b/src/exomem/governance/consolidation_verification_coordinator.py
@@ -1,0 +1,767 @@
+"""Receipt-first coordinator for plan-bound in-process verification."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NoReturn
+
+from . import (
+    consolidation_admission,
+    consolidation_authority,
+    consolidation_effect_coordinator,
+    consolidation_fingerprints,
+    consolidation_plan,
+    consolidation_plan_store,
+    consolidation_rebuild,
+    consolidation_rebuild_journal,
+    consolidation_receipts,
+    consolidation_seal,
+    consolidation_verification,
+    consolidation_verification_journal,
+)
+
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_UUID4 = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z")
+_ENTRY_PHASES = frozenset({"verifying", "verified"})
+_PROBE_PRIOR_SCHEMA = "exomem.consolidation-probe-prior/v1"
+_PROBE_PRIOR_DOMAIN = _PROBE_PRIOR_SCHEMA.encode("ascii")
+_VERIFIED_PRIOR_SCHEMA = "exomem.consolidation-in-process-verified-prior/v1"
+_VERIFIED_PRIOR_DOMAIN = _VERIFIED_PRIOR_SCHEMA.encode("ascii")
+_VERIFICATION_RESULT_SCHEMA = "exomem.consolidation-verification-result/v1"
+_VERIFICATION_RESULT_DOMAIN = _VERIFICATION_RESULT_SCHEMA.encode("ascii")
+
+__all__ = [
+    "ConsolidationVerificationCoordinatorResult",
+    "ConsolidationVerificationCoordinatorUnavailable",
+    "verify_rebuilt_destination",
+]
+
+
+class ConsolidationVerificationCoordinatorUnavailable(RuntimeError):
+    """Content-free refusal for incomplete, changed, or failed verification."""
+
+    code = "CONSOLIDATION_VERIFICATION_COORDINATOR_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationVerificationCoordinatorResult:
+    verification_basis_digest: str
+    verification_result_digest: str
+    completed_probe_ids: tuple[str, ...]
+    probe_effects: tuple[consolidation_effect_coordinator.EffectExecutionResult, ...]
+    verification_effect: consolidation_effect_coordinator.EffectExecutionResult
+    verification_journal: consolidation_verification_journal.ConsolidationVerificationJournalState
+    seal_state: consolidation_seal.ConsolidationSealState
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationVerificationCoordinatorUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if type(value) is not str or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _uuid4(value: object) -> str:
+    if type(value) is not str or _UUID4.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _timestamp(value: object) -> str:
+    try:
+        checked, _parsed = consolidation_plan._timestamp(value)  # noqa: SLF001
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    return checked
+
+
+def _framed_digest(domain: bytes, value: object) -> str:
+    try:
+        encoded = consolidation_plan.canonical_closed_jcs(value)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    framed = len(domain).to_bytes(4, "big") + domain + len(encoded).to_bytes(8, "big") + encoded
+    return hashlib.sha256(framed).hexdigest()
+
+
+def _snapshot_census(vault_root: Path) -> str:
+    now = int(time.time())
+    if now < 0:
+        _fail()
+    return _digest(
+        consolidation_fingerprints.load_local_destination_snapshot(
+            vault_root,
+            now=now,
+        ).canonical_census_digest
+    )
+
+
+def _crash_point(_point: str) -> None:
+    """Narrow seam after durable verification and before phase advance."""
+
+
+def _canonical_surface_probe_runner(
+    _probe: consolidation_verification.VerificationProbe,
+    _context: consolidation_verification.VerificationProbeContext,
+) -> consolidation_verification.VerificationProbeTerminal:
+    """Closed adapter seam; unavailable until the canonical registry is installed."""
+
+    _fail()
+
+
+def _require_seal(
+    state: consolidation_seal.ConsolidationSealState,
+    *,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+) -> consolidation_seal.ConsolidationSealState:
+    if (
+        not isinstance(state, consolidation_seal.ConsolidationSealState)
+        or state.kind != "consolidation-sealed"
+        or state.phase not in _ENTRY_PHASES
+        or state.vault_binding_digest != vault_binding_digest
+        or state.run_id != run_id
+        or state.operation_id != operation_id
+        or state.journal_digest != journal_digest
+    ):
+        _fail()
+    return state
+
+
+def _advance_to_verified(
+    *,
+    admission: consolidation_admission.ConsolidationAdmission,
+    vault_root: Path,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+    recorded_at: str,
+) -> consolidation_seal.ConsolidationSealState:
+    current = _require_seal(
+        admission.reload().state,
+        vault_binding_digest=vault_binding_digest,
+        run_id=run_id,
+        operation_id=operation_id,
+        journal_digest=journal_digest,
+    )
+    if current.phase == "verified":
+        if current.recorded_at != recorded_at:
+            _fail()
+        return current
+    authority = consolidation_authority.issue_authority(
+        vault_binding_digest=vault_binding_digest,
+        run_id=run_id,
+        operation_id=operation_id,
+        journal_digest=journal_digest,
+        phase="verifying",
+        action="apply",
+    )
+    return consolidation_seal.ConsolidationSealStore(vault_root).advance_consolidation(
+        authority,
+        vault_binding_digest=vault_binding_digest,
+        action="apply",
+        target_phase="verified",
+        recorded_at=recorded_at,
+        expected_revision=current.revision,
+    )
+
+
+def _plan_verification(
+    value: object,
+) -> tuple[str, str]:
+    if not isinstance(value, Mapping) or frozenset(value) != {
+        "schema",
+        "positive_probe_digest",
+        "negative_probe_digest",
+    }:
+        _fail()
+    if value["schema"] != "exomem.consolidation-verification-plan/v1":
+        _fail()
+    return _digest(value["positive_probe_digest"]), _digest(value["negative_probe_digest"])
+
+
+def _last_rebuild_receipt(
+    vault_root: Path,
+    state: consolidation_rebuild_journal.ConsolidationRebuildJournalState,
+) -> tuple[int, str, str]:
+    if len(state.components) != len(consolidation_rebuild.DERIVATIVE_COMPONENTS) or any(
+        entry.status != "final" for entry in state.components
+    ):
+        _fail()
+    last = state.components[-1]
+    if last.terminal_event_id is None or last.terminal_payload_digest is None:
+        _fail()
+    try:
+        matching = [
+            record
+            for record in consolidation_receipts._active_records(vault_root)  # noqa: SLF001
+            if record.get("event_type") == "consolidation"
+            and record.get("phase") == "committed"
+            and record.get("event_id") == last.terminal_event_id
+        ]
+        if len(matching) != 1:
+            _fail()
+        nested = consolidation_receipts.validate_nested(
+            matching[0].get("consolidation_event"),
+            outer_phase="committed",
+        )
+    except consolidation_receipts.ConsolidationReceiptUnavailable:
+        _fail()
+    effect_ordinal = nested.get("effect_ordinal")
+    if (
+        nested.get("kind") != "rebuild-kind"
+        or nested.get("rebuild_ordinal") != len(consolidation_rebuild.DERIVATIVE_COMPONENTS) - 1
+        or nested.get("payload_digest") != last.terminal_payload_digest
+        or type(effect_ordinal) is not int
+        or effect_ordinal < 0
+    ):
+        _fail()
+    return effect_ordinal, last.terminal_event_id, last.terminal_payload_digest
+
+
+def _probe_prior_digest(
+    state: consolidation_verification_journal.ConsolidationVerificationJournalState,
+    probe: consolidation_verification.VerificationProbe,
+) -> str:
+    return _framed_digest(
+        _PROBE_PRIOR_DOMAIN,
+        {
+            "schema": _PROBE_PRIOR_SCHEMA,
+            "verification_basis_digest": state.binding_digest,
+            "probe_ordinal": probe.ordinal,
+            "probe_digest": probe.probe_digest,
+        },
+    )
+
+
+def _probe_event(
+    *,
+    state: consolidation_verification_journal.ConsolidationVerificationJournalState,
+    probe: consolidation_verification.VerificationProbe,
+    parent_event_id: str,
+    parent_payload_digest: str,
+) -> consolidation_receipts.ConsolidationEvent:
+    return consolidation_receipts.build_intent(
+        kind="in-process-probe",
+        run_id=state.run_id,
+        operation_id=state.operation_id,
+        phase="verifying",
+        effect_ordinal=state.last_rebuild_effect_ordinal + 1 + probe.ordinal,
+        probe_ordinal=probe.ordinal,
+        request_digest=state.request_digest,
+        prior_digest=_probe_prior_digest(state, probe),
+        target_digest=probe.expected_result_digest,
+        evidence=consolidation_receipts.build_evidence(
+            kind="in-process-probe",
+            digests={
+                "probe_digest": probe.probe_digest,
+                "probe_result_digest": probe.expected_result_digest,
+                "verification_basis_digest": state.binding_digest,
+            },
+        ),
+        semantic_parent_event_id=parent_event_id,
+        semantic_parent_payload_digest=parent_payload_digest,
+    )
+
+
+def _validate_existing_probe_effect(
+    *,
+    entry: consolidation_verification_journal.ConsolidationVerificationJournalEntry,
+    event: consolidation_receipts.ConsolidationEvent,
+    store: consolidation_effect_coordinator.ConsolidationEffectJournalStore,
+) -> None:
+    current = store.load_optional()
+    if entry.status == "prior":
+        if current is None:
+            return
+        if (
+            current.status != "prepared"
+            or current.kind != "in-process-probe"
+            or current.intent.event_id != event.event_id
+            or current.intent.payload_digest != event.payload_digest
+            or dict(current.intent_payload) != dict(event.payload)
+        ):
+            _fail()
+        return
+    if current is None or (
+        current.kind != "in-process-probe"
+        or current.intent.event_id != event.event_id
+        or current.intent.payload_digest != event.payload_digest
+        or dict(current.intent_payload) != dict(event.payload)
+    ):
+        _fail()
+    if entry.status == "result":
+        if current.status not in {"prepared", "final"}:
+            _fail()
+        if current.status == "final" and (
+            current.terminal is None
+            or current.terminal.event_id.rpartition(":")[2] != "committed"
+            or current.observed_state != "target"
+            or current.observed_digest != entry.result_digest
+        ):
+            _fail()
+        return
+    if (
+        entry.status != "final"
+        or current.status != "final"
+        or current.terminal is None
+        or current.observed_state != "target"
+        or current.observed_digest != entry.result_digest
+        or current.terminal.event_id != entry.terminal_event_id
+        or current.terminal.payload_digest != entry.terminal_payload_digest
+        or current.state_digest != entry.effect_journal_digest
+    ):
+        _fail()
+
+
+def _execute_probes(
+    *,
+    vault_root: Path,
+    store: consolidation_verification_journal.ConsolidationVerificationJournalStore,
+    authority: object,
+    timestamp: str,
+) -> tuple[consolidation_effect_coordinator.EffectExecutionResult, ...]:
+    effects: list[consolidation_effect_coordinator.EffectExecutionResult] = []
+    initial = store.load()
+    for probe in (entry.probe for entry in initial.probes):
+        state = store.load()
+        if probe.ordinal == 0:
+            parent_event_id = state.last_rebuild_terminal_event_id
+            parent_payload_digest = state.last_rebuild_terminal_payload_digest
+        else:
+            parent = state.probes[probe.ordinal - 1]
+            if (
+                parent.status != "final"
+                or parent.terminal_event_id is None
+                or parent.terminal_payload_digest is None
+            ):
+                _fail()
+            parent_event_id = parent.terminal_event_id
+            parent_payload_digest = parent.terminal_payload_digest
+        event = _probe_event(
+            state=state,
+            probe=probe,
+            parent_event_id=parent_event_id,
+            parent_payload_digest=parent_payload_digest,
+        )
+        effect_store = consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+            vault_root,
+            run_id=state.run_id,
+            effect_ordinal=state.last_rebuild_effect_ordinal + 1 + probe.ordinal,
+        )
+        entry = state.probes[probe.ordinal]
+        _validate_existing_probe_effect(entry=entry, event=event, store=effect_store)
+        prior_digest = _probe_prior_digest(state, probe)
+
+        def classify(
+            *,
+            expected_probe: consolidation_verification.VerificationProbe = probe,
+            expected_prior_digest: str = prior_digest,
+        ) -> consolidation_effect_coordinator.EffectObservation:
+            current = store.load().probes[expected_probe.ordinal]
+            if current.probe != expected_probe:
+                _fail()
+            if current.status == "prior":
+                return consolidation_effect_coordinator.EffectObservation(
+                    state="prior",
+                    digest=expected_prior_digest,
+                )
+            if current.status not in {"result", "final"}:
+                _fail()
+            return consolidation_effect_coordinator.EffectObservation(
+                state="target",
+                digest=_digest(current.result_digest),
+            )
+
+        def apply(
+            *,
+            expected_probe: consolidation_verification.VerificationProbe = probe,
+        ) -> None:
+            current = store.load()
+            context = consolidation_verification.VerificationProbeContext(
+                vault_root=vault_root,
+                canonical_census_digest=current.canonical_census_digest,
+                verification_basis_digest=current.binding_digest,
+                authority=authority,
+            )
+            terminal = consolidation_verification._run_probe(  # noqa: SLF001
+                _canonical_surface_probe_runner,
+                expected_probe,
+                context,
+            )
+            if _snapshot_census(vault_root) != current.canonical_census_digest:
+                _fail()
+            store.record_probe_result(expected_probe, terminal.result_digest)
+
+        effect = consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=vault_root,
+            event=event,
+            journal=effect_store,
+            classify=classify,
+            apply_effect=apply,
+            timestamp=timestamp,
+        )
+        if (
+            effect.role != "committed"
+            or effect.observed_state != "target"
+            or effect.observed_digest != probe.expected_result_digest
+        ):
+            _fail()
+        store.finalize_probe(
+            probe,
+            effect.observed_digest,
+            terminal_event_id=effect.terminal.event_id,
+            terminal_payload_digest=effect.terminal.payload_digest,
+            effect_journal_digest=effect.journal_digest,
+        )
+        effects.append(effect)
+    return tuple(effects)
+
+
+def _verification_result_digest(
+    state: consolidation_verification_journal.ConsolidationVerificationJournalState,
+) -> str:
+    if any(entry.status != "final" for entry in state.probes):
+        _fail()
+    return _framed_digest(
+        _VERIFICATION_RESULT_DOMAIN,
+        {
+            "schema": _VERIFICATION_RESULT_SCHEMA,
+            "verification_basis_digest": state.binding_digest,
+            "probes": tuple(
+                {
+                    "probe_ordinal": entry.probe.ordinal,
+                    "probe_digest": entry.probe.probe_digest,
+                    "result_digest": _digest(entry.result_digest),
+                    "terminal_event_id": entry.terminal_event_id,
+                    "terminal_payload_digest": entry.terminal_payload_digest,
+                    "effect_journal_digest": entry.effect_journal_digest,
+                }
+                for entry in state.probes
+            ),
+        },
+    )
+
+
+def _verified_event(
+    state: consolidation_verification_journal.ConsolidationVerificationJournalState,
+    *,
+    result_digest: str,
+) -> consolidation_receipts.ConsolidationEvent:
+    parent = state.probes[-1]
+    if (
+        parent.status != "final"
+        or parent.terminal_event_id is None
+        or parent.terminal_payload_digest is None
+    ):
+        _fail()
+    prior = _framed_digest(
+        _VERIFIED_PRIOR_DOMAIN,
+        {
+            "schema": _VERIFIED_PRIOR_SCHEMA,
+            "verification_basis_digest": state.binding_digest,
+        },
+    )
+    return consolidation_receipts.build_intent(
+        kind="in-process-verified",
+        run_id=state.run_id,
+        operation_id=state.operation_id,
+        phase="verifying",
+        effect_ordinal=state.last_rebuild_effect_ordinal + len(state.probes) + 1,
+        request_digest=state.request_digest,
+        prior_digest=prior,
+        target_digest=result_digest,
+        evidence=consolidation_receipts.build_evidence(
+            kind="in-process-verified",
+            digests={
+                "verification_basis_digest": state.binding_digest,
+                "verification_result_digest": result_digest,
+            },
+        ),
+        semantic_parent_event_id=parent.terminal_event_id,
+        semantic_parent_payload_digest=parent.terminal_payload_digest,
+    )
+
+
+def _execute_verified_terminal(
+    *,
+    vault_root: Path,
+    store: consolidation_verification_journal.ConsolidationVerificationJournalStore,
+    timestamp: str,
+) -> consolidation_effect_coordinator.EffectExecutionResult:
+    state = store.load()
+    result_digest = _verification_result_digest(state)
+    event = _verified_event(state, result_digest=result_digest)
+    effect_store = consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+        vault_root,
+        run_id=state.run_id,
+        effect_ordinal=state.last_rebuild_effect_ordinal + len(state.probes) + 1,
+    )
+    current_effect = effect_store.load_optional()
+    terminal = state.terminal
+    if terminal.status == "prior":
+        if current_effect is None:
+            pass
+        elif (
+            current_effect.status != "prepared"
+            or current_effect.kind != "in-process-verified"
+            or current_effect.intent.event_id != event.event_id
+            or current_effect.intent.payload_digest != event.payload_digest
+            or dict(current_effect.intent_payload) != dict(event.payload)
+        ):
+            _fail()
+    elif current_effect is None or (
+        current_effect.kind != "in-process-verified"
+        or current_effect.intent.event_id != event.event_id
+        or current_effect.intent.payload_digest != event.payload_digest
+        or dict(current_effect.intent_payload) != dict(event.payload)
+    ):
+        _fail()
+    elif terminal.status == "result":
+        if current_effect.status not in {"prepared", "final"}:
+            _fail()
+    elif (
+        terminal.status != "final"
+        or current_effect.status != "final"
+        or current_effect.terminal is None
+        or current_effect.observed_digest != terminal.result_digest
+        or current_effect.terminal.event_id != terminal.terminal_event_id
+        or current_effect.terminal.payload_digest != terminal.terminal_payload_digest
+        or current_effect.state_digest != terminal.effect_journal_digest
+    ):
+        _fail()
+    prior_digest = _framed_digest(
+        _VERIFIED_PRIOR_DOMAIN,
+        {
+            "schema": _VERIFIED_PRIOR_SCHEMA,
+            "verification_basis_digest": state.binding_digest,
+        },
+    )
+
+    def classify() -> consolidation_effect_coordinator.EffectObservation:
+        current = store.load().terminal
+        if current.status == "prior":
+            return consolidation_effect_coordinator.EffectObservation(
+                state="prior",
+                digest=prior_digest,
+            )
+        if current.status not in {"result", "final"}:
+            _fail()
+        return consolidation_effect_coordinator.EffectObservation(
+            state="target",
+            digest=_digest(current.result_digest),
+        )
+
+    effect = consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+        vault_root=vault_root,
+        event=event,
+        journal=effect_store,
+        classify=classify,
+        apply_effect=lambda: store.record_terminal_result(result_digest),
+        timestamp=timestamp,
+    )
+    if (
+        effect.role != "committed"
+        or effect.observed_state != "target"
+        or effect.observed_digest != result_digest
+    ):
+        _fail()
+    store.finalize_terminal(
+        result_digest,
+        terminal_event_id=effect.terminal.event_id,
+        terminal_payload_digest=effect.terminal.payload_digest,
+        effect_journal_digest=effect.journal_digest,
+    )
+    return effect
+
+
+def verify_rebuilt_destination(
+    *,
+    vault_root: Path | str,
+    admission: consolidation_admission.ConsolidationAdmission,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+    request_digest: str,
+    plan_digest: str,
+    verification_plan: consolidation_verification.VerificationPlan,
+    verified_at: str,
+) -> ConsolidationVerificationCoordinatorResult:
+    """Run exact in-process probes and advance only a proven result to verified."""
+
+    root = Path(vault_root).absolute()
+    checked_vault = _digest(vault_binding_digest)
+    checked_run = _uuid4(run_id)
+    checked_operation = _uuid4(operation_id)
+    checked_journal = _digest(journal_digest)
+    checked_request = _digest(request_digest)
+    checked_plan_digest = _digest(plan_digest)
+    checked_time = _timestamp(verified_at)
+    checked_plan = consolidation_verification._checked_plan(verification_plan)  # noqa: SLF001
+    if (
+        not isinstance(admission, consolidation_admission.ConsolidationAdmission)
+        or admission.vault_root != root
+        or admission.vault_binding_digest != checked_vault
+    ):
+        _fail()
+    try:
+        stored = consolidation_plan_store.ConsolidationPlanStore(root).load(
+            checked_run,
+            plan_kind="cutover",
+            plan_digest=checked_plan_digest,
+        )
+        preimage = stored.preimage
+        if (
+            stored.digest != checked_plan_digest
+            or not isinstance(preimage, Mapping)
+            or preimage.get("run_id") != checked_run
+            or preimage.get("plan_kind") != "cutover"
+        ):
+            _fail()
+        positive_digest, negative_digest = _plan_verification(preimage.get("verification_plan"))
+        if (
+            positive_digest != checked_plan.positive_probe_digest
+            or negative_digest != checked_plan.negative_probe_digest
+        ):
+            _fail()
+        current_seal = _require_seal(
+            admission.reload().state,
+            vault_binding_digest=checked_vault,
+            run_id=checked_run,
+            operation_id=checked_operation,
+            journal_digest=checked_journal,
+        )
+        if current_seal.phase == "verified":
+            if current_seal.recorded_at != checked_time:
+                _fail()
+        elif current_seal.recorded_at >= checked_time:
+            _fail()
+        rebuild = consolidation_rebuild_journal.ConsolidationRebuildJournalStore(
+            root,
+            run_id=checked_run,
+        ).load()
+        if (
+            rebuild.operation_id != checked_operation
+            or rebuild.request_digest != checked_request
+            or rebuild.plan_digest != checked_plan_digest
+            or _snapshot_census(root) != rebuild.canonical_census_digest
+        ):
+            _fail()
+        last_ordinal, last_event_id, last_payload_digest = _last_rebuild_receipt(
+            root,
+            rebuild,
+        )
+        journal_store = consolidation_verification_journal.ConsolidationVerificationJournalStore(
+            root,
+            run_id=checked_run,
+        )
+        if current_seal.phase == "verifying":
+            state = journal_store.create(
+                operation_id=checked_operation,
+                request_digest=checked_request,
+                plan_digest=checked_plan_digest,
+                rebuild_journal_digest=rebuild.state_digest,
+                canonical_census_digest=rebuild.canonical_census_digest,
+                verification_plan=checked_plan,
+                last_rebuild_terminal_event_id=last_event_id,
+                last_rebuild_terminal_payload_digest=last_payload_digest,
+                last_rebuild_effect_ordinal=last_ordinal,
+            )
+        else:
+            state = journal_store.load()
+        if (
+            state.operation_id != checked_operation
+            or state.request_digest != checked_request
+            or state.plan_digest != checked_plan_digest
+            or state.rebuild_journal_digest != rebuild.state_digest
+            or state.canonical_census_digest != rebuild.canonical_census_digest
+            or state.positive_probe_digest != checked_plan.positive_probe_digest
+            or state.negative_probe_digest != checked_plan.negative_probe_digest
+            or tuple(entry.probe for entry in state.probes) != checked_plan.probes
+            or state.last_rebuild_terminal_event_id != last_event_id
+            or state.last_rebuild_terminal_payload_digest != last_payload_digest
+            or state.last_rebuild_effect_ordinal != last_ordinal
+        ):
+            _fail()
+        authority = consolidation_authority.issue_authority(
+            vault_binding_digest=checked_vault,
+            run_id=checked_run,
+            operation_id=checked_operation,
+            journal_digest=checked_journal,
+            phase="verifying",
+            action="verify",
+        )
+        probe_effects = _execute_probes(
+            vault_root=root,
+            store=journal_store,
+            authority=authority,
+            timestamp=checked_time,
+        )
+        verification_effect = _execute_verified_terminal(
+            vault_root=root,
+            store=journal_store,
+            timestamp=checked_time,
+        )
+        final_state = journal_store.load()
+        result_digest = _verification_result_digest(final_state)
+        if (
+            len(probe_effects) != len(checked_plan.probes)
+            or final_state.terminal.status != "final"
+            or final_state.terminal.result_digest != result_digest
+            or _snapshot_census(root) != final_state.canonical_census_digest
+        ):
+            _fail()
+        _crash_point("before-verified")
+        seal_state = _advance_to_verified(
+            admission=admission,
+            vault_root=root,
+            vault_binding_digest=checked_vault,
+            run_id=checked_run,
+            operation_id=checked_operation,
+            journal_digest=checked_journal,
+            recorded_at=checked_time,
+        )
+        return ConsolidationVerificationCoordinatorResult(
+            verification_basis_digest=final_state.binding_digest,
+            verification_result_digest=result_digest,
+            completed_probe_ids=tuple(entry.probe.probe_id for entry in final_state.probes),
+            probe_effects=probe_effects,
+            verification_effect=verification_effect,
+            verification_journal=final_state,
+            seal_state=seal_state,
+        )
+    except ConsolidationVerificationCoordinatorUnavailable:
+        raise
+    except (
+        consolidation_admission.ConsolidationAdmissionUnavailable,
+        consolidation_authority.ConsolidationAuthorityUnavailable,
+        consolidation_effect_coordinator.ConsolidationEffectUnavailable,
+        consolidation_fingerprints.ConsolidationFingerprintUnavailable,
+        consolidation_plan.ConsolidationPlanUnavailable,
+        consolidation_plan_store.ConsolidationPlanStoreUnavailable,
+        consolidation_rebuild_journal.ConsolidationRebuildJournalUnavailable,
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        consolidation_seal.ConsolidationSealUnavailable,
+        consolidation_verification.ConsolidationVerificationUnavailable,
+        consolidation_verification_journal.ConsolidationVerificationJournalUnavailable,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ):
+        _fail()

--- a/src/exomem/governance/consolidation_verification_journal.py
+++ b/src/exomem/governance/consolidation_verification_journal.py
@@ -1,0 +1,761 @@
+"""Owner-only exact-state journal for consolidation verification probes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Literal, NoReturn
+
+from .. import reserved_paths
+from ..kbdir import kb_dirname
+from . import consolidation_plan, consolidation_verification
+
+JOURNAL_SCHEMA = "exomem.consolidation-verification-journal/v1"
+
+_DESCRIPTOR_ID = "consolidation-tree"
+_OWNER = "consolidation.run"
+_BINDING_SCHEMA = "exomem.consolidation-verification-basis/v1"
+_BINDING_DOMAIN = _BINDING_SCHEMA.encode("ascii")
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_EVENT_ID = re.compile(r"[0-9a-f]{64}:committed\Z")
+_UUID4 = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z")
+_MAX_JOURNAL_BYTES = 2 * 1024 * 1024
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_STATUSES = frozenset({"prior", "result", "final"})
+_PROBE_BASE_FIELDS = frozenset(
+    {
+        "schema",
+        "ordinal",
+        "probe_kind",
+        "probe_id",
+        "executor_id",
+        "contract_digest",
+        "expected_result_digest",
+        "probe_digest",
+        "status",
+    }
+)
+_PROBE_RESULT_FIELDS = _PROBE_BASE_FIELDS | frozenset({"result_digest"})
+_PROBE_FINAL_FIELDS = _PROBE_RESULT_FIELDS | frozenset(
+    {"terminal_event_id", "terminal_payload_digest", "effect_journal_digest"}
+)
+_TERMINAL_BASE_FIELDS = frozenset({"status"})
+_TERMINAL_RESULT_FIELDS = _TERMINAL_BASE_FIELDS | frozenset({"result_digest"})
+_TERMINAL_FINAL_FIELDS = _TERMINAL_RESULT_FIELDS | frozenset(
+    {"terminal_event_id", "terminal_payload_digest", "effect_journal_digest"}
+)
+_BASIS_FIELDS = frozenset(
+    {
+        "run_id",
+        "operation_id",
+        "request_digest",
+        "plan_digest",
+        "rebuild_journal_digest",
+        "canonical_census_digest",
+        "positive_probe_digest",
+        "negative_probe_digest",
+        "last_rebuild_terminal_event_id",
+        "last_rebuild_terminal_payload_digest",
+        "last_rebuild_effect_ordinal",
+        "probes",
+    }
+)
+_RECORD_FIELDS = _BASIS_FIELDS | frozenset({"schema", "binding_digest", "revision", "terminal"})
+
+__all__ = [
+    "JOURNAL_SCHEMA",
+    "ConsolidationVerificationJournalEntry",
+    "ConsolidationVerificationJournalState",
+    "ConsolidationVerificationJournalStore",
+    "ConsolidationVerificationJournalTerminal",
+    "ConsolidationVerificationJournalUnavailable",
+]
+
+
+class ConsolidationVerificationJournalUnavailable(RuntimeError):
+    """Content-free refusal for a missing, changed, or corrupt journal."""
+
+    code = "CONSOLIDATION_VERIFICATION_JOURNAL_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationVerificationJournalEntry:
+    probe: consolidation_verification.VerificationProbe
+    status: Literal["prior", "result", "final"]
+    result_digest: str | None
+    terminal_event_id: str | None
+    terminal_payload_digest: str | None
+    effect_journal_digest: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationVerificationJournalTerminal:
+    status: Literal["prior", "result", "final"]
+    result_digest: str | None
+    terminal_event_id: str | None
+    terminal_payload_digest: str | None
+    effect_journal_digest: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationVerificationJournalState:
+    schema: str
+    run_id: str
+    operation_id: str
+    request_digest: str
+    plan_digest: str
+    rebuild_journal_digest: str
+    canonical_census_digest: str
+    positive_probe_digest: str
+    negative_probe_digest: str
+    last_rebuild_terminal_event_id: str
+    last_rebuild_terminal_payload_digest: str
+    last_rebuild_effect_ordinal: int
+    binding_digest: str
+    revision: int
+    probes: tuple[ConsolidationVerificationJournalEntry, ...]
+    terminal: ConsolidationVerificationJournalTerminal
+    state_digest: str
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationVerificationJournalUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if type(value) is not str or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _event_id(value: object) -> str:
+    if type(value) is not str or _EVENT_ID.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _uuid4(value: object) -> str:
+    if type(value) is not str or _UUID4.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _integer(value: object, *, minimum: int = 0) -> int:
+    if type(value) is not int or not minimum <= value <= _MAX_SAFE_INTEGER:
+        _fail()
+    return value
+
+
+def _mapping(value: object, fields: frozenset[str]) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or frozenset(value) != fields:
+        _fail()
+    return value
+
+
+def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            _fail()
+        result[key] = value
+    return result
+
+
+def _reject_number(_value: str) -> NoReturn:
+    _fail()
+
+
+def _parse_integer(value: str) -> int:
+    if value.startswith("-"):
+        _fail()
+    try:
+        return _integer(int(value))
+    except ValueError:
+        _fail()
+
+
+def _decode(raw: bytes) -> Mapping[str, object]:
+    if not isinstance(raw, bytes) or not raw or len(raw) > _MAX_JOURNAL_BYTES:
+        _fail()
+    try:
+        value = json.loads(
+            raw,
+            object_pairs_hook=_pairs,
+            parse_int=_parse_integer,
+            parse_float=_reject_number,
+            parse_constant=_reject_number,
+        )
+    except (
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        ConsolidationVerificationJournalUnavailable,
+    ):
+        _fail()
+    if not isinstance(value, Mapping):
+        _fail()
+    try:
+        canonical = consolidation_plan.canonical_closed_jcs(value)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    if canonical != raw:
+        _fail()
+    return value
+
+
+def _probe_value(entry: ConsolidationVerificationJournalEntry) -> dict[str, object]:
+    probe = entry.probe
+    value: dict[str, object] = {
+        "schema": probe.schema,
+        "ordinal": probe.ordinal,
+        "probe_kind": probe.probe_kind,
+        "probe_id": probe.probe_id,
+        "executor_id": probe.executor_id,
+        "contract_digest": probe.contract_digest,
+        "expected_result_digest": probe.expected_result_digest,
+        "probe_digest": probe.probe_digest,
+        "status": entry.status,
+    }
+    if entry.status in {"result", "final"}:
+        value["result_digest"] = entry.result_digest
+    if entry.status == "final":
+        value.update(
+            terminal_event_id=entry.terminal_event_id,
+            terminal_payload_digest=entry.terminal_payload_digest,
+            effect_journal_digest=entry.effect_journal_digest,
+        )
+    return value
+
+
+def _terminal_value(
+    terminal: ConsolidationVerificationJournalTerminal,
+) -> dict[str, object]:
+    value: dict[str, object] = {"status": terminal.status}
+    if terminal.status in {"result", "final"}:
+        value["result_digest"] = terminal.result_digest
+    if terminal.status == "final":
+        value.update(
+            terminal_event_id=terminal.terminal_event_id,
+            terminal_payload_digest=terminal.terminal_payload_digest,
+            effect_journal_digest=terminal.effect_journal_digest,
+        )
+    return value
+
+
+def _basis_value(state: ConsolidationVerificationJournalState) -> dict[str, object]:
+    return {
+        "run_id": state.run_id,
+        "operation_id": state.operation_id,
+        "request_digest": state.request_digest,
+        "plan_digest": state.plan_digest,
+        "rebuild_journal_digest": state.rebuild_journal_digest,
+        "canonical_census_digest": state.canonical_census_digest,
+        "positive_probe_digest": state.positive_probe_digest,
+        "negative_probe_digest": state.negative_probe_digest,
+        "last_rebuild_terminal_event_id": state.last_rebuild_terminal_event_id,
+        "last_rebuild_terminal_payload_digest": state.last_rebuild_terminal_payload_digest,
+        "last_rebuild_effect_ordinal": state.last_rebuild_effect_ordinal,
+        "probes": tuple(
+            {
+                key: value
+                for key, value in _probe_value(entry).items()
+                if key
+                not in {
+                    "status",
+                    "result_digest",
+                    "terminal_event_id",
+                    "terminal_payload_digest",
+                    "effect_journal_digest",
+                }
+            }
+            for entry in state.probes
+        ),
+    }
+
+
+def _binding_digest(state: ConsolidationVerificationJournalState) -> str:
+    try:
+        raw = consolidation_plan.canonical_closed_jcs(
+            {"schema": _BINDING_SCHEMA, **_basis_value(state)}
+        )
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    framed = (
+        len(_BINDING_DOMAIN).to_bytes(4, "big")
+        + _BINDING_DOMAIN
+        + len(raw).to_bytes(8, "big")
+        + raw
+    )
+    return hashlib.sha256(framed).hexdigest()
+
+
+def _state_value(state: ConsolidationVerificationJournalState) -> dict[str, object]:
+    return {
+        "schema": state.schema,
+        **{key: value for key, value in _basis_value(state).items() if key != "probes"},
+        "binding_digest": state.binding_digest,
+        "revision": state.revision,
+        "probes": tuple(_probe_value(entry) for entry in state.probes),
+        "terminal": _terminal_value(state.terminal),
+    }
+
+
+def _state_bytes(state: ConsolidationVerificationJournalState) -> bytes:
+    try:
+        raw = consolidation_plan.canonical_closed_jcs(_state_value(state))
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    if len(raw) > _MAX_JOURNAL_BYTES:
+        _fail()
+    return raw
+
+
+def _parse_probe(value: object, *, ordinal: int) -> ConsolidationVerificationJournalEntry:
+    if not isinstance(value, Mapping):
+        _fail()
+    status = value.get("status")
+    fields = {
+        "prior": _PROBE_BASE_FIELDS,
+        "result": _PROBE_RESULT_FIELDS,
+        "final": _PROBE_FINAL_FIELDS,
+    }.get(status)
+    if fields is None:
+        _fail()
+    row = _mapping(value, fields)
+    kind = row["probe_kind"]
+    if row["schema"] != consolidation_verification.VERIFICATION_PROBE_SCHEMA or kind not in {
+        "positive",
+        "negative",
+    }:
+        _fail()
+    if _integer(row["ordinal"]) != ordinal:
+        _fail()
+    probe_kind: Literal["positive", "negative"] = "positive" if kind == "positive" else "negative"
+    probe = consolidation_verification._build_probe(  # noqa: SLF001
+        {
+            "probe_id": row["probe_id"],
+            "executor_id": row["executor_id"],
+            "contract_digest": row["contract_digest"],
+            "expected_result_digest": row["expected_result_digest"],
+        },
+        ordinal=ordinal,
+        probe_kind=probe_kind,
+    )
+    if _digest(row["probe_digest"]) != probe.probe_digest:
+        _fail()
+    result_digest = None
+    event_id = None
+    payload_digest = None
+    journal_digest = None
+    if status in {"result", "final"}:
+        result_digest = _digest(row["result_digest"])
+        if result_digest != probe.expected_result_digest:
+            _fail()
+    if status == "final":
+        event_id = _event_id(row["terminal_event_id"])
+        payload_digest = _digest(row["terminal_payload_digest"])
+        journal_digest = _digest(row["effect_journal_digest"])
+    return ConsolidationVerificationJournalEntry(
+        probe=probe,
+        status=status,
+        result_digest=result_digest,
+        terminal_event_id=event_id,
+        terminal_payload_digest=payload_digest,
+        effect_journal_digest=journal_digest,
+    )
+
+
+def _parse_terminal(value: object) -> ConsolidationVerificationJournalTerminal:
+    if not isinstance(value, Mapping):
+        _fail()
+    status = value.get("status")
+    fields = {
+        "prior": _TERMINAL_BASE_FIELDS,
+        "result": _TERMINAL_RESULT_FIELDS,
+        "final": _TERMINAL_FINAL_FIELDS,
+    }.get(status)
+    if fields is None:
+        _fail()
+    row = _mapping(value, fields)
+    result = _digest(row["result_digest"]) if status in {"result", "final"} else None
+    return ConsolidationVerificationJournalTerminal(
+        status=status,
+        result_digest=result,
+        terminal_event_id=_event_id(row["terminal_event_id"]) if status == "final" else None,
+        terminal_payload_digest=(
+            _digest(row["terminal_payload_digest"]) if status == "final" else None
+        ),
+        effect_journal_digest=(
+            _digest(row["effect_journal_digest"]) if status == "final" else None
+        ),
+    )
+
+
+def _parse_state(raw: bytes) -> ConsolidationVerificationJournalState:
+    value = _mapping(_decode(raw), _RECORD_FIELDS)
+    if value["schema"] != JOURNAL_SCHEMA:
+        _fail()
+    rows = value["probes"]
+    if isinstance(rows, (str, bytes)) or not isinstance(rows, Sequence) or not rows:
+        _fail()
+    probes = tuple(_parse_probe(row, ordinal=ordinal) for ordinal, row in enumerate(rows))
+    kinds = tuple(entry.probe.probe_kind for entry in probes)
+    if kinds != tuple(sorted(kinds, key={"positive": 0, "negative": 1}.get)):
+        _fail()
+    if len({entry.probe.probe_id for entry in probes}) != len(probes):
+        _fail()
+    ranks = tuple({"final": 0, "result": 1, "prior": 2}[entry.status] for entry in probes)
+    if tuple(sorted(ranks)) != ranks or ranks.count(1) > 1:
+        _fail()
+    terminal = _parse_terminal(value["terminal"])
+    if terminal.status != "prior" and any(entry.status != "final" for entry in probes):
+        _fail()
+    expected_revision = (
+        1
+        + sum(
+            2 if entry.status == "final" else 1 if entry.status == "result" else 0
+            for entry in probes
+        )
+        + (2 if terminal.status == "final" else 1 if terminal.status == "result" else 0)
+    )
+    state = ConsolidationVerificationJournalState(
+        schema=JOURNAL_SCHEMA,
+        run_id=_uuid4(value["run_id"]),
+        operation_id=_uuid4(value["operation_id"]),
+        request_digest=_digest(value["request_digest"]),
+        plan_digest=_digest(value["plan_digest"]),
+        rebuild_journal_digest=_digest(value["rebuild_journal_digest"]),
+        canonical_census_digest=_digest(value["canonical_census_digest"]),
+        positive_probe_digest=_digest(value["positive_probe_digest"]),
+        negative_probe_digest=_digest(value["negative_probe_digest"]),
+        last_rebuild_terminal_event_id=_event_id(value["last_rebuild_terminal_event_id"]),
+        last_rebuild_terminal_payload_digest=_digest(value["last_rebuild_terminal_payload_digest"]),
+        last_rebuild_effect_ordinal=_integer(value["last_rebuild_effect_ordinal"]),
+        binding_digest=_digest(value["binding_digest"]),
+        revision=_integer(value["revision"], minimum=1),
+        probes=probes,
+        terminal=terminal,
+        state_digest=hashlib.sha256(raw).hexdigest(),
+    )
+    positive = tuple(entry.probe for entry in probes if entry.probe.probe_kind == "positive")
+    negative = tuple(entry.probe for entry in probes if entry.probe.probe_kind == "negative")
+    plan = consolidation_verification.build_verification_plan(
+        positive_probes=tuple(
+            {
+                "probe_id": probe.probe_id,
+                "executor_id": probe.executor_id,
+                "contract_digest": probe.contract_digest,
+                "expected_result_digest": probe.expected_result_digest,
+            }
+            for probe in positive
+        ),
+        negative_probes=tuple(
+            {
+                "probe_id": probe.probe_id,
+                "executor_id": probe.executor_id,
+                "contract_digest": probe.contract_digest,
+                "expected_result_digest": probe.expected_result_digest,
+            }
+            for probe in negative
+        ),
+    )
+    if (
+        tuple(entry.probe for entry in probes) != plan.probes
+        or state.positive_probe_digest != plan.positive_probe_digest
+        or state.negative_probe_digest != plan.negative_probe_digest
+        or state.revision != expected_revision
+        or state.binding_digest != _binding_digest(state)
+    ):
+        _fail()
+    return state
+
+
+@contextmanager
+def _authority(vault_root: Path, *, mutation: bool) -> Iterator[None]:
+    try:
+        with reserved_paths._subsystem_authority_scope(_OWNER):  # noqa: SLF001
+            with reserved_paths._identity_coordination_scope(  # noqa: SLF001
+                vault_root,
+                descriptor_ids=(_DESCRIPTOR_ID,),
+                identity_may_change=mutation,
+            ):
+                yield
+    except ConsolidationVerificationJournalUnavailable:
+        raise
+    except (OSError, RuntimeError, ValueError):
+        _fail()
+
+
+class ConsolidationVerificationJournalStore:
+    """CAS-persist a plan-bound verification matrix and its exact terminals."""
+
+    def __init__(self, vault_root: Path | str, *, run_id: str) -> None:
+        self.vault_root = Path(vault_root).absolute()
+        self.run_id = _uuid4(run_id)
+        self.path = (
+            self.vault_root
+            / kb_dirname()
+            / "_Consolidation"
+            / "runs"
+            / self.run_id
+            / "verification.json"
+        )
+
+    def _read(self) -> bytes:
+        return reserved_paths._read_owner_bytes(  # noqa: SLF001
+            self.vault_root,
+            self.path,
+            _DESCRIPTOR_ID,
+            limit=_MAX_JOURNAL_BYTES,
+        )
+
+    def _read_optional(self) -> bytes | None:
+        try:
+            return self._read()
+        except FileNotFoundError:
+            return None
+
+    def _publish(
+        self,
+        raw: bytes,
+        *,
+        expected_sha256: str | None = None,
+        require_missing: bool = False,
+    ) -> None:
+        reserved_paths._publish_owner_bytes(  # noqa: SLF001
+            self.vault_root,
+            self.path,
+            _DESCRIPTOR_ID,
+            raw,
+            expected_sha256=expected_sha256,
+            require_missing=require_missing,
+        )
+
+    def _load_locked(self) -> tuple[ConsolidationVerificationJournalState, bytes]:
+        try:
+            raw = self._read()
+        except FileNotFoundError:
+            _fail()
+        state = _parse_state(raw)
+        if state.run_id != self.run_id:
+            _fail()
+        return state, raw
+
+    def create(
+        self,
+        *,
+        operation_id: str,
+        request_digest: str,
+        plan_digest: str,
+        rebuild_journal_digest: str,
+        canonical_census_digest: str,
+        verification_plan: consolidation_verification.VerificationPlan,
+        last_rebuild_terminal_event_id: str,
+        last_rebuild_terminal_payload_digest: str,
+        last_rebuild_effect_ordinal: int,
+    ) -> ConsolidationVerificationJournalState:
+        plan = consolidation_verification._checked_plan(verification_plan)  # noqa: SLF001
+        candidate = ConsolidationVerificationJournalState(
+            schema=JOURNAL_SCHEMA,
+            run_id=self.run_id,
+            operation_id=_uuid4(operation_id),
+            request_digest=_digest(request_digest),
+            plan_digest=_digest(plan_digest),
+            rebuild_journal_digest=_digest(rebuild_journal_digest),
+            canonical_census_digest=_digest(canonical_census_digest),
+            positive_probe_digest=plan.positive_probe_digest,
+            negative_probe_digest=plan.negative_probe_digest,
+            last_rebuild_terminal_event_id=_event_id(last_rebuild_terminal_event_id),
+            last_rebuild_terminal_payload_digest=_digest(last_rebuild_terminal_payload_digest),
+            last_rebuild_effect_ordinal=_integer(last_rebuild_effect_ordinal),
+            binding_digest="0" * 64,
+            revision=1,
+            probes=tuple(
+                ConsolidationVerificationJournalEntry(
+                    probe=probe,
+                    status="prior",
+                    result_digest=None,
+                    terminal_event_id=None,
+                    terminal_payload_digest=None,
+                    effect_journal_digest=None,
+                )
+                for probe in plan.probes
+            ),
+            terminal=ConsolidationVerificationJournalTerminal(
+                status="prior",
+                result_digest=None,
+                terminal_event_id=None,
+                terminal_payload_digest=None,
+                effect_journal_digest=None,
+            ),
+            state_digest="0" * 64,
+        )
+        candidate = replace(candidate, binding_digest=_binding_digest(candidate))
+        raw = _state_bytes(candidate)
+        target = replace(candidate, state_digest=hashlib.sha256(raw).hexdigest())
+        with _authority(self.vault_root, mutation=True):
+            existing = self._read_optional()
+            if existing is None:
+                self._publish(raw, require_missing=True)
+                return target
+            current = _parse_state(existing)
+            if current.run_id == self.run_id and _basis_value(current) == _basis_value(target):
+                return current
+            _fail()
+
+    def load(self) -> ConsolidationVerificationJournalState:
+        with _authority(self.vault_root, mutation=False):
+            state, _raw = self._load_locked()
+            return state
+
+    def record_probe_result(
+        self,
+        probe: consolidation_verification.VerificationProbe,
+        result_digest: str,
+    ) -> ConsolidationVerificationJournalState:
+        if type(probe) is not consolidation_verification.VerificationProbe:
+            _fail()
+        result = _digest(result_digest)
+        with _authority(self.vault_root, mutation=True):
+            current, raw = self._load_locked()
+            if not 0 <= probe.ordinal < len(current.probes):
+                _fail()
+            entry = current.probes[probe.ordinal]
+            if entry.probe != probe or result != probe.expected_result_digest:
+                _fail()
+            if entry.status in {"result", "final"}:
+                if entry.result_digest == result:
+                    return current
+                _fail()
+            if entry.status != "prior" or any(
+                prior.status != "final" for prior in current.probes[: probe.ordinal]
+            ):
+                _fail()
+            entries = list(current.probes)
+            entries[probe.ordinal] = replace(
+                entry,
+                status="result",
+                result_digest=result,
+            )
+            return self._replace_locked(current, raw, probes=tuple(entries))
+
+    def finalize_probe(
+        self,
+        probe: consolidation_verification.VerificationProbe,
+        result_digest: str,
+        *,
+        terminal_event_id: str,
+        terminal_payload_digest: str,
+        effect_journal_digest: str,
+    ) -> ConsolidationVerificationJournalState:
+        result = _digest(result_digest)
+        event_id = _event_id(terminal_event_id)
+        payload = _digest(terminal_payload_digest)
+        journal = _digest(effect_journal_digest)
+        with _authority(self.vault_root, mutation=True):
+            current, raw = self._load_locked()
+            if not 0 <= probe.ordinal < len(current.probes):
+                _fail()
+            entry = current.probes[probe.ordinal]
+            if entry.probe != probe:
+                _fail()
+            if entry.status == "final":
+                if (
+                    entry.result_digest == result
+                    and entry.terminal_event_id == event_id
+                    and entry.terminal_payload_digest == payload
+                    and entry.effect_journal_digest == journal
+                ):
+                    return current
+                _fail()
+            if entry.status != "result" or entry.result_digest != result:
+                _fail()
+            entries = list(current.probes)
+            entries[probe.ordinal] = replace(
+                entry,
+                status="final",
+                terminal_event_id=event_id,
+                terminal_payload_digest=payload,
+                effect_journal_digest=journal,
+            )
+            return self._replace_locked(current, raw, probes=tuple(entries))
+
+    def record_terminal_result(self, result_digest: str) -> ConsolidationVerificationJournalState:
+        result = _digest(result_digest)
+        with _authority(self.vault_root, mutation=True):
+            current, raw = self._load_locked()
+            if any(entry.status != "final" for entry in current.probes):
+                _fail()
+            if current.terminal.status in {"result", "final"}:
+                if current.terminal.result_digest == result:
+                    return current
+                _fail()
+            if current.terminal.status != "prior":
+                _fail()
+            terminal = replace(current.terminal, status="result", result_digest=result)
+            return self._replace_locked(current, raw, terminal=terminal)
+
+    def finalize_terminal(
+        self,
+        result_digest: str,
+        *,
+        terminal_event_id: str,
+        terminal_payload_digest: str,
+        effect_journal_digest: str,
+    ) -> ConsolidationVerificationJournalState:
+        result = _digest(result_digest)
+        event_id = _event_id(terminal_event_id)
+        payload = _digest(terminal_payload_digest)
+        journal = _digest(effect_journal_digest)
+        with _authority(self.vault_root, mutation=True):
+            current, raw = self._load_locked()
+            terminal = current.terminal
+            if terminal.status == "final":
+                if (
+                    terminal.result_digest == result
+                    and terminal.terminal_event_id == event_id
+                    and terminal.terminal_payload_digest == payload
+                    and terminal.effect_journal_digest == journal
+                ):
+                    return current
+                _fail()
+            if terminal.status != "result" or terminal.result_digest != result:
+                _fail()
+            return self._replace_locked(
+                current,
+                raw,
+                terminal=replace(
+                    terminal,
+                    status="final",
+                    terminal_event_id=event_id,
+                    terminal_payload_digest=payload,
+                    effect_journal_digest=journal,
+                ),
+            )
+
+    def _replace_locked(
+        self,
+        current: ConsolidationVerificationJournalState,
+        raw: bytes,
+        *,
+        probes: tuple[ConsolidationVerificationJournalEntry, ...] | None = None,
+        terminal: ConsolidationVerificationJournalTerminal | None = None,
+    ) -> ConsolidationVerificationJournalState:
+        candidate = replace(
+            current,
+            revision=current.revision + 1,
+            probes=current.probes if probes is None else probes,
+            terminal=current.terminal if terminal is None else terminal,
+            state_digest="0" * 64,
+        )
+        target_raw = _state_bytes(candidate)
+        target = replace(candidate, state_digest=hashlib.sha256(target_raw).hexdigest())
+        self._publish(target_raw, expected_sha256=hashlib.sha256(raw).hexdigest())
+        return target

--- a/tests/test_consolidation_verification.py
+++ b/tests/test_consolidation_verification.py
@@ -1,0 +1,571 @@
+"""Receipt-first in-process verification after consolidation rebuilds."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from exomem.governance import consolidation_receipts
+
+_tests_package = ModuleType("tests")
+_tests_package.__path__ = [str(Path(__file__).parent)]
+sys.modules.setdefault("tests", _tests_package)
+
+from tests.test_consolidation_content_publication import (  # noqa: E402
+    JOURNAL_DIGEST,
+    OPERATION_ID,
+    PLAN_DIGEST,
+    RUN_ID,
+    VAULT_BINDING,
+)
+from tests.test_consolidation_rebuild_coordinator import (  # noqa: E402
+    POST_PUBLICATION_CENSUS,
+    _published_run,
+    _terminal,
+)
+
+VERIFIED_AT = "2026-08-30T12:00:07.000Z"
+DRIFTED_CENSUS = hashlib.sha256(b"verification-drifted-census").hexdigest()
+
+
+class SimulatedVerificationCrash(BaseException):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _private_writer_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from exomem import writer_lease
+
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR",
+        str(tmp_path / "writer-state"),
+    )
+    writer_lease.reset_managers_for_tests()
+    yield
+    writer_lease.reset_managers_for_tests()
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode()).hexdigest()
+
+
+def _probe(probe_id: str) -> dict[str, str]:
+    return {
+        "probe_id": probe_id,
+        "executor_id": "canonical-governance-surface-v1",
+        "contract_digest": _digest(f"{probe_id}:contract"),
+        "expected_result_digest": _digest(f"{probe_id}:pass"),
+    }
+
+
+def _verification_plan():
+    from exomem.governance import consolidation_verification
+
+    return consolidation_verification.build_verification_plan(
+        positive_probes=(
+            _probe("owner-note-full"),
+            _probe("delegated-approved-projection"),
+        ),
+        negative_probes=(
+            _probe("delegated-private-body-absent-pair"),
+            _probe("wrong-purpose-wire-equivalence"),
+        ),
+    )
+
+
+def _rebuilt_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from exomem.governance import (
+        consolidation_rebuild_coordinator,
+        consolidation_verification_coordinator,
+    )
+
+    vault, arguments, _after = _published_run(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        consolidation_rebuild_coordinator,
+        "_snapshot_census",
+        lambda _root: POST_PUBLICATION_CENSUS,
+    )
+    monkeypatch.setattr(
+        consolidation_rebuild_coordinator,
+        "_component_rebuilder",
+        lambda: _terminal,
+    )
+    rebuilt = consolidation_rebuild_coordinator.rebuild_published_destination(**arguments)
+    assert rebuilt.seal_state.phase == "verifying"
+
+    plan = _verification_plan()
+    stored = SimpleNamespace(
+        digest=PLAN_DIGEST,
+        preimage={
+            "run_id": RUN_ID,
+            "plan_kind": "cutover",
+            "verification_plan": {
+                "schema": "exomem.consolidation-verification-plan/v1",
+                "positive_probe_digest": plan.positive_probe_digest,
+                "negative_probe_digest": plan.negative_probe_digest,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        consolidation_verification_coordinator.consolidation_plan_store.ConsolidationPlanStore,
+        "load",
+        lambda _store, _run_id, *, plan_kind, plan_digest: stored,
+    )
+    monkeypatch.setattr(
+        consolidation_verification_coordinator,
+        "_snapshot_census",
+        lambda _root: POST_PUBLICATION_CENSUS,
+    )
+    verify_arguments = {
+        key: arguments[key]
+        for key in (
+            "vault_root",
+            "admission",
+            "vault_binding_digest",
+            "run_id",
+            "operation_id",
+            "journal_digest",
+            "request_digest",
+            "plan_digest",
+        )
+    }
+    verify_arguments.update(
+        verification_plan=plan,
+        verified_at=VERIFIED_AT,
+    )
+    return vault, verify_arguments, plan
+
+
+def _install_passing_runner(
+    monkeypatch: pytest.MonkeyPatch,
+    calls: list[str],
+) -> None:
+    from exomem.governance import (
+        consolidation_authority,
+        consolidation_verification,
+        consolidation_verification_coordinator,
+    )
+
+    def run(probe, context):
+        consolidation_authority.require_authority(
+            context.authority,
+            vault_binding_digest=VAULT_BINDING,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            phase="verifying",
+            action="verify",
+        )
+        calls.append(probe.probe_id)
+        return consolidation_verification.VerificationProbeTerminal(
+            schema=consolidation_verification.VERIFICATION_PROBE_TERMINAL_SCHEMA,
+            probe_id=probe.probe_id,
+            probe_digest=probe.probe_digest,
+            result_digest=probe.expected_result_digest,
+            outcome="passed",
+        )
+
+    monkeypatch.setattr(
+        consolidation_verification_coordinator,
+        "_canonical_surface_probe_runner",
+        run,
+    )
+
+
+def _verification_records(vault: Path) -> list[dict[str, object]]:
+    return [
+        record
+        for record in consolidation_receipts._active_records(vault)  # noqa: SLF001
+        if record.get("event_type") == "consolidation"
+        and isinstance(record.get("consolidation_event"), dict)
+        and record["consolidation_event"].get("kind") in {"in-process-probe", "in-process-verified"}
+    ]
+
+
+def test_probe_and_matrix_digests_are_fixed_framed_jcs_vectors() -> None:
+    plan = _verification_plan()
+
+    assert plan.positive_probe_digest == (
+        "3270b6c5047a088e38bdbf5e7ebbc4b4c483869a8aa669ea501b4b785bc307df"
+    )
+    assert plan.negative_probe_digest == (
+        "cc9a67cc0748b61a11a6c9073e040dbb817727fbce00cbdf4860d957d8a21efc"
+    )
+    assert tuple(probe.probe_digest for probe in plan.probes) == (
+        "425c0416e0a1efd536e97c0395d6d7b4105b57fcb62d8db2aa4f399eac8ea269",
+        "14bf94b53db7a43ca1f4b35616068ab50bca5a4d7392c77faa19f00b9e990697",
+        "cb7f779b936cba0d1daefdbcc556d04a5bff777b8bc81a834ea766400fc290c8",
+        "5968f29ee48f0e48bf8ec49bf30499a309854ff71b000dc0a98dd5ccef3036a7",
+    )
+
+
+def test_probe_plan_is_bounded_and_requires_the_closed_executor() -> None:
+    from exomem.governance import consolidation_verification
+
+    with pytest.raises(consolidation_verification.ConsolidationVerificationUnavailable):
+        consolidation_verification.build_verification_plan(
+            positive_probes=tuple(_probe(f"positive-{ordinal}") for ordinal in range(1024)),
+            negative_probes=(_probe("one-negative"),),
+        )
+    changed = _probe("changed-executor")
+    changed["executor_id"] = "caller-selected-runner-v1"
+    with pytest.raises(consolidation_verification.ConsolidationVerificationUnavailable):
+        consolidation_verification.build_verification_plan(
+            positive_probes=(changed,),
+            negative_probes=(_probe("one-negative"),),
+        )
+
+
+def test_verification_runs_bound_positive_and_negative_probes_then_advances_seal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_verification_coordinator,
+        consolidation_verification_journal,
+    )
+
+    vault, arguments, plan = _rebuilt_run(tmp_path, monkeypatch)
+    calls: list[str] = []
+    _install_passing_runner(monkeypatch, calls)
+
+    result = consolidation_verification_coordinator.verify_rebuilt_destination(
+        **arguments,
+    )
+
+    expected_ids = tuple(probe.probe_id for probe in plan.probes)
+    assert tuple(calls) == expected_ids
+    assert result.completed_probe_ids == expected_ids
+    assert result.verification_basis_digest == result.verification_journal.binding_digest
+    assert result.seal_state.phase == "verified"
+    assert all(entry.status == "final" for entry in result.verification_journal.probes)
+    assert result.verification_journal.terminal.status == "final"
+    assert (
+        consolidation_verification_journal.ConsolidationVerificationJournalStore(
+            vault,
+            run_id=RUN_ID,
+        ).load()
+        == result.verification_journal
+    )
+
+    records = _verification_records(vault)
+    intents = [
+        consolidation_receipts.validate_nested(record["consolidation_event"], outer_phase="intent")
+        for record in records
+        if record["phase"] == "intent"
+    ]
+    assert [intent["kind"] for intent in intents] == [
+        "in-process-probe",
+        "in-process-probe",
+        "in-process-probe",
+        "in-process-probe",
+        "in-process-verified",
+    ]
+    assert [intent["probe_ordinal"] for intent in intents[:-1]] == [0, 1, 2, 3]
+    assert intents[-1].get("probe_ordinal") is None
+    assert all(
+        later["semantic_parent_event_id"] == previous["event_id"]
+        for previous, later in zip(
+            [record for record in records if record["phase"] == "committed"][:-1],
+            intents[1:],
+            strict=True,
+        )
+    )
+
+
+def test_uninstalled_canonical_probe_registry_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_seal,
+        consolidation_verification_coordinator,
+    )
+
+    vault, arguments, _plan = _rebuilt_run(tmp_path, monkeypatch)
+
+    with pytest.raises(
+        consolidation_verification_coordinator.ConsolidationVerificationCoordinatorUnavailable,
+        match="^CONSOLIDATION_VERIFICATION_COORDINATOR_UNAVAILABLE$",
+    ):
+        consolidation_verification_coordinator.verify_rebuilt_destination(**arguments)
+
+    assert (
+        consolidation_seal.ConsolidationSealStore(vault)
+        .load(vault_binding_digest=VAULT_BINDING)
+        .phase
+        == "verifying"
+    )
+    assert not any(record["phase"] == "committed" for record in _verification_records(vault))
+
+
+def test_tampered_verification_journal_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_plan,
+        consolidation_verification_coordinator,
+        consolidation_verification_journal,
+    )
+
+    vault, arguments, _plan = _rebuilt_run(tmp_path, monkeypatch)
+    _install_passing_runner(monkeypatch, [])
+    consolidation_verification_coordinator.verify_rebuilt_destination(
+        **arguments,
+    )
+    store = consolidation_verification_journal.ConsolidationVerificationJournalStore(
+        vault,
+        run_id=RUN_ID,
+    )
+    value = json.loads(store.path.read_bytes())
+    value["probes"][0]["probe_id"] = "tampered-probe"
+    store.path.write_bytes(consolidation_plan.canonical_closed_jcs(value))
+
+    with pytest.raises(
+        consolidation_verification_journal.ConsolidationVerificationJournalUnavailable,
+        match="^CONSOLIDATION_VERIFICATION_JOURNAL_UNAVAILABLE$",
+    ):
+        store.load()
+
+
+def test_mismatched_probe_result_fails_closed_in_verifying(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_seal,
+        consolidation_verification,
+        consolidation_verification_coordinator,
+    )
+
+    vault, arguments, _plan = _rebuilt_run(tmp_path, monkeypatch)
+
+    def mismatched(probe, _context):
+        return consolidation_verification.VerificationProbeTerminal(
+            schema=consolidation_verification.VERIFICATION_PROBE_TERMINAL_SCHEMA,
+            probe_id=probe.probe_id,
+            probe_digest=probe.probe_digest,
+            result_digest=_digest("unexpected-wire-result"),
+            outcome="passed",
+        )
+
+    monkeypatch.setattr(
+        consolidation_verification_coordinator,
+        "_canonical_surface_probe_runner",
+        mismatched,
+    )
+
+    with pytest.raises(
+        consolidation_verification_coordinator.ConsolidationVerificationCoordinatorUnavailable,
+        match="^CONSOLIDATION_VERIFICATION_COORDINATOR_UNAVAILABLE$",
+    ):
+        consolidation_verification_coordinator.verify_rebuilt_destination(
+            **arguments,
+        )
+
+    assert (
+        consolidation_seal.ConsolidationSealStore(vault)
+        .load(vault_binding_digest=VAULT_BINDING)
+        .phase
+        == "verifying"
+    )
+    assert not any(record["phase"] == "committed" for record in _verification_records(vault))
+
+
+def test_retry_after_probe_result_does_not_rerun_the_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_effect_coordinator,
+        consolidation_verification_coordinator,
+    )
+
+    _vault, arguments, plan = _rebuilt_run(tmp_path, monkeypatch)
+    calls: list[str] = []
+    crashed = False
+    _install_passing_runner(monkeypatch, calls)
+
+    def crash_after_result(point: str) -> None:
+        nonlocal crashed
+        if point == "after-effect" and not crashed:
+            crashed = True
+            raise SimulatedVerificationCrash
+
+    monkeypatch.setattr(
+        consolidation_effect_coordinator,
+        "_crash_point",
+        crash_after_result,
+    )
+    with pytest.raises(SimulatedVerificationCrash):
+        consolidation_verification_coordinator.verify_rebuilt_destination(
+            **arguments,
+        )
+    assert calls == [plan.probes[0].probe_id]
+
+    monkeypatch.setattr(
+        consolidation_effect_coordinator,
+        "_crash_point",
+        lambda _point: None,
+    )
+    result = consolidation_verification_coordinator.verify_rebuilt_destination(
+        **arguments,
+    )
+
+    assert result.seal_state.phase == "verified"
+    assert calls.count(plan.probes[0].probe_id) == 1
+    assert tuple(calls) == tuple(probe.probe_id for probe in plan.probes)
+
+
+def test_retry_after_probe_prepared_runs_the_probe_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_effect_coordinator,
+        consolidation_verification_coordinator,
+    )
+
+    _vault, arguments, plan = _rebuilt_run(tmp_path, monkeypatch)
+    calls: list[str] = []
+    crashed = False
+    _install_passing_runner(monkeypatch, calls)
+
+    def crash_after_prepared(point: str) -> None:
+        nonlocal crashed
+        if point == "after-prepared" and not crashed:
+            crashed = True
+            raise SimulatedVerificationCrash
+
+    monkeypatch.setattr(
+        consolidation_effect_coordinator,
+        "_crash_point",
+        crash_after_prepared,
+    )
+    with pytest.raises(SimulatedVerificationCrash):
+        consolidation_verification_coordinator.verify_rebuilt_destination(
+            **arguments,
+        )
+    assert calls == []
+
+    monkeypatch.setattr(
+        consolidation_effect_coordinator,
+        "_crash_point",
+        lambda _point: None,
+    )
+    result = consolidation_verification_coordinator.verify_rebuilt_destination(
+        **arguments,
+    )
+
+    assert result.seal_state.phase == "verified"
+    assert tuple(calls) == tuple(probe.probe_id for probe in plan.probes)
+
+
+def test_retry_after_verified_terminal_only_advances_the_seal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_verification_coordinator
+
+    _vault, arguments, plan = _rebuilt_run(tmp_path, monkeypatch)
+    calls: list[str] = []
+    _install_passing_runner(monkeypatch, calls)
+
+    def crash(point: str) -> None:
+        if point == "before-verified":
+            raise SimulatedVerificationCrash
+
+    monkeypatch.setattr(consolidation_verification_coordinator, "_crash_point", crash)
+    with pytest.raises(SimulatedVerificationCrash):
+        consolidation_verification_coordinator.verify_rebuilt_destination(
+            **arguments,
+        )
+    assert tuple(calls) == tuple(probe.probe_id for probe in plan.probes)
+
+    monkeypatch.setattr(
+        consolidation_verification_coordinator,
+        "_crash_point",
+        lambda _point: None,
+    )
+    monkeypatch.setattr(
+        consolidation_verification_coordinator,
+        "_canonical_surface_probe_runner",
+        lambda *_args: pytest.fail("final probes must not rerun"),
+    )
+    result = consolidation_verification_coordinator.verify_rebuilt_destination(
+        **arguments,
+    )
+
+    assert result.seal_state.phase == "verified"
+
+
+def test_canonical_census_drift_during_probe_keeps_destination_sealed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_seal,
+        consolidation_verification_coordinator,
+    )
+
+    vault, arguments, _plan = _rebuilt_run(tmp_path, monkeypatch)
+    _install_passing_runner(monkeypatch, [])
+    snapshots = iter((POST_PUBLICATION_CENSUS, DRIFTED_CENSUS))
+    monkeypatch.setattr(
+        consolidation_verification_coordinator,
+        "_snapshot_census",
+        lambda _root: next(snapshots),
+    )
+
+    with pytest.raises(
+        consolidation_verification_coordinator.ConsolidationVerificationCoordinatorUnavailable
+    ):
+        consolidation_verification_coordinator.verify_rebuilt_destination(
+            **arguments,
+        )
+
+    assert (
+        consolidation_seal.ConsolidationSealStore(vault)
+        .load(vault_binding_digest=VAULT_BINDING)
+        .phase
+        == "verifying"
+    )
+
+
+def test_changed_probe_matrix_is_rejected_before_any_probe_runs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_verification,
+        consolidation_verification_coordinator,
+    )
+
+    _vault, arguments, _plan = _rebuilt_run(tmp_path, monkeypatch)
+    arguments["verification_plan"] = consolidation_verification.build_verification_plan(
+        positive_probes=(_probe("changed-owner-probe"),),
+        negative_probes=(_probe("wrong-purpose-wire-equivalence"),),
+    )
+    calls: list[str] = []
+    _install_passing_runner(monkeypatch, calls)
+
+    with pytest.raises(
+        consolidation_verification_coordinator.ConsolidationVerificationCoordinatorUnavailable
+    ):
+        consolidation_verification_coordinator.verify_rebuilt_destination(
+            **arguments,
+        )
+
+    assert calls == []


### PR DESCRIPTION
## Summary\n\n- bind the approved positive and negative probe matrices to fixed executor and contract digests\n- persist probe results and terminal evidence before advancing the consolidation seal\n- replay prepared, result, and final states without rerunning completed probes\n- refuse verification when the canonical surface registry is unavailable, the census changes, or journal evidence does not match\n\nThis is stacked on #1002. It installs the closed verification protocol and crash-safe evidence path. The canonical governance-surface registry is the next stacked slice; until it is installed, production verification deliberately fails closed at the verifying phase.\n\nThis does not read, write, or consolidate a live vault.\n\n## Verification\n\n- focused verification suite: 11 passed\n- affected governance suites: 137 passed\n- independent review: no remaining findings\n- independent verifier: passed focused and affected suites\n- Ruff format and changed-file checks\n- repository Ruff undefined-name check\n- uv lock --check\n- openspec validate --all --strict: 168 passed\n- public artifact validation: 3450 files and 3518 text payloads clean\n- Python compilation and git diff --check