### PR TITLE
fix(hosted): bind migration replay to target request

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -47,7 +47,7 @@ from .provider_identity import (
     authenticate_cell_provider_recovery_envelopes,
     provider_operation_resource_name,
 )
-from .repository import OperationRepository
+from .repository import OperationRepository, canonical_request_sha256
 from .wire_protocol import runtime_identity
 
 
@@ -1254,8 +1254,11 @@ class LiveLifecyclePlane:
         )
         values["workloadMode"] = "migrate"
         values["routes"]["enabled"] = False
-        values["initOperationId"] = operation_id
-        values["initRequestId"] = _deterministic_uuid4(operation_id + ":runtime-migration")
+        migration_operation_id = (
+            f"{operation_id}:runtime-migration:{canonical_request_sha256(request)}"
+        )
+        values["initOperationId"] = migration_operation_id
+        values["initRequestId"] = _deterministic_uuid4(migration_operation_id)
         await self._helm.transition_release(
             self._owner(metadata),
             values,

--- a/infra/provisioner/src/exomem_provisioner/operation_recovery.py
+++ b/infra/provisioner/src/exomem_provisioner/operation_recovery.py
@@ -49,10 +49,14 @@ _FIXED_MODES = (
     "resume-retarget-preflight",
     "resume-retarget",
     "verify-resume-retarget",
+    "retry-retarget-preflight",
+    "retry-retarget",
+    "verify-retry-retarget",
 )
 _RECOVERY_MARKER = "_init_retry_recovery_v1"
 _RETARGET_MARKER = "_runtime_retarget_recovery_v1"
 _RETARGET_RESUME_MARKER = "_runtime_retarget_resume_v1"
+_RETARGET_RETRY_MARKER = "_runtime_retarget_retry_v1"
 _RECOVERY_MARKER_KEYS = frozenset(
     {"schema", "preflight_sha256", "helper_source_sha256", "claim_generation", "committed_at"}
 )
@@ -72,6 +76,17 @@ _RETARGET_RESUME_MARKER_KEYS = frozenset(
     {
         "schema",
         "retarget_marker_sha256",
+        "preflight_sha256",
+        "helper_source_sha256",
+        "claim_generation",
+        "committed_at",
+    }
+)
+_RETARGET_RETRY_MARKER_KEYS = frozenset(
+    {
+        "schema",
+        "retarget_marker_sha256",
+        "resume_marker_sha256",
         "preflight_sha256",
         "helper_source_sha256",
         "claim_generation",
@@ -184,6 +199,21 @@ class RetargetResumePreState:
     has_recovery_marker: bool
     has_retarget_marker: bool
     has_resume_marker: bool
+
+
+@dataclass(frozen=True, slots=True)
+class RetargetRetryPreState:
+    action: str
+    state: str
+    checkpoint: str
+    error_code: str | None
+    has_claim: bool
+    has_result: bool
+    finalized: bool
+    has_recovery_marker: bool
+    has_retarget_marker: bool
+    has_resume_marker: bool
+    has_retry_marker: bool
 
 
 class RecoveryLiveObserver(Protocol):
@@ -331,6 +361,33 @@ def retarget_resume_transition_values(before: RetargetResumePreState) -> dict[st
         or not before.has_retarget_marker
     ):
         raise RecoveryRefusal("retarget resume preflight failed")
+    return {
+        "state": OperationState.PENDING,
+        "checkpoint": "volume-owned",
+        "error_code": None,
+        "claim_owner": None,
+        "claim_token": None,
+        "claim_expires_at": None,
+        "finalized_at": None,
+    }
+
+
+def retarget_retry_transition_values(before: RetargetRetryPreState) -> dict[str, object]:
+    if before.has_retry_marker:
+        raise RecoveryRefusal("already retried")
+    if (
+        before.action != "provision"
+        or before.state != "error"
+        or before.checkpoint != "failed"
+        or before.error_code != "PROVISIONER_PROVIDER_METADATA_CONFLICT"
+        or before.has_claim
+        or before.has_result
+        or not before.finalized
+        or not before.has_recovery_marker
+        or not before.has_retarget_marker
+        or not before.has_resume_marker
+    ):
+        raise RecoveryRefusal("retarget retry preflight failed")
     return {
         "state": OperationState.PENDING,
         "checkpoint": "volume-owned",
@@ -502,6 +559,49 @@ def parse_retarget_resume_marker(value: object) -> dict[str, object]:
         datetime.fromisoformat(value["committed_at"].replace("Z", "+00:00"))
     except ValueError as error:
         raise RecoveryRefusal("retarget resume marker is invalid") from error
+    return dict(value)
+
+
+def retarget_retry_marker(
+    *,
+    retarget_marker_sha256: str,
+    resume_marker_sha256: str,
+    preflight_sha256: str,
+    helper_source_sha256: str,
+    claim_generation: int,
+    committed_at: datetime,
+) -> dict[str, object]:
+    marker = {
+        "schema": 1,
+        "retarget_marker_sha256": retarget_marker_sha256,
+        "resume_marker_sha256": resume_marker_sha256,
+        "preflight_sha256": preflight_sha256,
+        "helper_source_sha256": helper_source_sha256,
+        "claim_generation": claim_generation,
+        "committed_at": _json_value(committed_at),
+    }
+    return parse_retarget_retry_marker(marker)
+
+
+def parse_retarget_retry_marker(value: object) -> dict[str, object]:
+    if not isinstance(value, dict) or set(value) != _RETARGET_RETRY_MARKER_KEYS:
+        raise RecoveryRefusal("retarget retry marker is invalid")
+    if (
+        value.get("schema") != 1
+        or not isinstance(value.get("claim_generation"), int)
+        or value["claim_generation"] < 0
+        or not isinstance(value.get("committed_at"), str)
+        or any(
+            not isinstance(value.get(key), str) or len(value[key]) != 64
+            for key in _RETARGET_RETRY_MARKER_KEYS
+            if key.endswith("sha256")
+        )
+    ):
+        raise RecoveryRefusal("retarget retry marker is invalid")
+    try:
+        datetime.fromisoformat(value["committed_at"].replace("Z", "+00:00"))
+    except ValueError as error:
+        raise RecoveryRefusal("retarget retry marker is invalid") from error
     return dict(value)
 
 
@@ -1015,6 +1115,140 @@ class RecoveryService:
         except Exception as error:
             raise RecoveryRefusal("retarget-resume-verification-failed") from error
 
+    async def retry_retarget_preflight(self, operation_id: str) -> dict[str, object]:
+        try:
+            async with self._sessions.begin() as session:
+                snapshot = await self._retarget_retry_preflight(session, operation_id)
+                observation = await self._observer.observe(
+                    snapshot.operation, snapshot.resources
+                )
+                validate_live_observation(observation)
+                return {
+                    "status": "retarget-retry-ready",
+                    "state": snapshot.operation.state.value,
+                    "checkpoint": snapshot.operation.checkpoint,
+                    "error_code": snapshot.operation.error_code,
+                    "resource_kind_counts": {
+                        **{
+                            kind.value: 1
+                            for kind in (
+                                ResourceKind.HELM_RELEASE,
+                                ResourceKind.KUBERNETES_NAMESPACE,
+                                ResourceKind.PVC,
+                                ResourceKind.VOLUME,
+                            )
+                        },
+                        ResourceKind.ROUTE.value: 0,
+                        "provider-object": 0,
+                    },
+                    "active_reservation": True,
+                }
+        except RecoveryRefusal:
+            raise
+        except Exception as error:
+            raise RecoveryRefusal("retarget-retry-preflight-failed") from error
+
+    async def retry_retarget(self, operation_id: str) -> dict[str, object]:
+        try:
+            async with self._sessions.begin() as session:
+                await self._require_database_identity(session)
+                current = await session.get(Operation, operation_id, with_for_update=True)
+                if current is None:
+                    raise RecoveryRefusal("operation is unavailable")
+                existing = current.progress.get(_RETARGET_RETRY_MARKER)
+                if existing is not None:
+                    return self._retarget_retry_result(current, existing, "already-retried")
+                snapshot = await self._retarget_retry_preflight_locked(session, current)
+                first = await self._observer.observe(snapshot.operation, snapshot.resources)
+                validate_live_observation(first)
+                second = await self._observer.observe(snapshot.operation, snapshot.resources)
+                validate_live_observation(second)
+                if first != second:
+                    raise RecoveryRefusal("live recovery preflight failed")
+                now = await self._database_now(session)
+                retarget = parse_retarget_marker(current.progress.get(_RETARGET_MARKER))
+                resume = parse_retarget_resume_marker(
+                    current.progress.get(_RETARGET_RESUME_MARKER)
+                )
+                evidence_digest = self._preflight_evidence_digest(snapshot, first, second)
+                marker = retarget_retry_marker(
+                    retarget_marker_sha256=canonical_sha256(retarget),
+                    resume_marker_sha256=canonical_sha256(resume),
+                    preflight_sha256=evidence_digest,
+                    helper_source_sha256=self._helper_source_sha256,
+                    claim_generation=current.claim_generation,
+                    committed_at=now,
+                )
+                progress = {**current.progress, _RETARGET_RETRY_MARKER: marker}
+                transition = retarget_retry_transition_values(
+                    self._retarget_retry_pre_state(current)
+                )
+                updated = await session.scalar(
+                    update(Operation)
+                    .where(
+                        Operation.id == current.id,
+                        Operation.action == OperationAction.PROVISION,
+                        Operation.state == OperationState.ERROR,
+                        Operation.checkpoint == "failed",
+                        Operation.error_code == "PROVISIONER_PROVIDER_METADATA_CONFLICT",
+                        Operation.claim_owner.is_(None),
+                        Operation.claim_token.is_(None),
+                        Operation.claim_expires_at.is_(None),
+                        Operation.result_ciphertext.is_(None),
+                        cast(Operation.result_redacted, JSONB) == cast({}, JSONB),
+                        Operation.finalized_at.is_not(None),
+                        Operation.canonical_request_sha256 == current.canonical_request_sha256,
+                        Operation.request_ciphertext == current.request_ciphertext,
+                        Operation.claim_generation == current.claim_generation,
+                        Operation.updated_at == current.updated_at,
+                        cast(Operation.progress, JSONB) == cast(current.progress, JSONB),
+                        cast(Operation.progress, JSONB).has_key(_RECOVERY_MARKER),
+                        cast(Operation.progress, JSONB).has_key(_RETARGET_MARKER),
+                        cast(Operation.progress, JSONB).has_key(_RETARGET_RESUME_MARKER),
+                        ~cast(Operation.progress, JSONB).has_key(_RETARGET_RETRY_MARKER),
+                    )
+                    .values(
+                        **transition,
+                        available_at=now,
+                        updated_at=now,
+                        progress=progress,
+                    )
+                    .returning(Operation)
+                )
+                if updated is None:
+                    reread = await session.get(Operation, operation_id, with_for_update=True)
+                    if reread is not None and _RETARGET_RETRY_MARKER in reread.progress:
+                        return self._retarget_retry_result(
+                            reread,
+                            reread.progress[_RETARGET_RETRY_MARKER],
+                            "already-retried",
+                        )
+                    raise RecoveryRefusal("already progressed")
+                await session.flush()
+                return self._retarget_retry_result(updated, marker, "retarget-retried")
+        except RecoveryRefusal:
+            raise
+        except Exception as error:
+            raise RecoveryRefusal("retarget-retry-failed") from error
+
+    async def verify_retry_retarget(self, operation_id: str) -> dict[str, object]:
+        try:
+            async with self._sessions.begin() as session:
+                await self._require_database_identity(session)
+                operation = await session.get(Operation, operation_id)
+                if operation is None:
+                    raise RecoveryRefusal("operation is unavailable")
+                marker = operation.progress.get(_RETARGET_RETRY_MARKER)
+                if marker is None:
+                    raise RecoveryRefusal("retarget retry attribution is unavailable")
+                return self._retarget_retry_result(
+                    operation, marker, "retarget-retry-verified"
+                )
+        except RecoveryRefusal:
+            raise
+        except Exception as error:
+            raise RecoveryRefusal("retarget-retry-verification-failed") from error
+
     async def _retarget_resume_preflight(
         self, session: AsyncSession, operation_id: str
     ) -> _RecoverySnapshot:
@@ -1061,6 +1295,75 @@ class RecoveryService:
             )
         ):
             raise RecoveryRefusal("retarget resume preflight failed")
+        resources = await self._resources(session, operation)
+        reservation = await self._reservation(session, operation)
+        return _RecoverySnapshot(
+            operation=operation,
+            resources=resources,
+            reservation=reservation,
+            operation_sha256=_hash_model(operation),
+            preserved_sha256=_hash_model(operation, excluded=self._CHANGED_COLUMNS),
+            request_sha256=operation.canonical_request_sha256,
+            request_ciphertext_sha256=hashlib.sha256(
+                operation.request_ciphertext.encode()
+            ).hexdigest(),
+            resources_sha256=canonical_sha256(
+                {item.id: _hash_model(item) for item in sorted(resources, key=lambda item: item.id)}
+            ),
+            reservation_sha256=_hash_model(reservation),
+            tenant_fence_sha256=_hash_model(fence),
+        )
+
+    async def _retarget_retry_preflight(
+        self, session: AsyncSession, operation_id: str
+    ) -> _RecoverySnapshot:
+        await self._require_database_identity(session)
+        operation = await session.get(Operation, operation_id, with_for_update=True)
+        if operation is None:
+            raise RecoveryRefusal("operation is unavailable")
+        return await self._retarget_retry_preflight_locked(session, operation)
+
+    async def _retarget_retry_preflight_locked(
+        self, session: AsyncSession, operation: Operation
+    ) -> _RecoverySnapshot:
+        fence = await session.get(TenantFence, operation.tenant_id, with_for_update=True)
+        if (
+            fence is None
+            or fence.fence_generation != operation.fence_generation
+            or operation.cell_id is None
+            or operation.external_operation_id != operation.provider_operation_id
+            or operation.fence_generation != operation.provider_fence_generation
+        ):
+            raise RecoveryRefusal("retarget retry preflight failed")
+        retarget_retry_transition_values(self._retarget_retry_pre_state(operation))
+        parse_recovery_marker(operation.progress.get(_RECOVERY_MARKER))
+        retarget = parse_retarget_marker(operation.progress.get(_RETARGET_MARKER))
+        resume = parse_retarget_resume_marker(operation.progress.get(_RETARGET_RESUME_MARKER))
+        if (
+            resume["retarget_marker_sha256"] != canonical_sha256(retarget)
+            or operation.canonical_request_sha256 != retarget["target_request_sha256"]
+        ):
+            raise RecoveryRefusal("retarget retry preflight failed")
+        await self._lock_conflicts(session, operation)
+        request = self._codec.decrypt_json(
+            operation.request_ciphertext,
+            purpose=f"operation-request:{operation.action.value}:{operation.idempotency_key}",
+        )
+        if (
+            canonical_request_sha256(request) != operation.canonical_request_sha256
+            or request.get("tenantId") != operation.tenant_id
+            or request.get("cellId") != operation.cell_id
+            or request.get("operationId") != operation.external_operation_id
+            or request.get("fenceGeneration") != operation.fence_generation
+            or request.get("checkpoint") != operation.caller_checkpoint
+            or request.get("provisionMode") != "serve"
+            or not self._deployment_lock.matches_runtime_request(
+                request,
+                wire_protocol=operation.wire_protocol.value,
+                selection=self._runtime_selection,
+            )
+        ):
+            raise RecoveryRefusal("retarget retry preflight failed")
         resources = await self._resources(session, operation)
         reservation = await self._reservation(session, operation)
         return _RecoverySnapshot(
@@ -1328,6 +1631,29 @@ class RecoveryService:
         )
 
     @staticmethod
+    def _retarget_retry_pre_state(operation: Operation) -> RetargetRetryPreState:
+        return RetargetRetryPreState(
+            action=operation.action.value,
+            state=operation.state.value,
+            checkpoint=operation.checkpoint,
+            error_code=operation.error_code,
+            has_claim=any(
+                value is not None
+                for value in (
+                    operation.claim_owner,
+                    operation.claim_token,
+                    operation.claim_expires_at,
+                )
+            ),
+            has_result=(operation.result_ciphertext is not None or operation.result_redacted != {}),
+            finalized=operation.finalized_at is not None,
+            has_recovery_marker=_RECOVERY_MARKER in operation.progress,
+            has_retarget_marker=_RETARGET_MARKER in operation.progress,
+            has_resume_marker=_RETARGET_RESUME_MARKER in operation.progress,
+            has_retry_marker=_RETARGET_RETRY_MARKER in operation.progress,
+        )
+
+    @staticmethod
     def _preflight_evidence_digest(
         snapshot: _RecoverySnapshot, first: LiveObservation, second: LiveObservation
     ) -> str:
@@ -1557,6 +1883,34 @@ class RecoveryService:
             "recovery_digest": canonical_sha256(marker),
         }
 
+    @staticmethod
+    def _retarget_retry_result(
+        operation: Operation, marker_value: object, status: str
+    ) -> dict[str, object]:
+        marker = parse_retarget_retry_marker(marker_value)
+        retarget = parse_retarget_marker(operation.progress.get(_RETARGET_MARKER))
+        resume = parse_retarget_resume_marker(operation.progress.get(_RETARGET_RESUME_MARKER))
+        if (
+            marker["retarget_marker_sha256"] != canonical_sha256(retarget)
+            or marker["resume_marker_sha256"] != canonical_sha256(resume)
+            or operation.canonical_request_sha256 != retarget["target_request_sha256"]
+        ):
+            raise RecoveryRefusal("retarget retry attribution is unavailable")
+        if operation.state not in {
+            OperationState.PENDING,
+            OperationState.CLAIMED,
+            OperationState.ERROR,
+            OperationState.FINAL,
+        }:
+            raise RecoveryRefusal("retarget retry attribution is unavailable")
+        return {
+            "status": status,
+            "state": operation.state.value,
+            "checkpoint": operation.checkpoint,
+            "error_code": operation.error_code,
+            "recovery_digest": canonical_sha256(marker),
+        }
+
 
 @dataclass(frozen=True, slots=True)
 class _ProductionRecoveryObserver:
@@ -1748,6 +2102,12 @@ async def _run(args: argparse.Namespace) -> dict[str, object]:
                 return await service.resume_retarget(operation_id)
             case "verify-resume-retarget":
                 return await service.verify_resume_retarget(operation_id)
+            case "retry-retarget-preflight":
+                return await service.retry_retarget_preflight(operation_id)
+            case "retry-retarget":
+                return await service.retry_retarget(operation_id)
+            case "verify-retry-retarget":
+                return await service.verify_retry_retarget(operation_id)
         raise RecoveryRefusal("recovery mode is invalid")
     except RecoveryRefusal:
         raise

--- a/infra/provisioner/tests/test_live_provider.py
+++ b/infra/provisioner/tests/test_live_provider.py
@@ -38,6 +38,7 @@ from exomem_provisioner.provider_identity import (
     cell_provider_recovery_envelopes,
     provider_operation_resource_name,
 )
+from exomem_provisioner.repository import canonical_request_sha256
 
 
 class _NotFound(Exception):
@@ -764,7 +765,11 @@ async def test_live_rollforward_uses_target_fingerprint_and_original_helm_author
         assert values["image"] == config.image
         assert values["providerRecoveryEnvelopes"] == original_request["_providerRecoveryEnvelopes"]
         assert values["routes"]["enabled"] is False
-    assert transitions[0][1]["initOperationId"] == "rollforward-alpha"
+    migration_operation_id = (
+        f"rollforward-alpha:runtime-migration:{canonical_request_sha256(request)}"
+    )
+    assert transitions[0][1]["initOperationId"] == migration_operation_id
+    assert transitions[1][1]["initOperationId"] == migration_operation_id
     assert rollbacks == [(owner, "rollforward-alpha")]
 
 

--- a/infra/provisioner/tests/test_operation_recovery.py
+++ b/infra/provisioner/tests/test_operation_recovery.py
@@ -124,6 +124,9 @@ def test_recovery_command_has_only_fixed_modes_and_environment_free_help(
         "resume-retarget-preflight",
         "resume-retarget",
         "verify-resume-retarget",
+        "retry-retarget-preflight",
+        "retry-retarget",
+        "verify-retry-retarget",
     ):
         assert parser.parse_args([mode, "--stdin"]).mode == mode
     with pytest.raises(recovery.RecoveryRefusal):
@@ -459,6 +462,69 @@ def test_retarget_resume_marker_is_exact_and_bound_to_the_retarget_receipt() -> 
     }
     with pytest.raises(recovery.RecoveryRefusal):
         recovery.parse_retarget_resume_marker({**marker, "cellId": "cell-alpha"})
+
+
+def test_retarget_retry_accepts_only_the_exact_failed_resumed_retarget() -> None:
+    recovery = _module()
+    before = recovery.RetargetRetryPreState(
+        action="provision",
+        state="error",
+        checkpoint="failed",
+        error_code="PROVISIONER_PROVIDER_METADATA_CONFLICT",
+        has_claim=False,
+        has_result=False,
+        finalized=True,
+        has_recovery_marker=True,
+        has_retarget_marker=True,
+        has_resume_marker=True,
+        has_retry_marker=False,
+    )
+
+    transition = recovery.retarget_retry_transition_values(before)
+
+    assert transition["state"].value == "pending"
+    assert transition["checkpoint"] == "volume-owned"
+    assert transition["error_code"] is None
+    assert transition["finalized_at"] is None
+    for changed in (
+        {"state": "pending"},
+        {"checkpoint": "retarget-runtime-stopped"},
+        {"error_code": None},
+        {"has_claim": True},
+        {"has_result": True},
+        {"finalized": False},
+        {"has_recovery_marker": False},
+        {"has_retarget_marker": False},
+        {"has_resume_marker": False},
+        {"has_retry_marker": True},
+    ):
+        with pytest.raises(recovery.RecoveryRefusal):
+            recovery.retarget_retry_transition_values(replace(before, **changed))
+
+
+def test_retarget_retry_marker_binds_both_prior_recovery_receipts() -> None:
+    recovery = _module()
+    marker = recovery.retarget_retry_marker(
+        retarget_marker_sha256="a" * 64,
+        resume_marker_sha256="b" * 64,
+        preflight_sha256="c" * 64,
+        helper_source_sha256="d" * 64,
+        claim_generation=5,
+        committed_at=datetime(2030, 1, 3, tzinfo=UTC),
+    )
+
+    assert recovery.parse_retarget_retry_marker(marker) == marker
+    assert set(marker) == {
+        "schema",
+        "retarget_marker_sha256",
+        "resume_marker_sha256",
+        "preflight_sha256",
+        "helper_source_sha256",
+        "claim_generation",
+        "committed_at",
+    }
+    with pytest.raises(recovery.RecoveryRefusal):
+        recovery.parse_retarget_retry_marker({**marker, "cellId": "cell-alpha"})
 
 
 def test_database_stays_at_0006_without_recovery_receipt_table() -> None:

--- a/openspec/changes/standardize-hosted-runtime-upgrades/specs/hosted-runtime-upgrade/spec.md
+++ b/openspec/changes/standardize-hosted-runtime-upgrades/specs/hosted-runtime-upgrade/spec.md
@@ -237,6 +237,16 @@ checkpoint identity. Repetition SHALL verify the existing receipt without a seco
 - **WHEN** that exact retargeted operation fails closed before tenant mutation because its source authorization bundle is stale
 - **THEN** a separately invoked signed recovery validates both prior recovery receipts, the selected target request, the unchanged four-resource identity, active reservation, stable unrouted live state, and absence of conflicts before making the same operation claimable once; the offline migration may read the stale bundle only to render its non-serving Job, and serving still requires a freshly transitioned target-version bundle
 
+#### Scenario: Offline migration replay identity is bound to the selected target request
+
+- **WHEN** a recovered retarget runs its target-image migration after an earlier initialization proof exists for the same provider operation lineage
+- **THEN** the migration initialization identity is derived from the durable operation and canonical selected-target request digest, so retries of that exact request are byte-stable and a different target request cannot collide with its proof
+
+#### Scenario: A failed resumed retarget receives one separately attributed retry
+
+- **WHEN** that resumed retarget fails closed with a provider-metadata conflict before migration while the same four resources remain stopped, unrouted, reserved, and conflict-free
+- **THEN** a separately invoked signed retry validates the original recovery, retarget, and resume receipts plus the unchanged selected-target request and live identity before appending one content-free retry receipt and making the same operation claimable once more
+
 #### Scenario: Retarget mismatch is a no-op
 
 - **WHEN** any request, receipt, claim, fence, resource, reservation, live identity, runtime, route, result, or compare-and-swap invariant differs


### PR DESCRIPTION
## Summary
- derive the offline migration init operation identity from the durable provider operation plus the canonical target request digest
- keep retries for the same target byte-stable while preventing a retarget from colliding with an older init proof
- add one separately attributed, compare-and-swap retry for an already-resumed retarget that failed closed before migration
- require the original recovery, retarget, and resume receipts plus unchanged target request, four-resource identity, reservation, and stable unrouted live state

## Verification
- `PYTHONPATH=src:infra/provisioner/src infra/provisioner/.venv/bin/pytest infra/provisioner/tests -q` (534 passed, 17 skipped)
- `uvx ruff check` on all changed Python files
- `openspec validate --all --strict` (174 passed)
- `git diff --check`