### PR TITLE
perf(recall): reuse query vectors and batch frame collapse

### DIFF
--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -16,7 +16,7 @@ import os
 import threading
 import time
 from collections import OrderedDict
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from collections.abc import Set as AbstractSet
 from datetime import date
 from pathlib import Path
@@ -1166,6 +1166,17 @@ def find(
                 _trim_find_cache(cache_size)
         return unit_hits
     mixed = effective_result_level == "mixed"
+    query_vector: Any = None
+    query_vector_ready = False
+
+    def _query_vector() -> Any:
+        nonlocal query_vector, query_vector_ready
+        if not query_vector_ready:
+            from . import embeddings
+
+            query_vector = embeddings.embed_texts([query], is_query=True)[0]
+            query_vector_ready = True
+        return query_vector
 
     # ---- Hot cache lookup (freshness-keyed; see _freshness_key above) ----
     # prefer_used bypasses the cache entirely — simplest correct interaction;
@@ -1337,6 +1348,7 @@ def find(
                 degraded_out=degraded,
                 failed_out=failed,
                 retrieval_trace=retrieval_trace,
+                query_vector_provider=_query_vector,
             )
         if retrieval_trace is not None:
             retrieval_trace.snapshot_result_plan("unit")
@@ -1423,6 +1435,7 @@ def find(
                 eligible_paths=eligible_paths,
                 recall_scope="kb" if scope == "kb-only" else "vault",
                 retrieval_trace=retrieval_trace,
+                query_vector_provider=_query_vector if mixed else None,
             )
 
     if retrieval_trace is not None and (mode == "keyword" or not query_norm):
@@ -1891,6 +1904,7 @@ def _vector_unit_candidates(
     degraded_out: list[str] | None,
     failed_out: list[str] | None,
     timings: FindTimings | None,
+    query_vector_provider: Callable[[], Any] | None = None,
 ) -> tuple[list[Any], dict[str, Any], str]:
     """Return bounded vector candidates without opening every Markdown parent."""
     model_name = "BAAI/bge-base-en-v1.5"
@@ -1912,7 +1926,11 @@ def _vector_unit_candidates(
 
         index = embeddings.get_embedding_index(vault_root)
         with _span(timings, "vector.unit.embed"):
-            query_vector = embeddings.embed_texts([query], is_query=True)[0]
+            query_vector = (
+                query_vector_provider()
+                if query_vector_provider is not None
+                else embeddings.embed_texts([query], is_query=True)[0]
+            )
         hits = index.search_semantic_units(
             query_vector,
             k=candidate_limit,
@@ -1964,6 +1982,7 @@ def _find_semantic_units(
     failed_out: list[str] | None,
     retrieval_trace: Any | None = None,
     timings: FindTimings | None = None,
+    query_vector_provider: Callable[[], Any] | None = None,
 ) -> list[SemanticUnitHit]:
     """Rank current, exactly eligible units through lexical and vector lanes."""
     from . import lexstore
@@ -2180,6 +2199,7 @@ def _find_semantic_units(
             degraded_out=degraded_out,
             failed_out=failed_out,
             timings=timings,
+            query_vector_provider=query_vector_provider,
         )
         if (
             vector_allowed_refs is not None
@@ -3096,6 +3116,7 @@ def _find_semantic(
     eligible_paths: set[str] | None = None,
     recall_scope: str | None = None,
     retrieval_trace: Any | None = None,
+    query_vector_provider: Callable[[], Any] | None = None,
 ) -> list[Hit]:
     """Hybrid (BM25+vector) or vector-only mode.
 
@@ -3169,6 +3190,7 @@ def _find_semantic(
             lexical_repair=lexical_repair,
             eligible_paths=eligible_paths,
             capture_trace=retrieval_trace is not None,
+            query_vector_provider=query_vector_provider,
         )
     except lexstore.CatalogUnavailable as error:
         _raise_catalog_outcome(error.readiness)

--- a/src/exomem/find_candidates.py
+++ b/src/exomem/find_candidates.py
@@ -159,6 +159,7 @@ def collect_candidates(
     lexical_repair: bool = True,
     eligible_paths: set[str] | None = None,
     capture_trace: bool = False,
+    query_vector_provider: Callable[[], Any] | None = None,
 ) -> CandidateBundle:
     """Collect vector/BM25/keyword/CLIP/graph/temporal lanes and fuse them."""
     from . import bm25, embeddings, epistemic_graph, fusion, lexstore, readiness, runtime_resources
@@ -215,7 +216,11 @@ def collect_candidates(
                 with _span(timings, "vector.index"):
                     idx = embeddings.get_embedding_index(vault_root)
                 with _span(timings, "vector.embed"):
-                    query_vec = embeddings.embed_texts([query], is_query=True)[0]
+                    query_vec = (
+                        query_vector_provider()
+                        if query_vector_provider is not None
+                        else embeddings.embed_texts([query], is_query=True)[0]
+                    )
                 with _span(timings, "vector.search"):
                     chunk_hits = idx.search(
                         query_vec,

--- a/src/exomem/find_candidates.py
+++ b/src/exomem/find_candidates.py
@@ -463,11 +463,13 @@ def collect_candidates(
     admitted_raw_paths = set().union(*raw_rankings) & recall_paths
     parent_hints: Mapping[str, str | None] | None = None
     if admitted_raw_paths:
+        recall_checkpoint = snapshot.recall_checkpoint(scope)
         hint_result = lexstore.emitted_parent_hints_result(
             vault_root,
             admitted_raw_paths,
             scope=scope,
             freshness=snapshot.for_scope(scope),
+            recall_checkpoint=recall_checkpoint,
         )
         if hint_result.readiness.complete:
             parent_hints = hint_result.value

--- a/src/exomem/find_candidates.py
+++ b/src/exomem/find_candidates.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from collections.abc import Set as AbstractSet
 from dataclasses import dataclass
 from pathlib import Path
@@ -90,6 +90,7 @@ def collapse_frame_children(
     page_of: PageOf,
     attribution: dict[str, tuple[str, float | None]],
     *aux_maps: dict,
+    parent_hints: Mapping[str, str | None] | None = None,
     recall_paths: AbstractSet[str] | None = None,
 ) -> list[str]:
     """Remap scene-frame sidecar candidates onto their parent video sidecar."""
@@ -109,7 +110,16 @@ def collapse_frame_children(
     for rel in ranking:
         if not admitted(rel):
             continue
-        page = page_of(rel)
+        # A ready catalog's explicit NULL proves this is an ordinary page, so
+        # avoid its otherwise pointless Markdown hydration. A non-NULL hint is
+        # only a hydration selector: the parsed child remains authoritative if
+        # it was deleted, became malformed, or changed parent_media after the
+        # catalog snapshot.
+        page = (
+            None
+            if parent_hints is not None and parent_hints.get(rel) is None and rel in parent_hints
+            else page_of(rel)
+        )
         parent = page.parent_media if page is not None else None
         if parent:
             parent_sidecar = parent + ".md"
@@ -274,17 +284,6 @@ def collect_candidates(
                 failed_out.append("vector")
             if timings is not None:
                 timings.error("vector", e)
-    vector_ranking = collapse_frame_children(
-        vector_ranking,
-        vault_root,
-        page_of,
-        frame_attribution,
-        chunk_text_by_path,
-        vector_score_by_path,
-        recall_paths=recall_paths,
-    )
-    vector_ranking = _eligible(vector_ranking)
-
     clip_ranking: list[str] = []
     clip_score_by_path: dict[str, float] = {}
     clip_frame_ts_by_path: dict[str, float | None] = {}
@@ -370,17 +369,6 @@ def collect_candidates(
             "reason": "clip_disabled",
             "model": embeddings.CLIP_MODEL_NAME,
         }
-    clip_ranking = collapse_frame_children(
-        clip_ranking,
-        vault_root,
-        page_of,
-        frame_attribution,
-        clip_score_by_path,
-        clip_frame_ts_by_path,
-        recall_paths=recall_paths,
-    )
-    clip_ranking = _eligible(clip_ranking)
-
     bm25_ranking: list[str] = []
     bm25_score_by_path: dict[str, float] = {}
     keyword_ranking: list[str] = []
@@ -457,16 +445,6 @@ def collect_candidates(
             log.warning("BM25 search failed: %s; using vector-only", e)
             if timings is not None:
                 timings.error("bm25", e)
-        bm25_ranking = collapse_frame_children(
-            bm25_ranking,
-            vault_root,
-            page_of,
-            frame_attribution,
-            bm25_score_by_path,
-            recall_paths=recall_paths,
-        )
-        bm25_ranking = _eligible(bm25_ranking)
-
         with _span(timings, "keyword"):
             # Over-fetch by the same factor the BM25 lane uses, and for the same
             # reason: `collapse_frame_children` and `_eligible` below can drop
@@ -481,23 +459,71 @@ def collect_candidates(
                 repair=lexical_repair,
                 k=candidate_k * 3,
             )
-        keyword_ranking = collapse_frame_children(
-            keyword_ranking,
+    raw_rankings = (vector_ranking, clip_ranking, bm25_ranking, keyword_ranking)
+    admitted_raw_paths = set().union(*raw_rankings) & recall_paths
+    parent_hints: Mapping[str, str | None] | None = None
+    if admitted_raw_paths:
+        hint_result = lexstore.emitted_parent_hints_result(
             vault_root,
-            page_of,
-            frame_attribution,
-            recall_paths=recall_paths,
+            admitted_raw_paths,
+            scope=scope,
+            freshness=snapshot.for_scope(scope),
         )
-        keyword_ranking = _eligible(keyword_ranking)
-        if capture_trace:
-            lane_statuses["keyword"] = {
-                "status": "participated" if keyword_ranking else "available_nonmatching",
-                "backend": "case_insensitive_substring",
-                "metric": {"name": "rank", "direction": "lower", "rounding": "none"},
-            }
-        rankings = [
-            r for r in (vector_ranking, bm25_ranking, keyword_ranking, clip_ranking) if r
-        ]
+        if hint_result.readiness.complete:
+            parent_hints = hint_result.value
+
+    vector_ranking = collapse_frame_children(
+        vector_ranking,
+        vault_root,
+        page_of,
+        frame_attribution,
+        chunk_text_by_path,
+        vector_score_by_path,
+        parent_hints=parent_hints,
+        recall_paths=recall_paths,
+    )
+    vector_ranking = _eligible(vector_ranking)
+    clip_ranking = collapse_frame_children(
+        clip_ranking,
+        vault_root,
+        page_of,
+        frame_attribution,
+        clip_score_by_path,
+        clip_frame_ts_by_path,
+        parent_hints=parent_hints,
+        recall_paths=recall_paths,
+    )
+    clip_ranking = _eligible(clip_ranking)
+    bm25_ranking = collapse_frame_children(
+        bm25_ranking,
+        vault_root,
+        page_of,
+        frame_attribution,
+        bm25_score_by_path,
+        parent_hints=parent_hints,
+        recall_paths=recall_paths,
+    )
+    bm25_ranking = _eligible(bm25_ranking)
+    keyword_ranking = collapse_frame_children(
+        keyword_ranking,
+        vault_root,
+        page_of,
+        frame_attribution,
+        parent_hints=parent_hints,
+        recall_paths=recall_paths,
+    )
+    keyword_ranking = _eligible(keyword_ranking)
+    if capture_trace and mode != "vector":
+        lane_statuses["keyword"] = {
+            "status": "participated" if keyword_ranking else "available_nonmatching",
+            "backend": "case_insensitive_substring",
+            "metric": {"name": "rank", "direction": "lower", "rounding": "none"},
+        }
+    rankings = [
+        r
+        for r in (vector_ranking, bm25_ranking, keyword_ranking, clip_ranking)
+        if r
+    ]
 
     graph_ranking: list[str] = []
     graph_in_degree_by_path: dict[str, int] = {}

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -1356,6 +1356,25 @@ def search_substring_result(
     )
 
 
+def emitted_parent_hints_result(
+    vault_root: Path,
+    paths: set[str],
+    *,
+    scope: str = "kb",
+    freshness: tuple | None = None,
+) -> CatalogQueryResult[dict[str, str | None]]:
+    """Current emitted-parent metadata for every requested scoped page.
+
+    The caller may treat explicit ``None`` as an ordinary page only when this
+    complete result proves the requested candidate set has no missing rows.
+    """
+    if not _catalog_usable():
+        return CatalogQueryResult(None, CatalogReadiness("unsupported", False, backend()))
+    if not paths:
+        return CatalogQueryResult({}, CatalogReadiness("available", True, backend()))
+    return get_store(vault_root).emitted_parent_hints_result(paths, scope, freshness)
+
+
 def search_semantic_units(
     vault_root: Path,
     query: str,
@@ -5120,6 +5139,50 @@ class LexicalStore:
             params,
         ).fetchall()
         return sorted(str(row[0]) for row in rows)
+
+    def emitted_parent_hints_result(
+        self,
+        paths: set[str],
+        scope: str,
+        freshness: tuple | None,
+    ) -> CatalogQueryResult[dict[str, str | None]]:
+        """Read emitted-parent hints from one ready catalog snapshot.
+
+        A complete result must name every requested path. A missing row is not
+        evidence of an ordinary page: it means the snapshot cannot safely
+        collapse the candidates without the legacy Markdown hydration path.
+        """
+        requested = set(paths)
+        result = self._serve_from_ready_catalog_result(
+            scope,
+            freshness,
+            lambda conn: self._emitted_parent_hints_query(conn, requested, scope),
+            "lexical emitted-parent hint query failed (%s); candidate collapse hydrates",
+        )
+        if not result.readiness.complete or result.value is None:
+            return result
+        if requested <= result.value.keys():
+            return result
+        _schedule_runtime_catalog_repair(self.vault_root)
+        return CatalogQueryResult(
+            None, CatalogReadiness("stale", False, result.readiness.backend)
+        )
+
+    def _emitted_parent_hints_query(
+        self,
+        conn: sqlite3.Connection,
+        paths: set[str],
+        scope: str,
+    ) -> dict[str, str | None]:
+        """One JSON-backed scoped query, independent of SQLite bind limits."""
+        col = "in_vault" if scope == "vault" else "in_kb"
+        rows = conn.execute(
+            "SELECT p.path, p.emitted_parent_path FROM pages p "
+            "JOIN json_each(?) requested ON requested.value = p.path "
+            f"WHERE p.{col} = 1",
+            (json.dumps(sorted(paths), ensure_ascii=False),),
+        ).fetchall()
+        return {str(path): parent for path, parent in rows}
 
     def search_substring(
         self,

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -4792,8 +4792,12 @@ class LexicalStore:
         """
         from . import freshness as freshness_module
 
-        readiness = self.catalog_readiness(
-            scope, freshness, recall_checkpoint=recall_checkpoint
+        readiness = (
+            self.catalog_readiness(scope, freshness)
+            if recall_checkpoint is None
+            else self.catalog_readiness(
+                scope, freshness, recall_checkpoint=recall_checkpoint
+            )
         )
         if not readiness.complete:
             return CatalogQueryResult(None, readiness)

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -1362,6 +1362,7 @@ def emitted_parent_hints_result(
     *,
     scope: str = "kb",
     freshness: tuple | None = None,
+    recall_checkpoint: Any | None = None,
 ) -> CatalogQueryResult[dict[str, str | None]]:
     """Current emitted-parent metadata for every requested scoped page.
 
@@ -1372,7 +1373,9 @@ def emitted_parent_hints_result(
         return CatalogQueryResult(None, CatalogReadiness("unsupported", False, backend()))
     if not paths:
         return CatalogQueryResult({}, CatalogReadiness("available", True, backend()))
-    return get_store(vault_root).emitted_parent_hints_result(paths, scope, freshness)
+    return get_store(vault_root).emitted_parent_hints_result(
+        paths, scope, freshness, recall_checkpoint
+    )
 
 
 def search_semantic_units(
@@ -4618,6 +4621,7 @@ class LexicalStore:
         *,
         allow_delta: bool = True,
         schedule_repair: bool = True,
+        recall_checkpoint: Any | None = None,
     ) -> CatalogReadiness:
         """Decide, without ever rebuilding/healing/walking, whether the exact
         category/kind projection can be served for `scope` at `freshness`.
@@ -4634,7 +4638,11 @@ class LexicalStore:
         from . import freshness as freshness_module
 
         backend_name = backend()
-        target_checkpoint = freshness_module.recall_checkpoint(self.vault_root, scope)
+        target_checkpoint = (
+            recall_checkpoint
+            if recall_checkpoint is not None
+            else freshness_module.recall_checkpoint(self.vault_root, scope)
+        )
         target_state = _checkpoint_state(target_checkpoint)
         if backend_name == "python":
             return CatalogReadiness("unsupported", False, backend_name)
@@ -4707,6 +4715,7 @@ class LexicalStore:
                             freshness,
                             allow_delta=False,
                             schedule_repair=schedule_repair,
+                            recall_checkpoint=target_checkpoint,
                         )
             if schedule_repair:
                 _schedule_runtime_catalog_repair(self.vault_root)
@@ -4765,6 +4774,8 @@ class LexicalStore:
         freshness: tuple | None,
         query_fn: Callable[[sqlite3.Connection], _CatalogValue],
         failure_message: str,
+        *,
+        recall_checkpoint: Any | None = None,
     ) -> CatalogQueryResult[_CatalogValue]:
         """Validate readiness AND run `query_fn(conn)` bound to ONE connection and
         read transaction, so a concurrent publication cannot swap the catalog file
@@ -4781,7 +4792,9 @@ class LexicalStore:
         """
         from . import freshness as freshness_module
 
-        readiness = self.catalog_readiness(scope, freshness)
+        readiness = self.catalog_readiness(
+            scope, freshness, recall_checkpoint=recall_checkpoint
+        )
         if not readiness.complete:
             return CatalogQueryResult(None, readiness)
         try:
@@ -4791,7 +4804,11 @@ class LexicalStore:
                 # returned; the whole validate-then-query runs inside it.
                 conn.execute("BEGIN")
                 stored = self._meta_checkpoint(conn, scope)
-                target = freshness_module.recall_checkpoint(self.vault_root, scope)
+                target = (
+                    recall_checkpoint
+                    if recall_checkpoint is not None
+                    else freshness_module.recall_checkpoint(self.vault_root, scope)
+                )
                 if (
                     _checkpoint_state(stored) != _checkpoint_state(target)
                     or not self._schema_is_current(conn)
@@ -5145,6 +5162,7 @@ class LexicalStore:
         paths: set[str],
         scope: str,
         freshness: tuple | None,
+        recall_checkpoint: Any | None = None,
     ) -> CatalogQueryResult[dict[str, str | None]]:
         """Read emitted-parent hints from one ready catalog snapshot.
 
@@ -5158,6 +5176,7 @@ class LexicalStore:
             freshness,
             lambda conn: self._emitted_parent_hints_query(conn, requested, scope),
             "lexical emitted-parent hint query failed (%s); candidate collapse hydrates",
+            recall_checkpoint=recall_checkpoint,
         )
         if not result.readiness.complete or result.value is None:
             return result

--- a/tests/test_find_scene_frames.py
+++ b/tests/test_find_scene_frames.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 
 from exomem import find as find_mod
-from exomem import preserve, scene_frames, semantic_contract
+from exomem import find_candidates
+from exomem import lexstore, preserve, scene_frames, semantic_contract
+from exomem.find_types import ParsedPage
 from exomem.embeddings import Scene
 from exomem.find import find
 
@@ -159,3 +161,132 @@ def test_collapse_keeps_parent_best_rank(vault: Path) -> None:
     assert collapsed == [VIDEO_REL + ".md"]
     assert scores[VIDEO_REL + ".md"] == 0.9  # parent's own score kept (keep-best)
     assert (VIDEO_REL + ".md") in attribution  # frame still attributed for enrichment
+
+
+def _frame_page(vault: Path, rel: str, parent_media: str | None) -> ParsedPage:
+    return ParsedPage(
+        path=vault / rel,
+        rel_path=rel,
+        frontmatter={
+            "type": "source",
+            **({"parent_media": parent_media} if parent_media else {}),
+            "evidence_file": rel.removesuffix(".md"),
+            "frame_ts": 5.0,
+        },
+        body="frame",
+        title="frame",
+        mtime=0.0,
+    )
+
+
+def test_collapse_hints_skip_ordinary_hydration_and_keep_child_authoritative(vault: Path) -> None:
+    parent = "Knowledge Base/video.mp4.md"
+    child = "Knowledge Base/video.mp4.frames/scene-000-005.000.jpg.md"
+    ordinary = "Knowledge Base/ordinary.md"
+    for rel in (parent, child, ordinary):
+        path = vault / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("---\ntype: insight\n---\n# page\n", encoding="utf-8")
+
+    calls: list[str] = []
+
+    def page_of(rel: str) -> ParsedPage | None:
+        calls.append(rel)
+        return _frame_page(vault, rel, "Knowledge Base/video.mp4") if rel == child else None
+
+    attribution: dict[str, tuple[str, float | None]] = {}
+    collapsed = find_candidates.collapse_frame_children(
+        [ordinary, child],
+        vault,
+        page_of,
+        attribution,
+        parent_hints={ordinary: None, child: parent},
+        recall_paths={ordinary, child, parent},
+    )
+
+    assert collapsed == [ordinary, parent]
+    assert calls == [child]
+    assert attribution == {parent: (child.removesuffix(".md"), 5.0)}
+
+
+def test_collapse_large_hints_match_legacy_and_hydrate_only_child(vault: Path) -> None:
+    parent = "Knowledge Base/video.mp4.md"
+    child = "Knowledge Base/video.mp4.frames/scene-000-005.000.jpg.md"
+    ordinary = [f"Knowledge Base/ordinary-{number:03d}.md" for number in range(449)]
+    for rel in [parent, child, *ordinary]:
+        path = vault / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("---\ntype: insight\n---\n# page\n", encoding="utf-8")
+    ranking = [*ordinary, child]
+    recall_paths = set(ranking) | {parent}
+
+    def page_of(rel: str) -> ParsedPage | None:
+        return _frame_page(vault, rel, "Knowledge Base/video.mp4") if rel == child else None
+
+    legacy_attribution: dict[str, tuple[str, float | None]] = {}
+    legacy_aux = {child: 0.4, ordinary[0]: 0.9}
+    legacy = find_candidates.collapse_frame_children(
+        ranking, vault, page_of, legacy_attribution, legacy_aux, recall_paths=recall_paths
+    )
+
+    calls: list[str] = []
+
+    def counting_page_of(rel: str) -> ParsedPage | None:
+        calls.append(rel)
+        return page_of(rel)
+
+    hinted_attribution: dict[str, tuple[str, float | None]] = {}
+    hinted_aux = {child: 0.4, ordinary[0]: 0.9}
+    hinted = find_candidates.collapse_frame_children(
+        ranking,
+        vault,
+        counting_page_of,
+        hinted_attribution,
+        hinted_aux,
+        parent_hints={**{rel: None for rel in ordinary}, child: parent},
+        recall_paths=recall_paths,
+    )
+
+    assert calls == [child]
+    assert hinted == legacy
+    assert hinted_attribution == legacy_attribution
+    assert hinted_aux == legacy_aux
+
+
+def test_collapse_hinted_child_stays_standalone_when_parent_disappears(vault: Path) -> None:
+    parent = "Knowledge Base/video.mp4.md"
+    child = "Knowledge Base/video.mp4.frames/scene-000-005.000.jpg.md"
+    child_path = vault / child
+    child_path.parent.mkdir(parents=True, exist_ok=True)
+    child_path.write_text("---\ntype: source\n---\n# frame\n", encoding="utf-8")
+
+    collapsed = find_candidates.collapse_frame_children(
+        [child],
+        vault,
+        lambda rel: _frame_page(vault, rel, None),
+        {},
+        parent_hints={child: parent},
+        recall_paths={child, parent},
+    )
+
+    assert collapsed == [child]
+
+
+def test_incomplete_parent_hints_fall_back_to_legacy_hydration(
+    vault: Path, monkeypatch
+) -> None:
+    _setup_video_with_frames(vault)
+    calls = 0
+
+    def incomplete(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return lexstore.CatalogQueryResult(
+            None, lexstore.CatalogReadiness("stale", False, lexstore.backend())
+        )
+
+    monkeypatch.setattr(lexstore, "emitted_parent_hints_result", incomplete)
+    hits = find(vault, query="unobtainium flux", mode="hybrid")
+
+    assert [hit.path for hit in hits] == [VIDEO_REL + ".md"]
+    assert calls == 1

--- a/tests/test_lexstore.py
+++ b/tests/test_lexstore.py
@@ -1383,6 +1383,79 @@ def test_bm25_vault_scope_reaches_outside_kb(tmp_path):
     assert vault_hits and vault_hits[0][0] == "Projects/out.md"
 
 
+def test_emitted_parent_hints_return_every_scoped_path(tmp_path):
+    parent = _write_page(tmp_path, "Knowledge Base/media/demo.mp4.md", "transcript")
+    child = _write_page(
+        tmp_path,
+        "Knowledge Base/media/demo.mp4.frames/scene-000-005.000.jpg.md",
+        "frame OCR",
+    )
+    child.write_text(
+        "---\n"
+        "type: source\n"
+        "parent_media: Knowledge Base/media/demo.mp4\n"
+        "evidence_file: Knowledge Base/media/demo.mp4.frames/scene-000-005.000.jpg\n"
+        "---\n# frame\n\nframe OCR\n",
+        encoding="utf-8",
+    )
+    _write_page(tmp_path, "Projects/ordinary.md", "outside scope")
+
+    # Establish the sidecar through its normal maintenance seam, then query the
+    # readiness-bound normal-table catalog directly.
+    assert lexstore.search_bm25(tmp_path, "transcript", k=3, scope="kb")
+    result = lexstore.emitted_parent_hints_result(
+        tmp_path,
+        {
+            parent.relative_to(tmp_path).as_posix(),
+            child.relative_to(tmp_path).as_posix(),
+        },
+        scope="kb",
+    )
+
+    assert result.readiness.complete
+    assert result.value == {
+        "Knowledge Base/media/demo.mp4.md": None,
+        "Knowledge Base/media/demo.mp4.frames/scene-000-005.000.jpg.md": "Knowledge Base/media/demo.mp4.md",
+    }
+
+
+def test_emitted_parent_hints_use_json_for_large_path_sets(tmp_path):
+    paths = {
+        f"Knowledge Base/large/page-{number:04d}.md"
+        for number in range(1_100)
+    }
+    for rel in paths:
+        _write_page(tmp_path, rel, "ordinary page")
+
+    assert lexstore.search_bm25(tmp_path, "ordinary", k=3, scope="kb")
+    result = lexstore.emitted_parent_hints_result(tmp_path, paths, scope="kb")
+
+    assert result.readiness.complete
+    assert result.value == {path: None for path in paths}
+
+
+def test_emitted_parent_hints_missing_row_is_incomplete(tmp_path):
+    known = _write_page(tmp_path, "Knowledge Base/known.md", "known page")
+    out_of_scope = _write_page(tmp_path, "Projects/out-of-scope.md", "outside page")
+    assert lexstore.search_bm25(tmp_path, "known", k=3, scope="kb")
+
+    result = lexstore.emitted_parent_hints_result(
+        tmp_path,
+        {known.relative_to(tmp_path).as_posix(), "Knowledge Base/missing.md"},
+        scope="kb",
+    )
+
+    assert not result.readiness.complete
+    assert result.readiness.status == "stale"
+    assert result.value is None
+
+    scoped_out = lexstore.emitted_parent_hints_result(
+        tmp_path, {out_of_scope.relative_to(tmp_path).as_posix()}, scope="kb"
+    )
+    assert not scoped_out.readiness.complete
+    assert scoped_out.value is None
+
+
 # ---------------------------------------------------------------- substring primitive
 
 

--- a/tests/test_retrieval_explainability.py
+++ b/tests/test_retrieval_explainability.py
@@ -1281,20 +1281,36 @@ def test_mixed_explanation_preserves_divergent_page_and_unit_plans(
     _prepare_semantic_catalog(tmp_path, [tmp_path / page_path])
 
     class FakeIndex:
-        def search(self, _query_vector, *, k: int, allowed_paths=None):
+        def __init__(self) -> None:
+            self.page_query_vectors: list[object] = []
+            self.unit_query_vectors: list[object] = []
+
+        def search(self, query_vector, *, k: int, allowed_paths=None):
             assert k > 0
             assert allowed_paths == {page_path}
+            self.page_query_vectors.append(query_vector)
             return [(page_path, 0, "Session lifetime is thirty days", 0.82)]
 
-        def search_semantic_units(self, *_args, **_kwargs):
+        def search_semantic_units(self, query_vector, **_kwargs):
+            self.unit_query_vectors.append(query_vector)
             raise RuntimeError("unit vector backend failed")
 
+    index = FakeIndex()
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
     monkeypatch.setenv("EXOMEM_DISABLE_CLIP", "1")
-    monkeypatch.setattr(embeddings, "get_embedding_index", lambda _root: FakeIndex())
-    monkeypatch.setattr(
-        embeddings, "embed_texts", lambda _texts, *, is_query: [[0.1, 0.2]]
-    )
+    monkeypatch.setattr(embeddings, "get_embedding_index", lambda _root: index)
+    embed_calls = 0
+    embedded_vectors: list[object] = []
+
+    def embed_texts(_texts, *, is_query: bool):
+        nonlocal embed_calls
+        assert is_query is True
+        embed_calls += 1
+        vector = [0.1, 0.2]
+        embedded_vectors.append(vector)
+        return [vector]
+
+    monkeypatch.setattr(embeddings, "embed_texts", embed_texts)
 
     explained = commands.op_ask_memory(
         tmp_path,
@@ -1328,6 +1344,62 @@ def test_mixed_explanation_preserves_divergent_page_and_unit_plans(
     assert "fusion" not in plans["unit"]
     assert plans["unit"]["rerank"]["reason"] == "result_level_unit"
     assert plans["page"]["final_ordering"] != plans["unit"]["final_ordering"]
+    assert embed_calls == 1
+    assert index.unit_query_vectors[0] is embedded_vectors[0]
+    assert index.page_query_vectors[0] is embedded_vectors[0]
+
+
+def test_mixed_vector_embedding_failure_is_retried_for_page_lane(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page_path = _write_unit_page(tmp_path)
+    _prepare_semantic_catalog(tmp_path, [tmp_path / page_path])
+
+    class FakeIndex:
+        def search(self, _query_vector, *, k: int, allowed_paths=None):
+            assert k > 0
+            assert allowed_paths == {page_path}
+            return [(page_path, 0, "Session lifetime is thirty days", 0.82)]
+
+        def search_semantic_units(self, *_args, **_kwargs):
+            raise AssertionError("unit search must not run after embedding fails")
+
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("EXOMEM_DISABLE_CLIP", "1")
+    monkeypatch.setattr(embeddings, "get_embedding_index", lambda _root: FakeIndex())
+    embed_calls = 0
+
+    def embed_texts(_texts, *, is_query: bool):
+        nonlocal embed_calls
+        assert is_query is True
+        embed_calls += 1
+        if embed_calls == 1:
+            raise RuntimeError("transient unit embedding failure")
+        return [[0.1, 0.2]]
+
+    monkeypatch.setattr(embeddings, "embed_texts", embed_texts)
+
+    explained = commands.op_ask_memory(
+        tmp_path,
+        query="session lifetime",
+        result_level="mixed",
+        mode="hybrid",
+        graph=False,
+        rerank=False,
+        scope="kb-only",
+        detail="compact",
+        explain=True,
+    )
+
+    plans = explained["retrieval_profile"]["result_plans"]
+    assert embed_calls == 2
+    assert plans["unit"]["lanes"]["vector"] == {
+        "status": "failed",
+        "reason": "search_failed",
+        "model": "BAAI/bge-base-en-v1.5",
+    }
+    assert plans["page"]["lanes"]["vector"]["status"] == "participated"
 
 
 def test_disabled_vector_mode_explains_its_useful_keyword_fallback(


### PR DESCRIPTION
## Summary

Mixed recall was embedding the same query twice and hydrating every candidate Markdown file just to determine whether it was a scene frame. This PR removes both sources of duplicate work without changing ranking, filtering, or attribution.

## Changes

- Compute a mixed request's query vector lazily once and reuse it in the semantic-unit and page lanes.
- Read `parent_media` hints for all raw candidates in one checkpoint-validated lexical-catalog query.
- Hydrate only actual scene-frame children, preserving frame attribution and parent-score semantics.
- Fall back to the existing per-file path if the catalog is unavailable, incomplete, or missing any requested row.

## Measured scope

Before this change, on the quiesced live cell:

| Query | Total |
| --- | ---: |
| Page hybrid, limit 5 | 0.36–0.41 s |
| Page hybrid, limit 30, warm | 1.07 s |
| Page hybrid, limit 30, initial passes | 4–6 s |
| One warm query embed | 12–20 ms |

The limit-dependent cliff is the candidate-hydration cost this PR removes. Post-deploy measurements will be recorded on #935.

## Verification

- 10 focused changed-behaviour tests pass locally.
- Query-vector and frame-collapse diffs were independently reviewed with no findings.
- Privacy validation passes.
- Tests cover shared vector identity, retry after a failed embed, output equivalence, incomplete-catalog fallback, selective child hydration, and batches above SQLite's ordinary bind limit.

Closes #984
Refs #935
