### PR TITLE
feat(governance): enforce durable vault admission

### DIFF
--- a/openspec/changes/add-governed-vault-consolidation/design.md
+++ b/openspec/changes/add-governed-vault-consolidation/design.md
@@ -959,6 +959,21 @@ operation, but no second operation or plan kind can reuse it.
 
 ### 9. Seal every ordinary content surface, including the owner's
 
+An exactly absent seal subtree denotes a legacy vault that has not enrolled in
+the consolidation lifecycle; it is not an implicit `open` member. Enrollment is
+an explicit offline/pre-start owner operation after authenticated cell identity
+already exists. It creates the immutable revision-0 `open` snapshot and active
+pointer under exclusive runtime-lifetime authority, then reloads the exact
+identity-bound state before serving begins. Ordinary dispatch, readiness, and
+admission never create or adopt identity or seal state. Hosted enrollment uses
+the cell lifetime lock. Local enrollment requires a process-safe vault presence
+registry that blocks new server/direct-CLI registrations and proves all live
+slots have drained without serializing concurrent reads; until that registry is
+available, local enrollment remains unavailable. Any seal-path presence other
+than a complete authenticated store—including a crash between revision-0
+snapshot and active-pointer publication—fails closed and is recovered only by
+the explicit enrollment operation.
+
 Apply first acquires the destination writer authority and transitions to a
 durable destination-wide seal. The seal drains admitted reads, writes,
 transfers, and background writers, then rejects all new ordinary content reads

--- a/openspec/changes/add-governed-vault-consolidation/specs/hosted-mutation-safety/spec.md
+++ b/openspec/changes/add-governed-vault-consolidation/specs/hosted-mutation-safety/spec.md
@@ -1,5 +1,31 @@
 ## ADDED Requirements
 
+### Requirement: Consolidation enrollment is explicit and offline
+
+An exactly absent consolidation-seal subtree SHALL denote a legacy vault that
+is not enrolled, not an inferred `open` state. Enrollment SHALL be an explicit
+owner-only pre-start operation over an already authenticated cell identity. It
+SHALL exclude every server and direct-CLI runtime for that vault, create the
+immutable revision-0 `open` snapshot and active pointer, and reload their exact
+identity binding before the runtime may advertise readiness. Hosted SHALL use
+its cell lifetime exclusion; local SHALL use process-safe vault presence slots
+that allow concurrent readers but block new registrations during enrollment.
+Ordinary dispatch, readiness, and admission SHALL NOT initialize a seal or
+adopt identity. Any seal-path presence other than a complete authenticated
+store SHALL fail closed.
+
+#### Scenario: Enrollment is requested while a runtime is live
+
+- **WHEN** a Hosted cell, local server, or direct CLI invocation holds runtime presence for the destination
+- **THEN** enrollment refuses before identity or seal publication
+- **AND** ordinary traffic continues under the unchanged legacy or enrolled state
+
+#### Scenario: Enrollment crashes after the initial snapshot
+
+- **WHEN** revision 0 is durable but its active pointer is absent after restart
+- **THEN** ordinary admission and readiness fail closed
+- **AND** only an exact explicit enrollment retry may complete that pointer without adopting a different identity or timestamp
+
 ### Requirement: A durable consolidation seal composes with the shared vault boundary
 
 The destination-wide consolidation seal SHALL be keyed by canonical vault

--- a/openspec/changes/add-governed-vault-consolidation/tasks.md
+++ b/openspec/changes/add-governed-vault-consolidation/tasks.md
@@ -487,12 +487,20 @@ binds that reference and observed digest; no caller field selects K.
   consolidation-sealed(vault,run,operation,phase,journal)`: deletion dominates,
   only the exact consolidation journal can unseal its own kind, and generic
   resume/consolidation recovery never reopens deletion. Other canonical vault
-  identities remain independently available.
+  identities remain independently available. Prove exact seal-subtree absence is
+  the only legacy-unenrolled fast path; empty, partial, linked, stray, malformed,
+  or mismatched stores fail closed. Prove first enrollment is explicit and
+  offline: Hosted excludes its lifetime holder, local excludes server/direct-CLI
+  presence without serializing concurrent readers, and no ordinary request,
+  readiness probe, or admission path creates/adopts identity or revision 0.
 - [ ] 6.5 Implement one durable seal/admission state integrated with the shared
   lifecycle and process-safe writer boundary. Place the outer sealed response before
   retrieval, raw serialization, enumeration, mutation dispatch, and error assembly;
   retain existing release decisions/projectors/scrubber underneath it and keep
-  deletion-seal semantics irreversible.
+  deletion-seal semantics irreversible. Add explicit owner-only pre-start
+  enrollment over an existing authenticated identity, Hosted lifetime exclusion,
+  and a vault-keyed local runtime-presence registry; do not lazily initialize or
+  adopt through product dispatch.
 - [ ] 6.6 Add red Hosted owner-control admission tests in
   `tests/test_consolidation_control_admission.py` proving apply and its
   identical tagged-request/operation-id resume,

--- a/src/exomem/cli_ops.py
+++ b/src/exomem/cli_ops.py
@@ -135,6 +135,7 @@ _SERVICE_UNAVAILABLE_CODES = frozenset(
         "WRITER_COORDINATOR_UNAVAILABLE",
         "WRITER_COORDINATOR_CONTRACT_ABSENT",
         "MUTATION_LOCK_UNAVAILABLE",
+        "VAULT_UNAVAILABLE",
         # Retrieval-index-reliability (restore-indexed-category-recall): a safe
         # exact category/kind plan whose maintained semantic catalog cannot yet
         # prove completeness — retryable with bounded `retry_after_ms`, never a

--- a/src/exomem/governance/consolidation_runtime.py
+++ b/src/exomem/governance/consolidation_runtime.py
@@ -1,0 +1,313 @@
+"""Production admission and readiness wiring for durable consolidation seals."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Any
+
+from ..cli_ops import OpError
+from . import (
+    consolidation_admission,
+    consolidation_authority,
+    consolidation_identity,
+    consolidation_seal,
+)
+
+_BOUND_ADMISSION: ContextVar[consolidation_admission.ConsolidationAdmission | None] = (
+    ContextVar("exomem_consolidation_admission", default=None)
+)
+_BOUND_RESOLVER: ContextVar[
+    tuple[Path, Callable[[], consolidation_admission.ConsolidationAdmission | None]] | None
+] = ContextVar("exomem_consolidation_admission_resolver", default=None)
+_BOUND_VERIFICATION: ContextVar[
+    tuple[consolidation_admission.ConsolidationAdmission, object] | None
+] = ContextVar("exomem_consolidation_verification_admission", default=None)
+
+
+class ConsolidationRuntimeUnavailable(RuntimeError):
+    """Internal content-free refusal to construct the production boundary."""
+
+
+def _public_refusal() -> OpError:
+    return OpError("VAULT_UNAVAILABLE", "vault is unavailable")
+
+
+def _local_admission(vault_root: Path) -> consolidation_admission.ConsolidationAdmission | None:
+    store = consolidation_seal.ConsolidationSealStore(vault_root)
+    try:
+        state = store.load_optional()
+        if state is None:
+            return None
+        identity = consolidation_identity.load_local_identity(
+            vault_root,
+            now=int(time.time()),
+        )
+        if identity.record_digest != state.vault_binding_digest:
+            raise ConsolidationRuntimeUnavailable
+        return consolidation_admission.ConsolidationAdmission(
+            vault_root,
+            vault_binding_digest=identity.record_digest,
+            store=store,
+        )
+    except (
+        consolidation_admission.ConsolidationAdmissionUnavailable,
+        consolidation_identity.ConsolidationIdentityUnavailable,
+        consolidation_seal.ConsolidationSealUnavailable,
+        OSError,
+        RuntimeError,
+        ValueError,
+    ) as error:
+        raise ConsolidationRuntimeUnavailable from error
+
+
+def load_hosted_admission(
+    binding: Any,
+    *,
+    custody: Any | None = None,
+    now: int | None = None,
+) -> consolidation_admission.ConsolidationAdmission | None:
+    """Construct the exact Hosted admission only when a seal store exists."""
+
+    vault_root = Path(binding.vault_root).absolute()
+    store = consolidation_seal.ConsolidationSealStore(vault_root)
+    try:
+        state = store.load_optional()
+        if state is None:
+            return None
+        current_time = int(time.time()) if now is None else now
+        if custody is None:
+            from . import authorization_custody
+
+            custody = authorization_custody.load_authorization_custody(
+                vault_root,
+                now=current_time,
+            )
+        identity = consolidation_identity.load_hosted_identity(
+            binding,
+            custody=custody,
+            now=current_time,
+        )
+        if identity.record_digest != state.vault_binding_digest:
+            raise ConsolidationRuntimeUnavailable
+        return consolidation_admission.ConsolidationAdmission(
+            vault_root,
+            vault_binding_digest=identity.record_digest,
+            store=store,
+        )
+    except (
+        consolidation_admission.ConsolidationAdmissionUnavailable,
+        consolidation_identity.ConsolidationIdentityUnavailable,
+        consolidation_seal.ConsolidationSealUnavailable,
+        OSError,
+        RuntimeError,
+        ValueError,
+    ) as error:
+        raise ConsolidationRuntimeUnavailable from error
+
+
+@contextmanager
+def bind_admission(
+    admission: consolidation_admission.ConsolidationAdmission,
+) -> Iterator[None]:
+    """Bind a trusted Hosted/supervisor-owned admission to this invocation."""
+
+    if not isinstance(admission, consolidation_admission.ConsolidationAdmission):
+        raise TypeError("admission must be a ConsolidationAdmission")
+    token = _BOUND_ADMISSION.set(admission)
+    try:
+        yield
+    finally:
+        _BOUND_ADMISSION.reset(token)
+
+
+@contextmanager
+def bind_hosted_admission(binding: Any) -> Iterator[None]:
+    """Bind a trusted Hosted identity resolver without request-supplied facts."""
+
+    vault_root = Path(binding.vault_root).absolute()
+    token = _BOUND_RESOLVER.set(
+        (vault_root, lambda: load_hosted_admission(binding))
+    )
+    try:
+        yield
+    finally:
+        _BOUND_RESOLVER.reset(token)
+
+
+def _require_verification(
+    admission: consolidation_admission.ConsolidationAdmission,
+    authority: object,
+) -> None:
+    try:
+        state = admission.reload().state
+        if state.kind != "consolidation-sealed" or state.phase != "verifying":
+            raise ConsolidationRuntimeUnavailable
+        consolidation_authority.require_authority(
+            authority,
+            vault_binding_digest=state.vault_binding_digest,
+            run_id=state.run_id,
+            operation_id=state.operation_id,
+            journal_digest=state.journal_digest,
+            phase="verifying",
+            action="verify",
+        )
+    except (
+        consolidation_admission.ConsolidationAdmissionUnavailable,
+        consolidation_authority.ConsolidationAuthorityUnavailable,
+        ConsolidationRuntimeUnavailable,
+    ) as error:
+        raise ConsolidationRuntimeUnavailable from error
+
+
+@contextmanager
+def bind_verification_admission(
+    admission: consolidation_admission.ConsolidationAdmission,
+    authority: object,
+) -> Iterator[None]:
+    """Admit exact in-process verification without widening ordinary traffic."""
+
+    if not isinstance(admission, consolidation_admission.ConsolidationAdmission):
+        raise TypeError("admission must be a ConsolidationAdmission")
+    _require_verification(admission, authority)
+    admission_token = _BOUND_ADMISSION.set(admission)
+    verification_token = _BOUND_VERIFICATION.set((admission, authority))
+    try:
+        yield
+    finally:
+        _BOUND_VERIFICATION.reset(verification_token)
+        _BOUND_ADMISSION.reset(admission_token)
+
+
+def _resolve_admission(
+    vault_root: Path,
+) -> consolidation_admission.ConsolidationAdmission | None:
+    bound = _BOUND_ADMISSION.get()
+    if bound is not None:
+        if bound.vault_root != vault_root.absolute():
+            raise ConsolidationRuntimeUnavailable
+        return bound
+    resolver = _BOUND_RESOLVER.get()
+    if resolver is not None:
+        expected_root, load = resolver
+        if expected_root != vault_root.absolute():
+            raise ConsolidationRuntimeUnavailable
+        return load()
+    return _local_admission(vault_root)
+
+
+@contextmanager
+def _admit(vault_root: Path, *, kind: str) -> Iterator[None]:
+    try:
+        admission = _resolve_admission(Path(vault_root).absolute())
+    except ConsolidationRuntimeUnavailable:
+        raise _public_refusal() from None
+    if admission is None:
+        yield
+        return
+    verification = _BOUND_VERIFICATION.get()
+    if verification is not None:
+        expected_admission, authority = verification
+        try:
+            if admission is not expected_admission or kind != "read":
+                raise ConsolidationRuntimeUnavailable
+            _require_verification(admission, authority)
+        except ConsolidationRuntimeUnavailable:
+            raise _public_refusal() from None
+        yield
+        return
+    try:
+        if kind == "read":
+            boundary = admission.admit_read()
+        elif kind == "mutation":
+            boundary = admission.admit_mutation()
+        elif kind == "transfer":
+            boundary = admission.admit_transfer()
+        elif kind == "background":
+            boundary = admission.admit_background()
+        else:  # pragma: no cover - only closed wrappers below call this helper
+            raise AssertionError(f"unknown consolidation admission kind: {kind}")
+        with boundary:
+            yield
+    except consolidation_admission.ConsolidationAdmissionUnavailable:
+        raise _public_refusal() from None
+
+
+@contextmanager
+def admit_command(vault_root: Path, *, read_only: bool) -> Iterator[None]:
+    """Apply one content-free outer boundary before command dispatch."""
+
+    with _admit(vault_root, kind="read" if read_only else "mutation"):
+        yield
+
+
+@contextmanager
+def admit_mutation(vault_root: Path) -> Iterator[None]:
+    """Apply the outer boundary to a non-command mutation surface."""
+
+    with _admit(vault_root, kind="mutation"):
+        yield
+
+
+@contextmanager
+def admit_transfer(vault_root: Path) -> Iterator[None]:
+    """Apply the outer boundary to an upload or download lifetime."""
+
+    with _admit(vault_root, kind="transfer"):
+        yield
+
+
+@contextmanager
+def admit_upload(vault_root: Path) -> Iterator[None]:
+    """Hold both transfer and mutation admission for an upload lifetime."""
+
+    with admit_transfer(vault_root):
+        with admit_mutation(vault_root):
+            yield
+
+
+@contextmanager
+def admit_background(vault_root: Path) -> Iterator[None]:
+    """Apply the outer boundary to one background operation."""
+
+    with _admit(vault_root, kind="background"):
+        yield
+
+
+def readiness(
+    vault_root: Path,
+    *,
+    admission: consolidation_admission.ConsolidationAdmission | None = None,
+) -> dict[str, bool]:
+    """Return phase-free public admission readiness from durable state."""
+
+    try:
+        resolved = admission if admission is not None else _resolve_admission(vault_root)
+        admitted = resolved is None or resolved.reload().state.kind == "open"
+    except (
+        ConsolidationRuntimeUnavailable,
+        consolidation_admission.ConsolidationAdmissionUnavailable,
+        OSError,
+        RuntimeError,
+        ValueError,
+    ):
+        admitted = False
+    return {"admitted": admitted}
+
+
+__all__ = [
+    "ConsolidationRuntimeUnavailable",
+    "admit_background",
+    "admit_command",
+    "admit_mutation",
+    "admit_transfer",
+    "admit_upload",
+    "bind_admission",
+    "bind_hosted_admission",
+    "bind_verification_admission",
+    "load_hosted_admission",
+    "readiness",
+]

--- a/src/exomem/governance/consolidation_seal.py
+++ b/src/exomem/governance/consolidation_seal.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import re
+import stat
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
@@ -209,6 +211,43 @@ class ConsolidationSealStore:
     def _snapshot_path(self, revision: int) -> Path:
         return self.base / "snapshots" / f"{revision}.json"
 
+    @staticmethod
+    def _linked(path: Path) -> bool:
+        is_junction = getattr(os.path, "isjunction", lambda _path: False)
+        return os.path.islink(path) or bool(is_junction(path))
+
+    def _validate_layout_locked(self, state: ConsolidationSealState) -> None:
+        try:
+            if self._linked(self.base) or not stat.S_ISDIR(
+                os.stat(self.base, follow_symlinks=False).st_mode
+            ):
+                _fail("SEAL_STORE_CORRUPT")
+            top = {entry.name: entry for entry in os.scandir(self.base)}
+            if set(top) != {"active.json", "snapshots"}:
+                _fail("SEAL_STORE_CORRUPT")
+            if top["active.json"].is_symlink() or not top["active.json"].is_file(
+                follow_symlinks=False
+            ):
+                _fail("SEAL_STORE_CORRUPT")
+            snapshots_path = self.base / "snapshots"
+            if self._linked(snapshots_path) or not top["snapshots"].is_dir(
+                follow_symlinks=False
+            ):
+                _fail("SEAL_STORE_CORRUPT")
+            snapshots = {
+                entry.name: entry for entry in os.scandir(snapshots_path)
+            }
+            expected = {f"{revision}.json" for revision in range(state.revision + 1)}
+            if set(snapshots) != expected or any(
+                entry.is_symlink() or not entry.is_file(follow_symlinks=False)
+                for entry in snapshots.values()
+            ):
+                _fail("SEAL_STORE_CORRUPT")
+        except ConsolidationSealUnavailable:
+            raise
+        except (OSError, ValueError):
+            _fail("SEAL_STORE_CORRUPT")
+
     def _read_optional(self, path: Path, *, limit: int) -> bytes | None:
         try:
             return reserved_paths._read_owner_bytes(  # noqa: SLF001
@@ -388,6 +427,26 @@ class ConsolidationSealStore:
             if error.code == "SEAL_INPUT_INVALID":
                 _fail("SEAL_STORE_CORRUPT")
             raise
+
+    def load_optional(self) -> ConsolidationSealState | None:
+        """Load a complete store, returning ``None`` only for exact absence."""
+
+        # Legacy-unenrolled vaults must not enter writer coordination merely to
+        # prove that no seal path exists. Explicit enrollment owns the separate
+        # offline/runtime-presence exclusion that makes this fast path stable.
+        if not os.path.lexists(self.base):
+            return None
+        with _authority(self.vault_root, mutation=False):
+            if not os.path.lexists(self.base):
+                return None
+            try:
+                state, _active = self._load_locked()
+            except ConsolidationSealUnavailable as error:
+                if error.code == "SEAL_NOT_INITIALIZED":
+                    _fail("SEAL_STORE_CORRUPT")
+                raise
+            self._validate_layout_locked(state)
+            return state
 
     @staticmethod
     def _require_vault(state: ConsolidationSealState, expected: str) -> None:

--- a/src/exomem/governance/consolidation_verification_coordinator.py
+++ b/src/exomem/governance/consolidation_verification_coordinator.py
@@ -20,6 +20,7 @@ from . import (
     consolidation_rebuild,
     consolidation_rebuild_journal,
     consolidation_receipts,
+    consolidation_runtime,
     consolidation_seal,
     consolidation_verification,
     consolidation_verification_journal,
@@ -336,6 +337,7 @@ def _validate_existing_probe_effect(
 def _execute_probes(
     *,
     vault_root: Path,
+    admission: consolidation_admission.ConsolidationAdmission,
     store: consolidation_verification_journal.ConsolidationVerificationJournalStore,
     manifest: consolidation_verification_manifest.VerificationManifest,
     vault_binding_digest: str,
@@ -427,11 +429,12 @@ def _execute_probes(
                 authority=authority,
                 contract=expected_contract,
             )
-            terminal = consolidation_verification._run_probe(  # noqa: SLF001
-                _canonical_surface_probe_runner,
-                expected_probe,
-                context,
-            )
+            with consolidation_runtime.bind_verification_admission(admission, authority):
+                terminal = consolidation_verification._run_probe(  # noqa: SLF001
+                    _canonical_surface_probe_runner,
+                    expected_probe,
+                    context,
+                )
             if _snapshot_census(vault_root) != current.canonical_census_digest:
                 _fail()
             store.record_probe_result(expected_probe, terminal.result_digest)
@@ -759,6 +762,7 @@ def verify_rebuilt_destination(
         )
         probe_effects = _execute_probes(
             vault_root=root,
+            admission=admission,
             store=journal_store,
             manifest=manifest,
             vault_binding_digest=checked_vault,

--- a/src/exomem/runtime_readiness.py
+++ b/src/exomem/runtime_readiness.py
@@ -352,6 +352,7 @@ def build_runtime_readiness(
     observability: Mapping[str, Any] | None = None,
     traffic: Mapping[str, Any] | None = None,
     retrieval: Mapping[str, Any] | None = None,
+    consolidation: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the public readiness payload from already-measured coordination state."""
     enabled = bool(coordination.get("enabled"))
@@ -372,6 +373,13 @@ def build_runtime_readiness(
             reasons.append("coordination_role_unknown")
         if replica_id is None:
             reasons.append("replica_identity_missing")
+
+    consolidation_payload: dict[str, bool] | None = None
+    if consolidation is not None:
+        consolidation_admitted = bool(consolidation.get("admitted"))
+        consolidation_payload = {"admitted": consolidation_admitted}
+        if not consolidation_admitted:
+            reasons.append("vault_admission_unavailable")
 
     retrieval_payload: dict[str, object] | None = None
     retrieval_admitted = True
@@ -430,6 +438,8 @@ def build_runtime_readiness(
     }
     if retrieval_payload is not None:
         payload["retrieval"] = retrieval_payload
+    if consolidation_payload is not None:
+        payload["consolidation"] = consolidation_payload
     if traffic is not None:
         payload["traffic"] = dict(traffic)
     return payload
@@ -546,23 +556,34 @@ def runtime_readiness(
 ) -> dict[str, Any]:
     """Measure this process's eligibility without exposing vault or credential state."""
     from . import readiness
+    from .governance import consolidation_runtime
     from .session_validation_cache import session_store_readiness
     from .writer_lease import coordination_status
 
     coordination: Mapping[str, Any]
-    configured_vault: Path | None = None
+    configured_raw = os.environ.get("EXOMEM_VAULT_PATH", "").strip()
+    configured_path = Path(configured_raw).expanduser() if configured_raw else None
+    configured_vault = (
+        configured_path
+        if configured_path is not None and configured_path.is_absolute()
+        else None
+    )
+    consolidation_vault = (
+        configured_path.resolve(strict=False)
+        if configured_path is not None
+        else None
+    )
+    consolidation = (
+        consolidation_runtime.readiness(consolidation_vault)
+        if consolidation_vault is not None
+        else None
+    )
     try:
-        configured_raw = os.environ.get("EXOMEM_VAULT_PATH", "").strip()
         # Only an absolute path names a boundary this process can probe. A
         # relative one resolves against whatever the service's cwd happens to
         # be, so it would measure some other boundary and publish that as this
         # vault's state; that is a blind "free", which is the failure being
         # fixed here. Fall through to the process-local `unknown` instead.
-        configured_vault = (
-            Path(configured_raw)
-            if configured_raw and Path(configured_raw).is_absolute()
-            else None
-        )
         measured = _bounded_coordination_status(
             configured_vault,
             coordination_status,
@@ -613,4 +634,5 @@ def runtime_readiness(
             else get_silent_traffic_monitor().snapshot()
         ),
         retrieval=retrieval,
+        consolidation=consolidation,
     )

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -492,6 +492,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
             expose_tier2=expose_tier2,
             private_authenticator=security_authority,
             transfer_security_authority=security_authority,
+            consolidation_binding=runtime.hosted_binding,
         )
     else:
         runtime_activation = LocalRuntimeActivation(runtime.vault_root)

--- a/src/exomem/server_hosted.py
+++ b/src/exomem/server_hosted.py
@@ -14,7 +14,7 @@ import stat
 import threading
 import time
 from collections.abc import AsyncIterator, Callable, Mapping
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, ExitStack, nullcontext
 from pathlib import Path
 from typing import Any, BinaryIO
 from urllib.parse import quote
@@ -43,6 +43,7 @@ from .governance import (
     authorization_request,
     authorization_session_lifecycle,
     authorization_transport,
+    consolidation_runtime,
 )
 from .hosted_runtime import (
     HostedCellConfig,
@@ -818,7 +819,7 @@ def _open_bounded_vault_file(
 async def _stream_bounded_file(
     stream: BinaryIO,
     size: int,
-    admission: AbstractContextManager[None],
+    admission: AbstractContextManager[Any],
 ) -> AsyncIterator[bytes]:
     remaining = size
     try:
@@ -862,6 +863,7 @@ def register_hosted_routes(
     private_authenticator: Any | None = None,
     transfer_security_authority: hosted_transfer.TransferSecurityAuthority | None = None,
     runtime_temp_authority: hosted_runtime_temp.HostedRuntimeTempAuthority | None = None,
+    consolidation_binding: Any | None = None,
 ) -> None:
     """Register private v1 plus the two exact public transfer-v2 capabilities."""
 
@@ -906,6 +908,22 @@ def register_hosted_routes(
         invoke = invoke_command
     guard_factory = mutation_guard_factory or _default_mutation_guard
     preserve_stream = preserve_stream_func or _default_preserve_stream
+
+    def _new_transfer_admission(*, upload: bool) -> AbstractContextManager[Any]:
+        with ExitStack() as stack:
+            with (
+                consolidation_runtime.bind_hosted_admission(consolidation_binding)
+                if consolidation_binding is not None
+                else nullcontext()
+            ):
+                stack.enter_context(
+                    consolidation_runtime.admit_upload(config.vault_root)
+                    if upload
+                    else consolidation_runtime.admit_transfer(config.vault_root)
+                )
+            stack.enter_context(lifecycle.admit_public_transfer())
+            return stack.pop_all()
+
     upload_idempotency = IdempotencyStore(config.state_root / "idempotency-hosted.sqlite")
     private_v1_upload_slot = threading.Lock()
     try:
@@ -1202,6 +1220,9 @@ def register_hosted_routes(
                 with (
                     capabilities.active_surface(descriptor),
                     principal_module.request_scope(bound_principal),
+                    consolidation_runtime.bind_hosted_admission(consolidation_binding)
+                    if consolidation_binding is not None
+                    else nullcontext(),
                 ):
                     selector_error: SelectorCoverageError | None = None
                     try:
@@ -1720,7 +1741,7 @@ def register_hosted_routes(
     async def _upload(request: Request) -> HostedJSONResponse:
         started = time.perf_counter()
         context: gateway.TrustedGatewayContext | None = None
-        transfer_admission: AbstractContextManager[None] | None = None
+        transfer_admission: AbstractContextManager[Any] | None = None
         runtime_temp_reservation: AbstractContextManager[Path] | None = None
         runtime_temp_reserved = False
         upload_slot_held = False
@@ -1731,9 +1752,7 @@ def register_hosted_routes(
                     "HOSTED_TRANSFER_V1_DISABLED",
                     "private transfer compatibility is disabled",
                 )
-            admitted_transfer = lifecycle.admit_public_transfer()
-            admitted_transfer.__enter__()
-            transfer_admission = admitted_transfer
+            transfer_admission = _new_transfer_admission(upload=True)
             if not private_v1_upload_slot.acquire(blocking=False):
                 raise gateway.HostedGatewayError(
                     "HOSTED_TRANSFER_UNAVAILABLE", "another private upload is active"
@@ -1866,7 +1885,7 @@ def register_hosted_routes(
     async def _download(request: Request) -> Response:
         started = time.perf_counter()
         context: gateway.TrustedGatewayContext | None = None
-        transfer_admission: AbstractContextManager[None] | None = None
+        transfer_admission: AbstractContextManager[Any] | None = None
         try:
             context = _trusted_context(request, config, private_authenticator)
             if not config.private_v1_transfer_enabled():
@@ -1881,9 +1900,7 @@ def register_hosted_routes(
                 expected_tenant_scope=None,
                 expected_principal_scope=context.principal_scope,
             )
-            admitted_transfer = lifecycle.admit_public_transfer()
-            admitted_transfer.__enter__()
-            transfer_admission = admitted_transfer
+            transfer_admission = _new_transfer_admission(upload=False)
             if request.query_params:
                 raise gateway.HostedGatewayError(
                     "HOSTED_SELECTOR_REJECTED", "download does not accept URL selectors"
@@ -1935,11 +1952,11 @@ def register_hosted_routes(
                 request_id=context.request_id if context else None,
                 started=started,
             )
-        except Exception:  # noqa: BLE001 - private boundary redacts path/open details
+        except Exception as exc:  # noqa: BLE001 - private boundary redacts path/open details
             if transfer_admission is not None:
                 transfer_admission.__exit__(None, None, None)
             return _error_response(
-                "INTERNAL",
+                getattr(exc, "code", "INTERNAL"),
                 config=config,
                 operation="download",
                 request_id=context.request_id if context else None,

--- a/src/exomem/server_runtime.py
+++ b/src/exomem/server_runtime.py
@@ -56,6 +56,7 @@ class ServerRuntime:
     hosted_config: HostedCellConfig | None = None
     hosted_lifecycle: HostedCellLifecycle | None = None
     hosted_security_authority: Any | None = None
+    hosted_binding: HostedBindingV2 | None = None
     hosted_lifetime_lock: AbstractContextManager[None] | None = None
 
 
@@ -110,6 +111,10 @@ class LocalRuntimeActivation:
 
     def start(self) -> None:
         """Launch local workers once; safe from health and timer races."""
+        from .governance import consolidation_runtime
+
+        if not consolidation_runtime.readiness(self.vault_root)["admitted"]:
+            return
         with self._lock:
             if self._started:
                 return
@@ -272,7 +277,7 @@ def _initialize_hosted_runtime() -> ServerRuntime:
     lifetime_lock.__enter__()
     try:
         _cleanup_hosted_transfer_temp(config)
-        return _initialize_locked_hosted_runtime(config, lifetime_lock)
+        return _initialize_locked_hosted_runtime(config, lifetime_lock, binding=binding)
     except BaseException:
         lifetime_lock.__exit__(*sys.exc_info())
         raise
@@ -300,6 +305,8 @@ def _hosted_authorization_session_readiness_provider(
 def _initialize_locked_hosted_runtime(
     config: HostedCellConfig,
     lifetime_lock: AbstractContextManager[None],
+    *,
+    binding: HostedBindingV2 | None,
 ) -> ServerRuntime:
     """Finish hosted startup while retaining exclusive target-root ownership."""
 
@@ -314,6 +321,14 @@ def _initialize_locked_hosted_runtime(
     security_authority = _initialize_hosted_security(config)
     vault_root = config.vault_root
 
+    from .governance import consolidation_runtime
+
+    if binding is None:
+        consolidation = consolidation_runtime.readiness(vault_root)
+    else:
+        with consolidation_runtime.bind_hosted_admission(binding):
+            consolidation = consolidation_runtime.readiness(vault_root)
+
     source_schema = schema.load_source_schema(vault_root)
     project_keys_hint = project_keys.keys_hint(vault_root)
     projection_runtime.preactivate_projection_runtime(vault_root)
@@ -326,7 +341,7 @@ def _initialize_locked_hosted_runtime(
     mutation_ready, mutation_reason = probe_hosted_mutation_authority(vault_root)
 
     startup = lifecycle.complete_startup(
-        vault_ready=True,
+        vault_ready=consolidation["admitted"],
         mutation_authority_ready=mutation_ready,
         service_auth_ready=(
             security_authority is not None or config.service_credential is not None
@@ -343,7 +358,7 @@ def _initialize_locked_hosted_runtime(
 
     media_worker = None
     file_watcher = None
-    if mutation_ready and startup.phase == "active":
+    if mutation_ready and startup.phase == "active" and lifecycle.readiness().ready:
         # Retrieval catalog warm-up is core service work, not an optional
         # hosted worker.  A zero optional-worker budget must still converge
         # truthful retrieval admission for lean cells.
@@ -358,6 +373,14 @@ def _initialize_locked_hosted_runtime(
                     feature,
                     ready=False,
                     reason_code="HOSTED_MUTATION_AUTHORITY_UNAVAILABLE",
+                )
+    elif not consolidation["admitted"]:
+        for feature in ("embeddings", "file-watcher", "media"):
+            if config.has_feature(feature):
+                lifecycle.set_worker_status(
+                    feature,
+                    ready=False,
+                    reason_code="HOSTED_VAULT_UNAVAILABLE",
                 )
     elif config.resource_limits.worker_count == 0:
         for feature in ("embeddings", "file-watcher", "media"):
@@ -431,6 +454,7 @@ def _initialize_locked_hosted_runtime(
         hosted_config=config,
         hosted_lifecycle=lifecycle,
         hosted_security_authority=security_authority,
+        hosted_binding=binding,
         hosted_lifetime_lock=lifetime_lock,
     )
 

--- a/src/exomem/server_transfer.py
+++ b/src/exomem/server_transfer.py
@@ -239,22 +239,7 @@ def register_transfer_routes(
                 return True
         return False
 
-    @mcp_app.custom_route("/upload", methods=["POST"])
-    async def _upload(request: Request) -> JSONResponse:
-        if not config.enabled:
-            return JSONResponse(
-                {
-                    "code": "UPLOAD_DISABLED",
-                    "reason": "uploads are off: set EXOMEM_UPLOAD_TOKEN (or configure "
-                    "Cloudflare Access via EXOMEM_CF_ACCESS_TEAM_DOMAIN + EXOMEM_CF_ACCESS_AUD)",
-                },
-                status_code=503,
-            )
-        if not _authorized(request):
-            return JSONResponse(
-                {"code": "UNAUTHORIZED", "reason": "missing or invalid upload credential"},
-                status_code=401,
-            )
+    async def _upload_admitted(request: Request) -> JSONResponse:
         from .cli_ops import OpError, error_dict, http_status_for
         from .writer_lease import get_manager
 
@@ -355,6 +340,35 @@ def register_transfer_routes(
             )
         return JSONResponse(result.as_dict(), status_code=201)
 
+    @mcp_app.custom_route("/upload", methods=["POST"])
+    async def _upload(request: Request) -> JSONResponse:
+        if not config.enabled:
+            return JSONResponse(
+                {
+                    "code": "UPLOAD_DISABLED",
+                    "reason": "uploads are off: set EXOMEM_UPLOAD_TOKEN (or configure "
+                    "Cloudflare Access via EXOMEM_CF_ACCESS_TEAM_DOMAIN + EXOMEM_CF_ACCESS_AUD)",
+                },
+                status_code=503,
+            )
+        if not _authorized(request):
+            return JSONResponse(
+                {"code": "UNAUTHORIZED", "reason": "missing or invalid upload credential"},
+                status_code=401,
+            )
+        from .cli_ops import OpError, error_dict, http_status_for
+        from .governance import consolidation_runtime
+
+        try:
+            with consolidation_runtime.admit_upload(vault_root):
+                return await _upload_admitted(request)
+        except OpError as exc:
+            error = error_dict(exc)
+            return JSONResponse(
+                {"code": error["code"], "reason": error["message"]},
+                status_code=http_status_for(error["code"]),
+            )
+
     @mcp_app.custom_route("/upload", methods=["GET"])
     async def _upload_form(request: Request) -> HTMLResponse:
         q = request.query_params
@@ -403,42 +417,56 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
                 {"code": "UNAUTHORIZED", "reason": "missing or invalid download credential"},
                 status_code=401,
             )
-        path = request.query_params.get("path", "")
-        if not path.strip():
-            return JSONResponse(
-                {"code": "INVALID_PATH", "reason": "query param `path` (vault-relative) is required"},
-                status_code=400,
-            )
+        from .cli_ops import OpError, error_dict, http_status_for
+        from .governance import consolidation_runtime
+
         try:
-            abs_path, rel = resolve_under_vault(
-                vault_root, path, must_exist=True, must_be_file=True
+            with consolidation_runtime.admit_transfer(vault_root):
+                path = request.query_params.get("path", "")
+                if not path.strip():
+                    return JSONResponse(
+                        {
+                            "code": "INVALID_PATH",
+                            "reason": "query param `path` (vault-relative) is required",
+                        },
+                        status_code=400,
+                    )
+                try:
+                    abs_path, rel = resolve_under_vault(
+                        vault_root, path, must_exist=True, must_be_file=True
+                    )
+                    # A download hands over complete bytes, so only full disclosure
+                    # authorizes it. Refusal remains byte-identical to absence.
+                    if not egress.release_allows_download(
+                        vault_root,
+                        rel,
+                        principal=download_principal(request, config),
+                    ):
+                        raise VaultPathError("NOT_FOUND", f"path does not exist: {rel}")
+                    try:
+                        snapshot = reserved_paths.read_generic_bytes(vault_root, rel)
+                    except reserved_paths.ReservedPathLeafError:
+                        raise VaultPathError(
+                            "NOT_FOUND", f"path does not exist: {rel}"
+                        ) from None
+                except VaultPathError as exc:
+                    status = 404 if exc.code == "NOT_FOUND" else 400
+                    return JSONResponse(
+                        {"code": exc.code, "reason": exc.reason}, status_code=status
+                    )
+                filename = quote(abs_path.name, safe="")
+                return Response(
+                    snapshot.data,
+                    media_type="application/octet-stream",
+                    headers={
+                        "content-disposition": f"attachment; filename*=utf-8''{filename}"
+                    },
+                )
+        except OpError as exc:
+            error = error_dict(exc)
+            return JSONResponse(
+                {"code": error["code"], "reason": error["message"]},
+                status_code=http_status_for(error["code"]),
             )
-            # Release gate on the download TARGET after path resolution but before
-            # the response snapshot is opened or its bytes are read (design D1: the
-            # transfer routes bypass `invoke_command`, so they carry the gate
-            # explicitly). A download hands over the item's COMPLETE bytes, so only
-            # full disclosure authorizes one — otherwise any ceiling could be
-            # escaped by asking for the artifact instead of the text.
-            #
-            # Raised as the route's own NOT_FOUND rather than a new code, so a
-            # withheld artifact is byte-identical to one that never existed:
-            # a distinct "forbidden" reply would itself be an existence oracle.
-            if not egress.release_allows_download(
-                vault_root, rel, principal=download_principal(request, config)
-            ):
-                raise VaultPathError("NOT_FOUND", f"path does not exist: {rel}")
-            try:
-                snapshot = reserved_paths.read_generic_bytes(vault_root, rel)
-            except reserved_paths.ReservedPathLeafError:
-                raise VaultPathError("NOT_FOUND", f"path does not exist: {rel}") from None
-        except VaultPathError as exc:
-            status = 404 if exc.code == "NOT_FOUND" else 400
-            return JSONResponse({"code": exc.code, "reason": exc.reason}, status_code=status)
-        filename = quote(abs_path.name, safe="")
-        return Response(
-            snapshot.data,
-            media_type="application/octet-stream",
-            headers={"content-disposition": f"attachment; filename*=utf-8''{filename}"},
-        )
 
     return config

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -4207,6 +4207,55 @@ def _fixed_projected_command_completion(
     return wrapped
 
 
+def _consolidation_command_admission(
+    function: Callable[..., Any],
+) -> Callable[..., Any]:
+    @wraps(function)
+    def wrapped(
+        command: Any,
+        *injected: Any,
+        idempotency_key: str | None = None,
+        public_idempotency_key: str | None | object = _PUBLIC_IDEMPOTENCY_KEY_UNSET,
+        idempotency_principal_scope: str | None = None,
+        implicit_idempotency_scope: str | None = None,
+        mutation_request_id: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        def invoke() -> Any:
+            return function(
+                command,
+                *injected,
+                idempotency_key=idempotency_key,
+                public_idempotency_key=public_idempotency_key,
+                idempotency_principal_scope=idempotency_principal_scope,
+                implicit_idempotency_scope=implicit_idempotency_scope,
+                mutation_request_id=mutation_request_id,
+                **kwargs,
+            )
+
+        if (
+            not injected
+            or not isinstance(injected[0], (str, os.PathLike))
+        ):
+            return invoke()
+        from .commands import invocation_is_read_only
+        from .governance import consolidation_runtime
+        from .governance.egress import SelectorCoverageError
+
+        try:
+            read_only = invocation_is_read_only(command, kwargs)
+        except SelectorCoverageError:
+            read_only = False
+        with consolidation_runtime.admit_command(
+            Path(injected[0]),
+            read_only=read_only,
+        ):
+            return invoke()
+
+    return wrapped
+
+
+@_consolidation_command_admission
 @_fixed_projected_command_completion
 def invoke_command(
     command: Any,

--- a/tests/test_consolidation_control_admission.py
+++ b/tests/test_consolidation_control_admission.py
@@ -7,7 +7,9 @@ import sys
 import threading
 import time
 from contextlib import ExitStack
+from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -874,6 +876,296 @@ def test_lost_seal_terminal_ack_replays_the_exact_durable_terminal(
     replayed = _seal_with_recovered_control(restarted)
 
     assert replayed == sealed
+
+
+def test_shared_command_dispatcher_enters_the_outer_consolidation_admission(
+    tmp_path: Path,
+) -> None:
+    from exomem import commands, writer_lease
+    from exomem.governance import consolidation_runtime
+
+    admission = _open_admission(tmp_path)
+    calls: list[int] = []
+    command = next(command for command in commands.COMMANDS if command.name == "get")
+
+    def leaf(_vault_root: Path, **_kwargs: object) -> object:
+        calls.append(admission.snapshot().active_reads)
+        raise RuntimeError("leaf reached")
+
+    with consolidation_runtime.bind_admission(admission):
+        with pytest.raises(RuntimeError, match="^leaf reached$"):
+            writer_lease.invoke_command(
+                replace(command, leaf=leaf),
+                tmp_path,
+                path="Knowledge Base/Notes/example.md",
+            )
+
+    assert calls == [1]
+    assert admission.snapshot().active_total == 0
+
+
+def test_shared_command_dispatcher_refuses_before_leaf_and_error_assembly(
+    tmp_path: Path,
+) -> None:
+    from exomem import commands, writer_lease
+    from exomem.cli_ops import OpError
+    from exomem.governance import consolidation_runtime
+
+    admission = _open_admission(tmp_path)
+    _seal_with_new_control(admission)
+    calls: list[str] = []
+    command = next(command for command in commands.COMMANDS if command.name == "get")
+
+    def leaf(_vault_root: Path, **_kwargs: object) -> object:
+        calls.append("leaf")
+        return {"path": "private"}
+
+    with consolidation_runtime.bind_admission(admission):
+        with pytest.raises(OpError) as error:
+            writer_lease.invoke_command(
+                replace(command, leaf=leaf),
+                tmp_path,
+                path="Knowledge Base/Notes/example.md",
+            )
+
+    assert calls == []
+    assert error.value.code == "VAULT_UNAVAILABLE"
+    assert str(error.value) == "VAULT_UNAVAILABLE: vault is unavailable"
+
+
+def test_runtime_transfer_upload_and_background_paths_share_the_outer_admission(
+    tmp_path: Path,
+) -> None:
+    from exomem.governance import consolidation_runtime
+
+    admission = _open_admission(tmp_path)
+    with consolidation_runtime.bind_admission(admission):
+        with consolidation_runtime.admit_transfer(tmp_path):
+            snapshot = admission.snapshot()
+            assert snapshot.active_transfers == 1
+            assert snapshot.active_mutations == 0
+        with consolidation_runtime.admit_upload(tmp_path):
+            snapshot = admission.snapshot()
+            assert snapshot.active_transfers == 1
+            assert snapshot.active_mutations == 1
+        with consolidation_runtime.admit_background(tmp_path):
+            snapshot = admission.snapshot()
+            assert snapshot.active_background == 1
+
+    assert admission.snapshot().active_total == 0
+
+
+def test_exactly_absent_seal_preserves_legacy_dispatch_without_identity_adoption(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import commands, writer_lease
+    from exomem.governance import consolidation_identity, consolidation_seal
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        consolidation_identity,
+        "load_local_identity",
+        lambda *_args, **_kwargs: pytest.fail("legacy dispatch loaded an identity"),
+    )
+    monkeypatch.setattr(
+        consolidation_identity,
+        "adopt_local_identity",
+        lambda *_args, **_kwargs: pytest.fail("legacy dispatch adopted an identity"),
+    )
+    monkeypatch.setattr(
+        consolidation_seal.ConsolidationSealStore,
+        "initialize_open",
+        lambda *_args, **_kwargs: pytest.fail("legacy dispatch initialized a seal"),
+    )
+    command = next(command for command in commands.COMMANDS if command.name == "get")
+
+    result = writer_lease.invoke_command(
+        replace(command, leaf=lambda *_args, **_kwargs: calls.append("leaf") or "ok"),
+        tmp_path,
+        path="Knowledge Base/Notes/example.md",
+    )
+
+    assert result == "ok"
+    assert calls == ["leaf"]
+
+
+def test_fresh_dispatcher_reconstructs_the_durable_seal_before_the_leaf(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import commands, writer_lease
+    from exomem.cli_ops import OpError
+    from exomem.governance import consolidation_identity
+
+    admission = _open_admission(tmp_path)
+    _seal_with_new_control(admission)
+    monkeypatch.setattr(
+        consolidation_identity,
+        "load_local_identity",
+        lambda *_args, **_kwargs: SimpleNamespace(record_digest=VAULT_BINDING),
+    )
+    calls: list[str] = []
+    command = next(command for command in commands.COMMANDS if command.name == "get")
+
+    with pytest.raises(OpError) as error:
+        writer_lease.invoke_command(
+            replace(
+                command,
+                leaf=lambda *_args, **_kwargs: calls.append("leaf"),
+            ),
+            tmp_path,
+            path="Knowledge Base/Notes/example.md",
+        )
+
+    assert calls == []
+    assert error.value.code == "VAULT_UNAVAILABLE"
+
+
+@pytest.mark.parametrize("identity_digest", [None, OTHER_VAULT_BINDING])
+def test_enrolled_runtime_refuses_missing_or_mismatched_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    identity_digest: str | None,
+) -> None:
+    from exomem import commands, writer_lease
+    from exomem.cli_ops import OpError
+    from exomem.governance import consolidation_identity
+
+    _open_admission(tmp_path)
+    if identity_digest is None:
+        monkeypatch.setattr(
+            consolidation_identity,
+            "load_local_identity",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                consolidation_identity.ConsolidationIdentityUnavailable()
+            ),
+        )
+    else:
+        monkeypatch.setattr(
+            consolidation_identity,
+            "load_local_identity",
+            lambda *_args, **_kwargs: SimpleNamespace(record_digest=identity_digest),
+        )
+    command = next(command for command in commands.COMMANDS if command.name == "get")
+
+    with pytest.raises(OpError) as error:
+        writer_lease.invoke_command(
+            command,
+            tmp_path,
+            path="Knowledge Base/Notes/example.md",
+        )
+
+    assert error.value.code == "VAULT_UNAVAILABLE"
+
+
+def test_malformed_runtime_seal_has_the_same_content_free_refusal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import commands, writer_lease
+    from exomem.cli_ops import OpError
+    from exomem.governance import consolidation_identity, consolidation_seal
+
+    _open_admission(tmp_path)
+    active = consolidation_seal.ConsolidationSealStore(tmp_path).base / "active.json"
+    active.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        consolidation_identity,
+        "load_local_identity",
+        lambda *_args, **_kwargs: SimpleNamespace(record_digest=VAULT_BINDING),
+    )
+    command = next(command for command in commands.COMMANDS if command.name == "get")
+
+    with pytest.raises(OpError) as error:
+        writer_lease.invoke_command(
+            command,
+            tmp_path,
+            path="Knowledge Base/Notes/example.md",
+        )
+
+    assert error.value.code == "VAULT_UNAVAILABLE"
+    assert str(error.value) == "VAULT_UNAVAILABLE: vault is unavailable"
+
+
+def test_partial_runtime_seal_store_has_the_same_content_free_refusal(
+    tmp_path: Path,
+) -> None:
+    from exomem import commands, writer_lease
+    from exomem.cli_ops import OpError
+    from exomem.governance import consolidation_seal
+
+    consolidation_seal.ConsolidationSealStore(tmp_path).base.mkdir(parents=True)
+    command = next(command for command in commands.COMMANDS if command.name == "get")
+
+    with pytest.raises(OpError) as error:
+        writer_lease.invoke_command(
+            command,
+            tmp_path,
+            path="Knowledge Base/Notes/example.md",
+        )
+
+    assert error.value.code == "VAULT_UNAVAILABLE"
+    assert str(error.value) == "VAULT_UNAVAILABLE: vault is unavailable"
+
+
+def test_stray_runtime_seal_state_has_the_same_content_free_refusal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import commands, writer_lease
+    from exomem.cli_ops import OpError
+    from exomem.governance import consolidation_identity, consolidation_seal
+
+    _open_admission(tmp_path)
+    (consolidation_seal.ConsolidationSealStore(tmp_path).base / "stray.json").write_text(
+        "{}", encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        consolidation_identity,
+        "load_local_identity",
+        lambda *_args, **_kwargs: SimpleNamespace(record_digest=VAULT_BINDING),
+    )
+    command = next(command for command in commands.COMMANDS if command.name == "get")
+
+    with pytest.raises(OpError) as error:
+        writer_lease.invoke_command(
+            command,
+            tmp_path,
+            path="Knowledge Base/Notes/example.md",
+        )
+
+    assert error.value.code == "VAULT_UNAVAILABLE"
+    assert str(error.value) == "VAULT_UNAVAILABLE: vault is unavailable"
+
+
+def test_hosted_binding_resolves_the_same_shared_dispatcher_admission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import commands, writer_lease
+    from exomem.cli_ops import OpError
+    from exomem.governance import consolidation_runtime
+
+    admission = _open_admission(tmp_path)
+    _seal_with_new_control(admission)
+    binding = SimpleNamespace(vault_root=tmp_path)
+    monkeypatch.setattr(
+        consolidation_runtime,
+        "load_hosted_admission",
+        lambda supplied: admission if supplied is binding else None,
+    )
+    command = next(command for command in commands.COMMANDS if command.name == "get")
+
+    with consolidation_runtime.bind_hosted_admission(binding):
+        with pytest.raises(OpError) as error:
+            writer_lease.invoke_command(
+                command,
+                tmp_path,
+                path="Knowledge Base/Notes/example.md",
+            )
+
+    assert error.value.code == "VAULT_UNAVAILABLE"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_download_endpoint.py
+++ b/tests/test_download_endpoint.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+from contextlib import contextmanager
+from pathlib import Path
 
 import pytest
 from starlette.testclient import TestClient
@@ -43,6 +45,36 @@ def test_download_streams_file_with_minted_token(vault, monkeypatch: pytest.Monk
 def test_download_master_token_works(vault, monkeypatch: pytest.MonkeyPatch) -> None:
     c = _client(vault, monkeypatch, EXOMEM_UPLOAD_TOKEN="sek")
     assert _get(c, "Knowledge Base/index.md", "sek").status_code == 200
+
+
+def test_download_enters_consolidation_transfer_admission(
+    vault,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_runtime
+
+    events: list[str] = []
+
+    @contextmanager
+    def admission(_vault_root: Path):
+        events.append("transfer-enter")
+        try:
+            yield
+        finally:
+            events.append("transfer-exit")
+
+    monkeypatch.setattr(
+        consolidation_runtime,
+        "admit_transfer",
+        admission,
+        raising=False,
+    )
+    client = _client(vault, monkeypatch, EXOMEM_UPLOAD_TOKEN="sek")
+
+    response = _get(client, "Knowledge Base/index.md", "sek")
+
+    assert response.status_code == 200
+    assert events == ["transfer-enter", "transfer-exit"]
 
 
 def test_upload_scoped_token_rejected_on_download(vault, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_hosted_cell.py
+++ b/tests/test_hosted_cell.py
@@ -540,6 +540,47 @@ def test_hosted_initialize_starts_only_explicitly_granted_workers(
     assert calls.count("restart:watcher") == 1
 
 
+def test_hosted_initialize_starts_no_workers_while_consolidation_sealed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_runtime
+
+    values, _config = _provisioned(tmp_path, grants="embeddings,media,file-watcher")
+    values["EXOMEM_HOSTED_WORKER_LIMIT"] = "2"
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+    calls: list[str] = []
+    monkeypatch.setattr(
+        consolidation_runtime,
+        "readiness",
+        lambda _vault: {"admitted": False},
+    )
+    monkeypatch.setattr(
+        server_runtime,
+        "_start_compute_runtime",
+        lambda _vault: calls.append("compute"),
+    )
+    monkeypatch.setattr(
+        server_runtime,
+        "_start_media_worker",
+        lambda _vault: calls.append("media"),
+    )
+    monkeypatch.setattr(
+        server_runtime,
+        "_start_file_watcher",
+        lambda _vault: calls.append("watcher"),
+    )
+
+    runtime = server_runtime.initialize_runtime(load_dotenv_func=lambda **_kwargs: None)
+
+    assert calls == []
+    assert runtime.hosted_lifecycle is not None
+    assert runtime.hosted_lifecycle.readiness().ready is False
+    assert runtime.media_worker is None
+    assert runtime.file_watcher is None
+
+
 def test_zero_worker_limit_keeps_granted_background_features_disabled(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_hosted_private_routes.py
+++ b/tests/test_hosted_private_routes.py
@@ -2231,6 +2231,127 @@ def test_hosted_upload_holds_injected_mutation_guard_only_around_commit(
     assert (config.vault_root / path).read_bytes() == b"private evidence"
 
 
+def test_hosted_upload_and_download_enter_consolidation_admission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_runtime
+
+    events: list[str] = []
+
+    @contextmanager
+    def admission(_vault_root: Path, kind: str) -> Iterator[None]:
+        events.append(f"{kind}-enter")
+        try:
+            yield
+        finally:
+            events.append(f"{kind}-exit")
+
+    monkeypatch.setattr(
+        consolidation_runtime,
+        "admit_transfer",
+        lambda root: admission(root, "transfer"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        consolidation_runtime,
+        "admit_mutation",
+        lambda root: admission(root, "mutation"),
+        raising=False,
+    )
+    client, config, _lifecycle, _invoker = _cell(
+        tmp_path,
+        cell_id="cell-transfer-admission",
+        credential="transfer-admission-service-credential-0001",
+    )
+    upload_grant = gateway.mint_transfer_grant(
+        config,
+        tenant_scope="tenant-001",
+        principal_scope=DEFAULT_PRINCIPAL,
+        operation="upload",
+        jti="upload-admission",
+        max_bytes=128,
+    )
+    uploaded = client.post(
+        "/private/exomem/v1/upload",
+        headers={
+            **_headers(config, idempotency_key="upload-admission-001"),
+            gateway.TRANSFER_GRANT_HEADER: upload_grant,
+        },
+        files={"file": ("proof.bin", b"private evidence", "application/octet-stream")},
+        data={"scope": "Case", "category": "Evidence"},
+    )
+    assert uploaded.status_code == 201, uploaded.text
+    path = uploaded.json()["data"]["path"]
+    assert events == [
+        "transfer-enter",
+        "mutation-enter",
+        "mutation-exit",
+        "transfer-exit",
+    ]
+
+    events.clear()
+    download_grant = gateway.mint_transfer_grant(
+        config,
+        tenant_scope="tenant-001",
+        principal_scope=DEFAULT_PRINCIPAL,
+        operation="download",
+        jti="download-admission",
+        max_bytes=128,
+    )
+    downloaded = client.post(
+        "/private/exomem/v1/download",
+        headers={
+            **_headers(config),
+            gateway.TRANSFER_GRANT_HEADER: download_grant,
+        },
+        json={"path": path},
+    )
+
+    assert downloaded.status_code == 200, downloaded.text
+    assert downloaded.content == b"private evidence"
+    assert events == ["transfer-enter", "transfer-exit"]
+
+
+def test_hosted_download_maps_consolidation_seal_to_public_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_runtime
+
+    @contextmanager
+    def sealed(_vault_root: Path) -> Iterator[None]:
+        raise cli_ops.OpError("VAULT_UNAVAILABLE", "vault is unavailable")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(consolidation_runtime, "admit_transfer", sealed)
+    client, config, _lifecycle, _invoker = _cell(
+        tmp_path,
+        cell_id="cell-sealed-download",
+        credential="sealed-download-service-credential-0001",
+    )
+    grant = gateway.mint_transfer_grant(
+        config,
+        tenant_scope="tenant-001",
+        principal_scope=DEFAULT_PRINCIPAL,
+        operation="download",
+        jti="download-sealed",
+        max_bytes=128,
+    )
+
+    response = client.post(
+        "/private/exomem/v1/download",
+        headers={
+            **_headers(config),
+            gateway.TRANSFER_GRANT_HEADER: grant,
+        },
+        json={"path": "Knowledge Base/Notes/private.md"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "VAULT_UNAVAILABLE"
+
+
 def test_hosted_transfer_scope_expiry_cross_cell_and_download_isolation(tmp_path: Path) -> None:
     alpha, alpha_config, _alpha_lifecycle, _alpha_invoker = _cell(
         tmp_path,

--- a/tests/test_runtime_readiness.py
+++ b/tests/test_runtime_readiness.py
@@ -201,6 +201,98 @@ def test_ready_retrieval_catalog_admits_runtime_readiness() -> None:
     assert snapshot["reasons"] == []
 
 
+def test_consolidation_seal_withholds_runtime_readiness_without_phase_disclosure() -> None:
+    snapshot = build_runtime_readiness(
+        coordination={
+            "enabled": False,
+            "role": "writer",
+            "coordinator_healthy": True,
+            "replica_id": None,
+        },
+        release="test",
+        mcp_tool_surface_sha256="f" * 64,
+        consolidation={"admitted": False},
+    )
+
+    assert snapshot["status"] == "not_ready"
+    assert snapshot["takeover_eligible"] is False
+    assert snapshot["reasons"] == ["vault_admission_unavailable"]
+    assert snapshot["consolidation"] == {"admitted": False}
+
+
+def test_runtime_loads_durable_consolidation_before_other_readiness_probes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import runtime_readiness as readiness_module
+    from exomem.governance import consolidation_runtime
+
+    observed: list[str] = []
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(tmp_path))
+    monkeypatch.setattr(
+        consolidation_runtime,
+        "readiness",
+        lambda _vault: observed.append("consolidation") or {"admitted": False},
+    )
+    monkeypatch.setattr(
+        readiness_module,
+        "_bounded_coordination_status",
+        lambda *_args, **_kwargs: observed.append("coordination")
+        or {
+            "enabled": False,
+            "role": "standalone",
+            "replica_id": None,
+            "coordinator_healthy": True,
+        },
+    )
+    monkeypatch.setattr(
+        readiness_module,
+        "_measure_observability",
+        lambda: {},
+    )
+
+    snapshot = readiness_module.runtime_readiness(mcp_tool_surface_sha256="f" * 64)
+
+    assert observed[:2] == ["consolidation", "coordination"]
+    assert snapshot["status"] == "not_ready"
+    assert snapshot["consolidation"] == {"admitted": False}
+
+
+def test_relative_configured_vault_still_loads_consolidation_readiness(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import runtime_readiness as readiness_module
+    from exomem.governance import consolidation_runtime
+
+    vault = tmp_path / "relative-vault"
+    observed: list[Path] = []
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", "relative-vault")
+    monkeypatch.setattr(
+        consolidation_runtime,
+        "readiness",
+        lambda supplied: observed.append(supplied) or {"admitted": False},
+    )
+    monkeypatch.setattr(
+        readiness_module,
+        "_bounded_coordination_status",
+        lambda *_args, **_kwargs: {
+            "enabled": False,
+            "role": "standalone",
+            "replica_id": None,
+            "coordinator_healthy": True,
+        },
+    )
+    monkeypatch.setattr(readiness_module, "_measure_observability", lambda: {})
+
+    snapshot = readiness_module.runtime_readiness(mcp_tool_surface_sha256="f" * 64)
+
+    assert observed == [vault]
+    assert snapshot["status"] == "not_ready"
+    assert snapshot["consolidation"] == {"admitted": False}
+
+
 def test_retrieval_repair_progress_is_bounded_and_privacy_safe() -> None:
     snapshot = build_runtime_readiness(
         coordination={

--- a/tests/test_server_runtime.py
+++ b/tests/test_server_runtime.py
@@ -85,6 +85,33 @@ def test_initialize_runtime_does_not_start_workers_before_transport(
     assert events == [f"projection:{vault}"]
 
 
+def test_local_runtime_activation_does_not_start_while_consolidation_sealed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_runtime
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    calls: list[str] = []
+    monkeypatch.setattr(
+        consolidation_runtime,
+        "readiness",
+        lambda _vault: {"admitted": False},
+    )
+    activation = server_runtime.LocalRuntimeActivation(vault)
+    monkeypatch.setattr(
+        activation,
+        "_activate",
+        lambda: calls.append("activate"),
+    )
+
+    activation.start()
+
+    assert calls == []
+    assert activation._thread is None  # noqa: SLF001
+
+
 def test_local_runtime_activation_waits_for_liveness_and_starts_once(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_upload_endpoint.py
+++ b/tests/test_upload_endpoint.py
@@ -110,6 +110,52 @@ def test_upload_happy_path_lands_in_evidence(vault, monkeypatch: pytest.MonkeyPa
     assert written.read_bytes() == b"\x89PNGrealbytes"
 
 
+def test_upload_enters_consolidation_transfer_and_mutation_admission(
+    vault,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.governance import consolidation_runtime
+
+    events: list[str] = []
+
+    @contextmanager
+    def admission(_vault_root: Path, kind: str):
+        events.append(f"{kind}-enter")
+        try:
+            yield
+        finally:
+            events.append(f"{kind}-exit")
+
+    monkeypatch.setattr(
+        consolidation_runtime,
+        "admit_transfer",
+        lambda root: admission(root, "transfer"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        consolidation_runtime,
+        "admit_mutation",
+        lambda root: admission(root, "mutation"),
+        raising=False,
+    )
+    client = _client(vault, monkeypatch, EXOMEM_UPLOAD_TOKEN="sekret")
+
+    response = client.post(
+        "/upload",
+        files={"file": ("proof.bin", b"proof", "application/octet-stream")},
+        data={"scope": "Case", "category": "Evidence"},
+        headers={"Authorization": "Bearer sekret"},
+    )
+
+    assert response.status_code == 201, response.text
+    assert events == [
+        "transfer-enter",
+        "mutation-enter",
+        "mutation-exit",
+        "transfer-exit",
+    ]
+
+
 def test_upload_supported_media_routes_through_canonical_reconciliation(
     vault, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- enforce the durable consolidation seal at the shared command dispatcher and authenticated local/Hosted upload and download boundaries
- load valid, partial, malformed, and identity-mismatched seal state before readiness or worker startup, with one content-free unavailable response
- preserve the exact in-process verification authority without widening ordinary sealed traffic
- define first governance enrollment as an explicit owner-only offline lifecycle operation in OpenSpec; exact seal absence remains the legacy-unenrolled state until that separate slice lands

Stacked after #1018. This does not merge or touch a live vault.

## Verification

- affected command, admission, startup, readiness, transfer, Hosted, and verification suites: 321 passed
- independent adversarial reproduction: 246 passed, no blockers
- Ruff on all changed Python files
- targeted mypy on the new runtime and affected server modules
- openspec validate --all --strict: 168 passed
- public repository artifact validation: clean
- git diff --check