### PR TITLE
fix(deploy): prove listener process-tree ownership

### DIFF
--- a/scripts/_service-common.ps1
+++ b/scripts/_service-common.ps1
@@ -1068,9 +1068,9 @@ function Test-ExomemProcessTreeMembership {
 
     if ($RootPid -le 0 -or $CandidatePid -le 0 -or $MaxDepth -le 0) { return $false }
     $currentPid = $CandidatePid
+    $childCreatedAt = $null
     $seen = @{}
     foreach ($depth in 1..$MaxDepth) {
-        if ($currentPid -eq $RootPid) { return $true }
         if ($currentPid -le 0 -or $seen.ContainsKey($currentPid)) { return $false }
         $seen[$currentPid] = $true
         try {
@@ -1081,6 +1081,15 @@ function Test-ExomemProcessTreeMembership {
             return $false
         }
         if (-not $process) { return $false }
+        try {
+            $createdAt = [datetime]$process.CreationDate
+        } catch {
+            return $false
+        }
+        if (-not $createdAt) { return $false }
+        if ($childCreatedAt -and $createdAt -gt $childCreatedAt) { return $false }
+        if ($currentPid -eq $RootPid) { return $true }
+        $childCreatedAt = $createdAt
         $currentPid = [int]$process.ParentProcessId
     }
     return $false
@@ -1098,7 +1107,20 @@ function Assert-ExomemListenerOwnedByWorker {
         $listeners = @(Get-ExomemConfiguredListenerPids -ServiceName $ServiceName)
         if ($listeners.Count -eq 1) {
             $listenerPid = [int]$listeners[0]
-            if (Test-ExomemProcessTreeMembership -RootPid $WorkerPid -CandidatePid $listenerPid) {
+            $currentWorkerPid = Get-ExomemServiceWorkerPid -ServiceName $ServiceName
+            $belongsToTree = $listenerPid -eq $WorkerPid -or (
+                Test-ExomemProcessTreeMembership -RootPid $WorkerPid -CandidatePid $listenerPid
+            )
+            if ($currentWorkerPid -eq $WorkerPid -and $belongsToTree) {
+                $confirmedWorkerPid = Get-ExomemServiceWorkerPid -ServiceName $ServiceName
+                $confirmedListeners = @(Get-ExomemConfiguredListenerPids -ServiceName $ServiceName)
+                if (
+                    $confirmedWorkerPid -ne $WorkerPid -or
+                    $confirmedListeners.Count -ne 1 -or
+                    [int]$confirmedListeners[0] -ne $listenerPid
+                ) {
+                    throw "The configured listener or service worker changed during process-tree ownership proof."
+                }
                 Write-Host "Configured listener belongs to the selected worker process tree: $WorkerPid -> $listenerPid"
                 return
             }

--- a/scripts/_service-common.ps1
+++ b/scripts/_service-common.ps1
@@ -1058,6 +1058,34 @@ function Assert-ExomemStoppedResumeAuthority {
     Write-Host "Explicit stopped-transition recovery authority proven: $ServiceName"
 }
 
+function Test-ExomemProcessTreeMembership {
+    <# Prove that CandidatePid is RootPid or one of its descendants. #>
+    param(
+        [int]$RootPid,
+        [int]$CandidatePid,
+        [int]$MaxDepth = 64
+    )
+
+    if ($RootPid -le 0 -or $CandidatePid -le 0 -or $MaxDepth -le 0) { return $false }
+    $currentPid = $CandidatePid
+    $seen = @{}
+    foreach ($depth in 1..$MaxDepth) {
+        if ($currentPid -eq $RootPid) { return $true }
+        if ($currentPid -le 0 -or $seen.ContainsKey($currentPid)) { return $false }
+        $seen[$currentPid] = $true
+        try {
+            $process = Get-CimInstance Win32_Process `
+                -Filter "ProcessId=$currentPid" `
+                -ErrorAction Stop | Select-Object -First 1
+        } catch {
+            return $false
+        }
+        if (-not $process) { return $false }
+        $currentPid = [int]$process.ParentProcessId
+    }
+    return $false
+}
+
 function Assert-ExomemListenerOwnedByWorker {
     param(
         [string]$ServiceName = "exomem",
@@ -1068,12 +1096,15 @@ function Assert-ExomemListenerOwnedByWorker {
     $deadline = (Get-Date).AddSeconds($TimeoutSec)
     do {
         $listeners = @(Get-ExomemConfiguredListenerPids -ServiceName $ServiceName)
-        if ($listeners.Count -eq 1 -and [int]$listeners[0] -eq $WorkerPid) {
-            Write-Host "Configured listener belongs to the selected worker: $WorkerPid"
-            return
+        if ($listeners.Count -eq 1) {
+            $listenerPid = [int]$listeners[0]
+            if (Test-ExomemProcessTreeMembership -RootPid $WorkerPid -CandidatePid $listenerPid) {
+                Write-Host "Configured listener belongs to the selected worker process tree: $WorkerPid -> $listenerPid"
+                return
+            }
         }
         if ($listeners.Count -ne 0) {
-            throw "The configured listener is not owned by the newly selected service worker pid $WorkerPid."
+            throw "The configured listener is not owned by the newly selected service worker process tree rooted at pid $WorkerPid."
         }
         Start-Sleep -Milliseconds 250
     } while ((Get-Date) -lt $deadline)

--- a/tests/test_deploy_restart_gate.py
+++ b/tests/test_deploy_restart_gate.py
@@ -310,12 +310,23 @@ _LIVE_ACCEPTANCE_DRIVER = """
         [int]$WorkerPid,
         [int]$ListenerPid,
         [switch]$ListenerIsDescendant,
+        [int]$CurrentWorkerPid = 0,
+        [switch]$ListenerChangesAfterProof,
         [string]$ExpectedVersion,
         [string]$ServedVersion
     )
     $ErrorActionPreference = "Stop"
     . $Common
-    function Get-ExomemConfiguredListenerPids { return @($ListenerPid) }
+    if (-not $CurrentWorkerPid) { $CurrentWorkerPid = $WorkerPid }
+    $script:ListenerReads = 0
+    function Get-ExomemConfiguredListenerPids {
+        $script:ListenerReads += 1
+        if ($ListenerChangesAfterProof -and $script:ListenerReads -gt 1) {
+            return @($ListenerPid + 1)
+        }
+        return @($ListenerPid)
+    }
+    function Get-ExomemServiceWorkerPid { return $CurrentWorkerPid }
     function Test-ExomemProcessTreeMembership {
         param([int]$RootPid, [int]$CandidatePid)
         return $RootPid -eq $CandidatePid -or [bool]$ListenerIsDescendant
@@ -341,7 +352,8 @@ _PROCESS_TREE_DRIVER = """
         [string]$Common,
         [int]$RootPid,
         [int]$CandidatePid,
-        [string]$ParentMap = ""
+        [string]$ParentMap = "",
+        [switch]$RootIsNewer
     )
     $ErrorActionPreference = "Stop"
     . $Common
@@ -357,9 +369,14 @@ _PROCESS_TREE_DRIVER = """
         }
         $processId = [int]$Matches[1]
         if (-not $script:Parents.ContainsKey($processId)) { return $null }
+        $created = ([datetime]"2026-01-01T00:00:00Z").AddSeconds($processId)
+        if ($RootIsNewer -and $processId -eq $RootPid) {
+            $created = [datetime]"2030-01-01T00:00:00Z"
+        }
         return [pscustomobject]@{
             ProcessId = $processId
             ParentProcessId = [int]$script:Parents[$processId]
+            CreationDate = $created
         }
     }
     if (Test-ExomemProcessTreeMembership -RootPid $RootPid -CandidatePid $CandidatePid) {
@@ -1405,7 +1422,7 @@ class TestInstallerLiveAcceptance:
             "-CandidatePid",
             "4103",
             "-ParentMap",
-            "4103:4102,4102:4101",
+            "4103:4102,4102:4101,4101:100",
         )
         assert result.returncode == 0, _flat(result)
 
@@ -1422,6 +1439,41 @@ class TestInstallerLiveAcceptance:
             "4103",
             "-ParentMap",
             "4103:4102,4102:9999",
+        )
+        assert result.returncode == 1, _flat(result)
+        assert "NOT-MEMBER" in _flat(result)
+
+    def test_process_tree_membership_refuses_a_missing_root(
+        self, process_tree_driver: Path
+    ) -> None:
+        result = _run(
+            process_tree_driver,
+            "-Common",
+            str(COMMON),
+            "-RootPid",
+            "4101",
+            "-CandidatePid",
+            "4103",
+            "-ParentMap",
+            "4103:4102,4102:4101",
+        )
+        assert result.returncode == 1, _flat(result)
+        assert "NOT-MEMBER" in _flat(result)
+
+    def test_process_tree_membership_refuses_a_reused_root_pid(
+        self, process_tree_driver: Path
+    ) -> None:
+        result = _run(
+            process_tree_driver,
+            "-Common",
+            str(COMMON),
+            "-RootPid",
+            "4101",
+            "-CandidatePid",
+            "4103",
+            "-ParentMap",
+            "4103:4102,4102:4101,4101:100",
+            "-RootIsNewer",
         )
         assert result.returncode == 1, _flat(result)
         assert "NOT-MEMBER" in _flat(result)
@@ -1610,6 +1662,49 @@ class TestInstallerLiveAcceptance:
             "1.2.3",
         )
         assert accepted.returncode == 0, _flat(accepted)
+
+    def test_listener_refuses_a_stale_service_worker_root(
+        self, live_acceptance_driver: Path
+    ) -> None:
+        refused = _run(
+            live_acceptance_driver,
+            "-Common",
+            str(COMMON),
+            "-WorkerPid",
+            "4101",
+            "-ListenerPid",
+            "4102",
+            "-ListenerIsDescendant",
+            "-CurrentWorkerPid",
+            "4999",
+            "-ExpectedVersion",
+            "1.2.3",
+            "-ServedVersion",
+            "1.2.3",
+        )
+        assert refused.returncode == 1, _flat(refused)
+        assert "listener" in _flat(refused).lower()
+
+    def test_listener_identity_is_rechecked_after_ancestry_proof(
+        self, live_acceptance_driver: Path
+    ) -> None:
+        refused = _run(
+            live_acceptance_driver,
+            "-Common",
+            str(COMMON),
+            "-WorkerPid",
+            "4101",
+            "-ListenerPid",
+            "4102",
+            "-ListenerIsDescendant",
+            "-ListenerChangesAfterProof",
+            "-ExpectedVersion",
+            "1.2.3",
+            "-ServedVersion",
+            "1.2.3",
+        )
+        assert refused.returncode == 1, _flat(refused)
+        assert "listener" in _flat(refused).lower()
 
     def test_health_must_equal_the_target_interpreter_version(
         self, live_acceptance_driver: Path

--- a/tests/test_deploy_restart_gate.py
+++ b/tests/test_deploy_restart_gate.py
@@ -309,12 +309,17 @@ _LIVE_ACCEPTANCE_DRIVER = """
         [string]$Common,
         [int]$WorkerPid,
         [int]$ListenerPid,
+        [switch]$ListenerIsDescendant,
         [string]$ExpectedVersion,
         [string]$ServedVersion
     )
     $ErrorActionPreference = "Stop"
     . $Common
     function Get-ExomemConfiguredListenerPids { return @($ListenerPid) }
+    function Test-ExomemProcessTreeMembership {
+        param([int]$RootPid, [int]$CandidatePid)
+        return $RootPid -eq $CandidatePid -or [bool]$ListenerIsDescendant
+    }
     function Invoke-RestMethod {
         return [pscustomobject]@{ version = $ServedVersion }
     }
@@ -329,6 +334,40 @@ _LIVE_ACCEPTANCE_DRIVER = """
         exit 1
     }
     Write-Host "DRIVER-COMPLETED"
+"""
+
+_PROCESS_TREE_DRIVER = """
+    param(
+        [string]$Common,
+        [int]$RootPid,
+        [int]$CandidatePid,
+        [string]$ParentMap = ""
+    )
+    $ErrorActionPreference = "Stop"
+    . $Common
+    $script:Parents = @{}
+    foreach ($entry in @($ParentMap -split ",") | Where-Object { $_ }) {
+        $pair = $entry -split ":", 2
+        $script:Parents[[int]$pair[0]] = [int]$pair[1]
+    }
+    function Get-CimInstance {
+        param([string]$ClassName, [string]$Filter, [string]$ErrorAction)
+        if ($ClassName -ne "Win32_Process" -or $Filter -notmatch '^ProcessId=(\\d+)$') {
+            throw "unexpected process query"
+        }
+        $processId = [int]$Matches[1]
+        if (-not $script:Parents.ContainsKey($processId)) { return $null }
+        return [pscustomobject]@{
+            ProcessId = $processId
+            ParentProcessId = [int]$script:Parents[$processId]
+        }
+    }
+    if (Test-ExomemProcessTreeMembership -RootPid $RootPid -CandidatePid $CandidatePid) {
+        Write-Host "MEMBER"
+        exit 0
+    }
+    Write-Host "NOT-MEMBER"
+    exit 1
 """
 
 _INSTALL_MCP_FAILURE_CLEANUP_DRIVER = r"""
@@ -759,6 +798,13 @@ def failed_start_receipt_driver(tmp_path: Path) -> Path:
 def live_acceptance_driver(tmp_path: Path) -> Path:
     script = tmp_path / "live-acceptance-driver.ps1"
     _write_executable(script, _LIVE_ACCEPTANCE_DRIVER)
+    return script
+
+
+@pytest.fixture()
+def process_tree_driver(tmp_path: Path) -> Path:
+    script = tmp_path / "process-tree-driver.ps1"
+    _write_executable(script, _PROCESS_TREE_DRIVER)
     return script
 
 
@@ -1347,6 +1393,39 @@ class TestStoppedGate:
 
 
 class TestInstallerLiveAcceptance:
+    def test_process_tree_membership_accepts_a_nested_listener(
+        self, process_tree_driver: Path
+    ) -> None:
+        result = _run(
+            process_tree_driver,
+            "-Common",
+            str(COMMON),
+            "-RootPid",
+            "4101",
+            "-CandidatePid",
+            "4103",
+            "-ParentMap",
+            "4103:4102,4102:4101",
+        )
+        assert result.returncode == 0, _flat(result)
+
+    def test_process_tree_membership_refuses_an_unrelated_listener(
+        self, process_tree_driver: Path
+    ) -> None:
+        result = _run(
+            process_tree_driver,
+            "-Common",
+            str(COMMON),
+            "-RootPid",
+            "4101",
+            "-CandidatePid",
+            "4103",
+            "-ParentMap",
+            "4103:4102,4102:9999",
+        )
+        assert result.returncode == 1, _flat(result)
+        assert "NOT-MEMBER" in _flat(result)
+
     def test_fresh_doctor_failure_leaves_no_autostart_service_and_retry_is_fresh(
         self, tmp_path: Path
     ) -> None:
@@ -1512,6 +1591,25 @@ class TestInstallerLiveAcceptance:
         )
         assert mismatch.returncode == 1, _flat(mismatch)
         assert "listener" in _flat(mismatch).lower()
+
+    def test_descendant_listener_belongs_to_the_new_worker_tree(
+        self, live_acceptance_driver: Path
+    ) -> None:
+        accepted = _run(
+            live_acceptance_driver,
+            "-Common",
+            str(COMMON),
+            "-WorkerPid",
+            "4101",
+            "-ListenerPid",
+            "4102",
+            "-ListenerIsDescendant",
+            "-ExpectedVersion",
+            "1.2.3",
+            "-ServedVersion",
+            "1.2.3",
+        )
+        assert accepted.returncode == 0, _flat(accepted)
 
     def test_health_must_equal_the_target_interpreter_version(
         self, live_acceptance_driver: Path


### PR DESCRIPTION
The Windows service uses a launcher process whose descendant owns the HTTP listener. Deployment previously required the listener PID to equal the launcher PID, so a healthy 0.68.0 restart was stopped during acceptance.

This change accepts the listener only when it is in the current service worker tree. It fails closed if the root exits, a PID is reused, or either the worker or listener changes during the proof.

Verification:
- Windows: `60 passed` in `tests/test_deploy_restart_gate.py`
- Ruff: clean
- Public artifact privacy gate: 3,495 files / 3,564 text payloads clean
- Independent real-CIM review: live descendant accepted; stale-root reproduction refused