### PR TITLE
feat(governance): coordinate exact-cell transport verification

### DIFF
--- a/src/exomem/governance/consolidation_transport_coordinator.py
+++ b/src/exomem/governance/consolidation_transport_coordinator.py
@@ -1,0 +1,977 @@
+"""Receipt-first coordinator for exact-cell transport verification.
+
+The durable consolidation seal remains closed while this module stops normal
+routing, exercises each public surface through a single-use process-local read
+route, and prepares the routing-open effect.  Completion and unsealing are a
+separate successor-producing step.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, NoReturn
+
+from . import (
+    consolidation_admission,
+    consolidation_authority,
+    consolidation_effect_coordinator,
+    consolidation_plan,
+    consolidation_receipts,
+    consolidation_seal,
+    consolidation_transport_journal,
+    consolidation_transport_verification,
+    consolidation_verification_journal,
+)
+
+TRANSPORT_PROBE_TERMINAL_SCHEMA = "exomem.consolidation-transport-probe-terminal/v1"
+
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_ENTRY_PHASES = (
+    "verified",
+    "transport-stopping",
+    "transport-verifying",
+    "transport-verified",
+    "routing-opening",
+)
+_STOP_PRIOR_SCHEMA = "exomem.consolidation-transport-stop-prior/v1"
+_PROBE_PRIOR_SCHEMA = "exomem.consolidation-transport-probe-prior/v1"
+_VERIFIED_PRIOR_SCHEMA = "exomem.consolidation-transport-verified-prior/v1"
+_VERIFIED_RESULT_SCHEMA = "exomem.consolidation-transport-verified-result/v1"
+_ROUTING_PRIOR_SCHEMA = "exomem.consolidation-routing-open-prior/v1"
+_ROUTING_RESULT_SCHEMA = "exomem.consolidation-routing-open-result/v1"
+
+__all__ = [
+    "TRANSPORT_PROBE_TERMINAL_SCHEMA",
+    "ConsolidationTransportCoordinatorResult",
+    "ConsolidationTransportCoordinatorUnavailable",
+    "TransportProbeContext",
+    "TransportProbeTerminal",
+    "TransportRoutingEffectContext",
+    "TransportRoutingObservation",
+    "TransportSupervisor",
+    "verify_exact_cell_transport",
+]
+
+
+class ConsolidationTransportCoordinatorUnavailable(RuntimeError):
+    """Content-free refusal for incomplete or contradictory transport state."""
+
+    code = "CONSOLIDATION_TRANSPORT_COORDINATOR_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True, slots=True)
+class TransportRoutingObservation:
+    state: Literal["prior", "prepared", "target", "mixed"]
+    digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class TransportRoutingEffectContext:
+    plan_digest: str
+    verification_basis_digest: str
+    prior_digest: str
+    target_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class TransportProbeContext:
+    admission: consolidation_admission.ConsolidationAdmission
+    plan_digest: str
+    verification_basis_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class TransportProbeTerminal:
+    schema: str
+    probe_id: str
+    probe_digest: str
+    result_digest: str
+    outcome: Literal["passed"]
+
+
+class TransportSupervisor:
+    """Trusted adapter for routing state and real public-surface probes."""
+
+    def revalidate_pre_stop_basis(self, basis: Mapping[str, object]) -> str:
+        raise NotImplementedError
+
+    def classify_stop(
+        self,
+        context: TransportRoutingEffectContext,
+    ) -> TransportRoutingObservation:
+        raise NotImplementedError
+
+    def stop_and_drain(self, context: TransportRoutingEffectContext) -> None:
+        raise NotImplementedError
+
+    def revalidate_basis(
+        self,
+        plan: consolidation_transport_verification.TransportVerificationPlan,
+    ) -> str:
+        raise NotImplementedError
+
+    def run_probe(
+        self,
+        probe: consolidation_transport_verification.TransportProbe,
+        context: TransportProbeContext,
+    ) -> TransportProbeTerminal:
+        raise NotImplementedError
+
+    def classify_open(
+        self,
+        context: TransportRoutingEffectContext,
+    ) -> TransportRoutingObservation:
+        raise NotImplementedError
+
+    def open_routing(self, context: TransportRoutingEffectContext) -> None:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationTransportCoordinatorResult:
+    completed_probe_ids: tuple[str, ...]
+    stop_effect: consolidation_effect_coordinator.EffectExecutionResult
+    probe_effects: tuple[consolidation_effect_coordinator.EffectExecutionResult, ...]
+    verification_effect: consolidation_effect_coordinator.EffectExecutionResult
+    routing_effect: consolidation_effect_coordinator.EffectExecutionResult
+    transport_journal: consolidation_transport_journal.ConsolidationTransportJournalState
+    seal_state: consolidation_seal.ConsolidationSealState
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationTransportCoordinatorUnavailable from None
+
+
+def _crash_point(_point: str) -> None:
+    """Narrow test seam at coordinator-owned cross-store boundaries."""
+
+
+def _digest(value: object) -> str:
+    if type(value) is not str or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _timestamp(value: object) -> str:
+    try:
+        checked, _parsed = consolidation_plan._timestamp(value)  # noqa: SLF001
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    return checked
+
+
+def _framed_digest(schema: str, value: Mapping[str, object]) -> str:
+    try:
+        raw = consolidation_plan.canonical_closed_jcs({"schema": schema, **value})
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    domain = schema.encode("ascii")
+    framed = len(domain).to_bytes(4, "big") + domain + len(raw).to_bytes(8, "big") + raw
+    return hashlib.sha256(framed).hexdigest()
+
+
+def _require_parent(
+    state: consolidation_verification_journal.ConsolidationVerificationJournalState,
+    *,
+    run_id: str,
+    operation_id: str,
+    plan_digest: str,
+) -> consolidation_verification_journal.ConsolidationVerificationJournalState:
+    terminal = state.terminal
+    if (
+        state.run_id != run_id
+        or state.operation_id != operation_id
+        or state.plan_digest != plan_digest
+        or any(entry.status != "final" for entry in state.probes)
+        or terminal.status != "final"
+        or terminal.result_digest is None
+        or terminal.terminal_event_id is None
+        or terminal.terminal_payload_digest is None
+        or terminal.effect_journal_digest is None
+    ):
+        _fail()
+    return state
+
+
+def _require_seal(
+    state: consolidation_seal.ConsolidationSealState,
+    *,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+) -> consolidation_seal.ConsolidationSealState:
+    if (
+        state.kind != "consolidation-sealed"
+        or state.phase not in _ENTRY_PHASES
+        or state.vault_binding_digest != vault_binding_digest
+        or state.run_id != run_id
+        or state.operation_id != operation_id
+        or state.journal_digest != journal_digest
+    ):
+        _fail()
+    return state
+
+
+def _phase_index(phase: str | None) -> int:
+    if phase not in _ENTRY_PHASES:
+        _fail()
+    return _ENTRY_PHASES.index(phase)
+
+
+def _ensure_phase(
+    *,
+    admission: consolidation_admission.ConsolidationAdmission,
+    vault_root: Path,
+    vault_binding_digest: str,
+    run_id: str,
+    operation_id: str,
+    journal_digest: str,
+    target_phase: str,
+    recorded_at: str,
+) -> consolidation_seal.ConsolidationSealState:
+    current = _require_seal(
+        admission.reload().state,
+        vault_binding_digest=vault_binding_digest,
+        run_id=run_id,
+        operation_id=operation_id,
+        journal_digest=journal_digest,
+    )
+    current_index = _phase_index(current.phase)
+    target_index = _phase_index(target_phase)
+    if current_index >= target_index:
+        return current
+    if current_index + 1 != target_index:
+        _fail()
+    authority = consolidation_authority.issue_authority(
+        vault_binding_digest=vault_binding_digest,
+        run_id=run_id,
+        operation_id=operation_id,
+        journal_digest=journal_digest,
+        phase=str(current.phase),
+        action="apply",
+    )
+    return consolidation_seal.ConsolidationSealStore(vault_root).advance_consolidation(
+        authority,
+        vault_binding_digest=vault_binding_digest,
+        action="apply",
+        target_phase=target_phase,
+        recorded_at=recorded_at,
+        expected_revision=current.revision,
+    )
+
+
+def _effect_ordinal(
+    parent: consolidation_verification_journal.ConsolidationVerificationJournalState,
+    offset: int,
+) -> int:
+    return parent.last_rebuild_effect_ordinal + len(parent.probes) + 1 + offset
+
+
+def _effect_store(
+    vault_root: Path,
+    *,
+    run_id: str,
+    ordinal: int,
+) -> consolidation_effect_coordinator.ConsolidationEffectJournalStore:
+    return consolidation_effect_coordinator.ConsolidationEffectJournalStore(
+        vault_root,
+        run_id=run_id,
+        effect_ordinal=ordinal,
+    )
+
+
+def _routing_observation(
+    value: object,
+) -> consolidation_effect_coordinator.EffectObservation:
+    if type(value) is not TransportRoutingObservation:
+        _fail()
+    return consolidation_effect_coordinator.EffectObservation(
+        state=value.state,
+        digest=_digest(value.digest),
+    )
+
+
+def _stop_event(
+    parent: consolidation_verification_journal.ConsolidationVerificationJournalState,
+    *,
+    routing_stop_digest: str,
+) -> tuple[consolidation_receipts.ConsolidationEvent, str]:
+    terminal = parent.terminal
+    if terminal.terminal_event_id is None or terminal.terminal_payload_digest is None:
+        _fail()
+    prior = _framed_digest(
+        _STOP_PRIOR_SCHEMA,
+        {
+            "verification_basis_digest": parent.binding_digest,
+            "verification_result_digest": _digest(terminal.result_digest),
+        },
+    )
+    return (
+        consolidation_receipts.build_intent(
+            kind="transport-stop",
+            run_id=parent.run_id,
+            operation_id=parent.operation_id,
+            phase="transport-stopping",
+            effect_ordinal=_effect_ordinal(parent, 1),
+            request_digest=parent.request_digest,
+            prior_digest=prior,
+            target_digest=routing_stop_digest,
+            evidence=consolidation_receipts.build_evidence(
+                kind="transport-stop",
+                digests={
+                    "routing_stop_digest": routing_stop_digest,
+                    "verification_basis_digest": parent.binding_digest,
+                },
+            ),
+            semantic_parent_event_id=terminal.terminal_event_id,
+            semantic_parent_payload_digest=terminal.terminal_payload_digest,
+        ),
+        prior,
+    )
+
+
+def _execute_stop(
+    *,
+    vault_root: Path,
+    parent: consolidation_verification_journal.ConsolidationVerificationJournalState,
+    plan_digest: str,
+    routing_stop_digest: str,
+    supervisor: TransportSupervisor,
+    timestamp: str,
+) -> consolidation_effect_coordinator.EffectExecutionResult:
+    event, prior = _stop_event(parent, routing_stop_digest=routing_stop_digest)
+    context = TransportRoutingEffectContext(
+        plan_digest=plan_digest,
+        verification_basis_digest=parent.binding_digest,
+        prior_digest=prior,
+        target_digest=routing_stop_digest,
+    )
+    return consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+        vault_root=vault_root,
+        event=event,
+        journal=_effect_store(
+            vault_root,
+            run_id=parent.run_id,
+            ordinal=_effect_ordinal(parent, 1),
+        ),
+        classify=lambda: _routing_observation(supervisor.classify_stop(context)),
+        apply_effect=lambda: supervisor.stop_and_drain(context),
+        resume_effect=lambda: supervisor.stop_and_drain(context),
+        timestamp=timestamp,
+    )
+
+
+def _aggregate_effect(
+    effect: consolidation_effect_coordinator.EffectExecutionResult,
+    *,
+    kind: Literal["transport-stop", "transport-probe", "transport-verified", "routing-open"],
+    probe_ordinal: int | None = None,
+) -> consolidation_transport_journal.ConsolidationTransportJournalEffect:
+    if (
+        effect.role != "committed"
+        or effect.observed_state != "target"
+        or not effect.terminal.event_id.endswith(":committed")
+    ):
+        _fail()
+    return consolidation_transport_journal.ConsolidationTransportJournalEffect(
+        kind=kind,
+        probe_ordinal=probe_ordinal,
+        status="final",
+        result_digest=_digest(effect.observed_digest),
+        terminal_event_id=effect.terminal.event_id,
+        terminal_payload_digest=effect.terminal.payload_digest,
+        effect_journal_digest=effect.journal_digest,
+    )
+
+
+def _probe_prior_digest(
+    state: consolidation_transport_journal.ConsolidationTransportJournalState,
+    probe: consolidation_transport_verification.TransportProbe,
+) -> str:
+    return _framed_digest(
+        _PROBE_PRIOR_SCHEMA,
+        {
+            "verification_basis_digest": state.binding_digest,
+            "probe_ordinal": probe.ordinal,
+            "probe_digest": probe.probe_digest,
+        },
+    )
+
+
+def _parent_for_probe(
+    state: consolidation_transport_journal.ConsolidationTransportJournalState,
+    probe: consolidation_transport_verification.TransportProbe,
+) -> tuple[str, str]:
+    parent = state.effects[probe.ordinal]
+    if (
+        parent.status != "final"
+        or parent.terminal_event_id is None
+        or parent.terminal_payload_digest is None
+    ):
+        _fail()
+    return parent.terminal_event_id, parent.terminal_payload_digest
+
+
+def _probe_event(
+    state: consolidation_transport_journal.ConsolidationTransportJournalState,
+    probe: consolidation_transport_verification.TransportProbe,
+    *,
+    effect_ordinal: int,
+) -> consolidation_receipts.ConsolidationEvent:
+    parent_event, parent_payload = _parent_for_probe(state, probe)
+    return consolidation_receipts.build_intent(
+        kind="transport-probe",
+        run_id=state.run_id,
+        operation_id=state.operation_id,
+        phase="transport-verifying",
+        effect_ordinal=effect_ordinal,
+        probe_ordinal=probe.ordinal,
+        request_digest=state.request_digest,
+        prior_digest=_probe_prior_digest(state, probe),
+        target_digest=probe.expected_result_digest,
+        evidence=consolidation_receipts.build_evidence(
+            kind="transport-probe",
+            digests={
+                "probe_digest": probe.probe_digest,
+                "probe_result_digest": probe.expected_result_digest,
+                "verification_basis_digest": state.binding_digest,
+            },
+        ),
+        semantic_parent_event_id=parent_event,
+        semantic_parent_payload_digest=parent_payload,
+    )
+
+
+def _validate_probe_terminal(
+    value: object,
+    *,
+    probe: consolidation_transport_verification.TransportProbe,
+) -> TransportProbeTerminal:
+    if (
+        type(value) is not TransportProbeTerminal
+        or value.schema != TRANSPORT_PROBE_TERMINAL_SCHEMA
+        or value.probe_id != probe.probe_id
+        or value.probe_digest != probe.probe_digest
+        or value.result_digest != probe.expected_result_digest
+        or value.outcome != "passed"
+    ):
+        _fail()
+    return value
+
+
+def _finalize_aggregate(
+    store: consolidation_transport_journal.ConsolidationTransportJournalStore,
+    *,
+    kind: str,
+    result: consolidation_effect_coordinator.EffectExecutionResult,
+    probe_ordinal: int | None = None,
+) -> consolidation_transport_journal.ConsolidationTransportJournalState:
+    store.record_transport_effect_result(
+        kind=kind,
+        probe_ordinal=probe_ordinal,
+        result_digest=result.observed_digest,
+    )
+    return store.finalize_transport_effect(
+        kind=kind,
+        probe_ordinal=probe_ordinal,
+        result_digest=result.observed_digest,
+        terminal_event_id=result.terminal.event_id,
+        terminal_payload_digest=result.terminal.payload_digest,
+        effect_journal_digest=result.journal_digest,
+    )
+
+
+def _execute_probes(
+    *,
+    vault_root: Path,
+    admission: consolidation_admission.ConsolidationAdmission,
+    parent: consolidation_verification_journal.ConsolidationVerificationJournalState,
+    plan: consolidation_transport_verification.TransportVerificationPlan,
+    store: consolidation_transport_journal.ConsolidationTransportJournalStore,
+    supervisor: TransportSupervisor,
+    timestamp: str,
+) -> tuple[consolidation_effect_coordinator.EffectExecutionResult, ...]:
+    effects: list[consolidation_effect_coordinator.EffectExecutionResult] = []
+    authority = consolidation_authority.issue_authority(
+        vault_binding_digest=plan.basis.vault_binding_digest,
+        run_id=plan.basis.run_id,
+        operation_id=plan.basis.operation_id,
+        journal_digest=plan.basis.journal_digest,
+        phase="transport-verifying",
+        action="probe",
+    )
+    for probe in plan.probes:
+        state = store.load()
+        ordinal = _effect_ordinal(parent, 2 + probe.ordinal)
+        event = _probe_event(state, probe, effect_ordinal=ordinal)
+        prior = _probe_prior_digest(state, probe)
+
+        def classify(
+            *,
+            expected_probe: consolidation_transport_verification.TransportProbe = probe,
+            expected_prior: str = prior,
+        ) -> consolidation_effect_coordinator.EffectObservation:
+            current = store.load().effects[1 + expected_probe.ordinal]
+            if current.status == "prior":
+                return consolidation_effect_coordinator.EffectObservation(
+                    state="prior",
+                    digest=expected_prior,
+                )
+            if current.status not in {"result", "final"}:
+                _fail()
+            return consolidation_effect_coordinator.EffectObservation(
+                state="target",
+                digest=_digest(current.result_digest),
+            )
+
+        def apply(
+            *,
+            expected_probe: consolidation_transport_verification.TransportProbe = probe,
+        ) -> None:
+            route = consolidation_transport_verification.issue_transport_probe_route(
+                authority,
+                plan=plan,
+                probe=expected_probe,
+            )
+            context = TransportProbeContext(
+                admission=admission,
+                plan_digest=plan.digest,
+                verification_basis_digest=store.load().binding_digest,
+            )
+            with consolidation_transport_verification.transport_probe_route_scope(
+                route,
+                plan=plan,
+                probe=expected_probe,
+            ):
+                terminal = _validate_probe_terminal(
+                    supervisor.run_probe(expected_probe, context),
+                    probe=expected_probe,
+                )
+            _crash_point(f"after-probe-route:{expected_probe.ordinal}")
+            store.record_transport_effect_result(
+                kind="transport-probe",
+                probe_ordinal=expected_probe.ordinal,
+                result_digest=terminal.result_digest,
+            )
+            _crash_point(f"after-probe-result:{expected_probe.ordinal}")
+
+        effect = consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+            vault_root=vault_root,
+            event=event,
+            journal=_effect_store(
+                vault_root,
+                run_id=parent.run_id,
+                ordinal=ordinal,
+            ),
+            classify=classify,
+            apply_effect=apply,
+            timestamp=timestamp,
+        )
+        _crash_point(f"after-probe-effect-final:{probe.ordinal}")
+        _finalize_aggregate(
+            store,
+            kind="transport-probe",
+            probe_ordinal=probe.ordinal,
+            result=effect,
+        )
+        _crash_point(f"after-probe-aggregate-final:{probe.ordinal}")
+        effects.append(effect)
+    return tuple(effects)
+
+
+def _transport_verified_result(
+    state: consolidation_transport_journal.ConsolidationTransportJournalState,
+) -> str:
+    probe_effects = state.effects[1 : 1 + len(state.probes)]
+    if any(
+        effect.status != "final"
+        or effect.result_digest is None
+        or effect.terminal_event_id is None
+        or effect.terminal_payload_digest is None
+        or effect.effect_journal_digest is None
+        for effect in probe_effects
+    ):
+        _fail()
+    return _framed_digest(
+        _VERIFIED_RESULT_SCHEMA,
+        {
+            "verification_basis_digest": state.binding_digest,
+            "probe_effects": tuple(
+                {
+                    "probe_ordinal": effect.probe_ordinal,
+                    "result_digest": effect.result_digest,
+                    "terminal_event_id": effect.terminal_event_id,
+                    "terminal_payload_digest": effect.terminal_payload_digest,
+                    "effect_journal_digest": effect.effect_journal_digest,
+                }
+                for effect in probe_effects
+            ),
+        },
+    )
+
+
+def _execute_transport_verified(
+    *,
+    vault_root: Path,
+    parent: consolidation_verification_journal.ConsolidationVerificationJournalState,
+    store: consolidation_transport_journal.ConsolidationTransportJournalStore,
+    timestamp: str,
+) -> consolidation_effect_coordinator.EffectExecutionResult:
+    state = store.load()
+    result_digest = _transport_verified_result(state)
+    prior_digest = _framed_digest(
+        _VERIFIED_PRIOR_SCHEMA,
+        {"verification_basis_digest": state.binding_digest},
+    )
+    parent_effect = state.effects[len(state.probes)]
+    if (
+        parent_effect.status != "final"
+        or parent_effect.terminal_event_id is None
+        or parent_effect.terminal_payload_digest is None
+    ):
+        _fail()
+    ordinal = _effect_ordinal(parent, 2 + len(state.probes))
+    event = consolidation_receipts.build_intent(
+        kind="transport-verified",
+        run_id=state.run_id,
+        operation_id=state.operation_id,
+        phase="transport-verifying",
+        effect_ordinal=ordinal,
+        request_digest=state.request_digest,
+        prior_digest=prior_digest,
+        target_digest=result_digest,
+        evidence=consolidation_receipts.build_evidence(
+            kind="transport-verified",
+            digests={
+                "verification_basis_digest": state.binding_digest,
+                "verification_result_digest": result_digest,
+            },
+        ),
+        semantic_parent_event_id=parent_effect.terminal_event_id,
+        semantic_parent_payload_digest=parent_effect.terminal_payload_digest,
+    )
+
+    def classify() -> consolidation_effect_coordinator.EffectObservation:
+        current = store.load().effects[1 + len(state.probes)]
+        if current.status == "prior":
+            return consolidation_effect_coordinator.EffectObservation(
+                state="prior",
+                digest=prior_digest,
+            )
+        if current.status not in {"result", "final"}:
+            _fail()
+        return consolidation_effect_coordinator.EffectObservation(
+            state="target",
+            digest=_digest(current.result_digest),
+        )
+
+    effect = consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+        vault_root=vault_root,
+        event=event,
+        journal=_effect_store(vault_root, run_id=state.run_id, ordinal=ordinal),
+        classify=classify,
+        apply_effect=lambda: store.record_transport_effect_result(
+            kind="transport-verified",
+            result_digest=result_digest,
+        ),
+        timestamp=timestamp,
+    )
+    _crash_point("after-transport-verified-effect-final")
+    _finalize_aggregate(store, kind="transport-verified", result=effect)
+    _crash_point("after-transport-verified-aggregate-final")
+    return effect
+
+
+def _execute_routing_open(
+    *,
+    vault_root: Path,
+    admission: consolidation_admission.ConsolidationAdmission,
+    vault_binding_digest: str,
+    parent: consolidation_verification_journal.ConsolidationVerificationJournalState,
+    store: consolidation_transport_journal.ConsolidationTransportJournalStore,
+    supervisor: TransportSupervisor,
+    recorded_at: str,
+) -> consolidation_effect_coordinator.EffectExecutionResult:
+    state = store.load()
+    verified = state.effects[1 + len(state.probes)]
+    if (
+        verified.status != "final"
+        or verified.result_digest is None
+        or verified.terminal_event_id is None
+        or verified.terminal_payload_digest is None
+    ):
+        _fail()
+    prior_digest = _framed_digest(
+        _ROUTING_PRIOR_SCHEMA,
+        {
+            "verification_basis_digest": state.binding_digest,
+            "verification_result_digest": verified.result_digest,
+        },
+    )
+    target_digest = _framed_digest(
+        _ROUTING_RESULT_SCHEMA,
+        {
+            "routing_basis_digest": state.basis_digest,
+            "verification_result_digest": verified.result_digest,
+        },
+    )
+    context = TransportRoutingEffectContext(
+        plan_digest=state.plan_digest,
+        verification_basis_digest=state.binding_digest,
+        prior_digest=prior_digest,
+        target_digest=target_digest,
+    )
+    ordinal = _effect_ordinal(parent, 3 + len(state.probes))
+    event = consolidation_receipts.build_intent(
+        kind="routing-open",
+        run_id=state.run_id,
+        operation_id=state.operation_id,
+        phase="routing-opening",
+        effect_ordinal=ordinal,
+        request_digest=state.request_digest,
+        prior_digest=prior_digest,
+        target_digest=target_digest,
+        evidence=consolidation_receipts.build_evidence(
+            kind="routing-open",
+            digests={
+                "routing_basis_digest": state.basis_digest,
+                "routing_result_digest": target_digest,
+            },
+        ),
+        semantic_parent_event_id=verified.terminal_event_id,
+        semantic_parent_payload_digest=verified.terminal_payload_digest,
+    )
+
+    def apply() -> None:
+        _ensure_phase(
+            admission=admission,
+            vault_root=vault_root,
+            vault_binding_digest=vault_binding_digest,
+            run_id=state.run_id,
+            operation_id=state.operation_id,
+            journal_digest=state.apply_journal_digest,
+            target_phase="routing-opening",
+            recorded_at=recorded_at,
+        )
+        _crash_point("after-routing-opening-phase")
+        supervisor.open_routing(context)
+        _crash_point("after-routing-open-side-effect")
+
+    effect = consolidation_effect_coordinator._execute_effect(  # noqa: SLF001
+        vault_root=vault_root,
+        event=event,
+        journal=_effect_store(vault_root, run_id=state.run_id, ordinal=ordinal),
+        classify=lambda: _routing_observation(supervisor.classify_open(context)),
+        apply_effect=apply,
+        resume_effect=apply,
+        timestamp=recorded_at,
+    )
+    _crash_point("after-routing-open-effect-final")
+    _finalize_aggregate(store, kind="routing-open", result=effect)
+    _crash_point("after-routing-open-aggregate-final")
+    return effect
+
+def verify_exact_cell_transport(
+    *,
+    vault_root: Path | str,
+    admission: consolidation_admission.ConsolidationAdmission,
+    journal_digest: str,
+    basis: Mapping[str, object],
+    contracts: Sequence[Mapping[str, object]],
+    supervisor: TransportSupervisor,
+    recorded_at: str,
+) -> ConsolidationTransportCoordinatorResult:
+    """Stop, probe, and prepare routing for one exact sealed destination cell."""
+
+    try:
+        root = Path(vault_root).absolute()
+        checked_journal = _digest(journal_digest)
+        checked_time = _timestamp(recorded_at)
+        if (
+            not isinstance(admission, consolidation_admission.ConsolidationAdmission)
+            or admission.vault_root != root
+            or not isinstance(supervisor, TransportSupervisor)
+            or not isinstance(basis, Mapping)
+            or isinstance(contracts, (str, bytes))
+            or not isinstance(contracts, Sequence)
+        ):
+            _fail()
+        vault_binding = _digest(basis.get("vault_binding_digest"))
+        run_id = str(basis.get("run_id"))
+        operation_id = str(basis.get("operation_id"))
+        request_plan = _digest(basis.get("plan_digest"))
+        if admission.vault_binding_digest != vault_binding:
+            _fail()
+        parent = _require_parent(
+            consolidation_verification_journal.ConsolidationVerificationJournalStore(
+                root, run_id=run_id
+            ).load(),
+            run_id=run_id,
+            operation_id=operation_id,
+            plan_digest=request_plan,
+        )
+        _require_seal(
+            admission.reload().state,
+            vault_binding_digest=vault_binding,
+            run_id=run_id,
+            operation_id=operation_id,
+            journal_digest=checked_journal,
+        )
+        expected_pre_stop_basis = (
+            consolidation_transport_verification.transport_verification_basis_fingerprint(
+                basis
+            )
+        )
+        if (
+            _digest(supervisor.revalidate_pre_stop_basis(basis))
+            != expected_pre_stop_basis
+        ):
+            _fail()
+        _ensure_phase(
+            admission=admission,
+            vault_root=root,
+            vault_binding_digest=vault_binding,
+            run_id=run_id,
+            operation_id=operation_id,
+            journal_digest=checked_journal,
+            target_phase="transport-stopping",
+            recorded_at=checked_time,
+        )
+        routing_stop_digest = _digest(basis.get("routing_stop_digest"))
+        stop_effect = _execute_stop(
+            vault_root=root,
+            parent=parent,
+            plan_digest=request_plan,
+            routing_stop_digest=routing_stop_digest,
+            supervisor=supervisor,
+            timestamp=checked_time,
+        )
+        _crash_point("after-stop-effect-final")
+        stop_aggregate = _aggregate_effect(stop_effect, kind="transport-stop")
+
+        authority = consolidation_authority.issue_authority(
+            vault_binding_digest=vault_binding,
+            run_id=run_id,
+            operation_id=operation_id,
+            journal_digest=checked_journal,
+            phase="transport-stopping",
+            action="apply",
+        )
+        binding = consolidation_transport_verification.issue_exact_destination_binding(
+            authority,
+            journal_digest=checked_journal,
+            basis=basis,
+        )
+        plan = consolidation_transport_verification.build_transport_verification_plan(
+            basis=basis,
+            contracts=contracts,
+            exact_destination_binding=binding,
+        )
+        if _digest(supervisor.revalidate_basis(plan)) != plan.basis.digest:
+            _fail()
+        store = consolidation_transport_journal.ConsolidationTransportJournalStore(
+            root,
+            run_id=run_id,
+        )
+        store.create(
+            verification_journal=parent,
+            transport_plan=plan,
+            transport_stop_effect=stop_aggregate,
+        )
+        _crash_point("after-transport-journal")
+        _ensure_phase(
+            admission=admission,
+            vault_root=root,
+            vault_binding_digest=vault_binding,
+            run_id=run_id,
+            operation_id=operation_id,
+            journal_digest=checked_journal,
+            target_phase="transport-verifying",
+            recorded_at=checked_time,
+        )
+        _crash_point("after-transport-verifying")
+        probe_effects = _execute_probes(
+            vault_root=root,
+            admission=admission,
+            parent=parent,
+            plan=plan,
+            store=store,
+            supervisor=supervisor,
+            timestamp=checked_time,
+        )
+        if _digest(supervisor.revalidate_basis(plan)) != plan.basis.digest:
+            _fail()
+        verification_effect = _execute_transport_verified(
+            vault_root=root,
+            parent=parent,
+            store=store,
+            timestamp=checked_time,
+        )
+        _ensure_phase(
+            admission=admission,
+            vault_root=root,
+            vault_binding_digest=vault_binding,
+            run_id=run_id,
+            operation_id=operation_id,
+            journal_digest=checked_journal,
+            target_phase="transport-verified",
+            recorded_at=checked_time,
+        )
+        _crash_point("after-transport-verified-phase")
+        if _digest(supervisor.revalidate_basis(plan)) != plan.basis.digest:
+            _fail()
+        routing_effect = _execute_routing_open(
+            vault_root=root,
+            admission=admission,
+            vault_binding_digest=vault_binding,
+            parent=parent,
+            store=store,
+            supervisor=supervisor,
+            recorded_at=checked_time,
+        )
+        seal_state = _require_seal(
+            admission.reload().state,
+            vault_binding_digest=vault_binding,
+            run_id=run_id,
+            operation_id=operation_id,
+            journal_digest=checked_journal,
+        )
+        if seal_state.phase != "routing-opening":
+            _fail()
+        final = store.load()
+        return ConsolidationTransportCoordinatorResult(
+            completed_probe_ids=tuple(probe.probe_id for probe in plan.probes),
+            stop_effect=stop_effect,
+            probe_effects=probe_effects,
+            verification_effect=verification_effect,
+            routing_effect=routing_effect,
+            transport_journal=final,
+            seal_state=seal_state,
+        )
+    except ConsolidationTransportCoordinatorUnavailable:
+        raise
+    except (
+        consolidation_admission.ConsolidationAdmissionUnavailable,
+        consolidation_authority.ConsolidationAuthorityUnavailable,
+        consolidation_effect_coordinator.ConsolidationEffectUnavailable,
+        consolidation_plan.ConsolidationPlanUnavailable,
+        consolidation_receipts.ConsolidationReceiptUnavailable,
+        consolidation_seal.ConsolidationSealUnavailable,
+        consolidation_transport_journal.ConsolidationTransportJournalUnavailable,
+        consolidation_transport_verification.ConsolidationTransportVerificationUnavailable,
+        consolidation_verification_journal.ConsolidationVerificationJournalUnavailable,
+        NotImplementedError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ):
+        _fail()

--- a/src/exomem/governance/consolidation_transport_journal.py
+++ b/src/exomem/governance/consolidation_transport_journal.py
@@ -1,0 +1,863 @@
+"""Owner-only aggregate journal for exact-cell transport verification.
+
+The in-process verification journal is already terminal before transport work
+begins.  This store chains a transport plan to that exact terminal and tracks
+only monotonic digest outcomes plus receipt/effect references.  Request bodies,
+authentication material, process-local route leases, and consolidation
+authority never cross this boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Literal, NoReturn, cast
+
+from .. import reserved_paths
+from ..kbdir import kb_dirname
+from . import (
+    consolidation_plan,
+    consolidation_transport_verification,
+    consolidation_verification_journal,
+)
+
+JOURNAL_SCHEMA = "exomem.consolidation-transport-verification-journal/v1"
+
+_BINDING_SCHEMA = "exomem.consolidation-transport-verification-journal-basis/v1"
+_BINDING_DOMAIN = _BINDING_SCHEMA.encode("ascii")
+_DESCRIPTOR_ID = "consolidation-tree"
+_OWNER = "consolidation.run"
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_EVENT_ID = re.compile(r"[0-9a-f]{64}:committed\Z")
+_UUID4 = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
+)
+_MAX_JOURNAL_BYTES = 2 * 1024 * 1024
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_STATUSES = frozenset({"prior", "result", "final"})
+_KINDS = frozenset(
+    {
+        "transport-stop",
+        "transport-probe",
+        "transport-verified",
+        "routing-open",
+        "complete",
+    }
+)
+_PROBE_FIELDS = frozenset(
+    {
+        "schema",
+        "ordinal",
+        "probe_id",
+        "probe_kind",
+        "surface",
+        "contract_digest",
+        "expected_result_digest",
+        "probe_digest",
+    }
+)
+_EFFECT_BASE_FIELDS = frozenset({"kind", "status"})
+_PROBE_EFFECT_BASE_FIELDS = _EFFECT_BASE_FIELDS | frozenset({"probe_ordinal"})
+_EFFECT_RESULT_FIELDS = _EFFECT_BASE_FIELDS | frozenset({"result_digest"})
+_PROBE_EFFECT_RESULT_FIELDS = _PROBE_EFFECT_BASE_FIELDS | frozenset(
+    {"result_digest"}
+)
+_EFFECT_FINAL_FIELDS = _EFFECT_RESULT_FIELDS | frozenset(
+    {"terminal_event_id", "terminal_payload_digest", "effect_journal_digest"}
+)
+_PROBE_EFFECT_FINAL_FIELDS = _PROBE_EFFECT_RESULT_FIELDS | frozenset(
+    {"terminal_event_id", "terminal_payload_digest", "effect_journal_digest"}
+)
+_RECORD_FIELDS = frozenset(
+    {
+        "schema",
+        "run_id",
+        "operation_id",
+        "request_digest",
+        "cutover_plan_digest",
+        "apply_journal_digest",
+        "verification_manifest_digest",
+        "canonical_census_digest",
+        "in_process_verification_basis_digest",
+        "in_process_verification_result_digest",
+        "in_process_verified_terminal_event_id",
+        "in_process_verified_terminal_payload_digest",
+        "in_process_verified_effect_journal_digest",
+        "in_process_verified_effect_ordinal",
+        "plan_digest",
+        "basis_digest",
+        "routing_stop_digest",
+        "transport_stop_effect",
+        "binding_digest",
+        "revision",
+        "probes",
+        "effects",
+    }
+)
+
+__all__ = [
+    "JOURNAL_SCHEMA",
+    "ConsolidationTransportJournalEffect",
+    "ConsolidationTransportJournalState",
+    "ConsolidationTransportJournalStore",
+    "ConsolidationTransportJournalUnavailable",
+]
+
+
+class ConsolidationTransportJournalUnavailable(RuntimeError):
+    """Content-free refusal for a missing, changed, or corrupt journal."""
+
+    code = "CONSOLIDATION_TRANSPORT_JOURNAL_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationTransportJournalEffect:
+    kind: Literal[
+        "transport-stop",
+        "transport-probe",
+        "transport-verified",
+        "routing-open",
+        "complete",
+    ]
+    probe_ordinal: int | None
+    status: Literal["prior", "result", "final"]
+    result_digest: str | None
+    terminal_event_id: str | None
+    terminal_payload_digest: str | None
+    effect_journal_digest: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolidationTransportJournalState:
+    schema: str
+    run_id: str
+    operation_id: str
+    request_digest: str
+    cutover_plan_digest: str
+    apply_journal_digest: str
+    verification_manifest_digest: str
+    canonical_census_digest: str
+    in_process_verification_basis_digest: str
+    in_process_verification_result_digest: str
+    in_process_verified_terminal_event_id: str
+    in_process_verified_terminal_payload_digest: str
+    in_process_verified_effect_journal_digest: str
+    in_process_verified_effect_ordinal: int
+    plan_digest: str
+    basis_digest: str
+    routing_stop_digest: str
+    binding_digest: str
+    revision: int
+    probes: tuple[consolidation_transport_verification.TransportProbe, ...]
+    effects: tuple[ConsolidationTransportJournalEffect, ...]
+    state_digest: str
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationTransportJournalUnavailable from None
+
+
+def _digest(value: object) -> str:
+    if type(value) is not str or _DIGEST.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _event_id(value: object) -> str:
+    if type(value) is not str or _EVENT_ID.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _uuid4(value: object) -> str:
+    if type(value) is not str or _UUID4.fullmatch(value) is None:
+        _fail()
+    return value
+
+
+def _integer(value: object, *, minimum: int = 0) -> int:
+    if type(value) is not int or not minimum <= value <= _MAX_SAFE_INTEGER:
+        _fail()
+    return value
+
+
+def _mapping(value: object, fields: frozenset[str]) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or frozenset(value) != fields:
+        _fail()
+    return value
+
+
+def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            _fail()
+        result[key] = value
+    return result
+
+
+def _reject_number(_value: str) -> NoReturn:
+    _fail()
+
+
+def _parse_integer(value: str) -> int:
+    if value.startswith("-"):
+        _fail()
+    try:
+        return _integer(int(value))
+    except ValueError:
+        _fail()
+
+
+def _decode(raw: bytes) -> Mapping[str, object]:
+    if not isinstance(raw, bytes) or not raw or len(raw) > _MAX_JOURNAL_BYTES:
+        _fail()
+    try:
+        value = json.loads(
+            raw,
+            object_pairs_hook=_pairs,
+            parse_int=_parse_integer,
+            parse_float=_reject_number,
+            parse_constant=_reject_number,
+        )
+    except (
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        ConsolidationTransportJournalUnavailable,
+    ):
+        _fail()
+    if not isinstance(value, Mapping):
+        _fail()
+    try:
+        canonical = consolidation_plan.canonical_closed_jcs(value)
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    if canonical != raw:
+        _fail()
+    return value
+
+
+def _probe_value(
+    probe: consolidation_transport_verification.TransportProbe,
+) -> dict[str, object]:
+    return {
+        "schema": probe.schema,
+        "ordinal": probe.ordinal,
+        "probe_id": probe.probe_id,
+        "probe_kind": probe.probe_kind,
+        "surface": probe.surface,
+        "contract_digest": probe.contract_digest,
+        "expected_result_digest": probe.expected_result_digest,
+        "probe_digest": probe.probe_digest,
+    }
+
+
+def _effect_value(effect: ConsolidationTransportJournalEffect) -> dict[str, object]:
+    value: dict[str, object] = {"kind": effect.kind, "status": effect.status}
+    if effect.kind == "transport-probe":
+        value["probe_ordinal"] = effect.probe_ordinal
+    if effect.status in {"result", "final"}:
+        value["result_digest"] = effect.result_digest
+    if effect.status == "final":
+        value.update(
+            terminal_event_id=effect.terminal_event_id,
+            terminal_payload_digest=effect.terminal_payload_digest,
+            effect_journal_digest=effect.effect_journal_digest,
+        )
+    return value
+
+
+def _basis_value(state: ConsolidationTransportJournalState) -> dict[str, object]:
+    return {
+        "run_id": state.run_id,
+        "operation_id": state.operation_id,
+        "request_digest": state.request_digest,
+        "cutover_plan_digest": state.cutover_plan_digest,
+        "apply_journal_digest": state.apply_journal_digest,
+        "verification_manifest_digest": state.verification_manifest_digest,
+        "canonical_census_digest": state.canonical_census_digest,
+        "in_process_verification_basis_digest": (
+            state.in_process_verification_basis_digest
+        ),
+        "in_process_verification_result_digest": (
+            state.in_process_verification_result_digest
+        ),
+        "in_process_verified_terminal_event_id": (
+            state.in_process_verified_terminal_event_id
+        ),
+        "in_process_verified_terminal_payload_digest": (
+            state.in_process_verified_terminal_payload_digest
+        ),
+        "in_process_verified_effect_journal_digest": (
+            state.in_process_verified_effect_journal_digest
+        ),
+        "in_process_verified_effect_ordinal": state.in_process_verified_effect_ordinal,
+        "plan_digest": state.plan_digest,
+        "basis_digest": state.basis_digest,
+        "routing_stop_digest": state.routing_stop_digest,
+        "transport_stop_effect": _effect_value(state.effects[0]),
+        "probes": tuple(_probe_value(probe) for probe in state.probes),
+    }
+
+
+def _binding_digest(state: ConsolidationTransportJournalState) -> str:
+    try:
+        raw = consolidation_plan.canonical_closed_jcs(
+            {"schema": _BINDING_SCHEMA, **_basis_value(state)}
+        )
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    framed = (
+        len(_BINDING_DOMAIN).to_bytes(4, "big")
+        + _BINDING_DOMAIN
+        + len(raw).to_bytes(8, "big")
+        + raw
+    )
+    return hashlib.sha256(framed).hexdigest()
+
+
+def _state_value(state: ConsolidationTransportJournalState) -> dict[str, object]:
+    return {
+        "schema": state.schema,
+        **_basis_value(state),
+        "binding_digest": state.binding_digest,
+        "revision": state.revision,
+        "effects": tuple(_effect_value(effect) for effect in state.effects),
+    }
+
+
+def _state_bytes(state: ConsolidationTransportJournalState) -> bytes:
+    try:
+        raw = consolidation_plan.canonical_closed_jcs(_state_value(state))
+    except consolidation_plan.ConsolidationPlanUnavailable:
+        _fail()
+    if len(raw) > _MAX_JOURNAL_BYTES:
+        _fail()
+    return raw
+
+
+def _parse_probe(
+    value: object,
+    *,
+    ordinal: int,
+) -> consolidation_transport_verification.TransportProbe:
+    row = _mapping(value, _PROBE_FIELDS)
+    if (
+        row["schema"]
+        != consolidation_transport_verification.TRANSPORT_VERIFICATION_PROBE_SCHEMA
+        or _integer(row["ordinal"]) != ordinal
+    ):
+        _fail()
+    try:
+        probe = consolidation_transport_verification._checked_probe(  # noqa: SLF001
+            {
+                "probe_id": row["probe_id"],
+                "probe_kind": row["probe_kind"],
+                "surface": row["surface"],
+                "contract_digest": row["contract_digest"],
+                "expected_result_digest": row["expected_result_digest"],
+            },
+            ordinal=ordinal,
+        )
+    except consolidation_transport_verification.ConsolidationTransportVerificationUnavailable:
+        _fail()
+    if _digest(row["probe_digest"]) != probe.probe_digest:
+        _fail()
+    return probe
+
+
+def _parse_effect(value: object) -> ConsolidationTransportJournalEffect:
+    if not isinstance(value, Mapping):
+        _fail()
+    kind = value.get("kind")
+    status = value.get("status")
+    if kind not in _KINDS or status not in _STATUSES:
+        _fail()
+    is_probe = kind == "transport-probe"
+    fields = {
+        (False, "prior"): _EFFECT_BASE_FIELDS,
+        (False, "result"): _EFFECT_RESULT_FIELDS,
+        (False, "final"): _EFFECT_FINAL_FIELDS,
+        (True, "prior"): _PROBE_EFFECT_BASE_FIELDS,
+        (True, "result"): _PROBE_EFFECT_RESULT_FIELDS,
+        (True, "final"): _PROBE_EFFECT_FINAL_FIELDS,
+    }[(is_probe, status)]
+    row = _mapping(value, fields)
+    return ConsolidationTransportJournalEffect(
+        kind=cast(
+            Literal[
+                "transport-stop",
+                "transport-probe",
+                "transport-verified",
+                "routing-open",
+                "complete",
+            ],
+            kind,
+        ),
+        probe_ordinal=_integer(row["probe_ordinal"]) if is_probe else None,
+        status=cast(Literal["prior", "result", "final"], status),
+        result_digest=(
+            _digest(row["result_digest"])
+            if status in {"result", "final"}
+            else None
+        ),
+        terminal_event_id=(
+            _event_id(row["terminal_event_id"]) if status == "final" else None
+        ),
+        terminal_payload_digest=(
+            _digest(row["terminal_payload_digest"])
+            if status == "final"
+            else None
+        ),
+        effect_journal_digest=(
+            _digest(row["effect_journal_digest"])
+            if status == "final"
+            else None
+        ),
+    )
+
+
+def _prior_effects(
+    probes: tuple[consolidation_transport_verification.TransportProbe, ...],
+) -> tuple[ConsolidationTransportJournalEffect, ...]:
+    def prior(
+        kind: Literal[
+            "transport-stop",
+            "transport-probe",
+            "transport-verified",
+            "routing-open",
+            "complete",
+        ],
+        probe_ordinal: int | None = None,
+    ) -> ConsolidationTransportJournalEffect:
+        return ConsolidationTransportJournalEffect(
+            kind=kind,
+            probe_ordinal=probe_ordinal,
+            status="prior",
+            result_digest=None,
+            terminal_event_id=None,
+            terminal_payload_digest=None,
+            effect_journal_digest=None,
+        )
+
+    return (
+        prior("transport-stop"),
+        *(prior("transport-probe", probe.ordinal) for probe in probes),
+        prior("transport-verified"),
+        prior("routing-open"),
+        prior("complete"),
+    )
+
+
+def _parse_state(raw: bytes) -> ConsolidationTransportJournalState:
+    value = _mapping(_decode(raw), _RECORD_FIELDS)
+    if value["schema"] != JOURNAL_SCHEMA:
+        _fail()
+    raw_probes = value["probes"]
+    raw_effects = value["effects"]
+    if (
+        isinstance(raw_probes, (str, bytes))
+        or not isinstance(raw_probes, Sequence)
+        or not raw_probes
+        or isinstance(raw_effects, (str, bytes))
+        or not isinstance(raw_effects, Sequence)
+    ):
+        _fail()
+    probes = tuple(
+        _parse_probe(item, ordinal=ordinal)
+        for ordinal, item in enumerate(raw_probes)
+    )
+    effects = tuple(_parse_effect(item) for item in raw_effects)
+    bound_stop_effect = _parse_effect(value["transport_stop_effect"])
+    expected_effects = _prior_effects(probes)
+    if tuple((item.kind, item.probe_ordinal) for item in effects) != tuple(
+        (item.kind, item.probe_ordinal) for item in expected_effects
+    ) or not effects or effects[0] != bound_stop_effect:
+        _fail()
+    ranks = tuple({"final": 0, "result": 1, "prior": 2}[item.status] for item in effects)
+    if tuple(sorted(ranks)) != ranks or ranks.count(1) > 1:
+        _fail()
+    routing_stop_digest = _digest(value["routing_stop_digest"])
+    for effect in effects:
+        if effect.status == "prior":
+            continue
+        if effect.kind == "transport-stop":
+            expected_result = routing_stop_digest
+        elif effect.kind == "transport-probe":
+            if effect.probe_ordinal is None or not 0 <= effect.probe_ordinal < len(probes):
+                _fail()
+            expected_result = probes[effect.probe_ordinal].expected_result_digest
+        else:
+            continue
+        if effect.result_digest != expected_result:
+            _fail()
+    expected_revision = 1 + sum(
+        2 if effect.status == "final" else 1 if effect.status == "result" else 0
+        for effect in effects
+    )
+    state = ConsolidationTransportJournalState(
+        schema=JOURNAL_SCHEMA,
+        run_id=_uuid4(value["run_id"]),
+        operation_id=_uuid4(value["operation_id"]),
+        request_digest=_digest(value["request_digest"]),
+        cutover_plan_digest=_digest(value["cutover_plan_digest"]),
+        apply_journal_digest=_digest(value["apply_journal_digest"]),
+        verification_manifest_digest=_digest(value["verification_manifest_digest"]),
+        canonical_census_digest=_digest(value["canonical_census_digest"]),
+        in_process_verification_basis_digest=_digest(
+            value["in_process_verification_basis_digest"]
+        ),
+        in_process_verification_result_digest=_digest(
+            value["in_process_verification_result_digest"]
+        ),
+        in_process_verified_terminal_event_id=_event_id(
+            value["in_process_verified_terminal_event_id"]
+        ),
+        in_process_verified_terminal_payload_digest=_digest(
+            value["in_process_verified_terminal_payload_digest"]
+        ),
+        in_process_verified_effect_journal_digest=_digest(
+            value["in_process_verified_effect_journal_digest"]
+        ),
+        in_process_verified_effect_ordinal=_integer(
+            value["in_process_verified_effect_ordinal"]
+        ),
+        plan_digest=_digest(value["plan_digest"]),
+        basis_digest=_digest(value["basis_digest"]),
+        routing_stop_digest=routing_stop_digest,
+        binding_digest=_digest(value["binding_digest"]),
+        revision=_integer(value["revision"], minimum=1),
+        probes=probes,
+        effects=effects,
+        state_digest=hashlib.sha256(raw).hexdigest(),
+    )
+    if state.revision != expected_revision or state.binding_digest != _binding_digest(state):
+        _fail()
+    return state
+
+
+def _checked_plan(
+    value: object,
+) -> consolidation_transport_verification.TransportVerificationPlan:
+    if type(value) is not consolidation_transport_verification.TransportVerificationPlan:
+        _fail()
+    checked = cast(
+        consolidation_transport_verification.TransportVerificationPlan,
+        value,
+    )
+    if not checked.probes:
+        _fail()
+    try:
+        plan, _probe = consolidation_transport_verification._checked_plan_member(  # noqa: SLF001
+            checked,
+            checked.probes[0],
+        )
+    except consolidation_transport_verification.ConsolidationTransportVerificationUnavailable:
+        _fail()
+    return plan
+
+
+@contextmanager
+def _authority(vault_root: Path, *, mutation: bool) -> Iterator[None]:
+    try:
+        with reserved_paths._subsystem_authority_scope(_OWNER):  # noqa: SLF001
+            with reserved_paths._identity_coordination_scope(  # noqa: SLF001
+                vault_root,
+                descriptor_ids=(_DESCRIPTOR_ID,),
+                identity_may_change=mutation,
+            ):
+                yield
+    except ConsolidationTransportJournalUnavailable:
+        raise
+    except (OSError, RuntimeError, ValueError):
+        _fail()
+
+
+class ConsolidationTransportJournalStore:
+    """CAS-persist one exact transport plan and its ordered effect terminals."""
+
+    def __init__(self, vault_root: Path | str, *, run_id: str) -> None:
+        self.vault_root = Path(vault_root).absolute()
+        self.run_id = _uuid4(run_id)
+        self.path = (
+            self.vault_root
+            / kb_dirname()
+            / "_Consolidation"
+            / "runs"
+            / self.run_id
+            / "transport-verification.json"
+        )
+
+    def _read(self) -> bytes:
+        return reserved_paths._read_owner_bytes(  # noqa: SLF001
+            self.vault_root,
+            self.path,
+            _DESCRIPTOR_ID,
+            limit=_MAX_JOURNAL_BYTES,
+        )
+
+    def _read_optional(self) -> bytes | None:
+        try:
+            return self._read()
+        except FileNotFoundError:
+            return None
+
+    def _publish(
+        self,
+        raw: bytes,
+        *,
+        expected_sha256: str | None = None,
+        require_missing: bool = False,
+    ) -> None:
+        reserved_paths._publish_owner_bytes(  # noqa: SLF001
+            self.vault_root,
+            self.path,
+            _DESCRIPTOR_ID,
+            raw,
+            expected_sha256=expected_sha256,
+            require_missing=require_missing,
+        )
+
+    def _load_locked(self) -> tuple[ConsolidationTransportJournalState, bytes]:
+        try:
+            raw = self._read()
+        except FileNotFoundError:
+            _fail()
+        state = _parse_state(raw)
+        if state.run_id != self.run_id:
+            _fail()
+        return state, raw
+
+    def create(
+        self,
+        *,
+        verification_journal: consolidation_verification_journal.ConsolidationVerificationJournalState,
+        transport_plan: consolidation_transport_verification.TransportVerificationPlan,
+        transport_stop_effect: ConsolidationTransportJournalEffect,
+    ) -> ConsolidationTransportJournalState:
+        if type(verification_journal) is not (
+            consolidation_verification_journal.ConsolidationVerificationJournalState
+        ):
+            _fail()
+        parent = verification_journal
+        terminal = parent.terminal
+        if (
+            parent.run_id != self.run_id
+            or any(entry.status != "final" for entry in parent.probes)
+            or terminal.status != "final"
+            or terminal.result_digest is None
+            or terminal.terminal_event_id is None
+            or terminal.terminal_payload_digest is None
+            or terminal.effect_journal_digest is None
+        ):
+            _fail()
+        plan = _checked_plan(transport_plan)
+        basis = plan.basis
+        if (
+            type(transport_stop_effect) is not ConsolidationTransportJournalEffect
+            or transport_stop_effect.kind != "transport-stop"
+            or transport_stop_effect.probe_ordinal is not None
+            or transport_stop_effect.status != "final"
+            or transport_stop_effect.result_digest != basis.routing_stop_digest
+            or transport_stop_effect.terminal_event_id is None
+            or transport_stop_effect.terminal_payload_digest is None
+            or transport_stop_effect.effect_journal_digest is None
+        ):
+            _fail()
+        if (
+            basis.run_id != parent.run_id
+            or basis.operation_id != parent.operation_id
+            or basis.plan_digest != parent.plan_digest
+            or basis.canonical_census_digest != parent.canonical_census_digest
+        ):
+            _fail()
+        effects = list(_prior_effects(plan.probes))
+        effects[0] = transport_stop_effect
+        candidate = ConsolidationTransportJournalState(
+            schema=JOURNAL_SCHEMA,
+            run_id=parent.run_id,
+            operation_id=parent.operation_id,
+            request_digest=parent.request_digest,
+            cutover_plan_digest=parent.plan_digest,
+            apply_journal_digest=basis.journal_digest,
+            verification_manifest_digest=basis.verification_manifest_digest,
+            canonical_census_digest=parent.canonical_census_digest,
+            in_process_verification_basis_digest=parent.binding_digest,
+            in_process_verification_result_digest=terminal.result_digest,
+            in_process_verified_terminal_event_id=terminal.terminal_event_id,
+            in_process_verified_terminal_payload_digest=(
+                terminal.terminal_payload_digest
+            ),
+            in_process_verified_effect_journal_digest=terminal.effect_journal_digest,
+            in_process_verified_effect_ordinal=(
+                parent.last_rebuild_effect_ordinal + len(parent.probes) + 1
+            ),
+            plan_digest=plan.digest,
+            basis_digest=basis.digest,
+            routing_stop_digest=basis.routing_stop_digest,
+            binding_digest="0" * 64,
+            revision=3,
+            probes=plan.probes,
+            effects=tuple(effects),
+            state_digest="0" * 64,
+        )
+        candidate = replace(candidate, binding_digest=_binding_digest(candidate))
+        raw = _state_bytes(candidate)
+        target = replace(candidate, state_digest=hashlib.sha256(raw).hexdigest())
+        with _authority(self.vault_root, mutation=True):
+            existing = self._read_optional()
+            if existing is None:
+                self._publish(raw, require_missing=True)
+                return target
+            current = _parse_state(existing)
+            if current.run_id == self.run_id and _basis_value(current) == _basis_value(target):
+                return current
+            _fail()
+
+    def load(self) -> ConsolidationTransportJournalState:
+        with _authority(self.vault_root, mutation=False):
+            state, _raw = self._load_locked()
+            return state
+
+    @staticmethod
+    def _effect_index(
+        state: ConsolidationTransportJournalState,
+        *,
+        kind: str,
+        probe_ordinal: int | None,
+    ) -> int:
+        matches = [
+            index
+            for index, effect in enumerate(state.effects)
+            if effect.kind == kind and effect.probe_ordinal == probe_ordinal
+        ]
+        if len(matches) != 1:
+            _fail()
+        return matches[0]
+
+    @staticmethod
+    def _validate_result(
+        state: ConsolidationTransportJournalState,
+        effect: ConsolidationTransportJournalEffect,
+        result_digest: str,
+    ) -> str:
+        result = _digest(result_digest)
+        if effect.kind == "transport-stop":
+            expected = state.routing_stop_digest
+        elif effect.kind == "transport-probe":
+            if (
+                effect.probe_ordinal is None
+                or not 0 <= effect.probe_ordinal < len(state.probes)
+            ):
+                _fail()
+            expected = state.probes[effect.probe_ordinal].expected_result_digest
+        else:
+            return result
+        if result != expected:
+            _fail()
+        return result
+
+    def record_transport_effect_result(
+        self,
+        *,
+        kind: str,
+        result_digest: str,
+        probe_ordinal: int | None = None,
+    ) -> ConsolidationTransportJournalState:
+        if kind != "transport-probe" and probe_ordinal is not None:
+            _fail()
+        with _authority(self.vault_root, mutation=True):
+            current, raw = self._load_locked()
+            index = self._effect_index(
+                current,
+                kind=kind,
+                probe_ordinal=probe_ordinal,
+            )
+            effect = current.effects[index]
+            result = self._validate_result(current, effect, result_digest)
+            if effect.status in {"result", "final"}:
+                if effect.result_digest == result:
+                    return current
+                _fail()
+            if effect.status != "prior" or any(
+                prior.status != "final" for prior in current.effects[:index]
+            ):
+                _fail()
+            effects = list(current.effects)
+            effects[index] = replace(
+                effect,
+                status="result",
+                result_digest=result,
+            )
+            return self._replace_locked(current, raw, effects=tuple(effects))
+
+    def finalize_transport_effect(
+        self,
+        *,
+        kind: str,
+        result_digest: str,
+        terminal_event_id: str,
+        terminal_payload_digest: str,
+        effect_journal_digest: str,
+        probe_ordinal: int | None = None,
+    ) -> ConsolidationTransportJournalState:
+        if kind != "transport-probe" and probe_ordinal is not None:
+            _fail()
+        event_id = _event_id(terminal_event_id)
+        payload_digest = _digest(terminal_payload_digest)
+        journal_digest = _digest(effect_journal_digest)
+        with _authority(self.vault_root, mutation=True):
+            current, raw = self._load_locked()
+            index = self._effect_index(
+                current,
+                kind=kind,
+                probe_ordinal=probe_ordinal,
+            )
+            effect = current.effects[index]
+            result = self._validate_result(current, effect, result_digest)
+            if effect.status == "final":
+                if (
+                    effect.result_digest == result
+                    and effect.terminal_event_id == event_id
+                    and effect.terminal_payload_digest == payload_digest
+                    and effect.effect_journal_digest == journal_digest
+                ):
+                    return current
+                _fail()
+            if effect.status != "result" or effect.result_digest != result:
+                _fail()
+            effects = list(current.effects)
+            effects[index] = replace(
+                effect,
+                status="final",
+                terminal_event_id=event_id,
+                terminal_payload_digest=payload_digest,
+                effect_journal_digest=journal_digest,
+            )
+            return self._replace_locked(current, raw, effects=tuple(effects))
+
+    def _replace_locked(
+        self,
+        current: ConsolidationTransportJournalState,
+        raw: bytes,
+        *,
+        effects: tuple[ConsolidationTransportJournalEffect, ...],
+    ) -> ConsolidationTransportJournalState:
+        candidate = replace(
+            current,
+            revision=current.revision + 1,
+            effects=effects,
+            state_digest="0" * 64,
+        )
+        target_raw = _state_bytes(candidate)
+        target = replace(candidate, state_digest=hashlib.sha256(target_raw).hexdigest())
+        self._publish(target_raw, expected_sha256=hashlib.sha256(raw).hexdigest())
+        return target

--- a/src/exomem/governance/consolidation_transport_verification.py
+++ b/src/exomem/governance/consolidation_transport_verification.py
@@ -90,6 +90,7 @@ __all__ = [
     "build_transport_verification_plan",
     "issue_exact_destination_binding",
     "issue_transport_probe_route",
+    "transport_verification_basis_fingerprint",
     "transport_probe_route_scope",
 ]
 
@@ -415,6 +416,15 @@ def issue_exact_destination_binding(
         checked_journal,
         _EXACT_DESTINATION_SEAL,
     )
+
+
+def transport_verification_basis_fingerprint(
+    basis: Mapping[str, object],
+) -> str:
+    """Digest the closed pre-stop facts before the stopped-cell binding exists."""
+
+    checked = _basis_from_input(basis)
+    return _framed_digest(_BASIS_DOMAIN, _basis_input_value(checked))
 
 
 def _checked_basis(

--- a/tests/test_consolidation_transport_verification.py
+++ b/tests/test_consolidation_transport_verification.py
@@ -5,10 +5,16 @@ import copy
 import dataclasses
 import hashlib
 import pickle
+import sys
 import threading
 from pathlib import Path
+from types import ModuleType
 
 import pytest
+
+_tests_package = ModuleType("tests")
+_tests_package.__path__ = [str(Path(__file__).parent)]
+sys.modules.setdefault("tests", _tests_package)
 
 VAULT_BINDING = hashlib.sha256(b"transport-vault-binding").hexdigest()
 RUN_ID = "00000000-0000-4000-8000-000000000121"
@@ -556,3 +562,779 @@ def test_wrong_transport_authority_or_binding_never_opens_probe_route() -> None:
             plan=plan,
             probe=plan.probes[0],
         )
+
+
+def _finalized_verification_journal(vault: Path):
+    from exomem.governance import (
+        consolidation_verification,
+        consolidation_verification_journal,
+    )
+
+    def contract(probe_id: str) -> dict[str, str]:
+        return {
+            "probe_id": probe_id,
+            "executor_id": "canonical-governance-surface-v1",
+            "contract_digest": hashlib.sha256(
+                f"{probe_id}:contract".encode()
+            ).hexdigest(),
+            "expected_result_digest": hashlib.sha256(
+                f"{probe_id}:result".encode()
+            ).hexdigest(),
+        }
+
+    verification_plan = consolidation_verification.build_verification_plan(
+        positive_probes=(contract("transport-parent-positive"),),
+        negative_probes=(contract("transport-parent-negative"),),
+    )
+    store = consolidation_verification_journal.ConsolidationVerificationJournalStore(
+        vault,
+        run_id=RUN_ID,
+    )
+    state = store.create(
+        operation_id=OPERATION_ID,
+        request_digest=hashlib.sha256(b"transport-request").hexdigest(),
+        plan_digest=PLAN_DIGEST,
+        rebuild_journal_digest=hashlib.sha256(b"transport-rebuild-journal").hexdigest(),
+        canonical_census_digest=CENSUS_DIGEST,
+        verification_plan=verification_plan,
+        last_rebuild_terminal_event_id=f"{'1' * 64}:committed",
+        last_rebuild_terminal_payload_digest="2" * 64,
+        last_rebuild_effect_ordinal=20,
+    )
+    for probe in verification_plan.probes:
+        state = store.record_probe_result(probe, probe.expected_result_digest)
+        state = store.finalize_probe(
+            probe,
+            probe.expected_result_digest,
+            terminal_event_id=f"{probe.ordinal + 3:064x}:committed",
+            terminal_payload_digest=f"{probe.ordinal + 5:064x}",
+            effect_journal_digest=f"{probe.ordinal + 7:064x}",
+        )
+    verification_result = hashlib.sha256(b"transport-parent-verified").hexdigest()
+    state = store.record_terminal_result(verification_result)
+    state = store.finalize_terminal(
+        verification_result,
+        terminal_event_id=f"{'9' * 64}:committed",
+        terminal_payload_digest="a" * 64,
+        effect_journal_digest="b" * 64,
+    )
+    return store, state
+
+
+def test_transport_progress_chains_the_final_verification_journal(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import (
+        consolidation_transport_journal,
+    )
+
+    _verification_store, verified = _finalized_verification_journal(tmp_path)
+    plan = _transport_plan()
+    store = consolidation_transport_journal.ConsolidationTransportJournalStore(
+        tmp_path,
+        run_id=RUN_ID,
+    )
+    stop_effect = consolidation_transport_journal.ConsolidationTransportJournalEffect(
+        kind="transport-stop",
+        probe_ordinal=None,
+        status="final",
+        result_digest=plan.basis.routing_stop_digest,
+        terminal_event_id=f"{'c' * 64}:committed",
+        terminal_payload_digest="d" * 64,
+        effect_journal_digest="e" * 64,
+    )
+
+    attached = store.create(
+        verification_journal=verified,
+        transport_plan=plan,
+        transport_stop_effect=stop_effect,
+    )
+
+    assert attached.in_process_verification_basis_digest == verified.binding_digest
+    assert attached.plan_digest == plan.digest
+    assert attached.basis_digest == plan.basis.digest
+    assert tuple(effect.kind for effect in attached.effects) == (
+        "transport-stop",
+        *("transport-probe" for _probe in plan.probes),
+        "transport-verified",
+        "routing-open",
+        "complete",
+    )
+    assert tuple(
+        effect.probe_ordinal
+        for effect in attached.effects
+        if effect.kind == "transport-probe"
+    ) == tuple(range(len(plan.probes)))
+    assert attached.effects[0] == stop_effect
+    assert all(effect.status == "prior" for effect in attached.effects[1:])
+
+    with pytest.raises(
+        consolidation_transport_journal.ConsolidationTransportJournalUnavailable
+    ):
+        store.record_transport_effect_result(
+            kind="transport-probe",
+            probe_ordinal=1,
+            result_digest=plan.probes[1].expected_result_digest,
+        )
+
+    probed = store.record_transport_effect_result(
+        kind="transport-probe",
+        probe_ordinal=0,
+        result_digest=plan.probes[0].expected_result_digest,
+    )
+    probed = store.finalize_transport_effect(
+        kind="transport-probe",
+        probe_ordinal=0,
+        result_digest=plan.probes[0].expected_result_digest,
+        terminal_event_id=f"{'f' * 64}:committed",
+        terminal_payload_digest="1" * 64,
+        effect_journal_digest="2" * 64,
+    )
+    assert probed.effects[1].status == "final"
+
+
+def test_transport_journal_is_digest_only_and_rejects_plan_drift(tmp_path: Path) -> None:
+    from exomem.governance import (
+        consolidation_transport_journal,
+        consolidation_transport_verification,
+    )
+
+    _verification_store, verified = _finalized_verification_journal(tmp_path)
+    plan = _transport_plan()
+    store = consolidation_transport_journal.ConsolidationTransportJournalStore(
+        tmp_path,
+        run_id=RUN_ID,
+    )
+    stop_effect = consolidation_transport_journal.ConsolidationTransportJournalEffect(
+        kind="transport-stop",
+        probe_ordinal=None,
+        status="final",
+        result_digest=plan.basis.routing_stop_digest,
+        terminal_event_id=f"{'c' * 64}:committed",
+        terminal_payload_digest="d" * 64,
+        effect_journal_digest="e" * 64,
+    )
+    state = store.create(
+        verification_journal=verified,
+        transport_plan=plan,
+        transport_stop_effect=stop_effect,
+    )
+    assert state.plan_digest == plan.digest
+
+    raw = store.path.read_bytes()
+    assert b"transport-parent-positive" not in raw
+    assert b"authority" not in raw.lower()
+    assert b"exactdestinationbinding" not in raw.lower()
+
+    changed_basis = _transport_basis(canonical_census_digest="f" * 64)
+    changed = consolidation_transport_verification.build_transport_verification_plan(
+        basis=changed_basis,
+        contracts=_surface_contracts(),
+        exact_destination_binding=_exact_destination_binding(changed_basis),
+    )
+    with pytest.raises(
+        consolidation_transport_journal.ConsolidationTransportJournalUnavailable
+    ):
+        store.create(
+            verification_journal=verified,
+            transport_plan=changed,
+            transport_stop_effect=stop_effect,
+        )
+
+
+def _verified_integration_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from exomem import writer_lease
+    from exomem.governance import consolidation_verification_coordinator
+    from tests.test_consolidation_verification import (  # noqa: PLC0415
+        _install_passing_runner,
+        _rebuilt_run,
+        _verification_manifest,
+    )
+
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR",
+        str(tmp_path / "writer-state"),
+    )
+    writer_lease.reset_managers_for_tests()
+    manifest = _verification_manifest()
+    vault, arguments, _plan = _rebuilt_run(
+        tmp_path,
+        monkeypatch,
+        manifest=manifest,
+    )
+    calls: list[str] = []
+    _install_passing_runner(monkeypatch, calls)
+    verified = consolidation_verification_coordinator.verify_rebuilt_destination(
+        **arguments,
+    )
+    assert verified.seal_state.phase == "verified"
+    return vault, arguments, manifest, verified
+
+
+def _integration_transport_basis(arguments, manifest, verified):
+    return {
+        "schema": "exomem.consolidation-transport-verification-basis/v1",
+        "vault_binding_digest": arguments["vault_binding_digest"],
+        "run_id": arguments["run_id"],
+        "operation_id": arguments["operation_id"],
+        "plan_digest": arguments["plan_digest"],
+        "verification_manifest_digest": manifest.digest,
+        "canonical_census_digest": verified.verification_journal.canonical_census_digest,
+        "release_build_digest": hashlib.sha256(b"integration-release").hexdigest(),
+        "surface_profile": "standalone-v1",
+        "surface_descriptor_digest": hashlib.sha256(
+            b"integration-descriptor"
+        ).hexdigest(),
+        "configuration_digest": hashlib.sha256(b"integration-config").hexdigest(),
+        "trust_digest": hashlib.sha256(b"integration-trust").hexdigest(),
+        "principal_mapping_digest": hashlib.sha256(
+            b"integration-principals"
+        ).hexdigest(),
+        "routing_stop_digest": hashlib.sha256(b"integration-routing-stop").hexdigest(),
+        "transport_supervisor_readiness_digest": hashlib.sha256(
+            b"integration-supervisor"
+        ).hexdigest(),
+        "hosted_profile_selection_record_digest": hashlib.sha256(
+            b"integration-hosted-selection"
+        ).hexdigest(),
+        "hosted_profile_selection_verifier_generation": 9,
+        "hosted_owner_entitlement_verifier_readiness_digest": hashlib.sha256(
+            b"integration-hosted-entitlement"
+        ).hexdigest(),
+    }
+
+
+def _pre_stop_basis_digest(basis):
+    from exomem.governance import consolidation_transport_verification
+
+    return consolidation_transport_verification.transport_verification_basis_fingerprint(
+        basis
+    )
+
+
+def test_transport_coordinator_stops_probes_and_opens_in_receipt_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_admission,
+        consolidation_receipts,
+        consolidation_transport_coordinator,
+    )
+
+    vault, arguments, manifest, verified = _verified_integration_run(
+        tmp_path,
+        monkeypatch,
+    )
+    basis = _integration_transport_basis(arguments, manifest, verified)
+    calls: list[str] = []
+
+    class Supervisor(consolidation_transport_coordinator.TransportSupervisor):
+        def __init__(self) -> None:
+            self.stopped = False
+            self.opened = False
+
+        def revalidate_pre_stop_basis(self, basis) -> str:
+            return _pre_stop_basis_digest(basis)
+
+        def classify_stop(self, context):
+            return consolidation_transport_coordinator.TransportRoutingObservation(
+                state="target" if self.stopped else "prior",
+                digest=(
+                    context.target_digest if self.stopped else context.prior_digest
+                ),
+            )
+
+        def stop_and_drain(self, context) -> None:
+            calls.append("stop")
+            self.stopped = True
+
+        def revalidate_basis(self, plan) -> str:
+            calls.append("revalidate")
+            return plan.basis.digest
+
+        def run_probe(self, probe, context):
+            assert not hasattr(context, "authority")
+            assert not hasattr(context, "route")
+            assert context.plan_digest
+            calls.append(probe.probe_id)
+            with context.admission.admit_read():
+                pass
+            with pytest.raises(
+                consolidation_admission.ConsolidationAdmissionUnavailable,
+                match="^CONSOLIDATION_SEALED$",
+            ):
+                with context.admission.admit_mutation():
+                    pass
+            return consolidation_transport_coordinator.TransportProbeTerminal(
+                schema=consolidation_transport_coordinator.TRANSPORT_PROBE_TERMINAL_SCHEMA,
+                probe_id=probe.probe_id,
+                probe_digest=probe.probe_digest,
+                result_digest=probe.expected_result_digest,
+                outcome="passed",
+            )
+
+        def classify_open(self, context):
+            return consolidation_transport_coordinator.TransportRoutingObservation(
+                state="target" if self.opened else "prior",
+                digest=(
+                    context.target_digest if self.opened else context.prior_digest
+                ),
+            )
+
+        def open_routing(self, context) -> None:
+            calls.append("open")
+            self.opened = True
+
+    supervisor = Supervisor()
+    result = consolidation_transport_coordinator.verify_exact_cell_transport(
+        vault_root=vault,
+        admission=arguments["admission"],
+        journal_digest=arguments["journal_digest"],
+        basis=basis,
+        contracts=_surface_contracts(),
+        supervisor=supervisor,
+        recorded_at="2026-08-31T12:00:09.000Z",
+    )
+
+    assert supervisor.stopped and supervisor.opened
+    assert result.seal_state.phase == "routing-opening"
+    assert tuple(effect.status for effect in result.transport_journal.effects) == (
+        *("final" for _effect in result.transport_journal.effects[:-1]),
+        "prior",
+    )
+    assert calls == [
+        "stop",
+        "revalidate",
+        *(probe["probe_id"] for probe in _surface_contracts()),
+        "revalidate",
+        "revalidate",
+        "open",
+    ]
+    records = [
+        consolidation_receipts.validate_nested(
+            record["consolidation_event"],
+            outer_phase=record["phase"],
+        )
+        for record in consolidation_receipts._active_records(vault)  # noqa: SLF001
+        if record.get("event_type") == "consolidation"
+        and isinstance(record.get("consolidation_event"), dict)
+        and record["consolidation_event"].get("kind")
+        in {
+            "transport-stop",
+            "transport-probe",
+            "transport-verified",
+            "routing-open",
+        }
+    ]
+    assert [record["kind"] for record in records if record["record_role"] == "intent"] == [
+        "transport-stop",
+        *("transport-probe" for _probe in _surface_contracts()),
+        "transport-verified",
+        "routing-open",
+    ]
+    with pytest.raises(
+        consolidation_admission.ConsolidationAdmissionUnavailable,
+        match="^CONSOLIDATION_SEALED$",
+    ):
+        with arguments["admission"].admit_read():
+            pass
+
+
+def test_transport_probe_failure_never_opens_routing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_admission,
+        consolidation_transport_coordinator,
+    )
+
+    vault, arguments, manifest, verified = _verified_integration_run(
+        tmp_path,
+        monkeypatch,
+    )
+    basis = _integration_transport_basis(arguments, manifest, verified)
+
+    class FailingSupervisor(consolidation_transport_coordinator.TransportSupervisor):
+        stopped = False
+        opened = False
+
+        def revalidate_pre_stop_basis(self, basis) -> str:
+            return _pre_stop_basis_digest(basis)
+
+        def classify_stop(self, context):
+            return consolidation_transport_coordinator.TransportRoutingObservation(
+                state="target" if self.stopped else "prior",
+                digest=context.target_digest if self.stopped else context.prior_digest,
+            )
+
+        def stop_and_drain(self, _context) -> None:
+            self.stopped = True
+
+        def revalidate_basis(self, plan) -> str:
+            return plan.basis.digest
+
+        def run_probe(self, probe, _context):
+            if probe.ordinal == 1:
+                raise RuntimeError("private transport detail")
+            return consolidation_transport_coordinator.TransportProbeTerminal(
+                schema=consolidation_transport_coordinator.TRANSPORT_PROBE_TERMINAL_SCHEMA,
+                probe_id=probe.probe_id,
+                probe_digest=probe.probe_digest,
+                result_digest=probe.expected_result_digest,
+                outcome="passed",
+            )
+
+        def classify_open(self, context):
+            return consolidation_transport_coordinator.TransportRoutingObservation(
+                state="prior",
+                digest=context.prior_digest,
+            )
+
+        def open_routing(self, _context) -> None:
+            self.opened = True
+
+    supervisor = FailingSupervisor()
+    with pytest.raises(
+        consolidation_transport_coordinator.ConsolidationTransportCoordinatorUnavailable
+    ):
+        consolidation_transport_coordinator.verify_exact_cell_transport(
+            vault_root=vault,
+            admission=arguments["admission"],
+            journal_digest=arguments["journal_digest"],
+            basis=basis,
+            contracts=_surface_contracts(),
+            supervisor=supervisor,
+            recorded_at="2026-08-31T12:00:09.000Z",
+        )
+
+    assert supervisor.stopped and not supervisor.opened
+    assert arguments["admission"].reload().state.phase == "transport-verifying"
+    with pytest.raises(
+        consolidation_admission.ConsolidationAdmissionUnavailable,
+        match="^CONSOLIDATION_SEALED$",
+    ):
+        with arguments["admission"].admit_read():
+            pass
+
+
+def test_transport_basis_drift_before_open_keeps_routing_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_transport_coordinator
+
+    vault, arguments, manifest, verified = _verified_integration_run(
+        tmp_path,
+        monkeypatch,
+    )
+    basis = _integration_transport_basis(arguments, manifest, verified)
+
+    class DriftingSupervisor(consolidation_transport_coordinator.TransportSupervisor):
+        stopped = False
+        opened = False
+        revalidations = 0
+
+        def revalidate_pre_stop_basis(self, basis) -> str:
+            return _pre_stop_basis_digest(basis)
+
+        def classify_stop(self, context):
+            return consolidation_transport_coordinator.TransportRoutingObservation(
+                state="target" if self.stopped else "prior",
+                digest=context.target_digest if self.stopped else context.prior_digest,
+            )
+
+        def stop_and_drain(self, _context) -> None:
+            self.stopped = True
+
+        def revalidate_basis(self, plan) -> str:
+            self.revalidations += 1
+            return plan.basis.digest if self.revalidations < 3 else "f" * 64
+
+        def run_probe(self, probe, _context):
+            return consolidation_transport_coordinator.TransportProbeTerminal(
+                schema=consolidation_transport_coordinator.TRANSPORT_PROBE_TERMINAL_SCHEMA,
+                probe_id=probe.probe_id,
+                probe_digest=probe.probe_digest,
+                result_digest=probe.expected_result_digest,
+                outcome="passed",
+            )
+
+        def classify_open(self, context):
+            return consolidation_transport_coordinator.TransportRoutingObservation(
+                state="prior",
+                digest=context.prior_digest,
+            )
+
+        def open_routing(self, _context) -> None:
+            self.opened = True
+
+    supervisor = DriftingSupervisor()
+    with pytest.raises(
+        consolidation_transport_coordinator.ConsolidationTransportCoordinatorUnavailable
+    ):
+        consolidation_transport_coordinator.verify_exact_cell_transport(
+            vault_root=vault,
+            admission=arguments["admission"],
+            journal_digest=arguments["journal_digest"],
+            basis=basis,
+            contracts=_surface_contracts(),
+            supervisor=supervisor,
+            recorded_at="2026-08-31T12:00:09.000Z",
+        )
+
+    assert supervisor.stopped and not supervisor.opened
+    assert arguments["admission"].reload().state.phase == "transport-verified"
+
+
+def test_transport_readiness_drift_refuses_before_stopping_routing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_transport_coordinator
+
+    vault, arguments, manifest, verified = _verified_integration_run(
+        tmp_path,
+        monkeypatch,
+    )
+    basis = _integration_transport_basis(arguments, manifest, verified)
+
+    class RefusingSupervisor(consolidation_transport_coordinator.TransportSupervisor):
+        stopped = False
+
+        def revalidate_pre_stop_basis(self, _basis) -> str:
+            return "f" * 64
+
+        def classify_stop(self, _context):
+            raise AssertionError("routing classification must follow readiness")
+
+        def stop_and_drain(self, _context) -> None:
+            self.stopped = True
+
+        def revalidate_basis(self, _plan) -> str:
+            raise AssertionError("the exact stopped-cell plan must not exist")
+
+        def run_probe(self, _probe, _context):
+            raise AssertionError("probes must not run")
+
+        def classify_open(self, _context):
+            raise AssertionError("routing must remain closed")
+
+        def open_routing(self, _context) -> None:
+            raise AssertionError("routing must remain closed")
+
+    supervisor = RefusingSupervisor()
+    with pytest.raises(
+        consolidation_transport_coordinator.ConsolidationTransportCoordinatorUnavailable
+    ):
+        consolidation_transport_coordinator.verify_exact_cell_transport(
+            vault_root=vault,
+            admission=arguments["admission"],
+            journal_digest=arguments["journal_digest"],
+            basis=basis,
+            contracts=_surface_contracts(),
+            supervisor=supervisor,
+            recorded_at="2026-08-31T12:00:09.000Z",
+        )
+
+    assert not supervisor.stopped
+    assert arguments["admission"].reload().state.phase == "verified"
+
+
+def test_transport_retry_adopts_final_effects_without_repeating_side_effects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import (
+        consolidation_receipts,
+        consolidation_transport_coordinator,
+    )
+
+    vault, arguments, manifest, verified = _verified_integration_run(
+        tmp_path,
+        monkeypatch,
+    )
+    basis = _integration_transport_basis(arguments, manifest, verified)
+
+    class StableSupervisor(consolidation_transport_coordinator.TransportSupervisor):
+        stopped = False
+        opened = False
+        stop_calls = 0
+        open_calls = 0
+        probe_calls = 0
+
+        def revalidate_pre_stop_basis(self, basis) -> str:
+            return _pre_stop_basis_digest(basis)
+
+        def classify_stop(self, context):
+            return consolidation_transport_coordinator.TransportRoutingObservation(
+                state="target" if self.stopped else "prior",
+                digest=context.target_digest if self.stopped else context.prior_digest,
+            )
+
+        def stop_and_drain(self, _context) -> None:
+            self.stop_calls += 1
+            self.stopped = True
+
+        def revalidate_basis(self, plan) -> str:
+            return plan.basis.digest
+
+        def run_probe(self, probe, _context):
+            self.probe_calls += 1
+            return consolidation_transport_coordinator.TransportProbeTerminal(
+                schema=consolidation_transport_coordinator.TRANSPORT_PROBE_TERMINAL_SCHEMA,
+                probe_id=probe.probe_id,
+                probe_digest=probe.probe_digest,
+                result_digest=probe.expected_result_digest,
+                outcome="passed",
+            )
+
+        def classify_open(self, context):
+            return consolidation_transport_coordinator.TransportRoutingObservation(
+                state="target" if self.opened else "prior",
+                digest=context.target_digest if self.opened else context.prior_digest,
+            )
+
+        def open_routing(self, _context) -> None:
+            self.open_calls += 1
+            self.opened = True
+
+    supervisor = StableSupervisor()
+    call = {
+        "vault_root": vault,
+        "admission": arguments["admission"],
+        "journal_digest": arguments["journal_digest"],
+        "basis": basis,
+        "contracts": _surface_contracts(),
+        "supervisor": supervisor,
+        "recorded_at": "2026-08-31T12:00:09.000Z",
+    }
+    first = consolidation_transport_coordinator.verify_exact_cell_transport(**call)
+    first_ids = tuple(
+        record["event_id"]
+        for record in consolidation_receipts._active_records(vault)  # noqa: SLF001
+    )
+    second = consolidation_transport_coordinator.verify_exact_cell_transport(**call)
+    second_ids = tuple(
+        record["event_id"]
+        for record in consolidation_receipts._active_records(vault)  # noqa: SLF001
+    )
+
+    assert first.transport_journal == second.transport_journal
+    assert first_ids == second_ids
+    assert supervisor.stop_calls == 1
+    assert supervisor.open_calls == 1
+    assert supervisor.probe_calls == len(_surface_contracts())
+
+
+@pytest.mark.parametrize(
+    "crash_at",
+    (
+        "after-stop-effect-final",
+        "after-transport-journal",
+        "after-transport-verifying",
+        "after-probe-route:0",
+        "after-probe-result:0",
+        "after-probe-effect-final:0",
+        "after-probe-aggregate-final:0",
+        "after-transport-verified-effect-final",
+        "after-transport-verified-aggregate-final",
+        "after-transport-verified-phase",
+        "after-routing-opening-phase",
+        "after-routing-open-side-effect",
+        "after-routing-open-effect-final",
+        "after-routing-open-aggregate-final",
+    ),
+)
+def test_transport_cross_store_crash_stays_sealed_and_resumes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    crash_at: str,
+) -> None:
+    from exomem.governance import (
+        consolidation_admission,
+        consolidation_transport_coordinator,
+    )
+
+    vault, arguments, manifest, verified = _verified_integration_run(
+        tmp_path,
+        monkeypatch,
+    )
+    basis = _integration_transport_basis(arguments, manifest, verified)
+
+    class CrashSupervisor(consolidation_transport_coordinator.TransportSupervisor):
+        stopped = False
+        opened = False
+
+        def revalidate_pre_stop_basis(self, current) -> str:
+            return _pre_stop_basis_digest(current)
+
+        def classify_stop(self, context):
+            return consolidation_transport_coordinator.TransportRoutingObservation(
+                state="target" if self.stopped else "prior",
+                digest=context.target_digest if self.stopped else context.prior_digest,
+            )
+
+        def stop_and_drain(self, _context) -> None:
+            self.stopped = True
+
+        def revalidate_basis(self, plan) -> str:
+            return plan.basis.digest
+
+        def run_probe(self, probe, _context):
+            return consolidation_transport_coordinator.TransportProbeTerminal(
+                schema=consolidation_transport_coordinator.TRANSPORT_PROBE_TERMINAL_SCHEMA,
+                probe_id=probe.probe_id,
+                probe_digest=probe.probe_digest,
+                result_digest=probe.expected_result_digest,
+                outcome="passed",
+            )
+
+        def classify_open(self, context):
+            return consolidation_transport_coordinator.TransportRoutingObservation(
+                state="target" if self.opened else "prior",
+                digest=context.target_digest if self.opened else context.prior_digest,
+            )
+
+        def open_routing(self, _context) -> None:
+            self.opened = True
+
+    def crash(point: str) -> None:
+        if point == crash_at:
+            raise RuntimeError("simulated crash")
+
+    supervisor = CrashSupervisor()
+    call = {
+        "vault_root": vault,
+        "admission": arguments["admission"],
+        "journal_digest": arguments["journal_digest"],
+        "basis": basis,
+        "contracts": _surface_contracts(),
+        "supervisor": supervisor,
+        "recorded_at": "2026-08-31T12:00:09.000Z",
+    }
+    monkeypatch.setattr(consolidation_transport_coordinator, "_crash_point", crash)
+    with pytest.raises(
+        consolidation_transport_coordinator.ConsolidationTransportCoordinatorUnavailable
+    ):
+        consolidation_transport_coordinator.verify_exact_cell_transport(**call)
+
+    with pytest.raises(
+        consolidation_admission.ConsolidationAdmissionUnavailable,
+        match="^CONSOLIDATION_SEALED$",
+    ):
+        with arguments["admission"].admit_read():
+            pass
+
+    monkeypatch.setattr(
+        consolidation_transport_coordinator,
+        "_crash_point",
+        lambda _point: None,
+    )
+    resumed = consolidation_transport_coordinator.verify_exact_cell_transport(**call)
+    assert resumed.seal_state.phase == "routing-opening"
+    assert all(effect.status == "final" for effect in resumed.transport_journal.effects[:-1])


### PR DESCRIPTION
## Summary

- add a strict transport-verification journal chained to the exact finalized in-process verification terminal
- coordinate receipt-first routing stop/drain, isolated exact-cell probes, transport verification, and routing-open preparation while the durable vault seal remains closed
- revalidate the closed Hosted/readiness basis before stopping and the exact stopped-cell plan before verification and routing open
- recover monotonically across effect, aggregate-journal, phase, and routing boundaries without replaying committed side effects

Stacked after #1015. This layer deliberately stops at `routing-opening`; `complete` remains prior and the vault remains sealed. No live transport supervisor is registered by this PR. Real authenticated MCP/REST/Hosted/CLI transport and fresh-process startup recovery are the next stack slices.

## Verification

- `uv run pytest -q tests/test_consolidation_transport_verification.py tests/test_consolidation_verification.py tests/test_consolidation_receipts.py tests/test_consolidation_seal.py tests/test_consolidation_verification_manifest.py tests/test_consolidation_verification_coverage.py tests/test_consolidation_verification_registry.py` — 154 passed
- 14 injected coordinator cross-store crash boundaries — all remained sealed and resumed
- Ruff on all changed Python files
- mypy on all changed governance modules
- `uv run python scripts/validate-public-artifacts.py --repository`
- `git diff --check`