### PR TITLE
fix(runtime): stop activation work before shutdown

### DIFF
--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -1271,6 +1271,8 @@ class FileWatcher:
     def stop(self) -> None:
         self._stop.set()
         self._wake.set()
+        self._seed_published.set()
+        self._seed_complete.set()
         if self._observer is not None:
             try:
                 self._observer.stop()

--- a/src/exomem/server_runtime.py
+++ b/src/exomem/server_runtime.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import anyio
+
 from . import (
     env_compat,
     hosted_runtime,
@@ -106,6 +108,7 @@ class LocalRuntimeActivation:
         self.fallback_seconds = fallback_seconds
         self._lock = threading.Lock()
         self._started = False
+        self._shutdown = threading.Event()
         self._timer: threading.Timer | None = None
         self._thread: threading.Thread | None = None
         self.media_worker: Any | None = None
@@ -114,31 +117,44 @@ class LocalRuntimeActivation:
     def start(self) -> None:
         """Launch local workers once; safe from health and timer races."""
         with self._lock:
-            if self._started:
+            if self._started or self._shutdown.is_set():
                 return
             self._started = True
             timer = self._timer
+            thread = threading.Thread(
+                target=self._activate,
+                name="exomem-local-activation",
+                daemon=True,
+            )
+            self._thread = thread
+            thread.start()
         if timer is not None:
             timer.cancel()
-        thread = threading.Thread(
-            target=self._activate,
-            name="exomem-local-activation",
-            daemon=True,
-        )
-        with self._lock:
-            self._thread = thread
-        thread.start()
 
     def _activate(self) -> None:
+        if self._shutdown.is_set():
+            return
         self._start_component("file watcher", self._start_file_watcher)
+        if self._shutdown.is_set():
+            self._stop_background_workers()
+            return
         if self.file_watcher is None:
             # A maintained projection is authoritative only while something is
             # actually maintaining it.  The explicit watcher-off mode and a
             # watcher startup failure retain the supported walk-backed path.
             self._downgrade_recall_runtime()
         self._wait_for_recall_seed()
+        if self._shutdown.is_set():
+            self._stop_background_workers()
+            return
         self._start_component("retrieval", _start_compute_runtime)
+        if self._shutdown.is_set():
+            self._stop_background_workers()
+            return
         self._wait_for_required_admission()
+        if self._shutdown.is_set():
+            self._stop_background_workers()
+            return
         self._start_component(
             "file watcher recovery",
             self._finish_file_watcher_startup,
@@ -148,7 +164,11 @@ class LocalRuntimeActivation:
             ("media", self._start_media_worker),
         )
         for label, starter in starters:
+            if self._shutdown.is_set():
+                break
             self._start_component(label, starter)
+        if self._shutdown.is_set():
+            self._stop_background_workers()
 
     def _wait_for_recall_seed(self) -> None:
         """Order maintained-catalog verification behind watcher authority."""
@@ -196,7 +216,7 @@ class LocalRuntimeActivation:
 
         if not warmup.warmup_enabled():
             return
-        while True:
+        while not self._shutdown.is_set():
             catalog_ready = readiness.is_ready("retrieval_catalog")
             semantic_ready = readiness.is_ready("semantic_corpus")
             if catalog_ready and (semantic_ready or not readiness.is_warming()):
@@ -210,6 +230,20 @@ class LocalRuntimeActivation:
                 return
             missing = "retrieval_catalog" if not catalog_ready else "semantic_corpus"
             readiness.wait(missing, timeout=0.1)
+
+    def _stop_background_workers(self) -> None:
+        """Stop workers already owned by this activation during shutdown."""
+        for label, worker in (
+            ("media", self.media_worker),
+            ("file watcher", self.file_watcher),
+        ):
+            stop = getattr(worker, "stop", None)
+            if not callable(stop):
+                continue
+            try:
+                stop()
+            except Exception:  # noqa: BLE001 - shutdown still has to join activation
+                log.warning("%s runtime shutdown failed", label, exc_info=True)
 
     def _start_component(self, label: str, starter: Callable[[Path], Any]) -> None:
         try:
@@ -248,7 +282,16 @@ class LocalRuntimeActivation:
             try:
                 yield {}
             finally:
-                timer.cancel()
+                with self._lock:
+                    self._shutdown.set()
+                    timer = self._timer
+                    self._timer = None
+                    thread = self._thread
+                if timer is not None:
+                    timer.cancel()
+                self._stop_background_workers()
+                if thread is not None and thread is not threading.current_thread():
+                    await anyio.to_thread.run_sync(thread.join)
 
         return _lifespan
 

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -1570,6 +1570,28 @@ def test_reconcile_seed_completion_is_observable(vault, monkeypatch: pytest.Monk
     assert not thread.is_alive()
 
 
+def test_stop_unblocks_an_inflight_seed_wait(vault) -> None:
+    watcher = file_watcher.FileWatcher(vault)
+    waiting = threading.Event()
+    result: list[bool] = []
+
+    def wait_for_seed() -> None:
+        waiting.set()
+        result.append(watcher.wait_until_seeded(timeout=60.0))
+
+    thread = threading.Thread(target=wait_for_seed)
+    thread.start()
+    try:
+        assert waiting.wait(timeout=1.0)
+        watcher.stop()
+        thread.join(timeout=0.5)
+        assert not thread.is_alive()
+        assert result == [False]
+    finally:
+        watcher._seed_complete.set()
+        thread.join(timeout=1.0)
+
+
 def test_reconcile_no_drift_dispatches_nothing(vault, monkeypatch: pytest.MonkeyPatch) -> None:
     file_watcher.clear_self_write_registry()
     calls = _spy_reconcile_fanout(monkeypatch)

--- a/tests/test_server_runtime.py
+++ b/tests/test_server_runtime.py
@@ -426,6 +426,91 @@ def test_local_runtime_activation_falls_back_without_liveness_probe(
         readiness.reset()
 
 
+def test_local_runtime_lifespan_waits_for_inflight_activation_before_teardown(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_DISABLE_WARMUP", "1")
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    entered = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def start_compute(_root: Path) -> None:
+        entered.set()
+        assert release.wait(timeout=2.0)
+        finished.set()
+
+    monkeypatch.setattr(server_runtime, "_start_file_watcher", lambda _root: None)
+    monkeypatch.setattr(server_runtime, "_start_compute_runtime", start_compute)
+    monkeypatch.setattr(server_runtime, "_start_graph_drain", lambda _root: None)
+    monkeypatch.setattr(server_runtime, "_start_media_worker", lambda _root: None)
+    activation = server_runtime.LocalRuntimeActivation(vault, fallback_seconds=60.0)
+
+    async def exercise() -> None:
+        lifetime = activation.lifespan()(SimpleNamespace())
+        await lifetime.__aenter__()
+        activation.start()
+        assert await asyncio.to_thread(entered.wait, 1.0)
+        exiting = asyncio.create_task(lifetime.__aexit__(None, None, None))
+        await asyncio.sleep(0.05)
+        assert not exiting.done()
+        release.set()
+        await asyncio.wait_for(exiting, timeout=1.0)
+        assert finished.is_set()
+        assert activation._thread is not None
+        assert not activation._thread.is_alive()
+
+    try:
+        asyncio.run(exercise())
+    finally:
+        release.set()
+        thread = activation._thread
+        if thread is not None:
+            thread.join(timeout=1.0)
+        readiness.reset()
+
+
+def test_local_runtime_lifespan_interrupts_a_stuck_admission_wait(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_WARMUP", raising=False)
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    compute_started = threading.Event()
+    exited = threading.Event()
+
+    def start_compute(_root: Path) -> None:
+        readiness.begin_warm()
+        compute_started.set()
+
+    monkeypatch.setattr(server_runtime, "_start_file_watcher", lambda _root: None)
+    monkeypatch.setattr(server_runtime, "_start_compute_runtime", start_compute)
+    monkeypatch.setattr(server_runtime, "_start_graph_drain", lambda _root: None)
+    monkeypatch.setattr(server_runtime, "_start_media_worker", lambda _root: None)
+    activation = server_runtime.LocalRuntimeActivation(vault, fallback_seconds=60.0)
+
+    async def exercise() -> None:
+        async with activation.lifespan()(SimpleNamespace()):
+            activation.start()
+            assert await asyncio.to_thread(compute_started.wait, 1.0)
+        exited.set()
+
+    runner = threading.Thread(target=lambda: asyncio.run(exercise()), daemon=True)
+    runner.start()
+    try:
+        assert compute_started.wait(timeout=1.0)
+        assert exited.wait(timeout=0.5)
+        assert activation._thread is not None
+        assert not activation._thread.is_alive()
+    finally:
+        readiness.mark_ready("retrieval_catalog")
+        readiness.mark_ready("semantic_corpus")
+        readiness.finish_warm()
+        runner.join(timeout=1.0)
+        readiness.reset()
+
+
 def test_media_worker_startup_reconciles_media_missed_while_service_was_stopped(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
The local MCP runtime could leave its startup thread running after the application lifespan had exited. That leaked media and retrieval startup work into later test or application state, intermittently invalidating otherwise valid authorization-session requests.

This change makes shutdown explicit and cooperative: it stops phase progression, interrupts warm-admission and watcher-seed waits, stops workers already owned by the activation, and waits for the activation thread to finish before lifespan teardown completes.

Verification:
- `96 passed` across `test_server_runtime.py`, `test_file_watcher.py`, and `test_authorization_session_wire_reconnect.py`
- exact core shard passed the previously failing actual-wire authorization test in sequence
- Ruff on changed files passed
- public repository artifact privacy gate passed
- independent concurrency review passed after one fix round