### PR TITLE
fix(benchmarks): blind the judge to vendor frontmatter structure

### DIFF
--- a/benchmarks/membench/judge/__init__.py
+++ b/benchmarks/membench/judge/__init__.py
@@ -33,6 +33,7 @@ from membench.judge.blinding import (
     leakage_scan,
     normalize_for_judge,
     shuffled,
+    structural_leakage_scan,
 )
 from membench.judge.handshake import (
     HandshakeRequest,
@@ -75,5 +76,6 @@ __all__ = [
     "normalize_for_judge",
     "parse_judge_verdict",
     "shuffled",
+    "structural_leakage_scan",
     "write_requests",
 ]

--- a/benchmarks/membench/judge/blinding.py
+++ b/benchmarks/membench/judge/blinding.py
@@ -13,9 +13,33 @@ Three mechanical guarantees back the judge policy:
   stable per-source numbering within one request (share one
   :class:`SourceNumbering` across all fields of a request).
 - :func:`leakage_scan` is the hard gate: it flags residual identifying
-  tokens, and a leaky request FAILS the judge phase (the handshake writer
-  refuses to serialize it). The scan is deliberately broader than the
-  rewriter — anything the rewriter cannot neutralize fails closed.
+  tokens AND residual identifying *structure*, and a leaky request FAILS the
+  judge phase (the handshake writer refuses to serialize it). The scan is
+  deliberately broader than the rewriter — anything the rewriter cannot
+  neutralize fails closed.
+
+The structural axis exists because token blinding alone loses to schema
+shape (task 4b.18): a frontmatter key run such as ``type / exomem_id /
+title / source_type / captured / tags / ingested_into`` names the product
+outright while every value is neutral and the token scan returns zero hits,
+and scrubbing the product name out of the key leaves ``[system]_id:`` —
+a residue that advertises a product-named field was removed. So
+:func:`normalize_for_judge` canonicalizes any registered vendor key run to
+one fixed neutral block BEFORE token rewriting, and
+:func:`structural_leakage_scan` flags any that survives. The failure
+predicate is byte identity on that axis: one semantic payload rendered with
+two providers' native FRONTMATTER KEY RUNS must reach the judge as identical
+frontmatter bytes, which is stronger than "no sampled classifier told them
+apart".
+
+The axis is the key run, and the remainder is named rather than implied: body
+scaffolding is a second structural tell this module does NOT normalize. The
+two producers wrap the same payload in different section headers
+(`src/exomem/add.py` writes ``## Capture``,
+`benchmarks/membench/native/basic_memory.py` writes ``## Observations``), so a
+whole-document byte-identity claim would be false. Normalizing prose headings
+is a separate scope decision, not an oversight here — the same way
+:func:`_key_runs` names its column-0 block-list limit instead of hiding it.
 
 Order randomization uses :func:`deterministic_permutation`: a permutation
 derived from a seed string via hashlib, reproducible forever for the same
@@ -25,6 +49,7 @@ seed.
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -49,6 +74,58 @@ _PRODUCT_RES: tuple[re.Pattern[str], ...] = (
     re.compile(r"graybox", re.IGNORECASE),
     re.compile(r"(?<![A-Za-z0-9])mem0(?![A-Za-z0-9])", re.IGNORECASE),
 )
+
+#: Fence line of a YAML frontmatter block.
+_FRONTMATTER_FENCE = "---"
+
+#: The token scrubber rewrites ``exomem_id:`` to this; the key shape survives
+#: even though the product name does not, so the residue is its own signature.
+_SCRUBBED_ID_KEY = f"{NEUTRAL_SYSTEM_TOKEN}_id"
+
+#: A header line: ``key: value``, ``key:``, or the scrubbed-id residue key.
+#: ``key:value`` with no separating space is deliberately NOT matched: it is
+#: not valid YAML block-mapping syntax and neither registered producer emits
+#: it, so matching it would only widen the false-positive surface.
+_KEY_LINE_RE = re.compile(
+    r"^[ \t]*("
+    + re.escape(_SCRUBBED_ID_KEY)
+    + r"|[A-Za-z_][A-Za-z0-9_.-]*)[ \t]*:(?:[ \t].*)?$"
+)
+
+#: Registered vendor structural signatures: a header-line run whose key set is
+#: a superset of one of these identifies its producer with zero token hits.
+#: Both are read off the producers that actually emit them in this repo —
+#: `src/exomem/add.py` (the source-page writer) and
+#: `benchmarks/membench/native/basic_memory.py` (note frontmatter) — never an
+#: invented convenience shape.
+_STRUCTURAL_SIGNATURES: tuple[tuple[str, frozenset[str]], ...] = (
+    (
+        "exomem-source-frontmatter",
+        frozenset({"type", "source_type", "captured", "ingested_into"}),
+    ),
+    ("exomem-id-key", frozenset({"exomem_id"})),
+    ("system-id-residue", frozenset({_SCRUBBED_ID_KEY})),
+    (
+        "basic-memory-note-frontmatter",
+        frozenset({"title", "type", "permalink", "tags"}),
+    ),
+)
+
+#: Marker prefix for a structural hit in :func:`leakage_scan` output. Token
+#: hits are returned verbatim; a structure has no single verbatim token to
+#: return, so it is named instead — refusals stay explainable either way.
+STRUCTURE_LEAK_PREFIX = "structure:"
+
+#: Keys carried through structural canonicalization, in this fixed order.
+#: ``title`` is the only frontmatter field with content a judge grades; every
+#: other key is provenance or identity, which is exactly what blinding removes.
+CANONICAL_FRONTMATTER_KEYS: tuple[str, ...] = ("title",)
+
+#: Line breaks as the SCAN sees them. `write_requests` scans one serialized
+#: JSON line in which every document newline is the two-character escape
+#: ``\\n``, so a scan that only understood real newlines would find no key run
+#: in the exact bytes the gate binds on. Longest alternatives first.
+_SCAN_LINE_SPLIT_RE = re.compile(r"\\r\\n|\\n|\r\n|\n|\r")
 
 # leakage_scan patterns: broader than the rewriter on purpose (fail closed).
 _LEAK_RES: tuple[tuple[str, re.Pattern[str]], ...] = (
@@ -148,12 +225,225 @@ class SourceNumbering:
         return f"[ctx:{number}]"
 
 
+def _fenced_run(
+    lines: Sequence[str], opening: int
+) -> tuple[int, int, dict[str, str]] | None:
+    """The run delimited by a ``---`` fence pair at ``opening``, or ``None``.
+
+    Inside a fence the run is bounded by the FENCE, not by the first non-key
+    line, because a producer can emit a value that is not a single line. Basic
+    Memory writes ``f"title: {source.title}"`` unescaped
+    (`native/basic_memory.py:158`) over a ``SourceRecord.title`` that is an
+    unconstrained ``str`` (`membench/schema.py:229`), so a title carrying a
+    newline splits the block and — under a consecutive-line rule — would let
+    ``permalink:`` walk past the gate into judge-visible text.
+
+    Acceptance is deliberately narrow, because a false positive here DELETES
+    content rather than merely refusing it: the interior must hold at least two
+    key lines and strictly more key lines than other non-empty lines. Prose
+    between two thematic breaks fails that; a frontmatter block with a
+    line-broken value passes it. The returned span INCLUDES both fences.
+    The residual is the mirror image of the rule: a value carrying at least
+    as many line breaks as the block has keys makes ``other_lines`` catch up
+    with ``key_lines``, the fenced run is rejected, the consecutive rule takes
+    over, and ``permalink:`` can walk past the gate again. Neither registered
+    producer emits such a value; it is named here, like the column-0 and
+    ``key:value`` limits, rather than hidden.
+    """
+
+    closing = None
+    for index in range(opening + 1, len(lines)):
+        if lines[index].strip() == _FRONTMATTER_FENCE:
+            closing = index
+            break
+    if closing is None:
+        return None
+    keys: dict[str, str] = {}
+    key_lines = 0
+    other_lines = 0
+    for line in lines[opening + 1 : closing]:
+        match = _KEY_LINE_RE.match(line)
+        if match is not None:
+            key_lines += 1
+            keys.setdefault(match.group(1), line.partition(":")[2])
+        elif line.strip():
+            other_lines += 1
+    if key_lines < 2 or other_lines >= key_lines:
+        return None
+    return (opening, closing + 1, keys)
+
+
+def _unfenced_run(
+    lines: Sequence[str], start: int, floor: int
+) -> tuple[int, int, dict[str, str]] | None:
+    """The maximal run of consecutive header lines at ``start``, or ``None``.
+
+    An indented non-empty line (a YAML block value such as a ``- item`` under
+    its key) continues a run without contributing a key; anything else ends it.
+    A block list written at column 0 therefore splits an UNFENCED run — a known
+    limit, and neither registered producer writes one outside a fence. A ``---``
+    immediately on either side is absorbed into the span, never below ``floor``
+    (which is where the previous run ended), so spans never overlap.
+    """
+
+    index = start
+    keys: dict[str, str] = {}
+    while index < len(lines):
+        line = lines[index]
+        match = _KEY_LINE_RE.match(line)
+        if match is not None:
+            keys.setdefault(match.group(1), line.partition(":")[2])
+            index += 1
+            continue
+        if keys and line[:1] in (" ", "\t") and line.strip():
+            index += 1  # block value continuation; contributes no key
+            continue
+        break
+    if not keys:
+        return None
+    first, stop = start, index
+    if first - 1 >= floor and lines[first - 1].strip() == _FRONTMATTER_FENCE:
+        first -= 1
+    if stop < len(lines) and lines[stop].strip() == _FRONTMATTER_FENCE:
+        stop += 1
+    return (first, stop, keys)
+
+
+def _key_runs(lines: Sequence[str]) -> list[tuple[int, int, dict[str, str]]]:
+    """Header-line runs, as ``(start, stop, keys)`` in increasing start order.
+
+    ``stop`` is exclusive and the span is what a caller should REPLACE: any
+    ``---`` fence belonging to the run is already inside it. ``keys`` maps
+    key → raw value text in first-seen order. A fenced block is preferred over
+    the consecutive-line reading whenever it qualifies (see :func:`_fenced_run`).
+    """
+
+    runs: list[tuple[int, int, dict[str, str]]] = []
+    index = 0
+    floor = 0
+    while index < len(lines):
+        run = None
+        if lines[index].strip() == _FRONTMATTER_FENCE:
+            run = _fenced_run(lines, index)
+        if run is None:
+            run = _unfenced_run(lines, index, floor)
+        if run is None:
+            index += 1
+            continue
+        runs.append(run)
+        index = floor = run[1]
+    return runs
+
+
+def _matched_signatures(present: set[str]) -> list[str]:
+    """Names of the registered vendor signatures satisfied by ``present``."""
+
+    return [name for name, required in _STRUCTURAL_SIGNATURES if required <= present]
+
+
+def _unwrap_once(value: str) -> str:
+    """One layer of quoting removed, or ``value`` unchanged if it carries none."""
+
+    if len(value) < 2 or value[0] != value[-1] or value[0] not in "\"'":
+        return value
+    if value[0] == '"':
+        try:
+            decoded = json.loads(value)
+        except ValueError:
+            return value[1:-1]
+        return decoded if isinstance(decoded, str) else value[1:-1]
+    return value[1:-1]
+
+
+def _canonical_value(raw: str) -> str:
+    """Value text with producer-specific quoting removed, to a FIXED POINT.
+
+    One producer renders scalars through ``json.dumps``
+    (``src/exomem/vault.py`` ``yaml_scalar``) while the other writes them bare,
+    so one title can arrive as ``"A: B"`` and as ``A: B``. Quoting is shape,
+    not content, and byte identity has to survive it.
+
+    Unwrapping ONCE is not enough, and the difference is a one-way tell: a
+    title that itself carries quotes gets double-wrapped by ``yaml_scalar``
+    (``"Quarterly"`` becomes ``"\\"Quarterly\\""``) while the other producer
+    writes it bare, so a single unwrap leaves the first still quoted and the
+    second bare. Iterating to a fixed point closes it. Each pass removes at
+    least two characters, so the loop terminates; a value whose quotes are
+    content rather than shape (``He said "go": deadline moved``) is not
+    surrounded by a matched pair and is returned untouched.
+    """
+
+    value = raw.strip()
+    while True:
+        unwrapped = _unwrap_once(value)
+        if unwrapped == value:
+            return value
+        value = unwrapped
+
+
+def _canonical_block(keys: dict[str, str]) -> list[str]:
+    """The one neutral block every registered vendor shape collapses to.
+
+    Fixed key set, fixed order, fixed delimiter — so two native shapes of one
+    payload become the same bytes. An empty carry means the block held nothing
+    but provenance, and it disappears entirely rather than leaving a husk.
+    """
+
+    carried = [
+        f"{key}: {_canonical_value(keys[key])}"
+        for key in CANONICAL_FRONTMATTER_KEYS
+        if _canonical_value(keys.get(key, ""))
+    ]
+    if not carried:
+        return []
+    return [_FRONTMATTER_FENCE, *carried, _FRONTMATTER_FENCE]
+
+
+def _canonicalize_structure(text: str) -> str:
+    """Rewrite every registered vendor key run to the one neutral block.
+
+    Real newlines only: this REWRITES text, so it must not treat a literal
+    backslash-n inside content as a line break the way the scan deliberately
+    does. Runs already carry their own fences in their span, and are replaced
+    back-to-front so earlier indices stay valid.
+    """
+
+    lines = text.split("\n")
+    out = list(lines)
+    for start, stop, keys in reversed(_key_runs(lines)):
+        if not _matched_signatures(set(keys)):
+            continue
+        out[start:stop] = _canonical_block(keys)
+    return "\n".join(out)
+
+
+def structural_leakage_scan(text: str) -> list[str]:
+    """Registered vendor structural signatures still present in ``text``.
+
+    Returns ``structure:<signature>`` markers (empty = clean). Splitting is
+    escape-tolerant on purpose: the gate binds on one serialized JSON line
+    whose document newlines are two-character escapes.
+    """
+
+    found: dict[str, None] = {}
+    lines = _SCAN_LINE_SPLIT_RE.split(text)
+    for _start, _stop, keys in _key_runs(lines):
+        for name in _matched_signatures(set(keys)):
+            found.setdefault(f"{STRUCTURE_LEAK_PREFIX}{name}")
+    return list(found)
+
+
 def normalize_for_judge(text: str, numbering: SourceNumbering | None = None) -> str:
     """Rewrite provider-identifying shapes in ``text`` into neutral tokens.
 
-    Source-like shapes (refs, sentinels, vault paths) become ``[ctx:N]``;
-    a sentinel and a bare mention of the same source id share one N.
-    Product names become :data:`NEUTRAL_SYSTEM_TOKEN`.
+    Structure is neutralized FIRST: a registered vendor frontmatter key run
+    collapses to :data:`CANONICAL_FRONTMATTER_KEYS` in a fixed block, which is
+    what makes the FRONTMATTER of a structure swap byte-identical (the body
+    scaffolding is the named remainder — see the module docstring) and what
+    removes ``exomem_id:`` as a key rather than scrubbing it into a
+    ``[system]_id:`` residue. Then source-like shapes (refs, sentinels, vault paths) become
+    ``[ctx:N]`` — a sentinel and a bare mention of the same source id share one
+    N — and product names become :data:`NEUTRAL_SYSTEM_TOKEN`.
     """
 
     numbers = numbering if numbering is not None else SourceNumbering()
@@ -164,7 +454,8 @@ def normalize_for_judge(text: str, numbering: SourceNumbering | None = None) -> 
     def _ctx_sentinel(match: re.Match[str]) -> str:
         return numbers.token(match.group(1))
 
-    out = _EXOMEM_URI_RE.sub(_ctx_whole, text)
+    out = _canonicalize_structure(text)
+    out = _EXOMEM_URI_RE.sub(_ctx_whole, out)
     out = SENTINEL_RE.sub(_ctx_sentinel, out)
     out = _VAULT_PATH_RE.sub(_ctx_whole, out)
     out = _MD_PATH_RE.sub(_ctx_whole, out)
@@ -175,15 +466,19 @@ def normalize_for_judge(text: str, numbering: SourceNumbering | None = None) -> 
 
 
 def leakage_scan(text: str) -> list[str]:
-    """Residual provider-identifying tokens in ``text`` (empty = clean).
+    """Residual provider-identifying tokens AND structure in ``text``.
 
-    Used as a hard gate by the handshake writer: any hit means the request
-    is refused, never written. Matches are returned verbatim (deduplicated,
-    order of first appearance) so refusals are explainable.
+    Empty = clean. Used as a hard gate by the handshake writer: any hit means
+    the request is refused, never written. Token matches are returned verbatim
+    (deduplicated, order of first appearance) so refusals are explainable; a
+    structural hit has no single verbatim token to quote and is named instead,
+    as ``structure:<signature>``, appended after the token hits.
     """
 
     found: dict[str, None] = {}
     for _kind, pattern in _LEAK_RES:
         for match in pattern.finditer(text):
             found.setdefault(match.group(0))
+    for marker in structural_leakage_scan(text):
+        found.setdefault(marker)
     return list(found)

--- a/openspec/changes/add-competitive-benchmark-programme/tasks.md
+++ b/openspec/changes/add-competitive-benchmark-programme/tasks.md
@@ -421,8 +421,18 @@ them. Mission acceptance criteria (§14) close only from this ledger.
       network run occurred.
 - [ ] 5.2 Families 1–9 fixtures + runs vs exomem + grep-markdown + no-memory
       (controls score non-trivially)
-- [ ] 5.3 4b.18 structural-blinding fix + structure-swap test (hard-gates all
+- [x] 5.3 4b.18 structural-blinding fix + structure-swap test (hard-gates all
       judge use)
+      Landed 2026-09-02 (`benchmarks/membench/judge/blinding.py`): structure is
+      canonicalized before the token rewriters (fence-delimited block carrying only
+      `title`, values unwrapped to a fixed point), `leakage_scan` gains a structural
+      axis over four registered vendor signatures, and `handshake.write_requests`
+      refuses a structural leak on the serialized line before writing. The
+      byte-identity guarantee is scoped to the frontmatter key-run axis; body
+      scaffolding (`## Capture` vs `## Observations`) is named as the open
+      remainder. Fresh review REQUEST_CHANGES -> correction -> recheck APPROVE;
+      14 mutations, zero survivors. `tests/test_membench_agreement.py:103` becomes
+      strictly harder once the v0.1 seed-1 corpus is present in a checkout.
 - [ ] 5.4 Competitor drivers (basic-memory, supermemory) + ⛳ independent
       adversarial review of every fairness packet and the glue diff BEFORE
       competitor runs

--- a/tests/test_membench_judge_contract.py
+++ b/tests/test_membench_judge_contract.py
@@ -15,6 +15,7 @@ import pytest
 
 from membench.judge import (
     ClaudeCliBackend,
+    HandshakeRequest,
     LeakageError,
     NoneBackend,
     OpenAICompatBackend,
@@ -25,9 +26,11 @@ from membench.judge import (
     leakage_scan,
     load_requests,
     make_judge_item,
+    normalize_for_judge,
+    structural_leakage_scan,
     write_requests,
 )
-from membench.judge.blinding import BlindingMap
+from membench.judge.blinding import NEUTRAL_SYSTEM_TOKEN, BlindingMap
 from membench.reporting import (
     GATE_CONFLICT_NOTE,
     build_comparison_report,
@@ -35,6 +38,8 @@ from membench.reporting import (
 )
 from membench.runner import MembenchResultManifest
 from protocol.contracts import derive_preregistration_identity
+
+from exomem.vault import yaml_scalar
 
 _DIMENSIONS_OK = {
     "factual_qa": {"pass": 1, "fail": 0, "not_applicable": 0, "unsupported": 0},
@@ -253,6 +258,304 @@ def test_leakage_scan_catches_leaks_and_writer_refuses(tmp_path: Path) -> None:
         write_requests(run_dir, "judge", [leaky], samples=2, seed="s")
     assert "Q-0001" in str(excinfo.value)
     assert not (run_dir / "judge-requests").exists(), "refusal must write nothing"
+
+
+# --------------------------------------------- structural blinding (task 4b.18)
+#
+# Token blinding alone loses to schema shape: a human recognised the vendor at a
+# glance across 84 documents while `leakage_scan` returned zero hits, because the
+# frontmatter KEY SET names the product even when every value is neutral. The two
+# shapes below are copied key-for-key, in order, from the producers that actually
+# emit them in this repo -- no invented convenience shape.
+
+_SWAP_TITLE = "Quarterly deadline moved"
+#: A title that splits its own frontmatter line. `SourceRecord.title` is an
+#: unconstrained `str` (`membench/schema.py:229`) and `basic_memory.py:158`
+#: interpolates it unescaped, so this reaches a rendered note as written.
+_NEWLINE_TITLE = "Quarterly deadline\nmoved to week nine"
+_SWAP_BODY = (
+    "The deadline moved to week nine after the review board met.\n"
+    "Two teams confirmed the new date in writing.\n"
+)
+
+
+def _exomem_shaped(title: str = _SWAP_TITLE, body: str = _SWAP_BODY) -> str:
+    """One payload in exomem's native metadata shape.
+
+    Producer: ``src/exomem/add.py`` source-page writer (:639-671) -- the key run
+    ``type / exomem_id / title / source_type / captured / tags / ingested_into``
+    inside a ``---`` fence. This is exactly the key list task 4b.18 names.
+    """
+
+    return (
+        "---\n"
+        "type: source\n"
+        "exomem_id: 6b0f2a41-6f0e-4a1a-9a2e-2c9b7f5d1e33\n"
+        # `add.py:642` renders the title through `yaml_scalar`, so a title
+        # carrying YAML-special characters arrives quoted here while the other
+        # producer writes it bare. Called, not imitated -- the fixture has to be
+        # what the producer emits.
+        f"title: {yaml_scalar(title.strip())}\n"
+        "source_type: other\n"
+        "captured: 2026-01-14\n"
+        "tags: [bench]\n"
+        "ingested_into: []\n"
+        "---\n"
+        "\n"
+        f"{body}"
+    )
+
+
+def _basic_memory_shaped(title: str = _SWAP_TITLE, body: str = _SWAP_BODY) -> str:
+    """The same payload in the other contender's native metadata shape.
+
+    Producer: ``benchmarks/membench/native/basic_memory.py`` (:78-84 conclusion
+    notes, :135-141 entity notes, :155-161 source notes) -- the key run
+    ``title / type / permalink / tags`` inside a ``---`` fence.
+    """
+
+    return (
+        "---\n"
+        f"title: {title}\n"
+        "type: note\n"
+        "permalink: quarterly-deadline-moved\n"
+        "tags: [bench]\n"
+        "---\n"
+        "\n"
+        f"{body}"
+    )
+
+
+def _scrubbed_exomem_shaped(title: str = _SWAP_TITLE, body: str = _SWAP_BODY) -> str:
+    """The exomem shape as it survives today's TOKEN scrubber.
+
+    ``normalize_for_judge`` rewrites the product name inside the ``exomem_id:``
+    key, so the key reaches the judge as ``[system]_id:``. That residue carries
+    zero token hits while still advertising both the vendor key run and the fact
+    that a product-named field was scrubbed -- 4b.18's second sentence.
+    """
+
+    return _exomem_shaped(title, body).replace(
+        "exomem_id:", f"{NEUTRAL_SYSTEM_TOKEN}_id:"
+    )
+
+
+_TOKEN_LEAK_NEEDLES = (
+    "exomem",
+    "basic-memory",
+    "basic memory",
+    "basic_memory",
+    "mem0",
+    "graybox",
+    "[ref:",
+    "src-",
+    "knowledge base/",
+    ".md",
+)
+
+
+def test_frontmatter_structure_swap_is_byte_identical_after_normalization() -> None:
+    """The failure predicate of the structure-swap test, on the key-run axis.
+
+    One identical semantic payload, each vendor's native FRONTMATTER KEY RUN:
+    the frontmatter bytes that reach the judge must be identical. Byte identity
+    is what proves "no classifier distinguishes them" on this axis -- a sampled
+    classifier could only fail to find the tell.
+
+    Scope is the key run, and the fixtures hold the body constant to say so
+    honestly. The producers also differ in body scaffolding (`## Capture` vs
+    `## Observations`), which this module does not normalize; that axis is the
+    named remainder in `blinding.py`'s docstring, not something this test
+    quietly claims to have closed.
+    """
+
+    from_exomem = normalize_for_judge(_exomem_shaped())
+    from_basic_memory = normalize_for_judge(_basic_memory_shaped())
+
+    assert from_exomem == from_basic_memory, (
+        "structure swap is attributable: identical content in two native shapes "
+        f"reaches the judge as different bytes\n--- exomem ---\n{from_exomem!r}\n"
+        f"--- basic-memory ---\n{from_basic_memory!r}"
+    )
+
+    # ... and the shape both collapsed into is the ONE canonical block: fence,
+    # the fixed neutral key set in its fixed order, fence. Dropping the fences
+    # would still be "identical", and identically wrong -- a bare `title:` line
+    # left in running prose is not a normalized frontmatter block.
+    assert from_exomem.splitlines()[:3] == ["---", f"title: {_SWAP_TITLE}", "---"], (
+        f"canonical block is not fence-delimited: {from_exomem.splitlines()[:3]!r}"
+    )
+
+    # ... and normalization must not have achieved identity by deleting the
+    # payload: the semantic content the judge grades survives.
+    assert _SWAP_TITLE in from_exomem
+    assert "The deadline moved to week nine" in from_exomem
+    assert "Two teams confirmed the new date in writing." in from_exomem
+
+    # ... and it must hold for a title the two producers spell differently.
+    # `yaml_scalar` quotes a title containing YAML-special characters; the
+    # other producer never quotes. Real corpus titles do contain colons, so
+    # quoting is a shape the swap has to survive, not an edge case.
+    # A title that itself carries quotes is DOUBLE-wrapped by `yaml_scalar` and
+    # written bare by the other producer, so one unwrap is not enough: it leaves
+    # exomem still quoted and basic-memory bare, which is a one-way tell.
+    # `"Quarterly"` is the load-bearing one: it is wholly wrapped, so
+    # `yaml_scalar` double-wraps it and a single unwrap leaves exomem at
+    # `"Quarterly"` while basic-memory reaches `Quarterly`.
+    for quoted_title in ("Deadline: moved to week nine", '"Quarterly"'):
+        from_exomem = normalize_for_judge(_exomem_shaped(quoted_title))
+        from_basic_memory = normalize_for_judge(_basic_memory_shaped(quoted_title))
+        assert f"title: {quoted_title}" in _basic_memory_shaped(quoted_title)
+        assert f"title: {quoted_title}\n" not in _exomem_shaped(quoted_title), (
+            f"{quoted_title!r} is not a case yaml_scalar quotes; it proves nothing"
+        )
+        assert from_exomem == from_basic_memory, (
+            "producer-specific quoting of one title is still an attributable "
+            f"shape\n--- exomem ---\n{from_exomem!r}\n"
+            f"--- basic-memory ---\n{from_basic_memory!r}"
+        )
+
+    # ... and unwrapping stops at a fixed point rather than eating quotes that
+    # are content: this title is not surrounded by a matched pair.
+    content_quotes = 'He said "go": deadline moved'
+    assert content_quotes in normalize_for_judge(_exomem_shaped(content_quotes))
+
+
+def test_leakage_scan_flags_vendor_frontmatter_structure() -> None:
+    """Structure is a leak with zero token hits -- the whole of 4b.18."""
+
+    for label, shaped in (
+        ("basic-memory", _basic_memory_shaped()),
+        ("exomem (token-scrubbed)", _scrubbed_exomem_shaped()),
+        # `basic_memory.py:158` writes `title: {source.title}` unescaped over an
+        # unconstrained `SourceRecord.title` (`schema.py:229`), so a newline in
+        # a title splits the key run. Bounded by the fence, the run survives it.
+        ("basic-memory (title carries a newline)", _basic_memory_shaped(_NEWLINE_TITLE)),
+    ):
+        lowered = shaped.lower()
+        for needle in _TOKEN_LEAK_NEEDLES:
+            assert needle not in lowered, (
+                f"{label} fixture must carry ZERO token hits, found {needle!r}"
+            )
+        assert leakage_scan(shaped), (
+            f"{label} frontmatter key run identifies the vendor and went undetected"
+        )
+
+
+def test_every_registered_structural_signature_is_load_bearing() -> None:
+    """Each registered signature catches a key run no other signature covers.
+
+    On a whole page the registry overlaps on purpose -- an exomem source block
+    satisfies several entries at once -- so a whole-page fixture cannot show
+    that any one entry earns its place. A quoted excerpt can, and an excerpt is
+    what a candidate answer quoting part of a page actually contains. Each run
+    below is a contiguous slice of its producer's block, and the assertion is
+    exact equality: one marker, so exactly one registered signature fired.
+    """
+
+    cases = (
+        # `src/exomem/add.py` :640, :643-648 -- the block minus its id/title/tags
+        (
+            "exomem-source-frontmatter",
+            "type: source\n"
+            "source_type: other\n"
+            "captured: 2026-01-14\n"
+            "ingested_into: []\n",
+        ),
+        # `src/exomem/add.py` :641 alone
+        ("exomem-id-key", "exomem_id: 6b0f2a41-6f0e-4a1a-9a2e-2c9b7f5d1e33\n"),
+        # ... and the same line once the token scrubber has been over it
+        (
+            "system-id-residue",
+            f"{NEUTRAL_SYSTEM_TOKEN}_id: 6b0f2a41-6f0e-4a1a-9a2e-2c9b7f5d1e33\n",
+        ),
+        # `benchmarks/membench/native/basic_memory.py` :135-140, fences dropped
+        (
+            "basic-memory-note-frontmatter",
+            "title: Quarterly deadline moved\n"
+            "type: note\n"
+            "permalink: quarterly-deadline-moved\n"
+            "tags: [bench]\n",
+        ),
+        # ... and the same excerpt indented, which is how a candidate answer
+        # quoting a document normally carries it. A key-line rule anchored hard
+        # at column 0 would miss every indented quotation of a vendor block.
+        (
+            "basic-memory-note-frontmatter",
+            "    title: Quarterly deadline moved\n"
+            "    type: note\n"
+            "    permalink: quarterly-deadline-moved\n"
+            "    tags: [bench]\n",
+        ),
+    )
+    for signature, excerpt in cases:
+        assert structural_leakage_scan(excerpt) == [f"structure:{signature}"], (
+            f"{signature} is not the one signature this excerpt matches: "
+            f"{structural_leakage_scan(excerpt)}"
+        )
+        assert not structural_leakage_scan(normalize_for_judge(excerpt)), (
+            f"{signature} survives normalization"
+        )
+
+
+def test_system_id_residue_cannot_survive() -> None:
+    """`[system]_id:` is itself a fingerprint; the fix removes the key, not the token."""
+
+    out = normalize_for_judge(_exomem_shaped())
+    assert "exomem_id" not in out
+    assert f"{NEUTRAL_SYSTEM_TOKEN}_id" not in out
+    for key in ("source_type:", "captured:", "ingested_into:", "permalink:"):
+        assert key not in out, f"vendor-identifying key {key!r} reached the judge"
+    assert leakage_scan(out) == [], f"normalized output still leaks: {leakage_scan(out)}"
+
+    # D4 binds on every vendor-identifying key, so a title that splits its own
+    # key run must not carry `permalink:` past the gate either. Reachable:
+    # `basic_memory.py:158` interpolates an unconstrained title unescaped.
+    split = normalize_for_judge(_basic_memory_shaped(_NEWLINE_TITLE))
+    for key in ("permalink:", "tags:", "type:"):
+        assert key not in split, (
+            f"a newline in a title let {key!r} walk past the gate:\n{split!r}"
+        )
+    assert leakage_scan(split) == [], f"normalized output still leaks: {leakage_scan(split)}"
+
+
+def test_write_requests_refuses_structural_leak_before_writing(tmp_path: Path) -> None:
+    """The gate binds at the writer: a structural leak is refused fail-closed."""
+
+    run_dir = _make_run_dir(tmp_path, "run-structural")
+    leaky = RequestItem(
+        item_id="Q-0002",
+        blinded_provider_token="system-A",
+        payload={"prompt": "grade this excerpt:\n\n" + _scrubbed_exomem_shaped()},
+    )
+    with pytest.raises(LeakageError) as excinfo:
+        write_requests(run_dir, "judge", [leaky], samples=2, seed="s")
+    assert "Q-0002" in str(excinfo.value)
+    assert not (run_dir / "judge-requests").exists(), "refusal must write nothing"
+
+
+def test_structural_scan_runs_on_serialized_request_bytes() -> None:
+    """Pin: the structural check reads the EXACT serialized line, escapes and all.
+
+    ``write_requests`` scans ``json.dumps(request.model_dump(), ...)`` -- one
+    physical line in which every document newline is the two-character escape
+    ``\\n``. A structural check that only understands real newlines would see no
+    key run there and the gate would pass a leak through.
+    """
+
+    request = HandshakeRequest(
+        request_id="Q-0003",
+        sample_index=0,
+        blinded_provider_token="system-A",
+        payload={"prompt": "grade this excerpt:\n\n" + _scrubbed_exomem_shaped()},
+    )
+    line = json.dumps(request.model_dump(), ensure_ascii=False, sort_keys=True)
+    assert "\n" not in line, "the writer scans one serialized line, not raw text"
+    assert "\\n" in line, "document newlines reach the scan JSON-escaped"
+
+    assert leakage_scan(line), (
+        "structural scan missed the vendor key run in the serialized request line"
+    )
 
 
 # -------------------------------------------------------------- order shuffle


### PR DESCRIPTION
## What

Ledger 5.3 of `add-competitive-benchmark-programme`: the judge's blinding now normalizes frontmatter *structure*, not just tokens, and the leakage scan refuses vendor-shaped key runs at the handshake write boundary.

Before this change a page's frontmatter key set identified its vendor with zero token hits (4b.18), and a scrubbed `exomem_id:` left a `[system]_id:` residue that advertised the scrub.

## How

- `normalize_for_judge` canonicalizes structure before the token rewriters: frontmatter becomes a fence-delimited block carrying only `title`, values unwrapped to a fixed point.
- `leakage_scan` gains a structural axis over four registered vendor signatures, scanning real and JSON-escaped newlines, because the gate binds on the serialized request line at `handshake.write_requests` (unchanged file).
- A fence-bounded key run keeps a line-broken title from splitting the block.
- The byte-identity guarantee is scoped to the frontmatter key-run axis; body scaffolding is named in the module as the open remainder.

## Verification

- Red-first: five new tests observed failing against `main` before implementation.
- `tests/test_membench_judge_contract.py`: 14 passed. Scoped three-file set: 0 FAILED.
- `ruff --select F` clean; public-artifact privacy gate clean (3562 files); `tests/harness_modules.txt` unchanged; `tests/test_ci_reliability_contract.py` 24 passed.
- Fresh independent review: REQUEST_CHANGES on two findings (overclaimed docstring and test name; asymmetric quote unwrap), corrected, targeted recheck APPROVE. Reviewer ran 14 mutations against the guards with zero survivors.

## Follow-ups (not in this change)

- Prose `exomem_id` -> `[system]_id` residue with zero hits, identical on `main`.
- `tests/test_membench_agreement.py:103` becomes strictly harder once the v0.1 seed-1 corpus is present in a checkout; not exercised here because that corpus is absent.
- Body section headers (`## Capture` vs `## Observations`) are a second structural axis outside 4b.18's scope.
