### PR TITLE
fix(records): close workflow dogfood mutation gaps

### DIFF
--- a/src/exomem/records.py
+++ b/src/exomem/records.py
@@ -710,12 +710,17 @@ def create_collection(
             ),
         )
         try:
+            source_is_written = any(write.path == source for write in writes)
             vault.batch_atomic_write(
                 [*writes, *log_plan.writes],
                 vault_root=root,
                 required_guards=(
                     *_portable_absence_guards(root, path, source),
-                    *((source_guard,) if source_guard is not None else ()),
+                    *(
+                        (source_guard,)
+                        if source_guard is not None and not source_is_written
+                        else ()
+                    ),
                 ),
             )
         except vault.BatchWriteError:

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -78,6 +78,42 @@ _MAX_REVIEWED_STAMP_AGE = dt.timedelta(hours=24)
 _MAX_REVIEWED_STAMP_SKEW = dt.timedelta(minutes=5)
 
 
+def _structured_item_product_route(source: str) -> str | None:
+    """Return the owning mutation surface for an exact structured-item identity."""
+    try:
+        frontmatter, _body, marker = vault.parse_frontmatter(source, strict=True)
+    except vault.FrontmatterError:
+        return None
+    if marker is None or type(frontmatter.get("schema_version")) is not int:
+        return None
+    item_type = frontmatter.get("type")
+    identity_field, route = (
+        ("plan_id", "plan_memory")
+        if item_type == "plan"
+        else ("record_id", "record_memory")
+        if item_type == "record"
+        else (None, None)
+    )
+    if identity_field is None:
+        return None
+    try:
+        uuid.UUID(str(frontmatter.get("collection_id", "")))
+        uuid.UUID(str(frontmatter.get(identity_field, "")))
+    except (ValueError, AttributeError, TypeError):
+        return None
+    return route
+
+
+def _reject_generic_structured_item_write(path: str, source: str) -> None:
+    route = _structured_item_product_route(source)
+    if route is None:
+        return
+    raise SemanticWriteError(
+        "STRUCTURED_ITEM_REQUIRES_PRODUCT_ROUTE",
+        f"{path} is owned by {route}; use that product route so its schema and audit chain remain valid",
+    )
+
+
 def rewrite_wikilinks_for_move(text: str, old_rel: str, new_rel: str) -> tuple[str, int]:
     """Pure canonical path-only rewrite shared by move staging and review carry."""
     old_no_ext = old_rel.removesuffix(".md")
@@ -1720,6 +1756,12 @@ def _preflight_existing(
         before_hash,
     }:
         raise SemanticWriteError("STALE_SEMANTIC_WRITE", "page changed before semantic preflight")
+    # Tier-2 overwrite is the deliberate break-glass route for repairing a
+    # malformed structured item that its typed adapter can no longer load.
+    # It still creates an inspectable collection-audit gap; routine generic
+    # writers must never create that gap themselves.
+    if operation != "tier2_overwrite":
+        _reject_generic_structured_item_write(path, before_source)
 
     closure_required = bool(
         operation == "tier2_overwrite"

--- a/tests/test_record_mutation.py
+++ b/tests/test_record_mutation.py
@@ -439,6 +439,67 @@ item_schema:
         records.create_collection(tmp_path, manifest_path, manifest, why="retry creation")
 
 
+def test_create_markdown_log_inside_an_existing_empty_collection_directory(
+    tmp_path: Path,
+) -> None:
+    from exomem import records
+
+    _activity_log(tmp_path)
+    collection = tmp_path / "Knowledge Base/Records/Project/Delivery Outcomes"
+    collection.mkdir(parents=True)
+    manifest_path = collection.relative_to(tmp_path).joinpath("_collection.md").as_posix()
+    manifest = """---
+type: collection
+exomem_id: 7f2f8a4d-67b5-4d6d-9b91-b5b97b25dd7a
+title: Delivery outcomes
+semantic_profile: records
+collection_version: 1
+schema_version: 1
+lifecycle: active
+storage:
+  strategy: markdown-log
+  source: Delivery log.md
+  format_version: 1
+  section: {level: 2, title: Outcomes}
+  item_heading:
+    level: 3
+    fields:
+      - {name: observed_on, type: date, format: "%Y-%m-%d"}
+      - {name: change_key, type: string}
+      - {name: outcome, type: string}
+    separator: " · "
+    note: {field: summary, open: " (", close: ")"}
+  child_rows:
+    prefix: "- "
+    delimiter: "|"
+    fields: [field, value]
+    container_field: details
+  insertion: newest-first
+item_schema:
+  natural_key: [observed_on, change_key, outcome]
+  fields:
+    observed_on: {type: date, required: true}
+    change_key: {type: string, required: true}
+    outcome: {type: string, required: true}
+    summary: {type: string, required: true}
+    details:
+      type: array
+      items: {type: object}
+---
+"""
+
+    result = records.create_collection(
+        tmp_path,
+        manifest_path,
+        manifest,
+        why="create an observed delivery log",
+    )
+
+    assert result["outcome"] == "committed"
+    assert (collection / "_collection.md").is_file()
+    assert (collection / "Delivery log.md").read_text(encoding="utf-8") == "## Outcomes\n"
+
+
 def test_create_collection_without_scaffold_has_an_audited_absent_source_state(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_structured_item_generic_write_boundary.py
+++ b/tests/test_structured_item_generic_write_boundary.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+from exomem import create_file as create_file_module
+from exomem import edit as edit_module
+
+
+@pytest.mark.parametrize(
+    ("item_type", "item_id_field", "route"),
+    (
+        ("plan", "plan_id", "plan_memory"),
+        ("record", "record_id", "record_memory"),
+    ),
+)
+def test_generic_edit_refuses_structured_collection_items_without_changing_bytes(
+    vault: Path,
+    item_type: str,
+    item_id_field: str,
+    route: str,
+) -> None:
+    relative = f"Knowledge Base/{item_type.title()}s/Owned/Items/item.md"
+    target = vault / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        "---\n"
+        f"type: {item_type}\n"
+        "collection_id: 11111111-1111-4111-8111-111111111111\n"
+        f"{item_id_field}: 22222222-2222-4222-8222-222222222222\n"
+        "schema_version: 1\n"
+        "title: Owned item\n"
+        "---\n\n"
+        "Original body.\n",
+        encoding="utf-8",
+    )
+    before = target.read_bytes()
+
+    with pytest.raises(edit_module.EditError) as raised:
+        edit_module.edit(
+            vault,
+            path=relative,
+            old_string="Original body.",
+            new_string="Changed outside the owning product.",
+            why="exercise the structured-item ownership boundary",
+            today=dt.date(2026, 9, 1),
+        )
+
+    assert raised.value.code == "STRUCTURED_ITEM_REQUIRES_PRODUCT_ROUTE"
+    assert route in raised.value.reason
+    assert target.read_bytes() == before
+
+
+def test_tier2_overwrite_remains_available_for_exact_structured_item_repair(
+    vault: Path,
+) -> None:
+    relative = "Knowledge Base/Planning/Owned/Items/item.md"
+    target = vault / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    damaged = (
+        "---\n"
+        "type: plan\n"
+        "collection_id: 11111111-1111-4111-8111-111111111111\n"
+        "plan_id: 22222222-2222-4222-8222-222222222222\n"
+        "schema_version: 1\n"
+        "title: Owned item\n"
+        "legacy_unknown: remove me\n"
+        "---\n\n"
+        "Original body.\n"
+    )
+    repaired = damaged.replace("legacy_unknown: remove me\n", "")
+    target.write_text(damaged, encoding="utf-8")
+
+    result = create_file_module.create_file(
+        vault,
+        path=relative,
+        content=repaired,
+        overwrite=True,
+        today=dt.date(2026, 9, 1),
+    )
+
+    assert result.path == relative
+    assert target.read_text(encoding="utf-8") == repaired


### PR DESCRIPTION
## Summary
- stop markdown-log collection creation from rechecking its own published source as an absent read-only guard
- refuse routine generic writes to exact Planning and Records item identities, while preserving Tier-2 overwrite as the audited repair escape hatch
- add regressions for the live pre-existing-directory failure, ownership routing, and break-glass repair

## Verification
- 127 passed, 2 skipped (platform-specific)
- Ruff checks and targeted format checks passed
- Python compile checks passed
- openspec validate --all --strict: 174 passed, 0 failed