### PR TITLE
fix(hosted): complete retargeted provisions in place

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/adapters.py
+++ b/infra/provisioner/src/exomem_provisioner/adapters.py
@@ -2030,6 +2030,11 @@ class HelmCliAdapter:
             raise MetadataConflict("current Helm values are invalid")
         return value
 
+    async def current_release_values(self, metadata: OpaqueProviderMetadata) -> dict[str, Any]:
+        environment = {"HELM_DRIVER": "configmap"}
+        await self._require_version(environment)
+        return await self._current_values(metadata, environment)
+
     async def _revision_values(
         self,
         metadata: OpaqueProviderMetadata,

--- a/infra/provisioner/src/exomem_provisioner/lifecycle.py
+++ b/infra/provisioner/src/exomem_provisioner/lifecycle.py
@@ -663,6 +663,13 @@ class LifecyclePlane(Protocol):
         request: dict[str, Any],
         values: dict[str, Any],
     ) -> None: ...
+    async def provision_retarget_required(
+        self,
+        metadata: OpaqueProviderMetadata,
+        request: dict[str, Any],
+        config: LifecycleConfig,
+    ) -> bool: ...
+    async def stop_stranded_provision(self, metadata: OpaqueProviderMetadata) -> None: ...
     async def volume_claim_bound(self, metadata: OpaqueProviderMetadata) -> bool: ...
     def is_initialized(self, metadata: OpaqueProviderMetadata) -> bool: ...
     async def initialize(
@@ -962,6 +969,34 @@ class HighFidelityProviderPlane:
         if self._lose_after_bind:
             self._lose_after_bind = False
             raise LostAcknowledgement("CSI binding committed before acknowledgement")
+
+    async def provision_retarget_required(
+        self,
+        metadata: OpaqueProviderMetadata,
+        request: dict[str, Any],
+        config: LifecycleConfig,
+    ) -> bool:
+        cell = self._require_cell(metadata)
+        desired = _fixed_helm_values(metadata, request, config)
+        changed = any(
+            cell.helm_values.get(key) != desired[key]
+            for key in ("image", "expectedRelease", "expectedProtocol")
+        )
+        if not changed:
+            return False
+        if cell.runtime_admitted or cell.control_route or cell.transfer_route:
+            raise MetadataConflict("retargeted provision is already admitted or routed")
+        if config.migration_mode not in {"binding-v1-to-v2", "state-root-v1"}:
+            raise MetadataConflict("retargeted provision requires a declared migration")
+        return True
+
+    async def stop_stranded_provision(self, metadata: OpaqueProviderMetadata) -> None:
+        cell = self._require_cell(metadata)
+        if cell.runtime_admitted or cell.control_route or cell.transfer_route:
+            raise MetadataConflict("retargeted provision is already admitted or routed")
+        cell.in_flight = 0
+        cell.quiesced = True
+        cell.replicas = 0
 
     def lose_acknowledgement_after_csi_bind_once(self) -> None:
         self._lose_after_bind = True
@@ -1979,6 +2014,7 @@ class CellLifecycleDriver:
         self, request: dict[str, Any], context: EffectContext
     ) -> DriverPending | DriverFinal:
         metadata = _metadata_from_context(context)
+        operation_id = context.provider_operation_id
         if not self._plane.has_namespace(metadata):
             await self._plane.ensure_namespace(metadata, request)
             return DriverPending(
@@ -2006,7 +2042,12 @@ class CellLifecycleDriver:
             "initialized",
             "runtime-admitted",
             "routes-open",
-        }:
+            "retarget-runtime-stop-wait",
+            "retarget-runtime-stopped",
+        } and not (
+            context.checkpoint.startswith("retarget-vault-fingerprinted-")
+            or context.checkpoint.startswith("retarget-migration-complete-")
+        ):
             return DriverPending(
                 "release-applied",
                 1,
@@ -2023,7 +2064,12 @@ class CellLifecycleDriver:
             "initialized",
             "runtime-admitted",
             "routes-open",
-        }:
+            "retarget-runtime-stop-wait",
+            "retarget-runtime-stopped",
+        } and not (
+            context.checkpoint.startswith("retarget-vault-fingerprinted-")
+            or context.checkpoint.startswith("retarget-migration-complete-")
+        ):
             return DriverPending("volume-registration-required", 1)
         if request["provisionMode"] == "restore-candidate":
             return DriverFinal(
@@ -2034,6 +2080,46 @@ class CellLifecycleDriver:
                     ),
                 }
             )
+        if context.checkpoint == "volume-owned" and await self._plane.provision_retarget_required(
+            metadata, request, self._config
+        ):
+            await self._plane.stop_stranded_provision(metadata)
+            return DriverPending("retarget-runtime-stop-wait", 1)
+        if context.checkpoint == "retarget-runtime-stop-wait":
+            if not await self._plane.runtime_stopped(metadata):
+                return DriverPending("retarget-runtime-stop-wait", 1)
+            return DriverPending("retarget-runtime-stopped", 1)
+        if context.checkpoint == "retarget-runtime-stopped":
+            before = await self._plane.canonical_vault_fingerprint(
+                metadata, request, operation_id, phase="before"
+            )
+            if re.fullmatch(r"[0-9a-f]{64}", before) is None:
+                raise DriverTerminal("PROVISIONER_VAULT_FINGERPRINT_INVALID")
+            return DriverPending(f"retarget-vault-fingerprinted-{before}", 1)
+        if context.checkpoint.startswith("retarget-vault-fingerprinted-"):
+            fingerprint = context.checkpoint.removeprefix("retarget-vault-fingerprinted-")
+            if re.fullmatch(r"[0-9a-f]{64}", fingerprint) is None:
+                raise DriverTerminal("PROVISIONER_CHECKPOINT_INVALID")
+            if not await self._plane.runtime_stopped(metadata):
+                return DriverPending("retarget-runtime-stop-wait", 1)
+            await self._plane.run_runtime_migration(metadata, request, self._config, operation_id)
+            return DriverPending(f"retarget-migration-complete-{fingerprint}", 1)
+        if context.checkpoint.startswith("retarget-migration-complete-"):
+            fingerprint = context.checkpoint.removeprefix("retarget-migration-complete-")
+            if re.fullmatch(r"[0-9a-f]{64}", fingerprint) is None:
+                raise DriverTerminal("PROVISIONER_CHECKPOINT_INVALID")
+            try:
+                await self._plane.upgrade_runtime(metadata, request, self._config, operation_id)
+                after = await self._plane.canonical_vault_fingerprint(
+                    metadata, request, operation_id, phase="after"
+                )
+                if after != fingerprint:
+                    raise DriverTerminal("PROVISIONER_VAULT_PRESERVATION_MISMATCH")
+                await self._exact_health(metadata, request, context)
+                return DriverPending("initialized", 1)
+            except (DriverTerminal, MetadataConflict):
+                await self._stop_failed_rollforward(metadata)
+                raise
         if not self._plane.is_initialized(metadata):
             if not await self._plane.initialize(metadata, request, self._config):
                 return DriverPending("initializing", 2)

--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -906,6 +906,97 @@ class LiveLifecyclePlane:
         await self._helm.ensure_release(owned, desired)
         await self._refresh(metadata)
 
+    async def provision_retarget_required(
+        self,
+        metadata: OpaqueProviderMetadata,
+        request: dict[str, Any],
+        config: LifecycleConfig,
+    ) -> bool:
+        if request.get("provisionMode") != "serve":
+            return False
+        internal_operation_id = self._operation_ids.get(self._key(metadata))
+        if internal_operation_id is None:
+            raise MetadataConflict("retargeted provision operation is unavailable")
+        operation = await self._repository.get_by_id(internal_operation_id)
+        marker = operation.progress.get("_runtime_retarget_recovery_v1") if operation else None
+        marker_keys = {
+            "schema",
+            "preflight_sha256",
+            "source_request_sha256",
+            "target_request_sha256",
+            "target_runtime_sha256",
+            "helper_source_sha256",
+            "claim_generation",
+            "committed_at",
+        }
+        target_runtime = request.get("runtimeTarget")
+        target_runtime_sha256 = (
+            hashlib.sha256(
+                json.dumps(
+                    target_runtime, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+                ).encode("utf-8")
+            ).hexdigest()
+            if isinstance(target_runtime, dict)
+            else ""
+        )
+        if (
+            operation is None
+            or operation.action.value != "provision"
+            or operation.external_operation_id != metadata.operation_id
+            or operation.tenant_id != metadata.tenant_id
+            or operation.cell_id != metadata.subject_id
+            or operation.fence_generation != metadata.fence_generation
+            or not isinstance(marker, dict)
+            or set(marker) != marker_keys
+            or marker.get("schema") != 1
+            or marker.get("target_request_sha256") != operation.canonical_request_sha256
+            or marker.get("target_runtime_sha256") != target_runtime_sha256
+            or marker.get("source_request_sha256") == marker.get("target_request_sha256")
+            or not isinstance(marker.get("claim_generation"), int)
+            or marker["claim_generation"] < 0
+            or not isinstance(marker.get("committed_at"), str)
+            or any(
+                not isinstance(marker.get(key), str) or len(marker[key]) != 64
+                for key in marker_keys
+                if key.endswith("sha256")
+            )
+        ):
+            raise MetadataConflict("retargeted provision recovery receipt is invalid")
+        desired = _fixed_helm_values(self._owner(metadata), request, config)
+        current = await self._helm.current_release_values(self._owner(metadata))
+        for key in ("image", "expectedRelease", "expectedProtocol"):
+            if not isinstance(current.get(key), str):
+                raise MetadataConflict("current Helm runtime selection is invalid")
+        changed = any(
+            current[key] != desired[key] for key in ("image", "expectedRelease", "expectedProtocol")
+        )
+        operation_digest = hashlib.sha256(metadata.operation_id.encode("utf-8")).hexdigest()
+        marker = current.get("runtimeUpgrade")
+        transition_owned = (
+            isinstance(marker, dict)
+            and marker.get("schemaVersion") == 1
+            and marker.get("operationDigest") == operation_digest
+            and isinstance(marker.get("priorRevision"), int)
+            and not isinstance(marker.get("priorRevision"), bool)
+            and marker["priorRevision"] >= 1
+        )
+        if not changed and not transition_owned:
+            return False
+        snapshot = self._snapshot(metadata)
+        if snapshot.runtime_admitted or snapshot.routes != (False, False):
+            raise MetadataConflict("retargeted provision is already admitted or routed")
+        if config.migration_mode not in {"binding-v1-to-v2", "state-root-v1"}:
+            raise MetadataConflict("retargeted provision requires a declared migration")
+        return True
+
+    async def stop_stranded_provision(self, metadata: OpaqueProviderMetadata) -> None:
+        snapshot = self._snapshot(metadata)
+        if snapshot.runtime_admitted or snapshot.routes != (False, False):
+            raise MetadataConflict("retargeted provision is already admitted or routed")
+        if snapshot.runtime_desired_replicas != 0:
+            await self._cell.scale(self._owner(metadata), 0)
+            await self._refresh(metadata)
+
     async def volume_claim_bound(self, metadata: OpaqueProviderMetadata) -> bool:
         return await self._cell.volume_claim_bound(self._owner(metadata))
 

--- a/infra/provisioner/tests/test_provider_lifecycle.py
+++ b/infra/provisioner/tests/test_provider_lifecycle.py
@@ -1236,6 +1236,67 @@ async def test_provision_adopts_partial_attempt_and_waits_for_volume_health_and_
 
 
 @pytest.mark.asyncio
+async def test_retargeted_stranded_provision_migrates_before_runtime_admission() -> None:
+    plane = HighFidelityProviderPlane(location="fsn1")
+    source_target = _runtime_target(
+        releaseVersion="0.21.0",
+        gatewayContractDigest="e" * 64,
+        schemaDigest="f" * 64,
+    )
+    target = _runtime_target()
+    source_config = replace(
+        _config(),
+        image="registry.invalid/exomem@sha256:" + "e" * 64,
+        release_version="0.21.0",
+        runtime_target=source_target,
+    )
+    config = replace(
+        _config(),
+        runtime_target=target,
+        migration_mode="state-root-v1",
+        legacy_runtime_units={
+            ("0.21.0", "1"): {
+                **source_target,
+                "runtimeImage": "registry.invalid/exomem@sha256:" + "e" * 64,
+                "sourceCommit": "e" * 40,
+            }
+        },
+    )
+    source_request = _v2_request(runtimeTarget=source_target)
+    target_request = _v2_request(runtimeTarget=target)
+    await plane.seed_ready_cell(_metadata(), source_request, source_config)
+    cell = plane._cells[plane._key(_metadata())]
+    cell.runtime_admitted = False
+    cell.control_route = False
+    cell.transfer_route = False
+    before_volume = plane.bound_handle(_metadata())
+    before_fingerprint = plane.vault_fingerprint(_metadata())
+    driver = CellLifecycleDriver(plane=plane, volume_worker=None, config=config)
+
+    final, checkpoints = await _run_action(
+        driver,
+        "provision",
+        target_request,
+        _context(checkpoint="volume-owned", wire_protocol=WIRE_PROTOCOL_V2),
+    )
+
+    assert checkpoints[:5] == [
+        "retarget-runtime-stop-wait",
+        "retarget-runtime-stopped",
+        f"retarget-vault-fingerprinted-{before_fingerprint}",
+        f"retarget-migration-complete-{before_fingerprint}",
+        "initialized",
+    ]
+    assert final.result["providerRef"] == plane.provider_reference(_metadata())
+    assert plane.bound_handle(_metadata()) == before_volume
+    assert plane.vault_fingerprint(_metadata()) == before_fingerprint
+    assert plane.helm_values(_metadata())["image"] == config.image
+    assert plane.helm_values(_metadata())["expectedRelease"] == "0.22.0"
+    assert plane.runtime_admitted(_metadata()) is True
+    assert plane.routes_enabled(_metadata()) == (True, True)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "policy",
     [

--- a/openspec/changes/standardize-hosted-runtime-upgrades/specs/hosted-runtime-upgrade/spec.md
+++ b/openspec/changes/standardize-hosted-runtime-upgrades/specs/hosted-runtime-upgrade/spec.md
@@ -227,6 +227,11 @@ checkpoint identity. Repetition SHALL verify the existing receipt without a seco
 - **WHEN** the operator authorizes a recovered `volume-owned` provision with no route, result, admitted runtime, conflicting operation, or active claim
 - **THEN** one compare-and-swap transaction retargets that same operation to the selected runtime and makes it claimable without replacing its cell or volume
 
+#### Scenario: A retargeted stranded provision resumes through the declared migration
+
+- **WHEN** the retargeted operation resumes while its never-routed source-runtime Helm release and retained volume still exist
+- **THEN** the worker proves the runtime stopped, fingerprints the same vault, runs the deployment lock's declared migration, upgrades the existing release in place, proves the fingerprint unchanged and exact target health, and only then admits the runtime and opens routes
+
 #### Scenario: Retarget mismatch is a no-op
 
 - **WHEN** any request, receipt, claim, fence, resource, reservation, live identity, runtime, route, result, or compare-and-swap invariant differs


### PR DESCRIPTION
Completes signed retarget recovery by making a never-routed volume-owned provision run the declared offline migration before target admission. Preserves the existing operation, cell, PVC/PV, provider volume, and vault fingerprint.\n\nVerification:\n- 530 provisioner tests passed, 17 skipped\n- strict OpenSpec validation passed\n- ruff and diff checks passed