### PR TITLE
fix(governance): require mandatory verification lanes

### DIFF
--- a/src/exomem/governance/consolidation_verification_manifest.py
+++ b/src/exomem/governance/consolidation_verification_manifest.py
@@ -26,6 +26,7 @@ _UUID4 = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-
 _IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}\Z")
 _COMMAND = re.compile(r"[a-z][a-z0-9_]{0,127}\Z")
 _SURFACES = frozenset({"cli", "hosted", "mcp", "rest"})
+_MANDATORY_VERIFICATION_ROWS = frozenset({"graph", "keyword", "raw-read", "security"})
 _FORBIDDEN_ARGUMENT_KEYS = frozenset(
     {
         "authorization_session_credential",
@@ -412,6 +413,61 @@ def _parsed_contract_input(value: object, probe_kind: str) -> dict[str, object]:
     return result
 
 
+def _mandatory_rows_for_contract(contract: VerificationContract) -> frozenset[str]:
+    if contract.surface != "rest":
+        return frozenset()
+    arguments = contract_arguments(contract)
+    query = arguments.get("query")
+    path = arguments.get("path")
+    rows: set[str] = set()
+    search_row: str | None = None
+    if (
+        contract.command_name == "ask_memory"
+        and type(query) is str
+        and bool(query.strip())
+        and arguments.get("mode") == "keyword"
+        and arguments.get("graph") is False
+        and arguments.get("rerank") is False
+        and arguments.get("deep", False) is False
+        and arguments.get("graph_enrich", False) is False
+    ):
+        search_row = "keyword"
+    elif (
+        contract.command_name == "connect_memory"
+        and arguments.get("operation") == "graph-context"
+        and type(path) is str
+        and bool(path.strip())
+        and "query" not in arguments
+        and "unit_ref" not in arguments
+        and arguments.get("include_model_suggestions", False) is False
+    ):
+        search_row = "graph"
+    raw_read = (
+        contract.command_name == "read_memory"
+        and type(path) is str
+        and bool(path.strip())
+        and arguments.get("include_raw") is True
+        and arguments.get("frontmatter_only", False) is False
+        and "unit_ref" not in arguments
+    )
+    if contract.probe_kind == "positive":
+        if search_row is not None:
+            rows.add(search_row)
+        if raw_read:
+            rows.add("raw-read")
+    elif search_row is not None or raw_read:
+        rows.add("security")
+    return frozenset(rows)
+
+
+def _require_mandatory_verification_rows(manifest: VerificationManifest) -> None:
+    rows = frozenset(
+        row for contract in manifest.contracts for row in _mandatory_rows_for_contract(contract)
+    )
+    if not _MANDATORY_VERIFICATION_ROWS <= rows:
+        _fail()
+
+
 def _bind_to_stored_plan(
     *,
     run_id: str,
@@ -438,6 +494,7 @@ def _bind_to_stored_plan(
         != manifest.verification_plan.negative_probe_digest
     ):
         _fail()
+    _require_mandatory_verification_rows(manifest)
     attestations = getattr(bundle, "attestations", None)
     principal_requirements = getattr(bundle, "principal_requirements", None)
     if (
@@ -500,6 +557,8 @@ def _bind_to_stored_plan(
             continue
         attestation = by_fingerprint.get(contract.principal_attestation_fingerprint or "")
         purposes = getattr(attestation, "purposes", (contract.purpose,))
+        if not isinstance(purposes, Sequence) or isinstance(purposes, (str, bytes)):
+            _fail()
         if (
             attestation is None
             or getattr(attestation, "principal_id", None) != contract.principal_id

--- a/tests/test_consolidation_plan.py
+++ b/tests/test_consolidation_plan.py
@@ -185,15 +185,44 @@ def _verification_manifest():
             {
                 **common,
                 "probe_id": "owner-destination-present",
-                "arguments": {"path": "Knowledge Base/Notes/destination.md"},
+                "arguments": {
+                    "path": "Knowledge Base/Notes/destination.md",
+                    "include_raw": True,
+                },
                 "expected_result_digest": _digest("destination-present-wire"),
+            },
+            {
+                **common,
+                "probe_id": "owner-keyword-present",
+                "command_name": "ask_memory",
+                "arguments": {
+                    "query": "destination",
+                    "mode": "keyword",
+                    "graph": False,
+                    "rerank": False,
+                },
+                "expected_result_digest": _digest("keyword-present-wire"),
+            },
+            {
+                **common,
+                "probe_id": "owner-graph-present",
+                "command_name": "connect_memory",
+                "arguments": {
+                    "operation": "graph-context",
+                    "path": "Knowledge Base/Notes/destination.md",
+                    "include_model_suggestions": False,
+                },
+                "expected_result_digest": _digest("graph-present-wire"),
             },
         ),
         negative_contracts=(
             {
                 **common,
                 "probe_id": "owner-private-absent",
-                "arguments": {"path": "Knowledge Base/Notes/private.md"},
+                "arguments": {
+                    "path": "Knowledge Base/Notes/private.md",
+                    "include_raw": True,
+                },
                 "expected_result_digest": _digest("private-absent-wire"),
             },
         ),

--- a/tests/test_consolidation_verification_manifest.py
+++ b/tests/test_consolidation_verification_manifest.py
@@ -41,8 +41,11 @@ def _owner_contract() -> dict[str, object]:
         "principal_kind": "owner",
         "principal_id": "owner",
         "purpose": "owner-verification",
-        "command_name": "get",
-        "arguments": {"path": "Knowledge Base/Notes/destination.md"},
+        "command_name": "read_memory",
+        "arguments": {
+            "path": "Knowledge Base/Notes/destination.md",
+            "include_raw": True,
+        },
         "expected_result_digest": _digest("owner-note-full:wire"),
     }
 
@@ -56,23 +59,55 @@ def _delegated_contract() -> dict[str, object]:
         "principal_id": "external",
         "principal_attestation_fingerprint": ATTESTATION_FINGERPRINT,
         "purpose": "support",
-        "command_name": "find",
+        "command_name": "ask_memory",
         "arguments": {
             "query": "approved compiled abstraction",
             "mode": "keyword",
             "graph": False,
+            "rerank": False,
             "limit": 10,
         },
         "expected_result_digest": _digest("delegated-approved-projection:wire"),
     }
 
 
+def _graph_contract() -> dict[str, object]:
+    return {
+        **_delegated_contract(),
+        "probe_id": "delegated-approved-graph",
+        "command_name": "connect_memory",
+        "arguments": {
+            "operation": "graph-context",
+            "path": "Knowledge Base/Notes/destination.md",
+            "include_model_suggestions": False,
+            "depth": 1,
+        },
+        "expected_result_digest": _digest("delegated-approved-graph:wire"),
+    }
+
+
+def _owner_keyword_contract() -> dict[str, object]:
+    contract = {
+        **_delegated_contract(),
+        "probe_id": "owner-keyword",
+        "principal_kind": "owner",
+        "principal_id": "owner",
+        "purpose": "owner-verification",
+        "expected_result_digest": _digest("owner-keyword:wire"),
+    }
+    contract.pop("principal_attestation_fingerprint")
+    return contract
+
+
 def _negative_contract() -> dict[str, object]:
     return {
         **_delegated_contract(),
         "probe_id": "delegated-private-body-absent",
-        "command_name": "get",
-        "arguments": {"path": "Knowledge Base/Notes/private.md"},
+        "command_name": "read_memory",
+        "arguments": {
+            "path": "Knowledge Base/Notes/private.md",
+            "include_raw": True,
+        },
         "expected_result_digest": _digest("delegated-private-body-absent:wire"),
     }
 
@@ -81,7 +116,7 @@ def _manifest():
     from exomem.governance import consolidation_verification_manifest
 
     return consolidation_verification_manifest.build_verification_manifest(
-        positive_contracts=(_owner_contract(), _delegated_contract()),
+        positive_contracts=(_owner_contract(), _delegated_contract(), _graph_contract()),
         negative_contracts=(_negative_contract(),),
     )
 
@@ -149,7 +184,7 @@ def test_manifest_is_canonical_round_trippable_and_builds_the_exact_probe_plan()
     )
     assert consolidation_verification_manifest.contract_arguments(
         manifest.positive_contracts[0]
-    ) == {"path": "Knowledge Base/Notes/destination.md"}
+    ) == {"include_raw": True, "path": "Knowledge Base/Notes/destination.md"}
 
 
 @pytest.mark.parametrize(
@@ -338,7 +373,12 @@ def test_manifest_store_accepts_the_complete_owner_and_delegated_purpose_matrix(
         "expected_result_digest": _digest("delegated-audit-denied:wire"),
     }
     manifest = consolidation_verification_manifest.build_verification_manifest(
-        positive_contracts=(_owner_contract(), _delegated_contract(), audit_positive),
+        positive_contracts=(
+            _owner_contract(),
+            _delegated_contract(),
+            _graph_contract(),
+            audit_positive,
+        ),
         negative_contracts=(_negative_contract(), audit_negative),
     )
     _install_stored_plan(
@@ -362,11 +402,24 @@ def test_manifest_store_accepts_an_owner_only_destination_policy(
     owner_negative = {
         **_owner_contract(),
         "probe_id": "owner-private-absent",
-        "arguments": {"path": "Knowledge Base/Notes/private.md"},
+        "arguments": {
+            "path": "Knowledge Base/Notes/private.md",
+            "include_raw": True,
+        },
         "expected_result_digest": _digest("owner-private-absent:wire"),
     }
+    owner_keyword = _owner_keyword_contract()
+    owner_graph = {
+        **_graph_contract(),
+        "probe_id": "owner-graph",
+        "principal_kind": "owner",
+        "principal_id": "owner",
+        "purpose": "owner-verification",
+        "expected_result_digest": _digest("owner-graph:wire"),
+    }
+    owner_graph.pop("principal_attestation_fingerprint")
     manifest = consolidation_verification_manifest.build_verification_manifest(
-        positive_contracts=(_owner_contract(),),
+        positive_contracts=(_owner_contract(), owner_keyword, owner_graph),
         negative_contracts=(owner_negative,),
     )
     _install_stored_plan(monkeypatch, manifest, principal_requirements=())
@@ -375,3 +428,217 @@ def test_manifest_store_accepts_an_owner_only_destination_policy(
         tmp_path / "vault"
     )
     assert store.persist(RUN_ID, PLAN_DIGEST, manifest) == manifest
+
+
+@pytest.mark.parametrize(
+    ("missing_row", "positive_contracts", "negative_contracts"),
+    [
+        (
+            "keyword",
+            (_owner_contract(), _graph_contract()),
+            (_negative_contract(),),
+        ),
+        (
+            "graph",
+            (_owner_contract(), _delegated_contract()),
+            (_negative_contract(),),
+        ),
+        (
+            "raw-read",
+            (_owner_keyword_contract(), _delegated_contract(), _graph_contract()),
+            (_negative_contract(),),
+        ),
+        (
+            "security",
+            (_owner_contract(), _delegated_contract(), _graph_contract()),
+            (
+                {
+                    **_negative_contract(),
+                    "probe_id": "optional-vector-negative",
+                    "command_name": "ask_memory",
+                    "arguments": {
+                        "query": "private body",
+                        "mode": "vector",
+                        "graph": False,
+                        "limit": 10,
+                    },
+                    "expected_result_digest": _digest("optional-vector-negative:wire"),
+                },
+            ),
+        ),
+    ],
+)
+def test_manifest_store_rejects_missing_mandatory_non_model_verification_row(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    missing_row: str,
+    positive_contracts: tuple[dict[str, object], ...],
+    negative_contracts: tuple[dict[str, object], ...],
+) -> None:
+    from exomem.governance import consolidation_verification_manifest
+
+    manifest = consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=positive_contracts,
+        negative_contracts=negative_contracts,
+    )
+    _install_stored_plan(monkeypatch, manifest)
+
+    with pytest.raises(
+        consolidation_verification_manifest.ConsolidationVerificationManifestUnavailable,
+        match="^CONSOLIDATION_VERIFICATION_MANIFEST_UNAVAILABLE$",
+    ):
+        consolidation_verification_manifest.ConsolidationVerificationManifestStore(
+            tmp_path / f"vault-{missing_row}"
+        ).persist(RUN_ID, PLAN_DIGEST, manifest)
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {
+            "query": "approved compiled abstraction",
+            "mode": "vector",
+            "graph": False,
+            "rerank": False,
+            "limit": 10,
+        },
+        {
+            "query": "approved compiled abstraction",
+            "mode": "hybrid",
+            "graph": False,
+            "rerank": False,
+            "limit": 10,
+        },
+        {
+            "query": "approved compiled abstraction",
+            "mode": "keyword",
+            "graph": False,
+            "rerank": True,
+            "limit": 10,
+        },
+        {
+            "query": "approved compiled abstraction",
+            "mode": "keyword",
+            "graph": False,
+            "limit": 10,
+        },
+        {
+            "query": "approved compiled abstraction",
+            "mode": "keyword",
+            "graph": False,
+            "rerank": False,
+            "deep": True,
+            "limit": 10,
+        },
+        {
+            "query": "approved compiled abstraction",
+            "mode": "keyword",
+            "graph": False,
+            "rerank": False,
+            "deep": "true",
+            "limit": 10,
+        },
+        {
+            "query": "approved compiled abstraction",
+            "mode": "keyword",
+            "graph": False,
+            "rerank": False,
+            "graph_enrich": "1",
+            "limit": 10,
+        },
+        {
+            "query": "   ",
+            "mode": "keyword",
+            "graph": False,
+            "rerank": False,
+            "limit": 10,
+        },
+    ],
+)
+def test_non_mandatory_recall_profile_cannot_satisfy_the_keyword_row(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    arguments: dict[str, object],
+) -> None:
+    from exomem.governance import consolidation_verification_manifest
+
+    optional_recall = {
+        **_delegated_contract(),
+        "probe_id": "optional-model-recall",
+        "arguments": arguments,
+        "expected_result_digest": _digest("optional-model-recall:wire"),
+    }
+    manifest = consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=(_owner_contract(), _graph_contract(), optional_recall),
+        negative_contracts=(_negative_contract(),),
+    )
+    _install_stored_plan(monkeypatch, manifest)
+
+    with pytest.raises(
+        consolidation_verification_manifest.ConsolidationVerificationManifestUnavailable,
+        match="^CONSOLIDATION_VERIFICATION_MANIFEST_UNAVAILABLE$",
+    ):
+        consolidation_verification_manifest.ConsolidationVerificationManifestStore(
+            tmp_path / "vault-optional-model"
+        ).persist(RUN_ID, PLAN_DIGEST, manifest)
+
+
+@pytest.mark.parametrize("missing_row", ["graph", "raw-read"])
+def test_truthy_string_flag_cannot_satisfy_a_mandatory_non_model_row(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    missing_row: str,
+) -> None:
+    from exomem.governance import consolidation_verification_manifest
+
+    raw = _owner_contract()
+    graph = _graph_contract()
+    if missing_row == "graph":
+        graph["arguments"] = {
+            **graph["arguments"],
+            "include_model_suggestions": "true",
+        }
+    else:
+        raw["arguments"] = {
+            **raw["arguments"],
+            "frontmatter_only": "true",
+        }
+    manifest = consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=(raw, _delegated_contract(), graph),
+        negative_contracts=(_negative_contract(),),
+    )
+    _install_stored_plan(monkeypatch, manifest)
+
+    with pytest.raises(
+        consolidation_verification_manifest.ConsolidationVerificationManifestUnavailable,
+        match="^CONSOLIDATION_VERIFICATION_MANIFEST_UNAVAILABLE$",
+    ):
+        consolidation_verification_manifest.ConsolidationVerificationManifestStore(
+            tmp_path / f"vault-truthy-{missing_row}"
+        ).persist(RUN_ID, PLAN_DIGEST, manifest)
+
+
+def test_non_rest_contracts_cannot_satisfy_the_in_process_mandatory_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_verification_manifest
+
+    positive = tuple(
+        {**contract, "surface": "mcp"}
+        for contract in (_owner_contract(), _delegated_contract(), _graph_contract())
+    )
+    negative = ({**_negative_contract(), "surface": "mcp"},)
+    manifest = consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=positive,
+        negative_contracts=negative,
+    )
+    _install_stored_plan(monkeypatch, manifest)
+
+    with pytest.raises(
+        consolidation_verification_manifest.ConsolidationVerificationManifestUnavailable,
+        match="^CONSOLIDATION_VERIFICATION_MANIFEST_UNAVAILABLE$",
+    ):
+        consolidation_verification_manifest.ConsolidationVerificationManifestStore(
+            tmp_path / "vault-mcp-only"
+        ).persist(RUN_ID, PLAN_DIGEST, manifest)

--- a/tests/test_consolidation_verification_registry.py
+++ b/tests/test_consolidation_verification_registry.py
@@ -160,6 +160,68 @@ def test_owner_probe_crosses_real_dispatch_egress_receipt_and_rest_adapter(
     )
 
 
+def test_mandatory_graph_probe_executes_the_live_product_route_without_models(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import commands, embeddings, find
+    from exomem.governance import (
+        consolidation_verification_manifest,
+        consolidation_verification_registry,
+    )
+
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", "1")
+    vault = tmp_path / "vault"
+    public = vault / "Knowledge Base" / "Notes" / "public.md"
+    related = vault / "Knowledge Base" / "Notes" / "related.md"
+    public.parent.mkdir(parents=True)
+    public.write_text("# Public\n\n[[Knowledge Base/Notes/related.md]]\n", encoding="utf-8")
+    related.write_text("# Related\n\nGraph neighbour.\n", encoding="utf-8")
+
+    def forbid_model(*_args, **_kwargs):
+        raise AssertionError("mandatory graph verification must not invoke a model lane")
+
+    monkeypatch.setattr(embeddings, "embed_texts", forbid_model)
+    monkeypatch.setattr(find, "find", forbid_model)
+    arguments = {
+        "operation": "graph-context",
+        "path": "Knowledge Base/Notes/public.md",
+        "include_model_suggestions": False,
+        "depth": 1,
+    }
+    expected = commands.op_connect_memory(vault, **arguments)
+    wire = consolidation_verification_registry.render_rest_verification_wire(
+        success=True,
+        data=expected,
+    )
+    contract = {
+        "probe_id": "owner-graph-context",
+        "executor_id": "canonical-governance-surface-v1",
+        "surface": "rest",
+        "principal_kind": "owner",
+        "principal_id": "owner",
+        "purpose": "consolidation-verification",
+        "command_name": "connect_memory",
+        "arguments": arguments,
+        "expected_result_digest": (
+            consolidation_verification_registry.verification_wire_result_digest("rest", wire)
+        ),
+    }
+    manifest = consolidation_verification_manifest.build_verification_manifest(
+        positive_contracts=(contract,),
+        negative_contracts=({**contract, "probe_id": "owner-graph-context-negative"},),
+    )
+
+    terminal = consolidation_verification_registry.run_probe(
+        manifest.verification_plan.positive_probes[0],
+        _context(vault, manifest),
+    )
+
+    assert terminal.result_digest == contract["expected_result_digest"]
+    assert terminal.outcome == "passed"
+
+
 def test_probe_refuses_forged_authority_and_mismatched_contract_before_dispatch(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- require executable REST evidence for keyword recall, path-bound graph context, raw reads, and negative disclosure before a stored cutover manifest is admissible
- prevent hybrid/vector, implicit or explicit reranking, deep/model enrichment, truthy-string coercions, whitespace queries, legacy commands, and non-REST contracts from substituting for mandatory no-model rows
- prove the graph row through the live product registry with model calls forbidden and keep plan-store fixtures aligned with the complete matrix

Stacked on #1010. This does not touch or consolidate any live vault.

## Verification

- `EXOMEM_DISABLE_EMBEDDINGS=1 EXOMEM_DISABLE_MEDIA_EXTRACTION=1 uv run --frozen python -m pytest -q tests/test_consolidation_plan.py tests/test_consolidation_verification.py tests/test_consolidation_verification_manifest.py tests/test_consolidation_verification_registry.py` — 127 passed
- Ruff on all four changed files with `E,F,I,B,UP,BLE`
- targeted mypy on `consolidation_verification_manifest.py`
- `uv lock --check`
- `openspec validate add-governed-vault-consolidation --strict`
- `git diff --check`
- independent adversarial review: no findings