### PR TITLE
fix(hosted): replay stable security bootstrap for migration

### DIFF
--- a/openspec/changes/standardize-hosted-runtime-upgrades/specs/hosted-runtime-upgrade/spec.md
+++ b/openspec/changes/standardize-hosted-runtime-upgrades/specs/hosted-runtime-upgrade/spec.md
@@ -242,6 +242,12 @@ checkpoint identity. Repetition SHALL verify the existing receipt without a seco
 - **WHEN** a recovered retarget runs its target-image migration after an earlier initialization proof exists for the same provider operation lineage
 - **THEN** the migration initialization identity is derived from the durable operation and canonical selected-target request digest, so retries of that exact request are byte-stable and a different target request cannot collide with its proof
 
+#### Scenario: Target migration replays an unchanged stable credential authority
+
+- **WHEN** target-image initialization uses its selected-target migration identity and the existing security authority is stable with the same active credential version and digest
+- **THEN** it atomically records a bootstrap result for the new operation identity and returns the unchanged durable security snapshot without rotating, replacing, or exposing credential material
+- **AND** a non-stable authority, changed active version, or mismatched projected credential fails closed without recording the new operation
+
 #### Scenario: A failed resumed retarget receives one separately attributed retry
 
 - **WHEN** that resumed retarget fails closed with a provider-metadata conflict before migration while the same four resources remain stopped, unrouted, reserved, and conflict-free

--- a/openspec/changes/standardize-hosted-runtime-upgrades/tasks.md
+++ b/openspec/changes/standardize-hosted-runtime-upgrades/tasks.md
@@ -90,3 +90,4 @@
 - [ ] 8.9 Run free preflight, prepare the explicit eligible reviewer client, and conduct the human-timed Claude/OpenAI promotion ceremony
 - [ ] 8.10 Complete personal-account OAuth and full read/write/reconnect acceptance on `0.68.1`, keep the personal tenant live, and record final fleet, lock, cohort, authority, capacity, and operation state
 - [ ] 8.11 Land and publish the signed one-way retarget helper, advance the two never-routed recovered provisions in place to `0.68.1`, and verify their original operation, cell, PVC, PV, and provider-volume identities are preserved
+- [ ] 8.12 Make target-image initialization replay an unchanged stable credential authority under the selected-target migration identity, publish the corrected signed `0.68.1` image, and prove mismatched or rotating authority still fails closed

--- a/src/exomem/hosted_security.py
+++ b/src/exomem/hosted_security.py
@@ -958,7 +958,19 @@ class HostedSecurityAuthority:
                 "SELECT 1 FROM credential_state WHERE singleton=1"
             ).fetchone()
             if existing is not None:
-                raise HostedCredentialTransitionInvalid()
+                row = self._read_state(connection)
+                if row["phase"] != "stable" or row["active_version"] != active_version:
+                    raise HostedCredentialTransitionInvalid()
+                self._validate_recorded_bundle(row, bundle)
+                snapshot = self._snapshot(row)
+                self._record_operation(
+                    connection,
+                    operation_id=operation_id,
+                    action="bootstrap",
+                    request_digest=request_digest,
+                    result={"snapshot": _snapshot_payload(snapshot)},
+                )
+                return snapshot
             connection.execute(
                 """
                 INSERT INTO credential_state(

--- a/tests/test_hosted_security.py
+++ b/tests/test_hosted_security.py
@@ -281,6 +281,31 @@ def test_security_authority_bootstraps_private_durable_digest_only_state(
         request_digest=_digest("bootstrap-request"),
     )
     assert replay == snapshot
+    migration_replay = authority.bootstrap(
+        active_version="active",
+        operation_id="runtime-migration-bootstrap",
+        request_digest=_digest("runtime-migration-request"),
+    )
+    assert migration_replay == snapshot
+    with sqlite3.connect(database) as connection:
+        recorded = connection.execute(
+            "SELECT action, request_digest, result_json FROM operations "
+            "WHERE operation_id='runtime-migration-bootstrap'"
+        ).fetchone()
+    assert recorded is not None
+    assert recorded[0] == "bootstrap"
+    assert recorded[1] == _digest("runtime-migration-request")
+    assert json.loads(recorded[2]) == {
+        "snapshot": {
+            "phase": "stable",
+            "revision": 1,
+            "active_version": "active",
+            "pending_version": None,
+            "preferred_version": "active",
+            "rotation_id": None,
+            "proof_valid_until": None,
+        }
+    }
     with pytest.raises(security.HostedOperationConflict):
         authority.bootstrap(
             active_version="active",
@@ -319,6 +344,56 @@ def test_security_descriptor_owner_converges_and_is_verified_as_root(
     security._converge_descriptor_owner(7, expected_uid=10001, expected_gid=10002)
 
     assert ownership_changes == [(7, 10001, 10002)]
+
+
+def test_bootstrap_new_operation_refuses_changed_or_nonstable_authority(
+    tmp_path: Path,
+) -> None:
+    active = _credential("active")
+    pending = _credential("pending")
+    current_bundle = [_bundle(active=active)]
+    authority = security.HostedSecurityAuthority(
+        tmp_path / "state",
+        cell_id="cell-alpha",
+        vault_id="vault-alpha",
+        bundle_loader=lambda: current_bundle[0],
+    )
+    authority.bootstrap(
+        active_version="active",
+        operation_id="bootstrap-1",
+        request_digest=_digest("bootstrap"),
+    )
+
+    current_bundle[0] = _bundle(active=_credential("changed"))
+    with pytest.raises(security.HostedSecurityStateInvalid):
+        authority.bootstrap(
+            active_version="active",
+            operation_id="changed-bootstrap",
+            request_digest=_digest("changed-bootstrap"),
+        )
+
+    current_bundle[0] = _bundle(active=active, pending=pending)
+    authority.stage(
+        pending_version="pending",
+        expected_revision=1,
+        operation_id="stage-1",
+        request_digest=_digest("stage"),
+    )
+    current_bundle[0] = _bundle(active=active)
+    with pytest.raises(security.HostedCredentialTransitionInvalid):
+        authority.bootstrap(
+            active_version="active",
+            operation_id="staged-bootstrap",
+            request_digest=_digest("staged-bootstrap"),
+        )
+
+    database = tmp_path / "state" / "hosted-security.sqlite"
+    with sqlite3.connect(database) as connection:
+        recorded = connection.execute(
+            "SELECT operation_id FROM operations WHERE operation_id IN (?, ?)",
+            ("changed-bootstrap", "staged-bootstrap"),
+        ).fetchall()
+    assert recorded == []
 
 
 def test_security_authority_rejects_foreign_runtime_owner(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make an unchanged stable hosted credential authority replayable under a new target-migration operation identity
- keep changed credentials and non-stable rotation state fail-closed
- specify the recovered-retarget migration invariant

## Verification
- synthetic exact 0.39.2 image -> corrected 0.68.1 source migration
- 133 passed, 1 skipped across hosted security, binding, and state migration
- 39 hosted security tests passed
- targeted Ruff passed
- OpenSpec strict: 174 passed