### PR TITLE
fix(hosted): retarget v2 recovery operations

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/operation_recovery.py
+++ b/infra/provisioner/src/exomem_provisioner/operation_recovery.py
@@ -288,28 +288,43 @@ def retarget_transition_values(before: RetargetPreState, *, now: datetime) -> di
     }
 
 
-def retarget_legacy_provision_request(
-    request: dict[str, object], *, release_version: str, protocol_version: str
+def retarget_provision_request(
+    request: dict[str, object], *, wire_protocol: str, runtime_target: dict[str, object]
 ) -> dict[str, object]:
-    if (
-        request.get("provisionMode") != "serve"
-        or "runtimeTarget" in request
-        or not isinstance(request.get("releaseVersion"), str)
-        or not isinstance(request.get("protocolVersion"), str)
-        or not release_version
-        or not protocol_version
-    ):
+    if request.get("provisionMode") != "serve" or not runtime_target:
         raise RecoveryRefusal("retarget request is invalid")
-    if (
-        request["releaseVersion"] == release_version
-        and request["protocolVersion"] == protocol_version
-    ):
-        raise RecoveryRefusal("request already targets selected runtime")
-    return {
-        **request,
-        "releaseVersion": release_version,
-        "protocolVersion": protocol_version,
-    }
+    if wire_protocol == "exomem-cell-provisioner.v1":
+        release_version = runtime_target.get("releaseVersion")
+        protocol_version = runtime_target.get("protocolVersion")
+        if (
+            "runtimeTarget" in request
+            or not isinstance(request.get("releaseVersion"), str)
+            or not isinstance(request.get("protocolVersion"), str)
+            or not isinstance(release_version, str)
+            or not isinstance(protocol_version, str)
+        ):
+            raise RecoveryRefusal("retarget request is invalid")
+        if (
+            request["releaseVersion"] == release_version
+            and request["protocolVersion"] == protocol_version
+        ):
+            raise RecoveryRefusal("request already targets selected runtime")
+        return {
+            **request,
+            "releaseVersion": release_version,
+            "protocolVersion": protocol_version,
+        }
+    if wire_protocol == "exomem-cell-provisioner.v2":
+        if (
+            "releaseVersion" in request
+            or "protocolVersion" in request
+            or not isinstance(request.get("runtimeTarget"), dict)
+        ):
+            raise RecoveryRefusal("retarget request is invalid")
+        if request["runtimeTarget"] == runtime_target:
+            raise RecoveryRefusal("request already targets selected runtime")
+        return {**request, "runtimeTarget": dict(runtime_target)}
+    raise RecoveryRefusal("retarget request is invalid")
 
 
 def recovery_marker(
@@ -436,6 +451,7 @@ class RecoveryService:
         database_schema: str,
         database_lock_timeout_seconds: int,
         deployment_lock: DeploymentLock,
+        source_deployment_lock: DeploymentLock | None = None,
         observer: RecoveryLiveObserver,
         runtime_selection: Literal["active", "rollback"] | None = None,
     ) -> None:
@@ -446,6 +462,7 @@ class RecoveryService:
         self._database_schema = database_schema
         self._database_lock_timeout_seconds = database_lock_timeout_seconds
         self._deployment_lock = deployment_lock
+        self._source_deployment_lock = source_deployment_lock or deployment_lock
         self._runtime_selection = runtime_selection
         self._observer = observer
         self._helper_source_sha256 = hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
@@ -844,8 +861,7 @@ class RecoveryService:
             or request.get("fenceGeneration") != operation.fence_generation
             or request.get("checkpoint") != operation.caller_checkpoint
             or request.get("provisionMode") != "serve"
-            or operation.wire_protocol.value != "exomem-cell-provisioner.v1"
-            or not self._deployment_lock.matches_runtime_request(
+            or not self._source_deployment_lock.matches_runtime_request(
                 request,
                 wire_protocol=operation.wire_protocol.value,
                 selection=self._runtime_selection,
@@ -854,10 +870,12 @@ class RecoveryService:
             raise RecoveryRefusal("retarget preflight failed")
         selected = self._deployment_lock.selected_runtime(self._runtime_selection)
         target_runtime = selected.runtimeTarget.model_dump(mode="json")
-        target_request = retarget_legacy_provision_request(
+        if selected.compatibilityDigest is not None:
+            target_runtime["compatibilityDigest"] = selected.compatibilityDigest
+        target_request = retarget_provision_request(
             request,
-            release_version=selected.runtimeTarget.releaseVersion,
-            protocol_version=selected.runtimeTarget.protocolVersion,
+            wire_protocol=operation.wire_protocol.value,
+            runtime_target=target_runtime,
         )
         resources = await self._resources(session, operation)
         reservation = await self._reservation(session, operation)
@@ -1365,6 +1383,7 @@ async def _run(args: argparse.Namespace) -> dict[str, object]:
             database_schema=settings.database_schema,
             database_lock_timeout_seconds=settings.database_lock_timeout_seconds,
             deployment_lock=settings.deployment_lock,
+            source_deployment_lock=settings.source_deployment_lock,
             runtime_selection=settings.runtime_selection,
             observer=observer,
         )

--- a/infra/provisioner/src/exomem_provisioner/recovery_settings.py
+++ b/infra/provisioner/src/exomem_provisioner/recovery_settings.py
@@ -23,6 +23,7 @@ _RECOVERY_ENVIRONMENT = {
     "EXOMEM_RECOVERY_ENVELOPE_KEY": "envelope_key",
     "EXOMEM_RECOVERY_PROVIDER_RECOVERY_PUBLIC_KEY": "provider_recovery_public_key",
     "EXOMEM_RECOVERY_DEPLOYMENT_LOCK_JSON": "deployment_lock",
+    "EXOMEM_RECOVERY_SOURCE_DEPLOYMENT_LOCK_JSON": "source_deployment_lock",
     "EXOMEM_RECOVERY_RUNTIME_SELECTION": "runtime_selection",
     "EXOMEM_RECOVERY_HCLOUD_TOKEN": "hcloud_token",
     "EXOMEM_RECOVERY_HCLOUD_LOCATION": "hcloud_location",
@@ -52,6 +53,7 @@ class RecoverySettings(BaseModel):
         min_length=40, max_length=128, pattern=r"^[A-Za-z0-9_-]+$"
     )
     deployment_lock: DeploymentLock
+    source_deployment_lock: DeploymentLock
     runtime_selection: Literal["active", "rollback"]
     hcloud_token: SecretStr = Field(min_length=32, max_length=4096)
     hcloud_location: str = Field(pattern=r"^[a-z0-9][a-z0-9-]{1,31}$")
@@ -82,6 +84,7 @@ class RecoverySettings(BaseModel):
     @model_validator(mode="after")
     def validate_selected_runtime(self) -> RecoverySettings:
         self.deployment_lock.selected_runtime(self.runtime_selection)
+        self.source_deployment_lock.selected_runtime(self.runtime_selection)
         return self
 
     @property
@@ -110,7 +113,11 @@ def load_recovery_settings(
             source["EXOMEM_RECOVERY_DEPLOYMENT_LOCK_JSON"],
             object_pairs_hook=_reject_duplicate_json_keys,
         )
-        if not isinstance(lock_value, dict):
+        source_lock_value = json.loads(
+            source["EXOMEM_RECOVERY_SOURCE_DEPLOYMENT_LOCK_JSON"],
+            object_pairs_hook=_reject_duplicate_json_keys,
+        )
+        if not isinstance(lock_value, dict) or not isinstance(source_lock_value, dict):
             raise ValueError("recovery deployment lock is invalid")
         values: dict[str, object] = {
             field: source[name] for name, field in _RECOVERY_ENVIRONMENT.items()
@@ -119,6 +126,7 @@ def load_recovery_settings(
             source["EXOMEM_RECOVERY_DATABASE_LOCK_TIMEOUT_SECONDS"]
         )
         values["deployment_lock"] = lock_value
+        values["source_deployment_lock"] = source_lock_value
         return RecoverySettings.model_validate(values)
     except (TypeError, ValueError, json.JSONDecodeError) as error:
         raise ValueError("recovery environment is invalid") from error

--- a/infra/provisioner/tests/test_operation_recovery.py
+++ b/infra/provisioner/tests/test_operation_recovery.py
@@ -34,6 +34,7 @@ def _recovery_environment(**overrides: str) -> dict[str, str]:
         "EXOMEM_RECOVERY_ENVELOPE_KEY": "e" * 32,
         "EXOMEM_RECOVERY_PROVIDER_RECOVERY_PUBLIC_KEY": "p" * 43,
         "EXOMEM_RECOVERY_DEPLOYMENT_LOCK_JSON": _selected_deployment_lock_json(),
+        "EXOMEM_RECOVERY_SOURCE_DEPLOYMENT_LOCK_JSON": _selected_deployment_lock_json(),
         "EXOMEM_RECOVERY_RUNTIME_SELECTION": "active",
         "EXOMEM_RECOVERY_HCLOUD_TOKEN": "h" * 32,
         "EXOMEM_RECOVERY_HCLOUD_LOCATION": "fsn1",
@@ -49,6 +50,7 @@ def test_recovery_settings_accept_only_the_exact_minimal_environment() -> None:
 
     assert settings.database_name == "recovery_db"
     assert settings.deployment_lock.components.provisioner.image.endswith("b" * 64)
+    assert settings.source_deployment_lock == settings.deployment_lock
     assert settings.runtime_selection == "active"
     assert settings.hcloud_location == "fsn1"
     for name, value in (
@@ -235,7 +237,7 @@ def test_recovery_marker_is_content_free_and_exact() -> None:
             recovery.parse_recovery_marker({**marker, **changed})
 
 
-def test_retarget_request_changes_only_the_legacy_runtime_pair() -> None:
+def test_retarget_request_changes_only_the_v1_legacy_runtime_pair() -> None:
     recovery = _module()
     source = {
         "operationId": "provider-alpha",
@@ -250,31 +252,78 @@ def test_retarget_request_changes_only_the_legacy_runtime_pair() -> None:
         "provisionMode": "serve",
     }
 
-    target = recovery.retarget_legacy_provision_request(
+    target = recovery.retarget_provision_request(
         source,
-        release_version="0.68.1",
-        protocol_version="1",
+        wire_protocol="exomem-cell-provisioner.v1",
+        runtime_target={"releaseVersion": "0.68.1", "protocolVersion": "1"},
     )
 
     assert target == {**source, "releaseVersion": "0.68.1", "protocolVersion": "1"}
     assert source["releaseVersion"] == "0.66.0"
     with pytest.raises(recovery.RecoveryRefusal):
-        recovery.retarget_legacy_provision_request(
+        recovery.retarget_provision_request(
             {**source, "provisionMode": "restore-candidate"},
-            release_version="0.68.1",
-            protocol_version="1",
+            wire_protocol="exomem-cell-provisioner.v1",
+            runtime_target={"releaseVersion": "0.68.1", "protocolVersion": "1"},
         )
     with pytest.raises(recovery.RecoveryRefusal):
-        recovery.retarget_legacy_provision_request(
+        recovery.retarget_provision_request(
             {**source, "runtimeTarget": {}},
-            release_version="0.68.1",
-            protocol_version="1",
+            wire_protocol="exomem-cell-provisioner.v1",
+            runtime_target={"releaseVersion": "0.68.1", "protocolVersion": "1"},
         )
     with pytest.raises(recovery.RecoveryRefusal, match="already targets"):
-        recovery.retarget_legacy_provision_request(
+        recovery.retarget_provision_request(
             target,
-            release_version="0.68.1",
-            protocol_version="1",
+            wire_protocol="exomem-cell-provisioner.v1",
+            runtime_target={"releaseVersion": "0.68.1", "protocolVersion": "1"},
+        )
+
+
+def test_retarget_request_changes_only_the_complete_v2_runtime_target() -> None:
+    recovery = _module()
+    source_target = {
+        "releaseVersion": "0.66.0",
+        "protocolVersion": "1",
+        "agentProfile": "hosted-alpha-agent-v4",
+        "gatewayContractDigest": "a" * 64,
+        "commandFingerprint": "b" * 64,
+        "schemaDigest": "c" * 64,
+        "compatibilityDigest": "d" * 64,
+    }
+    selected = {
+        **source_target,
+        "releaseVersion": "0.68.1",
+        "gatewayContractDigest": "e" * 64,
+        "schemaDigest": "f" * 64,
+        "compatibilityDigest": "1" * 64,
+    }
+    source = {
+        "operationId": "provider-alpha",
+        "checkpoint": "requested",
+        "fenceGeneration": 7,
+        "tenantId": "tenant-alpha",
+        "cellId": "cell-alpha",
+        "serviceCredential": "secret-alpha",
+        "workerPolicy": {"workerCount": 0, "semantic": False, "media": False},
+        "provisionMode": "serve",
+        "runtimeTarget": source_target,
+        "_providerRecoveryEnvelopes": {"namespace": "opaque"},
+    }
+
+    target = recovery.retarget_provision_request(
+        source,
+        wire_protocol="exomem-cell-provisioner.v2",
+        runtime_target=selected,
+    )
+
+    assert target == {**source, "runtimeTarget": selected}
+    assert source["runtimeTarget"] is source_target
+    with pytest.raises(recovery.RecoveryRefusal):
+        recovery.retarget_provision_request(
+            {**source, "releaseVersion": "0.66.0"},
+            wire_protocol="exomem-cell-provisioner.v2",
+            runtime_target=selected,
         )
 
 

--- a/infra/provisioner/tests/test_postgresql17.py
+++ b/infra/provisioner/tests/test_postgresql17.py
@@ -435,7 +435,7 @@ async def test_postgresql17_recovery_cas_inserts_one_immutable_receipt(
                         "schemaDigest": "c" * 64,
                     }
 
-            return type("Selected", (), {"runtimeTarget": Target()})()
+            return type("Selected", (), {"runtimeTarget": Target(), "compatibilityDigest": None})()
 
     class Observer:
         async def observe(

--- a/openspec/changes/standardize-hosted-runtime-upgrades/design.md
+++ b/openspec/changes/standardize-hosted-runtime-upgrades/design.md
@@ -174,12 +174,13 @@ authorize one forward retarget to the reviewed upgrade target. The signed provis
 accepts only the same operation that already carries the one-way init-retry recovery receipt,
 is at `PENDING|CLAIMED / volume-owned` with no live claim, result, route, or admitted runtime,
 and still owns the exact authenticated namespace, Helm release, PVC, provider volume, tenant
-fence, and unreleased reservation. It decrypts and verifies the existing v1 request against the
-expand lock's retained catalog, changes only `releaseVersion` and `protocolVersion`, and commits
+fence, and unreleased reservation. It decrypts and verifies the existing request against the
+separately supplied signed source lock, replaces only the v1 release/protocol pair or the complete
+v2 `runtimeTarget` with the separately supplied signed target lock's selection, and commits
 the new ciphertext, canonical hash, pending state, and a content-free one-way retarget receipt
 in one compare-and-swap transaction. It never changes or replaces the operation, tenant, cell,
 fence, reservation, resource, PVC, PV, provider-volume, service credential, worker policy, or
-caller checkpoint. The target remains cataloged for this persisted v1 operation until its
+caller checkpoint. A persisted v1 target remains cataloged until its
 unfinished and desired-state evidence no longer requires that compatibility path.
 
 ## Risks / Trade-offs

--- a/openspec/changes/standardize-hosted-runtime-upgrades/specs/hosted-runtime-upgrade/spec.md
+++ b/openspec/changes/standardize-hosted-runtime-upgrades/specs/hosted-runtime-upgrade/spec.md
@@ -210,12 +210,14 @@ Rollback SHALL choose the last safe action from the execution phase. Before any 
 
 ### Requirement: Stranded private-alpha provisions may retarget forward in place
 
-An explicitly authorized recovery MAY retarget a never-routed unfinished v1 provision from a
-reviewed legacy runtime to the selected forward runtime only after the signed helper proves the
+An explicitly authorized recovery MAY retarget a never-routed unfinished provision from a
+reviewed source runtime to the selected forward runtime only after the signed helper proves both
+the source and target deployment locks and
 existing init-retry receipt, exact request and request hash, tenant fence, operation and provider
 identity, four authenticated durable resources, one unreleased reservation, no result, no route,
 no admitted runtime, two stable live observations, and no unexpired worker claim. The transaction
-SHALL change only the request's release/protocol pair, encrypted request, canonical request hash,
+SHALL change only a v1 request's release/protocol pair or a v2 request's complete `runtimeTarget`,
+encrypted request, canonical request hash,
 claim fields, availability timestamp, and append-only content-free retarget receipt while
 preserving every operation, tenant, cell, fence, resource, volume, credential, policy, and caller
 checkpoint identity. Repetition SHALL verify the existing receipt without a second mutation.


### PR DESCRIPTION
## Summary
- verify the stranded operation against its original signed deployment lock
- replace the complete v2 runtime target from the new signed deployment lock
- retain v1 support and preserve every non-runtime request field

## Verification
- 529 provisioner tests passed, 17 skipped
- ruff, diff check, and strict OpenSpec validation passed