### PR TITLE
chore(openspec): file the Windows catalog-identity defect

### DIFF
--- a/openspec/changes/fix-catalog-identity-on-windows/.openspec.yaml
+++ b/openspec/changes/fix-catalog-identity-on-windows/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/fix-catalog-identity-on-windows/design.md
+++ b/openspec/changes/fix-catalog-identity-on-windows/design.md
@@ -1,0 +1,70 @@
+## Context
+
+`_publish_markdown_catalog_generation` builds its predecessor map as
+
+```python
+by_identity = {item.item_identity: item for item in active_namespace.items}
+```
+
+and then looks each mutation up by the relative path the mutation carries:
+
+```python
+predecessor = by_identity.get(relative)
+if predecessor is None or predecessor.content_hash != mutation.expected_before_hash:
+    raise CatalogPublicationError(
+        "catalog content identity no longer matches the reviewed predecessor"
+    )
+```
+
+Both arms of that condition produce the same message, so the observed failure is
+either *no predecessor at that key* or *a predecessor whose hash differs*. The
+two are worth separating before anything else, because they point at completely
+different bugs — a key that does not match, versus content that does not.
+
+## What has already been excluded
+
+**Path separators.** The obvious hypothesis is a `\` key meeting a `/` key, and
+the module already handles that: `str(path).replace("\\", "/")` and `.as_posix()`
+appear at every construction site, and `relative` itself comes from
+`write.path.absolute().relative_to(root).as_posix()`. This is not a naive
+separator bug.
+
+## The lead worth checking first
+
+The module computes a normalized alias for each target —
+`unicodedata.normalize("NFC", relative).casefold()` — but uses it **only** to
+detect colliding membership targets. The `by_identity` lookup itself is an exact
+match on the raw posix relative path.
+
+That asymmetry is benign wherever the stored `item_identity` and the live path
+text are byte-identical, which is the normal case on Linux. On Windows they need
+not be: `relative` is derived from a live filesystem path, and casing there is
+preserved but not significant, so a path that reaches publication through a
+differently-cased or alias route yields a key the exact-match lookup misses
+while the alias computation would have matched it.
+
+This is a hypothesis, not a diagnosis. It has not been confirmed, and it does not
+explain the `test_graph_epoch_protocol` failures, which may or may not share the
+cause. `item_identity`'s producer has not been traced.
+
+## Goals / Non-Goals
+
+**Goals.** Establish which arm of the condition fires. Reproduce without a
+Windows runner if possible. Fix the identity match so it holds on every declared
+platform. Cover it where a pull request will see it.
+
+**Non-Goals.** Widening the identity rule into case-insensitivity as a
+convenience — if casing is the cause, the fix is to compare identities the way
+they are minted, not to relax the comparison. Touching the advisory nature of the
+nightly lane, which is deliberate.
+
+## Risks / Trade-offs
+
+**A relaxed comparison would hide a real collision.** The alias computation
+exists to refuse colliding membership targets; reusing it as the lookup key
+without care could let two distinct targets match one predecessor. Whatever the
+fix, the collision refusal has to keep working.
+
+**No Windows host here.** Everything above was read from source and from nightly
+logs. A fix proposed without a reproduction is a guess, which is why task 1 is
+the reproduction and not the patch.

--- a/openspec/changes/fix-catalog-identity-on-windows/proposal.md
+++ b/openspec/changes/fix-catalog-identity-on-windows/proposal.md
@@ -1,0 +1,62 @@
+# Proposal: fix-catalog-identity-on-windows
+
+## Why
+
+Catalog publication refuses on Windows. Every governed mutation that publishes a
+v4 catalog generation raises
+
+```
+CatalogPublicationError: catalog content identity no longer matches the reviewed predecessor
+```
+
+from `governance/catalog_publication.py`, surfacing as `SemanticWriteError`
+(`semantic_writes.py`) for a semantic write and `DeleteFileError`
+(`delete_file.py`) for a removal. One root cause, thirty-two distinct failing
+tests in `tests/test_governance_active_tuple.py` alone, plus related failures in
+`test_graph_epoch_protocol.py` and `test_graph_lifecycle_windows.py`. Linux is
+green throughout.
+
+**It arrived with the v4 catalog wave.** Bisected against the nightly matrix: the
+lane was clean at `542db604` and failing at `3e643525`, and between them sit
+PRs #800-#818, the wave that moved semantic writes, trash, move, recovery,
+companion backfill and media sidecars onto v4 catalog publication.
+
+**It has been invisible because the lane that sees it is advisory.** Since
+`e85a88c1 chore(ci): move expensive gates off every PR (#787)` the
+cross-platform matrix runs nightly and manual only, with a skipped placeholder
+on pull requests. Nothing merged red; the matrix simply never ran on those PRs,
+which is what #787 intended. The required Windows coverage on a PR is the
+focused native-NTFS contract, and that contract does not exercise catalog
+publication.
+
+Separately, the nightly signal was itself degraded: the lane's session cap fired
+below real Windows runtime, so shards reported clean summaries as failures and
+buried these among clocks. That is `bound-cross-platform-session`, and it is why
+this was not noticed sooner.
+
+## What Changes
+
+- Catalog publication's predecessor-identity match holds on every platform the
+  package declares, not only where the path text happens to round-trip.
+- The failure is covered by a test that runs on the required PR gate, so this
+  class of defect cannot again be visible only in an advisory nightly lane.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `governance-kernel` — the v4 tuple publication contract states that
+  predecessor identity is matched platform-independently.
+
+## Impact
+
+- `src/exomem/governance/catalog_publication.py` — the identity lookup.
+- Whatever produces `item_identity` upstream, which this change has not yet
+  traced.
+- `tests/` — a reproduction that does not require a Windows runner.
+
+## Status
+
+**This files the defect; it does not fix it.** The tasks are unticked. Confirming
+a fix needs either a Windows host or a reproduction that forces the mismatch on
+any platform, and inventing one is the first task rather than an assumption.

--- a/openspec/changes/fix-catalog-identity-on-windows/specs/governance-kernel/spec.md
+++ b/openspec/changes/fix-catalog-identity-on-windows/specs/governance-kernel/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Catalog predecessor identity matches on every declared platform
+
+A v4 catalog generation SHALL match each mutation to its reviewed predecessor by
+an identity that is stable across the platforms the package declares support for,
+so that the same governed write publishes on each of them or refuses on all of
+them for the same reason. A refusal SHALL distinguish a predecessor that is
+absent at the requested identity from one whose content hash differs, because
+those name different defects. Matching SHALL NOT be relaxed in a way that lets
+two distinct membership targets resolve to one predecessor.
+
+#### Scenario: The same governed write publishes on every declared platform
+
+- **WHEN** a governed semantic write or removal publishes a catalog generation on any platform the package declares
+- **THEN** the mutation matches its reviewed predecessor
+- **AND** the outcome does not depend on how that platform spells the path
+
+#### Scenario: A refusal names which identity check failed
+
+- **WHEN** catalog publication refuses a mutation
+- **THEN** the refusal distinguishes an absent predecessor from a content-hash mismatch
+
+#### Scenario: Colliding membership targets are still refused
+
+- **WHEN** two distinct mutation targets normalize to one membership identity
+- **THEN** publication refuses the batch rather than matching both to one predecessor

--- a/openspec/changes/fix-catalog-identity-on-windows/tasks.md
+++ b/openspec/changes/fix-catalog-identity-on-windows/tasks.md
@@ -1,0 +1,28 @@
+## 1. Establish the failure precisely
+
+- [ ] 1.1 Split the two arms of the condition so the message distinguishes "no predecessor at this key" from "predecessor hash differs", and confirm from a nightly run which one fires.
+- [ ] 1.2 Trace what produces `item_identity` and compare it, byte for byte, with the `relative` the lookup uses.
+- [ ] 1.3 Reproduce on any platform by forcing the mismatch the trace reveals; only fall back to a Windows host if no such reproduction exists.
+
+## 2. Fix
+
+- [ ] 2.1 Make the predecessor match hold on every declared platform, comparing identities the way they are minted rather than relaxing the comparison.
+- [ ] 2.2 Confirm the colliding-membership refusal still refuses.
+
+## 3. Stop it hiding
+
+- [ ] 3.1 Cover the reproduction in a test that runs on the required pull-request gate, not only in the advisory nightly matrix.
+- [ ] 3.2 Confirm the nightly Windows shards clear `tests/test_governance_active_tuple.py`.
+
+## 4. Check the neighbours
+
+- [ ] 4.1 Determine whether `test_graph_epoch_protocol.py::test_protocol_artifact_reader_rejects_replace_during_guarded_read` and `test_graph_lifecycle_windows.py::test_windows_private_unlink_closes_delete_pending_handle_before_flush` share this cause or are separate.
+
+## 5. Verify
+
+- [ ] 5.1 Run the governance and graph suites plus lint.
+- [ ] 5.2 Run `openspec validate fix-catalog-identity-on-windows --strict` and `openspec validate --specs --strict`.
+
+## 6. Closure
+
+- [ ] 6.1 Once merged and therefore demonstrably shipped, sync the delta into `openspec/specs/` and archive with `openspec archive`.


### PR DESCRIPTION
## Why

Catalog publication refuses on Windows. Every governed mutation that publishes a v4 catalog generation raises

```
CatalogPublicationError: catalog content identity no longer matches the reviewed predecessor
```

surfacing as `SemanticWriteError` for a semantic write and `DeleteFileError` for a removal. One root cause, **32 distinct failing tests in `tests/test_governance_active_tuple.py`** alone, plus related failures in `test_graph_epoch_protocol.py` and `test_graph_lifecycle_windows.py`. Linux is green throughout.

**Bisected to the v4 catalog wave.** Against the nightly matrix: clean at `542db604`, failing at `3e643525`. Between them sit PRs #800–#818 — the wave that moved semantic writes, trash, move, recovery, companion backfill and media sidecars onto v4 catalog publication.

**Why it stayed invisible.** Since `e85a88c1 (#787)` the cross-platform matrix is nightly and manual only, with a skipped placeholder on PRs. Nothing merged red — the matrix simply never ran on those PRs, which is what #787 intended. The required Windows coverage on a PR is the focused native-NTFS contract, and that contract does not exercise catalog publication. Separately the nightly signal was itself degraded: the lane's session cap fired below real Windows runtime, so clean summaries were reported as failures and these were buried among clocks (that is #769).

## This files the defect; it does not fix it

Tasks are unticked deliberately. There is no Windows host here, and a fix proposed without a reproduction is a guess — so task 1 is the reproduction, not the patch.

**What is already excluded.** Path separators. The obvious hypothesis is a `\` key meeting a `/` key, and the module already handles it: `str(path).replace("\\", "/")` and `.as_posix()` appear at every construction site, and `relative` itself comes from `write.path.absolute().relative_to(root).as_posix()`.

**The lead worth checking first.** The module computes `unicodedata.normalize("NFC", relative).casefold()` for each target but uses it *only* to detect colliding membership targets — the `by_identity` lookup is an exact match on the raw posix relative path. That asymmetry is benign wherever stored identity and live path text are byte-identical, which is the normal case on Linux; on Windows casing is preserved but not significant, so a path reaching publication by a differently-cased route yields a key the exact-match lookup misses while the alias computation would have matched it. **A hypothesis, not a diagnosis** — it has not been confirmed, `item_identity`'s producer has not been traced, and it does not explain the `test_graph_epoch_protocol` failures.

**A trap for whoever picks it up.** Both arms of the failing condition emit the same message, so "no predecessor at that key" and "predecessor hash differs" are currently indistinguishable — two completely different bugs. Task 1.1 is splitting them.

## Verification

- `openspec validate fix-catalog-identity-on-windows --strict` valid; `--specs --strict` 112 passed; archive discipline OK (none task-complete).
- No source change.
