### PR TITLE
feat(claims): admit multilingual frozen stance verifier

### DIFF
--- a/.github/workflows/frozen-verifier.yml
+++ b/.github/workflows/frozen-verifier.yml
@@ -1,0 +1,85 @@
+name: frozen stance verifier
+
+on:
+  push:
+    paths:
+      - src/exomem/claims.py
+      - tests/test_frozen_verifier_real.py
+      - tests/test_frozen_verifiers.py
+      - pyproject.toml
+      - uv.lock
+      - .github/workflows/frozen-verifier.yml
+  pull_request:
+    paths:
+      - src/exomem/claims.py
+      - tests/test_frozen_verifier_real.py
+      - tests/test_frozen_verifiers.py
+      - pyproject.toml
+      - uv.lock
+      - .github/workflows/frozen-verifier.yml
+  schedule:
+    - cron: "17 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frozen-verifier-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  exact-multilingual-pin:
+    name: exact multilingual pin
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      HF_HOME: ${{ runner.temp }}/huggingface
+      EXOMEM_DISABLE_EMBEDDINGS: "1"
+      OMP_NUM_THREADS: "2"
+      TOKENIZERS_PARALLELISM: "false"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Verify lockfile
+        run: uv lock --check
+      - name: Cache exact model revision
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.HF_HOME }}/hub
+          key: >-
+            frozen-stance-linux-b5113eb38ab63efdd7f280f8c144ea8b13f978ce
+      - name: Download and verify the declared artifact manifest
+        run: |
+          uv run --frozen --extra nli python - <<'PY'
+          from pathlib import Path
+
+          from huggingface_hub import snapshot_download
+
+          from exomem import claims
+
+          pin = claims.VERIFIER_PINS[0]
+          downloaded = Path(
+              snapshot_download(
+                  repo_id=pin.model_name,
+                  revision=pin.model_revision,
+                  allow_patterns=list(pin.artifact_files),
+              )
+          )
+          digest, resident = claims._hash_resident_snapshot(pin)
+          assert downloaded == Path(resident), (downloaded, resident)
+          assert digest == pin.weights_sha256, (digest, pin.weights_sha256)
+          print(f"verified {pin.model_name}@{pin.model_revision}: {digest}")
+          PY
+      - name: Exercise production admission against the exact local bytes
+        env:
+          EXOMEM_CLAIM_POLARITY_NLI: "1"
+          EXOMEM_RUN_REAL_NLI: "1"
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
+        run: >-
+          uv run --frozen --extra nli python -m pytest
+          tests/test_frozen_verifier_real.py -q -vv

--- a/.github/workflows/frozen-verifier.yml
+++ b/.github/workflows/frozen-verifier.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      HF_HOME: ${{ runner.temp }}/huggingface
+      HF_HOME: /tmp/exomem-frozen-verifier-hf
       EXOMEM_DISABLE_EMBEDDINGS: "1"
       OMP_NUM_THREADS: "2"
       TOKENIZERS_PARALLELISM: "false"

--- a/README.md
+++ b/README.md
@@ -486,11 +486,21 @@ The server reads environment variables or a `.env` file. The main ones are:
 | `EXOMEM_MLX_WHISPER_MODEL` | HF repo for the MLX ASR model (default `mlx-community/whisper-large-v3-mlx`; use `mlx-community/whisper-large-v3-turbo` for speed). |
 | `EXOMEM_TESSERACT_CMD` | Path to the `tesseract` binary if not auto-discovered. |
 | `EXOMEM_CLAIM_LEVEL` | `1` enables the claim-level subsystem (default off). |
-| `EXOMEM_CLAIM_POLARITY_NLI` | `1` opts into the frozen stance verifier (default off). It still runs only if a repository pin matches the resident weights. |
+| `EXOMEM_CLAIM_POLARITY_NLI` | `1` opts into the frozen stance verifier (default off). It still runs only if the exact repository-pinned revision and declared artifact manifest are resident and verified. |
+| `EXOMEM_CONTRADICTION_TOP_N` | Caps the surfaced contradiction queue and therefore verifier enrichment (default `40`; `0` is uncapped). This is the sole polarity-work bound. |
 
 `EXOMEM_CLAIM_NLI_MODEL` is **retired**. Model identity comes only from the
 in-repo pin registry; a value left in it selects nothing and is reported as
 ignored by `exomem doctor`.
+
+The shipped pin is the multilingual
+[`MoritzLaurer/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7`](https://huggingface.co/MoritzLaurer/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7)
+checkpoint at one exact upstream revision. Its admission fixtures check English,
+German, French, Estonian, and mixed English/Estonian examples. That is bounded
+evidence for those examples, not a promise of equal quality across every language
+in the model card. Its labels are NLI relations: `contradict`, `duplicate`,
+`refine`, or `neutral`. `neutral` includes unrelated, compatible, and uncertain
+pairs; it never means “proved unrelated.”
 
 ### Degradation modes
 
@@ -502,7 +512,7 @@ substitute. What "absent" means, per tier:
 | Semantic search | `--extra embeddings` | Keyword/BM25 retrieval; every surface still answers. |
 | Media extraction | `--extra media` | Server-side OCR/ASR/PDF extraction is skipped; the model-driven upload `text` path still works. |
 | Vector KNN (`sqlite-vec`) | with `embeddings` | Exact in-memory scan over the same vectors; identical results, more work. |
-| Frozen stance verifier | `--extra nli` | Review-queue entries carry **no** model polarity label — never a differently-produced label under the verifier's name. Write responses, rankings, and every other surface are byte-identical to a build with no verifier tier at all; only `exomem doctor` names the absence. The verifier runs only under a pinned weights digest, a versioned label map, and a green fixture set, and it labels review-queue entries only. |
+| Frozen stance verifier | `--extra nli` | Review-queue entries carry **no** model polarity label — never a differently-produced label under the verifier's name. Write responses, rankings, and every other surface are byte-identical to a build with no verifier tier at all; only `exomem doctor` names the absence. The verifier runs only under an exact pinned revision and artifact-manifest digest, a versioned label map, and a green bounded multilingual fixture set, and it labels review-queue entries only. Hosted cells do not install or enable it. |
 
 Legacy `EXOMEM_*` names (from the project's former working name, exomem) remain
 honored: each is promoted to its `EXOMEM_*` equivalent at startup, with an

--- a/docs/hosted-inference-boundary.md
+++ b/docs/hosted-inference-boundary.md
@@ -46,10 +46,12 @@ It is not an exception to the pure-substrate rule — it is the shape any
 model-backed tier has to take to be admissible at all, and any hosted
 inference proposal above inherits it:
 
-- A **pinned identity**: a repository pin naming the model, the sha256 digest
-  of its resolved weights, the label-map version, and the fixture set that
-  verified that pair. No runtime configuration, environment value, or vault
-  content may add, select, or alter a pin.
+- A **pinned identity**: a repository pin naming the model, exact upstream
+  revision, ordered artifact manifest, sha256 digest of those declared names
+  and bytes, label-map version, and fixture set that verified the pair. Extra
+  cache files and revisions do not alter that identity. No runtime
+  configuration, environment value, or vault content may add, select, or alter
+  a pin.
 - **Refusal degrades to absence.** Gate unset, digest mismatch, missing
   weights, missing dependency, or a red fixture set means no label — never a
   differently-produced label wearing the verifier's name.
@@ -59,6 +61,30 @@ inference proposal above inherits it:
 - **Provenance-marked review-queue output only.** Labels carry their method,
   model digest, and label-map version, and never enter note canon, decisions,
   retrieval, ranking, policy, or any synchronous write path.
+
+The admitted local checkpoint is multilingual, but Exomem's acceptance claim is
+deliberately narrower than its model card: the production fixture set checks
+English, German, French, Estonian, and mixed English/Estonian pairs. Its neutral
+fallback means only that the NLI head did not establish contradiction or
+entailment at the reviewed thresholds; it does not establish topical
+unrelatedness.
+
+## Why the current verifier is not in Hosted
+
+Hosted activation remains withheld. This change adds no `nli` extra or verifier
+weights to the Hosted image, no verifier capability grant, and no
+`EXOMEM_CLAIM_POLARITY_NLI` gate to a cell. The selected safetensors checkpoint
+is about 532 MiB before Torch/runtime overhead; the available full ONNX export
+is about 1,064 MiB. The upstream quantized ONNX export is smaller at about
+323 MiB, but it failed a genuine-contradiction fixture: its two directional
+contradiction probabilities were about 0.29 and 0.50, far below the reviewed
+0.93 symmetric threshold. It is therefore not an admissible capacity shortcut.
+
+A future Hosted proposal must first pass the exact multilingual fixture set and
+measure image size, cold and warm latency, peak RSS, concurrent-cell capacity,
+idle reclamation, scheduling, and failure isolation on the actual cell runtime.
+It may then propose an isolated serving shape or a separately calibrated
+artifact. Local admission does not grant Hosted admission.
 
 See the `frozen-verifiers` capability spec for the normative statement.
 

--- a/openspec/changes/archive/2026-08-31-admit-multilingual-frozen-stance-verifier/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-31-admit-multilingual-frozen-stance-verifier/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/archive/2026-08-31-admit-multilingual-frozen-stance-verifier/design.md
+++ b/openspec/changes/archive/2026-08-31-admit-multilingual-frozen-stance-verifier/design.md
@@ -1,0 +1,160 @@
+## Context
+
+The previous change built a sound verifier boundary but intentionally shipped an
+empty pin registry. Running three English checkpoints and two multilingual
+checkpoints against its nine fixtures exposed two distinct issues:
+
+- label map v1 treats a one-way entailment as `unrelated` because mean neutrality
+  is tested before asymmetric entailment; and
+- ordinary NLI cannot distinguish topically unrelated text from compatible but
+  non-entailing evidence. Calling either state `unrelated` overstates the model.
+
+The selected candidate is
+`MoritzLaurer/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7` at revision
+`b5113eb38ab63efdd7f280f8c144ea8b13f978ce` (MIT). It was trained on XNLI plus a
+27-language NLI corpus that includes mixed English/non-English pairs. The model
+card's broader language reach is useful prior evidence, not Exomem's acceptance
+claim; Exomem claims only the checked fixture set.
+
+Hosted cells are a separate constraint. The selected safetensors checkpoint is
+about 532 MiB before runtime overhead. The upstream full ONNX export is about
+1,064 MiB, while its 323 MiB quantized export failed a genuine-contradiction
+fixture. Adding Torch or a red quantization to every memory-capped tenant cell is
+not an acceptable way to make the feature look Hosted-ready.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- admit one exact real checkpoint through the production admission path;
+- make the logit-to-product-label contract faithful to NLI semantics;
+- verify English, non-English, and mixed-language pairs against the real bytes;
+- make cache identity reproducible across machines and independent of unrelated
+  cached files;
+- keep default-off, soft-fail, queue-only, pure-substrate behavior unchanged;
+- add real-model CI and retire the dead pair-limit knob; and
+- leave a hard, testable Hosted non-activation boundary.
+
+**Non-Goals:**
+
+- claiming equal quality across every language named by the model card;
+- detecting the language of a note or refusing unlisted languages;
+- changing semantic retrieval's English BGE model;
+- using verifier output to select, rank, create, suppress, or resolve queue items;
+- enabling the verifier in Hosted, adding its weights to the Hosted image, or
+  designing a cross-tenant inference service; and
+- changing Planning, Records, workflow contracts, or OpenSpec integration.
+
+## Decisions
+
+### D1. Label map v2 represents NLI relations, not topical relatedness
+
+The selected head declares columns `(entailment, neutral, contradiction)`. Exomem
+runs both text directions and applies the following reviewed map in order:
+
+1. `contradict` when the minimum directional contradiction probability is at
+   least `0.93`;
+2. `duplicate` when the minimum directional entailment probability is at least
+   `0.95`;
+3. `refine` when either directional entailment probability is at least `0.95`;
+4. `neutral` otherwise.
+
+Contradiction is symmetric, mutual entailment is an equivalence signal, and
+one-way entailment is the added-detail shape. The fallback is `neutral`, not
+`unrelated`: it includes unrelated text, compatible evidence, and any uncertain
+pair. V1 is removed rather than retained as a selectable map because no real pin
+ever used it and its public semantics are the defect being corrected.
+
+Alternatives rejected: lowering v1 thresholds until a model passed; treating
+high neutrality as `refine`; and combining the NLI output with the existing BGE
+cosine. The first two encode false semantics. The last would make a purported
+multilingual verifier depend on an English embedding model and a second unpinned
+measurement identity.
+
+### D2. The pin names revision and files, not an incidental cache directory
+
+`VerifierPin` gains an exact upstream revision and an ordered artifact-file
+manifest. Admission resolves `snapshots/<revision>`, requires every declared
+relative file, and hashes only those names and bytes. Extra files and extra
+revisions in the cache neither change the digest nor make the pin ambiguous.
+Missing, unreadable, or digest-mismatched declared files refuse admission.
+
+The production constructor receives that exact revision directory and remains
+`local_files_only=True`. Runtime never fetches. This closes the reproducibility
+gap where two users could download different subsets of one Hugging Face repo and
+obtain different whole-directory digests despite loading the same weights.
+
+### D3. The real fixture set is multilingual but its claim is bounded
+
+`stance-v2-multilingual` contains the corrected English corpus shapes plus
+same-language German, French, and Estonian examples and mixed English/Estonian
+pairs. It covers all four v2 labels, reordered restatements, added detail,
+negation/concordance that remains honestly neutral, shared-vocabulary neutral
+pairs, and cross-language contradiction/equivalence/refinement/neutrality.
+
+Every pair must pass exactly. The fixture metadata records its language shape so
+CI and diagnostics can state what was checked. This is admission evidence for
+those examples, not a general multilingual benchmark claim.
+
+### D4. Real-model CI exercises the same production admission path
+
+A dedicated workflow runs when verifier code, pin, fixtures, dependencies, or the
+workflow itself changes, and on schedule/manual dispatch. It caches Hugging Face
+artifacts, explicitly downloads only the pin's files at the pin's revision,
+installs the `nli` extra, enables the gate, and asserts that
+`verifier_admission()` is admitted before running the real fixture test.
+Ordinary CI keeps the dependency-absent and injected-predictor tests.
+
+The download step is CI setup, not runtime behavior. A changed model, revision,
+file manifest, digest, map, or fixture set cannot pass by updating only a fake.
+
+### D5. Hosted activation remains withheld
+
+This change adds neither the `nli` extra nor model artifacts to the Hosted image,
+sets no Hosted gate, and grants no verifier capability. The existing Hosted
+optional-compute rule applies: activation needs a trusted capability grant plus
+measured peak RSS, latency, concurrent-cell capacity, idle reclamation, image
+size, and failure isolation on the actual node/runtime.
+
+The rejected upstream quantized ONNX artifact is recorded as evidence, not used.
+A future Hosted proposal may produce a better calibrated quantization, a bounded
+per-cell worker, or another isolated serving shape, but it must pass the exact
+fixture set and the Hosted capacity gate before activation.
+
+### D6. The queue cap has one owner
+
+`EXOMEM_CLAIM_POLARITY_MAX_PAIRS` and `_max_polarity_pairs()` are removed. Their
+only production caller disappeared with synchronous polarity. The asynchronous
+enrichment already operates after `EXOMEM_CONTRADICTION_TOP_N` caps the surfaced
+queue, so a second dead cap would only mislead operators.
+
+## Risks / Trade-offs
+
+- **A broad multilingual model is still uneven across languages.** → Claim only
+  fixture-backed coverage, keep labels advisory, and preserve soft failure.
+- **A 532 MiB optional model is heavy locally.** → Keep the extra and gate
+  default-off, load lazily, and run only over the capped asynchronous queue.
+- **A conservative symmetric contradiction threshold can miss conflicts.** →
+  Prefer absence/neutrality to false contradiction; no label affects surfacing or
+  rank, and future map changes require a new version plus re-verification.
+- **Upstream cache layout could change.** → Bind exact revision and relative file
+  manifest; refusal is safer than guessing another path.
+- **A real-model workflow consumes bandwidth.** → Use a revision-keyed cache and a
+  path-scoped dedicated workflow while retaining scheduled verification.
+
+## Migration Plan
+
+1. Land v2, the exact pin, and the real fixtures while the gate remains default-off.
+2. Run ordinary dependency-absent tests and the real-model lane against the exact
+   revision.
+3. Remove the dead pair-limit knob and document `EXOMEM_CONTRADICTION_TOP_N` as the
+   only queue bound.
+4. Confirm the Hosted image and rendered cell environment still contain no verifier
+   grant, gate, dependency, or weight payload.
+5. Rollback is code-only: removing the pin returns every runtime to `no-pin`; no
+   vault or sidecar migration is involved.
+
+## Open Questions
+
+None block local admission. Hosted activation remains a separate, evidence-gated
+future change rather than an open implementation choice in this one.

--- a/openspec/changes/archive/2026-08-31-admit-multilingual-frozen-stance-verifier/proposal.md
+++ b/openspec/changes/archive/2026-08-31-admit-multilingual-frozen-stance-verifier/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+The frozen stance verifier has a safe admission boundary but no admitted model, and
+its untested v1 label map asks ordinary NLI to distinguish semantic relatedness from
+neutrality. Real checkpoints correctly refuse that contract. We should admit a real,
+multilingual verifier only after making its identity reproducible, its labels truthful,
+and its Hosted cost boundary explicit.
+
+## What Changes
+
+- Admit one reviewed multilingual NLI checkpoint at an exact upstream revision and
+  content-bound artifact manifest; runtime configuration still cannot select a model.
+- Replace the unadmitted v1 aggregation with a fixture-verified v2 relation map:
+  symmetric contradiction, mutual entailment (`duplicate`), one-way entailment
+  (`refine`), and otherwise `neutral`.
+- **BREAKING**: the admitted label vocabulary uses `neutral`, not `unrelated`;
+  NLI neutrality does not prove that two claims are topically unrelated. No real v1
+  pin has shipped, so this corrects the public contract before model labels exist.
+- Expand admission fixtures beyond English to same-language and mixed-language pairs,
+  while documenting that verified fixture coverage is narrower than the model card's
+  broad language claim.
+- Pin the upstream revision and exact files as well as their digest, so a cache with
+  extra files or revisions cannot change what is verified or loaded.
+- Add a real-model CI lane that resolves the exact revision and proves the production
+  admission path and multilingual fixtures, alongside the existing injected tests.
+- Retire the production-dead `EXOMEM_CLAIM_POLARITY_MAX_PAIRS` knob; the asynchronous
+  queue remains bounded by `EXOMEM_CONTRADICTION_TOP_N`.
+- Keep Hosted activation withheld. The verifier remains default-off, soft-failing,
+  local queue enrichment; a Hosted grant or image payload requires separate measured
+  memory/latency/capacity evidence. The rejected compact and quantized candidates are
+  not admitted merely because they fit the cell envelope.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `frozen-verifiers`: Require an exact revision/file manifest, truthful v2 NLI
+  semantics, multilingual real-model fixtures, and reproducible real-model admission.
+- `contradiction-queue`: Change the admitted queue label vocabulary from `unrelated`
+  to `neutral` and preserve provenance-only asynchronous enrichment.
+- `hosted-tenant-cell`: Make explicit that no Hosted verifier capability or model
+  payload is granted until its resource envelope is measured and admitted.
+
+## Impact
+
+The change affects `src/exomem/claims.py`, verifier diagnostics, contradiction-queue
+rendering, the optional `nli` dependency path, frozen-verifier/doctor/claims tests,
+real-model CI, and the Hosted inference boundary documentation. It does not change
+write behavior, ranking, retrieval, authority, Planning/Records workflows, or Hosted
+runtime grants and images.

--- a/openspec/changes/archive/2026-08-31-admit-multilingual-frozen-stance-verifier/specs/contradiction-queue/spec.md
+++ b/openspec/changes/archive/2026-08-31-admit-multilingual-frozen-stance-verifier/specs/contradiction-queue/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: Model polarity labels are admitted asynchronous enrichment
+
+A `corpus_contradictions` proximity pair MAY carry a model polarity label —
+`meta.polarity` from the closed set `contradict` / `refine` / `duplicate` /
+`neutral`, with `meta.polarity_score`, `meta.polarity_method: "nli"`,
+`meta.polarity_model_digest`, and `meta.polarity_label_map_version` — produced
+only by an admitted frozen verifier. `neutral` means that the admitted NLI map
+found no symmetric contradiction or qualifying entailment relation; it SHALL NOT
+be rendered or interpreted as proof that the claims are topically unrelated.
+The lexical heuristic SHALL NOT produce queue polarity metadata. The label SHALL
+be produced only on the asynchronous audit/sweep path; the synchronous write path
+SHALL invoke no polarity classification, and write-time warnings SHALL carry no
+polarity clause.
+
+The label SHALL record the `signal_version` it was computed against; a label
+whose recorded signal_version differs from the entry's SHALL be dropped, not
+served. Attaching, changing, or dropping a label SHALL NOT change the entry's
+`meta.signal_version`, its `meta.provenance`, its position under the queue's
+ordering rules, or the cap and omitted-count accounting; a recorded triage
+decision SHALL NOT resurface because a label arrived, changed, or was dropped.
+Asserted pairs SHALL NOT carry a model polarity label — the author's assertion
+outranks a model's guess. The model polarity label is distinct from the
+reader-recorded competing-alternatives pair stance, which remains a triage
+disposition under its own contract and is unaffected by this requirement.
+
+#### Scenario: The label arrives on the sweep, not the write
+
+- **WHEN** a write lands a proximity pair and the next audit pass runs with the
+  verifier admitted
+- **THEN** the write response carried no polarity, and after the pass the queue
+  entry carries the label with its digest and label-map version
+
+#### Scenario: Labelling alone resurfaces nothing and moves nothing
+
+- **WHEN** a dismissed proximity entry gains a `contradict` label
+- **THEN** the dismissal stands, `signal_version` is unchanged, and the entry's
+  rank relative to every other entry is unchanged
+
+#### Scenario: A stale label is dropped, not served
+
+- **WHEN** an entry's content changes so its `signal_version` no longer matches
+  the one its label was computed against
+- **THEN** the entry is served without the label until the verifier labels the
+  new content
+
+#### Scenario: Neutral does not claim unrelatedness
+
+- **WHEN** the verifier emits `neutral` for two compatible but non-entailing
+  claims
+- **THEN** the queue describes the NLI relation as neutral and does not call the
+  pair unrelated
+
+#### Scenario: The heuristic never wears the verifier's name
+
+- **WHEN** the verifier is refused and the audit contradiction pass runs with
+  the claim subsystem enabled
+- **THEN** entries carry no `meta.polarity` at all — no heuristic-method label is
+  written

--- a/openspec/changes/archive/2026-08-31-admit-multilingual-frozen-stance-verifier/specs/frozen-verifiers/spec.md
+++ b/openspec/changes/archive/2026-08-31-admit-multilingual-frozen-stance-verifier/specs/frozen-verifiers/spec.md
@@ -1,12 +1,4 @@
-# frozen-verifiers Specification
-
-## Purpose
-
-Define the local-only admission boundary for optional stance verifiers so
-model labels are pinned, fixture-verified, provenance-marked queue enrichment
-that stays off synchronous writes and degrades to silence when unavailable.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: A frozen verifier runs only under a pinned identity
 
@@ -47,8 +39,8 @@ label map's closed set.
 
 - **WHEN** an environment value names a model absent from the repository pin
   registry
-- **THEN** no verifier runs under that name, and the ignored value is reported
-  on the diagnostic surface
+- **THEN** no verifier runs under that name, and the ignored value is reported on
+  the diagnostic surface
 
 #### Scenario: The admitted bytes are the loaded bytes
 
@@ -80,41 +72,7 @@ label map's closed set.
 - **WHEN** either direction's logits contain NaN or infinity
 - **THEN** the label map refuses the output and no polarity label is attached
 
-### Requirement: Verifier output is provenance-marked queue enrichment only
-
-A frozen verifier's labels SHALL attach only to review-queue entries, carrying
-the method, model digest, and label-map version that produced them. Verifier
-output SHALL NOT enter note canon, decisions, retrieval, ranking, policy, or
-any synchronous write path, and SHALL NOT create, mutate, accept, or supersede
-any page, relation, or proposal.
-
-#### Scenario: The label stays on the review surface
-
-- **WHEN** a verifier labels a queue entry
-- **THEN** no page, relation, ranking position, or write response changes, and
-  the entry's label names its producing digest and label-map version
-
-### Requirement: Verifier absence degrades to byte-identical silence
-
-With the verifier's extra uninstalled, its opt-in gate off (the default), or
-its pin unsatisfied, every product surface SHALL behave byte-identically to a
-build that has no verifier tier at all, apart from an explicit degradation
-record on the diagnostic surface. A per-entry failure during an enrichment
-pass SHALL leave that entry unenriched and recorded, and SHALL NOT abort the
-pass.
-
-#### Scenario: Uninstalled means invisible
-
-- **WHEN** the extra is not installed and a full audit and write cycle runs
-- **THEN** queue entries, write responses, and rankings are byte-identical to
-  a no-verifier build's, and only the diagnostic surface names the absent
-  verifier
-
-#### Scenario: One bad entry does not take down the pass
-
-- **WHEN** the model raises on one claim pair mid-pass
-- **THEN** that entry is unenriched and recorded as degraded, and every other
-  entry's enrichment completes
+## ADDED Requirements
 
 ### Requirement: The admitted NLI map states only relations its head measures
 

--- a/openspec/changes/archive/2026-08-31-admit-multilingual-frozen-stance-verifier/specs/hosted-tenant-cell/spec.md
+++ b/openspec/changes/archive/2026-08-31-admit-multilingual-frozen-stance-verifier/specs/hosted-tenant-cell/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Hosted frozen-verifier activation is separately resource-admitted
+
+A Hosted cell SHALL NOT receive a frozen-verifier capability grant, verifier gate,
+runtime dependency, or model artifact merely because a local repository pin is
+admitted. Hosted activation SHALL require reviewed measurements of the exact
+runtime and artifact on the node in service, including image size, cold and warm
+latency, peak resident memory, concurrent-cell capacity, bounded scheduling or
+idle reclamation, and failure isolation. The exact hosted artifact/map pair SHALL
+also pass the repository's real multilingual fixture set. Until that evidence is
+accepted, the Hosted image and trusted cell configuration SHALL keep the verifier
+absent and off while preserving all ordinary capture, recall, and review behavior.
+
+#### Scenario: A local pin lands without Hosted capacity evidence
+
+- **WHEN** a release contains an admitted local verifier but no accepted Hosted
+  resource envelope for its exact runtime and artifact
+- **THEN** the Hosted image carries no verifier payload and trusted cell
+  configuration grants no verifier capability or gate
+
+#### Scenario: A smaller artifact fails semantic admission
+
+- **WHEN** a compact or quantized candidate fits the cell resource envelope but
+  misses any required real multilingual fixture
+- **THEN** it remains unadmitted and cannot be enabled in Hosted
+
+#### Scenario: Hosted verifier absence preserves the product
+
+- **WHEN** a Hosted tenant runs capture, recall, and review with the verifier
+  withheld
+- **THEN** those surfaces retain their existing behavior and only verifier
+  polarity metadata is absent

--- a/openspec/changes/archive/2026-08-31-admit-multilingual-frozen-stance-verifier/tasks.md
+++ b/openspec/changes/archive/2026-08-31-admit-multilingual-frozen-stance-verifier/tasks.md
@@ -1,0 +1,54 @@
+## 1. Truthful NLI relation map
+
+- [x] 1.1 Add red unit tests for v2 column order, symmetric contradiction,
+  mutual-entailment duplicate, one-way-entailment refine, neutral fallback,
+  threshold edges, invalid shapes, and non-finite refusal.
+- [x] 1.2 Implement label map v2 and the closed
+  `contradict`/`duplicate`/`refine`/`neutral` vocabulary; remove the unadmitted v1
+  map and update rendered queue semantics.
+
+## 2. Reproducible artifact identity
+
+- [x] 2.1 Add red tests that a pin requires an exact revision and artifact
+  manifest, ignores extra cache files/revisions, refuses a missing declared file,
+  and loads only the exact pinned revision locally.
+- [x] 2.2 Extend `VerifierPin`, hashing, admission, diagnostics, and the model loader
+  to bind the exact revision plus declared-file digest without any runtime fetch.
+
+## 3. Real multilingual admission
+
+- [x] 3.1 Add the `stance-v2-multilingual` fixture set with English, German,
+  French, Estonian, and mixed English/Estonian pairs covering every v2 label and
+  record each fixture's language shape.
+- [x] 3.2 Add the exact reviewed multilingual checkpoint pin and prove its
+  artifact manifest digest against revision
+  `b5113eb38ab63efdd7f280f8c144ea8b13f978ce`.
+- [x] 3.3 Add a real-model test that enables the production gate and requires the
+  exact pinned bytes to admit and pass every multilingual fixture.
+
+## 4. Queue and knob cleanup
+
+- [x] 4.1 Update contradiction-queue tests and documentation so `neutral` never
+  renders as or implies `unrelated`, while provenance, ranking, signal version,
+  write-path absence, and failure isolation remain unchanged.
+- [x] 4.2 Remove production-dead `EXOMEM_CLAIM_POLARITY_MAX_PAIRS`, its helper and
+  tests; retain `EXOMEM_CONTRADICTION_TOP_N` as the sole surfaced/enriched bound.
+
+## 5. CI and Hosted boundary
+
+- [x] 5.1 Add a path-scoped real-model workflow with revision-keyed Hugging Face
+  caching, exact-file download, the `nli` extra, production admission, and the real
+  multilingual fixture test.
+- [x] 5.2 Add regression coverage proving the Hosted image/config receives no
+  verifier extra, artifact, grant, or gate in this change, and update the Hosted
+  inference boundary with the measured rejection of the available quantized
+  candidate.
+
+## 6. Verification and closure
+
+- [x] 6.1 Run focused verifier, claims, doctor, queue, dependency-absent, real-model,
+  Hosted-boundary, and lint checks; record red-first and green evidence.
+- [x] 6.2 Run the completion-boundary full suite, strict OpenSpec validation, and
+  attribution against the current `origin/main` baseline for any unrelated red.
+- [x] 6.3 Sync the three delta specs, archive the completed change through
+  `openspec archive`, and re-run strict validation before delivery.

--- a/openspec/specs/contradiction-queue/spec.md
+++ b/openspec/specs/contradiction-queue/spec.md
@@ -324,12 +324,15 @@ surfaces there for review.
 
 A `corpus_contradictions` proximity pair MAY carry a model polarity label —
 `meta.polarity` from the closed set `contradict` / `refine` / `duplicate` /
-`unrelated`, with `meta.polarity_score`, `meta.polarity_method: "nli"`,
+`neutral`, with `meta.polarity_score`, `meta.polarity_method: "nli"`,
 `meta.polarity_model_digest`, and `meta.polarity_label_map_version` — produced
-only by an admitted frozen verifier. The lexical heuristic SHALL NOT produce
-queue polarity metadata. The label SHALL be produced only on the asynchronous
-audit/sweep path; the synchronous write path SHALL invoke no polarity
-classification, and write-time warnings SHALL carry no polarity clause.
+only by an admitted frozen verifier. `neutral` means that the admitted NLI map
+found no symmetric contradiction or qualifying entailment relation; it SHALL NOT
+be rendered or interpreted as proof that the claims are topically unrelated.
+The lexical heuristic SHALL NOT produce queue polarity metadata. The label SHALL
+be produced only on the asynchronous audit/sweep path; the synchronous write path
+SHALL invoke no polarity classification, and write-time warnings SHALL carry no
+polarity clause.
 
 The label SHALL record the `signal_version` it was computed against; a label
 whose recorded signal_version differs from the entry's SHALL be dropped, not
@@ -361,6 +364,13 @@ disposition under its own contract and is unaffected by this requirement.
   matches the one its label was computed against
 - **THEN** the entry is served without the label until the verifier labels the
   new content
+
+#### Scenario: Neutral does not claim unrelatedness
+
+- **WHEN** the verifier emits `neutral` for two compatible but non-entailing
+  claims
+- **THEN** the queue describes the NLI relation as neutral and does not call the
+  pair unrelated
 
 #### Scenario: The heuristic never wears the verifier's name
 

--- a/openspec/specs/hosted-tenant-cell/spec.md
+++ b/openspec/specs/hosted-tenant-cell/spec.md
@@ -277,6 +277,38 @@ A hosted cell MUST NOT add or invoke a server-side reasoning or generative model
 - **THEN** its output is limited to deterministic extraction, transcription, representation, or measurement used by existing Exomem behavior
 - **AND** no model decides whether a tenant is entitled, which cell receives a request, or what knowledge is authoritative
 
+### Requirement: Hosted frozen-verifier activation is separately resource-admitted
+
+A Hosted cell SHALL NOT receive a frozen-verifier capability grant, verifier gate,
+runtime dependency, or model artifact merely because a local repository pin is
+admitted. Hosted activation SHALL require reviewed measurements of the exact
+runtime and artifact on the node in service, including image size, cold and warm
+latency, peak resident memory, concurrent-cell capacity, bounded scheduling or
+idle reclamation, and failure isolation. The exact hosted artifact/map pair SHALL
+also pass the repository's real multilingual fixture set. Until that evidence is
+accepted, the Hosted image and trusted cell configuration SHALL keep the verifier
+absent and off while preserving all ordinary capture, recall, and review behavior.
+
+#### Scenario: A local pin lands without Hosted capacity evidence
+
+- **WHEN** a release contains an admitted local verifier but no accepted Hosted
+  resource envelope for its exact runtime and artifact
+- **THEN** the Hosted image carries no verifier payload and trusted cell
+  configuration grants no verifier capability or gate
+
+#### Scenario: A smaller artifact fails semantic admission
+
+- **WHEN** a compact or quantized candidate fits the cell resource envelope but
+  misses any required real multilingual fixture
+- **THEN** it remains unadmitted and cannot be enabled in Hosted
+
+#### Scenario: Hosted verifier absence preserves the product
+
+- **WHEN** a Hosted tenant runs capture, recall, and review with the verifier
+  withheld
+- **THEN** those surfaces retain their existing behavior and only verifier
+  polarity metadata is absent
+
 ### Requirement: Cell Lifecycle Supports Quiesce And Safe Shutdown
 
 The cell SHALL support an operator-controlled quiescing state that removes it from gateway readiness, rejects new mutations, allows bounded in-flight work to finish or cancel safely, and stops background writers before reporting quiesced. Shutdown, snapshot, restore, and deletion orchestration MUST use that state rather than destroying storage beneath an active process.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,6 +230,7 @@ markers = [
     # and the HF model cache). Excluded from the lean matrix; run in the dedicated
     # `retrieval-eval` CI job via `pytest -m embeddings`.
     "embeddings: loads live vector models; run only in the retrieval-eval job",
+    "nli: loads the exact frozen stance-verifier model; run only in its dedicated job",
     "governance_timing_release: exact-capacity actual-wire governance timing characterization",
 ]
 

--- a/src/exomem/claims.py
+++ b/src/exomem/claims.py
@@ -85,27 +85,6 @@ def claim_level_enabled() -> bool:
     return bool(os.environ.get("EXOMEM_CLAIM_LEVEL"))
 
 
-def _max_polarity_pairs() -> int:
-    """Hard cap on polarity checks per call (`EXOMEM_CLAIM_POLARITY_MAX_PAIRS`).
-
-    ORPHANED as of the frozen-verifier slice and kept only so the knob does not
-    change meaning under anyone who set it: its one caller was the write path's
-    `_refine_contradictions`, which is gone. The surviving polarity lane is the
-    audit sweep, and that lane is bounded by the surfaced set it runs over —
-    `EXOMEM_CONTRADICTION_TOP_N` — not by this. See follow-up 6.3 in the
-    `add-frozen-stance-verification` change. Default 20; bad values log + fall back.
-    """
-    raw = os.environ.get("EXOMEM_CLAIM_POLARITY_MAX_PAIRS")
-    if raw is None:
-        return 20
-    try:
-        v = int(raw)
-        return v if v > 0 else 20
-    except ValueError:
-        log.warning("invalid EXOMEM_CLAIM_POLARITY_MAX_PAIRS=%r; using 20", raw)
-        return 20
-
-
 # ---------------------------------------------------------------------------
 # Claim extraction (deterministic, section-based — no LLM required for v1)
 # ---------------------------------------------------------------------------
@@ -1067,7 +1046,7 @@ def claim_text_for_page(
 
 
 # ---------------------------------------------------------------------------
-# Polarity check  (contradict / refine / duplicate / unrelated)
+# Polarity check
 # ---------------------------------------------------------------------------
 
 
@@ -1075,10 +1054,10 @@ def claim_text_for_page(
 class PolarityResult:
     """One polarity verdict for a claim pair.
 
-    `label` ∈ {contradict, refine, duplicate, unrelated}. `score` is a coarse
-    [0,1] confidence in the label. `method` names the backend that produced it
-    (`heuristic` from the lexical fallback, `nli` from an admitted frozen
-    verifier — and ONLY an admitted one may ever carry the `nli` name).
+    The admitted NLI backend emits {contradict, refine, duplicate, neutral}; the
+    legacy lexical fallback may still emit ``unrelated`` for callers outside the
+    queue. ``score`` is a coarse [0,1] confidence and ``method`` names the
+    backend. Only an admitted frozen verifier may ever carry the ``nli`` name.
     """
 
     label: str
@@ -1178,18 +1157,17 @@ def _heuristic_polarity(
 
 
 # ---------------------------------------------------------------------------
-# Label map v1 — the frozen verifier's logit → label contract (design D4)
+# Label map v2 — the frozen verifier's logit → NLI-relation contract
 # ---------------------------------------------------------------------------
 
-#: The closed label set a verifier may emit. Shared by the heuristic and the
-#: frozen verifier so a label can never be minted outside this vocabulary.
-POLARITY_LABELS = frozenset({"contradict", "refine", "duplicate", "unrelated"})
+#: The closed label set the frozen verifier may emit.
+POLARITY_LABELS = frozenset({"contradict", "refine", "duplicate", "neutral"})
 
 #: The label-map version this build ships. A pin names the version it was
 #: verified against; changing a threshold, the label set, the column order, or
 #: the direction convention bumps this and demands fixture re-verification
 #: before the (digest, label-map) pair is admitted again.
-LABEL_MAP_VERSION = "v1"
+LABEL_MAP_VERSION = "v2"
 
 
 @dataclass(frozen=True)
@@ -1203,9 +1181,10 @@ class LabelMap:
     match this declaration is refused rather than coerced.
 
     `direction` names the aggregation convention over the two orderings of the
-    pair: contradiction takes the max (either direction contradicting is a
-    contradiction), entailment the min (both directions must entail for a
-    restatement), neutral the mean.
+    pair. Contradiction is symmetric (minimum directional probability), mutual
+    entailment is a restatement, remaining one-way entailment is refinement, and
+    everything else is honestly neutral — NLI neutrality never proves topical
+    unrelatedness.
     """
 
     version: str
@@ -1213,7 +1192,7 @@ class LabelMap:
     direction: str
     contradict_min: float
     duplicate_min: float
-    unrelated_min: float
+    refine_min: float
     labels: frozenset[str] = POLARITY_LABELS
 
     def apply(self, logits: Any) -> PolarityResult | None:
@@ -1232,29 +1211,47 @@ class LabelMap:
         shifted = arr - arr.max(axis=1, keepdims=True)
         exp = np.exp(shifted)
         probs = exp / exp.sum(axis=1, keepdims=True)
-        contra = float(probs[:, 0].max())
-        entail = float(probs[:, 1].min())
-        neutral = float(probs[:, 2].mean())
-        if contra >= self.contradict_min and contra >= entail:
-            return PolarityResult("contradict", round(contra, 4), "nli")
-        if entail >= self.duplicate_min:
-            return PolarityResult("duplicate", round(entail, 4), "nli")
-        if neutral >= self.unrelated_min:
-            return PolarityResult("unrelated", round(neutral, 4), "nli")
-        return PolarityResult(
-            "refine", round(max(0.0, min(1.0, max(entail, 1 - contra - neutral))), 4), "nli"
-        )
+        try:
+            entail_index = self.columns.index("entailment")
+            neutral_index = self.columns.index("neutral")
+            contradiction_index = self.columns.index("contradiction")
+        except ValueError:
+            return None
+        contradiction = float(probs[:, contradiction_index].min())
+        entail_min = float(probs[:, entail_index].min())
+        entail_max = float(probs[:, entail_index].max())
+        neutral = float(probs[:, neutral_index].mean())
+
+        # Softmax is calculated in float32, so an exact reviewed threshold can
+        # land one ulp below its decimal representation. Treat only that numeric
+        # representation error as inclusive; this is not a threshold relaxation.
+        def meets(value: float, threshold: float) -> bool:
+            lower_float32 = float(
+                np.nextafter(np.float32(threshold), np.float32(-np.inf))
+            )
+            return value >= lower_float32
+
+        if meets(contradiction, self.contradict_min):
+            return PolarityResult("contradict", round(contradiction, 4), "nli")
+        if meets(entail_min, self.duplicate_min):
+            return PolarityResult("duplicate", round(entail_min, 4), "nli")
+        if meets(entail_max, self.refine_min):
+            return PolarityResult("refine", round(entail_max, 4), "nli")
+        return PolarityResult("neutral", round(neutral, 4), "nli")
 
 
 #: Every label map this build can load. A pin may only name a key present here.
 _LABEL_MAPS: dict[str, LabelMap] = {
-    "v1": LabelMap(
-        version="v1",
-        columns=("contradiction", "entailment", "neutral"),
-        direction="bidirectional:contradiction=max,entailment=min,neutral=mean",
-        contradict_min=0.5,
-        duplicate_min=0.6,
-        unrelated_min=0.5,
+    "v2": LabelMap(
+        version="v2",
+        columns=("entailment", "neutral", "contradiction"),
+        direction=(
+            "bidirectional:contradiction=min,duplicate-entailment=min,"
+            "refine-entailment=max,neutral=fallback"
+        ),
+        contradict_min=0.93,
+        duplicate_min=0.95,
+        refine_min=0.95,
     ),
 }
 
@@ -1300,25 +1297,48 @@ _NLI_MODEL_ENV = "EXOMEM_CLAIM_NLI_MODEL"
 
 @dataclass(frozen=True)
 class VerifierPin:
-    """One admitted `(model, weights, label map, fixture set)` tuple.
+    """One admitted `(model revision, artifacts, label map, fixture set)` tuple.
 
-    All four move together. A pin is only ever added or changed in a reviewed
-    diff: no environment value, runtime configuration, or vault content may add,
-    select, or alter one, which is what makes "an unpinned model never labels"
-    a property of the code rather than of a deployment's configuration.
+    Every field moves together. ``model_revision`` selects one exact resident
+    snapshot and ``artifact_files`` declares the only files whose names and
+    bytes make up its digest. Extra cache metadata and other resident revisions
+    are outside the identity. A pin is only ever added or changed in a reviewed
+    diff: no environment value, runtime configuration, or vault content may
+    add, select, or alter one, which is what makes "an unpinned model never
+    labels" a property of the code rather than deployment configuration.
     """
 
     model_name: str
+    model_revision: str
+    artifact_files: tuple[str, ...]
     weights_sha256: str
     label_map_version: str
     fixture_set: str
 
 
-#: Every verifier this build may run. EMPTY in this build: no cross-encoder
-#: weights have been resolved and hashed in a reviewed environment yet, and a
-#: digest is never guessed. An empty registry refuses every verifier, which is
-#: the correct behaviour — absence, not a heuristic wearing the model's name.
-VERIFIER_PINS: tuple[VerifierPin, ...] = ()
+#: Every verifier this build may run. This exact multilingual checkpoint passed
+#: ``stance-v2-multilingual`` against these declared bytes. The model card's
+#: broader language list is prior evidence only; the fixture set is Exomem's
+#: bounded acceptance claim.
+VERIFIER_PINS: tuple[VerifierPin, ...] = (
+    VerifierPin(
+        model_name="MoritzLaurer/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7",
+        model_revision="b5113eb38ab63efdd7f280f8c144ea8b13f978ce",
+        artifact_files=(
+            "config.json",
+            "model.safetensors",
+            "special_tokens_map.json",
+            "spm.model",
+            "tokenizer.json",
+            "tokenizer_config.json",
+        ),
+        weights_sha256=(
+            "b1dbf445f78e823534f864406b773a5a6b46d04dd32b558588c29e3195349d22"
+        ),
+        label_map_version="v2",
+        fixture_set="stance-v2-multilingual",
+    ),
+)
 
 
 def _active_pin() -> VerifierPin | None:
@@ -1360,6 +1380,8 @@ class VerifierAdmission:
     reason: str
     detail: str = ""
     model_name: str | None = None
+    model_revision: str | None = None
+    artifact_files: tuple[str, ...] = ()
     model_digest: str | None = None
     label_map_version: str | None = None
     fixture_set: str | None = None
@@ -1371,6 +1393,8 @@ class VerifierAdmission:
             "reason": self.reason,
             "detail": self.detail,
             "model_name": self.model_name,
+            "model_revision": self.model_revision,
+            "artifact_files": list(self.artifact_files),
             "model_digest": self.model_digest,
             "label_map_version": self.label_map_version,
             "fixture_set": self.fixture_set,
@@ -1382,76 +1406,107 @@ class VerifierAdmission:
 # Resolve-and-hash: the pinned digest, computed once per process
 # ---------------------------------------------------------------------------
 
-_WEIGHTS_DIGEST_CACHE: dict[str, tuple[str | None, str]] = {}
+_WeightsIdentity = tuple[str, str, tuple[str, ...]]
+
+_WEIGHTS_DIGEST_CACHE: dict[_WeightsIdentity, tuple[str | None, str]] = {}
 _WEIGHTS_DIGEST_LOCK = threading.Lock()
 
 _VERIFIER_MODEL: Any = None
-_VERIFIER_MODEL_NAME: str | None = None
+_VERIFIER_MODEL_IDENTITY: _WeightsIdentity | None = None
 _VERIFIER_LOCK = threading.Lock()
 
 
-def _directory_digest(root: Path) -> str:
-    """sha256 over a snapshot directory's content, path-order stable.
+def _pin_identity(pin: VerifierPin) -> _WeightsIdentity:
+    return (pin.model_name, pin.model_revision, pin.artifact_files)
 
-    Names are hashed alongside bytes so a rename is a different digest, and the
-    walk is sorted so the answer does not depend on filesystem iteration order.
-    """
+
+def _safe_relative_artifact(relative: str) -> bool:
+    path = Path(relative)
+    return bool(relative) and not path.is_absolute() and ".." not in path.parts
+
+
+def _artifact_manifest_digest(root: Path, artifact_files: tuple[str, ...]) -> str:
+    """Hash the reviewed ordered manifest as ``relative-name + NUL + bytes``."""
     digest = hashlib.sha256()
-    for path in sorted(p for p in root.rglob("*") if p.is_file()):
-        digest.update(path.relative_to(root).as_posix().encode("utf-8"))
+    for relative in artifact_files:
+        digest.update(relative.encode("utf-8"))
         digest.update(b"\0")
-        with open(path, "rb") as handle:
+        with open(root / relative, "rb") as handle:
             for chunk in iter(lambda: handle.read(1 << 20), b""):
                 digest.update(chunk)
         digest.update(b"\0")
     return digest.hexdigest()
 
 
-def _hash_resident_snapshot(model_name: str) -> tuple[str | None, str]:
-    """`(digest, detail)` for the model's resident weights through the offline cache.
+def _hash_resident_snapshot(pin: VerifierPin) -> tuple[str | None, str]:
+    """``(digest, detail)`` for the pin's exact offline snapshot and manifest.
 
-    Exactly one resident revision is required. Zero means the weights are not
-    there; more than one means the loader's choice is not determined by this
-    directory, and a digest that does not name what will actually be loaded
-    would be a pin in name only.
+    Other revisions and undeclared files are deliberately ignored: neither can
+    change the identity that the repository reviewed. A missing, unsafe,
+    duplicated, or unreadable declared artifact refuses admission.
     """
     from . import model_cache
 
-    root = model_cache.hub_dir() / model_cache.snapshot_dirname(model_name) / "snapshots"
-    try:
-        revisions = sorted(p for p in root.iterdir() if p.is_dir())
-    except OSError:
-        return None, f"no resident snapshot for {model_name!r} under {root}"
-    if not revisions:
-        return None, f"no resident snapshot for {model_name!r} under {root}"
-    if len(revisions) > 1:
+    revision_path = Path(pin.model_revision)
+    if (
+        not pin.model_revision
+        or revision_path.is_absolute()
+        or len(revision_path.parts) != 1
+        or pin.model_revision in {".", ".."}
+    ):
         return None, (
-            f"resident snapshot for {model_name!r} is ambiguous: {len(revisions)} "
-            f"revisions under {root}"
+            f"pinned revision {pin.model_revision!r} for {pin.model_name!r} "
+            "is not one exact cache directory name"
         )
+    if not pin.artifact_files:
+        return None, f"pin for {pin.model_name!r} declares no artifact files"
+    if len(set(pin.artifact_files)) != len(pin.artifact_files):
+        return None, f"pin for {pin.model_name!r} declares duplicate artifact files"
+    unsafe = next(
+        (relative for relative in pin.artifact_files if not _safe_relative_artifact(relative)),
+        None,
+    )
+    if unsafe is not None:
+        return None, f"pin for {pin.model_name!r} declares unsafe artifact {unsafe!r}"
+
+    root = (
+        model_cache.hub_dir()
+        / model_cache.snapshot_dirname(pin.model_name)
+        / "snapshots"
+        / pin.model_revision
+    )
     try:
-        return _directory_digest(revisions[0]), str(revisions[0])
+        for relative in pin.artifact_files:
+            artifact = root / relative
+            if not artifact.is_file():
+                return None, (
+                    f"declared artifact {relative!r} is missing from the pinned "
+                    f"snapshot {root}"
+                )
+        return _artifact_manifest_digest(root, pin.artifact_files), str(root)
     except OSError as error:
-        return None, f"weights for {model_name!r} are unreadable: {error}"
+        return None, f"weights for {pin.model_name!r} are unreadable: {error}"
 
 
-def _resolve_weights(model_name: str) -> tuple[str | None, str]:
+def _resolve_weights(pin: VerifierPin) -> tuple[str | None, str]:
     """Memoized `_hash_resident_snapshot` — hashed once per process."""
-    cached = _WEIGHTS_DIGEST_CACHE.get(model_name)
+    identity = _pin_identity(pin)
+    cached = _WEIGHTS_DIGEST_CACHE.get(identity)
     if cached is not None:
         return cached
     with _WEIGHTS_DIGEST_LOCK:
-        cached = _WEIGHTS_DIGEST_CACHE.get(model_name)
+        cached = _WEIGHTS_DIGEST_CACHE.get(identity)
         if cached is not None:
             return cached
-        resolved = _hash_resident_snapshot(model_name)
-        _WEIGHTS_DIGEST_CACHE[model_name] = resolved
+        resolved = _hash_resident_snapshot(pin)
+        _WEIGHTS_DIGEST_CACHE[identity] = resolved
     return resolved
 
 
 def resolve_weights_digest(model_name: str) -> str | None:
-    """The resident weights digest for `model_name`, or None if unresolvable."""
-    return _resolve_weights(model_name)[0]
+    """The pinned resident weights digest for ``model_name``, if resolvable."""
+    pin = next((item for item in VERIFIER_PINS if item.model_name == model_name), None)
+    return _resolve_weights(pin)[0] if pin is not None else None
 
 
 def reset_verifier_cache() -> None:
@@ -1462,7 +1517,7 @@ def reset_verifier_cache() -> None:
     different snapshot; an operator who has just replaced weights) needs an
     explicit way to say the process's answer is stale.
     """
-    global _VERIFIER_MODEL, _VERIFIER_MODEL_NAME
+    global _VERIFIER_MODEL, _VERIFIER_MODEL_IDENTITY
 
     with _WEIGHTS_DIGEST_LOCK:
         _WEIGHTS_DIGEST_CACHE.clear()
@@ -1470,7 +1525,7 @@ def reset_verifier_cache() -> None:
         _FIXTURE_VERDICTS.clear()
     with _VERIFIER_LOCK:
         _VERIFIER_MODEL = None
-        _VERIFIER_MODEL_NAME = None
+        _VERIFIER_MODEL_IDENTITY = None
 
 
 # ---------------------------------------------------------------------------
@@ -1491,26 +1546,29 @@ class FixturePair:
     claim_b: str
     expected: str
     note: str
+    language_shape: str
     heuristic_fails: bool = False
 
 
-#: Golden pairs drawn from the f22 corpus shapes — genuine contradiction,
-#: concordant evidence, restatement, unrelated — plus the lexical heuristic's
-#: known failure cases. A (digest, label-map) pair is admitted only when it
-#: answers every one of these correctly.
+#: Bounded multilingual admission evidence. The English pairs preserve the
+#: original corpus shapes with corrected v2 semantics; the remaining pairs add
+#: checked German, French, Estonian, and mixed English/Estonian shapes. They are
+#: examples the pinned bytes must answer, not a language-wide quality claim.
 VERIFICATION_FIXTURES: dict[str, tuple[FixturePair, ...]] = {
-    "stance-v1": (
+    "stance-v2-multilingual": (
         FixturePair(
             "Raising the cache TTL reduces p99 latency.",
             "Raising the cache TTL increases p99 latency.",
             "contradict",
             "genuine contradiction, shared vocabulary",
+            "en/en",
         ),
         FixturePair(
             "The rollout regressed checkout throughput.",
             "Checkout got faster after we shipped it.",
             "contradict",
             "genuine contradiction across differing surface forms",
+            "en/en",
             heuristic_fails=True,
         ),
         FixturePair(
@@ -1518,12 +1576,14 @@ VERIFICATION_FIXTURES: dict[str, tuple[FixturePair, ...]] = {
             "Caching improves latency on repeat reads.",
             "duplicate",
             "restatement, near-identical surface",
+            "en/en",
         ),
         FixturePair(
             "Owned files are what retrieval quality depends on.",
             "Retrieval quality depends on owning the files.",
             "duplicate",
             "restatement, reordered surface",
+            "en/en",
             heuristic_fails=True,
         ),
         FixturePair(
@@ -1531,12 +1591,14 @@ VERIFICATION_FIXTURES: dict[str, tuple[FixturePair, ...]] = {
             "Batching similar work helps focus, most reliably in the morning.",
             "refine",
             "same stance, added detail",
+            "en/en",
         ),
         FixturePair(
             "Enabling the cache improves throughput.",
             "Disabling the cache degrades throughput.",
-            "refine",
-            "concordant evidence: antonym vocabulary, one stance",
+            "neutral",
+            "compatible but non-entailing evidence remains neutral",
+            "en/en",
             heuristic_fails=True,
         ),
         FixturePair(
@@ -1544,24 +1606,86 @@ VERIFICATION_FIXTURES: dict[str, tuple[FixturePair, ...]] = {
             "Batching helps focus.",
             "refine",
             "concordant evidence: negation parity differs, one stance",
+            "en/en",
             heuristic_fails=True,
         ),
         FixturePair(
             "Tesseract is required for image OCR on Windows.",
             "Pair dormancy reuses the stale-review activation calculation.",
-            "unrelated",
-            "disjoint topics",
+            "neutral",
+            "disjoint topics are inside NLI's neutral fallback",
+            "en/en",
+            heuristic_fails=True,
         ),
         FixturePair(
             "The upload route parses multipart bodies through Starlette.",
             "Dormant notes in a close pair are the forgotten-conclusion case.",
-            "unrelated",
-            "disjoint topics, shared house vocabulary",
+            "neutral",
+            "disjoint topics with shared house vocabulary remain neutral",
+            "en/en",
+            heuristic_fails=True,
+        ),
+        FixturePair(
+            "Der Cache reduziert die Latenz.",
+            "Der Cache erhöht die Latenz.",
+            "contradict",
+            "same-language German contradiction",
+            "de/de",
+            heuristic_fails=True,
+        ),
+        FixturePair(
+            "La sauvegarde démarre chaque nuit.",
+            "La sauvegarde démarre chaque nuit à deux heures.",
+            "refine",
+            "same-language French added detail",
+            "fr/fr",
+        ),
+        FixturePair(
+            "Varukoopia käivitub igal ööl.",
+            "Igal ööl käivitatakse varukoopia.",
+            "duplicate",
+            "same-language Estonian reordered restatement",
+            "et/et",
+            heuristic_fails=True,
+        ),
+        FixturePair(
+            "The cache reduces latency.",
+            "Vahemälu suurendab latentsust.",
+            "contradict",
+            "mixed English/Estonian contradiction",
+            "en/et",
+            heuristic_fails=True,
+        ),
+        FixturePair(
+            "The backup runs every night.",
+            "Varukoopia käivitub igal ööl.",
+            "duplicate",
+            "mixed English/Estonian equivalence",
+            "en/et",
+            heuristic_fails=True,
+        ),
+        FixturePair(
+            "The backup runs every night.",
+            "Varukoopia käivitub igal ööl kell kaks.",
+            "refine",
+            "mixed English/Estonian added detail",
+            "en/et",
+            heuristic_fails=True,
+        ),
+        FixturePair(
+            "The cache reduces latency.",
+            "Varukoopia käivitub igal ööl.",
+            "neutral",
+            "mixed English/Estonian neutral pair",
+            "en/et",
+            heuristic_fails=True,
         ),
     ),
 }
 
-_FIXTURE_VERDICTS: dict[tuple[str, str, str, str], tuple[bool, str]] = {}
+_FIXTURE_VERDICTS: dict[
+    tuple[str, str, tuple[str, ...], str, str, str], tuple[bool, str]
+] = {}
 _FIXTURE_LOCK = threading.Lock()
 
 
@@ -1593,7 +1717,14 @@ def _verify_fixtures(
     pin: VerifierPin, digest: str, label_map: LabelMap, predict
 ) -> tuple[bool, str]:
     """Memoized `_run_fixture_set`, keyed by the exact pair it verified."""
-    key = (pin.model_name, digest, pin.label_map_version, pin.fixture_set)
+    key = (
+        pin.model_name,
+        pin.model_revision,
+        pin.artifact_files,
+        digest,
+        pin.label_map_version,
+        pin.fixture_set,
+    )
     cached = _FIXTURE_VERDICTS.get(key)
     if cached is not None:
         return cached
@@ -1643,17 +1774,21 @@ def verifier_admission() -> VerifierAdmission:
             "label-map-unknown",
             detail=str(error),
             model_name=pin.model_name,
+            model_revision=pin.model_revision,
+            artifact_files=pin.artifact_files,
             label_map_version=pin.label_map_version,
             fixture_set=pin.fixture_set,
             ignored_model_env=ignored,
         )
-    digest, detail = _resolve_weights(pin.model_name)
+    digest, detail = _resolve_weights(pin)
     if digest is None:
         return VerifierAdmission(
             False,
             "weights-missing",
             detail=detail,
             model_name=pin.model_name,
+            model_revision=pin.model_revision,
+            artifact_files=pin.artifact_files,
             label_map_version=pin.label_map_version,
             fixture_set=pin.fixture_set,
             ignored_model_env=ignored,
@@ -1667,12 +1802,14 @@ def verifier_admission() -> VerifierAdmission:
                 f"{pin.weights_sha256} for {pin.model_name!r}."
             ),
             model_name=pin.model_name,
+            model_revision=pin.model_revision,
+            artifact_files=pin.artifact_files,
             model_digest=digest,
             label_map_version=pin.label_map_version,
             fixture_set=pin.fixture_set,
             ignored_model_env=ignored,
         )
-    predict = _load_verifier_predictor(pin.model_name)
+    predict = _load_verifier_predictor(pin)
     if predict is None:
         return VerifierAdmission(
             False,
@@ -1682,6 +1819,8 @@ def verifier_admission() -> VerifierAdmission:
                 "be loaded from the offline model cache."
             ),
             model_name=pin.model_name,
+            model_revision=pin.model_revision,
+            artifact_files=pin.artifact_files,
             model_digest=digest,
             label_map_version=pin.label_map_version,
             fixture_set=pin.fixture_set,
@@ -1694,6 +1833,8 @@ def verifier_admission() -> VerifierAdmission:
             "fixtures-failed",
             detail=fixture_detail,
             model_name=pin.model_name,
+            model_revision=pin.model_revision,
+            artifact_files=pin.artifact_files,
             model_digest=digest,
             label_map_version=pin.label_map_version,
             fixture_set=pin.fixture_set,
@@ -1704,6 +1845,8 @@ def verifier_admission() -> VerifierAdmission:
         "admitted",
         detail=fixture_detail,
         model_name=pin.model_name,
+        model_revision=pin.model_revision,
+        artifact_files=pin.artifact_files,
         model_digest=digest,
         label_map_version=pin.label_map_version,
         fixture_set=pin.fixture_set,
@@ -1726,11 +1869,22 @@ def verifier_status() -> dict:
     payload["gate"] = "EXOMEM_CLAIM_POLARITY_NLI"
     payload["retired_model_env"] = _NLI_MODEL_ENV
     payload["pinned_models"] = [pin.model_name for pin in VERIFIER_PINS]
+    payload["pins"] = [
+        {
+            "model_name": pin.model_name,
+            "model_revision": pin.model_revision,
+            "artifact_files": list(pin.artifact_files),
+            "weights_sha256": pin.weights_sha256,
+            "label_map_version": pin.label_map_version,
+            "fixture_set": pin.fixture_set,
+        }
+        for pin in VERIFIER_PINS
+    ]
     payload["label_map_versions"] = sorted(_LABEL_MAPS)
     return payload
 
 
-def _load_verifier_predictor(model_name: str):
+def _load_verifier_predictor(pin: VerifierPin):
     """The cross-encoder's `predict`, or None when the `nli` extra is absent.
 
     The constructor receives the exact snapshot directory whose bytes were
@@ -1743,19 +1897,20 @@ def _load_verifier_predictor(model_name: str):
     this path (design D5) — which is why vault text can never reach instruction
     position through this seam.
     """
-    global _VERIFIER_MODEL, _VERIFIER_MODEL_NAME
+    global _VERIFIER_MODEL, _VERIFIER_MODEL_IDENTITY
 
-    if _VERIFIER_MODEL is not None and _VERIFIER_MODEL_NAME == model_name:
+    identity = _pin_identity(pin)
+    if _VERIFIER_MODEL is not None and _VERIFIER_MODEL_IDENTITY == identity:
         return _VERIFIER_MODEL.predict
     with _VERIFIER_LOCK:
-        if _VERIFIER_MODEL is not None and _VERIFIER_MODEL_NAME == model_name:
+        if _VERIFIER_MODEL is not None and _VERIFIER_MODEL_IDENTITY == identity:
             return _VERIFIER_MODEL.predict
         try:
             from sentence_transformers import CrossEncoder
 
             from . import accel
 
-            digest, snapshot_detail = _resolve_weights(model_name)
+            digest, snapshot_detail = _resolve_weights(pin)
             if digest is None:
                 return None
             device = accel.select_device()
@@ -1768,7 +1923,7 @@ def _load_verifier_predictor(model_name: str):
             log.warning("frozen verifier unavailable (%s); no label is produced", error)
             return None
         _VERIFIER_MODEL = model
-        _VERIFIER_MODEL_NAME = model_name
+        _VERIFIER_MODEL_IDENTITY = identity
     return _VERIFIER_MODEL.predict
 
 
@@ -1786,8 +1941,11 @@ def verifier_polarity(claim_a: str, claim_b: str) -> PolarityResult | None:
             "frozen verifier refused (%s): %s", admission.reason, admission.detail
         )
         return None
+    pin = _active_pin()
+    if pin is None:
+        return None
     label_map = get_label_map(admission.label_map_version)
-    predict = _load_verifier_predictor(str(admission.model_name))
+    predict = _load_verifier_predictor(pin)
     if predict is None:
         return None
     return label_map.apply(predict([(claim_a, claim_b), (claim_b, claim_a)]))

--- a/tests/test_claims.py
+++ b/tests/test_claims.py
@@ -191,15 +191,6 @@ def test_claim_level_gate_on(monkeypatch) -> None:
     assert claims.claim_level_enabled() is True
 
 
-def test_max_polarity_pairs_default_and_override(monkeypatch) -> None:
-    monkeypatch.delenv("EXOMEM_CLAIM_POLARITY_MAX_PAIRS", raising=False)
-    assert claims._max_polarity_pairs() == 20
-    monkeypatch.setenv("EXOMEM_CLAIM_POLARITY_MAX_PAIRS", "5")
-    assert claims._max_polarity_pairs() == 5
-    monkeypatch.setenv("EXOMEM_CLAIM_POLARITY_MAX_PAIRS", "junk")
-    assert claims._max_polarity_pairs() == 20
-
-
 # ---------------- sidecar (FAKE vectors — torch-free) ----------------
 
 

--- a/tests/test_frozen_verifier_ci_contract.py
+++ b/tests/test_frozen_verifier_ci_contract.py
@@ -1,0 +1,40 @@
+"""Static contract for the path-scoped real frozen-verifier workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from exomem import claims
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "frozen-verifier.yml"
+
+
+def test_real_verifier_workflow_is_revision_keyed_and_downloads_the_pin_manifest() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    pin = claims.VERIFIER_PINS[0]
+
+    assert pin.model_revision in text
+    assert "snapshot_download" in text
+    assert "allow_patterns=list(pin.artifact_files)" in text
+    assert "_hash_resident_snapshot(pin)" in text
+    assert "--extra nli" in text
+    assert "EXOMEM_RUN_REAL_NLI: \"1\"" in text
+    assert "tests/test_frozen_verifier_real.py" in text
+
+
+def test_real_verifier_workflow_is_scoped_to_identity_and_behavior_changes() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    for path in (
+        "src/exomem/claims.py",
+        "tests/test_frozen_verifier_real.py",
+        "tests/test_frozen_verifiers.py",
+        "pyproject.toml",
+        "uv.lock",
+        ".github/workflows/frozen-verifier.yml",
+    ):
+        assert path in text
+    assert "schedule:" in text
+    assert "workflow_dispatch:" in text

--- a/tests/test_frozen_verifier_ci_contract.py
+++ b/tests/test_frozen_verifier_ci_contract.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
+
 from exomem import claims
 
 
@@ -38,3 +40,10 @@ def test_real_verifier_workflow_is_scoped_to_identity_and_behavior_changes() -> 
         assert path in text
     assert "schedule:" in text
     assert "workflow_dispatch:" in text
+
+
+def test_real_verifier_job_env_uses_only_job_available_contexts() -> None:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    job_env = workflow["jobs"]["exact-multilingual-pin"]["env"]
+
+    assert not any("${{ runner." in value for value in job_env.values())

--- a/tests/test_frozen_verifier_hosted_boundary.py
+++ b/tests/test_frozen_verifier_hosted_boundary.py
@@ -1,0 +1,55 @@
+"""Hosted must not inherit local frozen-verifier admission by accident."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CELL = ROOT / "infra" / "helm" / "cell"
+MODEL_NAME = "MoritzLaurer/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7"
+
+
+def test_hosted_image_contains_no_verifier_extra_or_artifact() -> None:
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+    hosted_stage = dockerfile.split("FROM builder-lean AS builder-hosted", 1)[1].split(
+        "# Final: ml", 1
+    )[0]
+
+    assert '".[embeddings-onnx]"' in hosted_stage
+    assert "[nli]" not in hosted_stage
+    assert MODEL_NAME not in hosted_stage
+    assert "model.safetensors" not in hosted_stage
+
+
+def test_hosted_cell_has_no_verifier_grant_or_gate() -> None:
+    for name in ("values.yaml", "values.initialize.yaml", "values.validation.yaml"):
+        values = yaml.safe_load((CELL / name).read_text(encoding="utf-8"))
+        grants = values["featureGrants"].split(",")
+        assert grants == ["embeddings", "file-watcher"]
+        assert not {"nli", "stance-verifier", "claim-polarity"} & set(grants)
+
+    schema = json.loads((CELL / "values.schema.json").read_text(encoding="utf-8"))
+    assert schema["properties"]["featureGrants"]["const"] == (
+        "embeddings,file-watcher"
+    )
+    rendered_inputs = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (CELL / "templates").glob("*.yaml")
+    )
+    assert "EXOMEM_CLAIM_POLARITY_NLI" not in rendered_inputs
+
+
+def test_hosted_boundary_records_the_rejected_quantized_candidate() -> None:
+    boundary = (ROOT / "docs" / "hosted-inference-boundary.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "323 MiB" in boundary
+    assert "0.29 and 0.50" in boundary
+    assert "0.93 symmetric threshold" in boundary
+    assert "adds no `nli` extra" in boundary
+    assert "Local admission does not grant Hosted admission" in boundary

--- a/tests/test_frozen_verifier_real.py
+++ b/tests/test_frozen_verifier_real.py
@@ -1,0 +1,44 @@
+"""Real-byte admission gate for the frozen multilingual stance verifier.
+
+The lean suite collects this file but skips the model load. Dedicated CI sets
+``EXOMEM_RUN_REAL_NLI=1`` after downloading the pin's exact declared files.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from exomem import claims
+
+
+pytestmark = [
+    pytest.mark.nli,
+    pytest.mark.skipif(
+        os.environ.get("EXOMEM_RUN_REAL_NLI") != "1",
+        reason="real frozen-verifier gate requires EXOMEM_RUN_REAL_NLI=1",
+    ),
+]
+
+
+def test_exact_pinned_multilingual_bytes_admit_every_fixture(monkeypatch) -> None:
+    pin = claims.VERIFIER_PINS[0]
+    digest, snapshot = claims._hash_resident_snapshot(pin)
+
+    assert digest == pin.weights_sha256
+    assert snapshot.endswith(f"/snapshots/{pin.model_revision}")
+
+    monkeypatch.setenv("EXOMEM_CLAIM_POLARITY_NLI", "1")
+    claims.reset_verifier_cache()
+    admission = claims.verifier_admission()
+
+    assert admission.admitted is True, admission.as_dict()
+    assert admission.model_revision == pin.model_revision
+    assert admission.artifact_files == pin.artifact_files
+    assert admission.label_map_version == "v2"
+    assert admission.fixture_set == "stance-v2-multilingual"
+    assert admission.detail == (
+        f"{len(claims.VERIFICATION_FIXTURES[pin.fixture_set])} fixtures green "
+        f"for {pin.fixture_set!r}"
+    )

--- a/tests/test_frozen_verifiers.py
+++ b/tests/test_frozen_verifiers.py
@@ -12,30 +12,32 @@ runs on a box with no cross-encoder weights and no `nli` extra installed.
 from __future__ import annotations
 
 import dataclasses
+import hashlib
+import math
 
 import pytest
 
 from exomem import claims
 
-# ---------------- 1.1 label map v1 (versioned in-repo artifact) ----------------
+# ---------------- 1.1 label map v2 (versioned in-repo artifact) ----------------
 
 
-def test_label_map_v1_is_the_declared_current_version() -> None:
-    assert claims.LABEL_MAP_VERSION == "v1"
-    assert claims.get_label_map("v1").version == "v1"
+def test_label_map_v2_is_the_declared_current_version() -> None:
+    assert claims.LABEL_MAP_VERSION == "v2"
+    assert claims.get_label_map("v2").version == "v2"
 
 
 def test_label_map_declares_logit_column_semantics_and_order() -> None:
     """D4: the map declares the columns and their ORDER, so a model whose head
     orders entailment/contradiction differently is a different pair."""
-    v1 = claims.get_label_map("v1")
-    assert v1.columns == ("contradiction", "entailment", "neutral")
-    assert v1.labels == frozenset({"contradict", "refine", "duplicate", "unrelated"})
+    v2 = claims.get_label_map("v2")
+    assert v2.columns == ("entailment", "neutral", "contradiction")
+    assert v2.labels == frozenset({"contradict", "refine", "duplicate", "neutral"})
 
 
 def test_unknown_label_map_version_refuses() -> None:
     with pytest.raises(ValueError, match="unknown label map"):
-        claims.get_label_map("v2")
+        claims.get_label_map("v1")
 
 
 def test_unversioned_label_map_refuses() -> None:
@@ -47,38 +49,92 @@ def test_unversioned_label_map_refuses() -> None:
 @pytest.mark.parametrize(
     ("logits", "expected"),
     [
-        # (contradiction, entailment, neutral) logits per direction.
-        ([[4.0, 0.0, 0.0], [4.0, 0.0, 0.0]], "contradict"),
-        ([[0.0, 4.0, 0.0], [0.0, 4.0, 0.0]], "duplicate"),
-        ([[0.0, 0.0, 4.0], [0.0, 0.0, 4.0]], "unrelated"),
-        ([[0.0, 2.0, 0.6], [0.0, 0.0, 0.6]], "refine"),
+        # (entailment, neutral, contradiction) logits per direction.
+        ([[0.0, 0.0, 6.0], [0.0, 0.0, 6.0]], "contradict"),
+        ([[6.0, 0.0, 0.0], [6.0, 0.0, 0.0]], "duplicate"),
+        ([[0.0, 6.0, 0.0], [0.0, 6.0, 0.0]], "neutral"),
+        ([[0.0, 6.0, 0.0], [6.0, 0.0, 0.0]], "refine"),
+        # A one-direction contradiction is uncertainty, not a symmetric conflict.
+        ([[0.0, 0.0, 6.0], [0.0, 6.0, 0.0]], "neutral"),
     ],
 )
-def test_label_map_v1_applies_the_promoted_threshold_logic(logits, expected) -> None:
-    result = claims.get_label_map("v1").apply(logits)
+def test_label_map_v2_applies_the_bidirectional_nli_relation(logits, expected) -> None:
+    result = claims.get_label_map("v2").apply(logits)
     assert result is not None
     assert result.label == expected
     assert result.method == "nli"
     assert 0.0 <= result.score <= 1.0
 
 
-def test_label_map_v1_refuses_a_wrong_shaped_head() -> None:
+def _logits_for(*, entailment: float, neutral: float, contradiction: float) -> list[float]:
+    return [math.log(entailment), math.log(neutral), math.log(contradiction)]
+
+
+def test_label_map_v2_threshold_edges_are_inclusive_and_reviewed() -> None:
+    v2 = claims.get_label_map("v2")
+    contradiction_edge = _logits_for(
+        entailment=0.035, neutral=0.035, contradiction=0.93
+    )
+    duplicate_edge = _logits_for(
+        entailment=0.95, neutral=0.025, contradiction=0.025
+    )
+    neutral_edge = _logits_for(
+        entailment=0.025, neutral=0.946, contradiction=0.029
+    )
+
+    assert v2.apply([contradiction_edge, contradiction_edge]).label == "contradict"
+    assert v2.apply([duplicate_edge, duplicate_edge]).label == "duplicate"
+    assert v2.apply([neutral_edge, duplicate_edge]).label == "refine"
+
+
+def test_label_map_v2_does_not_relax_thresholds_by_a_decimal_tolerance() -> None:
+    v2 = claims.get_label_map("v2")
+    contradiction_below = _logits_for(
+        entailment=0.03500025,
+        neutral=0.03500025,
+        contradiction=0.9299995,
+    )
+    entailment_below = _logits_for(
+        entailment=0.9499995,
+        neutral=0.02500025,
+        contradiction=0.02500025,
+    )
+
+    assert v2.apply([contradiction_below, contradiction_below]).label == "neutral"
+    assert v2.apply([entailment_below, entailment_below]).label == "neutral"
+
+
+def test_label_map_v2_refuses_a_wrong_shaped_head() -> None:
     """A two-column head is a different (digest, label-map) pair, not a coercion."""
-    assert claims.get_label_map("v1").apply([[1.0, 0.0], [1.0, 0.0]]) is None
-    assert claims.get_label_map("v1").apply([1.0, 0.0, 0.0]) is None
+    assert claims.get_label_map("v2").apply([[1.0, 0.0], [1.0, 0.0]]) is None
+    assert claims.get_label_map("v2").apply([1.0, 0.0, 0.0]) is None
 
 
 @pytest.mark.parametrize("bad_logit", [float("nan"), float("inf"), float("-inf")])
-def test_label_map_v1_refuses_non_finite_logits(bad_logit: float) -> None:
+def test_label_map_v2_refuses_non_finite_logits(bad_logit: float) -> None:
     """A numerically invalid head is absence, never a confident label."""
     logits = [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
     logits[0][0] = bad_logit
-    assert claims.get_label_map("v1").apply(logits) is None
+    assert claims.get_label_map("v2").apply(logits) is None
 
 
 # ---------------- 1.2 pin registry + admission (repository artifact) ----------------
 
 _FAKE_MODEL = "exomem-test/frozen-stance-fixture"
+_FAKE_REVISION = "rev0"
+_FAKE_ARTIFACTS = ("config.json", "model.safetensors")
+
+_REAL_MODEL = "MoritzLaurer/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7"
+_REAL_REVISION = "b5113eb38ab63efdd7f280f8c144ea8b13f978ce"
+_REAL_ARTIFACTS = (
+    "config.json",
+    "model.safetensors",
+    "special_tokens_map.json",
+    "spm.model",
+    "tokenizer.json",
+    "tokenizer_config.json",
+)
+_REAL_DIGEST = "b1dbf445f78e823534f864406b773a5a6b46d04dd32b558588c29e3195349d22"
 
 
 @pytest.fixture(autouse=True)
@@ -88,26 +144,39 @@ def _reset_verifier_state():
     claims.reset_verifier_cache()
 
 
+def _manifest_digest(snapshot, files: tuple[str, ...] = _FAKE_ARTIFACTS) -> str:
+    """Independent statement of the reviewed name+bytes manifest digest."""
+    digest = hashlib.sha256()
+    for relative in files:
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update((snapshot / relative).read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
 def _plant_weights(tmp_path, monkeypatch, *, model_name: str = _FAKE_MODEL) -> str:
     """Plant a resident snapshot in a throwaway hub cache; return its true digest."""
     from exomem import model_cache
 
     hub = tmp_path / "hub"
-    snapshot = hub / model_cache.snapshot_dirname(model_name) / "snapshots" / "rev0"
+    snapshot = hub / model_cache.snapshot_dirname(model_name) / "snapshots" / _FAKE_REVISION
     snapshot.mkdir(parents=True)
     (snapshot / "config.json").write_text('{"architectures": ["X"]}', encoding="utf-8")
     (snapshot / "model.safetensors").write_bytes(b"not-real-weights-but-stable-bytes")
     monkeypatch.setenv("HF_HUB_CACHE", str(hub))
-    return claims._directory_digest(snapshot)
+    return _manifest_digest(snapshot)
 
 
-def _pin(digest: str, *, label_map_version: str = "v1") -> tuple:
+def _pin(digest: str, *, label_map_version: str = "v2") -> tuple:
     return (
         claims.VerifierPin(
             model_name=_FAKE_MODEL,
+            model_revision=_FAKE_REVISION,
+            artifact_files=_FAKE_ARTIFACTS,
             weights_sha256=digest,
             label_map_version=label_map_version,
-            fixture_set="stance-v1",
+            fixture_set="stance-v2-multilingual",
         ),
     )
 
@@ -133,8 +202,78 @@ def test_pin_registry_is_an_immutable_repository_artifact() -> None:
     assert isinstance(claims.VERIFIER_PINS, tuple)
     for pin in claims.VERIFIER_PINS:
         assert isinstance(pin, claims.VerifierPin)
-        assert pin.model_name and pin.weights_sha256
+        assert pin.model_name and pin.model_revision and pin.weights_sha256
+        assert pin.artifact_files
         assert pin.label_map_version and pin.fixture_set
+
+
+def test_production_registry_pins_the_reviewed_multilingual_checkpoint() -> None:
+    assert claims.VERIFIER_PINS == (
+        claims.VerifierPin(
+            model_name=_REAL_MODEL,
+            model_revision=_REAL_REVISION,
+            artifact_files=_REAL_ARTIFACTS,
+            weights_sha256=_REAL_DIGEST,
+            label_map_version="v2",
+            fixture_set="stance-v2-multilingual",
+        ),
+    )
+
+
+def test_pin_identity_requires_an_exact_revision_and_artifact_manifest() -> None:
+    pin = _pin("0" * 64)[0]
+
+    assert pin.model_revision == _FAKE_REVISION
+    assert pin.artifact_files == _FAKE_ARTIFACTS
+
+
+def test_extra_cache_files_and_revisions_do_not_change_the_pinned_digest(
+    tmp_path, monkeypatch
+) -> None:
+    from exomem import model_cache
+
+    digest = _plant_weights(tmp_path, monkeypatch)
+    root = tmp_path / "hub" / model_cache.snapshot_dirname(_FAKE_MODEL) / "snapshots"
+    (root / _FAKE_REVISION / "README.md").write_text("unlisted", encoding="utf-8")
+    second = root / "rev1"
+    second.mkdir()
+    (second / "model.safetensors").write_bytes(b"another revision")
+
+    assert claims._hash_resident_snapshot(_pin(digest)[0]) == (
+        digest,
+        str(root / _FAKE_REVISION),
+    )
+
+
+def test_a_missing_declared_artifact_refuses_before_model_construction(
+    tmp_path, monkeypatch
+) -> None:
+    from exomem import model_cache
+
+    digest = _plant_weights(tmp_path, monkeypatch)
+    snapshot = (
+        tmp_path
+        / "hub"
+        / model_cache.snapshot_dirname(_FAKE_MODEL)
+        / "snapshots"
+        / _FAKE_REVISION
+    )
+    (snapshot / "model.safetensors").unlink()
+    monkeypatch.setattr(claims, "VERIFIER_PINS", _pin(digest))
+    monkeypatch.setenv("EXOMEM_CLAIM_POLARITY_NLI", "1")
+    called = False
+
+    def should_not_load(pin):
+        nonlocal called
+        called = True
+        return None
+
+    monkeypatch.setattr(claims, "_load_verifier_predictor", should_not_load)
+
+    admission = claims.verifier_admission()
+    assert admission.reason == "weights-missing"
+    assert "model.safetensors" in admission.detail
+    assert called is False
 
 
 def test_no_runtime_configuration_reads_a_model_name_into_a_pin() -> None:
@@ -225,19 +364,21 @@ def test_weights_are_hashed_once_per_process_and_cached(tmp_path, monkeypatch) -
     monkeypatch.setenv("EXOMEM_CLAIM_POLARITY_NLI", "1")
 
     calls = {"n": 0}
-    real = claims._directory_digest
+    real = claims._artifact_manifest_digest
 
-    def counting(root):
+    def counting(root, artifact_files):
         calls["n"] += 1
-        return real(root)
+        return real(root, artifact_files)
 
-    monkeypatch.setattr(claims, "_directory_digest", counting)
+    monkeypatch.setattr(claims, "_artifact_manifest_digest", counting)
     for _ in range(4):
         claims.resolve_weights_digest(_FAKE_MODEL)
     assert calls["n"] == 1
 
 
-def test_a_second_resident_revision_is_ambiguous_and_refuses(tmp_path, monkeypatch) -> None:
+def test_a_second_resident_revision_does_not_change_admission_identity(
+    tmp_path, monkeypatch
+) -> None:
     from exomem import model_cache
 
     digest = _plant_weights(tmp_path, monkeypatch)
@@ -248,11 +389,11 @@ def test_a_second_resident_revision_is_ambiguous_and_refuses(tmp_path, monkeypat
     (second / "model.safetensors").write_bytes(b"a different revision entirely")
     monkeypatch.setattr(claims, "VERIFIER_PINS", _pin(digest))
     monkeypatch.setenv("EXOMEM_CLAIM_POLARITY_NLI", "1")
+    monkeypatch.setattr(claims, "_load_verifier_predictor", lambda pin: _oracle_predict())
 
     admission = claims.verifier_admission()
-    assert admission.admitted is False
-    assert admission.reason == "weights-missing"
-    assert "ambiguous" in admission.detail
+    assert admission.admitted is True
+    assert admission.model_revision == _FAKE_REVISION
 
 
 def test_refused_verifier_never_lets_the_heuristic_wear_the_nli_name(monkeypatch) -> None:
@@ -368,19 +509,29 @@ def test_status_names_the_registry_and_the_shipped_label_maps(tmp_path, monkeypa
 
     status = claims.verifier_status()
     assert status["pinned_models"] == [_FAKE_MODEL]
-    assert status["label_map_versions"] == ["v1"]
+    assert status["label_map_versions"] == ["v2"]
+    assert status["pins"] == [
+        {
+            "model_name": _FAKE_MODEL,
+            "model_revision": _FAKE_REVISION,
+            "artifact_files": list(_FAKE_ARTIFACTS),
+            "weights_sha256": digest,
+            "label_map_version": "v2",
+            "fixture_set": "stance-v2-multilingual",
+        }
+    ]
 
 
 # ---------------- 1.4 verification fixture set ----------------
 
-#: Logit blocks that label map v1 maps to each label, used to drive fake
+#: Logit blocks that label map v2 maps to each label, used to drive fake
 #: verifiers. Shape is exactly what a cross-encoder emits for the two
-#: orderings of one pair: (2, 3) over (contradiction, entailment, neutral).
+#: orderings of one pair: (2, 3) over (entailment, neutral, contradiction).
 _LOGITS: dict[str, list[list[float]]] = {
-    "contradict": [[6.0, 0.0, 0.0], [6.0, 0.0, 0.0]],
-    "duplicate": [[0.0, 6.0, 0.0], [0.0, 6.0, 0.0]],
-    "unrelated": [[0.0, 0.0, 6.0], [0.0, 0.0, 6.0]],
-    "refine": [[0.0, 2.0, 0.6], [0.0, 0.0, 0.6]],
+    "contradict": [[0.0, 0.0, 6.0], [0.0, 0.0, 6.0]],
+    "duplicate": [[6.0, 0.0, 0.0], [6.0, 0.0, 0.0]],
+    "neutral": [[0.0, 6.0, 0.0], [0.0, 6.0, 0.0]],
+    "refine": [[0.0, 6.0, 0.0], [6.0, 0.0, 0.0]],
 }
 
 
@@ -392,7 +543,7 @@ def _oracle_predict(*, wrong: str | None = None, raises_on: str | None = None, c
     """
     answers = {
         (pair.claim_a, pair.claim_b): pair.expected
-        for pair in claims.VERIFICATION_FIXTURES["stance-v1"]
+        for pair in claims.VERIFICATION_FIXTURES["stance-v2-multilingual"]
     }
 
     def predict(pairs):
@@ -401,7 +552,7 @@ def _oracle_predict(*, wrong: str | None = None, raises_on: str | None = None, c
         claim_a, claim_b = pairs[0]
         if raises_on is not None and claim_a == raises_on:
             raise RuntimeError("forward pass exploded")
-        label = answers.get((claim_a, claim_b), "unrelated")
+        label = answers.get((claim_a, claim_b), "neutral")
         if wrong is not None and claim_a == wrong:
             label = "duplicate" if label != "duplicate" else "contradict"
         return _LOGITS[label]
@@ -414,16 +565,23 @@ def _admit(tmp_path, monkeypatch, predict) -> str:
     digest = _plant_weights(tmp_path, monkeypatch)
     monkeypatch.setattr(claims, "VERIFIER_PINS", _pin(digest))
     monkeypatch.setenv("EXOMEM_CLAIM_POLARITY_NLI", "1")
-    monkeypatch.setattr(claims, "_load_verifier_predictor", lambda name: predict)
+    monkeypatch.setattr(claims, "_load_verifier_predictor", lambda pin: predict)
     return digest
 
 
 def test_fixture_set_covers_the_four_corpus_shapes() -> None:
-    fixtures = claims.VERIFICATION_FIXTURES["stance-v1"]
-    assert len(fixtures) >= 8
+    fixtures = claims.VERIFICATION_FIXTURES["stance-v2-multilingual"]
+    assert len(fixtures) >= 12
     assert {pair.expected for pair in fixtures} == claims.POLARITY_LABELS
     for pair in fixtures:
-        assert pair.claim_a and pair.claim_b and pair.note
+        assert pair.claim_a and pair.claim_b and pair.note and pair.language_shape
+    assert {pair.language_shape for pair in fixtures} >= {
+        "en/en",
+        "de/de",
+        "fr/fr",
+        "et/et",
+        "en/et",
+    }
     # The heuristic's known failure cases are carried explicitly, not implied.
     assert sum(1 for pair in fixtures if pair.heuristic_fails) >= 3
 
@@ -435,12 +593,14 @@ def test_green_fixtures_admit_the_verifier(tmp_path, monkeypatch) -> None:
     assert admission.admitted is True
     assert admission.reason == "admitted"
     assert admission.model_digest == digest
-    assert admission.label_map_version == "v1"
-    assert admission.fixture_set == "stance-v1"
+    assert admission.model_revision == _FAKE_REVISION
+    assert admission.artifact_files == _FAKE_ARTIFACTS
+    assert admission.label_map_version == "v2"
+    assert admission.fixture_set == "stance-v2-multilingual"
 
 
 def test_one_red_fixture_refuses_the_pair(tmp_path, monkeypatch) -> None:
-    first = claims.VERIFICATION_FIXTURES["stance-v1"][0]
+    first = claims.VERIFICATION_FIXTURES["stance-v2-multilingual"][0]
     _admit(tmp_path, monkeypatch, _oracle_predict(wrong=first.claim_a))
 
     admission = claims.verifier_admission()
@@ -453,7 +613,7 @@ def test_one_red_fixture_refuses_the_pair(tmp_path, monkeypatch) -> None:
 def test_a_label_map_change_without_a_version_bump_refuses(tmp_path, monkeypatch) -> None:
     """The spec's re-verification scenario, exercised on the real mechanism.
 
-    Move v1's thresholds without bumping the version. Admission re-runs the
+    Move v2's thresholds without bumping the version. Admission re-runs the
     fixture set against the CURRENT map, so the stale pair fails there — the
     only way a threshold change can ride in is by staying green on the very
     fixtures that justified the pin.
@@ -463,21 +623,21 @@ def test_a_label_map_change_without_a_version_bump_refuses(tmp_path, monkeypatch
 
     claims.reset_verifier_cache()
     drifted = dataclasses.replace(
-        claims.get_label_map("v1"), contradict_min=0.999, duplicate_min=0.999
+        claims.get_label_map("v2"), contradict_min=0.999, duplicate_min=0.999
     )
-    monkeypatch.setitem(claims._LABEL_MAPS, "v1", drifted)
+    monkeypatch.setitem(claims._LABEL_MAPS, "v2", drifted)
 
     admission = claims.verifier_admission()
     assert admission.admitted is False
     assert admission.reason == "fixtures-failed"
-    assert admission.label_map_version == "v1"
+    assert admission.label_map_version == "v2"
 
 
 def test_absent_extra_refuses_as_a_missing_dependency(tmp_path, monkeypatch) -> None:
     digest = _plant_weights(tmp_path, monkeypatch)
     monkeypatch.setattr(claims, "VERIFIER_PINS", _pin(digest))
     monkeypatch.setenv("EXOMEM_CLAIM_POLARITY_NLI", "1")
-    monkeypatch.setattr(claims, "_load_verifier_predictor", lambda name: None)
+    monkeypatch.setattr(claims, "_load_verifier_predictor", lambda pin: None)
 
     admission = claims.verifier_admission()
     assert admission.admitted is False
@@ -492,14 +652,16 @@ def test_unknown_fixture_set_in_a_pin_refuses(tmp_path, monkeypatch) -> None:
         (
             claims.VerifierPin(
                 model_name=_FAKE_MODEL,
+                model_revision=_FAKE_REVISION,
+                artifact_files=_FAKE_ARTIFACTS,
                 weights_sha256=digest,
-                label_map_version="v1",
+                label_map_version="v2",
                 fixture_set="no-such-set",
             ),
         ),
     )
     monkeypatch.setenv("EXOMEM_CLAIM_POLARITY_NLI", "1")
-    monkeypatch.setattr(claims, "_load_verifier_predictor", lambda name: _oracle_predict())
+    monkeypatch.setattr(claims, "_load_verifier_predictor", lambda pin: _oracle_predict())
 
     admission = claims.verifier_admission()
     assert admission.admitted is False
@@ -513,7 +675,7 @@ def test_fixture_verification_runs_once_per_admitted_pair(tmp_path, monkeypatch)
 
     assert claims.verifier_admission().admitted is True
     after_first = len(calls)
-    assert after_first == len(claims.VERIFICATION_FIXTURES["stance-v1"])
+    assert after_first == len(claims.VERIFICATION_FIXTURES["stance-v2-multilingual"])
     for _ in range(3):
         assert claims.verifier_admission().admitted is True
     assert len(calls) == after_first
@@ -522,7 +684,9 @@ def test_fixture_verification_runs_once_per_admitted_pair(tmp_path, monkeypatch)
 def test_admitted_verifier_labels_through_the_label_map(tmp_path, monkeypatch) -> None:
     _admit(tmp_path, monkeypatch, _oracle_predict())
     fixture = next(
-        pair for pair in claims.VERIFICATION_FIXTURES["stance-v1"] if pair.expected == "contradict"
+        pair
+        for pair in claims.VERIFICATION_FIXTURES["stance-v2-multilingual"]
+        if pair.expected == "contradict"
     )
 
     result = claims.verifier_polarity(fixture.claim_a, fixture.claim_b)
@@ -592,7 +756,7 @@ def test_no_string_assembly_exists_behind_the_verifier_seam() -> None:
 
 def test_verifier_output_is_drawn_from_the_label_maps_closed_set(tmp_path, monkeypatch) -> None:
     _admit(tmp_path, monkeypatch, _oracle_predict())
-    for pair in claims.VERIFICATION_FIXTURES["stance-v1"]:
+    for pair in claims.VERIFICATION_FIXTURES["stance-v2-multilingual"]:
         result = claims.verifier_polarity(pair.claim_a, pair.claim_b)
         assert result is not None
         assert result.label in claims.POLARITY_LABELS
@@ -611,7 +775,7 @@ _PAGE_B = "Knowledge Base/Notes/Insights/ttl-increases.md"
 def _contradiction_fixture() -> claims.FixturePair:
     return next(
         pair
-        for pair in claims.VERIFICATION_FIXTURES["stance-v1"]
+        for pair in claims.VERIFICATION_FIXTURES["stance-v2-multilingual"]
         if pair.expected == "contradict" and not pair.heuristic_fails
     )
 
@@ -703,7 +867,7 @@ def test_admitted_verifier_writes_the_label_with_digest_and_label_map(
     assert meta["polarity"] == "contradict"
     assert meta["polarity_method"] == "nli"
     assert meta["polarity_model_digest"] == digest
-    assert meta["polarity_label_map_version"] == "v1"
+    assert meta["polarity_label_map_version"] == "v2"
     assert meta["polarity_signal_version"] == meta["signal_version"]
     assert 0.0 <= meta["polarity_score"] <= 1.0
     assert "CONTRADICT" in findings[0].detail
@@ -801,7 +965,7 @@ def test_a_stale_label_is_dropped_not_served() -> None:
         "score": 0.9,
         "method": "nli",
         "model_digest": "d" * 64,
-        "label_map_version": "v1",
+        "label_map_version": "v2",
         "signal_version": "2222222222222222",
     }
     before = dict(finding.meta)
@@ -818,13 +982,30 @@ def test_a_current_label_is_attached() -> None:
         "score": 0.7,
         "method": "nli",
         "model_digest": "d" * 64,
-        "label_map_version": "v1",
+        "label_map_version": "v2",
         "signal_version": "1111111111111111",
     }
 
     assert audit_module._attach_polarity_label(finding, label) is True
     assert finding.meta["polarity"] == "refine"
     assert finding.meta["polarity_signal_version"] == "1111111111111111"
+
+
+def test_a_neutral_label_never_renders_or_implies_unrelatedness() -> None:
+    finding = _proximity_finding(signal_version="1111111111111111")
+    label = {
+        "label": "neutral",
+        "score": 0.8,
+        "method": "nli",
+        "model_digest": "d" * 64,
+        "label_map_version": "v2",
+        "signal_version": "1111111111111111",
+    }
+
+    assert audit_module._attach_polarity_label(finding, label) is True
+    assert finding.meta["polarity"] == "neutral"
+    assert "likely NEUTRAL" in finding.detail
+    assert "unrelated" not in finding.detail.lower()
 
 
 # ---- 3.4 asserted pairs ----
@@ -954,7 +1135,7 @@ def test_the_declared_heuristic_failures_are_real() -> None:
     The precision table in tasks.md 5.1 is derived from these flags, so without
     this pin the table could drift into fiction while staying green.
     """
-    for pair in claims.VERIFICATION_FIXTURES["stance-v1"]:
+    for pair in claims.VERIFICATION_FIXTURES["stance-v2-multilingual"]:
         verdict = claims._heuristic_polarity(pair.claim_a, pair.claim_b)
         assert (verdict.label != pair.expected) == pair.heuristic_fails, (
             pair.claim_a,
@@ -968,7 +1149,7 @@ def test_an_admitted_verifier_answers_every_fixture(tmp_path, monkeypatch) -> No
     """Admission's own bar, and the table's upper arm: every pair or nothing."""
     _admit(tmp_path, monkeypatch, _oracle_predict())
     assert claims.verifier_admission().admitted is True
-    for pair in claims.VERIFICATION_FIXTURES["stance-v1"]:
+    for pair in claims.VERIFICATION_FIXTURES["stance-v2-multilingual"]:
         result = claims.verifier_polarity(pair.claim_a, pair.claim_b)
         assert result is not None
         assert result.label == pair.expected


### PR DESCRIPTION
## Summary

- admit one exact multilingual NLI checkpoint by revision, ordered artifact manifest, digest, v2 label map, and real fixture set
- make verifier labels truthful NLI relations: contradict, duplicate, refine, or neutral; neutrality never claims topical unrelatedness
- add revision-keyed real-model CI and keep Hosted activation absent until its resource and isolation envelope is separately admitted
- sync the three canonical specs and archive the completed OpenSpec change

## Verification

- 114 focused verifier, claims, queue, CI-contract, and Hosted-boundary tests passed
- 78 isolated lean verifier/doctor tests passed without the NLI extra
- the exact pinned 532 MiB model admitted and passed every English, German, French, Estonian, and mixed English/Estonian fixture
- all 169 strict OpenSpec items, Ruff F checks, compileall, workflow parsing, diff checks, and the public-artifact privacy gate passed
- all core-suite shards were exercised; the remaining failures reproduced unchanged on origin/main and are outside this diff. The local WSL harness run lacks its clean-runner Bun/bubblewrap and secure-mode prerequisites, so GitHub CI is authoritative for that tier.