### PR TITLE
feat(governance): generate closed verification coverage

### DIFF
--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -121,6 +121,9 @@ from .command_surface import (
     type_tag as _type_tag,  # noqa: F401 - re-exported for server.py
 )
 from .entity_types import EntityTypeId
+from .governance import (
+    consolidation_verification_coverage as consolidation_verification_coverage_module,
+)
 from .governance import egress as egress_module
 from .governance import operations as governance_operations
 from .governance import policy as governance_policy_module
@@ -8810,6 +8813,10 @@ validate_product_registry()
 egress_module.assert_alias_projectors_registered(
     {command.name: command for command in PRODUCT_COMMANDS},
     {command.name: command for command in COMMANDS},
+)
+consolidation_verification_coverage_module.build_coverage_inventory(
+    {command.name: command for command in COMMANDS},
+    product_registry={command.name: command for command in PRODUCT_COMMANDS},
 )
 
 

--- a/src/exomem/governance/consolidation_verification_coverage.py
+++ b/src/exomem/governance/consolidation_verification_coverage.py
@@ -1,0 +1,295 @@
+"""Closed-world coverage rows for governed-consolidation verification."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal, NoReturn
+
+from . import egress
+
+_IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}\Z")
+_CONDITIONAL_MUTATION_OUTCOMES = frozenset(
+    {
+        "apply-conditional",
+        "dry-run-default",
+        "dry-run-opt-in",
+        "mutation",
+        "save-conditional",
+        "validation",
+    }
+)
+_SELECTOR_OUTCOMES = _CONDITIONAL_MUTATION_OUTCOMES | {"structure"}
+_PROJECTOR_ADAPTERS = frozenset(
+    {
+        "artifact-reference",
+        "binary",
+        "hit",
+        "not-applicable",
+        "page",
+        "structure",
+        *_SELECTOR_OUTCOMES,
+    }
+)
+_RECEIPT_OUTCOMES = frozenset(
+    {
+        "artifact-reference",
+        "binary",
+        "frames",
+        "graph",
+        "hits",
+        "mutation",
+        "page",
+        "structure",
+        *_SELECTOR_OUTCOMES,
+    }
+)
+_TOMBSTONE_GATES = frozenset(
+    {
+        "artifact-reference",
+        "binary",
+        "frames",
+        "graph",
+        "hits",
+        "not-applicable",
+        "page",
+        "structure",
+        *_SELECTOR_OUTCOMES,
+    }
+)
+_PROBE_DISPOSITIONS = frozenset({"positive-negative", "seal-only"})
+_SEAL_DISPOSITIONS = frozenset({"mutation", "read", "transfer"})
+
+__all__ = [
+    "ConsolidationVerificationCoverageUnavailable",
+    "VerificationCoverageBranch",
+    "build_coverage_inventory",
+]
+
+
+class ConsolidationVerificationCoverageUnavailable(RuntimeError):
+    """Content-free refusal for an incomplete release/verification inventory."""
+
+    code = "CONSOLIDATION_VERIFICATION_COVERAGE_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationCoverageBranch:
+    branch_id: str
+    branch_kind: Literal["command", "product", "selector", "route"]
+    probe_disposition: str
+    seal_disposition: str
+    projector_adapter: str
+    receipt_outcome: str
+    tombstone_gate: str
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationVerificationCoverageUnavailable from None
+
+
+def _identifier(value: object) -> str:
+    if type(value) is not str or _IDENTIFIER.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _closed_row(value: object, fields: frozenset[str]) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or frozenset(value) != fields:
+        _fail()
+    return value
+
+
+def _text(row: Mapping[str, object], field: str) -> str:
+    value = row.get(field)
+    if type(value) is not str or not value:
+        _fail()
+    return value
+
+
+def _disposition(row: Mapping[str, object], field: str, allowed: frozenset[str]) -> str:
+    value = _text(row, field)
+    if value not in allowed:
+        _fail()
+    return value
+
+
+def _adapter(row: Mapping[str, object], field: str, allowed: frozenset[str]) -> str:
+    value = _text(row, field)
+    parts = value.split("+")
+    if parts != sorted(set(parts)) or not set(parts) <= allowed:
+        _fail()
+    return value
+
+
+def _command_rows(
+    registry: Mapping[str, Any],
+) -> list[VerificationCoverageBranch]:
+    try:
+        capabilities = egress.command_capability_registry(registry)
+    except (RuntimeError, TypeError):
+        _fail()
+    rows: list[VerificationCoverageBranch] = []
+    for name, raw in capabilities.items():
+        command_name = _identifier(name)
+        capability = _closed_row(
+            raw,
+            frozenset({"projector", "receipt", "tombstone"}),
+        )
+        command = registry.get(name)
+        if command is None or type(getattr(command, "read_only", None)) is not bool:
+            _fail()
+        projector = _adapter(capability, "projector", _PROJECTOR_ADAPTERS)
+        rows.append(
+            VerificationCoverageBranch(
+                branch_id=f"command:{command_name}",
+                branch_kind="command",
+                probe_disposition=(
+                    "seal-only"
+                    if not command.read_only and projector == "not-applicable"
+                    else "positive-negative"
+                ),
+                seal_disposition="read" if command.read_only else "mutation",
+                projector_adapter=projector,
+                receipt_outcome=_adapter(capability, "receipt", _RECEIPT_OUTCOMES),
+                tombstone_gate=_adapter(capability, "tombstone", _TOMBSTONE_GATES),
+            )
+        )
+    return rows
+
+
+def _product_rows(
+    product_registry: Mapping[str, Any], command_registry: Mapping[str, Any]
+) -> list[VerificationCoverageBranch]:
+    try:
+        capabilities = egress.alias_capability_registry(product_registry, command_registry)
+    except (RuntimeError, TypeError):
+        _fail()
+    rows: list[VerificationCoverageBranch] = []
+    for name, raw in capabilities.items():
+        product_name = _identifier(name)
+        capability = _closed_row(
+            raw,
+            frozenset({"projector", "receipt", "tombstone"}),
+        )
+        command = product_registry.get(name)
+        if command is None or type(getattr(command, "read_only", None)) is not bool:
+            _fail()
+        projector = _adapter(capability, "projector", _PROJECTOR_ADAPTERS)
+        rows.append(
+            VerificationCoverageBranch(
+                branch_id=f"product:{product_name}",
+                branch_kind="product",
+                probe_disposition=(
+                    "seal-only"
+                    if not command.read_only and projector == "not-applicable"
+                    else "positive-negative"
+                ),
+                seal_disposition="read" if command.read_only else "mutation",
+                projector_adapter=projector,
+                receipt_outcome=_adapter(capability, "receipt", _RECEIPT_OUTCOMES),
+                tombstone_gate=_adapter(capability, "tombstone", _TOMBSTONE_GATES),
+            )
+        )
+    return rows
+
+
+def _selector_rows(
+    capabilities: Mapping[tuple[str, str], Mapping[str, Mapping[str, str]]],
+) -> list[VerificationCoverageBranch]:
+    rows: list[VerificationCoverageBranch] = []
+    for key, branches in capabilities.items():
+        if type(key) is not tuple or len(key) != 2 or not isinstance(branches, Mapping):
+            _fail()
+        command_name = _identifier(key[0])
+        selector_name = _identifier(key[1])
+        for value, raw in branches.items():
+            selector_value = _identifier(value)
+            capability = _closed_row(raw, frozenset({"outcome", "tombstone"}))
+            outcome = _text(capability, "outcome")
+            if outcome not in _SELECTOR_OUTCOMES:
+                _fail()
+            tombstone = _text(capability, "tombstone")
+            if tombstone != ("not-applicable" if outcome == "mutation" else outcome):
+                _fail()
+            mutating = outcome in _CONDITIONAL_MUTATION_OUTCOMES
+            rows.append(
+                VerificationCoverageBranch(
+                    branch_id=(f"selector:{command_name}.{selector_name}={selector_value}"),
+                    branch_kind="selector",
+                    probe_disposition="seal-only" if outcome == "mutation" else "positive-negative",
+                    seal_disposition="mutation" if mutating else "read",
+                    projector_adapter=outcome,
+                    receipt_outcome=outcome,
+                    tombstone_gate=tombstone,
+                )
+            )
+    return rows
+
+
+def _route_rows(
+    capabilities: Mapping[str, Mapping[str, str]],
+) -> list[VerificationCoverageBranch]:
+    rows: list[VerificationCoverageBranch] = []
+    fields = frozenset({"projector", "receipt", "tombstone", "seal", "probe"})
+    for route, raw in capabilities.items():
+        route_name = _identifier(route)
+        capability = _closed_row(raw, fields)
+        rows.append(
+            VerificationCoverageBranch(
+                branch_id=f"route:{route_name}",
+                branch_kind="route",
+                probe_disposition=_disposition(capability, "probe", _PROBE_DISPOSITIONS),
+                seal_disposition=_disposition(capability, "seal", _SEAL_DISPOSITIONS),
+                projector_adapter=_adapter(capability, "projector", _PROJECTOR_ADAPTERS),
+                receipt_outcome=_adapter(capability, "receipt", _RECEIPT_OUTCOMES),
+                tombstone_gate=_adapter(capability, "tombstone", _TOMBSTONE_GATES),
+            )
+        )
+    return rows
+
+
+def build_coverage_inventory(
+    command_registry: Mapping[str, Any],
+    *,
+    product_registry: Mapping[str, Any] | None = None,
+    selector_capabilities: Mapping[tuple[str, str], Mapping[str, Mapping[str, str]]] | None = None,
+    route_capabilities: Mapping[str, Mapping[str, str]] | None = None,
+) -> tuple[VerificationCoverageBranch, ...]:
+    """Generate one complete inventory from the live release registries."""
+
+    if not isinstance(command_registry, Mapping):
+        _fail()
+    try:
+        selectors = (
+            egress.selector_capability_registry()
+            if selector_capabilities is None
+            else selector_capabilities
+        )
+        routes = (
+            egress.non_command_route_capability_registry()
+            if route_capabilities is None
+            else route_capabilities
+        )
+        rows = [
+            *_command_rows(command_registry),
+            *(
+                _product_rows(product_registry, command_registry)
+                if product_registry is not None
+                else ()
+            ),
+            *_selector_rows(selectors),
+            *_route_rows(routes),
+        ]
+    except ConsolidationVerificationCoverageUnavailable:
+        raise
+    except (KeyError, RuntimeError, TypeError, ValueError):
+        _fail()
+    ordered = tuple(sorted(rows, key=lambda row: row.branch_id))
+    if len({row.branch_id for row in ordered}) != len(ordered):
+        _fail()
+    return ordered

--- a/src/exomem/governance/egress.py
+++ b/src/exomem/governance/egress.py
@@ -2921,7 +2921,6 @@ _METADATA_ONLY_COMMANDS: frozenset[str] = frozenset(
         "capture_source",
         "preserve_evidence",
         "preserve_artifacts",
-        "compile_source",
         "observe_memory",
         "replace_memory",
         "edit_memory",
@@ -2931,9 +2930,6 @@ _METADATA_ONLY_COMMANDS: frozenset[str] = frozenset(
         "adopt_vault",
         "adoption_studio",
         "triage_memory",
-        "query_dataset",
-        "read_media",
-        "list_trash",
     }
 )
 
@@ -2966,6 +2962,7 @@ _COMMAND_PROJECTOR_KIND: dict[str, str] = {
     "audit": "structure",
     "overview": "structure",
     "list_directory": "structure",
+    "list_trash": "structure",
     "list_inbound_links": "structure",
     "evolution": "structure",
     "propose_compilation": "structure",
@@ -2993,6 +2990,7 @@ _COMMAND_OUTCOME_ADAPTER: dict[str, str] = {
             "audit",
             "overview",
             "list_directory",
+            "list_trash",
             "list_inbound_links",
             "evolution",
             "propose_compilation",
@@ -3113,13 +3111,244 @@ _SELECTOR_TOMBSTONE_ADAPTERS: dict[tuple[str, str], dict[str, str]] = {
     for key, values in _SELECTOR_ADAPTERS.items()
 }
 
-_EXPLICIT_TOMBSTONE_ROUTES: dict[str, str] = {
-    "direct-read": "page",
-    "download": "binary",
-    "frame": "binary",
-    "prompt": "artifact-reference",
-    "resource": "artifact-reference",
+_MUTATION_CAPABILITY: dict[str, str] = {
+    "projector": "not-applicable",
+    "receipt": "mutation",
+    "tombstone": "not-applicable",
 }
+
+# Every decorator-registered Exomem surface is named here, including branches
+# that are content-free or are generated from the command registry.  The
+# release test compares this set with the AST of the real registrations.  A
+# newly decorated route is therefore unknown until it receives an explicit
+# disposition; putting it in a module that already contains a gate is not
+# enough.
+_SURFACE_ROUTE_DISPOSITIONS: dict[str, str] = {
+    "hosted_transfer_routes:upload_options": "no-vault-content",
+    "hosted_transfer_routes:download_options": "no-vault-content",
+    "hosted_transfer_routes:upload": "governed",
+    "hosted_transfer_routes:download": "governed",
+    "server:continue_adoption": "governed",
+    "server:adoption_runs": "governed",
+    "server:adoption_run_resource": "governed",
+    "server_assets:_health": "no-vault-content",
+    "server_assets:_runtime_ready": "no-vault-content",
+    "server_assets:_metrics_json": "no-vault-content",
+    "server_assets:_favicon_ico": "no-vault-content",
+    "server_assets:_favicon_svg": "no-vault-content",
+    "server_assets:_studio_redirect": "no-vault-content",
+    "server_assets:_studio_shell": "no-vault-content",
+    "server_assets:_studio_asset": "no-vault-content",
+    "server_assets:_openid_configuration": "no-vault-content",
+    "server_assets:_oauth_protected_resource_bare": "no-vault-content",
+    "server_hosted:_contract": "no-vault-content",
+    "server_hosted:_agent_contract": "no-vault-content",
+    "server_hosted:_reader_status": "no-vault-content",
+    "server_hosted:_live": "no-vault-content",
+    "server_hosted:_ready": "no-vault-content",
+    "server_hosted:_command": "command-registry",
+    "server_hosted:_agent_command": "command-registry",
+    "server_hosted:_quiesce": "no-vault-content",
+    "server_hosted:_attest_authorization_membership": "no-vault-content",
+    # Private lifecycle portability is an authenticated operator-control lane:
+    # public routing is stopped, the cell is quiesced, and its own portability
+    # checkpoint governs the archive.  It is not an agent/product disclosure
+    # route and must not acquire paper projector or receipt adapters here.
+    "server_hosted:_export": "operator-control",
+    "server_hosted:_export_download": "operator-control",
+    "server_hosted:_release_export": "no-vault-content",
+    "server_hosted:_resume": "no-vault-content",
+    "server_hosted:_seal": "no-vault-content",
+    "server_hosted:_upload": "governed",
+    "server_hosted:_download": "governed",
+    "server_rest:_api_openapi": "no-vault-content",
+    "server_rest:_handler": "command-registry",
+    "server_transfer:_upload": "governed",
+    "server_transfer:_upload_form": "no-vault-content",
+    "server_transfer:_download": "governed",
+}
+_SURFACE_ROUTE_DISPOSITION_VALUES = frozenset(
+    {"command-registry", "governed", "no-vault-content", "operator-control"}
+)
+
+# Capabilities name the concrete release/reduction path each governed residual
+# uses. Operator-control portability is classified above rather than pretending
+# its lifecycle checkpoint is a disclosure projector or tombstone filter.
+_NON_COMMAND_ROUTE_CAPABILITIES: dict[str, dict[str, str]] = {
+    "hosted_transfer_routes:upload": dict(_MUTATION_CAPABILITY),
+    "hosted_transfer_routes:download": {
+        "projector": "binary",
+        "receipt": "binary",
+        "tombstone": "binary",
+        "seal": "transfer",
+        "probe": "positive-negative",
+    },
+    "server:continue_adoption": {
+        "projector": "structure",
+        "receipt": "structure",
+        "tombstone": "structure",
+        "seal": "read",
+        "probe": "positive-negative",
+    },
+    "server:adoption_runs": {
+        "projector": "structure",
+        "receipt": "structure",
+        "tombstone": "structure",
+        "seal": "read",
+        "probe": "positive-negative",
+    },
+    "server:adoption_run_resource": {
+        "projector": "structure",
+        "receipt": "structure",
+        "tombstone": "structure",
+        "seal": "read",
+        "probe": "positive-negative",
+    },
+    "server_hosted:_upload": dict(_MUTATION_CAPABILITY),
+    "server_hosted:_download": {
+        "projector": "binary",
+        "receipt": "binary",
+        "tombstone": "binary",
+        "seal": "transfer",
+        "probe": "positive-negative",
+    },
+    "server_transfer:_upload": dict(_MUTATION_CAPABILITY),
+    "server_transfer:_download": {
+        "projector": "binary",
+        "receipt": "binary",
+        "tombstone": "binary",
+        "seal": "transfer",
+        "probe": "positive-negative",
+    },
+}
+
+for _mutation_route in (
+    "hosted_transfer_routes:upload",
+    "server_hosted:_upload",
+    "server_transfer:_upload",
+):
+    _NON_COMMAND_ROUTE_CAPABILITIES[_mutation_route].update(
+        {"seal": "mutation", "probe": "seal-only"}
+    )
+
+_INTERNAL_RESIDUAL_ROUTE_CAPABILITIES: dict[str, dict[str, str]] = {
+    "internal:direct-read": {
+        "projector": "page",
+        "receipt": "page",
+        "tombstone": "page",
+        "seal": "read",
+        "probe": "positive-negative",
+    },
+    "internal:frame": {
+        "projector": "binary",
+        "receipt": "frames",
+        "tombstone": "frames",
+        "seal": "transfer",
+        "probe": "positive-negative",
+    },
+}
+
+
+def _coverage_command_names(registry: Mapping[str, Any]) -> tuple[str, ...]:
+    """Content-returning commands plus every command that can mutate state."""
+
+    if not isinstance(registry, Mapping):
+        raise TypeError("coverage commands require a {name: command} mapping")
+    mutations: set[str] = set()
+    for name, command in registry.items():
+        read_only = getattr(command, "read_only", None)
+        if type(read_only) is not bool:
+            raise TypeError("coverage command read_only dispositions must be boolean")
+        if not read_only:
+            mutations.add(name)
+    return tuple(sorted(set(content_returning_commands(registry)) | mutations))
+
+
+def command_capability_registry(registry: Mapping[str, Any]) -> dict[str, dict[str, str]]:
+    """Return complete release rows for content and mutation commands."""
+
+    assert_projectors_registered(registry)
+    assert_outcomes_registered(registry)
+    assert_tombstone_coverage()
+    capabilities: dict[str, dict[str, str]] = {}
+    content_commands = frozenset(content_returning_commands(registry))
+    for name in _coverage_command_names(registry):
+        if name not in content_commands:
+            if name not in _METADATA_ONLY_COMMANDS:
+                raise RuntimeError(
+                    "RELEASE_COVERAGE_MISSING: mutation lacks an explicit reduction disposition"
+                )
+            capabilities[name] = dict(_MUTATION_CAPABILITY)
+            continue
+        projector = _COMMAND_PROJECTOR_KIND.get(name)
+        receipt = _COMMAND_OUTCOME_ADAPTER.get(name)
+        tombstone = _COMMAND_TOMBSTONE_ADAPTER.get(name)
+        if not projector or not receipt or not tombstone:
+            raise RuntimeError(
+                "RELEASE_COVERAGE_MISSING: content command has an incomplete capability row"
+            )
+        capabilities[name] = {
+            "projector": projector,
+            "receipt": receipt,
+            "tombstone": tombstone,
+        }
+    return capabilities
+
+
+def alias_capability_registry(
+    alias_registry: Mapping[str, Any], leaf_registry: Mapping[str, Any]
+) -> dict[str, dict[str, str]]:
+    """Return capabilities derived from product leaves and selector branches."""
+
+    assert_alias_projectors_registered(alias_registry, leaf_registry)
+    leaves = command_capability_registry(leaf_registry)
+    capabilities: dict[str, dict[str, str]] = {}
+    for name in _coverage_command_names(alias_registry):
+        alias = alias_registry[name]
+        routes = set(derived_routes(getattr(alias, "leaf", None))) & set(leaf_registry)
+        if name in leaf_registry:
+            routes.add(name)
+        rows = []
+        for route in routes:
+            row = leaves.get(route)
+            if row is None:
+                raise RuntimeError(
+                    "RELEASE_COVERAGE_MISSING: alias route lacks a release capability row: "
+                    f"{name}->{route}"
+                )
+            rows.append(row)
+        for (command_name, _selector), values in _SELECTOR_ADAPTERS.items():
+            if command_name != name:
+                continue
+            tombstones = _SELECTOR_TOMBSTONE_ADAPTERS.get(
+                (command_name, _selector), {}
+            )
+            for value, outcome in values.items():
+                tombstone = tombstones.get(value)
+                if not tombstone:
+                    raise RuntimeError(
+                        "RELEASE_COVERAGE_MISSING: selector lacks a tombstone disposition"
+                    )
+                rows.append(
+                    {
+                        "projector": (
+                            "not-applicable" if outcome == "mutation" else outcome
+                        ),
+                        "receipt": outcome,
+                        "tombstone": tombstone,
+                    }
+                )
+        if not rows and not alias.read_only and name in _METADATA_ONLY_COMMANDS:
+            rows.append(dict(_MUTATION_CAPABILITY))
+        if not rows:
+            raise RuntimeError(
+                "RELEASE_COVERAGE_MISSING: product alias has no derived release disposition"
+            )
+        capabilities[name] = {
+            field: "+".join(sorted({row[field] for row in rows}))
+            for field in ("projector", "receipt", "tombstone")
+        }
+    return capabilities
 
 
 def selector_registry() -> dict[tuple[str, str], dict[str, str]]:
@@ -3141,6 +3370,48 @@ def selector_capability_registry() -> dict[tuple[str, str], dict[str, dict[str, 
     }
 
 
+def surface_route_disposition_registry() -> dict[str, str]:
+    """Return the reviewed classification of every decorated Exomem route."""
+
+    if not set(_SURFACE_ROUTE_DISPOSITIONS.values()) <= _SURFACE_ROUTE_DISPOSITION_VALUES:
+        raise RuntimeError("RELEASE_COVERAGE_MISSING: surface route disposition is unknown")
+    return dict(_SURFACE_ROUTE_DISPOSITIONS)
+
+
+def assert_surface_route_registrations_covered(registrations: Iterable[str]) -> None:
+    """Release-gate an inventory discovered from the real route decorators."""
+
+    surface_route_disposition_registry()
+    actual = frozenset(registrations)
+    expected = frozenset(_SURFACE_ROUTE_DISPOSITIONS)
+    if actual != expected:
+        raise RuntimeError(
+            "RELEASE_COVERAGE_MISSING: registered surface routes lack an explicit disposition"
+        )
+
+
+def non_command_route_capability_registry() -> dict[str, dict[str, str]]:
+    """Return capabilities for governed decorated and internal residual routes."""
+
+    surface_route_disposition_registry()
+    governed = {
+        route
+        for route, disposition in _SURFACE_ROUTE_DISPOSITIONS.items()
+        if disposition == "governed"
+    }
+    if governed != set(_NON_COMMAND_ROUTE_CAPABILITIES):
+        raise RuntimeError(
+            "RELEASE_COVERAGE_MISSING: governed route dispositions lack capability rows"
+        )
+    return {
+        route: dict(capability)
+        for route, capability in {
+            **_NON_COMMAND_ROUTE_CAPABILITIES,
+            **_INTERNAL_RESIDUAL_ROUTE_CAPABILITIES,
+        }.items()
+    }
+
+
 def assert_tombstone_coverage() -> None:
     missing: list[str] = []
     for command in _COMMAND_OUTCOME_ADAPTER:
@@ -3152,7 +3423,12 @@ def assert_tombstone_coverage() -> None:
             f"{command}.{selector}={value}" for value in values if not declared.get(value)
         )
     missing.extend(
-        f"explicit:{route}" for route, adapter in _EXPLICIT_TOMBSTONE_ROUTES.items() if not adapter
+        f"explicit:{route}"
+        for route, capability in {
+            **_NON_COMMAND_ROUTE_CAPABILITIES,
+            **_INTERNAL_RESIDUAL_ROUTE_CAPABILITIES,
+        }.items()
+        if not capability.get("tombstone")
     )
     if missing:
         raise RuntimeError(

--- a/tests/test_consolidation_verification_coverage.py
+++ b/tests/test_consolidation_verification_coverage.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from exomem import commands
+from exomem.governance import consolidation_verification_coverage, egress
+
+
+def _command_registry() -> dict[str, commands.Command]:
+    return {command.name: command for command in commands.COMMANDS}
+
+
+def _product_registry() -> dict[str, commands.Command]:
+    return {command.name: command for command in commands.PRODUCT_COMMANDS}
+
+
+def test_real_content_registries_generate_complete_closed_world_inventory() -> None:
+    canonical = _command_registry()
+    products = _product_registry()
+    inventory = consolidation_verification_coverage.build_coverage_inventory(
+        canonical, product_registry=products
+    )
+    by_id = {branch.branch_id: branch for branch in inventory}
+
+    expected_commands = {
+        f"command:{name}"
+        for name, command in canonical.items()
+        if name in egress.content_returning_commands(canonical) or not command.read_only
+    }
+    expected_products = {
+        f"product:{name}"
+        for name, command in products.items()
+        if name in egress.content_returning_commands(products) or not command.read_only
+    }
+    assert {branch_id for branch_id in by_id if branch_id.startswith("command:")} == (
+        expected_commands
+    )
+    assert {branch_id for branch_id in by_id if branch_id.startswith("product:")} == (
+        expected_products
+    )
+    assert by_id["command:note"].seal_disposition == "mutation"
+    assert by_id["command:note"].probe_disposition == "seal-only"
+    assert by_id["product:remember"].receipt_outcome == "mutation"
+    assert by_id["product:compile_source"].projector_adapter == "structure"
+    assert by_id["product:query_dataset"].receipt_outcome == "structure"
+    assert by_id["product:read_media"].tombstone_gate == "frames"
+    assert by_id["command:list_trash"].tombstone_gate == "structure"
+    assert "selector:record_memory.action=query" in by_id
+    assert "route:server_transfer:_download" in by_id
+    assert all(
+        branch.probe_disposition
+        and branch.seal_disposition
+        and branch.projector_adapter
+        and branch.receipt_outcome
+        and branch.tombstone_gate
+        for branch in inventory
+    )
+
+
+def test_new_content_command_without_release_capabilities_fails_closed() -> None:
+    registry = _command_registry()
+    registry["future_content"] = SimpleNamespace(read_only=True)
+
+    with pytest.raises(
+        consolidation_verification_coverage.ConsolidationVerificationCoverageUnavailable,
+        match="CONSOLIDATION_VERIFICATION_COVERAGE_UNAVAILABLE",
+    ):
+        consolidation_verification_coverage.build_coverage_inventory(registry)
+
+
+def test_new_selector_without_tombstone_disposition_fails_closed() -> None:
+    selectors = egress.selector_capability_registry()
+    selectors[("future_content", "mode")] = {"raw": {"outcome": "binary", "tombstone": ""}}
+
+    with pytest.raises(
+        consolidation_verification_coverage.ConsolidationVerificationCoverageUnavailable
+    ):
+        consolidation_verification_coverage.build_coverage_inventory(
+            _command_registry(),
+            selector_capabilities=selectors,
+        )
+
+
+def test_new_selector_with_invented_adapter_fails_closed() -> None:
+    selectors = egress.selector_capability_registry()
+    selectors[("future_content", "mode")] = {
+        "raw": {"outcome": "invented-adapter", "tombstone": "invented-gate"}
+    }
+
+    with pytest.raises(
+        consolidation_verification_coverage.ConsolidationVerificationCoverageUnavailable
+    ):
+        consolidation_verification_coverage.build_coverage_inventory(
+            _command_registry(),
+            selector_capabilities=selectors,
+        )
+
+
+def test_new_non_command_route_without_probe_disposition_fails_closed() -> None:
+    routes = egress.non_command_route_capability_registry()
+    routes["future-download"] = {
+        "projector": "binary",
+        "receipt": "binary",
+        "tombstone": "binary",
+        "seal": "transfer",
+    }
+
+    with pytest.raises(
+        consolidation_verification_coverage.ConsolidationVerificationCoverageUnavailable
+    ):
+        consolidation_verification_coverage.build_coverage_inventory(
+            _command_registry(),
+            route_capabilities=routes,
+        )
+
+
+def test_unknown_route_disposition_fails_closed() -> None:
+    routes = egress.non_command_route_capability_registry()
+    routes["future-resource"] = {
+        "projector": "artifact-reference",
+        "receipt": "artifact-reference",
+        "tombstone": "artifact-reference",
+        "seal": "read",
+        "probe": "owner-bypass",
+    }
+
+    with pytest.raises(
+        consolidation_verification_coverage.ConsolidationVerificationCoverageUnavailable
+    ):
+        consolidation_verification_coverage.build_coverage_inventory(
+            _command_registry(),
+            route_capabilities=routes,
+        )
+
+
+def test_unknown_route_adapter_fails_closed() -> None:
+    routes = egress.non_command_route_capability_registry()
+    routes["future-resource"] = {
+        "projector": "invented-projector",
+        "receipt": "invented-outcome",
+        "tombstone": "invented-gate",
+        "seal": "read",
+        "probe": "positive-negative",
+    }
+
+    with pytest.raises(
+        consolidation_verification_coverage.ConsolidationVerificationCoverageUnavailable
+    ):
+        consolidation_verification_coverage.build_coverage_inventory(
+            _command_registry(),
+            route_capabilities=routes,
+        )
+
+
+def test_complete_explicit_route_joins_inventory() -> None:
+    routes = egress.non_command_route_capability_registry()
+    routes["future-resource"] = {
+        "projector": "artifact-reference",
+        "receipt": "artifact-reference",
+        "tombstone": "artifact-reference",
+        "seal": "read",
+        "probe": "positive-negative",
+    }
+    inventory = consolidation_verification_coverage.build_coverage_inventory(
+        _command_registry(),
+        route_capabilities=routes,
+    )
+
+    assert "route:future-resource" in {branch.branch_id for branch in inventory}
+
+
+def _registered_surface_route_ids() -> frozenset[str]:
+    source = Path(__file__).resolve().parent.parent / "src" / "exomem"
+    registrations: set[str] = set()
+    for path in sorted(source.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            decorators = (
+                decorator
+                for decorator in node.decorator_list
+                if isinstance(decorator, ast.Call)
+                and isinstance(decorator.func, ast.Attribute)
+                and decorator.func.attr in {"custom_route", "prompt", "resource"}
+            )
+            for _decorator in decorators:
+                route_id = f"{path.stem}:{node.name}"
+                assert route_id not in registrations, (
+                    f"surface route id is ambiguous; split the handler: {route_id}"
+                )
+                registrations.add(route_id)
+    return frozenset(registrations)
+
+
+def test_every_registered_surface_route_has_an_explicit_disposition() -> None:
+    registrations = _registered_surface_route_ids()
+    dispositions = egress.surface_route_disposition_registry()
+
+    egress.assert_surface_route_registrations_covered(registrations)
+    assert registrations == frozenset(dispositions)
+    assert dispositions["server_hosted:_export"] == "operator-control"
+    assert dispositions["server_hosted:_export_download"] == "operator-control"
+    assert not {
+        "server_hosted:_export",
+        "server_hosted:_export_download",
+    } & set(egress.non_command_route_capability_registry())
+
+
+def test_new_real_surface_registration_fails_the_release_gate() -> None:
+    registrations = _registered_surface_route_ids() | {"future_server:new_content_route"}
+
+    with pytest.raises(RuntimeError, match="RELEASE_COVERAGE_MISSING"):
+        egress.assert_surface_route_registrations_covered(registrations)
+
+
+def test_command_registry_runs_the_coverage_gate_at_import() -> None:
+    assert "build_coverage_inventory" in inspect.getsource(commands)


### PR DESCRIPTION
## Summary

- generate one immutable consolidation-verification inventory from canonical commands, product aliases, selector branches, and registered non-command surfaces
- include every content-returning or mutating command, with explicit seal, probe, projector/reduction, receipt, and tombstone dispositions
- fail the release gate on unclassified decorators, incomplete branches, or unknown adapter vocabulary while keeping authenticated lifecycle portability explicitly classified as operator control

Stacked on #1006. This change does not merge the stack or touch a live vault.

## Verification

- red-first coverage regressions reproduced before implementation
- `579 passed` across consolidation coverage, governance postfilter, egress, and receipt suites
- Ruff on all changed files; repository-wide Ruff `F` rules
- `openspec validate --all --strict` (`168 passed, 0 failed`)
- `uv lock --check`
- public repository artifact validation (`3456 files, 3524 text payloads`)
- `git diff --check`
- independent adversarial re-review: no findings