### PR TITLE
fix(hosted): let recovery operator inspect pods

### DIFF
--- a/docs/runbooks/hosted/cell.md
+++ b/docs/runbooks/hosted/cell.md
@@ -122,7 +122,7 @@ The recovery helper runs only in a short-lived, non-network-published operator
 Pod. Use the exact digest selected by the deployment lock; do not use a tag or
 substitute the API/worker ServiceAccount. The chart renders the dedicated
 `exomem-init-retry-recovery` ServiceAccount and read-only ClusterRole. It can
-observe only namespaces, PVCs/PVs, ConfigMaps, StatefulSets, Jobs, and
+observe only namespaces, PVCs/PVs, ConfigMaps, Pods, StatefulSets, Jobs, and
 IngressRoutes. It cannot read Secrets or create, update, patch, or delete any
 Kubernetes object. Stop if that rendered role differs; do not widen the routine
 provisioner role.

--- a/infra/helm/platform/templates/recovery-operator.yaml
+++ b/infra/helm/platform/templates/recovery-operator.yaml
@@ -13,7 +13,7 @@ metadata:
   name: exomem-init-retry-recovery
 rules:
   - apiGroups: [""]
-    resources: ["namespaces", "persistentvolumeclaims", "persistentvolumes", "configmaps"]
+    resources: ["namespaces", "persistentvolumeclaims", "persistentvolumes", "configmaps", "pods"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["statefulsets"]

--- a/openspec/changes/standardize-hosted-runtime-upgrades/tasks.md
+++ b/openspec/changes/standardize-hosted-runtime-upgrades/tasks.md
@@ -77,15 +77,15 @@
 - [ ] 7.4 Review both repository diffs for tenant-data safety, authorization boundaries, secret handling, compatibility, rollback truthfulness, and unintended release/profile changes
 - [ ] 7.5 Verify the complete workflow end to end from a fresh execution record before authorizing production
 
-## 8. First execution: runtime 0.68.0
+## 8. First execution: runtime 0.68.1
 
-- [ ] 8.1 Verify the exact `v0.68.0` source commit, amd64 image digest, signed runtime candidate, source closure, attestations, protocol, profile, command fingerprint, schema digest, and compatibility digest
-- [ ] 8.2 Import the exact `0.68.0` agent and gateway fixtures into every Substrate release-pinned production site while retaining every release found by the live legacy inventory
+- [ ] 8.1 Verify the exact `v0.68.1` source commit, amd64 image digest, signed runtime candidate, source closure, attestations, protocol, profile, command fingerprint, schema digest, and compatibility digest
+- [ ] 8.2 Import the exact `0.68.1` agent and gateway fixtures into every Substrate release-pinned production site while retaining every release found by the live legacy inventory
 - [ ] 8.3 Land and deploy the reviewed Substrate trusted-release, rollforward, reviewer-client, migration, and operator changes; record the immutable consumer commit
-- [ ] 8.4 Compose, verify, review, and land the Exomem `0.68.0` expand/contract lock pair and provisioner image from the exact Substrate consumer and signed target evidence
-- [ ] 8.5 Create the schema-valid `0.68.0` execution record, run the live reconciled inventory, and resolve every ghost, divergence, stale assignment, unfinished operation, or capacity mismatch before mutation
+- [ ] 8.4 Compose, verify, review, and land the Exomem `0.68.1` expand/contract lock pair and provisioner image from the exact Substrate consumer and signed target evidence
+- [ ] 8.5 Create the schema-valid `0.68.1` execution record, run the live reconciled inventory, and resolve every ghost, divergence, stale assignment, unfinished operation, or capacity mismatch before mutation
 - [ ] 8.6 Deploy Substrate and the Exomem expand lock, then prove adoption changed no existing tenant resource or data
 - [ ] 8.7 If the reconciled fleet is empty, record the no-op; otherwise roll one canary and every remaining legacy cell sequentially with preservation and exact-runtime evidence
 - [ ] 8.8 Prove zero legacy dependencies and deploy the reviewed contract lock
 - [ ] 8.9 Run free preflight, prepare the explicit eligible reviewer client, and conduct the human-timed Claude/OpenAI promotion ceremony
-- [ ] 8.10 Complete personal-account OAuth and full read/write/reconnect acceptance on `0.68.0`, keep the personal tenant live, and record final fleet, lock, cohort, authority, capacity, and operation state
+- [ ] 8.10 Complete personal-account OAuth and full read/write/reconnect acceptance on `0.68.1`, keep the personal tenant live, and record final fleet, lock, cohort, authority, capacity, and operation state

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -816,6 +816,7 @@ def test_platform_renders_a_read_only_recovery_operator_identity() -> None:
         ("", "persistentvolumeclaims"),
         ("", "persistentvolumes"),
         ("", "configmaps"),
+        ("", "pods"),
         ("apps", "statefulsets"),
         ("batch", "jobs"),
         ("traefik.io", "ingressroutes"),
@@ -832,6 +833,7 @@ def test_platform_renders_a_read_only_recovery_operator_identity() -> None:
     )
     runbook = (ROOT / "docs/runbooks/hosted/cell.md").read_text(encoding="utf-8")
     assert "exomem-init-retry-recovery" in runbook
+    assert "ConfigMaps, Pods, StatefulSets" in runbook
     assert (
         "spec:\n  enableServiceLinks: false\n  serviceAccountName: exomem-init-retry-recovery"
         in runbook


### PR DESCRIPTION
Summary
- add Pods to the dedicated recovery operator read-only observation scope
- retain the no-Secrets and no-mutation RBAC boundary
- document and test the rendered scope
- retarget the first hosted runtime execution to signed release 0.68.1

Why
The fail-closed recovery preflight calls KubernetesProviderRegistry.inspect(), which lists namespaced Pods. The existing ClusterRole omitted Pods, so Kubernetes returned 403 before recovery could inspect either retained cell.

Verification
- HELM_BIN=/home/hugoa/.local/bin/helm uv run pytest -q tests/test_hosted_helm_contract.py: 60 passed
- openspec validate --all --strict: 171 passed, 0 failed
- independent review: no Critical or Important findings

No live cluster or tenant resource is changed by this PR.