### PR TITLE
test(auth): isolate wire sessions from startup activation

### DIFF
--- a/tests/test_authorization_session_wire_reconnect.py
+++ b/tests/test_authorization_session_wire_reconnect.py
@@ -14,7 +14,7 @@ import pytest
 from record_fixtures import copy_dataset_fixture
 from starlette.testclient import TestClient
 
-from exomem import commands, metrics, server, video_frames, writer_lease
+from exomem import commands, metrics, server, server_runtime, video_frames, writer_lease
 from exomem.governance import (
     authorization_custody,
     authorization_serving_membership,
@@ -331,6 +331,11 @@ def _configure_v4_authority(
 
 def _build_replica(vault: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(server, "load_dotenv", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        server_runtime.LocalRuntimeActivation,
+        "start",
+        lambda self: None,
+    )
     monkeypatch.setenv("EXOMEM_VAULT_PATH", str(vault))
     monkeypatch.setenv(
         "EXOMEM_WRITER_LEASE_STATE_DIR", str(vault.parent / "writer-lease-state")


### PR DESCRIPTION
The release matrix exposed a timing-dependent failure in the authorization-session wire test. Its server fixture allowed unrelated fallback runtime activation to publish a new catalog tuple while the test was still exercising routes, correctly causing fail-closed authorization admission during the acknowledgement window.

Keep production authorization semantics unchanged and make this actual-wire test own only the lifecycle it asserts by disabling `LocalRuntimeActivation.start` in its replica helper. This supersedes #1017; route ordering no longer hides the fixture race.

Verification:
- authorization reconnect module: 3 passed
- formerly flaky route: 20 consecutive passes
- authorization/runtime/watcher scope: 96 passed
- Ruff: passed
- public artifact privacy gate: 3,495 files / 3,563 text payloads clean
- `git diff --check`: passed