### PR TITLE
docs(openspec): propose governed curation lane

### DIFF
--- a/openspec/changes/add-governed-curation-lane/.openspec.yaml
+++ b/openspec/changes/add-governed-curation-lane/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/add-governed-curation-lane/design.md
+++ b/openspec/changes/add-governed-curation-lane/design.md
@@ -1,0 +1,346 @@
+## Context
+
+The no-nudge architecture now has deterministic sensors, review queues, and a
+served authority envelope. What it lacks is a safe executor for an agent's
+multi-step curation decision. The current `exomem-curate` workflow asks the
+agent to read each page and call individual write tools. That preserves
+judgment in the agent, but a sequence has no immutable identity, durable
+progress, crash recovery, or single reviewed preview.
+
+Two existing systems provide the pattern rather than a new architecture:
+
+- Adoption Studio separates deterministic context and validation from an
+  agent-authored proposal, review, and governed apply.
+- The writer boundary, mutation terminal, semantic validate/commit drafts,
+  governed trash, and supersession chain already provide the single-operation
+  safety properties curation needs to compose.
+
+The current Hosted v4 agent profile exposes `maintain_memory`, but the common
+invocation boundary refuses request-bound write maintenance except
+`structured-files`. Curation therefore needs one narrow remote exception for
+its exact reviewed-plan protocol; ordinary `fix`, `reconcile`, and ID backfill
+remain operator-only.
+
+That refusal is the subject of the still-active `bound-remote-maintenance`
+OpenSpec change. S8 is a deliberate successor constraint, not a contradiction:
+the older change blocks unbounded synchronous maintenance whose worker can
+outlive the request, while this design admits at most one evidenced content
+step per request. Implementation must preserve and extend its refusal tests,
+not delete or route around the common admission boundary.
+
+The design deliberately does not touch Planning/Records automation or the
+separate Exomem/OpenSpec workflow-contract work. Curation targets governed
+knowledge and entity material, not intended-future-state or observed-event
+state machines.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let the active agent author one strictly typed, immutable curation plan and
+  show its exact effects before any content mutation.
+- Apply a confirmed plan as bounded, individually receipted governed steps,
+  with deterministic recovery at every crash cut.
+- Expose honest partial, failed, interrupted, blocked, completed, and
+  compensated states; never imply multi-file atomicity.
+- Make exact replay and continuation safe across local CLI/MCP/REST and Hosted.
+- Preserve history when reversing work through a separately reviewed
+  compensation plan.
+- Keep plan execution content-language-neutral and usable for multilingual
+  Markdown.
+
+**Non-Goals:**
+
+- Server-side semantic judgment, proposal writing, same-modal text generation,
+  automatic authority inference, or automatic execution of surfaced work.
+- A new general workflow engine, arbitrary command runner, or arbitrary
+  Markdown patch format.
+- Multi-step atomicity or rollback that erases history.
+- Planning/Records lifecycle changes, OpenSpec orchestration, or a replacement
+  for the workflow-contract effort.
+- Changes to Adoption Studio run semantics or legacy maintenance modes.
+
+## Decisions
+
+### 1. Extend `maintain_memory` with one closed curation action set
+
+`maintain_memory(mode="curation")` gains the finite selector
+`curation_action`:
+
+| Action | Classification | Effect |
+|---|---|---|
+| `work-item` | read | Assemble bounded current pages, review refs, hashes, and allowed step schemas. |
+| `propose` | mutation | Validate and create one immutable forward plan; no knowledge page changes. |
+| `preview` | read | Return exact ordered actions, current binding state, blockers, and compensation classes. |
+| `status` | read | Inspect evidence and report durable progress, recovery needs, and the next action without writing. |
+| `apply` | mutation | Record approval for the exact forward plan and execute at most its next step. |
+| `resume` | mutation | Execute at most the next step of the already approved forward or compensation plan. |
+| `propose-compensation` | mutation | Derive a new immutable compensation plan from committed receipts. |
+| `apply-compensation` | mutation | Record approval for the exact compensation plan and execute at most its next step. |
+
+The signature reuses `plan_id` and `why` and adds only curation-specific
+arguments (`curation_action`, `run_id`, `plan`, `refs`, `paths`, and
+`expected_plan_fingerprint`). Argument validation refuses fields belonging to
+another maintenance mode. Unknown actions take the conservative mutation path
+and then fail with `INVALID_CURATION_ACTION` before any leaf dispatch.
+
+This is preferable to a new product command because maintenance is already the
+advanced product surface for audit and repair, and its registry entry already
+generates MCP, REST, CLI, OpenAPI, Hosted, and capability documentation. It is
+preferable to extending Adoption Studio because adoption's originals-never-
+modified and first-run run model are different invariants.
+
+Each apply-shaped request executes at most one content step. This bounds the
+vault mutation hold and Cloudflare request duration, gives every step one
+request/terminal identity, and makes partial progress visible. The shipped
+skill continues an approved run by calling `resume` until a terminal state or
+blocker; it does not ask the user to approve every already-reviewed step.
+
+### 2. Canonical run layout separates immutable intent from progress
+
+Runs live beneath:
+
+```
+Knowledge Base/_Governance/curation/runs/<run_id>/
+  plan.json
+  approval.json
+  state.json
+  receipts/<ordinal>-<step_id>/<attempt>.json
+  evidence/<operation_id>.json
+  compensation/<compensation_plan_id>/plan.json
+  compensation/<compensation_plan_id>/approval.json
+```
+
+`run_id` is `cur-<YYYYMMDD>-<plan-id-prefix>`. `plan.json` and compensation
+plans are create-only canonical JSON; `plan_id` is SHA-256 over their canonical
+bytes. Reusing a plan id with different bytes is a hard collision. `state.json`
+contains phase, active step, and receipt index; it never changes plan meaning.
+Approval and per-attempt step receipts are create-only terminal records, and at
+most one committed or recovered-committed receipt may exist for a step. State
+can be rebuilt from immutable plans, approvals, witnesses, and receipts, so a
+stale state projection is repairable rather than authoritative.
+
+Plans are governed content because they may contain agent-authored note bodies
+and exact pre-images needed for compensation. `_Governance` disclosure rules
+therefore apply. The local idempotency database remains a retry accelerator,
+not the only record of plan outcome.
+
+### 3. Plans use a closed step vocabulary, never command-name dispatch
+
+The v1 step kinds are:
+
+- `create-note` → the existing `remember` validate/commit path;
+- `create-entity` → `connect_memory(operation="create-entity")`;
+- `accept-relation` → the existing fingerprint- and hash-bound relation accept;
+- `edit` → the discriminated `edit_memory` validate/commit path;
+- `supersede` → `replace_memory` validate/commit;
+- `move`, `delete`, and `recover` → the matching `manage_memory_file` leaves.
+
+Every kind has a strict per-kind argument schema with unknown fields refused.
+An agent cannot submit a command name, raw filesystem operation, Python
+callable, or free-form patch program. Existing leaf safety stays authoritative:
+delete still requires its canonical confirmation semantics, source/evidence
+and relation validation still run, semantic draft tokens still bind content,
+and protected-tree/path confinement is never relaxed.
+
+`work-item` returns exact current hashes and registry identities. `propose`
+validates every step in order, runs existing validate-only preparation where
+available, records all read/write targets, expected present hashes and expected
+absences, relevant registry fingerprints, and the deterministic postcondition.
+It refuses an input binding that does not match live state; it never silently
+rebinds an agent's stale review. A plan fingerprint covers canonical plan bytes,
+the ordered binding manifest, and relevant schema/relation/entity registry
+identities.
+
+The executor refuses Planning, Records, workflow-contract, `_Schema`,
+`_Governance`, `_Adoption`, and other protected administrative targets except
+its own internal run artifacts. Those domains retain their typed owners.
+
+### 4. The agent decides; Exomem validates and executes
+
+Candidate sensors and existing review queues may point the agent at work. The
+`work-item` action only assembles bounded recorded context and deterministic
+measurements. `propose` accepts the agent's explicit interpretation and desired
+steps; Exomem performs schema, binding, registry, and policy checks without
+ranking or semantic inference.
+
+No language classifier participates in plan admission. Text fields remain
+Unicode, display titles can be multilingual, and executability depends on
+typed operation ids, paths, hashes, draft tokens, and registries. An agent may
+therefore author a Finnish, English, or mixed-language correction under the
+same contract. ASCII filename slug constraints remain the existing leaf rule,
+not an English-content requirement.
+
+### 5. Explicit plan approval is durable and bounded to exact bytes
+
+`apply` and `apply-compensation` require `plan_id`,
+`expected_plan_fingerprint`, and a bounded single-line `why`. The server
+recomputes the fingerprint and every live binding under the mutation boundary
+before recording a create-only approval artifact. Approval is stored once
+against those exact plan bytes. `resume` may act only on that stored approved
+identity and cannot switch to a newly proposed or changed plan.
+
+The served skill maps `propose`/`preview` to the existing
+`structural_suggestions` envelope class and maps `apply`, `resume`, and
+compensation execution to `restructure_execution`. It requires explicit
+in-conversation confirmation before the first apply call. No prominence or
+family disposition can lift that ceiling. This is an agent-contract gate plus
+server-side exact-plan binding; it does not pretend the server can infer human
+intent from prose.
+
+### 6. Each leaf commits a witness with its effect
+
+For a step, the executor first persists a `prepared` state containing the
+deterministic `operation_id = sha256(plan_id + ordinal + step_id)`. It then
+dispatches the existing governed leaf through a narrow internal adapter. The
+adapter supplies one content-free curation witness as an additional write to
+the leaf's canonical atomic batch. The witness binds:
+
+- run, plan, ordinal, step, operation, and parent-compensation identity;
+- exact before/after target manifest hashes;
+- the governed leaf's operation/draft/transition identity;
+- committed timestamp and result digest.
+
+The adapter may expose a private `additional_writes`/commit-witness seam in the
+underlying prepare/commit implementation, but public leaf schemas and ordinary
+behavior stay unchanged. It must not perform the page mutation itself or create
+a second implementation of leaf validation.
+
+After the leaf returns, the executor creates the terminal attempt receipt and
+advances `state.json`. Read-only `status` may diagnose every cut but never
+repairs it; the next mutation-shaped `apply` or `resume` performs any required
+receipt recovery. This produces four recoverable cuts:
+
+1. no prepared state: no step started;
+2. prepared state, no witness: no canonical effect committed, so exact retry is
+   allowed after live bindings still match;
+3. witness present, terminal receipt absent: the effect committed; status
+   reports recovery required, then exact resume verifies the witness and live
+   postcondition, creates a `recovered-committed` receipt, and never invokes the
+   leaf again;
+4. terminal receipt present: replay returns that terminal.
+
+An invalid witness, competing witness, or witness/postcondition disagreement is
+`CURATION_OUTCOME_UNCERTAIN` and blocks execution. Recovery never guesses from
+mtime, activity-log prose, or current content alone.
+
+### 7. Partial failure is a first-class terminal, not rollback
+
+After each step, phase derives from immutable receipts:
+
+- `proposed` before approval;
+- `approved` after approval but before the first step;
+- `executing` while a prepared step exists;
+- `partial` when at least one step committed and the next step failed or is
+  blocked;
+- `failed` when no content step committed and the plan cannot continue;
+- `completed` when every step has a committed receipt;
+- `compensating`, `compensated`, or `compensation-partial` for the reverse plan;
+- `blocked` when exact outcome cannot be proven.
+
+A clean leaf refusal records a failed attempt without a commit witness. A
+retryable operational failure may be retried by `resume` with the same
+operation id after guards are rechecked. Stale content, changed registries, or
+invalidated semantics require a new forward plan; immutable plan bytes are
+never edited in place.
+
+### 8. Compensation is a new reviewed plan that preserves history
+
+`propose-compensation` reads only committed step receipts, witnesses, and the
+sealed compensation material captured during proposal validation. It reverses
+committed steps in descending order:
+
+- created notes/entities are deleted to governed trash;
+- deleted items are recovered from their exact trash receipt;
+- moves are moved back when the original path is still safely available;
+- edits and accepted relations are corrected by superseding the current page
+  with the sealed pre-step document;
+- a supersession is corrected by superseding its committed successor with the
+  sealed predecessor document;
+- a prior recover is compensated by a new governed delete.
+
+The derived plan includes fresh live bindings and refuses collisions or drift.
+It is immutable, has its own fingerprint and approval rationale, uses the same
+one-step witness/receipt protocol, and links every result to the forward plan.
+The original plan, successor chain, trash entries, witnesses, and receipts are
+never removed. This is compensation, not time travel.
+
+### 9. Hosted and standalone use the identical executor
+
+The registry-derived surfaces expose the curation schema everywhere.
+`invocation_is_read_only` classifies only `work-item`, `preview`, and `status`
+as reads. Every other action takes the common writer authority, process-safe
+vault boundary, terminal projection, and tenant-scoped retry path.
+
+The request-bound maintenance refusal changes from a single
+`structured-files` exception to the explicit set `{structured-files,
+curation}`. No other maintenance write is admitted remotely. Hosted v4 needs no
+intercept or separate executor: its current profile already includes
+`maintain_memory`, and the generic gateway forwards the canonical arguments to
+the same leaf. Capability/profile generation and actual-wire tests prove the
+surface rather than relying on documentation.
+
+Standalone mode stores all canonical run material inside the vault and uses
+only the existing local mutation/runtime state; it requires no Hosted service,
+control plane, or network coordinator.
+
+### 10. Fault injection is part of acceptance
+
+The curation executor exposes test-only barriers after prepared-state commit,
+after leaf+witness commit, after terminal-receipt commit, and after each
+equivalent compensation cut. Tests terminate/recreate the executor at every
+barrier, then call `status` and exact replay. Acceptance requires one effect,
+one terminal receipt, correct next-step selection, and byte-identical plan
+identity at every cut. A changed plan id/fingerprint or altered target must
+refuse, not recover optimistically.
+
+## Risks / Trade-offs
+
+- **[Risk] Plan files duplicate pre-change content for compensation.** → Keep
+  them under governed `_Governance`, cap plan/step/body sizes, include them in
+  normal backup/disclosure policy, and never expose them through broad review
+  listings.
+- **[Risk] Adding an atomic witness seam touches several mature writers.** →
+  Keep the seam private and additive, test every allowed adapter against its
+  ordinary leaf, and reject a step kind whose leaf cannot prove witness+effect
+  in one batch.
+- **[Risk] One-step requests require several tool calls for a long plan.** →
+  The skill loops automatically after one approval; bounded calls are safer for
+  Hosted edge timeouts and make progress observable.
+- **[Risk] A content-free witness may not be enough to reconstruct a rich leaf
+  result.** → The curation receipt promises the closed curation terminal shape,
+  not the full legacy leaf payload; it retains a result digest and exact target
+  manifest while `response_detail=full` may include the live leaf result only
+  on the first delivery.
+- **[Risk] Independent edits can make compensation impossible.** → Refuse on
+  drift and require a freshly authored correction plan; never overwrite later
+  work to satisfy a reverse operation.
+- **[Risk] Remote curation weakens the broad maintenance refusal.** → Admit only
+  `mode="curation"`, require an immutable reviewed fingerprint, retain the
+  restructure ceiling, and test that every legacy write mode is still refused
+  before manager dispatch.
+
+## Migration Plan
+
+1. Add the curation plan/store and read-only work-item/preview/status paths
+   behind the new mode; no existing invocation changes.
+2. Add strict step schemas and validate-only plan preparation.
+3. Add the private leaf commit-witness seam and one adapter at a time with
+   crash tests before enabling its step kind.
+4. Add forward apply/resume, then compensation derivation/execution.
+5. Update read/write classification, the narrow request-bound exception,
+   schema fixtures, capability docs, scaffold workflow skill, and Hosted v4
+   generated artifacts.
+6. Run scoped suites during implementation, then the full lean corpus,
+   OpenSpec strict validation, artifact freshness, and privacy/leak gates.
+
+Rollback is code-only: older versions ignore the new run subtree and continue
+serving ordinary vault content. Already committed knowledge effects remain
+governed history; operators use the generated compensation plan rather than
+deleting run artifacts or attempting an out-of-band rollback.
+
+## Open Questions
+
+None. The v1 action set, step vocabulary, one-step execution bound, witness
+protocol, compensation rules, Hosted admission, and Planning/Records exclusion
+are fixed by this change.

--- a/openspec/changes/add-governed-curation-lane/proposal.md
+++ b/openspec/changes/add-governed-curation-lane/proposal.md
@@ -1,0 +1,89 @@
+## Why
+
+Exomem can now detect maintenance work and surface it without nudging, but the
+last mile is still manual: an agent can inspect relation debt, stale or
+duplicated conclusions, and structural drift, then must perform a sequence of
+independent writes with no durable plan, resumable status, or crash-safe proof
+of which steps committed. That leaves the highest-risk part of no-nudge
+curation—multi-step restructuring—outside the governed workflow.
+
+Adoption Studio already proves the useful shape for first-run material:
+deterministic context, an agent-authored proposal, explicit review, and apply
+through existing governed leaves. Ongoing curation needs the same separation of
+judgment from execution, but with ordered step receipts, partial-failure
+recovery, and compensation rather than a false multi-file atomicity promise.
+
+## What Changes
+
+- Add a governed curation run that accepts an agent-authored, immutable ordered
+  plan over existing content operations, validates and fingerprints every
+  target, and exposes preview/status/apply/resume/compensate actions.
+- Keep the active agent as the only semantic decider. Exomem may deterministically
+  assemble candidates and validate a supplied plan, but it does not rank,
+  interpret, or author curation work with a server-side model.
+- Execute one step at a time through existing governed leaves; persist a
+  terminal receipt for every step and explicit `partial`, `failed`,
+  `interrupted`, and `compensated` states instead of claiming cross-step
+  atomicity.
+- Make exact-plan replay idempotent. A replay verifies committed step receipts
+  and live state, resumes only uncommitted work, and refuses changed plan bytes,
+  stale bindings, or an uncertain outcome it cannot prove.
+- Model reversal as a separately reviewed compensation plan: recover governed
+  trash for move/delete effects and use a new superseding correction for
+  authored-content effects. Compensation never erases the original plan,
+  receipts, or history.
+- Extend the existing `maintain_memory` product command rather than adding a
+  parallel tool. The same registry-derived MCP, REST, CLI, and Hosted surface
+  exposes curation; request-bound remote execution is allowed only for this
+  exact reviewed-plan mode and remains behind the normal tenant, authority,
+  mutation-boundary, receipt, and idempotency gates.
+- Deliberately narrow the broad refusal introduced by the still-active
+  `bound-remote-maintenance` change only for this bounded one-step protocol.
+  Long-running remote `fix`, `reconcile`, and ID backfill remain refused; S8
+  does not revive their synchronous request shape.
+- Teach the shipped curation workflow skill to use the new run while preserving
+  the `restructure_execution` confirm-required ceiling. Candidate surfacing may
+  be quiet or advisory according to the existing envelope, but applying or
+  compensating a plan always requires explicit in-conversation confirmation.
+- Keep plan validation content-language-neutral: paths, hashes, registries, and
+  operation schemas—not English text classification—determine executability, so
+  agent-authored plans can curate multilingual Markdown.
+
+This change does not automate Planning/Records lifecycle decisions or redesign
+the separate Exomem/OpenSpec workflow contract.
+
+## Capabilities
+
+### New Capabilities
+
+- `governed-curation-lane`: Durable agent-authored curation plans, exact review
+  bindings, stepwise governed execution, per-step receipts, crash recovery,
+  exact replay, partial-failure visibility, and separately reviewed
+  compensation for ongoing knowledge maintenance.
+
+### Modified Capabilities
+
+- `command-surface`: Extend `maintain_memory` with the finite curation action
+  set, correct read/write classification, generated MCP/REST/CLI parity, and
+  stable review/apply error envelopes.
+- `hosted-gateway-contract`: Admit the same curation actions on the current
+  Hosted agent surface through the shared registry and mutation boundary,
+  without a Hosted-only executor or bypass of tenant and authority checks.
+- `delegation-envelope`: Bind curation plan apply and compensation explicitly
+  to the existing confirm-required `restructure_execution` class while keeping
+  proposal assembly under `structural_suggestions`.
+
+## Impact
+
+- Adds a focused curation run/plan executor and tests, reusing the existing
+  governed content leaves, review-state identities, mutation terminals,
+  idempotency store, writer boundary, and trash/supersession mechanisms.
+- Extends `maintain_memory` arguments, selector classification, tool schema,
+  generated capability documentation, bootstrap teaching, and the generic
+  Hosted profile/artifacts where required by the current release pipeline.
+- Adds deterministic crash-injection coverage around phase persistence, leaf
+  commit, step-receipt persistence, and compensation progress, plus standalone
+  and Hosted parity tests.
+- Leaves Adoption Studio semantics, the Planning and Records product commands,
+  OpenSpec lifecycle behavior, and legacy operator-only `fix`, `reconcile`, and
+  `backfill-ids` remote refusal unchanged.

--- a/openspec/changes/add-governed-curation-lane/specs/command-surface/spec.md
+++ b/openspec/changes/add-governed-curation-lane/specs/command-surface/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Maintain memory exposes one generated curation action surface
+
+The product registry SHALL extend `maintain_memory` with
+`mode="curation"` and the finite `curation_action` set `work-item`, `propose`,
+`preview`, `status`, `apply`, `resume`, `propose-compensation`, and
+`apply-compensation`. The registry-derived MCP tool, REST route, OpenAPI schema,
+CLI subcommand, generated capability documentation, and schema fixtures SHALL
+expose the same arguments and shared leaf implementation with no per-surface
+curation logic.
+
+#### Scenario: Curation is discovered on every product surface
+
+- **WHEN** the registry generates MCP, REST, OpenAPI, CLI, and capability output
+- **THEN** every surface exposes the same curation actions and input constraints
+  under `maintain_memory`
+
+### Requirement: Curation selector classification is conservative and exact
+
+`invocation_is_read_only` SHALL classify curation `work-item`, `preview`, and
+`status` as read-only and every other known curation action as a mutation. An
+omitted or unknown curation action SHALL take the conservative mutation path and
+then fail validation before leaf dispatch. Arguments belonging to another
+maintenance mode SHALL be refused rather than ignored or reinterpreted.
+
+#### Scenario: Read-only status bypasses mutation acquisition
+
+- **WHEN** `maintain_memory(mode="curation", curation_action="status")` is
+  invoked with a valid run id
+- **THEN** it follows the common read-only path and performs no canonical write
+
+#### Scenario: Unknown action cannot become an unreceipted read
+
+- **WHEN** a caller supplies a future or misspelled curation action
+- **THEN** the invocation is treated as write-capable and returns
+  `INVALID_CURATION_ACTION` before any curation or content leaf executes
+
+### Requirement: Curation mutations use the shared terminal envelope
+
+Successful curation plan creation, approval, step execution, resume, and
+compensation mutations SHALL pass through the common writer authority,
+vault-scoped mutation boundary, idempotency, canonical terminal, graph/due-state
+settlement, and response-detail projection. Expected plan, binding, and outcome
+failures SHALL retain stable application error codes and SHALL NOT be converted
+to successful result dictionaries.
+
+#### Scenario: Hosted or MCP acknowledgement is retried
+
+- **WHEN** a curation mutation acknowledgement is lost and the same principal
+  repeats the exact canonical request within its retry contract
+- **THEN** the common terminal path replays the result or the curation witness
+  recovers it without executing a second content effect

--- a/openspec/changes/add-governed-curation-lane/specs/delegation-envelope/spec.md
+++ b/openspec/changes/add-governed-curation-lane/specs/delegation-envelope/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Curation proposals and execution occupy different authority classes
+
+Agent-initiated curation context and proposal surfacing SHALL be governed by the
+existing `structural_suggestions` disposition. Forward-plan apply, resume, and
+compensation execution SHALL be governed by the existing
+`restructure_execution` class and SHALL remain confirm-required regardless of
+prominence, family disposition, repeated prior approvals, or stored plan state.
+The served bootstrap and curation workflow contract SHALL teach this split and
+require explicit in-conversation user confirmation before the first apply of
+each immutable forward or compensation plan.
+
+#### Scenario: Structural suggestions are off
+
+- **WHEN** `structural_suggestions` is off and the user has not explicitly
+  requested a curation review
+- **THEN** the agent does not proactively surface or propose curation work, while
+  an explicit user request remains available
+
+#### Scenario: Plan was proposed at maximal prominence
+
+- **WHEN** a valid curation plan exists while prominence is maximal
+- **THEN** the agent still obtains explicit confirmation before apply and no
+  setting turns the plan into silent execution
+
+#### Scenario: Compensation follows a previously approved plan
+
+- **WHEN** the user already approved the forward plan and a compensation plan is
+  later derived
+- **THEN** the compensation plan requires its own explicit confirmation because
+  it is a new immutable `restructure_execution` action

--- a/openspec/changes/add-governed-curation-lane/specs/governed-curation-lane/spec.md
+++ b/openspec/changes/add-governed-curation-lane/specs/governed-curation-lane/spec.md
@@ -1,0 +1,208 @@
+## ADDED Requirements
+
+### Requirement: Curation context remains deterministic and agent-decided
+
+The system SHALL provide a bounded curation work item containing only recorded
+page content, stable review references, deterministic measurements, current
+content hashes, relevant registry identities, and the closed plan-step schemas.
+The system MUST NOT use a server-side reasoning model, text generator, semantic
+authority score, or language classifier to select, rank, interpret, or author a
+curation plan. The active agent SHALL remain the sole author of the proposed
+interpretation and steps.
+
+#### Scenario: Agent requests context for surfaced maintenance work
+
+- **WHEN** the agent requests a curation work item for named review refs or paths
+- **THEN** Exomem returns bounded recorded context and exact bindings without
+  writing a plan or deciding what the material means
+
+#### Scenario: No model capability is installed
+
+- **WHEN** Exomem runs in a lean standalone installation with no optional model
+  runtime
+- **THEN** work-item, proposal validation, preview, execution, recovery, and
+  compensation remain available with identical authority semantics
+
+### Requirement: Forward plans are strict, immutable, and exactly bound
+
+The system SHALL accept an ordered agent-authored forward plan only through a
+strict schema, canonicalize it to immutable JSON, and derive `plan_id` as the
+SHA-256 digest of the canonical bytes. Proposal validation SHALL capture an
+ordered target manifest, expected present content hashes, expected absent
+paths, semantic draft or transition identities, relevant registry
+fingerprints, deterministic postconditions, and sealed compensation material.
+An agent-supplied binding that does not match current state MUST be refused and
+MUST NOT be silently refreshed. A stored plan MUST be create-only; the same id
+with different bytes MUST be refused as a collision.
+
+#### Scenario: Reviewed target changed before proposal
+
+- **WHEN** the agent submits a plan with the hash it reviewed and the live page
+  now has a different hash
+- **THEN** proposal creation refuses stale without storing a rebound plan
+
+#### Scenario: Plan bytes are changed after creation
+
+- **WHEN** a caller presents the stored plan id with different ordered steps or
+  arguments
+- **THEN** preview and execution refuse the identity mismatch and no step runs
+
+### Requirement: Curation exposes only governed step kinds
+
+The v1 forward step vocabulary SHALL be exactly `create-note`, `create-entity`,
+`accept-relation`, `edit`, `supersede`, `move`, `delete`, and `recover`. Each
+kind SHALL have a closed per-kind argument schema and SHALL dispatch through
+the matching existing governed leaf. A plan MUST NOT contain a command name,
+raw filesystem operation, callable, shell fragment, or free-form patch program.
+All existing leaf confirmation, draft, content-hash, relation, source/evidence,
+protected-tree, and path-confinement checks SHALL remain authoritative at plan
+validation and immediately before commit.
+
+#### Scenario: Plan requests an arbitrary command
+
+- **WHEN** a plan step supplies a product command name or a step kind outside
+  the closed vocabulary
+- **THEN** proposal validation refuses the step before storing an executable plan
+
+#### Scenario: Leaf guard changes after preview
+
+- **WHEN** a plan previews successfully but its target hash, relation candidate,
+  semantic draft, or registry changes before apply
+- **THEN** the canonical leaf refuses the step and curation cannot bypass or
+  weaken that refusal
+
+### Requirement: Curation leaves typed administrative domains to their owners
+
+The curation executor SHALL refuse direct step targets in Planning, Records,
+workflow-contract storage, `_Schema`, `_Governance`, `_Adoption`, trash internals,
+and every other protected administrative subtree except its own internally
+written run artifacts. Planning and Records changes SHALL continue to route
+only through their typed product commands, and OpenSpec lifecycle behavior
+SHALL remain outside curation.
+
+#### Scenario: Plan attempts to update a Planning item
+
+- **WHEN** an otherwise valid edit or move step targets a Planning collection
+  item
+- **THEN** proposal validation refuses the target and directs the caller to the
+  typed Planning owner without writing anything
+
+### Requirement: Exact plan approval gates bounded execution
+
+The first forward execution request SHALL require the exact `plan_id`, current
+`expected_plan_fingerprint`, and a bounded single-line approval rationale. The
+system SHALL revalidate the plan fingerprint and every live binding under the
+vault mutation boundary before recording approval. Approval SHALL bind only
+those immutable bytes. Each `apply` or `resume` request SHALL execute at most
+one content step, and `resume` SHALL run only the next step of the already
+approved forward or compensation plan.
+
+#### Scenario: Confirmed plan begins execution
+
+- **WHEN** the agent invokes apply after explicit user confirmation with the
+  exact current plan identity, fingerprint, and rationale
+- **THEN** Exomem durably binds approval to that plan and executes no more than
+  its next uncommitted step
+
+#### Scenario: Resume tries to switch plans
+
+- **WHEN** a resume request names a different or newly proposed plan from the
+  plan whose approval is stored
+- **THEN** the request is refused and neither plan advances
+
+### Requirement: Every committed step has atomic commit evidence
+
+Before invoking a content leaf, the executor SHALL persist a prepared step with
+a deterministic operation id derived from plan id, ordinal, and step id. The
+governed leaf SHALL commit one content-free curation witness in the same atomic
+batch as its canonical effect. The witness SHALL bind the run, plan, ordinal,
+step, operation id, exact before/after target manifest, governed leaf identity,
+result digest, and optional parent compensation identity. Terminal attempt
+receipts and approval artifacts SHALL be create-only, at most one committed or
+recovered-committed receipt SHALL exist per step, and state SHALL be derivable
+from the immutable plan, approval, witnesses, and receipts.
+
+#### Scenario: Process stops before the leaf commit
+
+- **WHEN** a crash occurs after prepared state is durable but before a matching
+  leaf witness commits
+- **THEN** recovery proves no step effect committed and permits exact retry only
+  if every live guard still matches
+
+#### Scenario: Process stops after the leaf commit
+
+- **WHEN** a crash occurs after effect and matching witness commit atomically but
+  before the terminal step receipt is stored
+- **THEN** read-only status reports that exact recovery is required, and the
+  next resume verifies the witness and live postcondition, writes one
+  recovered-committed receipt, and never invokes the leaf again
+
+#### Scenario: Evidence and live state disagree
+
+- **WHEN** a witness is invalid, competing, or inconsistent with the exact live
+  postcondition
+- **THEN** the run becomes blocked with `CURATION_OUTCOME_UNCERTAIN` and no
+  automatic retry or compensation proceeds
+
+### Requirement: Run phases report partial truth and exact replay
+
+The system SHALL derive run phase from the immutable plan, create-only approval,
+witnesses, and terminal receipts and SHALL expose at least `proposed`, `approved`, `executing`,
+`partial`, `failed`, `completed`, `blocked`, `compensating`, `compensation-partial`,
+and `compensated`. It MUST NOT report a multi-step atomic commit. Exact replay
+SHALL return already-committed step outcomes without executing their leaves;
+changed plan bytes, stale bindings, or an unprovable outcome SHALL refuse.
+
+#### Scenario: Third step fails after two commits
+
+- **WHEN** two ordered steps have committed receipts and the third cleanly fails
+- **THEN** status reports `partial`, identifies both committed steps and the
+  failed next step, and preserves the exact next permitted action
+
+#### Scenario: Completed apply is replayed
+
+- **WHEN** the same approved plan and next-step request is repeated after its
+  terminal receipt exists
+- **THEN** Exomem returns the stored outcome and creates no second content effect
+
+### Requirement: Compensation is a separate reviewed history-preserving plan
+
+The system SHALL derive compensation only from committed step receipts,
+matching witnesses, and sealed pre-step material. It SHALL create a new
+immutable compensation plan linked to the forward plan and reverse committed
+steps in descending order. Creation effects SHALL move to governed trash;
+deletions SHALL recover their exact trash entries; moves SHALL use a guarded
+inverse move; edits and accepted relations SHALL create a superseding
+correction from the sealed pre-step document; supersessions SHALL be corrected
+by superseding the committed successor; and recovered items SHALL be deleted
+through the governed delete leaf. Compensation SHALL require its own exact
+fingerprint and approval rationale and SHALL preserve all forward and reverse
+plans, witnesses, receipts, trash history, and supersession chains.
+
+#### Scenario: User approves compensation after a partial run
+
+- **WHEN** a forward run committed two steps before failing and the user reviews
+  and approves the derived compensation plan
+- **THEN** compensation processes only those committed effects in reverse order
+  through governed leaves and leaves the original evidence intact
+
+#### Scenario: Later work changed a compensation target
+
+- **WHEN** a target no longer matches the sealed forward receipt at compensation
+  proposal or apply time
+- **THEN** compensation refuses stale rather than overwriting the later work
+
+### Requirement: Plan execution is content-language-neutral
+
+The curation plan, work item, receipts, and validation paths SHALL preserve
+Unicode text and SHALL determine executability from typed step ids, operation
+schemas, paths, hashes, draft tokens, and registry ids rather than English
+keywords or monolingual entailment labels. Existing ASCII slug rules MAY still
+govern filenames while Unicode titles and bodies remain unchanged.
+
+#### Scenario: Multilingual plan is reviewed and applied
+
+- **WHEN** an agent proposes a typed correction whose title and body contain
+  non-English or mixed-language Unicode text
+- **THEN** the same validation, fingerprint, approval, receipt, recovery, and
+  compensation contract applies without language-specific fallback

--- a/openspec/changes/add-governed-curation-lane/specs/hosted-gateway-contract/spec.md
+++ b/openspec/changes/add-governed-curation-lane/specs/hosted-gateway-contract/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Hosted admits exact reviewed curation without a bespoke executor
+
+The current Hosted agent surface SHALL expose registry-derived
+`maintain_memory(mode="curation")` and forward it to the same curation leaf used
+by standalone MCP, REST, and CLI. The gateway and cell MUST NOT add a Hosted-only
+plan format, command intercept, executor, persistence path, or semantic model.
+All tenant mapping, authenticated principal, entitlement, path confinement,
+writer authority, process-safe mutation boundary, terminal receipt, and
+tenant-scoped idempotency checks SHALL run normally.
+
+#### Scenario: Hosted user applies a reviewed plan
+
+- **WHEN** an authenticated Hosted principal submits the exact approved plan id,
+  fingerprint, and rationale to its mapped cell
+- **THEN** the generic registry route invokes the shared curation executor under
+  that cell's ordinary mutation and receipt boundaries
+
+#### Scenario: Cross-tenant plan id is presented
+
+- **WHEN** a principal presents a run or plan identity stored only in another
+  tenant cell
+- **THEN** resolution fails inside the mapped cell without revealing whether the
+  other tenant's identity exists
+
+### Requirement: Remote maintenance refusal remains closed around curation
+
+The request-bound remote maintenance gate SHALL admit write execution only for
+`structured-files` and `curation`. `fix`, `reconcile`, `backfill-ids`, and every
+future unknown write mode SHALL retain the operator-only refusal before manager
+dispatch. Within curation, only an exact immutable reviewed plan may reach a
+content leaf; the mode MUST NOT become a wrapper for ordinary maintenance or an
+arbitrary command.
+
+#### Scenario: Hosted reconcile remains refused
+
+- **WHEN** a Hosted caller invokes write-mode reconcile after curation ships
+- **THEN** it still receives `MAINTENANCE_REQUIRES_CLI` before manager dispatch
+
+#### Scenario: Hosted curation omits its reviewed identity
+
+- **WHEN** a Hosted caller invokes an apply-shaped curation action without the
+  exact plan id, fingerprint, or required rationale
+- **THEN** the cell refuses before any content leaf executes
+
+### Requirement: Hosted and standalone curation evidence is portable
+
+Canonical curation plans, state, witnesses, and step receipts SHALL live inside
+the governed vault and SHALL use the same schema in Hosted and standalone
+deployments. Machine-local retry state MAY accelerate delivery but MUST NOT be
+the sole record required to inspect, resume, recover, or compensate a run after
+a process restart or Hosted cell replacement.
+
+#### Scenario: Hosted cell restarts between leaf and terminal receipt
+
+- **WHEN** a cell restarts after a step's effect and witness committed but before
+  its terminal receipt was written
+- **THEN** read-only status exposes the exact recoverable outcome and the next
+  resume reconstructs its terminal receipt from governed evidence without
+  control-plane intervention or a second content effect

--- a/openspec/changes/add-governed-curation-lane/tasks.md
+++ b/openspec/changes/add-governed-curation-lane/tasks.md
@@ -1,0 +1,70 @@
+## 1. Plan model and canonical store
+
+- [ ] 1.1 Add red pure-logic tests for canonical plan JSON, plan/run ids, strict step schemas, binding manifests, fingerprints, size caps, collisions, and unknown-field refusal.
+- [ ] 1.2 Implement the curation plan dataclasses/validators and closed v1 step vocabulary without any leaf dispatch.
+- [ ] 1.3 Add red store tests for create-only forward/compensation plans, state reconstruction from receipts, protected no-follow paths, and corrupt or competing artifacts.
+- [ ] 1.4 Implement the governed `_Governance/curation/runs` store for immutable plans, mutable projection state, create-only receipts, and evidence lookup.
+- [ ] 1.5 Add path-policy tests and enforcement that refuse Planning, Records, workflow-contract, `_Schema`, `_Governance`, `_Adoption`, trash internals, and other protected targets outside the run store.
+
+## 2. Deterministic work items and proposals
+
+- [ ] 2.1 Add red tests for bounded `work-item` assembly from explicit refs/paths, exact current hashes and registry ids, truncation disclosure, Unicode preservation, and no model calls.
+- [ ] 2.2 Implement deterministic work-item assembly and publish the closed per-kind input contracts.
+- [ ] 2.3 Add red proposal tests for stale agent bindings, ordered validate-only preparation, expected absence, registry drift, semantic/relation tokens, compensation pre-images, and immutable plan preview.
+- [ ] 2.4 Implement forward proposal validation by adapting the existing remember/entity/relation/edit/replace/move/delete/recover validation paths without writing knowledge content.
+- [ ] 2.5 Implement read-only preview/status projections with exact actions, binding health, blockers, phase, receipts, and next permitted action.
+
+## 3. Atomic step witnesses
+
+- [ ] 3.1 Add a red shared contract test proving a curation operation witness commits in the same batch as its content effect and never appears on a refused or rolled-back mutation.
+- [ ] 3.2 Add the private commit-witness seam to semantic create/edit/replace internals while keeping public command schemas and ordinary results unchanged.
+- [ ] 3.3 Add witness adapters and parity tests for `create-note`, `edit`, and `supersede` against their ordinary governed leaves.
+- [ ] 3.4 Add witness adapters and parity tests for `create-entity` and `accept-relation`, including relation fingerprint/hash revalidation.
+- [ ] 3.5 Add witness adapters and parity tests for governed `move`, `delete`, and `recover`, including canonical delete confirmation and exact trash identity.
+- [ ] 3.6 Reject any enabled step kind whose leaf cannot prove one atomic effect+witness commit.
+
+## 4. Forward execution and recovery
+
+- [ ] 4.1 Add red tests for exact-plan approval, bounded rationale, live revalidation under the mutation boundary, one-step execution, and refusal to resume another plan.
+- [ ] 4.2 Implement apply/resume with durable approval, deterministic operation ids, prepared state, single-step dispatch, terminal receipts, and phase derivation.
+- [ ] 4.3 Add deterministic fault barriers after prepared-state commit, leaf+witness commit, and terminal-receipt commit.
+- [ ] 4.4 Add crash/restart tests at every barrier proving read-only status never repairs, exact resume produces zero-or-one effect and recovered-committed receipts, replay selects the correct next step, and invalid evidence blocks.
+- [ ] 4.5 Add red tests and implementation for clean refusal, retryable pre-commit failure, stale-plan failure, partial runs, failed runs, completed replay, and state reconstruction after projection loss.
+- [ ] 4.6 Integrate curation step outcomes with the existing mutation terminal, idempotency, graph settlement, due-state batch carrier, and compact/full response projections.
+
+## 5. Compensation
+
+- [ ] 5.1 Add red derivation tests for reverse ordering and the exact compensation mapping for creation, deletion, move, edit, accepted relation, supersession, and recovery receipts.
+- [ ] 5.2 Implement create-only compensation plans from committed witnesses/receipts and sealed pre-step material, with fresh live bindings and forward-plan linkage.
+- [ ] 5.3 Add red approval/execution tests proving compensation has a distinct fingerprint/rationale, runs one step per request, and preserves all forward evidence.
+- [ ] 5.4 Implement compensation apply/resume through the same witness and receipt protocol.
+- [ ] 5.5 Add crash tests at every compensation barrier and drift/collision tests proving later work is never overwritten to force a reversal.
+
+## 6. Product command and standalone parity
+
+- [ ] 6.1 Add red registry/schema tests for `maintain_memory(mode="curation")`, the eight finite actions, curation-only arguments, and conservative unknown-action handling.
+- [ ] 6.2 Wire the curation actions into `op_maintain_memory` and `invocation_is_read_only`, keeping all non-curation maintenance behavior unchanged.
+- [ ] 6.3 Add MCP, REST, OpenAPI, and CLI parity tests over the shared leaf, including application errors and response-detail projection.
+- [ ] 6.4 Add standalone restart tests proving the governed run artifacts, not a Hosted or machine-local service, are sufficient to inspect, recover, resume, and compensate.
+- [ ] 6.5 Regenerate the golden MCP schema and generated capability documentation with an exact intentional-diff assertion for `maintain_memory` only.
+
+## 7. Hosted admission and release artifacts
+
+- [ ] 7.1 Add red common-boundary and private-route tests proving Hosted v4 discovers curation and admits its reviewed mutations through the generic registry route.
+- [ ] 7.2 Narrowly extend the request-bound maintenance exception to `structured-files` and `curation`; preserve pre-dispatch `MAINTENANCE_REQUIRES_CLI` for fix, reconcile, backfill, and unknown modes.
+- [ ] 7.3 Add Hosted tenant-isolation, entitlement, path-confinement, idempotency, process-restart recovery, and edge-duration tests for one-step execution.
+- [ ] 7.4 Regenerate current Hosted v4 Claude/OpenAI candidate artifacts and pass package freshness, actual-wire schema, capability membership, and historical release-identity gates.
+
+## 8. Agent contract and no-nudge integration
+
+- [ ] 8.1 Add red scaffold tests that map work-item/propose/preview to `structural_suggestions` and apply/resume/compensation to confirm-required `restructure_execution`.
+- [ ] 8.2 Update the generic `exomem-curate` workflow skill and core operation references to preview once, obtain explicit confirmation once per immutable plan, resume automatically until terminal, and stop on partial/blocked state.
+- [ ] 8.3 Add hookless bootstrap/custom-instruction carrier assertions without hardcoding an English-only workflow or weakening explicit-request availability when structural suggestions are off.
+- [ ] 8.4 Pass scaffold privacy/leak checks and verify no Planning/Records/OpenSpec workflow automation was added.
+
+## 9. Completion and OpenSpec closure
+
+- [ ] 9.1 Run the affected curation, semantic writer, file governance, command-surface, mutation-terminal, Hosted, workflow-skill, and artifact-freshness suites with explicit scope.
+- [ ] 9.2 Run `ruff check`, the full lean pytest corpus, strict OpenSpec validation, lock/diff checks, privacy scan, and all release artifact freshness gates; record unrelated environmental failures separately from attributable failures.
+- [ ] 9.3 Exercise one multilingual forward plan, crash recovery, partial run, exact replay, and compensation end to end on both standalone and Hosted test harnesses.
+- [ ] 9.4 Synchronize the accepted delta specs into canonical specs and archive `add-governed-curation-lane` only after implementation, tests, and merge evidence prove every non-optional task complete.


### PR DESCRIPTION
## What

Defines the S8 governed curation lane for ongoing knowledge maintenance:

- immutable agent-authored plans with exact review bindings
- one governed content step per request with atomic effect witnesses and per-attempt receipts
- crash recovery, exact replay, honest partial states, and history-preserving compensation
- the existing maintain_memory surface across MCP, REST, CLI, standalone, and Hosted
- explicit separation between structural suggestions and confirm-required restructure execution
- content-language-neutral validation for multilingual Markdown

## Boundaries

The active agent remains the sole semantic decider. The server validates and executes typed plans without a reasoning model. Planning, Records, OpenSpec workflow orchestration, Adoption Studio semantics, and legacy remote fix/reconcile/backfill behavior stay outside this change.

Hosted curation is a deliberate narrow successor to the broad remote-maintenance refusal: it admits only this bounded one-step reviewed-plan protocol and does not reopen long-running synchronous maintenance.

## Verification

- openspec validate add-governed-curation-lane --strict
- openspec validate --all --strict: 170 passed, 0 failed
- public artifact privacy scan: 3,503 files / 3,571 text payloads clean
- staged diff and whitespace checks clean