### PR TITLE
fix(hosted): retarget failed immutable runtime forward

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/operation_recovery.py
+++ b/infra/provisioner/src/exomem_provisioner/operation_recovery.py
@@ -52,11 +52,15 @@ _FIXED_MODES = (
     "retry-retarget-preflight",
     "retry-retarget",
     "verify-retry-retarget",
+    "successor-retarget-preflight",
+    "successor-retarget",
+    "verify-successor-retarget",
 )
 _RECOVERY_MARKER = "_init_retry_recovery_v1"
 _RETARGET_MARKER = "_runtime_retarget_recovery_v1"
 _RETARGET_RESUME_MARKER = "_runtime_retarget_resume_v1"
 _RETARGET_RETRY_MARKER = "_runtime_retarget_retry_v1"
+_RETARGET_SUCCESSOR_MARKER = "_runtime_retarget_successor_v1"
 _RECOVERY_MARKER_KEYS = frozenset(
     {"schema", "preflight_sha256", "helper_source_sha256", "claim_generation", "committed_at"}
 )
@@ -88,6 +92,19 @@ _RETARGET_RETRY_MARKER_KEYS = frozenset(
         "retarget_marker_sha256",
         "resume_marker_sha256",
         "preflight_sha256",
+        "helper_source_sha256",
+        "claim_generation",
+        "committed_at",
+    }
+)
+_RETARGET_SUCCESSOR_MARKER_KEYS = frozenset(
+    {
+        "schema",
+        "prior_receipts_sha256",
+        "preflight_sha256",
+        "source_request_sha256",
+        "target_request_sha256",
+        "target_runtime_sha256",
         "helper_source_sha256",
         "claim_generation",
         "committed_at",
@@ -214,6 +231,22 @@ class RetargetRetryPreState:
     has_retarget_marker: bool
     has_resume_marker: bool
     has_retry_marker: bool
+
+
+@dataclass(frozen=True, slots=True)
+class RetargetSuccessorPreState:
+    action: str
+    state: str
+    checkpoint: str
+    error_code: str | None
+    has_claim: bool
+    has_result: bool
+    finalized: bool
+    has_recovery_marker: bool
+    has_retarget_marker: bool
+    has_resume_marker: bool
+    has_retry_marker: bool
+    has_successor_marker: bool
 
 
 class RecoveryLiveObserver(Protocol):
@@ -388,6 +421,47 @@ def retarget_retry_transition_values(before: RetargetRetryPreState) -> dict[str,
         or not before.has_resume_marker
     ):
         raise RecoveryRefusal("retarget retry preflight failed")
+    return {
+        "state": OperationState.PENDING,
+        "checkpoint": "volume-owned",
+        "error_code": None,
+        "claim_owner": None,
+        "claim_token": None,
+        "claim_expires_at": None,
+        "finalized_at": None,
+    }
+
+
+def retarget_successor_transition_values(
+    before: RetargetSuccessorPreState,
+) -> dict[str, object]:
+    if (
+        before.action != "provision"
+        or before.has_claim
+        or before.has_result
+        or not before.has_recovery_marker
+        or not before.has_retarget_marker
+        or before.has_successor_marker
+    ):
+        raise RecoveryRefusal("successor retarget preflight failed")
+    if before.state == "pending":
+        valid_state = (
+            before.checkpoint == "volume-owned"
+            and before.error_code is None
+            and not before.finalized
+        )
+    elif before.state == "error":
+        valid_state = (
+            before.checkpoint == "failed"
+            and before.error_code == "PROVISIONER_PROVIDER_METADATA_CONFLICT"
+            and before.finalized
+            and before.has_resume_marker
+            and before.has_retry_marker
+        )
+    else:
+        valid_state = False
+    if not valid_state:
+        raise RecoveryRefusal("successor retarget preflight failed")
     return {
         "state": OperationState.PENDING,
         "checkpoint": "volume-owned",
@@ -602,6 +676,53 @@ def parse_retarget_retry_marker(value: object) -> dict[str, object]:
         datetime.fromisoformat(value["committed_at"].replace("Z", "+00:00"))
     except ValueError as error:
         raise RecoveryRefusal("retarget retry marker is invalid") from error
+    return dict(value)
+
+
+def retarget_successor_marker(
+    *,
+    prior_receipts_sha256: str,
+    preflight_sha256: str,
+    source_request_sha256: str,
+    target_request_sha256: str,
+    target_runtime_sha256: str,
+    helper_source_sha256: str,
+    claim_generation: int,
+    committed_at: datetime,
+) -> dict[str, object]:
+    marker = {
+        "schema": 1,
+        "prior_receipts_sha256": prior_receipts_sha256,
+        "preflight_sha256": preflight_sha256,
+        "source_request_sha256": source_request_sha256,
+        "target_request_sha256": target_request_sha256,
+        "target_runtime_sha256": target_runtime_sha256,
+        "helper_source_sha256": helper_source_sha256,
+        "claim_generation": claim_generation,
+        "committed_at": _json_value(committed_at),
+    }
+    return parse_retarget_successor_marker(marker)
+
+
+def parse_retarget_successor_marker(value: object) -> dict[str, object]:
+    if not isinstance(value, dict) or set(value) != _RETARGET_SUCCESSOR_MARKER_KEYS:
+        raise RecoveryRefusal("successor retarget marker is invalid")
+    if (
+        value.get("schema") != 1
+        or not isinstance(value.get("claim_generation"), int)
+        or value["claim_generation"] < 0
+        or not isinstance(value.get("committed_at"), str)
+        or any(
+            not isinstance(value.get(key), str) or len(value[key]) != 64
+            for key in _RETARGET_SUCCESSOR_MARKER_KEYS
+            if key.endswith("sha256")
+        )
+    ):
+        raise RecoveryRefusal("successor retarget marker is invalid")
+    try:
+        datetime.fromisoformat(value["committed_at"].replace("Z", "+00:00"))
+    except ValueError as error:
+        raise RecoveryRefusal("successor retarget marker is invalid") from error
     return dict(value)
 
 
@@ -1249,6 +1370,180 @@ class RecoveryService:
         except Exception as error:
             raise RecoveryRefusal("retarget-retry-verification-failed") from error
 
+    async def successor_retarget_preflight(self, operation_id: str) -> dict[str, object]:
+        try:
+            async with self._sessions.begin() as session:
+                now = await self._database_now(session)
+                snapshot = await self._retarget_successor_preflight(
+                    session, operation_id, now=now
+                )
+                observation = await self._observer.observe(
+                    snapshot.recovery.operation, snapshot.recovery.resources
+                )
+                validate_live_observation(observation)
+                return {
+                    "status": "successor-retarget-ready",
+                    "state": snapshot.recovery.operation.state.value,
+                    "checkpoint": snapshot.recovery.operation.checkpoint,
+                    "error_code": snapshot.recovery.operation.error_code,
+                    "resource_kind_counts": {
+                        **{
+                            kind.value: 1
+                            for kind in (
+                                ResourceKind.HELM_RELEASE,
+                                ResourceKind.KUBERNETES_NAMESPACE,
+                                ResourceKind.PVC,
+                                ResourceKind.VOLUME,
+                            )
+                        },
+                        ResourceKind.ROUTE.value: 0,
+                        "provider-object": 0,
+                    },
+                    "active_reservation": True,
+                }
+        except RecoveryRefusal:
+            raise
+        except Exception as error:
+            raise RecoveryRefusal("successor-retarget-preflight-failed") from error
+
+    async def successor_retarget(self, operation_id: str) -> dict[str, object]:
+        try:
+            async with self._sessions.begin() as session:
+                await self._require_database_identity(session)
+                current = await session.get(Operation, operation_id, with_for_update=True)
+                if current is None:
+                    raise RecoveryRefusal("operation is unavailable")
+                existing = current.progress.get(_RETARGET_SUCCESSOR_MARKER)
+                if existing is not None:
+                    return self._retarget_successor_result(
+                        current, existing, "already-successor-retargeted"
+                    )
+                now = await self._database_now(session)
+                snapshot = await self._retarget_successor_preflight_locked(
+                    session, current, now=now
+                )
+                first = await self._observer.observe(
+                    snapshot.recovery.operation, snapshot.recovery.resources
+                )
+                validate_live_observation(first)
+                second = await self._observer.observe(
+                    snapshot.recovery.operation, snapshot.recovery.resources
+                )
+                validate_live_observation(second)
+                if first != second:
+                    raise RecoveryRefusal("live recovery preflight failed")
+                prior_receipts_sha256 = self._prior_retarget_receipts_sha256(current)
+                evidence_digest = canonical_sha256(
+                    {
+                        "operation_sha256": snapshot.recovery.operation_sha256,
+                        "preserved_sha256": snapshot.recovery.preserved_sha256,
+                        "prior_receipts_sha256": prior_receipts_sha256,
+                        "source_request_sha256": canonical_request_sha256(
+                            snapshot.source_request
+                        ),
+                        "target_request_sha256": canonical_request_sha256(
+                            snapshot.target_request
+                        ),
+                        "request_ciphertext_sha256": (
+                            snapshot.recovery.request_ciphertext_sha256
+                        ),
+                        "resources_sha256": snapshot.recovery.resources_sha256,
+                        "reservation_sha256": snapshot.recovery.reservation_sha256,
+                        "tenant_fence_sha256": snapshot.recovery.tenant_fence_sha256,
+                        "first_observation_sha256": canonical_sha256(asdict(first)),
+                        "second_observation_sha256": canonical_sha256(asdict(second)),
+                    }
+                )
+                target_sha256 = canonical_request_sha256(snapshot.target_request)
+                marker = retarget_successor_marker(
+                    prior_receipts_sha256=prior_receipts_sha256,
+                    preflight_sha256=evidence_digest,
+                    source_request_sha256=current.canonical_request_sha256,
+                    target_request_sha256=target_sha256,
+                    target_runtime_sha256=snapshot.target_runtime_sha256,
+                    helper_source_sha256=self._helper_source_sha256,
+                    claim_generation=current.claim_generation,
+                    committed_at=now,
+                )
+                progress = {**current.progress, _RETARGET_SUCCESSOR_MARKER: marker}
+                transition = retarget_successor_transition_values(
+                    self._retarget_successor_pre_state(current)
+                )
+                purpose = f"operation-request:{current.action.value}:{current.idempotency_key}"
+                target_ciphertext = self._codec.encrypt_json(
+                    snapshot.target_request, purpose=purpose
+                )
+                updated = await session.scalar(
+                    update(Operation)
+                    .where(
+                        Operation.id == current.id,
+                        Operation.action == OperationAction.PROVISION,
+                        Operation.state == current.state,
+                        Operation.checkpoint == current.checkpoint,
+                        Operation.error_code == current.error_code,
+                        Operation.claim_owner.is_(None),
+                        Operation.claim_token.is_(None),
+                        Operation.claim_expires_at.is_(None),
+                        Operation.result_ciphertext.is_(None),
+                        cast(Operation.result_redacted, JSONB) == cast({}, JSONB),
+                        Operation.finalized_at == current.finalized_at,
+                        Operation.external_operation_id == current.provider_operation_id,
+                        Operation.fence_generation == current.provider_fence_generation,
+                        Operation.canonical_request_sha256 == current.canonical_request_sha256,
+                        Operation.request_ciphertext == current.request_ciphertext,
+                        Operation.claim_generation == current.claim_generation,
+                        Operation.updated_at == current.updated_at,
+                        cast(Operation.progress, JSONB) == cast(current.progress, JSONB),
+                        cast(Operation.progress, JSONB).has_key(_RECOVERY_MARKER),
+                        cast(Operation.progress, JSONB).has_key(_RETARGET_MARKER),
+                        ~cast(Operation.progress, JSONB).has_key(_RETARGET_SUCCESSOR_MARKER),
+                    )
+                    .values(
+                        **transition,
+                        canonical_request_sha256=target_sha256,
+                        request_ciphertext=target_ciphertext,
+                        available_at=now,
+                        updated_at=now,
+                        progress=progress,
+                    )
+                    .returning(Operation)
+                )
+                if updated is None:
+                    reread = await session.get(Operation, operation_id, with_for_update=True)
+                    if reread is not None and _RETARGET_SUCCESSOR_MARKER in reread.progress:
+                        return self._retarget_successor_result(
+                            reread,
+                            reread.progress[_RETARGET_SUCCESSOR_MARKER],
+                            "already-successor-retargeted",
+                        )
+                    raise RecoveryRefusal("already progressed")
+                await session.flush()
+                return self._retarget_successor_result(
+                    updated, marker, "successor-retargeted"
+                )
+        except RecoveryRefusal:
+            raise
+        except Exception as error:
+            raise RecoveryRefusal("successor-retarget-failed") from error
+
+    async def verify_successor_retarget(self, operation_id: str) -> dict[str, object]:
+        try:
+            async with self._sessions.begin() as session:
+                await self._require_database_identity(session)
+                operation = await session.get(Operation, operation_id)
+                if operation is None:
+                    raise RecoveryRefusal("operation is unavailable")
+                marker = operation.progress.get(_RETARGET_SUCCESSOR_MARKER)
+                if marker is None:
+                    raise RecoveryRefusal("successor retarget attribution is unavailable")
+                return self._retarget_successor_result(
+                    operation, marker, "successor-retarget-verified"
+                )
+        except RecoveryRefusal:
+            raise
+        except Exception as error:
+            raise RecoveryRefusal("successor-retarget-verification-failed") from error
+
     async def _retarget_resume_preflight(
         self, session: AsyncSession, operation_id: str
     ) -> _RecoverySnapshot:
@@ -1381,6 +1676,105 @@ class RecoveryService:
             ),
             reservation_sha256=_hash_model(reservation),
             tenant_fence_sha256=_hash_model(fence),
+        )
+
+    async def _retarget_successor_preflight(
+        self, session: AsyncSession, operation_id: str, *, now: datetime
+    ) -> _RetargetSnapshot:
+        await self._require_database_identity(session)
+        initial = await session.get(Operation, operation_id)
+        if initial is None:
+            raise RecoveryRefusal("operation is unavailable")
+        fence = await session.get(TenantFence, initial.tenant_id, with_for_update=True)
+        operation = await session.get(Operation, operation_id, with_for_update=True)
+        if (
+            operation is None
+            or fence is None
+            or fence.tenant_id != operation.tenant_id
+            or fence.fence_generation != operation.fence_generation
+        ):
+            raise RecoveryRefusal("successor retarget preflight failed")
+        return await self._retarget_successor_preflight_locked(
+            session, operation, now=now, fence=fence
+        )
+
+    async def _retarget_successor_preflight_locked(
+        self,
+        session: AsyncSession,
+        operation: Operation,
+        *,
+        now: datetime,
+        fence: TenantFence | None = None,
+    ) -> _RetargetSnapshot:
+        if fence is None:
+            fence = await session.get(TenantFence, operation.tenant_id, with_for_update=True)
+        if (
+            fence is None
+            or fence.fence_generation != operation.fence_generation
+            or operation.cell_id is None
+            or operation.external_operation_id != operation.provider_operation_id
+            or operation.fence_generation != operation.provider_fence_generation
+        ):
+            raise RecoveryRefusal("successor retarget preflight failed")
+        retarget_successor_transition_values(self._retarget_successor_pre_state(operation))
+        self._prior_retarget_receipts_sha256(operation)
+        await self._lock_conflicts(
+            session,
+            operation,
+            allow_expired_current=True,
+            now=now,
+        )
+        request = self._codec.decrypt_json(
+            operation.request_ciphertext,
+            purpose=f"operation-request:{operation.action.value}:{operation.idempotency_key}",
+        )
+        if (
+            canonical_request_sha256(request) != operation.canonical_request_sha256
+            or request.get("tenantId") != operation.tenant_id
+            or request.get("cellId") != operation.cell_id
+            or request.get("operationId") != operation.external_operation_id
+            or request.get("fenceGeneration") != operation.fence_generation
+            or request.get("checkpoint") != operation.caller_checkpoint
+            or request.get("provisionMode") != "serve"
+            or not self._source_deployment_lock.matches_runtime_request(
+                request,
+                wire_protocol=operation.wire_protocol.value,
+                selection=self._runtime_selection,
+            )
+        ):
+            raise RecoveryRefusal("successor retarget preflight failed")
+        selected = self._deployment_lock.selected_runtime(self._runtime_selection)
+        target_runtime = selected.runtimeTarget.model_dump(mode="json")
+        if selected.compatibilityDigest is not None:
+            target_runtime["compatibilityDigest"] = selected.compatibilityDigest
+        target_request = retarget_provision_request(
+            request,
+            wire_protocol=operation.wire_protocol.value,
+            runtime_target=target_runtime,
+        )
+        resources = await self._resources(session, operation)
+        reservation = await self._reservation(session, operation)
+        recovery = _RecoverySnapshot(
+            operation=operation,
+            resources=resources,
+            reservation=reservation,
+            operation_sha256=_hash_model(operation),
+            preserved_sha256=_hash_model(operation, excluded=self._CHANGED_COLUMNS),
+            request_sha256=operation.canonical_request_sha256,
+            request_ciphertext_sha256=hashlib.sha256(
+                operation.request_ciphertext.encode()
+            ).hexdigest(),
+            resources_sha256=canonical_sha256(
+                {item.id: _hash_model(item) for item in sorted(resources, key=lambda item: item.id)}
+            ),
+            reservation_sha256=_hash_model(reservation),
+            tenant_fence_sha256=_hash_model(fence),
+        )
+        return _RetargetSnapshot(
+            recovery=recovery,
+            source_request=request,
+            target_request=target_request,
+            target_runtime_sha256=canonical_sha256(target_runtime),
         )
 
     async def _preflight(self, session: AsyncSession, operation_id: str) -> _RecoverySnapshot:
@@ -1654,6 +2048,68 @@ class RecoveryService:
         )
 
     @staticmethod
+    def _retarget_successor_pre_state(operation: Operation) -> RetargetSuccessorPreState:
+        return RetargetSuccessorPreState(
+            action=operation.action.value,
+            state=operation.state.value,
+            checkpoint=operation.checkpoint,
+            error_code=operation.error_code,
+            has_claim=any(
+                value is not None
+                for value in (
+                    operation.claim_owner,
+                    operation.claim_token,
+                    operation.claim_expires_at,
+                )
+            ),
+            has_result=(operation.result_ciphertext is not None or operation.result_redacted != {}),
+            finalized=operation.finalized_at is not None,
+            has_recovery_marker=_RECOVERY_MARKER in operation.progress,
+            has_retarget_marker=_RETARGET_MARKER in operation.progress,
+            has_resume_marker=_RETARGET_RESUME_MARKER in operation.progress,
+            has_retry_marker=_RETARGET_RETRY_MARKER in operation.progress,
+            has_successor_marker=_RETARGET_SUCCESSOR_MARKER in operation.progress,
+        )
+
+    @staticmethod
+    def _prior_retarget_receipts_sha256(
+        operation: Operation, *, request_sha256: str | None = None
+    ) -> str:
+        recovery = parse_recovery_marker(operation.progress.get(_RECOVERY_MARKER))
+        retarget = parse_retarget_marker(operation.progress.get(_RETARGET_MARKER))
+        if (
+            request_sha256 or operation.canonical_request_sha256
+        ) != retarget["target_request_sha256"]:
+            raise RecoveryRefusal("successor retarget preflight failed")
+        resume_value = operation.progress.get(_RETARGET_RESUME_MARKER)
+        retry_value = operation.progress.get(_RETARGET_RETRY_MARKER)
+        resume_sha256 = ""
+        retry_sha256 = ""
+        if resume_value is not None:
+            resume = parse_retarget_resume_marker(resume_value)
+            if resume["retarget_marker_sha256"] != canonical_sha256(retarget):
+                raise RecoveryRefusal("successor retarget preflight failed")
+            resume_sha256 = canonical_sha256(resume)
+        if retry_value is not None:
+            if resume_value is None:
+                raise RecoveryRefusal("successor retarget preflight failed")
+            retry = parse_retarget_retry_marker(retry_value)
+            if (
+                retry["retarget_marker_sha256"] != canonical_sha256(retarget)
+                or retry["resume_marker_sha256"] != resume_sha256
+            ):
+                raise RecoveryRefusal("successor retarget preflight failed")
+            retry_sha256 = canonical_sha256(retry)
+        return canonical_sha256(
+            {
+                "recovery": canonical_sha256(recovery),
+                "retarget": canonical_sha256(retarget),
+                "resume": resume_sha256,
+                "retry": retry_sha256,
+            }
+        )
+
+    @staticmethod
     def _preflight_evidence_digest(
         snapshot: _RecoverySnapshot, first: LiveObservation, second: LiveObservation
     ) -> str:
@@ -1911,6 +2367,35 @@ class RecoveryService:
             "recovery_digest": canonical_sha256(marker),
         }
 
+    @staticmethod
+    def _retarget_successor_result(
+        operation: Operation, marker_value: object, status: str
+    ) -> dict[str, object]:
+        marker = parse_retarget_successor_marker(marker_value)
+        if (
+            operation.canonical_request_sha256 != marker["target_request_sha256"]
+            or marker["prior_receipts_sha256"]
+            != RecoveryService._prior_retarget_receipts_sha256(
+                operation, request_sha256=str(marker["source_request_sha256"])
+            )
+        ):
+            raise RecoveryRefusal("successor retarget attribution is unavailable")
+        if operation.state not in {
+            OperationState.PENDING,
+            OperationState.CLAIMED,
+            OperationState.ERROR,
+            OperationState.FINAL,
+        }:
+            raise RecoveryRefusal("successor retarget attribution is unavailable")
+        return {
+            "status": status,
+            "state": operation.state.value,
+            "checkpoint": operation.checkpoint,
+            "error_code": operation.error_code,
+            "recovery_digest": canonical_sha256(marker),
+        }
+
+
 
 @dataclass(frozen=True, slots=True)
 class _ProductionRecoveryObserver:
@@ -2108,6 +2593,12 @@ async def _run(args: argparse.Namespace) -> dict[str, object]:
                 return await service.retry_retarget(operation_id)
             case "verify-retry-retarget":
                 return await service.verify_retry_retarget(operation_id)
+            case "successor-retarget-preflight":
+                return await service.successor_retarget_preflight(operation_id)
+            case "successor-retarget":
+                return await service.successor_retarget(operation_id)
+            case "verify-successor-retarget":
+                return await service.verify_successor_retarget(operation_id)
         raise RecoveryRefusal("recovery mode is invalid")
     except RecoveryRefusal:
         raise

--- a/infra/provisioner/src/exomem_provisioner/operation_recovery.py
+++ b/infra/provisioner/src/exomem_provisioner/operation_recovery.py
@@ -516,6 +516,24 @@ def retarget_provision_request(
     raise RecoveryRefusal("retarget request is invalid")
 
 
+def request_targets_selected_runtime(
+    request: dict[str, object], *, wire_protocol: str, runtime_target: dict[str, object]
+) -> bool:
+    if wire_protocol == "exomem-cell-provisioner.v1":
+        return (
+            "runtimeTarget" not in request
+            and request.get("releaseVersion") == runtime_target.get("releaseVersion")
+            and request.get("protocolVersion") == runtime_target.get("protocolVersion")
+        )
+    if wire_protocol == "exomem-cell-provisioner.v2":
+        return (
+            "releaseVersion" not in request
+            and "protocolVersion" not in request
+            and request.get("runtimeTarget") == runtime_target
+        )
+    return False
+
+
 def recovery_marker(
     *,
     preflight_sha256: str,
@@ -2089,11 +2107,13 @@ class RecoveryService:
         retry_value = operation.progress.get(_RETARGET_RETRY_MARKER)
         resume_sha256 = ""
         retry_sha256 = ""
+        ordered_receipts = [recovery, retarget]
         if resume_value is not None:
             resume = parse_retarget_resume_marker(resume_value)
             if resume["retarget_marker_sha256"] != canonical_sha256(retarget):
                 raise RecoveryRefusal("successor retarget preflight failed")
             resume_sha256 = canonical_sha256(resume)
+            ordered_receipts.append(resume)
         if retry_value is not None:
             if resume_value is None:
                 raise RecoveryRefusal("successor retarget preflight failed")
@@ -2104,6 +2124,41 @@ class RecoveryService:
             ):
                 raise RecoveryRefusal("successor retarget preflight failed")
             retry_sha256 = canonical_sha256(retry)
+            ordered_receipts.append(retry)
+        claim_generations = [int(receipt["claim_generation"]) for receipt in ordered_receipts]
+        committed_at = [
+            RecoveryService._receipt_committed_at(receipt) for receipt in ordered_receipts
+        ]
+        retry_generation = int(retry["claim_generation"]) if retry_value is not None else None
+        retry_committed_at = (
+            RecoveryService._receipt_committed_at(retry) if retry_value is not None else None
+        )
+        after_retry_terminal = (
+            retry_generation is not None
+            and (
+                operation.state is OperationState.ERROR
+                or operation.checkpoint == "capacity-live-observation-mismatch"
+            )
+        )
+        if (
+            claim_generations != sorted(claim_generations)
+            or claim_generations[-1] > operation.claim_generation
+            or committed_at != sorted(committed_at)
+            or committed_at[-1] > operation.updated_at
+            or (
+                after_retry_terminal
+                and operation.claim_generation <= retry_generation
+            )
+            or (
+                operation.state is OperationState.ERROR
+                and (
+                    operation.finalized_at is None
+                    or retry_committed_at is None
+                    or operation.finalized_at < retry_committed_at
+                )
+            )
+        ):
+            raise RecoveryRefusal("successor retarget preflight failed")
         return canonical_sha256(
             {
                 "recovery": canonical_sha256(recovery),
@@ -2112,6 +2167,13 @@ class RecoveryService:
                 "retry": retry_sha256,
             }
         )
+
+    @staticmethod
+    def _receipt_committed_at(receipt: dict[str, object]) -> datetime:
+        value = datetime.fromisoformat(str(receipt["committed_at"]).replace("Z", "+00:00"))
+        if value.tzinfo is None:
+            raise RecoveryRefusal("successor retarget preflight failed")
+        return value
 
     @staticmethod
     def _preflight_evidence_digest(
@@ -2371,15 +2433,38 @@ class RecoveryService:
             "recovery_digest": canonical_sha256(marker),
         }
 
-    @staticmethod
     def _retarget_successor_result(
-        operation: Operation, marker_value: object, status: str
+        self, operation: Operation, marker_value: object, status: str
     ) -> dict[str, object]:
         marker = parse_retarget_successor_marker(marker_value)
+        purpose = f"operation-request:{operation.action.value}:{operation.idempotency_key}"
+        request = self._codec.decrypt_json(operation.request_ciphertext, purpose=purpose)
+        selected = self._deployment_lock.selected_runtime(self._runtime_selection)
+        target_runtime = selected.runtimeTarget.model_dump(mode="json")
+        if selected.compatibilityDigest is not None:
+            target_runtime["compatibilityDigest"] = selected.compatibilityDigest
         if (
             operation.canonical_request_sha256 != marker["target_request_sha256"]
+            or canonical_request_sha256(request) != operation.canonical_request_sha256
+            or request.get("tenantId") != operation.tenant_id
+            or request.get("cellId") != operation.cell_id
+            or request.get("operationId") != operation.external_operation_id
+            or request.get("fenceGeneration") != operation.fence_generation
+            or request.get("checkpoint") != operation.caller_checkpoint
+            or request.get("provisionMode") != "serve"
+            or operation.external_operation_id != operation.provider_operation_id
+            or operation.fence_generation != operation.provider_fence_generation
+            or not request_targets_selected_runtime(
+                request,
+                wire_protocol=operation.wire_protocol.value,
+                runtime_target=target_runtime,
+            )
+            or marker["target_runtime_sha256"] != canonical_sha256(target_runtime)
+            or marker["helper_source_sha256"] != self._helper_source_sha256
+            or int(marker["claim_generation"]) > operation.claim_generation
+            or self._receipt_committed_at(marker) > operation.updated_at
             or marker["prior_receipts_sha256"]
-            != RecoveryService._prior_retarget_receipts_sha256(
+            != self._prior_retarget_receipts_sha256(
                 operation, request_sha256=str(marker["source_request_sha256"])
             )
         ):

--- a/infra/provisioner/src/exomem_provisioner/operation_recovery.py
+++ b/infra/provisioner/src/exomem_provisioner/operation_recovery.py
@@ -446,7 +446,11 @@ def retarget_successor_transition_values(
         raise RecoveryRefusal("successor retarget preflight failed")
     if before.state == "pending":
         valid_state = (
-            before.checkpoint == "volume-owned"
+            before.checkpoint
+            in {
+                "volume-owned",
+                "capacity-live-observation-mismatch",
+            }
             and before.error_code is None
             and not before.finalized
         )

--- a/infra/provisioner/tests/test_operation_recovery.py
+++ b/infra/provisioner/tests/test_operation_recovery.py
@@ -127,6 +127,9 @@ def test_recovery_command_has_only_fixed_modes_and_environment_free_help(
         "retry-retarget-preflight",
         "retry-retarget",
         "verify-retry-retarget",
+        "successor-retarget-preflight",
+        "successor-retarget",
+        "verify-successor-retarget",
     ):
         assert parser.parse_args([mode, "--stdin"]).mode == mode
     with pytest.raises(recovery.RecoveryRefusal):
@@ -525,6 +528,152 @@ def test_retarget_retry_marker_binds_both_prior_recovery_receipts() -> None:
     }
     with pytest.raises(recovery.RecoveryRefusal):
         recovery.parse_retarget_retry_marker({**marker, "cellId": "cell-alpha"})
+
+
+def test_successor_retarget_accepts_pending_or_exhausted_prior_retarget_only() -> None:
+    recovery = _module()
+    pending = recovery.RetargetSuccessorPreState(
+        action="provision",
+        state="pending",
+        checkpoint="volume-owned",
+        error_code=None,
+        has_claim=False,
+        has_result=False,
+        finalized=False,
+        has_recovery_marker=True,
+        has_retarget_marker=True,
+        has_resume_marker=False,
+        has_retry_marker=False,
+        has_successor_marker=False,
+    )
+
+    assert recovery.retarget_successor_transition_values(pending) == {
+        "state": recovery.OperationState.PENDING,
+        "checkpoint": "volume-owned",
+        "error_code": None,
+        "claim_owner": None,
+        "claim_token": None,
+        "claim_expires_at": None,
+        "finalized_at": None,
+    }
+    exhausted = replace(
+        pending,
+        state="error",
+        checkpoint="failed",
+        error_code="PROVISIONER_PROVIDER_METADATA_CONFLICT",
+        finalized=True,
+        has_resume_marker=True,
+        has_retry_marker=True,
+    )
+    assert recovery.retarget_successor_transition_values(exhausted)["state"] is (
+        recovery.OperationState.PENDING
+    )
+    for changed in (
+        {"checkpoint": "requested"},
+        {"has_claim": True},
+        {"has_result": True},
+        {"has_recovery_marker": False},
+        {"has_retarget_marker": False},
+        {"has_successor_marker": True},
+        {"state": "error", "checkpoint": "failed", "error_code": "OTHER", "finalized": True},
+        {
+            "state": "error",
+            "checkpoint": "failed",
+            "error_code": "PROVISIONER_PROVIDER_METADATA_CONFLICT",
+            "finalized": True,
+            "has_resume_marker": True,
+            "has_retry_marker": False,
+        },
+    ):
+        with pytest.raises(recovery.RecoveryRefusal):
+            recovery.retarget_successor_transition_values(replace(pending, **changed))
+
+
+def test_successor_retarget_marker_binds_prior_chain_and_both_requests() -> None:
+    recovery = _module()
+    marker = recovery.retarget_successor_marker(
+        prior_receipts_sha256="a" * 64,
+        preflight_sha256="b" * 64,
+        source_request_sha256="c" * 64,
+        target_request_sha256="d" * 64,
+        target_runtime_sha256="e" * 64,
+        helper_source_sha256="f" * 64,
+        claim_generation=6,
+        committed_at=datetime(2030, 1, 4, tzinfo=UTC),
+    )
+
+    assert recovery.parse_retarget_successor_marker(marker) == marker
+    assert set(marker) == {
+        "schema",
+        "prior_receipts_sha256",
+        "preflight_sha256",
+        "source_request_sha256",
+        "target_request_sha256",
+        "target_runtime_sha256",
+        "helper_source_sha256",
+        "claim_generation",
+        "committed_at",
+    }
+    assert b"secret" not in recovery.canonical_receipt_bytes(marker)
+    with pytest.raises(recovery.RecoveryRefusal):
+        recovery.parse_retarget_successor_marker({**marker, "tenantId": "tenant-alpha"})
+
+
+def test_successor_retarget_prior_chain_refuses_reordered_or_unbound_receipts() -> None:
+    recovery = _module()
+    now = datetime(2030, 1, 4, tzinfo=UTC)
+    recovered = recovery.recovery_marker(
+        preflight_sha256="1" * 64,
+        helper_source_sha256="2" * 64,
+        claim_generation=4,
+        committed_at=now,
+    )
+    retargeted = recovery.retarget_marker(
+        preflight_sha256="3" * 64,
+        source_request_sha256="4" * 64,
+        target_request_sha256="5" * 64,
+        target_runtime_sha256="6" * 64,
+        helper_source_sha256="7" * 64,
+        claim_generation=4,
+        committed_at=now,
+    )
+    resumed = recovery.retarget_resume_marker(
+        retarget_marker_sha256=recovery.canonical_sha256(retargeted),
+        preflight_sha256="8" * 64,
+        helper_source_sha256="9" * 64,
+        claim_generation=5,
+        committed_at=now,
+    )
+    retried = recovery.retarget_retry_marker(
+        retarget_marker_sha256=recovery.canonical_sha256(retargeted),
+        resume_marker_sha256=recovery.canonical_sha256(resumed),
+        preflight_sha256="a" * 64,
+        helper_source_sha256="b" * 64,
+        claim_generation=6,
+        committed_at=now,
+    )
+    operation = type(
+        "PriorOperation",
+        (),
+        {
+            "canonical_request_sha256": "5" * 64,
+            "progress": {
+                "_init_retry_recovery_v1": recovered,
+                "_runtime_retarget_recovery_v1": retargeted,
+                "_runtime_retarget_resume_v1": resumed,
+                "_runtime_retarget_retry_v1": retried,
+            },
+        },
+    )()
+
+    digest = recovery.RecoveryService._prior_retarget_receipts_sha256(operation)
+    assert len(digest) == 64
+    operation.progress["_runtime_retarget_retry_v1"] = {
+        **retried,
+        "resume_marker_sha256": "c" * 64,
+    }
+    with pytest.raises(recovery.RecoveryRefusal):
+        recovery.RecoveryService._prior_retarget_receipts_sha256(operation)
 
 
 def test_database_stays_at_0006_without_recovery_receipt_table() -> None:

--- a/infra/provisioner/tests/test_operation_recovery.py
+++ b/infra/provisioner/tests/test_operation_recovery.py
@@ -556,6 +556,13 @@ def test_successor_retarget_accepts_pending_or_exhausted_prior_retarget_only() -
         "claim_expires_at": None,
         "finalized_at": None,
     }
+    capacity_blocked = replace(
+        pending,
+        checkpoint="capacity-live-observation-mismatch",
+    )
+    assert recovery.retarget_successor_transition_values(capacity_blocked)["checkpoint"] == (
+        "volume-owned"
+    )
     exhausted = replace(
         pending,
         state="error",

--- a/infra/provisioner/tests/test_operation_recovery.py
+++ b/infra/provisioner/tests/test_operation_recovery.py
@@ -4,7 +4,7 @@ import json
 import re
 import uuid
 from dataclasses import replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -268,6 +268,16 @@ def test_retarget_request_changes_only_the_v1_legacy_runtime_pair() -> None:
     )
 
     assert target == {**source, "releaseVersion": "0.68.1", "protocolVersion": "1"}
+    assert recovery.request_targets_selected_runtime(
+        target,
+        wire_protocol="exomem-cell-provisioner.v1",
+        runtime_target={"releaseVersion": "0.68.1", "protocolVersion": "1"},
+    )
+    assert not recovery.request_targets_selected_runtime(
+        source,
+        wire_protocol="exomem-cell-provisioner.v1",
+        runtime_target={"releaseVersion": "0.68.1", "protocolVersion": "1"},
+    )
     assert source["releaseVersion"] == "0.66.0"
     with pytest.raises(recovery.RecoveryRefusal):
         recovery.retarget_provision_request(
@@ -327,6 +337,16 @@ def test_retarget_request_changes_only_the_complete_v2_runtime_target() -> None:
     )
 
     assert target == {**source, "runtimeTarget": selected}
+    assert recovery.request_targets_selected_runtime(
+        target,
+        wire_protocol="exomem-cell-provisioner.v2",
+        runtime_target=selected,
+    )
+    assert not recovery.request_targets_selected_runtime(
+        source,
+        wire_protocol="exomem-cell-provisioner.v2",
+        runtime_target=selected,
+    )
     assert source["runtimeTarget"] is source_target
     with pytest.raises(recovery.RecoveryRefusal):
         recovery.retarget_provision_request(
@@ -629,11 +649,14 @@ def test_successor_retarget_marker_binds_prior_chain_and_both_requests() -> None
 def test_successor_retarget_prior_chain_refuses_reordered_or_unbound_receipts() -> None:
     recovery = _module()
     now = datetime(2030, 1, 4, tzinfo=UTC)
+    recovered_at = now - timedelta(minutes=3)
+    retargeted_at = now - timedelta(minutes=2)
+    resumed_at = now - timedelta(minutes=1)
     recovered = recovery.recovery_marker(
         preflight_sha256="1" * 64,
         helper_source_sha256="2" * 64,
         claim_generation=4,
-        committed_at=now,
+        committed_at=recovered_at,
     )
     retargeted = recovery.retarget_marker(
         preflight_sha256="3" * 64,
@@ -642,14 +665,14 @@ def test_successor_retarget_prior_chain_refuses_reordered_or_unbound_receipts() 
         target_runtime_sha256="6" * 64,
         helper_source_sha256="7" * 64,
         claim_generation=4,
-        committed_at=now,
+        committed_at=retargeted_at,
     )
     resumed = recovery.retarget_resume_marker(
         retarget_marker_sha256=recovery.canonical_sha256(retargeted),
         preflight_sha256="8" * 64,
         helper_source_sha256="9" * 64,
         claim_generation=5,
-        committed_at=now,
+        committed_at=resumed_at,
     )
     retried = recovery.retarget_retry_marker(
         retarget_marker_sha256=recovery.canonical_sha256(retargeted),
@@ -664,6 +687,11 @@ def test_successor_retarget_prior_chain_refuses_reordered_or_unbound_receipts() 
         (),
         {
             "canonical_request_sha256": "5" * 64,
+            "state": recovery.OperationState.PENDING,
+            "checkpoint": "capacity-live-observation-mismatch",
+            "finalized_at": None,
+            "claim_generation": 7,
+            "updated_at": now,
             "progress": {
                 "_init_retry_recovery_v1": recovered,
                 "_runtime_retarget_recovery_v1": retargeted,
@@ -679,6 +707,31 @@ def test_successor_retarget_prior_chain_refuses_reordered_or_unbound_receipts() 
         **retried,
         "resume_marker_sha256": "c" * 64,
     }
+    with pytest.raises(recovery.RecoveryRefusal):
+        recovery.RecoveryService._prior_retarget_receipts_sha256(operation)
+    operation.progress["_runtime_retarget_retry_v1"] = retried
+    operation.claim_generation = 5
+    with pytest.raises(recovery.RecoveryRefusal):
+        recovery.RecoveryService._prior_retarget_receipts_sha256(operation)
+    operation.claim_generation = 6
+    operation.progress["_runtime_retarget_retry_v1"] = {
+        **retried,
+        "claim_generation": 4,
+    }
+    with pytest.raises(recovery.RecoveryRefusal):
+        recovery.RecoveryService._prior_retarget_receipts_sha256(operation)
+    operation.progress["_runtime_retarget_retry_v1"] = {
+        **retried,
+        "committed_at": (resumed_at - timedelta(seconds=1)).isoformat(),
+    }
+    with pytest.raises(recovery.RecoveryRefusal):
+        recovery.RecoveryService._prior_retarget_receipts_sha256(operation)
+    operation.progress["_runtime_retarget_retry_v1"] = retried
+    operation.updated_at = now - timedelta(seconds=1)
+    with pytest.raises(recovery.RecoveryRefusal):
+        recovery.RecoveryService._prior_retarget_receipts_sha256(operation)
+    operation.updated_at = now
+    operation.claim_generation = 6
     with pytest.raises(recovery.RecoveryRefusal):
         recovery.RecoveryService._prior_retarget_receipts_sha256(operation)
 

--- a/infra/provisioner/tests/test_postgresql17.py
+++ b/infra/provisioner/tests/test_postgresql17.py
@@ -437,6 +437,43 @@ async def test_postgresql17_recovery_cas_inserts_one_immutable_receipt(
 
             return type("Selected", (), {"runtimeTarget": Target(), "compatibilityDigest": None})()
 
+    class SuccessorLock:
+        def matches_runtime_request(
+            self,
+            request: dict[str, object],
+            *,
+            wire_protocol: str,
+            selection: str | None = None,
+        ) -> bool:
+            assert selection is None
+            return (
+                wire_protocol == "exomem-cell-provisioner.v1"
+                and request["provisionMode"] == "serve"
+                and request["releaseVersion"] == "0.68.1"
+                and request["protocolVersion"] == "1"
+            )
+
+        def selected_runtime(self, selection: str | None):
+            assert selection is None
+
+            class Target:
+                releaseVersion = "0.68.3"
+                protocolVersion = "1"
+
+                @staticmethod
+                def model_dump(*, mode: str) -> dict[str, str]:
+                    assert mode == "json"
+                    return {
+                        "releaseVersion": "0.68.3",
+                        "protocolVersion": "1",
+                        "agentProfile": "hosted-alpha-agent-v4",
+                        "gatewayContractDigest": "a" * 64,
+                        "commandFingerprint": "b" * 64,
+                        "schemaDigest": "c" * 64,
+                    }
+
+            return type("Selected", (), {"runtimeTarget": Target(), "compatibilityDigest": None})()
+
     class Observer:
         async def observe(
             self, operation: Operation, resources: tuple[Resource, ...]
@@ -780,6 +817,50 @@ async def test_postgresql17_recovery_cas_inserts_one_immutable_receipt(
             assert await service.verify_retarget(operation_id) == {
                 **retargeted,
                 "status": "retarget-verified",
+            }
+        successor_service = RecoveryService(
+            sessions=database.session_factory,
+            codec=codec,
+            database_name=target.name,
+            database_role=target.role,
+            database_schema=target.schema,
+            database_lock_timeout_seconds=1,
+            deployment_lock=SuccessorLock(),  # type: ignore[arg-type]
+            source_deployment_lock=SuccessorLock(),  # type: ignore[arg-type]
+            observer=Observer(),
+        )
+        successor, successor_replay = await asyncio.gather(
+            successor_service.successor_retarget(operation_id),
+            successor_service.successor_retarget(operation_id),
+        )
+        assert {successor["status"], successor_replay["status"]} == {
+            "successor-retargeted",
+            "already-successor-retargeted",
+        }
+        successor_result = (
+            successor if successor["status"] == "successor-retargeted" else successor_replay
+        )
+        async with database.session_factory() as session:
+            operation = await session.get(Operation, operation_id)
+            assert operation is not None
+            decoded = codec.decrypt_json(
+                operation.request_ciphertext,
+                purpose="operation-request:provision:recovery-postgresql-key",
+            )
+            assert decoded == {
+                **request,
+                "releaseVersion": "0.68.3",
+                "protocolVersion": "1",
+            }
+            assert operation.canonical_request_sha256 == repository_module.canonical_request_sha256(
+                decoded
+            )
+            assert operation.state is OperationState.PENDING
+            assert operation.checkpoint == "volume-owned"
+            assert "_runtime_retarget_successor_v1" in operation.progress
+            assert await successor_service.verify_successor_retarget(operation_id) == {
+                **successor_result,
+                "status": "successor-retarget-verified",
             }
         for role, schema in (("wrong-role", target.schema), (target.role, "wrong_schema")):
             wrong_identity = RecoveryService(

--- a/infra/provisioner/tests/test_postgresql17.py
+++ b/infra/provisioner/tests/test_postgresql17.py
@@ -477,6 +477,43 @@ async def test_postgresql17_recovery_cas_inserts_one_immutable_receipt(
 
             return type("Selected", (), {"runtimeTarget": Target(), "compatibilityDigest": None})()
 
+    class SuccessorSourceLock:
+        def matches_runtime_request(
+            self,
+            request: dict[str, object],
+            *,
+            wire_protocol: str,
+            selection: str | None = None,
+        ) -> bool:
+            assert selection is None
+            return (
+                wire_protocol == "exomem-cell-provisioner.v1"
+                and request["provisionMode"] == "serve"
+                and request["releaseVersion"] == "0.68.1"
+                and request["protocolVersion"] == "1"
+            )
+
+        def selected_runtime(self, selection: str | None):
+            assert selection is None
+
+            class Target:
+                releaseVersion = "0.68.1"
+                protocolVersion = "1"
+
+                @staticmethod
+                def model_dump(*, mode: str) -> dict[str, str]:
+                    assert mode == "json"
+                    return {
+                        "releaseVersion": "0.68.1",
+                        "protocolVersion": "1",
+                        "agentProfile": "hosted-alpha-agent-v4",
+                        "gatewayContractDigest": "a" * 64,
+                        "commandFingerprint": "b" * 64,
+                        "schemaDigest": "c" * 64,
+                    }
+
+            return type("Selected", (), {"runtimeTarget": Target(), "compatibilityDigest": None})()
+
     class Observer:
         async def observe(
             self, operation: Operation, resources: tuple[Resource, ...]
@@ -822,6 +859,35 @@ async def test_postgresql17_recovery_cas_inserts_one_immutable_receipt(
                 "status": "retarget-verified",
             }
             prior_retarget_progress = dict(operation.progress)
+        prior_receipt_time = datetime.now(UTC)
+        retarget_receipt = prior_retarget_progress["_runtime_retarget_recovery_v1"]
+        resume_receipt = retarget_resume_marker(
+            retarget_marker_sha256=canonical_sha256(retarget_receipt),
+            preflight_sha256="a" * 64,
+            helper_source_sha256="b" * 64,
+            claim_generation=1,
+            committed_at=prior_receipt_time,
+        )
+        retry_receipt = retarget_retry_marker(
+            retarget_marker_sha256=canonical_sha256(retarget_receipt),
+            resume_marker_sha256=canonical_sha256(resume_receipt),
+            preflight_sha256="c" * 64,
+            helper_source_sha256="d" * 64,
+            claim_generation=2,
+            committed_at=prior_receipt_time,
+        )
+        prior_full_progress = {
+            **prior_retarget_progress,
+            "_runtime_retarget_resume_v1": resume_receipt,
+            "_runtime_retarget_retry_v1": retry_receipt,
+        }
+        async with database.session_factory.begin() as session:
+            operation = await session.get(Operation, operation_id, with_for_update=True)
+            assert operation is not None
+            operation.state = OperationState.PENDING
+            operation.checkpoint = "capacity-live-observation-mismatch"
+            operation.claim_generation = 3
+            operation.progress = prior_full_progress
         successor_service = RecoveryService(
             sessions=database.session_factory,
             codec=codec,
@@ -830,9 +896,60 @@ async def test_postgresql17_recovery_cas_inserts_one_immutable_receipt(
             database_schema=target.schema,
             database_lock_timeout_seconds=1,
             deployment_lock=SuccessorLock(),  # type: ignore[arg-type]
-            source_deployment_lock=SuccessorLock(),  # type: ignore[arg-type]
+            source_deployment_lock=SuccessorSourceLock(),  # type: ignore[arg-type]
             observer=Observer(),
         )
+
+        async def preserved_successor_state() -> dict[str, object]:
+            async with database.session_factory() as session:
+                operation = await session.get(Operation, operation_id)
+                assert operation is not None
+                resources = tuple(
+                    (
+                        await session.scalars(
+                            select(Resource)
+                            .where(Resource.operation_id == operation_id)
+                            .order_by(Resource.id)
+                        )
+                    ).all()
+                )
+                reservation = await session.scalar(
+                    select(CapacityReservation).where(
+                        CapacityReservation.reserving_operation_id == operation_id
+                    )
+                )
+                tenant_fence = await session.get(TenantFence, operation.tenant_id)
+                cell_lock = await session.get(CellOperationLock, operation.cell_id)
+                assert reservation is not None and tenant_fence is not None
+                assert cell_lock is not None
+                return {
+                    "operation": tuple(
+                        (column.name, getattr(operation, column.name))
+                        for column in operation.__table__.columns
+                        if column.name not in RecoveryService._CHANGED_COLUMNS
+                    ),
+                    "resources": tuple(
+                        tuple(
+                            (column.name, getattr(resource, column.name))
+                            for column in resource.__table__.columns
+                        )
+                        for resource in resources
+                    ),
+                    "reservation": tuple(
+                        (column.name, getattr(reservation, column.name))
+                        for column in reservation.__table__.columns
+                    ),
+                    "tenant_fence": tuple(
+                        (column.name, getattr(tenant_fence, column.name))
+                        for column in tenant_fence.__table__.columns
+                    ),
+                    "cell_lock": tuple(
+                        (column.name, getattr(cell_lock, column.name))
+                        for column in cell_lock.__table__.columns
+                    ),
+                }
+
+        pending_preserved = await preserved_successor_state()
         successor, successor_replay = await asyncio.gather(
             successor_service.successor_retarget(operation_id),
             successor_service.successor_retarget(operation_id),
@@ -866,28 +983,72 @@ async def test_postgresql17_recovery_cas_inserts_one_immutable_receipt(
                 **successor_result,
                 "status": "successor-retarget-verified",
             }
-        now = datetime.now(UTC)
-        retarget_receipt = prior_retarget_progress["_runtime_retarget_recovery_v1"]
-        resume_receipt = retarget_resume_marker(
-            retarget_marker_sha256=canonical_sha256(retarget_receipt),
-            preflight_sha256="a" * 64,
-            helper_source_sha256="b" * 64,
-            claim_generation=5,
-            committed_at=now,
-        )
-        retry_receipt = retarget_retry_marker(
-            retarget_marker_sha256=canonical_sha256(retarget_receipt),
-            resume_marker_sha256=canonical_sha256(resume_receipt),
-            preflight_sha256="c" * 64,
-            helper_source_sha256="d" * 64,
-            claim_generation=6,
-            committed_at=now,
-        )
+        assert await preserved_successor_state() == pending_preserved
         source_request = {
             **request,
             "releaseVersion": "0.68.1",
             "protocolVersion": "1",
         }
+        wrong_target_service = RecoveryService(
+            sessions=database.session_factory,
+            codec=codec,
+            database_name=target.name,
+            database_role=target.role,
+            database_schema=target.schema,
+            database_lock_timeout_seconds=1,
+            deployment_lock=Lock(),  # type: ignore[arg-type]
+            observer=Observer(),
+        )
+        with pytest.raises(RecoveryRefusal):
+            await wrong_target_service.verify_successor_retarget(operation_id)
+        async with database.session_factory.begin() as session:
+            operation = await session.get(Operation, operation_id, with_for_update=True)
+            assert operation is not None
+            target_ciphertext = operation.request_ciphertext
+            operation.request_ciphertext = codec.encrypt_json(
+                source_request,
+                purpose="operation-request:provision:recovery-postgresql-key",
+            )
+        with pytest.raises(RecoveryRefusal):
+            await successor_service.verify_successor_retarget(operation_id)
+        async with database.session_factory.begin() as session:
+            operation = await session.get(Operation, operation_id, with_for_update=True)
+            assert operation is not None
+            operation.request_ciphertext = target_ciphertext
+        async with database.session_factory.begin() as session:
+            operation = await session.get(Operation, operation_id, with_for_update=True)
+            assert operation is not None
+            provider_operation_id = operation.provider_operation_id
+            operation.provider_operation_id = "provider-substitution"
+        with pytest.raises(RecoveryRefusal):
+            await successor_service.verify_successor_retarget(operation_id)
+        async with database.session_factory.begin() as session:
+            operation = await session.get(Operation, operation_id, with_for_update=True)
+            assert operation is not None
+            operation.provider_operation_id = provider_operation_id
+            provider_fence_generation = operation.provider_fence_generation
+            operation.provider_fence_generation = 8
+        with pytest.raises(RecoveryRefusal):
+            await successor_service.verify_successor_retarget(operation_id)
+        async with database.session_factory.begin() as session:
+            operation = await session.get(Operation, operation_id, with_for_update=True)
+            assert operation is not None
+            operation.provider_fence_generation = provider_fence_generation
+            successor_progress = dict(operation.progress)
+            operation.progress = {
+                **successor_progress,
+                "_runtime_retarget_successor_v1": {
+                    **successor_progress["_runtime_retarget_successor_v1"],
+                    "helper_source_sha256": "f" * 64,
+                },
+            }
+        with pytest.raises(RecoveryRefusal):
+            await successor_service.verify_successor_retarget(operation_id)
+        async with database.session_factory.begin() as session:
+            operation = await session.get(Operation, operation_id, with_for_update=True)
+            assert operation is not None
+            operation.progress = successor_progress
+        now = datetime.now(UTC)
         async with database.session_factory.begin() as session:
             operation = await session.get(Operation, operation_id, with_for_update=True)
             assert operation is not None
@@ -903,10 +1064,9 @@ async def test_postgresql17_recovery_cas_inserts_one_immutable_receipt(
                 purpose="operation-request:provision:recovery-postgresql-key",
             )
             operation.progress = {
-                **prior_retarget_progress,
-                "_runtime_retarget_resume_v1": resume_receipt,
-                "_runtime_retarget_retry_v1": retry_receipt,
+                **prior_full_progress,
             }
+        exhausted_preserved = await preserved_successor_state()
         exhausted, exhausted_replay = await asyncio.gather(
             successor_service.successor_retarget(operation_id),
             successor_service.successor_retarget(operation_id),
@@ -928,6 +1088,7 @@ async def test_postgresql17_recovery_cas_inserts_one_immutable_receipt(
             assert operation.error_code is None
             assert operation.finalized_at is None
             assert "_runtime_retarget_successor_v1" in operation.progress
+        assert await preserved_successor_state() == exhausted_preserved
         for role, schema in (("wrong-role", target.schema), (target.role, "wrong_schema")):
             wrong_identity = RecoveryService(
                 sessions=database.session_factory,

--- a/infra/provisioner/tests/test_postgresql17.py
+++ b/infra/provisioner/tests/test_postgresql17.py
@@ -54,6 +54,9 @@ if PROVISIONER_TEST_IMAGE is None:
         LiveObservation,
         RecoveryRefusal,
         RecoveryService,
+        canonical_sha256,
+        retarget_resume_marker,
+        retarget_retry_marker,
     )
     from exomem_provisioner.provider_identity import cell_resource_name
     from exomem_provisioner.repository import OperationRepository, StaleFence
@@ -818,6 +821,7 @@ async def test_postgresql17_recovery_cas_inserts_one_immutable_receipt(
                 **retargeted,
                 "status": "retarget-verified",
             }
+            prior_retarget_progress = dict(operation.progress)
         successor_service = RecoveryService(
             sessions=database.session_factory,
             codec=codec,
@@ -862,6 +866,68 @@ async def test_postgresql17_recovery_cas_inserts_one_immutable_receipt(
                 **successor_result,
                 "status": "successor-retarget-verified",
             }
+        now = datetime.now(UTC)
+        retarget_receipt = prior_retarget_progress["_runtime_retarget_recovery_v1"]
+        resume_receipt = retarget_resume_marker(
+            retarget_marker_sha256=canonical_sha256(retarget_receipt),
+            preflight_sha256="a" * 64,
+            helper_source_sha256="b" * 64,
+            claim_generation=5,
+            committed_at=now,
+        )
+        retry_receipt = retarget_retry_marker(
+            retarget_marker_sha256=canonical_sha256(retarget_receipt),
+            resume_marker_sha256=canonical_sha256(resume_receipt),
+            preflight_sha256="c" * 64,
+            helper_source_sha256="d" * 64,
+            claim_generation=6,
+            committed_at=now,
+        )
+        source_request = {
+            **request,
+            "releaseVersion": "0.68.1",
+            "protocolVersion": "1",
+        }
+        async with database.session_factory.begin() as session:
+            operation = await session.get(Operation, operation_id, with_for_update=True)
+            assert operation is not None
+            operation.state = OperationState.ERROR
+            operation.checkpoint = "failed"
+            operation.error_code = "PROVISIONER_PROVIDER_METADATA_CONFLICT"
+            operation.finalized_at = now
+            operation.canonical_request_sha256 = repository_module.canonical_request_sha256(
+                source_request
+            )
+            operation.request_ciphertext = codec.encrypt_json(
+                source_request,
+                purpose="operation-request:provision:recovery-postgresql-key",
+            )
+            operation.progress = {
+                **prior_retarget_progress,
+                "_runtime_retarget_resume_v1": resume_receipt,
+                "_runtime_retarget_retry_v1": retry_receipt,
+            }
+        exhausted, exhausted_replay = await asyncio.gather(
+            successor_service.successor_retarget(operation_id),
+            successor_service.successor_retarget(operation_id),
+        )
+        assert {exhausted["status"], exhausted_replay["status"]} == {
+            "successor-retargeted",
+            "already-successor-retargeted",
+        }
+        async with database.session_factory() as session:
+            operation = await session.get(Operation, operation_id)
+            assert operation is not None
+            decoded = codec.decrypt_json(
+                operation.request_ciphertext,
+                purpose="operation-request:provision:recovery-postgresql-key",
+            )
+            assert decoded["releaseVersion"] == "0.68.3"
+            assert operation.state is OperationState.PENDING
+            assert operation.checkpoint == "volume-owned"
+            assert operation.error_code is None
+            assert operation.finalized_at is None
+            assert "_runtime_retarget_successor_v1" in operation.progress
         for role, schema in (("wrong-role", target.schema), (target.role, "wrong_schema")):
             wrong_identity = RecoveryService(
                 sessions=database.session_factory,

--- a/openspec/changes/standardize-hosted-runtime-upgrades/specs/hosted-runtime-upgrade/spec.md
+++ b/openspec/changes/standardize-hosted-runtime-upgrades/specs/hosted-runtime-upgrade/spec.md
@@ -255,7 +255,7 @@ checkpoint identity. Repetition SHALL verify the existing receipt without a seco
 
 #### Scenario: A broken immutable target is superseded without replacing the provision
 
-- **WHEN** a never-routed recovered provision is still pending at `volume-owned`, or exhausted its separately attributed retry with the same provider-metadata failure, and a signed patch runtime supersedes its immutable target
+- **WHEN** a never-routed recovered provision is still pending at `volume-owned` or the exact pre-driver `capacity-live-observation-mismatch` retry checkpoint, or exhausted its separately attributed retry with the same provider-metadata failure, and a signed patch runtime supersedes its immutable target
 - **THEN** a separately invoked signed successor retarget validates the full append-only recovery receipt chain, source and target deployment locks, exact encrypted request, unchanged four-resource identity, active reservation, stable unrouted live state, and absence of conflicts before atomically selecting the patch target and making the same operation claimable
 - **AND** it appends one content-free successor receipt bound to the complete prior receipt chain, source request, target request, target runtime, and live preflight evidence
 - **AND** any missing, reordered, mismatched, or already-superseded receipt, active claim, route, result, resource, reservation, fence, request, runtime, or live identity refuses without changing the operation, cell, PVC, PV, or provider volume

--- a/openspec/changes/standardize-hosted-runtime-upgrades/specs/hosted-runtime-upgrade/spec.md
+++ b/openspec/changes/standardize-hosted-runtime-upgrades/specs/hosted-runtime-upgrade/spec.md
@@ -253,6 +253,13 @@ checkpoint identity. Repetition SHALL verify the existing receipt without a seco
 - **WHEN** that resumed retarget fails closed with a provider-metadata conflict before migration while the same four resources remain stopped, unrouted, reserved, and conflict-free
 - **THEN** a separately invoked signed retry validates the original recovery, retarget, and resume receipts plus the unchanged selected-target request and live identity before appending one content-free retry receipt and making the same operation claimable once more
 
+#### Scenario: A broken immutable target is superseded without replacing the provision
+
+- **WHEN** a never-routed recovered provision is still pending at `volume-owned`, or exhausted its separately attributed retry with the same provider-metadata failure, and a signed patch runtime supersedes its immutable target
+- **THEN** a separately invoked signed successor retarget validates the full append-only recovery receipt chain, source and target deployment locks, exact encrypted request, unchanged four-resource identity, active reservation, stable unrouted live state, and absence of conflicts before atomically selecting the patch target and making the same operation claimable
+- **AND** it appends one content-free successor receipt bound to the complete prior receipt chain, source request, target request, target runtime, and live preflight evidence
+- **AND** any missing, reordered, mismatched, or already-superseded receipt, active claim, route, result, resource, reservation, fence, request, runtime, or live identity refuses without changing the operation, cell, PVC, PV, or provider volume
+
 #### Scenario: Retarget mismatch is a no-op
 
 - **WHEN** any request, receipt, claim, fence, resource, reservation, live identity, runtime, route, result, or compare-and-swap invariant differs

--- a/openspec/changes/standardize-hosted-runtime-upgrades/tasks.md
+++ b/openspec/changes/standardize-hosted-runtime-upgrades/tasks.md
@@ -90,4 +90,5 @@
 - [ ] 8.9 Run free preflight, prepare the explicit eligible reviewer client, and conduct the human-timed Claude/OpenAI promotion ceremony
 - [ ] 8.10 Complete personal-account OAuth and full read/write/reconnect acceptance on `0.68.1`, keep the personal tenant live, and record final fleet, lock, cohort, authority, capacity, and operation state
 - [ ] 8.11 Land and publish the signed one-way retarget helper, advance the two never-routed recovered provisions in place to `0.68.1`, and verify their original operation, cell, PVC, PV, and provider-volume identities are preserved
-- [ ] 8.12 Make target-image initialization replay an unchanged stable credential authority under the selected-target migration identity, publish the corrected signed `0.68.1` image, and prove mismatched or rotating authority still fails closed
+- [ ] 8.12 Make target-image initialization replay an unchanged stable credential authority under the selected-target migration identity, publish the corrected signed patch runtime, and prove mismatched or rotating authority still fails closed
+- [ ] 8.13 Publish and invoke one signed successor-retarget helper that advances both preserved never-routed operations from immutable `0.68.1` to the corrected patch target while preserving every operation, cell, PVC, PV, and provider-volume identity


### PR DESCRIPTION
## Summary
- add one append-only, evidence-bound successor retarget for preserved never-routed provisions
- accept only the pending pre-run shape or an exhausted attributed retry, preserving operation and storage identity
- bind the successor receipt to the complete prior receipt chain and signed source/target locks

## Verification
- 536 provisioner tests passed (PostgreSQL image gates excluded)
- real PostgreSQL 17 recovery CAS test passed
- 113 focused recovery/live/lifecycle tests passed
- OpenSpec strict validation: 174 passed
- Ruff and diff checks passed