### PR TITLE
fix(governance): require complete verification matrix

### DIFF
--- a/src/exomem/governance/consolidation_verification_manifest.py
+++ b/src/exomem/governance/consolidation_verification_manifest.py
@@ -420,7 +420,7 @@ def _bind_to_stored_plan(
     bundle: object,
     manifest: VerificationManifest,
 ) -> None:
-    """Bind exact manifest contracts to their plan and delegated attestations."""
+    """Bind exact contracts and require the full approved principal/purpose matrix."""
 
     preimage = getattr(plan, "preimage", None)
     verification = preimage.get("verification_plan") if isinstance(preimage, Mapping) else None
@@ -439,16 +439,62 @@ def _bind_to_stored_plan(
     ):
         _fail()
     attestations = getattr(bundle, "attestations", None)
-    if not isinstance(attestations, Sequence):
+    principal_requirements = getattr(bundle, "principal_requirements", None)
+    if (
+        not isinstance(attestations, Sequence)
+        or isinstance(attestations, (str, bytes))
+        or not isinstance(principal_requirements, Sequence)
+        or isinstance(principal_requirements, (str, bytes))
+    ):
         _fail()
     by_fingerprint: dict[str, object] = {}
+    by_principal: dict[str, object] = {}
     for attestation in attestations:
         fingerprint = getattr(attestation, "fingerprint", None)
-        if type(fingerprint) is not str or _DIGEST.fullmatch(fingerprint) is None:
+        principal_id = getattr(attestation, "principal_id", None)
+        purposes = getattr(attestation, "purposes", None)
+        if (
+            type(fingerprint) is not str
+            or _DIGEST.fullmatch(fingerprint) is None
+            or type(principal_id) is not str
+            or not isinstance(purposes, Sequence)
+            or isinstance(purposes, (str, bytes))
+        ):
             _fail()
-        if fingerprint in by_fingerprint:
+        checked_principal = _identifier(principal_id)
+        checked_purposes = tuple(_identifier(purpose) for purpose in purposes)
+        if not checked_purposes or checked_purposes != tuple(sorted(set(checked_purposes))):
+            _fail()
+        if fingerprint in by_fingerprint or checked_principal in by_principal:
             _fail()
         by_fingerprint[fingerprint] = attestation
+        by_principal[checked_principal] = attestation
+    required_pairs: set[tuple[str, str]] = set()
+    for requirement in principal_requirements:
+        if type(requirement) is not tuple or len(requirement) != 2:
+            _fail()
+        principal_id, purposes = requirement
+        if (
+            type(principal_id) is not str
+            or not isinstance(purposes, Sequence)
+            or isinstance(purposes, (str, bytes))
+        ):
+            _fail()
+        checked_principal = _identifier(principal_id)
+        checked_purposes = tuple(_identifier(purpose) for purpose in purposes)
+        if not checked_purposes or checked_purposes != tuple(sorted(set(checked_purposes))):
+            _fail()
+        attestation = by_principal.get(checked_principal)
+        attested_purposes = tuple(getattr(attestation, "purposes", ()))
+        for purpose in checked_purposes:
+            if purpose not in attested_purposes:
+                _fail()
+            pair = (checked_principal, purpose)
+            if pair in required_pairs:
+                _fail()
+            required_pairs.add(pair)
+    if set(by_principal) != {principal_id for principal_id, _purpose in required_pairs}:
+        _fail()
     for contract in manifest.contracts:
         if contract.principal_kind == "owner":
             continue
@@ -461,6 +507,22 @@ def _bind_to_stored_plan(
             or contract.purpose not in purposes
         ):
             _fail()
+    positive_pairs = {
+        (contract.principal_id, contract.purpose)
+        for contract in manifest.positive_contracts
+        if contract.principal_kind == "delegated"
+    }
+    negative_pairs = {
+        (contract.principal_id, contract.purpose)
+        for contract in manifest.negative_contracts
+        if contract.principal_kind == "delegated"
+    }
+    if (
+        not any(contract.principal_kind == "owner" for contract in manifest.positive_contracts)
+        or not required_pairs <= positive_pairs
+        or not required_pairs <= negative_pairs
+    ):
+        _fail()
 
 
 @contextmanager

--- a/tests/test_consolidation_verification_manifest.py
+++ b/tests/test_consolidation_verification_manifest.py
@@ -91,6 +91,9 @@ def _install_stored_plan(
     manifest,
     *,
     attestation_fingerprint: str = ATTESTATION_FINGERPRINT,
+    principal_requirements: tuple[tuple[str, tuple[str, ...]], ...] = (
+        ("external", ("support",)),
+    ),
 ) -> None:
     from exomem.governance import consolidation_plan_store
 
@@ -107,12 +110,15 @@ def _install_stored_plan(
         },
     )
     policy_bundle = SimpleNamespace(
-        attestations=(
+        attestations=tuple(
             SimpleNamespace(
-                principal_id="external",
+                principal_id=principal_id,
                 fingerprint=attestation_fingerprint,
-            ),
+                purposes=purposes,
+            )
+            for principal_id, purposes in principal_requirements
         ),
+        principal_requirements=principal_requirements,
     )
     monkeypatch.setattr(
         consolidation_plan_store.ConsolidationPlanStore,
@@ -242,3 +248,130 @@ def test_manifest_store_refuses_unattested_or_plan_mismatched_contracts(
         consolidation_verification_manifest.ConsolidationVerificationManifestStore(vault).persist(
             RUN_ID, PLAN_DIGEST, manifest
         )
+
+
+@pytest.mark.parametrize("missing_kind", ["positive", "negative"])
+def test_manifest_store_requires_both_probe_kinds_for_every_delegated_purpose(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    missing_kind: str,
+) -> None:
+    from exomem.governance import consolidation_verification_manifest
+
+    support_positive = _delegated_contract()
+    support_negative = _negative_contract()
+    audit_positive = {
+        **_delegated_contract(),
+        "probe_id": "delegated-audit-approved",
+        "purpose": "audit",
+        "expected_result_digest": _digest("delegated-audit-approved:wire"),
+    }
+    audit_negative = {
+        **_negative_contract(),
+        "probe_id": "delegated-audit-denied",
+        "purpose": "audit",
+        "expected_result_digest": _digest("delegated-audit-denied:wire"),
+    }
+    manifest = consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=(
+            _owner_contract(),
+            support_positive,
+            *((audit_positive,) if missing_kind == "negative" else ()),
+        ),
+        negative_contracts=(
+            support_negative,
+            *((audit_negative,) if missing_kind == "positive" else ()),
+        ),
+    )
+    _install_stored_plan(
+        monkeypatch,
+        manifest,
+        principal_requirements=(("external", ("audit", "support")),),
+    )
+
+    with pytest.raises(
+        consolidation_verification_manifest.ConsolidationVerificationManifestUnavailable,
+        match="^CONSOLIDATION_VERIFICATION_MANIFEST_UNAVAILABLE$",
+    ):
+        consolidation_verification_manifest.ConsolidationVerificationManifestStore(
+            tmp_path / "vault"
+        ).persist(RUN_ID, PLAN_DIGEST, manifest)
+
+
+def test_manifest_store_requires_a_positive_owner_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_verification_manifest
+
+    manifest = consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=(_delegated_contract(),),
+        negative_contracts=(_negative_contract(),),
+    )
+    _install_stored_plan(monkeypatch, manifest)
+
+    with pytest.raises(
+        consolidation_verification_manifest.ConsolidationVerificationManifestUnavailable,
+        match="^CONSOLIDATION_VERIFICATION_MANIFEST_UNAVAILABLE$",
+    ):
+        consolidation_verification_manifest.ConsolidationVerificationManifestStore(
+            tmp_path / "vault"
+        ).persist(RUN_ID, PLAN_DIGEST, manifest)
+
+
+def test_manifest_store_accepts_the_complete_owner_and_delegated_purpose_matrix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_verification_manifest
+
+    audit_positive = {
+        **_delegated_contract(),
+        "probe_id": "delegated-audit-approved",
+        "purpose": "audit",
+        "expected_result_digest": _digest("delegated-audit-approved:wire"),
+    }
+    audit_negative = {
+        **_negative_contract(),
+        "probe_id": "delegated-audit-denied",
+        "purpose": "audit",
+        "expected_result_digest": _digest("delegated-audit-denied:wire"),
+    }
+    manifest = consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=(_owner_contract(), _delegated_contract(), audit_positive),
+        negative_contracts=(_negative_contract(), audit_negative),
+    )
+    _install_stored_plan(
+        monkeypatch,
+        manifest,
+        principal_requirements=(("external", ("audit", "support")),),
+    )
+
+    store = consolidation_verification_manifest.ConsolidationVerificationManifestStore(
+        tmp_path / "vault"
+    )
+    assert store.persist(RUN_ID, PLAN_DIGEST, manifest) == manifest
+
+
+def test_manifest_store_accepts_an_owner_only_destination_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_verification_manifest
+
+    owner_negative = {
+        **_owner_contract(),
+        "probe_id": "owner-private-absent",
+        "arguments": {"path": "Knowledge Base/Notes/private.md"},
+        "expected_result_digest": _digest("owner-private-absent:wire"),
+    }
+    manifest = consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=(_owner_contract(),),
+        negative_contracts=(owner_negative,),
+    )
+    _install_stored_plan(monkeypatch, manifest, principal_requirements=())
+
+    store = consolidation_verification_manifest.ConsolidationVerificationManifestStore(
+        tmp_path / "vault"
+    )
+    assert store.persist(RUN_ID, PLAN_DIGEST, manifest) == manifest


### PR DESCRIPTION
## Summary

- bind persisted verification manifests to the exact destination-policy principal requirements
- require a positive owner probe plus positive and negative probes for every delegated principal/purpose pair
- fail closed on malformed, duplicate, unattested, or incomplete requirement sets before verification execution

Stacked after #1008. This does not merge or touch any live vault.

## Verification

- red-first matrix omissions: missing positive and missing negative rows both failed before implementation
- affected verification suites: 45 passed
- Ruff on both changed files
- `uv lock --check`
- `openspec validate --all --strict`: 168 passed
- public repository artifact validation: 3456 files / 3524 text payloads clean
- `git diff --check`