### PR TITLE
feat(governance): add exact-cell transport probe boundary

### DIFF
--- a/src/exomem/governance/consolidation_admission.py
+++ b/src/exomem/governance/consolidation_admission.py
@@ -19,7 +19,12 @@ from typing import NoReturn, cast
 from .. import held_fs, reserved_paths, writer_lease
 from ..cli_ops import OpError
 from ..mutation_lock import VaultMutationCoordinator
-from . import consolidation_authority, consolidation_plan, consolidation_seal
+from . import (
+    consolidation_authority,
+    consolidation_plan,
+    consolidation_seal,
+    consolidation_transport_verification,
+)
 
 _DESCRIPTOR_ID = "consolidation-tree"
 _OWNER = "consolidation.run"
@@ -513,6 +518,26 @@ class ConsolidationAdmission:
 
         return self.snapshot()
 
+    @staticmethod
+    def _ordinary_admitted(
+        state: consolidation_seal.ConsolidationSealState,
+        *,
+        kind: str,
+    ) -> bool:
+        if state.kind == "open":
+            return True
+        return (
+            kind == "read"
+            and state.kind == "consolidation-sealed"
+            and consolidation_transport_verification._active_route_matches(  # noqa: SLF001
+                vault_binding_digest=state.vault_binding_digest,
+                run_id=state.run_id,
+                operation_id=state.operation_id,
+                journal_digest=state.journal_digest,
+                phase=state.phase,
+            )
+        )
+
     @contextmanager
     def _admit(self, kind: str) -> Iterator[ConsolidationMutationAdmission | None]:
         if kind not in _PARTICIPANT_KINDS:
@@ -541,7 +566,7 @@ class ConsolidationAdmission:
                         holder_kind="reserved-state",
                         publish_holder_metadata=False,
                     ):
-                        if self._load_state().kind != "open":
+                        if not self._ordinary_admitted(self._load_state(), kind=kind):
                             _fail("CONSOLIDATION_SEALED")
                         if any(current.kind == "control" for current in self._load_participants()):
                             _fail("CONSOLIDATION_CONTROL_PENDING")
@@ -549,7 +574,7 @@ class ConsolidationAdmission:
                         published = True
                     # Another configured coordination root cannot share this
                     # gate. Rechecking the seal closes that publication race.
-                    if self._load_state().kind != "open":
+                    if not self._ordinary_admitted(self._load_state(), kind=kind):
                         self._remove_participant(participant_id)
                         published = False
                         _fail("CONSOLIDATION_SEALED")

--- a/src/exomem/governance/consolidation_transport_verification.py
+++ b/src/exomem/governance/consolidation_transport_verification.py
@@ -1,0 +1,472 @@
+"""Exact-cell transport verification basis and process-local probe route."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Literal, NoReturn, SupportsIndex, cast
+
+from . import consolidation_authority, consolidation_plan
+
+TRANSPORT_VERIFICATION_BASIS_SCHEMA = (
+    "exomem.consolidation-transport-verification-basis/v1"
+)
+TRANSPORT_VERIFICATION_PROBE_SCHEMA = (
+    "exomem.consolidation-transport-verification-probe/v1"
+)
+TRANSPORT_VERIFICATION_PLAN_SCHEMA = (
+    "exomem.consolidation-transport-verification-plan/v1"
+)
+
+_BASIS_DOMAIN = TRANSPORT_VERIFICATION_BASIS_SCHEMA.encode("ascii")
+_PROBE_DOMAIN = TRANSPORT_VERIFICATION_PROBE_SCHEMA.encode("ascii")
+_PLAN_DOMAIN = TRANSPORT_VERIFICATION_PLAN_SCHEMA.encode("ascii")
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_UUID4 = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
+)
+_IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}\Z")
+_SURFACES = ("mcp", "rest", "hosted", "cli")
+_POLARITIES = ("positive", "negative")
+_MAX_PROBES = 1024
+_ROUTE_SEAL = object()
+_ACTIVE_ROUTE: ContextVar[TransportProbeRoute | None] = ContextVar(
+    "exomem_consolidation_transport_probe_route",
+    default=None,
+)
+_BASIS_FIELDS = frozenset(
+    {
+        "schema",
+        "vault_binding_digest",
+        "run_id",
+        "operation_id",
+        "plan_digest",
+        "verification_manifest_digest",
+        "canonical_census_digest",
+        "release_build_digest",
+        "surface_profile",
+        "surface_descriptor_digest",
+        "configuration_digest",
+        "trust_digest",
+        "principal_mapping_digest",
+        "routing_stop_digest",
+        "transport_supervisor_readiness_digest",
+        "destination_kind",
+    }
+)
+_CONTRACT_FIELDS = frozenset(
+    {
+        "probe_id",
+        "probe_kind",
+        "surface",
+        "contract_digest",
+        "expected_result_digest",
+    }
+)
+
+__all__ = [
+    "TRANSPORT_VERIFICATION_BASIS_SCHEMA",
+    "TRANSPORT_VERIFICATION_PLAN_SCHEMA",
+    "TRANSPORT_VERIFICATION_PROBE_SCHEMA",
+    "ConsolidationTransportVerificationUnavailable",
+    "TransportProbe",
+    "TransportProbeRoute",
+    "TransportVerificationBasis",
+    "TransportVerificationPlan",
+    "build_transport_verification_plan",
+    "issue_transport_probe_route",
+    "require_active_transport_probe_route",
+    "transport_probe_route_scope",
+]
+
+
+class ConsolidationTransportVerificationUnavailable(RuntimeError):
+    """Content-free refusal for an invalid exact-cell transport gate."""
+
+    code = "CONSOLIDATION_TRANSPORT_VERIFICATION_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationTransportVerificationUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if type(value) is not str or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _uuid4(value: object) -> str:
+    if type(value) is not str or _UUID4.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _identifier(value: object) -> str:
+    if type(value) is not str or _IDENTIFIER.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _mapping(value: object, fields: frozenset[str]) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or frozenset(value) != fields:
+        _fail()
+    return value
+
+
+def _framed_digest(domain: bytes, value: object) -> str:
+    try:
+        encoded = consolidation_plan.canonical_closed_jcs(value)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    framed = len(domain).to_bytes(4, "big") + domain + len(encoded).to_bytes(8, "big") + encoded
+    return hashlib.sha256(framed).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class TransportVerificationBasis:
+    schema: str
+    vault_binding_digest: str
+    run_id: str
+    operation_id: str
+    plan_digest: str
+    verification_manifest_digest: str
+    canonical_census_digest: str
+    release_build_digest: str
+    surface_profile: str
+    surface_descriptor_digest: str
+    configuration_digest: str
+    trust_digest: str
+    principal_mapping_digest: str
+    routing_stop_digest: str
+    transport_supervisor_readiness_digest: str
+    destination_kind: Literal["real"]
+    digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class TransportProbe:
+    schema: str
+    ordinal: int
+    probe_id: str
+    probe_kind: Literal["positive", "negative"]
+    surface: Literal["mcp", "rest", "hosted", "cli"]
+    contract_digest: str
+    expected_result_digest: str
+    probe_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class TransportVerificationPlan:
+    schema: str
+    basis: TransportVerificationBasis
+    probes: tuple[TransportProbe, ...]
+    digest: str
+
+
+def _basis_value(basis: TransportVerificationBasis) -> dict[str, object]:
+    return {
+        "schema": basis.schema,
+        "vault_binding_digest": basis.vault_binding_digest,
+        "run_id": basis.run_id,
+        "operation_id": basis.operation_id,
+        "plan_digest": basis.plan_digest,
+        "verification_manifest_digest": basis.verification_manifest_digest,
+        "canonical_census_digest": basis.canonical_census_digest,
+        "release_build_digest": basis.release_build_digest,
+        "surface_profile": basis.surface_profile,
+        "surface_descriptor_digest": basis.surface_descriptor_digest,
+        "configuration_digest": basis.configuration_digest,
+        "trust_digest": basis.trust_digest,
+        "principal_mapping_digest": basis.principal_mapping_digest,
+        "routing_stop_digest": basis.routing_stop_digest,
+        "transport_supervisor_readiness_digest": (
+            basis.transport_supervisor_readiness_digest
+        ),
+        "destination_kind": basis.destination_kind,
+    }
+
+
+def _checked_basis(value: object) -> TransportVerificationBasis:
+    row = _mapping(value, _BASIS_FIELDS)
+    if (
+        row["schema"] != TRANSPORT_VERIFICATION_BASIS_SCHEMA
+        or row["destination_kind"] != "real"
+    ):
+        _fail()
+    basis = TransportVerificationBasis(
+        schema=TRANSPORT_VERIFICATION_BASIS_SCHEMA,
+        vault_binding_digest=_digest(row["vault_binding_digest"]),
+        run_id=_uuid4(row["run_id"]),
+        operation_id=_uuid4(row["operation_id"]),
+        plan_digest=_digest(row["plan_digest"]),
+        verification_manifest_digest=_digest(row["verification_manifest_digest"]),
+        canonical_census_digest=_digest(row["canonical_census_digest"]),
+        release_build_digest=_digest(row["release_build_digest"]),
+        surface_profile=_identifier(row["surface_profile"]),
+        surface_descriptor_digest=_digest(row["surface_descriptor_digest"]),
+        configuration_digest=_digest(row["configuration_digest"]),
+        trust_digest=_digest(row["trust_digest"]),
+        principal_mapping_digest=_digest(row["principal_mapping_digest"]),
+        routing_stop_digest=_digest(row["routing_stop_digest"]),
+        transport_supervisor_readiness_digest=_digest(
+            row["transport_supervisor_readiness_digest"]
+        ),
+        destination_kind="real",
+        digest="0" * 64,
+    )
+    return TransportVerificationBasis(
+        **{
+            **{field: getattr(basis, field) for field in _BASIS_FIELDS},
+            "digest": _framed_digest(_BASIS_DOMAIN, _basis_value(basis)),
+        }
+    )
+
+
+def _probe_value(probe: TransportProbe) -> dict[str, object]:
+    return {
+        "schema": probe.schema,
+        "ordinal": probe.ordinal,
+        "probe_id": probe.probe_id,
+        "probe_kind": probe.probe_kind,
+        "surface": probe.surface,
+        "contract_digest": probe.contract_digest,
+        "expected_result_digest": probe.expected_result_digest,
+    }
+
+
+def _checked_probe(value: object, *, ordinal: int) -> TransportProbe:
+    row = _mapping(value, _CONTRACT_FIELDS)
+    surface = row["surface"]
+    probe_kind = row["probe_kind"]
+    if surface not in _SURFACES or probe_kind not in _POLARITIES:
+        _fail()
+    probe = TransportProbe(
+        schema=TRANSPORT_VERIFICATION_PROBE_SCHEMA,
+        ordinal=ordinal,
+        probe_id=_identifier(row["probe_id"]),
+        probe_kind=cast(Literal["positive", "negative"], probe_kind),
+        surface=cast(Literal["mcp", "rest", "hosted", "cli"], surface),
+        contract_digest=_digest(row["contract_digest"]),
+        expected_result_digest=_digest(row["expected_result_digest"]),
+        probe_digest="0" * 64,
+    )
+    return TransportProbe(
+        schema=probe.schema,
+        ordinal=probe.ordinal,
+        probe_id=probe.probe_id,
+        probe_kind=probe.probe_kind,
+        surface=probe.surface,
+        contract_digest=probe.contract_digest,
+        expected_result_digest=probe.expected_result_digest,
+        probe_digest=_framed_digest(_PROBE_DOMAIN, _probe_value(probe)),
+    )
+
+
+def build_transport_verification_plan(
+    *,
+    basis: Mapping[str, object],
+    contracts: Sequence[Mapping[str, object]],
+) -> TransportVerificationPlan:
+    """Build one real-cell plan with both polarities on every public surface."""
+
+    if (
+        isinstance(contracts, (str, bytes))
+        or not isinstance(contracts, Sequence)
+        or not 1 <= len(contracts) <= _MAX_PROBES
+    ):
+        _fail()
+    checked_basis = _checked_basis(basis)
+    probes = tuple(
+        _checked_probe(contract, ordinal=ordinal)
+        for ordinal, contract in enumerate(contracts)
+    )
+    if len({probe.probe_id for probe in probes}) != len(probes):
+        _fail()
+    coverage = {(probe.surface, probe.probe_kind) for probe in probes}
+    if coverage != {
+        (surface, polarity)
+        for surface in _SURFACES
+        for polarity in _POLARITIES
+    }:
+        _fail()
+    value = {
+        "schema": TRANSPORT_VERIFICATION_PLAN_SCHEMA,
+        "basis": {**_basis_value(checked_basis), "basis_digest": checked_basis.digest},
+        "probes": tuple(
+            {**_probe_value(probe), "probe_digest": probe.probe_digest}
+            for probe in probes
+        ),
+    }
+    return TransportVerificationPlan(
+        schema=TRANSPORT_VERIFICATION_PLAN_SCHEMA,
+        basis=checked_basis,
+        probes=probes,
+        digest=_framed_digest(_PLAN_DOMAIN, value),
+    )
+
+
+class TransportProbeRoute:
+    """Opaque process-local permission for one supervised isolated probe route."""
+
+    __slots__ = (
+        "__journal_digest",
+        "__operation_id",
+        "__probe_digest",
+        "__run_id",
+        "__seal",
+        "__vault_binding_digest",
+    )
+    __vault_binding_digest: str
+    __run_id: str
+    __operation_id: str
+    __journal_digest: str
+    __probe_digest: str
+    __seal: object
+
+    def __init__(
+        self,
+        vault_binding_digest: str,
+        run_id: str,
+        operation_id: str,
+        journal_digest: str,
+        probe_digest: str,
+        seal: object,
+    ) -> None:
+        object.__setattr__(self, "_TransportProbeRoute__vault_binding_digest", vault_binding_digest)
+        object.__setattr__(self, "_TransportProbeRoute__run_id", run_id)
+        object.__setattr__(self, "_TransportProbeRoute__operation_id", operation_id)
+        object.__setattr__(self, "_TransportProbeRoute__journal_digest", journal_digest)
+        object.__setattr__(self, "_TransportProbeRoute__probe_digest", probe_digest)
+        object.__setattr__(self, "_TransportProbeRoute__seal", seal)
+
+    def __setattr__(self, _name: str, _value: object) -> NoReturn:
+        raise TypeError("transport probe route is immutable")
+
+    def __repr__(self) -> str:
+        return "<TransportProbeRoute process-local>"
+
+    def __reduce__(self) -> NoReturn:
+        raise TypeError("transport probe route is process-local")
+
+    def __reduce_ex__(self, _protocol: SupportsIndex) -> NoReturn:
+        raise TypeError("transport probe route is process-local")
+
+    def __copy__(self) -> NoReturn:
+        raise TypeError("transport probe route is process-local")
+
+    def __deepcopy__(self, _memo: object) -> NoReturn:
+        raise TypeError("transport probe route is process-local")
+
+    def _matches(
+        self,
+        *,
+        vault_binding_digest: str,
+        run_id: str,
+        operation_id: str,
+        journal_digest: str,
+    ) -> bool:
+        return self.__seal is _ROUTE_SEAL and (
+            self.__vault_binding_digest,
+            self.__run_id,
+            self.__operation_id,
+            self.__journal_digest,
+        ) == (vault_binding_digest, run_id, operation_id, journal_digest)
+
+    def _matches_probe(self, probe_digest: str) -> bool:
+        return self.__seal is _ROUTE_SEAL and self.__probe_digest == probe_digest
+
+
+def issue_transport_probe_route(
+    authority: object,
+    *,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+    probe_digest: str,
+) -> TransportProbeRoute:
+    """Consume exact probe authority before entering an auth-transparent route."""
+
+    checked_vault = _digest(vault_binding_digest)
+    checked_run = _uuid4(run_id)
+    checked_operation = _uuid4(operation_id)
+    checked_journal = _digest(journal_digest)
+    checked_probe = _digest(probe_digest)
+    try:
+        consolidation_authority.require_authority(
+            authority,
+            vault_binding_digest=checked_vault,
+            run_id=checked_run,
+            operation_id=checked_operation,
+            journal_digest=checked_journal,
+            phase="transport-verifying",
+            action="probe",
+        )
+    except consolidation_authority.ConsolidationAuthorityUnavailable:
+        _fail()
+    return TransportProbeRoute(
+        checked_vault,
+        checked_run,
+        checked_operation,
+        checked_journal,
+        checked_probe,
+        _ROUTE_SEAL,
+    )
+
+
+@contextmanager
+def transport_probe_route_scope(route: object) -> Iterator[None]:
+    """Mark only the supervisor's current execution context as the isolated route."""
+
+    if type(route) is not TransportProbeRoute or _ACTIVE_ROUTE.get() is not None:
+        _fail()
+    token = _ACTIVE_ROUTE.set(route)
+    try:
+        yield
+    finally:
+        _ACTIVE_ROUTE.reset(token)
+
+
+def require_active_transport_probe_route(*, probe_digest: str) -> None:
+    """Bind the supervisor's exact precommitted probe before transport execution."""
+
+    route = _ACTIVE_ROUTE.get()
+    if (
+        type(route) is not TransportProbeRoute
+        or not route._matches_probe(_digest(probe_digest))
+    ):
+        _fail()
+
+
+def _active_route_matches(
+    *,
+    vault_binding_digest: str,
+    run_id: str | None,
+    operation_id: str | None,
+    journal_digest: str | None,
+    phase: str | None,
+) -> bool:
+    """Internal admission seam; route state never comes from request data."""
+
+    route = _ACTIVE_ROUTE.get()
+    return (
+        type(route) is TransportProbeRoute
+        and phase == "transport-verifying"
+        and type(run_id) is str
+        and type(operation_id) is str
+        and type(journal_digest) is str
+        and route._matches(
+            vault_binding_digest=vault_binding_digest,
+            run_id=run_id,
+            operation_id=operation_id,
+            journal_digest=journal_digest,
+        )
+    )

--- a/src/exomem/governance/consolidation_transport_verification.py
+++ b/src/exomem/governance/consolidation_transport_verification.py
@@ -190,13 +190,22 @@ class _PlanAdmission:
     __seal: object
 
     def __init__(self, plan_digest: str, seal: object) -> None:
-        self.__plan_digest = plan_digest
-        self.__seal = seal
+        object.__setattr__(self, "_PlanAdmission__plan_digest", plan_digest)
+        object.__setattr__(self, "_PlanAdmission__seal", seal)
+
+    def __setattr__(self, _name: str, _value: object) -> NoReturn:
+        raise TypeError("transport verification plan admission is immutable")
 
     def _matches(self, plan_digest: str) -> bool:
         return self.__seal is _PLAN_SEAL and self.__plan_digest == plan_digest
 
     def __reduce__(self) -> NoReturn:
+        raise TypeError("transport verification plan admission is process-local")
+
+    def __copy__(self) -> NoReturn:
+        raise TypeError("transport verification plan admission is process-local")
+
+    def __deepcopy__(self, _memo: object) -> NoReturn:
         raise TypeError("transport verification plan admission is process-local")
 
 

--- a/src/exomem/governance/consolidation_transport_verification.py
+++ b/src/exomem/governance/consolidation_transport_verification.py
@@ -7,7 +7,7 @@ import re
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal, NoReturn, SupportsIndex, cast
 
 from . import consolidation_authority, consolidation_plan
@@ -40,6 +40,7 @@ _MAX_PROBES = 1024
 _MAX_SAFE_INTEGER = (1 << 53) - 1
 _ROUTE_SEAL = object()
 _EXACT_DESTINATION_SEAL = object()
+_PLAN_SEAL = object()
 _ACTIVE_ROUTE: ContextVar[TransportProbeRoute | None] = ContextVar(
     "exomem_consolidation_transport_probe_route",
     default=None,
@@ -151,6 +152,7 @@ class TransportVerificationBasis:
     vault_binding_digest: str
     run_id: str
     operation_id: str
+    journal_digest: str
     plan_digest: str
     verification_manifest_digest: str
     canonical_census_digest: str
@@ -182,12 +184,29 @@ class TransportProbe:
     probe_digest: str
 
 
+class _PlanAdmission:
+    __slots__ = ("__plan_digest", "__seal")
+    __plan_digest: str
+    __seal: object
+
+    def __init__(self, plan_digest: str, seal: object) -> None:
+        self.__plan_digest = plan_digest
+        self.__seal = seal
+
+    def _matches(self, plan_digest: str) -> bool:
+        return self.__seal is _PLAN_SEAL and self.__plan_digest == plan_digest
+
+    def __reduce__(self) -> NoReturn:
+        raise TypeError("transport verification plan admission is process-local")
+
+
 @dataclass(frozen=True, slots=True)
 class TransportVerificationPlan:
     schema: str
     basis: TransportVerificationBasis
     probes: tuple[TransportProbe, ...]
     digest: str
+    _admission: object = field(repr=False, compare=False)
 
 
 def _basis_value(basis: TransportVerificationBasis) -> dict[str, object]:
@@ -196,6 +215,7 @@ def _basis_value(basis: TransportVerificationBasis) -> dict[str, object]:
         "vault_binding_digest": basis.vault_binding_digest,
         "run_id": basis.run_id,
         "operation_id": basis.operation_id,
+        "journal_digest": basis.journal_digest,
         "plan_digest": basis.plan_digest,
         "verification_manifest_digest": basis.verification_manifest_digest,
         "canonical_census_digest": basis.canonical_census_digest,
@@ -227,7 +247,12 @@ def _basis_input_value(basis: TransportVerificationBasis) -> dict[str, object]:
     return {
         key: value
         for key, value in _basis_value(basis).items()
-        if key not in {"destination_kind", "exact_destination_binding_digest"}
+        if key
+        not in {
+            "destination_kind",
+            "exact_destination_binding_digest",
+            "journal_digest",
+        }
     }
 
 
@@ -240,6 +265,7 @@ def _basis_from_input(value: object) -> TransportVerificationBasis:
         vault_binding_digest=_digest(row["vault_binding_digest"]),
         run_id=_uuid4(row["run_id"]),
         operation_id=_uuid4(row["operation_id"]),
+        journal_digest="0" * 64,
         plan_digest=_digest(row["plan_digest"]),
         verification_manifest_digest=_digest(row["verification_manifest_digest"]),
         canonical_census_digest=_digest(row["canonical_census_digest"]),
@@ -271,15 +297,22 @@ def _basis_from_input(value: object) -> TransportVerificationBasis:
 class ExactDestinationBinding:
     """Opaque control proof that basis facts came from the exact stopped cell."""
 
-    __slots__ = ("__basis_fingerprint", "__binding_digest", "__seal")
+    __slots__ = (
+        "__basis_fingerprint",
+        "__binding_digest",
+        "__journal_digest",
+        "__seal",
+    )
     __basis_fingerprint: str
     __binding_digest: str
+    __journal_digest: str
     __seal: object
 
     def __init__(
         self,
         basis_fingerprint: str,
         binding_digest: str,
+        journal_digest: str,
         seal: object,
     ) -> None:
         object.__setattr__(
@@ -291,6 +324,11 @@ class ExactDestinationBinding:
             self,
             "_ExactDestinationBinding__binding_digest",
             binding_digest,
+        )
+        object.__setattr__(
+            self,
+            "_ExactDestinationBinding__journal_digest",
+            journal_digest,
         )
         object.__setattr__(self, "_ExactDestinationBinding__seal", seal)
 
@@ -321,6 +359,11 @@ class ExactDestinationBinding:
         if self.__seal is not _EXACT_DESTINATION_SEAL:
             _fail()
         return self.__binding_digest
+
+    def _journal_digest(self) -> str:
+        if self.__seal is not _EXACT_DESTINATION_SEAL:
+            _fail()
+        return self.__journal_digest
 
 
 def issue_exact_destination_binding(
@@ -360,6 +403,7 @@ def issue_exact_destination_binding(
     return ExactDestinationBinding(
         basis_fingerprint,
         binding_digest,
+        checked_journal,
         _EXACT_DESTINATION_SEAL,
     )
 
@@ -376,14 +420,21 @@ def _checked_basis(
     ):
         _fail()
     exact_digest = exact_destination_binding._binding_digest()
+    journal_digest = exact_destination_binding._journal_digest()
     basis = TransportVerificationBasis(
         **{
             **{
                 field: getattr(basis, field)
                 for field in TransportVerificationBasis.__slots__
-                if field not in {"digest", "exact_destination_binding_digest"}
+                if field
+                not in {
+                    "digest",
+                    "exact_destination_binding_digest",
+                    "journal_digest",
+                }
             },
             "exact_destination_binding_digest": exact_digest,
+            "journal_digest": journal_digest,
             "digest": "0" * 64,
         }
     )
@@ -478,11 +529,13 @@ def build_transport_verification_plan(
             for probe in probes
         ),
     }
+    plan_digest = _framed_digest(_PLAN_DOMAIN, value)
     return TransportVerificationPlan(
         schema=TRANSPORT_VERIFICATION_PLAN_SCHEMA,
         basis=checked_basis,
         probes=probes,
-        digest=_framed_digest(_PLAN_DOMAIN, value),
+        digest=plan_digest,
+        _admission=_PlanAdmission(plan_digest, _PLAN_SEAL),
     )
 
 
@@ -491,6 +544,10 @@ def _checked_plan_member(
     probe: object,
 ) -> tuple[TransportVerificationPlan, TransportProbe]:
     if type(plan) is not TransportVerificationPlan or type(probe) is not TransportProbe:
+        _fail()
+    if type(plan._admission) is not _PlanAdmission or not plan._admission._matches(
+        plan.digest
+    ):
         _fail()
     basis = plan.basis
     if (
@@ -507,6 +564,7 @@ def _checked_plan_member(
         _fail()
     for digest in (
         basis.vault_binding_digest,
+        basis.journal_digest,
         basis.plan_digest,
         basis.verification_manifest_digest,
         basis.canonical_census_digest,
@@ -681,7 +739,6 @@ class TransportProbeRoute:
 def issue_transport_probe_route(
     authority: object,
     *,
-    journal_digest: str,
     plan: object,
     probe: object,
 ) -> TransportProbeRoute:
@@ -691,7 +748,7 @@ def issue_transport_probe_route(
     checked_vault = checked_plan.basis.vault_binding_digest
     checked_run = checked_plan.basis.run_id
     checked_operation = checked_plan.basis.operation_id
-    checked_journal = _digest(journal_digest)
+    checked_journal = checked_plan.basis.journal_digest
     try:
         consolidation_authority.require_authority(
             authority,

--- a/src/exomem/governance/consolidation_transport_verification.py
+++ b/src/exomem/governance/consolidation_transport_verification.py
@@ -21,10 +21,14 @@ TRANSPORT_VERIFICATION_PROBE_SCHEMA = (
 TRANSPORT_VERIFICATION_PLAN_SCHEMA = (
     "exomem.consolidation-transport-verification-plan/v1"
 )
+EXACT_DESTINATION_BINDING_SCHEMA = (
+    "exomem.consolidation-exact-destination-binding/v1"
+)
 
 _BASIS_DOMAIN = TRANSPORT_VERIFICATION_BASIS_SCHEMA.encode("ascii")
 _PROBE_DOMAIN = TRANSPORT_VERIFICATION_PROBE_SCHEMA.encode("ascii")
 _PLAN_DOMAIN = TRANSPORT_VERIFICATION_PLAN_SCHEMA.encode("ascii")
+_EXACT_DESTINATION_DOMAIN = EXACT_DESTINATION_BINDING_SCHEMA.encode("ascii")
 _DIGEST = re.compile(r"[0-9a-f]{64}\Z")
 _UUID4 = re.compile(
     r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
@@ -33,12 +37,14 @@ _IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}\Z")
 _SURFACES = ("mcp", "rest", "hosted", "cli")
 _POLARITIES = ("positive", "negative")
 _MAX_PROBES = 1024
+_MAX_SAFE_INTEGER = (1 << 53) - 1
 _ROUTE_SEAL = object()
+_EXACT_DESTINATION_SEAL = object()
 _ACTIVE_ROUTE: ContextVar[TransportProbeRoute | None] = ContextVar(
     "exomem_consolidation_transport_probe_route",
     default=None,
 )
-_BASIS_FIELDS = frozenset(
+_BASIS_INPUT_FIELDS = frozenset(
     {
         "schema",
         "vault_binding_digest",
@@ -55,7 +61,9 @@ _BASIS_FIELDS = frozenset(
         "principal_mapping_digest",
         "routing_stop_digest",
         "transport_supervisor_readiness_digest",
-        "destination_kind",
+        "hosted_profile_selection_record_digest",
+        "hosted_profile_selection_verifier_generation",
+        "hosted_owner_entitlement_verifier_readiness_digest",
     }
 )
 _CONTRACT_FIELDS = frozenset(
@@ -72,14 +80,15 @@ __all__ = [
     "TRANSPORT_VERIFICATION_BASIS_SCHEMA",
     "TRANSPORT_VERIFICATION_PLAN_SCHEMA",
     "TRANSPORT_VERIFICATION_PROBE_SCHEMA",
+    "EXACT_DESTINATION_BINDING_SCHEMA",
     "ConsolidationTransportVerificationUnavailable",
     "TransportProbe",
     "TransportProbeRoute",
     "TransportVerificationBasis",
     "TransportVerificationPlan",
     "build_transport_verification_plan",
+    "issue_exact_destination_binding",
     "issue_transport_probe_route",
-    "require_active_transport_probe_route",
     "transport_probe_route_scope",
 ]
 
@@ -111,6 +120,12 @@ def _uuid4(value: object) -> str:
 
 def _identifier(value: object) -> str:
     if type(value) is not str or _IDENTIFIER.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _integer(value: object) -> int:
+    if type(value) is not int or not 0 <= value <= _MAX_SAFE_INTEGER:
         _fail()
     return value
 
@@ -147,6 +162,10 @@ class TransportVerificationBasis:
     principal_mapping_digest: str
     routing_stop_digest: str
     transport_supervisor_readiness_digest: str
+    hosted_profile_selection_record_digest: str
+    hosted_profile_selection_verifier_generation: int
+    hosted_owner_entitlement_verifier_readiness_digest: str
+    exact_destination_binding_digest: str
     destination_kind: Literal["real"]
     digest: str
 
@@ -190,18 +209,33 @@ def _basis_value(basis: TransportVerificationBasis) -> dict[str, object]:
         "transport_supervisor_readiness_digest": (
             basis.transport_supervisor_readiness_digest
         ),
+        "hosted_profile_selection_record_digest": (
+            basis.hosted_profile_selection_record_digest
+        ),
+        "hosted_profile_selection_verifier_generation": (
+            basis.hosted_profile_selection_verifier_generation
+        ),
+        "hosted_owner_entitlement_verifier_readiness_digest": (
+            basis.hosted_owner_entitlement_verifier_readiness_digest
+        ),
+        "exact_destination_binding_digest": basis.exact_destination_binding_digest,
         "destination_kind": basis.destination_kind,
     }
 
 
-def _checked_basis(value: object) -> TransportVerificationBasis:
-    row = _mapping(value, _BASIS_FIELDS)
-    if (
-        row["schema"] != TRANSPORT_VERIFICATION_BASIS_SCHEMA
-        or row["destination_kind"] != "real"
-    ):
+def _basis_input_value(basis: TransportVerificationBasis) -> dict[str, object]:
+    return {
+        key: value
+        for key, value in _basis_value(basis).items()
+        if key not in {"destination_kind", "exact_destination_binding_digest"}
+    }
+
+
+def _basis_from_input(value: object) -> TransportVerificationBasis:
+    row = _mapping(value, _BASIS_INPUT_FIELDS)
+    if row["schema"] != TRANSPORT_VERIFICATION_BASIS_SCHEMA:
         _fail()
-    basis = TransportVerificationBasis(
+    return TransportVerificationBasis(
         schema=TRANSPORT_VERIFICATION_BASIS_SCHEMA,
         vault_binding_digest=_digest(row["vault_binding_digest"]),
         run_id=_uuid4(row["run_id"]),
@@ -219,12 +253,147 @@ def _checked_basis(value: object) -> TransportVerificationBasis:
         transport_supervisor_readiness_digest=_digest(
             row["transport_supervisor_readiness_digest"]
         ),
+        hosted_profile_selection_record_digest=_digest(
+            row["hosted_profile_selection_record_digest"]
+        ),
+        hosted_profile_selection_verifier_generation=_integer(
+            row["hosted_profile_selection_verifier_generation"]
+        ),
+        hosted_owner_entitlement_verifier_readiness_digest=_digest(
+            row["hosted_owner_entitlement_verifier_readiness_digest"]
+        ),
+        exact_destination_binding_digest="0" * 64,
         destination_kind="real",
         digest="0" * 64,
     )
+
+
+class ExactDestinationBinding:
+    """Opaque control proof that basis facts came from the exact stopped cell."""
+
+    __slots__ = ("__basis_fingerprint", "__binding_digest", "__seal")
+    __basis_fingerprint: str
+    __binding_digest: str
+    __seal: object
+
+    def __init__(
+        self,
+        basis_fingerprint: str,
+        binding_digest: str,
+        seal: object,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "_ExactDestinationBinding__basis_fingerprint",
+            basis_fingerprint,
+        )
+        object.__setattr__(
+            self,
+            "_ExactDestinationBinding__binding_digest",
+            binding_digest,
+        )
+        object.__setattr__(self, "_ExactDestinationBinding__seal", seal)
+
+    def __setattr__(self, _name: str, _value: object) -> NoReturn:
+        raise TypeError("exact destination binding is immutable")
+
+    def __repr__(self) -> str:
+        return "<ExactDestinationBinding process-local>"
+
+    def __reduce__(self) -> NoReturn:
+        raise TypeError("exact destination binding is process-local")
+
+    def __reduce_ex__(self, _protocol: SupportsIndex) -> NoReturn:
+        raise TypeError("exact destination binding is process-local")
+
+    def __copy__(self) -> NoReturn:
+        raise TypeError("exact destination binding is process-local")
+
+    def __deepcopy__(self, _memo: object) -> NoReturn:
+        raise TypeError("exact destination binding is process-local")
+
+    def _matches(self, basis: TransportVerificationBasis) -> bool:
+        return self.__seal is _EXACT_DESTINATION_SEAL and self.__basis_fingerprint == (
+            _framed_digest(_BASIS_DOMAIN, _basis_input_value(basis))
+        )
+
+    def _binding_digest(self) -> str:
+        if self.__seal is not _EXACT_DESTINATION_SEAL:
+            _fail()
+        return self.__binding_digest
+
+
+def issue_exact_destination_binding(
+    authority: object,
+    *,
+    journal_digest: str,
+    basis: Mapping[str, object],
+) -> ExactDestinationBinding:
+    """Bind trusted routing-stop observations to the exact operation and cell."""
+
+    checked_basis = _basis_from_input(basis)
+    checked_journal = _digest(journal_digest)
+    try:
+        consolidation_authority.require_authority(
+            authority,
+            vault_binding_digest=checked_basis.vault_binding_digest,
+            run_id=checked_basis.run_id,
+            operation_id=checked_basis.operation_id,
+            journal_digest=checked_journal,
+            phase="transport-stopping",
+            action="apply",
+        )
+    except consolidation_authority.ConsolidationAuthorityUnavailable:
+        _fail()
+    basis_fingerprint = _framed_digest(
+        _BASIS_DOMAIN,
+        _basis_input_value(checked_basis),
+    )
+    binding_digest = _framed_digest(
+        _EXACT_DESTINATION_DOMAIN,
+        {
+            "schema": EXACT_DESTINATION_BINDING_SCHEMA,
+            "basis_fingerprint": basis_fingerprint,
+            "journal_digest": checked_journal,
+        },
+    )
+    return ExactDestinationBinding(
+        basis_fingerprint,
+        binding_digest,
+        _EXACT_DESTINATION_SEAL,
+    )
+
+
+def _checked_basis(
+    value: object,
+    *,
+    exact_destination_binding: object,
+) -> TransportVerificationBasis:
+    basis = _basis_from_input(value)
+    if (
+        type(exact_destination_binding) is not ExactDestinationBinding
+        or not exact_destination_binding._matches(basis)
+    ):
+        _fail()
+    exact_digest = exact_destination_binding._binding_digest()
+    basis = TransportVerificationBasis(
+        **{
+            **{
+                field: getattr(basis, field)
+                for field in TransportVerificationBasis.__slots__
+                if field not in {"digest", "exact_destination_binding_digest"}
+            },
+            "exact_destination_binding_digest": exact_digest,
+            "digest": "0" * 64,
+        }
+    )
     return TransportVerificationBasis(
         **{
-            **{field: getattr(basis, field) for field in _BASIS_FIELDS},
+            **{
+                field: getattr(basis, field)
+                for field in TransportVerificationBasis.__slots__
+                if field != "digest"
+            },
             "digest": _framed_digest(_BASIS_DOMAIN, _basis_value(basis)),
         }
     )
@@ -274,6 +443,7 @@ def build_transport_verification_plan(
     *,
     basis: Mapping[str, object],
     contracts: Sequence[Mapping[str, object]],
+    exact_destination_binding: object,
 ) -> TransportVerificationPlan:
     """Build one real-cell plan with both polarities on every public surface."""
 
@@ -283,7 +453,10 @@ def build_transport_verification_plan(
         or not 1 <= len(contracts) <= _MAX_PROBES
     ):
         _fail()
-    checked_basis = _checked_basis(basis)
+    checked_basis = _checked_basis(
+        basis,
+        exact_destination_binding=exact_destination_binding,
+    )
     probes = tuple(
         _checked_probe(contract, ordinal=ordinal)
         for ordinal, contract in enumerate(contracts)
@@ -313,12 +486,103 @@ def build_transport_verification_plan(
     )
 
 
+def _checked_plan_member(
+    plan: object,
+    probe: object,
+) -> tuple[TransportVerificationPlan, TransportProbe]:
+    if type(plan) is not TransportVerificationPlan or type(probe) is not TransportProbe:
+        _fail()
+    basis = plan.basis
+    if (
+        type(basis) is not TransportVerificationBasis
+        or plan.schema != TRANSPORT_VERIFICATION_PLAN_SCHEMA
+        or basis.schema != TRANSPORT_VERIFICATION_BASIS_SCHEMA
+        or basis.destination_kind != "real"
+        or _uuid4(basis.run_id) != basis.run_id
+        or _uuid4(basis.operation_id) != basis.operation_id
+        or _identifier(basis.surface_profile) != basis.surface_profile
+        or _integer(basis.hosted_profile_selection_verifier_generation)
+        != basis.hosted_profile_selection_verifier_generation
+    ):
+        _fail()
+    for digest in (
+        basis.vault_binding_digest,
+        basis.plan_digest,
+        basis.verification_manifest_digest,
+        basis.canonical_census_digest,
+        basis.release_build_digest,
+        basis.surface_descriptor_digest,
+        basis.configuration_digest,
+        basis.trust_digest,
+        basis.principal_mapping_digest,
+        basis.routing_stop_digest,
+        basis.transport_supervisor_readiness_digest,
+        basis.hosted_profile_selection_record_digest,
+        basis.hosted_owner_entitlement_verifier_readiness_digest,
+        basis.exact_destination_binding_digest,
+        basis.digest,
+    ):
+        _digest(digest)
+    if basis.digest != _framed_digest(_BASIS_DOMAIN, _basis_value(basis)):
+        _fail()
+    if (
+        type(plan.probes) is not tuple
+        or type(probe.ordinal) is not int
+        or not 0 <= probe.ordinal < len(plan.probes)
+        or plan.probes[probe.ordinal] != probe
+    ):
+        _fail()
+    for ordinal, candidate in enumerate(plan.probes):
+        if (
+            type(candidate) is not TransportProbe
+            or candidate.schema != TRANSPORT_VERIFICATION_PROBE_SCHEMA
+            or type(candidate.ordinal) is not int
+            or candidate.ordinal != ordinal
+            or candidate.surface not in _SURFACES
+            or candidate.probe_kind not in _POLARITIES
+            or _identifier(candidate.probe_id) != candidate.probe_id
+            or _digest(candidate.contract_digest) != candidate.contract_digest
+            or _digest(candidate.expected_result_digest)
+            != candidate.expected_result_digest
+            or _digest(candidate.probe_digest) != candidate.probe_digest
+            or candidate.probe_digest
+            != _framed_digest(_PROBE_DOMAIN, _probe_value(candidate))
+        ):
+            _fail()
+    coverage = {(candidate.surface, candidate.probe_kind) for candidate in plan.probes}
+    if coverage != {
+        (surface, polarity)
+        for surface in _SURFACES
+        for polarity in _POLARITIES
+    }:
+        _fail()
+    value = {
+        "schema": TRANSPORT_VERIFICATION_PLAN_SCHEMA,
+        "basis": {**_basis_value(basis), "basis_digest": basis.digest},
+        "probes": tuple(
+            {**_probe_value(candidate), "probe_digest": candidate.probe_digest}
+            for candidate in plan.probes
+        ),
+    }
+    if _digest(plan.digest) != _framed_digest(_PLAN_DOMAIN, value):
+        _fail()
+    return plan, probe
+
+
+@dataclass(slots=True)
+class _RouteLease:
+    active: bool = False
+    closed: bool = False
+
+
 class TransportProbeRoute:
     """Opaque process-local permission for one supervised isolated probe route."""
 
     __slots__ = (
         "__journal_digest",
+        "__lease",
         "__operation_id",
+        "__plan_digest",
         "__probe_digest",
         "__run_id",
         "__seal",
@@ -328,8 +592,10 @@ class TransportProbeRoute:
     __run_id: str
     __operation_id: str
     __journal_digest: str
+    __plan_digest: str
     __probe_digest: str
     __seal: object
+    __lease: _RouteLease
 
     def __init__(
         self,
@@ -337,14 +603,18 @@ class TransportProbeRoute:
         run_id: str,
         operation_id: str,
         journal_digest: str,
+        plan_digest: str,
         probe_digest: str,
+        lease: _RouteLease,
         seal: object,
     ) -> None:
         object.__setattr__(self, "_TransportProbeRoute__vault_binding_digest", vault_binding_digest)
         object.__setattr__(self, "_TransportProbeRoute__run_id", run_id)
         object.__setattr__(self, "_TransportProbeRoute__operation_id", operation_id)
         object.__setattr__(self, "_TransportProbeRoute__journal_digest", journal_digest)
+        object.__setattr__(self, "_TransportProbeRoute__plan_digest", plan_digest)
         object.__setattr__(self, "_TransportProbeRoute__probe_digest", probe_digest)
+        object.__setattr__(self, "_TransportProbeRoute__lease", lease)
         object.__setattr__(self, "_TransportProbeRoute__seal", seal)
 
     def __setattr__(self, _name: str, _value: object) -> NoReturn:
@@ -373,33 +643,55 @@ class TransportProbeRoute:
         operation_id: str,
         journal_digest: str,
     ) -> bool:
-        return self.__seal is _ROUTE_SEAL and (
+        return self.__seal is _ROUTE_SEAL and self.__lease.active and (
             self.__vault_binding_digest,
             self.__run_id,
             self.__operation_id,
             self.__journal_digest,
         ) == (vault_binding_digest, run_id, operation_id, journal_digest)
 
-    def _matches_probe(self, probe_digest: str) -> bool:
-        return self.__seal is _ROUTE_SEAL and self.__probe_digest == probe_digest
+    def _matches_plan_probe(
+        self,
+        *,
+        plan_digest: str,
+        probe_digest: str,
+    ) -> bool:
+        return self.__seal is _ROUTE_SEAL and (
+            self.__plan_digest,
+            self.__probe_digest,
+        ) == (plan_digest, probe_digest)
+
+    def _begin(self, *, plan_digest: str, probe_digest: str) -> None:
+        if (
+            self.__lease.active
+            or self.__lease.closed
+            or not self._matches_plan_probe(
+                plan_digest=plan_digest,
+                probe_digest=probe_digest,
+            )
+        ):
+            _fail()
+        self.__lease.active = True
+
+    def _finish(self) -> None:
+        self.__lease.active = False
+        self.__lease.closed = True
 
 
 def issue_transport_probe_route(
     authority: object,
     *,
-    vault_binding_digest: str,
-    run_id: str,
-    operation_id: str,
     journal_digest: str,
-    probe_digest: str,
+    plan: object,
+    probe: object,
 ) -> TransportProbeRoute:
     """Consume exact probe authority before entering an auth-transparent route."""
 
-    checked_vault = _digest(vault_binding_digest)
-    checked_run = _uuid4(run_id)
-    checked_operation = _uuid4(operation_id)
+    checked_plan, checked_probe = _checked_plan_member(plan, probe)
+    checked_vault = checked_plan.basis.vault_binding_digest
+    checked_run = checked_plan.basis.run_id
+    checked_operation = checked_plan.basis.operation_id
     checked_journal = _digest(journal_digest)
-    checked_probe = _digest(probe_digest)
     try:
         consolidation_authority.require_authority(
             authority,
@@ -417,33 +709,35 @@ def issue_transport_probe_route(
         checked_run,
         checked_operation,
         checked_journal,
-        checked_probe,
+        checked_plan.digest,
+        checked_probe.probe_digest,
+        _RouteLease(),
         _ROUTE_SEAL,
     )
 
 
 @contextmanager
-def transport_probe_route_scope(route: object) -> Iterator[None]:
+def transport_probe_route_scope(
+    route: object,
+    *,
+    plan: object,
+    probe: object,
+) -> Iterator[None]:
     """Mark only the supervisor's current execution context as the isolated route."""
 
+    checked_plan, checked_probe = _checked_plan_member(plan, probe)
     if type(route) is not TransportProbeRoute or _ACTIVE_ROUTE.get() is not None:
         _fail()
+    route._begin(
+        plan_digest=checked_plan.digest,
+        probe_digest=checked_probe.probe_digest,
+    )
     token = _ACTIVE_ROUTE.set(route)
     try:
         yield
     finally:
+        route._finish()
         _ACTIVE_ROUTE.reset(token)
-
-
-def require_active_transport_probe_route(*, probe_digest: str) -> None:
-    """Bind the supervisor's exact precommitted probe before transport execution."""
-
-    route = _ACTIVE_ROUTE.get()
-    if (
-        type(route) is not TransportProbeRoute
-        or not route._matches_probe(_digest(probe_digest))
-    ):
-        _fail()
 
 
 def _active_route_matches(

--- a/tests/test_consolidation_transport_verification.py
+++ b/tests/test_consolidation_transport_verification.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import dataclasses
 import hashlib
 import pickle
 import threading
@@ -77,14 +78,14 @@ def _sealed_at_transport_verifying(vault: Path) -> None:
         )
 
 
-def _probe_authority():
+def _probe_authority(*, journal_digest: str = JOURNAL_DIGEST):
     from exomem.governance import consolidation_authority
 
     return consolidation_authority.issue_authority(
         vault_binding_digest=VAULT_BINDING,
         run_id=RUN_ID,
         operation_id=OPERATION_ID,
-        journal_digest=JOURNAL_DIGEST,
+        journal_digest=journal_digest,
         phase="transport-verifying",
         action="probe",
     )
@@ -292,7 +293,6 @@ def test_exact_supervised_route_bypasses_only_read_admission_and_never_request_a
     )
     route = consolidation_transport_verification.issue_transport_probe_route(
         _probe_authority(),
-        journal_digest=JOURNAL_DIGEST,
         plan=plan,
         probe=probe,
     )
@@ -348,7 +348,6 @@ def test_transport_route_is_process_local_unforgeable_and_not_inherited_by_threa
     probe = plan.probes[0]
     route = consolidation_transport_verification.issue_transport_probe_route(
         _probe_authority(),
-        journal_digest=JOURNAL_DIGEST,
         plan=plan,
         probe=probe,
     )
@@ -395,7 +394,6 @@ def test_transport_route_is_revoked_in_async_child_when_parent_scope_exits(
     probe = plan.probes[0]
     route = consolidation_transport_verification.issue_transport_probe_route(
         _probe_authority(),
-        journal_digest=JOURNAL_DIGEST,
         plan=plan,
         probe=probe,
     )
@@ -445,14 +443,12 @@ def test_nonmember_probe_cannot_issue_or_enter_a_transport_route() -> None:
     ):
         consolidation_transport_verification.issue_transport_probe_route(
             _probe_authority(),
-            journal_digest=JOURNAL_DIGEST,
             plan=plan,
             probe=forged_probe,
         )
 
     route = consolidation_transport_verification.issue_transport_probe_route(
         _probe_authority(),
-        journal_digest=JOURNAL_DIGEST,
         plan=plan,
         probe=plan.probes[0],
     )
@@ -465,6 +461,69 @@ def test_nonmember_probe_cannot_issue_or_enter_a_transport_route() -> None:
             probe=forged_probe,
         ):
             pass
+
+
+def test_self_consistent_but_never_admitted_plan_cannot_issue_a_route() -> None:
+    from exomem.governance import consolidation_transport_verification as transport
+
+    plan = _transport_plan()
+    original = plan.probes[0]
+    preliminary = dataclasses.replace(
+        original,
+        contract_digest="c" * 64,
+        probe_digest="0" * 64,
+    )
+    forged_probe = dataclasses.replace(
+        preliminary,
+        probe_digest=transport._framed_digest(  # noqa: SLF001 - adversarial fixture
+            transport._PROBE_DOMAIN,  # noqa: SLF001 - adversarial fixture
+            transport._probe_value(preliminary),  # noqa: SLF001 - adversarial fixture
+        ),
+    )
+    forged_probes = (forged_probe, *plan.probes[1:])
+    value = {
+        "schema": plan.schema,
+        "basis": {
+            **transport._basis_value(plan.basis),  # noqa: SLF001 - adversarial fixture
+            "basis_digest": plan.basis.digest,
+        },
+        "probes": tuple(
+            {
+                **transport._probe_value(candidate),  # noqa: SLF001 - adversarial fixture
+                "probe_digest": candidate.probe_digest,
+            }
+            for candidate in forged_probes
+        ),
+    }
+    forged_plan = dataclasses.replace(
+        plan,
+        probes=forged_probes,
+        digest=transport._framed_digest(  # noqa: SLF001 - adversarial fixture
+            transport._PLAN_DOMAIN,  # noqa: SLF001 - adversarial fixture
+            value,
+        ),
+    )
+    with pytest.raises(transport.ConsolidationTransportVerificationUnavailable):
+        transport.issue_transport_probe_route(
+            _probe_authority(),
+            plan=forged_plan,
+            probe=forged_probe,
+        )
+
+
+def test_exact_destination_binding_journal_cannot_be_rebound_at_route_issuance() -> None:
+    from exomem.governance import consolidation_transport_verification
+
+    plan = _transport_plan()
+    other_journal = "d" * 64
+    with pytest.raises(
+        consolidation_transport_verification.ConsolidationTransportVerificationUnavailable
+    ):
+        consolidation_transport_verification.issue_transport_probe_route(
+            _probe_authority(journal_digest=other_journal),
+            plan=plan,
+            probe=plan.probes[0],
+        )
 
 
 def test_wrong_transport_authority_or_binding_never_opens_probe_route() -> None:
@@ -486,7 +545,6 @@ def test_wrong_transport_authority_or_binding_never_opens_probe_route() -> None:
     ):
         consolidation_transport_verification.issue_transport_probe_route(
             wrong_phase,
-            journal_digest=JOURNAL_DIGEST,
             plan=(plan := _transport_plan()),
             probe=plan.probes[0],
         )
@@ -494,8 +552,7 @@ def test_wrong_transport_authority_or_binding_never_opens_probe_route() -> None:
         consolidation_transport_verification.ConsolidationTransportVerificationUnavailable
     ):
         consolidation_transport_verification.issue_transport_probe_route(
-            _probe_authority(),
-            journal_digest="f" * 64,
+            _probe_authority(journal_digest="f" * 64),
             plan=plan,
             probe=plan.probes[0],
         )

--- a/tests/test_consolidation_transport_verification.py
+++ b/tests/test_consolidation_transport_verification.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import pickle
+import threading
+from pathlib import Path
+
+import pytest
+
+VAULT_BINDING = hashlib.sha256(b"transport-vault-binding").hexdigest()
+RUN_ID = "00000000-0000-4000-8000-000000000121"
+OPERATION_ID = "00000000-0000-4000-8000-000000000122"
+JOURNAL_DIGEST = hashlib.sha256(b"transport-apply-journal").hexdigest()
+PLAN_DIGEST = hashlib.sha256(b"transport-cutover-plan").hexdigest()
+MANIFEST_DIGEST = hashlib.sha256(b"transport-verification-manifest").hexdigest()
+CENSUS_DIGEST = hashlib.sha256(b"transport-post-cutover-census").hexdigest()
+RELEASE_BUILD_DIGEST = hashlib.sha256(b"transport-release-build").hexdigest()
+DESCRIPTOR_DIGEST = hashlib.sha256(b"transport-surface-descriptor").hexdigest()
+CONFIGURATION_DIGEST = hashlib.sha256(b"transport-configuration").hexdigest()
+TRUST_DIGEST = hashlib.sha256(b"transport-trust").hexdigest()
+PRINCIPAL_MAPPING_DIGEST = hashlib.sha256(b"transport-principal-mapping").hexdigest()
+ROUTING_STOP_DIGEST = hashlib.sha256(b"transport-routing-stop").hexdigest()
+SUPERVISOR_READINESS_DIGEST = hashlib.sha256(b"transport-supervisor-readiness").hexdigest()
+PROBE_DIGEST = hashlib.sha256(b"transport-rest-positive-probe").hexdigest()
+T0 = "2026-08-31T12:00:00.000Z"
+
+
+def _sealed_at_transport_verifying(vault: Path) -> None:
+    from exomem.governance import consolidation_authority, consolidation_seal
+
+    store = consolidation_seal.ConsolidationSealStore(vault)
+    current = store.initialize_open(
+        vault_binding_digest=VAULT_BINDING,
+        recorded_at=T0,
+    )
+    current = store.begin_consolidation(
+        vault_binding_digest=VAULT_BINDING,
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        sealed_at=T0,
+        expected_revision=current.revision,
+    )
+    for target_phase in (
+        "sealed",
+        "preimage-ready",
+        "policy-active",
+        "publishing",
+        "rebuilding",
+        "verifying",
+        "verified",
+        "transport-stopping",
+        "transport-verifying",
+    ):
+        authority = consolidation_authority.issue_authority(
+            vault_binding_digest=VAULT_BINDING,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            phase=current.phase,
+            action="apply",
+        )
+        current = store.advance_consolidation(
+            authority,
+            vault_binding_digest=VAULT_BINDING,
+            action="apply",
+            target_phase=target_phase,
+            recorded_at=T0,
+            expected_revision=current.revision,
+        )
+
+
+def _probe_authority():
+    from exomem.governance import consolidation_authority
+
+    return consolidation_authority.issue_authority(
+        vault_binding_digest=VAULT_BINDING,
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        phase="transport-verifying",
+        action="probe",
+    )
+
+
+def _transport_basis(**changes: object) -> dict[str, object]:
+    return {
+        "schema": "exomem.consolidation-transport-verification-basis/v1",
+        "vault_binding_digest": VAULT_BINDING,
+        "run_id": RUN_ID,
+        "operation_id": OPERATION_ID,
+        "plan_digest": PLAN_DIGEST,
+        "verification_manifest_digest": MANIFEST_DIGEST,
+        "canonical_census_digest": CENSUS_DIGEST,
+        "release_build_digest": RELEASE_BUILD_DIGEST,
+        "surface_profile": "standalone-v1",
+        "surface_descriptor_digest": DESCRIPTOR_DIGEST,
+        "configuration_digest": CONFIGURATION_DIGEST,
+        "trust_digest": TRUST_DIGEST,
+        "principal_mapping_digest": PRINCIPAL_MAPPING_DIGEST,
+        "routing_stop_digest": ROUTING_STOP_DIGEST,
+        "transport_supervisor_readiness_digest": SUPERVISOR_READINESS_DIGEST,
+        "destination_kind": "real",
+        **changes,
+    }
+
+
+def _surface_contracts() -> tuple[dict[str, object], ...]:
+    return tuple(
+        {
+            "probe_id": f"{surface}-{kind}",
+            "probe_kind": kind,
+            "surface": surface,
+            "contract_digest": hashlib.sha256(
+                f"{surface}-{kind}-contract".encode()
+            ).hexdigest(),
+            "expected_result_digest": hashlib.sha256(
+                f"{surface}-{kind}-result".encode()
+            ).hexdigest(),
+        }
+        for surface in ("mcp", "rest", "hosted", "cli")
+        for kind in ("positive", "negative")
+    )
+
+
+def test_transport_plan_binds_exact_real_cell_basis_and_every_surface_polarity() -> None:
+    from exomem.governance import consolidation_transport_verification
+
+    plan = consolidation_transport_verification.build_transport_verification_plan(
+        basis=_transport_basis(),
+        contracts=_surface_contracts(),
+    )
+
+    assert plan.basis.destination_kind == "real"
+    assert plan.basis.canonical_census_digest == CENSUS_DIGEST
+    assert plan.basis.routing_stop_digest == ROUTING_STOP_DIGEST
+    assert tuple((probe.surface, probe.probe_kind) for probe in plan.probes) == tuple(
+        (surface, kind)
+        for surface in ("mcp", "rest", "hosted", "cli")
+        for kind in ("positive", "negative")
+    )
+    assert len(plan.digest) == 64
+
+
+@pytest.mark.parametrize(
+    "contracts",
+    [
+        _surface_contracts()[:-1],
+        tuple(
+            contract
+            for contract in _surface_contracts()
+            if not (contract["surface"] == "mcp" and contract["probe_kind"] == "positive")
+        ),
+    ],
+)
+def test_transport_plan_refuses_missing_surface_or_polarity(
+    contracts: tuple[dict[str, object], ...],
+) -> None:
+    from exomem.governance import consolidation_transport_verification
+
+    with pytest.raises(
+        consolidation_transport_verification.ConsolidationTransportVerificationUnavailable
+    ):
+        consolidation_transport_verification.build_transport_verification_plan(
+            basis=_transport_basis(),
+            contracts=contracts,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "changed"),
+    [
+        ("canonical_census_digest", "0" * 64),
+        ("release_build_digest", "1" * 64),
+        ("surface_descriptor_digest", "2" * 64),
+        ("configuration_digest", "3" * 64),
+        ("trust_digest", "4" * 64),
+        ("principal_mapping_digest", "5" * 64),
+        ("routing_stop_digest", "6" * 64),
+        ("transport_supervisor_readiness_digest", "7" * 64),
+    ],
+)
+def test_each_transport_basis_field_changes_the_plan_digest(field: str, changed: str) -> None:
+    from exomem.governance import consolidation_transport_verification
+
+    baseline = consolidation_transport_verification.build_transport_verification_plan(
+        basis=_transport_basis(),
+        contracts=_surface_contracts(),
+    )
+    mutated = consolidation_transport_verification.build_transport_verification_plan(
+        basis=_transport_basis(**{field: changed}),
+        contracts=_surface_contracts(),
+    )
+    assert mutated.digest != baseline.digest
+
+
+def test_clone_transport_evidence_cannot_build_the_real_cell_gate() -> None:
+    from exomem.governance import consolidation_transport_verification
+
+    with pytest.raises(
+        consolidation_transport_verification.ConsolidationTransportVerificationUnavailable
+    ):
+        consolidation_transport_verification.build_transport_verification_plan(
+            basis=_transport_basis(destination_kind="clone"),
+            contracts=_surface_contracts(),
+        )
+
+
+def test_exact_supervised_route_bypasses_only_read_admission_and_never_request_auth(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import (
+        consolidation_admission,
+        consolidation_transport_verification,
+    )
+
+    _sealed_at_transport_verifying(tmp_path)
+    admission = consolidation_admission.ConsolidationAdmission(
+        tmp_path,
+        vault_binding_digest=VAULT_BINDING,
+    )
+    with pytest.raises(
+        consolidation_admission.ConsolidationAdmissionUnavailable,
+        match="^CONSOLIDATION_SEALED$",
+    ):
+        with admission.admit_read():
+            pass
+
+    route = consolidation_transport_verification.issue_transport_probe_route(
+        _probe_authority(),
+        vault_binding_digest=VAULT_BINDING,
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        probe_digest=PROBE_DIGEST,
+    )
+    request = {
+        "command": "ask_memory",
+        "arguments": {"query": "ordinary normal-auth request"},
+        "authorization": "ordinary-session",
+    }
+    assert "authority" not in repr(request).lower()
+    assert "probe_digest" not in repr(request)
+
+    with consolidation_transport_verification.transport_probe_route_scope(route):
+        consolidation_transport_verification.require_active_transport_probe_route(
+            probe_digest=PROBE_DIGEST
+        )
+        with pytest.raises(
+            consolidation_transport_verification.ConsolidationTransportVerificationUnavailable
+        ):
+            consolidation_transport_verification.require_active_transport_probe_route(
+                probe_digest="9" * 64
+            )
+        with admission.admit_read():
+            pass
+        for enter in (
+            admission.admit_mutation,
+            admission.admit_transfer,
+            admission.admit_background,
+        ):
+            with pytest.raises(
+                consolidation_admission.ConsolidationAdmissionUnavailable,
+                match="^CONSOLIDATION_SEALED$",
+            ):
+                with enter():
+                    pass
+
+    with pytest.raises(
+        consolidation_admission.ConsolidationAdmissionUnavailable,
+        match="^CONSOLIDATION_SEALED$",
+    ):
+        with admission.admit_read():
+            pass
+
+
+def test_transport_route_is_process_local_unforgeable_and_not_inherited_by_thread(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import (
+        consolidation_admission,
+        consolidation_transport_verification,
+    )
+
+    _sealed_at_transport_verifying(tmp_path)
+    admission = consolidation_admission.ConsolidationAdmission(
+        tmp_path,
+        vault_binding_digest=VAULT_BINDING,
+    )
+    route = consolidation_transport_verification.issue_transport_probe_route(
+        _probe_authority(),
+        vault_binding_digest=VAULT_BINDING,
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        probe_digest=PROBE_DIGEST,
+    )
+    for serializer in (pickle.dumps, copy.copy, copy.deepcopy):
+        with pytest.raises(TypeError):
+            serializer(route)
+
+    failures: list[str] = []
+
+    def unrelated_client() -> None:
+        try:
+            with admission.admit_read():
+                pass
+        except consolidation_admission.ConsolidationAdmissionUnavailable as error:
+            failures.append(error.code)
+
+    with consolidation_transport_verification.transport_probe_route_scope(route):
+        worker = threading.Thread(target=unrelated_client)
+        worker.start()
+        worker.join()
+        with admission.admit_read():
+            pass
+    assert failures == ["CONSOLIDATION_SEALED"]
+
+
+def test_wrong_transport_authority_or_binding_never_opens_probe_route() -> None:
+    from exomem.governance import (
+        consolidation_authority,
+        consolidation_transport_verification,
+    )
+
+    wrong_phase = consolidation_authority.issue_authority(
+        vault_binding_digest=VAULT_BINDING,
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        phase="verified",
+        action="apply",
+    )
+    with pytest.raises(
+        consolidation_transport_verification.ConsolidationTransportVerificationUnavailable
+    ):
+        consolidation_transport_verification.issue_transport_probe_route(
+            wrong_phase,
+            vault_binding_digest=VAULT_BINDING,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            probe_digest=PROBE_DIGEST,
+        )
+    with pytest.raises(
+        consolidation_transport_verification.ConsolidationTransportVerificationUnavailable
+    ):
+        consolidation_transport_verification.issue_transport_probe_route(
+            _probe_authority(),
+            vault_binding_digest="f" * 64,
+            run_id=RUN_ID,
+            operation_id=OPERATION_ID,
+            journal_digest=JOURNAL_DIGEST,
+            probe_digest=PROBE_DIGEST,
+        )

--- a/tests/test_consolidation_transport_verification.py
+++ b/tests/test_consolidation_transport_verification.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import copy
 import hashlib
 import pickle
@@ -22,7 +23,12 @@ TRUST_DIGEST = hashlib.sha256(b"transport-trust").hexdigest()
 PRINCIPAL_MAPPING_DIGEST = hashlib.sha256(b"transport-principal-mapping").hexdigest()
 ROUTING_STOP_DIGEST = hashlib.sha256(b"transport-routing-stop").hexdigest()
 SUPERVISOR_READINESS_DIGEST = hashlib.sha256(b"transport-supervisor-readiness").hexdigest()
-PROBE_DIGEST = hashlib.sha256(b"transport-rest-positive-probe").hexdigest()
+HOSTED_PROFILE_SELECTION_DIGEST = hashlib.sha256(
+    b"transport-hosted-profile-selection"
+).hexdigest()
+HOSTED_OWNER_ENTITLEMENT_READINESS_DIGEST = hashlib.sha256(
+    b"transport-hosted-owner-entitlement-readiness"
+).hexdigest()
 T0 = "2026-08-31T12:00:00.000Z"
 
 
@@ -101,7 +107,11 @@ def _transport_basis(**changes: object) -> dict[str, object]:
         "principal_mapping_digest": PRINCIPAL_MAPPING_DIGEST,
         "routing_stop_digest": ROUTING_STOP_DIGEST,
         "transport_supervisor_readiness_digest": SUPERVISOR_READINESS_DIGEST,
-        "destination_kind": "real",
+        "hosted_profile_selection_record_digest": HOSTED_PROFILE_SELECTION_DIGEST,
+        "hosted_profile_selection_verifier_generation": 7,
+        "hosted_owner_entitlement_verifier_readiness_digest": (
+            HOSTED_OWNER_ENTITLEMENT_READINESS_DIGEST
+        ),
         **changes,
     }
 
@@ -124,13 +134,40 @@ def _surface_contracts() -> tuple[dict[str, object], ...]:
     )
 
 
-def test_transport_plan_binds_exact_real_cell_basis_and_every_surface_polarity() -> None:
+def _exact_destination_binding(basis: dict[str, object]):
+    from exomem.governance import (
+        consolidation_authority,
+        consolidation_transport_verification,
+    )
+
+    authority = consolidation_authority.issue_authority(
+        vault_binding_digest=VAULT_BINDING,
+        run_id=RUN_ID,
+        operation_id=OPERATION_ID,
+        journal_digest=JOURNAL_DIGEST,
+        phase="transport-stopping",
+        action="apply",
+    )
+    return consolidation_transport_verification.issue_exact_destination_binding(
+        authority,
+        journal_digest=JOURNAL_DIGEST,
+        basis=basis,
+    )
+
+
+def _transport_plan():
     from exomem.governance import consolidation_transport_verification
 
-    plan = consolidation_transport_verification.build_transport_verification_plan(
-        basis=_transport_basis(),
+    basis = _transport_basis()
+    return consolidation_transport_verification.build_transport_verification_plan(
+        basis=basis,
         contracts=_surface_contracts(),
+        exact_destination_binding=_exact_destination_binding(basis),
     )
+
+
+def test_transport_plan_binds_exact_real_cell_basis_and_every_surface_polarity() -> None:
+    plan = _transport_plan()
 
     assert plan.basis.destination_kind == "real"
     assert plan.basis.canonical_census_digest == CENSUS_DIGEST
@@ -163,8 +200,9 @@ def test_transport_plan_refuses_missing_surface_or_polarity(
         consolidation_transport_verification.ConsolidationTransportVerificationUnavailable
     ):
         consolidation_transport_verification.build_transport_verification_plan(
-            basis=_transport_basis(),
+            basis=(basis := _transport_basis()),
             contracts=contracts,
+            exact_destination_binding=_exact_destination_binding(basis),
         )
 
 
@@ -179,31 +217,50 @@ def test_transport_plan_refuses_missing_surface_or_polarity(
         ("principal_mapping_digest", "5" * 64),
         ("routing_stop_digest", "6" * 64),
         ("transport_supervisor_readiness_digest", "7" * 64),
+        ("hosted_profile_selection_record_digest", "8" * 64),
+        ("hosted_profile_selection_verifier_generation", 8),
+        ("hosted_owner_entitlement_verifier_readiness_digest", "a" * 64),
     ],
 )
-def test_each_transport_basis_field_changes_the_plan_digest(field: str, changed: str) -> None:
+def test_each_transport_basis_field_changes_the_plan_digest(field: str, changed: object) -> None:
     from exomem.governance import consolidation_transport_verification
 
-    baseline = consolidation_transport_verification.build_transport_verification_plan(
-        basis=_transport_basis(),
-        contracts=_surface_contracts(),
-    )
+    baseline = _transport_plan()
+    mutated_basis = _transport_basis(**{field: changed})
     mutated = consolidation_transport_verification.build_transport_verification_plan(
-        basis=_transport_basis(**{field: changed}),
+        basis=mutated_basis,
         contracts=_surface_contracts(),
+        exact_destination_binding=_exact_destination_binding(mutated_basis),
     )
     assert mutated.digest != baseline.digest
 
 
-def test_clone_transport_evidence_cannot_build_the_real_cell_gate() -> None:
+def test_exact_destination_binding_cannot_be_reused_after_basis_drift() -> None:
     from exomem.governance import consolidation_transport_verification
 
+    basis = _transport_basis()
+    binding = _exact_destination_binding(basis)
     with pytest.raises(
         consolidation_transport_verification.ConsolidationTransportVerificationUnavailable
     ):
         consolidation_transport_verification.build_transport_verification_plan(
-            basis=_transport_basis(destination_kind="clone"),
+            basis={**basis, "canonical_census_digest": "b" * 64},
             contracts=_surface_contracts(),
+            exact_destination_binding=binding,
+        )
+
+
+def test_caller_label_or_forged_binding_cannot_make_clone_evidence_real() -> None:
+    from exomem.governance import consolidation_transport_verification
+
+    basis = _transport_basis(destination_kind="real")
+    with pytest.raises(
+        consolidation_transport_verification.ConsolidationTransportVerificationUnavailable
+    ):
+        consolidation_transport_verification.build_transport_verification_plan(
+            basis=basis,
+            contracts=_surface_contracts(),
+            exact_destination_binding=object(),
         )
 
 
@@ -227,13 +284,17 @@ def test_exact_supervised_route_bypasses_only_read_admission_and_never_request_a
         with admission.admit_read():
             pass
 
+    plan = _transport_plan()
+    probe = next(
+        candidate
+        for candidate in plan.probes
+        if candidate.surface == "rest" and candidate.probe_kind == "positive"
+    )
     route = consolidation_transport_verification.issue_transport_probe_route(
         _probe_authority(),
-        vault_binding_digest=VAULT_BINDING,
-        run_id=RUN_ID,
-        operation_id=OPERATION_ID,
         journal_digest=JOURNAL_DIGEST,
-        probe_digest=PROBE_DIGEST,
+        plan=plan,
+        probe=probe,
     )
     request = {
         "command": "ask_memory",
@@ -243,16 +304,11 @@ def test_exact_supervised_route_bypasses_only_read_admission_and_never_request_a
     assert "authority" not in repr(request).lower()
     assert "probe_digest" not in repr(request)
 
-    with consolidation_transport_verification.transport_probe_route_scope(route):
-        consolidation_transport_verification.require_active_transport_probe_route(
-            probe_digest=PROBE_DIGEST
-        )
-        with pytest.raises(
-            consolidation_transport_verification.ConsolidationTransportVerificationUnavailable
-        ):
-            consolidation_transport_verification.require_active_transport_probe_route(
-                probe_digest="9" * 64
-            )
+    with consolidation_transport_verification.transport_probe_route_scope(
+        route,
+        plan=plan,
+        probe=probe,
+    ):
         with admission.admit_read():
             pass
         for enter in (
@@ -288,13 +344,13 @@ def test_transport_route_is_process_local_unforgeable_and_not_inherited_by_threa
         tmp_path,
         vault_binding_digest=VAULT_BINDING,
     )
+    plan = _transport_plan()
+    probe = plan.probes[0]
     route = consolidation_transport_verification.issue_transport_probe_route(
         _probe_authority(),
-        vault_binding_digest=VAULT_BINDING,
-        run_id=RUN_ID,
-        operation_id=OPERATION_ID,
         journal_digest=JOURNAL_DIGEST,
-        probe_digest=PROBE_DIGEST,
+        plan=plan,
+        probe=probe,
     )
     for serializer in (pickle.dumps, copy.copy, copy.deepcopy):
         with pytest.raises(TypeError):
@@ -309,13 +365,106 @@ def test_transport_route_is_process_local_unforgeable_and_not_inherited_by_threa
         except consolidation_admission.ConsolidationAdmissionUnavailable as error:
             failures.append(error.code)
 
-    with consolidation_transport_verification.transport_probe_route_scope(route):
+    with consolidation_transport_verification.transport_probe_route_scope(
+        route,
+        plan=plan,
+        probe=probe,
+    ):
         worker = threading.Thread(target=unrelated_client)
         worker.start()
         worker.join()
         with admission.admit_read():
             pass
     assert failures == ["CONSOLIDATION_SEALED"]
+
+
+def test_transport_route_is_revoked_in_async_child_when_parent_scope_exits(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import (
+        consolidation_admission,
+        consolidation_transport_verification,
+    )
+
+    _sealed_at_transport_verifying(tmp_path)
+    admission = consolidation_admission.ConsolidationAdmission(
+        tmp_path,
+        vault_binding_digest=VAULT_BINDING,
+    )
+    plan = _transport_plan()
+    probe = plan.probes[0]
+    route = consolidation_transport_verification.issue_transport_probe_route(
+        _probe_authority(),
+        journal_digest=JOURNAL_DIGEST,
+        plan=plan,
+        probe=probe,
+    )
+
+    async def exercise() -> str:
+        release = asyncio.Event()
+
+        async def delayed_child() -> str:
+            await release.wait()
+            try:
+                with admission.admit_read():
+                    pass
+            except consolidation_admission.ConsolidationAdmissionUnavailable as error:
+                return error.code
+            return "admitted"
+
+        with consolidation_transport_verification.transport_probe_route_scope(
+            route,
+            plan=plan,
+            probe=probe,
+        ):
+            child = asyncio.create_task(delayed_child())
+        release.set()
+        return await child
+
+    assert asyncio.run(exercise()) == "CONSOLIDATION_SEALED"
+
+
+def test_nonmember_probe_cannot_issue_or_enter_a_transport_route() -> None:
+    from exomem.governance import consolidation_transport_verification
+
+    plan = _transport_plan()
+    foreign_plan = _transport_plan()
+    foreign_probe = copy.copy(foreign_plan.probes[0])
+    forged_probe = consolidation_transport_verification.TransportProbe(
+        schema=foreign_probe.schema,
+        ordinal=foreign_probe.ordinal,
+        probe_id=foreign_probe.probe_id,
+        probe_kind=foreign_probe.probe_kind,
+        surface=foreign_probe.surface,
+        contract_digest=foreign_probe.contract_digest,
+        expected_result_digest=foreign_probe.expected_result_digest,
+        probe_digest="9" * 64,
+    )
+    with pytest.raises(
+        consolidation_transport_verification.ConsolidationTransportVerificationUnavailable
+    ):
+        consolidation_transport_verification.issue_transport_probe_route(
+            _probe_authority(),
+            journal_digest=JOURNAL_DIGEST,
+            plan=plan,
+            probe=forged_probe,
+        )
+
+    route = consolidation_transport_verification.issue_transport_probe_route(
+        _probe_authority(),
+        journal_digest=JOURNAL_DIGEST,
+        plan=plan,
+        probe=plan.probes[0],
+    )
+    with pytest.raises(
+        consolidation_transport_verification.ConsolidationTransportVerificationUnavailable
+    ):
+        with consolidation_transport_verification.transport_probe_route_scope(
+            route,
+            plan=plan,
+            probe=forged_probe,
+        ):
+            pass
 
 
 def test_wrong_transport_authority_or_binding_never_opens_probe_route() -> None:
@@ -337,20 +486,16 @@ def test_wrong_transport_authority_or_binding_never_opens_probe_route() -> None:
     ):
         consolidation_transport_verification.issue_transport_probe_route(
             wrong_phase,
-            vault_binding_digest=VAULT_BINDING,
-            run_id=RUN_ID,
-            operation_id=OPERATION_ID,
             journal_digest=JOURNAL_DIGEST,
-            probe_digest=PROBE_DIGEST,
+            plan=(plan := _transport_plan()),
+            probe=plan.probes[0],
         )
     with pytest.raises(
         consolidation_transport_verification.ConsolidationTransportVerificationUnavailable
     ):
         consolidation_transport_verification.issue_transport_probe_route(
             _probe_authority(),
-            vault_binding_digest="f" * 64,
-            run_id=RUN_ID,
-            operation_id=OPERATION_ID,
-            journal_digest=JOURNAL_DIGEST,
-            probe_digest=PROBE_DIGEST,
+            journal_digest="f" * 64,
+            plan=plan,
+            probe=plan.probes[0],
         )


### PR DESCRIPTION
## Summary

- bind the real destination census, release/build, selected surface profile, configuration, trust, principal mapping, routing-stop proof, Hosted verifier readiness, and exact apply journal into one closed transport-verification plan
- require positive and negative precommitted probes for MCP, REST, Hosted, and CLI before the plan is admitted
- allow only the exact supervised read route while the durable consolidation seal remains active; mutation, transfer, background, unrelated-thread, expired async-context, changed-plan, clone-labelled, and cross-journal attempts remain closed

This is the exact-cell transport boundary foundation from OpenSpec 10.6, stacked on #1013. The receipt/phase coordinator and routing-open admission remain a following stacked slice. It does not touch a live vault.

## Verification

- `EXOMEM_DISABLE_EMBEDDINGS=1 EXOMEM_DISABLE_MEDIA_EXTRACTION=1 uv run --frozen python -m pytest -q tests/test_consolidation_transport_verification.py tests/test_consolidation_control_admission.py tests/test_consolidation_seal.py` — 70 passed
- Ruff on the three changed files
- mypy on both changed source modules
- `uv lock --check`
- `openspec validate add-governed-vault-consolidation --strict`
- independent correctness/concurrency review — no findings
- `git diff --check`