### PR TITLE
fix(records): recover creates and allow optional tables

### DIFF
--- a/src/exomem/cli_ops.py
+++ b/src/exomem/cli_ops.py
@@ -115,6 +115,10 @@ _REMEDIATION: dict[str, str] = {
     "PLAN_RESPONSE_TOO_LARGE": "Narrow the Planning query or request fewer rows.",
     "STALE_RECORD": "Re-read the record and retry with its current versions.",
     "STALE_RECORD_SNAPSHOT": "Re-run the query against the current collection snapshot.",
+    "RECORD_RECOVERY_REQUIRED": (
+        "Have the cell operator inspect and quarantine stale private transaction residue, "
+        "then retry the unchanged request."
+    ),
     "RECORD_ID_CONFLICT": "Use a new record ID or re-read the existing record before retrying.",
     "RECORD_NATURAL_KEY_CONFLICT": (
         "Update the named existing item instead of appending a second one for the same key. "
@@ -136,6 +140,7 @@ _SERVICE_UNAVAILABLE_CODES = frozenset(
         "WRITER_COORDINATOR_UNAVAILABLE",
         "WRITER_COORDINATOR_CONTRACT_ABSENT",
         "MUTATION_LOCK_UNAVAILABLE",
+        "RECORD_RECOVERY_REQUIRED",
         "MODEL_BUSY",
         # Retrieval-index-reliability (restore-indexed-category-recall): a safe
         # exact category/kind plan whose maintained semantic catalog cannot yet

--- a/src/exomem/record_formats.py
+++ b/src/exomem/record_formats.py
@@ -870,11 +870,7 @@ def _presentation_payload(
             ) from error
         selected[field_name] = value
     for table in recipe.tables:
-        rows = values.get(table.field)
-        if not isinstance(rows, list):
-            raise collections.CollectionError(
-                "UNRENDERABLE_RECORD_PRESENTATION", "presentation table is not an array"
-            )
+        rows = _presentation_table_rows(manifest, values, table)
         projected: list[dict[str, Any]] = []
         for index, row in enumerate(rows):
             projected.append(_presentation_child(row, table, index))
@@ -884,6 +880,23 @@ def _presentation_payload(
         "recipe": _presentation_recipe_identity(recipe),
         "values": selected,
     }
+
+
+def _presentation_table_rows(
+    manifest: collections.CollectionManifest,
+    values: Mapping[str, Any],
+    table: collections.RecordPresentationTable,
+) -> list[Any]:
+    rows = values.get(table.field)
+    if rows is None and not manifest.schema.fields[table.field].required:
+        return []
+    if not isinstance(rows, list):
+        raise collections.CollectionError(
+            "UNRENDERABLE_RECORD_PRESENTATION",
+            f"presentation table '{table.field}' must be an array when present",
+            {"field": table.field},
+        )
+    return rows
 
 
 def _presentation_recipe_identity(recipe: collections.RecordPresentation) -> dict[str, Any]:
@@ -963,7 +976,7 @@ def _presentation_block(
         lines.extend(
             ["| " + " | ".join(labels) + " |", "| " + " | ".join("---" for _ in labels) + " |"]
         )
-        for row in _presentation_payload(manifest, values)["values"][table.field]:
+        for row in payload["values"][table.field]:
             lines.append(
                 "| "
                 + " | ".join(_presentation_cell(row[column.field]) for column in table.columns)
@@ -2140,7 +2153,7 @@ def query_collection(
         vault_root, manifest, authorize_path=authorize_path, project_values=project_values
     )
     parsed = adapter.read()
-    _enforce_selected_child_cap(parsed.records, selected_child)
+    _enforce_selected_child_cap(parsed.records, selected_child, manifest)
     parsed = replace(
         parsed,
         records=tuple(
@@ -2753,11 +2766,7 @@ def _safe_presentation_values(
         return dict(values)
     result = dict(values)
     for table in recipe.tables:
-        rows = values.get(table.field)
-        if not isinstance(rows, list):
-            raise collections.CollectionError(
-                "UNRENDERABLE_RECORD_PRESENTATION", "presentation table is not an array"
-            )
+        rows = _presentation_table_rows(manifest, values, table)
         safe_rows: list[dict[str, Any]] = []
         for index, row in enumerate(rows):
             child = _presentation_child(row, table, index)
@@ -2876,19 +2885,40 @@ def _validate_query_projection_fields(
             )
 
 
-def _enforce_selected_child_cap(records: tuple[Record, ...], selected_child: str | None) -> None:
+def _enforce_selected_child_cap(
+    records: tuple[Record, ...],
+    selected_child: str | None,
+    manifest: collections.CollectionManifest,
+) -> None:
     """Count selected arrays only; never project a child before the global cap holds."""
     if selected_child is None:
         return
+    presentation_table = next(
+        (
+            table
+            for table in (
+                ()
+                if manifest.record_presentation is None
+                else manifest.record_presentation.tables
+            )
+            if table.field == selected_child
+        ),
+        None,
+    )
     total = 0
     for record in records:
-        if record.children and selected_child not in record.values:
+        if presentation_table is not None:
+            values = _presentation_table_rows(manifest, record.values, presentation_table)
+            total += len(values)
+        elif record.children and selected_child not in record.values:
             total += len(record.children)
         else:
             values = record.values.get(selected_child)
             if not isinstance(values, list):
                 raise collections.CollectionError(
-                    "UNRENDERABLE_RECORD_PRESENTATION", "selected child field is not an array"
+                    "UNRENDERABLE_RECORD_PRESENTATION",
+                    f"selected child field '{selected_child}' must be an array",
+                    {"field": selected_child},
                 )
             total += len(values)
         if total > _MAX_CHILD_ROWS:

--- a/src/exomem/records.py
+++ b/src/exomem/records.py
@@ -2537,6 +2537,11 @@ def _expect_hash(expected: str | None, actual: str, kind: str) -> None:
 
 def _publication_error(error: Exception) -> collections.CollectionError:
     if isinstance(error, vault.PathGuardError):
+        if error.code in {"BATCH_RESIDUE_LIMIT", "BATCH_RESIDUE_UNSAFE"}:
+            return collections.CollectionError(
+                "RECORD_RECOVERY_REQUIRED",
+                "private transaction residue blocks safe publication",
+            )
         return collections.CollectionError("STALE_RECORD", "canonical record changed before commit")
     if isinstance(error, vault.CreateOnlyConflict):
         return collections.CollectionError(

--- a/src/exomem/server_hosted.py
+++ b/src/exomem/server_hosted.py
@@ -183,6 +183,11 @@ def _hosted_refusal_guidance() -> dict[str, tuple[str, str]]:
     findings = semantic_authoring.AUTHORING_CONTRACT.findings
     unit = findings["missing_semantic_unit"]
     empty = findings["empty_rich_unit"]
+    record_recovery = cli_ops.OpError(
+        "RECORD_RECOVERY_REQUIRED",
+        "private transaction residue blocks safe record publication",
+    )
+    assert record_recovery.remediation is not None
 
     disposition = (
         "This memory needs a link to something already saved before it can be "
@@ -194,6 +199,10 @@ def _hosted_refusal_guidance() -> dict[str, tuple[str, str]]:
         "MAINTENANCE_REQUIRES_CLI": (
             REMOTE_MAINTENANCE_MESSAGE,
             REMOTE_MAINTENANCE_REMEDIATION,
+        ),
+        "RECORD_RECOVERY_REQUIRED": (
+            record_recovery.message,
+            record_recovery.remediation,
         ),
         "missing_semantic_unit": (
             "the memory has no semantic unit to record",

--- a/tests/test_cli_ops.py
+++ b/tests/test_cli_ops.py
@@ -86,6 +86,7 @@ def test_http_status_mapping() -> None:
     assert cli_ops.http_status_for("MUTATION_BUSY") == 409
     assert cli_ops.http_status_for("MUTATION_WARMING") == 409
     assert cli_ops.http_status_for("MUTATION_LOCK_UNAVAILABLE") == 503
+    assert cli_ops.http_status_for("RECORD_RECOVERY_REQUIRED") == 503
     assert cli_ops.http_status_for("INGRESS_BYPASSED") == 403
     assert cli_ops.http_status_for("INVALID_NOTE") == 400
 

--- a/tests/test_hosted_refusal_guidance.py
+++ b/tests/test_hosted_refusal_guidance.py
@@ -20,7 +20,7 @@ from types import SimpleNamespace
 from temporary_vault import temporary_vault
 
 from exomem import commands, find, schema, semantic_authoring, server_hosted
-from exomem.cli_ops import error_dict
+from exomem.cli_ops import OpError, error_dict
 from exomem.init import init_vault
 
 
@@ -51,6 +51,20 @@ def test_relation_disposition_refusal_carries_remediation() -> None:
         error = _error_block(code)
         assert error["remediation"], f"{code} must carry remediation"
         assert error["message"] != "hosted command failed", code
+
+
+def test_record_recovery_refusal_carries_operator_remediation() -> None:
+    error = _error_block("RECORD_RECOVERY_REQUIRED")
+
+    expected = OpError(
+        "RECORD_RECOVERY_REQUIRED",
+        "private transaction residue blocks safe publication",
+    )
+    assert error == {
+        "code": "RECORD_RECOVERY_REQUIRED",
+        "message": "private transaction residue blocks safe record publication",
+        "remediation": expected.remediation,
+    }
 
 
 def test_unknown_code_stays_generic_and_redacted() -> None:

--- a/tests/test_record_audit_protocol.py
+++ b/tests/test_record_audit_protocol.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 from record_fixtures import copy_vehicle_maintenance_fixture, copy_x3_fixture
 
-from exomem import graph_sync, record_formats, vault, writer_lease
+from exomem import cli_ops, graph_sync, record_formats, vault, writer_lease
 from exomem import structured_collections as collections
 
 
@@ -1102,3 +1102,80 @@ item_schema:
     assert not list(tmp_path.rglob(".exomem-batch-*"))
     monkeypatch.setattr(vault._BatchWorkspace, "create_artifact", real_create)
     assert records.create_collection(tmp_path, manifest_path, text, why="retry collection")
+
+
+@pytest.mark.skipif(os.name != "posix", reason="owner-only residue mode is a POSIX contract")
+@pytest.mark.parametrize("scaffold", [True, False])
+def test_record_create_reports_recovery_required_for_unsafe_batch_residue(
+    tmp_path: Path,
+    scaffold: bool,
+) -> None:
+    from exomem import records
+
+    _activity_log(tmp_path)
+    manifest_path = "Knowledge Base/Records/New/_collection.md"
+    text = """---
+type: collection
+exomem_id: 33333333-3333-4333-8333-333333333333
+title: New records
+semantic_profile: records
+collection_version: 1
+schema_version: 1
+lifecycle: active
+storage:
+  strategy: markdown-items
+  source: Events
+  format_version: 1
+item_schema:
+  natural_key: [occurred_on]
+  fields:
+    occurred_on:
+      type: date
+      required: true
+---
+"""
+    residue = tmp_path / "Knowledge Base" / f".exomem-batch-{'a' * 32}"
+    residue.mkdir(mode=0o700)
+    (residue / "stage-0.tmp").write_bytes(b"recoverable staged bytes")
+    residue.chmod(0o755)
+
+    validated = records.validate_collection_create(
+        tmp_path,
+        manifest_path,
+        text,
+        scaffold=scaffold,
+    )
+    assert validated["valid"] is True
+
+    with pytest.raises(collections.CollectionError) as blocked:
+        records.create_collection(
+            tmp_path,
+            manifest_path,
+            text,
+            why="create collection",
+            scaffold=scaffold,
+        )
+
+    assert blocked.value.code == "RECORD_RECOVERY_REQUIRED"
+    assert blocked.value.reason == "private transaction residue blocks safe publication"
+    assert not (tmp_path / manifest_path).exists()
+    assert not (tmp_path / "Knowledge Base/Records/New/Events").exists()
+    assert (residue / "stage-0.tmp").read_bytes() == b"recoverable staged bytes"
+    public = cli_ops.OpError(blocked.value.code, blocked.value.reason).as_public_dict()
+    assert public["remediation"] == (
+        "Have the cell operator inspect and quarantine stale private transaction residue, "
+        "then retry the unchanged request."
+    )
+
+    residue.rename(tmp_path / "quarantined-batch-residue")
+    created = records.create_collection(
+        tmp_path,
+        manifest_path,
+        text,
+        why="retry after operator recovery",
+        scaffold=scaffold,
+    )
+
+    assert created["outcome"] == "committed"
+    assert (tmp_path / manifest_path).is_file()
+    assert (tmp_path / "Knowledge Base/Records/New/Events").is_dir() is scaffold

--- a/tests/test_record_presentation.py
+++ b/tests/test_record_presentation.py
@@ -66,6 +66,44 @@ def _setup(vault: Path) -> collections.CollectionManifest:
     return collections.load_manifest(vault, path)
 
 
+def _setup_optional_laps(vault: Path) -> collections.CollectionManifest:
+    text = _manifest_text().replace(
+        "    measurements:\n",
+        "    laps:\n"
+        "      type: array\n"
+        "      items:\n"
+        "        type: object\n"
+        "    measurements:\n",
+        1,
+    ).replace(
+        "  notes: []\n",
+        "    - field: laps\n"
+        "      label: Laps\n"
+        "      columns:\n"
+        "        - field: lap\n"
+        "          type: integer\n"
+        "        - field: seconds\n"
+        "          type: integer\n"
+        "  notes: []\n",
+        1,
+    )
+    (vault / "Knowledge Base/log.md").parent.mkdir(parents=True, exist_ok=True)
+    (vault / "Knowledge Base/log.md").write_text("# Activity\n", encoding="utf-8")
+    path = vault / "Knowledge Base/Records/Observed/_collection.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(text, encoding="utf-8")
+    (path.parent / "Items").mkdir()
+    return collections.load_manifest(vault, path)
+
+
+def _optional_laps_values() -> dict[str, object]:
+    return {
+        "observed_on": "2026-08-13",
+        "subject": "Panel",
+        "measurements": [{"name": "One", "value": "1", "source": "[[Source]]"}],
+    }
+
+
 def test_records_only_presentation_is_normalized_and_legacy_presentation_is_opaque(
     tmp_path: Path,
 ) -> None:
@@ -110,6 +148,136 @@ def test_markdown_item_presentation_renders_from_canonical_values_and_preserves_
     managed = rendered.split("<!-- exomem-record-presentation:v1", 1)[1]
     assert "hidden" not in managed
     assert rendered.endswith("Authored prose.\r\n")
+
+
+@pytest.mark.parametrize(
+    ("include_laps", "laps", "expected_row"),
+    [
+        (False, None, None),
+        (True, None, None),
+        (True, [], None),
+        (True, [{"lap": 1, "seconds": 46}], "| 1 | 46 |"),
+    ],
+)
+def test_append_accepts_omitted_empty_and_populated_optional_presentation_tables(
+    tmp_path: Path,
+    include_laps: bool,
+    laps: object,
+    expected_row: str | None,
+) -> None:
+    manifest = _setup_optional_laps(tmp_path)
+    item = _optional_laps_values()
+    if include_laps:
+        item["laps"] = laps
+
+    result = records.append_record(
+        tmp_path,
+        manifest,
+        item=item,
+        item_key="11111111-1111-4111-8111-111111111111",
+        why="record optional lap observations",
+    )
+
+    assert result["outcome"] == "committed"
+    rendered = (tmp_path / result["affected_paths"][0]).read_text(encoding="utf-8")
+    assert "### Laps" in rendered
+    if expected_row is None:
+        assert "| 1 | 46 |" not in rendered
+    else:
+        assert expected_row in rendered
+    queried = record_formats.query_collection(
+        tmp_path,
+        collections.load_manifest(tmp_path, manifest.path),
+        limit=10,
+    )
+    assert queried.rows[0]["laps"] == ([] if laps is None else laps)
+    expanded = record_formats.query_collection(
+        tmp_path,
+        collections.load_manifest(tmp_path, manifest.path),
+        expand_child="laps",
+        limit=10,
+    )
+    if expected_row is None:
+        assert expanded.rows == []
+    else:
+        assert len(expanded.rows) == 1
+        assert expanded.rows[0]["lap"] == 1
+        assert expanded.rows[0]["seconds"] == 46
+
+
+@pytest.mark.parametrize("invalid", ["not an array", {"lap": 1}])
+def test_optional_presentation_table_rejects_present_non_array_values(
+    tmp_path: Path,
+    invalid: object,
+) -> None:
+    manifest = _setup_optional_laps(tmp_path)
+    item = _optional_laps_values()
+    item["laps"] = invalid
+
+    with pytest.raises(collections.CollectionError) as invalid_item:
+        records.append_record(
+            tmp_path,
+            manifest,
+            item=item,
+            item_key="11111111-1111-4111-8111-111111111111",
+            why="reject invalid lap observations",
+        )
+
+    assert invalid_item.value.code == "SCHEMA_FIELD_TYPE"
+    assert not list((tmp_path / manifest.storage.source).glob("*.md"))
+
+    with pytest.raises(collections.CollectionError) as unrenderable:
+        record_formats.render_markdown_item(
+            manifest,
+            item,
+            "11111111-1111-4111-8111-111111111111",
+        )
+    assert unrenderable.value.code == "UNRENDERABLE_RECORD_PRESENTATION"
+    assert unrenderable.value.reason == "presentation table 'laps' must be an array when present"
+    assert unrenderable.value.details == {"field": "laps"}
+
+
+def test_expand_optional_presentation_table_names_malformed_stored_field(tmp_path: Path) -> None:
+    manifest = _setup_optional_laps(tmp_path)
+    result = records.append_record(
+        tmp_path,
+        manifest,
+        item={**_optional_laps_values(), "laps": []},
+        item_key="11111111-1111-4111-8111-111111111111",
+        why="seed optional lap observations",
+    )
+    path = tmp_path / result["affected_paths"][0]
+    path.write_text(
+        path.read_text(encoding="utf-8").replace("laps: []", "laps: malformed", 1),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(collections.CollectionError) as invalid:
+        record_formats.query_collection(
+            tmp_path,
+            collections.load_manifest(tmp_path, manifest.path),
+            expand_child="laps",
+            limit=10,
+        )
+
+    assert invalid.value.code == "SCHEMA_FIELD_TYPE"
+    assert "laps" in invalid.value.reason
+
+
+def test_required_presentation_table_omission_remains_a_schema_failure(tmp_path: Path) -> None:
+    manifest = _setup(tmp_path)
+
+    with pytest.raises(collections.CollectionError) as missing:
+        records.append_record(
+            tmp_path,
+            manifest,
+            item={"observed_on": "2026-08-13", "subject": "Panel"},
+            item_key="11111111-1111-4111-8111-111111111111",
+            why="reject incomplete observations",
+        )
+
+    assert missing.value.code == "SCHEMA_REQUIRED_FIELD"
+    assert missing.value.reason == "required field is missing: measurements"
 
 
 def test_record_queries_project_nested_values_and_expand_the_selected_table(


### PR DESCRIPTION
## Summary

- distinguish unsafe private transaction residue from genuine canonical drift, return actionable `RECORD_RECOVERY_REQUIRED`/503 guidance, and preserve fail-closed/no-partial create behavior
- accept omitted, null, empty, and populated optional presentation arrays across render, query, and `expand_child`; keep malformed/required fields typed and field-named
- preserve safe hosted redaction while projecting the recovery remediation

## Root cause

Fresh collection creation was not self-invalidating its own guard. A stale permissive `.exomem-batch-*` workspace caused the portable absence guard to fail with `BATCH_RESIDUE_UNSAFE`, which Records flattened to `STALE_RECORD`. The residue was quarantined outside the vault; this change makes future incidents truthful and recoverable without weakening concurrency.

The presentation bug was independent: missing optional table fields were treated like present non-array values, including in the pre-expansion child cap.

## Verification

- 315 affected Records tests passed
- 117 presentation/child/hosted/recovery regressions passed after reviewer corrections
- 100 deterministic `validate → create → inspect → append` cycles: zero stale/append failures
- focused final matrix: 12 passed
- Ruff changed paths: clean
- `openspec validate --all --strict`: 174 passed
- author-independent review: ACCEPT after correction/recheck
