### PR TITLE
feat(governance): execute persisted REST verification contracts

### DIFF
--- a/src/exomem/governance/consolidation_plan_store.py
+++ b/src/exomem/governance/consolidation_plan_store.py
@@ -7,10 +7,13 @@ import re
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import NoReturn
+from typing import TYPE_CHECKING, NoReturn
 
 from .. import reserved_paths
 from . import consolidation_plan, consolidation_policy, consolidation_run_state, policy
+
+if TYPE_CHECKING:
+    from .consolidation_verification_manifest import VerificationManifest
 
 _DESCRIPTOR_ID = "consolidation-tree"
 _OWNER = "consolidation.run"
@@ -21,6 +24,7 @@ _MAX_SAFE_INTEGER = (1 << 53) - 1
 _MAX_PLAN_BYTES = 16 * 1024 * 1024
 _MAX_CONTROL_BYTES = 64 * 1024
 _MAX_POLICY_BUNDLE_BYTES = 16 * 1024 * 1024
+_MAX_VERIFICATION_MANIFEST_BYTES = 16 * 1024 * 1024
 
 
 class ConsolidationPlanStoreUnavailable(RuntimeError):
@@ -159,6 +163,7 @@ class ConsolidationPlanStore:
         plan: consolidation_plan.CanonicalConsolidationPlan,
         *,
         policy_bundle: consolidation_policy.DestinationPolicyPlan | None = None,
+        verification_manifest: VerificationManifest | None = None,
         expected_run_revision: int,
     ) -> consolidation_plan.CanonicalConsolidationPlan:
         """Create or adopt one byte-identical immutable plan."""
@@ -183,12 +188,21 @@ class ConsolidationPlanStore:
         directory = self._plan_dir(run_id, kind, digest)
         control_path = directory / "control-basis.json"
         policy_bundle_path = directory / "policy-bundle.json"
+        verification_manifest_path = directory / "verification-manifest.json"
         plan_path = directory / "plan.json"
 
         policy_bundle_raw: bytes | None = None
+        verification_manifest_raw: bytes | None = None
         if kind == "cutover":
+            from . import consolidation_verification_manifest as verification_manifest_module
+
             if not isinstance(policy_bundle, consolidation_policy.DestinationPolicyPlan):
                 _fail("PLAN_POLICY_BUNDLE_REQUIRED")
+            if not isinstance(
+                verification_manifest,
+                verification_manifest_module.VerificationManifest,
+            ):
+                _fail("PLAN_VERIFICATION_MANIFEST_REQUIRED")
             try:
                 policy_bundle_raw = consolidation_policy.canonical_destination_policy_bundle(
                     policy_bundle
@@ -198,9 +212,24 @@ class ConsolidationPlanStore:
                     != policy_bundle
                 ):
                     _fail("PLAN_STORE_INPUT_INVALID")
-            except consolidation_policy.DestinationPolicyUnavailable:
+                verification_manifest_module._bind_to_stored_plan(  # noqa: SLF001
+                    run_id=run_id,
+                    plan_digest=digest,
+                    plan=plan,
+                    bundle=policy_bundle,
+                    manifest=verification_manifest,
+                )
+                verification_manifest_raw = (
+                    verification_manifest_module.canonical_verification_manifest(
+                        verification_manifest
+                    )
+                )
+            except (
+                consolidation_policy.DestinationPolicyUnavailable,
+                verification_manifest_module.ConsolidationVerificationManifestUnavailable,
+            ):
                 _fail("PLAN_STORE_INPUT_INVALID")
-        elif policy_bundle is not None:
+        elif policy_bundle is not None or verification_manifest is not None:
             _fail("PLAN_STORE_INPUT_INVALID")
 
         with _authority(self.vault_root, mutation=True):
@@ -218,14 +247,27 @@ class ConsolidationPlanStore:
                 policy_bundle_path,
                 limit=_MAX_POLICY_BUNDLE_BYTES,
             )
+            existing_verification_manifest = self._read_optional(
+                verification_manifest_path,
+                limit=_MAX_VERIFICATION_MANIFEST_BYTES,
+            )
             existing_plan = self._read_optional(plan_path, limit=_MAX_PLAN_BYTES)
             if existing_control is None and (
-                existing_policy_bundle is not None or existing_plan is not None
+                existing_policy_bundle is not None
+                or existing_verification_manifest is not None
+                or existing_plan is not None
             ):
                 _fail("PLAN_STORE_CORRUPT")
             if (
-                kind == "cutover" and existing_plan is not None and existing_policy_bundle is None
-            ) or (kind != "cutover" and existing_policy_bundle is not None):
+                kind == "cutover"
+                and existing_plan is not None
+                and (existing_policy_bundle is None or existing_verification_manifest is None)
+            ) or (
+                kind != "cutover"
+                and (
+                    existing_policy_bundle is not None or existing_verification_manifest is not None
+                )
+            ):
                 _fail("PLAN_STORE_CORRUPT")
             if (
                 (
@@ -236,6 +278,10 @@ class ConsolidationPlanStore:
                     existing_policy_bundle is not None
                     and existing_policy_bundle != policy_bundle_raw
                 )
+                or (
+                    existing_verification_manifest is not None
+                    and existing_verification_manifest != verification_manifest_raw
+                )
                 or (existing_plan is not None and existing_plan != plan.canonical_bytes)
             ):
                 _fail("PLAN_STORE_CONFLICT")
@@ -243,6 +289,11 @@ class ConsolidationPlanStore:
                 self._publish_missing(control_path, plan.control_basis.canonical_bytes)
             if existing_policy_bundle is None and policy_bundle_raw is not None:
                 self._publish_missing(policy_bundle_path, policy_bundle_raw)
+            if existing_verification_manifest is None and verification_manifest_raw is not None:
+                self._publish_missing(
+                    verification_manifest_path,
+                    verification_manifest_raw,
+                )
             if existing_plan is None:
                 self._publish_missing(plan_path, plan.canonical_bytes)
         return plan
@@ -271,15 +322,26 @@ class ConsolidationPlanStore:
                 directory / "policy-bundle.json",
                 limit=_MAX_POLICY_BUNDLE_BYTES,
             )
+            verification_manifest_raw = self._read_optional(
+                directory / "verification-manifest.json",
+                limit=_MAX_VERIFICATION_MANIFEST_BYTES,
+            )
             plan_raw = self._read_optional(
                 directory / "plan.json",
                 limit=_MAX_PLAN_BYTES,
             )
-            if control_raw is None and policy_bundle_raw is None and plan_raw is None:
+            if (
+                control_raw is None
+                and policy_bundle_raw is None
+                and verification_manifest_raw is None
+                and plan_raw is None
+            ):
                 _fail("PLAN_NOT_FOUND")
             if control_raw is None or plan_raw is None:
                 _fail("PLAN_STORE_CORRUPT")
-            if (kind == "cutover") != (policy_bundle_raw is not None):
+            if (kind == "cutover") != (policy_bundle_raw is not None) or (
+                (kind == "cutover") != (verification_manifest_raw is not None)
+            ):
                 _fail("PLAN_STORE_CORRUPT")
             try:
                 control = consolidation_plan.parse_control_basis(control_raw)
@@ -306,6 +368,23 @@ class ConsolidationPlanStore:
             self._bind_run(record, plan)
             if bundle is not None:
                 self._bind_policy_bundle(record, plan, bundle)
+                from . import consolidation_verification_manifest as verification_manifest_module
+
+                if verification_manifest_raw is None:
+                    _fail("PLAN_STORE_CORRUPT")
+                try:
+                    manifest = verification_manifest_module.parse_verification_manifest(
+                        verification_manifest_raw
+                    )
+                    verification_manifest_module._bind_to_stored_plan(  # noqa: SLF001
+                        run_id=run_id,
+                        plan_digest=digest,
+                        plan=plan,
+                        bundle=bundle,
+                        manifest=manifest,
+                    )
+                except (verification_manifest_module.ConsolidationVerificationManifestUnavailable,):
+                    _fail("PLAN_STORE_CORRUPT")
         return plan, bundle
 
     def load(

--- a/src/exomem/governance/consolidation_verification.py
+++ b/src/exomem/governance/consolidation_verification.py
@@ -81,9 +81,17 @@ class VerificationPlan:
 @dataclass(frozen=True, slots=True)
 class VerificationProbeContext:
     vault_root: Path
+    vault_binding_digest: str
+    run_id: str
+    operation_id: str
+    journal_digest: str
+    plan_digest: str
     canonical_census_digest: str
     verification_basis_digest: str
+    verified_at: str
+    principals: tuple[object, ...]
     authority: object
+    contract: object
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/exomem/governance/consolidation_verification_coordinator.py
+++ b/src/exomem/governance/consolidation_verification_coordinator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import re
 import time
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import NoReturn
@@ -23,6 +23,11 @@ from . import (
     consolidation_seal,
     consolidation_verification,
     consolidation_verification_journal,
+    consolidation_verification_manifest,
+    consolidation_verification_registry,
+)
+from . import (
+    principal as governance_principal,
 )
 
 _DIGEST = re.compile(r"[0-9a-f]{64}\Z")
@@ -112,12 +117,12 @@ def _crash_point(_point: str) -> None:
 
 
 def _canonical_surface_probe_runner(
-    _probe: consolidation_verification.VerificationProbe,
-    _context: consolidation_verification.VerificationProbeContext,
+    probe: consolidation_verification.VerificationProbe,
+    context: consolidation_verification.VerificationProbeContext,
 ) -> consolidation_verification.VerificationProbeTerminal:
-    """Closed adapter seam; unavailable until the canonical registry is installed."""
+    """Run one exact contract through the fixed canonical surface registry."""
 
-    _fail()
+    return consolidation_verification_registry.run_probe(probe, context)
 
 
 def _require_seal(
@@ -332,12 +337,27 @@ def _execute_probes(
     *,
     vault_root: Path,
     store: consolidation_verification_journal.ConsolidationVerificationJournalStore,
+    manifest: consolidation_verification_manifest.VerificationManifest,
+    vault_binding_digest: str,
+    journal_digest: str,
+    verified_at: str,
+    principals: tuple[governance_principal.RequestPrincipal, ...],
     authority: object,
     timestamp: str,
 ) -> tuple[consolidation_effect_coordinator.EffectExecutionResult, ...]:
     effects: list[consolidation_effect_coordinator.EffectExecutionResult] = []
     initial = store.load()
+    if tuple(entry.probe for entry in initial.probes) != manifest.verification_plan.probes:
+        _fail()
     for probe in (entry.probe for entry in initial.probes):
+        contract = manifest.contracts[probe.ordinal]
+        if (
+            contract.probe_id != probe.probe_id
+            or contract.contract_digest != probe.contract_digest
+            or contract.expected_result_digest != probe.expected_result_digest
+            or contract.executor_id != probe.executor_id
+        ):
+            _fail()
         state = store.load()
         if probe.ordinal == 0:
             parent_event_id = state.last_rebuild_terminal_event_id
@@ -390,13 +410,22 @@ def _execute_probes(
         def apply(
             *,
             expected_probe: consolidation_verification.VerificationProbe = probe,
+            expected_contract: consolidation_verification_manifest.VerificationContract = contract,
         ) -> None:
             current = store.load()
             context = consolidation_verification.VerificationProbeContext(
                 vault_root=vault_root,
+                vault_binding_digest=vault_binding_digest,
+                run_id=current.run_id,
+                operation_id=current.operation_id,
+                journal_digest=journal_digest,
+                plan_digest=current.plan_digest,
                 canonical_census_digest=current.canonical_census_digest,
                 verification_basis_digest=current.binding_digest,
+                verified_at=verified_at,
+                principals=principals,
                 authority=authority,
+                contract=expected_contract,
             )
             terminal = consolidation_verification._run_probe(  # noqa: SLF001
                 _canonical_surface_probe_runner,
@@ -599,8 +628,8 @@ def verify_rebuilt_destination(
     journal_digest: str,
     request_digest: str,
     plan_digest: str,
-    verification_plan: consolidation_verification.VerificationPlan,
     verified_at: str,
+    attested_principals: Sequence[governance_principal.RequestPrincipal] = (),
 ) -> ConsolidationVerificationCoordinatorResult:
     """Run exact in-process probes and advance only a proven result to verified."""
 
@@ -612,7 +641,23 @@ def verify_rebuilt_destination(
     checked_request = _digest(request_digest)
     checked_plan_digest = _digest(plan_digest)
     checked_time = _timestamp(verified_at)
-    checked_plan = consolidation_verification._checked_plan(verification_plan)  # noqa: SLF001
+    if isinstance(attested_principals, (str, bytes)) or not isinstance(
+        attested_principals, Sequence
+    ):
+        _fail()
+    principals = tuple(attested_principals)
+    if len(principals) > 1024 or any(
+        type(item) is not governance_principal.RequestPrincipal
+        or not item.resolved
+        or item.audience_id == governance_principal.OWNER_AUDIENCE
+        for item in principals
+    ):
+        _fail()
+    principal_keys = tuple(
+        (item.audience_id, item.surface, item.authorization_session_id) for item in principals
+    )
+    if len(set(principal_keys)) != len(principal_keys):
+        _fail()
     if (
         not isinstance(admission, consolidation_admission.ConsolidationAdmission)
         or admission.vault_root != root
@@ -634,6 +679,12 @@ def verify_rebuilt_destination(
         ):
             _fail()
         positive_digest, negative_digest = _plan_verification(preimage.get("verification_plan"))
+        manifest = consolidation_verification_manifest.ConsolidationVerificationManifestStore(
+            root
+        ).load(checked_run, checked_plan_digest)
+        checked_plan = consolidation_verification._checked_plan(  # noqa: SLF001
+            manifest.verification_plan
+        )
         if (
             positive_digest != checked_plan.positive_probe_digest
             or negative_digest != checked_plan.negative_probe_digest
@@ -709,6 +760,11 @@ def verify_rebuilt_destination(
         probe_effects = _execute_probes(
             vault_root=root,
             store=journal_store,
+            manifest=manifest,
+            vault_binding_digest=checked_vault,
+            journal_digest=checked_journal,
+            verified_at=checked_time,
+            principals=principals,
             authority=authority,
             timestamp=checked_time,
         )
@@ -759,6 +815,8 @@ def verify_rebuilt_destination(
         consolidation_seal.ConsolidationSealUnavailable,
         consolidation_verification.ConsolidationVerificationUnavailable,
         consolidation_verification_journal.ConsolidationVerificationJournalUnavailable,
+        consolidation_verification_manifest.ConsolidationVerificationManifestUnavailable,
+        consolidation_verification_registry.ConsolidationVerificationRegistryUnavailable,
         OSError,
         RuntimeError,
         TypeError,

--- a/src/exomem/governance/consolidation_verification_manifest.py
+++ b/src/exomem/governance/consolidation_verification_manifest.py
@@ -1,0 +1,568 @@
+"""Immutable owner-only contracts for governed-consolidation probes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, NoReturn
+
+from .. import reserved_paths
+from . import consolidation_plan, consolidation_plan_store, consolidation_verification
+
+VERIFICATION_CONTRACT_SCHEMA = "exomem.consolidation-verification-contract/v1"
+VERIFICATION_MANIFEST_SCHEMA = "exomem.consolidation-verification-manifest/v1"
+
+_CONTRACT_DOMAIN = VERIFICATION_CONTRACT_SCHEMA.encode("ascii")
+_MANIFEST_DOMAIN = VERIFICATION_MANIFEST_SCHEMA.encode("ascii")
+_DESCRIPTOR_ID = "consolidation-tree"
+_OWNER = "consolidation.run"
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_UUID4 = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z")
+_IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}\Z")
+_COMMAND = re.compile(r"[a-z][a-z0-9_]{0,127}\Z")
+_SURFACES = frozenset({"cli", "hosted", "mcp", "rest"})
+_FORBIDDEN_ARGUMENT_KEYS = frozenset(
+    {
+        "authorization_session_credential",
+        "authorization_session_id",
+        "authority",
+        "cell_id",
+        "consolidation_authority",
+        "issuer",
+        "logical_vault_id",
+        "principal",
+        "principal_scope",
+        "purpose",
+    }
+)
+_COMMON_CONTRACT_FIELDS = frozenset(
+    {
+        "probe_id",
+        "executor_id",
+        "surface",
+        "principal_kind",
+        "principal_id",
+        "purpose",
+        "command_name",
+        "arguments",
+        "expected_result_digest",
+    }
+)
+_DELEGATED_CONTRACT_FIELDS = _COMMON_CONTRACT_FIELDS | frozenset(
+    {"principal_attestation_fingerprint"}
+)
+_MAX_CONTRACTS = 1024
+_MAX_ARGUMENT_BYTES = 1 * 1024 * 1024
+_MAX_MANIFEST_BYTES = 16 * 1024 * 1024
+
+__all__ = [
+    "VERIFICATION_CONTRACT_SCHEMA",
+    "VERIFICATION_MANIFEST_SCHEMA",
+    "ConsolidationVerificationManifestStore",
+    "ConsolidationVerificationManifestUnavailable",
+    "VerificationContract",
+    "VerificationManifest",
+    "build_verification_manifest",
+    "canonical_verification_manifest",
+    "contract_arguments",
+    "parse_verification_manifest",
+]
+
+
+class ConsolidationVerificationManifestUnavailable(RuntimeError):
+    """Content-free refusal for missing, changed, or malformed probe contracts."""
+
+    code = "CONSOLIDATION_VERIFICATION_MANIFEST_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationContract:
+    schema: str
+    probe_id: str
+    probe_kind: Literal["positive", "negative"]
+    executor_id: str
+    surface: Literal["cli", "hosted", "mcp", "rest"]
+    principal_kind: Literal["owner", "delegated"]
+    principal_id: str
+    principal_attestation_fingerprint: str | None
+    purpose: str
+    command_name: str
+    arguments_bytes: bytes
+    expected_result_digest: str
+    contract_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationManifest:
+    schema: str
+    positive_contracts: tuple[VerificationContract, ...]
+    negative_contracts: tuple[VerificationContract, ...]
+    verification_plan: consolidation_verification.VerificationPlan
+    digest: str
+
+    @property
+    def contracts(self) -> tuple[VerificationContract, ...]:
+        return self.positive_contracts + self.negative_contracts
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationVerificationManifestUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if type(value) is not str or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _identifier(value: object) -> str:
+    if type(value) is not str or _IDENTIFIER.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _framed_digest(domain: bytes, value: object) -> str:
+    try:
+        encoded = consolidation_plan.canonical_closed_jcs(value)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    framed = len(domain).to_bytes(4, "big") + domain + len(encoded).to_bytes(8, "big") + encoded
+    return hashlib.sha256(framed).hexdigest()
+
+
+def _forbidden_argument(value: object) -> bool:
+    if isinstance(value, Mapping):
+        return any(
+            type(key) is not str or key in _FORBIDDEN_ARGUMENT_KEYS or _forbidden_argument(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return any(_forbidden_argument(item) for item in value)
+    return False
+
+
+def _arguments_bytes(value: object) -> bytes:
+    if not isinstance(value, Mapping) or _forbidden_argument(value):
+        _fail()
+    try:
+        encoded = consolidation_plan.canonical_closed_jcs(value)
+    except (RecursionError, consolidation_plan.ConsolidationPlanUnavailable):
+        _fail()
+    if len(encoded) > _MAX_ARGUMENT_BYTES:
+        _fail()
+    return encoded
+
+
+def contract_arguments(contract: VerificationContract) -> dict[str, object]:
+    """Return a fresh mutable copy of one exact canonical command argument object."""
+
+    if not isinstance(contract, VerificationContract):
+        _fail()
+    try:
+        parsed = json.loads(contract.arguments_bytes)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        _fail()
+    if not isinstance(parsed, dict) or _arguments_bytes(parsed) != contract.arguments_bytes:
+        _fail()
+    return parsed
+
+
+def _contract_value(contract: VerificationContract) -> dict[str, object]:
+    value: dict[str, object] = {
+        "schema": contract.schema,
+        "probe_id": contract.probe_id,
+        "probe_kind": contract.probe_kind,
+        "executor_id": contract.executor_id,
+        "surface": contract.surface,
+        "principal_kind": contract.principal_kind,
+        "principal_id": contract.principal_id,
+        "purpose": contract.purpose,
+        "command_name": contract.command_name,
+        "arguments": contract_arguments(contract),
+        "expected_result_digest": contract.expected_result_digest,
+    }
+    if contract.principal_kind == "delegated":
+        value["principal_attestation_fingerprint"] = _digest(
+            contract.principal_attestation_fingerprint
+        )
+    elif contract.principal_attestation_fingerprint is not None:
+        _fail()
+    return value
+
+
+def _build_contract(
+    value: object,
+    *,
+    probe_kind: Literal["positive", "negative"],
+) -> VerificationContract:
+    if not isinstance(value, Mapping):
+        _fail()
+    principal_kind = value.get("principal_kind")
+    expected_fields = (
+        _COMMON_CONTRACT_FIELDS if principal_kind == "owner" else _DELEGATED_CONTRACT_FIELDS
+    )
+    if frozenset(value) != expected_fields:
+        _fail()
+    probe_id = _identifier(value["probe_id"])
+    executor_id = _identifier(value["executor_id"])
+    if executor_id != consolidation_verification.CANONICAL_SURFACE_EXECUTOR_ID:
+        _fail()
+    surface = value["surface"]
+    if surface not in _SURFACES:
+        _fail()
+    principal_id = _identifier(value["principal_id"])
+    purpose = _identifier(value["purpose"])
+    command_name = value["command_name"]
+    if type(command_name) is not str or _COMMAND.fullmatch(command_name) is None:
+        _fail()
+    fingerprint: str | None
+    if principal_kind == "owner":
+        if principal_id != "owner":
+            _fail()
+        fingerprint = None
+    elif principal_kind == "delegated":
+        if principal_id == "owner":
+            _fail()
+        fingerprint = _digest(value["principal_attestation_fingerprint"])
+    else:
+        _fail()
+    preliminary = VerificationContract(
+        schema=VERIFICATION_CONTRACT_SCHEMA,
+        probe_id=probe_id,
+        probe_kind=probe_kind,
+        executor_id=executor_id,
+        surface=surface,
+        principal_kind=principal_kind,
+        principal_id=principal_id,
+        principal_attestation_fingerprint=fingerprint,
+        purpose=purpose,
+        command_name=command_name,
+        arguments_bytes=_arguments_bytes(value["arguments"]),
+        expected_result_digest=_digest(value["expected_result_digest"]),
+        contract_digest="0" * 64,
+    )
+    return VerificationContract(
+        schema=preliminary.schema,
+        probe_id=preliminary.probe_id,
+        probe_kind=preliminary.probe_kind,
+        executor_id=preliminary.executor_id,
+        surface=preliminary.surface,
+        principal_kind=preliminary.principal_kind,
+        principal_id=preliminary.principal_id,
+        principal_attestation_fingerprint=preliminary.principal_attestation_fingerprint,
+        purpose=preliminary.purpose,
+        command_name=preliminary.command_name,
+        arguments_bytes=preliminary.arguments_bytes,
+        expected_result_digest=preliminary.expected_result_digest,
+        contract_digest=_framed_digest(_CONTRACT_DOMAIN, _contract_value(preliminary)),
+    )
+
+
+def _sequence(value: object) -> Sequence[object]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        _fail()
+    if not 1 <= len(value) <= _MAX_CONTRACTS:
+        _fail()
+    return value
+
+
+def _manifest_value(manifest: VerificationManifest) -> dict[str, object]:
+    return {
+        "schema": manifest.schema,
+        "positive_contracts": [_contract_value(item) for item in manifest.positive_contracts],
+        "negative_contracts": [_contract_value(item) for item in manifest.negative_contracts],
+    }
+
+
+def build_verification_manifest(
+    *,
+    positive_contracts: Sequence[Mapping[str, object]],
+    negative_contracts: Sequence[Mapping[str, object]],
+) -> VerificationManifest:
+    """Build exact owner-protected contracts and their public digest-only plan."""
+
+    positive_values = _sequence(positive_contracts)
+    negative_values = _sequence(negative_contracts)
+    if len(positive_values) + len(negative_values) > _MAX_CONTRACTS:
+        _fail()
+    positive = tuple(_build_contract(item, probe_kind="positive") for item in positive_values)
+    negative = tuple(_build_contract(item, probe_kind="negative") for item in negative_values)
+    contracts = positive + negative
+    if len({contract.probe_id for contract in contracts}) != len(contracts):
+        _fail()
+    try:
+        plan = consolidation_verification.build_verification_plan(
+            positive_probes=tuple(
+                {
+                    "probe_id": contract.probe_id,
+                    "executor_id": contract.executor_id,
+                    "contract_digest": contract.contract_digest,
+                    "expected_result_digest": contract.expected_result_digest,
+                }
+                for contract in positive
+            ),
+            negative_probes=tuple(
+                {
+                    "probe_id": contract.probe_id,
+                    "executor_id": contract.executor_id,
+                    "contract_digest": contract.contract_digest,
+                    "expected_result_digest": contract.expected_result_digest,
+                }
+                for contract in negative
+            ),
+        )
+    except consolidation_verification.ConsolidationVerificationUnavailable:
+        _fail()
+    preliminary = VerificationManifest(
+        schema=VERIFICATION_MANIFEST_SCHEMA,
+        positive_contracts=positive,
+        negative_contracts=negative,
+        verification_plan=plan,
+        digest="0" * 64,
+    )
+    value = _manifest_value(preliminary)
+    try:
+        raw = consolidation_plan.canonical_closed_jcs(value)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    if len(raw) > _MAX_MANIFEST_BYTES:
+        _fail()
+    return VerificationManifest(
+        schema=preliminary.schema,
+        positive_contracts=preliminary.positive_contracts,
+        negative_contracts=preliminary.negative_contracts,
+        verification_plan=preliminary.verification_plan,
+        digest=_framed_digest(_MANIFEST_DOMAIN, value),
+    )
+
+
+def canonical_verification_manifest(manifest: VerificationManifest) -> bytes:
+    """Return exact canonical bytes for one complete verification manifest."""
+
+    if not isinstance(manifest, VerificationManifest):
+        _fail()
+    rebuilt = build_verification_manifest(
+        positive_contracts=tuple(_contract_input(item) for item in manifest.positive_contracts),
+        negative_contracts=tuple(_contract_input(item) for item in manifest.negative_contracts),
+    )
+    if rebuilt != manifest:
+        _fail()
+    try:
+        return consolidation_plan.canonical_closed_jcs(_manifest_value(rebuilt))
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+
+
+def _contract_input(contract: VerificationContract) -> dict[str, object]:
+    value = _contract_value(contract)
+    value.pop("schema")
+    value.pop("probe_kind")
+    return value
+
+
+def parse_verification_manifest(raw: bytes) -> VerificationManifest:
+    """Parse only exact canonical verification-manifest bytes."""
+
+    try:
+        parsed = consolidation_plan._parse_canonical_mapping(  # noqa: SLF001
+            raw,
+            maximum=_MAX_MANIFEST_BYTES,
+        )
+        if frozenset(parsed) != {"schema", "positive_contracts", "negative_contracts"}:
+            _fail()
+        if parsed["schema"] != VERIFICATION_MANIFEST_SCHEMA:
+            _fail()
+        positive = parsed["positive_contracts"]
+        negative = parsed["negative_contracts"]
+        if not isinstance(positive, list) or not isinstance(negative, list):
+            _fail()
+        manifest = build_verification_manifest(
+            positive_contracts=tuple(_parsed_contract_input(item, "positive") for item in positive),
+            negative_contracts=tuple(_parsed_contract_input(item, "negative") for item in negative),
+        )
+        if canonical_verification_manifest(manifest) != raw:
+            _fail()
+        return manifest
+    except ConsolidationVerificationManifestUnavailable:
+        raise
+    except (
+        RecursionError,
+        consolidation_plan.ConsolidationPlanUnavailable,
+        consolidation_verification.ConsolidationVerificationUnavailable,
+    ):
+        _fail()
+
+
+def _parsed_contract_input(value: object, probe_kind: str) -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        _fail()
+    if value.get("schema") != VERIFICATION_CONTRACT_SCHEMA or value.get("probe_kind") != probe_kind:
+        _fail()
+    result = dict(value)
+    result.pop("schema")
+    result.pop("probe_kind")
+    return result
+
+
+def _bind_to_stored_plan(
+    *,
+    run_id: str,
+    plan_digest: str,
+    plan: object,
+    bundle: object,
+    manifest: VerificationManifest,
+) -> None:
+    """Bind exact manifest contracts to their plan and delegated attestations."""
+
+    preimage = getattr(plan, "preimage", None)
+    verification = preimage.get("verification_plan") if isinstance(preimage, Mapping) else None
+    if (
+        getattr(plan, "digest", None) != plan_digest
+        or not isinstance(preimage, Mapping)
+        or preimage.get("run_id") != run_id
+        or preimage.get("plan_kind") != "cutover"
+        or not isinstance(verification, Mapping)
+        or frozenset(verification) != {"schema", "positive_probe_digest", "negative_probe_digest"}
+        or verification.get("schema") != "exomem.consolidation-verification-plan/v1"
+        or verification.get("positive_probe_digest")
+        != manifest.verification_plan.positive_probe_digest
+        or verification.get("negative_probe_digest")
+        != manifest.verification_plan.negative_probe_digest
+    ):
+        _fail()
+    attestations = getattr(bundle, "attestations", None)
+    if not isinstance(attestations, Sequence):
+        _fail()
+    by_fingerprint: dict[str, object] = {}
+    for attestation in attestations:
+        fingerprint = getattr(attestation, "fingerprint", None)
+        if type(fingerprint) is not str or _DIGEST.fullmatch(fingerprint) is None:
+            _fail()
+        if fingerprint in by_fingerprint:
+            _fail()
+        by_fingerprint[fingerprint] = attestation
+    for contract in manifest.contracts:
+        if contract.principal_kind == "owner":
+            continue
+        attestation = by_fingerprint.get(contract.principal_attestation_fingerprint or "")
+        purposes = getattr(attestation, "purposes", (contract.purpose,))
+        if (
+            attestation is None
+            or getattr(attestation, "principal_id", None) != contract.principal_id
+            or getattr(attestation, "surface", contract.surface) != contract.surface
+            or contract.purpose not in purposes
+        ):
+            _fail()
+
+
+@contextmanager
+def _authority(vault_root: Path, *, mutation: bool) -> Iterator[None]:
+    try:
+        with reserved_paths._subsystem_authority_scope(_OWNER):  # noqa: SLF001
+            with reserved_paths._identity_coordination_scope(  # noqa: SLF001
+                vault_root,
+                descriptor_ids=(_DESCRIPTOR_ID,),
+                identity_may_change=mutation,
+            ):
+                yield
+    except ConsolidationVerificationManifestUnavailable:
+        raise
+    except (OSError, RuntimeError, ValueError):
+        _fail()
+
+
+class ConsolidationVerificationManifestStore:
+    """Persist exact probe contracts beside one immutable cutover plan."""
+
+    def __init__(self, vault_root: Path | str) -> None:
+        self.vault_root = Path(vault_root).absolute()
+        self.plan_store = consolidation_plan_store.ConsolidationPlanStore(self.vault_root)
+
+    def path(self, run_id: str, plan_digest: str) -> Path:
+        if type(run_id) is not str or _UUID4.fullmatch(run_id) is None:
+            _fail()
+        checked_digest = _digest(plan_digest)
+        return (
+            self.plan_store._plan_dir(run_id, "cutover", checked_digest)  # noqa: SLF001
+            / "verification-manifest.json"
+        )
+
+    def _bind(self, run_id: str, plan_digest: str, manifest: VerificationManifest) -> None:
+        try:
+            plan = self.plan_store.load(
+                run_id,
+                plan_kind="cutover",
+                plan_digest=plan_digest,
+            )
+            bundle = self.plan_store.load_policy_bundle(
+                run_id,
+                plan_kind="cutover",
+                plan_digest=plan_digest,
+            )
+        except consolidation_plan_store.ConsolidationPlanStoreUnavailable:
+            _fail()
+        _bind_to_stored_plan(
+            run_id=run_id,
+            plan_digest=plan_digest,
+            plan=plan,
+            bundle=bundle,
+            manifest=manifest,
+        )
+
+    def persist(
+        self,
+        run_id: str,
+        plan_digest: str,
+        manifest: VerificationManifest,
+    ) -> VerificationManifest:
+        """Create or adopt one byte-identical immutable manifest."""
+
+        raw = canonical_verification_manifest(manifest)
+        path = self.path(run_id, plan_digest)
+        self._bind(run_id, plan_digest, manifest)
+        with _authority(self.vault_root, mutation=True):
+            try:
+                existing = reserved_paths._read_owner_bytes(  # noqa: SLF001
+                    self.vault_root,
+                    path,
+                    _DESCRIPTOR_ID,
+                    limit=_MAX_MANIFEST_BYTES,
+                )
+            except FileNotFoundError:
+                reserved_paths._publish_owner_bytes(  # noqa: SLF001
+                    self.vault_root,
+                    path,
+                    _DESCRIPTOR_ID,
+                    raw,
+                    require_missing=True,
+                )
+            else:
+                if existing != raw:
+                    _fail()
+        return manifest
+
+    def load(self, run_id: str, plan_digest: str) -> VerificationManifest:
+        """Reload and rebind one exact immutable manifest after restart."""
+
+        path = self.path(run_id, plan_digest)
+        with _authority(self.vault_root, mutation=False):
+            try:
+                raw = reserved_paths._read_owner_bytes(  # noqa: SLF001
+                    self.vault_root,
+                    path,
+                    _DESCRIPTOR_ID,
+                    limit=_MAX_MANIFEST_BYTES,
+                )
+            except FileNotFoundError:
+                _fail()
+        manifest = parse_verification_manifest(raw)
+        self._bind(run_id, plan_digest, manifest)
+        return manifest

--- a/src/exomem/governance/consolidation_verification_registry.py
+++ b/src/exomem/governance/consolidation_verification_registry.py
@@ -1,0 +1,368 @@
+"""Closed executors for owner-protected consolidation verification contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
+from types import MappingProxyType
+from typing import NoReturn
+
+from .. import capabilities, cli_ops, commands, schema, writer_lease
+from . import (
+    authorization_custody,
+    authorization_request,
+    authorization_session_lifecycle,
+    consolidation_authority,
+    consolidation_plan_store,
+    consolidation_policy,
+    consolidation_verification,
+    consolidation_verification_manifest,
+    principal,
+    store,
+)
+
+VERIFICATION_WIRE_RESULT_SCHEMA = "exomem.consolidation-verification-wire-result/v1"
+
+_WIRE_DOMAIN = VERIFICATION_WIRE_RESULT_SCHEMA.encode("ascii")
+_MAX_WIRE_BYTES = 64 * 1024 * 1024
+
+__all__ = [
+    "ConsolidationVerificationRegistryUnavailable",
+    "VERIFICATION_WIRE_RESULT_SCHEMA",
+    "render_rest_verification_wire",
+    "run_probe",
+    "verification_wire_result_digest",
+]
+
+
+class ConsolidationVerificationRegistryUnavailable(RuntimeError):
+    """Content-free refusal for an unavailable executor or surface result."""
+
+    code = "CONSOLIDATION_VERIFICATION_REGISTRY_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationVerificationRegistryUnavailable from None
+
+
+def verification_wire_result_digest(surface: str, wire: bytes) -> str:
+    """Digest one exact bounded adapter representation with its surface identity."""
+
+    if surface not in {"rest"} or type(wire) is not bytes or len(wire) > _MAX_WIRE_BYTES:
+        _fail()
+    domain = _WIRE_DOMAIN + b"\0" + surface.encode("ascii")
+    framed = len(domain).to_bytes(4, "big") + domain + len(wire).to_bytes(8, "big") + wire
+    return hashlib.sha256(framed).hexdigest()
+
+
+def render_rest_verification_wire(
+    *,
+    success: bool,
+    data: object = None,
+    error: Mapping[str, object] | None = None,
+) -> bytes:
+    """Render the same REST response object as the public facade, including headers."""
+
+    from ..server_rest import RestJSONResponse
+
+    if type(success) is not bool or (success and error is not None):
+        _fail()
+    error_value = dict(error) if error is not None else None
+    envelope = cli_ops.envelope(success, data=data, error=error_value)
+    status = 200 if success else cli_ops.http_status_for(str((error_value or {}).get("code") or ""))
+    response = RestJSONResponse(envelope, status_code=status)
+    status_line = f"HTTP {response.status_code}\r\n".encode("ascii")
+    headers = b"".join(name + b": " + value + b"\r\n" for name, value in response.raw_headers)
+    wire = status_line + headers + b"\r\n" + response.body
+    if len(wire) > _MAX_WIRE_BYTES:
+        _fail()
+    return wire
+
+
+def _require_context(
+    probe: consolidation_verification.VerificationProbe,
+    context: consolidation_verification.VerificationProbeContext,
+) -> consolidation_verification_manifest.VerificationContract:
+    if (
+        type(probe) is not consolidation_verification.VerificationProbe
+        or type(context) is not consolidation_verification.VerificationProbeContext
+        or type(context.contract) is not consolidation_verification_manifest.VerificationContract
+    ):
+        _fail()
+    contract = context.contract
+    if (
+        contract.probe_id != probe.probe_id
+        or contract.probe_kind != probe.probe_kind
+        or contract.executor_id != probe.executor_id
+        or contract.contract_digest != probe.contract_digest
+        or contract.expected_result_digest != probe.expected_result_digest
+    ):
+        _fail()
+    try:
+        consolidation_authority.require_authority(
+            context.authority,
+            vault_binding_digest=context.vault_binding_digest,
+            run_id=context.run_id,
+            operation_id=context.operation_id,
+            journal_digest=context.journal_digest,
+            phase="verifying",
+            action="verify",
+        )
+    except consolidation_authority.ConsolidationAuthorityUnavailable:
+        _fail()
+    return contract
+
+
+def _revalidate_session(
+    vault_root,
+    who: principal.RequestPrincipal,
+    *,
+    now: int,
+) -> principal.RequestPrincipal:
+    context = who.verified_authorization_session
+    if not isinstance(context, authorization_session_lifecycle.AuthorizationSessionContext):
+        _fail()
+    connection: sqlite3.Connection | None = None
+    try:
+        custody = authorization_custody.load_authorization_custody(vault_root, now=now)
+        connection = store.open_authorization_session_connection(vault_root)
+        current = authorization_session_lifecycle.status_verified_session(
+            connection,
+            custody=custody,
+            context=context,
+            now=now,
+        )
+        return who.with_verified_authorization_session(
+            current,
+            issuer_family=current.issuer_family,
+        )
+    except (
+        authorization_custody.AuthorizationCustodyUnavailable,
+        authorization_session_lifecycle.AuthorizationSessionUnavailable,
+        FileNotFoundError,
+        OSError,
+        sqlite3.Error,
+        store.UnsupportedGovernanceSchema,
+        TypeError,
+        ValueError,
+    ):
+        _fail()
+    finally:
+        if connection is not None:
+            try:
+                connection.close()
+            except sqlite3.Error:
+                pass
+
+
+def _fresh_verification_time() -> tuple[int, str]:
+    """Return one trusted live instant for session and attestation freshness."""
+
+    current = datetime.now(UTC)
+    current = current.replace(microsecond=(current.microsecond // 1000) * 1000)
+    return (
+        int(current.timestamp()),
+        current.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+    )
+
+
+def _delegated_principal(
+    contract: consolidation_verification_manifest.VerificationContract,
+    context: consolidation_verification.VerificationProbeContext,
+) -> principal.RequestPrincipal:
+    matches = tuple(
+        item
+        for item in context.principals
+        if type(item) is principal.RequestPrincipal
+        and item.resolved
+        and item.audience_id == contract.principal_id
+        and item.surface == contract.surface
+    )
+    if len(matches) != 1:
+        _fail()
+    now, verified_at = _fresh_verification_time()
+    checked = _revalidate_session(
+        context.vault_root,
+        matches[0],
+        now=now,
+    )
+    try:
+        bundle = consolidation_plan_store.ConsolidationPlanStore(
+            context.vault_root
+        ).load_policy_bundle(
+            context.run_id,
+            plan_kind="cutover",
+            plan_digest=context.plan_digest,
+        )
+    except consolidation_plan_store.ConsolidationPlanStoreUnavailable:
+        _fail()
+    attestations = tuple(
+        item
+        for item in bundle.attestations
+        if item.fingerprint == contract.principal_attestation_fingerprint
+    )
+    if len(attestations) != 1:
+        _fail()
+    try:
+        consolidation_policy.verify_destination_principal_attestation(
+            attestations[0],
+            principal=checked,
+            destination_vault_id=bundle.destination_vault_id,
+            required_purpose=contract.purpose,
+            expected_nonce=bundle.nonce,
+            verified_at=verified_at,
+        )
+    except consolidation_policy.DestinationPolicyUnavailable:
+        _fail()
+    return checked.with_purpose(contract.purpose)
+
+
+def _request_principal(
+    contract: consolidation_verification_manifest.VerificationContract,
+    context: consolidation_verification.VerificationProbeContext,
+) -> principal.RequestPrincipal:
+    if contract.principal_kind == "owner":
+        if contract.surface != "rest" or contract.principal_id != principal.OWNER_AUDIENCE:
+            _fail()
+        return principal.resolve_rest_principal(None).with_purpose(contract.purpose)
+    if contract.principal_kind != "delegated":
+        _fail()
+    return _delegated_principal(contract, context)
+
+
+def _rest_command(
+    contract: consolidation_verification_manifest.VerificationContract,
+):
+    expose_tier2 = not os.environ.get("EXOMEM_DISABLE_TIER2")
+    available = {
+        command.name: command
+        for command in commands.product_commands_for("rest", expose_tier2=expose_tier2)
+    }
+    command = available.get(contract.command_name)
+    if command is None:
+        _fail()
+    return command
+
+
+def _execute_rest(
+    probe: consolidation_verification.VerificationProbe,
+    context: consolidation_verification.VerificationProbeContext,
+) -> consolidation_verification.VerificationProbeTerminal:
+    contract = _require_context(probe, context)
+    if contract.surface != "rest":
+        _fail()
+    command = _rest_command(contract)
+    raw = consolidation_verification_manifest.contract_arguments(contract)
+    if any(parameter.name == "purpose" for parameter in command.params):
+        raw["purpose"] = contract.purpose
+    try:
+        kwargs = cli_ops.coerce(
+            command.params,
+            raw,
+            guarded_fields=command.guarded_fields,
+            tool=command.name,
+        )
+        if not commands.invocation_is_read_only(command, kwargs):
+            _fail()
+        who = _request_principal(contract, context)
+        expose_tier2 = not os.environ.get("EXOMEM_DISABLE_TIER2")
+        descriptor = capabilities.ActiveSurfaceDescriptor(
+            surface="rest",
+            profile="openapi",
+            tier2_enabled=expose_tier2,
+            product_commands=tuple(
+                item.name
+                for item in commands.product_commands_for(
+                    "rest",
+                    expose_tier2=expose_tier2,
+                )
+            ),
+        )
+        injected = (
+            (context.vault_root, schema.load_source_schema(context.vault_root))
+            if command.needs_schema
+            else (context.vault_root,)
+        )
+        with writer_lease._verification_component_failure_scope() as component_failures:  # noqa: SLF001
+            leaf_error: BaseException | None = None
+            try:
+                with capabilities.active_surface(descriptor), principal.request_scope(who):
+                    try:
+                        result = writer_lease.invoke_command(command, *injected, **kwargs)
+                    except (
+                        authorization_request.AuthorizationContextUnavailable,
+                        authorization_request.AuthorizationRouteUnclassified,
+                        cli_ops.OpError,
+                        ValueError,
+                        TypeError,
+                    ) as error:
+                        leaf_error = error
+                        raise
+            except (
+                authorization_request.AuthorizationContextUnavailable,
+                authorization_request.AuthorizationRouteUnclassified,
+                cli_ops.OpError,
+                ValueError,
+                TypeError,
+            ) as error:
+                if error is not leaf_error or component_failures:
+                    _fail()
+                public = cli_ops.error_dict(error)
+                result = None
+            else:
+                if component_failures:
+                    _fail()
+                public = None
+    except ConsolidationVerificationRegistryUnavailable:
+        raise
+    except Exception:  # noqa: BLE001 - unknown failures remain content-free
+        _fail()
+    try:
+        wire = (
+            render_rest_verification_wire(success=True, data=result)
+            if public is None
+            else render_rest_verification_wire(success=False, error=public)
+        )
+    except ConsolidationVerificationRegistryUnavailable:
+        raise
+    except Exception:  # noqa: BLE001 - adapter failures remain content-free
+        _fail()
+    return consolidation_verification.VerificationProbeTerminal(
+        schema=consolidation_verification.VERIFICATION_PROBE_TERMINAL_SCHEMA,
+        probe_id=probe.probe_id,
+        probe_digest=probe.probe_digest,
+        result_digest=verification_wire_result_digest(contract.surface, wire),
+        outcome="passed",
+    )
+
+
+_EXECUTORS: Mapping[
+    str,
+    Callable[
+        [
+            consolidation_verification.VerificationProbe,
+            consolidation_verification.VerificationProbeContext,
+        ],
+        consolidation_verification.VerificationProbeTerminal,
+    ],
+] = MappingProxyType({consolidation_verification.CANONICAL_SURFACE_EXECUTOR_ID: _execute_rest})
+
+
+def run_probe(
+    probe: consolidation_verification.VerificationProbe,
+    context: consolidation_verification.VerificationProbeContext,
+) -> consolidation_verification.VerificationProbeTerminal:
+    """Dispatch only by the fixed executor id; probe ids never select behavior."""
+
+    if type(probe) is not consolidation_verification.VerificationProbe:
+        _fail()
+    executor = _EXECUTORS.get(probe.executor_id)
+    if executor is None:
+        _fail()
+    return executor(probe, context)

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -159,6 +159,27 @@ _ACTIVE_LEASE_MANAGER: ContextVar[Any | None] = ContextVar(
 _ACTIVE_DIRECT_MUTATION_GUARDS: ContextVar[tuple[tuple[str, Path], ...]] = ContextVar(
     "exomem_active_direct_mutation_guards", default=()
 )
+_ACTIVE_VERIFICATION_COMPONENT_FAILURES: ContextVar[list[str] | None] = ContextVar(
+    "exomem_active_verification_component_failures", default=None
+)
+
+
+@contextmanager
+def _verification_component_failure_scope() -> Iterator[list[str]]:
+    """Collect governed-boundary failures for one in-process verification probe."""
+
+    failures: list[str] = []
+    token = _ACTIVE_VERIFICATION_COMPONENT_FAILURES.set(failures)
+    try:
+        yield failures
+    finally:
+        _ACTIVE_VERIFICATION_COMPONENT_FAILURES.reset(token)
+
+
+def _mark_verification_component_failure(component: str) -> None:
+    failures = _ACTIVE_VERIFICATION_COMPONENT_FAILURES.get()
+    if failures is not None:
+        failures.append(component)
 
 
 def _direct_mutation_boundary(
@@ -919,11 +940,7 @@ class SchemaFenceState:
             or schema_version not in {3, 4}
         ):
             raise ValueError("schema fence version is invalid")
-        if (
-            isinstance(generation, bool)
-            or not isinstance(generation, int)
-            or generation < 1
-        ):
+        if isinstance(generation, bool) or not isinstance(generation, int) or generation < 1:
             raise ValueError("schema fence generation is invalid")
         return cls(enrolled, schema_version, generation)
 
@@ -1160,9 +1177,7 @@ class LeaseCoordinatorClient:
             # HTTPError subclasses URLError, so it has to be caught first for
             # the status to be visible at all.
             if exc.code in _CONTRACT_ABSENT_STATUSES:
-                raise _contract_absent_error(
-                    self.config.url, contract_route, exc.code
-                ) from None
+                raise _contract_absent_error(self.config.url, contract_route, exc.code) from None
             raise _coordinator_unavailable_error(exc) from None
         except (
             urllib.error.URLError,
@@ -1183,9 +1198,7 @@ def configured_schema_fence_operator_client(
     config = LeaseConfig.from_env(values)
     if not config.enabled:
         return None
-    operator_token = values.get(
-        "EXOMEM_LEASE_COORDINATOR_OPERATOR_TOKEN", ""
-    ).strip()
+    operator_token = values.get("EXOMEM_LEASE_COORDINATOR_OPERATOR_TOKEN", "").strip()
     if not operator_token:
         raise OpError(
             "SCHEMA_FENCE_OPERATOR_UNAVAILABLE",
@@ -2894,11 +2907,7 @@ class LeaseManager:
             try:
                 authorization_custody.require_standalone_mutation_admission(
                     Path(vault_root),
-                    now=(
-                        int(time.time())
-                        if attachment_now is None
-                        else attachment_now
-                    ),
+                    now=(int(time.time()) if attachment_now is None else attachment_now),
                 )
             except authorization_custody.AuthorizationCustodyUnavailable:
                 raise OpError(
@@ -3419,11 +3428,11 @@ class LeaseManager:
                             with_graph_outcome(
                                 terminal,
                                 {
-                            "graph_sync": "failed",
-                            "graph_sync_code": "GRAPH_SYNC_VAULT_AUTHORITY_MISSING",
-                            "graph_sync_remediation": (
-                                "Configure the vault mount and run reconcile to recover the derived graph."
-                            ),
+                                    "graph_sync": "failed",
+                                    "graph_sync_code": "GRAPH_SYNC_VAULT_AUTHORITY_MISSING",
+                                    "graph_sync_remediation": (
+                                        "Configure the vault mount and run reconcile to recover the derived graph."
+                                    ),
                                 },
                             )
                         )
@@ -3442,9 +3451,9 @@ class LeaseManager:
                             with_graph_outcome(
                                 terminal,
                                 {
-                            "graph_sync": "failed",
-                            "graph_sync_code": "GRAPH_SYNC_CHECKPOINT_MISSING",
-                            "graph_sync_remediation": "Run reconcile to recover the derived graph.",
+                                    "graph_sync": "failed",
+                                    "graph_sync_code": "GRAPH_SYNC_CHECKPOINT_MISSING",
+                                    "graph_sync_remediation": "Run reconcile to recover the derived graph.",
                                 },
                             )
                         )
@@ -3478,11 +3487,11 @@ class LeaseManager:
                         with_graph_outcome(
                             terminal,
                             {
-                        "graph_sync": "failed",
-                        "graph_sync_code": "GRAPH_SYNC_VAULT_AUTHORITY_MISSING",
-                        "graph_sync_remediation": (
-                            "Configure the vault mount and run reconcile to recover the derived graph."
-                        ),
+                                "graph_sync": "failed",
+                                "graph_sync_code": "GRAPH_SYNC_VAULT_AUTHORITY_MISSING",
+                                "graph_sync_remediation": (
+                                    "Configure the vault mount and run reconcile to recover the derived graph."
+                                ),
                             },
                         )
                     )
@@ -3506,16 +3515,16 @@ class LeaseManager:
                     if required is not None:
                         return retain_failure(
                             with_graph_outcome(
-                            terminal, graph_sync.committed_graph_failure(required)
+                                terminal, graph_sync.committed_graph_failure(required)
                             )
                         )
                     return retain_failure(
                         with_graph_outcome(
                             terminal,
                             {
-                        "graph_sync": "failed",
-                        "graph_sync_code": "GRAPH_SYNC_CHECKPOINT_MISSING",
-                        "graph_sync_remediation": "Run reconcile to recover the derived graph.",
+                                "graph_sync": "failed",
+                                "graph_sync_code": "GRAPH_SYNC_CHECKPOINT_MISSING",
+                                "graph_sync_remediation": "Run reconcile to recover the derived graph.",
                             },
                         )
                     )
@@ -3551,9 +3560,9 @@ class LeaseManager:
                     with_graph_outcome(
                         terminal,
                         {
-                    "graph_sync": "failed",
-                    "graph_sync_code": "GRAPH_SYNC_RESUME_FAILED",
-                    "graph_sync_remediation": "Run reconcile to recover the derived graph.",
+                            "graph_sync": "failed",
+                            "graph_sync_code": "GRAPH_SYNC_RESUME_FAILED",
+                            "graph_sync_remediation": "Run reconcile to recover the derived graph.",
                         },
                     )
                 )
@@ -3832,8 +3841,8 @@ class LeaseManager:
                 if (
                     graph_status["state"] == "current"
                     and not epistemic_graph.EpistemicGraphIndex(
-                    vault_root,
-                    mutation_coordinator=self._mutation_coordinator_for(vault_root),
+                        vault_root,
+                        mutation_coordinator=self._mutation_coordinator_for(vault_root),
                     ).available()
                 ):
                     graph_status = {
@@ -4304,12 +4313,13 @@ def invoke_command(
 
     if not injected or not is_vault_root(injected[0]):
         return _invoke()
-    # An error is a payload. `_invoke()` is evaluated as an ARGUMENT to
-    # `postfilter`, so a raising command never reached the filter and its
-    # message crossed this boundary untouched — `AMBIGUOUS_REFERENCE` embedded
-    # the colliding vault paths and made that a path oracle. Both the
-    # read-only and the mutation return are inside one try, so a future path
-    # through this function cannot open a fresh bypass either.
+
+    # An error is a payload. Both the leaf and terminal filter stay inside one
+    # guarded path so a raising command cannot bypass `postfilter_error` --
+    # `AMBIGUOUS_REFERENCE` once embedded colliding vault paths and made that a
+    # path oracle. They are evaluated as separate steps only so consolidation
+    # verification can distinguish a legitimate public leaf error from failure
+    # of the projector, scrubber, or receipt boundary itself.
     #
     # `kwargs` goes to the filter so it can tell a reference the CALLER sent
     # from one the vault volunteered. Only the latter may be redacted; see
@@ -4317,26 +4327,65 @@ def invoke_command(
     #
     # `BaseException`, not `Exception`: a "terminal" filter that a Cancelled or
     # a SystemExit walks straight past is not terminal.
+    def filtered_result(value: Any) -> Any:
+        try:
+            return postfilter(command.name, value, injected[0])
+        except BaseException:
+            _mark_verification_component_failure("egress-postfilter")
+            raise
+
+    def filtered_error(error: BaseException) -> None:
+        try:
+            postfilter_error(command.name, error, injected[0], request_kwargs=kwargs)
+        except BaseException:
+            _mark_verification_component_failure("egress-error-filter")
+            raise
+
+    def emit_receipt(collector: Any) -> None:
+        try:
+            emit_boundary_receipt(collector)
+        except BaseException:
+            _mark_verification_component_failure("egress-receipt")
+            raise
+
     if not read_only:
         try:
-            return postfilter(command.name, _invoke(), injected[0])
+            value = _invoke()
         except BaseException as error:
-            postfilter_error(command.name, error, injected[0], request_kwargs=kwargs)
+            filtered_error(error)
+            raise
+        try:
+            return filtered_result(value)
+        except BaseException as error:
+            filtered_error(error)
             raise
     # The try lives INSIDE the boundary so `collector` is still bound when the
     # filter runs: `disclosure_boundary`'s `finally` resets the contextvar on
     # the way out, so an except-block outside it records credential blocks into
     # a collector that is already gone, and emits no receipt for a governed read
     # that touched withheld items before failing.
-    with disclosure_boundary(injected[0], command.name) as collector:
-        try:
-            result = postfilter(command.name, _invoke(), injected[0])
-        except BaseException as error:
-            postfilter_error(command.name, error, injected[0], request_kwargs=kwargs)
-            emit_boundary_receipt(collector)
-            raise
-        emit_boundary_receipt(collector)
-        return result
+    leaf_error: BaseException | None = None
+    try:
+        with disclosure_boundary(injected[0], command.name) as collector:
+            try:
+                value = _invoke()
+            except BaseException as error:
+                leaf_error = error
+                filtered_error(error)
+                emit_receipt(collector)
+                raise
+            try:
+                result = filtered_result(value)
+            except BaseException as error:
+                filtered_error(error)
+                emit_receipt(collector)
+                raise
+            emit_receipt(collector)
+            return result
+    except BaseException as error:
+        if error is not leaf_error and not _ACTIVE_VERIFICATION_COMPONENT_FAILURES.get():
+            _mark_verification_component_failure("egress-disclosure-boundary")
+        raise
 
 
 def coordination_status(

--- a/tests/test_consolidation_plan.py
+++ b/tests/test_consolidation_plan.py
@@ -150,10 +150,53 @@ def _plan(
     basis_run_revision: int = 7,
     policy_bundle: consolidation_policy.DestinationPolicyPlan | None = None,
     plan_kind: str = "cutover",
+    verification_manifest: object | None = None,
 ) -> consolidation_plan.CanonicalConsolidationPlan:
+    plan_input = _plan_input(policy_bundle, plan_kind=plan_kind)
+    if verification_manifest is not None:
+        verification_plan = verification_manifest.verification_plan
+        plan_input["verification_plan"] = {
+            "schema": "exomem.consolidation-verification-plan/v1",
+            "positive_probe_digest": verification_plan.positive_probe_digest,
+            "negative_probe_digest": verification_plan.negative_probe_digest,
+        }
+        plan_input["rendering_definition"] = consolidation_plan.derive_rendering_definition(
+            plan_input
+        )
     return consolidation_plan.materialize_plan(
-        _plan_input(policy_bundle, plan_kind=plan_kind),
+        plan_input,
         materialization=_materialization(basis_run_revision=basis_run_revision),
+    )
+
+
+def _verification_manifest():
+    from exomem.governance import consolidation_verification_manifest
+
+    common = {
+        "executor_id": "canonical-governance-surface-v1",
+        "surface": "rest",
+        "principal_kind": "owner",
+        "principal_id": "owner",
+        "purpose": "consolidation-verification",
+        "command_name": "read_memory",
+    }
+    return consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=(
+            {
+                **common,
+                "probe_id": "owner-destination-present",
+                "arguments": {"path": "Knowledge Base/Notes/destination.md"},
+                "expected_result_digest": _digest("destination-present-wire"),
+            },
+        ),
+        negative_contracts=(
+            {
+                **common,
+                "probe_id": "owner-private-absent",
+                "arguments": {"path": "Knowledge Base/Notes/private.md"},
+                "expected_result_digest": _digest("private-absent-wire"),
+            },
+        ),
     )
 
 
@@ -640,30 +683,41 @@ def test_owner_only_plan_store_reloads_exact_bytes_and_replays_idempotently(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from exomem.governance import consolidation_plan_store
+    from exomem.governance import (
+        consolidation_plan_store,
+        consolidation_verification_manifest,
+    )
 
     vault = tmp_path / "vault"
     _create_run(vault, monkeypatch)
     policy_bundle = _policy_bundle(vault)
-    plan = _plan(basis_run_revision=1, policy_bundle=policy_bundle)
+    manifest = _verification_manifest()
+    plan = _plan(
+        basis_run_revision=1,
+        policy_bundle=policy_bundle,
+        verification_manifest=manifest,
+    )
     store = consolidation_plan_store.ConsolidationPlanStore(vault)
 
     with pytest.raises(consolidation_plan_store.ConsolidationPlanStoreUnavailable):
         store.persist(
             plan,
             policy_bundle=_policy_bundle(vault, name="Changed review"),
+            verification_manifest=manifest,
             expected_run_revision=1,
         )
 
     first = store.persist(
         plan,
         policy_bundle=policy_bundle,
+        verification_manifest=manifest,
         expected_run_revision=1,
     )
     assert (
         store.persist(
             plan,
             policy_bundle=policy_bundle,
+            verification_manifest=manifest,
             expected_run_revision=1,
         )
         == first
@@ -687,6 +741,7 @@ def test_owner_only_plan_store_reloads_exact_bytes_and_replays_idempotently(
         "control-basis.json",
         "plan.json",
         "policy-bundle.json",
+        "verification-manifest.json",
     ]
     if os.name != "nt":
         assert plan_dir.stat().st_mode & 0o777 == 0o700
@@ -697,6 +752,12 @@ def test_owner_only_plan_store_reloads_exact_bytes_and_replays_idempotently(
     assert (
         restarted.load_policy_bundle(RUN_ID, plan_kind="cutover", plan_digest=plan.digest)
         == policy_bundle
+    )
+    assert (
+        consolidation_verification_manifest.ConsolidationVerificationManifestStore(vault).load(
+            RUN_ID, plan.digest
+        )
+        == manifest
     )
 
 
@@ -709,20 +770,36 @@ def test_plan_store_refuses_wrong_run_revision_or_partial_state(
     vault = tmp_path / "vault"
     _create_run(vault, monkeypatch)
     policy_bundle = _policy_bundle(vault)
-    plan = _plan(basis_run_revision=1, policy_bundle=policy_bundle)
+    manifest = _verification_manifest()
+    plan = _plan(
+        basis_run_revision=1,
+        policy_bundle=policy_bundle,
+        verification_manifest=manifest,
+    )
     store = consolidation_plan_store.ConsolidationPlanStore(vault)
 
     with pytest.raises(consolidation_plan_store.ConsolidationPlanStoreUnavailable):
         store.persist(
             plan,
             policy_bundle=policy_bundle,
+            verification_manifest=manifest,
             expected_run_revision=2,
         )
     with pytest.raises(consolidation_plan_store.ConsolidationPlanStoreUnavailable):
         store.persist(plan, expected_run_revision=1)
+    with pytest.raises(
+        consolidation_plan_store.ConsolidationPlanStoreUnavailable,
+        match="^PLAN_VERIFICATION_MANIFEST_REQUIRED$",
+    ):
+        store.persist(
+            plan,
+            policy_bundle=policy_bundle,
+            expected_run_revision=1,
+        )
     store.persist(
         plan,
         policy_bundle=policy_bundle,
+        verification_manifest=manifest,
         expected_run_revision=1,
     )
     control_path = (
@@ -750,7 +827,12 @@ def test_plan_store_recovers_control_first_crash_without_changing_plan(
     vault = tmp_path / "vault"
     _create_run(vault, monkeypatch)
     policy_bundle = _policy_bundle(vault)
-    plan = _plan(basis_run_revision=1, policy_bundle=policy_bundle)
+    manifest = _verification_manifest()
+    plan = _plan(
+        basis_run_revision=1,
+        policy_bundle=policy_bundle,
+        verification_manifest=manifest,
+    )
     store = consolidation_plan_store.ConsolidationPlanStore(vault)
     original_publish = store._publish_missing
 
@@ -764,6 +846,7 @@ def test_plan_store_recovers_control_first_crash_without_changing_plan(
         store.persist(
             plan,
             policy_bundle=policy_bundle,
+            verification_manifest=manifest,
             expected_run_revision=1,
         )
 
@@ -772,6 +855,7 @@ def test_plan_store_recovers_control_first_crash_without_changing_plan(
         store.persist(
             plan,
             policy_bundle=policy_bundle,
+            verification_manifest=manifest,
             expected_run_revision=1,
         )
         == plan
@@ -790,11 +874,17 @@ def test_plan_store_refuses_missing_or_changed_policy_bundle(
     vault = tmp_path / "vault"
     _create_run(vault, monkeypatch)
     policy_bundle = _policy_bundle(vault)
-    plan = _plan(basis_run_revision=1, policy_bundle=policy_bundle)
+    manifest = _verification_manifest()
+    plan = _plan(
+        basis_run_revision=1,
+        policy_bundle=policy_bundle,
+        verification_manifest=manifest,
+    )
     store = consolidation_plan_store.ConsolidationPlanStore(vault)
     store.persist(
         plan,
         policy_bundle=policy_bundle,
+        verification_manifest=manifest,
         expected_run_revision=1,
     )
     path = (
@@ -817,6 +907,40 @@ def test_plan_store_refuses_missing_or_changed_policy_bundle(
         store.load(RUN_ID, plan_kind="cutover", plan_digest=plan.digest)
 
 
+@pytest.mark.parametrize("replacement", [None, b"{}"])
+def test_plan_store_refuses_missing_or_changed_verification_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replacement: bytes | None,
+) -> None:
+    from exomem.governance import consolidation_plan_store
+
+    vault = tmp_path / "vault"
+    _create_run(vault, monkeypatch)
+    policy_bundle = _policy_bundle(vault)
+    manifest = _verification_manifest()
+    plan = _plan(
+        basis_run_revision=1,
+        policy_bundle=policy_bundle,
+        verification_manifest=manifest,
+    )
+    store = consolidation_plan_store.ConsolidationPlanStore(vault)
+    store.persist(
+        plan,
+        policy_bundle=policy_bundle,
+        verification_manifest=manifest,
+        expected_run_revision=1,
+    )
+    path = store._plan_dir(RUN_ID, "cutover", plan.digest) / "verification-manifest.json"  # noqa: SLF001
+    if replacement is None:
+        path.unlink()
+    else:
+        path.write_bytes(replacement)
+
+    with pytest.raises(consolidation_plan_store.ConsolidationPlanStoreUnavailable):
+        store.load(RUN_ID, plan_kind="cutover", plan_digest=plan.digest)
+
+
 def test_plan_store_binds_only_executable_policy_documents(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -829,13 +953,19 @@ def test_plan_store_binds_only_executable_policy_documents(
     governance.mkdir(parents=True)
     (governance / "README.md").write_text("Authoring guidance only.\n", encoding="utf-8")
     policy_bundle = _policy_bundle(vault)
-    plan = _plan(basis_run_revision=1, policy_bundle=policy_bundle)
+    manifest = _verification_manifest()
+    plan = _plan(
+        basis_run_revision=1,
+        policy_bundle=policy_bundle,
+        verification_manifest=manifest,
+    )
     store = consolidation_plan_store.ConsolidationPlanStore(vault)
 
     assert (
         store.persist(
             plan,
             policy_bundle=policy_bundle,
+            verification_manifest=manifest,
             expected_run_revision=1,
         )
         == plan
@@ -1136,10 +1266,16 @@ def _stored_review(
     vault = tmp_path / "vault"
     _create_run(vault, monkeypatch)
     policy_bundle = _policy_bundle(vault)
-    plan = _plan(basis_run_revision=1, policy_bundle=policy_bundle)
+    manifest = _verification_manifest()
+    plan = _plan(
+        basis_run_revision=1,
+        policy_bundle=policy_bundle,
+        verification_manifest=manifest,
+    )
     consolidation_plan_store.ConsolidationPlanStore(vault).persist(
         plan,
         policy_bundle=policy_bundle,
+        verification_manifest=manifest,
         expected_run_revision=1,
     )
     review = consolidation_review.begin_review(

--- a/tests/test_consolidation_verification.py
+++ b/tests/test_consolidation_verification.py
@@ -67,16 +67,34 @@ def _probe(probe_id: str) -> dict[str, str]:
 
 
 def _verification_plan():
-    from exomem.governance import consolidation_verification
+    return _verification_manifest().verification_plan
 
-    return consolidation_verification.build_verification_plan(
-        positive_probes=(
-            _probe("owner-note-full"),
-            _probe("delegated-approved-projection"),
+
+def _contract(probe_id: str) -> dict[str, object]:
+    return {
+        "probe_id": probe_id,
+        "executor_id": "canonical-governance-surface-v1",
+        "surface": "rest",
+        "principal_kind": "owner",
+        "principal_id": "owner",
+        "purpose": "consolidation-verification",
+        "command_name": "get",
+        "arguments": {"path": f"Knowledge Base/Notes/{probe_id}.md"},
+        "expected_result_digest": _digest(f"{probe_id}:pass"),
+    }
+
+
+def _verification_manifest():
+    from exomem.governance import consolidation_verification_manifest
+
+    return consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=(
+            _contract("owner-note-full"),
+            _contract("delegated-approved-projection"),
         ),
-        negative_probes=(
-            _probe("delegated-private-body-absent-pair"),
-            _probe("wrong-purpose-wire-equivalence"),
+        negative_contracts=(
+            _contract("delegated-private-body-absent-pair"),
+            _contract("wrong-purpose-wire-equivalence"),
         ),
     )
 
@@ -84,6 +102,8 @@ def _verification_plan():
 def _rebuilt_run(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    *,
+    manifest=None,
 ):
     from exomem.governance import (
         consolidation_rebuild_coordinator,
@@ -104,7 +124,8 @@ def _rebuilt_run(
     rebuilt = consolidation_rebuild_coordinator.rebuild_published_destination(**arguments)
     assert rebuilt.seal_state.phase == "verifying"
 
-    plan = _verification_plan()
+    manifest = manifest or _verification_manifest()
+    plan = manifest.verification_plan
     stored = SimpleNamespace(
         digest=PLAN_DIGEST,
         preimage={
@@ -121,6 +142,11 @@ def _rebuilt_run(
         consolidation_verification_coordinator.consolidation_plan_store.ConsolidationPlanStore,
         "load",
         lambda _store, _run_id, *, plan_kind, plan_digest: stored,
+    )
+    monkeypatch.setattr(
+        consolidation_verification_coordinator.consolidation_verification_manifest.ConsolidationVerificationManifestStore,
+        "load",
+        lambda _store, _run_id, _plan_digest: manifest,
     )
     monkeypatch.setattr(
         consolidation_verification_coordinator,
@@ -140,11 +166,69 @@ def _rebuilt_run(
             "plan_digest",
         )
     }
-    verify_arguments.update(
-        verification_plan=plan,
-        verified_at=VERIFIED_AT,
-    )
+    verify_arguments.update(verified_at=VERIFIED_AT)
     return vault, verify_arguments, plan
+
+
+def _real_registry_manifest():
+    from exomem import cli_ops
+    from exomem.governance import (
+        consolidation_verification_manifest,
+        consolidation_verification_registry,
+    )
+
+    present_data = {
+        "path": "Knowledge Base/Notes/destination.md",
+        "frontmatter": {},
+        "has_frontmatter": False,
+    }
+    present_wire = consolidation_verification_registry.render_rest_verification_wire(
+        success=True,
+        data=present_data,
+    )
+    missing_error = cli_ops.error_dict(
+        ValueError("NOT_FOUND: file does not exist: Knowledge Base/Notes/absent.md")
+    )
+    missing_wire = consolidation_verification_registry.render_rest_verification_wire(
+        success=False,
+        error=missing_error,
+    )
+
+    def contract(probe_id: str, path: str, expected: str) -> dict[str, object]:
+        return {
+            "probe_id": probe_id,
+            "executor_id": "canonical-governance-surface-v1",
+            "surface": "rest",
+            "principal_kind": "owner",
+            "principal_id": "owner",
+            "purpose": "consolidation-verification",
+            "command_name": "read_memory",
+            "arguments": {"path": path, "frontmatter_only": True},
+            "expected_result_digest": expected,
+        }
+
+    return consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=(
+            contract(
+                "owner-present",
+                "Knowledge Base/Notes/destination.md",
+                consolidation_verification_registry.verification_wire_result_digest(
+                    "rest",
+                    present_wire,
+                ),
+            ),
+        ),
+        negative_contracts=(
+            contract(
+                "owner-absent",
+                "Knowledge Base/Notes/absent.md",
+                consolidation_verification_registry.verification_wire_result_digest(
+                    "rest",
+                    missing_wire,
+                ),
+            ),
+        ),
+    )
 
 
 def _install_passing_runner(
@@ -197,16 +281,16 @@ def test_probe_and_matrix_digests_are_fixed_framed_jcs_vectors() -> None:
     plan = _verification_plan()
 
     assert plan.positive_probe_digest == (
-        "3270b6c5047a088e38bdbf5e7ebbc4b4c483869a8aa669ea501b4b785bc307df"
+        "9c72df10e936be2d2727487907b97a7644fadfb53171477f2126744a98788612"
     )
     assert plan.negative_probe_digest == (
-        "cc9a67cc0748b61a11a6c9073e040dbb817727fbce00cbdf4860d957d8a21efc"
+        "d25ca94e49a9355f3e32809424f66a4f999ad683532426bc966c8dc8f1e3a689"
     )
     assert tuple(probe.probe_digest for probe in plan.probes) == (
-        "425c0416e0a1efd536e97c0395d6d7b4105b57fcb62d8db2aa4f399eac8ea269",
-        "14bf94b53db7a43ca1f4b35616068ab50bca5a4d7392c77faa19f00b9e990697",
-        "cb7f779b936cba0d1daefdbcc556d04a5bff777b8bc81a834ea766400fc290c8",
-        "5968f29ee48f0e48bf8ec49bf30499a309854ff71b000dc0a98dd5ccef3036a7",
+        "6cbf2cab57b9f55d2e84305a232fc52a087b6830388ddc366ffcc5c950be950a",
+        "7f210b108f73c767a81e42c10f8a8d859ac5448779aaf142774a5b33fbcad9b0",
+        "0cb339d0f20473ca576511bca06b500c8edb58fcd841bf9b07a8e05079cbfe70",
+        "010273dcec2db69ba2de795f2d25842c7a56c13644cc8beb20b07010879939ca",
     )
 
 
@@ -308,6 +392,27 @@ def test_uninstalled_canonical_probe_registry_fails_closed(
         == "verifying"
     )
     assert not any(record["phase"] == "committed" for record in _verification_records(vault))
+
+
+def test_installed_registry_verifies_real_present_and_absent_rest_responses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_verification_coordinator
+
+    manifest = _real_registry_manifest()
+    _vault, arguments, plan = _rebuilt_run(
+        tmp_path,
+        monkeypatch,
+        manifest=manifest,
+    )
+
+    result = consolidation_verification_coordinator.verify_rebuilt_destination(
+        **arguments,
+    )
+
+    assert result.seal_state.phase == "verified"
+    assert result.completed_probe_ids == tuple(probe.probe_id for probe in plan.probes)
 
 
 def test_tampered_verification_journal_fails_closed(
@@ -548,15 +653,17 @@ def test_changed_probe_matrix_is_rejected_before_any_probe_runs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from exomem.governance import (
-        consolidation_verification,
-        consolidation_verification_coordinator,
-    )
+    from exomem.governance import consolidation_verification_coordinator
 
     _vault, arguments, _plan = _rebuilt_run(tmp_path, monkeypatch)
-    arguments["verification_plan"] = consolidation_verification.build_verification_plan(
-        positive_probes=(_probe("changed-owner-probe"),),
-        negative_probes=(_probe("wrong-purpose-wire-equivalence"),),
+    changed_manifest = consolidation_verification_coordinator.consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=(_contract("changed-owner-probe"),),
+        negative_contracts=(_contract("wrong-purpose-wire-equivalence"),),
+    )
+    monkeypatch.setattr(
+        consolidation_verification_coordinator.consolidation_verification_manifest.ConsolidationVerificationManifestStore,
+        "load",
+        lambda _store, _run_id, _plan_digest: changed_manifest,
     )
     calls: list[str] = []
     _install_passing_runner(monkeypatch, calls)

--- a/tests/test_consolidation_verification_manifest.py
+++ b/tests/test_consolidation_verification_manifest.py
@@ -1,0 +1,244 @@
+"""Immutable, plan-bound contracts for consolidation verification probes."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+RUN_ID = "00000000-0000-4000-8000-000000000091"
+PLAN_DIGEST = hashlib.sha256(b"verification-manifest-plan").hexdigest()
+ATTESTATION_FINGERPRINT = hashlib.sha256(b"verification-manifest-attestation").hexdigest()
+
+
+@pytest.fixture(autouse=True)
+def _private_writer_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import writer_lease
+
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR",
+        str(tmp_path / "writer-state"),
+    )
+    writer_lease.reset_managers_for_tests()
+    yield
+    writer_lease.reset_managers_for_tests()
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode()).hexdigest()
+
+
+def _owner_contract() -> dict[str, object]:
+    return {
+        "probe_id": "owner-note-full",
+        "executor_id": "canonical-governance-surface-v1",
+        "surface": "rest",
+        "principal_kind": "owner",
+        "principal_id": "owner",
+        "purpose": "owner-verification",
+        "command_name": "get",
+        "arguments": {"path": "Knowledge Base/Notes/destination.md"},
+        "expected_result_digest": _digest("owner-note-full:wire"),
+    }
+
+
+def _delegated_contract() -> dict[str, object]:
+    return {
+        "probe_id": "delegated-approved-projection",
+        "executor_id": "canonical-governance-surface-v1",
+        "surface": "rest",
+        "principal_kind": "delegated",
+        "principal_id": "external",
+        "principal_attestation_fingerprint": ATTESTATION_FINGERPRINT,
+        "purpose": "support",
+        "command_name": "find",
+        "arguments": {
+            "query": "approved compiled abstraction",
+            "mode": "keyword",
+            "graph": False,
+            "limit": 10,
+        },
+        "expected_result_digest": _digest("delegated-approved-projection:wire"),
+    }
+
+
+def _negative_contract() -> dict[str, object]:
+    return {
+        **_delegated_contract(),
+        "probe_id": "delegated-private-body-absent",
+        "command_name": "get",
+        "arguments": {"path": "Knowledge Base/Notes/private.md"},
+        "expected_result_digest": _digest("delegated-private-body-absent:wire"),
+    }
+
+
+def _manifest():
+    from exomem.governance import consolidation_verification_manifest
+
+    return consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=(_owner_contract(), _delegated_contract()),
+        negative_contracts=(_negative_contract(),),
+    )
+
+
+def _install_stored_plan(
+    monkeypatch: pytest.MonkeyPatch,
+    manifest,
+    *,
+    attestation_fingerprint: str = ATTESTATION_FINGERPRINT,
+) -> None:
+    from exomem.governance import consolidation_plan_store
+
+    plan = SimpleNamespace(
+        digest=PLAN_DIGEST,
+        preimage={
+            "run_id": RUN_ID,
+            "plan_kind": "cutover",
+            "verification_plan": {
+                "schema": "exomem.consolidation-verification-plan/v1",
+                "positive_probe_digest": manifest.verification_plan.positive_probe_digest,
+                "negative_probe_digest": manifest.verification_plan.negative_probe_digest,
+            },
+        },
+    )
+    policy_bundle = SimpleNamespace(
+        attestations=(
+            SimpleNamespace(
+                principal_id="external",
+                fingerprint=attestation_fingerprint,
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        consolidation_plan_store.ConsolidationPlanStore,
+        "load",
+        lambda _store, _run_id, *, plan_kind, plan_digest: plan,
+    )
+    monkeypatch.setattr(
+        consolidation_plan_store.ConsolidationPlanStore,
+        "load_policy_bundle",
+        lambda _store, _run_id, *, plan_kind, plan_digest: policy_bundle,
+    )
+
+
+def test_manifest_is_canonical_round_trippable_and_builds_the_exact_probe_plan() -> None:
+    from exomem.governance import consolidation_verification_manifest
+
+    manifest = _manifest()
+    raw = consolidation_verification_manifest.canonical_verification_manifest(manifest)
+
+    assert consolidation_verification_manifest.parse_verification_manifest(raw) == manifest
+    assert manifest.positive_contracts[0].probe_kind == "positive"
+    assert manifest.negative_contracts[0].probe_kind == "negative"
+    assert tuple(contract.contract_digest for contract in manifest.contracts) == tuple(
+        probe.contract_digest for probe in manifest.verification_plan.probes
+    )
+    assert tuple(contract.expected_result_digest for contract in manifest.contracts) == tuple(
+        probe.expected_result_digest for probe in manifest.verification_plan.probes
+    )
+    assert consolidation_verification_manifest.contract_arguments(
+        manifest.positive_contracts[0]
+    ) == {"path": "Knowledge Base/Notes/destination.md"}
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        {"authorization_session_credential": "must-never-persist"},
+        {"principal_scope": "caller-selected"},
+        {"authority": {"phase": "verifying"}},
+    ],
+)
+def test_manifest_rejects_transport_identity_and_authority_arguments(
+    changed: dict[str, object],
+) -> None:
+    from exomem.governance import consolidation_verification_manifest
+
+    contract = _owner_contract()
+    contract["arguments"] = changed
+
+    with pytest.raises(
+        consolidation_verification_manifest.ConsolidationVerificationManifestUnavailable,
+        match="^CONSOLIDATION_VERIFICATION_MANIFEST_UNAVAILABLE$",
+    ):
+        consolidation_verification_manifest.build_verification_manifest(
+            positive_contracts=(contract,),
+            negative_contracts=(_negative_contract(),),
+        )
+
+
+def test_owner_only_manifest_store_replays_exact_bytes_after_restart(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_verification_manifest
+
+    vault = tmp_path / "vault"
+    manifest = _manifest()
+    _install_stored_plan(monkeypatch, manifest)
+    store = consolidation_verification_manifest.ConsolidationVerificationManifestStore(vault)
+
+    assert store.persist(RUN_ID, PLAN_DIGEST, manifest) == manifest
+    assert store.persist(RUN_ID, PLAN_DIGEST, manifest) == manifest
+    assert store.load(RUN_ID, PLAN_DIGEST) == manifest
+    assert store.path(RUN_ID, PLAN_DIGEST).name == "verification-manifest.json"
+
+    restarted = consolidation_verification_manifest.ConsolidationVerificationManifestStore(vault)
+    assert restarted.load(RUN_ID, PLAN_DIGEST) == manifest
+    assert restarted.path(RUN_ID, PLAN_DIGEST).read_bytes() == (
+        consolidation_verification_manifest.canonical_verification_manifest(manifest)
+    )
+
+
+@pytest.mark.parametrize("replacement", [None, b"{}"])
+def test_manifest_store_refuses_missing_or_tampered_contract_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replacement: bytes | None,
+) -> None:
+    from exomem.governance import consolidation_verification_manifest
+
+    vault = tmp_path / "vault"
+    manifest = _manifest()
+    _install_stored_plan(monkeypatch, manifest)
+    store = consolidation_verification_manifest.ConsolidationVerificationManifestStore(vault)
+    store.persist(RUN_ID, PLAN_DIGEST, manifest)
+    path = store.path(RUN_ID, PLAN_DIGEST)
+    if replacement is None:
+        path.unlink()
+    else:
+        path.write_bytes(replacement)
+
+    with pytest.raises(
+        consolidation_verification_manifest.ConsolidationVerificationManifestUnavailable,
+        match="^CONSOLIDATION_VERIFICATION_MANIFEST_UNAVAILABLE$",
+    ):
+        store.load(RUN_ID, PLAN_DIGEST)
+
+
+def test_manifest_store_refuses_unattested_or_plan_mismatched_contracts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_verification_manifest
+
+    vault = tmp_path / "vault"
+    manifest = _manifest()
+    _install_stored_plan(
+        monkeypatch,
+        manifest,
+        attestation_fingerprint=_digest("changed-attestation"),
+    )
+
+    with pytest.raises(
+        consolidation_verification_manifest.ConsolidationVerificationManifestUnavailable,
+        match="^CONSOLIDATION_VERIFICATION_MANIFEST_UNAVAILABLE$",
+    ):
+        consolidation_verification_manifest.ConsolidationVerificationManifestStore(vault).persist(
+            RUN_ID, PLAN_DIGEST, manifest
+        )

--- a/tests/test_consolidation_verification_registry.py
+++ b/tests/test_consolidation_verification_registry.py
@@ -1,0 +1,432 @@
+"""Canonical governed-surface execution for consolidation verification."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+VAULT_BINDING = hashlib.sha256(b"verification-registry-vault").hexdigest()
+JOURNAL_DIGEST = hashlib.sha256(b"verification-registry-journal").hexdigest()
+PLAN_DIGEST = hashlib.sha256(b"verification-registry-plan").hexdigest()
+RUN_ID = "00000000-0000-4000-8000-000000000092"
+OPERATION_ID = "00000000-0000-4000-8000-000000000093"
+VERIFIED_AT = "2026-08-31T12:00:00.000Z"
+
+
+@pytest.fixture(autouse=True)
+def _private_writer_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import writer_lease
+
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR",
+        str(tmp_path / "writer-state"),
+    )
+    monkeypatch.delenv("EXOMEM_DISABLE_TIER2", raising=False)
+    writer_lease.reset_managers_for_tests()
+    yield
+    writer_lease.reset_managers_for_tests()
+
+
+def _context(
+    vault: Path,
+    manifest,
+    *,
+    principals: tuple[object, ...] = (),
+):
+    from exomem.governance import consolidation_authority, consolidation_verification
+
+    return consolidation_verification.VerificationProbeContext(
+        vault_root=vault,
+        vault_binding_digest=VAULT_BINDING,
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        plan_digest=PLAN_DIGEST,
+        canonical_census_digest=hashlib.sha256(b"registry-census").hexdigest(),
+        verification_basis_digest=hashlib.sha256(b"registry-basis").hexdigest(),
+        verified_at=VERIFIED_AT,
+        principals=principals,
+        authority=consolidation_authority.issue_authority(
+            vault_binding_digest=VAULT_BINDING,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            phase="verifying",
+            action="verify",
+        ),
+        contract=manifest.contracts[0],
+    )
+
+
+def _owner_manifest(expected_result_digest: str):
+    from exomem.governance import consolidation_verification_manifest
+
+    return consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=(
+            {
+                "probe_id": "owner-read-memory",
+                "executor_id": "canonical-governance-surface-v1",
+                "surface": "rest",
+                "principal_kind": "owner",
+                "principal_id": "owner",
+                "purpose": "consolidation-verification",
+                "command_name": "read_memory",
+                "arguments": {
+                    "path": "Knowledge Base/Notes/public.md",
+                    "frontmatter_only": True,
+                },
+                "expected_result_digest": expected_result_digest,
+            },
+        ),
+        negative_contracts=(
+            {
+                "probe_id": "owner-absent-memory",
+                "executor_id": "canonical-governance-surface-v1",
+                "surface": "rest",
+                "principal_kind": "owner",
+                "principal_id": "owner",
+                "purpose": "consolidation-verification",
+                "command_name": "read_memory",
+                "arguments": {"path": "Knowledge Base/Notes/absent.md"},
+                "expected_result_digest": hashlib.sha256(b"unused-negative").hexdigest(),
+            },
+        ),
+    )
+
+
+def test_owner_probe_crosses_real_dispatch_egress_receipt_and_rest_adapter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import server_rest, writer_lease
+    from exomem.governance import (
+        consolidation_verification_registry,
+        egress,
+        principal,
+    )
+
+    vault = tmp_path / "vault"
+    path = vault / "Knowledge Base" / "Notes" / "public.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("# Public\n\nVisible.\n", encoding="utf-8")
+    expected_data = {
+        "path": "Knowledge Base/Notes/public.md",
+        "frontmatter": {},
+        "has_frontmatter": False,
+    }
+    expected_wire = consolidation_verification_registry.render_rest_verification_wire(
+        success=True,
+        data=expected_data,
+    )
+    expected_digest = consolidation_verification_registry.verification_wire_result_digest(
+        "rest",
+        expected_wire,
+    )
+    manifest = _owner_manifest(expected_digest)
+    calls: list[str] = []
+
+    def wrap(module, name: str, label: str) -> None:
+        original = getattr(module, name)
+
+        def traced(*args, **kwargs):
+            calls.append(label)
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(module, name, traced)
+
+    wrap(principal, "resolve_rest_principal", "identity")
+    wrap(principal, "request_scope", "principal-scope")
+    wrap(writer_lease, "invoke_command", "dispatch")
+    wrap(egress, "postfilter", "scrubber")
+    wrap(egress, "emit_boundary_receipt", "receipt")
+    wrap(server_rest.RestJSONResponse, "render", "response")
+
+    terminal = consolidation_verification_registry.run_probe(
+        manifest.verification_plan.positive_probes[0],
+        _context(vault, manifest),
+    )
+
+    assert terminal.result_digest == expected_digest
+    assert terminal.outcome == "passed"
+    assert {"identity", "principal-scope", "dispatch", "scrubber", "receipt", "response"} <= set(
+        calls
+    )
+
+
+def test_probe_refuses_forged_authority_and_mismatched_contract_before_dispatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import writer_lease
+    from exomem.governance import consolidation_verification_registry
+
+    expected_wire = consolidation_verification_registry.render_rest_verification_wire(
+        success=True,
+        data={"unused": True},
+    )
+    manifest = _owner_manifest(
+        consolidation_verification_registry.verification_wire_result_digest(
+            "rest",
+            expected_wire,
+        )
+    )
+    probe = manifest.verification_plan.positive_probes[0]
+    context = _context(tmp_path / "vault", manifest)
+    monkeypatch.setattr(
+        writer_lease,
+        "invoke_command",
+        lambda *_args, **_kwargs: pytest.fail("dispatch must not run"),
+    )
+
+    for changed in (
+        dataclasses.replace(context, authority=object()),
+        dataclasses.replace(context, contract=manifest.negative_contracts[0]),
+    ):
+        with pytest.raises(
+            consolidation_verification_registry.ConsolidationVerificationRegistryUnavailable,
+            match="^CONSOLIDATION_VERIFICATION_REGISTRY_UNAVAILABLE$",
+        ):
+            consolidation_verification_registry.run_probe(probe, changed)
+
+
+def test_delegated_probe_revalidates_live_session_and_destination_attestation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import writer_lease
+    from exomem.governance import (
+        authorization_session_lifecycle,
+        consolidation_plan_store,
+        consolidation_policy,
+        consolidation_verification_manifest,
+        consolidation_verification_registry,
+        principal,
+    )
+
+    audience = "delegated-user"
+    fingerprint = hashlib.sha256(b"delegated-attestation").hexdigest()
+    projected = {"path": "Knowledge Base/Notes/approved.md", "body": "approved"}
+    wire = consolidation_verification_registry.render_rest_verification_wire(
+        success=True,
+        data=projected,
+    )
+    expected_digest = consolidation_verification_registry.verification_wire_result_digest(
+        "rest",
+        wire,
+    )
+    manifest = consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=(
+            {
+                "probe_id": "delegated-approved",
+                "executor_id": "canonical-governance-surface-v1",
+                "surface": "rest",
+                "principal_kind": "delegated",
+                "principal_id": audience,
+                "principal_attestation_fingerprint": fingerprint,
+                "purpose": "support",
+                "command_name": "read_memory",
+                "arguments": {"path": "Knowledge Base/Notes/approved.md"},
+                "expected_result_digest": expected_digest,
+            },
+        ),
+        negative_contracts=(
+            {
+                "probe_id": "delegated-denied",
+                "executor_id": "canonical-governance-surface-v1",
+                "surface": "rest",
+                "principal_kind": "delegated",
+                "principal_id": audience,
+                "principal_attestation_fingerprint": fingerprint,
+                "purpose": "support",
+                "command_name": "read_memory",
+                "arguments": {"path": "Knowledge Base/Notes/private.md"},
+                "expected_result_digest": hashlib.sha256(b"unused-denied").hexdigest(),
+            },
+        ),
+    )
+    session = authorization_session_lifecycle.AuthorizationSessionContext(
+        session_id="session-1",
+        principal_id=audience,
+        issuer_family="rest-cf-access",
+        cell_id="cell-1",
+        logical_vault_id="vault-1",
+        keyring_id="keyring-1",
+        credential_generation=1,
+        expires_at=2_000_000_000,
+    )
+    who = principal.RequestPrincipal(
+        audience_id=audience,
+        surface="rest",
+        authorization_session_id=session.session_id,
+        resolved=True,
+        issuer_family=session.issuer_family,
+        verified_authorization_session=session,
+    )
+    attestation = SimpleNamespace(fingerprint=fingerprint)
+    bundle = SimpleNamespace(
+        attestations=(attestation,),
+        destination_vault_id="vault-1",
+        nonce="nonce-1",
+    )
+    calls: list[tuple[str, object]] = []
+    fresh_now = 2_000_000_001
+    fresh_verified_at = "2033-05-18T03:33:21.000Z"
+    monkeypatch.setattr(
+        consolidation_verification_registry,
+        "_fresh_verification_time",
+        lambda: (fresh_now, fresh_verified_at),
+    )
+    monkeypatch.setattr(
+        consolidation_verification_registry,
+        "_revalidate_session",
+        lambda _root, value, *, now: calls.append(("session", now)) or value,
+    )
+    monkeypatch.setattr(
+        consolidation_plan_store.ConsolidationPlanStore,
+        "load_policy_bundle",
+        lambda _store, _run_id, *, plan_kind, plan_digest: bundle,
+    )
+    monkeypatch.setattr(
+        consolidation_policy,
+        "verify_destination_principal_attestation",
+        lambda *args, **kwargs: (
+            calls.append(("attestation", kwargs["verified_at"])) or SimpleNamespace()
+        ),
+    )
+    monkeypatch.setattr(
+        writer_lease,
+        "invoke_command",
+        lambda *_args, **_kwargs: projected,
+    )
+
+    terminal = consolidation_verification_registry.run_probe(
+        manifest.verification_plan.positive_probes[0],
+        _context(tmp_path / "vault", manifest, principals=(who,)),
+    )
+
+    assert terminal.result_digest == expected_digest
+    assert calls == [
+        ("session", fresh_now),
+        ("attestation", fresh_verified_at),
+    ]
+
+
+@pytest.mark.parametrize(
+    "component",
+    ["identity-scope", "postfilter", "error-filter", "receipt", "response"],
+)
+def test_probe_refuses_component_failure_that_looks_like_a_public_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    component: str,
+) -> None:
+    from exomem import server_rest
+    from exomem.governance import (
+        consolidation_verification_manifest,
+        consolidation_verification_registry,
+        egress,
+        principal,
+    )
+
+    vault = tmp_path / "vault"
+    private = vault / "Knowledge Base" / "Notes" / "private.md"
+    private.parent.mkdir(parents=True)
+    if component != "error-filter":
+        private.write_text("# Private\n", encoding="utf-8")
+    expected_digest = hashlib.sha256(f"{component}-public-result".encode()).hexdigest()
+    contract = {
+        "probe_id": "owner-hidden-memory",
+        "executor_id": "canonical-governance-surface-v1",
+        "surface": "rest",
+        "principal_kind": "owner",
+        "principal_id": "owner",
+        "purpose": "consolidation-verification",
+        "command_name": "read_memory",
+        "arguments": {"path": "Knowledge Base/Notes/private.md"},
+        "expected_result_digest": expected_digest,
+    }
+    manifest = consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=(
+            {
+                **contract,
+                "probe_id": "owner-visible-memory",
+                "arguments": {"path": "Knowledge Base/Notes/public.md"},
+            },
+        ),
+        negative_contracts=(contract,),
+    )
+    context = dataclasses.replace(
+        _context(vault, manifest),
+        contract=manifest.negative_contracts[0],
+    )
+    target = {
+        "identity-scope": (principal, "request_scope"),
+        "postfilter": (egress, "postfilter"),
+        "error-filter": (egress, "postfilter_error"),
+        "receipt": (egress, "emit_boundary_receipt"),
+        "response": (server_rest.RestJSONResponse, "render"),
+    }[component]
+
+    def fail_component(*_args, **_kwargs):
+        raise ValueError("NOT_FOUND: path does not exist")
+
+    monkeypatch.setattr(*target, fail_component)
+
+    with pytest.raises(
+        consolidation_verification_registry.ConsolidationVerificationRegistryUnavailable,
+        match="^CONSOLIDATION_VERIFICATION_REGISTRY_UNAVAILABLE$",
+    ):
+        consolidation_verification_registry.run_probe(
+            manifest.verification_plan.negative_probes[0],
+            context,
+        )
+
+
+def test_probe_refuses_commands_disabled_on_the_live_rest_surface(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import writer_lease
+    from exomem.governance import (
+        consolidation_verification_manifest,
+        consolidation_verification_registry,
+    )
+
+    expected_digest = hashlib.sha256(b"disabled-tier2-wire").hexdigest()
+    tier2_contract = {
+        "probe_id": "owner-tier2-query",
+        "executor_id": "canonical-governance-surface-v1",
+        "surface": "rest",
+        "principal_kind": "owner",
+        "principal_id": "owner",
+        "purpose": "consolidation-verification",
+        "command_name": "query_dataset",
+        "arguments": {"query": "select 1"},
+        "expected_result_digest": expected_digest,
+    }
+    manifest = consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=(tier2_contract,),
+        negative_contracts=({**tier2_contract, "probe_id": "owner-tier2-query-negative"},),
+    )
+    monkeypatch.setenv("EXOMEM_DISABLE_TIER2", "1")
+    monkeypatch.setattr(
+        writer_lease,
+        "invoke_command",
+        lambda *_args, **_kwargs: pytest.fail("disabled REST command must not dispatch"),
+    )
+
+    with pytest.raises(
+        consolidation_verification_registry.ConsolidationVerificationRegistryUnavailable,
+        match="^CONSOLIDATION_VERIFICATION_REGISTRY_UNAVAILABLE$",
+    ):
+        consolidation_verification_registry.run_probe(
+            manifest.verification_plan.positive_probes[0],
+            _context(tmp_path / "vault", manifest),
+        )


### PR DESCRIPTION
## What this adds

- persists the exact owner-only verification manifest with every cutover plan and revalidates it after restart
- executes plan-bound REST probes through the real identity, dispatch, governance egress, receipt, and response boundaries
- revalidates delegated sessions and destination attestations at a trusted live instant
- fails closed when identity, projector, scrubber, receipt, or response components fail, and honors the deployed REST tier-2 setting

This is the REST canonical-executor slice stacked on #1004. CLI, MCP, Hosted matrix coverage and registry-derived coverage gates remain later verification slices. No live vault is read, migrated, or modified by this PR.

## Verification

- 106 focused plan, manifest, registry, and coordinator tests passed
- 884 scoped writer, governance egress, receipt, REST registry, and tier-2 tests passed
- independent final verifier: 602 affected tests passed
- independent adversarial re-review: no findings
- repository Ruff F gate and changed-file Ruff formatting passed
- `uv lock --check` and `git diff --check` passed
- `openspec validate --all --strict`: 168 passed, 0 failed
- public repository artifact validation: 3454 files, 3522 text payloads clean